### PR TITLE
fix(docs): Add perl-FindBin in building markdown for alinux4…

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -246,7 +246,7 @@ AgentSight is an optional component that provides eBPF-based audit and observabi
 - **dnf (Alinux / Anolis OS / Fedora / RHEL / CentOS / etc.)**
 
 ```bash
-sudo dnf install -y clang llvm libbpf-devel elfutils-libelf-devel zlib-devel openssl-devel perl perl-IPC-Cmd
+sudo dnf install -y clang llvm libbpf-devel elfutils-libelf-devel zlib-devel openssl-devel perl perl-IPC-Cmd perl-FindBin
 sudo dnf install -y kernel-devel-$(uname -r)
 ```
 

--- a/docs/BUILDING_CN.md
+++ b/docs/BUILDING_CN.md
@@ -247,7 +247,7 @@ AgentSight 是可选组件，提供基于 eBPF 的审计和可观测性能力，
 - **dnf（Alinux / Anolis OS / Fedora / RHEL / CentOS 等）**
 
 ```bash
-sudo dnf install -y clang llvm libbpf-devel elfutils-libelf-devel zlib-devel openssl-devel perl perl-IPC-Cmd
+sudo dnf install -y clang llvm libbpf-devel elfutils-libelf-devel zlib-devel openssl-devel perl perl-IPC-Cmd perl-FindBin
 sudo dnf install -y kernel-devel-$(uname -r)
 ```
 


### PR DESCRIPTION
…/like env

## Description

When following the build guide and build agentsight in alinux4, I got the following error:
error: failed to run custom build command for `libbpf-sys v1.6.3+v1.6.3`

Caused by:
  process didn't exit successfully: `/root/source/anolisa/src/agentsight/target/release/build/libbpf-sys-196ad7864bf09ecf/build-script-build` (exit status: 101)
  --- stdout
  Using feature vendored-libbpf=true
  Using feature vendored-libelf=false
  Using feature vendored-zlib=false
  Using feature static-libbpf=true
  Using feature static-libelf=false
  Using feature static-zlib=false

  --- stderr

  thread 'main' (59952) panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libbpf-sys-1.6.3+v1.6.3/build.rs:110:9:
  pkg-config is required to compile libbpf-sys with the selected set of features
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


## Related Issue

no-issue: Just change the BUILDING markdown.
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `agent-sec-core`
- [ ] `os-skills`
- [x] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

agentsight is now built sucessfully in my env.

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
