### PR TITLE
feat(cosh): enhance extension  with commands 

### DIFF
--- a/src/copilot-shell/packages/cli/src/services/FileCommandLoader-extension.test.ts
+++ b/src/copilot-shell/packages/cli/src/services/FileCommandLoader-extension.test.ts
@@ -8,8 +8,10 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
 import mock from 'mock-fs';
 import { FileCommandLoader } from './FileCommandLoader.js';
+import { _spawnImpl } from './command-factory.js';
 import type { Config } from '@copilot-shell/core';
 import { Storage } from '@copilot-shell/core';
+import type { MessageActionReturn } from '../ui/commands/types.js';
 
 describe('FileCommandLoader - Extension Commands Support', () => {
   const projectRoot = '/test/project';
@@ -353,5 +355,88 @@ describe('FileCommandLoader - Extension Commands Support', () => {
     // Extensions are sorted alphabetically, so ext-a comes before ext-b
     expect(commands[0].extensionName).toBe('ext-a');
     expect(commands[1].extensionName).toBe('ext-b');
+  });
+
+  it('regression: cosh-extension.json + run command substitutes ${extensionPath} and omits $ prefix by default', async () => {
+    const extensionDir = path.join(
+      projectRoot,
+      '.copilot-shell',
+      'extensions',
+      'cosh-ext',
+    );
+
+    mock({
+      [userCommandsDir]: {},
+      [projectCommandsDir]: {},
+      [extensionDir]: {
+        'cosh-extension.json': JSON.stringify({
+          name: 'cosh-ext',
+          version: '1.0.0',
+        }),
+        commands: {
+          // ${extensionPath} should be replaced with the real extension dir path
+          'status.toml': 'run = "echo ${extensionPath}/status"\n',
+        },
+      },
+    });
+
+    const mockConfig = {
+      getFolderTrustFeature: vi.fn(() => false),
+      getFolderTrust: vi.fn(() => true),
+      getProjectRoot: vi.fn(() => projectRoot),
+      storage: new Storage(projectRoot),
+      getExtensions: vi.fn(() => [
+        {
+          id: 'cosh-ext',
+          config: { name: 'cosh-ext', version: '1.0.0' },
+          contextFiles: [],
+          name: 'cosh-ext',
+          version: '1.0.0',
+          isActive: true,
+          path: extensionDir,
+        },
+      ]),
+    } as unknown as Config;
+
+    const loader = new FileCommandLoader(mockConfig);
+    const commands = await loader.loadCommands(new AbortController().signal);
+    expect(commands).toHaveLength(1);
+
+    // Set up a fake spawn that captures the shell command and controls lifecycle
+    let capturedCmd = '';
+    const procHandlers: Record<string, Array<(arg: unknown) => void>> = {};
+    const fakeStream = { on: vi.fn(), destroy: vi.fn() };
+    const fakeProc = {
+      stdout: fakeStream,
+      stderr: fakeStream,
+      on(ev: string, cb: (arg: unknown) => void) {
+        procHandlers[ev] = [...(procHandlers[ev] ?? []), cb];
+        return this;
+      },
+      kill: vi.fn(),
+    };
+    const spawnSpy = vi
+      .spyOn(_spawnImpl, 'fn')
+      .mockImplementation((_shell, args) => {
+        capturedCmd = (args as string[])[1]; // sh -c <command>
+        return fakeProc as never;
+      });
+
+    const actionPromise = commands[0].action!(
+      null as never,
+      '',
+    ) as Promise<MessageActionReturn>;
+
+    // All proc.on handlers are now registered; trigger close(0)
+    (procHandlers['close'] ?? []).forEach((h) => h(0));
+    const result = await actionPromise;
+
+    // ${extensionPath} must be substituted with the actual extension directory
+    expect(capturedCmd).toBe(`echo ${extensionDir}/status`);
+
+    // show_command defaults to false — no $ prefix in output
+    expect(result.content).not.toContain('$');
+
+    spawnSpy.mockRestore();
   });
 });

--- a/src/copilot-shell/packages/cli/src/services/FileCommandLoader.ts
+++ b/src/copilot-shell/packages/cli/src/services/FileCommandLoader.ts
@@ -11,7 +11,7 @@ import toml from '@iarna/toml';
 import { glob } from 'glob';
 import { z } from 'zod';
 import type { Config } from '@copilot-shell/core';
-import { EXTENSIONS_CONFIG_FILENAME, Storage } from '@copilot-shell/core';
+import { findExtensionConfigFilename, Storage } from '@copilot-shell/core';
 import type { ICommandLoader } from './types.js';
 import {
   parseMarkdownCommand,
@@ -26,19 +26,36 @@ import type { SlashCommand } from '../ui/commands/types.js';
 interface CommandDirectory {
   path: string;
   extensionName?: string;
+  /** Root path of the owning extension, used for variable substitution in `run` commands. */
+  extensionPath?: string;
 }
 
 /**
  * Defines the Zod schema for a command definition file. This serves as the
  * single source of truth for both validation and type inference.
+ *
+ * Supports two modes:
+ *   - `prompt`: send a prompt to the model (can include !{...} shell injection)
+ *   - `run`: execute a shell command directly, stream output to UI, no model involved
  */
-const TomlCommandDefSchema = z.object({
-  prompt: z.string({
-    required_error: "The 'prompt' field is required.",
-    invalid_type_error: "The 'prompt' field must be a string.",
-  }),
-  description: z.string().optional(),
-});
+const TomlCommandDefSchema = z
+  .object({
+    prompt: z
+      .string({
+        invalid_type_error: "The 'prompt' field must be a string.",
+      })
+      .optional(),
+    run: z
+      .string({
+        invalid_type_error: "The 'run' field must be a string.",
+      })
+      .optional(),
+    description: z.string().optional(),
+    show_command: z.boolean().optional(),
+  })
+  .refine((data) => data.prompt != null || data.run != null, {
+    message: "Either 'prompt' or 'run' field is required.",
+  });
 
 /**
  * Discovers and loads custom slash commands from .toml files in both the
@@ -105,6 +122,7 @@ export class FileCommandLoader implements ICommandLoader {
             path.join(dirInfo.path, file),
             dirInfo.path,
             dirInfo.extensionName,
+            dirInfo.extensionPath,
           ),
         );
 
@@ -172,6 +190,7 @@ export class FileCommandLoader implements ICommandLoader {
           dirs.push({
             path: cmdPath,
             extensionName: ext.name,
+            extensionPath: ext.path,
           });
         }
       }
@@ -188,9 +207,10 @@ export class FileCommandLoader implements ICommandLoader {
     path: string;
     name: string;
   }): string[] {
-    // Try to get extension config
+    // Try to get extension config — prefer cosh-extension.json, fall back to qwen-extension.json
     try {
-      const configPath = path.join(ext.path, EXTENSIONS_CONFIG_FILENAME);
+      const configFilename = findExtensionConfigFilename(ext.path);
+      const configPath = path.join(ext.path, configFilename);
       if (fsSync.existsSync(configPath)) {
         const configContent = fsSync.readFileSync(configPath, 'utf-8');
         const config = JSON.parse(configContent);
@@ -241,6 +261,7 @@ export class FileCommandLoader implements ICommandLoader {
     filePath: string,
     baseDir: string,
     extensionName?: string,
+    extensionPath?: string,
   ): Promise<SlashCommand | null> {
     let fileContent: string;
     try {
@@ -283,6 +304,7 @@ export class FileCommandLoader implements ICommandLoader {
       validDef,
       extensionName,
       '.toml',
+      extensionPath,
     );
   }
 

--- a/src/copilot-shell/packages/cli/src/services/command-factory.test.ts
+++ b/src/copilot-shell/packages/cli/src/services/command-factory.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ChildProcess } from 'node:child_process';
+import {
+  createSlashCommandFromDefinition,
+  _spawnImpl,
+} from './command-factory.js';
+import type { MessageActionReturn } from '../ui/commands/types.js';
+
+// Use vi.spyOn on the exported wrapper object so we avoid relying on ESM
+// built-in module mocking (node:child_process in jsdom env is not interceptable
+// via vi.mock).
+const mockSpawn = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Helper: builds a fake ChildProcess whose events can be triggered manually.
+// ---------------------------------------------------------------------------
+function makeFakeProc() {
+  const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  function makeStream(prefix: string) {
+    return {
+      on(event: string, cb: (...args: unknown[]) => void) {
+        const key = `${prefix}:${event}`;
+        listeners[key] = [...(listeners[key] ?? []), cb];
+        return this;
+      },
+      destroy: vi.fn(),
+    };
+  }
+
+  const proc = {
+    stdout: makeStream('stdout'),
+    stderr: makeStream('stderr'),
+    on(event: string, cb: (...args: unknown[]) => void) {
+      const key = `proc:${event}`;
+      listeners[key] = [...(listeners[key] ?? []), cb];
+      return this;
+    },
+    kill: vi.fn(),
+  } as unknown as ChildProcess;
+
+  const emit = {
+    stdout: (data: Buffer) =>
+      (listeners['stdout:data'] ?? []).forEach((cb) => cb(data)),
+    stderr: (data: Buffer) =>
+      (listeners['stderr:data'] ?? []).forEach((cb) => cb(data)),
+    close: (code: number | null) =>
+      (listeners['proc:close'] ?? []).forEach((cb) => cb(code)),
+    error: (err: Error) =>
+      (listeners['proc:error'] ?? []).forEach((cb) => cb(err)),
+  };
+
+  return { proc, emit };
+}
+
+// Shortcut: build a command with a `run` field and execute its action.
+async function runCmd(run: string): Promise<MessageActionReturn> {
+  const cmd = createSlashCommandFromDefinition(
+    '/base/check.toml',
+    '/base',
+    { run },
+    undefined,
+    '.toml',
+  );
+  return (await cmd.action!(null as never, '')) as MessageActionReturn;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('createSlashCommandFromDefinition - run field', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(_spawnImpl, 'fn').mockImplementation(mockSpawn as never);
+    mockSpawn.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('returns info message on successful exit (code 0)', async () => {
+    const { proc, emit } = makeFakeProc();
+    mockSpawn.mockReturnValue(proc);
+
+    const promise = runCmd('echo hello');
+    emit.stdout(Buffer.from('hello\n'));
+    emit.close(0);
+
+    const result = await promise;
+
+    expect(result.type).toBe('message');
+    expect(result.messageType).toBe('info');
+    expect(result.content).toContain('hello\n');
+    expect(result.content).not.toContain('exited with code');
+  });
+
+  it('returns error message on non-zero exit code', async () => {
+    const { proc, emit } = makeFakeProc();
+    mockSpawn.mockReturnValue(proc);
+
+    const promise = runCmd('exit 1');
+    emit.stderr(Buffer.from('error output\n'));
+    emit.close(1);
+
+    const result = await promise;
+
+    expect(result.messageType).toBe('error');
+    expect(result.content).toContain('[exited with code 1]');
+  });
+
+  it('returns error message when spawn emits process error (e.g. ENOENT)', async () => {
+    const { proc, emit } = makeFakeProc();
+    mockSpawn.mockReturnValue(proc);
+
+    const promise = runCmd('nonexistent-cmd');
+    emit.error(new Error('spawn sh ENOENT'));
+
+    const result = await promise;
+
+    expect(result.messageType).toBe('error');
+    expect(result.content).toContain(
+      '[failed to start process: spawn sh ENOENT]',
+    );
+  });
+
+  it('kills process and reports error after 30 s timeout', async () => {
+    const { proc, emit } = makeFakeProc();
+    mockSpawn.mockReturnValue(proc);
+
+    const promise = runCmd('sleep 9999');
+    vi.advanceTimersByTime(30_001);
+    emit.close(null); // simulate process killed
+
+    const result = await promise;
+
+    expect(proc.kill).toHaveBeenCalled();
+    expect(result.messageType).toBe('error');
+    expect(result.content).toContain('[process killed after 30s timeout]');
+  });
+
+  it('truncates output exceeding 512 KiB and returns info on exit 0', async () => {
+    const { proc, emit } = makeFakeProc();
+    mockSpawn.mockReturnValue(proc);
+
+    const promise = runCmd('yes');
+    emit.stdout(Buffer.alloc(600 * 1024, 'x')); // 600 KiB
+    emit.close(0);
+
+    const result = await promise;
+
+    expect(result.content).toContain('[output truncated at 512 KiB]');
+    expect(result.messageType).toBe('info');
+  });
+
+  it('omits $ prefix by default when show_command is not set', async () => {
+    const { proc, emit } = makeFakeProc();
+    mockSpawn.mockReturnValue(proc);
+
+    const cmd = createSlashCommandFromDefinition(
+      '/base/greet.toml',
+      '/base',
+      { run: 'echo hi' }, // show_command not set → defaults to false
+      undefined,
+      '.toml',
+    );
+    const promise = cmd.action!(
+      null as never,
+      '',
+    ) as Promise<MessageActionReturn>;
+    emit.stdout(Buffer.from('hi\n'));
+    emit.close(0);
+
+    const result = await promise;
+
+    expect(result.content).not.toMatch(/^\$ /);
+    expect(result.content).toContain('hi\n');
+  });
+
+  it('includes $ <command> prefix when show_command is explicitly true', async () => {
+    const { proc, emit } = makeFakeProc();
+    mockSpawn.mockReturnValue(proc);
+
+    const cmd = createSlashCommandFromDefinition(
+      '/base/greet.toml',
+      '/base',
+      { run: 'echo hi', show_command: true },
+      undefined,
+      '.toml',
+    );
+    const promise = cmd.action!(
+      null as never,
+      '',
+    ) as Promise<MessageActionReturn>;
+    emit.stdout(Buffer.from('hi\n'));
+    emit.close(0);
+
+    const result = await promise;
+
+    expect(result.content).toContain('$ echo hi');
+    expect(result.content).toContain('hi\n');
+  });
+});

--- a/src/copilot-shell/packages/cli/src/services/command-factory.ts
+++ b/src/copilot-shell/packages/cli/src/services/command-factory.ts
@@ -9,7 +9,17 @@
  * objects from parsed command definitions (TOML or Markdown).
  */
 
+import { spawn as _nodeSpawn } from 'node:child_process';
 import path from 'node:path';
+import { hydrateString } from '@copilot-shell/core';
+
+/**
+ * Thin wrapper around spawn, exported so unit tests can substitute a fake
+ * without relying on ESM built-in module mocking (which is unreliable in
+ * jsdom environment).
+ * @internal Do not use outside of command-factory and its tests.
+ */
+export const _spawnImpl = { fn: _nodeSpawn };
 import type {
   CommandContext,
   SlashCommand,
@@ -33,8 +43,16 @@ import {
 import { AtFileProcessor } from './prompt-processors/atFileProcessor.js';
 
 export interface CommandDefinition {
-  prompt: string;
+  /** Prompt to send to the model. Required if `run` is absent. */
+  prompt?: string;
+  /** Shell command to execute directly without involving the model. */
+  run?: string;
   description?: string;
+  /**
+   * When true, prepends `$ <command>` to the output.
+   * Defaults to false — output is shown without the raw command header.
+   */
+  show_command?: boolean;
 }
 
 /**
@@ -54,6 +72,7 @@ export function createSlashCommandFromDefinition(
   definition: CommandDefinition,
   extensionName: string | undefined,
   fileExtension: string,
+  extensionPath?: string,
 ): SlashCommand {
   const relativePathWithExt = path.relative(baseDir, filePath);
   const relativePath = relativePathWithExt.substring(
@@ -76,13 +95,110 @@ export function createSlashCommandFromDefinition(
   }
 
   const processors: IPromptProcessor[] = [];
-  const usesArgs = definition.prompt.includes(SHORTHAND_ARGS_PLACEHOLDER);
-  const usesShellInjection = definition.prompt.includes(
-    SHELL_INJECTION_TRIGGER,
-  );
-  const usesAtFileInjection = definition.prompt.includes(
-    AT_FILE_INJECTION_TRIGGER,
-  );
+
+  // ── Shell-only mode: `run` field executes directly, no model ──────────────
+  if (definition.run != null) {
+    // Apply ${extensionPath} and other variables if the command comes from an extension.
+    const shellCmd =
+      extensionPath != null
+        ? hydrateString(definition.run, {
+            extensionPath,
+            CLAUDE_PLUGIN_ROOT: extensionPath,
+            workspacePath: process.cwd(),
+            '/': path.sep,
+            pathSeparator: path.sep,
+          })
+        : definition.run;
+    const showCommand = definition.show_command ?? false;
+    return {
+      name: baseCommandName,
+      description,
+      kind: CommandKind.FILE,
+      extensionName,
+      action: async (): Promise<SlashCommandActionReturn> => {
+        /** Maximum bytes collected from stdout+stderr before truncation. */
+        const OUTPUT_CAP_BYTES = 512 * 1024; // 512 KiB
+        /** Kill process after this many milliseconds. */
+        const TIMEOUT_MS = 30_000;
+
+        const result = await new Promise<{
+          output: string;
+          code: number | null;
+          timedOut: boolean;
+          spawnError?: boolean;
+        }>((resolve) => {
+          let totalBytes = 0;
+          let truncated = false;
+          const proc = _spawnImpl.fn('sh', ['-c', shellCmd], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+
+          const timer = setTimeout(() => {
+            proc.kill();
+            resolve({ output: chunks.join(''), code: null, timedOut: true });
+          }, TIMEOUT_MS);
+
+          const chunks: string[] = [];
+
+          const collect = (d: Buffer) => {
+            if (truncated) return;
+            const remaining = OUTPUT_CAP_BYTES - totalBytes;
+            if (d.length >= remaining) {
+              chunks.push(d.subarray(0, remaining).toString());
+              chunks.push(
+                `\n[output truncated at ${OUTPUT_CAP_BYTES / 1024} KiB]`,
+              );
+              truncated = true;
+              proc.stdout.destroy();
+              proc.stderr.destroy();
+            } else {
+              totalBytes += d.length;
+              chunks.push(d.toString());
+            }
+          };
+
+          proc.stdout.on('data', collect);
+          proc.stderr.on('data', collect);
+
+          proc.on('error', (err) => {
+            clearTimeout(timer);
+            resolve({
+              output: `[failed to start process: ${err.message}]`,
+              code: null,
+              timedOut: false,
+              spawnError: true,
+            });
+          });
+
+          proc.on('close', (code) => {
+            clearTimeout(timer);
+            resolve({ output: chunks.join(''), code, timedOut: false });
+          });
+        });
+
+        const suffix = result.timedOut
+          ? `\n[process killed after ${TIMEOUT_MS / 1000}s timeout]`
+          : result.code !== 0 && result.code !== null
+            ? `\n[exited with code ${result.code}]`
+            : '';
+        const isError =
+          result.timedOut ||
+          result.spawnError === true ||
+          (result.code !== 0 && result.code !== null);
+        return {
+          type: 'message',
+          messageType: isError ? 'error' : 'info',
+          content: `${showCommand ? `$ ${shellCmd.trim()}\n` : ''}${result.output}${suffix}`,
+        };
+      },
+    };
+  }
+
+  // ── Prompt mode: send to model ────────────────────────────────────────────
+  const promptText = definition.prompt!;
+  const usesArgs = promptText.includes(SHORTHAND_ARGS_PLACEHOLDER);
+  const usesShellInjection = promptText.includes(SHELL_INJECTION_TRIGGER);
+  const usesAtFileInjection = promptText.includes(AT_FILE_INJECTION_TRIGGER);
 
   // 1. @-File Injection (Security First).
   // This runs first to ensure we're not executing shell commands that
@@ -118,14 +234,12 @@ export function createSlashCommandFromDefinition(
         );
         return {
           type: 'submit_prompt',
-          content: [{ text: definition.prompt }], // Fallback to unprocessed prompt
+          content: [{ text: promptText }], // Fallback to unprocessed prompt
         };
       }
 
       try {
-        let processedContent: PromptPipelineContent = [
-          { text: definition.prompt },
-        ];
+        let processedContent: PromptPipelineContent = [{ text: promptText }];
         for (const processor of processors) {
           processedContent = await processor.process(processedContent, context);
         }


### PR DESCRIPTION
## Description

Enhances TOML-based extension commands with two new capabilities:

1. **`${extensionPath}` variable substitution** — the `run` field now supports `${extensionPath}` (and related aliases like `${CLAUDE_PLUGIN_ROOT}`, `${workspacePath}`) via `hydrateString`, consistent with the hook system. This allows extension scripts to reference their own install directory without hardcoding paths.

2. **`show_command` display control** — a new optional boolean field `show_command` (default `false`) controls whether the raw `$ <command>` header is prepended to the command output. The default is now `false` (clean output); set `show_command = true` to opt into the terminal-style header.

Additionally fixes:
- `spawn` `error` event was not setting `isError = true` due to `code: null` — resolved with an explicit `spawnError` flag.

## Related Issue

no-issue: self-contained capability enhancement and crash fix for extension TOML commands

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
# Unit tests covering all new behaviors
cd src/copilot-shell
npx vitest run packages/cli/src/services/command-factory.test.ts \
                packages/cli/src/services/FileCommandLoader-extension.test.ts