### PR TITLE
fix(cosh): update dashscope tests to expect QwenCode user agent

### DIFF
--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -147,9 +147,9 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const headers = provider.buildHeaders();
 
       expect(headers).toEqual({
-        'User-Agent': `CopilotShell/1.0.0 (${process.platform}; ${process.arch})`,
+        'User-Agent': `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
         'X-DashScope-CacheControl': 'enable',
-        'X-DashScope-UserAgent': `CopilotShell/1.0.0 (${process.platform}; ${process.arch})`,
+        'X-DashScope-UserAgent': `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
         'X-DashScope-AuthType': AuthType.QWEN_OAUTH,
       });
     });
@@ -168,8 +168,8 @@ describe('DashScopeOpenAICompatibleProvider', () => {
 
       const headers = providerWithCustomHeaders.buildHeaders();
 
-      expect(headers['User-Agent']).toContain('CopilotShell/1.0.0');
-      expect(headers['X-DashScope-UserAgent']).toContain('CopilotShell/1.0.0');
+      expect(headers['User-Agent']).toContain('QwenCode/1.0.0');
+      expect(headers['X-DashScope-UserAgent']).toContain('QwenCode/1.0.0');
       expect(headers['X-DashScope-AuthType']).toBe(AuthType.QWEN_OAUTH);
       expect(headers['X-Custom']).toBe('1');
       expect(headers['X-DashScope-CacheControl']).toBe('disable');
@@ -185,10 +185,10 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const headers = provider.buildHeaders();
 
       expect(headers['User-Agent']).toBe(
-        `CopilotShell/unknown (${process.platform}; ${process.arch})`,
+        `QwenCode/unknown (${process.platform}; ${process.arch})`,
       );
       expect(headers['X-DashScope-UserAgent']).toBe(
-        `CopilotShell/unknown (${process.platform}; ${process.arch})`,
+        `QwenCode/unknown (${process.platform}; ${process.arch})`,
       );
     });
   });
@@ -204,9 +204,9 @@ describe('DashScopeOpenAICompatibleProvider', () => {
           timeout: 60000,
           maxRetries: 2,
           defaultHeaders: {
-            'User-Agent': `CopilotShell/1.0.0 (${process.platform}; ${process.arch})`,
+            'User-Agent': `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
             'X-DashScope-CacheControl': 'enable',
-            'X-DashScope-UserAgent': `CopilotShell/1.0.0 (${process.platform}; ${process.arch})`,
+            'X-DashScope-UserAgent': `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
             'X-DashScope-AuthType': AuthType.QWEN_OAUTH,
           },
         }),


### PR DESCRIPTION
## Description

During a previous rebranding effort, the User-Agent header in `dashscope.ts` was incorrectly changed from `QwenCode` to `CopilotShell`, which caused Qwen OAuth authentication to fail with 400 bad request errors. This PR reverts the User-Agent back to `QwenCode` to restore proper OAuth authentication with the DashScope API, and updates the corresponding unit tests to align with the corrected value.

## Related Issue

no-issue: restores a regression introduced by an incorrect rebranding change; the fix is self-contained and directly tied to the accompanying commit `4674a47aa249b6866919fa6ca914de27bab1ad20`. #95 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass

## Testing

Updated unit tests in `dashscope.test.ts`:

- `buildHeaders > should build DashScope-specific headers` — asserts `User-Agent: QwenCode/<version>`
- `buildHeaders > should merge custom headers` — asserts `QwenCode` in merged header map
- `buildHeaders > should handle unknown CLI version` — asserts fallback `QwenCode/unknown`
- `buildClient > should create OpenAI client` — asserts client is constructed with correct `QwenCode` User-Agent

Run:
```bash
cd src/copilot-shell
npx vitest run packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
```

## Additional Notes

The Qwen OAuth server validates the `User-Agent` header and requires it to contain `QwenCode`. Using `CopilotShell` results in a `400 Bad Request` response during API calls even after successful token acquisition.