### PR TITLE
feat(agent-sec-core): add bundled loongshield build flow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/agent-sec-core/third_party/loongshield"]
+	path = src/agent-sec-core/third_party/loongshield
+	url = https://github.com/openanolis/loongshield.git

--- a/AGENT.md
+++ b/AGENT.md
@@ -39,7 +39,7 @@ make test
 
 # agent-sec-core (Linux only, per-component)
 cd src/agent-sec-core
-make build-sandbox
+make build-all
 pytest tests/integration-test/ tests/unit-test/ -v
 
 # agentsight (Linux only, optional, per-component)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Each component has its own build workflow:
 
 - **os-skills**: `cd src/os-skills` — skill definitions are static assets, no compilation needed
 
-- **agent-sec-core** (Linux only): `cd src/agent-sec-core && make build-sandbox`
+- **agent-sec-core** (Linux only): `cd src/agent-sec-core && make build-all`
 
 - **agentsight** (Linux only, optional): `cd src/agentsight && make build`
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -340,16 +340,30 @@ co /skills
 
 ```bash
 cd src/agent-sec-core
-make build-sandbox
+make build-all
 ```
 
-Artifact: `linux-sandbox/target/release/linux-sandbox`
+If you cloned without `--recursive`, initialize the bundled source once from the repository root:
+
+```bash
+git submodule update --init --recursive src/agent-sec-core/third_party/loongshield
+```
+
+This always builds `linux-sandbox` and tries to build the bundled `loongshield` submodule at `third_party/loongshield`.
+If the current host does not satisfy `loongshield`'s own `make env-check`, the `loongshield` build is skipped and `agent-sec-core` still builds successfully.
+
+Artifacts:
+- `linux-sandbox/target/release/linux-sandbox`
+- `third_party/loongshield/build/src/daemon/loongshield` when the host supports building loongshield
 
 **Install**
 
 ```bash
-sudo make install-sandbox
+sudo make install
 ```
+
+This always installs `linux-sandbox`, `sign-skill.sh`, and the agent-sec-core skill files.
+`loongshield` is installed only when the current host supports building it.
 
 #### 4.2.4 agentsight (Optional, Linux only)
 

--- a/docs/BUILDING_CN.md
+++ b/docs/BUILDING_CN.md
@@ -341,16 +341,30 @@ co /skills
 
 ```bash
 cd src/agent-sec-core
-make build-sandbox
+make build-all
 ```
 
-产物：`linux-sandbox/target/release/linux-sandbox`
+如果你克隆仓库时没有使用 `--recursive`，请先执行一次：
+
+```bash
+git submodule update --init --recursive src/agent-sec-core/third_party/loongshield
+```
+
+这会始终构建 `linux-sandbox`，并尝试构建内置在 `third_party/loongshield` 的 `loongshield` 子模块。
+如果当前宿主机不满足 `loongshield` 自身的 `make env-check`，则会跳过 `loongshield` 构建，但 `agent-sec-core` 仍然可以构建成功。
+
+产物：
+- `linux-sandbox/target/release/linux-sandbox`
+- `third_party/loongshield/build/src/daemon/loongshield`，仅在宿主机支持构建 loongshield 时生成
 
 **安装**
 
 ```bash
-sudo make install-sandbox
+sudo make install
 ```
+
+这会始终安装 `linux-sandbox`、`sign-skill.sh` 和 agent-sec-core 的 skill 文件。
+只有当前宿主机支持构建 loongshield 时，才会顺带安装 `loongshield`。
 
 #### 4.2.4 agentsight（可选，仅 Linux）
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -13,7 +13,7 @@
 # Components (build order):
 #   cosh     copilot-shell      (Node.js / TypeScript)
 #   skills   os-skills          (Markdown skill definitions, no compilation)
-#   sec-core agent-sec-core     (Rust sandbox, Linux only)
+#   sec-core agent-sec-core     (Rust sandbox + bundled loongshield, Linux only)
 #   sight    agentsight         (eBPF / Rust, Linux only, NOT built by default)
 # ──────────────────────────────────────────────────────────────────
 set -euo pipefail
@@ -666,19 +666,34 @@ build_skills() {
 }
 
 build_sec_core() {
-    step "Building agent-sec-core (linux-sandbox)"
+    step "Building agent-sec-core (linux-sandbox + bundled loongshield when supported)"
     local dir="$PROJECT_ROOT/src/agent-sec-core"
     [[ -d "$dir" ]] || die "Directory not found: $dir"
+
+    if [[ ! -f "$dir/third_party/loongshield/Makefile" ]]; then
+        info "Initializing bundled loongshield submodule ..."
+        git -C "$PROJECT_ROOT" submodule update --init --recursive -- src/agent-sec-core/third_party/loongshield || warn "Unable to initialize loongshield submodule; sec-core will continue without it"
+    fi
+
     cd "$dir"
 
-    info "cargo build --release (linux-sandbox) ..."
-    if [[ -f Makefile ]] && grep -q 'build-sandbox' Makefile; then
+    info "make build-all ..."
+    if [[ -f Makefile ]] && grep -q 'build-all' Makefile; then
+        make build-all
+    elif [[ -f Makefile ]] && grep -q 'build-sandbox' Makefile; then
         make build-sandbox
     else
         cd linux-sandbox && cargo build --release && cd ..
     fi
 
+    local loongshield_bin="third_party/loongshield/build/src/daemon/loongshield"
     local bin="linux-sandbox/target/release/linux-sandbox"
+    if [[ -f "$loongshield_bin" ]]; then
+        ok "loongshield built successfully"
+    else
+        info "loongshield build skipped on this host or submodule unavailable"
+    fi
+
     if [[ -f "$bin" ]]; then
         ARTIFACT_NAMES+=("agent-sec-core")
         ARTIFACT_PATHS+=("src/agent-sec-core/$bin")
@@ -739,9 +754,9 @@ install_sec_core() {
     [[ -d "$dir" ]] || die "Directory not found: $dir"
     cd "$dir"
 
-    info "sudo make install-sandbox ..."
-    sudo make install-sandbox
-    ok "agent-sec-core (linux-sandbox) installed to /usr/local/bin/"
+    info "sudo make install ..."
+    sudo make install
+    ok "agent-sec-core installed; loongshield is installed when the host supports building it"
 }
 
 install_sight() {
@@ -811,7 +826,7 @@ $(echo -e "${BOLD}Examples:${NC}")
 $(echo -e "${BOLD}Components:${NC}")
   cosh     copilot-shell      Node.js / TypeScript AI terminal assistant       [default]
   skills   os-skills          Markdown skill definitions (deploy only)          [default]
-  sec-core agent-sec-core     Rust secure sandbox (Linux only)                  [default]
+  sec-core agent-sec-core     Rust sandbox + bundled loongshield hardening core (Linux only) [default]
   sight    agentsight         eBPF observability/audit agent (Linux only)        [optional]
 
 $(echo -e "${BOLD}What this script does:${NC}")

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -12,9 +12,26 @@ python-code-pretty: ## Format Python code using black and isort
 # BUILD
 # =============================================================================
 
+LOONGSHIELD_DIR ?= third_party/loongshield
+LOONGSHIELD_ABS_DIR := $(abspath $(LOONGSHIELD_DIR))
+
+.PHONY: loongshield
+loongshield: ## Build bundled loongshield when the host is supported
+	@if [ ! -f "$(LOONGSHIELD_ABS_DIR)/Makefile" ]; then \
+		echo "==> Skipping loongshield: submodule not initialized at $(LOONGSHIELD_ABS_DIR)"; \
+		echo "    Run: git submodule update --init --recursive src/agent-sec-core/third_party/loongshield"; \
+	elif ! $(MAKE) -s -C $(LOONGSHIELD_ABS_DIR) env-check >/dev/null 2>&1; then \
+		echo "==> Skipping loongshield: current host does not satisfy loongshield build requirements"; \
+	else \
+		$(MAKE) -C $(LOONGSHIELD_ABS_DIR) bootstrap; \
+	fi
+
 .PHONY: build-sandbox
 build-sandbox: ## Build linux-sandbox binary
 	cd linux-sandbox && cargo build --release
+
+.PHONY: build-all
+build-all: loongshield build-sandbox ## Build linux-sandbox and try to build bundled loongshield
 
 # =============================================================================
 # INSTALL
@@ -24,12 +41,22 @@ PREFIX      ?= /usr/local
 SKILL_DIR   ?= /usr/share/anolisa/skills/agent-sec-core
 
 .PHONY: install-sandbox
-install-sandbox: ## Install linux-sandbox binary only
+install-sandbox: build-sandbox ## Install linux-sandbox binary only
 	install -d -m 0755 $(DESTDIR)$(PREFIX)/bin
 	install -p -m 0755 linux-sandbox/target/release/linux-sandbox $(DESTDIR)$(PREFIX)/bin/
 
+.PHONY: install-loongshield
+install-loongshield: ## Install bundled loongshield when the host is supported
+	@if [ ! -f "$(LOONGSHIELD_ABS_DIR)/Makefile" ]; then \
+		echo "==> Skipping loongshield install: submodule not initialized at $(LOONGSHIELD_ABS_DIR)"; \
+	elif ! $(MAKE) -s -C $(LOONGSHIELD_ABS_DIR) env-check >/dev/null 2>&1; then \
+		echo "==> Skipping loongshield install: current host does not satisfy loongshield build requirements"; \
+	else \
+		$(MAKE) -C $(LOONGSHIELD_ABS_DIR) DESTDIR="$(DESTDIR)" PREFIX="$(PREFIX)" install; \
+	fi
+
 .PHONY: install
-install: ## Install linux-sandbox binary, sign-skill.sh and skill files
+install: build-sandbox install-loongshield ## Install linux-sandbox, skill files, and loongshield when available
 	install -d -m 0755 $(DESTDIR)$(PREFIX)/bin
 	install -p -m 0755 linux-sandbox/target/release/linux-sandbox $(DESTDIR)$(PREFIX)/bin/
 	install -p -m 0755 tools/sign-skill.sh $(DESTDIR)$(PREFIX)/bin/
@@ -46,4 +73,3 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .DEFAULT_GOAL := help
-

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -168,13 +168,26 @@ sudo loongshield seharden --scan --config agentos_baseline
 python3 skill/scripts/asset-verify/verifier.py
 ```
 
-### Build Sandbox from Source
+### Build from Source
+
+Initialize the bundled source once if you cloned without `--recursive`:
 
 ```bash
-make build-sandbox
+git submodule update --init --recursive src/agent-sec-core/third_party/loongshield
 ```
 
-The binary is output to `linux-sandbox/target/release/linux-sandbox`.
+Then build:
+
+```bash
+make build-all
+```
+
+This always builds `linux-sandbox` and tries to build the bundled `loongshield` submodule at `third_party/loongshield`.
+If the host does not satisfy `loongshield`'s own `make env-check`, the `loongshield` build is skipped and `agent-sec-core` still builds successfully.
+
+Artifacts:
+- `linux-sandbox/target/release/linux-sandbox`
+- `third_party/loongshield/build/src/daemon/loongshield` when the host supports building loongshield
 
 ### Install via RPM
 
@@ -227,14 +240,20 @@ sign-skill.sh <skill-directory>
 ## Development
 
 ```bash
-# Build sandbox
-make build-sandbox
+# Build sandbox and try the bundled loongshield dependency
+make build-all
+
+# Try only the bundled loongshield dependency
+make loongshield
 
 # Run Rust tests
 cd linux-sandbox && cargo test
 
 # Run e2e tests (requires sandbox installed)
 python3 tests/e2e/linux-sandbox/e2e_test.py
+
+# Install the full local runtime
+sudo make install
 
 # Format Python code
 make python-code-pretty

--- a/src/agent-sec-core/README_CN.md
+++ b/src/agent-sec-core/README_CN.md
@@ -168,13 +168,26 @@ sudo loongshield seharden --scan --config agentos_baseline
 python3 skill/scripts/asset-verify/verifier.py
 ```
 
-### 从源码构建沙箱
+### 从源码构建
+
+如果你克隆仓库时没有使用 `--recursive`，请先执行一次：
 
 ```bash
-make build-sandbox
+git submodule update --init --recursive src/agent-sec-core/third_party/loongshield
 ```
 
-二进制文件输出到 `linux-sandbox/target/release/linux-sandbox`。
+然后执行：
+
+```bash
+make build-all
+```
+
+这会始终构建 `linux-sandbox`，并尝试构建内置在 `third_party/loongshield` 的 `loongshield` 子模块。
+如果宿主机不满足 `loongshield` 自身的 `make env-check`，则会跳过 `loongshield` 构建，但 `agent-sec-core` 仍然可以构建成功。
+
+产物：
+- `linux-sandbox/target/release/linux-sandbox`
+- `third_party/loongshield/build/src/daemon/loongshield`，仅在宿主机支持构建 loongshield 时生成
 
 ### RPM 安装
 
@@ -227,14 +240,20 @@ sign-skill.sh <技能目录>
 ## 开发
 
 ```bash
-# 构建沙箱
-make build-sandbox
+# 构建 sandbox，并尝试构建内置 loongshield 依赖
+make build-all
+
+# 仅尝试构建内置 loongshield 依赖
+make loongshield
 
 # 运行 Rust 测试
 cd linux-sandbox && cargo test
 
 # 运行端到端测试（需先安装沙箱）
 python3 tests/e2e/linux-sandbox/e2e_test.py
+
+# 安装完整本地运行时
+sudo make install
 
 # 格式化 Python 代码
 make python-code-pretty


### PR DESCRIPTION
## Description

 This PR adds a bundled `loongshield` build flow to `agent-sec-core` and updates the build/docs flow around it.

`agent-sec-core` now exposes a single `make build-all` entrypoint that always builds `linux-sandbox` and attempts to build the bundled `third_party/loongshield` submodule when the host environment is supported. If the host does not pass `loongshield`'s `env-check`, the `loongshield` build is skipped and `agent-sec-core` still builds successfully.

### Changes

  - add `loongshield` as a git submodule under `src/agent-sec-core/third_party/loongshield`
  - add `make loongshield` and `make build-all` targets in `agent-sec-core`
  - update `make install` to install bundled `loongshield` when the host supports building it
  - keep build/install behavior non-blocking on unsupported hosts by checking `loongshield` build prerequisites first
  - update the top-level `scripts/build-all.sh` flow to initialize the submodule and use `make build-all`
  - update root and component docs to use the new build/install commands and describe submodule initialization

 ### Why

  Before this change, `agent-sec-core` only documented/builds `linux-sandbox` directly. This PR makes the bundled hardening dependency part of the standard build flow while preserving compatibility
  on hosts that cannot build `loongshield`.

 ### Testing

  - ran `make -n build-all` in `src/agent-sec-core` to verify the new build flow and fallback behavior
  - reviewed updated documentation and top-level build script references for consistency

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

https://github.com/alibaba/anolisa/issues/106

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
