### PR TITLE
feat(cosh): Added built-in cd command support for changing directory

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -373,6 +373,26 @@ export default {
     'Add directories to the workspace. Use comma to separate multiple paths',
   'Show all directories in the workspace':
     'Show all directories in the workspace',
+  'Switch the working directory for the current session':
+    'Switch the working directory for the current session',
+  'Please provide a path to switch to. Usage: /dir cd <path>':
+    'Please provide a path to switch to. Usage: /dir cd <path>',
+  'Directory "{{path}}" does not exist.':
+    'Directory "{{path}}" does not exist.',
+  'Failed to change directory to "{{path}}": {{error}}':
+    'Failed to change directory to "{{path}}": {{error}}',
+  'Switched working directory to: {{path}}':
+    'Switched working directory to: {{path}}',
+  'You are running Copilot Shell in your home directory. It is recommended to run in a project-specific directory. Use "/dir cd <path>" to switch to a project directory.':
+    'You are running Copilot Shell in your home directory. It is recommended to run in a project-specific directory. Use "/dir cd <path>" to switch to a project directory.',
+  'Warning: You are running Copilot Shell in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.':
+    'Warning: You are running Copilot Shell in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.',
+  'Could not verify the current directory due to a file system error.':
+    'Could not verify the current directory due to a file system error.',
+  'Ripgrep not available: Please install ripgrep globally to enable faster file content search. Falling back to built-in grep.':
+    'Ripgrep not available: Please install ripgrep globally to enable faster file content search. Falling back to built-in grep.',
+  'Ripgrep not available: {{message}}. Falling back to built-in grep.':
+    'Ripgrep not available: {{message}}. Falling back to built-in grep.',
   'set external editor preference': 'set external editor preference',
   'Select Editor': 'Select Editor',
   'Editor Preference': 'Editor Preference',

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -360,6 +360,24 @@ export default {
   'Add directories to the workspace. Use comma to separate multiple paths':
     '将目录添加到工作区。使用逗号分隔多个路径',
   'Show all directories in the workspace': '显示工作区中的所有目录',
+  'Switch the working directory for the current session':
+    '切换当前会话的工作目录',
+  'Please provide a path to switch to. Usage: /dir cd <path>':
+    '请提供要切换的路径。用法：/dir cd <路径>',
+  'Directory "{{path}}" does not exist.': '目录 "{{path}}" 不存在。',
+  'Failed to change directory to "{{path}}": {{error}}':
+    '切换到目录 "{{path}}" 失败：{{error}}',
+  'Switched working directory to: {{path}}': '已切换工作目录到：{{path}}',
+  'You are running Copilot Shell in your home directory. It is recommended to run in a project-specific directory. Use "/dir cd <path>" to switch to a project directory.':
+    '您正在主目录中运行 Copilot Shell。建议在特定项目目录中运行。使用 "/dir cd <路径>" 切换到项目目录。',
+  'Warning: You are running Copilot Shell in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.':
+    '警告：您正在根目录中运行 Copilot Shell。整个目录结构将作为上下文使用。强烈建议在特定项目目录中运行。',
+  'Could not verify the current directory due to a file system error.':
+    '由于文件系统错误，无法验证当前目录。',
+  'Ripgrep not available: Please install ripgrep globally to enable faster file content search. Falling back to built-in grep.':
+    'Ripgrep 不可用：请全局安装 ripgrep 以启用更快的文件内容搜索。回退到内置 grep。',
+  'Ripgrep not available: {{message}}. Falling back to built-in grep.':
+    'Ripgrep 不可用：{{message}}。回退到内置 grep。',
   'set external editor preference': '设置外部编辑器首选项',
   'Select Editor': '选择编辑器',
   'Editor Preference': '编辑器首选项',

--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -169,6 +169,15 @@ export const AppContainer = (props: AppContainerProps) => {
     config.isTrustedFolder(),
   );
 
+  const [startupWarnings, setStartupWarnings] = useState<string[]>(
+    props.startupWarnings || [],
+  );
+  const dismissWarning = useCallback((match: string) => {
+    setStartupWarnings((prev: string[]) =>
+      prev.filter((w: string) => !w.includes(match)),
+    );
+  }, []);
+
   const extensionManager = config.getExtensionManager();
 
   const { addConfirmUpdateExtensionRequest, confirmUpdateExtensionRequests } =
@@ -1664,7 +1673,8 @@ export const AppContainer = (props: AppContainerProps) => {
           <AppContext.Provider
             value={{
               version: props.version,
-              startupWarnings: props.startupWarnings || [],
+              startupWarnings,
+              dismissWarning,
             }}
           >
             <ShellFocusContext.Provider value={isFocused}>

--- a/src/copilot-shell/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -4,13 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { SlashCommand, CommandContext } from './types.js';
+import type {
+  SlashCommand,
+  CommandContext,
+  CommandCompletionItem,
+} from './types.js';
 import { CommandKind } from './types.js';
 import { MessageType } from '../types.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import { loadServerHierarchicalMemory } from '@copilot-shell/core';
 import { t } from '../../i18n/index.js';
+import process from 'node:process';
 
 export function expandHomeDir(p: string): string {
   if (!p) {
@@ -23,6 +29,53 @@ export function expandHomeDir(p: string): string {
     expandedPath = os.homedir() + p.substring(1);
   }
   return path.normalize(expandedPath);
+}
+
+/**
+ * Lists subdirectory suggestions for a given partial path input.
+ * Supports ~ expansion and returns results in ~/... format when under home dir.
+ */
+async function listDirectorySuggestions(
+  partialPath: string,
+): Promise<CommandCompletionItem[]> {
+  const input = partialPath || '~/';
+  const endsWithSep = input.endsWith('/') || input.endsWith(path.sep);
+  const expanded = expandHomeDir(input);
+
+  let searchDir: string;
+  let filterPrefix: string;
+
+  if (endsWithSep) {
+    searchDir = expanded;
+    filterPrefix = '';
+  } else {
+    searchDir = path.dirname(expanded);
+    filterPrefix = path.basename(expanded);
+  }
+
+  try {
+    const entries = fs.readdirSync(searchDir, { withFileTypes: true });
+    const results: CommandCompletionItem[] = [];
+    const homedir = os.homedir();
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith('.')) continue;
+      if (filterPrefix && !entry.name.startsWith(filterPrefix)) continue;
+
+      const fullPath = path.join(searchDir, entry.name);
+      let suggestion: string;
+      if (fullPath === homedir || fullPath.startsWith(homedir + path.sep)) {
+        suggestion = '~' + fullPath.substring(homedir.length) + '/';
+      } else {
+        suggestion = fullPath + '/';
+      }
+      results.push({ value: suggestion, label: suggestion });
+    }
+    return results;
+  } catch {
+    return [];
+  }
 }
 
 export const directoryCommand: SlashCommand = {
@@ -139,6 +192,8 @@ export const directoryCommand: SlashCommand = {
           if (gemini) {
             await gemini.addDirectoryContext();
           }
+          context.ui.dismissStartupWarning?.('home directory');
+          context.ui.dismissStartupWarning?.('home-directory');
           addItem(
             {
               type: MessageType.INFO,
@@ -157,6 +212,118 @@ export const directoryCommand: SlashCommand = {
           );
         }
         return;
+      },
+    },
+    {
+      name: 'cd',
+      get description() {
+        return t('Switch the working directory for the current session');
+      },
+      kind: CommandKind.BUILT_IN,
+      completion: async (_context: CommandContext, partialArg: string) =>
+        listDirectorySuggestions(partialArg),
+      action: async (context: CommandContext, args: string) => {
+        const {
+          ui: { addItem, dismissStartupWarning },
+          services: { config },
+        } = context;
+
+        if (!config) {
+          addItem(
+            {
+              type: MessageType.ERROR,
+              text: t('Configuration is not available.'),
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const rawPath = args.trim();
+        if (!rawPath) {
+          addItem(
+            {
+              type: MessageType.ERROR,
+              text: t(
+                'Please provide a path to switch to. Usage: /dir cd <path>',
+              ),
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const targetPath = expandHomeDir(rawPath).replace(/[/\\]+$/, '');
+
+        // Validate the target directory exists
+        try {
+          const stat = fs.statSync(targetPath);
+          if (!stat.isDirectory()) {
+            addItem(
+              {
+                type: MessageType.ERROR,
+                text: t('"{{path}}" is not a directory.', { path: rawPath }),
+              },
+              Date.now(),
+            );
+            return;
+          }
+        } catch {
+          addItem(
+            {
+              type: MessageType.ERROR,
+              text: t('Directory "{{path}}" does not exist.', {
+                path: rawPath,
+              }),
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // 1. Switch process working directory
+        try {
+          process.chdir(targetPath);
+        } catch (e) {
+          addItem(
+            {
+              type: MessageType.ERROR,
+              text: t('Failed to change directory to "{{path}}": {{error}}', {
+                path: rawPath,
+                error: (e as Error).message,
+              }),
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // 2. Replace workspace context directories with the new path
+        const workspaceContext = config.getWorkspaceContext();
+        workspaceContext.setDirectories([targetPath]);
+
+        // 3. Update config targetDir so Header and file completion reflect new path
+        config.setTargetDir(targetPath);
+
+        // 4. Refresh AI directory context
+        const gemini = config.getGeminiClient();
+        if (gemini) {
+          await gemini.addDirectoryContext();
+        }
+
+        // 5. Dismiss home directory warning if present
+        dismissStartupWarning?.('home directory');
+        dismissStartupWarning?.('home-directory');
+
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: t('Switched working directory to: {{path}}', {
+              path: targetPath,
+            }),
+          },
+          Date.now(),
+        );
       },
     },
     {

--- a/src/copilot-shell/packages/cli/src/ui/commands/types.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/types.ts
@@ -78,6 +78,8 @@ export interface CommandContext {
     extensionsUpdateState: Map<string, ExtensionUpdateStatus>;
     dispatchExtensionStateUpdate: (action: ExtensionUpdateAction) => void;
     addConfirmUpdateExtensionRequest: (value: ConfirmationRequest) => void;
+    /** Removes startup warnings that contain the given match string. */
+    dismissStartupWarning?: (match: string) => void;
   };
   // Session-specific data
   session: {

--- a/src/copilot-shell/packages/cli/src/ui/contexts/AppContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/AppContext.tsx
@@ -9,6 +9,7 @@ import { createContext, useContext } from 'react';
 export interface AppState {
   version: string;
   startupWarnings: string[];
+  dismissWarning: (match: string) => void;
 }
 
 export const AppContext = createContext<AppState | null>(null);

--- a/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -286,7 +286,14 @@ export const useShellCommandProcessor = (
 
               if (pwdFilePath && fs.existsSync(pwdFilePath)) {
                 const finalPwd = fs.readFileSync(pwdFilePath, 'utf8').trim();
-                if (finalPwd && finalPwd !== targetDir) {
+                // Normalize both paths before comparing to avoid false positives
+                // from trailing slashes or platform path differences.
+                const normalizedFinalPwd = path.normalize(finalPwd);
+                const normalizedTargetDir = path.normalize(targetDir);
+                if (
+                  normalizedFinalPwd &&
+                  normalizedFinalPwd !== normalizedTargetDir
+                ) {
                   const warning = `WARNING: shell mode is stateless; the directory change to '${finalPwd}' will not persist.`;
                   finalOutput = `${warning}\n\n${finalOutput}`;
                 }

--- a/src/copilot-shell/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useMemo, useEffect, useState } from 'react';
+import { useCallback, useMemo, useEffect, useState, useContext } from 'react';
 import { type PartListUnion } from '@google/genai';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import {
@@ -18,6 +18,7 @@ import {
   IdeClient,
 } from '@copilot-shell/core';
 import { useSessionStats } from '../contexts/SessionContext.js';
+import { AppContext } from '../contexts/AppContext.js';
 import type {
   Message,
   HistoryItemWithoutId,
@@ -97,6 +98,11 @@ export const useSlashCommandProcessor = (
   logger: Logger | null,
 ) => {
   const { stats: sessionStats, startNewSession } = useSessionStats();
+  const appContext = useContext(AppContext);
+  const dismissWarning = useMemo(
+    () => appContext?.dismissWarning ?? ((_: string) => {}),
+    [appContext?.dismissWarning],
+  );
   const [commands, setCommands] = useState<readonly SlashCommand[]>([]);
   const [reloadTrigger, setReloadTrigger] = useState(0);
 
@@ -216,6 +222,7 @@ export const useSlashCommandProcessor = (
         dispatchExtensionStateUpdate: actions.dispatchExtensionStateUpdate,
         addConfirmUpdateExtensionRequest:
           actions.addConfirmUpdateExtensionRequest,
+        dismissStartupWarning: dismissWarning,
       },
       session: {
         stats: sessionStats,
@@ -242,6 +249,7 @@ export const useSlashCommandProcessor = (
       setGeminiMdFileCount,
       reloadCommands,
       extensionsUpdateState,
+      dismissWarning,
     ],
   );
 

--- a/src/copilot-shell/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/src/copilot-shell/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -26,5 +26,6 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
     extensionsUpdateState: new Map(),
     dispatchExtensionStateUpdate: (_action: ExtensionUpdateAction) => {},
     addConfirmUpdateExtensionRequest: (_request) => {},
+    dismissStartupWarning: (_match: string) => {},
   };
 }

--- a/src/copilot-shell/packages/cli/src/utils/userStartupWarnings.ts
+++ b/src/copilot-shell/packages/cli/src/utils/userStartupWarnings.ts
@@ -31,7 +31,7 @@ const homeDirectoryCheck: WarningCheck = {
       ]);
 
       if (workspaceRealPath === homeRealPath) {
-        return 'You are running Copilot Shell in your home directory. It is recommended to run in a project-specific directory.';
+        return 'You are running Copilot Shell in your home directory. It is recommended to run in a project-specific directory. Use "/dir cd <path>" to switch to a project directory.';
       }
       return null;
     } catch (_err: unknown) {

--- a/src/copilot-shell/packages/cli/src/utils/userStartupWarnings.ts
+++ b/src/copilot-shell/packages/cli/src/utils/userStartupWarnings.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs/promises';
 import * as os from 'node:os';
 import path from 'node:path';
 import { canUseRipgrep } from '@copilot-shell/core';
+import { t } from '../i18n/index.js';
 
 type WarningCheckOptions = {
   workspaceRoot: string;
@@ -31,11 +32,15 @@ const homeDirectoryCheck: WarningCheck = {
       ]);
 
       if (workspaceRealPath === homeRealPath) {
-        return 'You are running Copilot Shell in your home directory. It is recommended to run in a project-specific directory. Use "/dir cd <path>" to switch to a project directory.';
+        return t(
+          'You are running Copilot Shell in your home directory. It is recommended to run in a project-specific directory. Use "/dir cd <path>" to switch to a project directory.',
+        );
       }
       return null;
     } catch (_err: unknown) {
-      return 'Could not verify the current directory due to a file system error.';
+      return t(
+        'Could not verify the current directory due to a file system error.',
+      );
     }
   },
 };
@@ -45,8 +50,9 @@ const rootDirectoryCheck: WarningCheck = {
   check: async (options: WarningCheckOptions) => {
     try {
       const workspaceRealPath = await fs.realpath(options.workspaceRoot);
-      const errorMessage =
-        'Warning: You are running Copilot Shell in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.';
+      const errorMessage = t(
+        'Warning: You are running Copilot Shell in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.',
+      );
 
       // Check for Unix root directory
       if (path.dirname(workspaceRealPath) === workspaceRealPath) {
@@ -55,7 +61,9 @@ const rootDirectoryCheck: WarningCheck = {
 
       return null;
     } catch (_err: unknown) {
-      return 'Could not verify the current directory due to a file system error.';
+      return t(
+        'Could not verify the current directory due to a file system error.',
+      );
     }
   },
 };
@@ -70,11 +78,18 @@ const ripgrepAvailabilityCheck: WarningCheck = {
     try {
       const isAvailable = await canUseRipgrep(options.useBuiltinRipgrep);
       if (!isAvailable) {
-        return 'Ripgrep not available: Please install ripgrep globally to enable faster file content search. Falling back to built-in grep.';
+        return t(
+          'Ripgrep not available: Please install ripgrep globally to enable faster file content search. Falling back to built-in grep.',
+        );
       }
       return null;
     } catch (error) {
-      return `Ripgrep not available: ${error instanceof Error ? error.message : 'Unknown error'}. Falling back to built-in grep.`;
+      return t(
+        'Ripgrep not available: {{message}}. Falling back to built-in grep.',
+        {
+          message: error instanceof Error ? error.message : 'Unknown error',
+        },
+      );
     }
   },
 };

--- a/src/copilot-shell/packages/core/src/config/config.ts
+++ b/src/copilot-shell/packages/core/src/config/config.ts
@@ -430,7 +430,7 @@ export class Config {
 
   private modelsConfig!: ModelsConfig;
   private readonly modelProvidersConfig?: ModelProvidersConfig;
-  private readonly targetDir: string;
+  private targetDir: string;
   private workspaceContext: WorkspaceContext;
   private readonly debugMode: boolean;
   private readonly inputFormat: InputFormat;
@@ -1088,6 +1088,11 @@ export class Config {
 
   getTargetDir(): string {
     return this.targetDir;
+  }
+
+  setTargetDir(dir: string): void {
+    this.targetDir = dir;
+    this.fileDiscoveryService = null;
   }
 
   getProjectRoot(): string {


### PR DESCRIPTION
## Description

Add a built-in `/dir cd <path>` sub-command that allows users to switch the working directory for the current session. When executed, the command:

1. Validates the target path exists and is a directory
2. Changes the process working directory via `process.chdir()`
3. Replaces workspace context directories with the new path
4. Updates `config.targetDir` so the header and file completion reflect the new path
5. Refreshes the AI directory context
6. Dismisses any active home-directory startup warnings
7. Supports tab-completion with `~` expansion and live subdirectory listing (hidden directories excluded)

## Related Issue

- [issues/13](https://github.com/alibaba/anolisa/issues/13)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `agent-sec-core`
- [ ] `os-skills`
- [ ] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

1. Start `cosh` in any directory
2. Run `/dir cd ~/some/path` — verify the header updates and subsequent file operations reference the new directory
3. Run `/dir cd` (no argument) — verify an error message is shown
4. Run `/dir cd /nonexistent` — verify a "does not exist" error is shown
5. Run `/dir cd /path/to/file` — verify a "not a directory" error is shown
6. Type `/dir cd ~/` and press Tab — verify subdirectory suggestions appear with `~/...` format
7. Start `cosh` from home directory — run `/dir cd` to a project path and confirm the home-directory startup warning is dismissed

## Additional Notes

The tab-completion helper `listDirectorySuggestions` uses synchronous `fs.readdirSync` for simplicity; hidden directories (dotfiles) are filtered out. The function normalises paths back to `~/...` notation when the resolved path falls under the user's home directory.