### PR TITLE
feat(cosh):add export command for session history

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1512,4 +1512,23 @@ export default {
   'Press Enter or wait 2s to continue': 'Press Enter or wait 2s to continue',
   '↑↓ or j/k to navigate · 1/2/3 select · Enter confirm · Esc cancel':
     '↑↓ or j/k to navigate · 1/2/3 select · Enter confirm · Esc cancel',
+  // Export command
+  'Export current session message history to a file':
+    'Export current session message history to a file',
+  'Export to Markdown format': 'Export to Markdown format',
+  'Export to HTML format': 'Export to HTML format',
+  'Export to JSON format': 'Export to JSON format',
+  'Export to JSONL format': 'Export to JSONL format',
+  'Could not determine current working directory.':
+    'Could not determine current working directory.',
+  'No active session found to export.': 'No active session found to export.',
+  'Session exported to markdown: {{filename}}':
+    'Session exported to markdown: {{filename}}',
+  'Session exported to HTML: {{filename}}':
+    'Session exported to HTML: {{filename}}',
+  'Session exported to JSON: {{filename}}':
+    'Session exported to JSON: {{filename}}',
+  'Session exported to JSONL: {{filename}}':
+    'Session exported to JSONL: {{filename}}',
+  'Failed to export session: {{error}}': 'Failed to export session: {{error}}',
 };

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -1343,4 +1343,19 @@ export default {
   'Press Enter or wait 2s to continue': '按 Enter 或等待 2 秒继续',
   '↑↓ or j/k to navigate · 1/2/3 select · Enter confirm · Esc cancel':
     '↑↓ 或 j/k 导航 · 1/2/3 选择 · Enter 确认 · Esc 取消',
+  // 导出命令
+  'Export current session message history to a file':
+    '将当前会话消息历史导出到文件',
+  'Export to Markdown format': '导出为 Markdown 格式',
+  'Export to HTML format': '导出为 HTML 格式',
+  'Export to JSON format': '导出为 JSON 格式',
+  'Export to JSONL format': '导出为 JSONL 格式',
+  'Could not determine current working directory.': '无法确定当前工作目录。',
+  'No active session found to export.': '未找到可导出的活跃会话。',
+  'Session exported to markdown: {{filename}}':
+    '会话已导出为 Markdown：{{filename}}',
+  'Session exported to HTML: {{filename}}': '会话已导出为 HTML：{{filename}}',
+  'Session exported to JSON: {{filename}}': '会话已导出为 JSON：{{filename}}',
+  'Session exported to JSONL: {{filename}}': '会话已导出为 JSONL：{{filename}}',
+  'Failed to export session: {{error}}': '导出会话失败：{{error}}',
 };

--- a/src/copilot-shell/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/src/copilot-shell/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -18,6 +18,7 @@ import { compressCommand } from '../ui/commands/compressCommand.js';
 import { copyCommand } from '../ui/commands/copyCommand.js';
 import { directoryCommand } from '../ui/commands/directoryCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
+import { exportCommand } from '../ui/commands/exportCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { hooksCommand } from '../ui/commands/hooksCommand.js';
@@ -69,6 +70,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       copyCommand,
       directoryCommand,
       editorCommand,
+      exportCommand,
       extensionsCommand,
       helpCommand,
       hooksCommand,

--- a/src/copilot-shell/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { exportCommand } from './exportCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { ChatRecord } from '@copilot-shell/core';
+import type { Part, Content } from '@google/genai';
+import {
+  collectSessionData,
+  normalizeSessionData,
+  toMarkdown,
+  toHtml,
+  toJson,
+  toJsonl,
+  generateExportFilename,
+} from '../utils/export/index.js';
+
+const mockSessionServiceMocks = vi.hoisted(() => ({
+  loadLastSession: vi.fn(),
+}));
+
+vi.mock('@copilot-shell/core', () => {
+  class SessionService {
+    constructor(_cwd: string) {}
+    async loadLastSession() {
+      return mockSessionServiceMocks.loadLastSession();
+    }
+  }
+
+  return {
+    SessionService,
+  };
+});
+
+vi.mock('../utils/export/index.js', () => ({
+  collectSessionData: vi.fn(),
+  normalizeSessionData: vi.fn(),
+  toMarkdown: vi.fn(),
+  toHtml: vi.fn(),
+  toJson: vi.fn(),
+  toJsonl: vi.fn(),
+  generateExportFilename: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
+}));
+
+describe('exportCommand', () => {
+  const mockSessionData = {
+    conversation: {
+      sessionId: 'test-session-id',
+      startTime: '2025-01-01T00:00:00Z',
+      messages: [
+        {
+          type: 'user',
+          message: {
+            parts: [{ text: 'Hello' }] as Part[],
+          } as Content,
+        },
+      ] as ChatRecord[],
+    },
+  };
+
+  let mockContext: ReturnType<typeof createMockCommandContext>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSessionServiceMocks.loadLastSession.mockResolvedValue(mockSessionData);
+
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
+          getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+        },
+      },
+    });
+
+    vi.mocked(collectSessionData).mockResolvedValue({
+      sessionId: 'test-session-id',
+      startTime: '2025-01-01T00:00:00Z',
+      messages: [],
+    });
+    vi.mocked(normalizeSessionData).mockImplementation((data) => data);
+    vi.mocked(toMarkdown).mockReturnValue('# Test Markdown');
+    vi.mocked(toHtml).mockReturnValue(
+      '<html><script id="chat-data" type="application/json">{"data": "test"}</script></html>',
+    );
+    vi.mocked(toJson).mockReturnValue('{ "sessionId": "test-session-id" }');
+    vi.mocked(toJsonl).mockReturnValue(
+      '{"type":"session_metadata","sessionId":"test-session-id"}',
+    );
+    vi.mocked(generateExportFilename).mockImplementation(
+      (ext: string) => `export-2025-01-01T00-00-00-000Z.${ext}`,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('command structure', () => {
+    it('should have correct name and description', () => {
+      expect(exportCommand.name).toBe('export');
+      expect(exportCommand.description).toBe(
+        'Export current session message history to a file',
+      );
+    });
+
+    it('should have md, html, json, and jsonl subcommands', () => {
+      expect(exportCommand.subCommands).toHaveLength(4);
+      expect(exportCommand.subCommands?.[0]?.name).toBe('md');
+      expect(exportCommand.subCommands?.[1]?.name).toBe('html');
+      expect(exportCommand.subCommands?.[2]?.name).toBe('json');
+      expect(exportCommand.subCommands?.[3]?.name).toBe('jsonl');
+    });
+
+    it('should have default action for export command', () => {
+      expect(exportCommand.action).toBeDefined();
+    });
+  });
+
+  describe('default action', () => {
+    it('should export session to markdown by default', async () => {
+      const result = await exportCommand.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Session exported to markdown: export-2025-01-01T00-00-00-000Z.md',
+      });
+
+      expect(toMarkdown).toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/dir/export-2025-01-01T00-00-00-000Z.md',
+        '# Test Markdown',
+        'utf-8',
+      );
+    });
+  });
+
+  describe('md subcommand', () => {
+    it('should export session to markdown file', async () => {
+      const mdCommand = exportCommand.subCommands?.[0];
+      expect(mdCommand).toBeDefined();
+      expect(mdCommand?.action).toBeDefined();
+
+      const result = await mdCommand?.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Session exported to markdown: export-2025-01-01T00-00-00-000Z.md',
+      });
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/dir/export-2025-01-01T00-00-00-000Z.md',
+        '# Test Markdown',
+        'utf-8',
+      );
+    });
+
+    it('should return error when config is not available', async () => {
+      mockContext = createMockCommandContext({
+        services: {
+          config: null,
+        },
+      });
+
+      const mdCommand = exportCommand.subCommands?.[0];
+      const result = await mdCommand?.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Configuration not available.',
+      });
+    });
+
+    it('should return error when no session found', async () => {
+      mockSessionServiceMocks.loadLastSession.mockResolvedValue(undefined);
+
+      const mdCommand = exportCommand.subCommands?.[0];
+      const result = await mdCommand?.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'No active session found to export.',
+      });
+    });
+
+    it('should return error when write fails', async () => {
+      vi.mocked(fs.writeFile).mockRejectedValue(
+        new Error('Write permission denied'),
+      );
+
+      const mdCommand = exportCommand.subCommands?.[0];
+      const result = await mdCommand?.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Failed to export session: Write permission denied',
+      });
+    });
+  });
+
+  describe('html subcommand', () => {
+    it('should export session to HTML file', async () => {
+      const htmlCommand = exportCommand.subCommands?.[1];
+      expect(htmlCommand).toBeDefined();
+
+      const result = await htmlCommand?.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Session exported to HTML: export-2025-01-01T00-00-00-000Z.html',
+      });
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/dir/export-2025-01-01T00-00-00-000Z.html',
+        '<html><script id="chat-data" type="application/json">{"data": "test"}</script></html>',
+        'utf-8',
+      );
+    });
+  });
+
+  describe('json subcommand', () => {
+    it('should export session to JSON file', async () => {
+      const jsonCommand = exportCommand.subCommands?.[2];
+      expect(jsonCommand).toBeDefined();
+
+      const result = await jsonCommand?.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Session exported to JSON: export-2025-01-01T00-00-00-000Z.json',
+      });
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/dir/export-2025-01-01T00-00-00-000Z.json',
+        '{ "sessionId": "test-session-id" }',
+        'utf-8',
+      );
+    });
+  });
+
+  describe('jsonl subcommand', () => {
+    it('should export session to JSONL file', async () => {
+      const jsonlCommand = exportCommand.subCommands?.[3];
+      expect(jsonlCommand).toBeDefined();
+
+      const result = await jsonlCommand?.action?.(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Session exported to JSONL: export-2025-01-01T00-00-00-000Z.jsonl',
+      });
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/dir/export-2025-01-01T00-00-00-000Z.jsonl',
+        '{"type":"session_metadata","sessionId":"test-session-id"}',
+        'utf-8',
+      );
+    });
+  });
+});

--- a/src/copilot-shell/packages/cli/src/ui/commands/exportCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/exportCommand.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  type CommandContext,
+  type SlashCommand,
+  type MessageActionReturn,
+  CommandKind,
+} from './types.js';
+import { SessionService } from '@copilot-shell/core';
+import {
+  collectSessionData,
+  normalizeSessionData,
+  toMarkdown,
+  toHtml,
+  toJson,
+  toJsonl,
+  generateExportFilename,
+  type ExportSessionData,
+} from '../utils/export/index.js';
+import { t } from '../../i18n/index.js';
+
+/**
+ * Format type for export.
+ */
+type ExportFormat = 'md' | 'html' | 'json' | 'jsonl';
+
+/**
+ * Format configuration mapping.
+ */
+const FORMAT_CONFIG: Record<
+  ExportFormat,
+  {
+    formatter: (data: ExportSessionData) => string;
+    successKey: string;
+  }
+> = {
+  md: {
+    formatter: toMarkdown,
+    successKey: 'Session exported to markdown: {{filename}}',
+  },
+  html: {
+    formatter: toHtml,
+    successKey: 'Session exported to HTML: {{filename}}',
+  },
+  json: {
+    formatter: toJson,
+    successKey: 'Session exported to JSON: {{filename}}',
+  },
+  jsonl: {
+    formatter: toJsonl,
+    successKey: 'Session exported to JSONL: {{filename}}',
+  },
+};
+
+/**
+ * Generic export action - exports session to specified format.
+ * @param context Command context
+ * @param format Export format (md, html, json, jsonl)
+ */
+async function exportSessionAction(
+  context: CommandContext,
+  format: ExportFormat,
+): Promise<MessageActionReturn> {
+  const { services } = context;
+  const { config } = services;
+
+  if (!config) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Configuration not available.'),
+    };
+  }
+
+  const cwd = config.getWorkingDir() || config.getProjectRoot();
+  if (!cwd) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Could not determine current working directory.'),
+    };
+  }
+
+  try {
+    // Load the current session
+    const sessionService = new SessionService(cwd);
+    const sessionData = await sessionService.loadLastSession();
+
+    if (!sessionData) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('No active session found to export.'),
+      };
+    }
+
+    const { conversation } = sessionData;
+
+    // Collect and normalize export data (SSOT)
+    const exportData = await collectSessionData(conversation, config);
+    const normalizedData = normalizeSessionData(
+      exportData,
+      conversation.messages,
+      config,
+    );
+
+    // Get format configuration
+    const { formatter, successKey } = FORMAT_CONFIG[format];
+
+    // Generate content from SSOT
+    const content = formatter(normalizedData);
+
+    const filename = generateExportFilename(format);
+    const filepath = path.join(cwd, filename);
+
+    // Write to file
+    await fs.writeFile(filepath, content, 'utf-8');
+
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: t(successKey, { filename }),
+    };
+  } catch (error) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Failed to export session: {{error}}', {
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    };
+  }
+}
+
+/**
+ * Action for the 'md' subcommand - exports session to markdown.
+ */
+async function exportMarkdownAction(
+  context: CommandContext,
+): Promise<MessageActionReturn> {
+  return exportSessionAction(context, 'md');
+}
+
+/**
+ * Action for the 'html' subcommand - exports session to HTML.
+ */
+async function exportHtmlAction(
+  context: CommandContext,
+): Promise<MessageActionReturn> {
+  return exportSessionAction(context, 'html');
+}
+
+/**
+ * Action for the 'json' subcommand - exports session to JSON.
+ */
+async function exportJsonAction(
+  context: CommandContext,
+): Promise<MessageActionReturn> {
+  return exportSessionAction(context, 'json');
+}
+
+/**
+ * Action for the 'jsonl' subcommand - exports session to JSONL.
+ */
+async function exportJsonlAction(
+  context: CommandContext,
+): Promise<MessageActionReturn> {
+  return exportSessionAction(context, 'jsonl');
+}
+
+/**
+ * Default export action - exports session to markdown format.
+ * This is the default behavior when `/export` is called without a subcommand.
+ */
+async function exportDefaultAction(
+  context: CommandContext,
+): Promise<MessageActionReturn> {
+  return exportSessionAction(context, 'md');
+}
+
+/**
+ * Export command for exporting session history to various formats.
+ * Default behavior: export to markdown format.
+ */
+export const exportCommand: SlashCommand = {
+  name: 'export',
+  kind: CommandKind.BUILT_IN,
+  get description() {
+    return t('Export current session message history to a file');
+  },
+  action: exportDefaultAction,
+  subCommands: [
+    {
+      name: 'md',
+      kind: CommandKind.BUILT_IN,
+      get description() {
+        return t('Export to Markdown format');
+      },
+      action: exportMarkdownAction,
+    },
+    {
+      name: 'html',
+      kind: CommandKind.BUILT_IN,
+      get description() {
+        return t('Export to HTML format');
+      },
+      action: exportHtmlAction,
+    },
+    {
+      name: 'json',
+      kind: CommandKind.BUILT_IN,
+      get description() {
+        return t('Export to JSON format');
+      },
+      action: exportJsonAction,
+    },
+    {
+      name: 'jsonl',
+      kind: CommandKind.BUILT_IN,
+      get description() {
+        return t('Export to JSONL format');
+      },
+      action: exportJsonlAction,
+    },
+  ],
+};

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/collect.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/collect.ts
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Config, ChatRecord } from '@copilot-shell/core';
+import type { SessionContext } from '../../../acp-integration/session/types.js';
+import type * as acp from '../../../acp-integration/acp.js';
+import { HistoryReplayer } from '../../../acp-integration/session/HistoryReplayer.js';
+import type { ExportMessage, ExportSessionData } from './types.js';
+
+/**
+ * Export session context that captures session updates into export messages.
+ * Implements SessionContext to work with HistoryReplayer.
+ */
+class ExportSessionContext implements SessionContext {
+  readonly sessionId: string;
+  readonly config: Config;
+  private messages: ExportMessage[] = [];
+  private currentMessage: {
+    type: 'user' | 'assistant';
+    role: 'user' | 'assistant' | 'thinking';
+    parts: Array<{ text: string }>;
+    timestamp: number;
+  } | null = null;
+  private activeRecordId: string | null = null;
+  private toolCallMap: Map<string, ExportMessage['toolCall']> = new Map();
+
+  constructor(sessionId: string, config: Config) {
+    this.sessionId = sessionId;
+    this.config = config;
+  }
+
+  async sendUpdate(update: acp.SessionUpdate): Promise<void> {
+    switch (update.sessionUpdate) {
+      case 'user_message_chunk':
+        this.handleMessageChunk('user', update.content);
+        break;
+      case 'agent_message_chunk':
+        this.handleMessageChunk('assistant', update.content);
+        break;
+      case 'agent_thought_chunk':
+        this.handleMessageChunk('assistant', update.content, 'thinking');
+        break;
+      case 'tool_call':
+        this.flushCurrentMessage();
+        this.handleToolCallStart(update);
+        break;
+      case 'tool_call_update':
+        this.handleToolCallUpdate(update);
+        break;
+      default:
+        // Ignore other update types
+        break;
+    }
+  }
+
+  setActiveRecordId(recordId: string | null): void {
+    this.activeRecordId = recordId;
+  }
+
+  private getMessageUuid(): string {
+    return this.activeRecordId ?? randomUUID();
+  }
+
+  private handleMessageChunk(
+    role: 'user' | 'assistant',
+    content: { type: string; text?: string },
+    messageRole: 'user' | 'assistant' | 'thinking' = role,
+  ): void {
+    if (content.type !== 'text' || !content.text) return;
+
+    // If we're starting a new message type, flush the previous one
+    if (
+      this.currentMessage &&
+      (this.currentMessage.type !== role ||
+        this.currentMessage.role !== messageRole)
+    ) {
+      this.flushCurrentMessage();
+    }
+
+    // Add to current message or create new one
+    if (
+      this.currentMessage &&
+      this.currentMessage.type === role &&
+      this.currentMessage.role === messageRole
+    ) {
+      this.currentMessage.parts.push({ text: content.text });
+    } else {
+      this.currentMessage = {
+        type: role,
+        role: messageRole,
+        parts: [{ text: content.text }],
+        timestamp: Date.now(),
+      };
+    }
+  }
+
+  private flushCurrentMessage(): void {
+    if (!this.currentMessage) return;
+
+    const message: ExportMessage = {
+      uuid: this.getMessageUuid(),
+      timestamp: new Date(this.currentMessage.timestamp).toISOString(),
+      type: this.currentMessage.type,
+      message: {
+        role: this.currentMessage.role,
+        parts: this.currentMessage.parts,
+      },
+    };
+
+    this.messages.push(message);
+    this.currentMessage = null;
+  }
+
+  private handleToolCallStart(update: acp.SessionUpdate): void {
+    if (update.sessionUpdate !== 'tool_call') return;
+
+    const toolCall: ExportMessage['toolCall'] = {
+      toolCallId: update.toolCallId,
+      kind: update.kind,
+      title: update.title,
+      status: 'pending',
+      // Cast rawInput from unknown to string | object | undefined
+      rawInput: update.rawInput as string | object | undefined,
+      locations: update.locations,
+    };
+
+    this.toolCallMap.set(update.toolCallId, toolCall);
+
+    const message: ExportMessage = {
+      uuid: randomUUID(),
+      timestamp: new Date().toISOString(),
+      type: 'tool_call',
+      toolCall,
+    };
+
+    this.messages.push(message);
+  }
+
+  private handleToolCallUpdate(update: acp.SessionUpdate): void {
+    if (update.sessionUpdate !== 'tool_call_update') return;
+
+    const existingToolCall = this.toolCallMap.get(update.toolCallId);
+    if (!existingToolCall) return;
+
+    // Update status
+    if (update.status) {
+      existingToolCall.status = update.status;
+    }
+
+    // Update content
+    if (update.content && update.content.length > 0) {
+      if (!existingToolCall.content) {
+        existingToolCall.content = [];
+      }
+      // update.content is an array, push each item individually
+      for (const item of update.content) {
+        existingToolCall.content.push(item);
+      }
+    }
+  }
+
+  getExportSessionData(startTime: string): ExportSessionData {
+    // Flush any remaining message
+    this.flushCurrentMessage();
+
+    return {
+      sessionId: this.sessionId,
+      startTime,
+      messages: this.messages,
+    };
+  }
+}
+
+/**
+ * Collects session data from ChatRecords using HistoryReplayer.
+ * This produces the initial ExportSessionData (SSOT) which is then normalized.
+ */
+export async function collectSessionData(
+  conversation: {
+    sessionId: string;
+    startTime: string;
+    messages: ChatRecord[];
+  },
+  config: Config,
+): Promise<ExportSessionData> {
+  const context = new ExportSessionContext(conversation.sessionId, config);
+  const replayer = new HistoryReplayer(context);
+
+  // Replay all records through the context
+  await replayer.replay(conversation.messages);
+
+  return context.getExportSessionData(conversation.startTime);
+}

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/html.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/html.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExportSessionData } from '../types.js';
+import { HTML_TEMPLATE } from './htmlTemplate.js';
+
+/**
+ * Escapes JSON for safe embedding in HTML.
+ */
+function escapeJsonForHtml(json: string): string {
+  return json
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+}
+
+/**
+ * Loads the HTML template.
+ * Currently we use an embedded html string.
+ * Consider using online html template in the future.
+ */
+export function loadHtmlTemplate(): string {
+  return HTML_TEMPLATE;
+}
+
+/**
+ * Injects JSON data into the HTML template.
+ */
+export function injectDataIntoHtmlTemplate(
+  template: string,
+  data: {
+    sessionId: string;
+    startTime: string;
+    messages: unknown[];
+  },
+): string {
+  const jsonData = JSON.stringify(data, null, 2);
+  const escapedJsonData = escapeJsonForHtml(jsonData);
+  const html = template.replace(
+    /<script id="chat-data" type="application\/json">\s*\/\/ DATA_PLACEHOLDER:.*?\s*<\/script>/s,
+    `<script id="chat-data" type="application/json">\n${escapedJsonData}\n    </script>`,
+  );
+  return html;
+}
+
+/**
+ * Converts ExportSessionData to HTML format.
+ */
+export function toHtml(sessionData: ExportSessionData): string {
+  const template = loadHtmlTemplate();
+  return injectDataIntoHtmlTemplate(template, sessionData);
+}

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/htmlTemplate.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/htmlTemplate.ts
@@ -1,0 +1,405 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * HTML template for chat export.
+ * Uses embedded styles and JavaScript for a self-contained export file.
+ */
+export const HTML_TEMPLATE = `<!DOCTYPE html>
+<html lang="en" class="dark">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Copilot Shell Chat Export</title>
+
+  <style>
+    :root {
+      --bg-primary: #18181b;
+      --bg-secondary: #27272a;
+      --bg-user: #3b82f6;
+      --bg-assistant: #27272a;
+      --text-primary: #f4f4f5;
+      --text-secondary: #a1a1aa;
+      --border-color: #3f3f46;
+      --accent-color: #3b82f6;
+    }
+
+    body {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      margin: 0;
+      padding: 0;
+      background-color: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .page-wrapper {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .header {
+      width: 100%;
+      padding: 16px 24px;
+      border-bottom: 1px solid var(--border-color);
+      background-color: rgba(24, 24, 27, 0.95);
+      backdrop-filter: blur(8px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      box-sizing: border-box;
+    }
+
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .logo {
+      font-size: 20px;
+      font-weight: 700;
+      color: var(--accent-color);
+    }
+
+    .meta {
+      display: flex;
+      gap: 24px;
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .meta-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .meta-label {
+      color: #71717a;
+    }
+
+    .chat-container {
+      width: 100%;
+      max-width: 900px;
+      padding: 40px 20px;
+      box-sizing: border-box;
+      flex: 1;
+    }
+
+    .message {
+      margin-bottom: 24px;
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .message-header {
+      padding: 12px 16px;
+      font-weight: 600;
+      font-size: 14px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .message-content {
+      padding: 16px;
+      background-color: var(--bg-secondary);
+      border-radius: 0 0 12px 12px;
+    }
+
+    .message.user .message-header {
+      background-color: var(--bg-user);
+    }
+
+    .message.assistant .message-header {
+      background-color: var(--bg-assistant);
+      border: 1px solid var(--border-color);
+      border-bottom: none;
+      border-radius: 12px 12px 0 0;
+    }
+
+    .message.assistant .message-content {
+      border: 1px solid var(--border-color);
+      border-top: none;
+    }
+
+    .message.tool_call .message-header {
+      background-color: #7c3aed;
+    }
+
+    .message.system .message-header {
+      background-color: #52525b;
+    }
+
+    .text-content {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    .tool-info {
+      font-size: 12px;
+      color: var(--text-secondary);
+      margin-top: 8px;
+    }
+
+    .tool-status {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 600;
+    }
+
+    .tool-status.completed {
+      background-color: #22c55e;
+      color: white;
+    }
+
+    .tool-status.failed {
+      background-color: #ef4444;
+      color: white;
+    }
+
+    .tool-status.in_progress {
+      background-color: #f59e0b;
+      color: white;
+    }
+
+    .tool-status.pending {
+      background-color: #6b7280;
+      color: white;
+    }
+
+    .code-block {
+      background-color: #1e1e1e;
+      border-radius: 8px;
+      padding: 12px;
+      margin: 8px 0;
+      overflow-x: auto;
+    }
+
+    .code-block pre {
+      margin: 0;
+      font-size: 13px;
+    }
+
+    /* Scrollbar styling */
+    ::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: var(--bg-primary);
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: var(--bg-secondary);
+      border-radius: 5px;
+      border: 2px solid var(--bg-primary);
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background: #52525b;
+    }
+
+    /* Responsive adjustments */
+    @media (max-width: 768px) {
+      .chat-container {
+        max-width: 100%;
+        padding: 20px 16px;
+      }
+
+      .header {
+        padding: 12px 16px;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+      }
+
+      .header-left {
+        width: 100%;
+        justify-content: space-between;
+      }
+
+      .meta {
+        width: 100%;
+        flex-direction: column;
+        gap: 6px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .chat-container {
+        padding: 16px 12px;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page-wrapper">
+    <div class="header">
+      <div class="header-left">
+        <div class="logo">Copilot Shell</div>
+      </div>
+      <div class="meta">
+        <div class="meta-item">
+          <span class="meta-label">Session Id</span>
+          <span id="session-id" class="font-mono">-</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Export Time</span>
+          <span id="session-date">-</span>
+        </div>
+      </div>
+    </div>
+
+    <div id="chat-container" class="chat-container"></div>
+  </div>
+
+  <script id="chat-data" type="application/json">
+    // DATA_PLACEHOLDER: Chat export data will be injected here
+  </script>
+
+  <script>
+    const chatDataElement = document.getElementById('chat-data');
+    const chatData = chatDataElement?.textContent
+      ? JSON.parse(chatDataElement.textContent)
+      : {};
+    const rawMessages = Array.isArray(chatData.messages) ? chatData.messages : [];
+    const messages = rawMessages.filter((record) => record && record.type !== 'system');
+
+    // Populate metadata
+    const sessionIdElement = document.getElementById('session-id');
+    if (sessionIdElement && chatData.sessionId) {
+      sessionIdElement.textContent = chatData.sessionId;
+    }
+
+    const sessionDateElement = document.getElementById('session-date');
+    if (sessionDateElement && chatData.startTime) {
+      try {
+        const date = new Date(chatData.startTime);
+        sessionDateElement.textContent = date.toLocaleString(undefined, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit'
+        });
+      } catch (e) {
+        sessionDateElement.textContent = chatData.startTime;
+      }
+    }
+
+    // Render messages
+    const container = document.getElementById('chat-container');
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function extractText(message) {
+      if (!message.message?.parts) return '';
+      return message.message.parts
+        .filter(part => 'text' in part)
+        .map(part => part.text)
+        .join('\\n');
+    }
+
+    function renderMessage(message) {
+      const div = document.createElement('div');
+      div.className = 'message ' + message.type;
+
+      const header = document.createElement('div');
+      header.className = 'message-header';
+
+      const content = document.createElement('div');
+      content.className = 'message-content';
+
+      if (message.type === 'user') {
+        header.textContent = 'User';
+        const textDiv = document.createElement('div');
+        textDiv.className = 'text-content';
+        textDiv.textContent = extractText(message);
+        content.appendChild(textDiv);
+      } else if (message.type === 'assistant') {
+        header.textContent = 'Assistant';
+        if (message.model) {
+          const modelSpan = document.createElement('span');
+          modelSpan.style.fontSize = '12px';
+          modelSpan.style.color = 'var(--text-secondary)';
+          modelSpan.textContent = ' (' + message.model + ')';
+          header.appendChild(modelSpan);
+        }
+        const textDiv = document.createElement('div');
+        textDiv.className = 'text-content';
+        textDiv.textContent = extractText(message);
+        content.appendChild(textDiv);
+      } else if (message.type === 'tool_call') {
+        const title = typeof message.toolCall?.title === 'string'
+          ? message.toolCall.title
+          : JSON.stringify(message.toolCall?.title || 'Unknown Tool');
+        header.textContent = 'Tool: ' + title;
+
+        if (message.toolCall) {
+          const infoDiv = document.createElement('div');
+          infoDiv.className = 'tool-info';
+
+          const statusSpan = document.createElement('span');
+          statusSpan.className = 'tool-status ' + message.toolCall.status;
+          statusSpan.textContent = message.toolCall.status;
+          infoDiv.appendChild(statusSpan);
+
+          if (message.toolCall.content && message.toolCall.content.length > 0) {
+            const codeDiv = document.createElement('div');
+            codeDiv.className = 'code-block';
+            const pre = document.createElement('pre');
+
+            for (const item of message.toolCall.content) {
+              if (item.type === 'content' && item.content) {
+                const contentData = item.content;
+                if (contentData.type === 'text' && contentData.text) {
+                  pre.textContent += contentData.text;
+                }
+              } else if (item.type === 'diff') {
+                pre.textContent += 'Diff for: ' + item.path + '\\n';
+                pre.textContent += item.newText || '';
+              }
+            }
+
+            codeDiv.appendChild(pre);
+            content.appendChild(codeDiv);
+          }
+
+          content.appendChild(infoDiv);
+        }
+      }
+
+      div.appendChild(header);
+      div.appendChild(content);
+      return div;
+    }
+
+    // Render all messages
+    for (const message of messages) {
+      container.appendChild(renderMessage(message));
+    }
+  </script>
+</body>
+
+</html>
+`;

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/json.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/json.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExportSessionData } from '../types.js';
+
+/**
+ * Converts ExportSessionData to JSON format.
+ * Outputs a single JSON object containing the entire session.
+ */
+export function toJson(sessionData: ExportSessionData): string {
+  return JSON.stringify(sessionData, null, 2);
+}

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/jsonl.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/jsonl.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExportSessionData } from '../types.js';
+
+/**
+ * Converts ExportSessionData to JSONL (JSON Lines) format.
+ * Each message is output as a separate JSON object on its own line.
+ */
+export function toJsonl(sessionData: ExportSessionData): string {
+  const lines: string[] = [];
+
+  // Add session metadata as the first line
+  lines.push(
+    JSON.stringify({
+      type: 'session_metadata',
+      sessionId: sessionData.sessionId,
+      startTime: sessionData.startTime,
+    }),
+  );
+
+  // Add each message as a separate line
+  for (const message of sessionData.messages) {
+    lines.push(JSON.stringify(message));
+  }
+
+  return lines.join('\n');
+}

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/markdown.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/formatters/markdown.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExportSessionData, ExportMessage } from '../types.js';
+
+/**
+ * Converts ExportSessionData to markdown format.
+ */
+export function toMarkdown(sessionData: ExportSessionData): string {
+  const lines: string[] = [];
+
+  // Add header with metadata
+  lines.push('# Chat Session Export\n');
+  lines.push(`**Session ID**: ${sessionData.sessionId}\n`);
+  lines.push(`**Start Time**: ${sessionData.startTime}\n`);
+  lines.push(`**Exported**: ${new Date().toISOString()}\n`);
+  lines.push('---\n');
+
+  // Process each message
+  for (const message of sessionData.messages) {
+    if (message.type === 'user') {
+      lines.push('## User\n');
+      const text = extractTextFromMessage(message);
+      lines.push(`${text}\n`);
+    } else if (message.type === 'assistant') {
+      lines.push('## Assistant\n');
+      const text = extractTextFromMessage(message);
+      lines.push(`${text}\n`);
+    } else if (message.type === 'tool_call') {
+      lines.push('## Tool Call\n');
+      if (message.toolCall) {
+        const title =
+          typeof message.toolCall.title === 'string'
+            ? message.toolCall.title
+            : JSON.stringify(message.toolCall.title);
+        lines.push(`**Tool**: ${title}\n`);
+        lines.push(`**Status**: ${message.toolCall.status}\n`);
+
+        if (message.toolCall.content && message.toolCall.content.length > 0) {
+          lines.push('```\n');
+          for (const contentItem of message.toolCall.content) {
+            if (contentItem.type === 'content' && contentItem['content']) {
+              const contentData = contentItem['content'] as {
+                type: string;
+                text?: string;
+              };
+              if (contentData.type === 'text' && contentData.text) {
+                lines.push(contentData.text);
+              }
+            } else if (contentItem.type === 'diff') {
+              lines.push(`Diff for: ${contentItem['path']}\n`);
+              lines.push(`${contentItem['newText']}\n`);
+            }
+          }
+          lines.push('\n```\n');
+        }
+      }
+    } else if (message.type === 'system') {
+      // Skip system messages or format them minimally
+      lines.push('_[System message]_\n');
+    }
+
+    lines.push('\n');
+  }
+
+  return lines.join('');
+}
+
+/**
+ * Extracts text content from an export message.
+ */
+function extractTextFromMessage(message: ExportMessage): string {
+  if (!message.message?.parts) return '';
+
+  const textParts: string[] = [];
+  for (const part of message.message.parts) {
+    if ('text' in part) {
+      textParts.push(part.text);
+    }
+  }
+
+  return textParts.join('\n');
+}

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/index.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type { ExportMessage, ExportSessionData } from './types.js';
+export { collectSessionData } from './collect.js';
+export { normalizeSessionData } from './normalize.js';
+export { toMarkdown } from './formatters/markdown.js';
+export {
+  toHtml,
+  loadHtmlTemplate,
+  injectDataIntoHtmlTemplate,
+} from './formatters/html.js';
+export { toJson } from './formatters/json.js';
+export { toJsonl } from './formatters/jsonl.js';
+export { generateExportFilename } from './utils.js';

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/normalize.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/normalize.ts
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Part } from '@google/genai';
+import type {
+  ChatRecord,
+  Config,
+  ToolResultDisplay,
+} from '@copilot-shell/core';
+import type { ExportMessage, ExportSessionData } from './types.js';
+
+/**
+ * Normalizes export session data by merging tool call information from tool_result records.
+ * This ensures the SSOT contains complete tool call metadata.
+ */
+export function normalizeSessionData(
+  sessionData: ExportSessionData,
+  originalRecords: ChatRecord[],
+  config: Config,
+): ExportSessionData {
+  const normalized = [...sessionData.messages];
+  const toolCallIndexById = new Map<string, number>();
+
+  // Build index of tool call messages
+  normalized.forEach((message, index) => {
+    if (message.type === 'tool_call' && message.toolCall?.toolCallId) {
+      toolCallIndexById.set(message.toolCall.toolCallId, index);
+    }
+  });
+
+  // Merge tool result information into tool call messages
+  for (const record of originalRecords) {
+    if (record.type !== 'tool_result') continue;
+
+    const toolCallMessage = buildToolCallMessageFromResult(record, config);
+    if (!toolCallMessage?.toolCall) continue;
+
+    const existingIndex = toolCallIndexById.get(
+      toolCallMessage.toolCall.toolCallId,
+    );
+
+    if (existingIndex === undefined) {
+      // No existing tool call, add this one
+      toolCallIndexById.set(
+        toolCallMessage.toolCall.toolCallId,
+        normalized.length,
+      );
+      normalized.push(toolCallMessage);
+      continue;
+    }
+
+    // Merge into existing tool call
+    const existingMessage = normalized[existingIndex];
+    if (existingMessage.type !== 'tool_call' || !existingMessage.toolCall) {
+      continue;
+    }
+
+    mergeToolCallData(existingMessage.toolCall, toolCallMessage.toolCall);
+  }
+
+  return {
+    ...sessionData,
+    messages: normalized,
+  };
+}
+
+/**
+ * Merges incoming tool call data into existing tool call.
+ */
+function mergeToolCallData(
+  existing: NonNullable<ExportMessage['toolCall']>,
+  incoming: NonNullable<ExportMessage['toolCall']>,
+): void {
+  if (!existing.content || existing.content.length === 0) {
+    existing.content = incoming.content;
+  }
+  if (existing.status === 'pending' || existing.status === 'in_progress') {
+    existing.status = incoming.status;
+  }
+  if (!existing.rawInput && incoming.rawInput) {
+    existing.rawInput = incoming.rawInput;
+  }
+  if (!existing.kind || existing.kind === 'other') {
+    existing.kind = incoming.kind;
+  }
+  if ((!existing.title || existing.title === '') && incoming.title) {
+    existing.title = incoming.title;
+  }
+  if (
+    (!existing.locations || existing.locations.length === 0) &&
+    incoming.locations &&
+    incoming.locations.length > 0
+  ) {
+    existing.locations = incoming.locations;
+  }
+}
+
+/**
+ * Builds a tool call message from a tool_result ChatRecord.
+ */
+function buildToolCallMessageFromResult(
+  record: ChatRecord,
+  _config: Config,
+): ExportMessage | null {
+  if (!record.toolCallResult) return null;
+
+  const toolCallId = record.toolCallResult.callId;
+  if (!toolCallId) return null;
+
+  // Extract tool name from functionResponse if available
+  let toolName = 'Unknown Tool';
+  if (record.message?.parts) {
+    for (const part of record.message.parts) {
+      if ('functionResponse' in part && part.functionResponse?.name) {
+        toolName = part.functionResponse.name;
+        break;
+      }
+    }
+  }
+
+  // Build tool call data
+  const toolCall: ExportMessage['toolCall'] = {
+    toolCallId,
+    kind: 'other',
+    title: toolName,
+    status: record.toolCallResult.error ? 'failed' : 'completed',
+    content: [],
+  };
+
+  // Add response content
+  if (record.toolCallResult.responseParts && toolCall.content) {
+    toolCall.content.push({
+      type: 'content',
+      content: {
+        type: 'text',
+        text: partsToText(record.toolCallResult.responseParts),
+      },
+    });
+  }
+
+  // Add result display if available
+  if (record.toolCallResult.resultDisplay && toolCall.content) {
+    const displayContent = formatResultDisplay(
+      record.toolCallResult.resultDisplay,
+    );
+    if (displayContent) {
+      toolCall.content.push(displayContent);
+    }
+  }
+
+  return {
+    uuid: record.uuid,
+    parentUuid: record.parentUuid,
+    sessionId: record.sessionId,
+    timestamp: record.timestamp,
+    type: 'tool_call',
+    toolCall,
+  };
+}
+
+/**
+ * Converts Part[] to text string.
+ */
+function partsToText(parts: Part[]): string {
+  const textParts: string[] = [];
+  for (const part of parts) {
+    if ('text' in part && part.text) {
+      textParts.push(part.text);
+    }
+  }
+  return textParts.join('\n');
+}
+
+/**
+ * Content item type for tool call display.
+ */
+type ToolCallContentItem = {
+  type: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Formats ToolResultDisplay into export content format.
+ */
+function formatResultDisplay(
+  display: ToolResultDisplay,
+): ToolCallContentItem | null {
+  if (typeof display === 'string') {
+    return {
+      type: 'content',
+      content: {
+        type: 'text',
+        text: display,
+      },
+    };
+  }
+
+  // Handle different display types
+  if ('fileDiff' in display) {
+    return {
+      type: 'diff',
+      path: display.fileName,
+      oldText: display.originalContent || '',
+      newText: display.newContent,
+    };
+  }
+
+  if ('type' in display) {
+    if (display.type === 'todo_list') {
+      return {
+        type: 'content',
+        content: {
+          type: 'text',
+          text: JSON.stringify(display.todos, null, 2),
+        },
+      };
+    }
+
+    if (display.type === 'plan_summary') {
+      return {
+        type: 'content',
+        content: {
+          type: 'text',
+          text: display.message + '\n\n' + display.plan,
+        },
+      };
+    }
+
+    if (display.type === 'task_execution') {
+      // TaskResultDisplay from TaskTool
+      return {
+        type: 'content',
+        content: {
+          type: 'text',
+          text: JSON.stringify(display, null, 2),
+        },
+      };
+    }
+  }
+
+  // Unknown display type
+  return {
+    type: 'content',
+    content: {
+      type: 'text',
+      text: JSON.stringify(display, null, 2),
+    },
+  };
+}

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/types.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/types.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Universal export message format - SSOT for all export formats.
+ * This is format-agnostic and contains all information needed for any export type.
+ */
+export interface ExportMessage {
+  uuid: string;
+  parentUuid?: string | null;
+  sessionId?: string;
+  timestamp: string;
+  type: 'user' | 'assistant' | 'system' | 'tool_call';
+
+  /** For user/assistant messages */
+  message?: {
+    role?: string;
+    parts?: Array<{ text: string }>;
+    content?: string;
+  };
+
+  /** Model used for assistant messages */
+  model?: string;
+
+  /** For tool_call messages */
+  toolCall?: {
+    toolCallId: string;
+    kind: string;
+    title: string | object;
+    status: 'pending' | 'in_progress' | 'completed' | 'failed';
+    rawInput?: string | object;
+    content?: Array<{
+      type: string;
+      [key: string]: unknown;
+    }>;
+    locations?: Array<{
+      path: string;
+      line?: number | null;
+    }>;
+    timestamp?: number;
+  };
+}
+
+/**
+ * Complete export session data - the single source of truth.
+ */
+export interface ExportSessionData {
+  sessionId: string;
+  startTime: string;
+  messages: ExportMessage[];
+}

--- a/src/copilot-shell/packages/cli/src/ui/utils/export/utils.ts
+++ b/src/copilot-shell/packages/cli/src/ui/utils/export/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Generates a filename with timestamp for export files.
+ */
+export function generateExportFilename(extension: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `export-${timestamp}.${extension}`;
+}


### PR DESCRIPTION
## Description

feat: add export command for session history.support html/json/jsonl/md export

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #238 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->
/export json
/export md

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
