### PR TITLE
feat(cosh): add Tab-completion for shell mode

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/InputPrompt.tsx
@@ -17,6 +17,7 @@ import chalk from 'chalk';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
 import { useCommandCompletion } from '../hooks/useCommandCompletion.js';
+import { useShellCompletion } from '../hooks/useShellCompletion.js';
 import type { Key } from '../hooks/useKeypress.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
@@ -129,6 +130,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   }, [dirs.length, dirsChanged]);
   const [reverseSearchActive, setReverseSearchActive] = useState(false);
   const [commandSearchActive, setCommandSearchActive] = useState(false);
+  const [shellCompletionTriggered, setShellCompletionTriggered] =
+    useState(false);
   const [textBeforeReverseSearch, setTextBeforeReverseSearch] = useState('');
   const [cursorPosition, setCursorPosition] = useState<[number, number]>([
     0, 0,
@@ -147,6 +150,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     reverseSearchActive,
     config,
     // Suppress completion when history navigation just occurred
+    !justNavigatedHistory,
+  );
+
+  const shellCompletion = useShellCompletion(
+    buffer,
+    config.getTargetDir(),
+    shellModeActive && shellCompletionTriggered,
     !justNavigatedHistory,
   );
 
@@ -422,6 +432,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
         if (shellModeActive) {
           setShellModeActive(false);
+          setShellCompletionTriggered(false);
+          resetEscapeState();
+          return;
+        }
+
+        if (shellCompletion.showSuggestions) {
+          shellCompletion.resetCompletionState();
+          setShellCompletionTriggered(false);
+          setExpandedSuggestionIndex(-1);
           resetEscapeState();
           return;
         }
@@ -539,6 +558,58 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       if (completion.isPerfectMatch && keyMatchers[Command.RETURN](key)) {
         handleSubmitAndClear(buffer.text);
         return;
+      }
+
+      // Shell mode Tab-completion handling.
+      // IMPORTANT: Enter key is NEVER intercepted here – it always falls through
+      // to the SUBMIT handler so the command is always executable.
+      if (shellModeActive && !reverseSearchActive) {
+        // Tab is the sole trigger / acceptor for shell completions.
+        // Exception: if the regular completion (e.g. @ AT-mode) is already
+        // showing suggestions, let Tab fall through to the regular handler
+        // below so that AT-completion still works inside shell mode.
+        if (key.name === 'tab' && !completion.showSuggestions) {
+          if (
+            shellCompletion.showSuggestions &&
+            shellCompletion.suggestions.length > 0
+          ) {
+            const targetIndex =
+              shellCompletion.activeSuggestionIndex === -1
+                ? 0
+                : shellCompletion.activeSuggestionIndex;
+            shellCompletion.handleAutocomplete(targetIndex);
+            setExpandedSuggestionIndex(-1);
+            // Keep completion open for directory paths so the user can
+            // continue navigating deeper into the file tree.
+            const completedValue =
+              shellCompletion.suggestions[targetIndex]?.value ?? '';
+            if (!completedValue.endsWith('/')) {
+              setShellCompletionTriggered(false);
+            }
+          } else {
+            // First Tab press – trigger shell completion.
+            setShellCompletionTriggered(true);
+          }
+          return; // Tab consumed by shell completion.
+        }
+
+        // Arrow-key navigation inside the suggestion list.
+        if (shellCompletion.showSuggestions) {
+          if (keyMatchers[Command.NAVIGATION_UP](key)) {
+            shellCompletion.navigateUp();
+            setExpandedSuggestionIndex(-1);
+            return;
+          }
+          if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
+            shellCompletion.navigateDown();
+            setExpandedSuggestionIndex(-1);
+            return;
+          }
+          // Any non-navigation key closes the suggestion list so the
+          // user can type freely again – Enter falls through to SUBMIT.
+          setShellCompletionTriggered(false);
+        }
+        // All other keys (including Enter) fall through to their normal handlers.
       }
 
       if (completion.showSuggestions) {
@@ -696,6 +767,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       focus,
       buffer,
       completion,
+      shellCompletion,
+      setShellCompletionTriggered,
       shellModeActive,
       setShellModeActive,
       onClearScreen,
@@ -732,6 +805,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const getActiveCompletion = () => {
     if (commandSearchActive) return commandSearchCompletion;
     if (reverseSearchActive) return reverseSearchCompletion;
+    if (shellModeActive && shellCompletionTriggered) return shellCompletion;
     return completion;
   };
 
@@ -945,9 +1019,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             mode={
               buffer.text.startsWith('/') &&
               !reverseSearchActive &&
-              !commandSearchActive
+              !commandSearchActive &&
+              !shellModeActive
                 ? 'slash'
-                : 'reverse'
+                : shellModeActive && shellCompletionTriggered
+                  ? 'shell'
+                  : 'reverse'
             }
             expandedIndex={expandedSuggestionIndex}
           />

--- a/src/copilot-shell/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -23,7 +23,7 @@ interface SuggestionsDisplayProps {
   width: number;
   scrollOffset: number;
   userInput: string;
-  mode: 'reverse' | 'slash';
+  mode: 'reverse' | 'slash' | 'shell';
   expandedIndex?: number;
 }
 

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useShellCompletion.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useShellCompletion.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useMemo, useEffect } from 'react';
+import * as fs from 'node:fs';
+import * as nodePath from 'node:path';
+import * as os from 'node:os';
+import type { Suggestion } from '../components/SuggestionsDisplay.js';
+import type { TextBuffer } from '../components/shared/text-buffer.js';
+import { logicalPosToOffset } from '../components/shared/text-buffer.js';
+import { useCompletion } from './useCompletion.js';
+import type { UseCommandCompletionReturn } from './useCommandCompletion.js';
+
+// ─── PATH command cache ──────────────────────────────────────────────────────
+
+const PATH_CACHE_TTL_MS = 30_000; // 30 s
+
+interface PathCommandCache {
+  commands: string[];
+  timestamp: number;
+}
+
+let _pathCommandCache: PathCommandCache | null = null;
+
+function getPathExecutables(): string[] {
+  const now = Date.now();
+  if (
+    _pathCommandCache &&
+    now - _pathCommandCache.timestamp < PATH_CACHE_TTL_MS
+  ) {
+    return _pathCommandCache.commands;
+  }
+
+  const pathEnv = process.env['PATH'] ?? '';
+  const dirs = pathEnv.split(nodePath.delimiter).filter(Boolean);
+  const seen = new Set<string>();
+
+  for (const dir of dirs) {
+    try {
+      const entries = fs.readdirSync(dir);
+      for (const entry of entries) {
+        if (seen.has(entry)) continue;
+        try {
+          const fullPath = nodePath.join(dir, entry);
+          const stat = fs.statSync(fullPath);
+          if (stat.isFile() && (stat.mode & 0o111) !== 0) {
+            seen.add(entry);
+          }
+        } catch {
+          // ignore permission / broken symlink errors
+        }
+      }
+    } catch {
+      // ignore unreadable PATH directories
+    }
+  }
+
+  const commands = Array.from(seen).sort();
+  _pathCommandCache = { commands, timestamp: now };
+  return commands;
+}
+
+// ─── Token parsing ───────────────────────────────────────────────────────────
+
+interface ShellToken {
+  /** Raw text of the token under/before the cursor */
+  value: string;
+  /** Start column (logical) of the token in the line */
+  start: number;
+  /** End column = cursor column */
+  end: number;
+  /** Whether this is the first token on the line (command position) */
+  isFirstToken: boolean;
+}
+
+/**
+ * Given a line and cursor column, return the token at/before the cursor.
+ * Handles backslash-escaped spaces.
+ */
+function parseTokenAtCursor(line: string, cursorCol: number): ShellToken {
+  // Walk backwards from cursor to find the start of the current token.
+  let tokenStart = 0;
+  for (let i = cursorCol - 1; i >= 0; i--) {
+    if (line[i] === ' ') {
+      // Check for escaped space: odd number of preceding backslashes
+      let backslashes = 0;
+      for (let j = i - 1; j >= 0 && line[j] === '\\'; j--) {
+        backslashes++;
+      }
+      if (backslashes % 2 === 0) {
+        tokenStart = i + 1;
+        break;
+      }
+    }
+  }
+
+  const value = line.slice(tokenStart, cursorCol);
+  const beforeToken = line.slice(0, tokenStart).trimStart();
+  const isFirstToken = beforeToken.length === 0;
+
+  return { value, start: tokenStart, end: cursorCol, isFirstToken };
+}
+
+// ─── Path completions ─────────────────────────────────────────────────────
+
+/** Maximum number of suggestions to return for any completion type */
+const MAX_SHELL_SUGGESTIONS = 100;
+
+function getPathCompletions(partial: string, cwd: string): Suggestion[] {
+  // Expand ~ prefix
+  let expanded = partial;
+  if (partial === '~' || partial.startsWith('~/')) {
+    expanded = os.homedir() + partial.slice(1);
+  }
+
+  const dirPart = nodePath.dirname(expanded);
+  const basePart = nodePath.basename(expanded);
+  const isAbsolute = nodePath.isAbsolute(expanded);
+
+  // Resolve the directory to scan
+  let resolvedDir: string;
+  if (isAbsolute) {
+    resolvedDir = dirPart;
+  } else if (dirPart === '.') {
+    resolvedDir = cwd;
+  } else {
+    resolvedDir = nodePath.resolve(cwd, dirPart);
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(resolvedDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const suggestions: Suggestion[] = [];
+  const showHidden = basePart.startsWith('.');
+
+  for (const entry of entries) {
+    // Hide dotfiles unless the prefix starts with '.'
+    if (!showHidden && entry.name.startsWith('.')) continue;
+    if (!entry.name.startsWith(basePart)) continue;
+
+    const isDir =
+      entry.isDirectory() ||
+      (entry.isSymbolicLink() &&
+        isSymlinkToDir(nodePath.join(resolvedDir, entry.name)));
+    const displayName = isDir ? entry.name + '/' : entry.name;
+
+    // Build the completion value (same format as what the user typed)
+    let completionValue: string;
+    if (dirPart === '.') {
+      // No directory prefix typed – just use the entry name
+      completionValue = displayName;
+    } else if (partial.startsWith('~/')) {
+      completionValue =
+        '~/' +
+        (dirPart === os.homedir()
+          ? ''
+          : nodePath.relative(os.homedir(), dirPart) + '/') +
+        displayName;
+    } else {
+      completionValue = nodePath.join(dirPart, displayName);
+      // Preserve trailing slash for dirs
+      if (isDir && !completionValue.endsWith('/')) {
+        completionValue += '/';
+      }
+    }
+
+    suggestions.push({ label: displayName, value: completionValue });
+    if (suggestions.length >= MAX_SHELL_SUGGESTIONS) break;
+  }
+
+  return suggestions.sort((a, b) => {
+    // Directories first, then alphabetical
+    const aIsDir = a.label.endsWith('/');
+    const bIsDir = b.label.endsWith('/');
+    if (aIsDir !== bIsDir) return aIsDir ? -1 : 1;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+function isSymlinkToDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// ─── Command completions ──────────────────────────────────────────────────
+
+function getCommandCompletions(prefix: string): Suggestion[] {
+  if (prefix.length === 0) return [];
+  const commands = getPathExecutables();
+  const suggestions: Suggestion[] = [];
+  for (const cmd of commands) {
+    if (!cmd.startsWith(prefix)) continue;
+    suggestions.push({ label: cmd, value: cmd });
+    if (suggestions.length >= MAX_SHELL_SUGGESTIONS) break;
+  }
+  return suggestions;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────
+
+/**
+ * Provides Tab-completion for shell (command) mode.
+ *
+ * - First token on a line → complete executables from PATH
+ * - Subsequent tokens     → complete file-system paths relative to `cwd`
+ *
+ * Completions are computed reactively whenever `enabled` is true and the
+ * buffer changes.  Pass `enabled = shellModeActive && shellCompletionTriggered`
+ * to implement Tab-triggered behaviour.
+ */
+export function useShellCompletion(
+  buffer: TextBuffer,
+  cwd: string,
+  enabled: boolean,
+  active: boolean = true,
+): UseCommandCompletionReturn {
+  const {
+    suggestions,
+    activeSuggestionIndex,
+    visibleStartIndex,
+    showSuggestions,
+    isLoadingSuggestions,
+    isPerfectMatch,
+    setSuggestions,
+    setShowSuggestions,
+    setActiveSuggestionIndex,
+    setVisibleStartIndex,
+    resetCompletionState,
+    navigateUp,
+    navigateDown,
+  } = useCompletion();
+
+  const cursorRow = buffer.cursor[0];
+  const cursorCol = buffer.cursor[1];
+  const currentLine = buffer.lines[cursorRow] ?? '';
+
+  // Parse the token at cursor.  Memoised so we only re-compute on actual changes.
+  const token = useMemo(
+    () => parseTokenAtCursor(currentLine, cursorCol),
+    [currentLine, cursorCol],
+  );
+
+  // Compute new suggestions whenever the token changes.
+  const newSuggestions = useMemo((): Suggestion[] => {
+    if (!enabled || !active) return [];
+    if (token.value === '' && token.isFirstToken) return [];
+
+    if (token.isFirstToken) {
+      return getCommandCompletions(token.value);
+    }
+    return getPathCompletions(token.value, cwd);
+  }, [enabled, active, token, cwd]);
+
+  // Sync computed suggestions into completion state.
+  useEffect(() => {
+    if (!enabled || !active) {
+      resetCompletionState();
+      return;
+    }
+    setSuggestions(newSuggestions);
+    setShowSuggestions(newSuggestions.length > 0);
+    setActiveSuggestionIndex(newSuggestions.length > 0 ? 0 : -1);
+    setVisibleStartIndex(0);
+  }, [
+    enabled,
+    active,
+    newSuggestions,
+    setSuggestions,
+    setShowSuggestions,
+    setActiveSuggestionIndex,
+    setVisibleStartIndex,
+    resetCompletionState,
+  ]);
+
+  // Apply the selected suggestion to the buffer.
+  const handleAutocomplete = useCallback(
+    (indexToUse: number) => {
+      if (indexToUse < 0 || indexToUse >= suggestions.length) return;
+      const suggestion = suggestions[indexToUse].value;
+
+      buffer.replaceRangeByOffset(
+        logicalPosToOffset(buffer.lines, cursorRow, token.start),
+        logicalPosToOffset(buffer.lines, cursorRow, token.end),
+        suggestion,
+      );
+    },
+    [buffer, cursorRow, token, suggestions],
+  );
+
+  return {
+    suggestions,
+    activeSuggestionIndex,
+    visibleStartIndex,
+    showSuggestions,
+    isLoadingSuggestions,
+    isPerfectMatch,
+    setActiveSuggestionIndex,
+    setShowSuggestions,
+    resetCompletionState,
+    navigateUp,
+    navigateDown,
+    handleAutocomplete,
+  };
+}


### PR DESCRIPTION
- Implement useShellCompletion hook with command completion ($PATH executables, 30s cache) and file-system path completion (supports ~/, absolute and relative paths; directories suffixed with /)
- Integrate shell completion into InputPrompt: Tab triggers/accepts completion, arrow keys navigate suggestions, Enter always falls through to execute the command without interception

## Description

Add Tab-key auto-completion for cosh shell mode (`!`).

When the user enters shell mode by typing `!`, pressing `Tab` now:
- Completes **command names** (executables on `$PATH`) when the cursor
  is on the first token; results are cached for 30 s to avoid repeated
  directory scans.
- Completes **file-system paths** on subsequent tokens, supporting
  `~/`-prefixed, absolute and relative paths; directories are displayed
  with a trailing `/` and kept open for further tab-navigation.
- Does **not** block `Enter` — the command is always executable
  regardless of completion state.
- Does **not** interfere with the existing `@`-file (AT-mode)
  completion inside shell mode; Tab falls through to the regular
  handler when AT suggestions are already visible.

## Related Issue

closes #22

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

1. Start cosh (`npm run start` in `src/copilot-shell`)
2. Type `!` to enter shell mode
3. Type a partial command (e.g. `gi`) and press `Tab` → command list
   appears; `↑`/`↓` to navigate, `Tab` again to accept
4. Type a partial path (e.g. `ls ~/`) and press `Tab` → file-system
   completions appear; directories are suffixed with `/`
5. Press `Tab` on a directory suggestion to navigate deeper
6. Press `Enter` at any time → command executes immediately
7. In regular (non-shell) mode, type `@filename` → dropdown appears,
   `Tab` accepts as before (no regression)

## Additional Notes

- PATH scan is done synchronously but only on the first `Tab` press;
  results are cached for 30 s at module level.
- Max suggestions per trigger: 100 (prevents UI overflow).
- New file: `packages/cli/src/ui/hooks/useShellCompletion.ts`
