### PR TITLE
chore(ci): add release-package and release-publish workflows

### DIFF
--- a/.github/actions/package-archive/action.yaml
+++ b/.github/actions/package-archive/action.yaml
@@ -18,8 +18,12 @@ inputs:
     description: 'Number of days to retain the uploaded artifact'
     required: false
     default: '14'
-  skill-sign-key:
+  skill-sign-private-key:
     description: 'ASCII-armored GPG private key for signing (skills only). Pass secrets.SKILL_SIGN_PRIVATE_KEY from the caller workflow.'
+    required: false
+    default: ''
+  skill-sign-public-key:
+    description: 'ASCII-armored GPG public key for signature verification (skills only). Pass vars.SKILL_SIGN_PUBLIC_KEY from the caller workflow.'
     required: false
     default: ''
 
@@ -31,6 +35,8 @@ runs:
     # -----------------------------------------------------------------
     - name: Create source archive
       shell: bash
+      env:
+        GPG_PUBLIC_KEY: ${{ inputs.skill-sign-public-key }}
       run: |
         COMPONENT="${{ inputs.component }}"
         VERSION="${{ inputs.version }}"
@@ -61,6 +67,15 @@ runs:
             skill_dir=$(dirname "$skillmd")
             cp -rp "$skill_dir" /tmp/build/${ARCHIVE_NAME}/skills/
           done
+        elif [ "$COMPONENT" = "agent-sec-core" ]; then
+          cp -r ${SRC_DIR}/. /tmp/build/${ARCHIVE_NAME}/
+          # Replace example keys in trusted-keys with the real GPG public key
+          # so the packaged archive ships the production key.
+          if [ -n "$GPG_PUBLIC_KEY" ]; then
+            TRUSTED_KEYS_DIR="/tmp/build/${ARCHIVE_NAME}/skill/scripts/asset-verify/trusted-keys"
+            rm -f "${TRUSTED_KEYS_DIR}"/*.asc
+            echo "$GPG_PUBLIC_KEY" > "${TRUSTED_KEYS_DIR}/agent-sec.asc"
+          fi
         else
           cp -r ${SRC_DIR}/. /tmp/build/${ARCHIVE_NAME}/
         fi
@@ -79,10 +94,10 @@ runs:
     # No external sign parameter needed; the action decides internally.
     # -----------------------------------------------------------------
     - name: Sign archive (os-skills)
-      if: inputs.component == 'os-skills'
+      if: inputs.component == 'os-skills' && inputs.skill-sign-private-key != ''
       shell: bash
       env:
-        GPG_PRIVATE_KEY: ${{ inputs.skill-sign-key }}
+        GPG_PRIVATE_KEY: ${{ inputs.skill-sign-private-key }}
       run: |
         bash src/agent-sec-core/tools/sign-skill.sh --batch /tmp/build/${ARCHIVE_NAME}/skills
 
@@ -92,18 +107,19 @@ runs:
     # -----------------------------------------------------------------
     # Step 3: Sign archive (agent-sec-core only)
     #
-    # Signing is automatically applied when component == agent-sec-core.
+    # Signing is automatically applied when component == agent-sec-core
     # No external sign parameter needed; the action decides internally.
-    #
-    # TODO: Replace this placeholder with the actual signing script once
-    # the signing infrastructure is ready.
     # -----------------------------------------------------------------
     - name: Sign archive (agent-sec-core)
-      if: inputs.component == 'agent-sec-core'
+      if: inputs.component == 'agent-sec-core' && inputs.skill-sign-private-key != ''
       shell: bash
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.skill-sign-private-key }}
       run: |
-        echo "⚠️  Signing is not yet implemented for agent-sec-core."
-        echo "    This step is a placeholder for the future signing pipeline."
+        bash src/agent-sec-core/tools/sign-skill.sh --skill-name agent-sec-core /tmp/build/${ARCHIVE_NAME}/skill
+
+        tar -czf "/tmp/archives/${ARCHIVE_FILE}" \
+          -C /tmp/build "${ARCHIVE_NAME}"
 
     # -----------------------------------------------------------------
     # Step 4: Summarize
@@ -111,8 +127,7 @@ runs:
     - name: Summarize
       shell: bash
       run: |
-        # TODO: Add 'agent-sec-core' here once its signing is implemented.
-        SIGNED=$([[ "${{ inputs.component }}" == "os-skills" ]] && echo "true" || echo "false")
+        SIGNED=$([[ "${{ inputs.component }}" =~ ^(os-skills|agent-sec-core)$ ]] && echo "true" || echo "false")
 
         echo "### Package Result" >> $GITHUB_STEP_SUMMARY
         echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/package-archive/action.yaml
+++ b/.github/actions/package-archive/action.yaml
@@ -1,0 +1,141 @@
+name: Package Archive
+description: >
+  Build a source archive for the given component and version.
+  Optionally signs the archive (os-skills only) and uploads it as a GitHub Actions artifact.
+
+inputs:
+  component:
+    description: 'Component name (e.g. copilot-shell, os-skills)'
+    required: true
+  version:
+    description: 'Version string without v prefix (e.g. 2.1.0)'
+    required: true
+  artifact-suffix:
+    description: 'Suffix appended to both the tar.gz filename and artifact name (e.g. ".preview"). Leave empty for official builds.'
+    required: false
+    default: ''
+  retention-days:
+    description: 'Number of days to retain the uploaded artifact'
+    required: false
+    default: '14'
+  skill-sign-key:
+    description: 'ASCII-armored GPG private key for signing (skills only). Pass secrets.SKILL_SIGN_PRIVATE_KEY from the caller workflow.'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # -----------------------------------------------------------------
+    # Step 1: Create source archive
+    # -----------------------------------------------------------------
+    - name: Create source archive
+      shell: bash
+      run: |
+        COMPONENT="${{ inputs.component }}"
+        VERSION="${{ inputs.version }}"
+        SUFFIX="${{ inputs.artifact-suffix }}"
+        ARCHIVE_NAME="${COMPONENT}-${VERSION}"
+        ARCHIVE_FILE="${ARCHIVE_NAME}${SUFFIX}.tar.gz"
+
+        case "$COMPONENT" in
+          copilot-shell)  SRC_DIR="src/copilot-shell" ;;
+          agent-sec-core) SRC_DIR="src/agent-sec-core" ;;
+          agentsight)     SRC_DIR="src/agentsight" ;;
+          os-skills)      SRC_DIR="src/os-skills" ;;
+          *)
+            echo "ERROR: Unknown component: $COMPONENT"
+            exit 1
+            ;;
+        esac
+
+        mkdir -p /tmp/build/${ARCHIVE_NAME}
+        if [ "$COMPONENT" = "os-skills" ]; then
+          # Copy top-level files (LICENSE, README, etc.) into archive root.
+          find "${SRC_DIR}" -maxdepth 1 -not -type d -exec cp -p {} /tmp/build/${ARCHIVE_NAME}/ \;
+
+          # Flatten skill directories (identified by containing SKILL.md) into
+          # skills/ subdirectory, mirroring the RPM spec install logic.
+          mkdir -p /tmp/build/${ARCHIVE_NAME}/skills
+          find "${SRC_DIR}" -name 'SKILL.md' | sort | while IFS= read -r skillmd; do
+            skill_dir=$(dirname "$skillmd")
+            cp -rp "$skill_dir" /tmp/build/${ARCHIVE_NAME}/skills/
+          done
+        else
+          cp -r ${SRC_DIR}/. /tmp/build/${ARCHIVE_NAME}/
+        fi
+
+        mkdir -p /tmp/archives
+        tar -czf "/tmp/archives/${ARCHIVE_FILE}" \
+          -C /tmp/build "${ARCHIVE_NAME}"
+
+        echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
+        echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >> $GITHUB_ENV
+
+    # -----------------------------------------------------------------
+    # Step 2: Sign archive (os-skills only)
+    #
+    # Signing is automatically applied when component == os-skills.
+    # No external sign parameter needed; the action decides internally.
+    # -----------------------------------------------------------------
+    - name: Sign archive (os-skills)
+      if: inputs.component == 'os-skills'
+      shell: bash
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.skill-sign-key }}
+      run: |
+        bash src/agent-sec-core/tools/sign-skill.sh --batch /tmp/build/${ARCHIVE_NAME}/skills
+
+        tar -czf "/tmp/archives/${ARCHIVE_FILE}" \
+          -C /tmp/build "${ARCHIVE_NAME}"
+
+    # -----------------------------------------------------------------
+    # Step 3: Sign archive (agent-sec-core only)
+    #
+    # Signing is automatically applied when component == agent-sec-core.
+    # No external sign parameter needed; the action decides internally.
+    #
+    # TODO: Replace this placeholder with the actual signing script once
+    # the signing infrastructure is ready.
+    # -----------------------------------------------------------------
+    - name: Sign archive (agent-sec-core)
+      if: inputs.component == 'agent-sec-core'
+      shell: bash
+      run: |
+        echo "⚠️  Signing is not yet implemented for agent-sec-core."
+        echo "    This step is a placeholder for the future signing pipeline."
+
+    # -----------------------------------------------------------------
+    # Step 4: Summarize
+    # -----------------------------------------------------------------
+    - name: Summarize
+      shell: bash
+      run: |
+        # TODO: Add 'agent-sec-core' here once its signing is implemented.
+        SIGNED=$([[ "${{ inputs.component }}" == "os-skills" ]] && echo "true" || echo "false")
+
+        echo "### Package Result" >> $GITHUB_STEP_SUMMARY
+        echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+        echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+        echo "| Component | \`${{ inputs.component }}\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| Version | \`${{ inputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| Archive | \`${ARCHIVE_FILE}\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| Size | $(du -sh /tmp/archives/${ARCHIVE_FILE} | cut -f1) |" >> $GITHUB_STEP_SUMMARY
+        if [ "$SIGNED" = "true" ]; then
+          echo "| Signing | ✅ Signed |" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Contents:**" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        tar -tzf /tmp/archives/${ARCHIVE_FILE} >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+    # -----------------------------------------------------------------
+    # Step 5: Upload artifact
+    # -----------------------------------------------------------------
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.component }}-${{ inputs.version }}${{ inputs.artifact-suffix }}
+        path: /tmp/archives/${{ env.ARCHIVE_FILE }}
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/package-archive/action.yaml
+++ b/.github/actions/package-archive/action.yaml
@@ -31,18 +31,14 @@ runs:
   using: composite
   steps:
     # -----------------------------------------------------------------
-    # Step 1: Create source archive
+    # Step 1: Resolve source directory
     # -----------------------------------------------------------------
-    - name: Create source archive
+    - name: Resolve source directory
       shell: bash
-      env:
-        GPG_PUBLIC_KEY: ${{ inputs.skill-sign-public-key }}
       run: |
         COMPONENT="${{ inputs.component }}"
         VERSION="${{ inputs.version }}"
         SUFFIX="${{ inputs.artifact-suffix }}"
-        ARCHIVE_NAME="${COMPONENT}-${VERSION}"
-        ARCHIVE_FILE="${ARCHIVE_NAME}${SUFFIX}.tar.gz"
 
         case "$COMPONENT" in
           copilot-shell)  SRC_DIR="src/copilot-shell" ;;
@@ -55,8 +51,61 @@ runs:
             ;;
         esac
 
+        echo "SRC_DIR=${SRC_DIR}" >> $GITHUB_ENV
+        echo "ARCHIVE_NAME=${COMPONENT}-${VERSION}" >> $GITHUB_ENV
+        echo "ARCHIVE_FILE=${COMPONENT}-${VERSION}${SUFFIX}.tar.gz" >> $GITHUB_ENV
+
+    # -----------------------------------------------------------------
+    # Step 2: Resolve LICENSE
+    #
+    # Detect the symlink here and record the resolved real path
+    # so Step 3 can substitute it during archive creation without
+    # modifying the source tree.
+    # -----------------------------------------------------------------
+    - name: Resolve LICENSE
+      shell: bash
+      run: |
+        LICENSE_RESOLVED=false
+        LICENSE_REAL_PATH=""
+        LICENSE_BUILD_TARGET=""
+
+        for src_license in "${SRC_DIR}/LICENSE" "${SRC_DIR}/license" \
+                           "${SRC_DIR}/LICENSE.txt" "${SRC_DIR}/license.txt"; do
+          # Use -L to detect symlinks; git on Linux restores path-reference LICENSE
+          # files as symlinks rather than plain text files.
+          if [ -L "${src_license}" ]; then
+            ref_path="$(realpath "${src_license}")"
+            if [ -f "${ref_path}" ]; then
+              LICENSE_RESOLVED=true
+              LICENSE_REAL_PATH="${ref_path}"
+              LICENSE_BUILD_TARGET="$(basename "${src_license}")"
+              echo "Detected LICENSE symlink: ${src_license} -> ${ref_path}"
+              break
+            else
+              echo "ERROR: LICENSE symlink target not found at ${ref_path}"
+              exit 1
+            fi
+          fi
+        done
+
+        echo "LICENSE_RESOLVED=${LICENSE_RESOLVED}" >> $GITHUB_ENV
+        echo "LICENSE_REAL_PATH=${LICENSE_REAL_PATH}" >> $GITHUB_ENV
+        echo "LICENSE_BUILD_TARGET=${LICENSE_BUILD_TARGET}" >> $GITHUB_ENV
+
+    # -----------------------------------------------------------------
+    # Step 3: Create source archive
+    #
+    # If Step 2 detected a LICENSE path reference, the resolved real
+    # file is copied into the build tree before packaging so the archive
+    # ships the actual license text. The source tree is never modified.
+    # -----------------------------------------------------------------
+    - name: Create source archive
+      shell: bash
+      env:
+        GPG_PUBLIC_KEY: ${{ inputs.skill-sign-public-key }}
+      run: |
         mkdir -p /tmp/build/${ARCHIVE_NAME}
-        if [ "$COMPONENT" = "os-skills" ]; then
+        if [ "${{ inputs.component }}" = "os-skills" ]; then
           # Copy top-level files (LICENSE, README, etc.) into archive root.
           find "${SRC_DIR}" -maxdepth 1 -not -type d -exec cp -p {} /tmp/build/${ARCHIVE_NAME}/ \;
 
@@ -67,7 +116,7 @@ runs:
             skill_dir=$(dirname "$skillmd")
             cp -rp "$skill_dir" /tmp/build/${ARCHIVE_NAME}/skills/
           done
-        elif [ "$COMPONENT" = "agent-sec-core" ]; then
+        elif [ "${{ inputs.component }}" = "agent-sec-core" ]; then
           cp -r ${SRC_DIR}/. /tmp/build/${ARCHIVE_NAME}/
           # Replace example keys in trusted-keys with the real GPG public key
           # so the packaged archive ships the production key.
@@ -80,15 +129,20 @@ runs:
           cp -r ${SRC_DIR}/. /tmp/build/${ARCHIVE_NAME}/
         fi
 
+        # Substitute resolved LICENSE into the build tree without touching the source.
+        # Remove the dangling symlink first (cp -r preserves symlinks, which become
+        # dangling in /tmp/build since the symlink target no longer exists there).
+        if [ "${LICENSE_RESOLVED}" = "true" ]; then
+          rm -f "/tmp/build/${ARCHIVE_NAME}/${LICENSE_BUILD_TARGET}"
+          cp -p "${LICENSE_REAL_PATH}" "/tmp/build/${ARCHIVE_NAME}/${LICENSE_BUILD_TARGET}"
+        fi
+
         mkdir -p /tmp/archives
         tar -czf "/tmp/archives/${ARCHIVE_FILE}" \
           -C /tmp/build "${ARCHIVE_NAME}"
 
-        echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
-        echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >> $GITHUB_ENV
-
     # -----------------------------------------------------------------
-    # Step 2: Sign archive (os-skills only)
+    # Step 4: Sign archive (os-skills only)
     #
     # Signing is automatically applied when component == os-skills.
     # No external sign parameter needed; the action decides internally.
@@ -104,10 +158,12 @@ runs:
         tar -czf "/tmp/archives/${ARCHIVE_FILE}" \
           -C /tmp/build "${ARCHIVE_NAME}"
 
+        echo "ARCHIVE_SIGNED=true" >> $GITHUB_ENV
+
     # -----------------------------------------------------------------
-    # Step 3: Sign archive (agent-sec-core only)
+    # Step 5: Sign archive (agent-sec-core only)
     #
-    # Signing is automatically applied when component == agent-sec-core
+    # Signing is automatically applied when component == agent-sec-core.
     # No external sign parameter needed; the action decides internally.
     # -----------------------------------------------------------------
     - name: Sign archive (agent-sec-core)
@@ -121,14 +177,14 @@ runs:
         tar -czf "/tmp/archives/${ARCHIVE_FILE}" \
           -C /tmp/build "${ARCHIVE_NAME}"
 
+        echo "ARCHIVE_SIGNED=true" >> $GITHUB_ENV
+
     # -----------------------------------------------------------------
-    # Step 4: Summarize
+    # Step 6: Summarize
     # -----------------------------------------------------------------
     - name: Summarize
       shell: bash
       run: |
-        SIGNED=$([[ "${{ inputs.component }}" =~ ^(os-skills|agent-sec-core)$ ]] && echo "true" || echo "false")
-
         echo "### Package Result" >> $GITHUB_STEP_SUMMARY
         echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
@@ -136,8 +192,11 @@ runs:
         echo "| Version | \`${{ inputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
         echo "| Archive | \`${ARCHIVE_FILE}\` |" >> $GITHUB_STEP_SUMMARY
         echo "| Size | $(du -sh /tmp/archives/${ARCHIVE_FILE} | cut -f1) |" >> $GITHUB_STEP_SUMMARY
-        if [ "$SIGNED" = "true" ]; then
+        if [ "${ARCHIVE_SIGNED:-false}" = "true" ]; then
           echo "| Signing | ✅ Signed |" >> $GITHUB_STEP_SUMMARY
+        fi
+        if [ "${LICENSE_RESOLVED}" = "true" ]; then
+          echo "| LICENSE | ✅ Resolved |" >> $GITHUB_STEP_SUMMARY
         fi
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Contents:**" >> $GITHUB_STEP_SUMMARY
@@ -146,7 +205,7 @@ runs:
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
     # -----------------------------------------------------------------
-    # Step 5: Upload artifact
+    # Step 7: Upload artifact
     # -----------------------------------------------------------------
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -88,7 +88,8 @@ jobs:
           version: ${{ needs.parse-tag.outputs.version }}
           artifact-suffix: ''
           retention-days: 28
-          skill-sign-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}
+          skill-sign-private-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}
+          skill-sign-public-key: ${{ vars.SKILL_SIGN_PUBLIC_KEY }}
 
   # =========================================================================
   # Step 2: Package (preview) → triggered by workflow_dispatch
@@ -110,4 +111,5 @@ jobs:
           version: ${{ inputs.version }}
           artifact-suffix: '.preview'
           retention-days: 14
-          skill-sign-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}
+          skill-sign-private-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}
+          skill-sign-public-key: ${{ vars.SKILL_SIGN_PUBLIC_KEY }}

--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -1,0 +1,113 @@
+name: Release Package
+
+on:
+  push:
+    tags:
+      - 'cosh/v*'
+      - 'sec-core/v*'
+      - 'sight/v*'
+      - 'skill/v*'
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to package (preview only, NOT used by release-publish)'
+        required: true
+        type: choice
+        options:
+          - copilot-shell
+          - agent-sec-core
+          - agentsight
+          - os-skills
+      version:
+        description: 'Version (e.g. 2.1.0, without v prefix)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  # =========================================================================
+  # Step 1: Parse tag → only runs on push tag
+  # =========================================================================
+  parse-tag:
+    name: Parse Tag
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    outputs:
+      component: ${{ steps.parse.outputs.component }}
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - name: Parse tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          SCOPE="${TAG%%/v*}"
+          VERSION="${TAG#*/v}"
+
+          case "$SCOPE" in
+            cosh)     COMPONENT="copilot-shell" ;;
+            sec-core) COMPONENT="agent-sec-core" ;;
+            sight)    COMPONENT="agentsight" ;;
+            skill)    COMPONENT="os-skills" ;;
+            *)
+              echo "Unknown scope: $SCOPE"
+              exit 1
+              ;;
+          esac
+
+          echo "component=$COMPONENT" >> $GITHUB_OUTPUT
+          echo "version=$VERSION"     >> $GITHUB_OUTPUT
+
+          echo "### Parsed Tag" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag | \`$TAG\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | \`$COMPONENT\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | \`$VERSION\` |" >> $GITHUB_STEP_SUMMARY
+
+  # =========================================================================
+  # Step 2: Package (official) → triggered by push tag
+  # Produces: {component}-{version}.tar.gz, retained 28 days
+  # This is the ONLY artifact accepted by release-publish.yaml
+  # =========================================================================
+  package-official:
+    name: Packaging (official)
+    needs: parse-tag
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Package archive
+        uses: ./.github/actions/package-archive
+        with:
+          component: ${{ needs.parse-tag.outputs.component }}
+          version: ${{ needs.parse-tag.outputs.version }}
+          artifact-suffix: ''
+          retention-days: 28
+          skill-sign-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}
+
+  # =========================================================================
+  # Step 2: Package (preview) → triggered by workflow_dispatch
+  # Produces: {component}-{version}.preview.tar.gz, retained 3 days
+  # For debugging and content verification ONLY.
+  # NOT used by release-publish.yaml (which only accepts official artifacts).
+  # =========================================================================
+  package-preview:
+    name: Packaging (preview)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Package archive
+        uses: ./.github/actions/package-archive
+        with:
+          component: ${{ inputs.component }}
+          version: ${{ inputs.version }}
+          artifact-suffix: '.preview'
+          retention-days: 14
+          skill-sign-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}

--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -93,7 +93,7 @@ jobs:
 
   # =========================================================================
   # Step 2: Package (preview) → triggered by workflow_dispatch
-  # Produces: {component}-{version}.preview.tar.gz, retained 3 days
+  # Produces: {component}-{version}.preview.tar.gz, retained 14 days
   # For debugging and content verification ONLY.
   # NOT used by release-publish.yaml (which only accepts official artifacts).
   # =========================================================================

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,0 +1,187 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to publish'
+        required: true
+        type: choice
+        options:
+          - copilot-shell
+          - agent-sec-core
+          - agentsight
+          - os-skills
+      version:
+        description: 'Version (e.g. 2.1.0, without v prefix)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run: preview release info without creating GitHub Release'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  # =========================================================================
+  # Step 1: Publish → downloads official artifact from release-package.yaml (push tag)
+  # Prerequisite: release-package.yaml must have run on the corresponding tag,
+  # and the official artifact must not have expired (28-day retention window).
+  #
+  # dry_run=true  → preview release info + tar -t contents, no Release created
+  # dry_run=false → create GitHub Release and upload artifact to Release Assets
+  # =========================================================================
+  publish:
+    name: >-
+      ${{ inputs.dry_run == true && 'Dry Run' || 'Publish' }}
+      ${{ inputs.component }}-${{ inputs.version }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find package run-id
+        id: find-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARTIFACT_NAME="${{ inputs.component }}-${{ inputs.version }}"
+
+          RUN_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/release-package.yaml/runs?status=success&per_page=50" \
+            --jq '.workflow_runs[].id' | while read rid; do
+              EXISTS=$(gh api \
+                "repos/${{ github.repository }}/actions/runs/${rid}/artifacts" \
+                --jq ".artifacts[] | select(.name==\"${ARTIFACT_NAME}\") | .id" 2>/dev/null)
+              if [ -n "$EXISTS" ]; then
+                echo "$rid"
+                break
+              fi
+            done)
+
+          if [ -z "$RUN_ID" ]; then
+            echo "ERROR: No successful run found in release-package.yaml with artifact: ${ARTIFACT_NAME}"
+            echo "Possible causes:"
+            echo "  1. release-package.yaml has not run for this tag yet."
+            echo "  2. The artifact has expired (28-day retention window)."
+            echo "  3. The component/version inputs do not match the tag used."
+            exit 1
+          fi
+
+          echo "Found run-id: $RUN_ID"
+          echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+
+          echo "### Package Run" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Artifact | \`${ARTIFACT_NAME}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Source Run | [#${RUN_ID}](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}) |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Download official artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.component }}-${{ inputs.version }}
+          path: /tmp/archives
+          run-id: ${{ steps.find-run.outputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Preview release info (dry_run)
+        if: inputs.dry_run == true
+        run: |
+          COMPONENT="${{ inputs.component }}"
+          VERSION="${{ inputs.version }}"
+          ARCHIVE="/tmp/archives/${COMPONENT}-${VERSION}.tar.gz"
+
+          case "$COMPONENT" in
+            copilot-shell)  TAG="cosh/v${VERSION}";     PREFIX="cosh/v" ;;
+            agent-sec-core) TAG="sec-core/v${VERSION}";  PREFIX="sec-core/v" ;;
+            agentsight)     TAG="sight/v${VERSION}";     PREFIX="sight/v" ;;
+            os-skills)      TAG="skill/v${VERSION}";     PREFIX="skill/v" ;;
+          esac
+
+          PREV_TAG=$(git tag --list "${PREFIX}*" --sort=-version:refname | grep -v "^${TAG}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            COMPARE_URL="https://github.com/${{ github.repository }}/commits/${TAG}"
+          else
+            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+          fi
+
+          echo "=========================================="
+          echo " DRY RUN - Release Preview"
+          echo "=========================================="
+          echo "  Component : ${COMPONENT}"
+          echo "  Version   : ${VERSION}"
+          echo "  Tag       : ${TAG}"
+          echo "  Prev Tag  : ${PREV_TAG:-'(none, first release)'}"
+          echo "  Compare   : ${COMPARE_URL}"
+          echo "  Archive   : $(ls -lh ${ARCHIVE} | awk '{print $5, $9}')"
+          echo ""
+          echo "--- Archive contents (tar -t) ---"
+          tar -tzf "${ARCHIVE}"
+          echo "=========================================="
+          echo " No GitHub Release was created (dry_run)"
+          echo "=========================================="
+
+          echo "### Dry Run Preview" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | \`${COMPONENT}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | \`${VERSION}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag | \`${TAG}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Previous Tag | \`${PREV_TAG:-'(none, first release)'}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Archive | \`${COMPONENT}-${VERSION}.tar.gz\` ($(du -sh ${ARCHIVE} | cut -f1)) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Changelog | [Compare](${COMPARE_URL}) |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Archive contents (tar -t):**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          tar -tzf "${ARCHIVE}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> **No GitHub Release was created** (dry_run=true). Re-run with \`dry_run=false\` to publish." >> $GITHUB_STEP_SUMMARY
+
+      - name: Create GitHub Release
+        if: inputs.dry_run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMPONENT="${{ inputs.component }}"
+          VERSION="${{ inputs.version }}"
+          ARCHIVE="/tmp/archives/${COMPONENT}-${VERSION}.tar.gz"
+
+          case "$COMPONENT" in
+            copilot-shell)  TAG="cosh/v${VERSION}";     PREFIX="cosh/v" ;;
+            agent-sec-core) TAG="sec-core/v${VERSION}";  PREFIX="sec-core/v" ;;
+            agentsight)     TAG="sight/v${VERSION}";     PREFIX="sight/v" ;;
+            os-skills)      TAG="skill/v${VERSION}";     PREFIX="skill/v" ;;
+          esac
+
+          PREV_TAG=$(git tag --list "${PREFIX}*" --sort=-version:refname | grep -v "^${TAG}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            COMPARE_URL="https://github.com/${{ github.repository }}/commits/${TAG}"
+          else
+            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+          fi
+
+          NOTES="## ${COMPONENT} v${VERSION}\n\n<!-- Add release notes here -->\n\n## What's Changed\n\n<!-- List the key changes in this release -->\n\n**Full Changelog**: ${COMPARE_URL}"
+
+          gh release create "$TAG" \
+            --title "${COMPONENT} v${VERSION}" \
+            --notes "$(printf '%b' "${NOTES}")" \
+            --target "$(git rev-list -n 1 $TAG)" \
+            "$ARCHIVE"
+
+          RELEASE_URL=$(gh release view "$TAG" --json url --jq '.url')
+
+          echo "### Release Created" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | \`${COMPONENT}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | \`${VERSION}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag | \`${TAG}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Release | [View Release](${RELEASE_URL}) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Changelog | [Compare](${COMPARE_URL}) |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

Split the monolithic release workflow into two independent workflows: `release-package.yaml` handles tag-triggered packaging and preview builds, while `release-publish.yaml` handles GitHub Release creation from pre-built official artifacts. This separation decouples the build and publish steps, allowing release managers to verify the packaged artifact (via dry-run) before making it publicly available. The two-stage design also enforces a clear artifact provenance contract: only official artifacts produced by `release-package.yaml` on tag push are accepted by `release-publish.yaml`.

```mermaid
flowchart TD
    subgraph PKG["release-package.yaml"]
        T1["push tag\ncosh/v* | sec-core/v* | sight/v* | skill/v*"]
        T2["workflow_dispatch\ncomponent + version"]

        T1 --> P1["parse-tag\n解析 tag → component + version"]
        P1 --> P2["package-official\n调用 package-archive action"]
        P2 --> A1["官方制品\n{component}-{version}.tar.gz\n保留 28 天"]

        T2 --> P3["package-preview\n调用 package-archive action"]
        P3 --> A2["预览制品\n{component}-{version}.preview.tar.gz\n保留 14 天\n仅供人工验证"]
    end

    subgraph PUB["release-publish.yaml"]
        T3["workflow_dispatch\ncomponent + version + dry_run"]

        T3 --> Q1["Find package run-id"]
        Q1 --> Q2{artifact 找到?}
        Q2 -- No --> ERR["exit 1\n未找到 / 已过期 / 输入不匹配"]
        Q2 -- Yes --> Q3["Download official artifact"]
        Q3 --> DR{dry_run?}
        DR -- true --> D1["Step Summary 预览\ntar -t 列出内容\n不创建 Release"]
        DR -- false --> D2["gh release create\n创建 GitHub Release\n上传 tar.gz"]
    end

    A1 -.->|"跨 workflow 下载\n28天内有效"| Q1
```

## Related Issue

closes #118

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

**release-package.yaml** key behaviors:
- Triggered by tags matching `cosh/v*`, `sec-core/v*`, `sight/v*`, `skill/v*`
- Official artifact: `{component}-{version}.tar.gz`, retained 28 days
- Preview artifact (via `workflow_dispatch`): `{component}-{version}.preview.tar.gz`, retained 14 days

**release-publish.yaml** key behaviors:
- Manual-only (`workflow_dispatch`); requires `component`, `version`, and `dry_run` inputs
- Looks up the official artifact from the latest successful `release-package.yaml` run
- `dry_run=true`: prints release info and archive contents only, no Release created
- `dry_run=false`: creates GitHub Release and uploads the artifact as a release asset
- Fails clearly if the artifact is not found or has exceeded the 28-day retention window

> **Merge suggestion**: please use **Squash and Merge** with title `chore(ci): add release-package and release-publish workflows` to keep the commit history clean.