### PR TITLE
feat(sight): add filewatch eBPF probe for file access monitoring

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -1,0 +1,115 @@
+# AGENTS.md — AgentSight Navigation Map
+
+> AI Agent 可观测性工具，基于 eBPF 捕获 LLM API 调用、Token 消耗和进程行为，无需修改 Agent 代码。
+
+## 1. Quick Start
+
+```bash
+make build-all          # 构建前端+Rust二进制
+sudo agentsight trace   # 启动 eBPF 追踪
+agentsight serve        # 启动 API 服务器 + Dashboard UI（http://127.0.0.1:7396）
+```
+
+详见 → [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
+
+## 2. Architecture
+
+数据流水线：`Probes → Parser → Aggregator → Analyzer → GenAI → Storage`
+
+```
+eBPF Probes → Event → Parser → ParsedMessage → Aggregator → AggregatedResult
+                 ↓                                                  ↓
+           ProcMon/SSL                                     Analyzer → AnalysisResult
+                                                                    ↓
+                                              GenAIBuilder → GenAISemanticEvent → Exporter
+                                                                    ↓
+                                                              Storage (SQLite/SLS)
+```
+
+详见 → [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+
+## 3. Module Map
+
+| 模块 | 位置 | 职责 | 关键类型 |
+|------|------|------|----------|
+| **Probes** | `src/probes/` | eBPF 探针管理 | `Probes`, `ProbesPoller`, `SslSniff`, `ProcMon`, `FileWatch` |
+| **Event** | `src/event.rs` | 统一事件枚举 | `Event::{Ssl, Proc, ProcMon, FileWatch}` |
+| **Parser** | `src/parser/` | 协议解析（HTTP/1.x, HTTP/2, SSE, ProcTrace） | `Parser`, `ParsedMessage` |
+| **Aggregator** | `src/aggregator/` | 请求-响应关联 | `Aggregator`, `AggregatedResult` |
+| **Analyzer** | `src/analyzer/` | Token/审计/消息分析 | `Analyzer`, `AnalysisResult` |
+| **GenAI** | `src/genai/` | 语义事件构建+导出 | `GenAIBuilder`, `GenAISemanticEvent`, `GenAIExporter` |
+| **Storage** | `src/storage/` | SQLite 持久化 | `Storage`, `SqliteStore`, `AuditStore`, `TokenStore` |
+| **Discovery** | `src/discovery/` | Agent 进程发现 | `AgentScanner`, `AgentMatcher`, `known_agents` |
+| **Health** | `src/health/` | Agent 健康检查 | `HealthChecker`, `HealthStore` |
+| **Tokenizer** | `src/tokenizer/` | LLM Token 计数 | `LlmTokenizer`, `MultiModelTokenizer` |
+| **ATIF** | `src/atif/` | 轨迹格式导出 | `AtifDocument`, `convert_trace_to_atif` |
+| **Server** | `src/server/` | HTTP API + 嵌入式前端 | `AppState`, `run_server` |
+| **Config** | `src/config.rs` | 统一配置 | `AgentsightConfig` |
+| **Unified** | `src/unified.rs` | 主编排器 | `AgentSight` |
+
+## 4. Critical Code Paths
+
+1. **SSL 捕获流程**: `sslsniff.bpf.c` → `Probes::run()` → `Event::Ssl` → `Parser::parse_ssl_event()` → `HttpConnectionAggregator` → `Analyzer::analyze_aggregated()` → `Storage::store()`
+2. **Agent 自动发现**: `procmon.bpf.c` → `Event::ProcMon::Exec` → `AgentSight::handle_procmon_event()` → `AgentScanner::on_process_create()` → `Probes::attach_process()`
+3. **Token 提取**: `SSE Parser` → `TokenParser::parse_event()` → `TokenRecord` → `TokenStore::add()`
+4. **GenAI 语义构建**: `AnalysisResult` → `GenAIBuilder::build()` → `GenAISemanticEvent::LLMCall` → `GenAIExporter::export()`
+
+## 5. eBPF Probes
+
+| 探针 | BPF 程序 | 功能 |
+|------|----------|------|
+| sslsniff | `src/bpf/sslsniff.bpf.c` | uprobe on SSL_read/SSL_write 捕获加密流量明文 |
+| proctrace | `src/bpf/proctrace.bpf.c` | tracepoint on execve 捕获命令行参数 |
+| procmon | `src/bpf/procmon.bpf.c` | 进程创建/退出事件（Agent 发现） |
+| filewatch | `src/bpf/filewatch.bpf.c` | 监控 .jsonl 文件打开事件 |
+
+构建时 `build.rs` 通过 `libbpf-cargo` 自动生成 eBPF skeleton。
+
+## 6. CLI Subcommands
+
+| 命令 | 入口 | 功能 |
+|------|------|------|
+| `agentsight trace` | `src/bin/cli/trace.rs` | eBPF 追踪（需 root） |
+| `agentsight serve` | `src/bin/cli/serve.rs` | API + Dashboard 服务器 |
+| `agentsight token` | `src/bin/cli/token.rs` | 查询 Token 消耗 |
+| `agentsight audit` | `src/bin/cli/audit.rs` | 查询审计事件 |
+| `agentsight discover` | `src/bin/cli/discover.rs` | 发现运行中的 AI Agent |
+| `agentsight metrics` | `src/bin/cli/metrics.rs` | Prometheus 格式指标 |
+
+## 7. API Endpoints
+
+| 路径 | 方法 | 功能 |
+|------|------|------|
+| `/health` | GET | 健康检查 |
+| `/metrics` | GET | Prometheus token 指标 |
+| `/api/sessions` | GET | 会话列表 |
+| `/api/sessions/{id}/traces` | GET | 会话下的 trace |
+| `/api/traces/{id}` | GET | trace 详情 |
+| `/api/agent-names` | GET | Agent 名称列表 |
+| `/api/timeseries` | GET | 时序 Token 统计 |
+| `/api/agent-health` | GET | Agent 健康状态 |
+| `/api/agent-health/{pid}` | DELETE | 删除健康条目 |
+| `/api/agent-health/{pid}/restart` | POST | 重启 Agent |
+| `/api/export/atif/trace/{id}` | GET | ATIF trace 导出 |
+| `/api/export/atif/session/{id}` | GET | ATIF session 导出 |
+
+## 8. Frontend
+
+React + TypeScript + Webpack + Tailwind CSS，位于 `dashboard/`。开发: `npm run dev`(localhost:3004)，嵌入构建: `npm run build:embed`。
+
+## 9. Configuration
+
+`AgentsightConfig`（`src/config.rs`），关键环境变量：SLS_*（阿里云日志服务导出）、`AGENTSIGHT_TOKENIZER_PATH`、`AGENTSIGHT_CHROME_TRACE`、`RUST_LOG`。
+
+## 10. Design Docs
+
+- [eBPF Probes 设计](docs/design-docs/ebpf-probes.md)
+- [数据流水线设计](docs/design-docs/data-pipeline.md)
+- [GenAI 语义层设计](docs/design-docs/genai-semantic.md)
+
+## 11. Prerequisites
+
+- Linux kernel >= 5.8（BTF 支持）
+- Rust >= 1.80
+- clang/llvm >= 11（eBPF 编译）
+- libbpf >= 0.8

--- a/src/agentsight/build.rs
+++ b/src/agentsight/build.rs
@@ -45,6 +45,10 @@ fn main() {
     // Generate procmon skeleton and bindings
     generate_skeleton(&mut out, "procmon");
     generate_header(&mut out, "procmon");
+
+    // Generate filewatch skeleton and bindings
+    generate_skeleton(&mut out, "filewatch");
+    generate_header(&mut out, "filewatch");
     
     // generate_header(&mut out, "frametypes");
     // generate_header(&mut out, "errors");

--- a/src/agentsight/docs/ARCHITECTURE.md
+++ b/src/agentsight/docs/ARCHITECTURE.md
@@ -1,0 +1,279 @@
+# Architecture — AgentSight
+
+## System Overview
+
+AgentSight 是一个 eBPF 驱动的 AI Agent 可观测性系统，通过内核态探针无侵入地捕获 LLM API 交互，经用户态流水线处理后持久化到 SQLite 或导出到阿里云 SLS。
+
+```mermaid
+graph TB
+    subgraph Kernel["Kernel Space (eBPF)"]
+        BPF_SSL[sslsniff.bpf.c]
+        BPF_PROC[proctrace.bpf.c]
+        BPF_MON[procmon.bpf.c]
+        BPF_FW[filewatch.bpf.c]
+    end
+
+    subgraph Shared["Shared BPF Resources"]
+        RB[Ring Buffer]
+        TMAP[traced_processes Map]
+    end
+
+    BPF_SSL --> RB
+    BPF_PROC --> RB
+    BPF_MON --> RB
+    BPF_FW --> RB
+    BPF_SSL --> TMAP
+    BPF_FW --> TMAP
+
+    subgraph UserSpace["User Space Pipeline"]
+        PROBES[Probes<br/>src/probes/]
+        EVENT[Event<br/>src/event.rs]
+        PARSER[Parser<br/>src/parser/]
+        AGG[Aggregator<br/>src/aggregator/]
+        ANALYZER[Analyzer<br/>src/analyzer/]
+        GENAI[GenAI Builder<br/>src/genai/]
+        STORE[Storage<br/>src/storage/]
+    end
+
+    RB --> PROBES
+    PROBES --> EVENT
+    EVENT --> PARSER
+    PARSER --> AGG
+    AGG --> ANALYZER
+    ANALYZER --> GENAI
+    ANALYZER --> STORE
+    GENAI --> STORE
+
+    subgraph Discovery["Agent Discovery"]
+        SCANNER[AgentScanner]
+        MATCHER[AgentMatcher]
+        REGISTRY[Known Agents Registry]
+    end
+
+    BPF_MON --> PROBES
+    PROBES --> SCANNER
+    SCANNER --> MATCHER
+    MATCHER --> REGISTRY
+    SCANNER -->|attach SSL| PROBES
+
+    subgraph Exporters["Exporters"]
+        JSONL[JSONL File]
+        SLS[Alibaba Cloud SLS]
+        SQLITE_GENAI[SQLite GenAI Store]
+    end
+
+    GENAI --> JSONL
+    GENAI --> SLS
+    GENAI --> SQLITE_GENAI
+
+    subgraph Server["HTTP Server (feature=server)"]
+        API[Actix-web API]
+        UI[Embedded Frontend]
+    end
+
+    STORE --> API
+    API --> UI
+```
+
+## Layer Architecture
+
+| Layer | 模块 | 职责 | 依赖方向 |
+|-------|------|------|----------|
+| **L0: Kernel** | `src/bpf/` | eBPF C 程序，内核态数据采集 | 无内部依赖 |
+| **L1: Capture** | `src/probes/`, `src/event.rs` | 探针加载、事件轮询、统一事件类型 | → L0 |
+| **L2: Parse** | `src/parser/` | HTTP/1.x, HTTP/2, SSE, ProcTrace 协议解析 | → L1 |
+| **L3: Aggregate** | `src/aggregator/` | 请求-响应关联、进程生命周期聚合 | → L2 |
+| **L4: Analyze** | `src/analyzer/`, `src/tokenizer/` | Token 提取、审计记录、消息解析 | → L3 |
+| **L5: Semantic** | `src/genai/`, `src/atif/` | 语义事件构建、轨迹格式导出 | → L4 |
+| **L6: Persist** | `src/storage/` | SQLite 持久化、SLS 远程导出 | → L4, L5 |
+| **L7: Serve** | `src/server/`, `src/health/` | HTTP API、前端、健康检查 | → L6 |
+| **L8: Entry** | `src/bin/`, `src/unified.rs`, `src/config.rs` | CLI 入口、编排器、配置 | → L1-L7 |
+| **Cross** | `src/discovery/` | Agent 进程发现与匹配 | 被 L1, L8 使用 |
+
+## Module Dependency Graph
+
+```mermaid
+graph LR
+    config[config]
+    probes[probes]
+    event[event]
+    parser[parser]
+    aggregator[aggregator]
+    analyzer[analyzer]
+    tokenizer[tokenizer]
+    genai[genai]
+    storage[storage]
+    discovery[discovery]
+    health[health]
+    atif[atif]
+    server[server]
+    unified[unified]
+
+    unified --> config
+    unified --> probes
+    unified --> parser
+    unified --> aggregator
+    unified --> analyzer
+    unified --> genai
+    unified --> storage
+    unified --> discovery
+    unified --> tokenizer
+
+    probes --> event
+    parser --> probes
+    aggregator --> parser
+    analyzer --> aggregator
+    analyzer --> tokenizer
+    genai --> analyzer
+    genai --> discovery
+    storage --> analyzer
+    server --> storage
+    server --> health
+    atif --> genai
+    atif --> storage
+```
+
+## Data Flow: SSL Capture to Storage
+
+这是最核心的端到端数据流：
+
+```mermaid
+sequenceDiagram
+    participant BPF as eBPF sslsniff
+    participant RB as Ring Buffer
+    participant P as Probes
+    participant PA as Parser
+    participant AG as Aggregator
+    participant AN as Analyzer
+    participant GB as GenAIBuilder
+    participant ST as Storage
+
+    BPF->>RB: SSL_read/SSL_write 数据
+    RB->>P: poll → Event::Ssl
+    P->>PA: parse_event()
+    PA->>PA: HTTP/1.x or HTTP/2 or SSE 解析
+    PA->>AG: ParsedMessage
+    AG->>AG: 请求-响应关联（LRU cache）
+    AG->>AN: AggregatedResult::HttpComplete/SseComplete
+    AN->>AN: TokenParser + AuditAnalyzer + MessageParser
+    AN->>GB: AnalysisResult
+    AN->>ST: AnalysisResult::Token/Audit/Http
+    GB->>GB: 构建 LLMCall 语义事件
+    GB->>ST: GenAISemanticEvent → JSONL/SLS/SQLite
+```
+
+## Key Design Decisions
+
+### 1. Shared Ring Buffer + Shared BPF Map
+
+`Probes` 管理器让 sslsniff、proctrace、procmon、filewatch 四个探针共享同一个 ring buffer 和 `traced_processes` BPF map。这减少了内核-用户空间的数据拷贝开销，并确保所有探针对 PID 过滤达成一致。
+
+**实现**: `src/probes/probes.rs:Probes::new()` — proctrace 创建 map 和 ring buffer，其他探针通过 handle 复用。
+
+### 2. Agent Auto-Discovery via ProcMon
+
+系统启动时 `AgentScanner` 扫描 `/proc` 发现已运行的 Agent，运行时通过 procmon 的 `Exec`/`Exit` 事件动态追踪 Agent 生命周期。发现新 Agent 后自动 attach SSL 探针。
+
+**实现**: `src/unified.rs:AgentSight::handle_procmon_event()` — 由 ProcMon 事件驱动，调用 `AgentScanner::on_process_create()`。
+
+### 3. Dual Export Path: AnalysisResult vs GenAISemanticEvent
+
+`Analyzer` 输出原始 `AnalysisResult`（Token/Audit/Http），`GenAIBuilder` 将其转换为高抽象的 `GenAISemanticEvent`（LLMCall/ToolUse/AgentInteraction）。两条路径独立存储，前者用于本地查询，后者用于远程导出和语义分析。
+
+**实现**: `src/unified.rs:AgentSight::try_process()` 第 287-309 行。
+
+### 4. Compile-Time Frontend Embedding
+
+`dashboard/` 构建产物通过 `include_dir!` 宏在编译时嵌入到 Rust 二进制中，运行时无需额外静态文件。通过 feature flag `server` 控制。
+
+**实现**: `src/server/mod.rs` — `static FRONTEND: Dir = include_dir!("$CARGO_MANIFEST_DIR/frontend-dist");`
+
+### 5. Pluggable GenAI Exporters
+
+`GenAIExporter` trait 定义了导出接口，当前实现：JSONL 文件（默认）、SQLite GenAI Store、阿里云 SLS Uploader。可通过 `AgentSight::add_genai_exporter()` 运行时注册。
+
+**实现**: `src/genai/exporter.rs` — `trait GenAIExporter`，`src/unified.rs:AgentSight::new()` 第 122-149 行。
+
+## File Structure
+
+```
+src/
+├── lib.rs                 # 库入口，re-exports 所有公共类型
+├── unified.rs             # AgentSight 主编排器
+├── config.rs              # AgentsightConfig 配置结构
+├── event.rs               # Event 统一枚举
+├── chrome_trace.rs        # Chrome Trace 导出
+├── ffi.rs                 # FFI 绑定
+├── bpf/                   # eBPF C 程序 + vmlinux 头文件
+│   ├── common.h           # 共享常量（event_source_t）
+│   ├── sslsniff.bpf.c     # SSL 探针
+│   ├── proctrace.bpf.c    # 进程追踪探针
+│   ├── procmon.bpf.c      # 进程监控探针
+│   ├── filewatch.bpf.c    # 文件监控探针
+│   └── *.h                # BPF 数据结构头文件
+├── probes/                # 用户态探针管理
+│   ├── probes.rs          # Probes 统一管理器
+│   ├── sslsniff.rs        # SslSniff 封装
+│   ├── proctrace.rs       # ProcTrace 封装
+│   ├── procmon.rs         # ProcMon 封装
+│   └── filewatch.rs       # FileWatch 封装
+├── parser/                # 协议解析
+│   ├── unified.rs         # Parser 统一入口
+│   ├── http/              # HTTP/1.x 解析
+│   ├── http2/             # HTTP/2 解析
+│   ├── sse/               # SSE 解析
+│   └── proctrace.rs       # ProcTrace 事件解析
+├── aggregator/            # 事件聚合
+│   ├── unified.rs         # Aggregator 统一入口
+│   ├── http/              # HTTP 请求-响应关联
+│   ├── http2.rs           # HTTP/2 流聚合
+│   └── proctrace/         # 进程生命周期聚合
+├── analyzer/              # 数据分析
+│   ├── unified.rs         # Analyzer 统一入口
+│   ├── audit/             # 审计记录生成
+│   ├── token/             # Token 使用提取
+│   └── message/           # LLM API 消息解析（OpenAI/Anthropic）
+├── genai/                 # GenAI 语义层
+│   ├── builder.rs         # GenAIBuilder（AnalysisResult → GenAISemanticEvent）
+│   ├── semantic.rs        # 语义数据结构（LLMCall, ToolUse 等）
+│   ├── exporter.rs        # GenAIExporter trait
+│   ├── storage.rs         # JSONL 本地存储
+│   └── sls.rs             # 阿里云 SLS 上传
+├── storage/               # 持久化
+│   ├── unified.rs         # Storage 统一门面
+│   └── sqlite/            # SQLite 实现
+│       ├── audit.rs       # AuditStore
+│       ├── token.rs       # TokenStore
+│       ├── http.rs        # HttpStore
+│       ├── genai.rs       # GenAISqliteStore（会话/trace/时序查询）
+│       └── token_consumption.rs  # Token 消耗明细
+├── discovery/             # Agent 发现
+│   ├── agent.rs           # AgentInfo, DiscoveredAgent
+│   ├── matcher.rs         # AgentMatcher trait + ProcessContext
+│   ├── registry.rs        # 内置 Agent 注册表
+│   ├── scanner.rs         # /proc 扫描器
+│   └── agents/            # 具体 Agent 匹配器（Cosh, OpenClaw）
+├── health/                # 健康检查
+│   ├── checker.rs         # HealthChecker（后台定期检查）
+│   ├── port_detector.rs   # TCP 端口检测
+│   └── store.rs           # HealthStore（AgentHealthState）
+├── tokenizer/             # Token 计数
+│   ├── llm_tok.rs         # LlmTokenizer（llm-tokenizer 封装）
+│   ├── model_mapping.rs   # 模型名 → HuggingFace ID 映射
+│   └── multi_model.rs     # MultiModelTokenizer（多模型支持）
+├── atif/                  # ATIF 轨迹格式
+│   ├── schema.rs          # ATIF v1.6 数据结构
+│   └── converter.rs       # GenAI → ATIF 转换
+├── server/                # HTTP 服务器（feature=server）
+│   ├── mod.rs             # Actix-web 服务器 + 前端嵌入
+│   └── handlers.rs        # API 处理函数
+└── bin/                   # 二进制入口
+    ├── agentsight.rs      # 主 CLI（trace/serve/token/audit/discover/metrics）
+    └── cli/               # 各子命令实现
+        ├── trace.rs
+        ├── serve.rs
+        ├── token.rs
+        ├── audit.rs
+        ├── discover.rs
+        └── metrics.rs
+```

--- a/src/agentsight/docs/DEVELOPMENT.md
+++ b/src/agentsight/docs/DEVELOPMENT.md
@@ -1,0 +1,199 @@
+# Development Guide — AgentSight
+
+## Prerequisites
+
+| 依赖 | 最低版本 | 用途 |
+|------|----------|------|
+| Linux kernel | >= 5.8 | BTF 支持，eBPF 运行时 |
+| Rust | >= 1.80 | 编译 Rust 代码 |
+| clang/llvm | >= 11 | 编译 eBPF C 程序 |
+| libbpf | >= 0.8 | eBPF 用户态库 |
+| Node.js | >= 16 | 前端构建 |
+| npm | >= 8 | 前端依赖管理 |
+
+### 安装构建依赖（CentOS/Alinux）
+
+```bash
+yum install -y clang llvm elfutils-libelf-devel libbpf-devel zlib-devel
+```
+
+## Build Commands
+
+### 仅构建 Rust 二进制（release）
+
+```bash
+cargo build --release
+# 产物：target/release/agentsight
+```
+
+### 构建前端并嵌入
+
+```bash
+cd dashboard
+npm install
+npm run build:embed    # 产物输出到 frontend-dist/
+```
+
+### 完整构建（前端 + Rust）
+
+```bash
+make build-all
+# 等效于: make build-frontend && make build
+```
+
+### 安装到系统
+
+```bash
+make install
+# 安装到 /usr/local/bin/agentsight 并设置 BPF capabilities
+# 可自定义: make install PREFIX=/opt/agentsight
+```
+
+### RPM 打包
+
+```bash
+make rpm    # 或使用 scripts/rpm-build.sh
+```
+
+## Development Workflow
+
+### 启动追踪 + 服务器
+
+```bash
+# Terminal 1: eBPF 追踪（需要 root）
+sudo agentsight trace
+
+# Terminal 2: API 服务器 + Dashboard
+agentsight serve
+# 打开 http://127.0.0.1:7396
+```
+
+### 前端开发（热重载）
+
+```bash
+cd dashboard
+npm install
+npm run dev    # http://localhost:3004，代理 API 到 localhost:7396
+```
+
+前端开发完成后重新构建嵌入：
+```bash
+cd dashboard && npm run build:embed
+make build    # 重新编译 Rust 以嵌入更新后的前端
+```
+
+## Project Structure
+
+```
+agentsight/
+├── src/           # Rust 源码
+│   ├── bpf/       # eBPF C 程序
+│   ├── probes/    # 探针管理
+│   ├── parser/    # 协议解析
+│   ├── aggregator/# 事件聚合
+│   ├── analyzer/  # 数据分析
+│   ├── genai/     # GenAI 语义层
+│   ├── storage/   # SQLite 持久化
+│   ├── discovery/ # Agent 发现
+│   ├── health/    # 健康检查
+│   ├── tokenizer/ # Token 计数
+│   ├── atif/      # ATIF 轨迹导出
+│   ├── server/    # HTTP API 服务器
+│   └── bin/       # CLI 入口
+├── dashboard/     # React 前端
+├── scripts/       # 部署脚本
+└── rpm-sources/   # RPM 打包源
+```
+
+详见 → [ARCHITECTURE.md](ARCHITECTURE.md)
+
+## Testing
+
+### Rust 单元测试
+
+```bash
+cargo test                    # 运行所有测试
+cargo test --lib              # 仅库测试
+cargo test -p agentsight -- <test_name>  # 运行特定测试
+```
+
+### 前端类型检查
+
+```bash
+cd dashboard && npm run typecheck
+```
+
+### 手动集成测试
+
+```bash
+# 1. 启动追踪
+sudo agentsight trace &
+
+# 2. 发起一个 LLM API 调用（使用任何 AI Agent）
+
+# 3. 查询结果
+agentsight token --last 1h
+agentsight audit --last 1h
+
+# 4. 启动服务器查看 Dashboard
+agentsight serve
+```
+
+## Code Style
+
+### Rust
+
+- 遵循标准 `rustfmt` 格式：`cargo fmt`
+- 使用 `clippy` 检查：`cargo clippy -- -D warnings`
+- 错误处理使用 `anyhow::Result`
+- 模块组织：每个模块有 `mod.rs`（声明）+ `unified.rs`（统一入口）+ 子模块
+
+### TypeScript (Frontend)
+
+- 使用 TypeScript strict 模式
+- Tailwind CSS 类名样式
+- 组件放在 `dashboard/src/components/`，页面放在 `dashboard/src/pages/`
+
+## Configuration
+
+运行时配置通过 `AgentsightConfig`（`src/config.rs`），支持以下方式：
+
+1. **默认值**: 内置默认配置
+2. **环境变量**: SLS 相关变量、`AGENTSIGHT_TOKENIZER_PATH` 等
+3. **CLI 参数**: 各子命令支持 `--verbose`, `--storage-path` 等
+
+### 关键配置项
+
+| 配置 | 默认值 | 说明 |
+|------|--------|------|
+| `storage_base_path` | `/var/log/sysak/.agentsight` | SQLite 数据库目录 |
+| `db_name` | `agentsight.db` | 数据库文件名 |
+| `data_retention_days` | 30 | 数据保留天数（0=不限） |
+| `connection_cache_capacity` | 24 | HTTP 连接 LRU 缓存大小 |
+| `tokenizer_url` | Qwen3.5-27B tokenizer | 默认 tokenizer 下载 URL |
+
+## Debugging
+
+### 启用详细日志
+
+```bash
+sudo agentsight trace --verbose
+# 或
+RUST_LOG=debug sudo agentsight trace
+```
+
+### Chrome Trace 导出
+
+```bash
+AGENTSIGHT_CHROME_TRACE=1 sudo agentsight trace
+# 产物：trace.json，可在 chrome://tracing 查看
+```
+
+### 常见问题
+
+| 问题 | 原因 | 解决方案 |
+|------|------|----------|
+| `Failed to create probes` | 内核不支持 BTF | 检查 `/sys/kernel/btf/vmlinux` 是否存在 |
+| `Failed to attach probes` | 权限不足 | 使用 `sudo` 或 `setcap cap_bpf,cap_perfmon=ep` |
+| `Frontend not embedded` | 未构建前端 | `cd dashboard && npm run build:embed && make build` |
+| `Tokenizer not found` | 未下载 tokenizer | 设置 `AGENTSIGHT_TOKENIZER_PATH` 或自动下载 |

--- a/src/agentsight/docs/design-docs/data-pipeline.md
+++ b/src/agentsight/docs/design-docs/data-pipeline.md
@@ -1,0 +1,189 @@
+# Data Pipeline Design — AgentSight
+
+## Overview
+
+AgentSight 的核心是一条从 eBPF 探针到持久化的数据流水线，每层职责明确、数据单向流动：
+
+```
+Probes → Parser → Aggregator → Analyzer → GenAI → Storage
+```
+
+## Pipeline Stages
+
+### Stage 1: Event Capture (Probes)
+
+**Input**: Kernel eBPF events
+**Output**: `Event` enum
+
+```rust
+pub enum Event {
+    Ssl(SslEvent),       // SSL plaintext data
+    Proc(ProcEvent),     // Process execve event
+    ProcMon(ProcMonEvent), // Process create/exit
+    FileWatch(FileWatchEvent), // File open
+}
+```
+
+**Implementation**: `src/probes/probes.rs` — single thread polls shared ring buffer, dispatches by `event_source_t`.
+
+### Stage 2: Protocol Parsing (Parser)
+
+**Input**: `Event` (mainly `Event::Ssl`)
+**Output**: `ParseResult` (0 or more `ParsedMessage`)
+
+```rust
+pub enum ParsedMessage {
+    Http(ParsedHttpMessage),  // HTTP/1.x request or response
+    Http2(ParsedHttp2Frame),  // HTTP/2 frame
+    Sse(ParsedSseEvent),      // SSE event
+    Proc(ParsedProcEvent),    // Process event
+}
+```
+
+**Parsing strategy**:
+- `HttpParser`: State machine parsing HTTP/1.x request line/status line/headers/body
+- `Http2Parser`: Decodes HTTP/2 frames (HEADERS, DATA, SETTINGS, etc.)
+- `SseParser`: Parses SSE `data: ` lines as JSON
+- `ProcTraceParser`: Parses execve event command line args
+
+**Unified entry**: `Parser::parse_event()` — routes to corresponding parser by Event type.
+
+**Source**: `src/parser/unified.rs`
+
+### Stage 3: Event Aggregation (Aggregator)
+
+**Input**: `ParseResult`
+**Output**: `Vec<AggregatedResult>`
+
+```rust
+pub enum AggregatedResult {
+    HttpComplete(HttpPair),       // HTTP request-response pair
+    SseComplete(SsePair),         // HTTP request + SSE stream response
+    RequestOnly { request, .. },  // Timeout, no response received
+    ResponseOnly { response, .. },// No matching request
+    ProcessComplete(AggregatedProcess), // Process lifecycle complete
+    Http2StreamComplete(Http2Stream),   // HTTP/2 stream complete
+    Http2Frames { .. },           // HTTP/2 frame sequence
+}
+```
+
+**Correlation strategy**:
+- **HTTP/1.x**: Match request and response via (pid, fd) LRU connection cache
+- **HTTP/2**: Aggregate frames by stream ID
+- **SSE**: HTTP request + subsequent SSE event stream, ended by `[DONE]` marker
+- **Process**: Aggregate exec/exit events into complete lifecycle
+
+**Timeout handling**: Unmatched request/response output as RequestOnly/ResponseOnly after timeout.
+
+**Source**: `src/aggregator/unified.rs`
+
+### Stage 4: Analysis (Analyzer)
+
+**Input**: `AggregatedResult`
+**Output**: `Vec<AnalysisResult>`
+
+```rust
+pub enum AnalysisResult {
+    Audit(AuditRecord),        // Audit record
+    Token(TokenRecord),        // Token usage record
+    Http(HttpRecord),          // HTTP data record
+    Message(ParsedApiMessage), // Parsed API message
+}
+```
+
+**Analysis flow**:
+1. **Process events** → directly generate `AuditRecord`
+2. **HTTP events** → parallel execution:
+   - `AuditAnalyzer` → generates audit records (LLM calls, HTTP request summary)
+   - `TokenParser` → extracts token usage from SSE events (reverse search, first match)
+   - `HttpRecord` extraction → raw HTTP data export
+3. **Manual Token Computation** → if no token data in SSE, uses `MultiModelTokenizer` + chat template to compute
+
+**Source**: `src/analyzer/unified.rs`
+
+### Stage 5: GenAI Semantic Build (GenAI Builder)
+
+**Input**: `Vec<AnalysisResult>`
+**Output**: `Vec<GenAISemanticEvent>`
+
+```rust
+pub enum GenAISemanticEvent {
+    LLMCall(LLMCall),              // Complete LLM call
+    ToolUse(ToolUse),              // Tool invocation
+    AgentInteraction(AgentInteraction), // Agent interaction
+    StreamChunk(StreamChunk),      // Streaming response chunk
+}
+```
+
+**Build strategy**:
+- `LLMCall`: Extract request messages from HTTP request, output messages from SSE response
+- Agent name resolution: Map PID/comm to known Agent name via `AgentMatcher`
+- Unique ID generation: Based on session_prefix + AtomicU64 counter
+
+**Export**: After building, export via `GenAIExporter` trait to multiple backends:
+- `GenAIStore` → local JSONL file
+- `GenAISqliteStore` → SQLite database
+- `SlsUploader` → Alibaba Cloud SLS
+
+**Source**: `src/genai/builder.rs`
+
+### Stage 6: Persistence (Storage)
+
+**Input**: `AnalysisResult` + `GenAISemanticEvent`
+**Output**: SQLite tables / SLS logs / JSONL files
+
+**SQLite table structure**:
+
+| Store | Table | Content |
+|-------|-------|---------|
+| AuditStore | audit_events | Audit events |
+| TokenStore | token_records | Token usage records |
+| HttpStore | http_records | Raw HTTP data |
+| TokenConsumptionStores | token_consumption | Token consumption breakdown |
+| GenAISqliteStore | genai_events | GenAI semantic events |
+
+**Source**: `src/storage/unified.rs`, `src/storage/sqlite/`
+
+## Data Flow Diagram
+
+```mermaid
+graph LR
+    SSL[SSL Event] --> P[Parser]
+    P -->|ParsedMessage::Http| AGG[Aggregator]
+    P -->|ParsedMessage::Sse| AGG
+    P -->|ParsedMessage::Proc| AGG
+
+    AGG -->|HttpComplete| AN[Analyzer]
+    AGG -->|SseComplete| AN
+    AGG -->|ProcessComplete| AN
+
+    AN -->|AuditRecord| ST[Storage]
+    AN -->|TokenRecord| ST
+    AN -->|HttpRecord| ST
+
+    AN -->|AnalysisResult| GB[GenAIBuilder]
+    GB -->|GenAISemanticEvent| EXP[Exporters]
+    EXP -->|JSONL| FS[File System]
+    EXP -->|SLS| CLOUD[Cloud]
+    EXP -->|SQLite| DB[(Database)]
+```
+
+## Error Handling
+
+The pipeline adopts a lenient error handling strategy:
+- **Probe layer**: Ring buffer poll errors terminate the poll thread, but the main thread does not exit
+- **Parser layer**: Parse failures silently ignored, returns empty `ParseResult`
+- **Aggregator layer**: Timed-out unmatched events output as RequestOnly/ResponseOnly
+- **Analyzer layer**: Token extraction failure tries manual computation, then skips
+- **Storage layer**: Storage failures only log::warn, don't block the pipeline
+
+**Design principle**: The data pipeline never stops due to intermediate layer errors; single event failure doesn't affect other events.
+
+## Backpressure
+
+No explicit backpressure mechanism currently:
+- Ring buffer managed by kernel, discards old events on overflow
+- crossbeam channel uses unbounded mode
+- Main loop sleeps 10ms when idle, natural rate limiting
+
+**Potential improvement**: For high-load scenarios, introduce bounded channel + backpressure signaling.

--- a/src/agentsight/docs/design-docs/ebpf-probes.md
+++ b/src/agentsight/docs/design-docs/ebpf-probes.md
@@ -1,0 +1,127 @@
+# eBPF Probes Design — AgentSight
+
+## Overview
+
+AgentSight 使用 4 个 eBPF 探针从内核态捕获数据，所有探针共享同一个 ring buffer 和 `traced_processes` BPF map，由 `Probes` 管理器统一协调。
+
+## Probe Architecture
+
+```mermaid
+graph TB
+    subgraph BPF["BPF Programs (Kernel)"]
+        SSL[sslsniff.bpf.c<br/>uprobe: SSL_read/SSL_write]
+        PT[proctrace.bpf.c<br/>tracepoint: sched_process_exec]
+        PM[procmon.bpf.c<br/>tracepoint: sched_process_exec/fork/exit]
+        FW[filewatch.bpf.c<br/>tracepoint: do_sys_open]
+    end
+
+    subgraph Shared["Shared BPF Maps"]
+        RB[Ring Buffer<br/>events_rb]
+        TM[traced_processes<br/>HASH pid 1]
+    end
+
+    SSL -->|write| RB
+    PT -->|write| RB
+    PM -->|write| RB
+    FW -->|write| RB
+    SSL -->|lookup| TM
+    FW -->|lookup| TM
+
+    subgraph Userspace["User Space"]
+        P[Probes Poller Thread]
+        CH[crossbeam Channel]
+    end
+
+    RB -->|poll| P
+    P --> CH
+```
+
+## Probe Details
+
+### 1. sslsniff — SSL/TLS Traffic Capture
+
+- **BPF Type**: uprobe
+- **Attach Point**: `SSL_read` / `SSL_write` (OpenSSL/BoringSSL)
+- **Filter**: Only capture PIDs in `traced_processes` map
+- **Output**: `probe_SSL_data_t` struct (pid, timestamp, fd, data, len, comm)
+- **Source**: `src/bpf/sslsniff.bpf.c`, `src/bpf/sslsniff.h`
+- **Userspace**: `src/probes/sslsniff.rs`
+
+**How it works**:
+1. Userspace calls `SslSniff::attach_process(pid)` to attach SSL uprobe to target process's libssl.so
+2. When target process calls SSL_read/SSL_write, BPF program captures decrypted plaintext
+3. Data is passed to userspace via ring buffer, parsed as `SslEvent`
+
+**Key design**: Dynamic attach — probes are not attached at startup, but on-demand after Agent process discovery.
+
+### 2. proctrace — Process Command Line Tracing
+
+- **BPF Type**: tracepoint
+- **Attach Point**: `sched_process_exec`
+- **Filter**: None (captures all execve events)
+- **Output**: `VariableEvent` (variable-length: pid, ppid, comm, args)
+- **Source**: `src/bpf/proctrace.bpf.c`, `src/bpf/proctrace.h`
+- **Userspace**: `src/probes/proctrace.rs`
+
+**Key design**: Variable-length events — execve command line args have variable length, using `common_event_hdr` + `proc_event_header` + variable-length args format.
+
+### 3. procmon — Process Lifecycle Monitor
+
+- **BPF Type**: tracepoint
+- **Attach Point**: `sched_process_exec`, `sched_process_fork`, `sched_process_exit`
+- **Filter**: None
+- **Output**: `procmon_event_t` (Exec/Fork/Exit events)
+- **Source**: `src/bpf/procmon.bpf.c`, `src/bpf/procmon.h`
+- **Userspace**: `src/probes/procmon.rs`
+
+**Purpose**: Drives Agent auto-discovery. When a new process is created, checks if it's a known Agent and auto-attaches SSL probes.
+
+### 4. filewatch — File Open Monitor
+
+- **BPF Type**: tracepoint
+- **Attach Point**: `do_sys_open` / `do_sys_openat2`
+- **Filter**: Only monitor PIDs in `traced_processes` map opening `.jsonl` files
+- **Output**: `filewatch_event_t` (pid, filename)
+- **Source**: `src/bpf/filewatch.bpf.c`, `src/bpf/filewatch.h`
+- **Userspace**: `src/probes/filewatch.rs`
+
+**Purpose**: Monitor Agent processes opening .jsonl files for auxiliary Agent session identification.
+
+## Shared Resource Design
+
+### Ring Buffer (events_rb)
+
+All probes share one ring buffer, distinguished by `common_event_hdr.source` field:
+
+| source value | Event type | Parse method |
+|-------------|-----------|-------------|
+| 1 (EVENT_SOURCE_PROC) | proctrace event | `VariableEvent::from_bytes()` |
+| 2 (EVENT_SOURCE_SSL) | sslsniff event | `SslEvent::from_bpf()` |
+| 3 (EVENT_SOURCE_PROCMON) | procmon event | `procmon::Event::from_bytes()` |
+| 4 (EVENT_SOURCE_FILEWATCH) | filewatch event | `FileWatchEvent::from_bytes()` |
+
+**Implementation**: `src/probes/probes.rs:Probes::run()` lines 137-193 — single thread polls ring buffer, dispatches by source field into `Event` enum.
+
+### traced_processes Map
+
+BPF hash map, key=PID, value=1. Used by:
+- sslsniff: Only capture SSL traffic from traced processes
+- filewatch: Only monitor file opens from traced processes
+
+**Dynamic update**: `Probes::add_traced_pid()` / `Probes::remove_traced_pid()` at runtime.
+
+## Build-Time Code Generation
+
+`build.rs` uses `libbpf-cargo` at compile time to:
+1. Compile `src/bpf/*.bpf.c` to BPF bytecode
+2. Generate Rust skeleton files (auto-load, map access, etc.)
+3. Generate vmlinux type bindings via `bindgen`
+
+**Dependencies**: `build-dependencies` in Cargo.toml: `libbpf-cargo`, `bindgen`, `cc`.
+
+## Performance Considerations
+
+1. **Single poll thread**: One background thread polls ring buffer, dispatches via crossbeam channel
+2. **LRU cache**: HTTP connection aggregation uses LRU cache (default 24 entries) to prevent unbounded memory growth
+3. **PID filtering**: BPF-side filtering, only uploads data from traced processes, reducing kernel-userspace data copy
+4. **Non-blocking**: `Probes::try_recv()` is non-blocking, main loop sleeps 10ms when idle

--- a/src/agentsight/docs/design-docs/genai-semantic.md
+++ b/src/agentsight/docs/design-docs/genai-semantic.md
@@ -1,0 +1,178 @@
+# GenAI Semantic Layer Design — AgentSight
+
+## Overview
+
+The GenAI semantic layer is AgentSight's "understanding" layer, transforming raw HTTP/SSL data into structured LLM interaction semantic events, supporting multi-channel export (JSONL, SQLite, SLS) and standardized trajectory format (ATIF) export.
+
+## Architecture
+
+```mermaid
+graph TB
+    AN[AnalysisResult] --> GB[GenAIBuilder]
+    GB -->|build| GSE[GenAISemanticEvent]
+
+    GSE -->|LLMCall| EXP[GenAIExporter trait]
+    GSE -->|ToolUse| EXP
+    GSE -->|AgentInteraction| EXP
+    GSE -->|StreamChunk| EXP
+
+    EXP --> JSONL[GenAIStore<br/>JSONL File]
+    EXP --> SQLITE[GenAISqliteStore<br/>SQLite]
+    EXP --> SLS[SlsUploader<br/>Alibaba SLS]
+
+    subgraph ATIF["ATIF Export"]
+        GSE -->|query from SQLite| CONV[ATIF Converter]
+        CONV --> ATIF_DOC[AtifDocument v1.6]
+    end
+```
+
+## Core Types
+
+### GenAISemanticEvent
+
+Four semantic event types:
+
+| Type | Meaning | Trigger condition |
+|------|---------|-------------------|
+| `LLMCall` | Complete LLM API call | HTTP request + SSE/HTTP response |
+| `ToolUse` | Tool/function invocation | SSE response contains tool_calls |
+| `AgentInteraction` | Agent interaction/decision | Reasoning/planning intermediate steps |
+| `StreamChunk` | Streaming response chunk | Each chunk in SSE stream |
+
+### LLMCall Structure
+
+`LLMCall` is the most critical semantic type:
+
+```
+LLMCall
+├── call_id: String           # Unique ID (session_prefix + counter)
+├── start_timestamp_ns: u64   # Request time
+├── end_timestamp_ns: u64     # Response time
+├── duration_ns: u64          # Latency
+├── provider: String          # openai / anthropic
+├── model: String             # gpt-4, claude-3, etc.
+├── request: LLMRequest       # Request details
+│   ├── messages: Vec<InputMessage>  # Input messages
+│   ├── tools: Option<Vec<ToolDefinition>>  # Tool definitions
+│   └── stream: bool          # Stream mode
+├── response: LLMResponse     # Response details
+│   ├── messages: Vec<OutputMessage>  # Output messages
+│   └── streamed: bool        # Was streamed
+├── token_usage: Option<TokenUsage>  # Token stats
+├── agent_name: Option<String>  # Resolved Agent name
+└── pid: i32                  # Process ID
+```
+
+### MessagePart (OTel Compatible)
+
+Message content uses OpenTelemetry GenAI parts-based format:
+
+| Part type | Purpose |
+|-----------|---------|
+| `Text` | Plain text content |
+| `Reasoning` | Reasoning/thinking content (e.g., Claude thinking) |
+| `ToolCall` | Tool call request from model |
+| `ToolCallResponse` | Tool call return result |
+
+## GenAIBuilder Build Flow
+
+```mermaid
+sequenceDiagram
+    participant AN as Analyzer
+    participant GB as GenAIBuilder
+    participant AM as AgentMatcher
+    participant EXP as Exporters
+
+    AN->>GB: build(analysis_results)
+    loop each AnalysisResult
+        GB->>GB: Check HttpRecord
+        GB->>GB: Parse request body (messages, tools)
+        GB->>GB: Parse response body (SSE chunks)
+        GB->>GB: Extract token_usage
+        GB->>AM: Match PID to agent_name
+        AM-->>GB: agent_name (e.g. "OpenClaw")
+        GB->>GB: Build LLMCall / ToolUse / StreamChunk
+    end
+    GB->>EXP: export(genai_events)
+```
+
+**Source**: `src/genai/builder.rs`
+
+## Agent Name Resolution
+
+`GenAIBuilder` resolves process PID/comm to known Agent names via `AgentMatcher`:
+
+1. Build `ProcessContext { pid, comm, cmdline }`
+2. Iterate through all matchers in `known_agents()` registry
+3. First matching matcher provides agent_name
+
+**Known Agents**: Cosh (`src/discovery/agents/cosh.rs`), OpenClaw (`src/discovery/agents/openclaw.rs`)
+
+**Custom extension**: Implement `AgentMatcher` trait to add new Agent matchers.
+
+## GenAIExporter Trait
+
+```rust
+pub trait GenAIExporter: Send + Sync {
+    fn export(&self, events: &[GenAISemanticEvent]);
+    fn name(&self) -> &str;
+}
+```
+
+### Implementation Comparison
+
+| Exporter | Storage | Format | Use case |
+|----------|---------|--------|----------|
+| `GenAIStore` | Local JSONL file | One JSON per line | Default, simple debugging |
+| `GenAISqliteStore` | SQLite genai_events table | Structured SQL | Local queries, Dashboard |
+| `SlsUploader` | Alibaba Cloud SLS | Protobuf | Cloud centralization, large-scale deployment |
+
+**Export strategy**: JSONL + SQLite enabled by default; SLS enabled when environment variables configured.
+
+**Runtime registration**: `AgentSight::add_genai_exporter()` allows dynamic exporter addition.
+
+## ATIF Export
+
+ATIF (Agent Trajectory Interchange Format) v1.6 is a standardized Agent trajectory format, independent from the GenAI semantic layer:
+
+```mermaid
+graph LR
+    DB[(SQLite genai_events)] --> CONV[ATIF Converter]
+    CONV --> DOC[AtifDocument]
+    DOC --> API[/api/export/atif/...]
+```
+
+- **By trace**: `/api/export/atif/trace/{trace_id}`
+- **By session**: `/api/export/atif/session/{session_id}`
+
+**ATIF structure**: `AtifAgent` → `Vec<AtifStep>` → `AtifToolCall` + `AtifObservation`
+
+**Source**: `src/atif/converter.rs`, `src/atif/schema.rs`
+
+## Session & Trace Model
+
+The GenAI semantic layer introduces session and trace concepts:
+
+| Concept | Identifier | Lifecycle |
+|---------|-----------|-----------|
+| **Session** | `{timestamp_hex}_{pid_hex}` | One AgentSight run instance |
+| **Trace** | `{session_prefix}_{call_counter}` | One LLM API call |
+
+- Session created at `GenAIBuilder::new()`, tied to AgentSight process lifecycle
+- Trace generated per `build()` call via `AtomicU64` counter increment
+
+## Query API (via GenAISqliteStore)
+
+`GenAISqliteStore` provides rich query interfaces for the API layer:
+
+| Method | Purpose | API endpoint |
+|--------|---------|-------------|
+| `list_sessions()` | List sessions with stats | `/api/sessions` |
+| `list_traces_by_session()` | All traces under a session | `/api/sessions/{id}/traces` |
+| `get_trace_events()` | Trace detail events | `/api/traces/{id}` |
+| `list_agent_names()` | Agent name list | `/api/agent-names` |
+| `get_token_timeseries()` | Token time series data | `/api/timeseries` |
+| `get_model_timeseries()` | Model-dimension time series | `/api/timeseries` |
+| `get_agent_token_summary()` | Agent Token summary | `/metrics` |
+
+**Source**: `src/storage/sqlite/genai.rs`

--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -18,6 +18,10 @@ pub struct TraceCommand {
     #[structopt(long, default_value = "/tmp/agentsight.pid")]
     pub pid_file: String,
 
+    /// Enable file watch probe (monitors .jsonl file opens from traced processes)
+    #[structopt(long)]
+    pub enable_filewatch: bool,
+
     // --- SLS (Aliyun Log Service) Configuration ---
     /// SLS endpoint (e.g. cn-hangzhou.log.aliyuncs.com)
     #[structopt(long, env = "SLS_ENDPOINT")]
@@ -74,6 +78,7 @@ impl TraceCommand {
         // Build AgentSight config (empty target_pids means trace all processes)
         let config = AgentsightConfig::new()
             .set_verbose(self.verbose)
+            .set_enable_filewatch(self.enable_filewatch)
             .set_sls_endpoint(self.sls_endpoint.clone())
             .set_sls_access_key(self.sls_access_key_id.clone(), self.sls_access_key_secret.clone())
             .set_sls_project(self.sls_project.clone())

--- a/src/agentsight/src/bpf/common.h
+++ b/src/agentsight/src/bpf/common.h
@@ -19,6 +19,7 @@ typedef enum {
     EVENT_SOURCE_PROC = 1,   // Process events (proctrace)
     EVENT_SOURCE_SSL  = 2,   // SSL/TLS traffic events (sslsniff)
     EVENT_SOURCE_PROCMON = 3, // Process monitor events (procmon)
+    EVENT_SOURCE_FILEWATCH = 4, // File watch events (filewatch)
 } event_source_t;
 
 // Common event header - every ringbuffer event MUST start with this

--- a/src/agentsight/src/bpf/filewatch.bpf.c
+++ b/src/agentsight/src/bpf/filewatch.bpf.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// File watch BPF program
+// Monitors openat syscalls for .jsonl files from traced processes
+#include "vmlinux.h"
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "filewatch.h"
+#include "common.h"
+
+// Tracepoint for openat - captures file open events
+// Filters for .jsonl suffix at BPF layer to minimize user-space overhead
+SEC("tp/syscalls/sys_enter_openat")
+int trace_openat_enter(struct trace_event_raw_sys_enter *ctx)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+
+    // Only monitor traced processes
+    u32 *val = bpf_map_lookup_elem(&traced_processes, &pid);
+    if (!val)
+        return 0;
+
+    // Reserve space in ring buffer
+    struct filewatch_event *event = bpf_ringbuf_reserve(&rb, sizeof(*event), 0);
+    if (!event)
+        return 0;
+
+    // Read filename from user-space
+    const char *filename_ptr = (const char *)ctx->args[1];
+    int len = bpf_probe_read_user_str(event->filename, MAX_FILENAME_LEN, filename_ptr);
+
+    // len includes null terminator; need at least 7 chars: x.jsonl\0
+    if (len < 8) {
+        bpf_ringbuf_discard(event, 0);
+        return 0;
+    }
+
+    // Check .jsonl suffix (len includes null terminator, so last char is at len-2)
+    // suffix starts at offset len-7: '.', 'j', 's', 'o', 'n', 'l', '\0'
+    int off = len - 7;
+    if (event->filename[off]     != '.' ||
+        event->filename[off + 1] != 'j' ||
+        event->filename[off + 2] != 's' ||
+        event->filename[off + 3] != 'o' ||
+        event->filename[off + 4] != 'n' ||
+        event->filename[off + 5] != 'l') {
+        bpf_ringbuf_discard(event, 0);
+        return 0;
+    }
+
+    // Fill remaining event fields
+    event->source = EVENT_SOURCE_FILEWATCH;
+    event->timestamp_ns = bpf_ktime_get_ns();
+    event->pid = pid;
+    event->tid = (u32)pid_tgid;
+    event->uid = bpf_get_current_uid_gid();
+    event->flags = (s32)ctx->args[2];
+    bpf_get_current_comm(&event->comm, sizeof(event->comm));
+
+    bpf_ringbuf_submit(event, 0);
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/agentsight/src/bpf/filewatch.h
+++ b/src/agentsight/src/bpf/filewatch.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// File watch BPF program header
+// Monitors openat syscalls for .jsonl files from traced processes
+#ifndef __FILEWATCH_H
+#define __FILEWATCH_H
+
+#define TASK_COMM_LEN    16
+#define MAX_FILENAME_LEN 256
+
+typedef signed char         s8;
+typedef unsigned char       u8;
+typedef signed short        s16;
+typedef unsigned short      u16;
+typedef signed int          s32;
+typedef unsigned int        u32;
+typedef signed long long    s64;
+typedef unsigned long long  u64;
+
+// File watch event - fixed size
+struct filewatch_event {
+    u32 source;                      // EVENT_SOURCE_FILEWATCH
+    u64 timestamp_ns;
+    u32 pid;
+    u32 tid;
+    u32 uid;
+    s32 flags;                       // openat flags (O_RDONLY, O_WRONLY, etc.)
+    char comm[TASK_COMM_LEN];
+    char filename[MAX_FILENAME_LEN]; // captured file path
+};
+
+#endif /* __FILEWATCH_H */

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -107,6 +107,8 @@ pub struct AgentsightConfig {
     pub target_uid: Option<u32>,
     /// Poll timeout for ring buffer polling (milliseconds)
     pub poll_timeout_ms: u64,
+    /// Enable file watch probe (monitors .jsonl file opens from traced processes)
+    pub enable_filewatch: bool,
 
     // --- HTTP/Aggregation Configuration ---
     /// LRU cache capacity for HTTP connections
@@ -160,6 +162,7 @@ impl Default for AgentsightConfig {
             // Probe defaults
             target_uid: None,
             poll_timeout_ms: DEFAULT_POLL_TIMEOUT_MS,
+            enable_filewatch: false,
 
             // HTTP/Aggregation defaults
             connection_capacity: DEFAULT_CONNECTION_CAPACITY,
@@ -232,6 +235,12 @@ impl AgentsightConfig {
     /// Set target UID
     pub fn set_target_uid(mut self, uid: Option<u32>) -> Self {
         self.target_uid = uid;
+        self
+    }
+
+    /// Set enable_filewatch
+    pub fn set_enable_filewatch(mut self, enable: bool) -> Self {
+        self.enable_filewatch = enable;
         self
     }
 

--- a/src/agentsight/src/event.rs
+++ b/src/agentsight/src/event.rs
@@ -1,6 +1,7 @@
 use crate::probes::proctrace::VariableEvent as ProcEvent;
 use crate::probes::sslsniff::SslEvent;
 use crate::probes::procmon::Event as ProcMonEvent;
+use crate::probes::filewatch::FileWatchEvent;
 
 /// Unified event type that can represent any probe event
 ///
@@ -10,6 +11,7 @@ pub enum Event {
     Ssl(SslEvent),
     Proc(ProcEvent),
     ProcMon(ProcMonEvent),
+    FileWatch(FileWatchEvent),
 }
 
 impl Event {
@@ -19,6 +21,7 @@ impl Event {
             Event::Ssl(_) => "Ssl",
             Event::Proc(_) => "Proc",
             Event::ProcMon(_) => "ProcMon",
+            Event::FileWatch(_) => "FileWatch",
         }
     }
 }
@@ -37,6 +40,11 @@ impl Event {
     /// Check if this is a procmon event
     pub fn is_procmon(&self) -> bool {
         matches!(self, Event::ProcMon(_))
+    }
+
+    /// Check if this is a file watch event
+    pub fn is_filewatch(&self) -> bool {
+        matches!(self, Event::FileWatch(_))
     }
 
     /// Get SSL event if this is one
@@ -59,6 +67,14 @@ impl Event {
     pub fn as_procmon(&self) -> Option<&ProcMonEvent> {
         match self {
             Event::ProcMon(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// Get file watch event if this is one
+    pub fn as_filewatch(&self) -> Option<&FileWatchEvent> {
+        match self {
+            Event::FileWatch(e) => Some(e),
             _ => None,
         }
     }

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -82,6 +82,9 @@ pub use storage::{
 // Re-export unified entry point
 pub use unified::{AgentSight, ProcessResult};
 
+// Re-export file watch types
+pub use probes::FileWatchEvent;
+
 // Re-export discovery types
 pub use discovery::{AgentInfo, AgentMatcher, AgentScanner, DiscoveredAgent, ProcessContext, known_agents};
 

--- a/src/agentsight/src/parser/unified.rs
+++ b/src/agentsight/src/parser/unified.rs
@@ -109,6 +109,7 @@ impl Parser {
             Event::Ssl(ssl_event) => self.parse_ssl_event(Rc::new(ssl_event)),
             Event::Proc(proc_event) => self.parse_proc_event(&proc_event),
             Event::ProcMon(_) => ParseResult { messages: Vec::new() },
+            Event::FileWatch(_) => ParseResult { messages: Vec::new() },
         }
     }
 

--- a/src/agentsight/src/probes/filewatch.rs
+++ b/src/agentsight/src/probes/filewatch.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// File watch probe - monitors openat syscalls for .jsonl files from traced processes
+
+use crate::config;
+use anyhow::{Context, Result};
+use libbpf_rs::{
+    Link, MapHandle,
+    skel::{OpenSkel, SkelBuilder},
+};
+use std::{
+    mem::MaybeUninit,
+    os::fd::AsFd,
+};
+
+// ─── Generated skeleton ───────────────────────────────────────────────────────
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/filewatch.skel.rs"));
+    include!(concat!(env!("OUT_DIR"), "/filewatch.rs"));
+}
+use bpf::*;
+
+// Re-export raw type for size calculation in probes.rs
+pub type RawFileWatchEvent = bpf::filewatch_event;
+
+/// User-space file watch event
+#[derive(Debug, Clone)]
+pub struct FileWatchEvent {
+    pub pid: u32,
+    pub tid: u32,
+    pub uid: u32,
+    pub timestamp_ns: u64,
+    pub flags: i32,
+    pub comm: String,
+    pub filename: String,
+}
+
+impl FileWatchEvent {
+    /// Parse event from raw ring buffer data
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        let event_size = std::mem::size_of::<RawFileWatchEvent>();
+        if data.len() < event_size {
+            return None;
+        }
+
+        // SAFETY: BPF guarantees proper alignment and layout
+        let raw = unsafe { &*(data.as_ptr() as *const RawFileWatchEvent) };
+
+        // Parse comm (null-terminated)
+        let comm = raw.comm
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect::<Vec<u8>>();
+        let comm = String::from_utf8_lossy(&comm).into_owned();
+
+        // Parse filename (null-terminated)
+        let filename = raw.filename
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect::<Vec<u8>>();
+        let filename = String::from_utf8_lossy(&filename).into_owned();
+
+        Some(FileWatchEvent {
+            pid: raw.pid,
+            tid: raw.tid,
+            uid: raw.uid,
+            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
+            flags: raw.flags,
+            comm,
+            filename,
+        })
+    }
+}
+
+// ─── Main struct ──────────────────────────────────────────────────────────────
+pub struct FileWatch {
+    _open_object: Box<MaybeUninit<libbpf_rs::OpenObject>>,
+    skel: Box<FilewatchSkel<'static>>,
+    _links: Vec<Link>,
+}
+
+impl FileWatch {
+    /// Create a new FileWatch that reuses existing traced_processes and ring buffer maps
+    ///
+    /// # Arguments
+    /// * `traced_processes` - External MapHandle for process filtering
+    /// * `rb` - External ring buffer MapHandle
+    pub fn new_with_maps(traced_processes: &MapHandle, rb: &MapHandle) -> Result<Self> {
+        let mut builder = FilewatchSkelBuilder::default();
+        builder.obj_builder.debug(config::verbose());
+
+        let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
+        let mut open_skel = builder.open().context("failed to open filewatch BPF object")?;
+
+        // Reuse external traced_processes map
+        open_skel
+            .maps_mut()
+            .traced_processes()
+            .reuse_fd(traced_processes.as_fd())
+            .context("failed to reuse external traced_processes map for filewatch")?;
+
+        // Reuse external ring buffer
+        open_skel
+            .maps_mut()
+            .rb()
+            .reuse_fd(rb.as_fd())
+            .context("failed to reuse external rb map for filewatch")?;
+
+        let skel = open_skel.load().context("failed to load filewatch BPF object")?;
+
+        // SAFETY: skel borrows open_object which lives in a Box<MaybeUninit>
+        let skel =
+            unsafe { Box::from_raw(Box::into_raw(Box::new(skel)) as *mut FilewatchSkel<'static>) };
+
+        Ok(Self {
+            _open_object: open_object,
+            skel,
+            _links: Vec::new(),
+        })
+    }
+
+    /// Attach tracepoint for file monitoring
+    pub fn attach(&mut self) -> Result<()> {
+        let mut links = Vec::new();
+
+        let link = self
+            .skel
+            .progs_mut()
+            .trace_openat_enter()
+            .attach()
+            .context("failed to attach openat tracepoint")?;
+        links.push(link);
+
+        self._links = links;
+        Ok(())
+    }
+}

--- a/src/agentsight/src/probes/mod.rs
+++ b/src/agentsight/src/probes/mod.rs
@@ -3,6 +3,7 @@
 pub mod sslsniff;
 pub mod proctrace;
 pub mod procmon;
+pub mod filewatch;
 pub mod probes;
 
 // Re-export commonly used types
@@ -10,3 +11,4 @@ pub use probes::{Probes, ProbesPoller};
 pub use proctrace::{ProcTrace, ProcPoller, VariableEvent as ProcEvent};
 pub use sslsniff::{SslSniff, SslPoller, SslEvent};
 pub use procmon::{ProcMon, ProcMonEvent, Event as ProcMonEventExt};
+pub use filewatch::{FileWatch, FileWatchEvent};

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -19,6 +19,7 @@ use super::proctrace::{ProcTrace, VariableEvent, ProcEventHeader};
 use super::sslsniff::SslSniff;
 use super::sslsniff::bpf::probe_SSL_data_t as RawSslEvent;
 use super::procmon::{ProcMon, ProcMonEvent};
+use super::filewatch::{FileWatch, RawFileWatchEvent};
 
 const POLL_TIMEOUT_MS: u64 = 100;
 
@@ -26,6 +27,7 @@ const POLL_TIMEOUT_MS: u64 = 100;
 const EVENT_SOURCE_PROC: u32 = 1;
 const EVENT_SOURCE_SSL: u32 = 2;
 const EVENT_SOURCE_PROCMON: u32 = 3;
+const EVENT_SOURCE_FILEWATCH: u32 = 4;
 
 /// Unified probe manager that coordinates sslsniff and proctrace
 /// 
@@ -41,6 +43,8 @@ pub struct Probes {
     sslsniff: SslSniff,
     /// Process monitor probe (reuses ring buffer)
     procmon: ProcMon,
+    /// File watch probe (reuses traced_processes map and ring buffer, optional)
+    filewatch: Option<FileWatch>,
     /// Shared ring buffer handle (cloned from proctrace) for polling
     rb_handle: MapHandle,
     /// Unified event channel - events are converted to Event type inside the poller
@@ -54,7 +58,7 @@ impl Probes {
     /// # Arguments
     /// * `target_pids` - Initial PIDs to trace (empty means trace all matching UID)
     /// * `target_uid` - Optional UID filter
-    pub fn new(target_pids: &[u32], target_uid: Option<u32>) -> Result<Self> {
+    pub fn new(target_pids: &[u32], target_uid: Option<u32>, enable_filewatch: bool) -> Result<Self> {
         // Create proctrace first - it will own the traced_processes map and ring buffer
         let proctrace = ProcTrace::new_with_target(target_pids, target_uid)
             .context("failed to create proctrace")?;
@@ -73,12 +77,23 @@ impl Probes {
         let procmon = ProcMon::new_with_rb(&rb_handle)
             .context("failed to create procmon")?;
 
+        // Optionally create filewatch - it reuses both the traced_processes map and ring buffer
+        let filewatch = if enable_filewatch {
+            let fw = FileWatch::new_with_maps(&map_handle, &rb_handle)
+                .context("failed to create filewatch")?;
+            Some(fw)
+        } else {
+            log::info!("FileWatch probe disabled");
+            None
+        };
+
         let (event_tx, event_rx) = crossbeam_channel::unbounded();
         
         Ok(Self {
             proctrace,
             sslsniff,
             procmon,
+            filewatch,
             rb_handle,
             event_tx,
             event_rx,
@@ -91,6 +106,11 @@ impl Probes {
         self.procmon.attach()
             .context("failed to attach procmon")?;
         self.proctrace.attach().context("failed to attach proctrace")?;
+        // Attach filewatch for .jsonl file monitoring (if enabled)
+        if let Some(ref mut fw) = self.filewatch {
+            fw.attach()
+                .context("failed to attach filewatch")?;
+        }
         // sslsniff uses uprobes attached per-process via attach_process()
         Ok(())
     }
@@ -115,6 +135,7 @@ impl Probes {
         let proc_min_sz = mem::size_of::<ProcEventHeader>();
         let ssl_event_size = mem::size_of::<RawSslEvent>();
         let procmon_event_size = mem::size_of::<ProcMonEvent>();
+        let filewatch_event_size = mem::size_of::<RawFileWatchEvent>();
 
         let event_tx = self.event_tx.clone();
         let stop_flag = Arc::new(AtomicBool::new(false));
@@ -153,6 +174,14 @@ impl Probes {
                         // Process monitor event
                         if data.len() >= procmon_event_size {
                             super::procmon::Event::from_bytes(data).map(Event::ProcMon)
+                        } else {
+                            None
+                        }
+                    }
+                    EVENT_SOURCE_FILEWATCH => {
+                        // File watch event
+                        if data.len() >= filewatch_event_size {
+                            super::filewatch::FileWatchEvent::from_bytes(data).map(Event::FileWatch)
                         } else {
                             None
                         }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -30,7 +30,7 @@ use crate::discovery::AgentScanner;
 use crate::event::Event;
 use crate::genai::{GenAIBuilder, GenAIExporter, GenAIStore, SlsUploader};
 use crate::parser::Parser;
-use crate::probes::{Probes, ProbesPoller};
+use crate::probes::{Probes, ProbesPoller, FileWatchEvent};
 use crate::storage::{
     SqliteConfig, Storage, StorageBackend, TimePeriod, TokenQuery, TokenQueryResult,
 };
@@ -69,6 +69,8 @@ pub struct AgentSight {
     running: Arc<AtomicBool>,
     /// Event counter
     event_count: u64,
+    /// File watch callback for .jsonl file open events
+    filewatch_callback: Option<Box<dyn Fn(FileWatchEvent) + Send + 'static>>,
 }
 
 /// Result of processing an event
@@ -96,7 +98,7 @@ impl AgentSight {
 
         // Create probes - agent discovery is handled by AgentScanner via ProcMon events
         let mut probes =
-            Probes::new(&[], config.target_uid).context("Failed to create probes")?;
+            Probes::new(&[], config.target_uid, config.enable_filewatch).context("Failed to create probes")?;
 
         // Attach procmon for process monitoring
         probes.attach().context("Failed to attach probes")?;
@@ -194,6 +196,7 @@ impl AgentSight {
             _poller,
             running: Arc::new(AtomicBool::new(true)),
             event_count: 0,
+            filewatch_callback: None,
         })
     }
 
@@ -268,6 +271,12 @@ impl AgentSight {
             return None;
         }
 
+        // Handle FileWatch events via callback (not through the pipeline)
+        if let Event::FileWatch(ref fw_event) = event {
+            self.handle_filewatch_event(fw_event);
+            return None;
+        }
+
         // Parse the event
         let result = self.parser.parse_event(event);
 
@@ -325,6 +334,22 @@ impl AgentSight {
                 }
             }
         }
+    }
+
+    /// Handle FileWatch event via registered callback
+    fn handle_filewatch_event(&self, event: &FileWatchEvent) {
+        log::debug!("FileWatch: pid={} file={}", event.pid, event.filename);
+        if let Some(ref cb) = self.filewatch_callback {
+            cb(event.clone());
+        }
+    }
+
+    /// Register a callback for file watch events (.jsonl file opens)
+    pub fn on_filewatch<F>(&mut self, callback: F)
+    where
+        F: Fn(FileWatchEvent) + Send + 'static,
+    {
+        self.filewatch_callback = Some(Box::new(callback));
     }
 
     /// Run the event loop (blocking)


### PR DESCRIPTION
## Description

Add a new filewatch eBPF probe that monitors `.jsonl` file open events via the `openat` syscall tracepoint. This enables AgentSight to detect when AI Agents (e.g. Claude Code, Cursor) write interaction traces to log files, correlating file access with Agent processes.

Key changes:
- **eBPF program** (`filewatch.bpf.c`): hooks `sys_enter_openat` / `sys_exit_openat`, filters `.jsonl` suffix, captures file path + PID/TID/comm
- **Rust handler** (`filewatch.rs`): userspace event processing with ring buffer polling
- **Event type**: new `Event::FileWatch` variant integrated into the unified event pipeline
- **Config**: `filewatch_enabled` option to control probe activation
- **Docs**: added AGENTS.md, ARCHITECTURE.md, DEVELOPMENT.md, and design docs

## Related Issue

closes #257

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Tested on Anolis OS with kernel 5.10+ (BTF enabled):
- filewatch probe attaches and polls events successfully
- .jsonl file open events captured with correct path and process info
- Probe can be enabled/disabled via config

## Additional Notes

This probe complements existing sslsniff/procmon/proctrace probes to provide comprehensive Agent behavior observability.