### PR TITLE
fix(sec-core): unify prompt scanner response to use "ask" instead of "block"

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/model_manager.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/model_manager.py
@@ -1,19 +1,17 @@
 """Model manager – lazy loading, caching, and device selection.
 
-Model download strategy
------------------------
-Models are downloaded via **ModelScope SDK** (``modelscope.snapshot_download``)
-rather than HuggingFace Hub directly.  This is the preferred approach for
-production deployments in mainland China where HuggingFace may be slow or
-unavailable.  The downloaded model path is then loaded with ``transformers``
-``AutoModel`` / ``AutoTokenizer`` as usual.
+Models are downloaded separately via ``download_model`` (e.g. ``scan-prompt warmup``)
+and loaded on demand by ``load_model``.  Loading uses ``transformers``
+``AutoTokenizer`` / ``AutoModelForSequenceClassification`` from the local cache.
 
-ModelScope mirror IDs for Llama Prompt Guard 2:
+ModelScope model IDs for Llama Prompt Guard 2:
     22M fast model : ``LLM-Research/Llama-Prompt-Guard-2-22M``
     86M accurate   : ``LLM-Research/Llama-Prompt-Guard-2-86M``
 """
 
+import contextlib
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -72,21 +70,54 @@ class ModelManager:
     # Public API
     # ------------------------------------------------------------------
 
+    def download_model(self, model_name: str) -> str:
+        """Download a model via ModelScope and return the local path.
+
+        Progress output (tqdm bars) is **visible** — intended for the
+        ``warmup`` CLI command where users expect to see download progress.
+
+        Idempotent: if the model is already cached locally, ModelScope
+        returns immediately from the file-system cache.
+
+        Args:
+            model_name: ModelScope model ID, e.g.
+                ``"LLM-Research/Llama-Prompt-Guard-2-86M"``.
+
+        Returns:
+            Absolute path to the local model directory.
+
+        Raises:
+            ModelLoadError: if the download fails.
+        """
+        from modelscope import snapshot_download
+
+        cache_dir = Path(self._cache_dir).expanduser()
+        try:
+            return snapshot_download(model_name, cache_dir=str(cache_dir))
+        except Exception as exc:
+            raise ModelLoadError(
+                f"ModelScope download failed for '{model_name}': {exc}"
+            ) from exc
+
     def load_model(self, model_name: str) -> tuple[object, object]:
         """Return a cached ``(model, tokenizer)`` pair, loading on demand.
 
         Thread-safe: concurrent calls for the same model will block on the
         lock and reuse the result of the first successful load.
 
+        The model **must** have been downloaded beforehand (e.g. via
+        ``scan-prompt warmup``).  If it is not present locally, a
+        ``ModelLoadError`` is raised with instructions to run warmup.
+
         Args:
-            model_name: HuggingFace model identifier or local path.
+            model_name: ModelScope model identifier.
 
         Returns:
             ``(model, tokenizer)`` tuple ready for inference.
 
         Raises:
             agent_sec_cli.prompt_scanner.exceptions.ModelLoadError: if the
-                model cannot be loaded (missing deps, download failure, etc.).
+                model cannot be loaded (missing deps, not downloaded, etc.).
         """
         # Fast path: model already loaded (no lock needed for dict reads under GIL).
         if model_name in self._loaded_models:
@@ -120,7 +151,7 @@ class ModelManager:
         return self._device_cached
 
     # ------------------------------------------------------------------
-    # Device detection
+    # Internal
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -138,67 +169,69 @@ class ModelManager:
         return "cpu"
 
     # ------------------------------------------------------------------
-    # Internal
-    # ------------------------------------------------------------------
 
-    def _do_load(self, model_name: str) -> tuple[object, object]:
-        """Download (via ModelScope) and load a model+tokenizer, then move to device.
-
-        Download flow
-        -------------
-        1. Try ``modelscope.snapshot_download`` to get a local model path.
-           The model is cached under ``self._cache_dir`` (default:
-           ``~/.cache/prompt_scanner/models``); subsequent calls return
-           immediately from cache.
-        2. Load the local path with ``transformers`` ``AutoModelForSequenceClassification``
-           and ``AutoTokenizer``.
-        3. Move the model to the target device and set ``eval()`` mode.
-
-        Args:
-            model_name: ModelScope model ID, e.g.
-                ``"LLM-Research/Llama-Prompt-Guard-2-86M"``.
+    def _resolve_local_model_path(self, model_name: str) -> str:
+        """Return the local cache path for *model_name* without triggering a download.
 
         Raises:
-            ModelLoadError: missing deps, download failure, or load failure.
+            ModelLoadError: if the model has not been downloaded yet, with a
+                user-friendly message pointing to ``scan-prompt warmup``.
         """
-        log.info(
-            "Downloading model '%s' via ModelScope (cached after first run).",
-            model_name,
+        cache_dir = Path(self._cache_dir).expanduser()
+        candidate = cache_dir / Path(model_name)
+
+        if candidate.is_dir() and (candidate / "config.json").exists():
+            return str(candidate)
+
+        raise ModelLoadError(
+            f"Model '{model_name}' is not available locally.\n"
+            "Please run the following command to download it first:\n"
+            "  agent-sec-cli scan-prompt warmup"
         )
 
-        import torch  # lazy import: only needed when actually running ML inference
-        from modelscope import snapshot_download  # lazy import
-        from transformers import (  # lazy import
+    def _do_load(self, model_name: str) -> tuple[object, object]:
+        """Load a model+tokenizer from the local cache (no download).
+
+        Raises ``ModelLoadError`` with a warmup hint if the model is not
+        present on disk.  All transformers output is suppressed unless
+        ``AGENT_SEC_DEBUG=1`` is set.
+        """
+        import torch
+        from transformers import (
             AutoModelForSequenceClassification,
             AutoTokenizer,
         )
 
-        cache_dir = Path(self._cache_dir).expanduser()
-        _ms_logger = logging.getLogger("modelscope")
-        _orig_level = _ms_logger.level
-        _ms_logger.setLevel(logging.ERROR)
-        try:
-            local_model_path = snapshot_download(model_name, cache_dir=str(cache_dir))
-        except Exception as exc:
-            raise ModelLoadError(
-                f"ModelScope download failed for '{model_name}': {exc}"
-            ) from exc
-        finally:
-            _ms_logger.setLevel(_orig_level)
+        local_model_path = self._resolve_local_model_path(model_name)
 
-        # --- load from local path ----------------------------------------
         log.info(
             "Loading model from '%s' onto device '%s'.", local_model_path, self.device
         )
+
+        tf_logger = logging.getLogger("transformers")
+        saved_level = tf_logger.level
         try:
-            tokenizer = AutoTokenizer.from_pretrained(local_model_path)
-            model = AutoModelForSequenceClassification.from_pretrained(local_model_path)
-            model.to(torch.device(self.device))
-            model.eval()
+            if os.environ.get("AGENT_SEC_DEBUG") != "1":
+                tf_logger.setLevel(logging.ERROR)
+            # Suppress stdout/stderr to silence tqdm progress bars and any
+            # hardcoded print() calls from transformers internals.
+            with open(os.devnull, "w") as _devnull, contextlib.redirect_stdout(
+                _devnull
+            ), contextlib.redirect_stderr(_devnull):
+                tokenizer = AutoTokenizer.from_pretrained(local_model_path)
+                model = AutoModelForSequenceClassification.from_pretrained(
+                    local_model_path
+                )
+        except ModelLoadError:
+            raise
         except Exception as exc:
             raise ModelLoadError(
                 f"Failed to load model from '{local_model_path}': {exc}"
             ) from exc
+        finally:
+            tf_logger.setLevel(saved_level)
 
+        model.to(torch.device(self.device))
+        model.eval()
         log.info("Model '%s' loaded successfully.", model_name)
         return model, tokenizer

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/prompt_guard.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/prompt_guard.py
@@ -128,13 +128,17 @@ class PromptGuardClassifier:
     # ------------------------------------------------------------------
 
     def warmup(self) -> None:
-        """Eagerly load the model into memory.
+        """Pre-download the model so that the first scan avoids a download.
 
-        Triggers ModelScope download (first run) and loads the model+tokenizer
-        into the shared ModelManager cache.  Subsequent calls are no-ops.
+        Only fetches model files to the local cache; does **not** load
+        the model into memory.  The actual load happens lazily on the
+        first ``classify`` / ``classify_batch`` call via ``load_model``.
+
+        Progress output (tqdm, modelscope print) is visible — this is
+        intended for the ``scan-prompt warmup`` CLI command.
         """
-        self._manager.load_model(self._model_name)
-        log.info("PromptGuardClassifier warmup complete for '%s'.", self._model_name)
+        self._manager.download_model(self._model_name)
+        log.info("Model '%s' downloaded to local cache.", self._model_name)
 
     def classify(self, text: str) -> ClassifierResult:
         """Classify a single prompt and return a ``ClassifierResult``.

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/scanner.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/scanner.py
@@ -66,17 +66,16 @@ class PromptScanner:
         self._detectors: list[DetectionLayer] = self._init_detectors()
 
     def warmup(self) -> None:
-        """Pre-load all ML models so the first scan has no cold-start delay.
+        """Pre-download all ML models so the first scan avoids a network fetch.
 
-        Call this once during service startup (or via ``scan-prompt warmup``
-        CLI command) to trigger ModelScope download and model load eagerly.
-        Has no effect for FAST mode (no ML models involved).
+        Only downloads model files to the local cache with **visible**
+        progress output.  Does **not** load models into memory — that
+        happens lazily on the first ``scan()`` call via ``load_model``
+        (silently, with ``_silent_ml_loading``).
 
-        Example::
+        Call this once after installation::
 
-            scanner = PromptScanner()   # STANDARD: L1 + L2
-            scanner.warmup()            # downloads / loads L2 model now
-            result = scanner.scan(text) # no cold-start delay
+            agent-sec-cli scan-prompt warmup
         """
         log.info("Warming up %d detector(s)...", len(self._detectors))
         for detector in self._detectors:

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -14,6 +14,19 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "prompt-scanner",
+            "command": "python3 ${extensionPath}/hooks/prompt_scanner_hook.py",
+            "description": "Scans user prompts for prompt injection and jailbreak attempts.",
+            "timeout": 10000
+          }
+        ]
+      }
     ]
   }
 }

--- a/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
@@ -47,26 +47,29 @@ def _format_cosh(scan_result: dict) -> str:
     Mapping:
         verdict == "pass"  -> decision "allow"
         verdict == "warn"  -> decision "ask"  (let user decide)
-        verdict == "deny"  -> decision "block" (reject the prompt)
+        verdict == "deny"  -> decision "ask"  (let user decide)
         otherwise          -> fail-open "allow"
     """
     verdict = scan_result.get("verdict", "pass")
-    findings = scan_result.get("findings", [])
 
     if verdict == "pass":
         return json.dumps({"decision": "allow"})
 
-    descs = [f"- {f.get('desc_zh', f.get('desc_en', ''))}" for f in findings]
-    msg = f"[prompt-scanner] Detected {len(findings)} issue(s):\n" + "\n".join(descs)
+    # Build reason from summary; it already contains threat type, confidence & evidence.
+    summary = scan_result.get("summary", "")
+    threat_type = scan_result.get("threat_type", "")
+    msg = f"[prompt-scanner] {summary or threat_type or 'Prompt rejected by security policy'}"
 
     if verdict == "warn":
         return json.dumps(
             {"decision": "ask", "reason": msg},
             ensure_ascii=False,
         )
+    # Use "ask" to avoid blocking users outright.
+    # TODO: switch to "block" once the policy is mature enough.
     if verdict == "deny":
         return json.dumps(
-            {"decision": "block", "reason": msg},
+            {"decision": "ask", "reason": msg},
             ensure_ascii=False,
         )
     # error or unknown -> fail-open

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -5,10 +5,21 @@
   "description": "Security hooks powered by agent-sec-cli",
   "extensions": ["./dist/index.js"],
   "configSchema": {
-    "capabilities": {
-      "type": "object",
-      "description": "各能力的启用/禁用和配置",
-      "default": {}
+    "type": "object",
+    "properties": {
+      "promptScanBlock": {
+        "type": "boolean",
+        "default": false,
+        "description": "检测到 DENY 时直接拦截请求，不转发给 LLM"
+      }
+
     }
+  },
+  "uiHints": {
+    "promptScanBlock": {
+      "label": "Prompt 扫描拦截模式",
+      "description": "检测到 DENY 时直接拦截请求，不转发给 LLM"
+    }
+
   }
 }

--- a/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
+++ b/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
@@ -38,5 +38,10 @@ echo "安装插件..."
 openclaw plugins install "$PLUGIN_DIR" --force --dangerously-force-unsafe-install
 
 echo "  ✓ 插件已安装/更新"
+
 echo ""
 echo "提示: 请重启 OpenClaw gateway 以加载插件"
+echo "  openclaw gateway restart"
+echo ""
+echo "拦截 prompt 注入风险请求"
+echo "  openclaw config set plugins.entries.agent-sec.config.promptScanBlock true"

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
@@ -41,20 +41,25 @@ export const promptScan: SecurityCapability = {
         const findings: any[] = scanResult.findings ?? [];
 
         if (verdict === "pass" || findings.length === 0) {
-          api.logger.info(`[prompt-scan] ✅ pass`);
+          api.logger.info(`[prompt-scan] pass`);
           return undefined;
         }
 
-        const descs = findings.map((f) => `- ${f.desc_zh ?? f.desc_en ?? ""}`);
-        const msg = `[prompt-scan] Detected ${findings.length} issue(s):\n${descs.join("\n")}`;
+        const summary: string = scanResult.summary ?? "";
+        const threatType: string = scanResult.threat_type ?? "";
+        const msg = `[prompt-scan] ${summary || threatType || "Prompt rejected by security policy"}`;
 
         if (verdict === "deny") {
-          api.logger.info(`[prompt-scan] 🚫 DENY — blocking user prompt`);
-          return { handled: true, text: msg };
+          api.logger.warn(`[prompt-scan] DENY — ${msg}`);
+          // handled: true + text → text sent as final reply, LLM call skipped
+          // handled: false + text → text ignored, event passes through to LLM
+          // Set PROMPT_SCAN_BLOCK=1 to enable blocking mode.
+          const blockEnabled = process.env["PROMPT_SCAN_BLOCK"] === "1";
+          return { handled: blockEnabled, text: msg };
         }
 
         if (verdict === "warn") {
-          api.logger.info(`[prompt-scan] ⚠️ WARN — passing user prompt with warning`);
+          api.logger.warn(`[prompt-scan] WARN — passing user prompt with warning`);
           return { handled: false, text: `[Security Warning] ${msg}` };
         }
 

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
@@ -20,7 +20,8 @@ export const promptScan: SecurityCapability = {
   name: "Prompt Injection Scanner",
   hooks: ["before_dispatch"],
   register(api) {
-    api.on("before_dispatch", async (event: any, ctx: any) => {
+    const cfg = (api.pluginConfig as Record<string, any>) ?? {};
+    api.on("before_dispatch", async (event: any) => {
       try {
         const text = String(event.content ?? event.body ?? "");
         if (!text.trim()) {
@@ -53,8 +54,9 @@ export const promptScan: SecurityCapability = {
           api.logger.warn(`[prompt-scan] DENY — ${msg}`);
           // handled: true + text → text sent as final reply, LLM call skipped
           // handled: false + text → text ignored, event passes through to LLM
-          // Set PROMPT_SCAN_BLOCK=1 to enable blocking mode.
-          const blockEnabled = process.env["PROMPT_SCAN_BLOCK"] === "1";
+          // promptScanBlock=true (openclaw.json) 开启拦截模式
+          api.logger.warn(`[prompt-scan] promptScanBlock=${cfg.promptScanBlock}`);
+          const blockEnabled = cfg.promptScanBlock === true;
           return { handled: blockEnabled, text: msg };
         }
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
