### PR TITLE
fix(cosh): unittest failure introduced by PR#113

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/components/AppHeader.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/AppHeader.test.tsx
@@ -7,6 +7,7 @@
 import { render } from 'ink-testing-library';
 import { describe, expect, it, vi } from 'vitest';
 import { AppHeader } from './AppHeader.js';
+import { AppContext } from '../contexts/AppContext.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
 import { SettingsContext } from '../contexts/SettingsContext.js';
 import { type UIState, UIStateContext } from '../contexts/UIStateContext.js';
@@ -48,6 +49,13 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
     ...overrides,
   }) as UIState;
 
+const createMockAppState = () => ({
+  version: '1.2.3',
+  startupWarnings: [],
+  dismissWarning: vi.fn(),
+  featureTips: [],
+});
+
 const renderWithProviders = (
   uiState: UIState,
   settings = createSettings(),
@@ -57,11 +65,13 @@ const renderWithProviders = (
   return render(
     <ConfigContext.Provider value={config as never}>
       <SettingsContext.Provider value={settings}>
-        <VimModeProvider settings={settings}>
-          <UIStateContext.Provider value={uiState}>
-            <AppHeader version="1.2.3" />
-          </UIStateContext.Provider>
-        </VimModeProvider>
+        <AppContext.Provider value={createMockAppState()}>
+          <VimModeProvider settings={settings}>
+            <UIStateContext.Provider value={uiState}>
+              <AppHeader version="1.2.3" />
+            </UIStateContext.Provider>
+          </VimModeProvider>
+        </AppContext.Provider>
       </SettingsContext.Provider>
     </ConfigContext.Provider>,
   );

--- a/src/copilot-shell/packages/cli/src/utils/featureTips.test.ts
+++ b/src/copilot-shell/packages/cli/src/utils/featureTips.test.ts
@@ -18,7 +18,15 @@ vi.mock('@copilot-shell/core', () => ({
 }));
 
 // Dynamic import so the mock is active when the module loads
-const { getAndMarkUnshownFeatureTips } = await import('./featureTips.js');
+const { getAndMarkUnshownFeatureTips, FEATURE_TIPS } =
+  await import('./featureTips.js');
+
+// Pre-compute expected values from the actual registry
+const sortedTips = [...FEATURE_TIPS].sort(
+  (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
+);
+const highestPriorityTip = sortedTips[0];
+const allTipIds = FEATURE_TIPS.map((tip) => tip.id);
 
 describe('getAndMarkUnshownFeatureTips', () => {
   beforeEach(async () => {
@@ -29,10 +37,10 @@ describe('getAndMarkUnshownFeatureTips', () => {
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
-  it('should return the single tip on first call when state file does not exist', async () => {
+  it('should return the highest-priority tip on first call when state file does not exist', async () => {
     const tips = await getAndMarkUnshownFeatureTips();
     expect(tips).toHaveLength(1);
-    expect(tips[0].id).toBe('bash-interactive-shell');
+    expect(tips[0].id).toBe(highestPriorityTip.id);
 
     // State file should have been created
     const raw = await fs.readFile(
@@ -40,33 +48,38 @@ describe('getAndMarkUnshownFeatureTips', () => {
       'utf-8',
     );
     const state = JSON.parse(raw);
-    expect(state.shownTipIds).toContain('bash-interactive-shell');
+    expect(state.shownTipIds).toContain(highestPriorityTip.id);
   });
 
-  it('should return empty array on second call when all tips are shown', async () => {
-    // First call — marks the tip
-    await getAndMarkUnshownFeatureTips();
-    // Second call — all tips shown
-    const tips = await getAndMarkUnshownFeatureTips();
-    expect(tips).toHaveLength(0);
-  });
-
-  it('should return the highest-priority unshown tip when multiple tips exist', async () => {
-    // Pre-populate state with one shown tip ID to simulate partial consumption.
-    // We write 'bash-interactive-shell' as shown so the function will look for
-    // remaining unshown tips. Since the production registry only has one tip,
-    // this test verifies the priority-sorting logic by temporarily extending
-    // the internal registry via a fresh state file that claims one is already shown.
+  it('should return empty array when all tips are already shown', async () => {
+    // Pre-populate state with all tip IDs marked as shown
     await fs.writeFile(
       path.join(testDir, 'feature-tips-state.json'),
-      JSON.stringify({ shownTipIds: [] }),
+      JSON.stringify({ shownTipIds: allTipIds }),
       'utf-8',
     );
 
     const tips = await getAndMarkUnshownFeatureTips();
-    // With default registry (1 tip), should return it
-    expect(tips).toHaveLength(1);
-    expect(tips[0].id).toBe('bash-interactive-shell');
+    expect(tips).toHaveLength(0);
+  });
+
+  it('should return the highest-priority unshown tip and skip already-shown ones', async () => {
+    // Mark the highest-priority tip as shown
+    await fs.writeFile(
+      path.join(testDir, 'feature-tips-state.json'),
+      JSON.stringify({ shownTipIds: [highestPriorityTip.id] }),
+      'utf-8',
+    );
+
+    const tips = await getAndMarkUnshownFeatureTips();
+    if (FEATURE_TIPS.length > 1) {
+      expect(tips).toHaveLength(1);
+      // Should be the second-highest-priority tip
+      expect(tips[0].id).toBe(sortedTips[1].id);
+    } else {
+      // Only one tip in registry and it's already shown
+      expect(tips).toHaveLength(0);
+    }
   });
 
   it('should handle corrupted state file gracefully', async () => {
@@ -78,9 +91,9 @@ describe('getAndMarkUnshownFeatureTips', () => {
     );
 
     const tips = await getAndMarkUnshownFeatureTips();
-    // Should fall back to empty state and return the tip
+    // Should fall back to empty state and return the highest-priority tip
     expect(tips).toHaveLength(1);
-    expect(tips[0].id).toBe('bash-interactive-shell');
+    expect(tips[0].id).toBe(highestPriorityTip.id);
   });
 
   it('should auto-create directory when state directory does not exist', async () => {
@@ -102,7 +115,7 @@ describe('getAndMarkUnshownFeatureTips', () => {
     const tips = await getAndMarkUnshownFeatureTips();
     // Should still return the tip despite write failure
     expect(tips).toHaveLength(1);
-    expect(tips[0].id).toBe('bash-interactive-shell');
+    expect(tips[0].id).toBe(highestPriorityTip.id);
 
     // Restore permissions for cleanup
     await fs.chmod(testDir, 0o755);

--- a/src/copilot-shell/packages/cli/src/utils/featureTips.ts
+++ b/src/copilot-shell/packages/cli/src/utils/featureTips.ts
@@ -19,7 +19,7 @@ export interface FeatureTip {
   priority?: number;
 }
 
-const FEATURE_TIPS: readonly FeatureTip[] = [
+export const FEATURE_TIPS: readonly FeatureTip[] = [
   {
     id: 'bash-interactive-shell',
     emoji: '\uD83D\uDC1A',


### PR DESCRIPTION
## Description

Fix two test failures introduced by the feature tip banner PR (#113):

1. `AppHeader.test.tsx` — `FeatureTipBanner` (rendered inside `AppHeader`) calls `useAppContext()`, but the test's `renderWithProviders` helper did not wrap the component tree with `AppContext.Provider`, causing a runtime throw. Added the missing provider with a minimal mock `AppState`.

2. `featureTips.test.ts` — Tests were hardcoded against specific tip IDs (e.g. `'bash-interactive-shell'`), so every change to the `FEATURE_TIPS` registry required updating the test file. Refactored to import the exported `FEATURE_TIPS` array and derive all expected values (`highestPriorityTip`, `allTipIds`, `sortedTips`) dynamically, making the tests resilient to future tip additions or priority changes. Also exported `FEATURE_TIPS` from `featureTips.ts` (readonly) to support this.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue: test fix for existing PR #113

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell && npm run test
# cli:  211 files, 3304 tests passed
# core: 174 files, 3730 tests passed
```

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
