### PR TITLE
fix(cosh): add installation of extension examples and update package …

### DIFF
--- a/src/copilot-shell/Makefile
+++ b/src/copilot-shell/Makefile
@@ -68,6 +68,10 @@ install: dist/package.json
 		install -d "$(DESTDIR)$(DATADIR)/hooks"; \
 		cp -pr hooks/* "$(DESTDIR)$(DATADIR)/hooks/"; \
 	fi
+	@if [ -d dist/examples ]; then \
+		install -d "$(DESTDIR)$(LIBDIR)/examples"; \
+		cp -pr dist/examples/* "$(DESTDIR)$(LIBDIR)/examples/"; \
+	fi
 	# -- vendor binaries (current platform only) --
 	@if [ -n "$(VENDOR_ARCH)" ] && [ -n "$(VENDOR_PLATFORM)" ] && [ -d "dist/$(VENDOR_RG_DIR)" ]; then \
 		install -d "$(DESTDIR)$(LIBDIR)/$(VENDOR_RG_DIR)"; \

--- a/src/copilot-shell/esbuild.config.js
+++ b/src/copilot-shell/esbuild.config.js
@@ -13,6 +13,7 @@ import {
   mkdirSync,
   readdirSync,
   copyFileSync,
+  cpSync,
   existsSync,
 } from 'node:fs';
 
@@ -100,6 +101,32 @@ esbuild
           copyFileSync(
             path.join(hooksSource, file),
             path.join(hooksTarget, file),
+          );
+        }
+      }
+    }
+
+    // Copy extension examples into dist/examples/ so extensions new command works at runtime
+    const examplesSource = path.resolve(
+      __dirname,
+      'packages',
+      'cli',
+      'src',
+      'commands',
+      'extensions',
+      'examples',
+    );
+    const examplesTarget = path.resolve(__dirname, 'dist', 'examples');
+    if (existsSync(examplesSource)) {
+      mkdirSync(examplesTarget, { recursive: true });
+      for (const entry of readdirSync(examplesSource, {
+        withFileTypes: true,
+      })) {
+        if (entry.isDirectory()) {
+          cpSync(
+            path.join(examplesSource, entry.name),
+            path.join(examplesTarget, entry.name),
+            { recursive: true },
           );
         }
       }

--- a/src/copilot-shell/scripts/prepare-package.js
+++ b/src/copilot-shell/scripts/prepare-package.js
@@ -197,6 +197,7 @@ const distPackageJson = {
     'LICENSE',
     'locales',
     'hooks',
+    'examples',
   ],
   config: rootPackageJson.config,
   dependencies: {},


### PR DESCRIPTION
## Description

The `co extensions new` command fails when the CLI is bundled (RPM installation) because the `examples` directory containing boilerplate templates is not included in the build output.

After bundling, `import.meta.url` in `new.ts` resolves to the directory of `cli.js` (e.g. `/usr/lib/copilot-shell/`), so `join(__dirname, 'examples')` points to a non-existent path. This fix ensures examples are copied into `dist/examples/` during build and installed alongside the CLI.

Changes:
- **esbuild.config.js**: Copy `packages/cli/src/commands/extensions/examples/` to `dist/examples/` after bundling
- **Makefile**: Install `dist/examples/` to `$(LIBDIR)/examples/` during `make install`
- **prepare-package.js**: Add `examples` to the npm publish `files` list

## Related Issue

fixes #259

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] For `cosh`: Lint passes, type check passes, and tests pass

## Testing

1. Run `npm run bundle` in `src/copilot-shell/` and verify `dist/examples/` is created with all 5 template directories (agent, commands, context, mcp-server, skills)
2. Run `co extensions new test mcp-server` and verify the template is successfully created
3. Run `make install DESTDIR=/tmp/test-install PREFIX=/usr` and verify examples are installed to `/tmp/test-install/usr/lib/copilot-shell/examples/`

## Additional Notes

No changes to `new.ts` — the existing path resolution `join(__dirname, 'examples')` works correctly once examples are placed alongside `cli.js`.