### PR TITLE
feat(cosh): add custom skill paths support via settings.json

### DIFF
--- a/src/copilot-shell/packages/cli/src/config/config.ts
+++ b/src/copilot-shell/packages/cli/src/config/config.ts
@@ -995,6 +995,7 @@ export async function loadCliConfig(
     skillOS: settings.skillOS?.baseUrl
       ? { baseUrl: settings.skillOS.baseUrl }
       : undefined,
+    customSkillPaths: settings.skills?.customPaths ?? [],
     summarizeToolOutput: settings.model?.summarizeToolOutput,
     ideMode,
     chatCompression: settings.model?.chatCompression,

--- a/src/copilot-shell/packages/cli/src/config/settingsSchema.test.ts
+++ b/src/copilot-shell/packages/cli/src/config/settingsSchema.test.ts
@@ -311,5 +311,13 @@ describe('SettingsSchema', () => {
           .description,
       ).toBe('Enable debug logging of keystrokes to the console.');
     });
+
+    it('should have skills.customPaths setting', () => {
+      const schema = getSettingsSchema();
+      expect(schema.skills).toBeDefined();
+      expect(schema.skills.properties?.customPaths).toBeDefined();
+      expect(schema.skills.properties?.customPaths.type).toBe('array');
+      expect(schema.skills.properties?.customPaths.default).toEqual([]);
+    });
   });
 });

--- a/src/copilot-shell/packages/cli/src/config/settingsSchema.ts
+++ b/src/copilot-shell/packages/cli/src/config/settingsSchema.ts
@@ -1215,6 +1215,27 @@ const SETTINGS_SCHEMA = {
       },
     },
   },
+  skills: {
+    type: 'object',
+    label: 'Skills',
+    category: 'Skills',
+    requiresRestart: true,
+    default: {},
+    description: 'Configuration for skill discovery and custom skill paths.',
+    showInDialog: false,
+    properties: {
+      customPaths: {
+        type: 'array',
+        label: 'Custom Skill Paths',
+        category: 'Skills',
+        requiresRestart: true,
+        default: [] as string[],
+        description:
+          'Additional directories to scan for skills. Supports ~ (home directory), $VAR and ${VAR} environment variable expansion. Each path should point to a directory containing skill subdirectories with SKILL.md files.',
+        showInDialog: false,
+      },
+    },
+  },
 
   hooksConfig: {
     type: 'object',

--- a/src/copilot-shell/packages/core/src/config/config.test.ts
+++ b/src/copilot-shell/packages/core/src/config/config.test.ts
@@ -1543,3 +1543,36 @@ describe('Skill-OS Configuration', () => {
     expect(config.isRemoteSkillsEnabled()).toBe(true);
   });
 });
+
+describe('Custom Skill Paths Configuration', () => {
+  const baseParams: ConfigParameters = {
+    cwd: '/tmp',
+    embeddingModel: 'test-embedding-model',
+    targetDir: '/path/to/target',
+    debugMode: false,
+    usageStatisticsEnabled: false,
+    overrideExtensions: [],
+  };
+
+  it('should return empty array when customSkillPaths is not configured', () => {
+    const config = new Config({ ...baseParams });
+    expect(config.getCustomSkillPaths()).toEqual([]);
+  });
+
+  it('should return raw custom skill paths as configured', () => {
+    const config = new Config({
+      ...baseParams,
+      customSkillPaths: ['~/a', '/b'],
+    });
+    expect(config.getCustomSkillPaths()).toEqual(['~/a', '/b']);
+  });
+
+  it('should return resolved custom skill paths via getResolvedCustomSkillPaths', () => {
+    const config = new Config({
+      ...baseParams,
+      customSkillPaths: ['/absolute/path'],
+    });
+    const resolved = config.getResolvedCustomSkillPaths();
+    expect(resolved).toEqual(['/absolute/path']);
+  });
+});

--- a/src/copilot-shell/packages/core/src/config/config.ts
+++ b/src/copilot-shell/packages/core/src/config/config.ts
@@ -382,6 +382,8 @@ export interface ConfigParameters {
     /** Base URL of the remote Skill-OS API. When set, remote skills will be enabled. */
     baseUrl?: string;
   };
+  /** User-defined custom skill directory paths (supports ~, $VAR, ${VAR} expansion) */
+  customSkillPaths?: string[];
 }
 
 function normalizeConfigOutputFormat(
@@ -524,6 +526,7 @@ export class Config {
   private readonly skillOSConfig?: {
     baseUrl?: string;
   };
+  private readonly customSkillPaths: string[];
   private readonly enableHooks: boolean;
   private readonly hooks?: Record<string, unknown>;
   private readonly hooksConfig?: Record<string, unknown>;
@@ -643,6 +646,7 @@ export class Config {
     this.storage = new Storage(this.targetDir);
     this.vlmSwitchMode = params.vlmSwitchMode;
     this.skillOSConfig = params.skillOS;
+    this.customSkillPaths = params.customSkillPaths ?? [];
     this.enableHooks = params.enableHooks ?? false;
     this.hooks = params.hooks;
     this.hooksConfig = params.hooksConfig;
@@ -1829,6 +1833,20 @@ export class Config {
   // ============================================================================
   // Skill-OS Configuration
   // ============================================================================
+
+  /**
+   * 获取用户自定义技能路径（原始值，未展开）。
+   */
+  getCustomSkillPaths(): string[] {
+    return this.customSkillPaths;
+  }
+
+  /**
+   * 获取用户自定义技能路径（已展开 ~, $VAR, ${VAR} 并解析为绝对路径）。
+   */
+  getResolvedCustomSkillPaths(): string[] {
+    return this.storage.resolveCustomSkillPaths(this.customSkillPaths);
+  }
 
   /**
    * 获取 Skill-OS URL.

--- a/src/copilot-shell/packages/core/src/config/storage.test.ts
+++ b/src/copilot-shell/packages/core/src/config/storage.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { Storage } from './storage.js';
@@ -42,5 +42,82 @@ describe('Storage – additional helpers', () => {
       'mcp-oauth-tokens.json',
     );
     expect(Storage.getMcpOAuthTokensPath()).toBe(expected);
+  });
+});
+
+describe('Storage – resolveCustomSkillPaths', () => {
+  const storage = new Storage('/tmp/project');
+  const homeDir = os.homedir();
+
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('expands tilde to home directory', () => {
+    const result = storage.resolveCustomSkillPaths(['~/my-skills']);
+    expect(result).toEqual([path.join(homeDir, 'my-skills')]);
+  });
+
+  it('expands standalone tilde', () => {
+    const result = storage.resolveCustomSkillPaths(['~']);
+    expect(result).toEqual([homeDir]);
+  });
+
+  it('expands $HOME variable', () => {
+    process.env['HOME'] = homeDir;
+    const result = storage.resolveCustomSkillPaths(['$HOME/skills']);
+    expect(result).toEqual([path.join(homeDir, 'skills')]);
+  });
+
+  it('expands ${USER} variable', () => {
+    const username = process.env['USER'] || 'testuser';
+    process.env['USER'] = username;
+    const result = storage.resolveCustomSkillPaths([`/opt/\${USER}/skills`]);
+    expect(result).toEqual([`/opt/${username}/skills`]);
+  });
+
+  it('preserves absolute paths unchanged', () => {
+    const result = storage.resolveCustomSkillPaths(['/usr/local/skills']);
+    expect(result).toEqual(['/usr/local/skills']);
+  });
+
+  it('resolves relative paths to absolute', () => {
+    const result = storage.resolveCustomSkillPaths(['./local-skills']);
+    expect(result).toEqual([path.resolve('./local-skills')]);
+  });
+
+  it('filters out empty and whitespace-only strings', () => {
+    const result = storage.resolveCustomSkillPaths(['', '  ', '/valid']);
+    expect(result).toEqual(['/valid']);
+  });
+
+  it('returns empty array for empty input', () => {
+    const result = storage.resolveCustomSkillPaths([]);
+    expect(result).toEqual([]);
+  });
+
+  it('handles mixed paths correctly', () => {
+    process.env['HOME'] = homeDir;
+    const result = storage.resolveCustomSkillPaths(['~/a', '$HOME/b', '/c']);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(path.join(homeDir, 'a'));
+    expect(result[1]).toBe(path.join(homeDir, 'b'));
+    expect(result[2]).toBe('/c');
+  });
+
+  it('preserves undefined env vars as-is', () => {
+    delete process.env['UNDEFINED_VAR_XYZ'];
+    const result = storage.resolveCustomSkillPaths([
+      '$UNDEFINED_VAR_XYZ/skills',
+    ]);
+    // resolveEnvVarsInString preserves unresolved vars, then path.resolve makes absolute
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('$UNDEFINED_VAR_XYZ');
   });
 });

--- a/src/copilot-shell/packages/core/src/config/storage.ts
+++ b/src/copilot-shell/packages/core/src/config/storage.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
+import { resolveEnvVarsInString } from '../utils/envVarResolver.js';
 
 export const QWEN_DIR = '.copilot-shell';
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
@@ -159,6 +160,34 @@ export class Storage {
 
   getHistoryFilePath(): string {
     return path.join(this.getProjectTempDir(), 'shell_history');
+  }
+
+  /**
+   * Resolves an array of custom skill paths by expanding:
+   * - ~ and ~/ to user's home directory
+   * - $VAR and ${VAR} to environment variable values
+   * Then resolves to absolute paths.
+   *
+   * Invalid or empty paths after resolution are filtered out.
+   */
+  resolveCustomSkillPaths(rawPaths: string[]): string[] {
+    const homeDir = os.homedir();
+    return rawPaths
+      .map((p) => {
+        let expanded = p.trim();
+        if (!expanded) return '';
+        // Expand tilde
+        if (expanded === '~') {
+          expanded = homeDir;
+        } else if (expanded.startsWith('~/')) {
+          expanded = path.join(homeDir, expanded.slice(2));
+        }
+        // Expand environment variables ($VAR and ${VAR})
+        expanded = resolveEnvVarsInString(expanded);
+        // Resolve to absolute path
+        return path.resolve(expanded);
+      })
+      .filter((p) => p !== '');
   }
 
   private sanitizeCwd(cwd: string): string {

--- a/src/copilot-shell/packages/core/src/skills/skill-manager.test.ts
+++ b/src/copilot-shell/packages/core/src/skills/skill-manager.test.ts
@@ -528,4 +528,233 @@ Skill 3 content`);
       expect(errors.size).toBeGreaterThan(0);
     });
   });
+
+  describe('custom skill paths', () => {
+    it('refreshCache should include custom level in cache', async () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([]);
+      vi.mocked(fs.readdir).mockResolvedValue(
+        [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+      );
+
+      await manager.refreshCache();
+
+      // Access internal cache via listSkills with level filter
+      const customSkills = await manager.listSkills({ level: 'custom' });
+      expect(customSkills).toEqual([]);
+    });
+
+    it('listSkills should prioritize project over custom', async () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([
+        '/custom/skills',
+      ]);
+
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce([
+          { name: 'skill1', isDirectory: () => true, isFile: () => false },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>) // project
+        .mockResolvedValueOnce([
+          { name: 'skill1', isDirectory: () => true, isFile: () => false },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>) // custom
+        .mockResolvedValueOnce(
+          [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        ) // user
+        .mockResolvedValueOnce(
+          [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        ) // system
+        .mockResolvedValue(
+          [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        );
+
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile).mockResolvedValue(`---
+name: skill1
+description: First skill
+---
+Skill 1 content`);
+
+      const skills = await manager.listSkills({ force: true });
+      const skill1 = skills.find((s) => s.name === 'skill1');
+      expect(skill1).toBeDefined();
+      expect(skill1!.level).toBe('project');
+    });
+
+    it('listSkills should prioritize custom over user', async () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([
+        '/custom/skills',
+      ]);
+
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce(
+          [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        ) // project
+        .mockResolvedValueOnce([
+          { name: 'skill1', isDirectory: () => true, isFile: () => false },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>) // custom
+        .mockResolvedValueOnce([
+          { name: 'skill1', isDirectory: () => true, isFile: () => false },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>) // user
+        .mockResolvedValueOnce(
+          [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        ) // system
+        .mockResolvedValue(
+          [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        );
+
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile).mockResolvedValue(`---
+name: skill1
+description: First skill
+---
+Skill 1 content`);
+
+      const skills = await manager.listSkills({ force: true });
+      const skill1 = skills.find((s) => s.name === 'skill1');
+      expect(skill1).toBeDefined();
+      expect(skill1!.level).toBe('custom');
+    });
+
+    it('loadSkill should find custom skill before user skill', async () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([
+        '/custom/skills',
+      ]);
+
+      vi.mocked(fs.readdir)
+        .mockRejectedValueOnce(new Error('No project dir')) // project
+        .mockResolvedValueOnce([
+          { name: 'test-skill', isDirectory: () => true, isFile: () => false },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>) // custom
+        .mockResolvedValue(
+          [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        );
+
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile).mockResolvedValue(`---
+name: test-skill
+description: A test skill
+---
+Content`);
+
+      const skill = await manager.loadSkill('test-skill');
+      expect(skill).toBeDefined();
+      expect(skill!.level).toBe('custom');
+    });
+
+    it('should handle empty custom paths gracefully', async () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([]);
+      vi.mocked(fs.readdir).mockResolvedValue(
+        [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+      );
+
+      const skills = await manager.listSkills({
+        level: 'custom',
+        force: true,
+      });
+      expect(skills).toEqual([]);
+    });
+
+    it('should handle non-existent custom directories', async () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([
+        '/nonexistent/dir',
+      ]);
+      vi.mocked(fs.readdir).mockRejectedValue(new Error('Directory not found'));
+
+      const skills = await manager.listSkills({
+        level: 'custom',
+        force: true,
+      });
+      expect(skills).toEqual([]);
+    });
+
+    it('should load skills from multiple custom directories', async () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([
+        '/custom/dir1',
+        '/custom/dir2',
+      ]);
+
+      let callCount = 0;
+      vi.mocked(fs.readdir).mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // project - empty
+          return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+        }
+        if (callCount === 2) {
+          // custom dir1
+          return [
+            {
+              name: 'skill-a',
+              isDirectory: () => true,
+              isFile: () => false,
+            },
+          ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+        }
+        if (callCount === 3) {
+          // custom dir2
+          return [
+            {
+              name: 'skill-b',
+              isDirectory: () => true,
+              isFile: () => false,
+            },
+          ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+        }
+        // user, system
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+      });
+
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+
+      mockParseYaml.mockImplementation((yamlString: string) => {
+        if (yamlString.includes('name: skill-a')) {
+          return { name: 'skill-a', description: 'Skill A' };
+        }
+        if (yamlString.includes('name: skill-b')) {
+          return { name: 'skill-b', description: 'Skill B' };
+        }
+        return { name: 'unknown', description: 'Unknown' };
+      });
+
+      vi.mocked(fs.readFile).mockImplementation((filePath) => {
+        const pathStr = String(filePath);
+        if (pathStr.includes('skill-a')) {
+          return Promise.resolve(`---
+name: skill-a
+description: Skill A
+---
+Skill A content`);
+        }
+        if (pathStr.includes('skill-b')) {
+          return Promise.resolve(`---
+name: skill-b
+description: Skill B
+---
+Skill B content`);
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+
+      const skills = await manager.listSkills({ force: true });
+      const customSkills = skills.filter((s) => s.level === 'custom');
+      expect(customSkills).toHaveLength(2);
+      expect(customSkills.map((s) => s.name).sort()).toEqual([
+        'skill-a',
+        'skill-b',
+      ]);
+    });
+
+    it('getSkillsBaseDir should return first custom dir for custom level', () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([
+        '/custom/dir1',
+        '/custom/dir2',
+      ]);
+      const baseDir = manager.getSkillsBaseDir('custom');
+      expect(baseDir).toBe('/custom/dir1');
+    });
+
+    it('getSkillsBaseDir should return empty string when no custom paths', () => {
+      vi.spyOn(mockConfig, 'getResolvedCustomSkillPaths').mockReturnValue([]);
+      const baseDir = manager.getSkillsBaseDir('custom');
+      expect(baseDir).toBe('');
+    });
+  });
 });

--- a/src/copilot-shell/packages/core/src/skills/skill-manager.ts
+++ b/src/copilot-shell/packages/core/src/skills/skill-manager.ts
@@ -107,7 +107,7 @@ export class SkillManager {
 
     const levelsToCheck: SkillLevel[] = options.level
       ? [options.level]
-      : ['project', 'user', 'extension', 'system'];
+      : ['project', 'custom', 'user', 'extension', 'system'];
 
     // Check if we should use cache or force refresh
     const shouldUseCache = !options.force && this.skillsCache !== null;
@@ -189,10 +189,16 @@ export class SkillManager {
       return this.findSkillByNameAtLevel(name, level);
     }
 
-    // Try project level first
+    // Try project level first (highest priority)
     const projectSkill = await this.findSkillByNameAtLevel(name, 'project');
     if (projectSkill) {
       return projectSkill;
+    }
+
+    // Try custom level (user-defined paths from settings)
+    const customSkill = await this.findSkillByNameAtLevel(name, 'custom');
+    if (customSkill) {
+      return customSkill;
     }
 
     // Try user level
@@ -295,7 +301,13 @@ export class SkillManager {
     const skillsCache = new Map<SkillLevel, SkillConfig[]>();
     this.parseErrors.clear();
 
-    const levels: SkillLevel[] = ['project', 'user', 'extension', 'system'];
+    const levels: SkillLevel[] = [
+      'project',
+      'custom',
+      'user',
+      'extension',
+      'system',
+    ];
 
     for (const level of levels) {
       const levelSkills = await this.listSkillsAtLevel(level);
@@ -471,6 +483,12 @@ export class SkillManager {
       return Storage.getSystemSkillsDir();
     }
 
+    // Custom level: return first custom dir, or empty string
+    if (level === 'custom') {
+      const customDirs = this.config.getResolvedCustomSkillPaths();
+      return customDirs[0] ?? '';
+    }
+
     const baseDir =
       level === 'project'
         ? path.join(
@@ -498,6 +516,17 @@ export class SkillManager {
     // return empty array to avoid conflicts between project and global skills
     if (level === 'project' && isHomeDirectory) {
       return [];
+    }
+
+    // Custom level: scan all user-defined custom directories
+    if (level === 'custom') {
+      const customDirs = this.config.getResolvedCustomSkillPaths();
+      const allSkills: SkillConfig[] = [];
+      for (const dir of customDirs) {
+        const skills = await this.loadSkillsFromDir(dir, 'custom');
+        allSkills.push(...skills);
+      }
+      return allSkills;
     }
 
     if (level === 'extension') {
@@ -597,6 +626,13 @@ export class SkillManager {
         .map((level) => this.getSkillsBaseDir(level))
         .filter((baseDir) => fsSync.existsSync(baseDir)),
     );
+
+    // Also watch custom skill directories
+    for (const dir of this.config.getResolvedCustomSkillPaths()) {
+      if (fsSync.existsSync(dir)) {
+        watchTargets.add(dir);
+      }
+    }
 
     for (const existingPath of this.watchers.keys()) {
       if (!watchTargets.has(existingPath)) {

--- a/src/copilot-shell/packages/core/src/skills/types.ts
+++ b/src/copilot-shell/packages/core/src/skills/types.ts
@@ -7,10 +7,12 @@
 /**
  * Represents the storage level for a skill configuration.
  * - 'project': Stored in `.copilot-shell/skills/` within the project directory
+ * - 'custom': User-defined custom skill directories from settings.json
  * - 'user': Stored in `~/.copilot-shell/skills/` in the user's home directory
  * - 'extension': Provided by an installed extension
+ * - 'system': Stored in `/usr/share/anolisa/skills`
  */
-export type SkillLevel = 'project' | 'user' | 'extension' | 'system';
+export type SkillLevel = 'project' | 'custom' | 'user' | 'extension' | 'system';
 
 /**
  * Skill-OS Layer types - 反映 os 分层（skill 的范围和权限）

--- a/src/copilot-shell/packages/core/src/tools/ls.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/ls.test.ts
@@ -48,6 +48,7 @@ describe('LSTool', () => {
         getGlobalRemoteSkillsDir: () =>
           path.join(os.homedir(), '.copilot-shell', 'remote-skills'),
       },
+      getResolvedCustomSkillPaths: () => [],
     } as unknown as Config;
 
     lsTool = new LSTool(mockConfig);
@@ -335,6 +336,42 @@ describe('LSTool', () => {
 
       expect(result.llmContent).toContain('secondary-file.txt');
       expect(result.returnDisplay).toBe('Listed 1 item(s).');
+    });
+  });
+
+  describe('custom skill paths whitelist', () => {
+    it('should accept paths in custom skill directories', () => {
+      const customSkillDir = '/custom/skills';
+      const customMockConfig = {
+        getTargetDir: () => tempRootDir,
+        getWorkspaceContext: () =>
+          createMockWorkspaceContext(tempRootDir, [tempSecondaryDir]),
+        getFileService: () => new FileDiscoveryService(tempRootDir),
+        getFileFilteringOptions: () => ({
+          respectGitIgnore: true,
+          respectQwenIgnore: true,
+        }),
+        storage: {
+          getUserSkillsDir: () =>
+            path.join(os.homedir(), '.copilot-shell', 'skills'),
+          getRemoteSkillsDir: () =>
+            path.join(tempRootDir, '.copilot-shell', 'remote-skills'),
+          getGlobalRemoteSkillsDir: () =>
+            path.join(os.homedir(), '.copilot-shell', 'remote-skills'),
+        },
+        getResolvedCustomSkillPaths: () => [customSkillDir],
+      } as unknown as Config;
+
+      const customLsTool = new LSTool(customMockConfig);
+      const params = { path: path.join(customSkillDir, 'my-skill') };
+      expect(customLsTool.build(params)).toBeDefined();
+    });
+
+    it('should reject paths outside custom skill dirs and workspace', () => {
+      const params = { path: '/not-custom/skills' };
+      expect(() => lsTool.build(params)).toThrow(
+        'Path must be within one of the workspace directories',
+      );
     });
   });
 });

--- a/src/copilot-shell/packages/core/src/tools/ls.ts
+++ b/src/copilot-shell/packages/core/src/tools/ls.ts
@@ -328,13 +328,18 @@ export class LSTool extends BaseDeclarativeTool<LSToolParams, ToolResult> {
       Storage.getSystemSkillsDir(),
       params.path,
     );
+    // Check custom skill paths whitelist
+    const isUnderCustomSkills = this.config
+      .getResolvedCustomSkillPaths()
+      .some((dir) => isSubpath(dir, params.path));
 
     const workspaceContext = this.config.getWorkspaceContext();
     if (
       !workspaceContext.isPathWithinWorkspace(params.path) &&
       !isUnderUserSkills &&
       !isUnderRemoteSkills &&
-      !isUnderSystemSkills
+      !isUnderSystemSkills &&
+      !isUnderCustomSkills
     ) {
       const directories = workspaceContext.getDirectories();
       return `Path must be within one of the workspace directories: ${directories.join(

--- a/src/copilot-shell/packages/core/src/tools/read-file.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/read-file.test.ts
@@ -47,6 +47,7 @@ describe('ReadFileTool', () => {
         getGlobalRemoteSkillsDir: () =>
           path.join(os.homedir(), '.copilot-shell', 'remote-skills'),
       },
+      getResolvedCustomSkillPaths: () => [],
       getTruncateToolOutputThreshold: () => 2500,
       getTruncateToolOutputLines: () => 500,
     } as unknown as Config;
@@ -81,6 +82,43 @@ describe('ReadFileTool', () => {
     it('should throw error if path is outside root', () => {
       const params: ReadFileToolParams = {
         file_path: '/outside/root.txt',
+      };
+      expect(() => tool.build(params)).toThrow(
+        /File path must be within one of the workspace directories/,
+      );
+    });
+
+    it('should allow access to files in custom skill directories', () => {
+      const customSkillDir = '/custom/skills';
+      const customConfig = {
+        getFileService: () => new FileDiscoveryService(tempRootDir),
+        getFileSystemService: () => new StandardFileSystemService(),
+        getTargetDir: () => tempRootDir,
+        getWorkspaceContext: () => createMockWorkspaceContext(tempRootDir),
+        storage: {
+          getProjectTempDir: () => path.join(tempRootDir, '.temp'),
+          getUserSkillsDir: () =>
+            path.join(os.homedir(), '.copilot-shell', 'skills'),
+          getRemoteSkillsDir: () =>
+            path.join(tempRootDir, '.copilot-shell', 'remote-skills'),
+          getGlobalRemoteSkillsDir: () =>
+            path.join(os.homedir(), '.copilot-shell', 'remote-skills'),
+        },
+        getResolvedCustomSkillPaths: () => [customSkillDir],
+        getTruncateToolOutputThreshold: () => 2500,
+        getTruncateToolOutputLines: () => 500,
+      } as unknown as Config;
+      const customTool = new ReadFileTool(customConfig);
+      const params: ReadFileToolParams = {
+        file_path: path.join(customSkillDir, 'my-skill', 'SKILL.md'),
+      };
+      const result = customTool.build(params);
+      expect(typeof result).not.toBe('string');
+    });
+
+    it('should reject files outside custom skill dirs and workspace', () => {
+      const params: ReadFileToolParams = {
+        file_path: '/not-custom/skills/file.txt',
       };
       expect(() => tool.build(params)).toThrow(
         /File path must be within one of the workspace directories/,

--- a/src/copilot-shell/packages/core/src/tools/read-file.ts
+++ b/src/copilot-shell/packages/core/src/tools/read-file.ts
@@ -203,13 +203,18 @@ export class ReadFileTool extends BaseDeclarativeTool<
       Storage.getSystemSkillsDir(),
       resolvedFilePath,
     );
+    // Check custom skill paths whitelist
+    const isWithinCustomSkills = this.config
+      .getResolvedCustomSkillPaths()
+      .some((dir) => isSubpath(dir, resolvedFilePath));
 
     if (
       !workspaceContext.isPathWithinWorkspace(filePath) &&
       !isWithinTempDir &&
       !isWithinUserSkills &&
       !isWithinRemoteSkills &&
-      !isWithinSystemSkills
+      !isWithinSystemSkills &&
+      !isWithinCustomSkills
     ) {
       const directories = workspaceContext.getDirectories();
       return `File path must be within one of the workspace directories: ${directories.join(

--- a/src/copilot-shell/packages/core/src/tools/shell.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/shell.test.ts
@@ -64,6 +64,7 @@ describe('ShellTool', () => {
           .fn()
           .mockReturnValue('/test/dir/.copilot-shell/skills'),
       },
+      getResolvedCustomSkillPaths: vi.fn().mockReturnValue([]),
       getGeminiClient: vi.fn(),
       getGitCoAuthor: vi.fn().mockReturnValue({
         enabled: true,
@@ -155,7 +156,7 @@ describe('ShellTool', () => {
           is_background: false,
         }),
       ).toThrow(
-        'Explicitly running shell commands from within the user skills directory is not allowed. Please use absolute paths for command parameter instead.',
+        'Explicitly running shell commands from within the skills directory is not allowed. Please use absolute paths for command parameter instead.',
       );
     });
 
@@ -167,7 +168,7 @@ describe('ShellTool', () => {
           is_background: false,
         }),
       ).toThrow(
-        'Explicitly running shell commands from within the user skills directory is not allowed. Please use absolute paths for command parameter instead.',
+        'Explicitly running shell commands from within the skills directory is not allowed. Please use absolute paths for command parameter instead.',
       );
     });
 
@@ -179,7 +180,43 @@ describe('ShellTool', () => {
           is_background: false,
         }),
       ).toThrow(
-        'Explicitly running shell commands from within the user skills directory is not allowed. Please use absolute paths for command parameter instead.',
+        'Explicitly running shell commands from within the skills directory is not allowed. Please use absolute paths for command parameter instead.',
+      );
+    });
+
+    it('should throw an error for a directory within a custom skill path', () => {
+      (mockConfig.getResolvedCustomSkillPaths as Mock).mockReturnValue([
+        '/custom/skills',
+      ]);
+      (mockConfig.getWorkspaceContext as Mock).mockReturnValue(
+        createMockWorkspaceContext('/test/dir', ['/custom/skills']),
+      );
+      expect(() =>
+        shellTool.build({
+          command: 'ls',
+          directory: '/custom/skills/my-skill',
+          is_background: false,
+        }),
+      ).toThrow(
+        'Explicitly running shell commands from within the skills directory is not allowed. Please use absolute paths for command parameter instead.',
+      );
+    });
+
+    it('should throw an error for the custom skill directory itself', () => {
+      (mockConfig.getResolvedCustomSkillPaths as Mock).mockReturnValue([
+        '/custom/skills',
+      ]);
+      (mockConfig.getWorkspaceContext as Mock).mockReturnValue(
+        createMockWorkspaceContext('/test/dir', ['/custom/skills']),
+      );
+      expect(() =>
+        shellTool.build({
+          command: 'ls',
+          directory: '/custom/skills',
+          is_background: false,
+        }),
+      ).toThrow(
+        'Explicitly running shell commands from within the skills directory is not allowed. Please use absolute paths for command parameter instead.',
       );
     });
 

--- a/src/copilot-shell/packages/core/src/tools/shell.ts
+++ b/src/copilot-shell/packages/core/src/tools/shell.ts
@@ -632,8 +632,12 @@ export class ShellTool extends BaseDeclarativeTool<
         userSkillsDir,
         resolvedDirectoryPath,
       );
-      if (isWithinUserSkills) {
-        return `Explicitly running shell commands from within the user skills directory is not allowed. Please use absolute paths for command parameter instead.`;
+      // Also block custom skill directories
+      const isWithinCustomSkills = this.config
+        .getResolvedCustomSkillPaths()
+        .some((dir) => isSubpath(dir, resolvedDirectoryPath));
+      if (isWithinUserSkills || isWithinCustomSkills) {
+        return `Explicitly running shell commands from within the skills directory is not allowed. Please use absolute paths for command parameter instead.`;
       }
 
       const workspaceDirs = this.config.getWorkspaceContext().getDirectories();


### PR DESCRIPTION
## Description

Add support for user-defined custom skill directories via `skills.customPaths` in settings.json. Paths support tilde (~) and environment variable (`$VAR`, `${VAR}`) expansion through the existing `resolveEnvVarsInString` utility. Custom skills are loaded with a new `'custom'` skill level, following the priority order: project > custom > user > extension > system. Security policies ensure read-file and ls tools whitelist custom skill directories, while shell blocks execution within them.

## Related Issue

closes #69

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass

## Testing

```bash
cd src/copilot-shell/packages/core && npx vitest run   # 177 files, 3809 tests passed
cd src/copilot-shell/packages/cli && npx vitest run     # 211 files, 3310 tests passed
cd src/copilot-shell/packages/core && npx tsc --noEmit  # pass
cd src/copilot-shell/packages/cli && npx tsc --noEmit   # pass
```

New test coverage includes:
- `storage.test.ts`: 10 cases for `resolveCustomSkillPaths` (tilde, env vars, edge cases)
- `config.test.ts`: 3 cases for `customSkillPaths` config getter
- `skill-manager.test.ts`: 8 cases for custom skill loading, deduplication, and file watching
- `read-file.test.ts`: 2 cases for custom skill dir whitelist
- `ls.test.ts`: 2 cases for custom skill dir whitelist
- `shell.test.ts`: 2 cases for custom skill dir blocking
- `settingsSchema.test.ts`: 1 case for `skills.customPaths` schema validation

## Additional Notes

Example `settings.json` configuration:

```json
{
  "skills": {
    "customPaths": [
      "~/my-skills",
      "/opt/team-skills",
      "$HOME/shared/${USER}/skills"
    ]
  }
}
```