### PR TITLE
feat(cosh): add sandbox-guard install command and sandbox bypass app…

### DIFF
--- a/src/copilot-shell/Makefile
+++ b/src/copilot-shell/Makefile
@@ -83,7 +83,7 @@ install: dist/package.json
 	install -m 644 dist/LICENSE "$(DESTDIR)$(DOCDIR)/LICENSE"
 	# -- executables --
 	install -d "$(DESTDIR)$(BINDIR)"
-	sed 's|@@LIBDIR@@|$(LIBDIR)|g' scripts/cosh-wrapper.sh > "$(DESTDIR)$(BINDIR)/cosh"
+	sed 's|@@LIBDIR@@|$(LIBDIR)|g; s|@@DATADIR@@|$(DATADIR)|g' scripts/cosh-wrapper.sh > "$(DESTDIR)$(BINDIR)/cosh"
 	chmod 755 "$(DESTDIR)$(BINDIR)/cosh"
 	ln -sf cosh "$(DESTDIR)$(BINDIR)/co"
 	ln -sf cosh "$(DESTDIR)$(BINDIR)/copilot"

--- a/src/copilot-shell/esbuild.config.js
+++ b/src/copilot-shell/esbuild.config.js
@@ -7,7 +7,14 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
-import { writeFileSync, rmSync } from 'node:fs';
+import {
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+  readdirSync,
+  copyFileSync,
+  existsSync,
+} from 'node:fs';
 
 let esbuild;
 try {
@@ -81,6 +88,20 @@ esbuild
   .then(({ metafile }) => {
     if (process.env.DEV === 'true') {
       writeFileSync('./dist/esbuild.json', JSON.stringify(metafile, null, 2));
+    }
+    // Copy hooks/*.py into dist/hooks/ so installCommand can locate them at runtime
+    const hooksSource = path.resolve(__dirname, 'hooks');
+    const hooksTarget = path.resolve(__dirname, 'dist', 'hooks');
+    if (existsSync(hooksSource)) {
+      mkdirSync(hooksTarget, { recursive: true });
+      for (const file of readdirSync(hooksSource)) {
+        if (file.endsWith('.py')) {
+          copyFileSync(
+            path.join(hooksSource, file),
+            path.join(hooksTarget, file),
+          );
+        }
+      }
     }
   })
   .catch((error) => {

--- a/src/copilot-shell/hooks/sandbox-failure-handler.py
+++ b/src/copilot-shell/hooks/sandbox-failure-handler.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+sandbox-failure-handler.py - PostToolUseFailure hook
+当 run_shell_command 工具因沙箱执行失败时触发。
+解析出原始命令并发出 sandbox_bypass_request，触发 UI 层弹出审批对话框。
+
+stdin: PostToolUseFailure JSON
+  {
+    "tool_name": "run_shell_command",
+    "tool_input": {"command": "<sandboxed-cmd>"},
+    "error": "<error message>",
+    "error_type": "...",
+    ...
+  }
+
+stdout: HookOutput JSON
+  {
+    "hookSpecificOutput": {
+      "hookEventName": "PostToolUseFailure",
+      "sandbox_bypass_request": {
+        "original_command": "<original command>",
+        "reason": "沙箱执行失败: <error>"
+      }
+    }
+  }
+  OR {} (no action needed)
+"""
+
+from __future__ import annotations
+
+import sys
+import json
+import re
+import base64
+
+# 沙箱命令的特征前缀/模式
+# sandbox-guard.py 生成的格式:
+#   /usr/local/bin/linux-sandbox --sandbox-policy-cwd "..." ... -- bash -c 'ORIGINAL_CMD'
+# 若原始命令含 sudo，则格式为:
+#   ... -- bash -c 'COSH_RC=<base64> STRIPPED_CMD'
+_SANDBOX_CMD_RE = re.compile(
+    r"linux-sandbox\b.*?--\s+bash\s+-c\s+'((?:[^'\\]|\\.|'\\'')*)'",
+    re.DOTALL,
+)
+
+# COSH_RC 编码的还原命令（sandbox-guard.py 在剥离 sudo 时嵌入）
+_COSH_RC_RE = re.compile(r"\bCOSH_RC=([A-Za-z0-9+/=]+)")
+
+# 已知的沙箱失败特征关键词（出现在 error 中）
+SANDBOX_FAILURE_INDICATORS = [
+    "linux-sandbox",
+    "sandbox",
+    "permission denied",
+    "operation not permitted",
+    "not permitted",
+    "seccomp",
+]
+
+
+def unescape_bash_single_quote(s: str) -> str:
+    """将 bash 单引号转义 '\\'' 还原为 '"""
+    return s.replace("'\\''", "'")
+
+
+def extract_original_command(sandboxed_cmd: str) -> str | None:
+    """从 linux-sandbox 命令中提取用于 bypass 执行的原始命令。
+
+    优先尝试 COSH_RC 环境变量（含 sudo 等完整前缀的 base64 编码），
+    回退到从 bash -c '...' 中直接提取（无 sudo 的执行命令）。
+    """
+    # 优先：COSH_RC 存在时，解码 base64 获取完整原始命令（含 sudo）
+    m = _COSH_RC_RE.search(sandboxed_cmd)
+    if m:
+        try:
+            return base64.b64decode(m.group(1)).decode("utf-8")
+        except Exception:
+            pass
+    # 回退：从 bash -c '...' 提取（无 sudo 版本）
+    m = _SANDBOX_CMD_RE.search(sandboxed_cmd)
+    if m:
+        raw = m.group(1)
+        return unescape_bash_single_quote(raw)
+    return None
+
+
+def is_sandbox_failure(tool_input_cmd: str, error_msg: str) -> bool:
+    """判断是否是沙箱相关的失败"""
+    # 命令本身包含 linux-sandbox 特征
+    if "linux-sandbox" in tool_input_cmd:
+        return True
+    # 错误信息包含沙箱失败关键词
+    error_lower = error_msg.lower()
+    return any(kw in error_lower for kw in SANDBOX_FAILURE_INDICATORS)
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        print(json.dumps({}))
+        return
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    error_msg = input_data.get("error", "")
+
+    # 只处理 run_shell_command 的失败
+    if tool_name != "run_shell_command":
+        print(json.dumps({}))
+        return
+
+    sandboxed_cmd = tool_input.get("command", "")
+    if not sandboxed_cmd:
+        print(json.dumps({}))
+        return
+
+    # 判断是否是沙箱失败
+    if not is_sandbox_failure(sandboxed_cmd, error_msg):
+        print(json.dumps({}))
+        return
+
+    # 提取原始命令
+    original_cmd = extract_original_command(sandboxed_cmd)
+    if not original_cmd:
+        # 无法提取原始命令，不发出 bypass 请求
+        print(json.dumps({}))
+        return
+
+    # 截断过长的错误信息
+    reason_detail = error_msg[:200] if len(error_msg) > 200 else error_msg
+
+    result = {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUseFailure",
+            "sandbox_bypass_request": {
+                "original_command": original_cmd,
+                "reason": f"沙箱执行失败: {reason_detail}",
+            },
+        }
+    }
+
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/copilot-shell/hooks/sandbox-guard.py
+++ b/src/copilot-shell/hooks/sandbox-guard.py
@@ -14,6 +14,8 @@ stdout: HookOutput JSON (decision, systemMessage, hookSpecificOutput)
 import sys
 import json
 import re
+import os
+import base64
 
 LINUX_SANDBOX = "/usr/local/bin/linux-sandbox"
 
@@ -32,8 +34,8 @@ BLOCK_PATTERNS = [
 ]
 
 # 替换为沙箱执行的命令（文件系统/权限/服务类）- 网络隔离
+# 注意：sudo 不在此列表，由 strip_sudo() 预处理后对底层命令评估
 DANGEROUS_PATTERNS = [
-    (r"\bsudo\b", "sudo 提权命令"),
     (r"\bsu\b", "su 切换用户"),
     (r"\bpkexec\b", "pkexec 提权"),
     # rm 危险操作：-rf、-fr、-r -f、--recursive、--force 各种写法
@@ -70,6 +72,19 @@ NETWORK_PATTERNS = [
     (r"\bwget\b", "wget 网络下载"),
     (r"\bnc\b|\bnetcat\b", "netcat 网络工具"),
     (r"\bnmap\b", "nmap 网络扫描"),
+    # 包管理器：需要网络下载，且会写入系统目录（/var/lib、/etc 等），
+    # 沙箱执行会因文件系统只读而失败，触发 bypass 审批弹框让用户决策
+    (r"\byum\s+\S", "yum 包管理"),
+    (r"\bdnf\s+\S", "dnf 包管理"),
+    (r"\bapt\s+\S", "apt 包管理"),
+    (r"\bapt-get\s+\S", "apt-get 包管理"),
+    (r"\bapt-cache\s+\S", "apt-cache 包管理"),
+    (r"\bpip[23]?\s+\S", "pip 包管理"),
+    (r"\bnpm\s+\S", "npm 包管理"),
+    (r"\bpnpm\s+\S", "pnpm 包管理"),
+    (r"\byarn\s+\S", "yarn 包管理"),
+    (r"\bgem\s+\S", "gem 包管理"),
+    (r"\bcargo\s+(install|add|update)\b", "cargo 包管理"),
     # ssh 远程连接命令（排除 .ssh 目录路径，如 ~/.ssh/config 只是查看本地配置）
     (r"\bssh\s+[^/\s]", "ssh 远程连接"),
     (r"\bscp\b", "scp 远程传输"),
@@ -116,28 +131,69 @@ SANDBOX_FS_POLICY = json.dumps(
     separators=(",", ":"),
 )  # compact JSON
 
+# 匹配 sudo 及其常见无交互选项，覆盖自动化脚本最常见场景：
+#   sudo cmd
+#   sudo -n cmd
+#   sudo -u root cmd
+#   sudo -E -n cmd
+#   sudo -- cmd
+# 不尝试覆盖 -i/-s（交互式 shell），这类保留原始命令不处理。
+_SUDO_PREFIX_RE = re.compile(
+    r"^sudo\s+"
+    r"(?:(?:-[nEbkKHPvA]+|--(?:non-interactive|preserve-env|reset-timestamp))\s+)*"  # 无参选项
+    r"(?:(?:-[uUgcCTt])\s+\S+\s+)*"  # 带参选项（-u user 等）
+    r"(?:--\s+)?"  # 分隔符 --
+)
 
-def build_sandbox_command(original_command: str, cwd: str, network_policy: str = "restricted") -> str:
+
+def strip_sudo(command: str) -> tuple:
+    """剥离命令开头的 sudo 前缀及其非交互选项。
+
+    Returns:
+        (stripped_command, had_sudo): 剥离后命令 及 是否包含 sudo 前缀
+    """
+    cmd = command.strip()
+    m = _SUDO_PREFIX_RE.match(cmd)
+    if m:
+        rest = cmd[m.end():].strip()
+        # 确保剥离后仍有命令体（不是空串），且不是交互式 shell 调用
+        if rest and not re.match(r"^-[is]\b", rest):
+            return rest, True
+    return command, False
+
+
+def build_sandbox_command(original_command: str, cwd: str, network_policy: str = "restricted", restore_command: str = "") -> str:
     """将原始命令包裹进 linux-sandbox 执行
-    
+
     Args:
-        original_command: 原始命令
+        original_command: 沙箱内实际执行的命令（已剥离 sudo）
         cwd: 当前工作目录
         network_policy: 网络策略，"restricted" 或 "unrestricted"
+        restore_command: bypass 时还原执行的命令（含 sudo 等完整前缀）；
+                         与 original_command 相同或为空时不编码
     """
     # 转义单引号：' → '\''
     escaped_cmd = original_command.replace("'", "'\\''")
+
+    # 若 restore_command 与实际执行命令不同（如含 sudo），将其 base64 编码
+    # 嵌入为沙箱内 bash 的临时环境变量 COSH_RC，不影响命令执行语义，
+    # sandbox-failure-handler.py 在 bypass 时还原完整原始命令。
+    if restore_command and restore_command != original_command:
+        b64 = base64.b64encode(restore_command.encode()).decode()
+        full_bash_cmd = f"COSH_RC={b64} {escaped_cmd}"
+    else:
+        full_bash_cmd = escaped_cmd
 
     return (
         f"{LINUX_SANDBOX}"
         f' --sandbox-policy-cwd "{cwd}"'
         f" --file-system-sandbox-policy '{SANDBOX_FS_POLICY}'"
         f" --network-sandbox-policy '\"{network_policy}\"'"
-        f" -- bash -c '{escaped_cmd}'"
+        f" -- bash -c '{full_bash_cmd}'"
     )
 
 
-def detect_patterns(command: str, patterns: list) -> list[str]:
+def detect_patterns(command: str, patterns: list) -> list:
     """检测命令中的危险模式，返回匹配的原因列表"""
     reasons = []
     for pattern, reason in patterns:
@@ -164,8 +220,17 @@ def main():
         print(json.dumps({"decision": "allow"}))
         return
 
+    # ── sudo 预处理 
+    # 剥离 sudo 前缀后对底层命令做统一的危险性评估，避免把整条命令
+    # 塞进沙箱（沙箱内 sudo 因权限受限必然失败）。
+    stripped_command, has_sudo = strip_sudo(command)
+    is_root = (os.getuid() == 0)
+
+    # 用剥离 sudo 后的命令做危险检测（以底层命令的语义为准）
+    eval_command = stripped_command if has_sudo else command
+
     # 第一优先级：直接 block 的命令
-    block_reasons = detect_patterns(command, BLOCK_PATTERNS)
+    block_reasons = detect_patterns(eval_command, BLOCK_PATTERNS)
     if block_reasons:
         reasons_str = ", ".join(block_reasons)
         result = {
@@ -180,13 +245,37 @@ def main():
         return
 
     # 第二优先级：替换为沙箱执行（文件系统/权限类风险）
-    sandbox_reasons = detect_patterns(command, DANGEROUS_PATTERNS)
-    network_reasons = detect_patterns(command, NETWORK_PATTERNS)
-    
+    sandbox_reasons = detect_patterns(eval_command, DANGEROUS_PATTERNS)
+    network_reasons = detect_patterns(eval_command, NETWORK_PATTERNS)
+
     if not sandbox_reasons and not network_reasons:
-        # 安全命令，直接放行
-        print(json.dumps({"decision": "allow"}))
+        # 底层命令安全，根据 sudo + 身份决策：
+        #
+        #   root + sudo：sudo 在此上下文中多余，剥离后直接执行，
+        #   避免"root 执行 sudo"因沙箱权限报错。
+        #
+        #   非 root + sudo：保留 sudo，让系统正常完成权限提升后执行。
+        #
+        #   无 sudo：直接放行。
+        if has_sudo and is_root:
+            result = {
+                "decision": "allow",
+                "systemMessage": (
+                    "ℹ️ 检测到 root 用户使用 sudo，已自动剥离 sudo 前缀直接执行"
+                    "（root 不需要 sudo 进行权限提升）。"
+                ),
+                "hookSpecificOutput": {"tool_input": {"command": stripped_command}},
+            }
+            print(json.dumps(result, ensure_ascii=False))
+        else:
+            # 安全命令（含非 root 的合法 sudo），直接放行
+            print(json.dumps({"decision": "allow"}))
         return
+
+    # 底层命令危险：进沙箱隔离。
+    # 沙箱内不支持 sudo/pkexec 等提权机制，因此始终以剥离后的命令入沙箱，
+    # 并通过 systemMessage 告知用户 sudo 已被忽略、命令在受限环境中执行。
+    sandbox_source = stripped_command if has_sudo else command
 
     # 判断是否需要放开网络权限
     if network_reasons and not sandbox_reasons:
@@ -200,14 +289,22 @@ def main():
         all_reasons = sandbox_reasons + network_reasons
         policy_desc = "🔒 已替换安全沙箱执行（网络隔离）"
 
+    sudo_strip_note = (
+        "\nℹ️ 检测到 sudo 前缀：沙箱不支持权限提升，已自动剥离 sudo 后在受限环境中执行。"
+        if has_sudo
+        else ""
+    )
+
     # 构建沙箱命令
-    sandbox_cmd = build_sandbox_command(command, cwd, network_policy)
+    # sandbox_source 是沙箱内实际执行的命令（已剥离 sudo）
+    # command 是用户输入的原始完整命令（含 sudo），bypass 时用于还原执行
+    sandbox_cmd = build_sandbox_command(sandbox_source, cwd, network_policy, restore_command=command)
     reasons_str = ", ".join(all_reasons)
 
     result = {
         "decision": "allow",
         "systemMessage": (
-            f"{policy_desc} (检测到: {reasons_str})\n"
+            f"{policy_desc} (检测到: {reasons_str}){sudo_strip_note}\n"
             "💡 如沙箱执行出错且确认命令无风险，可在聊天框输入 `/hooks disable sandbox-guard` 临时关闭防护"
         ),
         "hookSpecificOutput": {"tool_input": {"command": sandbox_cmd}},

--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -705,6 +705,7 @@ export const AppContainer = (props: AppContainerProps) => {
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    sandboxBypassRequest,
   } = useGeminiStream(
     config.getGeminiClient(),
     historyManager.history,
@@ -1356,6 +1357,7 @@ export const AppContainer = (props: AppContainerProps) => {
     settingInputRequests.length > 0 ||
     pluginChoiceRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
+    !!sandboxBypassRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
     isModelDialogOpen ||
@@ -1420,6 +1422,7 @@ export const AppContainer = (props: AppContainerProps) => {
       settingInputRequests,
       pluginChoiceRequests,
       loopDetectionConfirmationRequest,
+      sandboxBypassRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1513,6 +1516,7 @@ export const AppContainer = (props: AppContainerProps) => {
       settingInputRequests,
       pluginChoiceRequests,
       loopDetectionConfirmationRequest,
+      sandboxBypassRequest,
       geminiMdFileCount,
       streamingState,
       initError,

--- a/src/copilot-shell/packages/cli/src/ui/commands/hooksCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/hooksCommand.ts
@@ -13,6 +13,12 @@ import type {
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 import type { HookRegistryEntry } from '@copilot-shell/core';
+import { HookEventName, HookType } from '@copilot-shell/core';
+import { SettingScope } from '../../config/settings.js';
+import process from 'node:process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Format hook source for display
@@ -252,13 +258,183 @@ const disableCommand: SlashCommand = {
   },
 };
 
+const installCommand: SlashCommand = {
+  name: 'install',
+  get description() {
+    return t('Install sandbox-guard hooks into user settings');
+  },
+  kind: CommandKind.BUILT_IN,
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<MessageActionReturn> => {
+    const { config, settings } = context.services;
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Config not loaded.'),
+      };
+    }
+
+    // Determine script paths
+    const scriptArg = args.trim();
+    const homeDir = process.env['HOME'] || process.env['USERPROFILE'] || '~';
+    const hooksDir = `${homeDir}/.copilot-shell/hooks`;
+
+    // Locate bundled hooks directory:
+    //   Production: $COSH_DATA_DIR/hooks/  (set by cosh-wrapper.sh at install time)
+    //   Development (esbuild bundle): dist/hooks/  (adjacent to dist/cli.js)
+    //   Development (tsc output):     packages/cli/dist/hooks/  (3 levels up)
+    let bundledHooksDir: string;
+    const dataDir = process.env['COSH_DATA_DIR'];
+    if (dataDir) {
+      bundledHooksDir = path.join(dataDir, 'hooks');
+    } else {
+      const thisFile = fileURLToPath(import.meta.url);
+      const distDir = path.dirname(thisFile);
+      const bundleHooksCandidate = path.join(distDir, 'hooks');
+      const tscHooksCandidate = path.join(distDir, '..', '..', '..', 'hooks');
+      bundledHooksDir = fs.existsSync(bundleHooksCandidate)
+        ? bundleHooksCandidate
+        : tscHooksCandidate;
+    }
+
+    // Resolve effective script paths:
+    //   Priority: explicit CLI arg > ~/.copilot-shell/hooks/ (after copy) > bundled fallback
+    // If the user dir script doesn't exist AND the bundled script does, use bundled path
+    // directly so hooks always work even without a successful copy.
+    function resolveScriptPath(scriptName: string, override?: string): string {
+      if (override) return override;
+      const userPath = path.join(hooksDir, scriptName);
+      if (fs.existsSync(userPath)) return userPath;
+      const bundledPath = path.join(bundledHooksDir, scriptName);
+      if (fs.existsSync(bundledPath)) return bundledPath;
+      return userPath; // fall back to user path (will be copied below)
+    }
+
+    // Ensure user hooks directory exists and copy bundled scripts (always overwrite)
+    const copyErrors: string[] = [];
+    try {
+      fs.mkdirSync(hooksDir, { recursive: true });
+      for (const script of ['sandbox-guard.py', 'sandbox-failure-handler.py']) {
+        const dest = path.join(hooksDir, script);
+        const src = path.join(bundledHooksDir, script);
+        if (fs.existsSync(src)) {
+          fs.copyFileSync(src, dest);
+          fs.chmodSync(dest, 0o755);
+        } else {
+          copyErrors.push(`bundled script not found: ${src}`);
+        }
+      }
+    } catch (err) {
+      copyErrors.push(String(err));
+    }
+
+    const guardScript = resolveScriptPath(
+      'sandbox-guard.py',
+      scriptArg || undefined,
+    );
+    const failureScript = resolveScriptPath('sandbox-failure-handler.py');
+    const preToolUseEntry = {
+      hooks: [
+        {
+          type: 'command',
+          command: `python3 ${guardScript}`,
+          name: 'sandbox-guard',
+        },
+      ],
+    };
+    const postToolUseFailureEntry = {
+      hooks: [
+        {
+          type: 'command',
+          command: `python3 ${failureScript}`,
+          name: 'sandbox-failure-handler',
+        },
+      ],
+    };
+
+    // Read current user hooks config (if any)
+    const currentHooks =
+      (
+        settings.forScope(SettingScope.User).settings as Record<string, unknown>
+      )['hooks'] ?? {};
+    const hooksConfig = (currentHooks ?? {}) as Record<string, unknown>;
+
+    // Check idempotency: skip if sandbox-guard is already registered
+    const preToolUseList = (hooksConfig['PreToolUse'] as unknown[]) ?? [];
+    const alreadyInstalled = preToolUseList.some(
+      (entry: unknown) =>
+        Array.isArray((entry as Record<string, unknown>)['hooks']) &&
+        ((entry as Record<string, unknown>)['hooks'] as unknown[]).some(
+          (h: unknown) =>
+            (h as Record<string, unknown>)['name'] === 'sandbox-guard',
+        ),
+    );
+
+    if (!alreadyInstalled) {
+      // Merge new hooks into the existing config
+      const newHooksConfig = {
+        ...hooksConfig,
+        PreToolUse: [...preToolUseList, preToolUseEntry],
+        PostToolUseFailure: [
+          ...((hooksConfig['PostToolUseFailure'] as unknown[]) ?? []),
+          postToolUseFailureEntry,
+        ],
+      };
+      settings.setValue(SettingScope.User, 'hooks', newHooksConfig);
+    }
+
+    // Activate hooks in the current session via dynamic registration
+    const hookSystem = config.getHookSystem();
+    if (hookSystem) {
+      hookSystem.registerHook(HookEventName.PreToolUse, {
+        type: HookType.Command,
+        command: `python3 ${guardScript}`,
+        name: 'sandbox-guard',
+      });
+      hookSystem.registerHook(HookEventName.PostToolUseFailure, {
+        type: HookType.Command,
+        command: `python3 ${failureScript}`,
+        name: 'sandbox-failure-handler',
+      });
+      // Enable both hooks
+      hookSystem.setHookEnabled('sandbox-guard', true);
+      hookSystem.setHookEnabled('sandbox-failure-handler', true);
+    }
+
+    const alreadyMsg = alreadyInstalled
+      ? t(' (already in settings, session hooks refreshed)')
+      : '';
+    const copyErrMsg =
+      copyErrors.length > 0
+        ? `\n⚠ Script copy warnings:\n${copyErrors.map((e) => `  - ${e}`).join('\n')}`
+        : '';
+
+    return {
+      type: 'message',
+      messageType: copyErrors.length > 0 ? 'error' : 'info',
+      content: t(
+        'sandbox-guard installed{{already}}\n- PreToolUse: {{guard}}\n- PostToolUseFailure: {{failure}}{{copyErr}}',
+        {
+          already: alreadyMsg,
+          guard: guardScript,
+          failure: failureScript,
+          copyErr: copyErrMsg,
+        },
+      ),
+    };
+  },
+};
+
 export const hooksCommand: SlashCommand = {
   name: 'hooks',
   get description() {
     return t('Manage Cosh hooks');
   },
   kind: CommandKind.BUILT_IN,
-  subCommands: [listCommand, enableCommand, disableCommand],
+  subCommands: [listCommand, enableCommand, disableCommand, installCommand],
   action: async (
     context: CommandContext,
     args: string,
@@ -283,12 +459,15 @@ export const hooksCommand: SlashCommand = {
       case 'disable':
         result = await disableCommand.action?.(context, subArgs);
         break;
+      case 'install':
+        result = await installCommand.action?.(context, subArgs);
+        break;
       default:
         return {
           type: 'message',
           messageType: 'error',
           content: t(
-            'Unknown subcommand: {{cmd}}. Available: list, enable, disable',
+            'Unknown subcommand: {{cmd}}. Available: list, enable, disable, install',
             {
               cmd: subcommand,
             },
@@ -298,7 +477,7 @@ export const hooksCommand: SlashCommand = {
     return result ?? { type: 'message', messageType: 'info', content: '' };
   },
   completion: async (context: CommandContext, partialArg: string) => {
-    const subcommands = ['list', 'enable', 'disable'];
+    const subcommands = ['list', 'enable', 'disable', 'install'];
     const parts = partialArg.split(/\s+/);
 
     if (parts.length <= 1) {

--- a/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
@@ -169,6 +169,22 @@ export const DialogManager = ({
       />
     );
   }
+  if (uiState.sandboxBypassRequest) {
+    const { original_command, reason, onComplete } =
+      uiState.sandboxBypassRequest;
+    return (
+      <ConsentPrompt
+        prompt={
+          `**沙箱执行失败 — 是否允许直接运行？**\n\n` +
+          `命令：\`${original_command}\`\n\n` +
+          `原因：${reason}\n\n` +
+          `确认后将临时禁用沙箱防护，执行完毕后自动恢复。`
+        }
+        onConfirm={onComplete}
+        terminalWidth={terminalWidth}
+      />
+    );
+  }
   if (uiState.confirmationRequest) {
     return (
       <ConsentPrompt

--- a/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -12,6 +12,7 @@ import type {
   ShellConfirmationRequest,
   ConfirmationRequest,
   LoopDetectionConfirmationRequest,
+  SandboxBypassRequest,
   HistoryItemWithoutId,
   StreamingState,
   SettingInputRequest,
@@ -64,6 +65,7 @@ export interface UIState {
   settingInputRequests: SettingInputRequest[];
   pluginChoiceRequests: PluginChoiceRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
+  sandboxBypassRequest: SandboxBypassRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -16,6 +16,7 @@ import type {
   ThoughtSummary,
   ToolCallRequestInfo,
   GeminiErrorEventValue,
+  SandboxBypassApprovalRequest,
 } from '@copilot-shell/core';
 import {
   GeminiEventType as ServerGeminiEventType,
@@ -42,6 +43,7 @@ import type {
   HistoryItemWithoutId,
   HistoryItemToolGroup,
   SlashCommandProcessorResult,
+  SandboxBypassRequest,
 } from '../types.js';
 import { StreamingState, MessageType, ToolCallStatus } from '../types.js';
 import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
@@ -149,6 +151,24 @@ export const useGeminiStream = (
     setShellInputFocused(true);
   }, [setShellInputFocused]);
 
+  const [sandboxBypassRequest, setSandboxBypassRequest] =
+    useState<SandboxBypassRequest | null>(null);
+
+  const handleSandboxBypassRequested = useCallback(
+    (request: SandboxBypassApprovalRequest): Promise<boolean> =>
+      new Promise<boolean>((resolve) => {
+        setSandboxBypassRequest({
+          original_command: request.original_command,
+          reason: request.reason,
+          onComplete: (approved: boolean) => {
+            setSandboxBypassRequest(null);
+            resolve(approved);
+          },
+        });
+      }),
+    [],
+  );
+
   const [toolCalls, scheduleToolCalls, markToolsAsSubmitted] =
     useReactToolScheduler(
       async (completedToolCallsFromScheduler) => {
@@ -172,6 +192,7 @@ export const useGeminiStream = (
       getPreferredEditor,
       onEditorClose,
       handlePasswordPrompt,
+      handleSandboxBypassRequested,
     );
 
   const pendingToolCallGroupDisplay = useMemo(
@@ -1392,5 +1413,6 @@ export const useGeminiStream = (
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    sandboxBypassRequest,
   };
 };

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -19,6 +19,7 @@ import type {
   ToolCall,
   Status as CoreStatus,
   EditorType,
+  SandboxBypassApprovalRequest,
 } from '@copilot-shell/core';
 import { CoreToolScheduler } from '@copilot-shell/core';
 import { useCallback, useState, useMemo } from 'react';
@@ -74,6 +75,9 @@ export function useReactToolScheduler(
   getPreferredEditor: () => EditorType | undefined,
   onEditorClose: () => void,
   onPasswordPrompt?: () => void,
+  onSandboxBypassRequested?: (
+    request: SandboxBypassApprovalRequest,
+  ) => Promise<boolean>,
 ): [TrackedToolCall[], ScheduleFn, MarkToolsAsSubmittedFn] {
   const [toolCallsForDisplay, setToolCallsForDisplay] = useState<
     TrackedToolCall[]
@@ -161,6 +165,7 @@ export function useReactToolScheduler(
         getPreferredEditor,
         onEditorClose,
         onPasswordPrompt,
+        onSandboxBypassRequested,
       }),
     [
       config,
@@ -170,6 +175,7 @@ export function useReactToolScheduler(
       getPreferredEditor,
       onEditorClose,
       onPasswordPrompt,
+      onSandboxBypassRequested,
     ],
   );
 

--- a/src/copilot-shell/packages/cli/src/ui/types.ts
+++ b/src/copilot-shell/packages/cli/src/ui/types.ts
@@ -413,6 +413,15 @@ export interface LoopDetectionConfirmationRequest {
   onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
 }
 
+export interface SandboxBypassRequest {
+  /** The command that failed inside the sandbox */
+  original_command: string;
+  /** Why bypass is being requested */
+  reason: string;
+  /** Called with true=allow, false=deny */
+  onComplete: (approved: boolean) => void;
+}
+
 export interface SettingInputRequest {
   settingName: string;
   settingDescription: string;

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -31,6 +31,7 @@ import {
   InputFormat,
   SkillTool,
 } from '../index.js';
+import type { SandboxBypassApprovalRequest } from '../index.js';
 import type {
   FunctionResponse,
   FunctionResponsePart,
@@ -355,6 +356,14 @@ interface CoreToolSchedulerOptions {
    * Optional callback invoked when a password prompt (e.g. sudo) is detected.
    */
   onPasswordPrompt?: () => void;
+  /**
+   * Optional callback invoked when a sandbox-guarded command fails and the
+   * sandbox-failure-handler hook requests a bypass approval dialog.
+   * Returns true if the user approved the bypass, false otherwise.
+   */
+  onSandboxBypassRequested?: (
+    request: SandboxBypassApprovalRequest,
+  ) => Promise<boolean>;
 }
 
 export class CoreToolScheduler {
@@ -368,6 +377,9 @@ export class CoreToolScheduler {
   private onEditorClose: () => void;
   private chatRecordingService?: ChatRecordingService;
   private onPasswordPrompt?: () => void;
+  private onSandboxBypassRequested?: (
+    request: SandboxBypassApprovalRequest,
+  ) => Promise<boolean>;
   private isFinalizingToolCalls = false;
   private isScheduling = false;
   private requestQueue: Array<{
@@ -387,6 +399,7 @@ export class CoreToolScheduler {
     this.onEditorClose = options.onEditorClose;
     this.chatRecordingService = options.chatRecordingService;
     this.onPasswordPrompt = options.onPasswordPrompt;
+    this.onSandboxBypassRequested = options.onSandboxBypassRequested;
   }
 
   private setStatusInternal(
@@ -1312,12 +1325,115 @@ export class CoreToolScheduler {
           } else {
             // It is a failure
             const error = new Error(toolResult.error.message);
-            const errorResponse = createErrorResponse(
-              scheduledCall.request,
-              error,
-              toolResult.error.type,
-            );
-            this.setStatusInternal(callId, 'error', errorResponse);
+
+            // Attempt sandbox bypass if hooks are enabled and a bypass callback is registered
+            let handledBySandboxBypass = false;
+            if (
+              this.config.getEnableHooks() &&
+              this.onSandboxBypassRequested &&
+              toolName === ShellTool.Name
+            ) {
+              const hookSystem = this.config.getHookSystem();
+              if (hookSystem) {
+                try {
+                  const failureOutput =
+                    await hookSystem.firePostToolUseFailureEvent(
+                      callId,
+                      toolName,
+                      scheduledCall.request.args,
+                      toolResult.error.message,
+                      toolResult.error.type,
+                    );
+                  const bypassRequest =
+                    failureOutput?.getSandboxBypassRequest?.();
+                  if (bypassRequest) {
+                    const approved =
+                      await this.onSandboxBypassRequested(bypassRequest);
+                    if (approved) {
+                      hookSystem.setHookEnabled('sandbox-guard', false);
+                      try {
+                        const originalArgs = {
+                          ...scheduledCall.request.args,
+                          command: bypassRequest.original_command,
+                        };
+                        const originalInvocation = this.buildInvocation(
+                          scheduledCall.tool,
+                          originalArgs,
+                        );
+                        if (!(originalInvocation instanceof Error)) {
+                          let retryPromise: Promise<ToolResult>;
+                          if (
+                            originalInvocation instanceof ShellToolInvocation
+                          ) {
+                            // Provide a setPidCallback so the bypass process pid
+                            // is tracked in tool call state. Without this, the
+                            // ShellInputPrompt would keep referencing the dead
+                            // linux-sandbox PTY and sudo password input would fail.
+                            const bypassSetPidCallback = (pid: number) => {
+                              this.toolCalls = this.toolCalls.map((tc) =>
+                                tc.request.callId === callId &&
+                                tc.status === 'executing'
+                                  ? { ...tc, pid }
+                                  : tc,
+                              );
+                              this.notifyToolCallsUpdate();
+                            };
+                            retryPromise = originalInvocation.execute(
+                              signal,
+                              liveOutputCallback,
+                              shellExecutionConfig,
+                              bypassSetPidCallback,
+                              this.onPasswordPrompt,
+                            );
+                          } else {
+                            retryPromise = originalInvocation.execute(
+                              signal,
+                              liveOutputCallback,
+                              shellExecutionConfig,
+                            );
+                          }
+                          const retryResult = await retryPromise;
+                          if (retryResult.error === undefined) {
+                            const retryContent = retryResult.llmContent;
+                            const retryResponse = convertToFunctionResponse(
+                              toolName,
+                              callId,
+                              retryContent,
+                            );
+                            this.setStatusInternal(callId, 'success', {
+                              callId,
+                              responseParts: retryResponse,
+                              resultDisplay: retryResult.returnDisplay,
+                              error: undefined,
+                              errorType: undefined,
+                            });
+                            handledBySandboxBypass = true;
+                          }
+                        }
+                      } finally {
+                        hookSystem.setHookEnabled('sandbox-guard', true);
+                      }
+                    }
+                  }
+                } catch (hookErr) {
+                  // Hook errors are non-fatal
+                  if (this.config.getDebugMode()) {
+                    console.debug(
+                      `PostToolUseFailure hook error (non-fatal): ${hookErr}`,
+                    );
+                  }
+                }
+              }
+            }
+
+            if (!handledBySandboxBypass) {
+              const errorResponse = createErrorResponse(
+                scheduledCall.request,
+                error,
+                toolResult.error.type,
+              );
+              this.setStatusInternal(callId, 'error', errorResponse);
+            }
           }
         } catch (executionError: unknown) {
           if (signal.aborted) {

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
@@ -16,6 +16,7 @@ import type {
   UserPromptSubmitInput,
   StopInput,
   PreToolUseInput,
+  PostToolUseFailureInput,
 } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
@@ -89,6 +90,29 @@ export class HookEventHandler {
     };
 
     return this.executeHooks(HookEventName.Stop, input);
+  }
+
+  /**
+   * Fire a PostToolUseFailure event
+   * Called after a tool execution fails, allowing hooks to react and request bypasses
+   */
+  async firePostToolUseFailureEvent(
+    toolUseId: string,
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    error: string,
+    errorType?: string,
+  ): Promise<AggregatedHookResult> {
+    const input: PostToolUseFailureInput = {
+      ...this.createBaseInput(HookEventName.PostToolUseFailure),
+      tool_use_id: toolUseId,
+      tool_name: toolName,
+      tool_input: toolInput,
+      error,
+      error_type: errorType,
+    };
+
+    return this.executeHooks(HookEventName.PostToolUseFailure, input);
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/hooks/hookRegistry.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookRegistry.ts
@@ -122,6 +122,44 @@ export class HookRegistry {
   }
 
   /**
+   * Dynamically register a hook for the current session.
+   * Useful for /hooks install to activate hooks immediately without restart.
+   */
+  registerHook(
+    eventName: HookEventName,
+    hookConfig: HookConfig,
+    source: HooksConfigSource = HooksConfigSource.User,
+  ): void {
+    const hookName = hookConfig.name || hookConfig.command || 'unknown-command';
+    const disabledHooks = this.config.getDisabledHooks();
+    const isDisabled = disabledHooks.includes(hookName);
+
+    // Skip duplicates: same name + eventName already registered
+    const isDuplicate = this.entries.some(
+      (existing) =>
+        existing.eventName === eventName &&
+        this.getHookName(existing) === hookName,
+    );
+    if (isDuplicate) {
+      debugLogger.debug(
+        `Hook "${hookName}" already registered for ${eventName}, skipping`,
+      );
+      return;
+    }
+
+    hookConfig.source = source;
+    this.entries.push({
+      config: hookConfig,
+      source,
+      eventName,
+      enabled: !isDisabled,
+    });
+    debugLogger.info(
+      `Dynamically registered hook "${hookName}" for ${eventName}`,
+    );
+  }
+
+  /**
    * Get hook name for identification and display purposes
    */
   private getHookName(

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -12,8 +12,14 @@ import { HookPlanner } from './hookPlanner.js';
 import { HookEventHandler } from './hookEventHandler.js';
 import type { HookRegistryEntry } from './hookRegistry.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import type { DefaultHookOutput, PreToolUseHookOutput } from './types.js';
-import { createHookOutput } from './types.js';
+import type {
+  DefaultHookOutput,
+  PreToolUseHookOutput,
+  PostToolUseFailureHookOutput,
+  HookEventName,
+  HookConfig,
+} from './types.js';
+import { createHookOutput, HooksConfigSource } from './types.js';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
 
@@ -115,5 +121,39 @@ export class HookSystem {
     return result.finalOutput
       ? createHookOutput('Stop', result.finalOutput)
       : undefined;
+  }
+
+  async firePostToolUseFailureEvent(
+    toolUseId: string,
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    error: string,
+    errorType?: string,
+  ): Promise<PostToolUseFailureHookOutput | undefined> {
+    const result = await this.hookEventHandler.firePostToolUseFailureEvent(
+      toolUseId,
+      toolName,
+      toolInput,
+      error,
+      errorType,
+    );
+    return result.finalOutput
+      ? (createHookOutput(
+          'PostToolUseFailure',
+          result.finalOutput,
+        ) as PostToolUseFailureHookOutput)
+      : undefined;
+  }
+
+  /**
+   * Dynamically register a hook for the current session.
+   * Used by /hooks install to activate hooks immediately without restart.
+   */
+  registerHook(
+    eventName: HookEventName,
+    hookConfig: HookConfig,
+    source: HooksConfigSource = HooksConfigSource.User,
+  ): void {
+    this.hookRegistry.registerHook(eventName, hookConfig, source);
   }
 }

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -129,6 +129,8 @@ export function createHookOutput(
       return new StopHookOutput(data);
     case HookEventName.PermissionRequest:
       return new PermissionRequestHookOutput(data);
+    case HookEventName.PostToolUseFailure:
+      return new PostToolUseFailureHookOutput(data);
     default:
       return new DefaultHookOutput(data);
   }
@@ -438,6 +440,17 @@ export interface PostToolUseFailureInput extends HookInput {
 }
 
 /**
+ * Sandbox bypass approval request
+ * Emitted by sandbox-failure-handler hook when a sandbox execution fails
+ */
+export interface SandboxBypassApprovalRequest {
+  /** The original command to run without sandbox wrapping */
+  original_command: string;
+  /** Human-readable reason why bypass is being requested */
+  reason: string;
+}
+
+/**
  * PostToolUseFailure hook output
  * Supports all three hook types: command, prompt, and agent
  */
@@ -445,7 +458,35 @@ export interface PostToolUseFailureOutput extends HookOutput {
   hookSpecificOutput?: {
     hookEventName: 'PostToolUseFailure';
     additionalContext?: string;
+    /** If present, the hook requests a sandbox bypass approval dialog */
+    sandbox_bypass_request?: SandboxBypassApprovalRequest;
   };
+}
+
+/**
+ * Specific hook output class for PostToolUseFailure events.
+ */
+export class PostToolUseFailureHookOutput extends DefaultHookOutput {
+  /**
+   * Get sandbox bypass request if provided by hook
+   */
+  getSandboxBypassRequest(): SandboxBypassApprovalRequest | undefined {
+    if (
+      this.hookSpecificOutput &&
+      'sandbox_bypass_request' in this.hookSpecificOutput
+    ) {
+      const req = this.hookSpecificOutput['sandbox_bypass_request'];
+      if (
+        typeof req === 'object' &&
+        req !== null &&
+        'original_command' in req &&
+        'reason' in req
+      ) {
+        return req as SandboxBypassApprovalRequest;
+      }
+    }
+    return undefined;
+  }
 }
 
 /**

--- a/src/copilot-shell/packages/core/src/tools/shell.ts
+++ b/src/copilot-shell/packages/core/src/tools/shell.ts
@@ -385,6 +385,16 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
 
       const summarizeConfig = this.config.getSummarizeToolOutputConfig();
+      // Synthesize an error for sandboxed commands that exit with a non-zero
+      // code without a Node.js-level exception.  This ensures PostToolUseFailure
+      // is fired so sandbox-failure-handler.py can request a bypass dialog.
+      const isSandboxedCommand = this.params.command.includes('linux-sandbox');
+      const isSandboxExitFailure =
+        !result.error &&
+        !result.aborted &&
+        result.exitCode !== null &&
+        result.exitCode !== 0 &&
+        isSandboxedCommand;
       const executionError = result.error
         ? {
             error: {
@@ -392,7 +402,16 @@ export class ShellToolInvocation extends BaseToolInvocation<
               type: ToolErrorType.SHELL_EXECUTE_ERROR,
             },
           }
-        : {};
+        : isSandboxExitFailure
+          ? {
+              error: {
+                message:
+                  result.output.trim() ||
+                  `Command exited with code ${result.exitCode}`,
+                type: ToolErrorType.SHELL_EXECUTE_ERROR,
+              },
+            }
+          : {};
       if (summarizeConfig && summarizeConfig[ShellTool.Name]) {
         const summary = await summarizeToolOutput(
           llmContent,

--- a/src/copilot-shell/scripts/copy_files.js
+++ b/src/copilot-shell/scripts/copy_files.js
@@ -81,6 +81,23 @@ if (packageName === 'cli') {
   if (fs.existsSync(examplesSource)) {
     fs.cpSync(examplesSource, examplesTarget, { recursive: true });
   }
+
+  // Copy hooks/*.py scripts into dist/hooks/ so installCommand can deploy them
+  const hooksSource = path.join('..', '..', 'hooks');
+  const hooksTarget = path.join('dist', 'hooks');
+  if (fs.existsSync(hooksSource)) {
+    if (!fs.existsSync(hooksTarget)) {
+      fs.mkdirSync(hooksTarget, { recursive: true });
+    }
+    for (const file of fs.readdirSync(hooksSource)) {
+      if (file.endsWith('.py')) {
+        fs.copyFileSync(
+          path.join(hooksSource, file),
+          path.join(hooksTarget, file),
+        );
+      }
+    }
+  }
 }
 
 console.log('Successfully copied files.');

--- a/src/copilot-shell/scripts/cosh-wrapper.sh
+++ b/src/copilot-shell/scripts/cosh-wrapper.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # copilot-shell wrapper — locates Node.js and launches cli.js
-# @@LIBDIR@@ is replaced at install time by `make install`.
+# @@LIBDIR@@ and @@DATADIR@@ are replaced at install time by `make install`.
 
 LIBDIR="@@LIBDIR@@"
+export COSH_DATA_DIR="@@DATADIR@@"
 
 # ── Resolve Node.js when not already in PATH (e.g. nvm-managed installs) ──
 if ! command -v node >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

Add a complete sandbox interception and bypass approval flow to copilot-shell. A new `/hooks install` slash command registers two Python hooks (`sandbox-guard` as `PreToolUse`, `sandbox-failure-handler` as `PostToolUseFailure`) with a single command. Dangerous shell commands (writes to `/etc/`, `rm -rf`, package manager operations, etc.) are automatically wrapped in `linux-sandbox` for isolation; when the sandbox blocks a legitimate privileged operation, a UI approval dialog lets the user authorize a one-time bypass that re-executes the original command — including the original `sudo` prefix — outside the sandbox.

Key implementation decisions:
- The full original command (with `sudo`) is preserved by encoding it as `COSH_RC=<base64>` inside the sandbox command string, since `sandbox-guard` (PreToolUse) and `sandbox-failure-handler` (PostToolUseFailure) run as separate processes with no shared state.
- A `bypassSetPidCallback` is added to the bypass execution path so the new PTY's pid is tracked in React state, enabling `ShellInputPrompt` to route sudo password input correctly.
- `/hooks install` now always overwrites existing hook scripts so RPM upgrades propagate fixes automatically.

## Related Issue

closes #25
closes #124

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell && make test
```

Manual end-to-end verification:
1. Run `node dist/cli.js`, execute `/hooks install` → confirms PreToolUse + PostToolUseFailure hooks registered
2. Execute `sudo cat 1 >> /etc/a.txt` → sandbox intercepts, fails with "Read-only file system", approval dialog appears with full `sudo cat 1 >> /etc/a.txt` command
3. Approve bypass → command re-executes outside sandbox, sudo password prompt appears and accepts keyboard input correctly
4. Execute `sudo yum update --security -y` → intercepted as network+package-manager command, sandbox fails, bypass dialog triggered
5. Deny bypass → tool reports error as normal, sandbox-guard re-enabled

## Additional Notes

- Hook scripts are installed to `/usr/share/copilot-shell/hooks/` in RPM builds; `cosh-wrapper.sh` injects `COSH_DATA_DIR` so `/hooks install` resolves bundled scripts correctly post-RPM-install.
- The `COSH_RC` base64 encoding adds no visible side effects to the sandboxed command execution — it is set as an environment variable within the `bash -c` string and ignored by the underlying command.