### PR TITLE
fix(agentsight): add user message to Qwen template test to fix valida…

### DIFF
--- a/src/agentsight/src/tokenizer/templates/qwen.rs
+++ b/src/agentsight/src/tokenizer/templates/qwen.rs
@@ -388,6 +388,10 @@ mod tests {
         let template = QwenChatTemplate::new();
         let messages = vec![
             serde_json::json!({
+                "role": "user",
+                "content": "What is the answer to life?"
+            }),
+            serde_json::json!({
                 "role": "assistant",
                 "content": "The answer is 42.",
                 "reasoning_content": "Let me think..."


### PR DESCRIPTION
## Description

Qwen's Jinja template requires messages to contain at least one user message. The `test_apply_chat_template_with_reasoning` test only passed an assistant message, causing `No user query found` validation error.

Added a user message before the assistant message to satisfy the template's requirement.
### fixed
<img width="744" height="59" alt="截屏2026-04-02 09 06 18" src="https://github.com/user-attachments/assets/0211d4b6-750c-45c4-939a-4de3de8f3455" />

### before
<img width="803" height="248" alt="截屏2026-04-02 08 42 23" src="https://github.com/user-attachments/assets/9d6671a7-52ef-4ab0-a753-b065dc536fe9" />



## Related Issue

- [x] [https://github.com/alibaba/anolisa/issues/40](https://github.com/alibaba/anolisa/issues/40)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `agentsight`

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/agentsight && cargo test test_apply_chat_template_with_reasoning
