### PR TITLE
ci(ci): lower contributor onboarding barriers

### DIFF
--- a/.github/commitlint.config.json
+++ b/.github/commitlint.config.json
@@ -4,13 +4,13 @@
   ],
   "rules": {
     "scope-enum": [
-      2,
+      1,
       "always",
       [
         "cosh",
-        "agent-sec-core",
-        "os-skills",
-        "agentsight",
+        "sec-core",
+        "skill",
+        "sight",
         "deps",
         "ci",
         "docs",

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,9 +35,9 @@ closes #
 <!-- Which sub-project does this PR affect? -->
 
 - [ ] `cosh` (copilot-shell)
-- [ ] `agent-sec-core`
-- [ ] `os-skills`
-- [ ] `agentsight`
+- [ ] `sec-core` (agent-sec-core)
+- [ ] `skill` (os-skills)
+- [ ] `sight` (agentsight)
 - [ ] Multiple / Project-wide
 
 ## Checklist
@@ -49,9 +49,10 @@ closes #
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have updated the documentation accordingly
 - [ ] For `cosh`: Lint passes, type check passes, and tests pass
-- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
-- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
-- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
+- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
+- [ ] For `sec-core` (Python): Ruff format and pytest pass
+- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
+- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
 - [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)
 
 ## Testing

--- a/.github/workflows/prelint.yml
+++ b/.github/workflows/prelint.yml
@@ -37,16 +37,20 @@ jobs:
 
   # =========================================================================
   # Job 2: PR Checks (title + branch name + linked issue + merge hint)
-  # All steps share one runner — no checkout needed.
+  # All steps run with continue-on-error so every check is always reported
+  # in one pass — contributors see all warnings at once, not one at a time.
+  # None of these checks block the PR (warnings only); only commit scope
+  # enforcement (commitlint) is a hard error.
   # =========================================================================
   pr-checks:
     name: 🔍 PR Checks
     runs-on: ubuntu-latest
     steps:
       # -----------------------------------------------------------------------
-      # Step 1: PR Title Validation
+      # Step 1: PR Title Validation (warning only)
       # -----------------------------------------------------------------------
       - name: 📋 Validate PR title
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -58,31 +62,32 @@ jobs:
             const pattern = /^(feat|fix|refactor|perf|docs|chore|test|ci|build|style|revert)(\(.+\))!?: .+/;
 
             if (!pattern.test(title)) {
-              core.setFailed(
-                `❌ PR title does not follow Conventional Commits format.\n\n` +
+              core.warning(
+                `PR title does not follow Conventional Commits format.\n` +
                 `Expected: type(scope): description\n` +
                 `Examples: feat(cosh): add json output\n` +
-                `          fix(agent-sec-core): handle sandbox escape\n\n` +
+                `          fix(sec-core): handle sandbox escape\n` +
                 `Valid types: feat, fix, refactor, perf, docs, chore, test, ci, build, style, revert\n` +
-                `Valid scopes: cosh, agent-sec-core, os-skills, agentsight, deps, ci, docs, chore\n\n` +
-                `Current title: "${title}"`
+                `Valid scopes: cosh, sec-core, skill, sight, deps, ci, docs, chore\n` +
+                `See CONTRIBUTING.md or AGENT.md for details.`
               );
               return;
             }
 
-            // Validate scope
-            const scopeMatch = title.match(/^\w+\(([^)]+)\)/);
+            // Validate scope (also accept legacy long names for forward compatibility)
+            const scopeMatch = title.match(/^\w+(\([^)]+\))/);
             if (scopeMatch) {
-              const scope = scopeMatch[1];
+              const scope = scopeMatch[1].slice(1, -1);
               const validScopes = [
-                'cosh', 'agent-sec-core', 'os-skills', 'agentsight',
+                'cosh', 'sec-core', 'skill', 'sight',
+                'agent-sec-core', 'agentsight', 'os-skills', // legacy aliases
                 'deps', 'ci', 'docs', 'chore'
               ];
               if (!validScopes.includes(scope)) {
-                core.setFailed(
-                  `❌ Scope "${scope}" in PR title is not in the allowed list.\n\n` +
-                  `Valid scopes: ${validScopes.join(', ')}\n\n` +
-                  `Current title: "${title}"`
+                core.warning(
+                  `Scope "${scope}" in PR title is not in the recommended list.\n` +
+                  `Recommended scopes: ${validScopes.join(', ')}\n` +
+                  `See CONTRIBUTING.md for the scope-to-path mapping.`
                 );
                 return;
               }
@@ -91,9 +96,10 @@ jobs:
             console.log('✅ PR title format is valid');
 
       # -----------------------------------------------------------------------
-      # Step 2: Branch Name Validation
+      # Step 2: Branch Name Validation (warning only, non-blocking for forks)
       # -----------------------------------------------------------------------
       - name: 🌿 Validate branch name
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -118,8 +124,8 @@ jobs:
               }
             }
 
-            // Valid scopes — sub-projects and project-wide categories
-            const validScopes = ['cosh', 'agent-sec-core', 'os-skills', 'agentsight', 'ci', 'docs', 'deps'];
+            // Valid scopes — short names preferred; legacy long names accepted for forward compatibility
+            const validScopes = ['cosh', 'sec-core', 'skill', 'sight', 'agent-sec-core', 'agentsight', 'os-skills', 'ci', 'docs', 'deps'];
             const scopePattern = validScopes.join('|');
 
             // Valid branch patterns per development spec
@@ -139,16 +145,14 @@ jobs:
             const isValid = validPatterns.some(p => p.test(branch));
 
             if (!isValid) {
-              core.setFailed(
-                `❌ Branch "${branch}" does not follow the naming convention.\n\n` +
-                `Valid formats:\n` +
-                `  feature/<scope>/<short-desc>       e.g. feature/cosh/json-output\n` +
-                `  feature/<scope>/<name>/<task>      e.g. feature/cosh/auth-refactor/oauth\n` +
-                `  fix/<scope>/<short-desc>           e.g. fix/agent-sec-core/sandbox-escape\n` +
-                `  release/<scope>/vX.Y              e.g. release/cosh/v2.1\n` +
-                `  hotfix/<scope>/<short-desc>        e.g. hotfix/os-skills/broken-load\n\n` +
+              core.warning(
+                `Branch "${branch}" does not match the recommended naming convention (non-blocking).\n` +
+                `Recommended formats:\n` +
+                `  feature/<scope>/<short-desc>  e.g. feature/cosh/json-output\n` +
+                `  fix/<scope>/<short-desc>      e.g. fix/sec-core/sandbox-escape\n` +
+                `  hotfix/<scope>/<short-desc>   e.g. hotfix/skill/broken-load\n` +
                 `Valid scopes: ${validScopes.join(', ')}\n` +
-                `Branch names must use lowercase letters, digits, hyphens, and dots only.`
+                `Fork contributors may use any branch name freely.`
               );
               return;
             }
@@ -156,9 +160,10 @@ jobs:
             console.log('✅ Branch name is valid');
 
       # -----------------------------------------------------------------------
-      # Step 3: Linked Issue Check
+      # Step 3: Linked Issue Check (warning only)
       # -----------------------------------------------------------------------
       - name: 🔗 Check linked issue
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -182,13 +187,25 @@ jobs:
               return;
             }
 
-            core.setFailed(
-              `❌ This PR does not reference a linked issue.\n\n` +
-              `Every PR must include one of the following in the PR description:\n\n` +
-              `  closes #<number>\n` +
-              `  fixes #<number>\n` +
-              `  resolves #<number>\n\n` +
+            core.warning(
+              `This PR does not reference a linked issue.\n` +
+              `Add one of the following to your PR description:\n` +
+              `  closes #<number>  /  fixes #<number>  /  resolves #<number>\n` +
               `If there is genuinely no applicable issue, add:\n` +
-              `  no-issue: <brief reason>\n\n` +
-              `Please create an issue first at https://github.com/alibaba/anolisa/issues/new`
+              `  no-issue: <brief reason>\n` +
+              `Create an issue first: https://github.com/alibaba/anolisa/issues/new`
             );
+
+      # -----------------------------------------------------------------------
+      # Step 4: Summary — always runs, prints consolidated status
+      # -----------------------------------------------------------------------
+      - name: 📊 PR Checks Summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('=== PR Checks Summary ===');
+            console.log('All checks completed. Any warnings above are non-blocking suggestions.');
+            console.log('The only hard error that blocks merging is a missing commit scope.');
+            console.log('See CONTRIBUTING.md or AGENT.md for guidance on commit messages and PR conventions.');
+

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,202 @@
+# Instructions for Coding Assistants
+
+This file provides context for AI coding assistants (Qoder, Claude, etc.) working in this repository.
+
+## Project Overview
+
+**ANOLISA** is a monorepo for an Agentic OS — a server-side operating layer designed for AI agent workloads.
+
+| Component | Path | Tech | Platform |
+|-----------|------|------|----------|
+| **copilot-shell** (`cosh`) | `src/copilot-shell/` | TypeScript / Node.js | All |
+| **agent-sec-core** | `src/agent-sec-core/` | Rust + Python | Linux only |
+| **agentsight** | `src/agentsight/` | Rust (eBPF) | Linux only |
+| **os-skills** | `src/os-skills/` | Python / Shell | All |
+
+> `agent-sec-core` and `agentsight` require Linux. Do **not** attempt to build them on macOS or Windows.
+
+## Development Commands
+
+```bash
+# Unified build (recommended — handles deps, build, and system install)
+./scripts/build-all.sh                                        # all default components
+./scripts/build-all.sh --no-install                           # build only, skip install
+./scripts/build-all.sh --ignore-deps                          # skip dep installation
+./scripts/build-all.sh --component cosh --component sec-core  # selected components
+
+# Unified test runner
+./tests/run-all-tests.sh
+./tests/run-all-tests.sh --filter shell   # copilot-shell only
+./tests/run-all-tests.sh --filter sec     # agent-sec-core only
+./tests/run-all-tests.sh --filter sight   # agentsight only
+
+# copilot-shell (per-component)
+cd src/copilot-shell
+make deps      # npm install + husky hooks (use make deps-ci in CI)
+make build
+make lint
+make test
+
+# agent-sec-core (Linux only, per-component)
+cd src/agent-sec-core
+make build-sandbox
+pytest tests/integration-test/ tests/unit-test/ -v
+
+# agentsight (Linux only, optional, per-component)
+cd src/agentsight
+make build
+cargo test
+
+# os-skills
+cd src/os-skills   # Skill definitions are static assets, no compilation needed
+```
+
+## Commit Message Rules
+
+> **scope is mandatory** — CI will error if scope is missing.
+
+Format: `type(scope): description`
+- Language: **English only**
+- `description`: lowercase first letter, no trailing period
+- Breaking changes: append `!` before colon, e.g. `feat(cosh)!: remove legacy flag`
+
+### Scope Inference (by changed file path)
+
+| Changed path | Scope |
+|---|---|
+| `src/copilot-shell/` | `cosh` |
+| `src/agent-sec-core/` | `sec-core` |
+| `src/os-skills/` | `skill` |
+| `src/agentsight/` | `sight` |
+| `.github/workflows/` | `ci` |
+| `docs/` | `docs` |
+| `**/package*.json`, `Cargo.lock`, `*.toml` (dep bumps) | `deps` |
+| Other root-level config / scripts / tooling | `chore` |
+
+**Multi-component changes**: use the scope covering the most changed files. PR title follows the same rule.
+
+### Issue Association
+
+If the branch name contains an issue number (e.g. `fix/cosh/42-json-output`), automatically append to commit footer:
+
+```
+Closes #42
+```
+
+### Examples
+
+```
+feat(cosh): add --json flag to config command
+fix(sec-core): handle sandbox escape edge case
+docs(docs): update installation guide for Linux
+chore(ci): pin ubuntu version to 22.04
+deps(deps): bump @types/node to 20.11.0
+```
+
+## Branch Naming
+
+> Recommended convention — not enforced for fork contributors. CI issues a suggestion, not an error.
+
+```
+feature/<scope>/<short-desc>    e.g. feature/cosh/json-output
+fix/<scope>/<short-desc>        e.g. fix/sec-core/sandbox-escape
+hotfix/<scope>/<short-desc>     e.g. hotfix/skill/broken-load
+release/<scope>/vX.Y            e.g. release/cosh/v2.1
+```
+
+Fork contributors may use any branch name freely.
+
+## PR Description
+
+When generating a PR description, use `.github/pull_request_template.md` as the base and fill in every section. Rules:
+
+### How to fill each section
+
+**Description** — 2–5 sentences covering:
+- What changed and why (motivation)
+- Key implementation decision if non-obvious
+
+**Related Issue** — always required:
+- Use `closes #<n>` / `fixes #<n>` / `resolves #<n>` so the issue auto-closes on merge
+- If no issue exists, write `no-issue: <brief reason>` (typo fix, doc tweak, etc.)
+
+**Type of Change** — check all that apply based on the diff:
+- `Bug fix` — patches a defect, no API change
+- `New feature` — adds functionality, no breaking change
+- `Breaking change` — changes existing behavior (also add `!` in PR title)
+- `Documentation update` — docs / comments only
+- `Refactoring` — internal restructure, no functional change
+- `Performance improvement` — measurable speedup
+- `CI/CD or build changes` — workflow / build scripts
+
+**Scope** — check the component(s) whose files were changed:
+- `cosh` → any file under `src/copilot-shell/`
+- `sec-core` → any file under `src/agent-sec-core/`
+- `skill` → any file under `src/os-skills/`
+- `sight` → any file under `src/agentsight/`
+- `Multiple / Project-wide` → cross-component or root-level changes
+
+**Checklist** — mark items that actually apply to this PR; skip items for unaffected components.
+
+**Testing** — describe what was run:
+- Command used (e.g. `cd src/copilot-shell && make test`)
+- Test scope (unit / integration / manual)
+- Any edge cases verified
+
+**Additional Notes** — screenshots, links, caveats, follow-up TODOs.
+
+### PR Title
+
+Same format as commit messages: `type(scope): description`
+- Use the scope of the component with the most changes
+- Breaking change: `feat(cosh)!: remove legacy config flag`
+
+### Full Example
+
+```markdown
+## Description
+
+Add `--json` output flag to the `config` command so scripts can consume
+configuration values without text parsing. Returns a JSON object with all
+current config keys.
+
+## Related Issue
+
+closes #42
+
+## Type of Change
+
+- [x] New feature (non-breaking change that adds functionality)
+
+## Scope
+
+- [x] `cosh` (copilot-shell)
+
+## Checklist
+
+- [x] I have read the Contributing Guide
+- [x] My code follows the project's code style
+- [x] I have added tests that prove my fix is effective or that my feature works
+- [x] For `cosh`: Lint passes, type check passes, and tests pass
+- [x] Lock files are up to date
+
+## Testing
+
+```bash
+cd src/copilot-shell && make test
+# All 142 tests pass; added 3 new unit tests for --json flag
+```
+
+## Additional Notes
+
+Output schema is intentionally flat for now; nested config support tracked in #55.
+```
+
+## Code Standards
+
+- All code and comments must be in **English**
+- **TypeScript**: ESLint + Prettier (configured in `src/copilot-shell/`)
+- **Python**: Ruff + Black (configured in `src/os-skills/` and `src/agent-sec-core/`)
+- **Rust**: `cargo fmt` + `cargo clippy -- -D warnings`
+- Do not hide errors or risks — make them visible and actionable
+- Every change should not only implement the desired functionality but also improve codebase quality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 We welcome contributions! This document covers the basics of contributing to the project.
 
+> **Done coding?** Ask your AI assistant: *"Read AGENT.md and help me generate a commit message and PR description."*
+
 ## Development Environment
 
 ### Prerequisites
@@ -19,38 +21,54 @@ We welcome contributions! This document covers the basics of contributing to the
 git clone https://github.com/alibaba/anolisa.git
 cd anolisa
 
+# Quick build: install deps + build + install to system (recommended)
+./scripts/build-all.sh
+
+# Build selected components only
+./scripts/build-all.sh --component cosh --component sec-core
+
 # Run unified tests
 ./tests/run-all-tests.sh
-
-# Install copilot-shell dependencies locally for dev
-cd src/copilot-shell
-npm ci
-npm run bundle
 ```
 
-> **Note:** `npm ci` (or `npm install`) automatically runs the `prepare` script, which initializes [husky](https://typicode.github.io/husky/) pre-commit hooks. On each commit, [lint-staged](https://github.com/lint-staged/lint-staged) will run **Prettier** and **ESLint** on your staged files. If you need to bypass the hooks in an emergency, use `git commit --no-verify`.
+For a full breakdown of build options and dependency installation, see [docs/BUILDING.md](docs/BUILDING.md).
 
 ### Package-Specific Development
 
-Each package has its own development workflow:
+Each component has its own build workflow:
 
-- **copilot-shell**: See [src/copilot-shell/CONTRIBUTING.md](src/copilot-shell/CONTRIBUTING.md)
-- **os-skills**: `cd src/os-skills` — Skill definitions loaded via Skill-OS framework
-- **agent-sec-core**: `cd src/agent-sec-core && make build-sandbox` (Linux only)
-- **agentsight**: `cd src/agentsight && cargo build` (requires libbpf)
+- **copilot-shell**:
+  ```bash
+  cd src/copilot-shell
+  make deps   # npm install + husky hooks
+  make build
+  ```
+  > `make deps` sets up [husky](https://typicode.github.io/husky/) pre-commit hooks that run Prettier and ESLint on staged files. Use `make deps-ci` in CI to skip hook installation.
 
-## Workspace Commands
+- **os-skills**: `cd src/os-skills` — skill definitions are static assets, no compilation needed
+
+- **agent-sec-core** (Linux only): `cd src/agent-sec-core && make build-sandbox`
+
+- **agentsight** (Linux only, optional): `cd src/agentsight && make build`
+
+## Build & Test Commands
 
 ```bash
-# Using root Makefile
-make install          # Install all dependencies
-make build            # Build copilot-shell
-make build-sec        # Build agent-sec-core sandbox (Linux)
-make build-sight      # Build agentsight (Linux)
-make test             # Run tests (with filters available)
-make lint             # Lint copilot-shell
-make format           # Format all sub-projects
-make rpm              # Build all RPM packages
+# Unified build (recommended — handles deps, build, and install automatically)
+./scripts/build-all.sh                                        # all default components
+./scripts/build-all.sh --no-install                           # build only, skip system install
+./scripts/build-all.sh --ignore-deps                          # skip dep installation
+./scripts/build-all.sh --component cosh --component sec-core  # selected components
+
+# Unified test runner
+./tests/run-all-tests.sh             # all components
+./tests/run-all-tests.sh --filter shell   # copilot-shell only
+./tests/run-all-tests.sh --filter sec     # agent-sec-core only
+
+# Per-component
+cd src/copilot-shell && make lint && make test
+cd src/agent-sec-core && pytest tests/integration-test/ tests/unit-test/
+cd src/agentsight && cargo test
 ```
 
 ## Contribution Process
@@ -59,7 +77,15 @@ make rpm              # Build all RPM packages
 2. **Fork and branch** - Create a feature branch from `main`.
 3. **Make your changes** - Follow existing code style and conventions.
 4. **Write tests** - Ensure adequate test coverage for your changes.
-5. **Run preflight checks** - `make lint && make test` before submitting.
+5. **Run preflight checks** — lint and test the affected component before submitting:
+   ```bash
+   # copilot-shell
+   cd src/copilot-shell && make lint && make test
+   # agent-sec-core
+   cd src/agent-sec-core && pytest tests/
+   # agentsight
+   cd src/agentsight && cargo clippy -- -D warnings && cargo test
+   ```
 6. **Submit a PR** - Link it to the issue and provide a clear description.
 
 ### Commit Messages
@@ -67,10 +93,48 @@ make rpm              # Build all RPM packages
 Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
-feat(cli): add --json flag to config command
-fix(core): handle empty response from API
-docs: update installation guide
+feat(cosh): add --json flag to config command
+fix(sec-core): handle sandbox escape edge case
+docs(docs): update installation guide
 ```
+
+**scope is mandatory** and must be one of the following:
+
+| Scope | Covers |
+|-------|--------|
+| `cosh` | `src/copilot-shell/` |
+| `sec-core` | `src/agent-sec-core/` |
+| `skill` | `src/os-skills/` |
+| `sight` | `src/agentsight/` |
+| `ci` | `.github/workflows/` |
+| `docs` | `docs/` or documentation updates |
+| `deps` | Dependency version bumps (lock files) |
+| `chore` | Other maintenance (config, scripts, tooling) |
+
+### Branch Naming
+
+Internal contributors should follow this convention:
+
+```
+feature/<scope>/<short-desc>    e.g. feature/cosh/json-output
+fix/<scope>/<short-desc>        e.g. fix/sec-core/sandbox-escape
+hotfix/<scope>/<short-desc>     e.g. hotfix/skill/broken-load
+```
+
+**Fork contributors**: branch naming is free — CI will only issue a suggestion, not block your PR.
+
+### CI Checks Explained
+
+When you open a PR, the following checks run automatically:
+
+| Check | Level | How to fix |
+|-------|-------|------------|
+| Commit scope missing | **Error** (blocks merge) | Add `(scope)` to every commit message, e.g. `fix(cosh): ...` |
+| Commit scope not in allowed list | Warning | Use one of the scopes above: `cosh`, `sec-core`, `skill`, `sight`, `ci`, `docs`, `deps`, `chore` |
+| PR title format | Warning | Follow `type(scope): description` — same as commit messages |
+| Branch name convention | Warning | Follow `feature/<scope>/<desc>` — not required for forks |
+| PR not linked to an issue | Warning | Add `closes #<n>` to your PR description, or `no-issue: <reason>` |
+| CI tests fail | **Error** (blocks merge) | Fix the failing tests before requesting review |
 
 ## Code Style
 


### PR DESCRIPTION
## Description

Reduces friction for external and fork contributors in three areas:

1. **CI warnings instead of errors** — PR title format, branch naming,
   and missing issue link are now non-blocking warnings. All three checks
   run in parallel (`continue-on-error: true`) so contributors see every
   issue in a single pass rather than fixing one at a time.
2. **Unified scope naming** — short aliases (`cosh / sec-core / skill / sight`)
   are now consistent across commitlint, prelint.yml, PR template, CONTRIBUTING.md,
   and AGENT.md (previously mixed long/short names).
3. **AI-assistant context** — new `AGENT.md` at repo root gives Qoder/Claude (any coding agent)
   structured rules for auto-inferring commit scope, generating PR descriptions,
   and following branch conventions. CONTRIBUTING.md is also expanded with
   a scope table, branch naming guide, and CI checks explained.

The only hard error that still blocks merging is a missing commit scope (`scope-empty`).

## Related Issue

no-issue: no-issue

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD or build changes
- [x] Documentation update

## Scope

- [x] `ci` (`.github/workflows/` + commitlint config + PR template)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] Lock files are up to date

## Testing

Changes are workflow/doc only. Verified locally by reviewing YAML syntax
and confirming `continue-on-error: true` is applied to all three pr-checks steps.

## Additional Notes

AGENT.md follows the pattern established by projects like page-agent.
Qoder reads it automatically when generating commits/PRs in this repo.