### PR TITLE
fix(sight): 修复http/2 token计算为0的问题

### DIFF
--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
  "futures",
  "gimli",
  "glob",
- "hf-hub 0.5.0 (git+https://github.com/chengshuyi/hf-hub.git?rev=05f5134f40dbb5dc9f1617df1aaef628d49e951f)",
+ "hf-hub",
  "hpack",
  "httparse",
  "include_dir",
@@ -1778,30 +1778,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hf-hub"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
-dependencies = [
- "dirs",
- "futures",
- "http 1.4.0",
- "indicatif",
- "libc",
- "log 0.4.29",
- "native-tls",
- "num_cpus",
- "rand",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "ureq 3.3.0",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "hf-hub"
-version = "0.5.0"
 source = "git+https://github.com/chengshuyi/hf-hub.git?rev=05f5134f40dbb5dc9f1617df1aaef628d49e951f#05f5134f40dbb5dc9f1617df1aaef628d49e951f"
 dependencies = [
  "dirs",
@@ -2425,7 +2401,7 @@ dependencies = [
  "blake3",
  "dashmap",
  "futures",
- "hf-hub 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hf-hub",
  "minijinja",
  "minijinja-contrib",
  "rayon",

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -79,13 +79,17 @@ actix-web = { version = "4", optional = true }
 actix-cors = { version = "0.7", optional = true }
 # Embed frontend static files into the binary (optional, enabled by "server" feature)
 include_dir = { version = "0.7", optional = true }
-hf-hub = { git = "https://github.com/chengshuyi/hf-hub.git", rev = "05f5134f40dbb5dc9f1617df1aaef628d49e951f" }
+# hf-hub for downloading tokenizer files (patched to use GitHub version below)
+hf-hub = "0.5"
 
 # [profile.release]
 # debug = true
 
 [profile.dev]
 debug-assertions = false
+
+[patch.crates-io]
+hf-hub = { git = "https://github.com/chengshuyi/hf-hub.git", rev = "05f5134f40dbb5dc9f1617df1aaef628d49e951f" }
 
 [build-dependencies]
 libbpf-cargo = "0.23.3"

--- a/src/agentsight/src/analyzer/token/parser.rs
+++ b/src/agentsight/src/analyzer/token/parser.rs
@@ -68,7 +68,7 @@ impl TokenParser {
     }
 
     /// Internal method to parse JSON and extract token usage
-    fn parse_json(&self, json: &serde_json::Value) -> Option<TokenUsage> {
+    pub fn parse_json(&self, json: &serde_json::Value) -> Option<TokenUsage> {
         // 1. Check for message_start event (Anthropic streaming)
         if json.get("type").and_then(|v| v.as_str()) == Some("message_start") {
             if let Some(message) = json.get("message") {

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -429,7 +429,7 @@ impl Analyzer {
         }
 
         // 2. Token analysis - extract from SSE events
-        let token_result = match result {
+        let mut token_result = match result {
             AggregatedResult::SseComplete(pair) => {
                 let pid = pair.request.source_event.pid;
                 let comm = pair.request.source_event.comm_str();
@@ -443,15 +443,6 @@ impl Analyzer {
             _ => None,
         };
         
-        if let Some(record) = token_result {
-            results.push(AnalysisResult::Token(record));
-        } else {
-            // Fallback: manually compute tokens using get_global_tokenizer
-            if let Some(record) = self.compute_tokens_manually(result) {
-                results.push(AnalysisResult::Token(record));
-            }
-        }
-
         // 5. Token consumption analysis - breakdown by message role
         // This runs for any HTTP request with messages (not just SSE responses)
         // if let Some(breakdown) = self.analyze_token_consumption(result) {
@@ -473,10 +464,44 @@ impl Analyzer {
 
         // 4. HTTP data export - extract raw HTTP request/response data
         if let Some(http_record) = self.extract_http_record(result) {
+            if token_result.is_none() && http_record.is_sse {
+                if let Some(body) = &http_record.response_body {
+                    if let Ok(x) = serde_json::from_str::<Vec<serde_json::Value>>(body) {
+                        if let Some(last) = x.last() {
+                            let parser = TokenParser::new();
+                            if let Some(usage) = parser.parse_json(last) {
+                                let record = TokenRecord::new(
+                                    http_record.pid,
+                                    http_record.comm.clone(),
+                                    usage.provider.to_string(),
+                                    usage.input_tokens,
+                                    usage.output_tokens,
+                                )
+                                .with_model(usage.model.clone().unwrap_or_default())
+                                .with_cache_tokens(
+                                    usage.cache_creation_input_tokens.unwrap_or(0),
+                                    usage.cache_read_input_tokens.unwrap_or(0),
+                                );
+
+                                token_result = Some(record);
+                            }
+                        }
+                    }
+                }
+            }
             results.push(AnalysisResult::Http(http_record));
+
         }
 
-        
+
+        if let Some(record) = token_result {
+            results.push(AnalysisResult::Token(record));
+        } else {
+            // Fallback: manually compute tokens using get_global_tokenizer
+            if let Some(record) = self.compute_tokens_manually(result) {
+                results.push(AnalysisResult::Token(record));
+            }
+        }
 
         results
     }


### PR DESCRIPTION
## Description
修复http/2 token计算为0的问题
修复cargo vendor报错的问题
<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #156 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
