### PR TITLE
fix(sec-core): preserve seharden wrapper defaults

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/BUILD.md
+++ b/src/agent-sec-core/agent-sec-cli/BUILD.md
@@ -36,7 +36,7 @@ uv sync
 ```bash
 # After installation, use the CLI command
 agent-sec-cli --help
-agent-sec-cli harden --mode scan
+agent-sec-cli harden --scan --config agentos_baseline
 agent-sec-cli verify
 ```
 
@@ -144,7 +144,7 @@ The CLI is now installed as a Python package:
 ```bash
 # Installed command (recommended)
 agent-sec-cli verify
-agent-sec-cli harden --mode scan
+agent-sec-cli harden --scan --config agentos_baseline
 ```
 
 ---

--- a/src/agent-sec-core/agent-sec-cli/README.md
+++ b/src/agent-sec-core/agent-sec-cli/README.md
@@ -84,9 +84,9 @@ After installation, use the `agent-sec-cli` command:
 
 ```bash
 # System hardening
-agent-sec-cli harden --mode scan
-agent-sec-cli harden --mode reinforce --config agentos_baseline
-agent-sec-cli harden --mode dry-run
+agent-sec-cli harden --scan --config agentos_baseline
+agent-sec-cli harden --reinforce --config agentos_baseline
+agent-sec-cli harden --reinforce --dry-run --config agentos_baseline
 
 # Skill integrity verification
 agent-sec-cli verify
@@ -103,8 +103,8 @@ agent-sec-cli summary --hours 72 --format json
 from agent_sec_cli.security_middleware import invoke
 
 # System hardening
-result = invoke("harden", mode="scan")
-print(result.stdout)
+result = invoke("harden", args=["--scan", "--config", "agentos_baseline"])
+print(result.success)
 
 # Verify a specific skill
 result = invoke("verify", skill="/path/to/skill")
@@ -253,14 +253,14 @@ python -m agent_sec_cli.asset_verify.verifier --skill /path/to/skill
 - **Solution:** Add trusted GPG keys to `asset_verify/trusted-keys/`
 
 **Issue:** `Permission denied` errors during hardening
-- **Solution:** Run with sudo: `sudo agent-sec-cli harden --mode reinforce`
+- **Solution:** Run with sudo: `sudo agent-sec-cli harden --reinforce --config agentos_baseline`
 
 ### Debug Mode
 
 Enable verbose output:
 
 ```bash
-python -m agent_sec_cli.cli harden --mode scan 2>&1 | tee debug.log
+python -m agent_sec_cli.cli harden --scan --config agentos_baseline 2>&1 | tee debug.log
 ```
 
 ---

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -2,12 +2,56 @@
 
 import typer
 from agent_sec_cli.security_middleware import invoke
+from agent_sec_cli.security_middleware.backends.hardening import (
+    DEFAULT_HARDEN_CONFIG,
+)
 
 app = typer.Typer(
     name="agent-sec-cli",
     help="AgentSecCore unified CLI entry point",
     add_completion=True,
 )
+
+_HARDEN_HELP_TEXT = f"""\
+Usage: agent-sec-cli harden [SEHARDEN_ARGS]...
+
+Defaults:
+  If omitted, the wrapper adds `--scan --config {DEFAULT_HARDEN_CONFIG}`.
+
+Examples:
+  agent-sec-cli harden --scan --config {DEFAULT_HARDEN_CONFIG}
+  agent-sec-cli harden --reinforce --config {DEFAULT_HARDEN_CONFIG}
+  agent-sec-cli harden --reinforce --dry-run --config {DEFAULT_HARDEN_CONFIG}
+
+Common SEHarden flags:
+  --scan              Run compliance scan.
+  --reinforce         Apply remediation actions.
+  --dry-run           Preview reinforce actions without changing the system.
+  --config <ruleset>  Select a profile name or YAML file.
+  --level <level>     Limit execution to a profile level.
+  --verbose           Show detailed rule-level evidence.
+  --log-level <lv>    Set log level: trace|debug|info|warn|error.
+
+Help:
+  agent-sec-cli harden --help             Show this concise wrapper help.
+  agent-sec-cli harden --downstream-help  Show full `loongshield seharden` help.
+"""
+
+
+def _with_default_harden_args(args: list[str]) -> list[str]:
+    """Add wrapper defaults when the caller does not provide them explicitly."""
+    normalized = list(args)
+    if (
+        "--scan" not in normalized
+        and "--reinforce" not in normalized
+        and "--dry-run" not in normalized
+    ):
+        normalized.insert(0, "--scan")
+    if "--config" not in normalized and not any(
+        arg.startswith("--config=") for arg in normalized
+    ):
+        normalized.extend(["--config", DEFAULT_HARDEN_CONFIG])
+    return normalized
 
 
 @app.command(name="log-sandbox", hidden=True)
@@ -51,32 +95,41 @@ def log_sandbox(
     raise typer.Exit(code=result.exit_code)
 
 
-@app.command()
+@app.command(
+    short_help="Scan or reinforce the system against a security baseline.",
+    context_settings={
+        "allow_extra_args": True,
+        "ignore_unknown_options": True,
+        "help_option_names": [],
+    },
+)
 def harden(
-    mode: str = typer.Option(
-        "scan",
-        "--mode",
-        help="Hardening mode (default: scan)",
-        case_sensitive=False,
+    ctx: typer.Context,
+    help_flag: bool = typer.Option(
+        False,
+        "--help",
+        "-h",
+        is_eager=True,
+        help="Show concise harden help and examples.",
     ),
-    config: str = typer.Option(
-        "agentos_baseline",
-        "--config",
-        help="Hardening config baseline (default: agentos_baseline)",
+    downstream_help: bool = typer.Option(
+        False,
+        "--downstream-help",
+        help="Show full `loongshield seharden` help and exit.",
     ),
 ):
-    """System security hardening."""
-    # Validate mode choices
-    if mode not in ["scan", "reinforce", "dry-run"]:
-        typer.echo(
-            f"Error: Invalid mode '{mode}'. Choose from: scan, reinforce, dry-run",
-            err=True,
-        )
-        raise typer.Exit(code=1)
+    """Scan or reinforce the system against a security baseline."""
+    if help_flag:
+        typer.echo(_HARDEN_HELP_TEXT.rstrip())
+        raise typer.Exit(code=0)
 
-    result = invoke("harden", mode=mode, config=config)
+    if downstream_help:
+        result = invoke("harden", args=["--help"])
+    else:
+        result = invoke("harden", args=_with_default_harden_args(list(ctx.args)))
+
     if result.stdout:
-        typer.echo(result.stdout)
+        typer.echo(result.stdout, nl=False)
     if result.error:
         typer.echo(result.error, err=True)
     raise typer.Exit(code=result.exit_code)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
@@ -1,15 +1,12 @@
-"""Hardening backend — subprocess wrapper for loongshield SEHarden.
+"""Hardening backend — passthrough wrapper for `loongshield seharden`.
 
-Output format (verified against loongshield source):
-
-    Log lines:  ``[LEVEL HH:MM:SS] source.lua:N: message``
-    Summary:    ``SEHarden Finished. X passed, Y fixed, Z failed, W manual, V dry-run-pending / N total.``
-    Per-rule:   ``[rule_id] STATUS: description``
-
-ANSI colour codes are stripped before parsing.
+The backend preserves the wrapper's legacy defaults and structured event data
+while allowing callers to forward raw seharden arguments directly.
 """
 
+import os
 import re
+import shutil
 import subprocess
 from typing import Any
 
@@ -17,42 +14,28 @@ from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
 
-# ---------------------------------------------------------------------------
-# ANSI escape sequence stripper
-# ---------------------------------------------------------------------------
+DEFAULT_HARDEN_CONFIG = "agentos_baseline"
+_DEFAULT_HARDEN_MODE = "scan"
+_FALLBACK_LOONGSHIELD_PATHS = ("/usr/sbin/loongshield",)
+_MISSING_LOONGSHIELD_ERROR = "loongshield not found. Install it or add it to PATH."
+
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def _strip_ansi(text: str) -> str:
-    """Remove ANSI colour / style escape sequences from *text*."""
-    return _ANSI_RE.sub("", text)
-
-
-# ---------------------------------------------------------------------------
-# Per-rule status patterns  (applied to ANSI-stripped lines)
-#
-# Matches lines like:
-#   [WARN  14:30:01] engine.lua:186: [1.1.3] FAIL: Ensure mounting of udf …
-#   [ERROR 14:30:04] engine.lua:307: [3.2.1] FAILED-TO-FIX: …
-#   [ERROR 14:30:04] engine.lua:295: [6.1.1] ENFORCE-ERROR: …
-#   [INFO  14:30:01] engine.lua:298: [1.1.3] DRY-RUN: would apply …
-#   [INFO  14:30:04] engine.lua:292: [5.1.1] MANUAL: No reinforce steps …
-#   [ERROR …] engine.lua:…: Engine Error: …
-# ---------------------------------------------------------------------------
 _RULE_STATUS_RE = re.compile(
     r"\[(?P<rule_id>[\w.]+)\]\s+"
     r"(?P<status>FAIL|FAILED|FAILED-TO-FIX|ERROR|ENFORCE-ERROR|DRY-RUN|MANUAL|SKIP):\s*"
     r"(?P<message>.+?)\s*$"
 )
-
 _ENGINE_ERROR_RE = re.compile(r"Engine\s+Error:\s*(?P<message>.+?)\s*$")
 
 
-class HardeningBackend(BaseBackend):
-    """Run ``loongshield seharden`` and parse its summary output."""
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI colour and style sequences from process output."""
+    return _ANSI_RE.sub("", text)
 
-    # Summary line — captures all 6 counters.
-    # Example: SEHarden Finished. 42 passed, 0 fixed, 0 failed, 0 manual, 0 dry-run-pending / 42 total.
+
+class HardeningBackend(BaseBackend):
+    """Execute `loongshield seharden` and keep structured hardening results."""
+
     _SUMMARY_RE = re.compile(
         r"SEHarden\s+Finished\.\s*"
         r"(?P<passed>\d+)\s+passed,\s*"
@@ -66,86 +49,210 @@ class HardeningBackend(BaseBackend):
     def execute(
         self,
         ctx: RequestContext,
-        mode: str = "scan",
-        config: str = "agentos_baseline",
+        args: list[str] | tuple[str, ...] | None = None,
         **kwargs: Any,
     ) -> ActionResult:
-        """Execute loongshield seharden in the requested *mode*.
+        """Execute `loongshield seharden` with raw args or legacy kwargs."""
+        raw_args = self._normalize_args(args=args, **kwargs)
+        mode, config = self._describe_request(raw_args)
+        loongshield_path = self._resolve_loongshield_path()
+        cmd = self._build_command(raw_args, loongshield_path=loongshield_path)
+        data = self._build_result_data(
+            raw_args=raw_args,
+            cmd=cmd,
+            tool_path=loongshield_path,
+            mode=mode,
+            config=config,
+        )
 
-        Modes:
-            scan      — ``--scan``
-            reinforce — ``--reinforce``
-            dry-run   — ``--reinforce --dry-run``
-        """
-        cmd = self._build_command(mode, config)
+        if not loongshield_path:
+            return ActionResult(
+                success=False,
+                exit_code=127,
+                error=_MISSING_LOONGSHIELD_ERROR,
+                data=data,
+            )
 
         try:
             proc = subprocess.run(
                 cmd,
+                check=False,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-        except FileNotFoundError:
+        except OSError as exc:
             return ActionResult(
                 success=False,
-                exit_code=127,
-                error="loongshield: command not found",
+                exit_code=getattr(exc, "errno", 1) or 1,
+                error=f"Failed to execute `loongshield seharden`: {exc}",
+                data=data,
             )
 
-        raw_output = proc.stdout or ""
-        clean_output = _strip_ansi(raw_output)
+        clean_output = _strip_ansi(proc.stdout or "")
+        data["returncode"] = proc.returncode
+        self._parse_output(clean_output, data)
 
-        data: dict = {"mode": mode, "config": config, "failures": [], "fixed_items": []}
+        return ActionResult(
+            success=(proc.returncode == 0),
+            stdout=clean_output,
+            exit_code=proc.returncode,
+            data=data,
+        )
 
-        # --- Parse summary line ---
+    @classmethod
+    def _normalize_args(
+        cls,
+        args: list[str] | tuple[str, ...] | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        raw_args = [str(arg) for arg in (args or [])]
+        if raw_args and kwargs:
+            mixed_keys = ", ".join(sorted(kwargs))
+            raise TypeError(
+                f"Do not mix passthrough args with legacy harden kwargs: {mixed_keys}"
+            )
+
+        if raw_args:
+            return raw_args
+
+        legacy_keys = {"mode", "config"}
+        unknown_keys = sorted(set(kwargs) - legacy_keys)
+        if unknown_keys:
+            unknown = ", ".join(unknown_keys)
+            raise TypeError(f"Unsupported harden kwargs: {unknown}")
+
+        if not kwargs:
+            return cls._legacy_args(
+                mode=_DEFAULT_HARDEN_MODE,
+                config=DEFAULT_HARDEN_CONFIG,
+            )
+
+        mode = str(kwargs.get("mode", _DEFAULT_HARDEN_MODE))
+        config = str(kwargs.get("config", DEFAULT_HARDEN_CONFIG))
+        return cls._legacy_args(mode=mode, config=config)
+
+    @staticmethod
+    def _legacy_args(mode: str, config: str) -> list[str]:
+        if mode == "dry-run":
+            return ["--reinforce", "--dry-run", "--config", config]
+        if mode == "reinforce":
+            return ["--reinforce", "--config", config]
+        if mode == "scan":
+            return ["--scan", "--config", config]
+        raise ValueError(
+            f"Invalid harden mode '{mode}'. Choose from: scan, reinforce, dry-run"
+        )
+
+    @staticmethod
+    def _describe_request(args: list[str]) -> tuple[str | None, str | None]:
+        mode: str | None = None
+        config: str | None = None
+        has_scan = "--scan" in args
+        has_reinforce = "--reinforce" in args
+        has_dry_run = "--dry-run" in args
+
+        if has_dry_run:
+            mode = "dry-run"
+        elif has_reinforce:
+            mode = "reinforce"
+        elif has_scan:
+            mode = "scan"
+
+        for index, arg in enumerate(args):
+            if arg == "--config" and index + 1 < len(args):
+                config = args[index + 1]
+            elif arg.startswith("--config="):
+                config = arg.split("=", 1)[1]
+
+        return mode, config
+
+    @staticmethod
+    def _build_command(
+        args: list[str] | tuple[str, ...], loongshield_path: str | None = None
+    ) -> list[str]:
+        return [loongshield_path or "loongshield", "seharden", *args]
+
+    @staticmethod
+    def _build_result_data(
+        raw_args: list[str],
+        cmd: list[str],
+        tool_path: str | None,
+        mode: str | None,
+        config: str | None,
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "argv": cmd,
+            "raw_args": raw_args,
+            "tool_path": tool_path,
+            "failures": [],
+            "fixed_items": [],
+        }
+        if mode is not None:
+            data["mode"] = mode
+        if config is not None:
+            data["config"] = config
+        return data
+
+    @staticmethod
+    def _resolve_loongshield_path() -> str | None:
+        resolved = shutil.which("loongshield")
+        if resolved:
+            return resolved
+
+        for candidate in _FALLBACK_LOONGSHIELD_PATHS:
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        return None
+
+    @classmethod
+    def _parse_output(cls, clean_output: str, data: dict[str, Any]) -> None:
         for line in reversed(clean_output.splitlines()):
-            m = self._SUMMARY_RE.search(line)
-            if m:
-                data["passed"] = int(m.group("passed"))
-                data["fixed"] = int(m.group("fixed"))
-                data["failed"] = int(m.group("failed"))
-                data["manual"] = int(m.group("manual"))
-                data["dry_run_pending"] = int(m.group("dry_run_pending"))
-                data["total"] = int(m.group("total"))
+            match = cls._SUMMARY_RE.search(line)
+            if match:
+                data["passed"] = int(match.group("passed"))
+                data["fixed"] = int(match.group("fixed"))
+                data["failed"] = int(match.group("failed"))
+                data["manual"] = int(match.group("manual"))
+                data["dry_run_pending"] = int(match.group("dry_run_pending"))
+                data["total"] = int(match.group("total"))
                 break
 
-        # --- Collect per-rule non-PASS entries ---
-        entries: list[dict] = []
+        entries: list[dict[str, str]] = []
         for line in clean_output.splitlines():
-            m = _RULE_STATUS_RE.search(line)
-            if m:
+            match = _RULE_STATUS_RE.search(line)
+            if match:
                 entries.append(
                     {
-                        "rule_id": m.group("rule_id"),
-                        "status": m.group("status"),
-                        "message": m.group("message").strip(),
+                        "rule_id": match.group("rule_id"),
+                        "status": match.group("status"),
+                        "message": match.group("message").strip(),
                     }
                 )
                 continue
-            m = _ENGINE_ERROR_RE.search(line)
-            if m:
+
+            engine_match = _ENGINE_ERROR_RE.search(line)
+            if engine_match:
                 entries.append(
                     {
                         "rule_id": "",
                         "status": "Engine Error",
-                        "message": m.group("message").strip(),
+                        "message": engine_match.group("message").strip(),
                     }
                 )
 
-        # --- Partition into failures vs fixed_items ---
-        # In reinforce mode, FAIL/FAILED lines are pre-fix detections;
-        # loongshield emits FAILED-TO-FIX / ENFORCE-ERROR for rules it
-        # could *not* fix, so plain FAIL/FAILED entries were remediated.
-        _FIX_DETECTED = frozenset({"FAIL", "FAILED"})
+        mode = data.get("mode")
+        fixed_statuses = frozenset({"FAIL", "FAILED"})
         if mode == "reinforce":
-            data["failures"] = [e for e in entries if e["status"] not in _FIX_DETECTED]
-            data["fixed_items"] = [e for e in entries if e["status"] in _FIX_DETECTED]
+            data["failures"] = [
+                entry for entry in entries if entry["status"] not in fixed_statuses
+            ]
+            data["fixed_items"] = [
+                entry for entry in entries if entry["status"] in fixed_statuses
+            ]
         else:
             data["failures"] = entries
 
-        # Fallback: if summary reports non-pass rules but nothing was captured,
-        # add a warning so the event is never silently incomplete.
         reported_nonpass = (
             data.get("failed", 0)
             + data.get("manual", 0)
@@ -163,23 +270,3 @@ class HardeningBackend(BaseBackend):
                     ),
                 }
             )
-
-        return ActionResult(
-            success=(proc.returncode == 0),
-            stdout=clean_output,
-            exit_code=proc.returncode,
-            data=data,
-        )
-
-    # ------------------------------------------------------------------
-    @staticmethod
-    def _build_command(mode: str, config: str) -> list[str]:
-        cmd = ["loongshield", "seharden"]
-        if mode == "dry-run":
-            cmd += ["--reinforce", "--dry-run"]
-        elif mode == "reinforce":
-            cmd.append("--reinforce")
-        else:
-            cmd.append("--scan")
-        cmd += ["--config", config]
-        return cmd

--- a/src/agent-sec-core/skill/SKILL.md
+++ b/src/agent-sec-core/skill/SKILL.md
@@ -93,7 +93,7 @@ Decision:             [LOCKED]
 
 子 skill: [references/agent-sec-seharden.md](references/agent-sec-seharden.md)
 前置条件: `loongshield` 在 PATH 中
-执行命令: 加载子 skill，传入 `$ARGUMENTS` = `scan`，执行 `agent-sec-cli harden --mode scan`
+执行命令: 加载子 skill，传入 `$ARGUMENTS` = `scan`，执行 `agent-sec-cli harden --scan --config agentos_baseline`
 
 **判定条件：**
 
@@ -176,7 +176,7 @@ FAIL 或 NOT_RUN 时停止，不继续后续 Phase，不进入 Decision。
 执行命令: 重新执行 Phase 1 scan 和 Phase 2 verify 作为复检
 
 ```bash
-sudo agent-sec-cli harden --mode scan
+sudo agent-sec-cli harden --scan --config agentos_baseline
 agent-sec-cli verify
 ```
 

--- a/src/agent-sec-core/skill/references/agent-sec-seharden.md
+++ b/src/agent-sec-core/skill/references/agent-sec-seharden.md
@@ -1,7 +1,7 @@
 ---
 name: agentos-baseline
 phase: 1
-description: Use the only supported Phase 1 flow: `agent-sec-cli harden --mode scan`.
+description: Use the only supported Phase 1 flow: `agent-sec-cli harden --scan --config agentos_baseline`.
 ---
 
 # Phase 1: SEHarden
@@ -34,12 +34,12 @@ If `$ARGUMENTS` is anything else, stop and tell the user:
 
 ## Exact Commands
 
-- `scan`: `agent-sec-cli harden --mode scan`
-- `dry-run`: `agent-sec-cli harden --mode dry-run`
-- `reinforce`: `agent-sec-cli harden --mode reinforce`
+- `scan`: `agent-sec-cli harden --scan --config agentos_baseline`
+- `dry-run`: `agent-sec-cli harden --reinforce --dry-run --config agentos_baseline`
+- `reinforce`: `agent-sec-cli harden --reinforce --config agentos_baseline`
 
 Always keep `--config agentos_baseline` explicit.
-The `--config agentos_baseline` profile is the built-in default in `agent-sec-cli`.
+The wrapper now passes arguments straight through to `loongshield seharden`.
 
 ## Execution Rules
 

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
@@ -1,27 +1,15 @@
-"""Unit tests for security_middleware.backends.hardening — HardeningBackend.
-
-All subprocess calls are mocked. Tests focus on:
-  - Command construction (_build_command)
-  - ANSI stripping
-  - Summary line parsing (all 6 counters)
-  - Per-rule failure extraction
-  - Engine Error detection
-  - FileNotFoundError handling
-"""
+"""Unit tests for security_middleware.backends.hardening."""
 
 import subprocess
 import unittest
 from unittest.mock import patch
 
 from agent_sec_cli.security_middleware.backends.hardening import (
+    _MISSING_LOONGSHIELD_ERROR,
     HardeningBackend,
     _strip_ansi,
 )
 from agent_sec_cli.security_middleware.context import RequestContext
-
-# ---------------------------------------------------------------------------
-# Realistic loongshield output fixtures
-# ---------------------------------------------------------------------------
 
 LOONGSHIELD_ALL_PASS = """\
 \x1b[32m[INFO  10:07:54]\x1b[0m engine.lua:150: [1.1.1] PASS: Ensure mounting of cramfs is disabled
@@ -38,9 +26,10 @@ LOONGSHIELD_WITH_FAILURES = """\
 """
 
 LOONGSHIELD_REINFORCE = """\
+\x1b[33m[WARN  14:30:01]\x1b[0m engine.lua:186: [fs.udf_disabled] FAIL: Ensure mounting of udf is disabled
 \x1b[31m[ERROR 14:30:04]\x1b[0m engine.lua:307: [fs.shadow_perms] FAILED-TO-FIX: Cannot set file permissions on /etc/shadow
 \x1b[31m[ERROR 14:30:04]\x1b[0m engine.lua:295: [kern.sysctl_apply] ENFORCE-ERROR: Failed to apply sysctl setting
-\x1b[32m[INFO  14:30:05]\x1b[0m engine.lua:292: SEHarden Finished. 18 passed, 3 fixed, 1 failed, 0 manual, 0 dry-run-pending / 22 total.
+\x1b[32m[INFO  14:30:05]\x1b[0m engine.lua:292: SEHarden Finished. 18 passed, 1 fixed, 1 failed, 0 manual, 0 dry-run-pending / 20 total.
 """
 
 LOONGSHIELD_DRYRUN = """\
@@ -55,53 +44,39 @@ LOONGSHIELD_ENGINE_ERROR = """\
 """
 
 
-def _mock_proc(stdout, returncode=0):
-    """Create a mock subprocess.CompletedProcess."""
+def _mock_proc(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(
-        args=["loongshield", "seharden"], returncode=returncode, stdout=stdout
+        args=["/usr/bin/loongshield", "seharden"],
+        returncode=returncode,
+        stdout=stdout,
     )
 
 
 class TestBuildCommand(unittest.TestCase):
-    def test_scan_mode(self):
-        cmd = HardeningBackend._build_command("scan", "agentos_baseline")
-        self.assertEqual(
-            cmd, ["loongshield", "seharden", "--scan", "--config", "agentos_baseline"]
+    def test_build_command_with_resolved_binary(self):
+        cmd = HardeningBackend._build_command(
+            ["--scan", "--config", "agentos_baseline"],
+            loongshield_path="/usr/bin/loongshield",
         )
-
-    def test_reinforce_mode(self):
-        cmd = HardeningBackend._build_command("reinforce", "agentos_baseline")
-        self.assertEqual(
-            cmd,
-            ["loongshield", "seharden", "--reinforce", "--config", "agentos_baseline"],
-        )
-
-    def test_dryrun_mode(self):
-        cmd = HardeningBackend._build_command("dry-run", "agentos_baseline")
         self.assertEqual(
             cmd,
             [
-                "loongshield",
+                "/usr/bin/loongshield",
                 "seharden",
-                "--reinforce",
-                "--dry-run",
+                "--scan",
                 "--config",
                 "agentos_baseline",
             ],
         )
 
-    def test_custom_config(self):
-        cmd = HardeningBackend._build_command("scan", "custom_cfg")
-        self.assertIn("custom_cfg", cmd)
+    def test_build_command_without_resolved_binary(self):
+        cmd = HardeningBackend._build_command(["--reinforce", "--dry-run"])
+        self.assertEqual(cmd, ["loongshield", "seharden", "--reinforce", "--dry-run"])
 
 
 class TestStripAnsi(unittest.TestCase):
     def test_strips_colour_codes(self):
-        raw = "\x1b[32mGREEN\x1b[0m normal"
-        self.assertEqual(_strip_ansi(raw), "GREEN normal")
-
-    def test_no_ansi_unchanged(self):
-        self.assertEqual(_strip_ansi("plain text"), "plain text")
+        self.assertEqual(_strip_ansi("\x1b[32mGREEN\x1b[0m normal"), "GREEN normal")
 
 
 class TestHardeningExecute(unittest.TestCase):
@@ -109,145 +84,272 @@ class TestHardeningExecute(unittest.TestCase):
         self.backend = HardeningBackend()
         self.ctx = RequestContext(action="harden")
 
-    @patch("subprocess.run")
-    def test_all_pass(self, mock_run):
-        mock_run.return_value = _mock_proc(LOONGSHIELD_ALL_PASS, 0)
-        result = self.backend.execute(self.ctx, mode="scan")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.os.access")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.os.path.isfile")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_missing_loongshield_returns_clear_error(
+        self, mock_which, mock_isfile, mock_access
+    ):
+        mock_which.return_value = None
+        mock_isfile.return_value = False
+        mock_access.return_value = False
 
-        self.assertTrue(result.success)
-        self.assertEqual(result.data["passed"], 23)
-        self.assertEqual(result.data["failed"], 0)
-        self.assertEqual(result.data["total"], 23)
+        result = self.backend.execute(self.ctx, args=["--scan"])
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.exit_code, 127)
+        self.assertEqual(result.error, _MISSING_LOONGSHIELD_ERROR)
+        self.assertEqual(result.data["argv"], ["loongshield", "seharden", "--scan"])
         self.assertEqual(result.data["failures"], [])
         self.assertEqual(result.data["fixed_items"], [])
 
-    @patch("subprocess.run")
-    def test_with_failures(self, mock_run):
-        mock_run.return_value = _mock_proc(LOONGSHIELD_WITH_FAILURES, 1)
-        result = self.backend.execute(self.ctx, mode="scan")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.os.access")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.os.path.isfile")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_falls_back_to_packaged_sbindir_binary(
+        self, mock_which, mock_isfile, mock_access, mock_run
+    ):
+        mock_which.return_value = None
+        mock_isfile.return_value = True
+        mock_access.return_value = True
+        mock_run.return_value = _mock_proc(LOONGSHIELD_ALL_PASS, 0)
 
+        result = self.backend.execute(self.ctx, args=["--scan"])
+
+        mock_run.assert_called_once_with(
+            [
+                "/usr/sbin/loongshield",
+                "seharden",
+                "--scan",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["tool_path"], "/usr/sbin/loongshield")
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_no_args_preserve_legacy_default_scan_and_config(
+        self, mock_which, mock_run
+    ):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(LOONGSHIELD_ALL_PASS, 0)
+
+        result = self.backend.execute(self.ctx)
+
+        mock_run.assert_called_once_with(
+            [
+                "/usr/bin/loongshield",
+                "seharden",
+                "--scan",
+                "--config",
+                "agentos_baseline",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["mode"], "scan")
+        self.assertEqual(result.data["config"], "agentos_baseline")
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_passthrough_args_are_executed_verbatim_and_parsed(
+        self, mock_which, mock_run
+    ):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(LOONGSHIELD_WITH_FAILURES, 1)
+
+        result = self.backend.execute(
+            self.ctx, args=["--scan", "--config", "agentos_baseline"]
+        )
+
+        mock_run.assert_called_once_with(
+            [
+                "/usr/bin/loongshield",
+                "seharden",
+                "--scan",
+                "--config",
+                "agentos_baseline",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
         self.assertFalse(result.success)
+        self.assertEqual(result.exit_code, 1)
         self.assertEqual(result.data["passed"], 20)
         self.assertEqual(result.data["failed"], 2)
         self.assertEqual(result.data["manual"], 1)
-        # In scan mode, all non-PASS go to failures
         self.assertEqual(len(result.data["failures"]), 3)
         self.assertEqual(result.data["fixed_items"], [])
+        self.assertEqual(
+            result.data["raw_args"], ["--scan", "--config", "agentos_baseline"]
+        )
 
-        statuses = [f["status"] for f in result.data["failures"]]
-        self.assertIn("FAIL", statuses)
-        self.assertIn("MANUAL", statuses)
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_nonzero_exit_code_is_preserved(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(LOONGSHIELD_WITH_FAILURES, 3)
 
-    @patch("subprocess.run")
-    def test_reinforce_failures(self, mock_run):
+        result = self.backend.execute(self.ctx, args=["--scan"])
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.exit_code, 3)
+        self.assertEqual(result.data["returncode"], 3)
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_legacy_mode_and_config_are_translated(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
         mock_run.return_value = _mock_proc(LOONGSHIELD_REINFORCE, 1)
-        result = self.backend.execute(self.ctx, mode="reinforce")
 
-        self.assertEqual(result.data["fixed"], 3)
-        # FAILED-TO-FIX / ENFORCE-ERROR → failures (unresolved)
-        statuses = [f["status"] for f in result.data["failures"]]
+        result = self.backend.execute(
+            self.ctx,
+            mode="reinforce",
+            config="agentos_baseline",
+        )
+
+        mock_run.assert_called_once_with(
+            [
+                "/usr/bin/loongshield",
+                "seharden",
+                "--reinforce",
+                "--config",
+                "agentos_baseline",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertEqual(result.data["mode"], "reinforce")
+        self.assertEqual(result.data["config"], "agentos_baseline")
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_reinforce_results_keep_failures_and_fixed_items(
+        self, mock_which, mock_run
+    ):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(LOONGSHIELD_REINFORCE, 1)
+
+        result = self.backend.execute(
+            self.ctx, args=["--reinforce", "--config", "agentos_baseline"]
+        )
+
+        self.assertEqual(result.data["fixed"], 1)
+        self.assertEqual(len(result.data["fixed_items"]), 1)
+        self.assertEqual(result.data["fixed_items"][0]["status"], "FAIL")
+        statuses = [item["status"] for item in result.data["failures"]]
         self.assertIn("FAILED-TO-FIX", statuses)
         self.assertIn("ENFORCE-ERROR", statuses)
-        # No plain FAIL lines in this fixture → fixed_items empty
-        self.assertEqual(result.data["fixed_items"], [])
 
-    @patch("subprocess.run")
-    def test_dryrun_entries(self, mock_run):
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_dry_run_entries_are_reported(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
         mock_run.return_value = _mock_proc(LOONGSHIELD_DRYRUN, 0)
-        result = self.backend.execute(self.ctx, mode="dry-run")
+
+        result = self.backend.execute(
+            self.ctx, args=["--reinforce", "--dry-run", "--config", "agentos_baseline"]
+        )
 
         self.assertTrue(result.success)
+        self.assertEqual(result.data["mode"], "dry-run")
         self.assertEqual(result.data["dry_run_pending"], 2)
-        # dry-run is not reinforce, so all entries go to failures
-        statuses = [f["status"] for f in result.data["failures"]]
+        statuses = [item["status"] for item in result.data["failures"]]
         self.assertIn("DRY-RUN", statuses)
 
-    @patch("subprocess.run")
-    def test_engine_error(self, mock_run):
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_dry_run_mode_detection_is_order_independent(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(LOONGSHIELD_DRYRUN, 0)
+
+        result = self.backend.execute(
+            self.ctx, args=["--dry-run", "--reinforce", "--config", "agentos_baseline"]
+        )
+
+        self.assertEqual(result.data["mode"], "dry-run")
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_engine_error_is_kept_in_failures(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
         mock_run.return_value = _mock_proc(LOONGSHIELD_ENGINE_ERROR, 1)
-        result = self.backend.execute(self.ctx, mode="scan")
+
+        result = self.backend.execute(self.ctx, args=["--scan"])
 
         engine_errors = [
-            f for f in result.data["failures"] if f["status"] == "Engine Error"
+            item for item in result.data["failures"] if item["status"] == "Engine Error"
         ]
         self.assertEqual(len(engine_errors), 1)
         self.assertIn("config file not found", engine_errors[0]["message"])
 
-    @patch("subprocess.run")
-    def test_file_not_found(self, mock_run):
-        mock_run.side_effect = FileNotFoundError("loongshield not found")
-        result = self.backend.execute(self.ctx, mode="scan")
-
-        self.assertFalse(result.success)
-        self.assertEqual(result.exit_code, 127)
-        self.assertIn("command not found", result.error)
-
-    @patch("subprocess.run")
-    def test_no_summary_line(self, mock_run):
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_no_summary_line_keeps_metadata_only(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
         mock_run.return_value = _mock_proc("some random output\n", 0)
-        result = self.backend.execute(self.ctx, mode="scan")
 
-        # No summary parsed → no counter keys
-        self.assertNotIn("passed", result.data)
+        result = self.backend.execute(self.ctx, args=["--help"])
+
         self.assertTrue(result.success)
+        self.assertNotIn("passed", result.data)
+        self.assertNotIn("mode", result.data)
+        self.assertEqual(result.stdout, "some random output\n")
 
-    @patch("subprocess.run")
-    def test_alphanumeric_rule_ids(self, mock_run):
-        """Rule IDs like fs.shm_noexec must be captured."""
-        output = (
-            "\x1b[33m[WARN  12:28:06]\x1b[0m engine.lua:186: "
-            "[fs.shm_noexec] FAIL: /dev/shm must be mounted noexec\n"
-            "\x1b[32m[INFO  12:28:06]\x1b[0m engine.lua:316: "
-            "SEHarden Finished. 22 passed, 0 fixed, 1 failed, 0 manual, "
-            "0 dry-run-pending / 23 total.\n"
-        )
-        mock_run.return_value = _mock_proc(output, 1)
-        result = self.backend.execute(self.ctx, mode="scan")
-
-        self.assertEqual(len(result.data["failures"]), 1)
-        self.assertEqual(result.data["failures"][0]["rule_id"], "fs.shm_noexec")
-        self.assertEqual(result.data["failures"][0]["status"], "FAIL")
-        self.assertIn("noexec", result.data["failures"][0]["message"])
-
-    @patch("subprocess.run")
-    def test_fallback_when_failures_unparsed(self, mock_run):
-        """If summary reports failures but regex misses them, add UNKNOWN entry."""
-        output = (
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_fallback_when_summary_reports_unparsed_failures(
+        self, mock_which, mock_run
+    ):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(
             "[WARN  14:30:01] engine.lua:186: [~~weird~~] ???: something odd\n"
             "[INFO  14:30:02] engine.lua:292: SEHarden Finished. "
-            "22 passed, 0 fixed, 1 failed, 0 manual, 0 dry-run-pending / 23 total.\n"
+            "22 passed, 0 fixed, 1 failed, 0 manual, 0 dry-run-pending / 23 total.\n",
+            1,
         )
-        mock_run.return_value = _mock_proc(output, 1)
-        result = self.backend.execute(self.ctx, mode="scan")
+
+        result = self.backend.execute(self.ctx, args=["--scan"])
 
         self.assertEqual(len(result.data["failures"]), 1)
         self.assertEqual(result.data["failures"][0]["status"], "UNKNOWN")
         self.assertIn("could not be parsed", result.data["failures"][0]["message"])
 
-    @patch("subprocess.run")
-    def test_reinforce_fail_goes_to_fixed_items(self, mock_run):
-        """In reinforce mode, FAIL entries are remediated → fixed_items."""
-        output = (
-            "\x1b[33m[WARN  12:28:06]\x1b[0m engine.lua:186: "
-            "[fs.shm_noexec] FAIL: /dev/shm must be mounted noexec\n"
-            "\x1b[32m[INFO  12:28:06]\x1b[0m engine.lua:316: "
-            "SEHarden Finished. 22 passed, 1 fixed, 0 failed, 0 manual, "
-            "0 dry-run-pending / 23 total.\n"
-        )
-        mock_run.return_value = _mock_proc(output, 0)
-        result = self.backend.execute(self.ctx, mode="reinforce")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_oserror_is_reported_clearly(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.side_effect = OSError("Permission denied")
 
-        self.assertEqual(result.data["failures"], [])
-        self.assertEqual(len(result.data["fixed_items"]), 1)
-        self.assertEqual(result.data["fixed_items"][0]["rule_id"], "fs.shm_noexec")
+        result = self.backend.execute(self.ctx, args=["--scan"])
 
-    @patch("subprocess.run")
-    def test_ansi_stripped_in_stdout(self, mock_run):
-        mock_run.return_value = _mock_proc(LOONGSHIELD_ALL_PASS, 0)
-        result = self.backend.execute(self.ctx, mode="scan")
+        self.assertFalse(result.success)
+        self.assertIn("Failed to execute `loongshield seharden`", result.error)
+        self.assertIn("Permission denied", result.error)
 
-        # stdout must be ANSI-free
-        self.assertNotIn("\x1b[", result.stdout)
+    def test_unknown_legacy_kwargs_are_rejected(self):
+        with self.assertRaises(TypeError):
+            self.backend.execute(self.ctx, profile="agentos_baseline")
+
+    def test_mixing_args_and_legacy_kwargs_is_rejected(self):
+        with self.assertRaises(TypeError):
+            self.backend.execute(
+                self.ctx,
+                args=["--scan"],
+                mode="reinforce",
+            )
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -1,0 +1,135 @@
+"""Unit tests for the top-level CLI entry points."""
+
+import unittest
+from unittest.mock import patch
+
+from agent_sec_cli.cli import app
+from agent_sec_cli.security_middleware.result import ActionResult
+from typer.testing import CliRunner
+
+
+class TestHardenCli(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_harden_help_shows_concise_summary(self):
+        result = self.runner.invoke(app, ["harden", "--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Usage: agent-sec-cli harden [SEHARDEN_ARGS]...", result.output)
+        self.assertIn("Defaults:", result.output)
+        self.assertIn("--scan --config agentos_baseline", result.output)
+        self.assertIn("Examples:", result.output)
+        self.assertIn("Common SEHarden flags:", result.output)
+        self.assertIn("--downstream-help", result.output)
+        self.assertNotIn(
+            "Pass arguments through to `loongshield seharden`.", result.output
+        )
+        self.assertNotIn("-- --help", result.output)
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_adds_default_scan_and_config_on_zero_args(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(success=True, exit_code=0)
+
+        result = self.runner.invoke(app, ["harden"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_invoke.assert_called_once_with(
+            "harden",
+            args=["--scan", "--config", "agentos_baseline"],
+        )
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_forwards_unknown_args_to_backend(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(success=True, exit_code=0)
+
+        result = self.runner.invoke(
+            app,
+            ["harden", "--scan", "--config", "agentos_baseline", "--dry-run"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        mock_invoke.assert_called_once_with(
+            "harden",
+            args=["--scan", "--config", "agentos_baseline", "--dry-run"],
+        )
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_adds_default_config_when_missing(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(success=True, exit_code=0)
+
+        result = self.runner.invoke(app, ["harden", "--scan"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_invoke.assert_called_once_with(
+            "harden",
+            args=["--scan", "--config", "agentos_baseline"],
+        )
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_adds_default_scan_when_only_config_is_provided(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(success=True, exit_code=0)
+
+        result = self.runner.invoke(app, ["harden", "--config", "custom_profile"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_invoke.assert_called_once_with(
+            "harden",
+            args=["--scan", "--config", "custom_profile"],
+        )
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_keeps_explicit_equals_style_config(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(success=True, exit_code=0)
+
+        result = self.runner.invoke(
+            app, ["harden", "--scan", "--config=custom_profile"]
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        mock_invoke.assert_called_once_with(
+            "harden",
+            args=["--scan", "--config=custom_profile"],
+        )
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_does_not_add_default_scan_for_reinforce(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(success=True, exit_code=0)
+
+        result = self.runner.invoke(app, ["harden", "--reinforce", "--dry-run"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_invoke.assert_called_once_with(
+            "harden",
+            args=["--reinforce", "--dry-run", "--config", "agentos_baseline"],
+        )
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_keeps_explicit_verbose(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(success=True, exit_code=0)
+
+        result = self.runner.invoke(app, ["harden", "--scan", "--verbose"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_invoke.assert_called_once_with(
+            "harden",
+            args=["--scan", "--verbose", "--config", "agentos_baseline"],
+        )
+
+    @patch("agent_sec_cli.cli.invoke")
+    def test_harden_downstream_help_uses_backend_help(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(
+            success=True,
+            exit_code=0,
+            stdout="seharden help\n",
+        )
+
+        result = self.runner.invoke(app, ["harden", "--downstream-help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, "seharden help\n")
+        mock_invoke.assert_called_once_with("harden", args=["--help"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Restore the `agent-sec-cli harden` wrapper defaults so zero-argument and config-only invocations continue to run `seharden` in scan mode with the `agentos_baseline` profile. The hardening backend now also keeps parsed SEHarden summary and per-rule results in `ActionResult.data` while preserving passthrough execution metadata and captured stdout.

The update keeps the concise wrapper help, downstream passthrough behavior, and legacy backend compatibility, and adds regression coverage for the wrapper defaults and structured hardening results.

## Related Issue

no-issue: follow-up fix for an unreleased sec-core harden wrapper change

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/agent-sec-core
agent-sec-cli/.venv/bin/python -m ruff check \
  agent-sec-cli/src/agent_sec_cli/cli.py \
  agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py \
  tests/unit-test/test_cli.py \
  tests/unit-test/security_middleware/backends/test_hardening_backend.py

agent-sec-cli/.venv/bin/python -m pytest \
  tests/unit-test/test_cli.py \
  tests/unit-test/security_middleware/backends/test_hardening_backend.py -q

agent-sec-cli/.venv/bin/python -m pytest tests/unit-test -q
```

Results:
- `ruff check` passed for the touched Python files.
- Targeted hardening CLI/backend tests passed: `26 passed`.
- Full unit-test suite passed: `102 passed`.

## Additional Notes

Running `pytest tests/` in `src/agent-sec-core` is currently blocked by a pre-existing e2e collection error caused by duplicate module names:
- `tests/e2e/linux-sandbox/e2e_test.py`
- `tests/e2e/skill-signing/e2e_test.py`

This PR does not modify those e2e tests.
