### PR TITLE
fix(sight): remove token consumption breakdown analysis

### DIFF
--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -442,7 +442,7 @@ impl Analyzer {
             }
             _ => None,
         };
-        
+
         // 5. Token consumption analysis - breakdown by message role
         // This runs for any HTTP request with messages (not just SSE responses)
         // if let Some(breakdown) = self.analyze_token_consumption(result) {

--- a/src/agentsight/src/bin/agentsight.rs
+++ b/src/agentsight/src/bin/agentsight.rs
@@ -12,7 +12,6 @@ mod cli;
 use cli::{token::TokenCommand, trace::TraceCommand, audit::AuditCommand, discover::DiscoverCommand, metrics::MetricsCommand};
 #[cfg(feature = "server")]
 use cli::serve::ServeCommand;
-use agentsight::token_breakdown::AnalyzeChatmlCommand;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "agentsight", about = "AI Agent observability tool - trace processes, SSL traffic, and LLM API calls via eBPF")]
@@ -25,8 +24,6 @@ pub enum Command {
     Audit(AuditCommand),
     /// Discover running AI agents on the system
     Discover(DiscoverCommand),
-    /// Analyze a ChatML file and output token consumption breakdown
-    AnalyzeChatml(AnalyzeChatmlCommand),
     /// Print per-agent token usage metrics in Prometheus text format
     Metrics(MetricsCommand),
     /// Start the API server
@@ -36,13 +33,12 @@ pub enum Command {
 
 fn main() {
     let cmd = Command::from_args();
-    
+
     match cmd {
         Command::Token(token_cmd) => token_cmd.execute(),
         Command::Trace(trace_cmd) => trace_cmd.execute(),
         Command::Audit(audit_cmd) => audit_cmd.execute(),
         Command::Discover(discover_cmd) => discover_cmd.execute(),
-        Command::AnalyzeChatml(cmd) => cmd.execute(),
         Command::Metrics(metrics_cmd) => metrics_cmd.execute(),
         #[cfg(feature = "server")]
         Command::Serve(serve_cmd) => serve_cmd.execute(),

--- a/src/agentsight/src/bin/cli/token.rs
+++ b/src/agentsight/src/bin/cli/token.rs
@@ -2,7 +2,6 @@
 
 use agentsight::{
     TimePeriod, TokenQueryResult, format_tokens_with_commas, Trend, TokenStore,
-    TokenConsumptionStore, TokenConsumptionFilter, TokenConsumptionQueryResult,
     SqliteConfig,
 };
 use structopt::StructOpt;
@@ -14,31 +13,19 @@ pub struct TokenCommand {
     /// Query by fixed time period
     #[structopt(long, possible_values = &["today", "yesterday", "week", "last_week", "month", "last_month"])]
     pub period: Option<String>,
-    
+
     /// Query last N hours
     #[structopt(long)]
     pub hours: Option<u64>,
-    
+
     /// Compare with previous period
     #[structopt(long)]
     pub compare: bool,
-    
-    /// Show breakdown by agent/task
-    #[structopt(long)]
-    pub breakdown: bool,
 
-    /// Show token consumption detail (by_role, output_by_type, tools, system_prompt)
-    #[structopt(long)]
-    pub detail: bool,
-
-    /// When --detail is set, also include the individual records in the output
-    #[structopt(long)]
-    pub records: bool,
-    
     /// Output as JSON
     #[structopt(long)]
     pub json: bool,
-    
+
     /// Custom data file path
     #[structopt(long)]
     pub data_file: Option<String>,
@@ -53,170 +40,50 @@ impl TokenCommand {
             .as_ref()
             .map(|p| std::path::PathBuf::from(p))
             .unwrap_or_else(|| SqliteConfig::default().db_path());
-        
-        if self.detail {
-            self.execute_detail(&data_path);
-        } else {
-            self.execute_summary(&data_path);
-        }
+
+        self.execute_summary(&data_path);
     }
 
     fn execute_summary(&self, data_path: &std::path::Path) {
         // Open token store
         let store = TokenStore::new(data_path);
         let query = agentsight::TokenQuery::new(&store);
-        
+
         // Execute query
         let result = if let Some(hours) = self.hours {
-            if self.compare && self.breakdown {
-                let mut r = query.by_hours_with_compare(hours);
-                r.breakdown = compute_breakdown_for_hours(&store, hours);
-                r
-            } else if self.compare {
+            if self.compare {
                 query.by_hours_with_compare(hours)
-            } else if self.breakdown {
-                let mut r = query.by_hours(hours);
-                r.breakdown = compute_breakdown_for_hours(&store, hours);
-                r
             } else {
                 query.by_hours(hours)
             }
         } else if let Some(ref period_str) = self.period {
             let period = super::parse_period(period_str);
-            if self.compare && self.breakdown {
-                query.full_query(period)
-            } else if self.compare {
+            if self.compare {
                 query.by_period_with_compare(period)
-            } else if self.breakdown {
-                query.by_period_with_breakdown(period)
             } else {
                 query.by_period(period)
             }
         } else {
-            if self.compare && self.breakdown {
-                query.full_query(TimePeriod::Today)
-            } else if self.compare {
+            if self.compare {
                 query.by_period_with_compare(TimePeriod::Today)
-            } else if self.breakdown {
-                query.by_period_with_breakdown(TimePeriod::Today)
             } else {
                 query.by_period(TimePeriod::Today)
             }
         };
-        
+
         // Output result
         if self.json {
             println!("{}", serde_json::to_string_pretty(&result).unwrap());
         } else {
-            print_human_readable(&result, self.compare, self.breakdown);
+            print_human_readable(&result, self.compare);
         }
     }
-
-    fn execute_detail(&self, data_path: &std::path::Path) {
-        let store = match TokenConsumptionStore::new(data_path) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("无法打开 token consumption 数据库: {}", e);
-                return;
-            }
-        };
-
-        // Build time filter
-        let filter = if let Some(hours) = self.hours {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0);
-            let start_ns = now.saturating_sub(hours * 3_600 * 1_000_000_000);
-            TokenConsumptionFilter {
-                start_ns: Some(start_ns),
-                end_ns: Some(now),
-                ..Default::default()
-            }
-        } else if let Some(ref period_str) = self.period {
-            let period = super::parse_period(period_str);
-            let (start_ns, end_ns) = period.time_range();
-            TokenConsumptionFilter {
-                start_ns: Some(start_ns),
-                end_ns: Some(end_ns),
-                ..Default::default()
-            }
-        } else {
-            // Default: today
-            let (start_ns, end_ns) = TimePeriod::Today.time_range();
-            TokenConsumptionFilter {
-                start_ns: Some(start_ns),
-                end_ns: Some(end_ns),
-                ..Default::default()
-            }
-        };
-
-        let period_label = if let Some(hours) = self.hours {
-            format!("最近 {} 小时", hours)
-        } else if let Some(ref p) = self.period {
-            super::parse_period(p).to_string()
-        } else {
-            TimePeriod::Today.to_string()
-        };
-
-        match store.aggregate(&filter, period_label, self.records) {
-            Ok(result) => {
-                if self.json {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                } else {
-                    print_detail_human_readable(&result, self.records);
-                }
-            }
-            Err(e) => eprintln!("查询失败: {}", e),
-        }
-    }
-}
-
-/// Compute breakdown for hours (helper)
-fn compute_breakdown_for_hours(store: &TokenStore, hours: u64) -> Vec<agentsight::TokenBreakdown> {
-    let records = store.by_last_hours(hours);
-    let total_tokens: u64 = records.iter().map(|r| r.total_tokens()).sum();
-
-    let mut agent_totals: HashMap<String, (u64, u64, u64, u64)> = HashMap::new();
-
-    for record in records.iter() {
-        let name = record.agent.as_ref().unwrap_or(&record.comm).clone();
-
-        let entry = agent_totals.entry(name).or_insert((0, 0, 0, 0));
-        entry.0 += record.total_tokens();
-        entry.1 += record.input_tokens;
-        entry.2 += record.output_tokens;
-        entry.3 += 1;
-    }
-
-    let mut breakdown: Vec<agentsight::TokenBreakdown> = agent_totals
-        .into_iter()
-        .map(|(name, (total, input, output, count))| {
-            let percentage = if total_tokens > 0 {
-                (total as f64 / total_tokens as f64) * 100.0
-            } else {
-                0.0
-            };
-            agentsight::TokenBreakdown {
-                name,
-                total_tokens: total,
-                input_tokens: input,
-                output_tokens: output,
-                request_count: count,
-                percentage,
-            }
-        })
-        .collect();
-
-    breakdown.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
-    breakdown
 }
 
 /// Print human-readable summary output
 fn print_human_readable(
     result: &TokenQueryResult,
     show_compare: bool,
-    show_breakdown: bool,
 ) {
     // Main result
     println!(
@@ -224,7 +91,7 @@ fn print_human_readable(
         result.period,
         format_tokens_with_commas(result.total_tokens)
     );
-    
+
     // Comparison
     if show_compare {
         if let Some(ref comp) = result.comparison {
@@ -233,7 +100,7 @@ fn print_human_readable(
                 Trend::Down => "下降",
                 Trend::Flat => "持平",
             };
-            
+
             println!(
                 "比上一时段（{}）{}了 {}。",
                 format_tokens_with_commas(comp.previous_total),
@@ -242,21 +109,7 @@ fn print_human_readable(
             );
         }
     }
-    
-    // Breakdown
-    if show_breakdown && !result.breakdown.is_empty() {
-        println!();
-        println!("主要消耗来源：");
-        for item in &result.breakdown {
-            println!(
-                "- {}：{} tokens ({:.0}%)",
-                item.name,
-                format_tokens_with_commas(item.total_tokens),
-                item.percentage
-            );
-        }
-    }
-    
+
     // Additional details
     if result.request_count > 0 {
         println!();
@@ -266,74 +119,6 @@ fn print_human_readable(
             format_tokens_with_commas(result.input_tokens),
             format_tokens_with_commas(result.output_tokens)
         );
-    }
-}
-
-/// Print human-readable detail output for token consumption breakdown
-fn print_detail_human_readable(result: &TokenConsumptionQueryResult, show_records: bool) {
-    println!("=== Token 消耗明细 ({}) ===", result.period);
-    println!("共 {} 条记录", result.record_count);
-    println!();
-
-    println!("输入 tokens：{}", format_tokens_with_commas(result.total_input_tokens));
-    println!("输出 tokens：{}", format_tokens_with_commas(result.total_output_tokens));
-    println!("总计 tokens：{}", format_tokens_with_commas(result.total_tokens));
-    println!();
-
-    if result.tools_tokens > 0 {
-        println!("工具定义占用：{} tokens", format_tokens_with_commas(result.tools_tokens));
-    }
-    if result.system_prompt_tokens > 0 {
-        println!("系统提示占用：{} tokens", format_tokens_with_commas(result.system_prompt_tokens));
-    }
-
-    if !result.by_role.is_empty() {
-        println!();
-        println!("按角色分布（输入）：");
-        let mut roles: Vec<_> = result.by_role.iter().collect();
-        roles.sort_by(|a, b| b.1.cmp(a.1));
-        for (role, tokens) in roles {
-            println!("  {:<12} {}", role, format_tokens_with_commas(*tokens));
-        }
-    }
-
-    if !result.output_by_type.is_empty() {
-        println!();
-        println!("按类型分布（输出）：");
-        let mut types: Vec<_> = result.output_by_type.iter().collect();
-        types.sort_by(|a, b| b.1.cmp(a.1));
-        for (typ, tokens) in types {
-            println!("  {:<12} {}", typ, format_tokens_with_commas(*tokens));
-        }
-    }
-
-    if show_records && !result.records.is_empty() {
-        println!();
-        println!("--- 明细记录 ---");
-        for rec in &result.records {
-            use std::time::{Duration, UNIX_EPOCH};
-            let ts = UNIX_EPOCH + Duration::from_nanos(rec.timestamp_ns);
-            let datetime = chrono::DateTime::<chrono::Utc>::from(ts).with_timezone(&chrono::Local);
-            println!(
-                "[{}] pid={} comm={} provider={} model={} in={} out={}",
-                datetime.format("%Y-%m-%d %H:%M:%S"),
-                rec.pid,
-                rec.comm,
-                rec.provider,
-                rec.model,
-                format_tokens_with_commas(rec.total_input_tokens as u64),
-                format_tokens_with_commas(rec.total_output_tokens as u64),
-            );
-            let by_role = rec.by_role();
-            if !by_role.is_empty() {
-                let mut roles: Vec<_> = by_role.iter().collect();
-                roles.sort_by(|a, b| b.1.cmp(a.1));
-                let role_str: Vec<String> = roles.iter()
-                    .map(|(r, t)| format!("{}:{}", r, t))
-                    .collect();
-                println!("  角色: {}", role_str.join(", "));
-            }
-        }
     }
 }
 

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -42,7 +42,6 @@ pub mod genai;
 pub mod atif;
 #[cfg(feature = "server")]
 pub mod server;
-pub mod token_breakdown;
 mod unified;
 pub mod ffi;
 
@@ -69,8 +68,6 @@ pub use analyzer::{
     AnthropicRequest, AnthropicResponse, AnthropicMessage, AnthropicUsage,
     MessageRole,
     AnalysisResult, PromptTokenCount, HttpRecord, Analyzer,
-    TokenConsumptionBreakdown, MessageTokenCount, OutputTokenCount,
-    count_request_tokens, count_response_tokens, RequestTokenCount, ResponseTokenCount,
 };
 pub use chrome_trace::{ChromeTraceEvent, TraceArgs, ToChromeTraceEvent, ns_to_us, next_flow_id};
 pub use storage::{
@@ -78,8 +75,6 @@ pub use storage::{
     SqliteStore, AuditStore,
     TokenStore, TokenQuery,
     HttpStore,
-    TokenConsumptionStore, TokenConsumptionRecord,
-    TokenConsumptionFilter, TokenConsumptionQueryResult,
     TimePeriod, TokenQueryResult, TokenBreakdown, TokenComparison, Trend,
     format_tokens, format_tokens_with_commas,
 };

--- a/src/os-skills/devops/sysom-agentsight/SKILL.md
+++ b/src/os-skills/devops/sysom-agentsight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentsight
-description: 通过命令行查询 AgentSight 平台的 token 消耗数据和审计事件。当用户询问 token 用量、花费、消耗趋势，或询问 LLM 调用、进程行为审计时使用此技能。
+description: 通过命令行查询 AgentSight 平台的 token 消耗数据和审计事件。当用户询问 token 用量、花费、消耗趋势,或询问 LLM 调用、进程行为审计时使用此技能。
 ---
 
 # Token 查询
@@ -13,9 +13,6 @@ description: 通过命令行查询 AgentSight 平台的 token 消耗数据和审
 | `/usr/local/bin/agentsight token --period yesterday` | 昨天消耗 |
 | `/usr/local/bin/agentsight token --hours 3` | 最近 3 小时 |
 | `/usr/local/bin/agentsight token --period today --compare` | 今天 vs 昨天对比 |
-| `/usr/local/bin/agentsight token --period today --breakdown` | 按任务分解 |
-| `/usr/local/bin/agentsight token --detail` | 按角色/类型明细 |
-| `/usr/local/bin/agentsight token --detail --records` | 含每条请求记录 |
 
 ## 返回示例
 
@@ -23,9 +20,6 @@ description: 通过命令行查询 AgentSight 平台的 token 消耗数据和审
 今天共消耗 125,000 tokens，比昨天（98,000）增长 27%。
 
 输入: 125,000 | 输出: 85,000
-
-按角色分布：
-  user: 80,000 | system: 30,000 | assistant: 15,000
 ```
 
 ---


### PR DESCRIPTION
## Description

This PR reverses the previous enable of token consumption breakdown feature:

- Keep the token consumption analysis code commented out in `unified.rs`
- Remove `--breakdown` and `--detail` flags from token command
- Remove `analyze-chatml` subcommand  
- Remove `TokenConsumption` related exports from `lib.rs`
- Update agentsight skill documentation to remove breakdown references

The token consumption breakdown feature is not ready for release yet.

## Related Issue

Closes #193

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- Verified the code compiles successfully with `cargo check`