### PR TITLE
fix(cosh): skip api key validation for non-dashscope providers

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1042,8 +1042,8 @@ export default {
   'Invalid auth method selected.': 'Invalid auth method selected.',
   'Failed to authenticate. Message: {{message}}':
     'Failed to authenticate. Message: {{message}}',
-  'Authenticated successfully with {{authType}} credentials.':
-    'Authenticated successfully with {{authType}} credentials.',
+  '{{authType}} credentials saved successfully.':
+    '{{authType}} credentials saved successfully.',
   // OpenAI API key validation errors
   'Invalid API key. Please check your API key and try again.':
     'Invalid API key. Please check your API key and try again.',

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -987,8 +987,8 @@ export default {
     '未找到 ANTHROPIC_BASE_URL 环境变量。',
   'Invalid auth method selected.': '选择了无效的认证方式。',
   'Failed to authenticate. Message: {{message}}': '认证失败。消息：{{message}}',
-  'Authenticated successfully with {{authType}} credentials.':
-    '使用 {{authType}} 凭据成功认证。',
+  '{{authType}} credentials saved successfully.':
+    '{{authType}} 认证方式凭据已保存。',
   // OpenAI API key validation errors
   'Invalid API key. Please check your API key and try again.':
     '无效的 API 密钥。请检查您的 API 密钥并重试。',

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -223,7 +223,7 @@ export const useAuthCommand = (
       addItem(
         {
           type: MessageType.INFO,
-          text: t('Authenticated successfully with {{authType}} credentials.', {
+          text: t('{{authType}} credentials saved successfully.', {
             authType,
           }),
         },

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.test.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.test.ts
@@ -264,6 +264,57 @@ describe('OpenAIContentGenerator (Refactored)', () => {
         'Authentication failed: Network connection failed',
       );
     });
+
+    it('should skip validation for non-DashScope providers', async () => {
+      // Create a generator with a custom (non-DashScope) baseUrl
+      const customConfig = {
+        model: 'custom-model',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.custom-provider.com/v1',
+        authType: AuthType.USE_OPENAI,
+        enableOpenAILogging: false,
+        timeout: 120000,
+        maxRetries: 3,
+        samplingParams: {
+          temperature: 0.7,
+          max_tokens: 1000,
+          top_p: 0.9,
+        },
+      };
+      const modelsRetrieve = vi.fn();
+      const mockProvider: OpenAICompatibleProvider = {
+        buildHeaders: vi.fn().mockReturnValue({}),
+        buildClient: vi.fn().mockReturnValue({
+          chat: { completions: { create: vi.fn() } },
+          embeddings: { create: vi.fn() },
+          models: { retrieve: modelsRetrieve },
+        } as unknown as OpenAI),
+        buildRequest: vi.fn().mockImplementation((req) => req),
+        getDefaultGenerationConfig: vi.fn().mockReturnValue({}),
+      };
+      const customGenerator = new OpenAIContentGenerator(
+        customConfig,
+        mockConfig,
+        mockProvider,
+      );
+
+      // Should resolve immediately without calling models.retrieve
+      await expect(customGenerator.validateApiKey()).resolves.toBeUndefined();
+      expect(modelsRetrieve).not.toHaveBeenCalled();
+    });
+
+    it('should still validate for DashScope providers', async () => {
+      // Default generator has no baseUrl, which isDashScopeProvider returns true for
+      mockOpenAIClient.models.retrieve.mockResolvedValue({
+        id: 'gpt-4',
+        object: 'model',
+        created: 1234567890,
+        owned_by: 'dashscope',
+      });
+
+      await expect(generator.validateApiKey()).resolves.toBeUndefined();
+      expect(mockOpenAIClient.models.retrieve).toHaveBeenCalledWith('gpt-4');
+    });
   });
 
   describe('shouldSuppressErrorLogging', () => {

--- a/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.ts
+++ b/src/copilot-shell/packages/core/src/core/openaiContentGenerator/openaiContentGenerator.ts
@@ -1,6 +1,9 @@
 import type { ContentGenerator } from '../contentGenerator.js';
 import type { Config } from '../../config/config.js';
-import { type OpenAICompatibleProvider } from './provider/index.js';
+import {
+  DashScopeOpenAICompatibleProvider,
+  type OpenAICompatibleProvider,
+} from './provider/index.js';
 import type {
   CountTokensParameters,
   CountTokensResponse,
@@ -73,9 +76,15 @@ export class OpenAIContentGenerator implements ContentGenerator {
    * @returns Promise<void> - resolves if both valid, rejects if either invalid
    */
   async validateApiKey(): Promise<void> {
+    // Only validate for DashScope providers; custom providers may not support /v1/models endpoint
+    const cgConfig = this.pipeline.getContentGeneratorConfig();
+    if (!DashScopeOpenAICompatibleProvider.isDashScopeProvider(cgConfig)) {
+      return;
+    }
+
     try {
       const openai = this.pipeline.getProvider().buildClient();
-      const model = this.pipeline.getContentGeneratorConfig().model;
+      const model = cgConfig.model;
 
       // Use models.retrieve() to directly check if the specific model exists
       // This avoids pagination issues with models.list() when providers have many models


### PR DESCRIPTION
## Description

When using a custom (non-DashScope) provider with correct API key, base URL, and model, authentication fails because `validateApiKey()` calls the `/v1/models/{model}` endpoint which many custom providers do not implement. This fix adds a provider check inside `OpenAIContentGenerator.validateApiKey()` to only perform the pre-check for DashScope providers, skipping it for all other OpenAI-compatible providers where this endpoint may not be available.

## Related Issue

closes #336

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run build && npm run test && npm run lint && npm run typecheck
# All checks pass: 217 cli test files (3412 passed), all core tests passed including 2 new tests for validateApiKey DashScope/non-DashScope behavior
```

## Additional Notes

- The `DashScopeOpenAICompatibleProvider.isDashScopeProvider()` method already existed and is reused to gate the validation
- Existing tests for DashScope validation continue to pass unchanged
- Two new tests added: one verifying skip for custom providers, one explicitly verifying DashScope still validates
