### PR TITLE
fix(scripts): remove redundant flag from rustup installation script

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -373,7 +373,7 @@ install_rust() {
     curl --proto '=https' --tlsv1.2 -sSf --connect-timeout 15 --max-time 120 \
         https://sh.rustup.rs \
         -o "$_rustup_script" 2>/dev/null || true
-    [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -s -- -y 2>/dev/null || true
+    [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -y 2>/dev/null || true
     rm -f "$_rustup_script"
     _source_cargo
     if ! cmd_exists rustc; then
@@ -382,7 +382,7 @@ install_rust() {
         curl -sSf --connect-timeout 15 --max-time 60 \
             http://mirrors.cloud.aliyuncs.com/repo/rust/rustup-init.sh \
             -o "$_rustup_script" 2>/dev/null || true
-        [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -s -- -y 2>/dev/null || true
+        [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -y 2>/dev/null || true
         rm -f "$_rustup_script"
         _source_cargo
     fi
@@ -391,7 +391,7 @@ install_rust() {
         curl --proto '=https' --tlsv1.2 -sSf --connect-timeout 15 --max-time 120 \
             https://mirrors.aliyun.com/repo/rust/rustup-init.sh \
             -o "$_rustup_script" 2>/dev/null || true
-        [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -s -- -y 2>/dev/null || true
+        [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -y 2>/dev/null || true
         rm -f "$_rustup_script"
         _source_cargo
     fi
@@ -400,7 +400,7 @@ install_rust() {
         curl --proto '=https' --tlsv1.2 -sSf --connect-timeout 15 --max-time 120 \
             https://rsproxy.cn/rustup-init.sh \
             -o "$_rustup_script" 2>/dev/null || true
-        [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -s -- -y 2>/dev/null || true
+        [[ -s "$_rustup_script" ]] && sh "$_rustup_script" -y 2>/dev/null || true
         rm -f "$_rustup_script"
         _source_cargo
     fi


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

This PR fixes rustup invocation in `scripts/build-all.sh` after switching from pipe execution to temp-file execution.

When running a local script file, passing `-s -- -y` incorrectly forwards `-s` to the script arguments and may break installer behavior.
This change updates all rustup mirror fallback calls to use `sh <script> -y`, keeping non-interactive install while preserving the temp-file execution model.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #231 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- Verified patch scope with `git diff up/main...HEAD -- scripts/build-all.sh`
- Confirmed all rustup fallback calls now use `sh "$_rustup_script" -y` pattern (no `-s --` when executing local files)
- No full integration build executed in this branch

## Additional Notes

<!-- Any additional information, screenshots, or context. -->

- This PR intentionally keeps temp-file execution to avoid `curl | sh` security alerts on some servers.
