### PR TITLE
feat(cosh): support 'ask' decision for PreToolUse hooks

### DIFF
--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
@@ -2157,6 +2157,321 @@ describe('CoreToolScheduler Sequential Execution', () => {
     expect(call2?.status).toBe('cancelled');
     expect(call3?.status).toBe('cancelled');
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Regression: Bug 1 — ask + ProceedAlways must NOT batch-approve other
+  //   pending hookForceAsk calls in the same scheduling round.
+  // ─────────────────────────────────────────────────────────────────────────
+  it('ask + ProceedAlways should NOT auto-approve other hookForceAsk-pending calls in the same batch', async () => {
+    // A tool with NO native confirmation requirement (shouldConfirmExecute
+    // returns false).  The hook turns every call into a mandatory ask dialog.
+    const executeFn = vi.fn().mockResolvedValue({
+      llmContent: 'done',
+      returnDisplay: 'done',
+    });
+    const noConfirmTool = new MockTool({
+      name: 'hookAskTool',
+      execute: executeFn,
+      shouldConfirmExecute: vi.fn().mockResolvedValue(false),
+    });
+
+    // Hook always returns an 'ask' decision
+    const hookAskOutput = {
+      isBlockingDecision: () => false,
+      shouldStopExecution: () => false,
+      isAskDecision: () => true,
+      systemMessage: 'Please verify this operation',
+      getModifiedToolInput: () => null,
+      getEffectiveReason: () => '',
+    };
+    const mockHookSystemAsk = {
+      firePreToolUseEvent: vi.fn().mockResolvedValue(hookAskOutput),
+      firePostToolUseEvent: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const toolRegistryAsk = {
+      getTool: () => noConfirmTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => noConfirmTool,
+      getToolByDisplayName: () => noConfirmTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsCompleteAsk = vi.fn();
+    const onToolCallsUpdateAsk = vi.fn();
+
+    const mockConfigAsk = {
+      getSessionId: () => 'test-session-ask',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getAllowedTools: () => [],
+      getToolRegistry: () => toolRegistryAsk,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getUseSmartEdit: () => false,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      isInteractive: () => true, // prevent auto-denial of approval prompts
+      getExperimentalZedIntegration: () => false,
+      getEnableHooks: () => true,
+      getHookSystem: () => mockHookSystemAsk,
+    } as unknown as Config;
+
+    const pendingAskConfirmations: Array<
+      (
+        outcome: ToolConfirmationOutcome,
+        payload?: ToolConfirmationPayload,
+      ) => Promise<void>
+    > = [];
+
+    const schedulerAsk = new CoreToolScheduler({
+      config: mockConfigAsk,
+      onAllToolCallsComplete: onAllToolCallsCompleteAsk,
+      onToolCallsUpdate: (toolCalls) => {
+        onToolCallsUpdateAsk(toolCalls);
+        toolCalls.forEach((call) => {
+          if (call.status === 'awaiting_approval') {
+            const waitingCall = call as WaitingToolCall;
+            const alreadyCaptured = pendingAskConfirmations.find(
+              (h) => h === waitingCall.confirmationDetails.onConfirm,
+            );
+            if (!alreadyCaptured) {
+              pendingAskConfirmations.push(
+                waitingCall.confirmationDetails.onConfirm,
+              );
+            }
+          }
+        });
+      },
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortControllerAsk = new AbortController();
+    const askRequests = [
+      {
+        callId: 'hook-ask-1',
+        name: 'hookAskTool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'p-ask-1',
+      },
+      {
+        callId: 'hook-ask-2',
+        name: 'hookAskTool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'p-ask-2',
+      },
+    ];
+
+    await schedulerAsk.schedule(askRequests, abortControllerAsk.signal);
+
+    // Both calls must be in awaiting_approval because the hook forced ask.
+    await vi.waitFor(() => {
+      const latestCalls = onToolCallsUpdateAsk.mock.calls.at(
+        -1,
+      )?.[0] as ToolCall[];
+      expect(
+        latestCalls?.filter((c) => c.status === 'awaiting_approval').length,
+      ).toBe(2);
+    });
+
+    expect(pendingAskConfirmations.length).toBe(2);
+
+    // Approve the first call with ProceedAlways.
+    await pendingAskConfirmations[0](ToolConfirmationOutcome.ProceedAlways);
+
+    // ── Key regression assertion ──────────────────────────────────────────
+    // The second hookForceAsk call must remain awaiting_approval.
+    // autoApproveCompatiblePendingTools must NOT silently promote it,
+    // because the hook wants to gate every invocation individually.
+    await vi.waitFor(() => {
+      const latestCalls = onToolCallsUpdateAsk.mock.calls.at(
+        -1,
+      )?.[0] as ToolCall[];
+      const secondCall = latestCalls?.find(
+        (c) => c.request.callId === 'hook-ask-2',
+      );
+      expect(secondCall?.status).toBe('awaiting_approval');
+    });
+
+    // Confirm the second call individually so the test can finish cleanly.
+    await pendingAskConfirmations[1](ToolConfirmationOutcome.ProceedOnce);
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsCompleteAsk).toHaveBeenCalled();
+      const completedCalls = onAllToolCallsCompleteAsk.mock
+        .calls[0][0] as ToolCall[];
+      expect(completedCalls.every((c) => c.status === 'success')).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Regression: Bug 2 — hookForceAsk must AUGMENT native confirmationDetails
+  //   (preserve type + original onConfirm side-effects), not replace them
+  //   with a bare info dialog.
+  // ─────────────────────────────────────────────────────────────────────────
+  it('hookForceAsk should augment native confirmationDetails, preserving original onConfirm side-effects', async () => {
+    let approvalMode = ApprovalMode.DEFAULT;
+
+    // Hook always returns 'ask'
+    const hookAugmentOutput = {
+      isBlockingDecision: () => false,
+      shouldStopExecution: () => false,
+      isAskDecision: () => true,
+      systemMessage: 'Hook inspection required',
+      getModifiedToolInput: () => null,
+      getEffectiveReason: () => '',
+    };
+    const mockHookSystemAugment = {
+      firePreToolUseEvent: vi.fn().mockResolvedValue(hookAugmentOutput),
+      firePostToolUseEvent: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // TestApprovalTool provides a native 'edit'-type confirmation whose
+    // onConfirm calls config.setApprovalMode(AUTO_EDIT) on ProceedAlways.
+    // toolRegistryAugment is declared first so it can be referenced directly
+    // inside the mockConfigAugment literal, avoiding a post-assignment cast.
+    // eslint-disable-next-line prefer-const
+    let testToolAugment: TestApprovalTool;
+    const toolRegistryAugment = {
+      getTool: () => testToolAugment,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => testToolAugment,
+      getToolByDisplayName: () => testToolAugment,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const mockConfigAugment = {
+      getSessionId: () => 'test-session-augment',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => approvalMode,
+      setApprovalMode: (mode: ApprovalMode) => {
+        approvalMode = mode;
+      },
+      getAllowedTools: () => [],
+      getToolRegistry: () => toolRegistryAugment,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getUseSmartEdit: () => false,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      isInteractive: () => true, // prevent auto-denial of approval prompts
+      getExperimentalZedIntegration: () => false,
+      getEnableHooks: () => true,
+      getHookSystem: () => mockHookSystemAugment,
+    } as unknown as Config;
+
+    testToolAugment = new TestApprovalTool(mockConfigAugment);
+
+    const onAllToolCallsCompleteAugment = vi.fn();
+    const onToolCallsUpdateAugment = vi.fn();
+    let capturedWaitingCall: WaitingToolCall | undefined;
+
+    const schedulerAugment = new CoreToolScheduler({
+      config: mockConfigAugment,
+      onAllToolCallsComplete: onAllToolCallsCompleteAugment,
+      onToolCallsUpdate: (toolCalls) => {
+        onToolCallsUpdateAugment(toolCalls);
+        if (!capturedWaitingCall) {
+          capturedWaitingCall = toolCalls.find(
+            (c) => c.status === 'awaiting_approval',
+          ) as WaitingToolCall | undefined;
+        }
+      },
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortControllerAugment = new AbortController();
+    await schedulerAugment.schedule(
+      [
+        {
+          callId: 'augment-1',
+          name: 'testApprovalTool',
+          args: { id: 'augment-test' },
+          isClientInitiated: false,
+          prompt_id: 'p-augment',
+        },
+      ],
+      abortControllerAugment.signal,
+    );
+
+    // Wait for the tool to enter awaiting_approval
+    await vi.waitFor(() => {
+      expect(capturedWaitingCall).toBeDefined();
+    });
+
+    // ── Key regression assertions ─────────────────────────────────────────
+    // 1. Confirmation type must still be 'edit' — NOT replaced with 'info'.
+    //    This proves the original confirmationDetails were augmented, not
+    //    discarded, so the IDE diff path and edit semantics remain intact.
+    expect(capturedWaitingCall!.confirmationDetails.type).toBe('edit');
+
+    // 2. The hook warning must appear in the title alongside the native title.
+    expect(capturedWaitingCall!.confirmationDetails.title).toContain(
+      'Confirm Test Tool augment-test',
+    );
+    expect(capturedWaitingCall!.confirmationDetails.title).toContain(
+      'Hook inspection required',
+    );
+
+    // Trigger ProceedAlways through the wrapped onConfirm stored in the call.
+    await capturedWaitingCall!.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedAlways,
+    );
+
+    // 3. The original tool onConfirm side-effect must have run:
+    //    TestApprovalTool.onConfirm sets config.setApprovalMode(AUTO_EDIT)
+    //    on ProceedAlways — if it was replaced by an empty onConfirm this
+    //    would remain DEFAULT.
+    expect(approvalMode).toBe(ApprovalMode.AUTO_EDIT);
+
+    // 4. Execution should complete successfully.
+    await vi.waitFor(() => {
+      expect(onAllToolCallsCompleteAugment).toHaveBeenCalled();
+      const completedCalls = onAllToolCallsCompleteAugment.mock
+        .calls[0][0] as ToolCall[];
+      expect(completedCalls[0].status).toBe('success');
+    });
+  });
 });
 
 describe('truncateAndSaveToFile', () => {

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -125,6 +125,13 @@ export type WaitingToolCall = {
   tool: AnyDeclarativeTool;
   invocation: AnyToolInvocation;
   confirmationDetails: ToolCallConfirmationDetails;
+  /**
+   * True when this call was forced into awaiting_approval by a hook 'ask'
+   * decision (regardless of whether the tool itself requires confirmation).
+   * Used by autoApproveCompatiblePendingTools to prevent batch silent
+   * approval of calls that the hook explicitly wants to gate one-by-one.
+   */
+  hookForceAsk?: boolean;
   startTime?: number;
   outcome?: ToolConfirmationOutcome;
 };
@@ -411,6 +418,7 @@ export class CoreToolScheduler {
     targetCallId: string,
     status: 'awaiting_approval',
     confirmationDetails: ToolCallConfirmationDetails,
+    hookForceAsk?: boolean,
   ): void;
   private setStatusInternal(
     targetCallId: string,
@@ -430,6 +438,7 @@ export class CoreToolScheduler {
     targetCallId: string,
     newStatus: Status,
     auxiliaryData?: unknown,
+    hookForceAsk?: boolean,
   ): void {
     this.toolCalls = this.toolCalls.map((currentCall) => {
       if (
@@ -482,6 +491,7 @@ export class CoreToolScheduler {
             tool: toolInstance,
             status: 'awaiting_approval',
             confirmationDetails: auxiliaryData as ToolCallConfirmationDetails,
+            hookForceAsk,
             startTime: existingStartTime,
             outcome,
             invocation,
@@ -818,6 +828,8 @@ export class CoreToolScheduler {
 
         // Fire PreToolUse hook BEFORE confirmation — allows hooks to
         // modify/block the command before the user sees the approval dialog.
+        let hookForceAsk = false;
+        let hookAskMessage: string | undefined;
         if (this.config.getEnableHooks()) {
           const hookSystem = this.config.getHookSystem();
           if (hookSystem) {
@@ -846,6 +858,12 @@ export class CoreToolScheduler {
                   continue;
                 }
 
+                // Ask: force user confirmation regardless of YOLO/allowlist
+                if (hookOutput.isAskDecision()) {
+                  hookForceAsk = true;
+                  hookAskMessage = hookOutput.systemMessage;
+                }
+
                 // Modify: replace tool_input and rebuild invocation
                 const modifiedInput = hookOutput.getModifiedToolInput();
                 if (modifiedInput) {
@@ -871,8 +889,13 @@ export class CoreToolScheduler {
                   }
                 }
 
-                // Emit systemMessage notification to UI
-                if (hookOutput.systemMessage && this.outputUpdateHandler) {
+                // Emit systemMessage notification to UI (only for non-ask decisions;
+                // for ask decisions the message is shown in the confirmation dialog)
+                if (
+                  hookOutput.systemMessage &&
+                  !hookForceAsk &&
+                  this.outputUpdateHandler
+                ) {
                   this.outputUpdateHandler(
                     reqInfo.callId,
                     hookOutput.systemMessage + '\n',
@@ -901,7 +924,44 @@ export class CoreToolScheduler {
           const confirmationDetails =
             await invocation.shouldConfirmExecute(signal);
 
-          if (!confirmationDetails) {
+          // If hook requested 'ask', ensure the user always sees a confirmation
+          // dialog — regardless of YOLO/allowlist.
+          //
+          // When the tool already has its own confirmation details (e.g. exec/edit)
+          // we AUGMENT the existing dialog by appending the hook warning to the
+          // title, so the tool's original onConfirm side-effects (IDE diff result
+          // back-fill, allowlist update, AUTO_EDIT mode) are preserved.
+          //
+          // When the tool has NO native confirmation we synthesize an info dialog.
+          // In that case we use an empty onConfirm intentionally: ProceedAlways
+          // must NOT add the command to the allowlist — the hook wants to be
+          // consulted on every future invocation.
+          let effectiveConfirmationDetails:
+            | ToolCallConfirmationDetails
+            | false = confirmationDetails;
+          if (hookForceAsk) {
+            const askPrompt =
+              hookAskMessage ||
+              'A hook has requested confirmation before executing this tool.';
+            if (confirmationDetails) {
+              // Augment: spread original details to preserve type discriminant
+              // and onConfirm; only override the title to surface the hook msg.
+              effectiveConfirmationDetails = {
+                ...confirmationDetails,
+                title: `${confirmationDetails.title} — ⚠️ Hook: ${askPrompt}`,
+              } as ToolCallConfirmationDetails;
+            } else {
+              // No native confirmation: synthesize a minimal info dialog.
+              effectiveConfirmationDetails = {
+                type: 'info',
+                title: 'Hook Requires Confirmation',
+                prompt: askPrompt,
+                onConfirm: async () => {},
+              };
+            }
+          }
+
+          if (!effectiveConfirmationDetails) {
             this.setToolCallOutcome(
               reqInfo.callId,
               ToolConfirmationOutcome.ProceedAlways,
@@ -916,7 +976,7 @@ export class CoreToolScheduler {
           const isExitPlanModeTool = reqInfo.name === 'exit_plan_mode';
 
           if (isPlanMode && !isExitPlanModeTool) {
-            if (confirmationDetails) {
+            if (effectiveConfirmationDetails) {
               this.setStatusInternal(reqInfo.callId, 'error', {
                 callId: reqInfo.callId,
                 responseParts: convertToFunctionResponse(
@@ -932,8 +992,10 @@ export class CoreToolScheduler {
               this.setStatusInternal(reqInfo.callId, 'scheduled');
             }
           } else if (
-            this.config.getApprovalMode() === ApprovalMode.YOLO ||
-            doesToolInvocationMatch(toolCall.tool, invocation, allowedTools)
+            // hookForceAsk overrides YOLO/allowlist — hook explicitly requested user confirmation
+            !hookForceAsk &&
+            (this.config.getApprovalMode() === ApprovalMode.YOLO ||
+              doesToolInvocationMatch(toolCall.tool, invocation, allowedTools))
           ) {
             this.setToolCallOutcome(
               reqInfo.callId,
@@ -968,21 +1030,23 @@ export class CoreToolScheduler {
 
             // Allow IDE to resolve confirmation
             if (
-              confirmationDetails.type === 'edit' &&
-              confirmationDetails.ideConfirmation
+              effectiveConfirmationDetails &&
+              effectiveConfirmationDetails.type === 'edit' &&
+              effectiveConfirmationDetails.ideConfirmation
             ) {
-              confirmationDetails.ideConfirmation.then((resolution) => {
+              const ideDetails = effectiveConfirmationDetails;
+              ideDetails.ideConfirmation!.then((resolution) => {
                 if (resolution.status === 'accepted') {
                   this.handleConfirmationResponse(
                     reqInfo.callId,
-                    confirmationDetails.onConfirm,
+                    ideDetails.onConfirm,
                     ToolConfirmationOutcome.ProceedOnce,
                     signal,
                   );
                 } else {
                   this.handleConfirmationResponse(
                     reqInfo.callId,
-                    confirmationDetails.onConfirm,
+                    ideDetails.onConfirm,
                     ToolConfirmationOutcome.Cancel,
                     signal,
                   );
@@ -990,9 +1054,11 @@ export class CoreToolScheduler {
               });
             }
 
-            const originalOnConfirm = confirmationDetails.onConfirm;
+            const activeDetails =
+              effectiveConfirmationDetails as ToolCallConfirmationDetails;
+            const originalOnConfirm = activeDetails.onConfirm;
             const wrappedConfirmationDetails: ToolCallConfirmationDetails = {
-              ...confirmationDetails,
+              ...activeDetails,
               onConfirm: (
                 outcome: ToolConfirmationOutcome,
                 payload?: ToolConfirmationPayload,
@@ -1009,6 +1075,7 @@ export class CoreToolScheduler {
               reqInfo.callId,
               'awaiting_approval',
               wrappedConfirmationDetails,
+              hookForceAsk,
             );
           }
         } catch (error) {
@@ -1639,6 +1706,14 @@ export class CoreToolScheduler {
     ) as WaitingToolCall[];
 
     for (const pendingTool of pendingTools) {
+      // Never silently approve a tool that was forced into awaiting_approval by
+      // a hook 'ask' decision — the hook explicitly requested per-invocation
+      // confirmation.  Each such call must be presented to the user individually
+      // so the hook warning is never silently skipped within a batch.
+      if (pendingTool.hookForceAsk) {
+        continue;
+      }
+
       try {
         const stillNeedsConfirmation =
           await pendingTool.invocation.shouldConfirmExecute(signal);

--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
@@ -131,6 +131,7 @@ export class HookAggregator {
     const reasons: string[] = [];
     const additionalContexts: string[] = [];
     let hasBlock = false;
+    let hasAsk = false;
     let hasContinueFalse = false;
     let stopReason: string | undefined;
     const otherHookSpecificFields: Record<string, unknown> = {};
@@ -139,6 +140,11 @@ export class HookAggregator {
       // Check for blocking decisions
       if (output.decision === 'block' || output.decision === 'deny') {
         hasBlock = true;
+      } else if (output.decision === 'ask') {
+        // ask decision is only tracked if no blocking decision found yet
+        if (!hasBlock) {
+          hasAsk = true;
+        }
       }
 
       // Collect reasons
@@ -178,6 +184,8 @@ export class HookAggregator {
     // Set merged decision
     if (hasBlock) {
       merged.decision = 'block';
+    } else if (hasAsk) {
+      merged.decision = 'ask';
     } else if (outputs.some((o) => o.decision === 'allow')) {
       merged.decision = 'allow';
     }

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -180,6 +180,13 @@ export class DefaultHookOutput implements HookOutput {
   }
 
   /**
+   * Check if this output represents an 'ask' decision (force user confirmation)
+   */
+  isAskDecision(): boolean {
+    return this.decision === 'ask';
+  }
+
+  /**
    * Check if this output requests to stop execution
    */
   shouldStopExecution(): boolean {


### PR DESCRIPTION
## Description

This PR improves ask hook behavior for PreToolUse in cosh.

It ensures hook warnings are always visible to users and prevents warnings from
being silently skipped after ProceedAlways or Allow always.

Main changes:
- preserve native confirmation details when hook returns ask
- augment existing confirmation with hook warning instead of replacing it
- prevent batch auto-approval of hook-forced ask pending calls
- add regression tests for batch auto-approve and onConfirm side effects

## Related Issue

closes #275

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] cosh (copilot-shell)
- [ ] sec-core (agent-sec-core)
- [ ] skill (os-skills)
- [ ] sight (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For cosh: Lint passes, type check passes, and tests pass
- [ ] For sec-core (Rust): cargo clippy -- -D warnings and cargo fmt --check pass
- [ ] For sec-core (Python): Ruff format and pytest pass
- [ ] For skill: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For sight: cargo clippy -- -D warnings and cargo fmt --check pass
- [ ] Lock files are up to date (package-lock.json / Cargo.lock)

## Testing

Executed with vitest:
- npx vitest packages/core/src/core/coreToolScheduler.test.ts --run
- npx vitest packages/core/src/core/coreToolScheduler.test.ts --run -t "ask + ProceedAlways should NOT auto-approve other hookForceAsk-pending calls in the same batch"
- npx vitest packages/core/src/core/coreToolScheduler.test.ts --run -t "hookForceAsk should augment native confirmationDetails, preserving original onConfirm side-effects"
- npx vitest packages/core/src/hooks/hookAggregator.test.ts --run

## Additional Notes

No lock file changes.