### PR TITLE
feat(cosh): add BeforeModel, AfterModel, and BeforeToolSelection hooks

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -554,6 +554,7 @@ export const AppContainer = (props: AppContainerProps) => {
       quit: (messages: HistoryItem[]) => {
         setQuittingMessages(messages);
         setTimeout(async () => {
+          await config.shutdown();
           await runExitCleanup();
           process.exit(0);
         }, 100);
@@ -566,6 +567,7 @@ export const AppContainer = (props: AppContainerProps) => {
       openResumeDialog,
     }),
     [
+      config,
       openAuthDialog,
       openThemeDialog,
       openEditorDialog,

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -917,6 +917,10 @@ export const useGeminiStream = (
               userMessageTimestamp,
             );
             break;
+          case ServerGeminiEventType.AfterModelHookStop:
+            // AfterModel hook requested stop — agent loop is ended by client.ts.
+            // No UI action needed here; just acknowledge the event.
+            break;
           default: {
             // enforces exhaustive switch-case
             const unreachable: never = event;

--- a/src/copilot-shell/packages/core/src/aliyun/aliyunContentGenerator.ts
+++ b/src/copilot-shell/packages/core/src/aliyun/aliyunContentGenerator.ts
@@ -334,9 +334,28 @@ export class AliyunContentGenerator implements ContentGenerator {
     }
 
     // Convert tools (from config)
+    // Respect functionCallingConfig mode and allowedFunctionNames (BeforeToolSelection hook support)
+    const rawConfig = request.config as Record<string, unknown> | undefined;
+    const functionCallingConfig = rawConfig?.['functionCallingConfig'] as
+      | Record<string, unknown>
+      | undefined;
+    const callingMode = functionCallingConfig?.['mode'] as string | undefined;
+    const allowedFunctionNames = functionCallingConfig?.[
+      'allowedFunctionNames'
+    ] as string[] | undefined;
+    // If mode=NONE, the tool-building block below is skipped entirely.
+    // Otherwise, build allowedSet from allowedFunctionNames for name-based filtering.
+    const allowedSet =
+      callingMode === 'NONE'
+        ? null
+        : allowedFunctionNames && allowedFunctionNames.length > 0
+          ? new Set(allowedFunctionNames)
+          : null; // null = no name filter (pass all tools)
+
     let tools: AliyunTool[] | undefined;
     const requestTools = request.config?.tools;
     if (
+      callingMode !== 'NONE' &&
       requestTools &&
       Array.isArray(requestTools) &&
       requestTools.length > 0
@@ -359,6 +378,8 @@ export class AliyunContentGenerator implements ContentGenerator {
           ).functionDeclarations;
           if (funcDecls) {
             for (const func of funcDecls) {
+              // Skip functions not in the allowed list (if restriction is active)
+              if (allowedSet && !allowedSet.has(func.name)) continue;
               // Handle both Gemini tools (parameters) and MCP tools (parametersJsonSchema)
               let parameters: Record<string, unknown> | undefined;
 

--- a/src/copilot-shell/packages/core/src/config/config.ts
+++ b/src/copilot-shell/packages/core/src/config/config.ts
@@ -98,6 +98,7 @@ import { FileExclusions } from '../utils/ignorePatterns.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import { isToolEnabled, type ToolName } from '../utils/tool-utils.js';
 import { getErrorMessage } from '../utils/errors.js';
+import { setDebugLogSession } from '../utils/debugLogger.js';
 
 // Local config modules
 import type { FileFilteringOptions } from './constants.js';
@@ -704,6 +705,9 @@ export class Config {
     }
     this.initialized = true;
 
+    // Activate debug log session so all debugLogger.*() calls write to file
+    setDebugLogSession({ getSessionId: () => this.sessionId });
+
     // Initialize centralized FileDiscoveryService
     this.getFileService();
     if (this.getCheckpointingEnabled()) {
@@ -912,6 +916,8 @@ export class Config {
    * Releases resources owned by the config instance.
    */
   async shutdown(): Promise<void> {
+    // Fire SessionEnd hook before releasing resources
+    await this.geminiClient?.shutdown();
     this.skillManager?.stopWatching();
   }
 
@@ -929,6 +935,8 @@ export class Config {
       : undefined;
     if (this.initialized) {
       logStartSession(this, new StartSessionEvent(this));
+      // Update debug log latest symlink to point to the new session
+      setDebugLogSession({ getSessionId: () => this.sessionId });
     }
     return this.sessionId;
   }

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -79,6 +79,11 @@ import { createHookOutput } from '../hooks/types.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import { type File, type IdeContext } from '../ide/types.js';
 import type { StopHookOutput } from '../hooks/types.js';
+import {
+  SessionStartSource,
+  SessionEndReason,
+  PreCompactTrigger,
+} from '../hooks/types.js';
 
 const MAX_TURNS = 100;
 
@@ -114,8 +119,14 @@ export class GeminiClient {
         resumedSessionData.conversation,
       );
       this.chat = await this.startChat(resumedHistory);
+
+      // Fire SessionStart hook (resume)
+      await this.fireSessionStartHook(SessionStartSource.Resume);
     } else {
       this.chat = await this.startChat();
+
+      // Fire SessionStart hook (startup)
+      await this.fireSessionStartHook(SessionStartSource.Startup);
     }
   }
 
@@ -162,7 +173,13 @@ export class GeminiClient {
   }
 
   async resetChat(): Promise<void> {
+    // Fire SessionEnd hook before clearing
+    await this.fireSessionEndHook(SessionEndReason.Clear);
+
     this.chat = await this.startChat();
+
+    // Fire SessionStart hook after clear
+    await this.fireSessionStartHook(SessionStartSource.Clear);
   }
 
   getLoopDetectionService(): LoopDetectionService {
@@ -212,6 +229,50 @@ export class GeminiClient {
         'startChat',
       );
       throw new Error(`Failed to initialize chat: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Fire SessionStart hook (advisory only - does not block startup)
+   */
+  private async fireSessionStartHook(
+    source: SessionStartSource,
+  ): Promise<void> {
+    if (!this.config.getEnableHooks()) return;
+    const hookSystem = this.config.getHookSystem();
+    if (!hookSystem) return;
+    try {
+      await hookSystem.fireSessionStartEvent(source);
+    } catch {
+      // Advisory: do not block startup on hook failure
+    }
+  }
+
+  /**
+   * Fire SessionEnd hook (best effort - does not block exit)
+   */
+  private async fireSessionEndHook(reason: SessionEndReason): Promise<void> {
+    if (!this.config.getEnableHooks()) return;
+    const hookSystem = this.config.getHookSystem();
+    if (!hookSystem) return;
+    try {
+      await hookSystem.fireSessionEndEvent(reason);
+    } catch {
+      // Best effort: do not block exit on hook failure
+    }
+  }
+
+  /**
+   * Fire PreCompact hook (advisory only - does not block compression)
+   */
+  private async firePreCompactHook(trigger: PreCompactTrigger): Promise<void> {
+    if (!this.config.getEnableHooks()) return;
+    const hookSystem = this.config.getHookSystem();
+    if (!hookSystem) return;
+    try {
+      await hookSystem.firePreCompactEvent(trigger);
+    } catch {
+      // Advisory: do not block compression on hook failure
     }
   }
 
@@ -747,6 +808,11 @@ export class GeminiClient {
     prompt_id: string,
     force: boolean = false,
   ): Promise<ChatCompressionInfo> {
+    // Fire PreCompact hook before compression
+    await this.firePreCompactHook(
+      force ? PreCompactTrigger.Manual : PreCompactTrigger.Auto,
+    );
+
     const compressionService = new ChatCompressionService();
 
     const { newHistory, info } = await compressionService.compress(

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -15,6 +15,9 @@ import type {
 
 // Config
 import { ApprovalMode, type Config } from '../config/config.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const hookDebugLogger = createDebugLogger('HOOK_DEBUG');
 
 // Core modules
 import type { ContentGenerator } from './contentGenerator.js';
@@ -102,6 +105,9 @@ export class GeminiClient {
    */
   private hasFailedCompressionAttempt = false;
 
+  /** Guard to prevent SessionEnd from being fired more than once. */
+  private hasShutdown = false;
+
   constructor(private readonly config: Config) {
     this.loopDetector = new LoopDetectionService(config);
   }
@@ -170,6 +176,17 @@ export class GeminiClient {
     const toolDeclarations = toolRegistry.getFunctionDeclarations();
     const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
     this.getChat().setTools(tools);
+  }
+
+  /**
+   * Gracefully shut down the client, firing SessionEnd hook.
+   * Called on normal exit (/quit, Ctrl+C).
+   * Idempotent: subsequent calls are no-ops.
+   */
+  async shutdown(): Promise<void> {
+    if (this.hasShutdown) return;
+    this.hasShutdown = true;
+    await this.fireSessionEndHook(SessionEndReason.PromptInputExit);
   }
 
   async resetChat(): Promise<void> {
@@ -242,8 +259,12 @@ export class GeminiClient {
     const hookSystem = this.config.getHookSystem();
     if (!hookSystem) return;
     try {
-      await hookSystem.fireSessionStartEvent(source);
-    } catch {
+      const result = await hookSystem.fireSessionStartEvent(source);
+      hookDebugLogger.info(
+        `[Hook Debug] SessionStart: completed, hasOutput=${!!result}`,
+      );
+    } catch (e) {
+      hookDebugLogger.error(`[Hook Debug] SessionStart: hook threw error=${e}`);
       // Advisory: do not block startup on hook failure
     }
   }
@@ -256,8 +277,12 @@ export class GeminiClient {
     const hookSystem = this.config.getHookSystem();
     if (!hookSystem) return;
     try {
-      await hookSystem.fireSessionEndEvent(reason);
-    } catch {
+      const result = await hookSystem.fireSessionEndEvent(reason);
+      hookDebugLogger.info(
+        `[Hook Debug] SessionEnd: completed, hasOutput=${!!result}`,
+      );
+    } catch (e) {
+      hookDebugLogger.error(`[Hook Debug] SessionEnd: hook threw error=${e}`);
       // Best effort: do not block exit on hook failure
     }
   }
@@ -650,6 +675,10 @@ export class GeminiClient {
       }
       yield event;
       if (event.type === GeminiEventType.Error) {
+        return turn;
+      }
+      // AfterModel hook requested stop: end agent loop cleanly (no error shown).
+      if (event.type === GeminiEventType.AfterModelHookStop) {
         return turn;
       }
     }

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -1321,6 +1321,71 @@ export class CoreToolScheduler {
               outputFile,
               contentLength,
             };
+
+            // Fire PostToolUse hook after successful tool execution
+            if (this.config.getEnableHooks()) {
+              const hookSystem = this.config.getHookSystem();
+              if (hookSystem) {
+                try {
+                  const postToolOutput = await hookSystem.firePostToolUseEvent(
+                    toolName,
+                    scheduledCall.request.args,
+                    {
+                      llmContent: typeof content === 'string' ? content : '',
+                      returnDisplay:
+                        typeof toolResult.returnDisplay === 'string'
+                          ? toolResult.returnDisplay
+                          : undefined,
+                    },
+                  );
+
+                  if (postToolOutput) {
+                    // If hook denies, replace tool result with reason
+                    if (postToolOutput.isBlockingDecision()) {
+                      const reason = postToolOutput.getEffectiveReason();
+                      const blockedResponse = convertToFunctionResponse(
+                        toolName,
+                        callId,
+                        reason,
+                      );
+                      successResponse.responseParts = blockedResponse;
+                    }
+
+                    // Append additional context to tool result
+                    const additionalContext =
+                      postToolOutput.getAdditionalContext();
+                    if (
+                      additionalContext &&
+                      !postToolOutput.isBlockingDecision()
+                    ) {
+                      const augmented = convertToFunctionResponse(
+                        toolName,
+                        callId,
+                        (typeof content === 'string' ? content : '') +
+                          '\n' +
+                          additionalContext,
+                      );
+                      successResponse.responseParts = augmented;
+                    }
+
+                    // Handle continue=false
+                    if (postToolOutput.shouldStopExecution()) {
+                      this.setStatusInternal(
+                        callId,
+                        'success',
+                        successResponse,
+                      );
+                      continue;
+                    }
+                  }
+                } catch (hookError) {
+                  console.error(
+                    `PostToolUse hook error for ${toolName}: ${hookError}`,
+                  );
+                }
+              }
+            }
+
             this.setStatusInternal(callId, 'success', successResponse);
           } else {
             // It is a failure

--- a/src/copilot-shell/packages/core/src/core/geminiChat.test.ts
+++ b/src/copilot-shell/packages/core/src/core/geminiChat.test.ts
@@ -118,6 +118,8 @@ describe('GeminiChat', () => {
         getTool: vi.fn(),
       }),
       getContentGenerator: vi.fn().mockReturnValue(mockContentGenerator),
+      getEnableHooks: vi.fn().mockReturnValue(false),
+      getHookSystem: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
 
     // Disable 429 simulation for tests

--- a/src/copilot-shell/packages/core/src/core/geminiChat.ts
+++ b/src/copilot-shell/packages/core/src/core/geminiChat.ts
@@ -11,6 +11,7 @@ import type {
   GenerateContentResponse,
   Content,
   GenerateContentConfig,
+  GenerateContentParameters,
   SendMessageParameters,
   Part,
   Tool,
@@ -31,6 +32,11 @@ import {
   ContentRetryFailureEvent,
 } from '../telemetry/types.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
+import { defaultHookTranslator } from '../hooks/hookTranslator.js';
+import type { LLMRequest } from '../hooks/hookTranslator.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const hookDebugLogger = createDebugLogger('HOOK_DEBUG');
 
 export enum StreamEventType {
   /** A regular content chunk from the API. */
@@ -185,6 +191,24 @@ export class InvalidStreamError extends Error {
     super(message);
     this.name = 'InvalidStreamError';
     this.type = type;
+  }
+}
+
+/**
+ * Thrown by processStreamResponse when an AfterModel hook requests stop or deny.
+ * Distinguishes hook-requested stops from API errors so turn.ts can handle
+ * them gracefully without showing an error to the user.
+ */
+export class AfterModelHookStopError extends Error {
+  /** If true, the model turn was removed from history (decision: "deny"). */
+  readonly discardedModelTurn: boolean;
+  readonly hookStopReason?: string;
+
+  constructor(reason?: string, discardedModelTurn = false) {
+    super('AfterModel hook requested stop');
+    this.name = 'AfterModelHookStopError';
+    this.discardedModelTurn = discardedModelTurn;
+    this.hookStopReason = reason;
   }
 }
 
@@ -347,15 +371,128 @@ export class GeminiChat {
     params: SendMessageParameters,
     prompt_id: string,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    // Build the request object
+    let request: GenerateContentParameters = {
+      model,
+      contents: requestContents,
+      config: { ...this.generationConfig, ...params.config },
+    };
+
+    // Fire BeforeModel hook
+    if (this.config.getEnableHooks()) {
+      const hookSystem = this.config.getHookSystem();
+      if (hookSystem) {
+        hookDebugLogger.info(
+          `[Hook Debug] BeforeModel: firing hook, model=${model}, contents.length=${requestContents.length}`,
+        );
+        try {
+          const beforeModelResult =
+            await hookSystem.fireBeforeModelEvent(request);
+          if (beforeModelResult) {
+            hookDebugLogger.info(
+              `[Hook Debug] BeforeModel: received result, decision=${beforeModelResult.isBlockingDecision() ? 'BLOCK' : beforeModelResult.shouldStopExecution() ? 'STOP' : 'ALLOW'}`,
+            );
+            // If hook says stop execution, return empty stream
+            if (beforeModelResult.shouldStopExecution()) {
+              hookDebugLogger.warn(
+                '[Hook Debug] BeforeModel: hook requested stop execution, returning empty stream',
+              );
+              return this.createEmptyStream();
+            }
+            // If hook blocks with a synthetic response, use that instead
+            if (beforeModelResult.isBlockingDecision()) {
+              const syntheticHookResponse =
+                beforeModelResult.getSyntheticResponse();
+              if (syntheticHookResponse) {
+                hookDebugLogger.info(
+                  `[Hook Debug] BeforeModel: using synthetic response from hook (text.length=${syntheticHookResponse.text?.length ?? 0})`,
+                );
+                const syntheticSDKResponse =
+                  defaultHookTranslator.fromHookLLMResponse(
+                    syntheticHookResponse,
+                  );
+                return this.processStreamResponse(
+                  model,
+                  this.createSingleChunkStream(syntheticSDKResponse),
+                  request,
+                );
+              }
+              hookDebugLogger.warn(
+                '[Hook Debug] BeforeModel: blocking decision without synthetic response, returning empty stream',
+              );
+              return this.createEmptyStream();
+            }
+            // Apply request modifications from hook
+            const mods = beforeModelResult.getLLMRequestModifications();
+            if (mods) {
+              hookDebugLogger.info(
+                '[Hook Debug] BeforeModel: applying request modifications from hook',
+              );
+              request = defaultHookTranslator.fromHookLLMRequest(
+                mods as LLMRequest,
+                request,
+              );
+            }
+          } else {
+            hookDebugLogger.debug(
+              '[Hook Debug] BeforeModel: no hook result (no matching hooks)',
+            );
+          }
+        } catch (hookError) {
+          hookDebugLogger.error(
+            `[Hook Debug] BeforeModel: hook error: ${hookError}`,
+          );
+          console.error(`BeforeModel hook error: ${hookError}`);
+        }
+      }
+    }
+
+    // Fire BeforeToolSelection hook
+    if (this.config.getEnableHooks()) {
+      const hookSystem = this.config.getHookSystem();
+      if (hookSystem) {
+        hookDebugLogger.info('[Hook Debug] BeforeToolSelection: firing hook');
+        try {
+          const toolSelResult =
+            await hookSystem.fireBeforeToolSelectionEvent(request);
+          if (toolSelResult) {
+            const hookToolConfig = toolSelResult.getToolConfig();
+            if (hookToolConfig) {
+              hookDebugLogger.info(
+                `[Hook Debug] BeforeToolSelection: applying tool config modification, mode=${hookToolConfig.mode}, allowedFunctions=${JSON.stringify(hookToolConfig.allowedFunctionNames ?? [])}`,
+              );
+              const sdkToolConfig =
+                defaultHookTranslator.fromHookToolConfig(hookToolConfig);
+              request = {
+                ...request,
+                config: {
+                  ...request.config,
+                  ...sdkToolConfig,
+                },
+              };
+            } else {
+              hookDebugLogger.debug(
+                '[Hook Debug] BeforeToolSelection: no tool config modification from hook',
+              );
+            }
+          } else {
+            hookDebugLogger.debug(
+              '[Hook Debug] BeforeToolSelection: no hook result (no matching hooks)',
+            );
+          }
+        } catch (hookError) {
+          hookDebugLogger.error(
+            `[Hook Debug] BeforeToolSelection: hook error: ${hookError}`,
+          );
+          console.error(`BeforeToolSelection hook error: ${hookError}`);
+        }
+      }
+    }
+
     const apiCall = () =>
-      this.config.getContentGenerator().generateContentStream(
-        {
-          model,
-          contents: requestContents,
-          config: { ...this.generationConfig, ...params.config },
-        },
-        prompt_id,
-      );
+      this.config
+        .getContentGenerator()
+        .generateContentStream(request, prompt_id);
     const streamResponse = await retryWithBackoff(apiCall, {
       shouldRetryOnError: (error: unknown) => {
         if (error instanceof Error) {
@@ -373,7 +510,25 @@ export class GeminiChat {
       authType: this.config.getContentGeneratorConfig()?.authType,
     });
 
-    return this.processStreamResponse(model, streamResponse);
+    return this.processStreamResponse(model, streamResponse, request);
+  }
+
+  /**
+   * Create an empty async generator stream.
+   * Used when a BeforeModel hook blocks the LLM call.
+   */
+  private async *createEmptyStream(): AsyncGenerator<GenerateContentResponse> {
+    // Yield nothing - the stream is intentionally empty
+  }
+
+  /**
+   * Create a single-chunk async generator from a GenerateContentResponse.
+   * Used for synthetic responses from BeforeModel hooks.
+   */
+  private async *createSingleChunkStream(
+    response: GenerateContentResponse,
+  ): AsyncGenerator<GenerateContentResponse> {
+    yield response;
   }
 
   /**
@@ -500,6 +655,7 @@ export class GeminiChat {
   private async *processStreamResponse(
     model: string,
     streamResponse: AsyncGenerator<GenerateContentResponse>,
+    originalRequest?: GenerateContentParameters,
   ): AsyncGenerator<GenerateContentResponse> {
     // Collect ALL parts from the model response (including thoughts for recording)
     const allModelParts: Part[] = [];
@@ -624,6 +780,97 @@ export class GeminiChat {
         ...consolidatedHistoryParts,
       ],
     });
+
+    // Fire AfterModel hook after stream completes (observation + response modification + stop signal)
+    if (originalRequest && this.config.getEnableHooks()) {
+      const hookSystem = this.config.getHookSystem();
+      if (hookSystem) {
+        hookDebugLogger.info(
+          `[Hook Debug] AfterModel: firing hook, response.parts=${consolidatedHistoryParts.length}, hasFinishReason=${hasFinishReason}`,
+        );
+        try {
+          // Build accumulated response for the hook
+          const accumulatedResponse: GenerateContentResponse = {
+            candidates: [
+              {
+                content: {
+                  role: 'model',
+                  parts: consolidatedHistoryParts,
+                },
+                finishReason: hasFinishReason ? 'STOP' : undefined,
+              },
+            ],
+            usageMetadata,
+          } as GenerateContentResponse;
+          const afterResult = await hookSystem.fireAfterModelEvent(
+            originalRequest,
+            accumulatedResponse,
+          );
+          if (afterResult) {
+            hookDebugLogger.info(
+              `[Hook Debug] AfterModel: hook completed, decision=${afterResult.isBlockingDecision() ? 'BLOCK' : afterResult.shouldStopExecution() ? 'STOP' : 'ALLOW'}`,
+            );
+
+            // Apply modified response to history if hook provided one.
+            // Note: streaming text already rendered to UI cannot be reverted;
+            // this only updates the stored history entry.
+            const modifiedResponse = afterResult.getModifiedResponse();
+            if (modifiedResponse) {
+              hookDebugLogger.info(
+                '[Hook Debug] AfterModel: applying modified response to history',
+              );
+              const modifiedSDKResponse =
+                defaultHookTranslator.fromHookLLMResponse(modifiedResponse);
+              const modifiedParts =
+                modifiedSDKResponse.candidates?.[0]?.content?.parts ?? [];
+              if (
+                this.history.length > 0 &&
+                this.history[this.history.length - 1].role === 'model'
+              ) {
+                this.history[this.history.length - 1] = {
+                  ...this.history[this.history.length - 1],
+                  parts: modifiedParts,
+                };
+              }
+            }
+
+            // Blocking decision (decision: "deny"): discard model turn and stop agent loop.
+            if (afterResult.isBlockingDecision()) {
+              hookDebugLogger.warn(
+                '[Hook Debug] AfterModel: blocking decision, discarding model turn from history',
+              );
+              if (
+                this.history.length > 0 &&
+                this.history[this.history.length - 1].role === 'model'
+              ) {
+                this.history.pop();
+              }
+              throw new AfterModelHookStopError(afterResult.reason, true);
+            }
+
+            // continue: false — keep history, signal agent loop to stop.
+            if (afterResult.shouldStopExecution()) {
+              hookDebugLogger.warn(
+                '[Hook Debug] AfterModel: shouldStopExecution, stopping agent loop',
+              );
+              throw new AfterModelHookStopError(afterResult.reason, false);
+            }
+          } else {
+            hookDebugLogger.debug(
+              '[Hook Debug] AfterModel: no hook result (no matching hooks)',
+            );
+          }
+        } catch (hookError) {
+          if (hookError instanceof AfterModelHookStopError) {
+            throw hookError; // Re-throw stop signal, not a real error
+          }
+          hookDebugLogger.error(
+            `[Hook Debug] AfterModel: hook error: ${hookError}`,
+          );
+          console.error(`AfterModel hook error: ${hookError}`);
+        }
+      }
+    }
   }
 }
 

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -252,11 +252,66 @@ export class ContentGenerationPipeline {
       baseRequest.stream_options = { include_usage: true };
     }
 
-    // Add tools if present
+    // Add tools if present, respecting functionCallingConfig mode and allowedFunctionNames
     if (request.config?.tools) {
-      baseRequest.tools = await this.converter.convertGeminiToolsToOpenAI(
-        request.config.tools,
-      );
+      const rawConfig = request.config as Record<string, unknown>;
+      const functionCallingConfig = rawConfig?.['functionCallingConfig'] as
+        | Record<string, unknown>
+        | undefined;
+      const callingMode = functionCallingConfig?.['mode'] as string | undefined;
+      const allowedFunctionNames = functionCallingConfig?.[
+        'allowedFunctionNames'
+      ] as string[] | undefined;
+
+      // mode=NONE means BeforeToolSelection hook disabled all tools entirely.
+      // OpenAI API has no native mode concept, so we simply omit tools from the request.
+      if (callingMode === 'NONE') {
+        // Do not set baseRequest.tools — omitting tools disables function calling.
+      } else {
+        let toolsToUse = request.config.tools;
+
+        // Apply allowedFunctionNames filter if specified (BeforeToolSelection hook support)
+        if (allowedFunctionNames && allowedFunctionNames.length > 0) {
+          const allowedSet = new Set(allowedFunctionNames);
+          // Filter function declarations WITHIN each tool object, not whole tool objects.
+          // All function declarations may be grouped in a single Tool, so we must
+          // produce a new Tool with only the allowed declarations.
+          toolsToUse = (request.config.tools as unknown[]).reduce(
+            (acc: unknown[], tool: unknown) => {
+              if (!tool || typeof tool !== 'object') return acc;
+              const t = tool as Record<string, unknown>;
+              const decls = t['functionDeclarations'];
+              if (Array.isArray(decls)) {
+                const filteredDecls = decls.filter(
+                  (d: unknown) =>
+                    d &&
+                    typeof d === 'object' &&
+                    allowedSet.has(
+                      (d as Record<string, unknown>)['name'] as string,
+                    ),
+                );
+                if (filteredDecls.length > 0) {
+                  acc.push({ ...t, functionDeclarations: filteredDecls });
+                }
+              } else {
+                // Non-function tools (e.g. googleSearch) are kept as-is
+                acc.push(tool);
+              }
+              return acc;
+            },
+            [],
+          ) as typeof request.config.tools;
+        }
+
+        const convertedTools =
+          await this.converter.convertGeminiToolsToOpenAI(toolsToUse);
+        // Only set tools if the result is non-empty.
+        // OpenAI API requires tools to be a non-empty array when present;
+        // sending tools:[] causes a 400 error on most providers.
+        if (convertedTools.length > 0) {
+          baseRequest.tools = convertedTools;
+        }
+      }
     }
 
     // Let provider enhance the request (e.g., add metadata, cache control)

--- a/src/copilot-shell/packages/core/src/core/turn.ts
+++ b/src/copilot-shell/packages/core/src/core/turn.ts
@@ -27,6 +27,7 @@ import {
   toFriendlyError,
 } from '../utils/errors.js';
 import type { GeminiChat } from './geminiChat.js';
+import { AfterModelHookStopError } from './geminiChat.js';
 import {
   getThoughtText,
   parseThought,
@@ -64,6 +65,7 @@ export enum GeminiEventType {
   Citation = 'citation',
   Retry = 'retry',
   HookSystemMessage = 'hook_system_message',
+  AfterModelHookStop = 'after_model_hook_stop',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -204,6 +206,10 @@ export type ServerGeminiHookSystemMessageEvent = {
   value: string;
 };
 
+export type ServerGeminiAfterModelHookStopEvent = {
+  type: GeminiEventType.AfterModelHookStop;
+};
+
 // The original union type, now composed of the individual types
 export type ServerGeminiStreamEvent =
   | ServerGeminiChatCompressedEvent
@@ -212,6 +218,7 @@ export type ServerGeminiStreamEvent =
   | ServerGeminiErrorEvent
   | ServerGeminiFinishedEvent
   | ServerGeminiHookSystemMessageEvent
+  | ServerGeminiAfterModelHookStopEvent
   | ServerGeminiLoopDetectedEvent
   | ServerGeminiMaxSessionTurnsEvent
   | ServerGeminiThoughtEvent
@@ -330,6 +337,18 @@ export class Turn {
       if (signal.aborted) {
         yield { type: GeminiEventType.UserCancelled };
         // Regular cancellation error, fail gracefully.
+        return;
+      }
+
+      // AfterModel hook stop signal: not a real error, handle gracefully.
+      if (e instanceof AfterModelHookStopError) {
+        if (e.hookStopReason) {
+          yield {
+            type: GeminiEventType.HookSystemMessage,
+            value: e.hookStopReason,
+          };
+        }
+        yield { type: GeminiEventType.AfterModelHookStop };
         return;
       }
 

--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
@@ -11,8 +11,15 @@ import {
   PostToolUseHookOutput,
   StopHookOutput,
   PermissionRequestHookOutput,
+  BeforeModelHookOutput,
+  AfterModelHookOutput,
+  BeforeToolSelectionHookOutput,
 } from './types.js';
-import type { HookOutput, HookExecutionResult } from './types.js';
+import type {
+  HookOutput,
+  HookExecutionResult,
+  BeforeToolSelectionOutput,
+} from './types.js';
 
 /**
  * Aggregated result from multiple hook executions
@@ -93,6 +100,15 @@ export class HookAggregator {
         break;
       case HookEventName.PermissionRequest:
         merged = this.mergePermissionRequestOutputs(outputs);
+        break;
+      case HookEventName.BeforeModel:
+      case HookEventName.AfterModel:
+        merged = this.mergeWithFieldReplacement(outputs);
+        break;
+      case HookEventName.BeforeToolSelection:
+        merged = this.mergeToolSelectionOutputs(
+          outputs as BeforeToolSelectionOutput[],
+        );
         break;
       default:
         merged = this.mergeSimple(outputs);
@@ -328,6 +344,95 @@ export class HookAggregator {
   }
 
   /**
+   * Merge outputs with later fields replacing earlier fields.
+   * Used for BeforeModel and AfterModel events where later hooks override earlier ones.
+   */
+  private mergeWithFieldReplacement(outputs: HookOutput[]): HookOutput {
+    let merged: HookOutput = {};
+
+    for (const output of outputs) {
+      // Later outputs override earlier ones
+      merged = {
+        ...merged,
+        ...output,
+        hookSpecificOutput: {
+          ...merged.hookSpecificOutput,
+          ...output.hookSpecificOutput,
+        },
+      };
+    }
+
+    return merged;
+  }
+
+  /**
+   * Merge tool selection outputs with union strategy.
+   *
+   * Rules:
+   * - allowedFunctionNames: union of all hooks (sorted for deterministic caching)
+   * - mode: NONE wins (most restrictive), then ANY > AUTO
+   * - This means hooks can only add/enable tools, not filter them out individually
+   */
+  private mergeToolSelectionOutputs(
+    outputs: BeforeToolSelectionOutput[],
+  ): BeforeToolSelectionOutput {
+    const merged: BeforeToolSelectionOutput = {};
+
+    const allFunctionNames = new Set<string>();
+    let hasNoneMode = false;
+    let hasAnyMode = false;
+
+    for (const output of outputs) {
+      const toolConfig = output.hookSpecificOutput?.toolConfig;
+      if (!toolConfig) {
+        continue;
+      }
+
+      // Check mode
+      if (toolConfig.mode === 'NONE') {
+        hasNoneMode = true;
+      } else if (toolConfig.mode === 'ANY') {
+        hasAnyMode = true;
+      }
+
+      // Collect function names (union of all hooks)
+      if (toolConfig.allowedFunctionNames) {
+        for (const name of toolConfig.allowedFunctionNames) {
+          allFunctionNames.add(name);
+        }
+      }
+    }
+
+    // Determine final mode and function names
+    let finalMode: 'AUTO' | 'ANY' | 'NONE';
+    let finalFunctionNames: string[] = [];
+
+    if (hasNoneMode) {
+      // NONE mode wins - most restrictive
+      finalMode = 'NONE';
+      finalFunctionNames = [];
+    } else if (hasAnyMode) {
+      // ANY mode if present (and no NONE)
+      finalMode = 'ANY';
+      finalFunctionNames = Array.from(allFunctionNames).sort();
+    } else {
+      // Default to AUTO mode
+      finalMode = 'AUTO';
+      finalFunctionNames = Array.from(allFunctionNames).sort();
+    }
+
+    merged.hookSpecificOutput = {
+      hookEventName: 'BeforeToolSelection',
+      toolConfig: {
+        mode: finalMode,
+        allowedFunctionNames: finalFunctionNames,
+      },
+    };
+
+    return merged;
+  }
+
+  /**
    * Create the appropriate specific hook output class based on event type
    */
   private createSpecificHookOutput(
@@ -343,6 +448,12 @@ export class HookAggregator {
         return new StopHookOutput(output);
       case HookEventName.PermissionRequest:
         return new PermissionRequestHookOutput(output);
+      case HookEventName.BeforeModel:
+        return new BeforeModelHookOutput(output);
+      case HookEventName.AfterModel:
+        return new AfterModelHookOutput(output);
+      case HookEventName.BeforeToolSelection:
+        return new BeforeToolSelectionHookOutput(output);
       default:
         return new DefaultHookOutput(output);
     }

--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
@@ -8,6 +8,7 @@ import {
   HookEventName,
   DefaultHookOutput,
   PreToolUseHookOutput,
+  PostToolUseHookOutput,
   StopHookOutput,
   PermissionRequestHookOutput,
 } from './types.js';
@@ -336,6 +337,8 @@ export class HookAggregator {
     switch (eventName) {
       case HookEventName.PreToolUse:
         return new PreToolUseHookOutput(output);
+      case HookEventName.PostToolUse:
+        return new PostToolUseHookOutput(output);
       case HookEventName.Stop:
         return new StopHookOutput(output);
       case HookEventName.PermissionRequest:

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
@@ -17,6 +17,18 @@ import type {
   StopInput,
   PreToolUseInput,
   PostToolUseFailureInput,
+  PostToolUseInput,
+  NotificationInput,
+  SessionStartInput,
+  SessionEndInput,
+  PreCompactInput,
+  McpToolContext,
+} from './types.js';
+import type {
+  NotificationType,
+  SessionStartSource,
+  SessionEndReason,
+  PreCompactTrigger,
 } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
@@ -113,6 +125,104 @@ export class HookEventHandler {
     };
 
     return this.executeHooks(HookEventName.PostToolUseFailure, input);
+  }
+
+  /**
+   * Fire a PostToolUse event
+   * Called after a tool executes successfully, for result auditing, context injection,
+   * or hiding sensitive output from the agent
+   */
+  async firePostToolUseEvent(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    toolResponse: Record<string, unknown>,
+    mcpContext?: McpToolContext,
+    originalRequestName?: string,
+  ): Promise<AggregatedHookResult> {
+    const input: PostToolUseInput = {
+      ...this.createBaseInput(HookEventName.PostToolUse),
+      tool_name: toolName,
+      tool_input: toolInput,
+      tool_response: toolResponse,
+      ...(mcpContext && { mcp_context: mcpContext }),
+      ...(originalRequestName && {
+        original_request_name: originalRequestName,
+      }),
+    };
+
+    const context: HookEventContext = { toolName };
+    return this.executeHooks(HookEventName.PostToolUse, input, context);
+  }
+
+  /**
+   * Fire a Notification event
+   * Fires when the CLI emits a system alert (e.g., Tool Permissions).
+   * Observability only - cannot block alerts or grant permissions automatically.
+   */
+  async fireNotificationEvent(
+    type: NotificationType,
+    message: string,
+    details: Record<string, unknown>,
+  ): Promise<AggregatedHookResult> {
+    const input: NotificationInput = {
+      ...this.createBaseInput(HookEventName.Notification),
+      notification_type: type,
+      message,
+      details,
+    };
+
+    return this.executeHooks(HookEventName.Notification, input);
+  }
+
+  /**
+   * Fire a SessionStart event
+   * Fires on application startup, resuming a session, or after a /clear command.
+   * Advisory only - continue and decision fields are ignored.
+   */
+  async fireSessionStartEvent(
+    source: SessionStartSource,
+  ): Promise<AggregatedHookResult> {
+    const input: SessionStartInput = {
+      ...this.createBaseInput(HookEventName.SessionStart),
+      source,
+    };
+
+    const context: HookEventContext = { trigger: source };
+    return this.executeHooks(HookEventName.SessionStart, input, context);
+  }
+
+  /**
+   * Fire a SessionEnd event
+   * Fires when the CLI exits or a session is cleared.
+   * Best effort - the CLI will not wait for this hook to complete.
+   */
+  async fireSessionEndEvent(
+    reason: SessionEndReason,
+  ): Promise<AggregatedHookResult> {
+    const input: SessionEndInput = {
+      ...this.createBaseInput(HookEventName.SessionEnd),
+      reason,
+    };
+
+    const context: HookEventContext = { trigger: reason };
+    return this.executeHooks(HookEventName.SessionEnd, input, context);
+  }
+
+  /**
+   * Fire a PreCompact event
+   * Fires before the CLI summarizes history to save tokens.
+   * Advisory only - cannot block or modify the compression process.
+   */
+  async firePreCompactEvent(
+    trigger: PreCompactTrigger,
+  ): Promise<AggregatedHookResult> {
+    const input: PreCompactInput = {
+      ...this.createBaseInput(HookEventName.PreCompact),
+      trigger,
+    };
+
+    const context: HookEventContext = { trigger };
+    return this.executeHooks(HookEventName.PreCompact, input, context);
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
@@ -22,6 +22,9 @@ import type {
   SessionStartInput,
   SessionEndInput,
   PreCompactInput,
+  BeforeModelInput,
+  AfterModelInput,
+  BeforeToolSelectionInput,
   McpToolContext,
 } from './types.js';
 import type {
@@ -31,6 +34,11 @@ import type {
   PreCompactTrigger,
 } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { defaultHookTranslator } from './hookTranslator.js';
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from '@google/genai';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
 
@@ -78,13 +86,20 @@ export class HookEventHandler {
     toolName: string,
     toolInput: Record<string, unknown>,
   ): Promise<AggregatedHookResult> {
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.firePreToolUseEvent: tool=${toolName}`,
+    );
     const input: PreToolUseInput = {
       ...this.createBaseInput(HookEventName.PreToolUse),
       tool_name: toolName,
       tool_input: toolInput,
     };
 
-    return this.executeHooks(HookEventName.PreToolUse, input);
+    const result = await this.executeHooks(HookEventName.PreToolUse, input);
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.firePreToolUseEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
+    );
+    return result;
   }
 
   /**
@@ -139,6 +154,9 @@ export class HookEventHandler {
     mcpContext?: McpToolContext,
     originalRequestName?: string,
   ): Promise<AggregatedHookResult> {
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.firePostToolUseEvent: tool=${toolName}`,
+    );
     const input: PostToolUseInput = {
       ...this.createBaseInput(HookEventName.PostToolUse),
       tool_name: toolName,
@@ -151,7 +169,15 @@ export class HookEventHandler {
     };
 
     const context: HookEventContext = { toolName };
-    return this.executeHooks(HookEventName.PostToolUse, input, context);
+    const result = await this.executeHooks(
+      HookEventName.PostToolUse,
+      input,
+      context,
+    );
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.firePostToolUseEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
+    );
+    return result;
   }
 
   /**
@@ -182,13 +208,24 @@ export class HookEventHandler {
   async fireSessionStartEvent(
     source: SessionStartSource,
   ): Promise<AggregatedHookResult> {
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.fireSessionStartEvent: source=${source}`,
+    );
     const input: SessionStartInput = {
       ...this.createBaseInput(HookEventName.SessionStart),
       source,
     };
 
     const context: HookEventContext = { trigger: source };
-    return this.executeHooks(HookEventName.SessionStart, input, context);
+    const result = await this.executeHooks(
+      HookEventName.SessionStart,
+      input,
+      context,
+    );
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.fireSessionStartEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
+    );
+    return result;
   }
 
   /**
@@ -199,13 +236,24 @@ export class HookEventHandler {
   async fireSessionEndEvent(
     reason: SessionEndReason,
   ): Promise<AggregatedHookResult> {
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.fireSessionEndEvent: reason=${reason}`,
+    );
     const input: SessionEndInput = {
       ...this.createBaseInput(HookEventName.SessionEnd),
       reason,
     };
 
     const context: HookEventContext = { trigger: reason };
-    return this.executeHooks(HookEventName.SessionEnd, input, context);
+    const result = await this.executeHooks(
+      HookEventName.SessionEnd,
+      input,
+      context,
+    );
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.fireSessionEndEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
+    );
+    return result;
   }
 
   /**
@@ -223,6 +271,86 @@ export class HookEventHandler {
 
     const context: HookEventContext = { trigger };
     return this.executeHooks(HookEventName.PreCompact, input, context);
+  }
+
+  /**
+   * Fire a BeforeModel event
+   * Called before sending a request to the LLM.
+   * Can modify the request, provide a synthetic response, or block the call.
+   */
+  async fireBeforeModelEvent(
+    llmRequest: GenerateContentParameters,
+  ): Promise<AggregatedHookResult> {
+    debugLogger.info(
+      '[Hook Debug] hookEventHandler.fireBeforeModelEvent: translating SDK request to hook format',
+    );
+    const input: BeforeModelInput = {
+      ...this.createBaseInput(HookEventName.BeforeModel),
+      llm_request: defaultHookTranslator.toHookLLMRequest(llmRequest),
+    };
+    debugLogger.debug(
+      `[Hook Debug] hookEventHandler.fireBeforeModelEvent: input.llm_request.model=${input.llm_request.model}`,
+    );
+
+    const result = await this.executeHooks(HookEventName.BeforeModel, input);
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.fireBeforeModelEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
+    );
+    return result;
+  }
+
+  /**
+   * Fire an AfterModel event
+   * Called after receiving a response from the LLM.
+   * Can modify the response, stop execution, or observe for logging.
+   */
+  async fireAfterModelEvent(
+    llmRequest: GenerateContentParameters,
+    llmResponse: GenerateContentResponse,
+  ): Promise<AggregatedHookResult> {
+    debugLogger.info(
+      '[Hook Debug] hookEventHandler.fireAfterModelEvent: translating SDK request/response to hook format',
+    );
+    const input: AfterModelInput = {
+      ...this.createBaseInput(HookEventName.AfterModel),
+      llm_request: defaultHookTranslator.toHookLLMRequest(llmRequest),
+      llm_response: defaultHookTranslator.toHookLLMResponse(llmResponse),
+    };
+    debugLogger.debug(
+      `[Hook Debug] hookEventHandler.fireAfterModelEvent: response.text.length=${input.llm_response.text?.length ?? 0}`,
+    );
+
+    const result = await this.executeHooks(HookEventName.AfterModel, input);
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.fireAfterModelEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
+    );
+    return result;
+  }
+
+  /**
+   * Fire a BeforeToolSelection event
+   * Called before selecting tools for the LLM request.
+   * Can modify tool configuration (mode, allowed function names).
+   */
+  async fireBeforeToolSelectionEvent(
+    llmRequest: GenerateContentParameters,
+  ): Promise<AggregatedHookResult> {
+    debugLogger.info(
+      '[Hook Debug] hookEventHandler.fireBeforeToolSelectionEvent: translating SDK request to hook format',
+    );
+    const input: BeforeToolSelectionInput = {
+      ...this.createBaseInput(HookEventName.BeforeToolSelection),
+      llm_request: defaultHookTranslator.toHookLLMRequest(llmRequest),
+    };
+
+    const result = await this.executeHooks(
+      HookEventName.BeforeToolSelection,
+      input,
+    );
+    debugLogger.info(
+      `[Hook Debug] hookEventHandler.fireBeforeToolSelectionEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
+    );
+    return result;
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/hooks/hookRunner.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookRunner.test.ts
@@ -519,7 +519,26 @@ describe('HookRunner', () => {
   });
 
   describe('expandCommand', () => {
-    it('should expand GEMINI_PROJECT_DIR placeholder', async () => {
+    it('should expand COPILOT_SHELL_PROJECT_DIR placeholder', async () => {
+      const mockProcess = createMockProcess(0, 'result');
+      mockSpawn.mockImplementation(() => mockProcess);
+
+      const hookConfig: HookConfig = {
+        type: HookType.Command,
+        command: 'echo $COPILOT_SHELL_PROJECT_DIR',
+        source: HooksConfigSource.Project,
+      };
+      const input = createMockInput({ cwd: '/test/project' });
+
+      await hookRunner.executeHook(hookConfig, HookEventName.PreToolUse, input);
+
+      // Verify spawn was called with expanded command
+      const spawnCall = mockSpawn.mock.calls[0];
+      const command = spawnCall[1][spawnCall[1].length - 1]; // Last arg is the command
+      expect(command).toContain('/test/project');
+    });
+
+    it('should expand GEMINI_PROJECT_DIR placeholder for compatibility', async () => {
       const mockProcess = createMockProcess(0, 'result');
       mockSpawn.mockImplementation(() => mockProcess);
 
@@ -538,7 +557,7 @@ describe('HookRunner', () => {
       expect(command).toContain('/test/project');
     });
 
-    it('should expand CLAUDE_PROJECT_DIR placeholder for compatibility', async () => {
+    it('should expand CLAUDE_PROJECT_DIR placeholder for Claude Code compatibility', async () => {
       const mockProcess = createMockProcess(0, 'result');
       mockSpawn.mockImplementation(() => mockProcess);
 

--- a/src/copilot-shell/packages/core/src/hooks/hookRunner.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookRunner.ts
@@ -222,8 +222,9 @@ export class HookRunner {
 
       const env = {
         ...process.env,
-        GEMINI_PROJECT_DIR: input.cwd,
-        CLAUDE_PROJECT_DIR: input.cwd, // For compatibility
+        COPILOT_SHELL_PROJECT_DIR: input.cwd,
+        GEMINI_PROJECT_DIR: input.cwd, // For Gemini CLI compatibility
+        CLAUDE_PROJECT_DIR: input.cwd, // For Claude Code compatibility
         QWEN_PROJECT_DIR: input.cwd, // For Qwen Code compatibility
         ...hookConfig.env,
       };
@@ -304,6 +305,14 @@ export class HookRunner {
       child.on('close', (exitCode) => {
         clearTimeout(timeoutHandle);
         const duration = Date.now() - startTime;
+
+        // Forward hook stderr to terminal for visibility
+        if (stderr.trim()) {
+          const hookId = hookConfig.name || hookConfig.command || 'unknown';
+          debugLogger.info(
+            `[Hook Debug] hookRunner: hook '${hookId}' stderr:\n${stderr.trim()}`,
+          );
+        }
 
         if (timedOut) {
           resolve({
@@ -393,8 +402,10 @@ export class HookRunner {
     debugLogger.debug(`Expanding hook command: ${command} (cwd: ${input.cwd})`);
     const escapedCwd = escapeShellArg(input.cwd, shellType);
     return command
-      .replace(/\$GEMINI_PROJECT_DIR/g, () => escapedCwd)
-      .replace(/\$CLAUDE_PROJECT_DIR/g, () => escapedCwd); // For compatibility
+      .replace(/\$COPILOT_SHELL_PROJECT_DIR/g, () => escapedCwd)
+      .replace(/\$GEMINI_PROJECT_DIR/g, () => escapedCwd) // For Gemini CLI compatibility
+      .replace(/\$CLAUDE_PROJECT_DIR/g, () => escapedCwd) // For Claude Code compatibility
+      .replace(/\$QWEN_PROJECT_DIR/g, () => escapedCwd); // For Qwen Code compatibility
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -15,9 +15,15 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import type {
   DefaultHookOutput,
   PreToolUseHookOutput,
+  PostToolUseHookOutput,
   PostToolUseFailureHookOutput,
   HookEventName,
   HookConfig,
+  McpToolContext,
+  NotificationType,
+  SessionStartSource,
+  SessionEndReason,
+  PreCompactTrigger,
 } from './types.js';
 import { createHookOutput, HooksConfigSource } from './types.js';
 
@@ -142,6 +148,70 @@ export class HookSystem {
           'PostToolUseFailure',
           result.finalOutput,
         ) as PostToolUseFailureHookOutput)
+      : undefined;
+  }
+
+  async firePostToolUseEvent(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    toolResponse: Record<string, unknown>,
+    mcpContext?: McpToolContext,
+    originalRequestName?: string,
+  ): Promise<PostToolUseHookOutput | undefined> {
+    const result = await this.hookEventHandler.firePostToolUseEvent(
+      toolName,
+      toolInput,
+      toolResponse,
+      mcpContext,
+      originalRequestName,
+    );
+    return result.finalOutput
+      ? (createHookOutput(
+          'PostToolUse',
+          result.finalOutput,
+        ) as PostToolUseHookOutput)
+      : undefined;
+  }
+
+  async fireNotificationEvent(
+    type: NotificationType,
+    message: string,
+    details: Record<string, unknown>,
+  ): Promise<DefaultHookOutput | undefined> {
+    const result = await this.hookEventHandler.fireNotificationEvent(
+      type,
+      message,
+      details,
+    );
+    return result.finalOutput
+      ? createHookOutput('Notification', result.finalOutput)
+      : undefined;
+  }
+
+  async fireSessionStartEvent(
+    source: SessionStartSource,
+  ): Promise<DefaultHookOutput | undefined> {
+    const result = await this.hookEventHandler.fireSessionStartEvent(source);
+    return result.finalOutput
+      ? createHookOutput('SessionStart', result.finalOutput)
+      : undefined;
+  }
+
+  async fireSessionEndEvent(
+    reason: SessionEndReason,
+  ): Promise<DefaultHookOutput | undefined> {
+    const result = await this.hookEventHandler.fireSessionEndEvent(reason);
+    return result.finalOutput
+      ? createHookOutput('SessionEnd', result.finalOutput)
+      : undefined;
+  }
+
+  async firePreCompactEvent(
+    trigger: PreCompactTrigger,
+  ): Promise<DefaultHookOutput | undefined> {
+    const result = await this.hookEventHandler.firePreCompactEvent(trigger);
+    return result.finalOutput
+      ? createHookOutput('PreCompact', result.finalOutput)
       : undefined;
   }
 

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -17,6 +17,9 @@ import type {
   PreToolUseHookOutput,
   PostToolUseHookOutput,
   PostToolUseFailureHookOutput,
+  BeforeModelHookOutput,
+  AfterModelHookOutput,
+  BeforeToolSelectionHookOutput,
   HookEventName,
   HookConfig,
   McpToolContext,
@@ -26,6 +29,10 @@ import type {
   PreCompactTrigger,
 } from './types.js';
 import { createHookOutput, HooksConfigSource } from './types.js';
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from '@google/genai';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
 
@@ -104,16 +111,23 @@ export class HookSystem {
     toolName: string,
     toolInput: Record<string, unknown>,
   ): Promise<PreToolUseHookOutput | undefined> {
+    debugLogger.info(
+      `[Hook Debug] hookSystem.firePreToolUseEvent: entering facade, tool=${toolName}`,
+    );
     const result = await this.hookEventHandler.firePreToolUseEvent(
       toolName,
       toolInput,
     );
-    return result.finalOutput
+    const output = result.finalOutput
       ? (createHookOutput(
           'PreToolUse',
           result.finalOutput,
         ) as PreToolUseHookOutput)
       : undefined;
+    debugLogger.info(
+      `[Hook Debug] hookSystem.firePreToolUseEvent: facade returning, hasOutput=${!!output}`,
+    );
+    return output;
   }
 
   async fireStopEvent(
@@ -158,6 +172,9 @@ export class HookSystem {
     mcpContext?: McpToolContext,
     originalRequestName?: string,
   ): Promise<PostToolUseHookOutput | undefined> {
+    debugLogger.info(
+      `[Hook Debug] hookSystem.firePostToolUseEvent: entering facade, tool=${toolName}`,
+    );
     const result = await this.hookEventHandler.firePostToolUseEvent(
       toolName,
       toolInput,
@@ -165,12 +182,16 @@ export class HookSystem {
       mcpContext,
       originalRequestName,
     );
-    return result.finalOutput
+    const output = result.finalOutput
       ? (createHookOutput(
           'PostToolUse',
           result.finalOutput,
         ) as PostToolUseHookOutput)
       : undefined;
+    debugLogger.info(
+      `[Hook Debug] hookSystem.firePostToolUseEvent: facade returning, hasOutput=${!!output}`,
+    );
+    return output;
   }
 
   async fireNotificationEvent(
@@ -191,19 +212,33 @@ export class HookSystem {
   async fireSessionStartEvent(
     source: SessionStartSource,
   ): Promise<DefaultHookOutput | undefined> {
+    debugLogger.info(
+      `[Hook Debug] hookSystem.fireSessionStartEvent: entering facade, source=${source}`,
+    );
     const result = await this.hookEventHandler.fireSessionStartEvent(source);
-    return result.finalOutput
+    const output = result.finalOutput
       ? createHookOutput('SessionStart', result.finalOutput)
       : undefined;
+    debugLogger.info(
+      `[Hook Debug] hookSystem.fireSessionStartEvent: facade returning, hasOutput=${!!output}`,
+    );
+    return output;
   }
 
   async fireSessionEndEvent(
     reason: SessionEndReason,
   ): Promise<DefaultHookOutput | undefined> {
+    debugLogger.info(
+      `[Hook Debug] hookSystem.fireSessionEndEvent: entering facade, reason=${reason}`,
+    );
     const result = await this.hookEventHandler.fireSessionEndEvent(reason);
-    return result.finalOutput
+    const output = result.finalOutput
       ? createHookOutput('SessionEnd', result.finalOutput)
       : undefined;
+    debugLogger.info(
+      `[Hook Debug] hookSystem.fireSessionEndEvent: facade returning, hasOutput=${!!output}`,
+    );
+    return output;
   }
 
   async firePreCompactEvent(
@@ -213,6 +248,68 @@ export class HookSystem {
     return result.finalOutput
       ? createHookOutput('PreCompact', result.finalOutput)
       : undefined;
+  }
+
+  async fireBeforeModelEvent(
+    llmRequest: GenerateContentParameters,
+  ): Promise<BeforeModelHookOutput | undefined> {
+    debugLogger.info(
+      '[Hook Debug] hookSystem.fireBeforeModelEvent: entering facade',
+    );
+    const result = await this.hookEventHandler.fireBeforeModelEvent(llmRequest);
+    const output = result.finalOutput
+      ? (createHookOutput(
+          'BeforeModel',
+          result.finalOutput,
+        ) as BeforeModelHookOutput)
+      : undefined;
+    debugLogger.info(
+      `[Hook Debug] hookSystem.fireBeforeModelEvent: facade returning, hasOutput=${!!output}`,
+    );
+    return output;
+  }
+
+  async fireAfterModelEvent(
+    llmRequest: GenerateContentParameters,
+    llmResponse: GenerateContentResponse,
+  ): Promise<AfterModelHookOutput | undefined> {
+    debugLogger.info(
+      '[Hook Debug] hookSystem.fireAfterModelEvent: entering facade',
+    );
+    const result = await this.hookEventHandler.fireAfterModelEvent(
+      llmRequest,
+      llmResponse,
+    );
+    const output = result.finalOutput
+      ? (createHookOutput(
+          'AfterModel',
+          result.finalOutput,
+        ) as AfterModelHookOutput)
+      : undefined;
+    debugLogger.info(
+      `[Hook Debug] hookSystem.fireAfterModelEvent: facade returning, hasOutput=${!!output}`,
+    );
+    return output;
+  }
+
+  async fireBeforeToolSelectionEvent(
+    llmRequest: GenerateContentParameters,
+  ): Promise<BeforeToolSelectionHookOutput | undefined> {
+    debugLogger.info(
+      '[Hook Debug] hookSystem.fireBeforeToolSelectionEvent: entering facade',
+    );
+    const result =
+      await this.hookEventHandler.fireBeforeToolSelectionEvent(llmRequest);
+    const output = result.finalOutput
+      ? (createHookOutput(
+          'BeforeToolSelection',
+          result.finalOutput,
+        ) as BeforeToolSelectionHookOutput)
+      : undefined;
+    debugLogger.info(
+      `[Hook Debug] hookSystem.fireBeforeToolSelectionEvent: facade returning, hasOutput=${!!output}`,
+    );
+    return output;
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/hooks/hookTranslator.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookTranslator.ts
@@ -1,0 +1,366 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  GenerateContentResponse,
+  GenerateContentParameters,
+  Content,
+  Part,
+} from '@google/genai';
+
+/**
+ * Decoupled LLM request format - stable across CLI versions.
+ * Hook scripts receive and return this format, not SDK-specific types.
+ */
+export interface LLMRequest {
+  model: string;
+  messages: Array<{
+    role: 'user' | 'model' | 'system';
+    content: string | Array<{ type: string; [key: string]: unknown }>;
+  }>;
+  config?: {
+    temperature?: number;
+    maxOutputTokens?: number;
+    topP?: number;
+    topK?: number;
+    stopSequences?: string[];
+    candidateCount?: number;
+    presencePenalty?: number;
+    frequencyPenalty?: number;
+    [key: string]: unknown;
+  };
+  toolConfig?: HookToolConfig;
+}
+
+/**
+ * Decoupled LLM response format - stable across CLI versions.
+ */
+export interface LLMResponse {
+  text?: string;
+  candidates: Array<{
+    content: {
+      role: 'model';
+      parts: string[];
+    };
+    finishReason?: 'STOP' | 'MAX_TOKENS' | 'SAFETY' | 'RECITATION' | 'OTHER';
+    index?: number;
+    safetyRatings?: Array<{
+      category: string;
+      probability: string;
+      blocked?: boolean;
+    }>;
+  }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
+}
+
+/**
+ * Decoupled tool configuration - stable across CLI versions.
+ */
+export interface HookToolConfig {
+  mode?: 'AUTO' | 'ANY' | 'NONE';
+  allowedFunctionNames?: string[];
+}
+
+// Type guards for Content structure
+function isContentWithParts(
+  content: unknown,
+): content is { role?: string; parts: unknown[] } {
+  return (
+    typeof content === 'object' &&
+    content !== null &&
+    'parts' in content &&
+    Array.isArray((content as Record<string, unknown>)['parts'])
+  );
+}
+
+function hasTextProperty(part: unknown): part is { text: string } {
+  return (
+    typeof part === 'object' &&
+    part !== null &&
+    'text' in part &&
+    typeof (part as Record<string, unknown>)['text'] === 'string'
+  );
+}
+
+/**
+ * Extract generation config from SDK request parameters.
+ */
+function extractGenerationConfig(
+  sdkRequest: GenerateContentParameters,
+): Record<string, unknown> | undefined {
+  if (!sdkRequest.config) return undefined;
+  return sdkRequest.config as Record<string, unknown>;
+}
+
+/**
+ * Hook translator for GenerateContent SDK types.
+ * Handles translation between SDK types and stable Hook API types.
+ *
+ * Note: This implementation intentionally extracts only text content from parts.
+ * Non-text parts (images, function calls, etc.) are filtered out to provide
+ * a simplified, stable interface for hooks.
+ */
+export class HookTranslatorImpl {
+  /**
+   * Convert SDK GenerateContentParameters to stable LLMRequest
+   */
+  toHookLLMRequest(sdkRequest: GenerateContentParameters): LLMRequest {
+    const messages: LLMRequest['messages'] = [];
+
+    // Convert contents to messages format (simplified)
+    if (sdkRequest.contents) {
+      const contents = Array.isArray(sdkRequest.contents)
+        ? sdkRequest.contents
+        : [sdkRequest.contents];
+
+      for (const content of contents) {
+        if (typeof content === 'string') {
+          messages.push({
+            role: 'user',
+            content,
+          });
+        } else if (isContentWithParts(content)) {
+          const role =
+            (content as Content).role === 'model'
+              ? ('model' as const)
+              : (content as Content).role === 'system'
+                ? ('system' as const)
+                : ('user' as const);
+
+          const parts = Array.isArray(content.parts)
+            ? content.parts
+            : [content.parts];
+
+          // Extract only text parts - intentionally filtering out non-text content
+          const textContent = parts
+            .filter(hasTextProperty)
+            .map((part) => (part as { text: string }).text)
+            .join('');
+
+          // Only add message if there's text content
+          if (textContent) {
+            messages.push({
+              role,
+              content: textContent,
+            });
+          }
+        }
+      }
+    }
+
+    // Safely extract generation config
+    const config = extractGenerationConfig(sdkRequest);
+
+    return {
+      model: sdkRequest.model || '',
+      messages,
+      config: config
+        ? {
+            temperature: config['temperature'] as number | undefined,
+            maxOutputTokens: config['maxOutputTokens'] as number | undefined,
+            topP: config['topP'] as number | undefined,
+            topK: config['topK'] as number | undefined,
+            stopSequences: config['stopSequences'] as string[] | undefined,
+            candidateCount: config['candidateCount'] as number | undefined,
+            presencePenalty: config['presencePenalty'] as number | undefined,
+            frequencyPenalty: config['frequencyPenalty'] as number | undefined,
+          }
+        : undefined,
+    };
+  }
+
+  /**
+   * Convert stable LLMRequest to SDK GenerateContentParameters.
+   * Merges hook modifications with the original base request.
+   */
+  fromHookLLMRequest(
+    hookRequest: LLMRequest,
+    baseRequest?: GenerateContentParameters,
+  ): GenerateContentParameters {
+    // Convert hook messages back to SDK Content format.
+    // If the hook returned a partial request without messages,
+    // fall back to the base request's contents.
+    const contents = hookRequest.messages
+      ? hookRequest.messages.map((message) => ({
+          role: message.role === 'model' ? 'model' : message.role,
+          parts: [
+            {
+              text:
+                typeof message.content === 'string'
+                  ? message.content
+                  : Array.isArray(message.content)
+                    ? message.content
+                        .map((part) =>
+                          typeof part === 'object' &&
+                          part !== null &&
+                          'text' in part
+                            ? String((part as Record<string, unknown>)['text'])
+                            : '',
+                        )
+                        .join('')
+                    : String(message.content),
+            },
+          ],
+        }))
+      : (baseRequest?.contents ?? []);
+
+    const result: GenerateContentParameters = {
+      ...baseRequest,
+      // Use || instead of ?? so empty strings also fall back to baseRequest model
+      model: hookRequest.model || baseRequest?.model || '',
+      contents,
+    };
+
+    // Add generation config if it exists in the hook request.
+    // Only apply fields that are explicitly provided (not undefined) to avoid
+    // overwriting baseConfig values with undefined.
+    if (hookRequest.config) {
+      const baseConfig = baseRequest
+        ? extractGenerationConfig(baseRequest)
+        : undefined;
+
+      const overrides: Record<string, unknown> = {};
+      const cfg = hookRequest.config;
+      if (cfg.temperature !== undefined)
+        overrides['temperature'] = cfg.temperature;
+      if (cfg.maxOutputTokens !== undefined)
+        overrides['maxOutputTokens'] = cfg.maxOutputTokens;
+      if (cfg.topP !== undefined) overrides['topP'] = cfg.topP;
+      if (cfg.topK !== undefined) overrides['topK'] = cfg.topK;
+      if (cfg.stopSequences !== undefined)
+        overrides['stopSequences'] = cfg.stopSequences;
+      if (cfg.candidateCount !== undefined)
+        overrides['candidateCount'] = cfg.candidateCount;
+      if (cfg.presencePenalty !== undefined)
+        overrides['presencePenalty'] = cfg.presencePenalty;
+      if (cfg.frequencyPenalty !== undefined)
+        overrides['frequencyPenalty'] = cfg.frequencyPenalty;
+
+      result.config = {
+        ...baseConfig,
+        ...overrides,
+      } as GenerateContentParameters['config'];
+    }
+
+    return result;
+  }
+
+  /**
+   * Convert SDK GenerateContentResponse to stable LLMResponse
+   */
+  toHookLLMResponse(sdkResponse: GenerateContentResponse): LLMResponse {
+    // Extract text from first candidate
+    const responseText =
+      sdkResponse.candidates?.[0]?.content?.parts
+        ?.filter(hasTextProperty)
+        .map((part: Part) => (part as { text: string }).text)
+        .join('') || undefined;
+
+    return {
+      text: responseText,
+      candidates: (sdkResponse.candidates || []).map((candidate) => {
+        // Extract text parts from the candidate
+        const textParts =
+          candidate.content?.parts
+            ?.filter(hasTextProperty)
+            .map((part: Part) => (part as { text: string }).text) || [];
+
+        return {
+          content: {
+            role: 'model' as const,
+            parts: textParts,
+          },
+          finishReason:
+            candidate.finishReason as LLMResponse['candidates'][0]['finishReason'],
+          index: candidate.index,
+          safetyRatings: candidate.safetyRatings?.map((rating) => ({
+            category: String(rating.category || ''),
+            probability: String(rating.probability || ''),
+            blocked: rating.blocked,
+          })),
+        };
+      }),
+      usageMetadata: sdkResponse.usageMetadata
+        ? {
+            promptTokenCount: sdkResponse.usageMetadata.promptTokenCount,
+            candidatesTokenCount:
+              sdkResponse.usageMetadata.candidatesTokenCount,
+            totalTokenCount: sdkResponse.usageMetadata.totalTokenCount,
+          }
+        : undefined,
+    };
+  }
+
+  /**
+   * Convert stable LLMResponse to SDK GenerateContentResponse
+   */
+  fromHookLLMResponse(hookResponse: LLMResponse): GenerateContentResponse {
+    const response: GenerateContentResponse = {
+      text: hookResponse.text,
+      candidates: hookResponse.candidates.map((candidate) => ({
+        content: {
+          role: 'model',
+          parts: candidate.content.parts.map((part) => ({
+            text: part,
+          })),
+        },
+        finishReason: candidate.finishReason,
+        index: candidate.index,
+        safetyRatings: candidate.safetyRatings,
+      })),
+      usageMetadata: hookResponse.usageMetadata,
+    } as GenerateContentResponse;
+
+    return response;
+  }
+
+  /**
+   * Convert SDK tool config to stable HookToolConfig
+   */
+  toHookToolConfig(sdkToolConfig: {
+    functionCallingConfig?: {
+      mode?: string;
+      allowedFunctionNames?: string[];
+    };
+  }): HookToolConfig {
+    return {
+      mode: sdkToolConfig.functionCallingConfig?.mode as HookToolConfig['mode'],
+      allowedFunctionNames:
+        sdkToolConfig.functionCallingConfig?.allowedFunctionNames,
+    };
+  }
+
+  /**
+   * Convert stable HookToolConfig to SDK tool config format
+   */
+  fromHookToolConfig(hookToolConfig: HookToolConfig): {
+    functionCallingConfig?: {
+      mode?: string;
+      allowedFunctionNames?: string[];
+    };
+  } {
+    const functionCallingConfig =
+      hookToolConfig.mode || hookToolConfig.allowedFunctionNames
+        ? {
+            mode: hookToolConfig.mode,
+            allowedFunctionNames: hookToolConfig.allowedFunctionNames,
+          }
+        : undefined;
+
+    return {
+      functionCallingConfig,
+    };
+  }
+}
+
+/**
+ * Default hook translator instance
+ */
+export const defaultHookTranslator = new HookTranslatorImpl();

--- a/src/copilot-shell/packages/core/src/hooks/index.ts
+++ b/src/copilot-shell/packages/core/src/hooks/index.ts
@@ -7,6 +7,14 @@
 // Export types
 export * from './types.js';
 
+// Export hook translator (SDK-agnostic LLM type system)
+export { defaultHookTranslator, HookTranslatorImpl } from './hookTranslator.js';
+export type {
+  LLMRequest,
+  LLMResponse,
+  HookToolConfig,
+} from './hookTranslator.js';
+
 // Export core components
 export { HookSystem } from './hookSystem.js';
 export { HookRegistry } from './hookRegistry.js';

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -129,6 +129,8 @@ export function createHookOutput(
       return new StopHookOutput(data);
     case HookEventName.PermissionRequest:
       return new PermissionRequestHookOutput(data);
+    case HookEventName.PostToolUse:
+      return new PostToolUseHookOutput(data);
     case HookEventName.PostToolUseFailure:
       return new PostToolUseFailureHookOutput(data);
     default:
@@ -461,6 +463,35 @@ export interface PostToolUseFailureOutput extends HookOutput {
     /** If present, the hook requests a sandbox bypass approval dialog */
     sandbox_bypass_request?: SandboxBypassApprovalRequest;
   };
+}
+
+/**
+ * Specific hook output class for PostToolUse events.
+ * Supports result auditing, context injection, hiding output, and tail tool calls.
+ */
+export class PostToolUseHookOutput extends DefaultHookOutput {
+  /**
+   * Get a tail tool call request if provided by hook.
+   * The result of this tail call will replace the original tool's response.
+   */
+  getTailToolCallRequest():
+    | { name: string; args: Record<string, unknown> }
+    | undefined {
+    if (
+      this.hookSpecificOutput &&
+      'tailToolCallRequest' in this.hookSpecificOutput
+    ) {
+      const request = this.hookSpecificOutput['tailToolCallRequest'];
+      if (
+        typeof request === 'object' &&
+        request !== null &&
+        !Array.isArray(request)
+      ) {
+        return request as { name: string; args: Record<string, unknown> };
+      }
+    }
+    return undefined;
+  }
 }
 
 /**

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -39,6 +39,12 @@ export enum HookEventName {
   SessionEnd = 'SessionEnd',
   // When a permission dialog is displayed
   PermissionRequest = 'PermissionRequest',
+  // BeforeModel - Before sending a request to the LLM
+  BeforeModel = 'BeforeModel',
+  // AfterModel - After receiving a response from the LLM
+  AfterModel = 'AfterModel',
+  // BeforeToolSelection - Before selecting tools for the LLM request
+  BeforeToolSelection = 'BeforeToolSelection',
 }
 
 /**
@@ -133,6 +139,12 @@ export function createHookOutput(
       return new PostToolUseHookOutput(data);
     case HookEventName.PostToolUseFailure:
       return new PostToolUseFailureHookOutput(data);
+    case HookEventName.BeforeModel:
+      return new BeforeModelHookOutput(data);
+    case HookEventName.AfterModel:
+      return new AfterModelHookOutput(data);
+    case HookEventName.BeforeToolSelection:
+      return new BeforeToolSelectionHookOutput(data);
     default:
       return new DefaultHookOutput(data);
   }
@@ -723,6 +735,151 @@ export interface SubagentStopOutput extends HookOutput {
     hookEventName: 'SubagentStop';
     additionalContext?: string;
   };
+}
+
+// ===== LLM Hook Types (Phase 2) =====
+
+/**
+ * Decoupled LLM request format - stable across CLI versions.
+ * Used by BeforeModel and BeforeToolSelection hooks.
+ */
+export type {
+  LLMRequest,
+  LLMResponse,
+  HookToolConfig,
+} from './hookTranslator.js';
+
+/**
+ * BeforeModel hook input - uses decoupled LLM types
+ */
+export interface BeforeModelInput extends HookInput {
+  llm_request: import('./hookTranslator.js').LLMRequest;
+}
+
+/**
+ * BeforeModel hook output
+ */
+export interface BeforeModelOutput extends HookOutput {
+  hookSpecificOutput?: {
+    hookEventName: 'BeforeModel';
+    llm_request?: Partial<import('./hookTranslator.js').LLMRequest>;
+    llm_response?: import('./hookTranslator.js').LLMResponse;
+  };
+}
+
+/**
+ * AfterModel hook input - uses decoupled LLM types
+ */
+export interface AfterModelInput extends HookInput {
+  llm_request: import('./hookTranslator.js').LLMRequest;
+  llm_response: import('./hookTranslator.js').LLMResponse;
+}
+
+/**
+ * AfterModel hook output
+ */
+export interface AfterModelOutput extends HookOutput {
+  hookSpecificOutput?: {
+    hookEventName: 'AfterModel';
+    llm_response?: Partial<import('./hookTranslator.js').LLMResponse>;
+  };
+}
+
+/**
+ * BeforeToolSelection hook input - uses decoupled LLM types
+ */
+export interface BeforeToolSelectionInput extends HookInput {
+  llm_request: import('./hookTranslator.js').LLMRequest;
+}
+
+/**
+ * BeforeToolSelection hook output
+ */
+export interface BeforeToolSelectionOutput extends HookOutput {
+  hookSpecificOutput?: {
+    hookEventName: 'BeforeToolSelection';
+    toolConfig?: import('./hookTranslator.js').HookToolConfig;
+  };
+}
+
+/**
+ * Specific hook output class for BeforeModel events.
+ * Supports request modification and synthetic response generation.
+ */
+export class BeforeModelHookOutput extends DefaultHookOutput {
+  /**
+   * Get synthetic LLM response if provided by hook.
+   * When present, the actual LLM call should be skipped.
+   */
+  getSyntheticResponse():
+    | import('./hookTranslator.js').LLMResponse
+    | undefined {
+    if (this.hookSpecificOutput && 'llm_response' in this.hookSpecificOutput) {
+      const hookResponse = this.hookSpecificOutput['llm_response'];
+      if (hookResponse && typeof hookResponse === 'object') {
+        return hookResponse as import('./hookTranslator.js').LLMResponse;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Get LLM request modifications if provided by hook.
+   * Returns a partial LLMRequest that should be merged with the original.
+   */
+  getLLMRequestModifications():
+    | Partial<import('./hookTranslator.js').LLMRequest>
+    | undefined {
+    if (this.hookSpecificOutput && 'llm_request' in this.hookSpecificOutput) {
+      const hookRequest = this.hookSpecificOutput['llm_request'];
+      if (hookRequest && typeof hookRequest === 'object') {
+        return hookRequest as Partial<import('./hookTranslator.js').LLMRequest>;
+      }
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Specific hook output class for AfterModel events.
+ * Supports response modification and observation.
+ */
+export class AfterModelHookOutput extends DefaultHookOutput {
+  /**
+   * Get modified LLM response if provided by hook.
+   */
+  getModifiedResponse(): import('./hookTranslator.js').LLMResponse | undefined {
+    if (this.hookSpecificOutput && 'llm_response' in this.hookSpecificOutput) {
+      const hookResponse = this.hookSpecificOutput['llm_response'];
+      if (
+        hookResponse &&
+        typeof hookResponse === 'object' &&
+        'candidates' in (hookResponse as Record<string, unknown>)
+      ) {
+        return hookResponse as import('./hookTranslator.js').LLMResponse;
+      }
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Specific hook output class for BeforeToolSelection events.
+ * Supports tool configuration modification (mode, allowed function names).
+ */
+export class BeforeToolSelectionHookOutput extends DefaultHookOutput {
+  /**
+   * Get tool configuration modifications if provided by hook.
+   */
+  getToolConfig(): import('./hookTranslator.js').HookToolConfig | undefined {
+    if (this.hookSpecificOutput && 'toolConfig' in this.hookSpecificOutput) {
+      const toolConfig = this.hookSpecificOutput['toolConfig'];
+      if (toolConfig && typeof toolConfig === 'object') {
+        return toolConfig as import('./hookTranslator.js').HookToolConfig;
+      }
+    }
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

Implement LLM lifecycle hooks (BeforeModel, AfterModel) and tool selection
control (BeforeToolSelection) for the copilot-shell hook system.

- **Hook types & aggregation**: add `BeforeModel`, `AfterModel`,
  `BeforeToolSelection` event types; multi-hook result aggregation with
  correct NONE/ANY/AUTO priority merge in `hookAggregator`
- **hookTranslator**: stable SDK↔hook contract layer; fix model fallback
  (`||` over `??`), array content serialization, undefined config merge,
  missing config fields, and `safetyRatings.blocked` passthrough
- **BeforeModel**: apply request overrides and synthetic response injection
  in `geminiChat`
- **AfterModel**: consume response mutation, stop, and deny signals via
  `AfterModelHookStopError`; propagate `AfterModelHookStop` event through
  `turn` → `client` → UI stream for graceful agent loop termination
- **BeforeToolSelection**: enforce `functionCallingConfig.mode=NONE` and
  `allowedFunctionNames` filtering in both OpenAI pipeline and Aliyun
  generator; omit `tools` field when filtered list is empty (prevents 400)
- **Lifecycle**: fix `client.shutdown()` idempotency to prevent duplicate
  `SessionEnd` hook fires
- **Env var**: rename primary hook env var to `COPILOT_SHELL_PROJECT_DIR`
  with backward-compatible aliases (`GEMINI_PROJECT_DIR`,
  `CLAUDE_PROJECT_DIR`, `QWEN_PROJECT_DIR`)
- Update tests and config mocks for hook-enabled code paths

## Related Issue

closes #144 

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)