### PR TITLE
fix(ci): improve PR auto-label matching and fallback behavior

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,8 @@
 # ---------------------------------------------------------------------------
 /.github/                               @kongche-jbw                # auto-label: scope:ci
 /docs/                                  @casparant                  # auto-label: scope:documentation
+*.md                                    @casparant                  # auto-label: scope:documentation
+/NOTICE                                 @casparant                  # auto-label: scope:documentation
 /scripts/                               @samchu-zsl                 # auto-label: scope:scripts
 /cliff.toml                             @samchu-zsl                 # auto-label: scope:ci
 /Makefile                               @casparant                  # auto-label: scope:scripts

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -40,10 +40,13 @@ jobs:
               if (!line || line.startsWith('#')) continue;
               const m = line.match(/#\s*auto-label:\s*(\S+)/);
               if (!m) continue;
-              const prefix = line.split(/\s+/)[0].replace(/^\//, '');
-              const label  = m[1];
-              const type   = label.startsWith('component:') ? 'component' : 'scope';
-              rules.push({ prefix, label, type });
+              const rawPrefix = line.split(/\s+/)[0];
+              // Detect glob patterns like *.md (suffix match), otherwise prefix match
+              const isGlob  = rawPrefix.startsWith('*');
+              const prefix  = isGlob ? rawPrefix.slice(1) : rawPrefix.replace(/^\//, '');
+              const label   = m[1];
+              const type    = label.startsWith('component:') ? 'component' : 'scope';
+              rules.push({ prefix, label, type, isGlob });
             }
 
             // ── Fetch changed files (paginate up to 300) ──────────────────
@@ -63,8 +66,9 @@ jobs:
             for (const fn of filenames) {
               let componentMatch = null, componentPrefix = null;
               let scopeMatch     = null, scopePrefix     = null;
-              for (const { prefix, label, type } of rules) {
-                if (fn.startsWith(prefix)) {
+              for (const { prefix, label, type, isGlob } of rules) {
+                const matched = isGlob ? fn.endsWith(prefix) : fn.startsWith(prefix);
+                if (matched) {
                   if (type === 'component') { componentMatch = label; componentPrefix = prefix; }
                   else                      { scopeMatch     = label; scopePrefix     = prefix; }
                 }
@@ -81,9 +85,10 @@ jobs:
                 scopeHit.add(scopeMatch);
               }
             }
-            if (scopeHit.size === 0) {
+            const hasComponent = Array.from(labels).some(l => l.startsWith('component:'));
+            if (scopeHit.size === 0 && !hasComponent) {
               labels.add('scope:chore');
-              reasons['scope:chore'] = 'no file matched any scope rule (fallback)';
+              reasons['scope:chore'] = 'no component or scope matched (fallback)';
             }
 
             if (labels.size > 0) {


### PR DESCRIPTION
## Description

This PR updates the PR-opened auto-label workflow to better align with CODEOWNERS annotations and reduce incorrect fallback labels.

Key changes:
- Added suffix-based matching for wildcard-style rules starting with * (for example, *.md) when parsing auto-label rules from CODEOWNERS.
- Added scope:documentation auto-label coverage for markdown files and NOTICE in CODEOWNERS.
- Updated fallback behavior so scope:chore is applied only when neither a scope label nor a component label is matched.
- Improved fallback reason text in workflow logs.

## Related Issue

no-issue: ci

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] cosh (copilot-shell)
- [ ] sec-core (agent-sec-core)
- [ ] skill (os-skills)
- [ ] sight (agentsight)
- [x] Multiple / Project-wide

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For cosh: Lint passes, type check passes, and tests pass
- [ ] For sec-core (Rust): cargo clippy -- -D warnings and cargo fmt --check pass
- [ ] For sec-core (Python): Ruff format and pytest pass
- [ ] For skill: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For sight: cargo clippy -- -D warnings and cargo fmt --check pass
- [x] Lock files are up to date (package-lock.json / Cargo.lock)

## Testing

Manual validation was performed by reviewing rule parsing and matching behavior against representative changed-file paths:

- Markdown files now match the documentation scope rule via wildcard suffix logic.
- NOTICE now matches the documentation scope rule explicitly.
- PRs with component-only matches no longer receive scope:chore.
- scope:chore is still applied when no component and no scope rules match.

No dedicated automated test was added for this workflow change.

## Additional Notes

This change is backward-compatible for existing prefix-based rules and improves maintainability of CODEOWNERS-driven labeling.