### PR TITLE
fix(cosh): validate openai api key and model via /models endpoint on auth

### DIFF
--- a/src/copilot-shell/packages/core/src/core/contentGenerator.ts
+++ b/src/copilot-shell/packages/core/src/core/contentGenerator.ts
@@ -298,8 +298,9 @@ export async function createContentGenerator(
   let baseGenerator: ContentGenerator;
 
   if (authType === AuthType.USE_OPENAI) {
-    const { createOpenAIContentGenerator } =
+    const { createOpenAIContentGenerator, validateOpenAICredentials } =
       await import('./openaiContentGenerator/index.js');
+    await validateOpenAICredentials(generatorConfig, config);
     baseGenerator = createOpenAIContentGenerator(generatorConfig, config);
   } else if (authType === AuthType.QWEN_OAUTH) {
     const { getQwenOAuthClient: getQwenOauthClient } =

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import OpenAI from 'openai';
 import type {
   ContentGenerator,
   ContentGeneratorConfig,
@@ -92,3 +93,43 @@ export function determineProvider(
 }
 
 export { type ErrorHandler, EnhancedErrorHandler } from './errorHandler.js';
+
+/**
+ * Validate OpenAI API credentials and model availability by calling the /models endpoint.
+ *
+ * - Throws if the API key is invalid (HTTP 401).
+ * - Throws if the configured model is not present in the returned models list.
+ * - Silently passes for all other errors (e.g. network issues, providers that do not
+ *   expose a /models endpoint) so that legitimate custom providers are not blocked.
+ */
+export async function validateOpenAICredentials(
+  contentGeneratorConfig: ContentGeneratorConfig,
+  cliConfig: Config,
+): Promise<void> {
+  const provider = determineProvider(contentGeneratorConfig, cliConfig);
+  const client = provider.buildClient();
+
+  let models: string[] | undefined;
+
+  try {
+    const response = await client.models.list();
+    models = response.data.map((m) => m.id);
+  } catch (error) {
+    if (error instanceof OpenAI.APIError && error.status === 401) {
+      throw new Error(
+        'Invalid API key. Please check your API key and try again.',
+      );
+    }
+    // For other errors (network issues, unsupported /models endpoint, etc.),
+    // skip credential validation to avoid blocking legitimate custom providers.
+    return;
+  }
+
+  // Validate that the configured model is available
+  const model = contentGeneratorConfig.model;
+  if (models && models.length > 0 && !models.includes(model)) {
+    throw new Error(
+      `Model "${model}" is not available with the provided credentials. Please verify the model name and try again.`,
+    );
+  }
+}

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.test.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.test.ts
@@ -25,8 +25,37 @@ vi.mock('../../../utils/request-tokenizer/index.js', () => ({
   RequestTokenEstimator: vi.fn(() => mockTokenizer),
 }));
 
+// Mock OpenAI client used by validateOpenAICredentials
+const mockModelsList = vi.fn();
+
+vi.mock('openai', async () => {
+  class MockAPIError extends Error {
+    status: number;
+    headers: Record<string, string>;
+    constructor(
+      status: number,
+      _error: unknown,
+      message: string,
+      headers: Record<string, string> = {},
+    ) {
+      super(message);
+      this.status = status;
+      this.headers = headers;
+      this.name = 'APIError';
+    }
+  }
+  const MockOpenAI = vi.fn(() => ({
+    models: { list: mockModelsList },
+    chat: { completions: { create: vi.fn() } },
+    embeddings: { create: vi.fn() },
+  }));
+  (MockOpenAI as unknown as Record<string, unknown>).APIError = MockAPIError;
+  return { default: MockOpenAI };
+});
+
 // Now import the modules that depend on the mocked modules
 import { OpenAIContentGenerator } from './openaiContentGenerator.js';
+import { validateOpenAICredentials } from './index.js';
 import type { Config } from '../../config/config.js';
 import { AuthType } from '../contentGenerator.js';
 import type {
@@ -401,5 +430,75 @@ describe('OpenAIContentGenerator (Refactored)', () => {
 
       expect(result).toBe(true);
     });
+  });
+});
+
+describe('validateOpenAICredentials', () => {
+  const baseGeneratorConfig = {
+    model: 'gpt-4',
+    apiKey: 'test-api-key',
+    baseUrl: 'https://api.openai.com/v1',
+    authType: AuthType.USE_OPENAI,
+  };
+
+  let mockCliConfig: Config;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCliConfig = {
+      getContentGeneratorConfig: vi.fn().mockReturnValue(baseGeneratorConfig),
+      getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+      getProxy: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+  });
+
+  it('throws with a clear message when the API key is invalid (401)', async () => {
+    const OpenAI = (await import('openai')).default;
+    const authError = new OpenAI.APIError(401, null, 'Unauthorized', {});
+    mockModelsList.mockRejectedValueOnce(authError);
+
+    await expect(
+      validateOpenAICredentials(baseGeneratorConfig, mockCliConfig),
+    ).rejects.toThrow(
+      'Invalid API key. Please check your API key and try again.',
+    );
+  });
+
+  it('throws when the configured model is not in the available models list', async () => {
+    mockModelsList.mockResolvedValueOnce({
+      data: [{ id: 'gpt-3.5-turbo' }, { id: 'gpt-4o' }],
+    });
+
+    await expect(
+      validateOpenAICredentials(baseGeneratorConfig, mockCliConfig),
+    ).rejects.toThrow(
+      'Model "gpt-4" is not available with the provided credentials.',
+    );
+  });
+
+  it('resolves successfully when the API key is valid and the model is available', async () => {
+    mockModelsList.mockResolvedValueOnce({
+      data: [{ id: 'gpt-3.5-turbo' }, { id: 'gpt-4' }, { id: 'gpt-4o' }],
+    });
+
+    await expect(
+      validateOpenAICredentials(baseGeneratorConfig, mockCliConfig),
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves without error when /models endpoint returns a non-auth error', async () => {
+    mockModelsList.mockRejectedValueOnce(new Error('Service unavailable'));
+
+    await expect(
+      validateOpenAICredentials(baseGeneratorConfig, mockCliConfig),
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves without error when /models endpoint returns an empty models list', async () => {
+    mockModelsList.mockResolvedValueOnce({ data: [] });
+
+    await expect(
+      validateOpenAICredentials(baseGeneratorConfig, mockCliConfig),
+    ).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

When a user enters an incorrect API key via `/auth` with a Custom Provider (OpenAI-compatible endpoint), the system incorrectly shows "Authenticated successfully". This happens because `createOpenAIContentGenerator` is a synchronous factory that only instantiates the client object without making any network call to verify the key.

The fix adds a `validateOpenAICredentials` step that calls the `/models` endpoint before completing authentication. If the server returns HTTP 401, an explicit error is thrown. If the endpoint returns a model list that does not include the configured model, a model-not-available error is thrown. All other errors (e.g. network issues, providers that don't expose `/models`) are silently ignored so that legitimate custom providers are not blocked.

## Related Issue

closes #213

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run build && npm run test && npm run lint && npm run typecheck
# 212 test files passed (3343 tests passed, 7 skipped)
# 5 new unit tests added for validateOpenAICredentials:
#   - throws on 401 invalid API key
#   - throws when configured model is not in available models list
#   - resolves when API key is valid and model is available
#   - resolves without error on non-auth errors (tolerates unsupported /models endpoints)
#   - resolves without error when /models returns an empty list
```

## Additional Notes

The validation is intentionally lenient for non-401 errors to avoid blocking users of custom OpenAI-compatible providers that may not implement the `/models` endpoint. Only 401 (invalid credentials) and model-not-found cases produce user-visible errors.