### PR TITLE
fix(cosh): disable remote and cache sub commands

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/skillsCommand.ts
@@ -14,7 +14,7 @@ import { MessageType, type HistoryItemSkillsList } from '../types.js';
 import { t } from '../../i18n/index.js';
 import { AsyncFzf } from 'fzf';
 import type { SkillConfig } from '@copilot-shell/core';
-
+/** FUTURE: Re-enable once remote registry is available
 const cacheClearSubCommand: SlashCommand = {
   name: 'clear',
   get description() {
@@ -127,6 +127,7 @@ const remoteSubCommand: SlashCommand = {
     }
   },
 };
+*/
 
 export const skillsCommand: SlashCommand = {
   name: 'skills',
@@ -134,7 +135,7 @@ export const skillsCommand: SlashCommand = {
     return t('List available skills.');
   },
   kind: CommandKind.BUILT_IN,
-  subCommands: [remoteSubCommand, cacheSubCommand],
+  subCommands: [], // _remoteSubCommand and _cacheSubCommand are disabled (remote registry unavailable)
   action: async (context: CommandContext, args?: string) => {
     const argParts = (args?.trim() ?? '').split(/\s+/);
     const skillName = argParts[0] ?? '';


### PR DESCRIPTION
## Description

disable unusable remote and cache sub commands
## Related Issue

[#48](https://github.com/alibaba/anolisa/issues/48)

- [x] Related issue linked (recommended for new features and non-trivial changes)

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `agent-sec-core`
- [ ] `os-skills`
- [ ] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<img width="432" height="211" alt="image" src="https://github.com/user-attachments/assets/6d2bd064-06f1-4ade-ad28-b171d27d5441" />


## Additional Notes

none
