### PR TITLE
feat(cosh): add secret redaction for model output and tool results

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -34,6 +34,7 @@ import {
   ToolConfirmationOutcome,
   logApiCancel,
   ApiCancelEvent,
+  redactSecrets,
 } from '@copilot-shell/core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -118,6 +119,13 @@ export const useGeminiStream = (
   const abortControllerRef = useRef<AbortController | null>(null);
   const turnCancelledRef = useRef(false);
   const isSubmittingQueryRef = useRef(false);
+  // Raw (unredacted) content accumulated for the current streaming turn.
+  // Kept separate so that secrets spanning multiple stream chunks can be
+  // detected and masked in their entirety rather than chunk-by-chunk.
+  const rawTurnContentRef = useRef('');
+  // Byte offset into the fully-redacted turn content that has already been
+  // committed to static history items (via addItem / split logic).
+  const committedStaticLengthRef = useRef(0);
   const [isResponding, setIsResponding] = useState<boolean>(false);
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   const [pendingHistoryItem, pendingHistoryItemRef, setPendingHistoryItem] =
@@ -453,7 +461,15 @@ export const useGeminiStream = (
         // Prevents additional output after a user initiated cancel.
         return '';
       }
-      let newGeminiMessageBuffer = currentGeminiMessageBuffer + eventValue;
+      // Accumulate raw (unredacted) content for this turn so that secrets
+      // spanning multiple stream chunks are detected as a whole.
+      rawTurnContentRef.current += eventValue;
+      // Redact the full accumulated raw content, then slice off the portion
+      // that has already been committed to static history items.
+      const fullyRedacted = redactSecrets(rawTurnContentRef.current);
+      let newGeminiMessageBuffer = fullyRedacted.slice(
+        committedStaticLengthRef.current,
+      );
       if (
         pendingHistoryItemRef.current?.type !== 'gemini' &&
         pendingHistoryItemRef.current?.type !== 'gemini_content'
@@ -462,7 +478,9 @@ export const useGeminiStream = (
           addItem(pendingHistoryItemRef.current, userMessageTimestamp);
         }
         setPendingHistoryItem({ type: 'gemini', text: '' });
-        newGeminiMessageBuffer = eventValue;
+        newGeminiMessageBuffer = fullyRedacted.slice(
+          committedStaticLengthRef.current,
+        );
       }
       // Split large messages for better rendering performance. Ideally,
       // we should maximize the amount of output sent to <Static />.
@@ -494,6 +512,9 @@ export const useGeminiStream = (
           userMessageTimestamp,
         );
         setPendingHistoryItem({ type: 'gemini_content', text: afterText });
+        // Track how much of the redacted content is now in static items so
+        // that subsequent chunks can derive the correct pending slice.
+        committedStaticLengthRef.current += splitPoint;
         newGeminiMessageBuffer = afterText;
       }
       return newGeminiMessageBuffer;
@@ -800,6 +821,9 @@ export const useGeminiStream = (
       signal: AbortSignal,
     ): Promise<StreamProcessingStatus> => {
       let geminiMessageBuffer = '';
+      // Reset per-turn raw buffer and committed-length tracker.
+      rawTurnContentRef.current = '';
+      committedStaticLengthRef.current = 0;
       let thoughtBuffer = '';
       const toolCallRequests: ToolCallRequestInfo[] = [];
       for await (const event of stream) {

--- a/src/copilot-shell/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/src/copilot-shell/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -113,6 +113,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -327,6 +328,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -551,6 +553,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -760,6 +763,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -969,6 +973,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -1178,6 +1183,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -1387,6 +1393,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -1679,6 +1686,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -1911,6 +1919,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -2199,6 +2208,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
@@ -2408,6 +2418,7 @@ IMPORTANT: Always use the todo_write tool to plan and track tasks throughout the
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -56,6 +56,7 @@ import {
   redactPartListUnion,
   redactAnsiOutput,
 } from '../utils/secretRedactor.js';
+import type { FileDiff } from '../tools/tools.js';
 
 export type ValidatingToolCall = {
   status: 'validating';
@@ -1226,6 +1227,20 @@ export class CoreToolScheduler {
               ansiOutput: import('../utils/terminalSerializer.js').AnsiOutput;
             };
             ansiDisplay.ansiOutput = redactAnsiOutput(ansiDisplay.ansiOutput);
+          } else if (
+            toolResult.returnDisplay &&
+            typeof toolResult.returnDisplay === 'object' &&
+            'fileDiff' in toolResult.returnDisplay
+          ) {
+            // Redact secrets from FileDiff display (WriteFile / EditFile results)
+            const diffDisplay = toolResult.returnDisplay as FileDiff;
+            diffDisplay.fileDiff = redactSecrets(diffDisplay.fileDiff);
+            diffDisplay.newContent = redactSecrets(diffDisplay.newContent);
+            if (diffDisplay.originalContent !== null) {
+              diffDisplay.originalContent = redactSecrets(
+                diffDisplay.originalContent,
+              );
+            }
           }
 
           if (signal.aborted) {

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -51,6 +51,11 @@ import { doesToolInvocationMatch } from '../utils/tool-utils.js';
 import levenshtein from 'fast-levenshtein';
 import { getPlanModeSystemReminder } from './prompts.js';
 import { ShellToolInvocation } from '../tools/shell.js';
+import {
+  redactSecrets,
+  redactPartListUnion,
+  redactAnsiOutput,
+} from '../utils/secretRedactor.js';
 
 export type ValidatingToolCall = {
   status: 'validating';
@@ -1207,6 +1212,22 @@ export class CoreToolScheduler {
 
         try {
           const toolResult: ToolResult = await promise;
+
+          // Redact secrets from tool result before further processing
+          toolResult.llmContent = redactPartListUnion(toolResult.llmContent);
+          if (typeof toolResult.returnDisplay === 'string') {
+            toolResult.returnDisplay = redactSecrets(toolResult.returnDisplay);
+          } else if (
+            toolResult.returnDisplay &&
+            typeof toolResult.returnDisplay === 'object' &&
+            'ansiOutput' in toolResult.returnDisplay
+          ) {
+            const ansiDisplay = toolResult.returnDisplay as {
+              ansiOutput: import('../utils/terminalSerializer.js').AnsiOutput;
+            };
+            ansiDisplay.ansiOutput = redactAnsiOutput(ansiDisplay.ansiOutput);
+          }
+
           if (signal.aborted) {
             this.setStatusInternal(
               callId,

--- a/src/copilot-shell/packages/core/src/core/prompts.ts
+++ b/src/copilot-shell/packages/core/src/core/prompts.ts
@@ -247,6 +247,7 @@ IMPORTANT: Always use the ${ToolNames.TODO_WRITE} tool to plan and track tasks t
 ## Security and Safety Rules
 - **Explain Critical Commands:** Before executing commands with '${ToolNames.SHELL}' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+- **Secret Protection:** NEVER output, display, or reveal any API keys, secret keys, access keys, or credentials in plain text. This includes keys in formats like \`sk-...\`, \`AK...\`, \`Bearer ...\`, etc. If you need to reference a key, always mask it (e.g., \`sk-****\`). If a user asks you to show, print, or expose any secret, refuse and explain the security risk.
 
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like '${ToolNames.READ_FILE}' or '${ToolNames.WRITE_FILE}'. Relative paths are not supported. You must provide an absolute path.

--- a/src/copilot-shell/packages/core/src/index.ts
+++ b/src/copilot-shell/packages/core/src/index.ts
@@ -51,6 +51,12 @@ export * from './qwen/qwenOAuth2.js';
 export * from './aliyun/aliyunCredentials.js';
 
 // Export utilities
+export {
+  redactSecrets,
+  redactPartListUnion,
+  redactAnsiOutput,
+  containsSecrets,
+} from './utils/secretRedactor.js';
 export * from './utils/paths.js';
 export { migrateConfigDirIfNeeded } from './utils/configDirMigration.js';
 export * from './utils/schemaValidator.js';

--- a/src/copilot-shell/packages/core/src/utils/secretRedactor.test.ts
+++ b/src/copilot-shell/packages/core/src/utils/secretRedactor.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { redactSecrets, containsSecrets } from './secretRedactor.js';
+
+describe('secretRedactor', () => {
+  describe('redactSecrets', () => {
+    it('should return non-string input unchanged', () => {
+      expect(redactSecrets('')).toBe('');
+    });
+
+    it('should not modify text without secrets', () => {
+      const text = 'Hello, this is a normal message without any secrets.';
+      expect(redactSecrets(text)).toBe(text);
+    });
+
+    it('should not modify normal code', () => {
+      const code = 'const x = 123;\nconsole.log("hello world");';
+      expect(redactSecrets(code)).toBe(code);
+    });
+
+    // --- OpenAI API Key ---
+    it('should redact OpenAI-style API keys (sk-...)', () => {
+      const text = 'My key is sk-abcdefghijklmnopqrstuvwx';
+      const result = redactSecrets(text);
+      expect(result).toContain('sk-');
+      expect(result).not.toContain('sk-abcdefghijklmnopqrstuvwx');
+      expect(result).toContain('*');
+    });
+
+    it('should not redact short sk- prefixed strings', () => {
+      const text = 'sk-short';
+      expect(redactSecrets(text)).toBe(text);
+    });
+
+    // --- Bearer Token ---
+    it('should redact Bearer tokens', () => {
+      const text =
+        'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc123';
+      const result = redactSecrets(text);
+      expect(result).toContain('Bearer ');
+      expect(result).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+      expect(result).toContain('*');
+    });
+
+    // --- Aliyun AccessKeySecret ---
+    it('should redact Aliyun accessKeySecret in JSON', () => {
+      const text = '{"accessKeySecret": "abcdefghijklmnopqrstuvwxyz123456"}';
+      const result = redactSecrets(text);
+      expect(result).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
+      expect(result).toContain('*');
+    });
+
+    it('should redact access_key_secret in JSON', () => {
+      const text = '{"access_key_secret": "abcdefghijklmnopqrstuvwxyz12"}';
+      const result = redactSecrets(text);
+      expect(result).not.toContain('abcdefghijklmnopqrstuvwxyz12');
+      expect(result).toContain('*');
+    });
+
+    // --- Generic secret fields ---
+    it('should redact apiKey field in JSON', () => {
+      const text = '{"apiKey": "sk-this-is-a-long-api-key-value"}';
+      const result = redactSecrets(text);
+      expect(result).not.toContain('sk-this-is-a-long-api-key-value');
+      expect(result).toContain('*');
+    });
+
+    it('should redact api_key field in JSON', () => {
+      const text = '{"api_key": "my-super-secret-key-12345678"}';
+      const result = redactSecrets(text);
+      expect(result).not.toContain('my-super-secret-key-12345678');
+      expect(result).toContain('*');
+    });
+
+    it('should redact password field in JSON', () => {
+      const text = '{"password": "supersecretpassword123"}';
+      const result = redactSecrets(text);
+      expect(result).not.toContain('supersecretpassword123');
+      expect(result).toContain('*');
+    });
+
+    // --- Environment variables ---
+    it('should redact API_KEY environment variable', () => {
+      const text = 'API_KEY=my-super-secret-api-key-value';
+      const result = redactSecrets(text);
+      expect(result).toContain('API_KEY=');
+      expect(result).not.toContain('my-super-secret-api-key-value');
+      expect(result).toContain('*');
+    });
+
+    it('should redact SECRET_KEY in export statement', () => {
+      const text = 'export SECRET_KEY="abcdef1234567890abcdef"';
+      const result = redactSecrets(text);
+      expect(result).toContain('SECRET_KEY=');
+      expect(result).not.toContain('abcdef1234567890abcdef');
+    });
+
+    it('should redact PASSWORD in env', () => {
+      const text = 'PASSWORD=mysecretpassword12345678';
+      const result = redactSecrets(text);
+      expect(result).toContain('PASSWORD=');
+      expect(result).not.toContain('mysecretpassword12345678');
+    });
+
+    // --- Anthropic-style keys ---
+    it('should redact Anthropic-style API keys (ant-...)', () => {
+      const text = 'key: ant-abcdefghijklmnopqrstuvwx';
+      const result = redactSecrets(text);
+      expect(result).toContain('ant-');
+      expect(result).not.toContain('ant-abcdefghijklmnopqrstuvwx');
+    });
+
+    // --- Multiple secrets ---
+    it('should redact multiple secrets in one text', () => {
+      const text =
+        'API_KEY=sk-abcdefghijklmnopqrstuvwx and password=supersecretpassword123';
+      const result = redactSecrets(text);
+      expect(result).not.toContain('sk-abcdefghijklmnopqrstuvwx');
+      expect(result).not.toContain('supersecretpassword123');
+    });
+
+    // --- Edge cases ---
+    it('should not redact short values', () => {
+      const text = '{"password": "short"}';
+      expect(redactSecrets(text)).toBe(text);
+    });
+
+    it('should handle mixed content with code and secrets', () => {
+      const code = `function getConfig() {
+  return {
+    host: "localhost",
+    apiKey: "sk-this-is-a-long-api-key-value-for-testing",
+    port: 3000
+  };
+}`;
+      const result = redactSecrets(code);
+      expect(result).toContain('localhost');
+      expect(result).toContain('3000');
+      expect(result).not.toContain(
+        'sk-this-is-a-long-api-key-value-for-testing',
+      );
+    });
+  });
+
+  describe('containsSecrets', () => {
+    it('should return true for text containing secrets', () => {
+      expect(containsSecrets('sk-abcdefghijklmnopqrstuvwx')).toBe(true);
+    });
+
+    it('should return false for clean text', () => {
+      expect(containsSecrets('Hello world')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(containsSecrets('')).toBe(false);
+    });
+  });
+});

--- a/src/copilot-shell/packages/core/src/utils/secretRedactor.ts
+++ b/src/copilot-shell/packages/core/src/utils/secretRedactor.ts
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Secret redaction utilities for preventing sensitive information leakage.
+ * Detects and masks API keys, tokens, passwords, and other credentials
+ * in text output and tool results.
+ */
+
+import type { Part, PartListUnion } from '@google/genai';
+import type { AnsiOutput } from './terminalSerializer.js';
+
+/**
+ * Represents a secret pattern to detect and redact.
+ */
+interface SecretPattern {
+  /** Regex pattern with a capture group for the secret value */
+  pattern: RegExp;
+  /**
+   * Replacement function or string.
+   * If a function, receives the full match and returns the redacted version.
+   */
+  replacement:
+    | string
+    | ((substring: string, ...args: Array<string | number>) => string);
+}
+
+/**
+ * Secret key field names used in JSON, YAML, and config files.
+ * Note: bare "token" and "secret" are intentionally excluded to avoid
+ * false positives with common programming terms.
+ */
+const SECRET_FIELD_NAMES =
+  'api[_-]?key|secret[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|password|passwd|credentials?';
+
+/**
+ * Ordered list of secret patterns to detect and redact.
+ * Order matters: more specific patterns should come first to avoid
+ * partial matches by more general patterns.
+ */
+const SECRET_PATTERNS: SecretPattern[] = [
+  // 1. OpenAI-style API keys: sk-... (at least 20 chars after sk-)
+  {
+    pattern: /\bsk-[a-zA-Z0-9_-]{20,}\b/g,
+    replacement: (match) => `sk-${'*'.repeat(Math.min(match.length - 3, 20))}`,
+  },
+
+  // 2. Bearer tokens: Bearer <token>
+  {
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/gi,
+    replacement: (match) => {
+      const prefix = match.slice(0, 7); // "Bearer "
+      return `${prefix}${'*'.repeat(8)}`;
+    },
+  },
+
+  // 3. Aliyun AccessKeySecret in JSON context:
+  //    "accessKeySecret": "value" or access_key_secret = "value"
+  {
+    pattern:
+      /["']?(?:accessKeySecret|access_key_secret|AccessKeySecret)["']?\s*[:=]\s*["']([a-zA-Z0-9+/=]{16,})["']/g,
+    replacement: (match) => {
+      const sepIndex = Math.max(match.indexOf(':'), match.indexOf('='));
+      if (sepIndex === -1) return match;
+      return `${match.slice(0, sepIndex + 1)} "${'*'.repeat(8)}"`;
+    },
+  },
+
+  // 4. Generic secret fields in JSON/config/JS format:
+  //    "apiKey": "value", apiKey: "value", api_key = "value", etc.
+  {
+    pattern: new RegExp(
+      `["']?\\b(?:${SECRET_FIELD_NAMES})\\b["']?\\s*[:=]\\s*["']([^"']{8,})["']`,
+      'gi',
+    ),
+    replacement: (match) => {
+      const sepIndex = Math.max(match.indexOf(':'), match.indexOf('='));
+      if (sepIndex === -1) return match;
+      return `${match.slice(0, sepIndex + 1)} "${'*'.repeat(8)}"`;
+    },
+  },
+
+  // 5. Environment variable assignment with sensitive names:
+  //    API_KEY=value, SECRET_KEY=value, ACCESS_KEY_ID=value, etc.
+  //    Note: uses (?:^|[\s"';]|export\s+) instead of \b because \b
+  //    doesn't match at underscore boundaries (e.g., ALIBABA_CLOUD_ACCESS_KEY_SECRET).
+  {
+    pattern:
+      /(?:^|[\s"';]|export\s+)(?:[A-Z_]*?(?:API[_-]?KEY|SECRET[_-]?KEY|ACCESS[_-]?KEY(?:[_-]?ID|[_-]?SECRET)?|ACCESS[_-]?SECRET|AUTH[_-]?TOKEN|API[_-]?SECRET|PRIVATE[_-]?KEY|PASSWORD|PASSWD))[A-Z_]*\s*=\s*['"]?([^\s'"#;]{8,})['"]?/gim,
+    replacement: (match) => {
+      const eqIndex = match.indexOf('=');
+      if (eqIndex === -1) return match;
+      return `${match.slice(0, eqIndex + 1)}${'*'.repeat(8)}`;
+    },
+  },
+
+  // 6. Anthropic API keys: ant-...
+  {
+    pattern: /\bant-[a-zA-Z0-9_-]{20,}\b/g,
+    replacement: (match) => `ant-${'*'.repeat(Math.min(match.length - 4, 20))}`,
+  },
+
+  // 7. Alibaba Cloud AccessKey ID: LTAI... (16+ chars)
+  {
+    pattern: /\bLTAI[a-zA-Z0-9]{12,}\b/g,
+    replacement: (match) => `LTAI${'*'.repeat(Math.min(match.length - 4, 20))}`,
+  },
+];
+
+/**
+ * Detect and redact sensitive information from a text string.
+ * Replaces detected secrets with masked versions (e.g., `sk-****`).
+ *
+ * @param text - The input text to scan for secrets
+ * @returns The text with sensitive information redacted
+ */
+export function redactSecrets(text: string): string {
+  if (!text || typeof text !== 'string') {
+    return text;
+  }
+
+  let result = text;
+
+  for (const { pattern, replacement } of SECRET_PATTERNS) {
+    // Reset lastIndex for global regexes
+    pattern.lastIndex = 0;
+    result = result.replace(
+      pattern,
+      replacement as Parameters<typeof String.prototype.replace>[1],
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Redact secrets from a PartListUnion (which may be a string, Part, or Part[]).
+ * Handles all forms of PartListUnion by extracting text, redacting, and reconstructing.
+ *
+ * @param content - The PartListUnion content to redact
+ * @returns The redacted content
+ */
+export function redactPartListUnion(content: PartListUnion): PartListUnion {
+  if (typeof content === 'string') {
+    return redactSecrets(content);
+  }
+
+  if (Array.isArray(content)) {
+    return content.map((part) => {
+      if (typeof part === 'string') {
+        return redactSecrets(part);
+      }
+      if (part && typeof part === 'object' && 'text' in part && part.text) {
+        return { ...part, text: redactSecrets(part.text) } as Part;
+      }
+      return part;
+    });
+  }
+
+  // Single Part object
+  if (
+    content &&
+    typeof content === 'object' &&
+    'text' in content &&
+    content.text
+  ) {
+    return { ...content, text: redactSecrets(content.text) } as Part;
+  }
+
+  return content;
+}
+
+/**
+ * Redact secrets from an AnsiOutput (terminal serialized output).
+ * Iterates through all lines and tokens, redacting text content.
+ *
+ * @param output - The AnsiOutput to redact
+ * @returns A new AnsiOutput with secrets redacted
+ */
+export function redactAnsiOutput(output: AnsiOutput): AnsiOutput {
+  return output.map((line) =>
+    line.map((token) => ({
+      ...token,
+      text: redactSecrets(token.text),
+    })),
+  );
+}
+
+/**
+ * Check if a text string contains any detectable secrets.
+ * Useful for logging/auditing without performing redaction.
+ *
+ * @param text - The input text to scan
+ * @returns True if secrets were detected
+ */
+export function containsSecrets(text: string): boolean {
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
+
+  for (const { pattern } of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    if (pattern.test(text)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Description

Add a secret redaction layer to prevent sensitive credentials from being displayed in the terminal. Introduces `secretRedactor.ts` with pattern-based detection for common key formats (OpenAI `sk-`, Anthropic `ant-`, Alibaba Cloud `LTAI`/`accessKeySecret`, Bearer tokens, generic `apiKey`/`password` fields, and environment variable assignments).

The redaction is applied at two interception points:
1. **Streamed model output** (`useGeminiStream.ts`): each stream chunk is accumulated into a raw turn buffer and redacted against the full buffer, fixing a streaming-split vulnerability where a secret spanning multiple chunks could partially leak.
2. **Tool execution results** (`coreToolScheduler.ts`): `llmContent`, `returnDisplay` (string and ANSI variants) are redacted before further processing.

A `Secret Protection` rule is also added to the system prompt to instruct the model to refuse revealing secrets at the source.

## Related Issue
fixes #83 
closes #83 

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
# Unit tests for redaction patterns
cd src/copilot-shell/packages/core
npx vitest run src/utils/secretRedactor.test.ts

# Snapshot tests for system prompt
npx vitest run src/core/prompts.test.ts

# Manual test: ask the model to output a secret key pattern
# e.g. "请帮我 cat xxx.settiing.json"
# Expected terminal output: sk-********************