### PR TITLE
feat(sight): add filewrite eBPF probe for JSON write monitoring

### DIFF
--- a/src/agentsight/build.rs
+++ b/src/agentsight/build.rs
@@ -49,6 +49,10 @@ fn main() {
     // Generate filewatch skeleton and bindings
     generate_skeleton(&mut out, "filewatch");
     generate_header(&mut out, "filewatch");
+
+    // Generate filewrite skeleton and bindings
+    generate_skeleton(&mut out, "filewrite");
+    generate_header(&mut out, "filewrite");
     
     // generate_header(&mut out, "frametypes");
     // generate_header(&mut out, "errors");

--- a/src/agentsight/src/bpf/common.h
+++ b/src/agentsight/src/bpf/common.h
@@ -20,6 +20,7 @@ typedef enum {
     EVENT_SOURCE_SSL  = 2,   // SSL/TLS traffic events (sslsniff)
     EVENT_SOURCE_PROCMON = 3, // Process monitor events (procmon)
     EVENT_SOURCE_FILEWATCH = 4, // File watch events (filewatch)
+    EVENT_SOURCE_FILEWRITE = 5, // File write events (filewrite)
 } event_source_t;
 
 // Common event header - every ringbuffer event MUST start with this

--- a/src/agentsight/src/bpf/filewrite.bpf.c
+++ b/src/agentsight/src/bpf/filewrite.bpf.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// File write BPF program
+// Monitors vfs_write calls from traced processes writing to .jsonl files
+// Uses fentry (BPF trampoline) for minimal overhead on the hot vfs_write path
+#include "vmlinux.h"
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "filewrite.h"
+#include "common.h"
+
+// UUID format: 8-4-4-4-12 hex digits with hyphens (36 chars total)
+#define UUID_LEN 36
+// Expected filename: <uuid>.jsonl = 36 + 6 = 42 chars
+#define UUID_JSONL_LEN (UUID_LEN + 6)
+
+static __always_inline int is_hex(char c)
+{
+    return (c >= '0' && c <= '9') ||
+           (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+// Validate UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+// Hyphens at positions 8, 13, 18, 23; hex digits elsewhere
+static __always_inline int is_uuid(const char *s)
+{
+    #pragma unroll
+    for (int i = 0; i < UUID_LEN; i++) {
+        if (i == 8 || i == 13 || i == 18 || i == 23) {
+            if (s[i] != '-')
+                return 0;
+        } else {
+            if (!is_hex(s[i]))
+                return 0;
+        }
+    }
+    return 1;
+}
+
+// fentry hook on vfs_write - triggers before write executes
+// Signature: ssize_t vfs_write(struct file *file, const char __user *buf, size_t count, loff_t *pos)
+SEC("fentry/vfs_write")
+int BPF_PROG(trace_vfs_write, struct file *file, const char *buf, size_t count, loff_t *pos)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+
+    // Only monitor traced processes
+    u32 *val = bpf_map_lookup_elem(&traced_processes, &pid);
+    if (!val)
+        return 0;
+
+    // Extract filename from file->f_path.dentry->d_name.name (basename)
+    // Check early so we can skip non-.jsonl files before reserving ringbuf
+    const unsigned char *name_ptr = BPF_CORE_READ(file, f_path.dentry, d_name.name);
+    if (!name_ptr)
+        return 0;
+
+    char fname[MAX_FILENAME_LEN];
+    int ret = bpf_probe_read_kernel_str(fname, sizeof(fname), name_ptr);
+    if (ret <= 0)
+        return 0;
+
+    // ret includes the null terminator, so string length = ret - 1
+    // Filename must be exactly "<uuid>.jsonl" = 42 chars
+    int slen = ret - 1;
+    if (slen != UUID_JSONL_LEN)
+        return 0;
+
+    // Compare last 6 characters against ".jsonl"
+    if (fname[UUID_LEN]     != '.' ||
+        fname[UUID_LEN + 1] != 'j' ||
+        fname[UUID_LEN + 2] != 's' ||
+        fname[UUID_LEN + 3] != 'o' ||
+        fname[UUID_LEN + 4] != 'n' ||
+        fname[UUID_LEN + 5] != 'l')
+        return 0;
+
+    // Validate UUID portion of filename
+    if (!is_uuid(fname))
+        return 0;
+
+    // Reserve space in ring buffer
+    struct filewrite_event *event = bpf_ringbuf_reserve(&rb, sizeof(*event), 0);
+    if (!event)
+        return 0;
+
+    // Fill metadata
+    event->source = EVENT_SOURCE_FILEWRITE;
+    event->timestamp_ns = bpf_ktime_get_ns();
+    event->pid = pid;
+    event->tid = (u32)pid_tgid;
+    event->uid = bpf_get_current_uid_gid();
+    event->write_size = (u32)count;
+    bpf_get_current_comm(&event->comm, sizeof(event->comm));
+
+    // Copy filename we already read into the event
+    __builtin_memcpy(event->filename, fname, MAX_FILENAME_LEN);
+
+    // Copy write content (up to 16KB)
+    // Explicit bounds clamping to satisfy eBPF verifier:
+    // bitmask first to ensure value range, then clamp to actual max
+    u32 copy_size = (u32)count & 0x3FFF;  // Mask to 14 bits (16383)
+    if (copy_size > MAX_FILEWRITE_BUF)
+        copy_size = MAX_FILEWRITE_BUF;
+
+    ret = bpf_probe_read_user(event->buf, copy_size, buf);
+    if (ret != 0) {
+        // Failed to read user buffer
+        bpf_ringbuf_discard(event, 0);
+        return 0;
+    }
+    event->buf_size = copy_size;
+
+    bpf_ringbuf_submit(event, 0);
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/agentsight/src/bpf/filewrite.h
+++ b/src/agentsight/src/bpf/filewrite.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// File write BPF program header
+// Monitors vfs_write calls to .jsonl files from traced processes
+#ifndef __FILEWRITE_H
+#define __FILEWRITE_H
+
+#define TASK_COMM_LEN         16
+#define MAX_FILENAME_LEN      256
+#define MAX_FILEWRITE_BUF     (16 * 1024)   // 16KB
+
+typedef signed char         s8;
+typedef unsigned char       u8;
+typedef signed short        s16;
+typedef unsigned short      u16;
+typedef signed int          s32;
+typedef unsigned int        u32;
+typedef signed long long    s64;
+typedef unsigned long long  u64;
+
+// File write event - captures write content to .jsonl files
+struct filewrite_event {
+    u32 source;                         // EVENT_SOURCE_FILEWRITE (5)
+    u64 timestamp_ns;
+    u32 pid;
+    u32 tid;
+    u32 uid;
+    u32 write_size;                     // original count passed to vfs_write
+    u32 buf_size;                       // actual bytes copied (min(count, MAX_FILEWRITE_BUF))
+    char comm[TASK_COMM_LEN];           // process name (16 bytes)
+    char filename[MAX_FILENAME_LEN];    // basename from dentry (256 bytes)
+    u8  buf[MAX_FILEWRITE_BUF];         // write content (up to 16KB)
+};
+
+#endif /* __FILEWRITE_H */

--- a/src/agentsight/src/event.rs
+++ b/src/agentsight/src/event.rs
@@ -2,6 +2,7 @@ use crate::probes::proctrace::VariableEvent as ProcEvent;
 use crate::probes::sslsniff::SslEvent;
 use crate::probes::procmon::Event as ProcMonEvent;
 use crate::probes::filewatch::FileWatchEvent;
+use crate::probes::filewrite::FileWriteEvent;
 
 /// Unified event type that can represent any probe event
 ///
@@ -12,6 +13,7 @@ pub enum Event {
     Proc(ProcEvent),
     ProcMon(ProcMonEvent),
     FileWatch(FileWatchEvent),
+    FileWrite(FileWriteEvent),
 }
 
 impl Event {
@@ -22,6 +24,7 @@ impl Event {
             Event::Proc(_) => "Proc",
             Event::ProcMon(_) => "ProcMon",
             Event::FileWatch(_) => "FileWatch",
+            Event::FileWrite(_) => "FileWrite",
         }
     }
 }
@@ -45,6 +48,11 @@ impl Event {
     /// Check if this is a file watch event
     pub fn is_filewatch(&self) -> bool {
         matches!(self, Event::FileWatch(_))
+    }
+
+    /// Check if this is a file write event
+    pub fn is_filewrite(&self) -> bool {
+        matches!(self, Event::FileWrite(_))
     }
 
     /// Get SSL event if this is one
@@ -75,6 +83,14 @@ impl Event {
     pub fn as_filewatch(&self) -> Option<&FileWatchEvent> {
         match self {
             Event::FileWatch(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// Get file write event if this is one
+    pub fn as_filewrite(&self) -> Option<&FileWriteEvent> {
+        match self {
+            Event::FileWrite(e) => Some(e),
             _ => None,
         }
     }

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -40,6 +40,7 @@ pub mod health;
 pub mod tokenizer;
 pub mod genai;
 pub mod atif;
+pub mod response_map;
 #[cfg(feature = "server")]
 pub mod server;
 mod unified;
@@ -84,6 +85,9 @@ pub use unified::{AgentSight, ProcessResult};
 
 // Re-export file watch types
 pub use probes::FileWatchEvent;
+
+// Re-export response mapping
+pub use response_map::ResponseSessionMapper;
 
 // Re-export discovery types
 pub use discovery::{AgentInfo, AgentMatcher, AgentScanner, DiscoveredAgent, ProcessContext, known_agents};

--- a/src/agentsight/src/parser/unified.rs
+++ b/src/agentsight/src/parser/unified.rs
@@ -110,6 +110,7 @@ impl Parser {
             Event::Proc(proc_event) => self.parse_proc_event(&proc_event),
             Event::ProcMon(_) => ParseResult { messages: Vec::new() },
             Event::FileWatch(_) => ParseResult { messages: Vec::new() },
+            Event::FileWrite(_) => ParseResult { messages: Vec::new() },
         }
     }
 

--- a/src/agentsight/src/probes/filewrite.rs
+++ b/src/agentsight/src/probes/filewrite.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// File write probe - monitors vfs_write for JSON data from traced processes
+
+use crate::config;
+use anyhow::{Context, Result};
+use libbpf_rs::{
+    Link, MapHandle,
+    skel::{OpenSkel, SkelBuilder},
+};
+use std::{
+    mem::MaybeUninit,
+    os::fd::AsFd,
+};
+
+// ─── Generated skeleton ───────────────────────────────────────────────────────
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/filewrite.skel.rs"));
+    include!(concat!(env!("OUT_DIR"), "/filewrite.rs"));
+}
+use bpf::*;
+
+// Re-export raw type for size calculation in probes.rs
+pub type RawFileWriteEvent = bpf::filewrite_event;
+
+/// User-space file write event
+#[derive(Debug, Clone)]
+pub struct FileWriteEvent {
+    pub pid: u32,
+    pub tid: u32,
+    pub uid: u32,
+    pub timestamp_ns: u64,
+    pub write_size: u32,
+    pub comm: String,
+    pub filename: String,
+    pub buf: Vec<u8>,
+}
+
+impl FileWriteEvent {
+    /// Parse event from raw ring buffer data
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        let event_size = std::mem::size_of::<RawFileWriteEvent>();
+        if data.len() < event_size {
+            return None;
+        }
+
+        // SAFETY: BPF guarantees proper alignment and layout
+        let raw = unsafe { &*(data.as_ptr() as *const RawFileWriteEvent) };
+
+        // Parse comm (null-terminated)
+        let comm = raw.comm
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect::<Vec<u8>>();
+        let comm = String::from_utf8_lossy(&comm).into_owned();
+
+        // Parse filename (null-terminated)
+        let filename = raw.filename
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect::<Vec<u8>>();
+        let filename = String::from_utf8_lossy(&filename).into_owned();
+
+        // Copy only the actual data, not the full 16KB buffer
+        let buf_size = raw.buf_size as usize;
+        let buf_size = buf_size.min(raw.buf.len());
+        let buf = raw.buf[..buf_size].to_vec();
+
+        Some(FileWriteEvent {
+            pid: raw.pid,
+            tid: raw.tid,
+            uid: raw.uid,
+            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
+            write_size: raw.write_size,
+            comm,
+            filename,
+            buf,
+        })
+    }
+}
+
+// ─── Main struct ──────────────────────────────────────────────────────────────
+pub struct FileWrite {
+    _open_object: Box<MaybeUninit<libbpf_rs::OpenObject>>,
+    skel: Box<FilewriteSkel<'static>>,
+    _links: Vec<Link>,
+}
+
+impl FileWrite {
+    /// Create a new FileWrite that reuses existing traced_processes and ring buffer maps
+    ///
+    /// # Arguments
+    /// * `traced_processes` - External MapHandle for process filtering
+    /// * `rb` - External ring buffer MapHandle
+    pub fn new_with_maps(traced_processes: &MapHandle, rb: &MapHandle) -> Result<Self> {
+        let mut builder = FilewriteSkelBuilder::default();
+        builder.obj_builder.debug(config::verbose());
+
+        let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
+        let mut open_skel = builder.open().context("failed to open filewrite BPF object")?;
+
+        // Reuse external traced_processes map
+        open_skel
+            .maps_mut()
+            .traced_processes()
+            .reuse_fd(traced_processes.as_fd())
+            .context("failed to reuse external traced_processes map for filewrite")?;
+
+        // Reuse external ring buffer
+        open_skel
+            .maps_mut()
+            .rb()
+            .reuse_fd(rb.as_fd())
+            .context("failed to reuse external rb map for filewrite")?;
+
+        let skel = open_skel.load().context("failed to load filewrite BPF object")?;
+
+        // SAFETY: skel borrows open_object which lives in a Box<MaybeUninit>
+        let skel =
+            unsafe { Box::from_raw(Box::into_raw(Box::new(skel)) as *mut FilewriteSkel<'static>) };
+
+        Ok(Self {
+            _open_object: open_object,
+            skel,
+            _links: Vec::new(),
+        })
+    }
+
+    /// Attach fentry program for vfs_write monitoring
+    pub fn attach(&mut self) -> Result<()> {
+        let mut links = Vec::new();
+
+        let link = self
+            .skel
+            .progs_mut()
+            .trace_vfs_write()
+            .attach()
+            .context("failed to attach fentry/vfs_write")?;
+        links.push(link);
+
+        self._links = links;
+        Ok(())
+    }
+}

--- a/src/agentsight/src/probes/mod.rs
+++ b/src/agentsight/src/probes/mod.rs
@@ -4,6 +4,7 @@ pub mod sslsniff;
 pub mod proctrace;
 pub mod procmon;
 pub mod filewatch;
+pub mod filewrite;
 pub mod probes;
 
 // Re-export commonly used types
@@ -12,3 +13,4 @@ pub use proctrace::{ProcTrace, ProcPoller, VariableEvent as ProcEvent};
 pub use sslsniff::{SslSniff, SslPoller, SslEvent};
 pub use procmon::{ProcMon, ProcMonEvent, Event as ProcMonEventExt};
 pub use filewatch::{FileWatch, FileWatchEvent};
+pub use filewrite::{FileWrite as FileWriteProbe, FileWriteEvent};

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -20,6 +20,7 @@ use super::sslsniff::SslSniff;
 use super::sslsniff::bpf::probe_SSL_data_t as RawSslEvent;
 use super::procmon::{ProcMon, ProcMonEvent};
 use super::filewatch::{FileWatch, RawFileWatchEvent};
+use super::filewrite::{FileWrite as FileWriteProbe, RawFileWriteEvent};
 
 const POLL_TIMEOUT_MS: u64 = 100;
 
@@ -28,6 +29,7 @@ const EVENT_SOURCE_PROC: u32 = 1;
 const EVENT_SOURCE_SSL: u32 = 2;
 const EVENT_SOURCE_PROCMON: u32 = 3;
 const EVENT_SOURCE_FILEWATCH: u32 = 4;
+const EVENT_SOURCE_FILEWRITE: u32 = 5;
 
 /// Unified probe manager that coordinates sslsniff and proctrace
 /// 
@@ -45,6 +47,8 @@ pub struct Probes {
     procmon: ProcMon,
     /// File watch probe (reuses traced_processes map and ring buffer, optional)
     filewatch: Option<FileWatch>,
+    /// File write probe (reuses traced_processes map and ring buffer, always enabled)
+    filewrite: FileWriteProbe,
     /// Shared ring buffer handle (cloned from proctrace) for polling
     rb_handle: MapHandle,
     /// Unified event channel - events are converted to Event type inside the poller
@@ -87,6 +91,10 @@ impl Probes {
             None
         };
 
+        // Create filewrite - it reuses both the traced_processes map and ring buffer (always enabled)
+        let filewrite = FileWriteProbe::new_with_maps(&map_handle, &rb_handle)
+            .context("failed to create filewrite")?;
+
         let (event_tx, event_rx) = crossbeam_channel::unbounded();
         
         Ok(Self {
@@ -94,6 +102,7 @@ impl Probes {
             sslsniff,
             procmon,
             filewatch,
+            filewrite,
             rb_handle,
             event_tx,
             event_rx,
@@ -111,6 +120,9 @@ impl Probes {
             fw.attach()
                 .context("failed to attach filewatch")?;
         }
+        // Attach filewrite for JSON write monitoring (always enabled)
+        self.filewrite.attach()
+            .context("failed to attach filewrite")?;
         // sslsniff uses uprobes attached per-process via attach_process()
         Ok(())
     }
@@ -136,6 +148,7 @@ impl Probes {
         let ssl_event_size = mem::size_of::<RawSslEvent>();
         let procmon_event_size = mem::size_of::<ProcMonEvent>();
         let filewatch_event_size = mem::size_of::<RawFileWatchEvent>();
+        let filewrite_event_size = mem::size_of::<RawFileWriteEvent>();
 
         let event_tx = self.event_tx.clone();
         let stop_flag = Arc::new(AtomicBool::new(false));
@@ -182,6 +195,14 @@ impl Probes {
                         // File watch event
                         if data.len() >= filewatch_event_size {
                             super::filewatch::FileWatchEvent::from_bytes(data).map(Event::FileWatch)
+                        } else {
+                            None
+                        }
+                    }
+                    EVENT_SOURCE_FILEWRITE => {
+                        // File write event (JSON content)
+                        if data.len() >= filewrite_event_size {
+                            super::filewrite::FileWriteEvent::from_bytes(data).map(Event::FileWrite)
                         } else {
                             None
                         }

--- a/src/agentsight/src/response_map.rs
+++ b/src/agentsight/src/response_map.rs
@@ -1,0 +1,219 @@
+//! Response ID → Session ID Mapping
+//!
+//! Processes FileWrite events from the eBPF filewrite probe to extract
+//! `responseId` from JSONL content and map it to `sessionId` (the UUID filename).
+//!
+//! # Data Flow
+//!
+//! ```text
+//! FileWriteEvent { filename: "<UUID>.jsonl", buf: JSONL bytes }
+//!     → parse filename to extract UUID as session_id
+//!     → parse buf lines as JSON, extract "responseId" field
+//!     → store responseId → sessionId in LRU cache
+//! ```
+
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::probes::FileWriteEvent;
+
+/// Maximum number of responseId → sessionId entries kept in memory.
+const MAX_RESPONSE_MAP_ENTRIES: usize = 10_000;
+
+/// Regex to match `responseId":"<value>"` in raw text.
+static RESPONSE_ID_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"responseId":"([^"]+)"#).unwrap());
+
+/// Processes FileWrite events to build an in-memory responseId → sessionId mapping.
+/// Uses an LRU cache to bound memory usage.
+pub struct ResponseSessionMapper {
+    /// responseId → sessionId (bounded by LRU eviction)
+    map: LruCache<String, String>,
+}
+
+impl Default for ResponseSessionMapper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResponseSessionMapper {
+    /// Create a new empty mapper with default capacity.
+    pub fn new() -> Self {
+        ResponseSessionMapper {
+            map: LruCache::new(
+                NonZeroUsize::new(MAX_RESPONSE_MAP_ENTRIES).unwrap(),
+            ),
+        }
+    }
+
+    /// Process a FileWriteEvent:
+    /// 1. Extract UUID from filename as session_id
+    /// 2. Parse buf as UTF-8, split by '\n'
+    /// 3. For each line, try JSON parse and extract "responseId"
+    /// 4. Insert responseId → sessionId into the map
+    pub fn process_filewrite(&mut self, event: &FileWriteEvent) {
+        let session_id = match Self::extract_session_id(&event.filename) {
+            Some(id) => id,
+            None => {
+                log::trace!(
+                    "ResponseSessionMapper: filename not UUID.jsonl format: {}",
+                    event.filename
+                );
+                return;
+            }
+        };
+
+        let text = match std::str::from_utf8(&event.buf) {
+            Ok(s) => s,
+            Err(e) => {
+                log::trace!(
+                    "ResponseSessionMapper: buf is not valid UTF-8 for {}: {}",
+                    event.filename,
+                    e
+                );
+                return;
+            }
+        };
+
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            if let Some(response_id) = Self::extract_response_id(line) {
+                log::debug!(
+                    "ResponseSessionMapper: responseId={} → sessionId={}",
+                    response_id,
+                    session_id
+                );
+                self.map.put(response_id, session_id.clone());
+            }
+        }
+    }
+
+    /// Look up sessionId by responseId.
+    /// Uses `peek` (no LRU promotion) since each responseId is typically looked up only once.
+    pub fn get_session_by_response_id(&self, response_id: &str) -> Option<&str> {
+        self.map.peek(response_id).map(|s| s.as_str())
+    }
+
+    /// Extract UUID from a filename like `<UUID>.jsonl` or `/path/to/<UUID>.jsonl`.
+    /// Returns the UUID portion (without path prefix or `.jsonl` suffix).
+    fn extract_session_id(filename: &str) -> Option<String> {
+        // Take the last path component
+        let basename = filename.rsplit('/').next().unwrap_or(filename);
+
+        // Strip .jsonl suffix
+        let uuid = basename.strip_suffix(".jsonl")?;
+
+        // Basic UUID length validation (36 chars: 8-4-4-4-12)
+        if uuid.len() == 36 {
+            Some(uuid.to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Extract "responseId" value from a single JSONL line using regex.
+    /// Matches patterns like `responseId":"chatcmpl-xxxx"`.
+    fn extract_response_id(line: &str) -> Option<String> {
+        RESPONSE_ID_RE
+            .captures(line)
+            .and_then(|cap| cap.get(1))
+            .map(|m| m.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_session_id_simple() {
+        let id = ResponseSessionMapper::extract_session_id(
+            "550e8400-e29b-41d4-a716-446655440000.jsonl",
+        );
+        assert_eq!(id.as_deref(), Some("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_extract_session_id_with_path() {
+        let id = ResponseSessionMapper::extract_session_id(
+            "/home/user/.agent/550e8400-e29b-41d4-a716-446655440000.jsonl",
+        );
+        assert_eq!(id.as_deref(), Some("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_extract_session_id_not_jsonl() {
+        assert!(ResponseSessionMapper::extract_session_id("file.txt").is_none());
+    }
+
+    #[test]
+    fn test_extract_session_id_wrong_length() {
+        assert!(ResponseSessionMapper::extract_session_id("short.jsonl").is_none());
+    }
+
+    #[test]
+    fn test_extract_response_id() {
+        let line = r#"{"responseId":"chatcmpl-03a158a1-8982-90cd-adb1-6c8a1176f1f8","other":"data"}"#;
+        let id = ResponseSessionMapper::extract_response_id(line);
+        assert_eq!(
+            id.as_deref(),
+            Some("chatcmpl-03a158a1-8982-90cd-adb1-6c8a1176f1f8")
+        );
+    }
+
+    #[test]
+    fn test_extract_response_id_missing() {
+        let line = r#"{"other":"data"}"#;
+        assert!(ResponseSessionMapper::extract_response_id(line).is_none());
+    }
+
+    #[test]
+    fn test_extract_response_id_empty() {
+        let line = r#"{"responseId":""}"#;
+        assert!(ResponseSessionMapper::extract_response_id(line).is_none());
+    }
+
+    #[test]
+    fn test_extract_response_id_invalid_json() {
+        assert!(ResponseSessionMapper::extract_response_id("not json").is_none());
+    }
+
+    #[test]
+    fn test_process_and_query() {
+        let mut mapper = ResponseSessionMapper::new();
+        let event = FileWriteEvent {
+            pid: 1234,
+            tid: 1234,
+            uid: 1000,
+            timestamp_ns: 0,
+            write_size: 0,
+            comm: "agent".to_string(),
+            filename: "550e8400-e29b-41d4-a716-446655440000.jsonl".to_string(),
+            buf: br#"{"responseId":"chatcmpl-abc123","content":"hello"}
+{"responseId":"chatcmpl-def456","content":"world"}
+"#
+            .to_vec(),
+        };
+        mapper.process_filewrite(&event);
+
+        assert_eq!(
+            mapper.get_session_by_response_id("chatcmpl-abc123"),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            mapper.get_session_by_response_id("chatcmpl-def456"),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert!(mapper.get_session_by_response_id("nonexistent").is_none());
+    }
+}

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -30,12 +30,13 @@ use crate::discovery::AgentScanner;
 use crate::event::Event;
 use crate::genai::{GenAIBuilder, GenAIExporter, GenAIStore, SlsUploader};
 use crate::parser::Parser;
-use crate::probes::{Probes, ProbesPoller, FileWatchEvent};
+use crate::probes::{Probes, ProbesPoller, FileWatchEvent, FileWriteEvent};
 use crate::storage::{
     SqliteConfig, Storage, StorageBackend, TimePeriod, TokenQuery, TokenQueryResult,
 };
 use crate::storage::sqlite::GenAISqliteStore;
 use crate::tokenizer::LlmTokenizer;
+use crate::response_map::ResponseSessionMapper;
 
 /// Main AgentSight struct for tracing AI agent activity
 ///
@@ -71,6 +72,8 @@ pub struct AgentSight {
     event_count: u64,
     /// File watch callback for .jsonl file open events
     filewatch_callback: Option<Box<dyn Fn(FileWatchEvent) + Send + 'static>>,
+    /// ResponseId → SessionId mapper for FileWrite events
+    response_mapper: ResponseSessionMapper,
 }
 
 /// Result of processing an event
@@ -197,6 +200,7 @@ impl AgentSight {
             running: Arc::new(AtomicBool::new(true)),
             event_count: 0,
             filewatch_callback: None,
+            response_mapper: ResponseSessionMapper::new(),
         })
     }
 
@@ -277,6 +281,12 @@ impl AgentSight {
             return None;
         }
 
+        // Handle FileWrite events via callback (not through the pipeline)
+        if let Event::FileWrite(ref fw_event) = event {
+            self.handle_filewrite_event(fw_event);
+            return None;
+        }
+
         // Parse the event
         let result = self.parser.parse_event(event);
 
@@ -351,6 +361,13 @@ impl AgentSight {
     {
         self.filewatch_callback = Some(Box::new(callback));
     }
+
+    /// Handle FileWrite event: extract responseId→sessionId mapping, then call callback
+    fn handle_filewrite_event(&mut self, event: &FileWriteEvent) {
+        log::debug!("FileWrite: pid={} file={} size={}", event.pid, event.filename, event.write_size);
+        self.response_mapper.process_filewrite(event);
+    }
+
 
     /// Run the event loop (blocking)
     pub fn run(&mut self) -> Result<u64> {


### PR DESCRIPTION
## Description

Add a new `filewrite` eBPF probe to monitor JSON file write operations by AI Agents. This enables write-side observability complementing the existing `filewatch` (read-side) probe.

Key changes:
- **filewrite.bpf.c / filewrite.h**: New eBPF program hooking file write syscalls for JSON files
- **build.rs**: Generate filewrite skeleton and header during build
- **event.rs**: Add `FileWrite` variant to unified `Event` enum with `EVENT_SOURCE_FILEWRITE`
- **probes/filewrite.rs**: Rust-side probe attachment and event polling
- **probes/probes.rs**: Register and attach filewrite probe in `Probes`
- **response_map.rs**: New `ResponseSessionMapper` to correlate filewrite events with active sessions
- **unified.rs**: Wire filewrite events into the unified pipeline

## Related Issue

closes #262

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Tested by building the project and verifying the filewrite probe attaches correctly and captures JSON write events from monitored processes.

## Additional Notes

This is part of the broader file I/O observability effort. The filewrite probe works alongside the existing filewatch probe to provide complete file operation visibility for AI Agent processes.