### PR TITLE
fix(sight): fix cosh session_id recognition by supporting snake_case …

### DIFF
--- a/src/agentsight/src/response_map.rs
+++ b/src/agentsight/src/response_map.rs
@@ -23,9 +23,10 @@ use crate::probes::FileWriteEvent;
 /// Maximum number of responseId → sessionId entries kept in memory.
 const MAX_RESPONSE_MAP_ENTRIES: usize = 10_000;
 
-/// Regex to match `responseId":"<value>"` in raw text.
+/// Regex to match `responseId":"<value>"` or `response_id":"<value>"` in raw text.
+/// Supports both camelCase (used by some agents) and snake_case (used by cosh).
 static RESPONSE_ID_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"responseId":"([^"]+)"#).unwrap());
+    Lazy::new(|| Regex::new(r#"(?:responseId|response_id)":"([^"]+)"#).unwrap());
 
 /// Processes FileWrite events to build an in-memory responseId → sessionId mapping.
 /// Uses an LRU cache to bound memory usage.
@@ -119,8 +120,8 @@ impl ResponseSessionMapper {
         }
     }
 
-    /// Extract "responseId" value from a single JSONL line using regex.
-    /// Matches patterns like `responseId":"chatcmpl-xxxx"`.
+    /// Extract "responseId" or "response_id" value from a single JSONL line using regex.
+    /// Matches patterns like `responseId":"chatcmpl-xxxx"` or `response_id":"chatcmpl-xxxx"`.
     fn extract_response_id(line: &str) -> Option<String> {
         RESPONSE_ID_RE
             .captures(line)
@@ -172,6 +173,17 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_response_id_snake_case() {
+        // cosh writes response_id in snake_case
+        let line = r#"{"response_id":"chatcmpl-f2748a8e-85d0-9058-b28f-c70e6f5fd590","model":"qwen-plus"}"#;
+        let id = ResponseSessionMapper::extract_response_id(line);
+        assert_eq!(
+            id.as_deref(),
+            Some("chatcmpl-f2748a8e-85d0-9058-b28f-c70e6f5fd590")
+        );
+    }
+
+    #[test]
     fn test_extract_response_id_missing() {
         let line = r#"{"other":"data"}"#;
         assert!(ResponseSessionMapper::extract_response_id(line).is_none());
@@ -215,5 +227,29 @@ mod tests {
             Some("550e8400-e29b-41d4-a716-446655440000")
         );
         assert!(mapper.get_session_by_response_id("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_process_and_query_snake_case() {
+        // cosh writes response_id (snake_case) in ui_telemetry records
+        let mut mapper = ResponseSessionMapper::new();
+        let event = FileWriteEvent {
+            pid: 5678,
+            tid: 5678,
+            uid: 1000,
+            timestamp_ns: 0,
+            write_size: 0,
+            comm: "node".to_string(),
+            filename: "a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl".to_string(),
+            buf: br#"{"type":"system","subtype":"ui_telemetry","systemPayload":{"uiEvent":{"event.name":"api_response","response_id":"chatcmpl-f2748a8e-85d0-9058-b28f-c70e6f5fd590","model":"qwen-plus"}}}
+"#
+            .to_vec(),
+        };
+        mapper.process_filewrite(&event);
+
+        assert_eq!(
+            mapper.get_session_by_response_id("chatcmpl-f2748a8e-85d0-9058-b28f-c70e6f5fd590"),
+            Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        );
     }
 }

--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -181,6 +181,8 @@ impl GenAISqliteStore {
     /// Initialize database tables
     fn init_tables(&self) -> Result<(), Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();
+
+        // Step 1: Create table (for new databases)
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS genai_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -229,9 +231,17 @@ impl GenAISqliteStore {
                 -- Full event as JSON (fallback)
                 event_json TEXT NOT NULL,
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-            );
+            );",
+        )?;
 
-            CREATE INDEX IF NOT EXISTS idx_genai_session_id ON genai_events(session_id);
+        // Step 2: Migration — add conversation_id column for existing databases
+        // that were created before conversation_id was added to the schema.
+        // Must run BEFORE index creation to avoid "no such column" errors.
+        let _ = conn.execute("ALTER TABLE genai_events ADD COLUMN conversation_id TEXT", []);
+
+        // Step 3: Create indexes (safe now that conversation_id column exists)
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_genai_session_id ON genai_events(session_id);
             CREATE INDEX IF NOT EXISTS idx_genai_trace_id ON genai_events(trace_id);
             CREATE INDEX IF NOT EXISTS idx_genai_conversation_id ON genai_events(conversation_id);
             CREATE INDEX IF NOT EXISTS idx_genai_instance ON genai_events(instance);
@@ -247,9 +257,6 @@ impl GenAISqliteStore {
             CREATE INDEX IF NOT EXISTS idx_genai_pid_timestamp ON genai_events(pid, start_timestamp_ns);
             CREATE INDEX IF NOT EXISTS idx_genai_instance_timestamp ON genai_events(instance, start_timestamp_ns);",
         )?;
-
-        // Migration: add conversation_id column for existing databases
-        let _ = conn.execute("ALTER TABLE genai_events ADD COLUMN conversation_id TEXT", []);
 
         Ok(())
     }


### PR DESCRIPTION
…response_id

Two issues fixed:

1. ResponseSessionMapper regex only matched camelCase `responseId` but cosh writes `response_id` (snake_case) in its JSONL telemetry events, causing mapper lookup to always fail for cosh sessions. Updated regex to match both `responseId` and `response_id`.

2. GenAI SQLite exporter failed to initialize on existing databases that lack the `conversation_id` column. The `ALTER TABLE` migration ran after index creation, so `CREATE INDEX ON genai_events(conversation_id)` failed before the column was added. Reordered init_tables() to run migration before index creation.

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue #300 

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #300 

## Type of Change

<!-- Check all that apply. -->

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
