### PR TITLE
feat(cosh): support custom skills path

### DIFF
--- a/src/copilot-shell/packages/core/src/extension/extensionManager.ts
+++ b/src/copilot-shell/packages/core/src/extension/extensionManager.ts
@@ -193,7 +193,10 @@ function filterMcpConfig(original: MCPServerConfig): MCPServerConfig {
   return Object.freeze(rest);
 }
 
-function getSkillDirs(config: ExtensionConfig, extensionPath: string): string[] {
+function getSkillDirs(
+  config: ExtensionConfig,
+  extensionPath: string,
+): string[] {
   const dirs = config.skills
     ? Array.isArray(config.skills)
       ? config.skills
@@ -867,7 +870,9 @@ export class ExtensionManager {
 
         const skills = (
           await Promise.all(
-            getSkillDirs(newExtensionConfig!, localSourcePath).map(loadSkillsFromDir),
+            getSkillDirs(newExtensionConfig!, localSourcePath).map(
+              loadSkillsFromDir,
+            ),
           )
         ).flat();
         const previousSkills = previous?.skills ?? [];

--- a/src/copilot-shell/packages/core/src/skills/skill-load.ts
+++ b/src/copilot-shell/packages/core/src/skills/skill-load.ts
@@ -25,7 +25,10 @@ export async function loadSkillsFromDir(
       const skillDir = path.join(baseDir, entry.name);
       const skillManifest = path.join(skillDir, SKILL_MANIFEST_FILE);
 
-      const manifestExists = await fs.access(skillManifest).then(() => true).catch(() => false);
+      const manifestExists = await fs
+        .access(skillManifest)
+        .then(() => true)
+        .catch(() => false);
       if (!manifestExists) {
         // No SKILL.md here, recurse into subdirectories
         skills.push(...(await loadSkillsFromDir(skillDir)));


### PR DESCRIPTION
## Description

Support custom extension skills directory and support skills in subdirectories

## Related Issue

[#40](https://github.com/alibaba/anolisa/issues/47)

- [x] Related issue linked (recommended for new features and non-trivial changes)

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `agent-sec-core`
- [ ] `os-skills`
- [ ] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<img width="692" height="314" alt="image" src="https://github.com/user-attachments/assets/fa1d0c79-af1d-4ec7-b849-2f9a6047f29e" />


## Additional Notes

none
