### PR TITLE
feat(cosh): add startup bash entry and simplify manual auth dialog

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -970,15 +970,30 @@ export default {
   // Dialogs - Auth
   // ============================================================================
   'Get started': 'Get started',
+  'Use Copilot Shell': 'Use Copilot Shell',
   'Qwen OAuth': 'Qwen OAuth',
   'Free · Up to 1,000 requests per day': 'Free · Up to 1,000 requests per day',
   'How would you like to authenticate for this project?':
     'How would you like to authenticate for this project?',
+
+  'Select authorization': 'Select authorization',
+  "Choose how you'd like to authenticate in Copilot Shell.":
+    "Choose how you'd like to authenticate in Copilot Shell.",
+
+  'Continue without Copilot Shell': 'Continue without Copilot Shell',
+  'Continue to Bash': 'Continue to Bash',
+  'Open an interactive Bash shell without configuring AI authentication':
+    'Open an interactive Bash shell without configuring AI authentication',
   'OpenAI API key is required to use OpenAI authentication.':
     'OpenAI API key is required to use OpenAI authentication.',
   'You must select an auth method to proceed. Press Ctrl+C again to exit.':
     'You must select an auth method to proceed. Press Ctrl+C again to exit.',
+  'You must select an auth method or continue to Bash to proceed. Press Ctrl+C again to exit.':
+    'You must select an auth method or continue to Bash to proceed. Press Ctrl+C again to exit.',
   '(Use Enter to Set Auth)': '(Use Enter to Set Auth)',
+  '(↑↓ Select · Tab Switch Section · Enter Continue)':
+    '(↑↓ Select · Tab Switch Section · Enter Continue)',
+  '(↑↓ Select · Enter Continue)': '(↑↓ Select · Enter Continue)',
   'Terms of Services and Privacy Notice for Copilot Shell':
     'Terms of Services and Privacy Notice for Copilot Shell',
   'Copilot Shell OAuth': 'Copilot Shell OAuth',

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -921,15 +921,30 @@ export default {
   // Dialogs - Auth
   // ============================================================================
   'Get started': '开始使用',
+  'Use Copilot Shell': '使用 Copilot Shell',
   'Qwen OAuth': 'Qwen OAuth',
   'Free · Up to 1,000 requests per day': '免费 · 每天最多 1,000 次请求',
   'How would you like to authenticate for this project?':
     '您希望如何为此项目进行身份验证？',
+
+  'Select authorization': '选择授权方式',
+  "Choose how you'd like to authenticate in Copilot Shell.":
+    '请选择你希望在 Copilot Shell 中使用的认证方式。',
+
+  'Continue without Copilot Shell': '不使用 Copilot Shell',
+  'Continue to Bash': '继续进入 Bash',
+  'Open an interactive Bash shell without configuring AI authentication':
+    '无需配置 AI 认证，直接进入交互式 Bash Shell',
   'OpenAI API key is required to use OpenAI authentication.':
     '使用 OpenAI 认证需要 OpenAI API 密钥',
   'You must select an auth method to proceed. Press Ctrl+C again to exit.':
     '您必须选择认证方法才能继续。再次按 Ctrl+C 退出',
+  'You must select an auth method or continue to Bash to proceed. Press Ctrl+C again to exit.':
+    '您必须选择一种认证方式，或继续进入 Bash，才能继续。再次按 Ctrl+C 可退出。',
   '(Use Enter to Set Auth)': '（使用 Enter 设置认证）',
+  '(↑↓ Select · Tab Switch Section · Enter Continue)':
+    '（↑↓ 选择 · Tab 切换分区 · Enter 继续）',
+  '(↑↓ Select · Enter Continue)': '（↑↓ 选择 · Enter 继续）',
   'Terms of Services and Privacy Notice for Copilot Shell':
     'Copilot Shell 的服务条款和隐私声明',
   OpenAI: 'OpenAI',

--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -437,13 +437,20 @@ export const AppContainer = (props: AppContainerProps) => {
     authError,
     onAuthError,
     isAuthDialogOpen,
+    showBashOptionInAuthDialog,
     isAuthenticating,
     pendingAuthType,
     qwenAuthState,
     handleAuthSelect,
+    handleContinueToBash,
     openAuthDialog,
     cancelAuthentication,
-  } = useAuthCommand(settings, config, historyManager.addItem);
+  } = useAuthCommand(
+    settings,
+    config,
+    historyManager.addItem,
+    initializationResult.shouldOpenAuthDialog,
+  );
 
   useInitializationAuthError(initializationResult.authError, onAuthError);
 
@@ -1403,6 +1410,7 @@ export const AppContainer = (props: AppContainerProps) => {
       isConfigInitialized,
       authError,
       isAuthDialogOpen,
+      showBashOptionInAuthDialog,
       pendingAuthType,
       // Qwen OAuth state
       qwenAuthState,
@@ -1497,6 +1505,7 @@ export const AppContainer = (props: AppContainerProps) => {
       isConfigInitialized,
       authError,
       isAuthDialogOpen,
+      showBashOptionInAuthDialog,
       pendingAuthType,
       // Qwen OAuth state
       qwenAuthState,
@@ -1595,6 +1604,7 @@ export const AppContainer = (props: AppContainerProps) => {
       handleThemeHighlight,
       handleApprovalModeSelect,
       handleAuthSelect,
+      handleContinueToBash,
       setAuthState,
       onAuthError,
       cancelAuthentication,
@@ -1638,6 +1648,7 @@ export const AppContainer = (props: AppContainerProps) => {
       handleThemeHighlight,
       handleApprovalModeSelect,
       handleAuthSelect,
+      handleContinueToBash,
       setAuthState,
       onAuthError,
       cancelAuthentication,

--- a/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -16,10 +16,11 @@ import type { UIState } from '../contexts/UIStateContext.js';
 import type { UIActions } from '../contexts/UIActionsContext.js';
 
 const createMockUIState = (overrides: Partial<UIState> = {}): UIState => {
-  // AuthDialog only uses authError and pendingAuthType
+  // AuthDialog only uses authError, pendingAuthType and showBashOptionInAuthDialog
   const baseState = {
     authError: null,
     pendingAuthType: undefined,
+    showBashOptionInAuthDialog: true,
   } as Partial<UIState>;
 
   return {
@@ -29,9 +30,9 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState => {
 };
 
 const createMockUIActions = (overrides: Partial<UIActions> = {}): UIActions => {
-  // AuthDialog only uses handleAuthSelect
   const baseActions = {
     handleAuthSelect: vi.fn(),
+    handleContinueToBash: vi.fn(),
   } as Partial<UIActions>;
 
   return {
@@ -464,7 +465,7 @@ describe('AuthDialog', () => {
 
     // Should show error message instead of calling handleAuthSelect
     expect(lastFrame()).toContain(
-      'You must select an auth method to proceed. Press Ctrl+C again to exit.',
+      'You must select an auth method or continue to Bash to proceed. Press Ctrl+C again to exit.',
     );
     expect(handleAuthSelect).not.toHaveBeenCalled();
     unmount();
@@ -526,6 +527,354 @@ describe('AuthDialog', () => {
 
     // Should not call handleAuthSelect
     expect(handleAuthSelect).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should render dual sections and bash entry', () => {
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
+    const { lastFrame } = renderAuthDialog(settings);
+
+    expect(lastFrame()).toContain('Get started');
+    expect(lastFrame()).toContain('Use Copilot Shell');
+    expect(lastFrame()).toContain('Continue without Copilot Shell');
+    expect(lastFrame()).not.toContain('Continue without AI');
+    expect(lastFrame()).toContain('Continue to Bash');
+    expect(lastFrame()).not.toContain('● Continue to Bash');
+  });
+
+  it('should hide bash section for manual auth dialog opens', () => {
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
+    const { lastFrame } = renderAuthDialog(settings, {
+      showBashOptionInAuthDialog: false,
+    });
+
+    expect(lastFrame()).toContain('Select authorization');
+    expect(lastFrame()).toContain(
+      "Choose how you'd like to authenticate in Copilot Shell.",
+    );
+    expect(lastFrame()).not.toContain('Use with AI');
+    expect(lastFrame()).not.toContain('Continue without Copilot Shell');
+    expect(lastFrame()).not.toContain('Continue to Bash');
+    expect(lastFrame()).toContain('(↑↓ Select · Enter Continue)');
+  });
+
+  it('should ignore tab when bash section is hidden', async () => {
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
+    const { lastFrame, stdin, unmount } = renderAuthDialog(settings, {
+      showBashOptionInAuthDialog: false,
+    });
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('● Aliyun Authentication');
+    });
+
+    stdin.write('\t');
+    await wait();
+
+    expect(lastFrame()).toContain('● Aliyun Authentication');
+    expect(lastFrame()).not.toContain('Continue to Bash');
+    unmount();
+  });
+
+  it('should navigate to bash with down arrow and trigger bash on enter', async () => {
+    const handleContinueToBash = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
+    const { lastFrame, stdin, unmount } = renderAuthDialog(
+      settings,
+      {},
+      { handleContinueToBash },
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('● Aliyun Authentication');
+    });
+
+    stdin.write('\u001b[B');
+    await wait();
+    stdin.write('\u001b[B');
+    await wait();
+    stdin.write('\u001b[B');
+    await wait();
+
+    expect(lastFrame()).toContain('● Continue to Bash');
+
+    stdin.write('\r');
+    await wait();
+
+    expect(handleContinueToBash).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('should wrap to bash with up arrow from first auth option', async () => {
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
+    const { lastFrame, stdin, unmount } = renderAuthDialog(settings);
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('● Aliyun Authentication');
+    });
+
+    stdin.write('\u001b[A');
+    await wait();
+
+    expect(lastFrame()).toContain('● Continue to Bash');
+    unmount();
+  });
+
+  it('should switch sections with tab and shift+tab', async () => {
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
+    const { lastFrame, stdin, unmount } = renderAuthDialog(settings);
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('● Aliyun Authentication');
+    });
+
+    stdin.write('\t');
+    await wait();
+    expect(lastFrame()).toContain('● Continue to Bash');
+
+    stdin.write('\x1b[Z');
+    await wait();
+    expect(lastFrame()).toContain('● Aliyun Authentication');
+    unmount();
+  });
+
+  it('should still select auth option on enter', async () => {
+    const handleAuthSelect = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
+    const { stdin, unmount } = renderAuthDialog(
+      settings,
+      {},
+      { handleAuthSelect },
+    );
+
+    stdin.write('\r');
+    await wait();
+
+    expect(handleAuthSelect).toHaveBeenCalledWith(AuthType.USE_ALIYUN);
     unmount();
   });
 

--- a/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { AuthType } from '@copilot-shell/core';
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
@@ -30,52 +30,76 @@ function parseDefaultAuthType(
 }
 
 export function AuthDialog(): React.JSX.Element {
-  const { pendingAuthType, authError } = useUIState();
-  const { handleAuthSelect: onAuthSelect } = useUIActions();
+  const { pendingAuthType, authError, showBashOptionInAuthDialog } =
+    useUIState();
+  const {
+    handleAuthSelect: onAuthSelect,
+    handleContinueToBash: onContinueToBash,
+  } = useUIActions();
   const config = useConfig();
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const authItems = useMemo(
+    () => [
+      {
+        key: AuthType.USE_ALIYUN,
+        label: t('Aliyun Authentication'),
+        title: t('Aliyun Authentication'),
+        description: t('Free with limited quota'),
+        value: AuthType.USE_ALIYUN,
+      },
+      {
+        key: AuthType.USE_OPENAI,
+        label: t('Custom Provider'),
+        title: t('Custom Provider'),
+        description: t(
+          'Paid · Use your own API key · Cost depends on provider',
+        ),
+        value: AuthType.USE_OPENAI,
+      },
+      {
+        key: AuthType.QWEN_OAUTH,
+        label: t('Qwen OAuth'),
+        title: t('Qwen OAuth'),
+        description: t('Free · Up to 1,000 requests per day'),
+        value: AuthType.QWEN_OAUTH,
+      },
+    ],
+    [],
+  );
+  const bashItem = useMemo(
+    () => ({
+      key: 'bash',
+      label: t('Continue to Bash'),
+      title: t('Continue to Bash'),
+      description: t(
+        'Open an interactive Bash shell without configuring AI authentication',
+      ),
+      value: 'bash' as const,
+    }),
+    [],
+  );
 
-  const items = [
-    {
-      key: AuthType.USE_ALIYUN,
-      label: t('Aliyun Authentication'),
-      title: t('Aliyun Authentication'),
-      description: t('Free with limited quota'),
-      value: AuthType.USE_ALIYUN,
-    },
-    {
-      key: AuthType.USE_OPENAI,
-      label: t('Custom Provider'),
-      title: t('Custom Provider'),
-      description: t('Paid · Use your own API key · Cost depends on provider'),
-      value: AuthType.USE_OPENAI,
-    },
-    {
-      key: AuthType.QWEN_OAUTH,
-      label: t('Qwen OAuth'),
-      title: t('Qwen OAuth'),
-      description: t('Free · Up to 1,000 requests per day'),
-      value: AuthType.QWEN_OAUTH,
-    },
-  ];
+  const orderedOptions = useMemo(
+    () =>
+      showBashOptionInAuthDialog
+        ? [...authItems.map((item) => item.value), bashItem.value]
+        : authItems.map((item) => item.value),
+    [authItems, bashItem, showBashOptionInAuthDialog],
+  );
 
   const initialAuthIndex = Math.max(
     0,
-    items.findIndex((item) => {
-      // Priority 1: pendingAuthType
+    authItems.findIndex((item) => {
       if (pendingAuthType) {
         return item.value === pendingAuthType;
       }
 
-      // Priority 2: config.getAuthType() - the source of truth
       const currentAuthType = config.getAuthType();
       if (currentAuthType) {
         return item.value === currentAuthType;
       }
 
-      // Priority 3: QWEN_DEFAULT_AUTH_TYPE env var
       const defaultAuthType = parseDefaultAuthType(
         process.env['QWEN_DEFAULT_AUTH_TYPE'],
       );
@@ -83,53 +107,181 @@ export function AuthDialog(): React.JSX.Element {
         return item.value === defaultAuthType;
       }
 
-      // Priority 4: 默认选中阿里云认证
       return item.value === AuthType.USE_ALIYUN;
     }),
   );
 
+  const [activeOption, setActiveOption] = useState<AuthType | 'bash'>(
+    authItems[initialAuthIndex]?.value ?? AuthType.USE_ALIYUN,
+  );
+  const [lastAuthOption, setLastAuthOption] = useState<AuthType>(
+    authItems[initialAuthIndex]?.value ?? AuthType.USE_ALIYUN,
+  );
+
+  useEffect(() => {
+    const nextOption =
+      authItems[initialAuthIndex]?.value ?? AuthType.USE_ALIYUN;
+    setActiveOption(nextOption);
+    setLastAuthOption(nextOption);
+  }, [initialAuthIndex, authItems]);
+
+  const activeSection = activeOption === 'bash' ? 'bash' : 'auth';
+  const authSelectedIndex = Math.max(
+    0,
+    authItems.findIndex((item) => item.value === lastAuthOption),
+  );
+
+  const authDisplayIndex = activeSection === 'auth' ? authSelectedIndex : null;
+  const bashDisplayIndex =
+    showBashOptionInAuthDialog && activeSection === 'bash' ? 0 : null;
+  const isManualAuthDialog = !showBashOptionInAuthDialog;
   const hasApiKey = Boolean(config.getContentGeneratorConfig()?.apiKey);
   const currentSelectedAuthType =
-    selectedIndex !== null
-      ? items[selectedIndex]?.value
-      : items[initialAuthIndex]?.value;
+    activeOption === 'bash' ? undefined : activeOption;
 
-  const handleAuthSelect = async (authMethod: AuthType) => {
+  useEffect(() => {
+    if (!showBashOptionInAuthDialog && activeOption === 'bash') {
+      const nextOption =
+        authItems[initialAuthIndex]?.value ??
+        lastAuthOption ??
+        AuthType.USE_ALIYUN;
+      setActiveOption(nextOption);
+      setLastAuthOption(nextOption);
+    }
+  }, [
+    showBashOptionInAuthDialog,
+    activeOption,
+    authItems,
+    initialAuthIndex,
+    lastAuthOption,
+  ]);
+
+  const handleAuthSelect = useCallback(
+    async (authMethod: AuthType) => {
+      setErrorMessage(null);
+      await onAuthSelect(authMethod);
+    },
+    [onAuthSelect],
+  );
+
+  const handleContinueToBash = useCallback(() => {
     setErrorMessage(null);
-    await onAuthSelect(authMethod);
-  };
+    onContinueToBash();
+  }, [onContinueToBash]);
 
-  const handleHighlight = (authMethod: AuthType) => {
-    const index = items.findIndex((item) => item.value === authMethod);
-    setSelectedIndex(index);
-  };
+  const handleHighlight = useCallback((value: AuthType | 'bash') => {
+    setActiveOption(value);
+    if (value !== 'bash') {
+      setLastAuthOption(value);
+    }
+  }, []);
 
-  // 用 useCallback 稳定 handler 引用，避免每次渲染都触发 unsubscribe/resubscribe
-  // 导致 CI 慢环境下出现短暂的无 handler 窗口，造成 ESC 按键漏检
-  const handleEscapeKeypress = useCallback(
+  const moveOption = useCallback(
+    (direction: 'up' | 'down') => {
+      const currentIndex = orderedOptions.findIndex(
+        (option) => option === activeOption,
+      );
+      const currentSafeIndex = currentIndex >= 0 ? currentIndex : 0;
+      const step = direction === 'down' ? 1 : -1;
+      const nextIndex =
+        (currentSafeIndex + step + orderedOptions.length) %
+        orderedOptions.length;
+      const nextOption = orderedOptions[nextIndex] ?? orderedOptions[0];
+      handleHighlight(nextOption);
+    },
+    [orderedOptions, activeOption, handleHighlight],
+  );
+
+  const moveSection = useCallback(
+    (direction: 'forward' | 'backward') => {
+      if (!showBashOptionInAuthDialog) {
+        return;
+      }
+
+      if (direction === 'forward') {
+        if (activeSection === 'auth') {
+          handleHighlight('bash');
+          return;
+        }
+        handleHighlight(lastAuthOption);
+        return;
+      }
+
+      if (activeSection === 'bash') {
+        handleHighlight(lastAuthOption);
+        return;
+      }
+      handleHighlight('bash');
+    },
+    [
+      showBashOptionInAuthDialog,
+      activeSection,
+      lastAuthOption,
+      handleHighlight,
+    ],
+  );
+
+  const handleDialogKeypress = useCallback(
     (key: Key) => {
       if (key.name === 'escape') {
-        // Prevent exit if there is an error message.
-        // This means they user is not authenticated yet.
         if (errorMessage) {
           return;
         }
         if (config.getAuthType() === undefined) {
-          // Prevent exiting if no auth method is set
           setErrorMessage(
             t(
-              'You must select an auth method to proceed. Press Ctrl+C again to exit.',
+              'You must select an auth method or continue to Bash to proceed. Press Ctrl+C again to exit.',
             ),
           );
           return;
         }
         onAuthSelect(undefined);
+        return;
+      }
+
+      if (key.name === 'up') {
+        setErrorMessage(null);
+        moveOption('up');
+        return;
+      }
+
+      if (key.name === 'down') {
+        setErrorMessage(null);
+        moveOption('down');
+        return;
+      }
+
+      if (key.name === 'tab') {
+        if (!showBashOptionInAuthDialog) {
+          return;
+        }
+        setErrorMessage(null);
+        moveSection(key.shift ? 'backward' : 'forward');
+        return;
+      }
+
+      if (key.name === 'return') {
+        if (activeOption === 'bash') {
+          handleContinueToBash();
+          return;
+        }
+        handleAuthSelect(activeOption);
       }
     },
-    [errorMessage, config, onAuthSelect],
+    [
+      errorMessage,
+      config,
+      onAuthSelect,
+      moveOption,
+      moveSection,
+      activeOption,
+      handleContinueToBash,
+      handleAuthSelect,
+      showBashOptionInAuthDialog,
+    ],
   );
 
-  useKeypress(handleEscapeKeypress, { isActive: true });
+  useKeypress(handleDialogKeypress, { isActive: true });
 
   return (
     <Box
@@ -139,25 +291,67 @@ export function AuthDialog(): React.JSX.Element {
       padding={1}
       width="100%"
     >
-      <Text bold>{t('Get started')}</Text>
-      <Box marginTop={1}>
-        <Text>{t('How would you like to authenticate for this project?')}</Text>
+      <Text bold>
+        {isManualAuthDialog ? t('Select authorization') : t('Get started')}
+      </Text>
+      {isManualAuthDialog && (
+        <Box marginTop={1}>
+          <Text>
+            {t("Choose how you'd like to authenticate in Copilot Shell.")}
+          </Text>
+        </Box>
+      )}
+      <Box marginTop={1} flexDirection="column">
+        {!isManualAuthDialog && (
+          <Text
+            bold
+            color={activeSection === 'auth' ? Colors.AccentBlue : Colors.Gray}
+          >
+            {t('Use Copilot Shell')}
+          </Text>
+        )}
+        <Box marginTop={1}>
+          <DescriptiveRadioButtonSelect
+            items={authItems}
+            initialIndex={authSelectedIndex}
+            activeIndexOverride={authDisplayIndex}
+            onSelect={handleAuthSelect}
+            onHighlight={handleHighlight}
+            isFocused={false}
+          />
+        </Box>
       </Box>
-      <Box marginTop={1}>
-        <DescriptiveRadioButtonSelect
-          items={items}
-          initialIndex={initialAuthIndex}
-          onSelect={handleAuthSelect}
-          onHighlight={handleHighlight}
-        />
-      </Box>
+      {showBashOptionInAuthDialog && (
+        <Box marginTop={1} flexDirection="column">
+          <Text
+            bold
+            color={activeSection === 'bash' ? Colors.AccentBlue : Colors.Gray}
+          >
+            {t('Continue without Copilot Shell')}
+          </Text>
+          <Box marginTop={1}>
+            <DescriptiveRadioButtonSelect
+              items={[bashItem]}
+              initialIndex={0}
+              activeIndexOverride={bashDisplayIndex}
+              onSelect={handleContinueToBash}
+              onHighlight={handleHighlight}
+              isFocused={false}
+            />
+          </Box>
+        </Box>
+      )}
       {(authError || errorMessage) && (
         <Box marginTop={1}>
           <Text color={Colors.AccentRed}>{authError || errorMessage}</Text>
         </Box>
       )}
       <Box marginTop={1}>
-        <Text color={Colors.AccentPurple}>{t('(Use Enter to Set Auth)')}</Text>
+        <Text color={Colors.AccentPurple}>
+          {showBashOptionInAuthDialog
+            ? t('(↑↓ Select · Tab Switch Section · Enter Continue)')
+            : t('(↑↓ Select · Enter Continue)')}
+        </Text>
       </Box>
       {hasApiKey && currentSelectedAuthType === AuthType.QWEN_OAUTH && (
         <Box marginTop={1}>

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -23,6 +23,7 @@ import type { LoadedSettings } from '../../config/settings.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 import type { OpenAICredentials } from '../components/OpenAIKeyPrompt.js';
 import { useQwenAuth } from '../hooks/useQwenAuth.js';
+import { appEvents, AppEvent } from '../../utils/events.js';
 import { AuthState, MessageType } from '../types.js';
 import type { HistoryItem } from '../types.js';
 import { t } from '../../i18n/index.js';
@@ -33,6 +34,7 @@ export const useAuthCommand = (
   settings: LoadedSettings,
   config: Config,
   addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
+  showBashOptionOnStartup: boolean,
 ) => {
   const unAuthenticated = config.getAuthType() === undefined;
 
@@ -44,6 +46,9 @@ export const useAuthCommand = (
 
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [isAuthDialogOpen, setIsAuthDialogOpen] = useState(unAuthenticated);
+  const [showBashOptionInAuthDialog, setShowBashOptionInAuthDialog] = useState(
+    showBashOptionOnStartup,
+  );
   const [pendingAuthType, setPendingAuthType] = useState<AuthType | undefined>(
     undefined,
   );
@@ -67,6 +72,7 @@ export const useAuthCommand = (
   const handleAuthFailure = useCallback(
     (error: unknown) => {
       setIsAuthenticating(false);
+      setShowBashOptionInAuthDialog(false);
       setIsAuthDialogOpen(true); // Reopen dialog to show error
 
       const errorMessage = t('Failed to authenticate. Message: {{message}}', {
@@ -228,6 +234,7 @@ export const useAuthCommand = (
       credentials?: OpenAICredentials | AliyunCredentialsExtended,
     ) => {
       if (!authType) {
+        setShowBashOptionInAuthDialog(false);
         setIsAuthDialogOpen(false);
         setAuthError(null);
         return;
@@ -251,6 +258,7 @@ export const useAuthCommand = (
 
       setPendingAuthType(authType);
       setAuthError(null);
+      setShowBashOptionInAuthDialog(false);
       setIsAuthDialogOpen(false);
       setIsAuthenticating(true);
 
@@ -353,7 +361,19 @@ export const useAuthCommand = (
   );
 
   const openAuthDialog = useCallback(() => {
+    setShowBashOptionInAuthDialog(false);
     setIsAuthDialogOpen(true);
+  }, []);
+
+  const handleContinueToBash = useCallback(() => {
+    setAuthError(null);
+    setIsAuthenticating(false);
+    setShowBashOptionInAuthDialog(false);
+    setIsAuthDialogOpen(false);
+    appEvents.emit(
+      AppEvent.SpawnShell,
+      process.platform === 'win32' ? 'cmd.exe' : 'bash',
+    );
   }, []);
 
   const cancelAuthentication = useCallback(() => {
@@ -369,6 +389,7 @@ export const useAuthCommand = (
 
     // Do not reset pendingAuthType here, persist the previously selected type.
     setIsAuthenticating(false);
+    setShowBashOptionInAuthDialog(false);
     setIsAuthDialogOpen(true);
     setAuthError(null);
   }, [isAuthenticating, pendingAuthType, cancelQwenAuth, config]);
@@ -419,10 +440,12 @@ export const useAuthCommand = (
     authError,
     onAuthError,
     isAuthDialogOpen,
+    showBashOptionInAuthDialog,
     isAuthenticating,
     pendingAuthType,
     qwenAuthState,
     handleAuthSelect,
+    handleContinueToBash,
     openAuthDialog,
     cancelAuthentication,
   };

--- a/src/copilot-shell/packages/cli/src/ui/components/shared/BaseSelectionList.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/shared/BaseSelectionList.tsx
@@ -24,6 +24,7 @@ export interface BaseSelectionListProps<
 > {
   items: TItem[];
   initialIndex?: number;
+  activeIndexOverride?: number | null;
   onSelect: (value: T) => void;
   onHighlight?: (value: T) => void;
   isFocused?: boolean;
@@ -53,6 +54,7 @@ export function BaseSelectionList<
 >({
   items,
   initialIndex = 0,
+  activeIndexOverride,
   onSelect,
   onHighlight,
   isFocused = true,
@@ -70,20 +72,29 @@ export function BaseSelectionList<
     showNumbers,
   });
 
+  const visibleActiveIndex =
+    activeIndexOverride === undefined ? activeIndex : activeIndexOverride;
   const [scrollOffset, setScrollOffset] = useState(0);
 
   // Handle scrolling for long lists
   useEffect(() => {
+    if (visibleActiveIndex === null) {
+      return;
+    }
+
     const newScrollOffset = Math.max(
       0,
-      Math.min(activeIndex - maxItemsToShow + 1, items.length - maxItemsToShow),
+      Math.min(
+        visibleActiveIndex - maxItemsToShow + 1,
+        items.length - maxItemsToShow,
+      ),
     );
-    if (activeIndex < scrollOffset) {
-      setScrollOffset(activeIndex);
-    } else if (activeIndex >= scrollOffset + maxItemsToShow) {
+    if (visibleActiveIndex < scrollOffset) {
+      setScrollOffset(visibleActiveIndex);
+    } else if (visibleActiveIndex >= scrollOffset + maxItemsToShow) {
       setScrollOffset(newScrollOffset);
     }
-  }, [activeIndex, items.length, scrollOffset, maxItemsToShow]);
+  }, [visibleActiveIndex, items.length, scrollOffset, maxItemsToShow]);
 
   const visibleItems = items.slice(scrollOffset, scrollOffset + maxItemsToShow);
   const numberColumnWidth = String(items.length).length;
@@ -101,7 +112,7 @@ export function BaseSelectionList<
 
       {visibleItems.map((item, index) => {
         const itemIndex = scrollOffset + index;
-        const isSelected = activeIndex === itemIndex;
+        const isSelected = visibleActiveIndex === itemIndex;
 
         // Determine colors based on selection and disabled state
         let titleColor = theme.text.primary;

--- a/src/copilot-shell/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.tsx
@@ -20,6 +20,8 @@ export interface DescriptiveRadioButtonSelectProps<T> {
   items: Array<DescriptiveRadioSelectItem<T>>;
   /** The initial index selected */
   initialIndex?: number;
+  /** Override the visible active index without changing internal navigation state. */
+  activeIndexOverride?: number | null;
   /** Function called when an item is selected. Receives the `value` of the selected item. */
   onSelect: (value: T) => void;
   /** Function called when an item is highlighted. Receives the `value` of the selected item. */
@@ -42,6 +44,7 @@ export interface DescriptiveRadioButtonSelectProps<T> {
 export function DescriptiveRadioButtonSelect<T>({
   items,
   initialIndex = 0,
+  activeIndexOverride,
   onSelect,
   onHighlight,
   isFocused = true,
@@ -53,6 +56,7 @@ export function DescriptiveRadioButtonSelect<T>({
     <BaseSelectionList<T, DescriptiveRadioSelectItem<T>>
       items={items}
       initialIndex={initialIndex}
+      activeIndexOverride={activeIndexOverride}
       onSelect={onSelect}
       onHighlight={onHighlight}
       isFocused={isFocused}

--- a/src/copilot-shell/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -36,6 +36,7 @@ export interface UIActions {
     authType: AuthType | undefined,
     credentials?: OpenAICredentials | AliyunCredentialsExtended,
   ) => Promise<void>;
+  handleContinueToBash: () => void;
   setAuthState: (state: AuthState) => void;
   onAuthError: (error: string) => void;
   cancelAuthentication: () => void;

--- a/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -44,6 +44,7 @@ export interface UIState {
   isConfigInitialized: boolean;
   authError: string | null;
   isAuthDialogOpen: boolean;
+  showBashOptionInAuthDialog: boolean;
   pendingAuthType: AuthType | undefined;
   // Qwen OAuth state
   qwenAuthState: QwenAuthState;


### PR DESCRIPTION
## Description

This PR refines the Copilot Shell authentication dialog for two entry scenarios.

For first-time startup, the dialog preserves the dual-path experience: users can select an AI authentication method or enter Bash directly. Upon exiting Bash, the app returns to the auth dialog in an unauthenticated state.

For manual `/auth` invocation, the dialog now uses a simplified authorization-only layout, making it feel like a focused "change auth method" flow rather than onboarding.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes task#81142636

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

The auth dialog now explicitly distinguishes onboarding-style startup behavior from manual auth management behavior. This keeps the startup flow flexible for new users while making /auth cleaner and less cognitively noisy for existing users who only want to switch authentication methods.
