### PR TITLE
Refactor(agent-sec-core):add python code format ci, and init format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,6 +230,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang llvm libssl-dev libseccomp-dev bubblewrap
 
+      - name: Check formatting
+        run: |
+          cd src/agent-sec-core
+          make python-code-pretty
+          if ! git diff-index --quiet HEAD --; then
+              echo "ERROR: Code style check failed. Please run 'make python-code-pretty' locally." >&2
+              git status --porcelain >&2
+              exit 1
+          fi
+          echo "Code style check passed."
+
       - name: Run Python tests
         run: |
           cd src/agent-sec-core

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -5,8 +5,8 @@
 .PHONY: python-code-pretty
 python-code-pretty: ## Format Python code using black and isort
 	@echo "🎨 Formatting code with black and isort..."
-	@uv run --project agent-sec-cli isort --profile black .
-	@uv run --project agent-sec-cli black .
+	@uv run --project agent-sec-cli isort --profile black --skip-glob "*/backend-skill/templates/*" .
+	@uv run --project agent-sec-cli black --force-exclude "backend-skill/templates/" .
 
 # =============================================================================
 # TEST

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -69,10 +69,12 @@ module-name = "agent_sec_cli._native"
 [tool.black]
 line-length = 100
 target-version = ["py311"]
+extend-exclude = "/backend-skill/templates/"
 
 [tool.isort]
 profile = "black"
 line_length = 100
+extend_skip_glob = ["dev-tools/backend-skill/templates/*"]
 
 [[tool.uv.index]]
 url = "https://mirrors.aliyun.com/pypi/simple/"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/__init__.py
@@ -8,7 +8,15 @@ from agent_sec_cli.asset_verify.errors import (
     ErrSigInvalid,
     ErrSigMissing,
 )
-from agent_sec_cli.asset_verify.verifier import compute_file_hash, load_config, load_trusted_keys, run_verification, verify_manifest_hashes, verify_skill, verify_skills_dir
+from agent_sec_cli.asset_verify.verifier import (
+    compute_file_hash,
+    load_config,
+    load_trusted_keys,
+    run_verification,
+    verify_manifest_hashes,
+    verify_skill,
+    verify_skills_dir,
+)
 
 __all__ = [
     "ErrConfigMissing",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
@@ -1,7 +1,6 @@
 """Skill verification error definitions."""
 
 
-
 class SkillVerifyError(Exception):
     """Base exception for skill verification"""
 
@@ -12,7 +11,9 @@ class ErrSigMissing(SkillVerifyError):
     code = 10
 
     def __init__(self, skill_name: str) -> None:
-        super().__init__(f"ERR_SIG_MISSING: Missing .skill-meta/.skill.sig in '{skill_name}'")
+        super().__init__(
+            f"ERR_SIG_MISSING: Missing .skill-meta/.skill.sig in '{skill_name}'"
+        )
 
 
 class ErrManifestMissing(SkillVerifyError):
@@ -36,7 +37,9 @@ class ErrSigInvalid(SkillVerifyError):
 class ErrHashMismatch(SkillVerifyError):
     code = 13
 
-    def __init__(self, skill_name: str, file_path: str, expected: str, actual: str) -> None:
+    def __init__(
+        self, skill_name: str, file_path: str, expected: str, actual: str
+    ) -> None:
         super().__init__(
             f"ERR_HASH_MISMATCH: File hash mismatch for '{file_path}' in '{skill_name}'\n"
             f"  Expected: {expected}\n"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/verifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/verifier.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Skill integrity verifier - Manifest + PGP signature verification."""
 
-
 import argparse
 import hashlib
 import json

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -1,8 +1,6 @@
 """CLI entry point for agent-sec-cli package."""
 
-
 import typer
-
 from agent_sec_cli.security_middleware import invoke
 
 app = typer.Typer(
@@ -70,9 +68,12 @@ def harden(
     """System security hardening."""
     # Validate mode choices
     if mode not in ["scan", "reinforce", "dry-run"]:
-        typer.echo(f"Error: Invalid mode '{mode}'. Choose from: scan, reinforce, dry-run", err=True)
+        typer.echo(
+            f"Error: Invalid mode '{mode}'. Choose from: scan, reinforce, dry-run",
+            err=True,
+        )
         raise typer.Exit(code=1)
-    
+
     result = invoke("harden", mode=mode, config=config)
     if result.stdout:
         typer.echo(result.stdout)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/sandbox/classify_command.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/sandbox/classify_command.py
@@ -15,7 +15,6 @@
     python3 classify_command.py --json "rm -rf /"
 """
 
-
 import json
 import re
 import shlex

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/sandbox/sandbox_policy.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/sandbox/sandbox_policy.py
@@ -11,7 +11,6 @@
     python3 sandbox_policy.py --cwd /workspace "rm -rf /"
 """
 
-
 import json
 import shlex
 from typing import Any, Dict, List, Optional

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/__init__.py
@@ -7,7 +7,6 @@ Public API
 - ``SecurityEvent``     — the canonical event dataclass
 """
 
-
 from typing import Optional
 
 from agent_sec_cli.security_events.schema import SecurityEvent

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
@@ -1,6 +1,5 @@
 """SecurityEvent pydantic model — the canonical event envelope."""
 
-
 import os
 import uuid
 from datetime import datetime, timezone

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/writer.py
@@ -1,6 +1,5 @@
 """Thread-safe, rotation-aware JSONL writer for security events."""
 
-
 import fcntl
 import json
 import re
@@ -162,7 +161,7 @@ class SecurityEventWriter:
             for entry in dir_path.iterdir():
                 if not entry.name.startswith(prefix):
                     continue
-                suffix = entry.name[len(prefix):]
+                suffix = entry.name[len(prefix) :]
                 if _BACKUP_SUFFIX_RE.match(suffix) and entry.is_file():
                     mtime = entry.stat().st_mtime
                     backup_files.append((entry, mtime))

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
@@ -7,7 +7,6 @@ Public API
 - ``RequestContext``             — per-call context (usually internal)
 """
 
-
 import sys
 from pathlib import PurePath
 from typing import List

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/asset_verify.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/asset_verify.py
@@ -1,6 +1,5 @@
 """Asset-verify backend — delegates to the asset_verify package."""
 
-
 from typing import Any
 
 from agent_sec_cli.asset_verify import run_verification

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/base.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/base.py
@@ -1,6 +1,5 @@
 """Abstract base class for all security middleware backends."""
 
-
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
@@ -9,7 +9,6 @@ Output format (verified against loongshield source):
 ANSI colour codes are stripped before parsing.
 """
 
-
 import re
 import subprocess
 from typing import Any
@@ -46,9 +45,7 @@ _RULE_STATUS_RE = re.compile(
     r"(?P<message>.+?)\s*$"
 )
 
-_ENGINE_ERROR_RE = re.compile(
-    r"Engine\s+Error:\s*(?P<message>.+?)\s*$"
-)
+_ENGINE_ERROR_RE = re.compile(r"Engine\s+Error:\s*(?P<message>.+?)\s*$")
 
 
 class HardeningBackend(BaseBackend):
@@ -118,19 +115,23 @@ class HardeningBackend(BaseBackend):
         for line in clean_output.splitlines():
             m = _RULE_STATUS_RE.search(line)
             if m:
-                entries.append({
-                    "rule_id": m.group("rule_id"),
-                    "status": m.group("status"),
-                    "message": m.group("message").strip(),
-                })
+                entries.append(
+                    {
+                        "rule_id": m.group("rule_id"),
+                        "status": m.group("status"),
+                        "message": m.group("message").strip(),
+                    }
+                )
                 continue
             m = _ENGINE_ERROR_RE.search(line)
             if m:
-                entries.append({
-                    "rule_id": "",
-                    "status": "Engine Error",
-                    "message": m.group("message").strip(),
-                })
+                entries.append(
+                    {
+                        "rule_id": "",
+                        "status": "Engine Error",
+                        "message": m.group("message").strip(),
+                    }
+                )
 
         # --- Partition into failures vs fixed_items ---
         # In reinforce mode, FAIL/FAILED lines are pre-fix detections;
@@ -146,18 +147,22 @@ class HardeningBackend(BaseBackend):
         # Fallback: if summary reports non-pass rules but nothing was captured,
         # add a warning so the event is never silently incomplete.
         reported_nonpass = (
-            data.get("failed", 0) + data.get("manual", 0)
-            + data.get("fixed", 0) + data.get("dry_run_pending", 0)
+            data.get("failed", 0)
+            + data.get("manual", 0)
+            + data.get("fixed", 0)
+            + data.get("dry_run_pending", 0)
         )
         if reported_nonpass > 0 and not data["failures"] and not data["fixed_items"]:
-            data["failures"].append({
-                "rule_id": "",
-                "status": "UNKNOWN",
-                "message": (
-                    f"Summary reports {reported_nonpass} non-pass rule(s) "
-                    "but per-rule details could not be parsed from output."
-                ),
-            })
+            data["failures"].append(
+                {
+                    "rule_id": "",
+                    "status": "UNKNOWN",
+                    "message": (
+                        f"Summary reports {reported_nonpass} non-pass rule(s) "
+                        "but per-rule details could not be parsed from output."
+                    ),
+                }
+            )
 
         return ActionResult(
             success=(proc.returncode == 0),

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/intent.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/intent.py
@@ -1,6 +1,5 @@
 """Intent backend — future stub for intent-level security analysis."""
 
-
 from typing import Any
 
 from agent_sec_cli.security_middleware.backends.base import BaseBackend

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/sandbox.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/sandbox.py
@@ -1,6 +1,5 @@
 """Sandbox prehook backend — log sandbox decisions, future: evaluate isolation correctness."""
 
-
 from typing import Any
 
 from agent_sec_cli.security_middleware.backends.base import BaseBackend

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/summary.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/summary.py
@@ -1,6 +1,5 @@
 """Summary backend — future stub for security event aggregation."""
 
-
 from typing import Any
 
 from agent_sec_cli.security_middleware.backends.base import BaseBackend

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/context.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/context.py
@@ -1,6 +1,5 @@
 """RequestContext — per-invocation context propagated through the call chain."""
 
-
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
@@ -1,11 +1,9 @@
 """Lifecycle hooks — transparent pre/post/error logging via security_events."""
 
-
 import copy
 from typing import Any, Dict
 
 from agent_sec_cli.security_events import SecurityEvent, log_event
-
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
 
@@ -15,9 +13,9 @@ from agent_sec_cli.security_middleware.result import ActionResult
 
 _ACTION_CATEGORY: Dict[str, str] = {
     "sandbox_prehook": "sandbox",
-    "harden":          "hardening",
-    "verify":          "asset_verify",
-    "summary":         "summary",
+    "harden": "hardening",
+    "verify": "asset_verify",
+    "summary": "summary",
 }
 
 
@@ -42,7 +40,9 @@ def pre_action(ctx: RequestContext, kwargs: Dict[str, Any]) -> None:
     # Intentionally empty — do not add log_event() here.
 
 
-def post_action(ctx: RequestContext, result: ActionResult, kwargs: Dict[str, Any]) -> None:
+def post_action(
+    ctx: RequestContext, result: ActionResult, kwargs: Dict[str, Any]
+) -> None:
     """Log the single completion event after the backend completes.
 
     Merges *kwargs* (request inputs) and *result.data* (backend outputs) into a

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/result.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/result.py
@@ -1,6 +1,5 @@
 """ActionResult — unified return type for all backend executions."""
 
-
 from dataclasses import dataclass, field
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/router.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/router.py
@@ -1,6 +1,5 @@
 """Router — action name to backend module registry with lazy imports."""
 
-
 import importlib
 from typing import Any, Dict
 
@@ -10,9 +9,9 @@ from typing import Any, Dict
 
 _REGISTRY: Dict[str, str] = {
     "sandbox_prehook": "agent_sec_cli.security_middleware.backends.sandbox",
-    "harden":          "agent_sec_cli.security_middleware.backends.hardening",
-    "verify":          "agent_sec_cli.security_middleware.backends.asset_verify",
-    "summary":         "agent_sec_cli.security_middleware.backends.summary",
+    "harden": "agent_sec_cli.security_middleware.backends.hardening",
+    "verify": "agent_sec_cli.security_middleware.backends.asset_verify",
+    "summary": "agent_sec_cli.security_middleware.backends.summary",
 }
 
 # Module base name → expected class name convention.
@@ -49,9 +48,7 @@ def get_backend(action: str) -> Any:
     """
     if action not in _REGISTRY:
         registered = ", ".join(sorted(_REGISTRY))
-        raise ValueError(
-            f"Unknown action {action!r}. Registered actions: {registered}"
-        )
+        raise ValueError(f"Unknown action {action!r}. Registered actions: {registered}")
 
     if action in _backend_cache:
         return _backend_cache[action]

--- a/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
@@ -156,9 +156,9 @@ def test_init(ws: Workspace):
 
     # Public key file must exist
     asc_files = list(ws.trusted_keys.glob("*.asc"))
-    assert len(asc_files) >= 1, (
-        f"No .asc in {ws.trusted_keys}: {list(ws.trusted_keys.iterdir())}"
-    )
+    assert (
+        len(asc_files) >= 1
+    ), f"No .asc in {ws.trusted_keys}: {list(ws.trusted_keys.iterdir())}"
     assert asc_files[0].stat().st_size > 0, "Exported .asc is empty"
 
 
@@ -184,12 +184,12 @@ def test_single_sign_and_verify(ws: Workspace):
     # Manifest must contain our files
     manifest = json.loads((signing / "Manifest.json").read_text())
     paths_in_manifest = {f["path"] for f in manifest["files"]}
-    assert "main.py" in paths_in_manifest, (
-        f"main.py not in manifest: {paths_in_manifest}"
-    )
-    assert "README.md" in paths_in_manifest, (
-        f"README.md not in manifest: {paths_in_manifest}"
-    )
+    assert (
+        "main.py" in paths_in_manifest
+    ), f"main.py not in manifest: {paths_in_manifest}"
+    assert (
+        "README.md" in paths_in_manifest
+    ), f"README.md not in manifest: {paths_in_manifest}"
     # .skill-meta/ contents should NOT be in manifest
     assert "Manifest.json" not in paths_in_manifest
     assert ".skill.sig" not in paths_in_manifest
@@ -272,9 +272,9 @@ def test_skill_name_override(ws: Workspace):
     assert r.returncode == 0
 
     manifest = json.loads((skill / SIGNING_DIR / "Manifest.json").read_text())
-    assert manifest["skill_name"] == "custom-name", (
-        f"Expected 'custom-name', got '{manifest['skill_name']}'"
-    )
+    assert (
+        manifest["skill_name"] == "custom-name"
+    ), f"Expected 'custom-name', got '{manifest['skill_name']}'"
 
 
 def test_hidden_files_excluded(ws: Workspace):
@@ -295,9 +295,9 @@ def test_hidden_files_excluded(ws: Workspace):
     paths = {f["path"] for f in manifest["files"]}
     assert "visible.txt" in paths
     assert ".hidden_file" not in paths, f".hidden_file should be excluded: {paths}"
-    assert ".hidden_dir/inner.txt" not in paths, (
-        f".hidden_dir should be excluded: {paths}"
-    )
+    assert (
+        ".hidden_dir/inner.txt" not in paths
+    ), f".hidden_dir should be excluded: {paths}"
     # .skill-meta dir itself should not appear
     meta_paths = [p for p in paths if p.startswith(".skill-meta")]
     assert not meta_paths, f".skill-meta paths should be excluded: {meta_paths}"
@@ -427,9 +427,9 @@ def test_gpg_private_key_env(ws: Workspace):
         },
     )
     assert r.returncode == 0, f"exit {r.returncode}: {r.stdout}\n{r.stderr}"
-    assert "imported and trusted" in r.stdout + r.stderr, (
-        f"Expected import message: {r.stdout}\n{r.stderr}"
-    )
+    assert (
+        "imported and trusted" in r.stdout + r.stderr
+    ), f"Expected import message: {r.stdout}\n{r.stderr}"
 
     # Verify
     env_trusted = load_trusted_keys(env_keys)

--- a/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
+++ b/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
@@ -13,7 +13,9 @@ import unittest
 sys.path.insert(
     0,
     os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", "..", "agent-sec-cli", "src")
+        os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "agent-sec-cli", "src"
+        )
     ),
 )
 

--- a/src/agent-sec-core/tests/unit-test/security_events/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_config.py
@@ -3,7 +3,11 @@
 import unittest
 from unittest.mock import patch
 
-from agent_sec_cli.security_events.config import FALLBACK_LOG_PATH, PRIMARY_LOG_PATH, get_log_path
+from agent_sec_cli.security_events.config import (
+    FALLBACK_LOG_PATH,
+    PRIMARY_LOG_PATH,
+    get_log_path,
+)
 
 
 class TestGetLogPath(unittest.TestCase):
@@ -17,7 +21,9 @@ class TestGetLogPath(unittest.TestCase):
     @patch("agent_sec_cli.security_events.config.os.access", return_value=False)
     @patch("agent_sec_cli.security_events.config.Path.is_dir", return_value=True)
     @patch("agent_sec_cli.security_events.config.Path.mkdir")
-    def test_fallback_when_primary_not_writable(self, mock_mkdir, mock_isdir, mock_access):
+    def test_fallback_when_primary_not_writable(
+        self, mock_mkdir, mock_isdir, mock_access
+    ):
         path = get_log_path()
         self.assertEqual(path, FALLBACK_LOG_PATH)
 

--- a/src/agent-sec-core/tests/unit-test/security_events/test_log_event.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_log_event.py
@@ -9,6 +9,7 @@ from agent_sec_cli.security_events.schema import SecurityEvent
 class TestGetWriter(unittest.TestCase):
     def test_singleton_returns_same_instance(self):
         import agent_sec_cli.security_events
+
         # Reset singleton
         agent_sec_cli.security_events._writer = None
         w1 = agent_sec_cli.security_events.get_writer()

--- a/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
@@ -54,8 +54,15 @@ class TestSecurityEventToDict(unittest.TestCase):
         evt = SecurityEvent(event_type="t", category="c", details={"a": 1})
         d = evt.to_dict()
         expected_keys = {
-            "event_id", "event_type", "category", "timestamp",
-            "trace_id", "pid", "uid", "session_id", "details",
+            "event_id",
+            "event_type",
+            "category",
+            "timestamp",
+            "trace_id",
+            "pid",
+            "uid",
+            "session_id",
+            "details",
         }
         self.assertEqual(set(d.keys()), expected_keys)
 

--- a/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
@@ -19,9 +19,7 @@ def _make_event(**overrides):
 
 class TestWriterBasic(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        )
+        self.tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
         self.tmp.close()
         self.writer = SecurityEventWriter(path=self.tmp.name)
 
@@ -52,9 +50,7 @@ class TestWriterBasic(unittest.TestCase):
 
 class TestWriterRotation(unittest.TestCase):
     def test_rotation_detection(self):
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        )
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
         tmp.close()
         writer = SecurityEventWriter(path=tmp.name)
 
@@ -83,9 +79,7 @@ class TestWriterAutoRotation(unittest.TestCase):
     """Test automatic file size-based rotation."""
 
     def setUp(self):
-        self.tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        )
+        self.tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
         self.tmp.close()
 
     def tearDown(self):
@@ -103,9 +97,7 @@ class TestWriterAutoRotation(unittest.TestCase):
     def test_auto_rotation_on_size_limit(self):
         """Test that log file is rotated when it exceeds max_bytes."""
         # Create writer with small max_bytes (500 bytes) for testing
-        writer = SecurityEventWriter(
-            path=self.tmp.name, max_bytes=500, backup_count=3
-        )
+        writer = SecurityEventWriter(path=self.tmp.name, max_bytes=500, backup_count=3)
 
         # Write events until rotation should occur
         for i in range(20):
@@ -116,13 +108,14 @@ class TestWriterAutoRotation(unittest.TestCase):
         dir_path = os.path.dirname(self.tmp.name)
         base_name = os.path.basename(self.tmp.name)
         backup_files = [
-            f for f in os.listdir(dir_path)
-            if f.startswith(f"{base_name}.") and os.path.isfile(os.path.join(dir_path, f))
+            f
+            for f in os.listdir(dir_path)
+            if f.startswith(f"{base_name}.")
+            and os.path.isfile(os.path.join(dir_path, f))
         ]
 
         self.assertTrue(
-            len(backup_files) > 0,
-            "At least one rotated backup file should exist"
+            len(backup_files) > 0, "At least one rotated backup file should exist"
         )
 
         # Original file should exist and be reasonably small (within 20% of max_bytes)
@@ -132,46 +125,40 @@ class TestWriterAutoRotation(unittest.TestCase):
 
     def test_backup_count_limit(self):
         """Test that old backups are deleted when backup_count is exceeded."""
-        writer = SecurityEventWriter(
-            path=self.tmp.name, max_bytes=300, backup_count=3
-        )
+        writer = SecurityEventWriter(path=self.tmp.name, max_bytes=300, backup_count=3)
 
         # Write enough events to trigger multiple rotations
         for i in range(50):
-            writer.write(_make_event(
-                event_type=f"evt_{i}",
-                details={"data": "y" * 50}
-            ))
+            writer.write(_make_event(event_type=f"evt_{i}", details={"data": "y" * 50}))
 
         # Count backup files
         dir_path = os.path.dirname(self.tmp.name)
         base_name = os.path.basename(self.tmp.name)
         backup_files = [
-            f for f in os.listdir(dir_path)
-            if f.startswith(f"{base_name}.") and os.path.isfile(os.path.join(dir_path, f))
+            f
+            for f in os.listdir(dir_path)
+            if f.startswith(f"{base_name}.")
+            and os.path.isfile(os.path.join(dir_path, f))
         ]
 
         self.assertLessEqual(
             len(backup_files),
             4,  # Allow 1 extra for timing
-            f"Should have at most 4 backup files, but found {len(backup_files)}: {backup_files}"
+            f"Should have at most 4 backup files, but found {len(backup_files)}: {backup_files}",
         )
 
     def test_rotation_preserves_events(self):
         """Test that events are not lost during rotation."""
         import time
 
-        writer = SecurityEventWriter(
-            path=self.tmp.name, max_bytes=1000, backup_count=5
-        )
+        writer = SecurityEventWriter(path=self.tmp.name, max_bytes=1000, backup_count=5)
 
         # Write events
         total_events = 15
         for i in range(total_events):
-            writer.write(_make_event(
-                event_id=f"event-{i}",
-                details={"payload": "z" * 40}
-            ))
+            writer.write(
+                _make_event(event_id=f"event-{i}", details={"payload": "z" * 40})
+            )
             # Small delay to ensure unique timestamps for backup files
             time.sleep(0.01)
 
@@ -179,7 +166,7 @@ class TestWriterAutoRotation(unittest.TestCase):
         total_count = 0
         dir_path = os.path.dirname(self.tmp.name)
         base_name = os.path.basename(self.tmp.name)
-        
+
         # Include main file and all backup files
         all_files = [self.tmp.name]
         if os.path.isdir(dir_path):
@@ -195,60 +182,54 @@ class TestWriterAutoRotation(unittest.TestCase):
         self.assertEqual(
             total_count,
             total_events,
-            f"Should have {total_events} total events across all files"
+            f"Should have {total_events} total events across all files",
         )
 
     def test_timestamp_format_in_backup_filename(self):
         """Test that backup files use timestamp format with millisecond precision."""
-        writer = SecurityEventWriter(
-            path=self.tmp.name, max_bytes=400, backup_count=5
-        )
+        writer = SecurityEventWriter(path=self.tmp.name, max_bytes=400, backup_count=5)
 
         # Write enough to trigger rotation
         for i in range(20):
-            writer.write(_make_event(
-                event_type=f"evt_{i}",
-                details={"data": "x" * 50}
-            ))
+            writer.write(_make_event(event_type=f"evt_{i}", details={"data": "x" * 50}))
 
         # Find backup files
         dir_path = os.path.dirname(self.tmp.name)
         base_name = os.path.basename(self.tmp.name)
         backup_files = [
-            f for f in os.listdir(dir_path)
-            if f.startswith(f"{base_name}.") and not f.endswith(".lock") and os.path.isfile(os.path.join(dir_path, f))
+            f
+            for f in os.listdir(dir_path)
+            if f.startswith(f"{base_name}.")
+            and not f.endswith(".lock")
+            and os.path.isfile(os.path.join(dir_path, f))
         ]
 
         # Check that backup files have timestamp pattern:
         #   YYYYMMDD-HHMMSS.fff            (millisecond precision)
         #   YYYYMMDD-HHMMSS.fff.<counter>   (collision-guard suffix)
         import re
+
         timestamp_pattern = re.compile(r"^\d{8}-\d{6}\.\d{3}(\.\d+)?$")
 
         for backup_file in backup_files:
             # Extract the timestamp suffix
-            suffix = backup_file[len(base_name) + 1:]
+            suffix = backup_file[len(base_name) + 1 :]
             self.assertTrue(
                 timestamp_pattern.match(suffix),
                 f"Backup file '{backup_file}' should have timestamp format "
-                f"YYYYMMDD-HHMMSS.fff[.N], got suffix: {suffix}"
+                f"YYYYMMDD-HHMMSS.fff[.N], got suffix: {suffix}",
             )
 
     def test_oldest_backups_are_deleted(self):
         """Test that oldest backup files are deleted when exceeding backup_count."""
         import time
-        
-        writer = SecurityEventWriter(
-            path=self.tmp.name, max_bytes=300, backup_count=3
-        )
+
+        writer = SecurityEventWriter(path=self.tmp.name, max_bytes=300, backup_count=3)
 
         # Write enough events to trigger multiple rotations (at least 5)
         # This should create more than 3 backups, triggering cleanup
         for i in range(60):
-            writer.write(_make_event(
-                event_type=f"evt_{i}",
-                details={"data": "y" * 50}
-            ))
+            writer.write(_make_event(event_type=f"evt_{i}", details={"data": "y" * 50}))
             # Small delay to ensure different timestamps
             time.sleep(0.01)
 
@@ -256,21 +237,23 @@ class TestWriterAutoRotation(unittest.TestCase):
         dir_path = os.path.dirname(self.tmp.name)
         base_name = os.path.basename(self.tmp.name)
         backup_files = [
-            f for f in os.listdir(dir_path)
-            if f.startswith(f"{base_name}.") and os.path.isfile(os.path.join(dir_path, f))
+            f
+            for f in os.listdir(dir_path)
+            if f.startswith(f"{base_name}.")
+            and os.path.isfile(os.path.join(dir_path, f))
         ]
 
         # Should have approximately backup_count (3) backup files, allow 1 extra for timing
         self.assertLessEqual(
             len(backup_files),
             4,
-            f"Should have at most 4 backup files after cleanup, but found {len(backup_files)}: {sorted(backup_files)}"
+            f"Should have at most 4 backup files after cleanup, but found {len(backup_files)}: {sorted(backup_files)}",
         )
 
         # Verify that the backups are the most recent ones (by mtime)
         backup_paths = [os.path.join(dir_path, f) for f in backup_files]
         mtimes = [os.path.getmtime(p) for p in backup_paths]
-        
+
         # All backup mtimes should be relatively recent (within last few seconds)
         current_time = time.time()
         for mtime in mtimes:
@@ -278,7 +261,7 @@ class TestWriterAutoRotation(unittest.TestCase):
             self.assertLess(
                 current_time - mtime,
                 10,
-                "Backup files should be recent, not old ones that should have been deleted"
+                "Backup files should be recent, not old ones that should have been deleted",
             )
 
         # Verify current file exists and is reasonably small
@@ -289,48 +272,50 @@ class TestWriterAutoRotation(unittest.TestCase):
     def test_cleanup_preserves_most_recent_backups(self):
         """Test that cleanup keeps the most recent backups, not random ones."""
         import time
-        
-        writer = SecurityEventWriter(
-            path=self.tmp.name, max_bytes=250, backup_count=2
-        )
+
+        writer = SecurityEventWriter(path=self.tmp.name, max_bytes=250, backup_count=2)
 
         # Trigger multiple rotations with delays
         rotation_times = []
         for batch in range(5):
             for i in range(10):
-                writer.write(_make_event(
-                    event_type=f"batch{batch}_evt{i}",
-                    details={"data": "z" * 50}
-                ))
+                writer.write(
+                    _make_event(
+                        event_type=f"batch{batch}_evt{i}", details={"data": "z" * 50}
+                    )
+                )
             time.sleep(0.05)  # Ensure different timestamps between batches
-        
+
         # Get backup files sorted by name (which includes timestamp)
         dir_path = os.path.dirname(self.tmp.name)
         base_name = os.path.basename(self.tmp.name)
-        backup_files = sorted([
-            f for f in os.listdir(dir_path)
-            if f.startswith(f"{base_name}.") and os.path.isfile(os.path.join(dir_path, f))
-        ])
+        backup_files = sorted(
+            [
+                f
+                for f in os.listdir(dir_path)
+                if f.startswith(f"{base_name}.")
+                and os.path.isfile(os.path.join(dir_path, f))
+            ]
+        )
 
         # Should have approximately 2 backups, allow 1 extra for timing
         self.assertLessEqual(
             len(backup_files),
             3,
-            f"Should have at most 3 backup files, but found {len(backup_files)}"
+            f"Should have at most 3 backup files, but found {len(backup_files)}",
         )
 
         # Verify they are ordered by timestamp (lexicographic sort = temporal sort)
         # The second backup should have a later timestamp than the first
-        ts1 = backup_files[0][len(base_name) + 1:]
-        ts2 = backup_files[1][len(base_name) + 1:]
+        ts1 = backup_files[0][len(base_name) + 1 :]
+        ts2 = backup_files[1][len(base_name) + 1 :]
         self.assertGreater(
-            ts2, ts1,
-            f"Backups should be ordered by timestamp: {ts1} < {ts2}"
+            ts2, ts1, f"Backups should be ordered by timestamp: {ts1} < {ts2}"
         )
 
     def test_cleanup_detailed_verification(self):
         """Comprehensive test of cleanup mechanism with detailed verification.
-        
+
         This test verifies:
         1. Exactly backup_count files are retained
         2. Old backups are actually deleted (not just ignored)
@@ -339,55 +324,56 @@ class TestWriterAutoRotation(unittest.TestCase):
         5. Backup file metadata (size, mtime) is valid
         """
         import time
-        
+
         # Use a larger max_bytes to accommodate event sizes
         # Each event with {"data": "x" * 50} is ~200-250 bytes
         max_bytes = 1000
-        
+
         writer = SecurityEventWriter(
             path=self.tmp.name, max_bytes=max_bytes, backup_count=3
         )
 
         # Write enough to trigger at least 5-6 rotations
         for i in range(100):
-            writer.write(_make_event(
-                event_type=f"evt_{i}",
-                details={"data": "x" * 50}
-            ))
+            writer.write(_make_event(event_type=f"evt_{i}", details={"data": "x" * 50}))
             time.sleep(0.01)  # Ensure different timestamps
-        
+
         # Analyze results
-        dir_path = os.path.dirname(self.tmp.name) or '.'
+        dir_path = os.path.dirname(self.tmp.name) or "."
         base_name = os.path.basename(self.tmp.name)
-        
+
         all_files = os.listdir(dir_path)
-        backup_files = sorted([
-            f for f in all_files
-            if f.startswith(f'{base_name}.') and os.path.isfile(os.path.join(dir_path, f))
-        ])
-        
+        backup_files = sorted(
+            [
+                f
+                for f in all_files
+                if f.startswith(f"{base_name}.")
+                and os.path.isfile(os.path.join(dir_path, f))
+            ]
+        )
+
         # Verification 1: Approximately backup_count backups, allow 1 extra for timing
         self.assertLessEqual(
             len(backup_files),
             4,
-            f"Should have at most 4 backup files, but found {len(backup_files)}: {backup_files}"
+            f"Should have at most 4 backup files, but found {len(backup_files)}: {backup_files}",
         )
-        
+
         # Verification 2: All backups have valid metadata
         backup_paths = []
         for bf in backup_files:
             filepath = os.path.join(dir_path, bf)
             backup_paths.append(filepath)
-            
+
             # File should exist and be readable
             self.assertTrue(os.path.exists(filepath))
             # File size should be >= 0 (allow empty files from immediate rotation)
             self.assertGreaterEqual(os.path.getsize(filepath), 0)
-            
+
             # Should have valid mtime
             mtime = os.path.getmtime(filepath)
             self.assertGreater(mtime, 0)
-        
+
         # Verification 3: All backups are recent (within last 5 seconds)
         current_time = time.time()
         for bf in backup_files:
@@ -397,30 +383,30 @@ class TestWriterAutoRotation(unittest.TestCase):
             self.assertLess(
                 age,
                 5,
-                f"Backup {bf} should be recent (< 5s old), but is {age:.1f}s old"
+                f"Backup {bf} should be recent (< 5s old), but is {age:.1f}s old",
             )
-        
+
         # Verification 4: Current file exists and is reasonably small
         # Note: May slightly exceed max_bytes if a single event is large
         self.assertTrue(
             os.path.exists(self.tmp.name),
-            "Current log file should exist after rotation"
+            "Current log file should exist after rotation",
         )
         current_size = os.path.getsize(self.tmp.name)
         # Allow some slack for the last event that triggered rotation
         self.assertLess(
             current_size,
             max_bytes + 300,  # max_bytes + one event size
-            f"Current file ({current_size} bytes) should be reasonably small (< {max_bytes + 300})"
+            f"Current file ({current_size} bytes) should be reasonably small (< {max_bytes + 300})",
         )
-        
+
         # Verification 5: Backups are ordered by time (newer backups have later mtimes)
         mtimes = [os.path.getmtime(p) for p in backup_paths]
         for i in range(len(mtimes) - 1):
             self.assertLessEqual(
                 mtimes[i],
                 mtimes[i + 1],
-                f"Backups should be ordered by time: backup[{i}] <= backup[{i+1}]"
+                f"Backups should be ordered by time: backup[{i}] <= backup[{i+1}]",
             )
 
 
@@ -442,11 +428,13 @@ class TestCleanupBackupMatching(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _create_file(self, name, age_offset=0):
         """Create a file in tmpdir and set its mtime to (now - age_offset) seconds."""
         import time
+
         path = os.path.join(self.tmpdir, name)
         with open(path, "w") as fh:
             fh.write("data\n")
@@ -472,7 +460,9 @@ class TestCleanupBackupMatching(unittest.TestCase):
 
         remaining = self._list_files()
         # Only the 2 most recent (by mtime) should survive
-        self.assertLessEqual(len(remaining), 2, f"Expected <= 2 backups, got: {remaining}")
+        self.assertLessEqual(
+            len(remaining), 2, f"Expected <= 2 backups, got: {remaining}"
+        )
         # The two oldest (age_offset=40, 30) should be gone
         self.assertNotIn("security-events.jsonl.20260101-120000.100", remaining)
         self.assertNotIn("security-events.jsonl.20260101-120000.100.1", remaining)
@@ -493,9 +483,13 @@ class TestCleanupBackupMatching(unittest.TestCase):
 
         remaining = self._list_files()
         # All non-backup files must survive
-        for name in ["security-events.jsonl.old", "security-events.jsonl.bak",
-                     "security-events.jsonl.lock", "security-events.jsonl.tmp",
-                     "security-events.jsonl.schema"]:
+        for name in [
+            "security-events.jsonl.old",
+            "security-events.jsonl.bak",
+            "security-events.jsonl.lock",
+            "security-events.jsonl.tmp",
+            "security-events.jsonl.schema",
+        ]:
             self.assertIn(name, remaining, f"{name} should NOT have been deleted")
         # The real backup should also survive (only 1 backup, limit is 5)
         self.assertIn("security-events.jsonl.20260101-120000.100", remaining)
@@ -532,9 +526,10 @@ class TestCleanupBackupMatching(unittest.TestCase):
 # Helper for cross-process tests (must be module-level & picklable)
 # ------------------------------------------------------------------
 
+
 def _child_writer(path, proc_id, event_count, max_bytes, backup_count):
     """Entry point executed inside each child process.
-    
+
     Returns a list of event_type strings that this process successfully
     passed to write() — used for post-mortem analysis when events are lost.
     """
@@ -563,9 +558,7 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        )
+        self.tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
         self.tmp.close()
 
     def tearDown(self):
@@ -595,9 +588,7 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         for p in procs:
             p.join(timeout=30)
         for i, p in enumerate(procs):
-            self.assertEqual(
-                p.exitcode, 0, f"Child {i} exited with code {p.exitcode}"
-            )
+            self.assertEqual(p.exitcode, 0, f"Child {i} exited with code {p.exitcode}")
         return procs
 
     def _collect_all_events(self):
@@ -606,7 +597,9 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         base_name = os.path.basename(self.tmp.name)
         all_files = [self.tmp.name]
         for name in os.listdir(dir_path):
-            if name.startswith(f"{base_name}.") and not name.endswith((".lock", ".tmp")):
+            if name.startswith(f"{base_name}.") and not name.endswith(
+                (".lock", ".tmp")
+            ):
                 all_files.append(os.path.join(dir_path, name))
 
         events = []
@@ -624,8 +617,15 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
 
     # Required fields that every serialised SecurityEvent must carry
     _REQUIRED_FIELDS = {
-        "event_id", "event_type", "category", "timestamp",
-        "trace_id", "pid", "uid", "session_id", "details",
+        "event_id",
+        "event_type",
+        "category",
+        "timestamp",
+        "trace_id",
+        "pid",
+        "uid",
+        "session_id",
+        "details",
     }
 
     def _assert_valid_event(self, record, context=""):
@@ -671,9 +671,7 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         # millisecond-precision backup timestamps never collide.
         # backup_count is set high so cleanup doesn't delete any backups,
         # allowing us to verify zero-loss across all files.
-        self._spawn_and_wait(
-            n_procs, events_per_proc, max_bytes=5000, backup_count=200
-        )
+        self._spawn_and_wait(n_procs, events_per_proc, max_bytes=5000, backup_count=200)
 
         events = self._collect_all_events()
         expected = n_procs * events_per_proc
@@ -702,20 +700,21 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         """
         n_procs = 4
         events_per_proc = 30
-        self._spawn_and_wait(
-            n_procs, events_per_proc, max_bytes=5000, backup_count=200
-        )
+        self._spawn_and_wait(n_procs, events_per_proc, max_bytes=5000, backup_count=200)
 
         dir_path = os.path.dirname(self.tmp.name)
         base_name = os.path.basename(self.tmp.name)
 
         # Identify backup files (sorted by name → chronological order)
-        backup_files = sorted([
-            os.path.join(dir_path, f)
-            for f in os.listdir(dir_path)
-            if f.startswith(f"{base_name}.") and not f.endswith(".lock")
-               and os.path.isfile(os.path.join(dir_path, f))
-        ])
+        backup_files = sorted(
+            [
+                os.path.join(dir_path, f)
+                for f in os.listdir(dir_path)
+                if f.startswith(f"{base_name}.")
+                and not f.endswith(".lock")
+                and os.path.isfile(os.path.join(dir_path, f))
+            ]
+        )
 
         # Skip if no rotation happened (nothing to verify)
         if not backup_files:
@@ -780,9 +779,7 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         n_procs = 6
         events_per_proc = 20
 
-        self._spawn_and_wait(
-            n_procs, events_per_proc, max_bytes=5000, backup_count=200
-        )
+        self._spawn_and_wait(n_procs, events_per_proc, max_bytes=5000, backup_count=200)
 
         events = self._collect_all_events()
         expected = n_procs * events_per_proc
@@ -797,7 +794,8 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         pids_seen = {e["event_type"].split("_")[0] for e in events}
         for pid in range(n_procs):
             self.assertIn(
-                f"p{pid}", pids_seen,
+                f"p{pid}",
+                pids_seen,
                 f"Process p{pid} has zero events — flock loser path likely broken",
             )
 
@@ -826,9 +824,7 @@ class TestWriterFireAndForget(unittest.TestCase):
 
 class TestWriterThreadSafety(unittest.TestCase):
     def test_concurrent_writes(self):
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        )
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
         tmp.close()
         writer = SecurityEventWriter(path=tmp.name)
 
@@ -844,8 +840,7 @@ class TestWriterThreadSafety(unittest.TestCase):
                 errors.append(e)
 
         threads = [
-            threading.Thread(target=_write_events, args=(t,))
-            for t in range(n_threads)
+            threading.Thread(target=_write_events, args=(t,)) for t in range(n_threads)
         ]
         for t in threads:
             t.start()

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_asset_verify_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_asset_verify_backend.py
@@ -6,10 +6,14 @@ run_verification is mocked — we test the backend's orchestration and error han
 import unittest
 from unittest.mock import patch
 
-from agent_sec_cli.security_middleware.backends.asset_verify import AssetVerifyBackend
+from agent_sec_cli.security_middleware.backends.asset_verify import (
+    AssetVerifyBackend,
+)
 from agent_sec_cli.security_middleware.context import RequestContext
 
-_PATCH_TARGET = "agent_sec_cli.security_middleware.backends.asset_verify.run_verification"
+_PATCH_TARGET = (
+    "agent_sec_cli.security_middleware.backends.asset_verify.run_verification"
+)
 
 
 class TestAssetVerifyBackend(unittest.TestCase):

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
@@ -65,15 +65,30 @@ def _mock_proc(stdout, returncode=0):
 class TestBuildCommand(unittest.TestCase):
     def test_scan_mode(self):
         cmd = HardeningBackend._build_command("scan", "agentos_baseline")
-        self.assertEqual(cmd, ["loongshield", "seharden", "--scan", "--config", "agentos_baseline"])
+        self.assertEqual(
+            cmd, ["loongshield", "seharden", "--scan", "--config", "agentos_baseline"]
+        )
 
     def test_reinforce_mode(self):
         cmd = HardeningBackend._build_command("reinforce", "agentos_baseline")
-        self.assertEqual(cmd, ["loongshield", "seharden", "--reinforce", "--config", "agentos_baseline"])
+        self.assertEqual(
+            cmd,
+            ["loongshield", "seharden", "--reinforce", "--config", "agentos_baseline"],
+        )
 
     def test_dryrun_mode(self):
         cmd = HardeningBackend._build_command("dry-run", "agentos_baseline")
-        self.assertEqual(cmd, ["loongshield", "seharden", "--reinforce", "--dry-run", "--config", "agentos_baseline"])
+        self.assertEqual(
+            cmd,
+            [
+                "loongshield",
+                "seharden",
+                "--reinforce",
+                "--dry-run",
+                "--config",
+                "agentos_baseline",
+            ],
+        )
 
     def test_custom_config(self):
         cmd = HardeningBackend._build_command("scan", "custom_cfg")

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_sandbox_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_sandbox_backend.py
@@ -37,9 +37,7 @@ class TestSandboxBackend(unittest.TestCase):
             self.assertEqual(result.data[key], "", f"{key} should default to empty")
 
     def test_extra_kwargs_ignored(self):
-        result = self.backend.execute(
-            self.ctx, decision="deny", extra_field="ignored"
-        )
+        result = self.backend.execute(self.ctx, decision="deny", extra_field="ignored")
         self.assertTrue(result.success)
         self.assertNotIn("extra_field", result.data)
 

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_invoke.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_invoke.py
@@ -31,7 +31,9 @@ class TestInvoke(unittest.TestCase):
     @patch("agent_sec_cli.security_middleware.router.get_backend")
     @patch("agent_sec_cli.security_middleware.lifecycle.on_error")
     @patch("agent_sec_cli.security_middleware.lifecycle.pre_action")
-    def test_invoke_calls_on_error_and_reraises(self, mock_pre, mock_on_err, mock_get_backend):
+    def test_invoke_calls_on_error_and_reraises(
+        self, mock_pre, mock_on_err, mock_get_backend
+    ):
         mock_backend = MagicMock()
         mock_backend.execute.side_effect = RuntimeError("backend boom")
         mock_get_backend.return_value = mock_backend

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_router.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_router.py
@@ -7,15 +7,21 @@ from agent_sec_cli.security_middleware import router
 
 class TestModuleToClassName(unittest.TestCase):
     def test_sandbox(self):
-        name = router._module_to_class_name("agent_sec_cli.security_middleware.backends.sandbox")
+        name = router._module_to_class_name(
+            "agent_sec_cli.security_middleware.backends.sandbox"
+        )
         self.assertEqual(name, "SandboxBackend")
 
     def test_asset_verify(self):
-        name = router._module_to_class_name("agent_sec_cli.security_middleware.backends.asset_verify")
+        name = router._module_to_class_name(
+            "agent_sec_cli.security_middleware.backends.asset_verify"
+        )
         self.assertEqual(name, "AssetVerifyBackend")
 
     def test_hardening(self):
-        name = router._module_to_class_name("agent_sec_cli.security_middleware.backends.hardening")
+        name = router._module_to_class_name(
+            "agent_sec_cli.security_middleware.backends.hardening"
+        )
         self.assertEqual(name, "HardeningBackend")
 
     def test_single_word(self):
@@ -52,7 +58,9 @@ class TestRegisterAction(unittest.TestCase):
         router._backend_cache.update(self._original_cache)
 
     def test_register_new_action(self):
-        router.register_action("custom_test", "agent_sec_cli.security_middleware.backends.sandbox")
+        router.register_action(
+            "custom_test", "agent_sec_cli.security_middleware.backends.sandbox"
+        )
         backend = router.get_backend("custom_test")
         self.assertTrue(hasattr(backend, "execute"))
 
@@ -60,7 +68,9 @@ class TestRegisterAction(unittest.TestCase):
         # Pre-cache sandbox_prehook
         b1 = router.get_backend("sandbox_prehook")
         # Re-register should invalidate cache
-        router.register_action("sandbox_prehook", "agent_sec_cli.security_middleware.backends.sandbox")
+        router.register_action(
+            "sandbox_prehook", "agent_sec_cli.security_middleware.backends.sandbox"
+        )
         b2 = router.get_backend("sandbox_prehook")
         # After invalidation, a new instance is created
         self.assertIsNot(b1, b2)


### PR DESCRIPTION
## Description

- 针对agent-sec-core增加python语言的代码风格检测CI（black+isort)
- 完成agents-sec-core的python代码init format

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->



## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
