### PR TITLE
Fix copilot-shell test failure when using "root" as the user.

### DIFF
--- a/src/copilot-shell/packages/core/src/tools/edit.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/edit.test.ts
@@ -62,6 +62,8 @@ describe('EditTool', () => {
       generateJson: vi.fn(),
     };
 
+    const fsService = new StandardFileSystemService();
+
     mockConfig = {
       getGeminiClient: vi.fn().mockReturnValue(geminiClient),
       getBaseLlmClient: vi.fn().mockReturnValue(baseLlmClient),
@@ -69,7 +71,7 @@ describe('EditTool', () => {
       getApprovalMode: vi.fn(),
       setApprovalMode: vi.fn(),
       getWorkspaceContext: () => createMockWorkspaceContext(rootDir),
-      getFileSystemService: () => new StandardFileSystemService(),
+      getFileSystemService: () => fsService,
       getIdeMode: () => false,
       getApiKey: () => 'test-api-key',
       getModel: () => 'test-model',
@@ -715,8 +717,12 @@ describe('EditTool', () => {
 
     it('should return FILE_WRITE_FAILURE on write error', async () => {
       fs.writeFileSync(filePath, 'content', 'utf8');
-      // Make file readonly to trigger a write error
-      fs.chmodSync(filePath, '444');
+      // Mock writeTextFile to simulate a write error (avoids relying on chmod
+      // which may not work when running as root, e.g. in CI on Ubuntu).
+      const fsService = mockConfig.getFileSystemService();
+      vi.spyOn(fsService, 'writeTextFile').mockRejectedValueOnce(
+        Object.assign(new Error('Permission denied'), { code: 'EACCES' }),
+      );
 
       const params: EditToolParams = {
         file_path: filePath,

--- a/src/copilot-shell/packages/core/src/utils/pathReader.test.ts
+++ b/src/copilot-shell/packages/core/src/utils/pathReader.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import mock from 'mock-fs';
 import * as path from 'node:path';
+import { promises as fsPromises } from 'node:fs';
 import { WorkspaceContext } from './workspaceContext.js';
 import { readPathFromWorkspace } from './pathReader.js';
 import type { Config } from '../config/config.js';
@@ -381,6 +382,14 @@ describe('readPathFromWorkspace', () => {
         filterFiles: vi.fn((files) => files),
       } as unknown as FileDiscoveryService;
       const config = createMockConfig(CWD, [], mockFileService);
+      // Mock readFile to throw EACCES, since root users ignore file-mode
+      // restrictions and would otherwise read the file successfully.
+      const readError = Object.assign(
+        new Error('EACCES: permission denied'),
+        { code: 'EACCES' },
+      );
+      vi.spyOn(fsPromises, 'readFile').mockRejectedValueOnce(readError);
+
       // processSingleFileContent catches the error and returns an error string.
       const result = await readPathFromWorkspace('unreadable.txt', config);
       const textResult = result[0] as string;


### PR DESCRIPTION
## Description

When run the test cases with "root", I got 2 errors:
FAIL src/tools/edit.test.ts > EditTool > Error Scenarios > should return FILE_WRITE_FAILURE on write error
AssertionError: expected undefined to be 'file_write_failure' // Object.is equality

Expected:
"file_write_failure"
Received:
undefined
❯ src/tools/edit.test.ts:728:34
726| const invocation = tool.build(params);
727| const result = await invocation.execute(new AbortController().signal);
728| expect(result.error?.type).toBe(ToolErrorType.FILE_WRITE_FAILURE);
| ^
729| });
730| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

FAIL src/utils/pathReader.test.ts > readPathFromWorkspace > should return an error string if reading a file with no permissions
AssertionError: expected 'you cannot read me' to contain 'Error reading file unreadable.txt'

Expected: "Error reading file unreadable.txt"
Received: "you cannot read me"

❯ src/utils/pathReader.test.ts:389:26
387|
388| // processSingleFileContent formats errors using the relative path from the target dir (CWD).
389| expect(textResult).toContain('Error reading file unreadable.txt');
| ^
390| expect(textResult).toMatch(/(EACCES|permission denied)/i);
391| },


## Related Issue
None.

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `agent-sec-core`
- [ ] `os-skills`
- [ ] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
./tests/run-all-tests.sh

## Additional Notes
None