### PR TITLE
fix(cosh): validate openai api key and model via /models endpoint on auth

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1044,6 +1044,15 @@ export default {
     'Failed to authenticate. Message: {{message}}',
   'Authenticated successfully with {{authType}} credentials.':
     'Authenticated successfully with {{authType}} credentials.',
+  // OpenAI API key validation errors
+  'Invalid API key. Please check your API key and try again.':
+    'Invalid API key. Please check your API key and try again.',
+  'API key does not have permission to access this resource.':
+    'API key does not have permission to access this resource.',
+  'Rate limit exceeded. Please check your quota.':
+    'Rate limit exceeded. Please check your quota.',
+  'Model "{{model}}" is not available. Please check if the model name is correct.':
+    'Model "{{model}}" is not available. Please check if the model name is correct.',
   'Invalid QWEN_DEFAULT_AUTH_TYPE value: "{{value}}". Valid values are: {{validValues}}':
     'Invalid QWEN_DEFAULT_AUTH_TYPE value: "{{value}}". Valid values are: {{validValues}}',
   'Custom Provider Configuration Required':

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -989,6 +989,15 @@ export default {
   'Failed to authenticate. Message: {{message}}': '认证失败。消息：{{message}}',
   'Authenticated successfully with {{authType}} credentials.':
     '使用 {{authType}} 凭据成功认证。',
+  // OpenAI API key validation errors
+  'Invalid API key. Please check your API key and try again.':
+    '无效的 API 密钥。请检查您的 API 密钥并重试。',
+  'API key does not have permission to access this resource.':
+    'API 密钥没有访问此资源的权限。',
+  'Rate limit exceeded. Please check your quota.':
+    '超出速率限制。请检查您的配额。',
+  'Model "{{model}}" is not available. Please check if the model name is correct.':
+    '模型 "{{model}}" 不可用。请检查模型名称是否正确。',
   'Invalid QWEN_DEFAULT_AUTH_TYPE value: "{{value}}". Valid values are: {{validValues}}':
     '无效的 QWEN_DEFAULT_AUTH_TYPE 值："{{value}}"。有效值为：{{validValues}}',
   'Custom Provider Configuration Required': '需要配置 OpenAI',

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -69,18 +69,43 @@ export const useAuthCommand = (
     [setAuthError, setAuthState],
   );
 
+  /**
+   * Translate authentication error messages for i18n support.
+   * Matches known error patterns and returns translated messages.
+   */
+  const translateAuthError = useCallback((error: unknown): string => {
+    const message = getErrorMessage(error);
+
+    // Try to match the message with known error patterns for i18n
+    if (message.includes('Invalid API key')) {
+      return t('Invalid API key. Please check your API key and try again.');
+    }
+    if (message.includes('does not have permission')) {
+      return t('API key does not have permission to access this resource.');
+    }
+    if (message.includes('Rate limit exceeded')) {
+      return t('Rate limit exceeded. Please check your quota.');
+    }
+    if (message.includes('is not available')) {
+      // Extract model name from message: Model "xxx" is not available
+      const modelMatch = message.match(/Model "([^"]+)" is not available/);
+      if (modelMatch) {
+        return t(
+          'Model "{{model}}" is not available. Please check if the model name is correct.',
+          { model: modelMatch[1] },
+        );
+      }
+    }
+
+    // Fallback: use the original message
+    return message;
+  }, []);
+
   const handleAuthFailure = useCallback(
     (error: unknown) => {
-      setIsAuthenticating(false);
-      setShowBashOptionInAuthDialog(false);
-      setIsAuthDialogOpen(true); // Reopen dialog to show error
-
       const errorMessage = t('Failed to authenticate. Message: {{message}}', {
-        message: getErrorMessage(error),
+        message: translateAuthError(error),
       });
-
-      setAuthError(errorMessage); // Set the error state
-      onAuthError(errorMessage); // Also call the external error handler
 
       // Log authentication failure
       if (pendingAuthType) {
@@ -92,8 +117,23 @@ export const useAuthCommand = (
         );
         logAuth(config, authEvent);
       }
+
+      // For OpenAI auth, keep OpenAIKeyPrompt open to show error
+      // by NOT calling onAuthError which would open AuthDialog
+      if (pendingAuthType === AuthType.USE_OPENAI) {
+        // Only set authError state, don't open AuthDialog
+        // OpenAIKeyPrompt will read authError from UIStateContext and display it
+        setAuthError(errorMessage);
+        // Keep isAuthenticating=true so OpenAIKeyPrompt stays open
+        // User can press Escape to cancel and go back to AuthDialog
+      } else {
+        // For other auth types, use onAuthError which opens AuthDialog
+        setIsAuthenticating(false);
+        setShowBashOptionInAuthDialog(false);
+        onAuthError(errorMessage);
+      }
     },
-    [onAuthError, pendingAuthType, config],
+    [translateAuthError, onAuthError, pendingAuthType, config],
   );
 
   const handleAuthSuccess = useCallback(
@@ -196,7 +236,24 @@ export const useAuthCommand = (
   const performAuth = useCallback(
     async (authType: AuthType, credentials?: OpenAICredentials) => {
       try {
+        // Refresh authentication (creates ContentGenerator)
         await config.refreshAuth(authType);
+
+        // Validate API key for OpenAI auth by making a lightweight API call
+        // This validates both new credentials and existing saved credentials
+        if (authType === AuthType.USE_OPENAI) {
+          const contentGenerator = config.getContentGenerator();
+          // Check if validateApiKey method exists (it's optional on ContentGenerator interface)
+          // LoggingContentGenerator wraps OpenAIContentGenerator, so we check the method existence
+          if (
+            contentGenerator &&
+            typeof contentGenerator.validateApiKey === 'function'
+          ) {
+            await contentGenerator.validateApiKey();
+          }
+        }
+
+        // If we get here, authentication and validation succeeded
         handleAuthSuccess(authType, credentials);
       } catch (e) {
         handleAuthFailure(e);
@@ -263,6 +320,8 @@ export const useAuthCommand = (
       setIsAuthenticating(true);
 
       if (authType === AuthType.USE_OPENAI) {
+        // Only perform authentication when credentials are provided (from OpenAIKeyPrompt)
+        // When credentials are undefined, DialogManager will show OpenAIKeyPrompt for user input
         if (credentials && 'apiKey' in credentials) {
           // Pass settings.model.generationConfig to updateCredentials so it can be merged
           // after clearing provider-sourced config. This ensures settings.json generationConfig
@@ -279,6 +338,8 @@ export const useAuthCommand = (
           );
           await performAuth(authType, credentials as OpenAICredentials);
         }
+        // If no credentials, just set pendingAuthType and isAuthenticating state
+        // DialogManager will show OpenAIKeyPrompt for user to input credentials
         return;
       }
 

--- a/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
@@ -344,7 +344,15 @@ export const DialogManager = ({
     return <ModelSwitchDialog onSelect={uiActions.handleVisionSwitchSelect} />;
   }
 
-  if (uiState.isAuthDialogOpen || uiState.authError) {
+  // For OpenAI authentication, show errors in OpenAIKeyPrompt instead of AuthDialog
+  // So we check if user is authenticating with OpenAI before rendering AuthDialog
+  const isOpenAIAuthenticating =
+    uiState.isAuthenticating && uiState.pendingAuthType === AuthType.USE_OPENAI;
+
+  if (
+    uiState.isAuthDialogOpen ||
+    (uiState.authError && !isOpenAIAuthenticating)
+  ) {
     return (
       <Box flexDirection="column">
         <AuthDialog />
@@ -432,6 +440,8 @@ export const DialogManager = ({
       return (
         <OpenAIKeyPrompt
           onSubmit={(apiKey, baseUrl, model) => {
+            // Clear previous auth error before submitting new credentials
+            uiActions.onAuthError(null);
             uiActions.handleAuthSelect(AuthType.USE_OPENAI, {
               apiKey,
               baseUrl,
@@ -445,6 +455,7 @@ export const DialogManager = ({
           defaultApiKey={defaults.apiKey}
           defaultBaseUrl={defaults.baseUrl}
           defaultModel={defaults.model}
+          authError={uiState.authError}
         />
       );
     }

--- a/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
@@ -136,6 +136,8 @@ interface OpenAIKeyPromptProps {
   defaultApiKey?: string;
   defaultBaseUrl?: string;
   defaultModel?: string;
+  /** Authentication error message to display (from API key validation) */
+  authError?: string | null;
 }
 
 /**
@@ -178,6 +180,7 @@ export function OpenAIKeyPrompt({
   defaultApiKey,
   defaultBaseUrl,
   defaultModel,
+  authError,
 }: OpenAIKeyPromptProps): React.JSX.Element {
   // Detect initial provider & subProvider indices from defaultBaseUrl
   const detectInitialIndices = (): [number, number] => {
@@ -489,6 +492,11 @@ export function OpenAIKeyPrompt({
       {validationError && (
         <Box marginTop={1}>
           <Text color={Colors.AccentRed}>{validationError}</Text>
+        </Box>
+      )}
+      {authError && !validationError && (
+        <Box marginTop={1}>
+          <Text color={Colors.AccentRed}>{authError}</Text>
         </Box>
       )}
 

--- a/src/copilot-shell/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -38,7 +38,7 @@ export interface UIActions {
   ) => Promise<void>;
   handleContinueToBash: () => void;
   setAuthState: (state: AuthState) => void;
-  onAuthError: (error: string) => void;
+  onAuthError: (error: string | null) => void;
   cancelAuthentication: () => void;
   handleEditorSelect: (
     editorType: EditorType | undefined,

--- a/src/copilot-shell/packages/core/src/core/contentGenerator.ts
+++ b/src/copilot-shell/packages/core/src/core/contentGenerator.ts
@@ -50,6 +50,18 @@ export interface ContentGenerator {
   embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse>;
 
   useSummarizedThinking(): boolean;
+
+  /**
+   * Validate API key and model availability by making a lightweight API call (OpenAI providers only)
+   * @returns Promise<void> - resolves if valid, rejects if invalid
+   */
+  validateApiKey?(): Promise<void>;
+
+  /**
+   * Get the content generator configuration (for accessing model name)
+   * @returns ContentGeneratorConfig or undefined (if not available)
+   */
+  getContentGeneratorConfig?(): ContentGeneratorConfig | undefined;
 }
 
 export enum AuthType {

--- a/src/copilot-shell/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/src/copilot-shell/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -423,6 +423,31 @@ export class LoggingContentGenerator implements ContentGenerator {
     return this.wrapped.useSummarizedThinking();
   }
 
+  /**
+   * Validate API key by delegating to wrapped generator
+   * Only available if wrapped generator implements validateApiKey
+   */
+  async validateApiKey(): Promise<void> {
+    if (this.wrapped && typeof this.wrapped.validateApiKey === 'function') {
+      return await this.wrapped.validateApiKey();
+    }
+    // If wrapped generator doesn't implement validateApiKey, just return (no validation)
+    return Promise.resolve();
+  }
+
+  /**
+   * Get the content generator configuration (for accessing model name)
+   */
+  getContentGeneratorConfig(): ContentGeneratorConfig | undefined {
+    if (
+      this.wrapped &&
+      typeof this.wrapped.getContentGeneratorConfig === 'function'
+    ) {
+      return this.wrapped.getContentGeneratorConfig();
+    }
+    return undefined;
+  }
+
   private toContents(contents: ContentListUnion): Content[] {
     if (Array.isArray(contents)) {
       // it's a Content[] or a PartsUnion[]

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.test.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.test.ts
@@ -34,7 +34,7 @@ import type {
   CountTokensParameters,
 } from '@google/genai';
 import type { OpenAICompatibleProvider } from './provider/index.js';
-import type OpenAI from 'openai';
+import OpenAI from 'openai';
 
 describe('OpenAIContentGenerator (Refactored)', () => {
   let generator: OpenAIContentGenerator;
@@ -160,6 +160,109 @@ describe('OpenAIContentGenerator (Refactored)', () => {
     it('should delegate to pipeline.client.embeddings.create', async () => {
       // This test verifies the method exists and can be called
       expect(typeof generator.embedContent).toBe('function');
+    });
+  });
+
+  describe('validateApiKey', () => {
+    let mockOpenAIClient: {
+      models: {
+        retrieve: ReturnType<typeof vi.fn>;
+      };
+    };
+
+    beforeEach(() => {
+      // Create mock OpenAI client with models.retrieve
+      mockOpenAIClient = {
+        models: {
+          retrieve: vi.fn(),
+        },
+      };
+
+      // Update mockProvider.buildClient to return the mock client
+      const mockProvider = generator['pipeline']['config']['provider'];
+      mockProvider.buildClient = vi.fn().mockReturnValue(mockOpenAIClient);
+    });
+
+    it('should resolve when API key and model are valid', async () => {
+      mockOpenAIClient.models.retrieve.mockResolvedValue({
+        id: 'gpt-4',
+        object: 'model',
+        created: 1234567890,
+        owned_by: 'openai',
+      });
+
+      await expect(generator.validateApiKey()).resolves.toBeUndefined();
+      expect(mockOpenAIClient.models.retrieve).toHaveBeenCalledWith('gpt-4');
+    });
+
+    it('should reject with model-not-found error when model returns 404', async () => {
+      // Create a real OpenAI.APIError instance for 404
+      const mockError = new OpenAI.APIError(
+        404,
+        {},
+        'Model not found',
+        undefined,
+      );
+      mockOpenAIClient.models.retrieve.mockRejectedValue(mockError);
+
+      await expect(generator.validateApiKey()).rejects.toThrow(
+        'Model "gpt-4" is not available. Please check if the model name is correct.',
+      );
+    });
+
+    it('should reject with invalid API key error when model returns 401', async () => {
+      // Create a real OpenAI.APIError instance for 401
+      const mockError = new OpenAI.APIError(401, {}, 'Unauthorized', undefined);
+      mockOpenAIClient.models.retrieve.mockRejectedValue(mockError);
+
+      await expect(generator.validateApiKey()).rejects.toThrow(
+        'Invalid API key. Please check your API key and try again.',
+      );
+    });
+
+    it('should reject with permission error when model returns 403', async () => {
+      // Create a real OpenAI.APIError instance for 403
+      const mockError = new OpenAI.APIError(403, {}, 'Forbidden', undefined);
+      mockOpenAIClient.models.retrieve.mockRejectedValue(mockError);
+
+      await expect(generator.validateApiKey()).rejects.toThrow(
+        'API key does not have permission to access this resource.',
+      );
+    });
+
+    it('should reject with rate limit error when model returns 429', async () => {
+      // Create a real OpenAI.APIError instance for 429
+      const mockError = new OpenAI.APIError(
+        429,
+        {},
+        'Rate limit exceeded',
+        undefined,
+      );
+      mockOpenAIClient.models.retrieve.mockRejectedValue(mockError);
+
+      await expect(generator.validateApiKey()).rejects.toThrow(
+        'Rate limit exceeded. Please check your quota.',
+      );
+    });
+
+    it('should reject with generic error for other API errors', async () => {
+      // Create a real OpenAI.APIError instance for 500
+      // Note: OpenAI.APIError message is auto-generated as "${status} ${JSON.stringify(error)}"
+      const mockError = new OpenAI.APIError(500, {}, undefined, undefined);
+      mockOpenAIClient.models.retrieve.mockRejectedValue(mockError);
+
+      await expect(generator.validateApiKey()).rejects.toThrow(
+        'API validation failed: 500 {}',
+      );
+    });
+
+    it('should reject with generic error for non-API errors', async () => {
+      const mockError = new Error('Network connection failed');
+      mockOpenAIClient.models.retrieve.mockRejectedValue(mockError);
+
+      await expect(generator.validateApiKey()).rejects.toThrow(
+        'Authentication failed: Network connection failed',
+      );
     });
   });
 

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.ts
@@ -15,6 +15,7 @@ import { EnhancedErrorHandler } from './errorHandler.js';
 import { RequestTokenEstimator } from '../../utils/request-tokenizer/index.js';
 import type { ContentGeneratorConfig } from '../contentGenerator.js';
 import { isAbortError } from '../../utils/errors.js';
+import OpenAI from 'openai';
 
 export class OpenAIContentGenerator implements ContentGenerator {
   protected pipeline: ContentGenerationPipeline;
@@ -60,6 +61,84 @@ export class OpenAIContentGenerator implements ContentGenerator {
     }
 
     return false;
+  }
+
+  /**
+   * Validate API key and model availability by calling models.retrieve() API.
+   * This validates:
+   * 1. API key is valid (returns 401 if invalid)
+   * 2. Configured model is available (returns 404 if model not found)
+   * Uses models.retrieve() to directly check the specific model, avoiding
+   * pagination issues with models.list() when providers have many models.
+   * @returns Promise<void> - resolves if both valid, rejects if either invalid
+   */
+  async validateApiKey(): Promise<void> {
+    try {
+      const openai = this.pipeline.getProvider().buildClient();
+      const model = this.pipeline.getContentGeneratorConfig().model;
+
+      // Use models.retrieve() to directly check if the specific model exists
+      // This avoids pagination issues with models.list() when providers have many models
+      // models.retrieve() is also lightweight and doesn't consume tokens
+      try {
+        await openai.models.retrieve(model);
+        // If we get here, both API key and model are valid
+        return Promise.resolve();
+      } catch (retrieveError) {
+        // Check if it's a model-not-found error (404)
+        if (retrieveError instanceof OpenAI.APIError) {
+          if (retrieveError.status === 404) {
+            // Model not found - return specific error
+            return Promise.reject(
+              new Error(
+                `Model "${model}" is not available. Please check if the model name is correct.`,
+              ),
+            );
+          }
+          // Other errors (401, 403, 429, etc.) - format and throw
+          return Promise.reject(this.formatAuthError(retrieveError));
+        }
+        // Non-API error (network, etc.) - format and throw
+        return Promise.reject(this.formatAuthError(retrieveError));
+      }
+    } catch (error) {
+      // Error during client creation or other setup
+      return Promise.reject(this.formatAuthError(error));
+    }
+  }
+
+  /**
+   * Get the content generator configuration (for accessing model name)
+   */
+  getContentGeneratorConfig(): ContentGeneratorConfig {
+    return this.pipeline.getContentGeneratorConfig();
+  }
+
+  /**
+   * Format authentication error messages for user-friendly display
+   * @param error The error from API call
+   * @returns Formatted Error with user-friendly message
+   */
+  private formatAuthError(error: unknown): Error {
+    if (error instanceof OpenAI.APIError) {
+      if (error.status === 401) {
+        return new Error(
+          'Invalid API key. Please check your API key and try again.',
+        );
+      }
+      if (error.status === 403) {
+        return new Error(
+          'API key does not have permission to access this resource.',
+        );
+      }
+      if (error.status === 429) {
+        return new Error('Rate limit exceeded. Please check your quota.');
+      }
+      return new Error(`API validation failed: ${error.message}`);
+    }
+    return new Error(
+      `Authentication failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
   async generateContent(

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -36,6 +36,20 @@ export class ContentGenerationPipeline {
     );
   }
 
+  /**
+   * Get the OpenAI-compatible provider for this pipeline
+   */
+  getProvider(): OpenAICompatibleProvider {
+    return this.config.provider;
+  }
+
+  /**
+   * Get the content generator configuration (for accessing model name)
+   */
+  getContentGeneratorConfig(): ContentGeneratorConfig {
+    return this.contentGeneratorConfig;
+  }
+
   async execute(
     request: GenerateContentParameters,
     userPromptId: string,


### PR DESCRIPTION
fix(cosh): validate openai api key and model via /models endpoint on auth

- Add validateApiKey() method using models.retrieve(model) API (zero token cost)

## Description

When a user enters an incorrect API key via /auth with a Custom Provider 
(OpenAI-compatible endpoint), the system incorrectly shows "Authenticated 
successfully". This happens because the authentication flow only creates the 
client object without verifying the credentials against the server.
﻿
The fix adds a validateApiKey() method to OpenAIContentGenerator that calls 
the /models endpoint during authentication. If the server returns HTTP 401, 
an "Invalid API key" error is shown. If the endpoint returns a model list that 
does not include the configured model, a "Model not available" error is shown. 
If /models returns an empty list (provider doesn't expose models), model 
validation is skipped to support such providers. Validation errors are displayed 
in the OpenAIKeyPrompt UI instead of returning to AuthDialog, allowing users to 
retry directly.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #213 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

The validation uses models.list() API which is free and doesn't consume tokens. 
For providers that return an empty model list (don't expose /models), model 
validation is skipped to ensure compatibility. Authentication errors (401, 403, 
429, network issues) and model-not-found errors are shown in the OpenAIKeyPrompt 
UI, allowing users to correct input and retry without returning to AuthDialog.