### PR TITLE
docs(sight): fix incorrect discover command in README

### DIFF
--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -141,7 +141,7 @@ Discover AI agents running on the system.
 agentsight discover
 
 # List all known agent types
-agentsight discover --list
+agentsight discover --list-known
 
 # Verbose output with executable paths
 agentsight discover --verbose

--- a/src/agentsight/README_CN.md
+++ b/src/agentsight/README_CN.md
@@ -141,7 +141,7 @@ agentsight serve --db /path/to/genai_events.db
 agentsight discover
 
 # 列出所有已知 Agent 类型
-agentsight discover --list
+agentsight discover --list-known
 
 # 详细输出（包含可执行文件路径）
 agentsight discover --verbose


### PR DESCRIPTION
## Description

Fix incorrect command in README documentation for agentsight discover feature.

The README incorrectly documented `agentsight discover --list` for listing known agent types, but the actual command should be `agentsight discover --list-known`.

Updated both English and Chinese README files to reflect the correct command usage.

## Related Issue

closes #191

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Verified the correct command is `agentsight discover --list-known` by checking the CLI implementation. Updated documentation to match the actual command usage.

## Additional Notes

Fixed in both `README.md` and `README_CN.md` to ensure consistency across all documentation.