### PR TITLE
feat(cosh): implement `ask` decision for UserPromptSubmit hook

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1586,4 +1586,10 @@ export default {
   'Login (subcommand help)': '  login <token>           Login to clawhub',
   'Show identity (subcommand help)':
     '  whoami                  Show current identity',
+
+  // ============================================================================
+  // Hook dialogs
+  // ============================================================================
+  '⚠️  **Hook Safety Check**': '⚠️  **Hook Safety Check**',
+  'Send this prompt or cancel?': 'Send this prompt or cancel?',
 };

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -1407,4 +1407,10 @@ export default {
   'View details (subcommand help)': '  inspect <slug>          查看技能详情',
   'Login (subcommand help)': '  login <token>           登录 clawhub',
   'Show identity (subcommand help)': '  whoami                  显示当前身份',
+
+  // ============================================================================
+  // Hook dialogs
+  // ============================================================================
+  '⚠️  **Hook Safety Check**': '⚠️  **Hook 安全检查提示**',
+  'Send this prompt or cancel?': '是否继续发送这条 prompt？',
 };

--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -733,6 +733,7 @@ export const AppContainer = (props: AppContainerProps) => {
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    userPromptConfirmationRequest,
     sandboxBypassRequest,
   } = useGeminiStream(
     config.getGeminiClient(),
@@ -1428,6 +1429,7 @@ export const AppContainer = (props: AppContainerProps) => {
     settingInputRequests.length > 0 ||
     pluginChoiceRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
+    !!userPromptConfirmationRequest ||
     !!sandboxBypassRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
@@ -1490,6 +1492,7 @@ export const AppContainer = (props: AppContainerProps) => {
       settingInputRequests,
       pluginChoiceRequests,
       loopDetectionConfirmationRequest,
+      userPromptConfirmationRequest,
       sandboxBypassRequest,
       geminiMdFileCount,
       streamingState,
@@ -1589,6 +1592,7 @@ export const AppContainer = (props: AppContainerProps) => {
       settingInputRequests,
       pluginChoiceRequests,
       loopDetectionConfirmationRequest,
+      userPromptConfirmationRequest,
       sandboxBypassRequest,
       geminiMdFileCount,
       streamingState,

--- a/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
@@ -53,6 +53,7 @@ import { AgentCreationWizard } from './subagents/create/AgentCreationWizard.js';
 import { AgentsManagerDialog } from './subagents/manage/AgentsManagerDialog.js';
 import { SkillsDialog } from './SkillsDialog.js';
 import { SessionPicker } from './SessionPicker.js';
+import { t } from '../../i18n/index.js';
 import {
   readOpenClawConfig,
   readQwenCodeConfig,
@@ -198,6 +199,16 @@ export const DialogManager = ({
     return (
       <LoopDetectionConfirmation
         onComplete={uiState.loopDetectionConfirmationRequest.onComplete}
+      />
+    );
+  }
+  if (uiState.userPromptConfirmationRequest) {
+    const { reason, resolve } = uiState.userPromptConfirmationRequest;
+    return (
+      <ConsentPrompt
+        prompt={`${t('⚠️  **Hook Safety Check**')}\n\n${reason}\n\n${t('Send this prompt or cancel?')}`}
+        onConfirm={resolve}
+        terminalWidth={terminalWidth}
       />
     );
   }

--- a/src/copilot-shell/packages/cli/src/ui/components/Footer.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/Footer.test.tsx
@@ -169,6 +169,7 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
     settingInputRequests: [],
     pluginChoiceRequests: [],
     loopDetectionConfirmationRequest: null,
+    userPromptConfirmationRequest: null,
     sandboxBypassRequest: null,
     streamingState: 'idle',
     initError: null,

--- a/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -12,6 +12,7 @@ import type {
   ShellConfirmationRequest,
   ConfirmationRequest,
   LoopDetectionConfirmationRequest,
+  UserPromptConfirmationRequest,
   SandboxBypassRequest,
   HistoryItemWithoutId,
   StreamingState,
@@ -68,6 +69,7 @@ export interface UIState {
   settingInputRequests: SettingInputRequest[];
   pluginChoiceRequests: PluginChoiceRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
+  userPromptConfirmationRequest: UserPromptConfirmationRequest | null;
   sandboxBypassRequest: SandboxBypassRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -3089,4 +3089,232 @@ describe('useGeminiStream', () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // UserPromptSubmit ask decision
+  // ---------------------------------------------------------------------------
+  describe('UserPromptSubmit ask decision', () => {
+    /**
+     * Build a mock sendMessageStream that:
+     * 1. Yields a UserPromptConfirmation event with a captured resolver.
+     * 2. Awaits the resolver (or the abort signal) before yielding more events.
+     *
+     * The test drives the flow by calling getCapturedResolve()(true/false),
+     * or by calling cancelOngoingRequest() which fires the abort signal.
+     */
+    function makeMockAskStream(reason = 'Prompt reviewed and approved') {
+      let capturedEventResolve: ((confirmed: boolean) => void) | null = null;
+
+      const setupMock = () => {
+        mockSendMessageStream.mockImplementation(
+          (_query: unknown, signal: AbortSignal) =>
+            (async function* () {
+              // Deferred promise that the test resolves via the event callback.
+              let resolveDeferred!: (confirmed: boolean) => void;
+              const deferredPromise = new Promise<boolean>((res) => {
+                resolveDeferred = res;
+              });
+
+              // Abort races with the user's choice — mirrors the real client.ts logic.
+              const abortPromise = new Promise<boolean>((res) => {
+                if (signal.aborted) {
+                  res(false);
+                  return;
+                }
+                signal.addEventListener('abort', () => res(false), {
+                  once: true,
+                });
+              });
+
+              capturedEventResolve = (confirmed: boolean) =>
+                resolveDeferred(confirmed);
+
+              yield {
+                type: ServerGeminiEventType.UserPromptConfirmation,
+                value: { reason, resolve: capturedEventResolve },
+              };
+
+              const confirmed = await Promise.race([
+                deferredPromise,
+                abortPromise,
+              ]);
+
+              if (confirmed) {
+                yield {
+                  type: ServerGeminiEventType.Content,
+                  value: 'AI response after confirmation',
+                };
+                yield {
+                  type: ServerGeminiEventType.Finished,
+                  value: { reason: 'STOP', usageMetadata: undefined },
+                };
+              } else {
+                yield { type: ServerGeminiEventType.UserCancelled };
+              }
+            })(),
+        );
+      };
+
+      return { setupMock, getCapturedResolve: () => capturedEventResolve };
+    }
+
+    it('should set userPromptConfirmationRequest when UserPromptConfirmation event is received', async () => {
+      const { setupMock, getCapturedResolve } = makeMockAskStream();
+      setupMock();
+
+      const { result } = renderTestHook();
+
+      // Fire off without awaiting — generator pauses at confirmation.
+      result.current.submitQuery('test query with ask keyword');
+
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).not.toBeNull();
+        expect(result.current.userPromptConfirmationRequest?.reason).toBe(
+          'Prompt reviewed and approved',
+        );
+        expect(
+          typeof result.current.userPromptConfirmationRequest?.resolve,
+        ).toBe('function');
+      });
+
+      // Clean up: resolve false to let the generator terminate.
+      await act(async () => {
+        getCapturedResolve()!(false);
+      });
+    });
+
+    it('should clear userPromptConfirmationRequest and continue when user confirms', async () => {
+      const { setupMock, getCapturedResolve } = makeMockAskStream();
+      setupMock();
+
+      const { result } = renderTestHook();
+
+      result.current.submitQuery('test query');
+
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).not.toBeNull();
+      });
+
+      // User confirms: call the wrapped resolver exposed by the hook state.
+      await act(async () => {
+        result.current.userPromptConfirmationRequest?.resolve(true);
+      });
+
+      // Dialog must be cleared.
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).toBeNull();
+      });
+
+      // The underlying event resolver must have been forwarded (captured).
+      expect(getCapturedResolve()).not.toBeNull();
+
+      // Content after confirmation should be added to history.
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'gemini',
+            text: 'AI response after confirmation',
+          }),
+          expect.any(Number),
+        );
+      });
+    });
+
+    it('should clear userPromptConfirmationRequest and handle UserCancelled when user rejects', async () => {
+      const { setupMock } = makeMockAskStream();
+      setupMock();
+
+      const { result } = renderTestHook();
+
+      result.current.submitQuery('test query');
+
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).not.toBeNull();
+      });
+
+      // User rejects: call resolve(false) via the hook state wrapper.
+      await act(async () => {
+        result.current.userPromptConfirmationRequest?.resolve(false);
+      });
+
+      // Dialog cleared.
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).toBeNull();
+      });
+
+      // UserCancelled path produces an info message.
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'info' }),
+          expect.any(Number),
+        );
+      });
+    });
+
+    it('should clear userPromptConfirmationRequest immediately when cancelOngoingRequest is called', async () => {
+      const { setupMock } = makeMockAskStream();
+      setupMock();
+
+      const { result } = renderTestHook();
+
+      result.current.submitQuery('test query');
+
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).not.toBeNull();
+      });
+
+      // ESC / cancel button — clears dialog AND fires abort signal.
+      await act(async () => {
+        result.current.cancelOngoingRequest();
+      });
+
+      // Dialog gone immediately.
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).toBeNull();
+      });
+
+      // Abort unblocks the generator → UserCancelled → info message.
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'info' }),
+          expect.any(Number),
+        );
+      });
+    });
+
+    it('should not reopen the dialog if stale resolve is called after cancel', async () => {
+      const { setupMock } = makeMockAskStream();
+      setupMock();
+
+      const { result } = renderTestHook();
+
+      result.current.submitQuery('test query');
+
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).not.toBeNull();
+      });
+
+      // Capture the resolver before cancelling.
+      const staleResolve =
+        result.current.userPromptConfirmationRequest?.resolve;
+      expect(staleResolve).toBeDefined();
+
+      // Cancel clears the dialog.
+      await act(async () => {
+        result.current.cancelOngoingRequest();
+      });
+
+      await waitFor(() => {
+        expect(result.current.userPromptConfirmationRequest).toBeNull();
+      });
+
+      // Calling the stale resolve AFTER cancel must NOT reopen the dialog.
+      await act(async () => {
+        staleResolve!(true);
+      });
+
+      // State stays null.
+      expect(result.current.userPromptConfirmationRequest).toBeNull();
+    });
+  });
 });

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -44,6 +44,7 @@ import type {
   HistoryItemToolGroup,
   SlashCommandProcessorResult,
   SandboxBypassRequest,
+  UserPromptConfirmationRequest,
 } from '../types.js';
 import { StreamingState, MessageType, ToolCallStatus } from '../types.js';
 import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
@@ -156,6 +157,9 @@ export const useGeminiStream = (
 
   const [sandboxBypassRequest, setSandboxBypassRequest] =
     useState<SandboxBypassRequest | null>(null);
+
+  const [userPromptConfirmationRequest, setUserPromptConfirmationRequest] =
+    useState<UserPromptConfirmationRequest | null>(null);
 
   const handleSandboxBypassRequested = useCallback(
     (request: SandboxBypassApprovalRequest): Promise<boolean> =>
@@ -307,6 +311,13 @@ export const useGeminiStream = (
     }
     turnCancelledRef.current = true;
     isSubmittingQueryRef.current = false;
+
+    // If a UserPromptSubmit 'ask' dialog is pending, clear it immediately so
+    // the UI is consistent before the abort signal unblocks the generator.
+    // The abort signal (fired below) will resolve the deferred Promise in
+    // client.ts via Promise.race, so no explicit resolve(false) is needed here.
+    setUserPromptConfirmationRequest(null);
+
     abortControllerRef.current?.abort();
 
     // Log API cancellation
@@ -938,6 +949,17 @@ export const useGeminiStream = (
             // AfterModel hook requested stop — agent loop is ended by client.ts.
             // No UI action needed here; just acknowledge the event.
             break;
+          case ServerGeminiEventType.UserPromptConfirmation:
+            // Hook returned 'ask' for UserPromptSubmit — show a confirmation
+            // dialog and resolve the deferred promise when user decides.
+            setUserPromptConfirmationRequest({
+              reason: event.value.reason,
+              resolve: (confirmed: boolean) => {
+                setUserPromptConfirmationRequest(null);
+                event.value.resolve(confirmed);
+              },
+            });
+            break;
           default: {
             // enforces exhaustive switch-case
             const unreachable: never = event;
@@ -1434,6 +1456,7 @@ export const useGeminiStream = (
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
+    userPromptConfirmationRequest,
     sandboxBypassRequest,
   };
 };

--- a/src/copilot-shell/packages/cli/src/ui/types.ts
+++ b/src/copilot-shell/packages/cli/src/ui/types.ts
@@ -425,6 +425,14 @@ export interface LoopDetectionConfirmationRequest {
   onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
 }
 
+/** Confirmation request for UserPromptSubmit hook 'ask' decisions. */
+export interface UserPromptConfirmationRequest {
+  /** The reason/message from the hook to display to the user. */
+  reason: string;
+  /** Resolve the deferred confirmation: true = proceed, false = cancel. */
+  resolve: (confirmed: boolean) => void;
+}
+
 export interface SandboxBypassRequest {
   /** The command that failed inside the sandbox */
   original_command: string;

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -34,6 +34,7 @@ import {
   Turn,
   type ChatCompressionInfo,
   type ServerGeminiStreamEvent,
+  type UserPromptConfirmationValue,
 } from './turn.js';
 
 // Services
@@ -539,6 +540,47 @@ export class GeminiClient {
           },
         };
         return new Turn(this.getChat(), prompt_id);
+      }
+
+      // Ask: pause the stream and wait for user confirmation before proceeding.
+      if (hookOutput?.isAskDecision()) {
+        const askReason =
+          hookOutput.reason ||
+          hookOutput.systemMessage ||
+          'Prompt reviewed and approved';
+        let resolveConfirmation!: (confirmed: boolean) => void;
+        const confirmationPromise = new Promise<boolean>((resolve) => {
+          resolveConfirmation = resolve;
+        });
+
+        // Race against the abort signal so that cancelOngoingRequest() always
+        // unblocks this await — even if the user never touches the dialog.
+        const abortPromise = new Promise<boolean>((resolve) => {
+          if (signal.aborted) {
+            resolve(false);
+            return;
+          }
+          signal.addEventListener('abort', () => resolve(false), {
+            once: true,
+          });
+        });
+
+        const confirmationValue: UserPromptConfirmationValue = {
+          reason: askReason,
+          resolve: resolveConfirmation,
+        };
+        yield {
+          type: GeminiEventType.UserPromptConfirmation,
+          value: confirmationValue,
+        };
+        const confirmed = await Promise.race([
+          confirmationPromise,
+          abortPromise,
+        ]);
+        if (!confirmed) {
+          yield { type: GeminiEventType.UserCancelled };
+          return new Turn(this.getChat(), prompt_id);
+        }
       }
 
       // Add additional context from hooks to the request

--- a/src/copilot-shell/packages/core/src/core/turn.ts
+++ b/src/copilot-shell/packages/core/src/core/turn.ts
@@ -66,6 +66,7 @@ export enum GeminiEventType {
   Retry = 'retry',
   HookSystemMessage = 'hook_system_message',
   AfterModelHookStop = 'after_model_hook_stop',
+  UserPromptConfirmation = 'user_prompt_confirmation',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -210,6 +211,18 @@ export type ServerGeminiAfterModelHookStopEvent = {
   type: GeminiEventType.AfterModelHookStop;
 };
 
+export interface UserPromptConfirmationValue {
+  /** The reason message displayed to the user (from the hook's reason/systemMessage). */
+  reason: string;
+  /** Resolve the deferred confirmation: true = proceed, false = cancel. */
+  resolve: (confirmed: boolean) => void;
+}
+
+export type ServerGeminiUserPromptConfirmationEvent = {
+  type: GeminiEventType.UserPromptConfirmation;
+  value: UserPromptConfirmationValue;
+};
+
 // The original union type, now composed of the individual types
 export type ServerGeminiStreamEvent =
   | ServerGeminiChatCompressedEvent
@@ -227,7 +240,8 @@ export type ServerGeminiStreamEvent =
   | ServerGeminiToolCallResponseEvent
   | ServerGeminiUserCancelledEvent
   | ServerGeminiSessionTokenLimitExceededEvent
-  | ServerGeminiRetryEvent;
+  | ServerGeminiRetryEvent
+  | ServerGeminiUserPromptConfirmationEvent;
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {


### PR DESCRIPTION
## Description

Implement the `ask` decision semantic for `UserPromptSubmit` hooks.

Previously, when a `UserPromptSubmit` hook returned `decision: "ask"`,
it was silently treated as `allow` with no user interaction. This PR
wires up the full confirmation flow: the stream generator pauses via a
deferred Promise, a `UserPromptConfirmation` event is yielded, the UI
renders a `ConsentPrompt` dialog, and the generator resumes only after
the user confirms or cancels.

A sample hook `hooks/prompt-safety-check.py` is also added to
demonstrate the feature — it triggers `ask` when the prompt contains
suspicious keywords (e.g. `ask`, `sudo`, `rm -rf`).

## Related Issue

close #327 

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

1. Register `hooks/prompt-safety-check.py` as a `UserPromptSubmit`
   hook in `settings.json`.
2. Send a prompt containing the word `ask` (or any keyword in the
   list).
3. Verify the `ConsentPrompt` dialog appears with the message
   "Prompt reviewed and approved".
4. Confirm → prompt proceeds to the model as normal.
5. Cancel → `UserCancelled` event is emitted; no message is sent.

TypeScript type check: `npx tsc --noEmit` passes in both `core` and
`cli` packages.

## Additional Notes

The deferred-Promise pattern mirrors the existing `sandboxBypassRequest`
flow: the async generator yields a `UserPromptConfirmation` event
(carrying a `resolve` callback), then awaits the promise. The UI calls
`resolve(true/false)` when the user decides, resuming the generator.