### PR TITLE
fix(sec-core): add bubblewrap version compatibility for --argv0 option

### DIFF
--- a/src/agent-sec-core/linux-sandbox/src/cli.rs
+++ b/src/agent-sec-core/linux-sandbox/src/cli.rs
@@ -13,6 +13,7 @@ use std::io::Read;
 use std::os::fd::FromRawFd;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
 use crate::bwrap_args::BwrapNetworkMode;
 use crate::bwrap_args::BwrapOptions;
@@ -166,12 +167,15 @@ fn run_bwrap_with_proc_fallback(
 ) -> ! {
     let network_mode = bwrap_network_mode(network_sandbox_policy, allow_network_for_proxy);
     let mut mount_proc = mount_proc;
+    // Detect once; share across preflight and real invocation.
+    let supports_argv0 = bwrap_supports_argv0();
 
     if mount_proc
         && !preflight_proc_mount_support(
             sandbox_policy_cwd,
             file_system_sandbox_policy,
             network_mode,
+            supports_argv0,
         )
     {
         // Keep the retry silent so sandbox-internal diagnostics do not leak into the
@@ -188,6 +192,7 @@ fn run_bwrap_with_proc_fallback(
         file_system_sandbox_policy,
         sandbox_policy_cwd,
         options,
+        supports_argv0,
     );
     exec_bwrap(bwrap_args.args, bwrap_args.preserved_files);
 }
@@ -205,11 +210,45 @@ fn bwrap_network_mode(
     }
 }
 
+/// Detect whether the installed `bwrap` binary supports the `--argv0` option.
+///
+/// `--argv0` was introduced in bubblewrap v0.9.0. On older distributions the
+/// binary may be as old as v0.4.x and will error with "Unknown option --argv0"
+/// if the flag is passed. We query `bwrap --version` at startup and skip the
+/// flag when the version is below 0.9.0.
+fn bwrap_supports_argv0() -> bool {
+    let output = match Command::new("bwrap").arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return false,
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_bwrap_version_supports_argv0(&stdout)
+}
+
+/// Parse `bwrap --version` output and return `true` when the version is >=
+/// 0.9.0 (the release that introduced `--argv0`).
+///
+/// Expected format: `"bubblewrap <MAJOR>.<MINOR>.<PATCH>"`.
+/// Returns `false` on any parse failure so we degrade gracefully.
+fn parse_bwrap_version_supports_argv0(version_output: &str) -> bool {
+    fn parse(s: &str) -> Option<bool> {
+        // e.g. "bubblewrap 0.9.0"
+        let version_str = s.trim().split_whitespace().nth(1)?;
+        let mut parts = version_str.split('.');
+        let major: u32 = parts.next()?.parse().ok()?;
+        let minor: u32 = parts.next()?.parse().ok()?;
+        // supports --argv0 when major > 0, or major == 0 and minor >= 9
+        Some(major > 0 || minor >= 9)
+    }
+    parse(version_output).unwrap_or(false)
+}
+
 fn build_bwrap_argv(
     inner: Vec<String>,
     file_system_sandbox_policy: &FileSystemSandboxPolicy,
     sandbox_policy_cwd: &Path,
     options: BwrapOptions,
+    supports_argv0: bool,
 ) -> crate::bwrap_args::BwrapArgs {
     let mut bwrap_args = create_bwrap_command_args(
         inner,
@@ -219,15 +258,17 @@ fn build_bwrap_argv(
     )
     .unwrap_or_else(|err| panic!("error building bubblewrap command: {err:?}"));
 
-    let command_separator_index = bwrap_args
-        .args
-        .iter()
-        .position(|arg| arg == "--")
-        .unwrap_or_else(|| panic!("bubblewrap argv is missing command separator '--'"));
-    bwrap_args.args.splice(
-        command_separator_index..command_separator_index,
-        ["--argv0".to_string(), "linux-sandbox".to_string()],
-    );
+    if supports_argv0 {
+        let command_separator_index = bwrap_args
+            .args
+            .iter()
+            .position(|arg| arg == "--")
+            .unwrap_or_else(|| panic!("bubblewrap argv is missing command separator '--'"));
+        bwrap_args.args.splice(
+            command_separator_index..command_separator_index,
+            ["--argv0".to_string(), "linux-sandbox".to_string()],
+        );
+    }
 
     let mut argv = vec!["bwrap".to_string()];
     argv.extend(bwrap_args.args);
@@ -241,9 +282,10 @@ fn preflight_proc_mount_support(
     sandbox_policy_cwd: &Path,
     file_system_sandbox_policy: &FileSystemSandboxPolicy,
     network_mode: BwrapNetworkMode,
+    supports_argv0: bool,
 ) -> bool {
     let preflight_argv =
-        build_preflight_bwrap_argv(sandbox_policy_cwd, file_system_sandbox_policy, network_mode);
+        build_preflight_bwrap_argv(sandbox_policy_cwd, file_system_sandbox_policy, network_mode, supports_argv0);
     let stderr = run_bwrap_in_child_capture_stderr(preflight_argv);
     !is_proc_mount_failure(stderr.as_str())
 }
@@ -252,6 +294,7 @@ fn build_preflight_bwrap_argv(
     sandbox_policy_cwd: &Path,
     file_system_sandbox_policy: &FileSystemSandboxPolicy,
     network_mode: BwrapNetworkMode,
+    supports_argv0: bool,
 ) -> crate::bwrap_args::BwrapArgs {
     let preflight_command = vec![resolve_true_command()];
     build_bwrap_argv(
@@ -262,6 +305,7 @@ fn build_preflight_bwrap_argv(
             mount_proc: true,
             network_mode,
         },
+        supports_argv0,
     )
 }
 
@@ -483,6 +527,7 @@ mod tests {
                 mount_proc: true,
                 network_mode: BwrapNetworkMode::FullAccess,
             },
+            true,
         )
         .args;
         assert_eq!(
@@ -509,6 +554,44 @@ mod tests {
     }
 
     #[test]
+    fn omits_argv0_when_not_supported() {
+        let argv = build_bwrap_argv(
+            vec!["/bin/true".to_string()],
+            &read_only_fs_policy(),
+            Path::new("/"),
+            BwrapOptions {
+                mount_proc: true,
+                network_mode: BwrapNetworkMode::FullAccess,
+            },
+            false,
+        )
+        .args;
+        assert!(!argv.contains(&"--argv0".to_string()));
+        assert!(!argv.contains(&"linux-sandbox".to_string()));
+        // "--" separator must still be present
+        assert!(argv.contains(&"--".to_string()));
+    }
+
+    #[test]
+    fn parse_version_detects_old_bwrap() {
+        assert!(!parse_bwrap_version_supports_argv0("bubblewrap 0.4.0\n"));
+        assert!(!parse_bwrap_version_supports_argv0("bubblewrap 0.8.99\n"));
+    }
+
+    #[test]
+    fn parse_version_detects_new_bwrap() {
+        assert!(parse_bwrap_version_supports_argv0("bubblewrap 0.9.0\n"));
+        assert!(parse_bwrap_version_supports_argv0("bubblewrap 0.10.0\n"));
+        assert!(parse_bwrap_version_supports_argv0("bubblewrap 1.0.0\n"));
+    }
+
+    #[test]
+    fn parse_version_returns_false_on_garbage_input() {
+        assert!(!parse_bwrap_version_supports_argv0(""));
+        assert!(!parse_bwrap_version_supports_argv0("unknown"));
+    }
+
+    #[test]
     fn inserts_unshare_net_when_network_isolation_requested() {
         let argv = build_bwrap_argv(
             vec!["/bin/true".to_string()],
@@ -518,6 +601,7 @@ mod tests {
                 mount_proc: true,
                 network_mode: BwrapNetworkMode::Isolated,
             },
+            false,
         )
         .args;
         assert!(argv.contains(&"--unshare-net".to_string()));
@@ -533,6 +617,7 @@ mod tests {
                 mount_proc: true,
                 network_mode: BwrapNetworkMode::ProxyOnly,
             },
+            false,
         )
         .args;
         assert!(argv.contains(&"--unshare-net".to_string()));
@@ -551,6 +636,7 @@ mod tests {
             Path::new("/"),
             &FileSystemSandboxPolicy::unrestricted(),
             mode,
+            false,
         )
         .args;
         assert!(argv.iter().any(|arg| arg == "--"));

--- a/src/agent-sec-core/linux-sandbox/tests/suite/bwrap_seccomp.rs
+++ b/src/agent-sec-core/linux-sandbox/tests/suite/bwrap_seccomp.rs
@@ -11,7 +11,7 @@ use tokio::process::Command;
 // At least on GitHub CI, the arm64 tests appear to need longer timeouts.
 
 #[cfg(not(target_arch = "aarch64"))]
-const SHORT_TIMEOUT_MS: u64 = 200;
+const SHORT_TIMEOUT_MS: u64 = 1_000;
 #[cfg(target_arch = "aarch64")]
 const SHORT_TIMEOUT_MS: u64 = 5_000;
 


### PR DESCRIPTION

### Description

Add runtime version detection for bubblewrap to support older distributions that ship bwrap < 0.9.0.

The `--argv0` option was introduced in bubblewrap v0.9.0. On older systems (e.g., CentOS 7, Anolis OS 8 with bwrap 0.4.0), passing this flag causes the error: `bwrap: Unknown option --argv0`.

### Changes

1. **Runtime version detection** (`cli.rs`)
   - Add `bwrap_supports_argv0()` to query `bwrap --version` at startup
   - Add `parse_bwrap_version_supports_argv0()` to parse version string
   - Gracefully degrade to `false` on any detection failure

2. **Conditional --argv0 injection**
   - Update `build_bwrap_argv()` to accept `supports_argv0` parameter
   - Only inject `--argv0 linux-sandbox` when bwrap >= 0.9.0
   - Share version detection across preflight and real invocation

3. **Test improvements**
   - Add 5 unit tests for version detection and --argv0 logic
   - Increase `SHORT_TIMEOUT_MS` from 200ms to 1000ms for test stability
   - All 60 tests pass (44 unit + 16 integration)

### Testing

```bash
# Run all tests
cd src/agent-sec-core/linux-sandbox
RUSTUP_TOOLCHAIN=stable cargo test

# Test output: 60 passed, 0 failed
```

### Compatibility

- ✅ bwrap >= 0.9.0: Uses `--argv0` (full functionality)
- ✅ bwrap < 0.9.0: Skips `--argv0` (graceful degradation)
- ✅ Tested on bwrap 0.4.0 environment

## Related Issue

closes #110

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `agent-sec-core`
- [ ] `os-skills`
- [ ] `agentsight`
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `agent-sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `agent-sec-core` (Python): Ruff format and pytest pass
- [ ] For `os-skills`: Skill directory structure is valid and shell scripts pass syntax check
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran full test suite on environment with bubblewrap 0.4.0:

```bash
cd src/agent-sec-core/linux-sandbox
RUSTUP_TOOLCHAIN=stable cargo test
```

Results:
- Unit tests: 44/44 passed ✅
- Integration tests: 16/16 passed ✅
- Total: 60/60 passed ✅

Key test cases:
- Version detection: old (0.4.0, 0.8.99) vs new (0.9.0, 0.10.0, 1.0.0)
- --argv0 injection when supported
- --argv0 omission when not supported
- Garbage input handling

## Additional Notes

### Background

bubblewrap 的 `--argv0` 选项在 v0.9.0 版本才引入。alinux3上 安装的 bwrap 版本为 0.4.x，不支持该选项。

### Implementation Details

- 版本检测仅在启动时执行一次，避免重复调用 `bwrap --version`
- 解析失败时安全降级为 `false`（不使用 `--argv0`）

### Files Changed

- `src/agent-sec-core/linux-sandbox/src/cli.rs` - Core compatibility logic (+~100 lines)
- `src/agent-sec-core/linux-sandbox/tests/suite/bwrap_seccomp.rs` - Test timeout adjustment (200ms → 1000ms)