### PR TITLE
feat(sight): add C FFI API with cbindgen header generation

### DIFF
--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "byteorder",
  "cached",
  "capstone",
+ "cbindgen",
  "cc",
  "chrono",
  "clru",
@@ -772,6 +773,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+dependencies = [
+ "clap 4.5.60",
+ "heck 0.4.1",
+ "indexmap",
+ "log 0.4.29",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -3610,6 +3630,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4120,6 +4149,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4818,6 +4888,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -95,3 +95,4 @@ hf-hub = { git = "https://github.com/chengshuyi/hf-hub.git", rev = "05f5134f40db
 libbpf-cargo = "0.23.3"
 bindgen = "0.69.4"
 cc = "1.1.31"
+cbindgen = "0.27"

--- a/src/agentsight/build.rs
+++ b/src/agentsight/build.rs
@@ -3,8 +3,8 @@ use std::env;
 use std::path::PathBuf;
 
 fn generate_skeleton(out: &mut PathBuf, name: &str) {
-    let c_path = format!("src/bpf/{}.bpf.c", name);
-    let rs_name = format!("{}.skel.rs", name);
+    let c_path = format!("src/bpf/{name}.bpf.c");
+    let rs_name = format!("{name}.skel.rs");
     out.push(&rs_name);
     SkeletonBuilder::new()
         .source(&c_path)
@@ -16,8 +16,8 @@ fn generate_skeleton(out: &mut PathBuf, name: &str) {
 }
 
 fn generate_header(out: &mut PathBuf, name: &str) {
-    let header_path = format!("src/bpf/{}.h", name);
-    let rs_name = format!("{}.rs", name);
+    let header_path = format!("src/bpf/{name}.h");
+    let rs_name = format!("{name}.rs");
 
     out.push(&rs_name);
     let bindings = bindgen::Builder::default()
@@ -67,4 +67,15 @@ fn main() {
             .expect("Failed to create frontend-dist directory");
     }
     println!("cargo:rerun-if-changed=frontend-dist");
+
+    // Generate C header from src/ffi.rs via cbindgen
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let header_path = PathBuf::from(&crate_dir).join("include").join("agentsight.h");
+    std::fs::create_dir_all(header_path.parent().unwrap())
+        .expect("Failed to create include/ directory");
+    cbindgen::generate(&crate_dir)
+        .expect("cbindgen failed to generate C header")
+        .write_to_file(&header_path);
+    println!("cargo:rerun-if-changed=src/ffi.rs");
+    println!("cargo:rerun-if-changed=cbindgen.toml");
 }

--- a/src/agentsight/docs/design-docs/c-ffi-api.md
+++ b/src/agentsight/docs/design-docs/c-ffi-api.md
@@ -1,0 +1,262 @@
+# v0.2 AgentSight C FFI API 文档
+
+本文档描述 AgentSight 提供的 C 语言接口。采用 **eventfd + read 模式**：AgentSight 内部通过 `eventfd` 通知调用方有新事件就绪，调用方可将该 fd 注册到自己的 epoll/select 事件循环中，被唤醒后调用 `agentsight_read()` 通过回调消费数据。
+
+## 1. C 数据结构
+
+```c
+/* HTTP 层数据 — 非 LLM 的 HTTPS 流量会产生此结构 */
+typedef struct {
+    int32_t     pid;
+    char        process_name[16];
+    uint64_t    timestamp_ns;
+    uint64_t    duration_ns;
+    const char* method;               /* "GET", "POST", ...; NUL-terminated */
+    const char* path;                 /* "/v1/chat/completions"; NUL-terminated */
+    uint16_t    status_code;
+    uint8_t     is_sse;
+    const char* request_headers;      /* JSON string */
+    uint32_t    request_headers_len;
+    const char* request_body;         /* JSON or raw text, may be NULL */
+    uint32_t    request_body_len;     /* 0 when request_body is NULL */
+    const char* response_headers;     /* JSON string */
+    uint32_t    response_headers_len;
+    const char* response_body;        /* JSON or raw text, may be NULL */
+    uint32_t    response_body_len;    /* 0 when response_body is NULL */
+} AgentsightHttpsData;
+
+/* LLM 语义层数据 — 仅当 HTTP 流量被识别为 LLM API 调用时产生 */
+typedef struct {
+    /* 追踪标识 */
+    const char* response_id;          /* LLM API 响应 ID（如 chatcmpl-xxx）; may be NULL */
+    const char* conversation_id;      /* 同一 user query 触发的调用链标识; may be NULL */
+    const char* session_id;           /* may be NULL */
+
+    /* 进程 */
+    int32_t     pid;
+    char        process_name[16];
+    const char* agent_name;           /* may be NULL */
+
+    /* 时间与延迟 */
+    uint64_t    timestamp_ns;
+    uint64_t    duration_ns;
+
+    /* 请求信息 */
+    const char* request_url;          /* 完整 API 地址，如 "https://api.openai.com/v1/chat/completions" */
+    const char* provider;             /* "openai", "anthropic", ... */
+    const char* model;
+    uint16_t    status_code;
+    uint8_t     is_sse;
+
+    /* LLM 特有信息 */
+    const char* finish_reason;        /* "stop", "length", "tool_calls", ...; may be NULL */
+
+    /* Token 用量（无信息时全为 0）
+     * llm_usage: true = 数据来自 LLM API 响应中的 usage 字段（精确值）
+     *            false = 由 AgentSight 本地 tokenizer 计算 */
+    bool        llm_usage;
+    uint32_t    input_tokens;
+    uint32_t    output_tokens;
+    uint32_t    total_tokens;
+    uint32_t    cache_creation_input_tokens;
+    uint32_t    cache_read_input_tokens;
+
+    /* 请求/响应语义内容（JSON 字符串） */
+    const char* request_messages;     /* LLMRequest.messages 序列化 JSON */
+    uint32_t    request_messages_len;
+    const char* response_messages;    /* LLMResponse.messages 序列化 JSON */
+    uint32_t    response_messages_len;
+} AgentsightLLMData;
+
+```
+
+## 2. C API 接口
+
+```c
+/* ---- 错误处理 ---- */
+/* 返回最近一次 API 调用的错误描述，未出错时返回 NULL。
+ * 返回的指针在下次 API 调用前有效，调用者应立即拷贝。 */
+const char* agentsight_last_error(void);
+
+/* ---- 配置 ---- */
+AgentsightConfigHandle* agentsight_config_new(void);
+void agentsight_config_set_verbose(AgentsightConfigHandle* cfg, int verbose);
+void agentsight_config_set_log_path(AgentsightConfigHandle* cfg, const char* path);
+/* 其他配置项待与调用方商定后补充 */
+void agentsight_config_free(AgentsightConfigHandle* cfg);
+
+/* ---- 回调类型 ---- */
+typedef void (*agentsight_https_callback_fn)(const AgentsightHttpsData* data, void* user_data);
+typedef void (*agentsight_llm_callback_fn)(const AgentsightLLMData* data, void* user_data);
+
+/* ---- 生命周期 ---- */
+AgentsightHandle* agentsight_new(AgentsightConfigHandle* cfg);
+int agentsight_start(AgentsightHandle* h);
+int agentsight_stop(AgentsightHandle* h);
+void agentsight_free(AgentsightHandle* h);
+const char* agentsight_version(void);
+
+/* ---- 事件通知 ---- */
+/* 获取 eventfd 文件描述符，可注册到调用方的 epoll/select 事件循环。
+ * 当有新事件就绪时，该 fd 变为可读（EPOLLIN）。
+ * 返回 >= 0 的 fd 表示成功，< 0 表示不支持（可降级为轮询模式）。
+ * 注意：该 fd 由 AgentSight 内部管理，调用方不得 close()。 */
+int agentsight_get_eventfd(AgentsightHandle* h);
+
+/* ---- 数据读取 ---- */
+/* 处理当前可用事件，通过回调返回数据。返回处理事件数，0=无事件，<0=出错。
+ * 两个回调独立，传 NULL 表示不关心该类型。
+ * flags: 0 = 非阻塞（处理当前队列后立即返回）
+ *        AGENTSIGHT_READ_BLOCK = 阻塞直到有至少一个事件 */
+#define AGENTSIGHT_READ_BLOCK 1
+int agentsight_read(AgentsightHandle* h,
+                    agentsight_https_callback_fn http_cb, void* http_ud,
+                    agentsight_llm_callback_fn  llm_cb,  void* llm_ud,
+                    int flags);
+
+```
+
+### 2.1 返回值
+
+| 函数 | 返回值 | 说明 |
+| --- | --- | --- |
+| `agentsight_config_new` | `AgentsightConfigHandle*` | 成功返回句柄，失败返回 NULL |
+| `agentsight_new` | `AgentsightHandle*` | 成功返回句柄，失败返回 NULL（可用 `agentsight_last_error` 查看原因） |
+| `agentsight_start` | `int` | 0=成功，<0=失败 |
+| `agentsight_stop` | `int` | 0=成功，<0=失败 |
+| `agentsight_get_eventfd` | `int` | >= 0 为有效 fd，< 0 表示不支持 eventfd |
+| `agentsight_read` | `int` | \>0=处理的事件数，0=无事件，<0=出错 |
+| `agentsight_last_error` | `const char*` | 错误描述字符串，无错误时返回 NULL |
+| `agentsight_version` | `const char*` | 版本号字符串（如 `"0.1.0"`），静态存储，无需释放 |
+
+### 2.2 配置默认值
+
+| 配置项 | 默认值 | 说明 |
+| --- | --- | --- |
+| `verbose` | 0 | 设为 1 开启调试日志输出 |
+| `log_path` | NULL | 日志文件保存路径，NULL 时输出到 stderr |
+
+> 其他配置项待与调用方商定后补充。
+
+### 2.3 线程安全
+
+* 同一 `AgentsightHandle` 不可多线程并发调用，所有 API（start/read/stop）须在同一线程执行
+
+* 回调函数在调用 `agentsight_read()` 的线程上同步执行，无需额外同步
+
+* 不同 `AgentsightHandle` 实例之间完全独立，可跨线程使用
+
+* `agentsight_get_eventfd()` 返回的 fd 可安全地在其他线程中用于 epoll/select 等待
+
+## 3. 使用示例
+
+### 3.1 eventfd + epoll 模式（推荐）
+
+```c
+/* --- 初始化阶段 --- */
+AgentsightConfigHandle* cfg = agentsight_config_new();
+agentsight_config_set_verbose(cfg, 1);  // 可选：开启调试日志
+
+AgentsightHandle* h = agentsight_new(cfg);
+agentsight_config_free(cfg);
+
+if (!h) {
+    fprintf(stderr, "agentsight_new failed: %s\n", agentsight_last_error());
+    return -1;
+}
+
+agentsight_start(h);
+
+/* 获取 eventfd，注册到统一 epoll */
+int as_efd = agentsight_get_eventfd(h);
+if (as_efd < 0) {
+    fprintf(stderr, "eventfd not supported, fallback to polling\n");
+    /* 降级到轮询模式，见 3.2 */
+}
+
+int epoll_fd = epoll_create1(0);
+struct epoll_event ev = {
+    .events   = EPOLLIN,
+    .data.ptr = h,
+};
+epoll_ctl(epoll_fd, EPOLL_CTL_ADD, as_efd, &ev);
+
+/* --- 事件循环（可与其他 fd 共用同一 epoll_wait）--- */
+while (running) {
+    struct epoll_event events[64];
+    int n = epoll_wait(epoll_fd, events, 64, 200 /* ms */);
+
+    for (int i = 0; i < n; i++) {
+        if (events[i].data.ptr == h) {
+            /* AgentSight 有数据就绪，非阻塞消费 */
+            agentsight_read(h, my_http_cb, http_ctx,
+                               my_llm_cb,  llm_ctx,
+                               0 /* non-blocking */);
+        } else {
+            handle_other_event(&events[i]);
+        }
+    }
+}
+
+/* --- 清理阶段 --- */
+epoll_ctl(epoll_fd, EPOLL_CTL_DEL, as_efd, NULL);
+agentsight_stop(h);
+agentsight_free(h);  /* 内部 close(as_efd)，调用方不得重复 close */
+close(epoll_fd);
+```
+
+### 3.2 轮询模式（降级 / 简单场景）
+
+```c
+AgentsightConfigHandle* cfg = agentsight_config_new();
+AgentsightHandle* h = agentsight_new(cfg);
+agentsight_config_free(cfg);
+
+if (!h) {
+    fprintf(stderr, "agentsight_new failed: %s\n", agentsight_last_error());
+    return -1;
+}
+
+agentsight_start(h);
+
+while (running) {
+    agentsight_read(h, my_http_cb, http_ctx,
+                       my_llm_cb,  llm_ctx,
+                       0 /* non-blocking */);
+    usleep(100000);  // 100ms 轮询间隔
+}
+
+agentsight_stop(h);
+agentsight_free(h);
+```
+
+## 4. 内存规则
+
+* 回调中的指针仅在回调执行期间有效，调用方需自行拷贝
+
+* `agentsight_new()` 内部拷贝配置，不消费 config handle，调用者须自行 `agentsight_config_free(cfg)`
+
+* 同一 config handle 可复用于创建多个 `AgentsightHandle` 实例
+
+* `agentsight_free()` 须在 `agentsight_stop()` 之后调用
+
+* `agentsight_get_eventfd()` 返回的 fd 由 `agentsight_free()` 内部关闭，调用方**不得**自行 `close()`
+
+## 5. HttpsData 与 LLMData 的关系
+
+一条被捕获的 HTTPS 流量只会产生一种数据：若被识别为 LLM API 调用，则产生 `AgentsightLLMData`；否则产生 `AgentsightHttpsData`。两者互斥，不会同时产生，无需关联。
+
+## 6. 编译与链接
+
+* 库文件：`libcoolbpf.so`（Linux）
+
+* 头文件：`include/agentsight.h`
+
+* 编译：`gcc -I/include/agentsight -lcoolbpf -o myapp myapp.c`
+
+## 7. 变更记录
+
+| 版本 | 变更 |
+| --- | --- |
+| v0.1 | 初始版本，轮询 read 模式 |
+| v0.2 | 升级为 eventfd + read 模式；新增 `agentsight_get_eventfd()`；`agentsight_read()` 增加 `flags` 参数；新增 `agentsight_config_set_log_path()`；大 buffer 指针增加 `_len` 字段；新增 `llm_usage` 字段区分 token 数据来源 |

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -54,14 +54,46 @@ pub fn hf_home() -> PathBuf {
 static VERBOSE: AtomicBool = AtomicBool::new(false);
 
 pub fn set_verbose(v: bool) {
-    VERBOSE.store(v, Ordering::SeqCst);
-    if std::env::var("RUST_LOG").is_err() {
-        let level = if v { "debug" } else { "warn" };
-        unsafe {
-            std::env::set_var("RUST_LOG", level);
+    init_logging(v, None);
+}
+
+/// Initialize logging with optional file output.
+///
+/// * `verbose` — true = debug level, false = warn level (unless `RUST_LOG` is set)
+/// * `log_path` — if `Some`, log output is appended to this file; otherwise stderr
+pub fn init_logging(verbose: bool, log_path: Option<&str>) {
+    VERBOSE.store(verbose, Ordering::SeqCst);
+
+    let level = if verbose {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Warn
+    };
+
+    let mut builder = env_logger::Builder::new();
+
+    // Respect RUST_LOG if set, otherwise use verbose-based level.
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        builder.parse_filters(&rust_log);
+    } else {
+        builder.filter_level(level);
+    }
+
+    // Direct output to file if log_path is provided.
+    if let Some(path) = log_path {
+        use std::fs::OpenOptions;
+        match OpenOptions::new().create(true).append(true).open(path) {
+            Ok(file) => {
+                builder.target(env_logger::Target::Pipe(Box::new(file)));
+            }
+            Err(e) => {
+                eprintln!("agentsight: failed to open log file {:?}: {}", path, e);
+            }
         }
     }
-    env_logger::init();
+
+    // init() may fail if called twice; that's fine.
+    let _ = builder.try_init();
 }
 
 pub fn verbose() -> bool {
@@ -127,6 +159,8 @@ pub struct AgentsightConfig {
     // --- Logging Configuration ---
     /// Enable verbose logging
     pub verbose: bool,
+    /// Log file path (None = stderr)
+    pub log_path: Option<String>,
 
     // --- SLS (Aliyun Log Service) Configuration ---
     /// SLS endpoint (e.g. "cn-hangzhou.log.aliyuncs.com")
@@ -176,6 +210,7 @@ impl Default for AgentsightConfig {
 
             // Logging defaults
             verbose: false,
+            log_path: None,
 
             // SLS defaults (read from env vars)
             sls_endpoint: std::env::var("SLS_ENDPOINT").ok(),
@@ -252,7 +287,7 @@ impl AgentsightConfig {
 
     /// Apply verbose setting to the global state
     pub fn apply_verbose(&self) {
-        set_verbose(self.verbose);
+        init_logging(self.verbose, self.log_path.as_deref());
     }
 
     /// Check if SLS configuration is complete

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -1,42 +1,657 @@
-//! FFI interface for AgentSight - C API for other languages
+//! FFI interface for AgentSight — C API for other languages
 //!
-//! This module provides C-compatible functions to use AgentSight from other languages.
+//! Implements the **eventfd + read** model described in `docs/design-docs/c-ffi-api.md`:
+//! AgentSight runs a background pipeline thread; completed events are pushed
+//! into an `mpsc` channel and the caller is notified via `eventfd`.
+//! The caller consumes events by calling `agentsight_read()` with callbacks.
 
-use crate::unified::AgentSight;
-use crate::config::AgentsightConfig;
-use std::ffi::{CStr, CString, c_char, c_int, c_uint, c_void};
+use std::ffi::{CStr, CString, c_char, c_int, c_void};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
 
-/// Run AgentSight in current thread (blocking)
+use crate::analyzer::HttpRecord;
+use crate::config::AgentsightConfig;
+use crate::genai::semantic::LLMCall;
+use crate::unified::AgentSight;
+
+// ===========================================================================
+// Internal FFI event types (shared with unified.rs via crate::ffi)
+// ===========================================================================
+
+/// Internal event for FFI communication between pipeline and consumer.
 ///
-/// This function creates an AgentSight instance internally and runs it.
-/// It blocks until agentsight_stop() is called from another thread.
-///
-/// # Arguments
-/// - target_pids: Array of PIDs to trace (null for auto-discover)
-/// - pid_count: Number of PIDs in array
-/// - verbose: Enable verbose logging (0=false, 1=true)
-///
-/// # Returns
-/// 0 on success, -1 on error
-#[unsafe(no_mangle)]
-pub extern "C" fn agentsight_run() {
-    std::thread::spawn(|| {
-        agent_run();
+/// Mutually exclusive: an HTTP exchange either becomes `Llm` (if recognised
+/// as an LLM API call) or `Https` (otherwise).  See §5 in c-ffi-api.md.
+pub(crate) enum FfiEvent {
+    Https(HttpRecord),
+    Llm(LLMCall),
+}
+
+/// Wraps an `mpsc::Sender<FfiEvent>` together with the `eventfd` descriptor
+/// so that a single `.send()` call both enqueues the event and wakes up the
+/// consumer's epoll/select loop.
+pub(crate) struct FfiEventSender {
+    tx: mpsc::Sender<FfiEvent>,
+    eventfd: i32,
+}
+
+impl FfiEventSender {
+    pub fn send(&self, event: FfiEvent) {
+        if self.tx.send(event).is_ok() {
+            // Write 1 to the eventfd counter to wake up the consumer.
+            let val: u64 = 1;
+            unsafe {
+                libc::write(self.eventfd, &val as *const u64 as *const c_void, 8);
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// Thread-local last-error storage
+// ===========================================================================
+
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<CString>> = const { std::cell::RefCell::new(None) };
+}
+
+fn set_last_error(msg: &str) {
+    LAST_ERROR.with(|e| {
+        *e.borrow_mut() = CString::new(msg.replace('\0', "")).ok();
     });
 }
 
-fn agent_run() {
-    // Build AgentSight with default settings (auto-attaches and starts polling)
-    let config = AgentsightConfig::new();
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+/// Create a `CString` from a Rust `&str`, replacing interior NUL bytes.
+fn safe_cstring(s: &str) -> CString {
+    CString::new(s.replace('\0', "")).unwrap()
+}
+
+/// Copy a Rust string into a fixed-size `[c_char; 16]` buffer (NUL-terminated).
+fn copy_process_name(name: &str) -> [c_char; 16] {
+    let mut buf = [0i8; 16];
+    let bytes = name.as_bytes();
+    let len = bytes.len().min(15);
+    for i in 0..len {
+        buf[i] = bytes[i] as c_char;
+    }
+    buf
+}
+
+/// Drain the eventfd counter so that epoll won't re-trigger.
+fn drain_eventfd(fd: i32) {
+    let mut buf: u64 = 0;
+    unsafe {
+        libc::read(fd, &mut buf as *mut u64 as *mut c_void, 8);
+    }
+}
+
+// ===========================================================================
+// C-compatible data structures  (§1 of c-ffi-api.md)
+// ===========================================================================
+
+/// HTTP layer data — non-LLM HTTPS traffic produces this structure.
+#[repr(C)]
+pub struct AgentsightHttpsData {
+    pub pid: i32,
+    pub process_name: [c_char; 16],
+    pub timestamp_ns: u64,
+    pub duration_ns: u64,
+    pub method: *const c_char,
+    pub path: *const c_char,
+    pub status_code: u16,
+    pub is_sse: u8,
+    pub request_headers: *const c_char,
+    pub request_headers_len: u32,
+    pub request_body: *const c_char,
+    pub request_body_len: u32,
+    pub response_headers: *const c_char,
+    pub response_headers_len: u32,
+    pub response_body: *const c_char,
+    pub response_body_len: u32,
+}
+
+/// LLM semantic layer data — only when the HTTP traffic is recognised as
+/// an LLM API call.
+#[repr(C)]
+pub struct AgentsightLLMData {
+    pub response_id: *const c_char,
+    pub conversation_id: *const c_char,
+    pub session_id: *const c_char,
+    pub pid: i32,
+    pub process_name: [c_char; 16],
+    pub agent_name: *const c_char,
+    pub timestamp_ns: u64,
+    pub duration_ns: u64,
+    pub request_url: *const c_char,
+    pub provider: *const c_char,
+    pub model: *const c_char,
+    pub status_code: u16,
+    pub is_sse: u8,
+    pub finish_reason: *const c_char,
+    pub llm_usage: bool,
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub total_tokens: u32,
+    pub cache_creation_input_tokens: u32,
+    pub cache_read_input_tokens: u32,
+    pub request_messages: *const c_char,
+    pub request_messages_len: u32,
+    pub response_messages: *const c_char,
+    pub response_messages_len: u32,
+}
+
+// ===========================================================================
+// Opaque handles
+// ===========================================================================
+
+/// Configuration handle (created → configured → passed to `agentsight_new`).
+/// cbindgen:no-export
+pub struct AgentsightConfigHandle {
+    verbose: i32,
+    log_path: Option<String>,
+}
+
+/// Main runtime handle.
+/// cbindgen:no-export
+pub struct AgentsightHandle {
+    rx: mpsc::Receiver<FfiEvent>,
+    /// Sender kept alive so the background thread's sends don't fail
+    /// after start; taken (moved) into the thread in `agentsight_start`.
+    tx: Option<mpsc::Sender<FfiEvent>>,
+    eventfd: i32,
+    running: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    /// Config stored until `agentsight_start()` moves it into the thread.
+    config: Option<AgentsightConfig>,
+}
+
+// ===========================================================================
+// Callback type aliases
+// ===========================================================================
+
+type HttpsCallbackFn = Option<unsafe extern "C" fn(*const AgentsightHttpsData, *mut c_void)>;
+type LlmCallbackFn = Option<unsafe extern "C" fn(*const AgentsightLLMData, *mut c_void)>;
+
+/// Flag for `agentsight_read()`: block until at least one event is available.
+pub const AGENTSIGHT_READ_BLOCK: c_int = 1;
+
+// ===========================================================================
+// Temporary data holders (keep CStrings alive during callbacks)
+// ===========================================================================
+
+struct HttpsDataHolder {
+    c_data: AgentsightHttpsData,
+    _method: CString,
+    _path: CString,
+    _req_headers: CString,
+    _req_body: Option<CString>,
+    _resp_headers: CString,
+    _resp_body: Option<CString>,
+}
+
+struct LlmDataHolder {
+    c_data: AgentsightLLMData,
+    _response_id: Option<CString>,
+    _conversation_id: Option<CString>,
+    _session_id: Option<CString>,
+    _agent_name: Option<CString>,
+    _request_url: CString,
+    _provider: CString,
+    _model: CString,
+    _finish_reason: Option<CString>,
+    _req_messages: CString,
+    _resp_messages: CString,
+}
+
+fn build_https_data(record: &HttpRecord) -> HttpsDataHolder {
+    let method = safe_cstring(&record.method);
+    let path = safe_cstring(&record.path);
+    let req_headers = safe_cstring(&record.request_headers);
+    let req_body = record.request_body.as_ref().map(|b| safe_cstring(b));
+    let resp_headers = safe_cstring(&record.response_headers);
+    let resp_body = record.response_body.as_ref().map(|b| safe_cstring(b));
+
+    let c_data = AgentsightHttpsData {
+        pid: record.pid as i32,
+        process_name: copy_process_name(&record.comm),
+        timestamp_ns: record.timestamp_ns,
+        duration_ns: record.duration_ns,
+        method: method.as_ptr(),
+        path: path.as_ptr(),
+        status_code: record.status_code,
+        is_sse: record.is_sse as u8,
+        request_headers: req_headers.as_ptr(),
+        request_headers_len: record.request_headers.len() as u32,
+        request_body: req_body.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        request_body_len: record.request_body.as_ref().map_or(0, |s| s.len() as u32),
+        response_headers: resp_headers.as_ptr(),
+        response_headers_len: record.response_headers.len() as u32,
+        response_body: resp_body.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        response_body_len: record.response_body.as_ref().map_or(0, |s| s.len() as u32),
+    };
+
+    HttpsDataHolder {
+        c_data,
+        _method: method,
+        _path: path,
+        _req_headers: req_headers,
+        _req_body: req_body,
+        _resp_headers: resp_headers,
+        _resp_body: resp_body,
+    }
+}
+
+fn build_llm_data(call: &LLMCall) -> LlmDataHolder {
+    let response_id = call.metadata.get("response_id").map(|s| safe_cstring(s));
+    let conversation_id = call.metadata.get("conversation_id").map(|s| safe_cstring(s));
+    let session_id = call.metadata.get("session_id").map(|s| safe_cstring(s));
+    let agent_name = call.agent_name.as_ref().map(|s| safe_cstring(s));
+
+    // Construct request_url from metadata
+    let server_addr = call.metadata.get("server.address").cloned().unwrap_or_default();
+    let server_port = call.metadata.get("server.port").cloned().unwrap_or_default();
+    let path = call.metadata.get("path").cloned().unwrap_or_default();
+    let url = if server_port.is_empty() {
+        format!("https://{}{}", server_addr, path)
+    } else {
+        format!("https://{}:{}{}", server_addr, server_port, path)
+    };
+    let request_url = safe_cstring(&url);
+
+    let provider = safe_cstring(&call.provider);
+    let model = safe_cstring(&call.model);
+
+    let status_code: u16 = call
+        .metadata
+        .get("status_code")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let is_sse: bool = call
+        .metadata
+        .get("is_sse")
+        .map_or(false, |s| s == "true");
+
+    let finish_reason = call
+        .response
+        .messages
+        .first()
+        .and_then(|m| m.finish_reason.as_ref())
+        .map(|s| safe_cstring(s));
+
+    let (llm_usage, input_tokens, output_tokens, total_tokens, cache_creation, cache_read) =
+        match &call.token_usage {
+            Some(u) => (
+                true,
+                u.input_tokens,
+                u.output_tokens,
+                u.total_tokens,
+                u.cache_creation_input_tokens.unwrap_or(0),
+                u.cache_read_input_tokens.unwrap_or(0),
+            ),
+            None => (false, 0, 0, 0, 0, 0),
+        };
+
+    let req_messages_json =
+        serde_json::to_string(&call.request.messages).unwrap_or_default();
+    let resp_messages_json =
+        serde_json::to_string(&call.response.messages).unwrap_or_default();
+    let req_messages = safe_cstring(&req_messages_json);
+    let resp_messages = safe_cstring(&resp_messages_json);
+
+    let c_data = AgentsightLLMData {
+        response_id: response_id.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        conversation_id: conversation_id.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        session_id: session_id.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        pid: call.pid,
+        process_name: copy_process_name(&call.process_name),
+        agent_name: agent_name.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        timestamp_ns: call.start_timestamp_ns,
+        duration_ns: call.duration_ns,
+        request_url: request_url.as_ptr(),
+        provider: provider.as_ptr(),
+        model: model.as_ptr(),
+        status_code,
+        is_sse: is_sse as u8,
+        finish_reason: finish_reason.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        llm_usage,
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        cache_creation_input_tokens: cache_creation,
+        cache_read_input_tokens: cache_read,
+        request_messages: req_messages.as_ptr(),
+        request_messages_len: req_messages_json.len() as u32,
+        response_messages: resp_messages.as_ptr(),
+        response_messages_len: resp_messages_json.len() as u32,
+    };
+
+    LlmDataHolder {
+        c_data,
+        _response_id: response_id,
+        _conversation_id: conversation_id,
+        _session_id: session_id,
+        _agent_name: agent_name,
+        _request_url: request_url,
+        _provider: provider,
+        _model: model,
+        _finish_reason: finish_reason,
+        _req_messages: req_messages,
+        _resp_messages: resp_messages,
+    }
+}
+
+/// Dispatch a single FFI event to the appropriate callback.
+///
+/// # Safety
+/// Caller must ensure the callback function pointers and user-data pointers
+/// are valid for the duration of the call.
+unsafe fn dispatch_event(
+    event: FfiEvent,
+    http_cb: HttpsCallbackFn,
+    http_ud: *mut c_void,
+    llm_cb: LlmCallbackFn,
+    llm_ud: *mut c_void,
+) {
+    match event {
+        FfiEvent::Https(record) => {
+            if let Some(cb) = http_cb {
+                let holder = build_https_data(&record);
+                unsafe { cb(&holder.c_data, http_ud) };
+            }
+        }
+        FfiEvent::Llm(call) => {
+            if let Some(cb) = llm_cb {
+                let holder = build_llm_data(&call);
+                unsafe { cb(&holder.c_data, llm_ud) };
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// C API functions  (§2 of c-ffi-api.md)
+// ===========================================================================
+
+// ---- Error handling ----
+
+/// Return the last error description, or NULL if no error.
+/// The pointer is valid until the next API call on the same thread.
+#[unsafe(no_mangle)]
+pub extern "C" fn agentsight_last_error() -> *const c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow().as_ref().map_or(ptr::null(), |s| s.as_ptr())
+    })
+}
+
+// ---- Configuration ----
+
+/// Create a new configuration with default values.
+#[unsafe(no_mangle)]
+pub extern "C" fn agentsight_config_new() -> *mut AgentsightConfigHandle {
+    Box::into_raw(Box::new(AgentsightConfigHandle {
+        verbose: 0,
+        log_path: None,
+    }))
+}
+
+/// Set the verbose flag (0 = off, 1 = on).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_config_set_verbose(
+    cfg: *mut AgentsightConfigHandle,
+    verbose: c_int,
+) {
+    if !cfg.is_null() {
+        unsafe { (*cfg).verbose = verbose };
+    }
+}
+
+/// Set the log file path (NULL → stderr).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_config_set_log_path(
+    cfg: *mut AgentsightConfigHandle,
+    path: *const c_char,
+) {
+    if cfg.is_null() {
+        return;
+    }
+    unsafe {
+        (*cfg).log_path = if path.is_null() {
+            None
+        } else {
+            Some(CStr::from_ptr(path).to_string_lossy().to_string())
+        };
+    }
+}
+
+/// Free the configuration handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_config_free(cfg: *mut AgentsightConfigHandle) {
+    if !cfg.is_null() {
+        unsafe { drop(Box::from_raw(cfg)) };
+    }
+}
+
+// ---- Lifecycle ----
+
+/// Create a new AgentSight handle.  Does NOT start the pipeline yet.
+/// Returns NULL on failure (call `agentsight_last_error()` for details).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_new(
+    cfg: *mut AgentsightConfigHandle,
+) -> *mut AgentsightHandle {
+    // Create eventfd
+    let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+    if efd < 0 {
+        set_last_error("Failed to create eventfd");
+        return ptr::null_mut();
+    }
+
+    // Build Rust config from the C handle
+    let mut config = AgentsightConfig::new();
+    if !cfg.is_null() {
+        let c = unsafe { &*cfg };
+        if c.verbose != 0 {
+            config.verbose = true;
+        }
+        config.log_path = c.log_path.clone();
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let running = Arc::new(AtomicBool::new(false));
+
+    Box::into_raw(Box::new(AgentsightHandle {
+        rx,
+        tx: Some(tx),
+        eventfd: efd,
+        running,
+        thread: None,
+        config: Some(config),
+    }))
+}
+
+/// Start the background pipeline thread.  Returns 0 on success, <0 on error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_start(h: *mut AgentsightHandle) -> c_int {
+    if h.is_null() {
+        set_last_error("NULL handle");
+        return -1;
+    }
+    let handle = unsafe { &mut *h };
+
+    // Take config and sender (can only start once)
+    let config = match handle.config.take() {
+        Some(c) => c,
+        None => {
+            set_last_error("agentsight_start called more than once");
+            return -1;
+        }
+    };
+    let tx = match handle.tx.take() {
+        Some(t) => t,
+        None => {
+            set_last_error("agentsight_start: sender already consumed");
+            return -1;
+        }
+    };
+
+    let running = handle.running.clone();
+    running.store(true, Ordering::SeqCst);
+    let eventfd = handle.eventfd;
+
+    handle.thread = Some(std::thread::spawn(move || {
+        ffi_background_thread(config, tx, eventfd, running);
+    }));
+
+    0
+}
+
+/// Background thread: creates AgentSight and runs the event loop.
+///
+/// This function creates AgentSight *inside* the thread to avoid `Send`
+/// constraints on eBPF objects.
+fn ffi_background_thread(
+    config: AgentsightConfig,
+    tx: mpsc::Sender<FfiEvent>,
+    eventfd: i32,
+    running: Arc<AtomicBool>,
+) {
+    let sender = FfiEventSender { tx, eventfd };
+
     let mut sight = match AgentSight::new(config) {
         Ok(s) => s,
         Err(e) => {
-            log::error!("agentsight_run failed: {}", e);
+            log::error!("agentsight background thread: AgentSight::new failed: {}", e);
             return;
         }
     };
 
-    let _ = sight.run();
+    // Install FFI event sender on the AgentSight instance.
+    sight.set_ffi_sender(sender);
+
+    // Event loop controlled by the external running flag.
+    while running.load(Ordering::SeqCst) {
+        if sight.try_process().is_none() {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    // Shutdown: flush pending events.
+    sight.shutdown();
 }
+
+/// Stop the background pipeline thread.  Returns 0 on success.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_stop(h: *mut AgentsightHandle) -> c_int {
+    if h.is_null() {
+        set_last_error("NULL handle");
+        return -1;
+    }
+    let handle = unsafe { &mut *h };
+    handle.running.store(false, Ordering::SeqCst);
+
+    // Wait for background thread to finish.
+    if let Some(th) = handle.thread.take() {
+        let _ = th.join();
+    }
+    0
+}
+
+/// Free the handle.  Must be called after `agentsight_stop()`.
+/// The eventfd is closed automatically via the `Drop` impl.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_free(h: *mut AgentsightHandle) {
+    if !h.is_null() {
+        unsafe { drop(Box::from_raw(h)) };
+    }
+}
+
+impl Drop for AgentsightHandle {
+    fn drop(&mut self) {
+        // Close the eventfd managed by this handle.
+        if self.eventfd >= 0 {
+            unsafe { libc::close(self.eventfd) };
+            self.eventfd = -1;
+        }
+        // Join the background thread if still running.
+        if let Some(th) = self.thread.take() {
+            self.running.store(false, Ordering::SeqCst);
+            let _ = th.join();
+        }
+    }
+}
+
+/// Return a static version string (e.g. "0.2.2").
+#[unsafe(no_mangle)]
+pub extern "C" fn agentsight_version() -> *const c_char {
+    static VERSION_CSTR: std::sync::OnceLock<CString> = std::sync::OnceLock::new();
+    VERSION_CSTR
+        .get_or_init(|| CString::new(env!("CARGO_PKG_VERSION")).unwrap())
+        .as_ptr()
+}
+
+// ---- Event notification ----
+
+/// Return the eventfd descriptor.  The caller may register it with
+/// epoll/select.  Returns <0 if eventfd is not supported.
+/// The fd is managed internally — the caller must NOT close it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_get_eventfd(h: *mut AgentsightHandle) -> c_int {
+    if h.is_null() {
+        return -1;
+    }
+    unsafe { (*h).eventfd }
+}
+
+// ---- Data reading ----
+
+/// Process available events via callbacks.
+///
+/// * `http_cb` / `llm_cb`: callbacks for HTTP / LLM events (NULL = ignore).
+/// * `flags`: 0 = non-blocking, `AGENTSIGHT_READ_BLOCK` = block until ≥1 event.
+///
+/// Returns the number of events processed, 0 if none, <0 on error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_read(
+    h: *mut AgentsightHandle,
+    http_cb: HttpsCallbackFn,
+    http_ud: *mut c_void,
+    llm_cb: LlmCallbackFn,
+    llm_ud: *mut c_void,
+    flags: c_int,
+) -> c_int {
+    if h.is_null() {
+        return -1;
+    }
+    let handle = unsafe { &*h };
+    let mut count: c_int = 0;
+
+    // Blocking mode: wait for at least one event.
+    if flags & AGENTSIGHT_READ_BLOCK != 0 {
+        match handle.rx.recv() {
+            Ok(event) => {
+                unsafe { dispatch_event(event, http_cb, http_ud, llm_cb, llm_ud) };
+                count += 1;
+            }
+            Err(_) => return -1,
+        }
+    }
+
+    // Non-blocking drain of remaining (or all) events.
+    while let Ok(event) = handle.rx.try_recv() {
+        unsafe { dispatch_event(event, http_cb, http_ud, llm_cb, llm_ud) };
+        count += 1;
+    }
+
+    // Drain the eventfd counter to prevent stale wakeups.
+    drain_eventfd(handle.eventfd);
+
+    count
+}
+
+

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -25,16 +25,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::aggregator::Aggregator;
 use crate::analyzer::Analyzer;
-use crate::config::{self, AgentsightConfig};
+use crate::config::AgentsightConfig;
 use crate::discovery::AgentScanner;
 use crate::event::Event;
+use crate::ffi::{FfiEvent, FfiEventSender};
 use crate::genai::{GenAIBuilder, GenAIExporter, GenAIStore, SlsUploader};
-use crate::genai::builder::BuildOutput;
 use crate::genai::semantic::GenAISemanticEvent;
 use crate::parser::Parser;
 use crate::probes::{Probes, ProbesPoller, FileWatchEvent, FileWriteEvent};
 use crate::storage::{
-    SqliteConfig, Storage, StorageBackend, TimePeriod, TokenQuery, TokenQueryResult,
+    SqliteConfig, Storage, TimePeriod, TokenQuery, TokenQueryResult,
 };
 use crate::storage::sqlite::GenAISqliteStore;
 use crate::tokenizer::LlmTokenizer;
@@ -78,6 +78,8 @@ pub struct AgentSight {
     response_mapper: ResponseSessionMapper,
     /// Pending GenAI events awaiting session_id resolution from ResponseSessionMapper
     pending_genai: Vec<PendingGenAI>,
+    /// Optional FFI event sender (set when running in FFI/C-API mode)
+    ffi_sender: Option<FfiEventSender>,
 }
 
 /// GenAI events waiting for session_id resolution via ResponseSessionMapper.
@@ -218,6 +220,7 @@ impl AgentSight {
             filewatch_callback: None,
             response_mapper: ResponseSessionMapper::new(),
             pending_genai: Vec::new(),
+            ffi_sender: None,
         })
     }
 
@@ -332,14 +335,23 @@ impl AgentSight {
                     // Session_id resolved (or no response_id) — export immediately
                     self.export_genai_events(&output.events);
                 }
+            } else if let Some(ref sender) = self.ffi_sender {
+                // No LLM event produced — send plain HTTP data via FFI channel
+                for ar in &analysis_results {
+                    if let crate::analyzer::AnalysisResult::Http(record) = ar {
+                        sender.send(FfiEvent::Https(record.clone()));
+                    }
+                }
             }
-            
-            // Store analysis results
-            for analysis_result in &analysis_results {
-                if let Err(e) = self.storage.store(analysis_result) {
-                    log::warn!("Failed to store analysis result: {}", e);
-                } else {
-                    log::debug!("Analysis result saved");
+
+            // In FFI mode data is delivered via callbacks; skip local storage.
+            if self.ffi_sender.is_none() {
+                for analysis_result in &analysis_results {
+                    if let Err(e) = self.storage.store(analysis_result) {
+                        log::warn!("Failed to store analysis result: {}", e);
+                    } else {
+                        log::debug!("Analysis result saved");
+                    }
                 }
             }
         }
@@ -418,14 +430,32 @@ impl AgentSight {
     /// Shutdown gracefully
     pub fn shutdown(&mut self) {
         self.running.store(false, Ordering::SeqCst);
+        // Flush all pending GenAI events before exit
+        self.flush_all_pending_genai();
         // poller will be dropped automatically when AgentSight is dropped
+    }
+
+    /// Install an FFI event sender for C API mode.
+    /// When set, completed events are pushed through this channel.
+    pub fn set_ffi_sender(&mut self, sender: FfiEventSender) {
+        self.ffi_sender = Some(sender);
     }
 
     /// Export GenAI events to all registered exporters
     fn export_genai_events(&self, events: &[GenAISemanticEvent]) {
-        for exporter in &self.genai_exporters {
-            exporter.export(events);
-            log::debug!("Exported {} GenAI events via '{}'", events.len(), exporter.name());
+        if let Some(ref sender) = self.ffi_sender {
+            // FFI mode: deliver LLMCall events via callback channel only.
+            for event in events {
+                if let GenAISemanticEvent::LLMCall(call) = event {
+                    sender.send(FfiEvent::Llm(call.clone()));
+                }
+            }
+        } else {
+            // Normal mode: export to all registered exporters.
+            for exporter in &self.genai_exporters {
+                exporter.export(events);
+                log::debug!("Exported {} GenAI events via '{}'", events.len(), exporter.name());
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Add C FFI API for AgentSight, enabling cross-language integration (C/C++/Python etc.) via the **eventfd + read** model.

**Key changes:**
- Integrate `cbindgen` into `build.rs` to auto-generate C header `include/agentsight.h` from `src/ffi.rs`
- Implement core C API: `agentsight_create()`, `agentsight_start()`, `agentsight_read()`, `agentsight_destroy()`
- Add `FfiEvent` / `FfiEventSender` types for pipeline-to-consumer communication
- Update `AgentsightConfig` and `AgentSight` to support FFI event channel
- Add design doc: `docs/design-docs/c-ffi-api.md`

## Related Issue

closes #305

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

C FFI API 的集成测试需在支持 eBPF 的环境中进行。设计文档中包含完整的使用示例。

## Additional Notes

- 采用 eventfd + read 模式，调用方可将 fd 注册到 epoll/select 事件循环
- 支持 HTTPS 和 LLM 两种事件类型的回调
- cbindgen 在构建时自动生成头文件，无需手动维护