### PR TITLE
fix(agentsight): add manual token computation as fallback mechanism

### DIFF
--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -23,6 +23,7 @@
 use crate::aggregator::AggregatedResult;
 use crate::parser::sse::ParsedSseEvent;
 use crate::tokenizer::LlmTokenizer;
+use crate::tokenizer::get_global_tokenizer;
 use crate::analyzer::token::extract_response_content;
 
 use super::{AuditAnalyzer, TokenParser, MessageParser, AuditRecord, TokenRecord, TokenUsage, ParsedApiMessage, AnalysisResult, PromptTokenCount, HttpRecord};
@@ -441,8 +442,14 @@ impl Analyzer {
             }
             _ => None,
         };
+        
         if let Some(record) = token_result {
             results.push(AnalysisResult::Token(record));
+        } else {
+            // Fallback: manually compute tokens using get_global_tokenizer
+            if let Some(record) = self.compute_tokens_manually(result) {
+                results.push(AnalysisResult::Token(record));
+            }
         }
 
         // 5. Token consumption analysis - breakdown by message role
@@ -538,6 +545,162 @@ impl Analyzer {
 
         // NOTE: tool_calls and reasoning_content extraction from SSE events
         // is handled in genai::builder via direct SSE response body parsing.
+
+        Some(record)
+    }
+
+    /// Manually compute token counts using get_global_tokenizer
+    ///
+    /// This method is called when token extraction from SSE events fails.
+    /// It uses the global tokenizer to compute input and output tokens
+    /// from the request messages and response content.
+    fn compute_tokens_manually(&self, result: &AggregatedResult) -> Option<TokenRecord> {
+        // Extract context from the aggregated result (only SseComplete has request info)
+        let (pid, comm, request_json, sse_events, path) = match result {
+            AggregatedResult::SseComplete(pair) => (
+                pair.request.source_event.pid,
+                pair.request.source_event.comm_str(),
+                pair.request.json_body(),
+                &pair.response.sse_events,
+                pair.request.path.as_str(),
+            ),
+            // ResponseOnly doesn't have request info, cannot compute tokens
+            _ => return None,
+        };
+
+        // Get request JSON
+        let request_json_ref = request_json.as_ref()?;
+
+        // Extract model name
+        let model = request_json_ref.get("model")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown");
+
+        // Try to get tokenizer for the model
+        let tokenizer = match get_global_tokenizer(model) {
+            Ok(t) => t,
+            Err(e) => {
+                log::debug!("Failed to get tokenizer for model '{}': {}", model, e);
+                return None;
+            }
+        };
+
+        // Extract provider from path
+        let provider = if path.contains("anthropic") {
+            "anthropic"
+        } else {
+            "openai"
+        };
+
+        // Count input tokens from request messages using chat template
+        let input_tokens = if let Some(messages) = request_json_ref.get("messages").and_then(|m| m.as_array()) {
+            if messages.is_empty() {
+                0
+            } else {
+                // Clone messages for in-place modification of tool_calls.arguments
+                let mut msgs = messages.clone();
+                
+                // Process tool_calls arguments: parse JSON string to object in place
+                for msg in msgs.iter_mut() {
+                    if let Some(tool_calls) = msg.get_mut("tool_calls").and_then(|tc| tc.as_array_mut()) {
+                        for tool_call in tool_calls.iter_mut() {
+                            if let Some(func) = tool_call.get_mut("function") {
+                                if let Some(args) = func.get("arguments") {
+                                    if let Some(args_str) = args.as_str() {
+                                        // Try to parse arguments string as JSON object
+                                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(args_str) {
+                                            func["arguments"] = parsed;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                // Extract tools JSON array for passing to template
+                let tools_json: Option<Vec<serde_json::Value>> = request_json_ref.get("tools")
+                    .and_then(|t| t.as_array())
+                    .map(|arr| arr.to_vec());
+                let tools_slice = tools_json.as_deref();
+                
+                // Apply chat template with tools to get the actual prompt sent to LLM
+                match tokenizer.apply_chat_template_with_tools(&msgs, tools_slice, true) {
+                    Ok(formatted) => tokenizer.count(&formatted).unwrap_or(0) as u64,
+                    Err(e) => {
+                        log::warn!("Failed to apply chat template: {}, falling back to raw count", e);
+                        // Fallback: count raw message content
+                        let mut total = 0u64;
+                        for msg in &msgs {
+                            if let Ok(msg_str) = serde_json::to_string(msg) {
+                                total += tokenizer.count(&msg_str).unwrap_or(0) as u64;
+                            }
+                        }
+                        total
+                    }
+                }
+            }
+        } else {
+            0
+        };
+
+        // Count output tokens from SSE events content
+        let output_tokens = {
+            let mut all_content = String::new();
+            let mut all_reasoning = String::new();
+            let mut all_tool_calls = Vec::new();
+
+            for event in sse_events {
+                if let Some(chunk) = event.json_body() {
+                    if let Some((content, reasoning, tool_calls)) = extract_response_content(Some(&chunk)) {
+                        if !content.is_empty() {
+                            all_content.push_str(&content);
+                        }
+                        if let Some(r) = reasoning {
+                            if !r.is_empty() {
+                                all_reasoning.push_str(&r);
+                            }
+                        }
+                        for tc in tool_calls {
+                            if !tc.is_empty() {
+                                all_tool_calls.push(tc);
+                            }
+                        }
+                    }
+                }
+            }
+
+            let mut total = 0u64;
+
+            // Count reasoning tokens
+            if !all_reasoning.is_empty() {
+                let reasoning_with_tags = format!("<think>\n{}\n</think>\n\n", all_reasoning);
+                total += tokenizer.count(&reasoning_with_tags).unwrap_or(0) as u64;
+            }
+
+            // Count text tokens
+            if !all_content.is_empty() {
+                total += tokenizer.count(&all_content).unwrap_or(0) as u64;
+            }
+
+            // Count tool call tokens
+            if !all_tool_calls.is_empty() {
+                let aggregated_tool_calls = all_tool_calls.join("");
+                total += tokenizer.count(&aggregated_tool_calls).unwrap_or(0) as u64;
+            }
+
+            total
+        };
+
+        // Create TokenRecord
+        let record = TokenRecord::new(
+            pid,
+            comm.to_string(),
+            provider.to_string(),
+            input_tokens,
+            output_tokens,
+        )
+        .with_model(model.to_string());
 
         Some(record)
     }


### PR DESCRIPTION
Problem:
When token extraction from SSE events fails, the system cannot obtain accurate token usage statistics, resulting in missing token metrics.

Solution:
1. Add compute_tokens_manually method to calculate tokens using global tokenizer
2. Automatically fallback to manual computation when token extraction fails
3. Support chat template processing, including JSON parsing of tool_calls arguments
4. Separately calculate input tokens (request messages) and output tokens (SSE response content)
5. Support token counting for reasoning, content, and tool_calls

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #140 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
