### PR TITLE
fix(sec-core): align skill-ledger tool name and add path validation

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
@@ -187,7 +187,10 @@ class SkillLedgerBackend(BaseBackend):
             f"Status:     {status}",
         ]
 
-        manifest = load_latest_manifest(skill_dir)
+        try:
+            manifest = load_latest_manifest(skill_dir)
+        except Exception:
+            manifest = None
         if manifest is not None:
             lines.append(f"Version:    {manifest.versionId}")
             lines.append(f"scanStatus: {manifest.scanStatus}")

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
@@ -22,6 +22,7 @@ from agent_sec_cli.skill_ledger.core.version_chain import (
 )
 from agent_sec_cli.skill_ledger.errors import SignatureInvalidError
 from agent_sec_cli.skill_ledger.signing.base import SigningBackend
+from agent_sec_cli.skill_ledger.utils import validate_skill_dir
 
 
 def audit(
@@ -33,6 +34,9 @@ def audit(
 
     Returns ``{"valid": bool, "versions_checked": int, "errors": [...]}``.
     """
+    # Validate skill directory before any work
+    validate_skill_dir(skill_dir)
+
     errors: list[dict[str, Any]] = []
     version_ids = list_version_ids(skill_dir)
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
@@ -44,7 +44,7 @@ from agent_sec_cli.skill_ledger.models.scan import (
 from agent_sec_cli.skill_ledger.scanner.parsers import parse_findings
 from agent_sec_cli.skill_ledger.scanner.registry import ScannerRegistry
 from agent_sec_cli.skill_ledger.signing.base import SigningBackend
-from agent_sec_cli.skill_ledger.utils import utc_now_iso
+from agent_sec_cli.skill_ledger.utils import utc_now_iso, validate_skill_dir
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +196,9 @@ def certify(
 
     Returns a JSON-serialisable result dict.
     """
+    # Validate skill directory before any work
+    validate_skill_dir(skill_dir)
+
     # Auto-remember: append to skillDirs if not already covered (best-effort)
     try:
         remember_skill_dir(Path(skill_dir))

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/checker.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/checker.py
@@ -33,6 +33,7 @@ from agent_sec_cli.skill_ledger.models.manifest import (
     SignedManifest,
 )
 from agent_sec_cli.skill_ledger.signing.base import SigningBackend
+from agent_sec_cli.skill_ledger.utils import validate_skill_dir
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,9 @@ def check(skill_dir: str, backend: SigningBackend) -> dict[str, Any]:
 
     Returns a JSON-serialisable dict with at minimum ``{"status": "<status>"}``.
     """
+    # Step 0: Validate skill directory
+    validate_skill_dir(skill_dir)
+
     # Auto-remember: append to skillDirs if not already covered (best-effort)
     try:
         remember_skill_dir(Path(skill_dir))

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/utils.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/utils.py
@@ -1,8 +1,24 @@
 """Shared utility helpers for skill-ledger."""
 
+import os
 from datetime import datetime, timezone
 
 
 def utc_now_iso() -> str:
     """Return the current UTC time as an ISO-8601 string."""
     return datetime.now(timezone.utc).isoformat()
+
+
+def validate_skill_dir(skill_dir: str) -> None:
+    """Validate that *skill_dir* exists, is a directory, and contains ``SKILL.md``.
+
+    Raises :class:`ValueError` on any validation failure.  Callers higher in
+    the stack (the middleware backend) catch generic ``Exception`` and convert
+    to ``{"status": "error", ...}``, exit 1.
+    """
+    if not os.path.isdir(skill_dir):
+        raise ValueError(
+            f"skill directory does not exist or is not a directory: {skill_dir}"
+        )
+    if not os.path.isfile(os.path.join(skill_dir, "SKILL.md")):
+        raise ValueError(f"SKILL.md not found in skill directory: {skill_dir}")

--- a/src/agent-sec-core/cosh_hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh_hooks/skill_ledger_hook.py
@@ -60,6 +60,7 @@ _WARNING_MESSAGES = {
     "warn": "\u26a0\ufe0f Skill '{name}' has low-risk findings \u2014 review recommended",
     "drifted": "\u26a0\ufe0f Skill '{name}' content has changed since last scan",
     "none": "\u26a0\ufe0f Skill '{name}' has not been security-scanned yet",
+    "error": "\u26a0\ufe0f Skill '{name}' check failed \u2014 invalid path or missing SKILL.md",
     "deny": (
         "\U0001f6a8 Skill '{name}' has high-risk findings"
         " \u2014 immediate review recommended"

--- a/src/agent-sec-core/docs/guide/SKILL_LEDGER_USER_GUIDE_CN.md
+++ b/src/agent-sec-core/docs/guide/SKILL_LEDGER_USER_GUIDE_CN.md
@@ -155,7 +155,7 @@ Skill Ledger 提供**两层防护**协同工作：
 ```
 
 - **第一层——自动 Hook（实时守卫）**：
-  - **OpenClaw**：插件拦截所有对 `SKILL.md` 的 `read_file` 调用，在 Skill 加载前自动运行 `check`。
+  - **OpenClaw**：插件拦截所有对 `SKILL.md` 的 `read` 调用，在 Skill 加载前自动运行 `check`。
   - **copilot-shell**：Python hook 脚本（`cosh_hooks/skill_ledger_hook.py`）通过 `PreToolUse` 事件在 Skill 调用前自动运行 `check`。
   - 两者均对非 `pass` 状态输出警告。**零配置、始终启用。**
 - **第二层——Agent 驱动扫描（深度审计）**：`skill-ledger` Skill 驱动完整的四阶段安全扫描并生成签名认证。**按需触发**，由用户请求发起。
@@ -164,7 +164,7 @@ Skill Ledger 提供**两层防护**协同工作：
 
 **工作原理：**
 
-OpenClaw 安全插件注册了一个 `before_tool_call` hook（优先级 80）。当 Agent 调用 `read_file` 读取任何 `SKILL.md` 文件时：
+OpenClaw 安全插件注册了一个 `before_tool_call` hook（优先级 80）。当 Agent 调用 `read` 读取任何 `SKILL.md` 文件时：
 
 1. Hook 从文件路径提取 Skill 目录
 2. 确保签名密钥存在（缺失时自动初始化）

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
@@ -17,7 +17,7 @@ type CheckResult = {
 // Constants
 // ---------------------------------------------------------------------------
 
-const READ_TOOL_NAMES = ["read_file"];
+const READ_TOOL_NAMES = ["read"];
 const PATH_PARAM_NAMES = ["file_path", "path"];
 const DEFAULT_TIMEOUT_MS = 5_000;
 

--- a/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
@@ -6,7 +6,7 @@ import { skillLedger } from "../src/capabilities/skill-ledger.js";
 
 // 每个 hook 的 mock 事件（字段与真实类型一致）
 // Note: before_tool_call has two entries — one for exec-based tools (code-scan)
-// and one for read_file-based tools (skill-ledger). The shared mock uses "exec" for
+// and one for read-based tools (skill-ledger). The shared mock uses "exec" for
 // code-scan / prompt-scan. skill-ledger uses its own dedicated mock events below.
 const mockEvents: Record<string, Record<string, unknown>> = {
   before_tool_call: {
@@ -35,11 +35,11 @@ const mockCtx: Record<string, Record<string, unknown>> = {
 
 const caps = [codeScan, promptScan];
 
-// skill-ledger needs a dedicated mock with read_file + SKILL.md path
+// skill-ledger needs a dedicated mock with read + SKILL.md path
 const skillLedgerMockEvents: Record<string, Record<string, unknown>> = {
   ...mockEvents,
   before_tool_call: {
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "/home/user/.openclaw/skills/github/SKILL.md" },
     runId: "run-002",
     toolCallId: "tc-002",
@@ -48,7 +48,7 @@ const skillLedgerMockEvents: Record<string, Record<string, unknown>> = {
 const skillLedgerMockCtx: Record<string, Record<string, unknown>> = {
   ...mockCtx,
   before_tool_call: {
-    sessionKey: "sk-001", runId: "run-002", toolName: "read_file", toolCallId: "tc-002",
+    sessionKey: "sk-001", runId: "run-002", toolName: "read", toolCallId: "tc-002",
   },
 };
 

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
@@ -85,7 +85,7 @@ console.log("\n[2] Positive filtering (should match → CLI invoked)");
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "/home/user/.openclaw/skills/github/SKILL.md" },
   });
   assert(result === undefined, "absolute path → returns undefined (allow)");
@@ -94,7 +94,7 @@ console.log("\n[2] Positive filtering (should match → CLI invoked)");
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { path: "/opt/skills/my-tool/SKILL.md" },
   });
   assert(result === undefined, "'path' param (alt name) → returns undefined");
@@ -103,7 +103,7 @@ console.log("\n[2] Positive filtering (should match → CLI invoked)");
 
 {
   const { logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "SKILL.md" },
   });
   assert(logs.some((l) => l.includes("[skill-ledger]")), "bare 'SKILL.md' → handler proceeds");
@@ -111,7 +111,7 @@ console.log("\n[2] Positive filtering (should match → CLI invoked)");
 
 {
   const { logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "  /skills/github/SKILL.md  " },
   });
   assert(logs.some((l) => l.includes("[skill-ledger]")), "whitespace-padded path → handler proceeds (trimmed)");
@@ -119,7 +119,7 @@ console.log("\n[2] Positive filtering (should match → CLI invoked)");
 
 {
   const { logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "/deeply/nested/dir/structure/skill-name/SKILL.md" },
   });
   assert(logs.some((l) => l.includes("[skill-ledger]")), "deeply nested path → handler proceeds");
@@ -157,16 +157,16 @@ console.log("\n[3] Negative filtering (should skip → no logs)");
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "/home/user/project/README.md" },
   });
-  assert(result === undefined, "read_file + README.md → returns undefined");
-  assert(logs.length === 0, "read_file + README.md → no logs (skipped)");
+  assert(result === undefined, "read + README.md → returns undefined");
+  assert(logs.length === 0, "read + README.md → no logs (skipped)");
 }
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "/skills/SKILL.md.bak" },
   });
   assert(result === undefined, "SKILL.md.bak → returns undefined");
@@ -175,7 +175,7 @@ console.log("\n[3] Negative filtering (should skip → no logs)");
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "/skills/SKILL.markdown" },
   });
   assert(result === undefined, "SKILL.markdown → returns undefined");
@@ -184,25 +184,25 @@ console.log("\n[3] Negative filtering (should skip → no logs)");
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: {},
   });
-  assert(result === undefined, "read_file + no path param → returns undefined");
-  assert(logs.length === 0, "read_file + no path param → no logs (skipped)");
+  assert(result === undefined, "read + no path param → returns undefined");
+  assert(logs.length === 0, "read + no path param → no logs (skipped)");
 }
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "" },
   });
-  assert(result === undefined, "read_file + empty path → returns undefined");
-  assert(logs.length === 0, "read_file + empty path → no logs (skipped)");
+  assert(result === undefined, "read + empty path → returns undefined");
+  assert(logs.length === 0, "read + empty path → no logs (skipped)");
 }
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "   " },
   });
   assert(result === undefined, "whitespace-only path → returns undefined");
@@ -211,7 +211,7 @@ console.log("\n[3] Negative filtering (should skip → no logs)");
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: 42 },
   });
   assert(result === undefined, "non-string file_path (number) → returns undefined");
@@ -223,7 +223,7 @@ console.log("\n[4] Fail-open (CLI unavailable → warn + allow)");
 
 {
   const { result, logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: { file_path: "/skills/test/SKILL.md" },
   });
   assert(result === undefined, "CLI failure → returns undefined (never blocks)");
@@ -252,15 +252,15 @@ console.log("\n[5] Malformed event resilience");
 }
 
 {
-  // read_file but params is missing → event.params[x] throws → caught by outer try-catch
-  const { result, logs } = await fire({ toolName: "read_file" });
+  // read but params is missing → event.params[x] throws → caught by outer try-catch
+  const { result, logs } = await fire({ toolName: "read" });
   assert(result === undefined, "missing params property → returns undefined (fail-open catch)");
   assert(logs.some((l) => l.includes("[WARN]")), "missing params → emits WARN from catch block");
 }
 
 {
   // params is null → event.params[x] throws → caught
-  const { result, logs } = await fire({ toolName: "read_file", params: null });
+  const { result, logs } = await fire({ toolName: "read", params: null });
   assert(result === undefined, "params: null → returns undefined (fail-open catch)");
   assert(logs.some((l) => l.includes("[WARN]")), "params: null → emits WARN from catch block");
 }
@@ -271,7 +271,7 @@ console.log("\n[6] Path param priority (file_path before path)");
 {
   // When both file_path and path are present, file_path should win
   const { logs } = await fire({
-    toolName: "read_file",
+    toolName: "read",
     params: {
       file_path: "/skills/alpha/SKILL.md",
       path: "/skills/beta/SKILL.md",

--- a/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
@@ -872,15 +872,13 @@ def test_list_scanners(ws: Workspace):
 
 
 def test_certify_empty_skill_dir(ws: Workspace):
-    """Certify a skill dir with no files → still succeeds (empty fileHashes)."""
+    """Certify a skill dir with no SKILL.md → exit 1, status=error."""
     skill = ws.skills_dir / "empty-skill"
     skill.mkdir(parents=True, exist_ok=True)
     env = ws.env()
 
     r = run_skill_ledger(["certify", str(skill)], env_extra=env)
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
-    out = parse_json_output(r.stdout)
-    assert "scanStatus" in out
+    assert r.returncode == 1, f"expected exit 1 for empty dir, got {r.returncode}"
 
 
 # ── Group 9: SKILL.md contract assertions ────────────────────────────────


### PR DESCRIPTION
## Description

Fix OpenClaw skill-ledger hook tool name mismatch and add input path validation for all skill-ledger CLI entry points.

- **Tool name fix**: `READ_TOOL_NAMES` was `["read_file"]` but OpenClaw's actual tool is `"read"`, so the hook never triggered.
- **Path validation**: Non-existent paths and directories missing `SKILL.md` now return `status=error` (exit 1) instead of silently proceeding with `status=none`.
- **Backend hardening**: `_do_status` handler wrapped `load_latest_manifest()` in try/except for corrupted manifests.
- **Hook UX**: Added `"error"` status to cosh hook `_WARNING_MESSAGES`.

## Related Issue

no-issue: bug discovered during integration testing

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Scope

- [x] `sec-core` (agent-sec-core)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sec-core` (Python): Ruff format and pytest pass

## Testing

- OpenClaw plugin: 23 test suites, 41 assertions — all pass
- Python unit tests: 114 tests (86 skill_ledger + 28 cosh_hooks) — all pass
- Code formatting: `make python-code-pretty` — no changes needed