### PR TITLE
fix(cosh): limit validateapikey to dashscope_providers

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -241,11 +241,22 @@ export const useAuthCommand = (
 
         // Validate API key for OpenAI auth by making a lightweight API call
         // This validates both new credentials and existing saved credentials
+        // TEMPORARY: Only validate for DashScope (compatible-mode), skip for other providers
+        // TODO: Add validation for other providers once we verify their API compatibility
         if (authType === AuthType.USE_OPENAI) {
           const contentGenerator = config.getContentGenerator();
-          // Check if validateApiKey method exists (it's optional on ContentGenerator interface)
-          // LoggingContentGenerator wraps OpenAIContentGenerator, so we check the method existence
+          const contentGeneratorConfig = config.getContentGeneratorConfig();
+
+          // Check if this is DashScope compatible-mode provider
+          const baseUrl = contentGeneratorConfig?.baseUrl;
+          const isDashScopeCompatibleMode =
+            baseUrl &&
+            baseUrl.includes('dashscope.aliyuncs.com') &&
+            baseUrl.includes('compatible-mode');
+
+          // Only validate for DashScope compatible-mode - other providers skip validation temporarily
           if (
+            isDashScopeCompatibleMode &&
             contentGenerator &&
             typeof contentGenerator.validateApiKey === 'function'
           ) {


### PR DESCRIPTION
## Description

Limit validateApiKey to DashScope compatible-mode providers only.Other providers' API compatibility is pending
verification.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->
- Test DashScope compatible-mode (should validate):
Provider: DashScope › China (Aliyun)
Base URL: https://dashscope.aliyuncs.com/compatible-mode/v1
Enter valid API key and model (e.g., qwen-plus)
Expected: ✅ Authentication succeeds (validateApiKey called)
- Test DashScope Coding Plan (should skip validation):
Provider: DashScope Coding Plan › China (Aliyun)
Base URL: https://coding.dashscope.aliyuncs.com/v1
Enter API key and model
Expected: ✅ Authentication succeeds (validateApiKey skipped, no 405 error)
- Test other providers (should skip validation):
Provider: DeepSeek / GLM / Kimi / MiniMax / Custom URL
Enter any API key and model
Expected: ✅ Authentication succeeds (validateApiKey skipped)
- Test invalid API key on DashScope compatible-mode:
Enter invalid/wrong API key
Expected: ❌ Authentication fails with error message

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
