### PR TITLE
feat(cosh): support immediate hook activation with extension 

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -499,6 +499,111 @@ describe('extensionsCommand', () => {
         expect.any(Number),
       );
     });
+
+    it('should call hookSystem.initialize() after installing an extension with hooks', async () => {
+      mockParseInstallSource.mockResolvedValue({
+        type: 'git',
+        source: 'https://github.com/test/extension',
+      });
+      mockInstallExtension.mockResolvedValue({
+        name: 'test-extension',
+        version: '1.0.0',
+        hooks: { PreToolUse: [{ matcher: 'run_shell_command', hooks: [] }] },
+      });
+      const mockHookInitialize = vi.fn().mockResolvedValue(undefined);
+      const ctx = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: mockGetExtensions,
+            getWorkingDir: () => '/test/dir',
+            getExtensionManager: () => realMockExtensionManager,
+            getHookSystem: () => ({ initialize: mockHookInitialize }),
+          },
+        },
+        ui: { dispatchExtensionStateUpdate: vi.fn() },
+      });
+
+      await installAction(ctx, 'https://github.com/test/extension');
+
+      expect(mockHookInitialize).toHaveBeenCalledOnce();
+      expect(ctx.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Extension "test-extension" installed successfully.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should NOT call hookSystem.initialize() when installed extension has no hooks', async () => {
+      mockParseInstallSource.mockResolvedValue({
+        type: 'git',
+        source: 'https://github.com/test/extension',
+      });
+      // extension with no hooks field
+      mockInstallExtension.mockResolvedValue({
+        name: 'test-extension',
+        version: '1.0.0',
+      });
+      const mockHookInitialize = vi.fn().mockResolvedValue(undefined);
+      const ctx = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: mockGetExtensions,
+            getWorkingDir: () => '/test/dir',
+            getExtensionManager: () => realMockExtensionManager,
+            getHookSystem: () => ({ initialize: mockHookInitialize }),
+          },
+        },
+        ui: { dispatchExtensionStateUpdate: vi.fn() },
+      });
+
+      await installAction(ctx, 'https://github.com/test/extension');
+
+      expect(mockHookInitialize).not.toHaveBeenCalled();
+    });
+
+    it('should still report install success when hookSystem.initialize() throws', async () => {
+      mockParseInstallSource.mockResolvedValue({
+        type: 'git',
+        source: 'https://github.com/test/extension',
+      });
+      mockInstallExtension.mockResolvedValue({
+        name: 'test-extension',
+        version: '1.0.0',
+        hooks: { PreToolUse: [{ matcher: 'run_shell_command', hooks: [] }] },
+      });
+      const mockHookInitialize = vi
+        .fn()
+        .mockRejectedValue(new Error('hook init failed'));
+      const ctx = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: mockGetExtensions,
+            getWorkingDir: () => '/test/dir',
+            getExtensionManager: () => realMockExtensionManager,
+            getHookSystem: () => ({ initialize: mockHookInitialize }),
+          },
+        },
+        ui: { dispatchExtensionStateUpdate: vi.fn() },
+      });
+
+      await installAction(ctx, 'https://github.com/test/extension');
+
+      // Install success message must still appear
+      expect(ctx.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Extension "test-extension" installed successfully.',
+        },
+        expect.any(Number),
+      );
+      // No error message about the install itself
+      expect(ctx.ui.addItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: MessageType.ERROR }),
+        expect.any(Number),
+      );
+    });
   });
 
   describe('uninstall', () => {
@@ -516,6 +621,11 @@ describe('extensionsCommand', () => {
       vi.resetAllMocks();
       realMockExtensionManager = Object.create(ExtensionManager.prototype);
       realMockExtensionManager.uninstallExtension = mockUninstallExtension;
+      // refreshCache is now called unconditionally after uninstall; mock it here
+      // so tests don't hit the real filesystem.
+      realMockExtensionManager.refreshCache = vi
+        .fn()
+        .mockResolvedValue(undefined);
 
       mockContext = createMockCommandContext({
         services: {
@@ -579,6 +689,127 @@ describe('extensionsCommand', () => {
         {
           type: MessageType.ERROR,
           text: 'Failed to uninstall extension "nonexistent-extension": Extension not found.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should call refreshCache() then hookSystem.initialize() after uninstall', async () => {
+      mockUninstallExtension.mockResolvedValue(undefined);
+      const mockRefreshCacheFn = vi.fn().mockResolvedValue(undefined);
+      const mockHookInitialize = vi.fn().mockResolvedValue(undefined);
+      realMockExtensionManager.refreshCache = mockRefreshCacheFn;
+      const ctx = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: mockGetExtensions,
+            getWorkingDir: () => '/test/dir',
+            getExtensionManager: () => realMockExtensionManager,
+            getHookSystem: () => ({ initialize: mockHookInitialize }),
+          },
+        },
+        ui: { dispatchExtensionStateUpdate: vi.fn() },
+      });
+
+      await uninstallAction(ctx, 'test-extension');
+
+      expect(mockRefreshCacheFn).toHaveBeenCalledOnce();
+      expect(mockHookInitialize).toHaveBeenCalledOnce();
+      // refreshCache must be called before initialize so system extensions re-enter cache first
+      expect(mockRefreshCacheFn.mock.invocationCallOrder[0]).toBeLessThan(
+        mockHookInitialize.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should call refreshCache + hookSystem.initialize() even when user extension had no hooks', async () => {
+      // Regression: user extension with no hooks is uninstalled, but a same-named
+      // system extension may have hooks that should immediately become active.
+      mockUninstallExtension.mockResolvedValue(undefined);
+      const mockRefreshCacheFn = vi.fn().mockResolvedValue(undefined);
+      const mockHookInitialize = vi.fn().mockResolvedValue(undefined);
+      realMockExtensionManager.refreshCache = mockRefreshCacheFn;
+      const ctx = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: mockGetExtensions,
+            getWorkingDir: () => '/test/dir',
+            getExtensionManager: () => realMockExtensionManager,
+            getHookSystem: () => ({ initialize: mockHookInitialize }),
+          },
+        },
+        ui: { dispatchExtensionStateUpdate: vi.fn() },
+      });
+
+      await uninstallAction(ctx, 'no-hooks-extension');
+
+      // Must still run both even though user extension had no hooks
+      expect(mockRefreshCacheFn).toHaveBeenCalledOnce();
+      expect(mockHookInitialize).toHaveBeenCalledOnce();
+    });
+
+    it('should still report uninstall success when hookSystem.initialize() throws', async () => {
+      mockUninstallExtension.mockResolvedValue(undefined);
+      const mockRefreshCacheFn = vi.fn().mockResolvedValue(undefined);
+      const mockHookInitialize = vi
+        .fn()
+        .mockRejectedValue(new Error('hook reinit failed'));
+      realMockExtensionManager.refreshCache = mockRefreshCacheFn;
+      const ctx = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: mockGetExtensions,
+            getWorkingDir: () => '/test/dir',
+            getExtensionManager: () => realMockExtensionManager,
+            getHookSystem: () => ({ initialize: mockHookInitialize }),
+          },
+        },
+        ui: { dispatchExtensionStateUpdate: vi.fn() },
+      });
+
+      await uninstallAction(ctx, 'test-extension');
+
+      // Uninstall success message must still appear
+      expect(ctx.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Extension "test-extension" uninstalled successfully.',
+        },
+        expect.any(Number),
+      );
+      // No error message about the uninstall itself
+      expect(ctx.ui.addItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: MessageType.ERROR }),
+        expect.any(Number),
+      );
+    });
+
+    it('should still call refreshCache() even when getHookSystem() returns undefined', async () => {
+      // Locks the fix: refreshCache must run unconditionally regardless of
+      // whether the hook system is available, so the cache stays consistent
+      // with disk after an uninstall (e.g. system extension re-enters cache).
+      mockUninstallExtension.mockResolvedValue(undefined);
+      const mockRefreshCacheFn = vi.fn().mockResolvedValue(undefined);
+      realMockExtensionManager.refreshCache = mockRefreshCacheFn;
+      const ctx = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: mockGetExtensions,
+            getWorkingDir: () => '/test/dir',
+            getExtensionManager: () => realMockExtensionManager,
+            // No getHookSystem — simulates hook system unavailable
+          },
+        },
+        ui: { dispatchExtensionStateUpdate: vi.fn() },
+      });
+
+      await uninstallAction(ctx, 'test-extension');
+
+      expect(mockRefreshCacheFn).toHaveBeenCalledOnce();
+      // Uninstall success should still be reported
+      expect(ctx.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Extension "test-extension" uninstalled successfully.',
         },
         expect.any(Number),
       );

--- a/src/copilot-shell/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -303,6 +303,18 @@ async function installAction(context: CommandContext, args: string) {
     );
     // FIXME: refresh command controlled by ui for now, cannot be auto refreshed by extensionManager
     context.ui.reloadCommands();
+    // Hook rebuild is best-effort: failure must not make install appear to fail.
+    try {
+      const hookSystem = context.services.config?.getHookSystem?.();
+      if (hookSystem && extension.hooks) {
+        await hookSystem.initialize();
+      }
+    } catch (hookErr) {
+      console.warn(
+        '[extensions] hook re-initialization failed after install:',
+        hookErr,
+      );
+    }
   } catch (error) {
     context.ui.addItem(
       {
@@ -357,6 +369,29 @@ async function uninstallAction(context: CommandContext, args: string) {
       Date.now(),
     );
     context.ui.reloadCommands();
+    // Cache refresh is unconditional: keeps disk state consistent even when the
+    // hook system is unavailable. Hook rebuild is best-effort afterwards.
+    // Each step has its own catch so the warn message accurately identifies the
+    // failing step and does not mask a refreshCache error as a hook-init error.
+    try {
+      await extensionManager.refreshCache();
+    } catch (cacheErr) {
+      console.warn(
+        '[extensions] cache refresh failed after uninstall:',
+        cacheErr,
+      );
+    }
+    try {
+      const hookSystem = context.services.config?.getHookSystem?.();
+      if (hookSystem) {
+        await hookSystem.initialize();
+      }
+    } catch (hookErr) {
+      console.warn(
+        '[extensions] hook re-initialization failed after uninstall:',
+        hookErr,
+      );
+    }
   } catch (error) {
     context.ui.addItem(
       {

--- a/src/copilot-shell/packages/core/src/extension/extensionManager.ts
+++ b/src/copilot-shell/packages/core/src/extension/extensionManager.ts
@@ -66,6 +66,8 @@ import {
 } from '../telemetry/types.js';
 import { loadSkillsFromDir } from '../skills/skill-load.js';
 import { loadSubagentFromDir } from '../subagents/subagent-manager.js';
+import type { HookDefinition } from '../hooks/types.js';
+import type { HookEventName } from '../hooks/types.js';
 
 // ============================================================================
 // Types and Interfaces
@@ -94,6 +96,7 @@ export interface Extension {
   commands?: string[];
   skills?: SkillConfig[];
   agents?: SubagentConfig[];
+  hooks?: { [K in HookEventName]?: HookDefinition[] };
 }
 
 export interface ExtensionConfig {
@@ -106,6 +109,7 @@ export interface ExtensionConfig {
   skills?: string | string[];
   agents?: string | string[];
   settings?: ExtensionSetting[];
+  hooks?: { [K in HookEventName]?: HookDefinition[] };
 }
 
 export interface ExtensionUpdateInfo {
@@ -521,15 +525,32 @@ export class ExtensionManager {
     fs.writeFileSync(this.configFilePath, JSON.stringify(config, null, 2));
   }
 
+  /** System-level extensions directory (RPM/deb installs). */
+  static readonly SYSTEM_EXTENSIONS_DIR = '/usr/share/anolisa/extensions';
+
   /**
    * Refreshes the extension cache from disk.
+   * Scans system-level dir first (lower priority), then user-level dir
+   * (higher priority, same-name entries overwrite system ones).
    */
   async refreshCache(): Promise<void> {
     this.extensionCache = new Map<string, Extension>();
-    const extensions = await this.loadExtensionsFromDir(os.homedir());
-    extensions.forEach((extension) => {
-      this.extensionCache!.set(extension.name, extension);
-    });
+
+    // 1. System-level extensions (RPM/deb installed, lower priority)
+    if (fs.existsSync(ExtensionManager.SYSTEM_EXTENSIONS_DIR)) {
+      const systemExts = await this.loadExtensionsFromDirectPath(
+        ExtensionManager.SYSTEM_EXTENSIONS_DIR,
+      );
+      for (const ext of systemExts) {
+        this.extensionCache.set(ext.name, ext);
+      }
+    }
+
+    // 2. User-level extensions (cosh extensions install, overrides system)
+    const userExts = await this.loadExtensionsFromDir(os.homedir());
+    for (const ext of userExts) {
+      this.extensionCache.set(ext.name, ext);
+    }
   }
 
   getLoadedExtensions(): Extension[] {
@@ -574,6 +595,43 @@ export class ExtensionManager {
     }
 
     return null;
+  }
+
+  /**
+   * Loads extensions by directly scanning subdirectories of the given path.
+   * Unlike loadExtensionsFromDir(), this does NOT append .copilot-shell/extensions/
+   * and is intended for system-level paths like /usr/share/anolisa/extensions.
+   */
+  async loadExtensionsFromDirectPath(dir: string): Promise<Extension[]> {
+    let subdirs: string[];
+    try {
+      subdirs = fs.readdirSync(dir);
+    } catch {
+      return [];
+    }
+
+    const extensions: Extension[] = [];
+    for (const subdir of subdirs) {
+      const extensionDir = path.join(dir, subdir);
+      let stat: fs.Stats | undefined;
+      try {
+        stat =
+          fs.statSync(extensionDir, { throwIfNoEntry: false }) ?? undefined;
+      } catch {
+        // EACCES or other permission errors – skip this entry gracefully
+        continue;
+      }
+      if (!stat?.isDirectory()) continue;
+
+      const extension = await this.loadExtension({
+        extensionDir,
+        workspaceDir: this.workspaceDir,
+      });
+      if (extension != null) {
+        extensions.push(extension);
+      }
+    }
+    return extensions;
   }
 
   async loadExtensionsFromDir(dir: string): Promise<Extension[]> {
@@ -636,6 +694,7 @@ export class ExtensionManager {
         config,
         settings: config.settings,
         contextFiles: [],
+        hooks: config.hooks,
       };
 
       if (config.mcpServers) {

--- a/src/copilot-shell/packages/core/src/extension/marketplace.ts
+++ b/src/copilot-shell/packages/core/src/extension/marketplace.ts
@@ -94,6 +94,10 @@ function parseSourceAndPluginName(source: string): {
  */
 function isOwnerRepoFormat(source: string): boolean {
   // owner/repo format: word/word, no slashes before, no protocol
+  // Exclude local paths starting with . (e.g. ./foo) or / (e.g. /usr/foo)
+  if (source.startsWith('.') || source.startsWith('/')) {
+    return false;
+  }
   const ownerRepoRegex = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
   return ownerRepoRegex.test(source);
 }


### PR DESCRIPTION
## Description

This PR makes extension hook registration and deregistration take effect **immediately within the running session**, without requiring a restart. Previously, hooks declared in a `cosh-extension.json` were only loaded at startup, so any extension installed or uninstalled at runtime had no effect on the active hook registry.

Key changes:

- **Immediate hook activation**: After a successful `extensions install`, `hookSystem.initialize()` is called so the new extension's hooks are registered in the current session.
- **Immediate hook deactivation**: After `extensions uninstall`, `extensionManager.refreshCache()` is called unconditionally (regardless of whether the hook system is available) to keep the in-memory cache consistent with disk. `hookSystem.initialize()` is then called to deregister the removed extension's hooks.
- **System extension recovery**: Because `refreshCache()` re-scans `SYSTEM_EXTENSIONS_DIR` before user-level extensions, a same-named system extension that was shadowed by the uninstalled user extension will have its hooks restored automatically.
- **Fault isolation**: `refreshCache` and `hookSystem.initialize` each have their own `try/catch`; a failure in either step is logged with an accurate message and does not surface as an install/uninstall error to the user.
- **Local path install fix**: `isOwnerRepoFormat` now explicitly rejects paths starting with `.` or `/`, preventing `extensions install ./local-path` from being misidentified as a GitHub `owner/repo` reference.
- **TOML `run` field**: Commands can now declare a `run` field instead of `prompt` to execute a shell script directly without sending anything to the model. Output is streamed back to the UI as a `message`.

## Related Issue

no-issue: self-contained feature improvement to extension lifecycle management

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass

## Testing

New unit tests added to `extensionsCommand.test.ts` (7 cases):

```
install
  ✓ should call hookSystem.initialize() after installing an extension with hooks
  ✓ should NOT call hookSystem.initialize() when installed extension has no hooks
  ✓ should still report install success when hookSystem.initialize() throws

uninstall
  ✓ should call refreshCache() then hookSystem.initialize() after uninstall
  ✓ should call refreshCache + hookSystem.initialize() even when user extension had no hooks
  ✓ should still report uninstall success when hookSystem.initialize() throws
  ✓ should still call refreshCache() even when getHookSystem() returns undefined
```

All 38 tests pass: `npx vitest run src/ui/commands/extensionsCommand.test.ts`

## Additional Notes

The `run` field in TOML commands is additive and backward-compatible — existing `prompt`-based commands are unaffected. The `example_hook/` directory added in this PR serves as both a functional example and a template for users who want to distribute hooks as an installable extension.