### PR TITLE
Fix/cosh/unify config dir source

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -257,8 +257,8 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
               </Text>
             </StatRow>
           )}
-        {(metrics.sandbox.totalRuns > 0 ||
-          metrics.sandbox.totalBlocked > 0) && (
+        {(metrics.sandbox?.totalRuns > 0 ||
+          metrics.sandbox?.totalBlocked > 0) && (
           <>
             <StatRow title={t('Sandbox Runs:')}>
               <Text color={theme.text.primary}>

--- a/src/copilot-shell/packages/core/src/aliyun/aliyunCredentials.ts
+++ b/src/copilot-shell/packages/core/src/aliyun/aliyunCredentials.ts
@@ -5,14 +5,13 @@
  */
 
 import * as path from 'node:path';
-import * as os from 'node:os';
 import { promises as fs } from 'node:fs';
 import {
   encryptCredential,
   decryptCredential,
 } from '../utils/credential-encryptor.js';
+import { Storage } from '../config/storage.js';
 
-const QWEN_DIR = '.copilot-shell';
 const ALIYUN_CREDS_FILENAME = 'aliyun_creds.json';
 
 /**
@@ -73,7 +72,7 @@ export interface AliyunCredentialsExtended extends AliyunCredentials {
  * 获取阿里云凭证文件路径
  */
 export function getAliyunCredsPath(): string {
-  return path.join(os.homedir(), QWEN_DIR, ALIYUN_CREDS_FILENAME);
+  return path.join(Storage.getGlobalQwenDir(), ALIYUN_CREDS_FILENAME);
 }
 
 /**

--- a/src/copilot-shell/packages/core/src/qwen/qwenOAuth2.ts
+++ b/src/copilot-shell/packages/core/src/qwen/qwenOAuth2.ts
@@ -7,13 +7,13 @@
 import crypto from 'crypto';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
-import * as os from 'os';
 
 import open from 'open';
 import { EventEmitter } from 'events';
 import type { Config } from '../config/config.js';
 import { randomUUID } from 'node:crypto';
 import { formatFetchErrorForUser } from '../utils/fetch.js';
+import { Storage } from '../config/storage.js';
 import {
   SharedTokenManager,
   TokenManagerError,
@@ -33,7 +33,6 @@ const QWEN_OAUTH_SCOPE = 'openid profile email model.completion';
 const QWEN_OAUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
 
 // File System Configuration
-const QWEN_DIR = '.copilot-shell';
 const QWEN_CREDENTIAL_FILENAME = 'oauth_creds.json';
 
 /**
@@ -1002,7 +1001,7 @@ export async function clearQwenCredentials(): Promise<void> {
 }
 
 function getQwenCachedCredentialPath(): string {
-  return path.join(os.homedir(), QWEN_DIR, QWEN_CREDENTIAL_FILENAME);
+  return path.join(Storage.getGlobalQwenDir(), QWEN_CREDENTIAL_FILENAME);
 }
 
 export const clearCachedCredentialFile = clearQwenCredentials;

--- a/src/copilot-shell/packages/core/src/qwen/sharedTokenManager.test.ts
+++ b/src/copilot-shell/packages/core/src/qwen/sharedTokenManager.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promises as fs, unlinkSync, type Stats } from 'node:fs';
 import * as os from 'os';
-import path from 'node:path';
+import path, * as pathNamed from 'node:path';
 
 import {
   SharedTokenManager,
@@ -36,7 +36,12 @@ vi.mock('node:fs', () => ({
 }));
 
 vi.mock('node:os', () => ({
+  default: {
+    homedir: vi.fn(),
+    tmpdir: vi.fn().mockReturnValue('/tmp'),
+  },
   homedir: vi.fn(),
+  tmpdir: vi.fn().mockReturnValue('/tmp'),
 }));
 
 vi.mock('node:path', () => ({
@@ -44,6 +49,9 @@ vi.mock('node:path', () => ({
     join: vi.fn(),
     dirname: vi.fn(),
   },
+  // Named exports for `import * as path` used by storage.ts
+  join: vi.fn(),
+  dirname: vi.fn(),
 }));
 
 /**
@@ -155,6 +163,7 @@ describe('SharedTokenManager', () => {
   const mockFs = vi.mocked(fs);
   const mockOs = vi.mocked(os);
   const mockPath = vi.mocked(path);
+  const mockPathNamed = vi.mocked(pathNamed);
   const mockUnlinkSync = vi.mocked(unlinkSync);
 
   beforeEach(() => {
@@ -177,6 +186,16 @@ describe('SharedTokenManager', () => {
       // Handle undefined/null input gracefully
       if (!filePath || typeof filePath !== 'string') {
         return '/home/user/.copilot-shell'; // Return the expected directory path
+      }
+      const parts = filePath.split('/');
+      const result = parts.slice(0, -1).join('/');
+      return result || '/';
+    });
+    // Also set up named exports used by storage.ts (import * as path)
+    mockPathNamed.join.mockImplementation((...args) => args.join('/'));
+    mockPathNamed.dirname.mockImplementation((filePath) => {
+      if (!filePath || typeof filePath !== 'string') {
+        return '/home/user/.copilot-shell';
       }
       const parts = filePath.split('/');
       const result = parts.slice(0, -1).join('/');

--- a/src/copilot-shell/packages/core/src/qwen/sharedTokenManager.ts
+++ b/src/copilot-shell/packages/core/src/qwen/sharedTokenManager.ts
@@ -6,7 +6,6 @@
 
 import path from 'node:path';
 import { promises as fs, unlinkSync } from 'node:fs';
-import * as os from 'os';
 import { randomUUID } from 'node:crypto';
 
 import type { IQwenOAuth2Client } from './qwenOAuth2.js';
@@ -17,9 +16,9 @@ import {
   isErrorResponse,
   CredentialsClearRequiredError,
 } from './qwenOAuth2.js';
+import { Storage } from '../config/storage.js';
 
 // File System Configuration
-const QWEN_DIR = '.copilot-shell';
 const QWEN_CREDENTIAL_FILENAME = 'oauth_creds.json';
 const QWEN_LOCK_FILENAME = 'oauth_creds.lock';
 
@@ -680,7 +679,7 @@ export class SharedTokenManager {
    * @returns The absolute path to the credentials file
    */
   private getCredentialFilePath(): string {
-    return path.join(os.homedir(), QWEN_DIR, QWEN_CREDENTIAL_FILENAME);
+    return path.join(Storage.getGlobalQwenDir(), QWEN_CREDENTIAL_FILENAME);
   }
 
   /**
@@ -689,7 +688,7 @@ export class SharedTokenManager {
    * @returns The absolute path to the lock file
    */
   private getLockFilePath(): string {
-    return path.join(os.homedir(), QWEN_DIR, QWEN_LOCK_FILENAME);
+    return path.join(Storage.getGlobalQwenDir(), QWEN_LOCK_FILENAME);
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/tools/web-search/providers/dashscope-provider.ts
+++ b/src/copilot-shell/packages/core/src/tools/web-search/providers/dashscope-provider.ts
@@ -5,7 +5,6 @@
  */
 
 import { promises as fs } from 'node:fs';
-import * as os from 'os';
 import * as path from 'path';
 import { BaseWebSearchProvider } from '../base-provider.js';
 import type {
@@ -14,6 +13,7 @@ import type {
   DashScopeProviderConfig,
 } from '../types.js';
 import type { QwenCredentials } from '../../../qwen/qwenOAuth2.js';
+import { Storage } from '../../../config/storage.js';
 
 interface DashScopeSearchItem {
   _id: string;
@@ -59,14 +59,13 @@ interface DashScopeSearchResponse {
 }
 
 // File System Configuration
-const QWEN_DIR = '.copilot-shell';
 const QWEN_CREDENTIAL_FILENAME = 'oauth_creds.json';
 
 /**
  * Get the path to the cached OAuth credentials file.
  */
 function getQwenCachedCredentialPath(): string {
-  return path.join(os.homedir(), QWEN_DIR, QWEN_CREDENTIAL_FILENAME);
+  return path.join(Storage.getGlobalQwenDir(), QWEN_CREDENTIAL_FILENAME);
 }
 
 /**

--- a/src/copilot-shell/packages/core/src/utils/configDirMigration.ts
+++ b/src/copilot-shell/packages/core/src/utils/configDirMigration.ts
@@ -7,9 +7,9 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { QWEN_DIR } from '../config/storage.js';
 
 const OLD_CONFIG_DIR = '.copilot';
-const NEW_CONFIG_DIR = '.copilot-shell';
 
 /**
  * Migrates the cosh configuration directory from ~/.copilot to ~/.copilot-shell
@@ -28,7 +28,7 @@ export async function migrateConfigDirIfNeeded(): Promise<string | null> {
   }
 
   const oldDir = path.join(homeDir, OLD_CONFIG_DIR);
-  const newDir = path.join(homeDir, NEW_CONFIG_DIR);
+  const newDir = path.join(homeDir, QWEN_DIR);
 
   const oldExists = fs.existsSync(oldDir);
   const newExists = fs.existsSync(newDir);
@@ -41,12 +41,12 @@ export async function migrateConfigDirIfNeeded(): Promise<string | null> {
   try {
     fs.cpSync(oldDir, newDir, { recursive: true });
     return (
-      `Config directory migrated from ~/${OLD_CONFIG_DIR} to ~/${NEW_CONFIG_DIR}. ` +
+      `Config directory migrated from ~/${OLD_CONFIG_DIR} to ~/${QWEN_DIR}. ` +
       `You may remove ~/${OLD_CONFIG_DIR} after confirming everything works.`
     );
   } catch (err) {
     return (
-      `Warning: Failed to migrate config from ~/${OLD_CONFIG_DIR} to ~/${NEW_CONFIG_DIR} ` +
+      `Warning: Failed to migrate config from ~/${OLD_CONFIG_DIR} to ~/${QWEN_DIR} ` +
       `(${err instanceof Error ? err.message : String(err)}). ` +
       `Falling back to ~/${OLD_CONFIG_DIR}.`
     );

--- a/src/copilot-shell/packages/core/src/utils/credential-encryptor.test.ts
+++ b/src/copilot-shell/packages/core/src/utils/credential-encryptor.test.ts
@@ -66,7 +66,7 @@ describe('credential-encryptor', () => {
     it('should read existing salt file', () => {
       encryptCredential('test');
       expect(mockReadFileSync).toHaveBeenCalledWith(
-        '/home/test/.copilot/.encryption-salt',
+        '/home/test/.copilot-shell/.encryption-salt',
       );
     });
 
@@ -93,12 +93,12 @@ describe('credential-encryptor', () => {
       const mod = await import('./credential-encryptor.js');
       mod.encryptCredential('test');
 
-      expect(mockMkdirSync).toHaveBeenCalledWith('/home/test/.copilot', {
+      expect(mockMkdirSync).toHaveBeenCalledWith('/home/test/.copilot-shell', {
         recursive: true,
         mode: 0o700,
       });
       expect(mockWriteFileSync).toHaveBeenCalledWith(
-        '/home/test/.copilot/.encryption-salt',
+        '/home/test/.copilot-shell/.encryption-salt',
         expect.any(Buffer),
         { mode: 0o600 },
       );

--- a/src/copilot-shell/packages/core/src/utils/credential-encryptor.ts
+++ b/src/copilot-shell/packages/core/src/utils/credential-encryptor.ts
@@ -20,7 +20,7 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
+import { Storage } from '../config/storage.js';
 
 const ENCRYPTED_PREFIX = 'enc:';
 const CREDENTIAL_PASSWORD = 'copilot-credential-encrypt';
@@ -29,11 +29,11 @@ const SALT_LENGTH = 32;
 let cachedKey: Buffer | null = null;
 
 /**
- * Read or create the persisted random salt at ~/.copilot/.encryption-salt.
+ * Read or create the persisted random salt at ~/.copilot-shell/.encryption-salt.
  * The salt is 32 raw bytes stored with mode 0o600.
  */
 function getOrCreateSalt(): Buffer {
-  const configDir = path.join(os.homedir(), '.copilot');
+  const configDir = Storage.getGlobalQwenDir();
   const saltPath = path.join(configDir, '.encryption-salt');
 
   try {

--- a/src/copilot-shell/packages/core/src/utils/paths.ts
+++ b/src/copilot-shell/packages/core/src/utils/paths.ts
@@ -11,7 +11,7 @@ import * as crypto from 'node:crypto';
 import type { Config } from '../config/config.js';
 import { isNodeError } from './errors.js';
 
-export const QWEN_DIR = '.copilot-shell';
+export { QWEN_DIR } from '../config/storage.js';
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
 
 /**

--- a/src/copilot-shell/packages/core/src/utils/projectSummary.ts
+++ b/src/copilot-shell/packages/core/src/utils/projectSummary.ts
@@ -6,6 +6,7 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { QWEN_DIR } from './paths.js';
 
 export interface ProjectSummaryInfo {
   hasHistory: boolean;
@@ -25,11 +26,7 @@ export interface ProjectSummaryInfo {
  * Reads and parses the project summary file to extract structured information
  */
 export async function getProjectSummaryInfo(): Promise<ProjectSummaryInfo> {
-  const summaryPath = path.join(
-    process.cwd(),
-    '.copilot-shell',
-    'PROJECT_SUMMARY.md',
-  );
+  const summaryPath = path.join(process.cwd(), QWEN_DIR, 'PROJECT_SUMMARY.md');
 
   try {
     await fs.access(summaryPath);

--- a/src/copilot-shell/scripts/telemetry.js
+++ b/src/copilot-shell/scripts/telemetry.js
@@ -12,6 +12,7 @@ import { existsSync, readFileSync } from 'node:fs';
 
 const projectRoot = join(import.meta.dirname, '..');
 
+// NOTE: This value must stay in sync with QWEN_DIR in packages/core/src/config/storage.ts
 const SETTINGS_DIRECTORY_NAME = '.copilot-shell';
 const USER_SETTINGS_DIR = join(
   process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH || '',

--- a/src/copilot-shell/scripts/telemetry_utils.js
+++ b/src/copilot-shell/scripts/telemetry_utils.js
@@ -23,10 +23,12 @@ const projectHash = crypto
   .update(projectRoot)
   .digest('hex');
 
+// NOTE: This value must stay in sync with QWEN_DIR in packages/core/src/config/storage.ts
+const QWEN_DIR_NAME = '.copilot-shell';
 // User-level .copilot-shell directory in home
-const USER_GEMINI_DIR = path.join(os.homedir(), '.copilot-shell');
+const USER_GEMINI_DIR = path.join(os.homedir(), QWEN_DIR_NAME);
 // Project-level .copilot-shell directory in the workspace
-const WORKSPACE_GEMINI_DIR = path.join(projectRoot, '.copilot-shell');
+const WORKSPACE_GEMINI_DIR = path.join(projectRoot, QWEN_DIR_NAME);
 
 // Telemetry artifacts are stored in a hashed directory under the user's ~/.copilot-shell/tmp
 export const OTEL_DIR = path.join(USER_GEMINI_DIR, 'tmp', projectHash, 'otel');


### PR DESCRIPTION
## Description

On startup, `cosh` was incorrectly creating `~/.copilot` in addition to `~/.copilot-shell` because `credential-encryptor.ts` still referenced the old path. Beyond that bug, several files each defined their own local `QWEN_DIR = '.copilot-shell'` constant instead of reusing the single source of truth in `config/storage.ts`, making future renames fragile.

This PR fixes the root cause and consolidates all config-directory references:
- **Bug fix**: `credential-encryptor.ts` now uses `Storage.getGlobalQwenDir()` (was `path.join(os.homedir(), '.copilot')`).
- **Refactor**: removed local `QWEN_DIR` constants from `qwenOAuth2.ts`, `sharedTokenManager.ts`, `dashscope-provider.ts`, `aliyunCredentials.ts`, and `configDirMigration.ts`; all now call `Storage.getGlobalQwenDir()`.
- `utils/paths.ts` re-exports `QWEN_DIR` from `config/storage.ts` instead of declaring its own copy.
- JS scripts (`telemetry.js`, `telemetry_utils.js`) add a sync comment pointing to `storage.ts` as the canonical source.
- Fixed a test regression in `sharedTokenManager.test.ts` where `vi.mock('node:path')` only exposed `default` exports, breaking `storage.ts` which uses `import * as path`.

Also fixed the following issues to ensure the tests pass:
- Fixed a crash in `StatsDisplay.tsx` where `metrics.sandbox` could be `undefined` at render time, causing `TypeError` on the `quit` history item.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #170 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Verified manually that ~/.copilot is no longer created on startup; only ~/.copilot-shell is created.

```bash
# core: 177 test files, all passed (was 1 failed — sharedTokenManager 15 failures)
# cli:  all test files passed (was 1 failed — HistoryItemDisplay 1 failure)
```

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
