### PR TITLE
fix(chore): install clang in rpm-build.sh for building agentsight

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -46,14 +46,8 @@ install_package() {
         dnf install -y "$pkg"
     elif command -v yum &>/dev/null; then
         yum install -y "$pkg"
-    elif command -v apt-get &>/dev/null; then
-        apt-get install -y "$pkg"
-    elif command -v zypper &>/dev/null; then
-        zypper install -y "$pkg"
-    elif command -v pacman &>/dev/null; then
-        pacman -S --noconfirm "$pkg"
     else
-        err "No supported package manager found (dnf/yum/apt-get/zypper/pacman)"
+        err "No supported package manager found (dnf/yum)"
         return 1
     fi
 }

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -38,6 +38,27 @@ err()  { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 ok()   { echo -e "${GREEN}[OK]${NC} $*" >&2; }
 
 # -----------------------------------------------------------------------------
+# Install a package using the available package manager
+# -----------------------------------------------------------------------------
+install_package() {
+    local pkg="$1"
+    if command -v dnf &>/dev/null; then
+        dnf install -y "$pkg"
+    elif command -v yum &>/dev/null; then
+        yum install -y "$pkg"
+    elif command -v apt-get &>/dev/null; then
+        apt-get install -y "$pkg"
+    elif command -v zypper &>/dev/null; then
+        zypper install -y "$pkg"
+    elif command -v pacman &>/dev/null; then
+        pacman -S --noconfirm "$pkg"
+    else
+        err "No supported package manager found (dnf/yum/apt-get/zypper/pacman)"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
 # Setup rpmbuild directory tree under scripts/rpmbuild/
 # -----------------------------------------------------------------------------
 setup_rpmbuild() {
@@ -287,6 +308,10 @@ build_agentsight() {
     local tarball_name="${pkg_name}-${pkg_version}.tar.gz"
 
     log "Step 1/3: Building agentsight..."
+    if ! command -v clang &>/dev/null; then
+        log "clang not found, installing..."
+        install_package clang || { err "Failed to install clang"; return 1; }
+    fi
     (
         cd "$SIGHT_DIR"
         cargo build --release


### PR DESCRIPTION
Fixes #75: install clang automatically before cargo build to resolve 'failed to execute clang' error on systems without clang in PATH.

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes # https://github.com/alibaba/anolisa/issues/75

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `agent-sec-core`
- [ ] `os-skills`
- [ ] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
