### PR TITLE
fix(sight): always show comparison data when --compare flag is used

### DIFF
--- a/src/agentsight/src/storage/sqlite/token.rs
+++ b/src/agentsight/src/storage/sqlite/token.rs
@@ -501,33 +501,33 @@ impl<'a> TokenQuery<'a> {
     /// Query with comparison
     pub fn by_period_with_compare(&self, period: TimePeriod) -> TokenQueryResult {
         let mut result = self.by_period(period);
-        
+
         // Get previous period data
         let prev_period = period.previous_period();
         let prev_result = self.by_period(prev_period);
-        
-        if prev_result.total_tokens > 0 {
-            let change = result.total_tokens as i64 - prev_result.total_tokens as i64;
-            let change_percent = if prev_result.total_tokens > 0 {
-                (change as f64 / prev_result.total_tokens as f64) * 100.0
+
+        let change = result.total_tokens as i64 - prev_result.total_tokens as i64;
+        let change_percent = if prev_result.total_tokens > 0 {
+            (change as f64 / prev_result.total_tokens as f64) * 100.0
+        } else if result.total_tokens > 0 {
+            100.0 // From 0 to non-zero is 100% increase
+        } else {
+            0.0
+        };
+
+        result.comparison = Some(TokenComparison {
+            previous_total: prev_result.total_tokens,
+            change,
+            change_percent,
+            trend: if change > 0 {
+                Trend::Up
+            } else if change < 0 {
+                Trend::Down
             } else {
-                0.0
-            };
-            
-            result.comparison = Some(TokenComparison {
-                previous_total: prev_result.total_tokens,
-                change,
-                change_percent,
-                trend: if change > 0 {
-                    Trend::Up
-                } else if change < 0 {
-                    Trend::Down
-                } else {
-                    Trend::Flat
-                },
-            });
-        }
-        
+                Trend::Flat
+            },
+        });
+
         result
     }
     
@@ -548,7 +548,7 @@ impl<'a> TokenQuery<'a> {
     /// Query hours with comparison
     pub fn by_hours_with_compare(&self, hours: u64) -> TokenQueryResult {
         let mut result = self.by_hours(hours);
-        
+
         // Get previous period data
         let prev_records = self.store.by_last_hours(hours * 2);
         let prev_records: Vec<_> = prev_records.into_iter().filter(|r| {
@@ -562,31 +562,31 @@ impl<'a> TokenQuery<'a> {
             let mid_ns = now.saturating_sub(hours_ns);
             r.timestamp_ns >= start_ns && r.timestamp_ns < mid_ns
         }).collect();
-        
+
         let prev_total: u64 = prev_records.iter().map(|r| r.total_tokens()).sum();
-        
-        if prev_total > 0 {
-            let change = result.total_tokens as i64 - prev_total as i64;
-            let change_percent = if prev_total > 0 {
-                (change as f64 / prev_total as f64) * 100.0
+
+        let change = result.total_tokens as i64 - prev_total as i64;
+        let change_percent = if prev_total > 0 {
+            (change as f64 / prev_total as f64) * 100.0
+        } else if result.total_tokens > 0 {
+            100.0 // From 0 to non-zero is 100% increase
+        } else {
+            0.0
+        };
+
+        result.comparison = Some(TokenComparison {
+            previous_total: prev_total,
+            change,
+            change_percent,
+            trend: if change > 0 {
+                Trend::Up
+            } else if change < 0 {
+                Trend::Down
             } else {
-                0.0
-            };
-            
-            result.comparison = Some(TokenComparison {
-                previous_total: prev_total,
-                change,
-                change_percent,
-                trend: if change > 0 {
-                    Trend::Up
-                } else if change < 0 {
-                    Trend::Down
-                } else {
-                    Trend::Flat
-                },
-            });
-        }
-        
+                Trend::Flat
+            },
+        });
+
         result
     }
     


### PR DESCRIPTION
## Description

Fix the issue where `agentsight token --compare` returns no comparison data when the previous period has zero or no token usage.

Previously, the comparison object was only created when `prev_result.total_tokens > 0`. This meant:
- If the previous period had 0 tokens, `comparison` field would be `None` (null in JSON)
- Users couldn't see any comparison information at all
- The `--compare` flag appeared to have no effect when there was no previous data

Now the comparison object is **always created** when `--compare` is used:
- Shows `previous_total: 0` if no data in previous period
- Shows 100% increase when going from 0 to non-zero
- Properly displays comparison even when both current and previous periods are 0
- Users can always see the previous period data and the trend

This fix applies to both:
- `by_period_with_compare()` for period-based queries (e.g., `--period week --compare`)
- `by_hours_with_compare()` for hours-based queries (e.g., `--hours 24 --compare`)

## Related Issue

closes #194

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Verified the fix by:
- Checking the code logic: comparison object is now always created
- Edge cases handled:
  - Previous period = 0, current period > 0 → Shows 100% increase
  - Previous period = 0, current period = 0 → Shows 0% change
  - Previous period > 0, current period = 0 → Shows decrease
  - Previous period > 0, current period > 0 → Normal comparison

## Additional Notes

The fix removes the conditional `if prev_result.total_tokens > 0` check and always populates the comparison field when comparison is requested. This matches user expectations that `--compare` should always show comparison data.