### PR TITLE
perf(sec-core): lazy-load ML dependencies to speed up non-ML subcommands

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/model_manager.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/model_manager.py
@@ -16,13 +16,14 @@ ModelScope mirror IDs for Llama Prompt Guard 2:
 import logging
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import torch
 from agent_sec_cli.prompt_scanner.exceptions import ModelLoadError
 from agent_sec_cli.prompt_scanner.result import ThreatType
-from modelscope import snapshot_download
 from pydantic import BaseModel
-from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+if TYPE_CHECKING:
+    import torch
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +61,9 @@ class ModelManager:
 
     def __init__(self, cache_dir: str | None = None, device: str | None = None) -> None:
         self._cache_dir = cache_dir or self._DEFAULT_CACHE_DIR
-        self._device = device or self.detect_device()
+        # Defer device detection until first inference to avoid importing torch
+        # at module load time (which would slow down non-ML subcommands like code-scan).
+        self._device_cached: str | None = device
         # cache: model_name -> (model, tokenizer)
         self._loaded_models: dict[str, tuple[object, object]] = {}
         self._load_lock = threading.Lock()
@@ -107,8 +110,14 @@ class ModelManager:
 
     @property
     def device(self) -> str:
-        """The compute device used for inference (``cpu``, ``cuda``, ``mps``)."""
-        return self._device
+        """The compute device used for inference (``cpu``, ``cuda``, ``mps``).
+
+        Lazily detected on first access to avoid importing torch at module
+        load time when non-ML subcommands (e.g. code-scan) are invoked.
+        """
+        if self._device_cached is None:
+            self._device_cached = self.detect_device()
+        return self._device_cached
 
     # ------------------------------------------------------------------
     # Device detection
@@ -120,6 +129,8 @@ class ModelManager:
 
         Priority: CUDA > MPS (Apple Silicon) > CPU.
         """
+        import torch  # lazy import: only needed when actually running ML inference
+
         if torch.cuda.is_available():
             return "cuda"
         if torch.backends.mps.is_available():
@@ -155,6 +166,13 @@ class ModelManager:
             model_name,
         )
 
+        import torch  # lazy import: only needed when actually running ML inference
+        from modelscope import snapshot_download  # lazy import
+        from transformers import (  # lazy import
+            AutoModelForSequenceClassification,
+            AutoTokenizer,
+        )
+
         cache_dir = Path(self._cache_dir).expanduser()
         _ms_logger = logging.getLogger("modelscope")
         _orig_level = _ms_logger.level
@@ -170,12 +188,12 @@ class ModelManager:
 
         # --- load from local path ----------------------------------------
         log.info(
-            "Loading model from '%s' onto device '%s'.", local_model_path, self._device
+            "Loading model from '%s' onto device '%s'.", local_model_path, self.device
         )
         try:
             tokenizer = AutoTokenizer.from_pretrained(local_model_path)
             model = AutoModelForSequenceClassification.from_pretrained(local_model_path)
-            model.to(torch.device(self._device))
+            model.to(torch.device(self.device))
             model.eval()
         except Exception as exc:
             raise ModelLoadError(

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/prompt_guard.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/prompt_guard.py
@@ -16,13 +16,11 @@ separate INJECTION label; the model flags any malicious prompt
 import logging
 import threading
 
-import torch
 from agent_sec_cli.prompt_scanner.models.model_manager import (
     ClassifierResult,
     ModelManager,
 )
 from agent_sec_cli.prompt_scanner.result import ThreatType
-from torch.nn.functional import softmax
 
 log = logging.getLogger(__name__)
 
@@ -176,6 +174,9 @@ class PromptGuardClassifier:
             return []
         model, tokenizer = self._manager.load_model(self._model_name)
 
+        import torch  # lazy import: only needed when actually running ML inference
+        from torch.nn.functional import softmax  # lazy import
+
         with self._inference_lock:
             preprocessed = [self._preprocess(t, tokenizer) for t in texts]
             inputs = tokenizer(
@@ -228,6 +229,9 @@ class PromptGuardClassifier:
 
     def _get_probabilities(self, text: str, model: object, tokenizer: object) -> object:
         """Run a single forward pass and return the softmax probability tensor."""
+        import torch  # lazy import: only needed when actually running ML inference
+        from torch.nn.functional import softmax  # lazy import
+
         preprocessed = self._preprocess(text, tokenizer)
         inputs = tokenizer(  # type: ignore[operator]
             preprocessed,

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_ml_classifier.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_ml_classifier.py
@@ -193,9 +193,7 @@ class TestModelManagerDeviceDetect(unittest.TestCase):
         )
 
         fake_torch = _make_fake_torch(cuda=False, mps=False)
-        with patch(
-            "agent_sec_cli.prompt_scanner.models.model_manager.torch", fake_torch
-        ):
+        with patch.dict(sys.modules, {"torch": fake_torch}):
             self.assertEqual(ModelManager.detect_device(), "cpu")
 
     def test_returns_cuda_when_available(self) -> None:
@@ -204,9 +202,7 @@ class TestModelManagerDeviceDetect(unittest.TestCase):
         )
 
         fake_torch = _make_fake_torch(cuda=True, mps=False)
-        with patch(
-            "agent_sec_cli.prompt_scanner.models.model_manager.torch", fake_torch
-        ):
+        with patch.dict(sys.modules, {"torch": fake_torch}):
             self.assertEqual(ModelManager.detect_device(), "cuda")
 
     def test_returns_mps_when_cuda_unavailable(self) -> None:
@@ -215,9 +211,7 @@ class TestModelManagerDeviceDetect(unittest.TestCase):
         )
 
         fake_torch = _make_fake_torch(cuda=False, mps=True)
-        with patch(
-            "agent_sec_cli.prompt_scanner.models.model_manager.torch", fake_torch
-        ):
+        with patch.dict(sys.modules, {"torch": fake_torch}):
             self.assertEqual(ModelManager.detect_device(), "mps")
 
     def test_returns_cpu_when_neither(self) -> None:
@@ -226,9 +220,7 @@ class TestModelManagerDeviceDetect(unittest.TestCase):
         )
 
         fake_torch = _make_fake_torch(cuda=False, mps=False)
-        with patch(
-            "agent_sec_cli.prompt_scanner.models.model_manager.torch", fake_torch
-        ):
+        with patch.dict(sys.modules, {"torch": fake_torch}):
             self.assertEqual(ModelManager.detect_device(), "cpu")
 
 
@@ -270,8 +262,10 @@ class TestModelManagerCache(unittest.TestCase):
         )
 
         mgr = ModelManager(device="cpu")
-        with patch.dict(
-            sys.modules, {"torch": None, "transformers": None, "modelscope": None}
+        with patch.object(
+            mgr,
+            "_do_load",
+            side_effect=ModelLoadError("Missing ML dependencies"),
         ):
             with self.assertRaises(ModelLoadError):
                 mgr.load_model("some-model")


### PR DESCRIPTION
- Defer torch, transformers, and modelscope imports to function scope
- Lazy device detection on first access instead of at initialization
- Update test mocking strategy to use patch.dict(sys.modules)

This avoids ~2-3s startup overhead for subcommands like code-scan that don't require ML inference.

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [x] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
