### PR TITLE
fix(cosh): allow left arrow to wrap from line start to previous line end

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -659,6 +659,70 @@ describe('useTextBuffer', () => {
       expect(getBufferState(result).cursor).toEqual([0, 4]); // logical cursor
     });
 
+    it('move: left should wrap across hard newlines (logical lines)', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'abc\ndef',
+          viewport: { width: 80, height: 5 },
+          isValidPath: () => false,
+        }),
+      );
+      // Move cursor to beginning of second logical line
+      act(() => result.current.move('down'));
+      expect(getBufferState(result).cursor).toEqual([1, 0]);
+      expect(getBufferState(result).visualCursor).toEqual([1, 0]);
+
+      // Press left - should go to end of first logical line
+      act(() => result.current.move('left'));
+      expect(getBufferState(result).cursor).toEqual([0, 3]);
+      expect(getBufferState(result).visualCursor).toEqual([0, 3]);
+    });
+
+    it('move: left should wrap across soft-wrapped visual lines without spaces (hard break)', () => {
+      // "longxline1" with viewport width 5 produces:
+      // visual line 0: "longx" (5 chars)
+      // visual line 1: "line1" (5 chars)
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'longxline1',
+          viewport: { width: 5, height: 4 },
+          isValidPath: () => false,
+        }),
+      );
+      expect(result.current.allVisualLines).toEqual(['longx', 'line1']);
+
+      // Place cursor at beginning of visual line 1
+      act(() => result.current.move('down'));
+      expect(getBufferState(result).visualCursor).toEqual([1, 0]);
+
+      // Press left - should move to end of visual line 0 (on 'x')
+      act(() => result.current.move('left'));
+      expect(getBufferState(result).visualCursor[0]).toEqual(0);
+      expect(getBufferState(result).visualCursor[1]).toEqual(4);
+      expect(getBufferState(result).cursor).toEqual([0, 4]);
+    });
+
+    it('move: right from last char of hard-break visual line should go to next visual line', () => {
+      // After the left-movement fix, verify right still works at the boundary
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'longxline1',
+          viewport: { width: 5, height: 4 },
+          isValidPath: () => false,
+        }),
+      );
+      // Move to the last character of visual line 0 ('x' at position 4)
+      for (let i = 0; i < 4; i++) {
+        act(() => result.current.move('right'));
+      }
+      expect(getBufferState(result).visualCursor).toEqual([0, 4]);
+
+      // Press right - should go to visual line 1
+      act(() => result.current.move('right'));
+      expect(getBufferState(result).visualCursor).toEqual([1, 0]);
+      expect(getBufferState(result).cursor).toEqual([0, 5]);
+    });
+
     it('move: up/down should preserve preferred visual column', () => {
       const text = 'abcde\nxy\n12345';
       const { result } = renderHook(() =>

--- a/src/copilot-shell/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/src/copilot-shell/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1100,6 +1100,23 @@ function textBufferReducerLogic(
             } else if (newVisualRow > 0) {
               newVisualRow--;
               newVisualCol = cpLen(visualLines[newVisualRow] ?? '');
+
+              // Fix soft wrap boundary ambiguity: when both visual lines
+              // belong to the same logical line and the end-of-previous-line
+              // position equals the start-of-next-line position, the cursor
+              // would map back to the next visual line's start (stuck cursor).
+              // Adjust by moving one character back to land on the last
+              // character of the previous visual line instead.
+              if (newVisualCol > 0) {
+                const prevMap = visualToLogicalMap[newVisualRow];
+                const nextMap = visualToLogicalMap[newVisualRow + 1];
+                if (prevMap && nextMap && prevMap[0] === nextMap[0]) {
+                  const endPos = prevMap[1] + newVisualCol;
+                  if (endPos >= nextMap[1]) {
+                    newVisualCol--;
+                  }
+                }
+              }
             }
             break;
           case 'right':


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Fixed issue https://github.com/alibaba/anolisa/issues/18.

When text wraps without spaces (e.g., CJK text), the end of a visual line and the start of the next share the same logical position. calculateVisualCursorFromLayout always resolves this to the next line's start, causing the left arrow to appear stuck.

Detect this ambiguity in move('left') and adjust the column by -1 to land on the last character of the previous visual line. Hard newlines and space-based wraps are unaffected.

This fix does not affect:

- Hard newlines (Enter key): different logical lines, no ambiguity
- Soft wraps with spaces: consumed space creates distinct positions
- Right arrow movement: existing behavior correctly resolves forward

## Related Issue

<!-- Link the related issue. Required for new features and non-trivial changes. -->

- [x] Related issue linked (recommended for new features and non-trivial changes)

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `agent-sec-core`
- [ ] `os-skills`
- [ ] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
