### PR TITLE
feat(agentsight): add 200MB size limit for genai_events.db

### DIFF
--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -5,9 +5,9 @@
 //!
 //! # Size Limit
 //!
-//! The database is limited to 200MB. When approaching the limit, old records
-//! are pruned automatically. The size check includes the main database file
-//! plus WAL and SHM files.
+//! The database size can be configured via `AGENTSIGHT_GENAI_DB_MAX_SIZE_MB` environment
+//! variable (default: 200 MB). When approaching 90% of the limit, old records are pruned
+//! automatically. The size check includes the main database file plus WAL and SHM files.
 
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -17,16 +17,30 @@ use crate::genai::semantic::GenAISemanticEvent;
 use crate::genai::exporter::GenAIExporter;
 use super::connection::{create_connection, default_base_path};
 
-// ─── Size limit constants ─────────────────────────────────────────────────────
+// ─── Size limit configuration ──────────────────────────────────────────────────
 
-/// Maximum database size: 200 MB
-const MAX_DB_SIZE: u64 = 200 * 1024 * 1024;
-/// Threshold to start pruning: 180 MB (90% of max)
-const PRUNE_THRESHOLD: u64 = 180 * 1024 * 1024;
+/// Environment variable name for max database size in MB
+const ENV_MAX_DB_SIZE_MB: &str = "AGENTSIGHT_GENAI_DB_MAX_SIZE_MB";
+/// Default max database size: 200 MB
+const DEFAULT_MAX_DB_SIZE_MB: u64 = 200;
 /// Percentage of records to prune per attempt
 const PRUNE_PERCENT: f64 = 0.05;
 /// Maximum prune retry attempts to avoid infinite loop
 const MAX_PRUNE_RETRIES: u32 = 3;
+
+/// Get max database size from environment variable or use default
+fn get_max_db_size() -> u64 {
+    std::env::var(ENV_MAX_DB_SIZE_MB)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MAX_DB_SIZE_MB)
+        * 1024 * 1024
+}
+
+/// Get prune threshold (90% of max)
+fn get_prune_threshold() -> u64 {
+    (get_max_db_size() as f64 * 0.9) as u64
+}
 
 // ─── Query result types ────────────────────────────────────────────────────────
 
@@ -142,11 +156,13 @@ impl GenAISqliteStore {
         
         // Log current database size on startup
         let current_size = store.get_total_db_size();
+        let max_size = get_max_db_size();
+        let threshold = get_prune_threshold();
         log::info!(
             "GenAISqliteStore initialized: db_size={}MB, threshold={}MB, max={}MB",
             current_size / 1024 / 1024,
-            PRUNE_THRESHOLD / 1024 / 1024,
-            MAX_DB_SIZE / 1024 / 1024
+            threshold / 1024 / 1024,
+            max_size / 1024 / 1024
         );
         
         Ok(store)
@@ -831,30 +847,31 @@ impl GenAISqliteStore {
     /// Keeps pruning until size drops below threshold to avoid repeated triggers.
     fn check_and_prune_if_needed(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut current_size = self.get_total_db_size();
+        let threshold = get_prune_threshold();
         
-        if current_size < PRUNE_THRESHOLD {
+        if current_size < threshold {
             return Ok(());
         }
         
         log::info!(
             "Database size {}MB exceeding threshold {}MB, pruning old records",
             current_size / 1024 / 1024,
-            PRUNE_THRESHOLD / 1024 / 1024
+            threshold / 1024 / 1024
         );
         
         // Keep pruning until below threshold (max 5 iterations to prevent infinite loop)
         let mut iterations = 0;
-        while current_size >= PRUNE_THRESHOLD && iterations < 5 {
+        while current_size >= threshold && iterations < 5 {
             iterations += 1;
             self.prune_old_records()?;
             self.checkpoint()?;
             current_size = self.get_total_db_size();
             
-            if current_size >= PRUNE_THRESHOLD {
+            if current_size >= threshold {
                 log::info!(
                     "Database still {}MB (threshold {}MB), continue pruning (iteration {})",
                     current_size / 1024 / 1024,
-                    PRUNE_THRESHOLD / 1024 / 1024,
+                    threshold / 1024 / 1024,
                     iterations
                 );
             }

--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -2,6 +2,12 @@
 //!
 //! Stores GenAI events (LLM calls, tool uses, etc.) to SQLite when SLS is not configured.
 //! Implements the GenAIExporter trait for pluggable integration.
+//!
+//! # Size Limit
+//!
+//! The database is limited to 200MB. When approaching the limit, old records
+//! are pruned automatically. The size check includes the main database file
+//! plus WAL and SHM files.
 
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -10,6 +16,17 @@ use rusqlite::{params, Connection};
 use crate::genai::semantic::GenAISemanticEvent;
 use crate::genai::exporter::GenAIExporter;
 use super::connection::{create_connection, default_base_path};
+
+// ─── Size limit constants ─────────────────────────────────────────────────────
+
+/// Maximum database size: 200 MB
+const MAX_DB_SIZE: u64 = 200 * 1024 * 1024;
+/// Threshold to start pruning: 180 MB (90% of max)
+const PRUNE_THRESHOLD: u64 = 180 * 1024 * 1024;
+/// Percentage of records to prune per attempt
+const PRUNE_PERCENT: f64 = 0.05;
+/// Maximum prune retry attempts to avoid infinite loop
+const MAX_PRUNE_RETRIES: u32 = 3;
 
 // ─── Query result types ────────────────────────────────────────────────────────
 
@@ -104,6 +121,7 @@ pub struct TraceEventDetail {
 /// SQLite-backed GenAI event storage
 pub struct GenAISqliteStore {
     conn: Mutex<Connection>,
+    db_path: PathBuf,
 }
 
 impl GenAISqliteStore {
@@ -118,8 +136,19 @@ impl GenAISqliteStore {
         let conn = create_connection(path)?;
         let store = GenAISqliteStore {
             conn: Mutex::new(conn),
+            db_path: path.to_path_buf(),
         };
         store.init_tables()?;
+        
+        // Log current database size on startup
+        let current_size = store.get_total_db_size();
+        log::info!(
+            "GenAISqliteStore initialized: db_size={}MB, threshold={}MB, max={}MB",
+            current_size / 1024 / 1024,
+            PRUNE_THRESHOLD / 1024 / 1024,
+            MAX_DB_SIZE / 1024 / 1024
+        );
+        
         Ok(store)
     }
 
@@ -569,8 +598,43 @@ impl GenAISqliteStore {
         Ok(result)
     }
 
-    /// Store a single GenAI event
+    /// Store a single GenAI event with size limit enforcement
     fn store_event(&self, event: &GenAISemanticEvent) -> Result<(), Box<dyn std::error::Error>> {
+        // Check size before write and prune if needed
+        self.check_and_prune_if_needed()?;
+
+        // Attempt insert with retry on SQLITE_FULL
+        let mut retries = 0;
+        loop {
+            match self.try_insert_event(event) {
+                Ok(()) => {
+                    // Success: execute checkpoint to flush WAL to main DB
+                    self.checkpoint()?;
+                    return Ok(());
+                }
+                Err(e) => {
+                    // Check if it's SQLITE_FULL (extended code 13)
+                    if let Some(rusqlite::Error::SqliteFailure(err, _)) = 
+                        e.downcast_ref::<rusqlite::Error>() {
+                        if err.extended_code == 13 && retries < MAX_PRUNE_RETRIES {
+                            retries += 1;
+                            log::warn!(
+                                "Database full (SQLITE_FULL), pruning old records (attempt {}/{})",
+                                retries, MAX_PRUNE_RETRIES
+                            );
+                            self.prune_old_records()?;
+                            self.checkpoint()?;
+                            continue;
+                        }
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Try to insert an event without size check
+    fn try_insert_event(&self, event: &GenAISemanticEvent) -> Result<(), Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();
         let event_json = serde_json::to_string(event)?;
 
@@ -733,6 +797,134 @@ impl GenAISqliteStore {
                 )?;
             }
         }
+        Ok(())
+    }
+
+    // ─── Size limit methods ───────────────────────────────────────────────────
+
+    /// Get total database size (main db + wal + shm)
+    fn get_total_db_size(&self) -> u64 {
+        let mut total = 0u64;
+        
+        // Main database file
+        if let Ok(meta) = std::fs::metadata(&self.db_path) {
+            total += meta.len();
+        }
+        
+        // WAL file
+        let wal_path = format!("{}-wal", self.db_path.display());
+        if let Ok(meta) = std::fs::metadata(&wal_path) {
+            total += meta.len();
+        }
+        
+        // SHM file
+        let shm_path = format!("{}-shm", self.db_path.display());
+        if let Ok(meta) = std::fs::metadata(&shm_path) {
+            total += meta.len();
+        }
+        
+        total
+    }
+
+    /// Check database size and prune if approaching limit
+    /// 
+    /// Keeps pruning until size drops below threshold to avoid repeated triggers.
+    fn check_and_prune_if_needed(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut current_size = self.get_total_db_size();
+        
+        if current_size < PRUNE_THRESHOLD {
+            return Ok(());
+        }
+        
+        log::info!(
+            "Database size {}MB exceeding threshold {}MB, pruning old records",
+            current_size / 1024 / 1024,
+            PRUNE_THRESHOLD / 1024 / 1024
+        );
+        
+        // Keep pruning until below threshold (max 5 iterations to prevent infinite loop)
+        let mut iterations = 0;
+        while current_size >= PRUNE_THRESHOLD && iterations < 5 {
+            iterations += 1;
+            self.prune_old_records()?;
+            self.checkpoint()?;
+            current_size = self.get_total_db_size();
+            
+            if current_size >= PRUNE_THRESHOLD {
+                log::info!(
+                    "Database still {}MB (threshold {}MB), continue pruning (iteration {})",
+                    current_size / 1024 / 1024,
+                    PRUNE_THRESHOLD / 1024 / 1024,
+                    iterations
+                );
+            }
+        }
+        
+        log::info!(
+            "Pruning complete, database size now {}MB",
+            current_size / 1024 / 1024
+        );
+        
+        Ok(())
+    }
+
+    /// Prune old records to free up space
+    /// 
+    /// Deletes a percentage of oldest records based on id.
+    fn prune_old_records(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = self.conn.lock().unwrap();
+        
+        // Get total count
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM genai_events",
+            [],
+            |row| row.get(0)
+        )?;
+        
+        if count == 0 {
+            return Ok(());
+        }
+        
+        // Calculate how many to delete (5% of total)
+        let delete_count = ((count as f64) * PRUNE_PERCENT).max(1.0) as i64;
+        
+        log::info!(
+            "Pruning {} of {} records ({:.1}%)",
+            delete_count, count, PRUNE_PERCENT * 100.0
+        );
+        
+        // Delete oldest records by id
+        let deleted = conn.execute(
+            "DELETE FROM genai_events WHERE id IN (
+                SELECT id FROM genai_events ORDER BY id ASC LIMIT ?1
+            )",
+            params![delete_count]
+        )?;
+        
+        log::info!("Deleted {} records", deleted);
+        
+        Ok(())
+    }
+
+    /// Execute WAL checkpoint and VACUUM to reclaim disk space
+    /// 
+    /// 1. VACUUM: rebuild database to compact data
+    /// 2. Checkpoint: flush and truncate WAL file
+    /// 
+    /// Note: VACUUM in WAL mode creates a new db file, so we need to
+    /// re-enable WAL and checkpoint after VACUUM.
+    fn checkpoint(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = self.conn.lock().unwrap();
+        
+        // VACUUM rebuilds the database (works better before checkpoint in WAL mode)
+        conn.execute_batch("VACUUM;")?;
+        
+        // Re-enable WAL mode (VACUUM may reset it)
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        
+        // Checkpoint with TRUNCATE to shrink WAL file
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+        
         Ok(())
     }
 }


### PR DESCRIPTION
- Add automatic pruning when database exceeds 180MB threshold (90%)
- Delete oldest 5% records per iteration until below threshold
- Implement VACUUM + checkpoint sequence for proper disk space reclamation
- Handle SQLITE_FULL errors with bounded retry (max 3 attempts)
- Check total size (main db + wal + shm) before each write
- Add startup log showing current db size and thresholds

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #209 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
