### PR TITLE
feat(sec-core): add skill-ledger cosh hook for PreToolUse

### DIFF
--- a/src/agent-sec-core/cosh_hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh_hooks/skill_ledger_hook.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Cosh hook script for skill-ledger.
+
+Reads a cosh PreToolUse JSON from stdin, resolves the skill directory
+from the skill name, invokes ``agent-sec-cli skill-ledger check`` via
+subprocess, and writes a cosh HookOutput JSON to stdout.
+
+Hook point: **PreToolUse** — matcher: ``skill``
+
+Input schema::
+
+    {
+        "session_id": "...",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "skill",
+        "tool_input": { "skill": "<skill-name>" },
+        "cwd": "/path/to/project"
+    }
+
+Output mapping (design doc §4 — warning-only, never block):
+
+    status "pass"     → { "decision": "allow" }
+    status otherwise  → { "decision": "allow", "reason": "⚠️ ..." }
+
+Copilot-shell settings.json configuration::
+
+    {
+      "hooks": {
+        "PreToolUse": [{
+          "matcher": "skill",
+          "hooks": [{
+            "type": "command",
+            "name": "skill-ledger",
+            "command": "python3 cosh_hooks/skill_ledger_hook.py",
+            "timeout": 10000
+          }]
+        }]
+      }
+    }
+
+This script is intentionally self-contained — it does NOT import any
+``agent_sec_cli`` package.  All it needs is the standard library and the
+``agent-sec-cli`` on $PATH.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# -- constants ---------------------------------------------------------------
+
+_TOOL_NAME = "skill"
+_CHECK_TIMEOUT = 5  # seconds for the CLI check call
+_INIT_TIMEOUT = 3  # seconds for key initialization
+
+# Warning messages per status (design doc §4)
+_WARNING_MESSAGES = {
+    "warn": "\u26a0\ufe0f Skill '{name}' has low-risk findings \u2014 review recommended",
+    "drifted": "\u26a0\ufe0f Skill '{name}' content has changed since last scan",
+    "none": "\u26a0\ufe0f Skill '{name}' has not been security-scanned yet",
+    "deny": (
+        "\U0001f6a8 Skill '{name}' has high-risk findings"
+        " \u2014 immediate review recommended"
+    ),
+    "tampered": ("\U0001f6a8 Skill '{name}' metadata signature verification failed"),
+}
+
+
+# -- helpers -----------------------------------------------------------------
+
+
+def _allow() -> str:
+    """Return a permissive cosh HookOutput JSON string."""
+    return json.dumps({"decision": "allow"})
+
+
+def _allow_with_reason(reason: str) -> str:
+    """Return an allow decision with a warning reason for display."""
+    return json.dumps({"decision": "allow", "reason": reason}, ensure_ascii=False)
+
+
+def _resolve_skill_dir(skill_name: str, cwd: str) -> tuple[str | None, bool]:
+    """Resolve a skill name to its on-disk directory.
+
+    Search order mirrors copilot-shell's SkillManager priority:
+    project (.copilot-shell/skills/) → user (~/.copilot-shell/skills/)
+    → system (/usr/share/anolisa/skills/) → extensions
+    (~/.copilot-shell/extensions/*/).
+
+    Returns ``(path, traversal_detected)``:
+    - ``(str, False)`` — resolved successfully.
+    - ``(None, True)`` — path escapes the skills base (traversal attempt).
+    - ``(None, False)`` — not found (remote or unknown skill).
+    """
+    traversal_detected = False
+    bases = [
+        Path(cwd) / ".copilot-shell" / "skills",
+        Path.home() / ".copilot-shell" / "skills",
+        Path("/usr/share/anolisa/skills"),
+    ]
+    for base in bases:
+        candidate = base / skill_name
+        try:
+            resolved = candidate.resolve()
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_relative_to(base.resolve()):
+            traversal_detected = True
+            continue  # path-traversal attempt — skip this base
+        if resolved.is_dir() and (resolved / "SKILL.md").is_file():
+            return str(resolved), False
+
+    # Search extension skill directories
+    ext_result = _resolve_extension_skill_dir(skill_name)
+    if ext_result is not None:
+        return ext_result, False
+
+    return None, traversal_detected
+
+
+def _get_extensions_dir() -> Path:
+    """Return the global copilot-shell extensions directory."""
+    return Path.home() / ".copilot-shell" / "extensions"
+
+
+def _read_json_file(filepath: Path) -> dict | None:
+    """Read and parse a JSON file, returning ``None`` on any error."""
+    try:
+        return json.loads(filepath.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _effective_extension_path(ext_dir: Path) -> Path:
+    """Resolve the effective extension path, following ``link`` installs.
+
+    If ``.qwen-extension-install.json`` declares ``"type": "link"``, the
+    ``source`` field points to the real extension root.
+    """
+    install_meta = _read_json_file(ext_dir / ".qwen-extension-install.json")
+    if install_meta and install_meta.get("type") == "link":
+        source = install_meta.get("source", "")
+        if source:
+            linked = Path(source)
+            if linked.is_dir():
+                return linked
+    return ext_dir
+
+
+def _extension_skill_bases(ext_path: Path) -> list[Path]:
+    """Read extension config and return the list of skill base directories.
+
+    Mirrors ``getSkillDirs()`` in copilot-shell's extensionManager.ts.
+    """
+    config: dict | None = None
+    for config_name in ("cosh-extension.json", "qwen-extension.json"):
+        config = _read_json_file(ext_path / config_name)
+        if config is not None:
+            break
+    if config is None:
+        return []
+
+    skills_field = config.get("skills")
+    if skills_field is None:
+        dirs = ["skills"]
+    elif isinstance(skills_field, list):
+        dirs = [str(d) for d in skills_field]
+    else:
+        dirs = [str(skills_field)]
+
+    return [ext_path / d for d in dirs]
+
+
+def _find_skill_recursive(
+    base: Path,
+    skill_name: str,
+    trust_root: Path,
+) -> str | None:
+    """Recursively search *base* for a skill directory named *skill_name*.
+
+    Mirrors copilot-shell's ``loadSkillsFromDir`` recursion:
+    directories containing ``SKILL.md`` are skills; others are containers
+    that are recursed into.
+
+    *trust_root* is used for path-traversal protection — the resolved
+    path must stay within *trust_root*.
+    """
+    if not base.is_dir():
+        return None
+    try:
+        entries = sorted(base.iterdir())
+    except OSError:
+        return None
+
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        has_manifest = (entry / "SKILL.md").is_file()
+        if has_manifest:
+            if entry.name == skill_name:
+                try:
+                    resolved = entry.resolve()
+                    if resolved.is_relative_to(trust_root.resolve()):
+                        return str(resolved)
+                except (OSError, ValueError):
+                    pass
+        else:
+            # Container directory (no SKILL.md) — recurse into it
+            result = _find_skill_recursive(entry, skill_name, trust_root)
+            if result is not None:
+                return result
+    return None
+
+
+def _resolve_extension_skill_dir(skill_name: str) -> str | None:
+    """Search installed extensions for a skill directory named *skill_name*.
+
+    Iterates every extension under ``~/.copilot-shell/extensions/``, reads
+    its config to determine skill directories, then recursively searches
+    each for ``<skill_name>/SKILL.md``.
+    """
+    extensions_dir = _get_extensions_dir()
+    if not extensions_dir.is_dir():
+        return None
+
+    for ext_entry in sorted(extensions_dir.iterdir()):
+        if not ext_entry.is_dir():
+            continue
+        effective_path = _effective_extension_path(ext_entry)
+        skill_bases = _extension_skill_bases(effective_path)
+        for skill_base in skill_bases:
+            result = _find_skill_recursive(skill_base, skill_name, effective_path)
+            if result is not None:
+                return result
+    return None
+
+
+def _keys_exist() -> bool:
+    """Return True if both key.pub and key.enc exist."""
+    xdg_data = os.environ.get("XDG_DATA_HOME", "")
+    if not xdg_data:
+        xdg_data = str(Path.home() / ".local" / "share")
+    data_dir = Path(xdg_data) / "skill-ledger"
+    return (data_dir / "key.pub").is_file() and (data_dir / "key.enc").is_file()
+
+
+def _ensure_keys() -> None:
+    """Auto-initialize signing keys if missing (fire-and-forget)."""
+    if _keys_exist():
+        return
+    try:
+        subprocess.run(
+            ["agent-sec-cli", "skill-ledger", "init-keys"],
+            capture_output=True,
+            text=True,
+            timeout=_INIT_TIMEOUT,
+        )
+    except Exception:
+        pass
+
+
+# -- main --------------------------------------------------------------------
+
+
+def main() -> None:
+    """Entry point — read stdin, check skill, write stdout."""
+    # 1. Read stdin JSON (PreToolUse event)
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError, ValueError):
+        print(_allow())
+        return
+
+    # 2. Verify this is a skill tool call
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != _TOOL_NAME:
+        print(_allow())
+        return
+
+    tool_input = input_data.get("tool_input", {})
+    skill_name = tool_input.get("skill", "")
+    if not isinstance(skill_name, str):
+        print(
+            _allow_with_reason(
+                "\u26a0\ufe0f Skill check skipped: skill name must be a string"
+            )
+        )
+        return
+    skill_name = skill_name.strip()
+    if not skill_name:
+        print(
+            _allow_with_reason(
+                "\u26a0\ufe0f Skill check skipped: skill name is empty or missing"
+            )
+        )
+        return
+
+    # 3. Resolve skill directory
+    cwd = input_data.get("cwd", os.environ.get("COPILOT_SHELL_PROJECT_DIR", "."))
+    skill_dir, traversal = _resolve_skill_dir(skill_name, cwd)
+    if traversal:
+        reason = "\U0001f6a8 Skill '{}' rejected: path traversal detected".format(
+            skill_name
+        )
+        print(_allow_with_reason(reason))
+        return
+    if skill_dir is None:
+        # Not found in any location (project/user/system/extension) — remote or unknown → fail-open
+        reason = (
+            "\u26a0\ufe0f Skill '{}' not found on disk \u2014 check skipped".format(
+                skill_name
+            )
+        )
+        print(_allow_with_reason(reason))
+        return
+
+    # 4. Ensure signing keys exist (auto-init if missing)
+    _ensure_keys()
+
+    # 5. Call agent-sec-cli skill-ledger check <skill_dir>
+    try:
+        proc = subprocess.run(
+            ["agent-sec-cli", "skill-ledger", "check", skill_dir],
+            capture_output=True,
+            text=True,
+            timeout=_CHECK_TIMEOUT,
+        )
+    except Exception:
+        # Timeout or CLI not found → fail-open
+        print(_allow())
+        return
+
+    # 6. Parse check result JSON — the CLI may use non-zero exit codes
+    #    for non-pass statuses (e.g. deny → rc=1), so we parse stdout
+    #    regardless of returncode.
+    try:
+        check_result = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        print(_allow())
+        return
+
+    status = check_result.get("status", "unknown")
+
+    # 7. Format output — always allow, warn on non-pass (design doc §4)
+    if status == "pass":
+        print(_allow())
+        return
+
+    template = _WARNING_MESSAGES.get(status)
+    if template:
+        reason = template.format(name=skill_name)
+    else:
+        reason = "\u26a0\ufe0f Skill '{}' has unknown status '{}'".format(
+            skill_name, status
+        )
+
+    print(_allow_with_reason(reason))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
@@ -1,0 +1,567 @@
+"""Unit tests for cosh_hooks/skill_ledger_hook.py.
+
+The hook is self-contained (no agent_sec_cli imports), so we test it
+by piping JSON via subprocess — identical to the code_scanner_hook tests.
+
+Tests are grouped into four categories:
+
+1. **Fail-open paths** — invalid input, wrong tool, missing skill dir.
+   These never invoke the CLI and verify the hook always returns allow.
+2. **Skill directory resolution** — project-level lookup, missing SKILL.md.
+3. **Extension skill resolution** — extension-level skills with recursive
+   directory search, link installs, and config parsing.
+4. **Output mapping** — status → warning message formatting.
+   Uses a mock CLI script to return canned check results, verifying the
+   hook's decision/reason output for every known status.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Path to the standalone cosh hook script
+_COSH_HOOK = str(
+    Path(__file__).resolve().parents[2] / ".." / "cosh_hooks" / "skill_ledger_hook.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(input_data, *, env_override=None):
+    """Run the hook as a subprocess with *input_data* as stdin JSON.
+
+    Returns the parsed JSON output dict.
+    """
+    env = os.environ.copy()
+    if env_override:
+        env.update(env_override)
+    proc = subprocess.run(
+        [sys.executable, _COSH_HOOK],
+        input=json.dumps(input_data) if isinstance(input_data, dict) else input_data,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+    assert proc.returncode == 0, f"Hook stderr: {proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def _make_skill_event(skill_name, cwd="."):
+    """Build a minimal PreToolUse event for the skill tool."""
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "skill",
+        "tool_input": {"skill": skill_name},
+        "cwd": cwd,
+    }
+
+
+def _create_skill_dir(parent, name="test-skill"):
+    """Create a minimal skill directory with a SKILL.md file.
+
+    Returns the absolute path to ``<parent>/.copilot-shell/skills/<name>/``.
+    """
+    skill_dir = Path(parent) / ".copilot-shell" / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: test-skill\ndescription: A test skill\n---\nHello\n"
+    )
+    return str(skill_dir)
+
+
+# ---------------------------------------------------------------------------
+# Fail-open tests — these never invoke the real CLI
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpen:
+    """Every error / unrecognized input must produce ``{"decision": "allow"}``."""
+
+    def test_invalid_json_allows(self):
+        """Malformed stdin should fail-open."""
+        output = _run_hook("not-json")
+        assert output == {"decision": "allow"}
+
+    def test_empty_stdin_allows(self):
+        output = _run_hook("")
+        assert output == {"decision": "allow"}
+
+    def test_wrong_tool_name_allows(self):
+        output = _run_hook(
+            {
+                "tool_name": "run_shell_command",
+                "tool_input": {"command": "echo hello"},
+            }
+        )
+        assert output == {"decision": "allow"}
+
+    def test_missing_tool_name_allows(self):
+        output = _run_hook({"tool_input": {"skill": "test"}})
+        assert output == {"decision": "allow"}
+
+    def test_missing_skill_name_allows(self):
+        output = _run_hook({"tool_name": "skill", "tool_input": {}})
+        assert output["decision"] == "allow"
+        assert "empty or missing" in output["reason"]
+
+    def test_empty_skill_name_allows(self):
+        output = _run_hook({"tool_name": "skill", "tool_input": {"skill": ""}})
+        assert output["decision"] == "allow"
+        assert "empty or missing" in output["reason"]
+
+    def test_whitespace_skill_name_allows(self):
+        output = _run_hook({"tool_name": "skill", "tool_input": {"skill": "   "}})
+        assert output["decision"] == "allow"
+        assert "empty or missing" in output["reason"]
+
+    def test_nonstring_skill_name_allows(self):
+        output = _run_hook({"tool_name": "skill", "tool_input": {"skill": 42}})
+        assert output["decision"] == "allow"
+        assert "must be a string" in output["reason"]
+
+    def test_skill_dir_not_found_allows(self):
+        """Skill name that resolves to no on-disk directory → fail-open."""
+        output = _run_hook(_make_skill_event("nonexistent-skill-xyz", "/tmp"))
+        assert output["decision"] == "allow"
+        assert "not found on disk" in output["reason"]
+        assert "nonexistent-skill-xyz" in output["reason"]
+
+    def test_path_traversal_blocked(self, tmp_path):
+        """A ``../`` skill name that escapes the skills base emits a warning.
+
+        Layout::
+            <tmp>/project/.copilot-shell/skills/   (skills base — empty)
+            <tmp>/project/.copilot-shell/evil/      (valid SKILL.md, outside base)
+
+        ``../evil`` resolves outside the skills base → hook must warn about
+        path traversal and never reach the CLI.
+        """
+        project = tmp_path / "project"
+        skills_base = project / ".copilot-shell" / "skills"
+        skills_base.mkdir(parents=True)
+        evil = project / ".copilot-shell" / "evil"
+        evil.mkdir()
+        (evil / "SKILL.md").write_text("---\nname: evil\n---\n")
+
+        output = _run_hook(_make_skill_event("../evil", str(project)))
+        assert output["decision"] == "allow"
+        assert "path traversal" in output["reason"]
+        assert "../evil" in output["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Skill directory resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestSkillDirResolution:
+    """Verify the hook correctly locates skill directories."""
+
+    def test_project_level_skill_found(self, mock_cli_env):
+        """Skill in <cwd>/.copilot-shell/skills/<name>/ should be found.
+
+        We verify by feeding a mock CLI that returns ``{"status": "warn"}``.
+        If the skill dir is found the hook calls the CLI and produces a
+        ``reason`` field; if the skill dir were *not* found, the hook would
+        return plain allow with no ``reason`` at all.
+        """
+        env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "reason" in output, "Skill dir not found — CLI was never called"
+
+    def test_missing_skill_md_not_found(self):
+        """Directory exists but no SKILL.md → not recognized as a skill."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / ".copilot-shell" / "skills" / "bad"
+            skill_dir.mkdir(parents=True)
+            # No SKILL.md file
+            output = _run_hook(_make_skill_event("bad", tmpdir))
+            assert output["decision"] == "allow"
+            assert "not found on disk" in output["reason"]
+            assert "bad" in output["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Extension skill resolution helpers
+# ---------------------------------------------------------------------------
+
+_SKILL_MD_TEMPLATE = "---\nname: {name}\ndescription: A test skill\n---\nHello\n"
+
+
+def _create_extension(
+    extensions_dir,
+    ext_name,
+    *,
+    skills_field=None,
+    config_filename="cosh-extension.json",
+    skill_entries=None,
+    link_source=None,
+):
+    """Create a fake extension directory with config and optional skills.
+
+    Parameters
+    ----------
+    extensions_dir : str | Path
+        The parent ``extensions/`` directory.
+    ext_name : str
+        Extension directory name.
+    skills_field : str | list | None
+        Value for the ``"skills"`` key in config JSON.
+        Omit to use the default (``["skills"]``).
+    config_filename : str
+        Config file name (default ``cosh-extension.json``).
+    skill_entries : list[tuple[str, str]] | None
+        List of ``(relative_dir, skill_name)`` tuples.  For each entry,
+        ``<ext_path>/<relative_dir>/<skill_name>/SKILL.md`` is created.
+    link_source : str | None
+        If set, write a ``.qwen-extension-install.json`` with
+        ``{"type": "link", "source": link_source}`` in the extension dir.
+
+    Returns
+    -------
+    Path
+        The extension directory path.
+    """
+    ext_dir = Path(extensions_dir) / ext_name
+    ext_dir.mkdir(parents=True, exist_ok=True)
+
+    if link_source is not None:
+        install_meta = ext_dir / ".qwen-extension-install.json"
+        install_meta.write_text(json.dumps({"type": "link", "source": link_source}))
+
+    # Write config to the effective path (link target or ext_dir itself)
+    effective_path = Path(link_source) if link_source else ext_dir
+    effective_path.mkdir(parents=True, exist_ok=True)
+
+    config: dict = {"name": ext_name, "version": "1.0.0"}
+    if skills_field is not None:
+        config["skills"] = skills_field
+    (effective_path / config_filename).write_text(json.dumps(config))
+
+    if skill_entries:
+        for rel_dir, skill_name in skill_entries:
+            skill_dir = effective_path / rel_dir / skill_name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(
+                _SKILL_MD_TEMPLATE.format(name=skill_name)
+            )
+
+    return ext_dir
+
+
+# ---------------------------------------------------------------------------
+# Extension skill resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionSkillResolution:
+    """Verify that extension-level skills are resolved by the hook."""
+
+    def test_extension_skill_default_skills_dir(self, tmp_path, monkeypatch):
+        """Extension with default ``skills/`` directory layout."""
+        ext_dir = tmp_path / "home" / ".copilot-shell" / "extensions"
+        _create_extension(
+            ext_dir,
+            "my-ext",
+            skill_entries=[("skills", "my-tool")],
+        )
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        output = _run_hook(_make_skill_event("my-tool", str(tmp_path / "project")))
+        assert output["decision"] == "allow"
+        # Should find the extension skill — produces "not found on disk" only
+        # when NOT found.  If found, it calls the CLI (which isn't on PATH
+        # here), so it'll fail-open silently with plain allow.
+        assert "reason" not in output or "not found on disk" not in output.get(
+            "reason", ""
+        )
+
+    def test_extension_skill_dot_skills(self, tmp_path, monkeypatch):
+        """Extension with ``"skills": "."`` (os-skills pattern).
+
+        Skill layout: ``<ext>/category/my-skill/SKILL.md`` where the
+        ``category/`` dir has no SKILL.md (container), so the hook must
+        recurse into it.
+        """
+        ext_dir = tmp_path / "home" / ".copilot-shell" / "extensions"
+        _create_extension(
+            ext_dir,
+            "os-skills",
+            skills_field=".",
+            skill_entries=[("system-admin", "alinux-admin")],
+        )
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        output = _run_hook(_make_skill_event("alinux-admin", str(tmp_path / "project")))
+        assert output["decision"] == "allow"
+        assert "reason" not in output or "not found on disk" not in output.get(
+            "reason", ""
+        )
+
+    def test_extension_link_type_install(self, tmp_path, monkeypatch):
+        """Extension with ``link`` type install metadata."""
+        link_target = tmp_path / "real-ext"
+        ext_dir = tmp_path / "home" / ".copilot-shell" / "extensions"
+        _create_extension(
+            ext_dir,
+            "linked-ext",
+            skills_field=".",
+            link_source=str(link_target),
+            skill_entries=[("tools", "my-linked-skill")],
+        )
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        output = _run_hook(
+            _make_skill_event("my-linked-skill", str(tmp_path / "project"))
+        )
+        assert output["decision"] == "allow"
+        assert "reason" not in output or "not found on disk" not in output.get(
+            "reason", ""
+        )
+
+    def test_extension_no_config_graceful(self, tmp_path, monkeypatch):
+        """Extension directory without any config file is skipped."""
+        ext_dir = tmp_path / "home" / ".copilot-shell" / "extensions" / "broken"
+        ext_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        output = _run_hook(_make_skill_event("anything", str(tmp_path / "project")))
+        assert output["decision"] == "allow"
+        assert "not found on disk" in output["reason"]
+
+    def test_extension_skill_not_found_still_reports(self, tmp_path, monkeypatch):
+        """Skill not in any extension → still returns 'not found on disk'."""
+        ext_dir = tmp_path / "home" / ".copilot-shell" / "extensions"
+        _create_extension(
+            ext_dir,
+            "my-ext",
+            skill_entries=[("skills", "other-skill")],
+        )
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        output = _run_hook(_make_skill_event("nonexistent", str(tmp_path / "project")))
+        assert output["decision"] == "allow"
+        assert "not found on disk" in output["reason"]
+
+    def test_extension_skill_invokes_cli(self, tmp_path, monkeypatch):
+        """Extension skill found → hook invokes CLI and returns its status.
+
+        Uses the mock CLI fixture pattern to verify end-to-end flow.
+        """
+        # Create the mock CLI
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        cli_script = bin_dir / "agent-sec-cli"
+        cli_script.write_text(f"#!{sys.executable}\n" + textwrap.dedent("""\
+                import os, sys
+                if len(sys.argv) >= 3 and sys.argv[2] == "init-keys":
+                    sys.exit(0)
+                output = os.environ.get("_MOCK_CHECK_OUTPUT", "")
+                rc = int(os.environ.get("_MOCK_CHECK_RC", "0"))
+                if output:
+                    print(output)
+                sys.exit(rc)
+            """))
+        cli_script.chmod(cli_script.stat().st_mode | stat.S_IEXEC)
+
+        # Create extension with skill
+        ext_dir = tmp_path / "home" / ".copilot-shell" / "extensions"
+        _create_extension(
+            ext_dir,
+            "test-ext",
+            skills_field=".",
+            skill_entries=[("category", "ext-skill")],
+        )
+
+        # Create fake key files
+        data_dir = tmp_path / "xdg-data" / "skill-ledger"
+        data_dir.mkdir(parents=True)
+        (data_dir / "key.pub").write_text("fake-pub")
+        (data_dir / "key.enc").write_text("fake-enc")
+
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+        env = {
+            "HOME": str(tmp_path / "home"),
+            "PATH": str(bin_dir) + os.pathsep + os.environ.get("PATH", ""),
+            "XDG_DATA_HOME": str(tmp_path / "xdg-data"),
+            "_MOCK_CHECK_OUTPUT": json.dumps({"status": "warn"}),
+            "_MOCK_CHECK_RC": "0",
+        }
+        output = _run_hook(
+            _make_skill_event("ext-skill", str(tmp_path / "project")),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "low-risk" in output["reason"]
+
+
+# A tiny script that pretends to be agent-sec-cli.
+# It reads _MOCK_CHECK_OUTPUT env var and prints it to stdout.
+# For "init-keys", it's a no-op.
+_MOCK_CLI_SCRIPT = f"#!{sys.executable}\n" + textwrap.dedent("""\
+    import os, sys
+    # init-keys → silent success
+    if len(sys.argv) >= 3 and sys.argv[2] == "init-keys":
+        sys.exit(0)
+    # check → return canned output from env
+    output = os.environ.get("_MOCK_CHECK_OUTPUT", "")
+    rc = int(os.environ.get("_MOCK_CHECK_RC", "0"))
+    if output:
+        print(output)
+    sys.exit(rc)
+""")
+
+
+@pytest.fixture()
+def mock_cli_env(tmp_path):
+    """Create a fake ``agent-sec-cli`` and a skill dir in a temp project.
+
+    Returns a dict with ``cwd``, ``skill_dir``, and a function
+    ``env(status, rc=0)`` that builds the env dict for a given canned
+    check response.
+    """
+    # Write the mock CLI script
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    cli_script = bin_dir / "agent-sec-cli"
+    cli_script.write_text(_MOCK_CLI_SCRIPT)
+    cli_script.chmod(cli_script.stat().st_mode | stat.S_IEXEC)
+
+    # Create skill directory
+    project = tmp_path / "project"
+    project.mkdir()
+    _create_skill_dir(str(project), "test-skill")
+
+    # Create fake key files so _ensure_keys() is a no-op
+    data_dir = tmp_path / "xdg-data" / "skill-ledger"
+    data_dir.mkdir(parents=True)
+    (data_dir / "key.pub").write_text("fake-pub")
+    (data_dir / "key.enc").write_text("fake-enc")
+
+    def _make_env(check_output, *, rc=0):
+        """Build env override dict for a given canned CLI response."""
+        return {
+            "PATH": str(bin_dir) + os.pathsep + os.environ.get("PATH", ""),
+            "XDG_DATA_HOME": str(tmp_path / "xdg-data"),
+            "_MOCK_CHECK_OUTPUT": check_output,
+            "_MOCK_CHECK_RC": str(rc),
+        }
+
+    return {
+        "cwd": str(project),
+        "make_env": _make_env,
+    }
+
+
+class TestOutputMapping:
+    """Verify status → decision/reason mapping for every known status."""
+
+    def test_pass_returns_silent_allow(self, mock_cli_env):
+        """status=pass → allow with NO reason field."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "pass"}))
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output == {"decision": "allow"}
+
+    def test_none_returns_warning(self, mock_cli_env):
+        """status=none → allow + 'not been security-scanned'."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "none"}))
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "not been security-scanned" in output["reason"]
+        assert "test-skill" in output["reason"]
+
+    def test_warn_returns_warning(self, mock_cli_env):
+        """status=warn → allow + 'low-risk findings'."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "low-risk" in output["reason"]
+
+    def test_deny_returns_warning(self, mock_cli_env):
+        """status=deny → allow + 'high-risk findings'."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "deny"}), rc=1)
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "high-risk" in output["reason"]
+
+    def test_drifted_returns_warning(self, mock_cli_env):
+        """status=drifted → allow + 'content has changed'."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "drifted"}), rc=1)
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "changed" in output["reason"]
+
+    def test_tampered_returns_warning(self, mock_cli_env):
+        """status=tampered → allow + 'signature verification failed'."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "tampered"}), rc=1)
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "signature verification failed" in output["reason"]
+
+    def test_unknown_status_returns_warning(self, mock_cli_env):
+        """Unrecognized status → allow + generic warning with status name."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "banana"}))
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "banana" in output["reason"]
+        assert "unknown status" in output["reason"]
+
+    def test_cli_invalid_json_stdout_allows(self, mock_cli_env):
+        """CLI returns non-JSON stdout → fail-open."""
+        env = mock_cli_env["make_env"]("not-json-at-all")
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output == {"decision": "allow"}
+
+    def test_cli_empty_stdout_allows(self, mock_cli_env):
+        """CLI returns empty stdout → fail-open."""
+        env = mock_cli_env["make_env"]("")
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output == {"decision": "allow"}
+
+    def test_cli_missing_status_field_returns_unknown(self, mock_cli_env):
+        """CLI returns JSON without 'status' → treated as unknown status."""
+        env = mock_cli_env["make_env"](json.dumps({"result": "ok"}))
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "unknown" in output["reason"]

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_models.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_models.py
@@ -157,11 +157,6 @@ class TestScanStatusAggregation(unittest.TestCase):
         ]
         self.assertEqual(aggregate_scan_status(scans), "warn")
 
-    def test_pass_over_none(self):
-        """A scanner that returned 'pass' is more severe than 'none'."""
-        scans = [ScanEntry(status="pass")]
-        self.assertEqual(aggregate_scan_status(scans), "pass")
-
     def test_unknown_status_treated_as_lowest(self):
         """Unknown status defaults to severity 0 — should not override known statuses."""
         scans = [

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_workflows.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_workflows.py
@@ -236,44 +236,6 @@ class TestCheckStateMachine(SkillDirTestCase):
         result = check(self.skill_dir, self.backend)
         self.assertEqual(result["status"], "warn")
 
-    def test_check_exit_code_pass_is_zero(self):
-        """check returning pass should indicate success (exit code 0)."""
-        findings_path = self._write_findings(
-            [
-                {"rule": "r1", "level": "pass", "message": "ok"},
-            ]
-        )
-        certify(self.skill_dir, self.backend, findings_path=findings_path)
-        result = check(self.skill_dir, self.backend)
-        self.assertEqual(result["status"], "pass")
-        # status "pass" should NOT be in the failure set
-        self.assertNotIn(result["status"], ("tampered", "deny"))
-
-    def test_check_tampered_is_security_critical(self):
-        """check returning tampered is a security-critical state."""
-        check(self.skill_dir, self.backend)
-        latest = os.path.join(self.skill_dir, ".skill-meta", "latest.json")
-        with open(latest, "r") as f:
-            data = json.load(f)
-        data["scanStatus"] = "pass"  # tamper without re-hashing
-        with open(latest, "w") as f:
-            json.dump(data, f)
-        result = check(self.skill_dir, self.backend)
-        self.assertEqual(result["status"], "tampered")
-        self.assertIn(result["status"], ("tampered", "deny"))
-
-    def test_check_deny_is_security_critical(self):
-        """check returning deny is a security-critical state."""
-        findings_path = self._write_findings(
-            [
-                {"rule": "dangerous-exec", "level": "deny", "message": "exec found"},
-            ]
-        )
-        certify(self.skill_dir, self.backend, findings_path=findings_path)
-        result = check(self.skill_dir, self.backend)
-        self.assertEqual(result["status"], "deny")
-        self.assertIn(result["status"], ("tampered", "deny"))
-
 
 # ---------------------------------------------------------------------------
 # Certify workflow


### PR DESCRIPTION
## Description

Add a standalone cosh PreToolUse hook that checks skill security status via `agent-sec-cli skill-ledger check` before skill invocation. The hook is warning-only and never blocks execution (fail-open).

Key changes:
- Path traversal guard using `resolve()` + `is_relative_to()` with diagnostic warning.
- Diagnostic reasons for all skill-specific early-exits (invalid name, not found on disk).
- Split timeouts: 5s for check, 3s for key init (within 10s cosh budget).
- Type hints on all functions, consistent with sibling hooks.
- 22 unit tests: strict equality for silent paths, mock CLI for output mapping, path-discriminative assertions.
- Remove 4 duplicate tests from test_workflows.py and test_models.py.

## Related Issue

no-issue: new feature — skill-ledger cosh hook for PreToolUse event

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
# Hook unit tests (22 tests)
cd src/agent-sec-core && python3 -m pytest tests/unit-test/cosh_hooks/test_skill_ledger_hook.py -v --noconftest

# Skill-ledger unit tests (63 tests)
cd src/agent-sec-core && uv run --project agent-sec-cli pytest tests/unit-test/skill_ledger/ -v
```

## Additional Notes

None.
