### PR TITLE
fix(cosh): restore QwenCode user agent for OAuth authentication

### DIFF
--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -45,7 +45,7 @@ export class DashScopeOpenAICompatibleProvider implements OpenAICompatibleProvid
 
   buildHeaders(): Record<string, string | undefined> {
     const version = this.cliConfig.getCliVersion() || 'unknown';
-    const userAgent = `CopilotShell/${version} (${process.platform}; ${process.arch})`;
+    const userAgent = `QwenCode/${version} (${process.platform}; ${process.arch})`;
     const { authType, customHeaders } = this.contentGeneratorConfig;
     const defaultHeaders = {
       'User-Agent': userAgent,


### PR DESCRIPTION
During a previous rebranding effort, the User-Agent header was incorrectly changed from 'QwenCode' to 'CopilotShell', which caused Qwen OAuth authentication to fail with 400 bad request errors.

This commit reverts the User-Agent back to 'QwenCode' to restore proper OAuth authentication with DashScope API.
