### PR TITLE
feat(sec-core): improve skill-ledger CLI and clean up imports

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/BUILD.md
+++ b/src/agent-sec-core/agent-sec-cli/BUILD.md
@@ -103,7 +103,7 @@ The package uses modern Python packaging with `pyproject.toml`:
 ### Dependencies
 
 **Runtime:**
-- gnupg >= 2.0
+- System `gpg` / `gnupg2` binary >= 2.0
 
 **Optional:**
 - pgpy >= 0.5 (faster PGP verification)

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 
 dependencies = [
     "cryptography>=42.0",
-    "gnupg>=2.0",
     "modelscope>=1.10",
     "pydantic>=2.0",
     "pyyaml>=6.0",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
@@ -11,6 +11,20 @@ from typing import Any
 from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
+from agent_sec_cli.skill_ledger.config import resolve_skill_dirs
+from agent_sec_cli.skill_ledger.core.auditor import audit
+from agent_sec_cli.skill_ledger.core.certifier import certify, certify_batch
+from agent_sec_cli.skill_ledger.core.checker import check
+from agent_sec_cli.skill_ledger.core.version_chain import (
+    list_version_ids,
+    load_latest_manifest,
+)
+from agent_sec_cli.skill_ledger.scanner.registry import ScannerRegistry
+from agent_sec_cli.skill_ledger.signing.ed25519 import NativeEd25519Backend
+from agent_sec_cli.skill_ledger.signing.key_manager import (
+    archive_current_public_key,
+    ensure_keys_not_exist,
+)
 
 
 class SkillLedgerBackend(BaseBackend):
@@ -41,14 +55,6 @@ class SkillLedgerBackend(BaseBackend):
         passphrase: str | None = None,
         **kw: Any,
     ) -> ActionResult:
-        from agent_sec_cli.skill_ledger.signing.ed25519 import (
-            NativeEd25519Backend,
-        )
-        from agent_sec_cli.skill_ledger.signing.key_manager import (
-            archive_current_public_key,
-            ensure_keys_not_exist,
-        )
-
         try:
             ensure_keys_not_exist(force=force)
         except Exception as exc:
@@ -81,11 +87,6 @@ class SkillLedgerBackend(BaseBackend):
     def _do_check(
         self, ctx: RequestContext, *, skill_dir: str, **kw: Any
     ) -> ActionResult:
-        from agent_sec_cli.skill_ledger.core.checker import check
-        from agent_sec_cli.skill_ledger.signing.ed25519 import (
-            NativeEd25519Backend,
-        )
-
         backend = NativeEd25519Backend()
         try:
             result = check(skill_dir, backend)
@@ -119,20 +120,10 @@ class SkillLedgerBackend(BaseBackend):
         scanner_names: list[str] | None = None,
         **kw: Any,
     ) -> ActionResult:
-        from agent_sec_cli.skill_ledger.core.certifier import (
-            certify,
-            certify_batch,
-        )
-        from agent_sec_cli.skill_ledger.signing.ed25519 import (
-            NativeEd25519Backend,
-        )
-
         backend = NativeEd25519Backend()
 
         try:
             if all_skills:
-                from agent_sec_cli.skill_ledger.config import resolve_skill_dirs
-
                 dirs = resolve_skill_dirs()
                 if not dirs:
                     return ActionResult(
@@ -180,15 +171,6 @@ class SkillLedgerBackend(BaseBackend):
     def _do_status(
         self, ctx: RequestContext, *, skill_dir: str, **kw: Any
     ) -> ActionResult:
-        from agent_sec_cli.skill_ledger.core.checker import check
-        from agent_sec_cli.skill_ledger.core.version_chain import (
-            list_version_ids,
-            load_latest_manifest,
-        )
-        from agent_sec_cli.skill_ledger.signing.ed25519 import (
-            NativeEd25519Backend,
-        )
-
         backend = NativeEd25519Backend()
 
         try:
@@ -239,11 +221,6 @@ class SkillLedgerBackend(BaseBackend):
         verify_snapshots: bool = False,
         **kw: Any,
     ) -> ActionResult:
-        from agent_sec_cli.skill_ledger.core.auditor import audit
-        from agent_sec_cli.skill_ledger.signing.ed25519 import (
-            NativeEd25519Backend,
-        )
-
         backend = NativeEd25519Backend()
 
         try:
@@ -256,4 +233,40 @@ class SkillLedgerBackend(BaseBackend):
             stdout=json.dumps(result, ensure_ascii=False) + "\n",
             data={"command": "audit", **result},
             exit_code=0 if result["valid"] else 1,
+        )
+
+    def _do_list_scanners(self, ctx: RequestContext, **kw: Any) -> ActionResult:
+        registry = ScannerRegistry.from_config()
+        scanners = registry.list_scanners(enabled_only=False)
+
+        if not scanners:
+            return ActionResult(
+                success=True,
+                stdout="No scanners registered.\n",
+                data={"command": "list-scanners", "scanners": []},
+            )
+
+        lines = [
+            f"{'NAME':<20} {'TYPE':<10} {'PARSER':<18} {'ENABLED':<8} DESCRIPTION",
+        ]
+        scanner_data = []
+        for s in scanners:
+            lines.append(
+                f"{s.name:<20} {s.type:<10} {s.parser:<18} "
+                f"{'yes' if s.enabled else 'no':<8} {s.description}"
+            )
+            scanner_data.append(
+                {
+                    "name": s.name,
+                    "type": s.type,
+                    "parser": s.parser,
+                    "enabled": s.enabled,
+                    "description": s.description,
+                }
+            )
+
+        return ActionResult(
+            success=True,
+            stdout="\n".join(lines) + "\n",
+            data={"command": "list-scanners", "scanners": scanner_data},
         )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
@@ -115,7 +115,7 @@ class SkillLedgerBackend(BaseBackend):
         all_skills: bool = False,
         findings: str | None = None,
         scanner: str = "skill-vetter",
-        scanner_version: str = "0.1.0",
+        scanner_version: str | None = None,
         scanner_names: list[str] | None = None,
         **kw: Any,
     ) -> ActionResult:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
@@ -255,21 +255,8 @@ def cmd_list_scanners() -> None:
 
     Use this to discover valid values for the --scanner flag in certify.
     """
-    from agent_sec_cli.skill_ledger.scanner.registry import ScannerRegistry
-
-    registry = ScannerRegistry.from_config()
-    scanners = registry.list_scanners(enabled_only=False)
-    if not scanners:
-        typer.echo("No scanners registered.")
-        raise typer.Exit(code=0)
-
-    typer.echo(f"{'NAME':<20} {'TYPE':<10} {'PARSER':<18} {'ENABLED':<8} DESCRIPTION")
-    for s in scanners:
-        typer.echo(
-            f"{s.name:<20} {s.type:<10} {s.parser:<18} "
-            f"{'yes' if s.enabled else 'no':<8} {s.description}"
-        )
-    raise typer.Exit(code=0)
+    result = invoke("skill_ledger", command="list-scanners")
+    _forward(result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
@@ -14,7 +14,22 @@ from agent_sec_cli.security_middleware import invoke
 
 app = typer.Typer(
     name="skill-ledger",
-    help="Skill change-tracking, integrity verification, and tamper-proof signing.",
+    help=(
+        "Skill security management — track changes, verify integrity, and sign skills.\n\n"
+        "Typical workflow:\n\n"
+        "  1. init-keys  Generate signing key pair (one-time setup)\n"
+        "  2. check      Verify a skill's integrity status\n"
+        "  3. certify    Record scan findings and sign the manifest\n"
+        "  4. status     View a human-readable summary\n"
+        "  5. audit      Deep-verify the full version history\n\n"
+        "Integrity statuses:\n\n"
+        "  pass      Files unchanged, signature valid, scan clean\n"
+        "  none      Never scanned — baseline will be created on first check\n"
+        "  drifted   Skill files changed since last certification\n"
+        "  warn      Scan found low-risk issues\n"
+        "  deny      Scan found high-risk issues\n"
+        "  tampered  Manifest signature verification failed"
+    ),
     add_completion=True,
 )
 
@@ -40,12 +55,26 @@ def _forward(result) -> None:
 
 @app.command("init-keys")
 def cmd_init_keys(
-    force: bool = typer.Option(False, "--force", help="Overwrite existing keys"),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite existing keys (old key pair is archived)"
+    ),
     use_passphrase: bool = typer.Option(
-        False, "--passphrase", help="Encrypt the private key with a passphrase"
+        False,
+        "--passphrase",
+        help="Protect the private key with an interactive passphrase (or set SKILL_LEDGER_PASSPHRASE env var for CI)",
     ),
 ) -> None:
-    """Generate Ed25519 signing key pair."""
+    """Generate an Ed25519 signing key pair (one-time setup).
+
+    Creates a key pair used to sign skill manifests. Run this once before
+    using any other skill-ledger command.
+
+    Key storage:
+      ~/.local/share/skill-ledger/key.enc  (encrypted private key, 0600)
+      ~/.local/share/skill-ledger/key.pub  (public key, 0644)
+
+    By default, no passphrase is required — safe for non-interactive use.
+    """
     # Resolve passphrase: env-var > --passphrase flag > None
     passphrase: str | None = None
     env_pass = os.environ.get("SKILL_LEDGER_PASSPHRASE")
@@ -74,9 +103,20 @@ def cmd_init_keys(
 
 @app.command("check")
 def cmd_check(
-    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+    skill_dir: str = typer.Argument(..., help="Path to the skill directory to check"),
 ) -> None:
-    """Check skill integrity status (used by hooks)."""
+    """Check a skill's integrity and output its security status as JSON.
+
+    Compares current file hashes against the signed manifest and verifies
+    the digital signature. Possible statuses:
+
+      pass      Files unchanged, signature valid, scan clean
+      none      Never scanned — a baseline manifest is created automatically
+      drifted   Skill files changed since last certification
+      warn      Signature valid, but scan found low-risk issues
+      deny      Signature valid, but scan found high-risk issues
+      tampered  Manifest signature verification failed — possible forgery
+    """
     result = invoke("skill_ledger", command="check", skill_dir=skill_dir)
     _forward(result)
 
@@ -88,24 +128,51 @@ def cmd_check(
 
 @app.command("certify")
 def cmd_certify(
-    skill_dir: Optional[str] = typer.Argument(None, help="Path to skill directory"),
+    skill_dir: Optional[str] = typer.Argument(
+        None, help="Path to the skill directory (omit when using --all)"
+    ),
     findings: Optional[str] = typer.Option(
-        None, "--findings", help="Path to findings JSON file (external mode)"
+        None,
+        "--findings",
+        help="Path to a findings JSON file from an external scanner (e.g., skill-vetter)",
     ),
     scanner: str = typer.Option(
-        "skill-vetter", "--scanner", help="Scanner identifier (used with --findings)"
+        "skill-vetter",
+        "--scanner",
+        help="Name of the scanner that produced the findings file",
     ),
-    scanner_version: str = typer.Option(
-        "0.1.0", "--scanner-version", help="Scanner version"
+    scanner_version: Optional[str] = typer.Option(
+        None,
+        "--scanner-version",
+        help="Version of the scanner that produced the findings",
     ),
     scanners: Optional[str] = typer.Option(
-        None, "--scanners", help="Comma-separated scanner names for auto-invoke mode"
+        None,
+        "--scanners",
+        help="Comma-separated scanner names to auto-invoke (e.g., 'skill-vetter,custom')",
     ),
     all_skills: bool = typer.Option(
-        False, "--all", help="Certify all skills from config.json skillDirs"
+        False,
+        "--all",
+        help="Certify every skill listed in ~/.config/skill-ledger/config.json skillDirs",
     ),
 ) -> None:
-    """Create or update a signed manifest with scan findings."""
+    """Record scan findings into a signed manifest for a skill.
+
+    Two input modes:
+
+      External findings (recommended for Agent-driven scans):
+        certify <dir> --findings <file> --scanner skill-vetter
+
+      Auto-invoke (run registered scanners automatically):
+        certify <dir> --scanners <names>
+
+    What certify does:
+      1. Verify file consistency (creates a new version if files changed)
+      2. Normalize findings and merge into the manifest scans[]
+      3. Aggregate scanStatus (pass / warn / deny)
+      4. Re-sign and write to .skill-meta/latest.json
+    """
     scanner_names = [s.strip() for s in scanners.split(",")] if scanners else None
     result = invoke(
         "skill_ledger",
@@ -127,9 +194,14 @@ def cmd_certify(
 
 @app.command("status")
 def cmd_status(
-    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+    skill_dir: str = typer.Argument(..., help="Path to the skill directory"),
 ) -> None:
-    """Show human-readable skill status (for debugging)."""
+    """Display a human-readable summary of a skill's security state.
+
+    Shows the current integrity status, version ID, scan results, and
+    file-change details in a readable format. Useful for quick inspection
+    without parsing JSON (unlike 'check', which outputs machine-readable JSON).
+    """
     result = invoke("skill_ledger", command="status", skill_dir=skill_dir)
     _forward(result)
 
@@ -141,12 +213,24 @@ def cmd_status(
 
 @app.command("audit")
 def cmd_audit(
-    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+    skill_dir: str = typer.Argument(..., help="Path to the skill directory to audit"),
     verify_snapshots: bool = typer.Option(
-        False, "--verify-snapshots", help="Also verify snapshot file hashes"
+        False,
+        "--verify-snapshots",
+        help="Also verify that snapshot file hashes match stored records",
     ),
 ) -> None:
-    """Deep-verify version chain integrity."""
+    """Verify the full version-chain integrity for a skill.
+
+    Walks every historical version in .skill-meta/versions/ and checks:
+
+      - Hash consistency (file hashes match the recorded values)
+      - Signature validity (each version's digital signature is correct)
+      - Chain linkage (each version references the previous signature)
+
+    Use --verify-snapshots to additionally validate snapshot file hashes
+    against the stored records — useful for detecting silent file corruption.
+    """
     result = invoke(
         "skill_ledger",
         command="audit",
@@ -157,18 +241,54 @@ def cmd_audit(
 
 
 # ---------------------------------------------------------------------------
+# list-scanners
+# ---------------------------------------------------------------------------
+
+
+@app.command("list-scanners")
+def cmd_list_scanners() -> None:
+    """List registered scanners and their configuration.
+
+    Shows all scanners defined in the built-in defaults and
+    ~/.config/skill-ledger/config.json, including their invocation type,
+    result parser, and enabled status.
+
+    Use this to discover valid values for the --scanner flag in certify.
+    """
+    from agent_sec_cli.skill_ledger.scanner.registry import ScannerRegistry
+
+    registry = ScannerRegistry.from_config()
+    scanners = registry.list_scanners(enabled_only=False)
+    if not scanners:
+        typer.echo("No scanners registered.")
+        raise typer.Exit(code=0)
+
+    typer.echo(f"{'NAME':<20} {'TYPE':<10} {'PARSER':<18} {'ENABLED':<8} DESCRIPTION")
+    for s in scanners:
+        typer.echo(
+            f"{s.name:<20} {s.type:<10} {s.parser:<18} "
+            f"{'yes' if s.enabled else 'no':<8} {s.description}"
+        )
+    raise typer.Exit(code=0)
+
+
+# ---------------------------------------------------------------------------
 # set-policy (stub)
 # ---------------------------------------------------------------------------
 
 
-@app.command("set-policy")
+@app.command("set-policy", hidden=True)
 def cmd_set_policy(
-    skill_dir: str = typer.Argument(..., help="Path to skill directory"),
+    skill_dir: str = typer.Argument(..., help="Path to the skill directory"),
     policy: str = typer.Option(
-        ..., "--policy", help="Execution policy: allow | block | warning"
+        ..., "--policy", help="Execution policy to apply: allow | block | warning"
     ),
 ) -> None:
-    """Set skill execution policy (coming soon)."""
+    """Set a skill's execution policy (coming soon).
+
+    Will control whether a skill is allowed to run, blocked, or triggers a
+    warning based on its security state. Not yet implemented.
+    """
     typer.echo("set-policy: this feature is coming soon.")
     raise typer.Exit(code=0)
 
@@ -178,9 +298,13 @@ def cmd_set_policy(
 # ---------------------------------------------------------------------------
 
 
-@app.command("rotate-keys")
+@app.command("rotate-keys", hidden=True)
 def cmd_rotate_keys() -> None:
-    """Rotate signing keys (coming soon)."""
+    """Rotate the signing key pair (coming soon).
+
+    Will archive the current key pair and generate a new one, allowing
+    continued verification of manifests signed with the old keys.
+    """
     typer.echo("rotate-keys: this feature is coming soon.")
     raise typer.Exit(code=0)
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
@@ -8,7 +8,6 @@ Implements ``agent-sec-cli skill-ledger audit <skill_dir> [--verify-snapshots]``
 4. Optionally verify snapshot file hashes
 """
 
-from pathlib import Path
 from typing import Any
 
 from agent_sec_cli.skill_ledger.core.file_hasher import (

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
@@ -103,12 +103,12 @@ def _determine_scan_status(findings: list[NormalizedFinding]) -> str:
 def _build_scan_entry(
     normalized: list[NormalizedFinding],
     scanner: str,
-    scanner_version: str,
+    scanner_version: str | None,
 ) -> ScanEntry:
     """Construct a :class:`ScanEntry` from normalised findings."""
     return ScanEntry(
         scanner=scanner,
-        version=scanner_version,
+        version=scanner_version or "unknown",
         status=_determine_scan_status(normalized),
         findings=[f.to_findings_dict() for f in normalized],
         scannedAt=utc_now_iso(),
@@ -181,7 +181,7 @@ def certify(
     backend: SigningBackend,
     findings_path: str | None = None,
     scanner: str = "skill-vetter",
-    scanner_version: str = "0.1.0",
+    scanner_version: str | None = None,
     scanner_names: list[str] | None = None,
 ) -> dict[str, Any]:
     """Execute the full certify workflow for a single skill directory.
@@ -262,7 +262,7 @@ def certify_batch(
     backend: SigningBackend,
     findings_path: str | None = None,
     scanner: str = "skill-vetter",
-    scanner_version: str = "0.1.0",
+    scanner_version: str | None = None,
     scanner_names: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Certify multiple skill directories (``--all`` mode).

--- a/src/agent-sec-core/agent-sec-cli/uv.lock
+++ b/src/agent-sec-core/agent-sec-cli/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.6"
 
 [[package]]
@@ -8,7 +8,6 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
-    { name = "gnupg" },
     { name = "modelscope" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -35,7 +34,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "gnupg", specifier = ">=2.0" },
     { name = "modelscope", specifier = ">=1.10" },
     { name = "pgpy", marker = "extra == 'pgpy'", specifier = ">=0.5" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -337,15 +335,6 @@ sdist = { url = "https://mirrors.aliyun.com/pypi/packages/e1/cf/b50ddf667c15276a
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4" },
 ]
-
-[[package]]
-name = "gnupg"
-version = "2.3.1"
-source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-dependencies = [
-    { name = "psutil" },
-]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/96/6c/21f99b450d2f0821ff35343b9a7843b71e98de35192454606435c72991a8/gnupg-2.3.1.tar.gz", hash = "sha256:8db5a05c369dbc231dab4c98515ce828f2dffdc14f1534441a6c59b71c6d2031" }
 
 [[package]]
 name = "h11"
@@ -783,22 +772,6 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746" },
-]
-
-[[package]]
-name = "psutil"
-version = "7.2.2"
-source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372" }
-wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee" },
 ]
 
 [[package]]

--- a/src/agent-sec-core/skills/skill-ledger/SKILL.md
+++ b/src/agent-sec-core/skills/skill-ledger/SKILL.md
@@ -240,8 +240,7 @@ cat /tmp/skill-vetter-findings-<SKILL_NAME>.json | python3 -c "import json,sys; 
 ```bash
 agent-sec-cli skill-ledger certify <SKILL_DIR> \
   --findings /tmp/skill-vetter-findings-<SKILL_NAME>.json \
-  --scanner skill-vetter \
-  --scanner-version 0.1.0
+  --scanner skill-vetter
 ```
 
 > 当 Scanner Registry 中有多个 `skill` 类型扫描器时，对每个扫描器分别调用 `certify --findings <对应 findings> --scanner <对应 scanner>`。`certify` 会自动合并同一 Skill 的多个 scanner 条目到 `scans[]` 数组。

--- a/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
@@ -863,6 +863,14 @@ def test_rotate_keys_stub(ws: Workspace):
     assert "coming soon" in r.stdout.lower()
 
 
+def test_list_scanners(ws: Workspace):
+    """list-scanners → exit 0, prints header and at least skill-vetter."""
+    r = run_skill_ledger(["list-scanners"], env_extra=ws.env())
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    assert "NAME" in r.stdout, f"Expected header row in output:\n{r.stdout}"
+    assert "skill-vetter" in r.stdout, f"Expected skill-vetter in output:\n{r.stdout}"
+
+
 def test_certify_empty_skill_dir(ws: Workspace):
     """Certify a skill dir with no files → still succeeds (empty fileHashes)."""
     skill = ws.skills_dir / "empty-skill"
@@ -962,7 +970,10 @@ def test_contract_certify_explicit_scanner_flags(ws: Workspace):
 
     SKILL.md invocation:
       agent-sec-cli skill-ledger certify <DIR> \\
-        --findings ... --scanner skill-vetter --scanner-version 0.1.0
+        --findings ... --scanner skill-vetter
+
+    --scanner-version is optional (defaults to 'unknown' if omitted).
+    This test verifies that explicit values are accepted.
     """
     skill = make_skill(ws.skills_dir, "contract-flags", {"run.sh": "echo hi"})
     env = ws.env()
@@ -1301,6 +1312,7 @@ def main():
         # Group 8: stubs & edge cases
         test("set-policy stub", lambda: test_set_policy_stub(ws))
         test("rotate-keys stub", lambda: test_rotate_keys_stub(ws))
+        test("list-scanners", lambda: test_list_scanners(ws))
         test("Certify: empty skill dir", lambda: test_certify_empty_skill_dir(ws))
 
         # Group 9: SKILL.md contract assertions


### PR DESCRIPTION
## Description

Improve skill-ledger CLI usability with beginner-friendly help text, a new list-scanners discovery command, and corrected --scanner-version default. Also cleans up imports per DEVELOPMENT.md §3 and removes unused dependencies.

### Changes

- CLI help improvements: Rewrite all skill-ledger --help text with workflow overview, integrity status reference, and detailed option descriptions
- Add list-scanners subcommand: Prints registered scanners from built-in defaults and ~/.config/skill-ledger/config.json, helping users discover valid --scanner values
- Route list-scanners through invoke() middleware for tracing and lifecycle consistency
- Make --scanner-version optional: Change default from hardcoded "0.1.0" to None (falls back to "unknown"), preventing stale audit trails when scanner version is unknown
- Hide stub commands: set-policy and rotate-keys are hidden from --help via hidden=True since they are not yet implemented
- Add E2E test for list-scanners: Verifies exit 0, header row, and skill-vetter presence (test count 40 → 41)
- Move function-body imports to file header per DEVELOPMENT.md section 3
- Remove unused Path import in auditor.py (ruff F401)
- Remove unused gnupg dependency: agent-sec-cli invokes gpg via subprocess, not the Python gnupg binding — removed from pyproject.toml and updated BUILD.md

## Related Issue

no-issue: CLI usability improvements, import hygiene, and dependency cleanup identified during development

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] sec-core (agent-sec-core)

## Checklist

- [x] I have read the [Contributing Guide](../../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For sec-core (Python): Ruff format and pytest pass
- [x] Lock files are up to date (uv.lock)

## Testing

```bash
# Unit tests (67/67 passed)
cd src/agent-sec-core/agent-sec-cli && uv run pytest ../tests/unit-test/skill_ledger/ -v

# E2E tests (41/41 passed)
cd src/agent-sec-core/agent-sec-cli && uv run python ../tests/e2e/skill-ledger/e2e_test.py
```
