### PR TITLE
fix(tokenless): skip compression for skill and content-retrieval tools

### DIFF
--- a/src/tokenless/hooks/copilot-shell/README.md
+++ b/src/tokenless/hooks/copilot-shell/README.md
@@ -23,8 +23,9 @@ Intercept and optimize LLM interactions via copilot-shell hooks for **significan
 
 1. copilot-shell fires `PostToolUse` after every tool call completes.
 2. The hook reads the JSON payload from stdin (includes `tool_response`).
-3. Compresses the response via `tokenless compress-response`.
-4. Returns a JSON response with `suppressOutput: true` and the compressed content as `additionalContext`.
+3. Skip logic is applied: content-retrieval tools (Read, Glob, etc.) and skill files pass through uncompressed.
+4. Compresses the response via `tokenless compress-response`.
+5. Returns a JSON response with `suppressOutput: true` and the compressed content as `additionalContext`.
 
 ### Schema Compression (`tokenless-compress-schema.sh`)
 
@@ -142,6 +143,6 @@ echo '{"llm_request":{"tools":[{"name":"test","description":"A test tool","param
 | `rtk too old` warning | Upgrade: `cargo install rtk` |
 | Command not rewritten | Not all commands have RTK equivalents — check `rtk rewrite "cmd"` directly |
 | `tokenless not installed` warning | Build and install: `make install` |
-| Response not compressed | Responses shorter than 200 bytes are skipped (not worth compressing) |
+| Response not compressed | Responses shorter than 200 bytes, content-retrieval tools (Read, Glob, etc.), or skill files are skipped |
 | Schema compression not active | Expected — waiting for anolisa protocol to add `tools` to LLMRequest |
 | JSON parse error | Ensure the settings JSON is valid — use `jq . < settings.json` to validate |

--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# tokenless-hook-version: 1
-# Token-Less copilot-shell hook — compresses tool call responses to save ~26% response tokens.
-# Requires: tokenless, jq
+# tokenless-hook-version: 6
+# Token-Less copilot-shell hook — compresses tool call responses.
+# Stats are recorded automatically by tokenless compress-response.
+# Requires: jq
 #
 # Hook event: PostToolUse
 #
@@ -57,15 +58,41 @@ INPUT=$(cat || {
 TOOL_RESPONSE=$(echo "$INPUT" | jq -c '.tool_response // empty' 2>/dev/null || echo '')
 
 if [ -z "$TOOL_RESPONSE" ] || [ "$TOOL_RESPONSE" = "null" ] || [ "$TOOL_RESPONSE" = "{}" ]; then
-  # No response or empty response — nothing to compress.
   exit 0
 fi
 
-# --- Skip small responses (not worth compressing) ---
+# --- Skip content-retrieval tools ---
+# Tools that return content the agent explicitly requested must not be compressed
+# because truncation would make the content incomplete and unusable.
+SKIP_TOOLS="Read read_file Glob list_directory NotebookRead read glob notebookread"
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo 'unknown')
+
+if [ "$TOOL_NAME" != "unknown" ] && echo "$SKIP_TOOLS" | grep -qw "$TOOL_NAME"; then
+  exit 0
+fi
+
+# --- Skip small responses ---
 
 RESPONSE_LEN=${#TOOL_RESPONSE}
 if [ "$RESPONSE_LEN" -lt 200 ]; then
   exit 0
+fi
+
+# --- Skip skill files (YAML frontmatter markdown) ---
+# Skill files (.md with YAML frontmatter) must not be compressed because
+# truncation would break the skill metadata and make agent skills unusable.
+# Detection failure is intentionally non-fatal (fail-open): if detection
+# fails, we continue to compression rather than blocking the response.
+TOOL_RESPONSE_RAW=$(echo "$INPUT" | jq -r '.tool_response // empty' 2>/dev/null || echo '')
+if [ -n "$TOOL_RESPONSE_RAW" ]; then
+  case "$TOOL_RESPONSE_RAW" in
+    ---*)
+      # Extract first 20 lines and check for typical skill metadata fields
+      if echo "$TOOL_RESPONSE_RAW" | head -n 20 | grep -qE '^(name|description):'; then
+        exit 0
+      fi
+      ;;
+  esac
 fi
 
 # --- Compress response via tokenless ---

--- a/src/tokenless/openclaw/README.md
+++ b/src/tokenless/openclaw/README.md
@@ -44,6 +44,7 @@ All options are set via `openclaw.plugin.json` config or the OpenClaw UI:
 | `rtk_enabled` | boolean | `true` | Enable RTK command rewriting |
 | `schema_compression_enabled` | boolean | `true` | Enable tool schema compression |
 | `response_compression_enabled` | boolean | `true` | Enable tool response compression |
+| `skip_tools` | string[] | `["Read", "read_file", "Glob", "list_directory", "NotebookRead", "read", "glob", "notebookread"]` | Tool names whose responses should not be compressed |
 | `verbose` | boolean | `false` | Log detailed rewrite/compression info to console |
 
 ## Architecture

--- a/src/tokenless/openclaw/index.ts
+++ b/src/tokenless/openclaw/index.ts
@@ -35,6 +35,17 @@ function checkRtk(): boolean {
   return rtkAvailable;
 }
 
+function isSkillContent(message: any): boolean {
+  // Skill files (.md with YAML frontmatter) must not be compressed because
+  // truncation would break the skill metadata and make agent skills unusable.
+  if (typeof message !== "string") return false;
+  const trimmed = message.trimStart();
+  if (!trimmed.startsWith("---")) return false;
+  // Check the first few lines for typical skill metadata fields
+  const firstLines = trimmed.split("\n", 20).join("\n");
+  return /^name:/m.test(firstLines) || /^description:/m.test(firstLines);
+}
+
 function checkTokenless(): boolean {
   if (tokenlessAvailable !== null) return tokenlessAvailable;
   try {
@@ -109,6 +120,7 @@ export default {
   const rtkEnabled = pluginConfig.rtk_enabled !== false;
   const schemaCompressionEnabled = pluginConfig.schema_compression_enabled !== false;
   const responseCompressionEnabled = pluginConfig.response_compression_enabled !== false;
+  const skipTools: Set<string> = new Set((pluginConfig.skip_tools ?? ["Read", "read_file", "Glob", "list_directory", "NotebookRead"]).map((t: string) => t.toLowerCase()));
   const verbose = pluginConfig.verbose !== false;
 
   // ---- 1. RTK command rewriting (before_tool_call) ----------------------------
@@ -167,6 +179,12 @@ export default {
         // Skip exec tool results when RTK is enabled — RTK already produces
         // optimized output, double-compression is wasteful.
         if (rtkEnabled && rtkAvailable && event.toolName === "exec") return;
+
+        // Skip content-retrieval tools — agent needs complete responses
+        if (event.toolName && skipTools.has(event.toolName.toLowerCase())) return;
+
+        // Skip skill content to avoid breaking YAML frontmatter metadata.
+        if (isSkillContent(event.message)) return;
 
         const compressed = tryCompressResponse(event.message);
         if (!compressed) return;

--- a/src/tokenless/openclaw/openclaw.plugin.json
+++ b/src/tokenless/openclaw/openclaw.plugin.json
@@ -9,6 +9,11 @@
       "rtk_enabled": { "type": "boolean", "default": true },
       "schema_compression_enabled": { "type": "boolean", "default": true },
       "response_compression_enabled": { "type": "boolean", "default": true },
+      "skip_tools": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["Read", "read_file", "Glob", "list_directory", "NotebookRead", "read", "glob", "notebookread"]
+      },
       "verbose": { "type": "boolean", "default": false }
     }
   },
@@ -16,6 +21,7 @@
     "rtk_enabled": { "label": "Enable RTK command rewriting" },
     "schema_compression_enabled": { "label": "Enable schema compression" },
     "response_compression_enabled": { "label": "Enable response compression" },
+    "skip_tools": { "label": "Tool names whose responses should not be compressed" },
     "verbose": { "label": "Verbose logging" }
   }
 }

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 3
+%define anolis_release 4
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -111,6 +111,13 @@ if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
 fi
 
 %changelog
+* Sat Apr 25 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-4
+- Fix: skip compression for content-retrieval tools and skill files
+  - Added tool-name-based skip list: Read, read_file, Glob, list_directory, NotebookRead
+  - Added skill file (YAML frontmatter) detection to avoid breaking metadata
+  - Configurable via skip_tools in OpenClaw plugin and SKIP_TOOLS in copilot-shell hook
+  - Fail-open design: original response passes through on any error path
+
 * Sat Apr 11 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-3
 - Fix: Response compression not working issue
   - Fixed `tokenless compress-response` command not taking effect


### PR DESCRIPTION
    fix(tokenless): skip compression for skill and content-retrieval tools

    Content-retrieval tools (Read, Glob, etc.) return content the agent
    explicitly requested — truncating these responses makes them incomplete.
    Skill files with YAML frontmatter also break when truncated.

    Add tool-name-based skip list as the primary filter (cheapest, most
    reliable), with skill content detection as a fallback. Configurable via
    skip_tools in both OpenClaw plugin and copilot-shell hook.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes #331


## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless`(tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```code
  测试覆盖 (9 个分类, 59 个用例)

  ┌──────────────────┬─────────────────────────────────────────────────────────────┬───────┐
  │       分类       │                            描述                             │ 结果  │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ A. 环境完整性    │ 二进制、hook、插件文件、jq 可用性                           │ 7/7   │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ B. 插件配置      │ skip_tools 配置项、默认值、类型                             │ 7/7   │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ C. 源代码分析    │ isSkillContent、skipTools Set、RTK skip                     │ 7/7   │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ D. Hook 脚本分析 │ SKIP_TOOLS、grep -qw、阈值、Skill 检测                      │ 10/10 │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ E. 运行时功能    │ Read/Glob/NotebookRead 跳过、Bash/Write 压缩、Skill/MD/JSON │ 13/13 │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ F. 安全性测试    │ ReadFile/Globals 部分匹配、大小写                           │ 4/4   │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ G. 二进制测试    │ compress-response、rtk rewrite                              │ 4/4   │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ H. 边界压力      │ 100KB、阈值边界、100KB Skill                                │ 4/4   │
  ├──────────────────┼─────────────────────────────────────────────────────────────┼───────┤
  │ I. Node 模块加载 │ JS 编译、JSON 格式有效性                                    │ 3/3   │
  └──────────────────┴─────────────────────────────────────────────────────────────┴───────┘

  全量测试结果汇总
  ┌────────────────┬─────────────────────────┬───────┐
  │      层级      │        测试类型         │ 结果  │
  ├────────────────┼─────────────────────────┼───────┤
  │ Hook 运行时    │ copilot-shell bash 脚本 │ 59/59 │
  ├────────────────┼─────────────────────────┼───────┤
  │ OpenClaw 插件  │ Node.js 直接加载模拟    │ 17/17 │
  ├────────────────┼─────────────────────────┼───────┤
  │ openclaw agent │ 真实 LLM 端到端调用     │ PASS  │
  └────────────────┴─────────────────────────┴───────┘
```

  关键功能验证确认

  - 内容检索工具 (Read, read_file, Glob, list_directory, NotebookRead) → 全部正确跳过压缩
  - 普通工具 (Bash, Write) → 正确执行压缩
  - Skill 文件 (YAML frontmatter 含 name/description) → 正确跳过
  - Markdown 普通分隔线 (---但无 skill 字段) → 正确压缩
  - 部分匹配防护 (ReadFile 不误匹配 Read, Globals 不误匹配 Glob) → grep -qw 生效
  - 阈值边界 (JSON 表示 < 200 byte 跳过, >= 200 byte 压缩) → 正确