### PR TITLE
feat(sec-core): add skill-ledger CLI for skill integrity tracking and signing

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "cryptography>=42.0",
     "gnupg>=2.0",
     "pydantic>=2.0",
     "typer>=0.9.0",
@@ -47,6 +48,7 @@ dev = [
 
 [project.scripts]
 agent-sec-cli = "agent_sec_cli.cli:main"
+skill-ledger = "agent_sec_cli.skill_ledger.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/alibaba/anolisa"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/__init__.py
@@ -1,0 +1,1 @@
+"""skill-ledger — Skill change-tracking, integrity verification, and tamper-proof signing."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
@@ -1,0 +1,349 @@
+"""skill-ledger CLI — Typer application with all subcommands.
+
+Entry point:  ``skill-ledger = "agent_sec_cli.skill_ledger.cli:main"``
+"""
+
+import json
+import logging
+from typing import Optional
+
+import typer
+
+from agent_sec_cli.skill_ledger.errors import SkillLedgerError
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(
+    name="skill-ledger",
+    help="Skill change-tracking, integrity verification, and tamper-proof signing.",
+    add_completion=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_backend():
+    """Instantiate the configured signing backend (currently always Ed25519)."""
+    from agent_sec_cli.skill_ledger.signing.ed25519 import NativeEd25519Backend
+
+    return NativeEd25519Backend()
+
+
+def _emit_event(event_type: str, category: str, details: dict) -> None:
+    """Fire-and-forget security event logging (integration with security_events)."""
+    try:
+        from agent_sec_cli.security_events import SecurityEvent, log_event
+
+        log_event(
+            SecurityEvent(
+                event_type=event_type,
+                category=category,
+                details=details,
+            )
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to emit security event %r", event_type, exc_info=True)
+
+
+def _json_output(data: dict) -> None:
+    """Print compact JSON to stdout (hook-compatible one-liner)."""
+    typer.echo(json.dumps(data, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# init-keys
+# ---------------------------------------------------------------------------
+
+
+@app.command("init-keys")
+def cmd_init_keys(
+    force: bool = typer.Option(False, "--force", help="Overwrite existing keys"),
+    use_passphrase: bool = typer.Option(
+        False, "--passphrase", help="Encrypt the private key with a passphrase"
+    ),
+) -> None:
+    """Generate Ed25519 signing key pair.
+
+    By default the private key is stored **unencrypted** (no interactive
+    prompt).  Pass ``--passphrase`` to encrypt it, or set the
+    ``SKILL_LEDGER_PASSPHRASE`` environment variable.
+    """
+    import os
+
+    from agent_sec_cli.skill_ledger.signing.key_manager import ensure_keys_not_exist
+
+    try:
+        ensure_keys_not_exist(force=force)
+    except SkillLedgerError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+
+    # Resolve passphrase: env-var > --passphrase flag > None (no encryption)
+    passphrase: str | None = None
+    env_pass = os.environ.get("SKILL_LEDGER_PASSPHRASE")
+    if env_pass:
+        passphrase = env_pass
+    elif use_passphrase:
+        import getpass
+
+        passphrase = getpass.getpass("Enter passphrase for new signing key: ")
+        confirm = getpass.getpass("Confirm passphrase: ")
+        if passphrase != confirm:
+            typer.echo("Error: passphrases do not match", err=True)
+            raise typer.Exit(code=1)
+        if not passphrase:
+            typer.echo("Error: passphrase cannot be empty", err=True)
+            raise typer.Exit(code=1)
+
+    backend = _get_backend()
+    try:
+        result = backend.generate_keys(passphrase)
+    except Exception as exc:
+        typer.echo(f"Error generating keys: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    _emit_event("skill_ledger_init_keys", "skill_ledger", {"fingerprint": result["fingerprint"]})
+    _json_output(result)
+
+
+# ---------------------------------------------------------------------------
+# check
+# ---------------------------------------------------------------------------
+
+
+@app.command("check")
+def cmd_check(
+    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+) -> None:
+    """Check skill integrity status (used by hooks)."""
+    from agent_sec_cli.skill_ledger.core.checker import check
+
+    backend = _get_backend()
+    try:
+        result = check(skill_dir, backend)
+    except SkillLedgerError as exc:
+        _json_output({"status": "error", "error": str(exc)})
+        raise typer.Exit(code=1)
+
+    _emit_event("skill_ledger_check", "skill_ledger", result)
+    _json_output(result)
+
+    # Non-zero exit for security-critical states so callers can gate on $?
+    status = result.get("status", "")
+    if status in ("tampered", "deny"):
+        raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# certify
+# ---------------------------------------------------------------------------
+
+
+@app.command("certify")
+def cmd_certify(
+    skill_dir: Optional[str] = typer.Argument(None, help="Path to skill directory"),
+    findings: Optional[str] = typer.Option(
+        None, "--findings", help="Path to findings JSON file (external mode)"
+    ),
+    scanner: str = typer.Option(
+        "skill-vetter", "--scanner", help="Scanner identifier (used with --findings)"
+    ),
+    scanner_version: str = typer.Option(
+        "0.1.0", "--scanner-version", help="Scanner version"
+    ),
+    scanners: Optional[str] = typer.Option(
+        None, "--scanners", help="Comma-separated scanner names for auto-invoke mode"
+    ),
+    all_skills: bool = typer.Option(
+        False, "--all", help="Certify all skills from config.json skillDirs"
+    ),
+) -> None:
+    """Create or update a signed manifest with scan findings.
+
+    Two input modes:
+
+    - With --findings: read an external findings file (e.g. from skill-vetter).
+
+    - Without --findings: auto-invoke registered non-skill scanners.
+      (In v1 only skill-vetter is registered; auto-invoke has no effect.)
+    """
+    from agent_sec_cli.skill_ledger.core.certifier import certify, certify_batch
+
+    backend = _get_backend()
+    scanner_names = [s.strip() for s in scanners.split(",")] if scanners else None
+
+    try:
+        if all_skills:
+            from agent_sec_cli.skill_ledger.config import resolve_skill_dirs
+
+            dirs = resolve_skill_dirs()
+            if not dirs:
+                typer.echo("No skill directories found in config.json", err=True)
+                raise typer.Exit(code=1)
+            results = certify_batch(
+                dirs,
+                backend,
+                findings_path=findings,
+                scanner=scanner,
+                scanner_version=scanner_version,
+                scanner_names=scanner_names,
+            )
+            _emit_event("skill_ledger_certify_batch", "skill_ledger", {"results": results})
+            _json_output({"results": results})
+        else:
+            if skill_dir is None:
+                typer.echo("Error: skill_dir is required (or use --all)", err=True)
+                raise typer.Exit(code=1)
+            result = certify(
+                skill_dir,
+                backend,
+                findings_path=findings,
+                scanner=scanner,
+                scanner_version=scanner_version,
+                scanner_names=scanner_names,
+            )
+            _emit_event("skill_ledger_certify", "skill_ledger", result)
+            _json_output(result)
+    except SkillLedgerError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+@app.command("status")
+def cmd_status(
+    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+) -> None:
+    """Show human-readable skill status (for debugging)."""
+    from agent_sec_cli.skill_ledger.core.checker import check
+    from agent_sec_cli.skill_ledger.core.version_chain import (
+        list_version_ids,
+        load_latest_manifest,
+    )
+
+    backend = _get_backend()
+
+    # Run check
+    try:
+        result = check(skill_dir, backend)
+    except SkillLedgerError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    status = result.get("status", "unknown")
+    skill_name = _skill_name(skill_dir)
+
+    typer.echo(f"Skill:      {skill_name}")
+    typer.echo(f"Directory:  {skill_dir}")
+    typer.echo(f"Status:     {status}")
+
+    manifest = load_latest_manifest(skill_dir)
+    if manifest is not None:
+        typer.echo(f"Version:    {manifest.versionId}")
+        typer.echo(f"scanStatus: {manifest.scanStatus}")
+        typer.echo(f"Policy:     {manifest.policy}")
+        typer.echo(f"Scans:      {len(manifest.scans)}")
+        typer.echo(f"Files:      {len(manifest.fileHashes)}")
+        if manifest.signature is not None:
+            typer.echo(f"Signed by:  {manifest.signature.keyFingerprint}")
+
+    versions = list_version_ids(skill_dir)
+    typer.echo(f"Versions:   {len(versions)}")
+
+    if status == "drifted":
+        typer.echo(f"  Added:    {result.get('added', [])}")
+        typer.echo(f"  Removed:  {result.get('removed', [])}")
+        typer.echo(f"  Modified: {result.get('modified', [])}")
+    elif status == "tampered":
+        typer.echo(f"  Reason:   {result.get('reason', '')}")
+
+
+# ---------------------------------------------------------------------------
+# audit
+# ---------------------------------------------------------------------------
+
+
+@app.command("audit")
+def cmd_audit(
+    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+    verify_snapshots: bool = typer.Option(
+        False, "--verify-snapshots", help="Also verify snapshot file hashes"
+    ),
+) -> None:
+    """Deep-verify version chain integrity."""
+    from agent_sec_cli.skill_ledger.core.auditor import audit
+
+    backend = _get_backend()
+
+    try:
+        result = audit(skill_dir, backend, verify_snapshots=verify_snapshots)
+    except SkillLedgerError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    _emit_event("skill_ledger_audit", "skill_ledger", result)
+    _json_output(result)
+
+    if not result["valid"]:
+        raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# set-policy (stub)
+# ---------------------------------------------------------------------------
+
+
+@app.command("set-policy")
+def cmd_set_policy(
+    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+    policy: str = typer.Option(
+        ..., "--policy", help="Execution policy: allow | block | warning"
+    ),
+) -> None:
+    """Set skill execution policy (coming soon)."""
+    typer.echo("set-policy: this feature is coming soon.")
+    raise typer.Exit(code=0)
+
+
+# ---------------------------------------------------------------------------
+# rotate-keys (stub)
+# ---------------------------------------------------------------------------
+
+
+@app.command("rotate-keys")
+def cmd_rotate_keys() -> None:
+    """Rotate signing keys (coming soon)."""
+    typer.echo("rotate-keys: this feature is coming soon.")
+    raise typer.Exit(code=0)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _skill_name(skill_dir: str) -> str:
+    from pathlib import Path
+
+    return Path(skill_dir).name
+
+
+# ---------------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point for the ``skill-ledger`` CLI."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
@@ -1,0 +1,116 @@
+"""Configuration loading for skill-ledger (``~/.config/skill-ledger/config.json``)."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.skill_ledger.errors import ConfigError
+from agent_sec_cli.skill_ledger.paths import get_config_dir
+
+_DEFAULT_CONFIG: dict[str, Any] = {
+    "signingBackend": "ed25519",
+    "skillDirs": [],
+    # ── Scanner / parser registry (see design doc §2) ──
+    "scanners": [
+        {
+            "name": "skill-vetter",
+            "type": "skill",
+            "parser": "findings-array",
+            "description": "LLM-driven 4-phase skill audit",
+        },
+    ],
+    "parsers": {
+        "findings-array": {
+            "type": "findings-array",
+        },
+    },
+}
+
+
+def config_path() -> Path:
+    """Return the path to ``config.json``."""
+    return get_config_dir() / "config.json"
+
+
+def _deep_merge_config(defaults: dict[str, Any], user: dict[str, Any]) -> dict[str, Any]:
+    """Merge *user* config onto *defaults* with list-of-dict awareness.
+
+    Rules:
+    - Scalar / list top-level keys: user value wins outright.
+    - ``scanners`` (list[dict]): merge by ``name`` — user entries override
+      defaults with the same ``name``; defaults not in user are preserved.
+    - ``parsers`` (dict[str, dict]): shallow dict merge per parser name.
+    """
+    merged = dict(defaults)
+    for key, user_val in user.items():
+        if key == "scanners" and isinstance(user_val, list):
+            # Index defaults by name for O(1) lookup
+            by_name: dict[str, dict[str, Any]] = {}
+            for s in defaults.get("scanners", []):
+                if isinstance(s, dict) and "name" in s:
+                    by_name[s["name"]] = s
+            # User entries override by name
+            for s in user_val:
+                if isinstance(s, dict) and "name" in s:
+                    by_name[s["name"]] = s
+            merged["scanners"] = list(by_name.values())
+        elif key == "parsers" and isinstance(user_val, dict):
+            merged_parsers = dict(defaults.get("parsers", {}))
+            merged_parsers.update(user_val)
+            merged["parsers"] = merged_parsers
+        else:
+            merged[key] = user_val
+    return merged
+
+
+def load_config() -> dict[str, Any]:
+    """Load and return the config file.  Returns defaults if the file does not exist."""
+    path = config_path()
+    if not path.is_file():
+        return dict(_DEFAULT_CONFIG)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        cfg = json.loads(raw)
+        if not isinstance(cfg, dict):
+            raise ConfigError(f"config.json must be a JSON object, got {type(cfg).__name__}")
+        return _deep_merge_config(_DEFAULT_CONFIG, cfg)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def resolve_skill_dirs(config: dict[str, Any] | None = None) -> list[Path]:
+    """Expand ``skillDirs`` entries (glob + single-dir) into concrete directories.
+
+    Supports two formats per entry:
+    - ``"path/*"`` — glob pattern: each matching subdirectory is a skill
+    - ``"path/to/skill"`` — single skill directory
+    """
+    if config is None:
+        config = load_config()
+
+    skill_dirs: list[Path] = []
+    for entry in config.get("skillDirs", []):
+        entry = str(entry)
+        expanded = Path(entry).expanduser()
+
+        if entry.endswith("/*"):
+            # Glob mode: parent directory, each subdirectory is a skill
+            parent = expanded.parent
+            if parent.is_dir():
+                for child in sorted(parent.iterdir()):
+                    if child.is_dir() and not child.name.startswith("."):
+                        skill_dirs.append(child)
+        else:
+            # Single directory
+            if expanded.is_dir():
+                skill_dirs.append(expanded)
+
+    return skill_dirs
+
+
+def save_config(config: dict[str, Any]) -> Path:
+    """Write *config* to ``config.json``.  Creates parent dirs if needed."""
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core business logic for skill-ledger operations."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
@@ -1,0 +1,147 @@
+"""Audit command — deep verification of the version chain integrity.
+
+Implements ``skill-ledger audit <skill_dir> [--verify-snapshots]``:
+
+1. Load all public keys (key.pub + keyring/)
+2. Walk versions/ chronologically
+3. Verify each manifest's hash, signature, and chain linkage
+4. Optionally verify snapshot file hashes
+"""
+
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.skill_ledger.core.file_hasher import compute_file_hashes, diff_file_hashes
+from agent_sec_cli.skill_ledger.core.version_chain import (
+    list_version_ids,
+    load_latest_manifest,
+    load_version_manifest,
+    snapshot_dir_path,
+)
+from agent_sec_cli.skill_ledger.errors import SignatureInvalidError
+from agent_sec_cli.skill_ledger.signing.base import SigningBackend
+
+
+def audit(
+    skill_dir: str,
+    backend: SigningBackend,
+    verify_snapshots: bool = False,
+) -> dict[str, Any]:
+    """Perform a deep integrity audit of the version chain.
+
+    Returns ``{"valid": bool, "versions_checked": int, "errors": [...]}``.
+    """
+    errors: list[dict[str, Any]] = []
+    version_ids = list_version_ids(skill_dir)
+
+    if not version_ids:
+        return {
+            "valid": True,
+            "versions_checked": 0,
+            "errors": [],
+            "message": "No versions found — nothing to audit",
+        }
+
+    prev_signature: str | None = None
+
+    for vid in version_ids:
+        manifest = load_version_manifest(skill_dir, vid)
+
+        if manifest is None:
+            errors.append({"versionId": vid, "error": f"Version file {vid}.json is missing"})
+            prev_signature = None
+            continue
+
+        # 3a: Verify manifestHash
+        expected_hash = manifest.compute_manifest_hash()
+        if manifest.manifestHash != expected_hash:
+            errors.append({
+                "versionId": vid,
+                "error": "manifestHash does not match manifest content",
+            })
+
+        # 3b: Verify signature
+        if manifest.signature is not None:
+            try:
+                backend.verify(
+                    manifest.manifestHash.encode("utf-8"),
+                    manifest.signature.value,
+                    manifest.signature.keyFingerprint,
+                )
+            except SignatureInvalidError as exc:
+                errors.append({"versionId": vid, "error": f"Signature invalid: {exc}"})
+        else:
+            errors.append({"versionId": vid, "error": "Missing signature"})
+
+        # 3c: Verify previousManifestSignature chain
+        if prev_signature is not None:
+            if manifest.previousManifestSignature != prev_signature:
+                errors.append({
+                    "versionId": vid,
+                    "error": (
+                        "previousManifestSignature does not match "
+                        "the prior version's signature — chain broken"
+                    ),
+                })
+        else:
+            if vid == version_ids[0]:
+                # First version: previousManifestSignature should be None
+                if manifest.previousManifestSignature is not None:
+                    errors.append({
+                        "versionId": vid,
+                        "error": "First version should have null previousManifestSignature",
+                    })
+            else:
+                # Previous version was missing — cannot verify chain linkage
+                errors.append({
+                    "versionId": vid,
+                    "error": (
+                        "Cannot verify previousManifestSignature — "
+                        "prior version manifest is missing"
+                    ),
+                })
+
+        # 3d: Optional snapshot verification
+        if verify_snapshots:
+            snap_path = snapshot_dir_path(skill_dir, vid)
+            if snap_path.is_dir():
+                snap_hashes = compute_file_hashes(str(snap_path))
+                diff = diff_file_hashes(manifest.fileHashes, snap_hashes)
+                if not diff["match"]:
+                    errors.append({
+                        "versionId": vid,
+                        "error": (
+                            f"Snapshot mismatch — added: {diff['added']}, "
+                            f"removed: {diff['removed']}, modified: {diff['modified']}"
+                        ),
+                    })
+            else:
+                errors.append({
+                    "versionId": vid,
+                    "error": f"Snapshot directory {vid}.snapshot/ is missing",
+                })
+
+        # Track signature for chain verification
+        if manifest.signature is not None:
+            prev_signature = manifest.signature.value
+        else:
+            prev_signature = None
+
+    # Verify latest.json consistency
+    latest = load_latest_manifest(skill_dir)
+    if latest is not None and version_ids:
+        expected_latest_vid = version_ids[-1]
+        if latest.versionId != expected_latest_vid:
+            errors.append({
+                "versionId": "latest.json",
+                "error": (
+                    f"latest.json points to {latest.versionId} "
+                    f"but latest version is {expected_latest_vid}"
+                ),
+            })
+
+    return {
+        "valid": len(errors) == 0,
+        "versions_checked": len(version_ids),
+        "errors": errors,
+    }

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
@@ -1,0 +1,292 @@
+"""Certify command — three-phase manifest creation and scan-result signing.
+
+Implements ``skill-ledger certify`` with two input modes:
+
+- **External findings mode** (``--findings``): read a findings file produced
+  by an external scanner (e.g. skill-vetter via Agent).
+- **Auto-invoke mode** (no ``--findings``): auto-invoke registered non-``skill``
+  scanners from the registry.  In v1 no such scanners exist; framework only.
+
+Three execution phases:
+
+1. **Consistency** — ensure manifest exists and matches current files.
+2. **Collect**    — obtain scan results (external file or auto-invoke).
+3. **Update**     — normalise findings, merge scans[], aggregate, re-sign.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.skill_ledger.core.file_hasher import compute_file_hashes, diff_file_hashes
+from agent_sec_cli.skill_ledger.core.version_chain import (
+    create_snapshot,
+    get_previous_signature,
+    load_latest_manifest,
+    next_version_id,
+    save_manifest,
+)
+from agent_sec_cli.skill_ledger.errors import FindingsFileError
+from agent_sec_cli.skill_ledger.models.finding import NormalizedFinding
+from agent_sec_cli.skill_ledger.models.manifest import ManifestSignature, SignedManifest
+from agent_sec_cli.skill_ledger.models.scan import ScanEntry, aggregate_scan_status
+from agent_sec_cli.skill_ledger.scanner.parsers import parse_findings
+from agent_sec_cli.skill_ledger.scanner.registry import ScannerRegistry
+from agent_sec_cli.skill_ledger.signing.base import SigningBackend
+from agent_sec_cli.skill_ledger.utils import utc_now_iso
+
+logger = logging.getLogger(__name__)
+
+
+def _sign_manifest(manifest: SignedManifest, backend: SigningBackend) -> SignedManifest:
+    """Compute manifestHash, sign it, and attach the signature to *manifest*."""
+    manifest.manifestHash = manifest.compute_manifest_hash()
+    sig_value, fingerprint = backend.sign(manifest.manifestHash.encode("utf-8"))
+    manifest.signature = ManifestSignature(
+        algorithm=backend.name,
+        value=sig_value,
+        keyFingerprint=fingerprint,
+    )
+    return manifest
+
+
+def _load_findings(findings_path: str) -> list[dict[str, Any]]:
+    """Load and validate the findings JSON file."""
+    path = Path(findings_path)
+    if not path.is_file():
+        raise FindingsFileError(findings_path, "file does not exist")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise FindingsFileError(findings_path, f"invalid JSON: {exc}") from exc
+
+    # Accept both a bare list and {"findings": [...]}
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and "findings" in data:
+        findings = data["findings"]
+        if isinstance(findings, list):
+            return findings
+    raise FindingsFileError(
+        findings_path,
+        "expected a JSON array or an object with a 'findings' key",
+    )
+
+
+def _determine_scan_status(findings: list[NormalizedFinding]) -> str:
+    """Derive the scan status from a list of normalised findings.
+
+    - Any finding with ``level == "deny"``     → ``"deny"``
+    - Any finding with ``level == "warn"``     → ``"warn"``
+    - Otherwise                                → ``"pass"``
+    """
+    has_deny = any(f.level == "deny" for f in findings)
+    if has_deny:
+        return "deny"
+    has_warn = any(f.level == "warn" for f in findings)
+    if has_warn:
+        return "warn"
+    return "pass"
+
+
+def _build_scan_entry(
+    normalized: list[NormalizedFinding],
+    scanner: str,
+    scanner_version: str,
+) -> ScanEntry:
+    """Construct a :class:`ScanEntry` from normalised findings."""
+    return ScanEntry(
+        scanner=scanner,
+        version=scanner_version,
+        status=_determine_scan_status(normalized),
+        findings=[f.to_findings_dict() for f in normalized],
+        scannedAt=utc_now_iso(),
+    )
+
+
+def _resolve_parser_and_normalise(
+    raw_findings: list[dict[str, Any]],
+    scanner_name: str,
+    registry: ScannerRegistry,
+) -> list[NormalizedFinding]:
+    """Look up the parser for *scanner_name* and normalise raw findings.
+
+    Falls back to ``findings-array`` if the scanner is not registered
+    (backward-compatible).
+    """
+    parser_info = registry.get_parser_for_scanner(scanner_name)
+    if parser_info is None:
+        logger.debug(
+            "Scanner %r not in registry; falling back to findings-array parser",
+            scanner_name,
+        )
+    return parse_findings(raw_findings, parser_info)
+
+
+# ------------------------------------------------------------------
+# Auto-invoke mode (framework — v1 has no invocable scanners)
+# ------------------------------------------------------------------
+
+
+def _auto_invoke_scanners(
+    skill_dir: str,
+    registry: ScannerRegistry,
+    scanner_names: list[str] | None = None,
+) -> list[ScanEntry]:
+    """Invoke registered non-``skill`` scanners and collect results.
+
+    In v1 only ``skill-vetter`` (type ``"skill"``) is registered, so this
+    function returns an empty list.  The framework is ready for future
+    ``builtin``/``cli``/``api`` scanner adapters.
+    """
+    invocable = registry.list_invocable_scanners(names=scanner_names)
+
+    if not invocable:
+        logger.info("No auto-invocable scanners registered; skipping auto-invoke")
+        return []
+
+    # Future: iterate invocable scanners, call adapter, parse, build ScanEntry
+    entries: list[ScanEntry] = []
+    for scanner_info in invocable:
+        logger.warning(
+            "Scanner %r (type=%r) auto-invoke not yet implemented; skipping",
+            scanner_info.name,
+            scanner_info.type,
+        )
+        # TODO: dispatch by scanner_info.type:
+        #   "builtin" → call Python function
+        #   "cli"     → subprocess.run(...)
+        #   "api"     → HTTP POST
+    return entries
+
+
+# ------------------------------------------------------------------
+# Main certify workflow
+# ------------------------------------------------------------------
+
+
+def certify(
+    skill_dir: str,
+    backend: SigningBackend,
+    findings_path: str | None = None,
+    scanner: str = "skill-vetter",
+    scanner_version: str = "0.1.0",
+    scanner_names: list[str] | None = None,
+) -> dict[str, Any]:
+    """Execute the full certify workflow for a single skill directory.
+
+    Two input modes:
+
+    - *findings_path* provided → **external findings mode**: read the file,
+      normalise via parser, build a single ScanEntry.
+    - *findings_path* is ``None`` → **auto-invoke mode**: invoke all
+      registered non-``skill`` scanners and collect results.
+
+    Returns a JSON-serialisable result dict.
+    """
+    skill_name = Path(skill_dir).name
+    current_hashes = compute_file_hashes(skill_dir)
+    registry = ScannerRegistry.from_config()
+
+    # ── Phase 1: Ensure manifest consistency ──
+    manifest = load_latest_manifest(skill_dir)
+    new_version_created = False
+
+    if manifest is None or not diff_file_hashes(manifest.fileHashes, current_hashes)["match"]:
+        vid = next_version_id(skill_dir)
+        prev_sig = get_previous_signature(skill_dir)
+        prev_vid = manifest.versionId if manifest is not None else None
+
+        manifest = SignedManifest(
+            versionId=vid,
+            previousVersionId=prev_vid,
+            skillName=skill_name,
+            fileHashes=current_hashes,
+            scanStatus="none",
+            previousManifestSignature=prev_sig,
+        )
+        new_version_created = True
+        create_snapshot(skill_dir, vid)
+
+    # ── Phase 2: Collect scan results ──
+    scan_entries: list[ScanEntry] = []
+
+    if findings_path is not None:
+        # External findings mode
+        raw_findings = _load_findings(findings_path)
+        normalized = _resolve_parser_and_normalise(raw_findings, scanner, registry)
+        scan_entries.append(_build_scan_entry(normalized, scanner, scanner_version))
+    else:
+        # Auto-invoke mode
+        scan_entries = _auto_invoke_scanners(skill_dir, registry, scanner_names)
+
+    # ── Phase 3: Update manifest and sign ──
+    if scan_entries:
+        for entry in scan_entries:
+            # Merge: replace existing entry for same scanner, or append
+            manifest.scans = [s for s in manifest.scans if s.scanner != entry.scanner]
+            manifest.scans.append(entry)
+
+        manifest.scanStatus = aggregate_scan_status(manifest.scans)
+
+    # Short-circuit: nothing changed — avoid re-signing and overwriting
+    # Otherwise re-sign and persist (manifestHash recomputed each time)
+    if scan_entries or new_version_created:
+        _sign_manifest(manifest, backend)
+        save_manifest(skill_dir, manifest, write_version=True)
+
+    return {
+        "versionId": manifest.versionId,
+        "scanStatus": manifest.scanStatus,
+        "newVersion": new_version_created,
+        "skillName": skill_name,
+    }
+
+
+def certify_batch(
+    skill_dirs: list[Path],
+    backend: SigningBackend,
+    findings_path: str | None = None,
+    scanner: str = "skill-vetter",
+    scanner_version: str = "0.1.0",
+    scanner_names: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Certify multiple skill directories (``--all`` mode).
+
+    .. note::
+
+       *findings_path* applies only to the **first** skill directory when
+       set, because findings are scanner results for a specific skill.
+       For the remaining directories auto-invoke mode is used.
+
+    Returns a list of per-skill result dicts.
+    """
+    if findings_path and len(skill_dirs) > 1:
+        logger.warning(
+            "--findings applies to the first skill only; "
+            "remaining %d skills will use auto-invoke mode",
+            len(skill_dirs) - 1,
+        )
+
+    results: list[dict[str, Any]] = []
+    for idx, skill_dir in enumerate(skill_dirs):
+        # Only apply external findings to the first skill
+        effective_findings = findings_path if idx == 0 else None
+        try:
+            result = certify(
+                str(skill_dir),
+                backend,
+                findings_path=effective_findings,
+                scanner=scanner,
+                scanner_version=scanner_version,
+                scanner_names=scanner_names,
+            )
+            results.append(result)
+        except Exception as exc:
+            results.append({
+                "skillName": skill_dir.name,
+                "error": str(exc),
+            })
+    return results

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/checker.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/checker.py
@@ -1,0 +1,132 @@
+"""Check command — the full state machine from design doc §2.
+
+Implements ``skill-ledger check <skill_dir>``:
+
+1. Read ``latest.json``
+2. Missing → auto-create (sign) → ``{"status": "none"}``
+3. Compute current fileHashes, compare
+4. Mismatch → ``{"status": "drifted", "added": ..., "removed": ..., "modified": ...}``
+5. Match → verify signature → invalid → ``{"status": "tampered", "reason": ...}``
+6. Check scanStatus → ``deny`` / ``warn`` / ``none`` / ``pass``
+"""
+
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.skill_ledger.core.file_hasher import compute_file_hashes, diff_file_hashes
+from agent_sec_cli.skill_ledger.core.version_chain import (
+    create_snapshot,
+    load_latest_manifest,
+    next_version_id,
+    save_manifest,
+)
+from agent_sec_cli.skill_ledger.errors import SignatureInvalidError
+from agent_sec_cli.skill_ledger.models.manifest import ManifestSignature, SignedManifest
+from agent_sec_cli.skill_ledger.signing.base import SigningBackend
+
+
+def _auto_create_manifest(
+    skill_dir: str,
+    file_hashes: dict[str, str],
+    backend: SigningBackend,
+) -> dict[str, Any]:
+    """Create an initial manifest when none exists (scanStatus: "none").
+
+    Requires the signing private key (first-time auto-creation).
+    """
+    skill_name = Path(skill_dir).name
+    vid = next_version_id(skill_dir)
+
+    manifest = SignedManifest(
+        versionId=vid,
+        skillName=skill_name,
+        fileHashes=file_hashes,
+        scanStatus="none",
+    )
+
+    # Compute hash and sign
+    manifest.manifestHash = manifest.compute_manifest_hash()
+    sig_value, fingerprint = backend.sign(manifest.manifestHash.encode("utf-8"))
+    manifest.signature = ManifestSignature(
+        algorithm=backend.name,
+        value=sig_value,
+        keyFingerprint=fingerprint,
+    )
+
+    save_manifest(skill_dir, manifest)
+    create_snapshot(skill_dir, vid)
+
+    return {"status": "none", "versionId": vid}
+
+
+def check(skill_dir: str, backend: SigningBackend) -> dict[str, Any]:
+    """Execute the full check state machine.
+
+    Returns a JSON-serialisable dict with at minimum ``{"status": "<status>"}``.
+    """
+    # Step 1: Load latest.json
+    manifest = load_latest_manifest(skill_dir)
+
+    # Step 2: Compute current file hashes
+    current_hashes = compute_file_hashes(skill_dir)
+
+    # Step 2b: No manifest → auto-create
+    if manifest is None:
+        return _auto_create_manifest(skill_dir, current_hashes, backend)
+
+    # Step 3: Compare fileHashes (takes priority over signature verification)
+    diff = diff_file_hashes(manifest.fileHashes, current_hashes)
+
+    # Step 4: Mismatch → drifted
+    if not diff["match"]:
+        return {
+            "status": "drifted",
+            "added": diff["added"],
+            "removed": diff["removed"],
+            "modified": diff["modified"],
+        }
+
+    # Step 5: fileHashes match → verify signature
+    # 5a: Recompute manifestHash
+    expected_hash = manifest.compute_manifest_hash()
+    if manifest.manifestHash != expected_hash:
+        return {
+            "status": "tampered",
+            "reason": "manifestHash does not match manifest content",
+        }
+
+    # 5b: Verify digital signature
+    if manifest.signature is None:
+        # Legacy manifest without signature — treat as "none" (backward compat)
+        return {"status": "none", "reason": "manifest has no signature (legacy)"}
+
+    try:
+        backend.verify(
+            manifest.manifestHash.encode("utf-8"),
+            manifest.signature.value,
+            manifest.signature.keyFingerprint,
+        )
+    except SignatureInvalidError as exc:
+        return {"status": "tampered", "reason": str(exc)}
+
+    # Step 6: Signature valid → dispatch on scanStatus
+    scan_status = manifest.scanStatus
+
+    if scan_status == "deny":
+        findings = _collect_findings(manifest)
+        return {"status": "deny", "findings": findings}
+
+    if scan_status == "warn":
+        findings = _collect_findings(manifest)
+        return {"status": "warn", "findings": findings}
+
+    if scan_status == "none":
+        return {"status": "none"}
+
+    # pass (or any other value)
+    return {"status": "pass"}
+
+
+def _collect_findings(manifest: SignedManifest) -> list[dict[str, Any]]:
+    """Extract findings from all scans in the manifest."""
+    return [f for scan in manifest.scans for f in scan.findings]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/file_hasher.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/file_hasher.py
@@ -1,0 +1,71 @@
+"""File hashing and diff utilities for skill directories."""
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+# Directories to exclude when walking a skill directory.
+_EXCLUDED_DIRS = frozenset({".skill-meta", ".git"})
+
+
+def compute_file_hash(file_path: Path) -> str:
+    """Return ``"sha256:<hex>"`` for a single file."""
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            sha256.update(chunk)
+    return f"sha256:{sha256.hexdigest()}"
+
+
+def compute_file_hashes(skill_dir: str | Path) -> dict[str, str]:
+    """Walk *skill_dir* and return ``{relative_path: "sha256:<hex>", ...}``.
+
+    Excludes ``.skill-meta/`` and ``.git/`` directories.
+    Symbolic links are skipped to avoid cycles and directory escapes.
+    Files are sorted by relative path for deterministic ordering.
+    """
+    root = Path(skill_dir).resolve()
+    hashes: dict[str, str] = {}
+
+    for entry in sorted(root.rglob("*")):
+        if entry.is_symlink():
+            continue
+        if not entry.is_file():
+            continue
+        # Skip excluded directories
+        rel = entry.relative_to(root)
+        if any(part in _EXCLUDED_DIRS for part in rel.parts):
+            continue
+        hashes[str(rel)] = compute_file_hash(entry)
+
+    return hashes
+
+
+def diff_file_hashes(
+    stored: dict[str, str],
+    current: dict[str, str],
+) -> dict[str, Any]:
+    """Compare two fileHashes maps and return a structured diff.
+
+    Returns::
+
+        {
+            "match": bool,
+            "added": ["new_file.py", ...],
+            "removed": ["old_file.py", ...],
+            "modified": ["changed_file.py", ...],
+        }
+    """
+    stored_keys = set(stored.keys())
+    current_keys = set(current.keys())
+
+    added = sorted(current_keys - stored_keys)
+    removed = sorted(stored_keys - current_keys)
+    modified = sorted(k for k in stored_keys & current_keys if stored[k] != current[k])
+
+    return {
+        "match": not added and not removed and not modified,
+        "added": added,
+        "removed": removed,
+        "modified": modified,
+    }

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/version_chain.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/version_chain.py
@@ -1,0 +1,190 @@
+""".skill-meta/ directory management, version numbering, and snapshot creation.
+
+.. warning::
+
+   This module does **not** provide file-level locking.  If multiple
+   processes call :func:`save_manifest` concurrently on the same skill
+   directory, the writes may conflict.  Callers in concurrent
+   environments should serialise access externally (e.g. ``flock``).
+"""
+
+import re
+import shutil
+from pathlib import Path
+
+from agent_sec_cli.skill_ledger.errors import SkillLedgerError
+from agent_sec_cli.skill_ledger.models.manifest import ManifestSignature, SignedManifest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SKILL_META_DIR = ".skill-meta"
+VERSIONS_DIR = "versions"
+LATEST_JSON = "latest.json"
+
+_VERSION_RE = re.compile(r"^v(\d{6})\.json$")
+
+# Directories excluded when creating a snapshot of the skill directory.
+_SNAPSHOT_EXCLUDED = frozenset({".skill-meta", ".git"})
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def skill_meta_path(skill_dir: str | Path) -> Path:
+    return Path(skill_dir) / SKILL_META_DIR
+
+
+def latest_json_path(skill_dir: str | Path) -> Path:
+    return skill_meta_path(skill_dir) / LATEST_JSON
+
+
+def versions_dir_path(skill_dir: str | Path) -> Path:
+    return skill_meta_path(skill_dir) / VERSIONS_DIR
+
+
+def version_json_path(skill_dir: str | Path, version_id: str) -> Path:
+    return versions_dir_path(skill_dir) / f"{version_id}.json"
+
+
+def snapshot_dir_path(skill_dir: str | Path, version_id: str) -> Path:
+    return versions_dir_path(skill_dir) / f"{version_id}.snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Directory initialisation
+# ---------------------------------------------------------------------------
+
+
+def ensure_skill_meta(skill_dir: str | Path) -> Path:
+    """Create ``.skill-meta/versions/`` if it does not exist.  Returns the meta path."""
+    meta = skill_meta_path(skill_dir)
+    meta.mkdir(parents=True, exist_ok=True)
+    versions = versions_dir_path(skill_dir)
+    versions.mkdir(parents=True, exist_ok=True)
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Version ID management
+# ---------------------------------------------------------------------------
+
+
+def list_version_ids(skill_dir: str | Path) -> list[str]:
+    """Return sorted list of existing version IDs (e.g. ``["v000001", "v000002"]``)."""
+    vdir = versions_dir_path(skill_dir)
+    if not vdir.is_dir():
+        return []
+    ids: list[str] = []
+    for entry in vdir.iterdir():
+        m = _VERSION_RE.match(entry.name)
+        if m:
+            ids.append(f"v{m.group(1)}")
+    ids.sort()
+    return ids
+
+
+def next_version_id(skill_dir: str | Path) -> str:
+    """Return the next sequential version ID (``v000001`` if none exist).
+
+    Raises :class:`SkillLedgerError` if the maximum version (999999) is reached.
+    """
+    existing = list_version_ids(skill_dir)
+    if not existing:
+        return "v000001"
+    last = existing[-1]
+    num = int(last[1:])
+    if num >= 999999:
+        raise SkillLedgerError(
+            "Version ID overflow — maximum 999999 versions reached for "
+            f"{Path(skill_dir).name}"
+        )
+    return f"v{num + 1:06d}"
+
+
+# ---------------------------------------------------------------------------
+# Manifest I/O
+# ---------------------------------------------------------------------------
+
+
+def load_latest_manifest(skill_dir: str | Path) -> SignedManifest | None:
+    """Load ``latest.json`` if it exists, else return ``None``."""
+    path = latest_json_path(skill_dir)
+    if not path.is_file():
+        return None
+    return SignedManifest.from_file(str(path))
+
+
+def save_manifest(
+    skill_dir: str | Path,
+    manifest: SignedManifest,
+    *,
+    write_version: bool = True,
+) -> None:
+    """Write *manifest* to ``versions/<versionId>.json`` and ``latest.json``.
+
+    Both writes are atomic (write-tmp + rename).
+    """
+    ensure_skill_meta(skill_dir)
+    if write_version:
+        vpath = version_json_path(skill_dir, manifest.versionId)
+        manifest.write_to_file(str(vpath))
+    # Always update latest.json
+    manifest.write_to_file(str(latest_json_path(skill_dir)))
+
+
+def load_version_manifest(skill_dir: str | Path, version_id: str) -> SignedManifest | None:
+    """Load a specific version manifest, or ``None`` if it does not exist."""
+    path = version_json_path(skill_dir, version_id)
+    if not path.is_file():
+        return None
+    return SignedManifest.from_file(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Previous manifest signature extraction
+# ---------------------------------------------------------------------------
+
+
+def get_previous_signature(skill_dir: str | Path) -> str | None:
+    """Return the ``signature.value`` of the most recent version, or ``None``."""
+    ids = list_version_ids(skill_dir)
+    if not ids:
+        return None
+    last = load_version_manifest(skill_dir, ids[-1])
+    if last is None or last.signature is None:
+        return None
+    return last.signature.value
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+def create_snapshot(skill_dir: str | Path, version_id: str) -> Path:
+    """Copy the skill directory (excluding ``.skill-meta/`` and ``.git/``) into a snapshot.
+
+    Returns the snapshot directory path.
+    """
+    src = Path(skill_dir).resolve()
+    dst = snapshot_dir_path(skill_dir, version_id)
+    if dst.exists():
+        shutil.rmtree(dst)
+    dst.mkdir(parents=True)
+
+    for entry in sorted(src.rglob("*")):
+        rel = entry.relative_to(src)
+        if any(part in _SNAPSHOT_EXCLUDED for part in rel.parts):
+            continue
+        target = dst / rel
+        if entry.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif entry.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(entry, target)
+
+    return dst

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/errors.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/errors.py
@@ -1,0 +1,112 @@
+"""Custom exception hierarchy for skill-ledger."""
+
+
+class SkillLedgerError(Exception):
+    """Base exception for all skill-ledger errors."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Key management
+# ---------------------------------------------------------------------------
+
+
+class KeyNotFoundError(SkillLedgerError):
+    """Signing key files do not exist (run ``init-keys`` first)."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__(f"Signing key not found: {path}. Run 'skill-ledger init-keys' first.")
+        self.path = path
+
+
+class KeyAlreadyExistsError(SkillLedgerError):
+    """Signing key already exists and ``--force`` was not supplied."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__(f"Key already exists: {path}. Use --force to overwrite.")
+        self.path = path
+
+
+class PassphraseError(SkillLedgerError):
+    """Passphrase is incorrect or could not be obtained."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Manifest / signature
+# ---------------------------------------------------------------------------
+
+
+class ManifestNotFoundError(SkillLedgerError):
+    """``latest.json`` does not exist in ``.skill-meta/``."""
+
+    def __init__(self, skill_dir: str) -> None:
+        super().__init__(f"No manifest found in {skill_dir}/.skill-meta/latest.json")
+        self.skill_dir = skill_dir
+
+
+class ManifestCorruptedError(SkillLedgerError):
+    """``latest.json`` exists but cannot be parsed or has invalid structure."""
+
+    def __init__(self, skill_dir: str, reason: str) -> None:
+        super().__init__(f"Corrupted manifest in {skill_dir}: {reason}")
+        self.skill_dir = skill_dir
+        self.reason = reason
+
+
+class SignatureInvalidError(SkillLedgerError):
+    """Digital signature verification failed (possible tampering)."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"Signature verification failed: {reason}")
+        self.reason = reason
+
+
+class ManifestHashMismatchError(SkillLedgerError):
+    """Recomputed manifestHash does not match the stored value."""
+
+    def __init__(self) -> None:
+        super().__init__("manifestHash mismatch — manifest content has been modified")
+
+
+# ---------------------------------------------------------------------------
+# Version chain
+# ---------------------------------------------------------------------------
+
+
+class ChainBrokenError(SkillLedgerError):
+    """``previousManifestSignature`` does not match the prior version's signature."""
+
+    def __init__(self, version_id: str, reason: str) -> None:
+        super().__init__(f"Version chain broken at {version_id}: {reason}")
+        self.version_id = version_id
+        self.reason = reason
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class ConfigError(SkillLedgerError):
+    """Configuration file is missing or invalid."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"Configuration error: {reason}")
+        self.reason = reason
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+class FindingsFileError(SkillLedgerError):
+    """Findings JSON file is missing or invalid."""
+
+    def __init__(self, path: str, reason: str) -> None:
+        super().__init__(f"Invalid findings file {path}: {reason}")
+        self.path = path
+        self.reason = reason

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/__init__.py
@@ -1,0 +1,1 @@
+"""Data models for skill-ledger manifests and scan entries."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/finding.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/finding.py
@@ -1,0 +1,56 @@
+"""NormalizedFinding — universal contract for scanner outputs.
+
+All scanner results are normalised into this structure before being
+stored in ``ScanEntry.findings``.  See design doc §2 *NormalizedFinding*.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+# Allowed severity levels (aligned with scanStatus aggregation).
+VALID_LEVELS = frozenset({"deny", "warn", "pass"})
+
+
+class NormalizedFinding(BaseModel):
+    """A single finding produced by any scanner, in canonical form.
+
+    Attributes:
+        rule:     Rule / check identifier (e.g. ``"dangerous-exec"``).
+        level:    ``"deny"`` | ``"warn"`` | ``"pass"``.
+        message:  Human-readable description of the finding.
+        file:     (Optional) Affected file path relative to skill_dir.
+        line:     (Optional) Line number within *file*.
+        metadata: (Optional) Scanner-specific extra data.
+    """
+
+    rule: str
+    level: str  # "deny" | "warn" | "pass"
+    message: str
+    file: str | None = None
+    line: int | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("level")
+    @classmethod
+    def validate_level(cls, v: str) -> str:
+        """Normalise and validate the severity level."""
+        v = str(v).lower()
+        if v not in VALID_LEVELS:
+            raise ValueError(f"Invalid finding level {v!r}; expected one of {sorted(VALID_LEVELS)}")
+        return v
+
+    def to_findings_dict(self) -> dict[str, Any]:
+        """Return a plain dict suitable for ``ScanEntry.findings``."""
+        d: dict[str, Any] = {
+            "rule": self.rule,
+            "level": self.level,
+            "message": self.message,
+        }
+        if self.file is not None:
+            d["file"] = self.file
+        if self.line is not None:
+            d["line"] = self.line
+        if self.metadata:
+            d["metadata"] = self.metadata
+        return d

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/manifest.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/manifest.py
@@ -1,0 +1,121 @@
+"""SignedManifest Pydantic model with canonical JSON and manifestHash computation."""
+
+import hashlib
+import json
+import os
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from agent_sec_cli.skill_ledger.utils import utc_now_iso
+from agent_sec_cli.skill_ledger.models.scan import ScanEntry
+
+
+class ManifestSignature(BaseModel):
+    """Digital signature block embedded in a SignedManifest."""
+
+    algorithm: str = "ed25519"
+    value: str = ""  # base64-encoded signature
+    keyFingerprint: str = ""  # "sha256:<hex>"
+
+
+class SignedManifest(BaseModel):
+    """The canonical signed manifest stored in ``.skill-meta/``.
+
+    See the design doc §1 *SignedManifest 结构* for field semantics.
+    """
+
+    version: int = 1
+    versionId: str = "v000001"
+    previousVersionId: str | None = None
+
+    skillName: str = ""
+
+    fileHashes: dict[str, str] = Field(default_factory=dict)
+
+    scans: list[ScanEntry] = Field(default_factory=list)
+    scanStatus: str = "none"  # none | pass | warn | deny
+
+    policy: str = "warning"  # warning | allow | block
+
+    createdAt: str = Field(default_factory=utc_now_iso)
+
+    # ── Anti-tamper fields ──────────────────────────────────────
+    manifestHash: str = ""
+
+    previousManifestSignature: str | None = None
+
+    signature: ManifestSignature | None = None
+
+    # ------------------------------------------------------------------
+    # Canonical JSON
+    # ------------------------------------------------------------------
+
+    def _signable_dict(self) -> dict[str, Any]:
+        """Return all fields **except** ``manifestHash`` and ``signature``.
+
+        This is the data covered by the hash and signature.
+        """
+        d = self.model_dump()
+        d.pop("manifestHash", None)
+        d.pop("signature", None)
+        return d
+
+    def canonical_json_bytes(self) -> bytes:
+        """Canonical JSON serialisation (sorted keys, compact separators, UTF-8).
+
+        Deterministic output used for ``manifestHash`` computation.
+        """
+        d = self._signable_dict()
+        return json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+
+    def compute_manifest_hash(self) -> str:
+        """SHA-256 of the canonical JSON — returns ``"sha256:<hex>"``."""
+        digest = hashlib.sha256(self.canonical_json_bytes()).hexdigest()
+        return f"sha256:{digest}"
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+
+    def to_json(self, indent: int = 2) -> str:
+        """Full JSON representation (including ``manifestHash`` and ``signature``)."""
+        return json.dumps(
+            self.model_dump(),
+            indent=indent,
+            ensure_ascii=False,
+        )
+
+    @classmethod
+    def from_json(cls, text: str) -> "SignedManifest":
+        """Parse a JSON string into a ``SignedManifest``."""
+        return cls.model_validate_json(text)
+
+    @classmethod
+    def from_file(cls, path: str) -> "SignedManifest":
+        """Load a manifest from a JSON file path."""
+        from pathlib import Path
+
+        raw = Path(path).read_text(encoding="utf-8")
+        return cls.from_json(raw)
+
+    def write_to_file(self, path: str) -> None:
+        """Atomically write the manifest to *path* (write-tmp + replace)."""
+        from pathlib import Path
+        import tempfile
+
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        data = self.to_json()
+        fd, tmp_path = tempfile.mkstemp(dir=target.parent, suffix=".tmp")
+        try:
+            with open(fd, "w", encoding="utf-8") as fh:
+                fh.write(data)
+                fh.write("\n")
+                fh.flush()
+            os.replace(tmp_path, target)
+        except BaseException:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/scan.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/models/scan.py
@@ -1,0 +1,46 @@
+"""ScanEntry model and scanStatus aggregation logic."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from agent_sec_cli.skill_ledger.utils import utc_now_iso
+
+
+class ScanEntry(BaseModel):
+    """A single scanner's result within a manifest's ``scans[]`` array.
+
+    Attributes:
+        scanner:    Scanner identifier (e.g. ``"skill-vetter"``).
+        version:    Scanner version for reproducibility.
+        status:     Individual result: ``pass`` | ``warn`` | ``deny``.
+        findings:   Scanner-specific structured findings.
+        scannedAt:  ISO-8601 timestamp of when the scan was performed.
+    """
+
+    scanner: str = "skill-vetter"
+    version: str = "0.1.0"
+    status: str = "pass"
+    findings: list[dict[str, Any]] = Field(default_factory=list)
+    scannedAt: str = Field(default_factory=utc_now_iso)
+
+
+# Severity ordering: higher index = more severe.
+_SEVERITY_ORDER: dict[str, int] = {
+    "none": 0,
+    "pass": 1,
+    "warn": 2,
+    "deny": 3,
+}
+
+
+def aggregate_scan_status(scans: list[ScanEntry]) -> str:
+    """Compute the aggregate ``scanStatus`` from a list of scan entries.
+
+    Returns the **most severe** status across all entries.
+    An empty list yields ``"none"``.
+    """
+    if not scans:
+        return "none"
+    worst = max(scans, key=lambda s: _SEVERITY_ORDER.get(s.status, 0))
+    return worst.status

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/paths.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/paths.py
@@ -1,0 +1,39 @@
+"""XDG Base Directory resolution for skill-ledger.
+
+Provides ``get_data_dir()`` and ``get_config_dir()`` so that every module can
+resolve paths without pulling in unrelated dependencies.
+
+Testing strategy: set ``XDG_DATA_HOME`` / ``XDG_CONFIG_HOME`` env vars to a
+``tempfile.mkdtemp()`` directory — all key and config I/O is automatically
+redirected.
+
+TODO: Allow agent-sec-core to override these paths for system-level deployment.
+Approach TBD after agent-sec-core path conventions are finalized.
+"""
+
+import os
+from pathlib import Path
+
+_APP_NAME = "skill-ledger"
+
+
+def get_data_dir() -> Path:
+    """Return the skill-ledger data directory (XDG_DATA_HOME).
+
+    Default: ``~/.local/share/skill-ledger/``
+    """
+    base = os.environ.get("XDG_DATA_HOME", "")
+    if not base:
+        base = str(Path.home() / ".local" / "share")
+    return Path(base) / _APP_NAME
+
+
+def get_config_dir() -> Path:
+    """Return the skill-ledger config directory (XDG_CONFIG_HOME).
+
+    Default: ``~/.config/skill-ledger/``
+    """
+    base = os.environ.get("XDG_CONFIG_HOME", "")
+    if not base:
+        base = str(Path.home() / ".config")
+    return Path(base) / _APP_NAME

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/__init__.py
@@ -1,0 +1,1 @@
+"""Scanner registry and result parsing for skill-ledger."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/parsers.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/parsers.py
@@ -1,0 +1,111 @@
+"""Result parsers — normalise raw scanner output to NormalizedFinding[].
+
+In v1 only ``findings-array`` is implemented (identity transform).
+Future parser types (``sarif``, ``field-mapping``, ``custom``) plug in
+via :func:`parse_findings`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agent_sec_cli.skill_ledger.models.finding import VALID_LEVELS, NormalizedFinding
+from agent_sec_cli.skill_ledger.scanner.registry import ParserInfo
+
+logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# Parser dispatch
+# ------------------------------------------------------------------
+
+
+def parse_findings(
+    raw_findings: list[dict[str, Any]],
+    parser_info: ParserInfo | None,
+) -> list[NormalizedFinding]:
+    """Normalise *raw_findings* using the given parser.
+
+    Parameters:
+        raw_findings: The raw list of finding dicts from the scanner output.
+        parser_info:  Registry metadata for the parser.  If ``None``, fall
+                      back to ``findings-array`` (backward-compatible default).
+
+    Returns:
+        A list of :class:`NormalizedFinding` instances.
+    """
+    parser_type = parser_info.type if parser_info is not None else "findings-array"
+
+    if parser_type == "findings-array":
+        return _parse_findings_array(raw_findings)
+
+    # Future parser types — not implemented in this version
+    # "sarif", "field-mapping", "custom"
+    logger.warning(
+        "Parser type %r is not implemented; falling back to findings-array",
+        parser_type,
+    )
+    return _parse_findings_array(raw_findings)
+
+
+# ------------------------------------------------------------------
+# findings-array (identity parser)
+# ------------------------------------------------------------------
+
+
+def _parse_findings_array(
+    raw_findings: list[dict[str, Any]],
+) -> list[NormalizedFinding]:
+    """Identity parser — input is already ``[{rule, level, message, …}]``.
+
+    Each dict is mapped directly to :class:`NormalizedFinding`.
+    Fields not in the model are placed into ``metadata``.
+    Invalid entries (missing ``rule`` or ``level``) are skipped with a warning.
+    """
+    result: list[NormalizedFinding] = []
+    known_keys = {"rule", "level", "message", "file", "line", "metadata"}
+
+    for idx, item in enumerate(raw_findings):
+        if not isinstance(item, dict):
+            logger.warning("Skipping non-dict finding at index %d", idx)
+            continue
+
+        rule = item.get("rule")
+        level = item.get("level")
+        message = item.get("message", "")
+
+        if not rule or not level:
+            logger.warning(
+                "Skipping finding at index %d: missing 'rule' or 'level'", idx
+            )
+            continue
+
+        # Normalise level
+        level_lower = str(level).lower()
+        if level_lower not in VALID_LEVELS:
+            logger.warning(
+                "Unknown level %r at index %d; treating as 'warn'",
+                level,
+                idx,
+            )
+            level_lower = "warn"
+
+        # Collect extra keys into metadata
+        extra = {k: v for k, v in item.items() if k not in known_keys}
+        metadata = item.get("metadata", {})
+        if extra:
+            metadata = {**metadata, **extra}
+
+        result.append(
+            NormalizedFinding(
+                rule=str(rule),
+                level=level_lower,
+                message=str(message),
+                file=item.get("file"),
+                line=item.get("line"),
+                metadata=metadata,
+            )
+        )
+
+    return result

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/registry.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/registry.py
@@ -1,0 +1,159 @@
+"""Scanner Registry — load scanner/parser definitions from config.json.
+
+The registry provides lookup-by-name for scanners and parsers.  In v1 only
+``skill-vetter`` (type ``"skill"``, parser ``"findings-array"``) is registered.
+
+Usage::
+
+    from agent_sec_cli.skill_ledger.scanner.registry import ScannerRegistry
+
+    reg = ScannerRegistry.from_config()      # loads config.json
+    scanner = reg.get_scanner("skill-vetter")  # ScannerInfo | None
+    parser  = reg.get_parser("findings-array") # ParserInfo | None
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class ScannerInfo:
+    """Metadata for a registered scanner.
+
+    Attributes:
+        name:        Unique scanner identifier.
+        type:        Invocation type: ``builtin`` | ``cli`` | ``skill`` | ``api``.
+        parser:      Name of the associated result parser.
+        description: Human-readable description (optional).
+        enabled:     Whether the scanner is active (default ``True``).
+        extra:       All remaining config fields (``command``, ``endpoint``, …).
+    """
+
+    name: str
+    type: str  # "builtin" | "cli" | "skill" | "api"
+    parser: str = "findings-array"
+    description: str = ""
+    enabled: bool = True
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ScannerInfo:
+        """Construct from a raw config dict entry."""
+        known = {"name", "type", "parser", "description", "enabled"}
+        return cls(
+            name=d["name"],
+            type=d.get("type", "skill"),
+            parser=d.get("parser", "findings-array"),
+            description=d.get("description", ""),
+            enabled=d.get("enabled", True),
+            extra={k: v for k, v in d.items() if k not in known},
+        )
+
+
+@dataclass(frozen=True)
+class ParserInfo:
+    """Metadata for a registered result parser.
+
+    Attributes:
+        name:  Unique parser identifier (also the key in ``parsers{}``).
+        type:  Parser type: ``findings-array`` | ``sarif`` | ``field-mapping`` | ``custom``.
+        extra: All remaining config fields (``rootPath``, ``mappings``, …).
+    """
+
+    name: str
+    type: str  # "findings-array" | "sarif" | "field-mapping" | "custom"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, name: str, d: dict[str, Any]) -> ParserInfo:
+        """Construct from a raw config dict entry."""
+        return cls(
+            name=name,
+            type=d.get("type", "findings-array"),
+            extra={k: v for k, v in d.items() if k != "type"},
+        )
+
+
+class ScannerRegistry:
+    """In-memory registry of scanners and parsers loaded from config.
+
+    Provides O(1) lookup by name.
+    """
+
+    def __init__(
+        self,
+        scanners: dict[str, ScannerInfo],
+        parsers: dict[str, ParserInfo],
+    ) -> None:
+        self._scanners = scanners
+        self._parsers = parsers
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any] | None = None) -> ScannerRegistry:
+        """Build a registry from the loaded config (or load it fresh)."""
+        if config is None:
+            from agent_sec_cli.skill_ledger.config import load_config
+
+            config = load_config()
+
+        scanners: dict[str, ScannerInfo] = {}
+        for entry in config.get("scanners", []):
+            if isinstance(entry, dict) and "name" in entry:
+                info = ScannerInfo.from_dict(entry)
+                scanners[info.name] = info
+
+        parsers: dict[str, ParserInfo] = {}
+        for name, entry in config.get("parsers", {}).items():
+            if isinstance(entry, dict):
+                parsers[name] = ParserInfo.from_dict(name, entry)
+
+        return cls(scanners=scanners, parsers=parsers)
+
+    # ------------------------------------------------------------------
+    # Lookups
+    # ------------------------------------------------------------------
+
+    def get_scanner(self, name: str) -> Optional[ScannerInfo]:
+        """Return the scanner with *name*, or ``None``."""
+        return self._scanners.get(name)
+
+    def get_parser(self, name: str) -> Optional[ParserInfo]:
+        """Return the parser with *name*, or ``None``."""
+        return self._parsers.get(name)
+
+    def get_parser_for_scanner(self, scanner_name: str) -> Optional[ParserInfo]:
+        """Resolve scanner → parser name → parser info.  Returns ``None`` if not found."""
+        scanner = self.get_scanner(scanner_name)
+        if scanner is None:
+            return None
+        return self.get_parser(scanner.parser)
+
+    def list_scanners(self, *, enabled_only: bool = True) -> list[ScannerInfo]:
+        """Return all registered scanners, optionally filtered by ``enabled``."""
+        return [
+            s for s in self._scanners.values()
+            if not enabled_only or s.enabled
+        ]
+
+    def list_invocable_scanners(
+        self,
+        *,
+        names: list[str] | None = None,
+    ) -> list[ScannerInfo]:
+        """Return scanners that the CLI can auto-invoke (non-``skill`` type).
+
+        If *names* is given, only return scanners whose name is in the list.
+        """
+        scanners = self.list_scanners(enabled_only=True)
+        # Skip "skill" type — requires Agent, CLI cannot invoke
+        scanners = [s for s in scanners if s.type != "skill"]
+        if names is not None:
+            name_set = set(names)
+            scanners = [s for s in scanners if s.name in name_set]
+        return scanners

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/__init__.py
@@ -1,0 +1,1 @@
+"""Pluggable signing backends for skill-ledger."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/base.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/base.py
@@ -1,0 +1,52 @@
+"""Abstract base class for pluggable signing backends."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class SigningBackend(ABC):
+    """Interface that all signing backends must implement.
+
+    The default backend is :class:`NativeEd25519Backend`.  Additional backends
+    (GPG, PKCS#11) can be implemented against this interface and selected via
+    ``~/.config/skill-ledger/config.json``.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable backend identifier (e.g. ``"ed25519"``, ``"gpg"``)."""
+        pass
+
+    @abstractmethod
+    def generate_keys(self, passphrase: str | None = None) -> dict[str, Any]:
+        """Generate a new key pair and persist to storage.
+
+        Returns a dict with at least ``{"fingerprint": "sha256:..."}``.
+        """
+        pass
+
+    @abstractmethod
+    def sign(self, data: bytes) -> tuple[str, str]:
+        """Sign *data* and return ``(base64_signature, key_fingerprint)``.
+
+        The private key may require passphrase decryption on first use.
+        """
+        pass
+
+    @abstractmethod
+    def verify(self, data: bytes, signature_b64: str, fingerprint: str) -> bool:
+        """Verify *signature_b64* over *data* using the public key matching *fingerprint*.
+
+        Returns ``True`` on success.  Raises :class:`SignatureInvalidError` on
+        failure, or returns ``False`` if the fingerprint is unknown.
+        """
+        pass
+
+    @abstractmethod
+    def get_public_key_fingerprint(self) -> str:
+        """Return the fingerprint of the current signing public key.
+
+        Format: ``"sha256:<hex>"``.
+        """
+        pass

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/ed25519.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/ed25519.py
@@ -1,0 +1,251 @@
+"""NativeEd25519Backend — default signing backend using Python ``cryptography``."""
+
+import base64
+import hashlib
+import os
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+from agent_sec_cli.skill_ledger.errors import PassphraseError, SignatureInvalidError
+from agent_sec_cli.skill_ledger.signing.base import SigningBackend
+from agent_sec_cli.skill_ledger.signing.key_manager import (
+    clear_passphrase_cache,
+    get_passphrase,
+    load_keyring_public_keys,
+    read_key_enc,
+    read_key_pub,
+    write_key_enc,
+    write_key_pub,
+)
+
+# ---------------------------------------------------------------------------
+# Key encryption constants (design doc §1)
+# ---------------------------------------------------------------------------
+_SALT_LEN = 16
+_IV_LEN = 12
+_SCRYPT_N = 2**17  # 131072
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_KDF_KEY_LEN = 32  # AES-256
+
+
+# ---------------------------------------------------------------------------
+# Low-level crypto helpers
+# ---------------------------------------------------------------------------
+
+
+def _derive_key(passphrase: str, salt: bytes) -> bytes:
+    """Derive a 256-bit AES key from *passphrase* + *salt* using scrypt."""
+    kdf = Scrypt(salt=salt, length=_KDF_KEY_LEN, n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P)
+    return kdf.derive(passphrase.encode("utf-8"))
+
+
+def _encrypt_private_key(raw_private: bytes, passphrase: str) -> bytes:
+    """Encrypt Ed25519 raw private key → ``salt(16) + iv(12) + ciphertext_with_tag``.
+
+    The file layout matches the design doc §1 密钥管理.
+    """
+    salt = os.urandom(_SALT_LEN)
+    iv = os.urandom(_IV_LEN)
+    dk = _derive_key(passphrase, salt)
+    aesgcm = AESGCM(dk)
+    ct_with_tag = aesgcm.encrypt(iv, raw_private, None)
+    # Layout: salt | iv | ciphertext+authTag
+    return salt + iv + ct_with_tag
+
+
+def _decrypt_private_key(encrypted: bytes, passphrase: str) -> bytes:
+    """Decrypt the encrypted private key file back to raw Ed25519 seed."""
+    if len(encrypted) < _SALT_LEN + _IV_LEN + 1:
+        raise PassphraseError("Encrypted key file is too short — corrupted?")
+    salt = encrypted[:_SALT_LEN]
+    iv = encrypted[_SALT_LEN : _SALT_LEN + _IV_LEN]
+    ct_with_tag = encrypted[_SALT_LEN + _IV_LEN :]
+    dk = _derive_key(passphrase, salt)
+    aesgcm = AESGCM(dk)
+    try:
+        return aesgcm.decrypt(iv, ct_with_tag, None)
+    except Exception as exc:
+        raise PassphraseError("Decryption failed — wrong passphrase?") from exc
+
+
+def compute_fingerprint(public_key_bytes: bytes) -> str:
+    """Compute ``"sha256:<hex>"`` fingerprint of raw public key bytes."""
+    return f"sha256:{hashlib.sha256(public_key_bytes).hexdigest()}"
+
+
+# ---------------------------------------------------------------------------
+# NativeEd25519Backend
+# ---------------------------------------------------------------------------
+
+
+class NativeEd25519Backend(SigningBackend):
+    """Ed25519 signing using Python's ``cryptography`` library.
+
+    - Key generation: :meth:`generate_keys`
+    - Private key: AES-256-GCM encrypted (scrypt KDF), passphrase cached in-process
+    - Public key: raw 32-byte Ed25519 public key
+    - Verification: public-key only, no passphrase required (~sub-ms)
+    """
+
+    def __init__(self) -> None:
+        # Lazily loaded on first sign/verify
+        self._private_key: Ed25519PrivateKey | None = None
+        self._public_key: Ed25519PublicKey | None = None
+        self._fingerprint: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "ed25519"
+
+    # ------------------------------------------------------------------
+    # Key generation (used by init-keys)
+    # ------------------------------------------------------------------
+
+    def generate_keys(self, passphrase: str | None = None) -> dict[str, str]:
+        """Generate a new Ed25519 key pair and persist.
+
+        If *passphrase* is ``None`` or empty the raw 32-byte seed is stored
+        directly (no encryption, no interactive prompt).  Otherwise the seed
+        is encrypted with AES-256-GCM (scrypt KDF).
+
+        Returns ``{"fingerprint": "sha256:...", "publicKeyPath": "...",
+                    "privateKeyPath": "...", "encrypted": <bool>}``.
+        """
+        private_key = Ed25519PrivateKey.generate()
+        raw_private = private_key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+        raw_public = private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+        if passphrase:
+            key_bytes = _encrypt_private_key(raw_private, passphrase)
+            encrypted = True
+        else:
+            key_bytes = raw_private  # raw 32-byte seed
+            encrypted = False
+
+        enc_path = write_key_enc(key_bytes)
+        pub_path = write_key_pub(raw_public)
+
+        fp = compute_fingerprint(raw_public)
+
+        # Cache for immediate use
+        self._private_key = private_key
+        self._public_key = private_key.public_key()
+        self._fingerprint = fp
+
+        return {
+            "fingerprint": fp,
+            "publicKeyPath": str(pub_path),
+            "privateKeyPath": str(enc_path),
+            "encrypted": encrypted,
+        }
+
+    # ------------------------------------------------------------------
+    # Private key loading (lazy, passphrase-cached)
+    # ------------------------------------------------------------------
+
+    # Raw Ed25519 seed is exactly 32 bytes; encrypted file is always larger
+    # (salt=16 + iv=12 + ciphertext=32 + tag=16 = 76 bytes minimum).
+    _RAW_SEED_LEN = 32
+
+    def _ensure_private_key(self) -> Ed25519PrivateKey:
+        if self._private_key is not None:
+            return self._private_key
+
+        key_data = read_key_enc()
+
+        if len(key_data) == self._RAW_SEED_LEN:
+            # Unencrypted raw seed — no passphrase needed
+            raw_private = key_data
+        else:
+            # Encrypted — need passphrase
+            passphrase = get_passphrase()
+            try:
+                raw_private = _decrypt_private_key(key_data, passphrase)
+            except PassphraseError:
+                clear_passphrase_cache()
+                raise
+
+        self._private_key = Ed25519PrivateKey.from_private_bytes(raw_private)
+        return self._private_key
+
+    def _ensure_public_key(self) -> Ed25519PublicKey:
+        if self._public_key is not None:
+            return self._public_key
+
+        raw_public = read_key_pub()
+        self._public_key = Ed25519PublicKey.from_public_bytes(raw_public)
+        return self._public_key
+
+    def _ensure_fingerprint(self) -> str:
+        if self._fingerprint is not None:
+            return self._fingerprint
+
+        raw_public = read_key_pub()
+        self._fingerprint = compute_fingerprint(raw_public)
+        return self._fingerprint
+
+    # ------------------------------------------------------------------
+    # SigningBackend interface
+    # ------------------------------------------------------------------
+
+    def sign(self, data: bytes) -> tuple[str, str]:
+        """Sign *data* with the Ed25519 private key.
+
+        Returns ``(base64_signature, "sha256:<fingerprint>")``.
+        """
+        pk = self._ensure_private_key()
+        raw_sig = pk.sign(data)
+        sig_b64 = base64.b64encode(raw_sig).decode("ascii")
+        fp = self.get_public_key_fingerprint()
+        return sig_b64, fp
+
+    def verify(self, data: bytes, signature_b64: str, fingerprint: str) -> bool:
+        """Verify *signature_b64* over *data*.
+
+        Tries the primary public key first, then falls back to the keyring.
+        """
+        raw_sig = base64.b64decode(signature_b64)
+
+        # Try the primary public key
+        try:
+            primary_fp = self._ensure_fingerprint()
+            if primary_fp == fingerprint:
+                pub = self._ensure_public_key()
+                pub.verify(raw_sig, data)
+                return True
+        except InvalidSignature:
+            raise SignatureInvalidError("Ed25519 signature does not match primary key")
+
+        # Try keyring keys
+        for key_bytes in load_keyring_public_keys():
+            kf = compute_fingerprint(key_bytes)
+            if kf != fingerprint:
+                continue
+            try:
+                pub = Ed25519PublicKey.from_public_bytes(key_bytes)
+                pub.verify(raw_sig, data)
+                return True
+            except InvalidSignature:
+                raise SignatureInvalidError(
+                    f"Ed25519 signature does not match keyring key {fingerprint}"
+                )
+
+        raise SignatureInvalidError(
+            f"No key with fingerprint {fingerprint} found in key store or keyring"
+        )
+
+    def get_public_key_fingerprint(self) -> str:
+        return self._ensure_fingerprint()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/key_manager.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/signing/key_manager.py
@@ -1,0 +1,139 @@
+"""Key file I/O, XDG path resolution, and passphrase management."""
+
+import getpass
+import os
+from pathlib import Path
+
+from agent_sec_cli.skill_ledger.errors import KeyAlreadyExistsError, KeyNotFoundError
+from agent_sec_cli.skill_ledger.paths import get_data_dir
+
+# ---------------------------------------------------------------------------
+# Key file paths (data dir resolved via paths.get_data_dir)
+# ---------------------------------------------------------------------------
+
+
+def key_enc_path() -> Path:
+    """Path to the encrypted private key file."""
+    return get_data_dir() / "key.enc"
+
+
+def key_pub_path() -> Path:
+    """Path to the public key file."""
+    return get_data_dir() / "key.pub"
+
+
+def keyring_dir() -> Path:
+    """Path to the trusted public key ring directory."""
+    return get_data_dir() / "keyring"
+
+
+# ---------------------------------------------------------------------------
+# Key existence checks
+# ---------------------------------------------------------------------------
+
+
+def keys_exist() -> bool:
+    """Return ``True`` if both ``key.enc`` and ``key.pub`` exist."""
+    return key_enc_path().is_file() and key_pub_path().is_file()
+
+
+def ensure_keys_exist() -> None:
+    """Raise :class:`KeyNotFoundError` if keys are missing."""
+    if not key_enc_path().is_file():
+        raise KeyNotFoundError(str(key_enc_path()))
+    if not key_pub_path().is_file():
+        raise KeyNotFoundError(str(key_pub_path()))
+
+
+def ensure_keys_not_exist(force: bool = False) -> None:
+    """Raise :class:`KeyAlreadyExistsError` unless *force* is ``True``."""
+    if keys_exist() and not force:
+        raise KeyAlreadyExistsError(str(key_enc_path()))
+
+
+# ---------------------------------------------------------------------------
+# Key file read/write
+# ---------------------------------------------------------------------------
+
+
+def write_key_enc(data: bytes) -> Path:
+    """Write encrypted private key bytes.  Creates parent dirs, sets mode 0600."""
+    path = key_enc_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    path.chmod(0o600)
+    return path
+
+
+def read_key_enc() -> bytes:
+    """Read encrypted private key bytes."""
+    path = key_enc_path()
+    if not path.is_file():
+        raise KeyNotFoundError(str(path))
+    return path.read_bytes()
+
+
+def write_key_pub(data: bytes) -> Path:
+    """Write public key bytes.  Creates parent dirs, sets mode 0644."""
+    path = key_pub_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    path.chmod(0o644)
+    return path
+
+
+def read_key_pub() -> bytes:
+    """Read public key bytes."""
+    path = key_pub_path()
+    if not path.is_file():
+        raise KeyNotFoundError(str(path))
+    return path.read_bytes()
+
+
+def load_keyring_public_keys() -> list[bytes]:
+    """Load all ``*.pub`` files from the keyring directory.
+
+    Returns a list of raw public key bytes.  Returns an empty list if the
+    keyring directory does not exist.
+    """
+    kdir = keyring_dir()
+    if not kdir.is_dir():
+        return []
+    keys: list[bytes] = []
+    for pub_file in sorted(kdir.glob("*.pub")):
+        keys.append(pub_file.read_bytes())
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# Passphrase management
+# ---------------------------------------------------------------------------
+
+_cached_passphrase: str | None = None
+
+
+def get_passphrase(prompt: str = "Enter passphrase for skill-ledger signing key: ") -> str:
+    """Obtain the passphrase, trying env var first, then interactive prompt.
+
+    The passphrase is cached in-process for the session lifetime (like ssh-agent).
+    """
+    global _cached_passphrase  # noqa: PLW0603
+
+    if _cached_passphrase is not None:
+        return _cached_passphrase
+
+    # Try environment variable (for CI / non-interactive)
+    env_pass = os.environ.get("SKILL_LEDGER_PASSPHRASE")
+    if env_pass:
+        _cached_passphrase = env_pass
+        return _cached_passphrase
+
+    # Interactive prompt
+    _cached_passphrase = getpass.getpass(prompt)
+    return _cached_passphrase
+
+
+def clear_passphrase_cache() -> None:
+    """Clear the cached passphrase (e.g. after failed decryption)."""
+    global _cached_passphrase  # noqa: PLW0603
+    _cached_passphrase = None

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/utils.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/utils.py
@@ -1,0 +1,8 @@
+"""Shared utility helpers for skill-ledger."""
+
+from datetime import datetime, timezone
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()

--- a/src/agent-sec-core/agent-sec-cli/uv.lock
+++ b/src/agent-sec-core/agent-sec-cli/uv.lock
@@ -7,6 +7,7 @@ name = "agent-sec-cli"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "gnupg" },
     { name = "pydantic" },
     { name = "typer" },
@@ -29,6 +30,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=42.0" },
     { name = "gnupg", specifier = ">=2.0" },
     { name = "pgpy", marker = "extra == 'pgpy'", specifier = ">=0.5" },
     { name = "pydantic", specifier = ">=2.0" },

--- a/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
@@ -1,0 +1,856 @@
+#!/usr/bin/env python3
+"""End-to-end tests for the ``skill-ledger`` CLI.
+
+Exercises every subcommand through the real binary (``uv run skill-ledger``),
+verifying **JSON stdout**, **exit codes**, and **filesystem side effects**.
+
+All key material and config files are isolated via ``XDG_DATA_HOME`` and
+``XDG_CONFIG_HOME`` environment variables so the host keyring is never touched.
+
+Prerequisites: Python 3.11, uv
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).resolve().parents[3]  # agent-sec-core/
+CLI_DIR = REPO_ROOT / "agent-sec-cli"
+
+# ── Colours ────────────────────────────────────────────────────────────────
+
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+BLUE = "\033[0;34m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+
+# ── Result tracker ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class Results:
+    passed: int = 0
+    failed: int = 0
+    errors: list = field(default_factory=list)
+
+
+results = Results()
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def run_skill_ledger(
+    args: list[str],
+    env_extra: dict | None = None,
+    *,
+    cwd: str | Path | None = None,
+) -> subprocess.CompletedProcess:
+    """Run ``uv run skill-ledger <args>`` with isolated XDG env."""
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    cmd = ["uv", "run", "skill-ledger"] + args
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd or str(CLI_DIR),
+    )
+
+
+def parse_json_output(stdout: str) -> dict:
+    """Parse the first JSON line from CLI stdout."""
+    for line in stdout.strip().splitlines():
+        line = line.strip()
+        if line.startswith("{") or line.startswith("["):
+            return json.loads(line)
+    raise ValueError(f"No JSON found in stdout:\n{stdout}")
+
+
+def make_skill(parent: Path, name: str, files: dict[str, str]) -> Path:
+    """Create a fake skill directory with the given files."""
+    skill_dir = parent / name
+    for rel, content in files.items():
+        p = skill_dir / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return skill_dir
+
+
+def write_findings_file(parent: Path, name: str, findings: list | dict) -> Path:
+    """Write a findings JSON file and return its path."""
+    path = parent / name
+    path.write_text(json.dumps(findings, ensure_ascii=False))
+    return path
+
+
+def test(name: str, fn):
+    """Run a single named test, catch exceptions, record results."""
+    print(f"\n{BLUE}--- {name} ---{NC}")
+    try:
+        fn()
+        print(f"{GREEN}✓ PASS{NC}")
+        results.passed += 1
+    except AssertionError as exc:
+        print(f"{RED}✗ FAIL  {exc}{NC}")
+        results.failed += 1
+        results.errors.append((name, exc))
+    except Exception as exc:
+        print(f"{RED}✗ ERROR {exc}{NC}")
+        results.failed += 1
+        results.errors.append((name, exc))
+
+
+# ── Workspace ──────────────────────────────────────────────────────────────
+
+
+class Workspace:
+    """Shared test workspace: isolated XDG dirs, skills dir."""
+
+    def __init__(self):
+        self.root = Path(tempfile.mkdtemp(prefix="e2e_skill_ledger_"))
+        self.xdg_data = self.root / "xdg_data"
+        self.xdg_config = self.root / "xdg_config"
+        self.xdg_data.mkdir()
+        self.xdg_config.mkdir()
+        self.skills_dir = self.root / "skills"
+        self.skills_dir.mkdir()
+        self.fixtures = self.root / "fixtures"
+        self.fixtures.mkdir()
+
+        # Redirect all skill-ledger key/config I/O to temp dirs
+        os.environ["XDG_DATA_HOME"] = str(self.xdg_data)
+        os.environ["XDG_CONFIG_HOME"] = str(self.xdg_config)
+
+    def env(self, extra: dict | None = None) -> dict:
+        """Return env dict with XDG isolation (for subprocess)."""
+        e = {
+            "XDG_DATA_HOME": str(self.xdg_data),
+            "XDG_CONFIG_HOME": str(self.xdg_config),
+        }
+        if extra:
+            e.update(extra)
+        return e
+
+    def cleanup(self):
+        for key in ("XDG_DATA_HOME", "XDG_CONFIG_HOME"):
+            os.environ.pop(key, None)
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+# ── Group 1: init-keys ─────────────────────────────────────────────────────
+
+
+def test_init_keys_no_passphrase(ws: Workspace):
+    """init-keys without passphrase → exit 0, encrypted: false."""
+    r = run_skill_ledger(["init-keys"], env_extra=ws.env())
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out.get("encrypted") is False, f"expected encrypted=false, got {out}"
+    assert out.get("fingerprint", "").startswith("sha256:"), f"bad fingerprint: {out}"
+
+
+def test_init_keys_json_structure(ws: Workspace):
+    """JSON output must contain all 4 expected fields."""
+    # Keys already exist from test_init_keys_no_passphrase — re-gen with --force
+    r = run_skill_ledger(["init-keys", "--force"], env_extra=ws.env())
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    for key in ("fingerprint", "publicKeyPath", "privateKeyPath", "encrypted"):
+        assert key in out, f"Missing field '{key}' in output: {out}"
+    assert len(out["fingerprint"]) > 10
+    assert len(out["publicKeyPath"]) > 0
+    assert len(out["privateKeyPath"]) > 0
+
+
+def test_init_keys_reject_duplicate(ws: Workspace):
+    """Second init-keys without --force → exit 1."""
+    # Generate fresh keys in a separate XDG
+    alt_data = ws.root / "alt_data"
+    alt_data.mkdir()
+    env = ws.env({"XDG_DATA_HOME": str(alt_data)})
+    r1 = run_skill_ledger(["init-keys"], env_extra=env)
+    assert r1.returncode == 0, f"first init failed: {r1.stderr}"
+
+    r2 = run_skill_ledger(["init-keys"], env_extra=env)
+    assert r2.returncode != 0, "Expected non-zero exit without --force"
+    assert "already exists" in r2.stderr.lower() or "already exists" in r2.stdout.lower(), (
+        f"Expected 'already exists' message: stdout={r2.stdout}, stderr={r2.stderr}"
+    )
+
+
+def test_init_keys_force_overwrite(ws: Workspace):
+    """--force overwrites existing keys and produces a new fingerprint."""
+    alt_data = ws.root / "force_data"
+    alt_data.mkdir()
+    env = ws.env({"XDG_DATA_HOME": str(alt_data)})
+    r1 = run_skill_ledger(["init-keys"], env_extra=env)
+    assert r1.returncode == 0
+    fp1 = parse_json_output(r1.stdout)["fingerprint"]
+
+    r2 = run_skill_ledger(["init-keys", "--force"], env_extra=env)
+    assert r2.returncode == 0, f"exit {r2.returncode}: {r2.stderr}"
+    fp2 = parse_json_output(r2.stdout)["fingerprint"]
+
+    # New key pair → almost certainly different fingerprint
+    assert fp1 != fp2, f"Fingerprint should change after --force: {fp1}"
+
+
+def test_init_keys_with_passphrase_env(ws: Workspace):
+    """SKILL_LEDGER_PASSPHRASE env var → encrypted: true."""
+    alt_data = ws.root / "pass_data"
+    alt_data.mkdir()
+    env = ws.env({
+        "XDG_DATA_HOME": str(alt_data),
+        "SKILL_LEDGER_PASSPHRASE": "test-passphrase-123",
+    })
+    r = run_skill_ledger(["init-keys", "--passphrase"], env_extra=env)
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out.get("encrypted") is True, f"expected encrypted=true, got {out}"
+
+
+# ── Group 2: Happy path lifecycle ──────────────────────────────────────────
+
+
+def test_full_lifecycle_pass(ws: Workspace):
+    """init-keys → check (none) → certify --findings (pass) → check (pass) → audit (valid)."""
+    skill = make_skill(ws.skills_dir, "lifecycle-pass", {
+        "main.py": "print('hello')\n",
+        "README.md": "# Test\n",
+    })
+    env = ws.env()
+
+    # check → auto-create → status=none
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"check exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "none", f"expected none, got {out}"
+
+    # certify with pass findings
+    findings = write_findings_file(ws.fixtures, "pass.json", [
+        {"rule": "no-sudo", "level": "pass", "message": "No sudo found"},
+    ])
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0, f"certify exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["scanStatus"] == "pass", f"expected pass, got {out}"
+
+    # check → pass
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"check exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "pass", f"expected pass, got {out}"
+
+    # audit → valid
+    r = run_skill_ledger(["audit", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"audit exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["valid"] is True, f"expected valid=true, got {out}"
+
+
+def test_multi_version_lifecycle(ws: Workspace):
+    """certify → modify file → certify → audit validates 2-version chain."""
+    skill = make_skill(ws.skills_dir, "multi-ver", {"data.txt": "v1"})
+    env = ws.env()
+
+    # First certify
+    findings = write_findings_file(ws.fixtures, "mv-pass.json", [
+        {"rule": "safe", "level": "pass", "message": "OK"},
+    ])
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0, f"certify1 exit {r.returncode}: {r.stderr}"
+    out1 = parse_json_output(r.stdout)
+    assert out1["newVersion"] is True
+
+    # Modify file → new version
+    (skill / "data.txt").write_text("v2")
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0, f"certify2 exit {r.returncode}: {r.stderr}"
+    out2 = parse_json_output(r.stdout)
+    assert out2["newVersion"] is True
+    assert out2["versionId"] != out1["versionId"], "Expected different versionId"
+
+    # audit → valid, 2 versions
+    r = run_skill_ledger(["audit", str(skill)], env_extra=env)
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["valid"] is True
+    assert out["versions_checked"] == 2, f"expected 2, got {out['versions_checked']}"
+
+
+def test_lifecycle_with_warn_findings(ws: Workspace):
+    """certify with warn findings → check returns warn, exit 0."""
+    skill = make_skill(ws.skills_dir, "lifecycle-warn", {"app.sh": "#!/bin/bash\n"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "warn.json", [
+        {"rule": "shell-warning", "level": "warn", "message": "Script lacks set -e"},
+        {"rule": "no-sudo", "level": "pass", "message": "No sudo found"},
+    ])
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0, f"certify exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["scanStatus"] == "warn", f"expected warn, got {out}"
+
+    # check → warn (exit 0 — warn does NOT block)
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"check should exit 0 for warn: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "warn"
+
+
+# ── Group 3: check state machine ──────────────────────────────────────────
+
+
+def test_check_no_manifest_auto_creates(ws: Workspace):
+    """First check on new skill → auto-create manifest, status=none."""
+    skill = make_skill(ws.skills_dir, "check-new", {"f.txt": "hello"})
+    env = ws.env()
+
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "none"
+
+    # .skill-meta/latest.json must exist
+    latest = skill / ".skill-meta" / "latest.json"
+    assert latest.exists(), f"latest.json not created: {list(skill.rglob('*'))}"
+
+
+def test_check_after_file_add_drifted(ws: Workspace):
+    """Adding a file after certify → status=drifted."""
+    skill = make_skill(ws.skills_dir, "check-add", {"original.txt": "content"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "add-pass.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    # Add a new file
+    (skill / "new_file.txt").write_text("I am new")
+
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "drifted", f"expected drifted, got {out}"
+    assert "new_file.txt" in out.get("added", [])
+
+
+def test_check_after_file_modify_drifted(ws: Workspace):
+    """Modifying a file after certify → status=drifted."""
+    skill = make_skill(ws.skills_dir, "check-modify", {"data.txt": "original"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "mod-pass.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    # Modify existing file
+    (skill / "data.txt").write_text("CHANGED")
+
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "drifted"
+    assert "data.txt" in out.get("modified", [])
+
+
+def test_check_after_file_remove_drifted(ws: Workspace):
+    """Removing a file after certify → status=drifted."""
+    skill = make_skill(ws.skills_dir, "check-remove", {
+        "keep.txt": "keep",
+        "delete_me.txt": "gone",
+    })
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "rm-pass.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    # Remove a file
+    (skill / "delete_me.txt").unlink()
+
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "drifted"
+    assert "delete_me.txt" in out.get("removed", [])
+
+
+def test_check_tampered_manifest_hash(ws: Workspace):
+    """Tamper with latest.json without re-hashing → status=tampered, exit 1."""
+    skill = make_skill(ws.skills_dir, "check-tamper", {"f.txt": "safe"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "tamper-pass.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    # Tamper: modify a field in latest.json without re-hashing
+    latest = skill / ".skill-meta" / "latest.json"
+    data = json.loads(latest.read_text())
+    data["scanStatus"] = "deny"  # tamper without re-hashing
+    latest.write_text(json.dumps(data))
+
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 1, f"expected exit 1 for tampered, got {r.returncode}"
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "tampered", f"expected tampered, got {out}"
+
+
+def test_check_deny_exit_code_1(ws: Workspace):
+    """Certify with deny findings → check returns deny with exit 1."""
+    skill = make_skill(ws.skills_dir, "check-deny", {"danger.sh": "rm -rf /"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "deny.json", [
+        {"rule": "dangerous-cmd", "level": "deny", "message": "rm -rf detected"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    r = run_skill_ledger(["check", str(skill)], env_extra=env)
+    assert r.returncode == 1, f"expected exit 1 for deny, got {r.returncode}"
+    out = parse_json_output(r.stdout)
+    assert out["status"] == "deny", f"expected deny, got {out}"
+
+
+# ── Group 4: certify command ──────────────────────────────────────────────
+
+
+def test_certify_external_findings_bare_array(ws: Workspace):
+    """--findings with bare JSON array → exit 0, correct scanStatus."""
+    skill = make_skill(ws.skills_dir, "certify-bare", {"a.txt": "a"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "bare.json", [
+        {"rule": "r1", "level": "pass", "message": "ok"},
+        {"rule": "r2", "level": "warn", "message": "caution"},
+    ])
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["scanStatus"] == "warn"  # warn dominates pass
+
+
+def test_certify_external_findings_wrapped(ws: Workspace):
+    """--findings with {"findings": [...]} wrapper → exit 0."""
+    skill = make_skill(ws.skills_dir, "certify-wrap", {"b.txt": "b"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "wrapped.json", {
+        "findings": [
+            {"rule": "r1", "level": "pass", "message": "ok"},
+        ]
+    })
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["scanStatus"] == "pass"
+
+
+def test_certify_deny_finding_produces_deny(ws: Workspace):
+    """deny-level finding → scanStatus=deny."""
+    skill = make_skill(ws.skills_dir, "certify-deny", {"c.txt": "c"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "deny-f.json", [
+        {"rule": "r-pass", "level": "pass", "message": "ok"},
+        {"rule": "r-deny", "level": "deny", "message": "blocked"},
+    ])
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["scanStatus"] == "deny"  # deny dominates all
+
+
+def test_certify_missing_findings_file(ws: Workspace):
+    """--findings pointing to nonexistent file → exit 1."""
+    skill = make_skill(ws.skills_dir, "certify-missing", {"d.txt": "d"})
+    env = ws.env()
+
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", "/tmp/nonexistent_findings.json"],
+        env_extra=env,
+    )
+    assert r.returncode == 1, f"expected exit 1, got {r.returncode}"
+
+
+def test_certify_invalid_json_findings(ws: Workspace):
+    """--findings with invalid JSON → exit 1."""
+    skill = make_skill(ws.skills_dir, "certify-badjson", {"e.txt": "e"})
+    env = ws.env()
+
+    bad_file = ws.fixtures / "bad.json"
+    bad_file.write_text("{not valid json!!!")
+
+    r = run_skill_ledger(
+        ["certify", str(skill), "--findings", str(bad_file)],
+        env_extra=env,
+    )
+    assert r.returncode == 1, f"expected exit 1 for invalid JSON, got {r.returncode}"
+
+
+def test_certify_no_findings_auto_invoke(ws: Workspace):
+    """certify without --findings → auto-invoke mode, exit 0 (no-op in v1)."""
+    skill = make_skill(ws.skills_dir, "certify-auto", {"f.txt": "f"})
+    env = ws.env()
+
+    r = run_skill_ledger(["certify", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    # Without findings, scanStatus stays at initial value
+    assert "scanStatus" in out
+
+
+def test_certify_no_skill_dir_no_all(ws: Workspace):
+    """certify without skill_dir and without --all → exit 1."""
+    env = ws.env()
+    r = run_skill_ledger(["certify"], env_extra=env)
+    assert r.returncode == 1, f"expected exit 1, got {r.returncode}"
+    combined = r.stdout + r.stderr
+    assert "required" in combined.lower() or "skill_dir" in combined.lower(), (
+        f"Expected error about missing skill_dir: {combined}"
+    )
+
+
+# ── Group 5: certify --all ────────────────────────────────────────────────
+
+
+def test_certify_all_multiple_skills(ws: Workspace):
+    """--all certifies all skills from config.json skillDirs."""
+    env = ws.env()
+
+    # Create skills
+    batch_root = ws.root / "batch_skills"
+    batch_root.mkdir()
+    for name in ("skill-x", "skill-y", "skill-z"):
+        make_skill(batch_root, name, {"main.py": f"# {name}\n"})
+
+    # Write config.json with skillDirs glob
+    config_dir = ws.xdg_config / "skill-ledger"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config = {"skillDirs": [str(batch_root / "*")]}
+    (config_dir / "config.json").write_text(json.dumps(config))
+
+    findings = write_findings_file(ws.fixtures, "all-pass.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    r = run_skill_ledger(
+        ["certify", "--all", "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert "results" in out, f"Expected 'results' key: {out}"
+    assert len(out["results"]) == 3, f"Expected 3 results, got {len(out['results'])}"
+
+
+def test_certify_all_no_skill_dirs(ws: Workspace):
+    """--all with empty skillDirs → exit 1."""
+    env = ws.env()
+
+    # Write config.json with empty skillDirs
+    config_dir = ws.xdg_config / "skill-ledger"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config = {"skillDirs": []}
+    (config_dir / "config.json").write_text(json.dumps(config))
+
+    r = run_skill_ledger(["certify", "--all"], env_extra=env)
+    assert r.returncode == 1, f"expected exit 1, got {r.returncode}"
+    combined = r.stdout + r.stderr
+    assert "no skill directories" in combined.lower(), f"Expected no-dirs message: {combined}"
+
+
+# ── Group 6: audit command ────────────────────────────────────────────────
+
+
+def test_audit_valid_chain(ws: Workspace):
+    """Multi-version audit → valid=true, exit 0."""
+    skill = make_skill(ws.skills_dir, "audit-valid", {"a.txt": "a"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "audit-p.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    # Version 1
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+    # Version 2
+    (skill / "a.txt").write_text("a-v2")
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    r = run_skill_ledger(["audit", str(skill)], env_extra=env)
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["valid"] is True
+    assert out["versions_checked"] >= 2
+
+
+def test_audit_no_versions(ws: Workspace):
+    """Skill with no .skill-meta → valid=true, 0 versions checked."""
+    skill = make_skill(ws.skills_dir, "audit-none", {"x.txt": "x"})
+    env = ws.env()
+
+    # Do NOT run check/certify — no manifest
+    r = run_skill_ledger(["audit", str(skill)], env_extra=env)
+    assert r.returncode == 0
+    out = parse_json_output(r.stdout)
+    assert out["valid"] is True
+    assert out["versions_checked"] == 0
+
+
+def test_audit_tampered_version_file(ws: Workspace):
+    """Tamper with a version JSON → valid=false, exit 1."""
+    skill = make_skill(ws.skills_dir, "audit-tamper", {"f.txt": "f"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "audit-t.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    # Tamper with the version file
+    versions_dir = skill / ".skill-meta" / "versions"
+    version_files = sorted(versions_dir.glob("v*.json"))
+    assert len(version_files) >= 1, f"No version files found: {list(versions_dir.iterdir())}"
+    vf = version_files[0]
+    data = json.loads(vf.read_text())
+    data["scanStatus"] = "deny"  # tamper without re-hashing
+    vf.write_text(json.dumps(data))
+
+    r = run_skill_ledger(["audit", str(skill)], env_extra=env)
+    assert r.returncode == 1, f"expected exit 1 for tampered audit, got {r.returncode}"
+    out = parse_json_output(r.stdout)
+    assert out["valid"] is False
+    assert len(out["errors"]) > 0
+
+
+def test_audit_verify_snapshots(ws: Workspace):
+    """--verify-snapshots validates snapshot file hashes match manifest."""
+    skill = make_skill(ws.skills_dir, "audit-snap", {"s.txt": "snapshot-test"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "audit-s.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    r = run_skill_ledger(
+        ["audit", str(skill), "--verify-snapshots"],
+        env_extra=env,
+    )
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["valid"] is True
+
+
+# ── Group 7: status command ───────────────────────────────────────────────
+
+
+def test_status_human_readable_output(ws: Workspace):
+    """status shows human-readable info after certify."""
+    skill = make_skill(ws.skills_dir, "status-show", {"m.txt": "main"})
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "status-p.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    r = run_skill_ledger(["status", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+
+    output = r.stdout
+    for label in ("Skill:", "Status:", "scanStatus:", "Version:", "Signed by:"):
+        assert label in output, f"Missing '{label}' in status output:\n{output}"
+
+
+def test_status_drifted_shows_details(ws: Workspace):
+    """status after file modification shows added/removed/modified details."""
+    skill = make_skill(ws.skills_dir, "status-drift", {
+        "orig.txt": "original",
+        "removeme.txt": "to be removed",
+    })
+    env = ws.env()
+
+    findings = write_findings_file(ws.fixtures, "status-d.json", [
+        {"rule": "ok", "level": "pass", "message": "pass"},
+    ])
+    run_skill_ledger(["certify", str(skill), "--findings", str(findings)], env_extra=env)
+
+    # Cause drift: add, remove, modify
+    (skill / "new.txt").write_text("new")
+    (skill / "removeme.txt").unlink()
+    (skill / "orig.txt").write_text("MODIFIED")
+
+    r = run_skill_ledger(["status", str(skill)], env_extra=env)
+    assert r.returncode == 0
+    output = r.stdout
+    assert "drifted" in output.lower(), f"Expected 'drifted' in output:\n{output}"
+    assert "Added:" in output, f"Expected 'Added:' in output:\n{output}"
+    assert "Removed:" in output, f"Expected 'Removed:' in output:\n{output}"
+    assert "Modified:" in output, f"Expected 'Modified:' in output:\n{output}"
+
+
+# ── Group 8: stubs & edge cases ───────────────────────────────────────────
+
+
+def test_set_policy_stub(ws: Workspace):
+    """set-policy → exit 0, 'coming soon' in output."""
+    skill = make_skill(ws.skills_dir, "stub-policy", {"x.txt": "x"})
+    r = run_skill_ledger(
+        ["set-policy", str(skill), "--policy", "allow"],
+        env_extra=ws.env(),
+    )
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    assert "coming soon" in r.stdout.lower()
+
+
+def test_rotate_keys_stub(ws: Workspace):
+    """rotate-keys → exit 0, 'coming soon' in output."""
+    r = run_skill_ledger(["rotate-keys"], env_extra=ws.env())
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    assert "coming soon" in r.stdout.lower()
+
+
+def test_certify_empty_skill_dir(ws: Workspace):
+    """Certify a skill dir with no files → still succeeds (empty fileHashes)."""
+    skill = ws.skills_dir / "empty-skill"
+    skill.mkdir(parents=True, exist_ok=True)
+    env = ws.env()
+
+    r = run_skill_ledger(["certify", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert "scanStatus" in out
+
+
+# ── Main ───────────────────────────────────────────────────────────────────
+
+
+def main():
+    # Pre-flight
+    uv = shutil.which("uv")
+    if not uv:
+        print(f"{RED}ERROR: uv not found — cannot run e2e tests{NC}")
+        sys.exit(1)
+    if not CLI_DIR.exists():
+        print(f"{RED}ERROR: {CLI_DIR} not found{NC}")
+        sys.exit(1)
+
+    ws = Workspace()
+    try:
+        print("=" * 60)
+        print(f"{BOLD}skill-ledger CLI E2E Tests{NC}")
+        print(f"  CLI dir   : {CLI_DIR}")
+        print(f"  workspace : {ws.root}")
+        print("=" * 60)
+
+        # Group 1: init-keys (run first — all subsequent tests need keys)
+        test("init-keys: no passphrase", lambda: test_init_keys_no_passphrase(ws))
+        test("init-keys: JSON structure", lambda: test_init_keys_json_structure(ws))
+        test("init-keys: reject duplicate", lambda: test_init_keys_reject_duplicate(ws))
+        test("init-keys: --force overwrite", lambda: test_init_keys_force_overwrite(ws))
+        test("init-keys: passphrase env var", lambda: test_init_keys_with_passphrase_env(ws))
+
+        # Group 2: happy path lifecycles
+        test("Lifecycle: full pass flow", lambda: test_full_lifecycle_pass(ws))
+        test("Lifecycle: multi-version chain", lambda: test_multi_version_lifecycle(ws))
+        test("Lifecycle: warn findings", lambda: test_lifecycle_with_warn_findings(ws))
+
+        # Group 3: check state machine
+        test("Check: no manifest → auto-create", lambda: test_check_no_manifest_auto_creates(ws))
+        test("Check: file added → drifted", lambda: test_check_after_file_add_drifted(ws))
+        test("Check: file modified → drifted", lambda: test_check_after_file_modify_drifted(ws))
+        test("Check: file removed → drifted", lambda: test_check_after_file_remove_drifted(ws))
+        test("Check: tampered manifest → exit 1", lambda: test_check_tampered_manifest_hash(ws))
+        test("Check: deny status → exit 1", lambda: test_check_deny_exit_code_1(ws))
+
+        # Group 4: certify command
+        test("Certify: bare array findings", lambda: test_certify_external_findings_bare_array(ws))
+        test("Certify: wrapped findings", lambda: test_certify_external_findings_wrapped(ws))
+        test("Certify: deny finding", lambda: test_certify_deny_finding_produces_deny(ws))
+        test("Certify: missing findings file", lambda: test_certify_missing_findings_file(ws))
+        test("Certify: invalid JSON", lambda: test_certify_invalid_json_findings(ws))
+        test("Certify: auto-invoke mode", lambda: test_certify_no_findings_auto_invoke(ws))
+        test("Certify: no skill_dir no --all", lambda: test_certify_no_skill_dir_no_all(ws))
+
+        # Group 5: certify --all
+        test("Certify --all: multiple skills", lambda: test_certify_all_multiple_skills(ws))
+        test("Certify --all: no skill dirs", lambda: test_certify_all_no_skill_dirs(ws))
+
+        # Group 6: audit
+        test("Audit: valid chain", lambda: test_audit_valid_chain(ws))
+        test("Audit: no versions", lambda: test_audit_no_versions(ws))
+        test("Audit: tampered version file", lambda: test_audit_tampered_version_file(ws))
+        test("Audit: --verify-snapshots", lambda: test_audit_verify_snapshots(ws))
+
+        # Group 7: status
+        test("Status: human-readable output", lambda: test_status_human_readable_output(ws))
+        test("Status: drifted details", lambda: test_status_drifted_shows_details(ws))
+
+        # Group 8: stubs & edge cases
+        test("set-policy stub", lambda: test_set_policy_stub(ws))
+        test("rotate-keys stub", lambda: test_rotate_keys_stub(ws))
+        test("Certify: empty skill dir", lambda: test_certify_empty_skill_dir(ws))
+
+    finally:
+        ws.cleanup()
+
+    # Summary
+    print()
+    print("=" * 60)
+    total = results.passed + results.failed
+    print(f"{BOLD}Results: {results.passed}/{total} passed{NC}")
+    if results.errors:
+        for name, exc in results.errors:
+            print(f"  {RED}FAIL{NC} {name}: {exc}")
+    print("=" * 60)
+
+    if results.failed:
+        print(f"{RED}{results.failed} test(s) failed{NC}")
+        sys.exit(1)
+    else:
+        print(f"{GREEN}All tests passed!{NC}")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_models.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_models.py
@@ -1,0 +1,187 @@
+"""Unit tests for skill_ledger models — manifest hashing, scan aggregation, finding normalization.
+
+These tests protect the most critical invariants:
+1. Manifest hash determinism — if canonical JSON changes, ALL existing signatures break.
+2. Severity aggregation ordering — deny > warn > pass > none is a core security contract.
+3. Finding serialization — optional fields only appear when set (compact manifest).
+"""
+
+import unittest
+
+from agent_sec_cli.skill_ledger.models.finding import NormalizedFinding
+from agent_sec_cli.skill_ledger.models.manifest import ManifestSignature, SignedManifest
+from agent_sec_cli.skill_ledger.models.scan import ScanEntry, aggregate_scan_status
+
+
+class TestManifestHashDeterminism(unittest.TestCase):
+    """The same logical manifest must ALWAYS produce the same hash.
+
+    If this breaks, every existing signed manifest in production becomes
+    unverifiable — ``check`` will return ``tampered`` on valid data.
+    """
+
+    def _make_manifest(self, **overrides) -> SignedManifest:
+        defaults = dict(
+            versionId="v000001",
+            skillName="test-skill",
+            fileHashes={"run.sh": "sha256:aaa", "SKILL.md": "sha256:bbb"},
+            scanStatus="pass",
+            createdAt="2026-01-01T00:00:00+00:00",
+        )
+        defaults.update(overrides)
+        return SignedManifest(**defaults)
+
+    def test_same_manifest_same_hash(self):
+        """Identical manifests must produce identical hashes — non-negotiable."""
+        m1 = self._make_manifest()
+        m2 = self._make_manifest()
+        self.assertEqual(m1.compute_manifest_hash(), m2.compute_manifest_hash())
+
+    def test_hash_is_sha256_prefixed(self):
+        h = self._make_manifest().compute_manifest_hash()
+        self.assertTrue(h.startswith("sha256:"))
+        self.assertEqual(len(h), len("sha256:") + 64)  # hex SHA-256
+
+    def test_hash_excludes_manifestHash_and_signature(self):
+        """Changing manifestHash or signature must NOT change the computed hash.
+
+        These fields are the output of the hashing process, not inputs.
+        """
+        m1 = self._make_manifest()
+        m2 = self._make_manifest()
+        m2.manifestHash = "sha256:fake"
+        m2.signature = ManifestSignature(
+            algorithm="ed25519", value="sig123", keyFingerprint="sha256:fp"
+        )
+        self.assertEqual(m1.compute_manifest_hash(), m2.compute_manifest_hash())
+
+    def test_hash_changes_on_fileHashes_change(self):
+        """Any file change must produce a different hash — core integrity guarantee."""
+        m1 = self._make_manifest()
+        m2 = self._make_manifest(fileHashes={"run.sh": "sha256:CHANGED"})
+        self.assertNotEqual(m1.compute_manifest_hash(), m2.compute_manifest_hash())
+
+    def test_hash_changes_on_scanStatus_change(self):
+        """Tampering scanStatus (e.g. deny→pass) must change the hash."""
+        m1 = self._make_manifest(scanStatus="deny")
+        m2 = self._make_manifest(scanStatus="pass")
+        self.assertNotEqual(m1.compute_manifest_hash(), m2.compute_manifest_hash())
+
+    def test_hash_changes_on_versionId_change(self):
+        m1 = self._make_manifest(versionId="v000001")
+        m2 = self._make_manifest(versionId="v000002")
+        self.assertNotEqual(m1.compute_manifest_hash(), m2.compute_manifest_hash())
+
+    def test_hash_changes_on_scans_change(self):
+        """Adding a scan entry must change the hash — scan results are signed."""
+        m1 = self._make_manifest()
+        m2 = self._make_manifest()
+        m2.scans = [ScanEntry(scanner="test", version="1.0", status="pass")]
+        self.assertNotEqual(m1.compute_manifest_hash(), m2.compute_manifest_hash())
+
+
+class TestManifestSerializationRoundtrip(unittest.TestCase):
+    """Serialization/deserialization must be lossless — manifests are stored as JSON."""
+
+    def test_roundtrip_preserves_all_fields(self):
+        original = SignedManifest(
+            versionId="v000003",
+            previousVersionId="v000002",
+            skillName="my-skill",
+            fileHashes={"a.sh": "sha256:aaa"},
+            scans=[ScanEntry(scanner="sv", version="1", status="warn",
+                             findings=[{"rule": "r1", "level": "warn", "message": "m"}])],
+            scanStatus="warn",
+            policy="warning",
+            createdAt="2026-01-01T00:00:00+00:00",
+            manifestHash="sha256:hash123",
+            previousManifestSignature="prevsig",
+            signature=ManifestSignature(
+                algorithm="ed25519", value="sig", keyFingerprint="sha256:fp"
+            ),
+        )
+        text = original.to_json()
+        restored = SignedManifest.from_json(text)
+        # Hash must survive roundtrip — otherwise check breaks on loaded manifests
+        self.assertEqual(original.compute_manifest_hash(), restored.compute_manifest_hash())
+        self.assertEqual(original.versionId, restored.versionId)
+        self.assertEqual(original.previousVersionId, restored.previousVersionId)
+        self.assertEqual(original.fileHashes, restored.fileHashes)
+        self.assertEqual(original.scanStatus, restored.scanStatus)
+        self.assertEqual(original.signature.value, restored.signature.value)
+        self.assertEqual(len(original.scans), len(restored.scans))
+        self.assertEqual(original.scans[0].scanner, restored.scans[0].scanner)
+
+
+class TestScanStatusAggregation(unittest.TestCase):
+    """Severity ordering: deny > warn > pass > none.
+
+    This is the security contract: the most severe scanner result
+    determines the overall skill status shown to the user.
+    """
+
+    def test_empty_scans_returns_none(self):
+        self.assertEqual(aggregate_scan_status([]), "none")
+
+    def test_single_pass(self):
+        scans = [ScanEntry(status="pass")]
+        self.assertEqual(aggregate_scan_status(scans), "pass")
+
+    def test_deny_dominates_all(self):
+        """Even one deny scanner overrides any number of pass/warn results."""
+        scans = [
+            ScanEntry(scanner="a", status="pass"),
+            ScanEntry(scanner="b", status="warn"),
+            ScanEntry(scanner="c", status="deny"),
+        ]
+        self.assertEqual(aggregate_scan_status(scans), "deny")
+
+    def test_warn_dominates_pass(self):
+        scans = [
+            ScanEntry(scanner="a", status="pass"),
+            ScanEntry(scanner="b", status="warn"),
+        ]
+        self.assertEqual(aggregate_scan_status(scans), "warn")
+
+    def test_pass_over_none(self):
+        """A scanner that returned 'pass' is more severe than 'none'."""
+        scans = [ScanEntry(status="pass")]
+        self.assertEqual(aggregate_scan_status(scans), "pass")
+
+    def test_unknown_status_treated_as_lowest(self):
+        """Unknown status defaults to severity 0 — should not override known statuses."""
+        scans = [
+            ScanEntry(scanner="a", status="pass"),
+            ScanEntry(scanner="b", status="unknown_future_status"),
+        ]
+        result = aggregate_scan_status(scans)
+        self.assertEqual(result, "pass")
+
+
+class TestNormalizedFindingToDict(unittest.TestCase):
+    """to_findings_dict() must only include optional fields when set.
+
+    This keeps manifests compact and avoids false diffs when comparing versions.
+    """
+
+    def test_minimal_finding_omits_optional_fields(self):
+        f = NormalizedFinding(rule="test-rule", level="warn", message="msg")
+        d = f.to_findings_dict()
+        self.assertEqual(d, {"rule": "test-rule", "level": "warn", "message": "msg"})
+        self.assertNotIn("file", d)
+        self.assertNotIn("line", d)
+        self.assertNotIn("metadata", d)
+
+    def test_full_finding_includes_all_fields(self):
+        f = NormalizedFinding(
+            rule="dangerous-exec", level="deny", message="exec found",
+            file="run.sh", line=42, metadata={"pattern": "child_process"},
+        )
+        d = f.to_findings_dict()
+        self.assertEqual(d["file"], "run.sh")
+        self.assertEqual(d["line"], 42)
+        self.assertEqual(d["metadata"]["pattern"], "child_process")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_scanner.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_scanner.py
@@ -1,0 +1,209 @@
+"""Unit tests for scanner registry and result parsers.
+
+These tests protect:
+1. Parser normalization — the data ingestion boundary for all external scanner output.
+   Malformed/unexpected input must be handled gracefully, not crash the pipeline.
+2. Registry lookup chain — scanner → parser name → parser info resolution.
+   Fallback to findings-array for unknown scanners is a backward compat contract.
+3. Status derivation from findings — deny > warn > pass is the per-scanner logic.
+"""
+
+import unittest
+
+from agent_sec_cli.skill_ledger.core.certifier import _determine_scan_status
+from agent_sec_cli.skill_ledger.models.finding import NormalizedFinding
+from agent_sec_cli.skill_ledger.scanner.parsers import parse_findings
+from agent_sec_cli.skill_ledger.scanner.registry import (
+    ParserInfo,
+    ScannerInfo,
+    ScannerRegistry,
+)
+
+
+class TestFindingsArrayParser(unittest.TestCase):
+    """The findings-array parser is the identity parser — input is already
+    in standard format.  But real-world data is messy.  These tests verify
+    that the parser handles edge cases without crashing the certify pipeline.
+    """
+
+    def test_valid_findings_parsed(self):
+        raw = [
+            {"rule": "dangerous-exec", "level": "deny", "message": "exec found"},
+            {"rule": "obfuscated", "level": "warn", "message": "hex encoding"},
+        ]
+        result = parse_findings(raw, None)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].rule, "dangerous-exec")
+        self.assertEqual(result[0].level, "deny")
+        self.assertEqual(result[1].level, "warn")
+
+    def test_missing_rule_skipped(self):
+        """Findings without 'rule' are invalid — skip, don't crash."""
+        raw = [
+            {"level": "warn", "message": "no rule"},
+            {"rule": "valid", "level": "pass", "message": "ok"},
+        ]
+        result = parse_findings(raw, None)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].rule, "valid")
+
+    def test_missing_level_skipped(self):
+        """Findings without 'level' are invalid — skip, don't crash."""
+        raw = [{"rule": "r1", "message": "no level"}]
+        result = parse_findings(raw, None)
+        self.assertEqual(len(result), 0)
+
+    def test_unknown_level_normalized_to_warn(self):
+        """Unknown level strings are treated as 'warn' — safe conservative default."""
+        raw = [{"rule": "r1", "level": "HIGH", "message": "unknown"}]
+        result = parse_findings(raw, None)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].level, "warn")
+
+    def test_level_case_insensitive(self):
+        """Level matching is case-insensitive — 'DENY' should work like 'deny'."""
+        raw = [{"rule": "r1", "level": "DENY", "message": "caps"}]
+        result = parse_findings(raw, None)
+        self.assertEqual(result[0].level, "deny")
+
+    def test_extra_fields_captured_in_metadata(self):
+        """Scanner-specific fields not in the model are preserved, not dropped."""
+        raw = [
+            {
+                "rule": "r1",
+                "level": "pass",
+                "message": "ok",
+                "severity_score": 0.9,
+                "cwe_id": "CWE-78",
+            }
+        ]
+        result = parse_findings(raw, None)
+        self.assertIn("severity_score", result[0].metadata)
+        self.assertIn("cwe_id", result[0].metadata)
+        self.assertEqual(result[0].metadata["severity_score"], 0.9)
+
+    def test_non_dict_items_skipped(self):
+        """Non-dict items in the findings list are skipped — handles garbage input."""
+        raw = [
+            "not a dict",
+            42,
+            {"rule": "valid", "level": "pass", "message": "ok"},
+        ]
+        result = parse_findings(raw, None)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].rule, "valid")
+
+    def test_empty_list_returns_empty(self):
+        result = parse_findings([], None)
+        self.assertEqual(result, [])
+
+
+class TestParserDispatch(unittest.TestCase):
+    """parse_findings() dispatches by parser type. Unknown types fall back safely."""
+
+    def test_none_parser_uses_findings_array(self):
+        """No parser info → fall back to findings-array (backward compat)."""
+        raw = [{"rule": "r1", "level": "pass", "message": "ok"}]
+        result = parse_findings(raw, None)
+        self.assertEqual(len(result), 1)
+
+    def test_findings_array_parser_dispatches(self):
+        parser = ParserInfo(name="findings-array", type="findings-array")
+        raw = [{"rule": "r1", "level": "deny", "message": "bad"}]
+        result = parse_findings(raw, parser)
+        self.assertEqual(result[0].level, "deny")
+
+    def test_unknown_parser_type_falls_back(self):
+        """Future parser types not yet implemented → fall back to findings-array."""
+        parser = ParserInfo(name="sarif-future", type="sarif")
+        raw = [{"rule": "r1", "level": "warn", "message": "m"}]
+        result = parse_findings(raw, parser)
+        self.assertEqual(len(result), 1)
+
+
+class TestScannerRegistry(unittest.TestCase):
+    """Registry is the configuration backbone — tests ensure lookup correctness."""
+
+    def _make_registry(self):
+        config = {
+            "scanners": [
+                {"name": "skill-vetter", "type": "skill", "parser": "findings-array"},
+                {"name": "pattern-scanner", "type": "builtin", "parser": "findings-array"},
+                {"name": "disabled-one", "type": "cli", "enabled": False},
+            ],
+            "parsers": {
+                "findings-array": {"type": "findings-array"},
+            },
+        }
+        return ScannerRegistry.from_config(config)
+
+    def test_get_scanner_returns_info(self):
+        reg = self._make_registry()
+        sv = reg.get_scanner("skill-vetter")
+        self.assertIsNotNone(sv)
+        self.assertEqual(sv.type, "skill")
+        self.assertEqual(sv.parser, "findings-array")
+
+    def test_get_scanner_unknown_returns_none(self):
+        reg = self._make_registry()
+        self.assertIsNone(reg.get_scanner("nonexistent"))
+
+    def test_get_parser_for_scanner_chain(self):
+        """scanner → parser name → parser info lookup chain must work."""
+        reg = self._make_registry()
+        pi = reg.get_parser_for_scanner("skill-vetter")
+        self.assertIsNotNone(pi)
+        self.assertEqual(pi.type, "findings-array")
+
+    def test_get_parser_for_unknown_scanner_returns_none(self):
+        reg = self._make_registry()
+        self.assertIsNone(reg.get_parser_for_scanner("unknown"))
+
+    def test_list_invocable_excludes_skill_type(self):
+        """skill-type scanners require Agent — CLI must not auto-invoke them."""
+        reg = self._make_registry()
+        invocable = reg.list_invocable_scanners()
+        names = [s.name for s in invocable]
+        self.assertNotIn("skill-vetter", names)
+        self.assertIn("pattern-scanner", names)
+
+    def test_list_invocable_excludes_disabled(self):
+        reg = self._make_registry()
+        invocable = reg.list_invocable_scanners()
+        names = [s.name for s in invocable]
+        self.assertNotIn("disabled-one", names)
+
+    def test_list_invocable_with_name_filter(self):
+        reg = self._make_registry()
+        invocable = reg.list_invocable_scanners(names=["pattern-scanner"])
+        self.assertEqual(len(invocable), 1)
+        self.assertEqual(invocable[0].name, "pattern-scanner")
+
+
+class TestDetermineStatusFromFindings(unittest.TestCase):
+    """Per-scanner status derived from normalized findings — deny > warn > pass."""
+
+    def test_empty_findings_returns_pass(self):
+        self.assertEqual(_determine_scan_status([]), "pass")
+
+    def test_all_pass_returns_pass(self):
+        findings = [NormalizedFinding(rule="r1", level="pass", message="ok")]
+        self.assertEqual(_determine_scan_status(findings), "pass")
+
+    def test_deny_present_returns_deny(self):
+        findings = [
+            NormalizedFinding(rule="r1", level="pass", message="ok"),
+            NormalizedFinding(rule="r2", level="deny", message="bad"),
+        ]
+        self.assertEqual(_determine_scan_status(findings), "deny")
+
+    def test_warn_without_deny_returns_warn(self):
+        findings = [
+            NormalizedFinding(rule="r1", level="pass", message="ok"),
+            NormalizedFinding(rule="r2", level="warn", message="iffy"),
+        ]
+        self.assertEqual(_determine_scan_status(findings), "warn")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_workflows.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_workflows.py
@@ -1,0 +1,482 @@
+"""End-to-end workflow tests for check, certify, and audit.
+
+These tests use real Ed25519 cryptography with temp directories — no mocks
+for the signing layer.  They protect the actual security-critical paths:
+
+1. **Check state machine** — the security gate called on every skill invocation.
+   Every state (none/drifted/tampered/deny/warn/pass) must be correct.
+2. **Certify scan merge** — scanner results are accumulated correctly, old
+   entries for the same scanner replaced (not duplicated).
+3. **Audit chain integrity** — broken previousManifestSignature chain and
+   tampered manifestHash must both be detected.
+"""
+
+import base64
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
+
+from agent_sec_cli.skill_ledger.core.auditor import audit
+from agent_sec_cli.skill_ledger.core.certifier import certify
+from agent_sec_cli.skill_ledger.core.checker import check
+from agent_sec_cli.skill_ledger.core.file_hasher import compute_file_hashes, diff_file_hashes
+from agent_sec_cli.skill_ledger.errors import SignatureInvalidError
+from agent_sec_cli.skill_ledger.signing.base import SigningBackend
+
+
+# ---------------------------------------------------------------------------
+# In-memory Ed25519 backend for testing (no filesystem key storage)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryEd25519Backend(SigningBackend):
+    """A test-only signing backend that holds keys in memory."""
+
+    def __init__(self):
+        self._private_key = Ed25519PrivateKey.generate()
+        raw_pub = self._private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+        self._fingerprint = f"sha256:{hashlib.sha256(raw_pub).hexdigest()}"
+
+    @property
+    def name(self) -> str:
+        return "ed25519"
+
+    def generate_keys(self, passphrase=None):
+        """No-op for in-memory backend — keys are generated in __init__."""
+        return {"fingerprint": self._fingerprint}
+
+    def sign(self, data: bytes) -> tuple[str, str]:
+        raw_sig = self._private_key.sign(data)
+        return base64.b64encode(raw_sig).decode("ascii"), self._fingerprint
+
+    def verify(self, data: bytes, signature_b64: str, fingerprint: str) -> bool:
+        if fingerprint != self._fingerprint:
+            raise SignatureInvalidError(f"Unknown fingerprint {fingerprint}")
+        from cryptography.exceptions import InvalidSignature
+        raw_sig = base64.b64decode(signature_b64)
+        try:
+            self._private_key.public_key().verify(raw_sig, data)
+            return True
+        except InvalidSignature:
+            raise SignatureInvalidError("Signature verification failed")
+
+    def get_public_key_fingerprint(self) -> str:
+        return self._fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Test helper: manage a temp skill directory
+# ---------------------------------------------------------------------------
+
+
+class SkillDirTestCase(unittest.TestCase):
+    """Base class that creates a temp skill directory with sample files."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.skill_dir = os.path.join(self.tmpdir, "test-skill")
+        os.makedirs(self.skill_dir)
+        # Create sample skill files
+        self._write_file("run.sh", "#!/bin/bash\necho hello\n")
+        self._write_file("SKILL.md", "# Test Skill\n")
+        self.backend = InMemoryEd25519Backend()
+        # Patch config to avoid touching user's real config
+        self._patch_config()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_file(self, name: str, content: str):
+        path = os.path.join(self.skill_dir, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+
+    def _write_findings(self, findings: list[dict]) -> str:
+        path = os.path.join(self.tmpdir, "findings.json")
+        with open(path, "w") as f:
+            json.dump(findings, f)
+        return path
+
+    def _patch_config(self):
+        """Point config to a temp config dir so tests don't touch real user config."""
+        config_dir = os.path.join(self.tmpdir, "config")
+        os.makedirs(config_dir, exist_ok=True)
+        os.environ["XDG_CONFIG_HOME"] = self.tmpdir
+        self.addCleanup(lambda: os.environ.pop("XDG_CONFIG_HOME", None))
+
+
+# ---------------------------------------------------------------------------
+# Check state machine
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStateMachine(SkillDirTestCase):
+    """Tests for the check command — the security gate.
+
+    The check state machine has 6 possible outputs:
+    none, drifted, tampered, deny, warn, pass.
+    Each represents a distinct security posture.
+    """
+
+    def test_no_manifest_creates_one_returns_none(self):
+        """First check on a fresh skill → auto-create manifest, status=none."""
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "none")
+        # .skill-meta/latest.json should now exist
+        latest = os.path.join(self.skill_dir, ".skill-meta", "latest.json")
+        self.assertTrue(os.path.isfile(latest))
+
+    def test_unchanged_after_certify_pass(self):
+        """certify with all-pass findings → check returns pass."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "ok"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "pass")
+
+    def test_drifted_after_file_change(self):
+        """Modifying a skill file → check returns drifted."""
+        # First, establish a signed manifest
+        check(self.skill_dir, self.backend)
+        # Modify a file
+        self._write_file("run.sh", "#!/bin/bash\necho MODIFIED\n")
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "drifted")
+        self.assertIn("modified", result)
+
+    def test_drifted_on_file_added(self):
+        """Adding a new file → check returns drifted with added list."""
+        check(self.skill_dir, self.backend)
+        self._write_file("new_file.py", "print('hello')\n")
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "drifted")
+        self.assertIn("new_file.py", result["added"])
+
+    def test_drifted_on_file_removed(self):
+        """Removing a file → check returns drifted with removed list."""
+        check(self.skill_dir, self.backend)
+        os.remove(os.path.join(self.skill_dir, "run.sh"))
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "drifted")
+        self.assertIn("run.sh", result["removed"])
+
+    def test_tampered_manifest_hash(self):
+        """Directly editing the manifest JSON → tampered (hash mismatch)."""
+        check(self.skill_dir, self.backend)  # creates signed manifest
+        latest = os.path.join(self.skill_dir, ".skill-meta", "latest.json")
+        with open(latest, "r") as f:
+            data = json.load(f)
+        # Tamper: change scanStatus without re-hashing
+        data["scanStatus"] = "pass"
+        with open(latest, "w") as f:
+            json.dump(data, f)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "tampered")
+
+    def test_tampered_wrong_key_signature(self):
+        """Signing with a different key → tampered (signature mismatch)."""
+        check(self.skill_dir, self.backend)
+        # Re-sign the manifest with a different key
+        other_backend = InMemoryEd25519Backend()
+        latest = os.path.join(self.skill_dir, ".skill-meta", "latest.json")
+        with open(latest, "r") as f:
+            data = json.load(f)
+        # Recompute hash and sign with wrong key
+        from agent_sec_cli.skill_ledger.models.manifest import SignedManifest
+        m = SignedManifest.from_json(json.dumps(data))
+        m.manifestHash = m.compute_manifest_hash()
+        sig_val, fp = other_backend.sign(m.manifestHash.encode("utf-8"))
+        data["manifestHash"] = m.manifestHash
+        data["signature"]["value"] = sig_val
+        data["signature"]["keyFingerprint"] = fp
+        with open(latest, "w") as f:
+            json.dump(data, f)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "tampered")
+
+    def test_deny_status_passthrough(self):
+        """certify with deny findings → check returns deny."""
+        findings_path = self._write_findings([
+            {"rule": "dangerous-exec", "level": "deny", "message": "exec found"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "deny")
+
+    def test_warn_status_passthrough(self):
+        """certify with warn findings → check returns warn."""
+        findings_path = self._write_findings([
+            {"rule": "obfuscated", "level": "warn", "message": "hex encoded"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "warn")
+
+    def test_check_exit_code_pass_is_zero(self):
+        """check returning pass should indicate success (exit code 0)."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "ok"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "pass")
+        # status "pass" should NOT be in the failure set
+        self.assertNotIn(result["status"], ("tampered", "deny"))
+
+    def test_check_tampered_is_security_critical(self):
+        """check returning tampered is a security-critical state."""
+        check(self.skill_dir, self.backend)
+        latest = os.path.join(self.skill_dir, ".skill-meta", "latest.json")
+        with open(latest, "r") as f:
+            data = json.load(f)
+        data["scanStatus"] = "pass"  # tamper without re-hashing
+        with open(latest, "w") as f:
+            json.dump(data, f)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "tampered")
+        self.assertIn(result["status"], ("tampered", "deny"))
+
+    def test_check_deny_is_security_critical(self):
+        """check returning deny is a security-critical state."""
+        findings_path = self._write_findings([
+            {"rule": "dangerous-exec", "level": "deny", "message": "exec found"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        result = check(self.skill_dir, self.backend)
+        self.assertEqual(result["status"], "deny")
+        self.assertIn(result["status"], ("tampered", "deny"))
+
+
+# ---------------------------------------------------------------------------
+# Certify workflow
+# ---------------------------------------------------------------------------
+
+
+class TestCertifyWorkflow(SkillDirTestCase):
+    """Tests for the certify command — manifest creation and scan merging."""
+
+    def test_certify_creates_version_and_snapshot(self):
+        """First certify → creates v000001 manifest + snapshot."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "clean"},
+        ])
+        result = certify(self.skill_dir, self.backend, findings_path=findings_path)
+        self.assertEqual(result["versionId"], "v000001")
+        self.assertTrue(result["newVersion"])
+        self.assertEqual(result["scanStatus"], "pass")
+        # Version file and snapshot should exist
+        v_file = os.path.join(self.skill_dir, ".skill-meta", "versions", "v000001.json")
+        v_snap = os.path.join(self.skill_dir, ".skill-meta", "versions", "v000001.snapshot")
+        self.assertTrue(os.path.isfile(v_file))
+        self.assertTrue(os.path.isdir(v_snap))
+
+    def test_recertify_same_files_no_new_version(self):
+        """Certifying again without file changes → same versionId, no new version."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "clean"},
+        ])
+        r1 = certify(self.skill_dir, self.backend, findings_path=findings_path)
+        r2 = certify(self.skill_dir, self.backend, findings_path=findings_path)
+        self.assertEqual(r1["versionId"], r2["versionId"])
+        self.assertFalse(r2["newVersion"])
+
+    def test_certify_after_file_change_creates_new_version(self):
+        """File change between certifies → new version created."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "clean"},
+        ])
+        r1 = certify(self.skill_dir, self.backend, findings_path=findings_path)
+        self._write_file("run.sh", "#!/bin/bash\necho modified\n")
+        r2 = certify(self.skill_dir, self.backend, findings_path=findings_path)
+        self.assertEqual(r1["versionId"], "v000001")
+        self.assertEqual(r2["versionId"], "v000002")
+        self.assertTrue(r2["newVersion"])
+
+    def test_scan_entry_merge_replaces_same_scanner(self):
+        """Re-certifying with the same scanner replaces the old entry, not appends."""
+        findings_warn = self._write_findings([
+            {"rule": "r1", "level": "warn", "message": "first scan"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_warn)
+
+        findings_pass = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "fixed"},
+        ])
+        result = certify(self.skill_dir, self.backend, findings_path=findings_pass)
+        self.assertEqual(result["scanStatus"], "pass")  # was warn, now pass
+
+        # Verify only one scan entry in manifest (not two)
+        latest = os.path.join(self.skill_dir, ".skill-meta", "latest.json")
+        with open(latest, "r") as f:
+            data = json.load(f)
+        self.assertEqual(len(data["scans"]), 1)
+
+    def test_deny_finding_produces_deny_status(self):
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "ok"},
+            {"rule": "r2", "level": "deny", "message": "bad"},
+        ])
+        result = certify(self.skill_dir, self.backend, findings_path=findings_path)
+        self.assertEqual(result["scanStatus"], "deny")
+
+    def test_auto_invoke_mode_no_crash(self):
+        """Certify without --findings (auto-invoke) should not crash in v1."""
+        # First create a manifest
+        check(self.skill_dir, self.backend)
+        # Auto-invoke mode — no invocable scanners, should succeed gracefully
+        result = certify(self.skill_dir, self.backend)
+        self.assertIn("versionId", result)
+
+
+# ---------------------------------------------------------------------------
+# Audit chain verification
+# ---------------------------------------------------------------------------
+
+
+class TestAuditChainIntegrity(SkillDirTestCase):
+    """Tests for the audit command — version chain integrity verification."""
+
+    def test_valid_single_version_passes(self):
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "ok"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        result = audit(self.skill_dir, self.backend)
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["versions_checked"], 1)
+
+    def test_valid_multi_version_chain(self):
+        """Two certifies with file change → two versions, chain should be valid."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "ok"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        self._write_file("run.sh", "#!/bin/bash\necho v2\n")
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        result = audit(self.skill_dir, self.backend)
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["versions_checked"], 2)
+
+    def test_tampered_hash_detected(self):
+        """Modifying a version manifest's content → audit detects hash mismatch."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "ok"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        # Tamper with the version file
+        v_file = os.path.join(self.skill_dir, ".skill-meta", "versions", "v000001.json")
+        with open(v_file, "r") as f:
+            data = json.load(f)
+        data["scanStatus"] = "deny"  # tamper: was "pass", now "deny" — without re-hashing
+        with open(v_file, "w") as f:
+            json.dump(data, f)
+        result = audit(self.skill_dir, self.backend)
+        self.assertFalse(result["valid"])
+        error_msgs = [e["error"] for e in result["errors"]]
+        self.assertTrue(any("manifestHash" in msg for msg in error_msgs))
+
+    def test_broken_chain_detected(self):
+        """Corrupting previousManifestSignature → audit detects chain break."""
+        findings_path = self._write_findings([
+            {"rule": "r1", "level": "pass", "message": "ok"},
+        ])
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+        self._write_file("run.sh", "#!/bin/bash\necho v2\n")
+        certify(self.skill_dir, self.backend, findings_path=findings_path)
+
+        # Tamper with v000002's previousManifestSignature
+        v2_file = os.path.join(self.skill_dir, ".skill-meta", "versions", "v000002.json")
+        with open(v2_file, "r") as f:
+            data = json.load(f)
+        data["previousManifestSignature"] = "BROKEN"
+        # Re-hash and re-sign to avoid hash mismatch detection (test chain specifically)
+        from agent_sec_cli.skill_ledger.models.manifest import SignedManifest
+        m = SignedManifest.from_json(json.dumps(data))
+        m.manifestHash = m.compute_manifest_hash()
+        sig_val, fp = self.backend.sign(m.manifestHash.encode("utf-8"))
+        data["manifestHash"] = m.manifestHash
+        data["signature"]["value"] = sig_val
+        data["signature"]["keyFingerprint"] = fp
+        with open(v2_file, "w") as f:
+            json.dump(data, f)
+
+        result = audit(self.skill_dir, self.backend)
+        self.assertFalse(result["valid"])
+        error_msgs = [e["error"] for e in result["errors"]]
+        self.assertTrue(any("chain broken" in msg for msg in error_msgs))
+
+    def test_no_versions_returns_valid(self):
+        """Empty .skill-meta (no versions) → audit succeeds with 0 checked."""
+        os.makedirs(os.path.join(self.skill_dir, ".skill-meta", "versions"), exist_ok=True)
+        result = audit(self.skill_dir, self.backend)
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["versions_checked"], 0)
+
+
+# ---------------------------------------------------------------------------
+# File hash diff
+# ---------------------------------------------------------------------------
+
+
+class TestFileHashDiff(SkillDirTestCase):
+    """Tests for file integrity diff — drives drifted/unchanged decisions."""
+
+    def test_identical_hashes_match(self):
+        hashes = compute_file_hashes(self.skill_dir)
+        diff = diff_file_hashes(hashes, hashes)
+        self.assertTrue(diff["match"])
+        self.assertEqual(diff["added"], [])
+        self.assertEqual(diff["removed"], [])
+        self.assertEqual(diff["modified"], [])
+
+    def test_added_file_detected(self):
+        old = compute_file_hashes(self.skill_dir)
+        self._write_file("new.py", "print('hi')\n")
+        new = compute_file_hashes(self.skill_dir)
+        diff = diff_file_hashes(old, new)
+        self.assertFalse(diff["match"])
+        self.assertIn("new.py", diff["added"])
+
+    def test_removed_file_detected(self):
+        old = compute_file_hashes(self.skill_dir)
+        os.remove(os.path.join(self.skill_dir, "run.sh"))
+        new = compute_file_hashes(self.skill_dir)
+        diff = diff_file_hashes(old, new)
+        self.assertFalse(diff["match"])
+        self.assertIn("run.sh", diff["removed"])
+
+    def test_modified_file_detected(self):
+        old = compute_file_hashes(self.skill_dir)
+        self._write_file("run.sh", "#!/bin/bash\necho CHANGED\n")
+        new = compute_file_hashes(self.skill_dir)
+        diff = diff_file_hashes(old, new)
+        self.assertFalse(diff["match"])
+        self.assertIn("run.sh", diff["modified"])
+
+    def test_skill_meta_excluded(self):
+        """The .skill-meta directory must be excluded from hashing."""
+        os.makedirs(os.path.join(self.skill_dir, ".skill-meta"), exist_ok=True)
+        with open(os.path.join(self.skill_dir, ".skill-meta", "latest.json"), "w") as f:
+            f.write("{}")
+        hashes = compute_file_hashes(self.skill_dir)
+        self.assertNotIn(".skill-meta/latest.json", hashes)
+
+    def test_git_dir_excluded(self):
+        """The .git directory must be excluded from hashing."""
+        os.makedirs(os.path.join(self.skill_dir, ".git"), exist_ok=True)
+        with open(os.path.join(self.skill_dir, ".git", "config"), "w") as f:
+            f.write("[core]")
+        hashes = compute_file_hashes(self.skill_dir)
+        self.assertNotIn(".git/config", hashes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Implements the **skill-ledger CLI** (T1 from the Skill Security Spec) — a cryptographic integrity tracking system for skills within agent-sec-core.

- CLI entry point with 7 subcommands: `init-keys`, `check`, `certify`, `status`, `audit`, `set-policy` (stub), `rotate-keys` (stub)
- Ed25519 signing backend with AES-256-GCM encrypted key storage
- `SignedManifest` model with cryptographic version chain (`previousManifestSignature`)
- File hashing (SHA-256) and drift/tamper detection (checker)
- Certifier: version creation, snapshot, scan aggregation, and manifest signing
- Auditor: full version-chain integrity verification with optional snapshot check
- Scanner registry and `findings-array` parser for extensible scan integration
- Unit tests for models, scanner/parser, and end-to-end workflows
- E2E tests covering full lifecycle: init-keys → check → certify → audit → tamper detection

## Related Issue

no-issue: initial implementation of skill-ledger CLI per internal security spec

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sec-core` (agent-sec-core)
- [ ] `cosh` (copilot-shell)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
# Unit tests
pytest tests/unit-test/skill_ledger/

# E2E tests
pytest tests/e2e/skill-ledger/
```

Both suites pass, covering:
- Model serialization/deserialization
- Scanner registry and findings-array parser
- Full workflow: key init → check (none/drifted/tampered) → certify → audit → version chain integrity

## Additional Notes

- `set-policy` and `rotate-keys` are registered as CLI stubs (print "coming soon") per the spec's MVP scoping decision.
- `SigningBackend` interface is defined for future GPG/PKCS#11 backends; only `NativeEd25519Backend` is implemented in this version.