### PR TITLE
fix(cosh): unify PreToolUse ask dialog to info type with diff preview

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -343,6 +343,17 @@ export const ToolConfirmationMessage: React.FC<
             ))}
           </Box>
         )}
+        {infoProps.fileDiff && (
+          <Box marginTop={1}>
+            <DiffRenderer
+              diffContent={infoProps.fileDiff}
+              filename={infoProps.fileName ?? ''}
+              availableTerminalHeight={availableBodyContentHeight()}
+              contentWidth={contentWidth}
+              settings={settings}
+            />
+          </Box>
+        )}
       </Box>
     );
   } else {

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
@@ -2326,11 +2326,12 @@ describe('CoreToolScheduler Sequential Execution', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // Regression: Bug 2 — hookForceAsk must AUGMENT native confirmationDetails
-  //   (preserve type + original onConfirm side-effects), not replace them
-  //   with a bare info dialog.
+  // Regression: hookForceAsk must always synthesize an 'info' dialog that
+  //   shows the hook message in the prompt body (not just the title), while
+  //   still forwarding the original onConfirm so native side-effects
+  //   (e.g. setApprovalMode, allowlisting) are preserved.
   // ─────────────────────────────────────────────────────────────────────────
-  it('hookForceAsk should augment native confirmationDetails, preserving original onConfirm side-effects', async () => {
+  it('hookForceAsk should synthesize an info dialog with hook message in prompt, preserving original onConfirm side-effects', async () => {
     let approvalMode = ApprovalMode.DEFAULT;
 
     // Hook always returns 'ask'
@@ -2439,18 +2440,19 @@ describe('CoreToolScheduler Sequential Execution', () => {
       expect(capturedWaitingCall).toBeDefined();
     });
 
-    // ── Key regression assertions ─────────────────────────────────────────
-    // 1. Confirmation type must still be 'edit' — NOT replaced with 'info'.
-    //    This proves the original confirmationDetails were augmented, not
-    //    discarded, so the IDE diff path and edit semantics remain intact.
-    expect(capturedWaitingCall!.confirmationDetails.type).toBe('edit');
+    // ── Key assertions ──────────────────────────────────────────────────────
+    // 1. Confirmation type must be 'info' — hook message shown in prompt body,
+    //    not buried in a title augmented onto the native 'edit' dialog.
+    expect(capturedWaitingCall!.confirmationDetails.type).toBe('info');
 
-    // 2. The hook warning must appear in the title alongside the native title.
-    expect(capturedWaitingCall!.confirmationDetails.title).toContain(
-      'Confirm Test Tool augment-test',
-    );
-    expect(capturedWaitingCall!.confirmationDetails.title).toContain(
-      'Hook inspection required',
+    // 2. The hook warning must appear in the prompt (not just the title).
+    expect(
+      (capturedWaitingCall!.confirmationDetails as { prompt?: string }).prompt,
+    ).toContain('Hook inspection required');
+
+    // 3. The title should be the generic hook header.
+    expect(capturedWaitingCall!.confirmationDetails.title).toBe(
+      'Hook Requires Confirmation',
     );
 
     // Trigger ProceedAlways through the wrapped onConfirm stored in the call.
@@ -2458,13 +2460,13 @@ describe('CoreToolScheduler Sequential Execution', () => {
       ToolConfirmationOutcome.ProceedAlways,
     );
 
-    // 3. The original tool onConfirm side-effect must have run:
+    // 4. The original tool onConfirm side-effect must have run:
     //    TestApprovalTool.onConfirm sets config.setApprovalMode(AUTO_EDIT)
     //    on ProceedAlways — if it was replaced by an empty onConfirm this
     //    would remain DEFAULT.
     expect(approvalMode).toBe(ApprovalMode.AUTO_EDIT);
 
-    // 4. Execution should complete successfully.
+    // 5. Execution should complete successfully.
     await vi.waitFor(() => {
       expect(onAllToolCallsCompleteAugment).toHaveBeenCalled();
       const completedCalls = onAllToolCallsCompleteAugment.mock

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -943,22 +943,29 @@ export class CoreToolScheduler {
             const askPrompt =
               hookAskMessage ||
               'A hook has requested confirmation before executing this tool.';
-            if (confirmationDetails) {
-              // Augment: spread original details to preserve type discriminant
-              // and onConfirm; only override the title to surface the hook msg.
-              effectiveConfirmationDetails = {
-                ...confirmationDetails,
-                title: `${confirmationDetails.title} — ⚠️ Hook: ${askPrompt}`,
-              } as ToolCallConfirmationDetails;
-            } else {
-              // No native confirmation: synthesize a minimal info dialog.
-              effectiveConfirmationDetails = {
-                type: 'info',
-                title: 'Hook Requires Confirmation',
-                prompt: askPrompt,
-                onConfirm: async () => {},
-              };
-            }
+            // Always synthesize an 'info' dialog so the hook message is shown
+            // prominently in the prompt body rather than buried in the title.
+            // If the tool has a native confirmation, forward its onConfirm so
+            // side-effects (e.g. allowlisting via ProceedAlways) are preserved.
+            // For 'edit'-type confirmations, also copy fileName/fileDiff so the
+            // UI can render a diff preview below the hook message.
+            effectiveConfirmationDetails = {
+              type: 'info',
+              title: 'Hook Requires Confirmation',
+              prompt: askPrompt,
+              ...(confirmationDetails && confirmationDetails.type === 'edit'
+                ? {
+                    fileName: confirmationDetails.fileName,
+                    fileDiff: confirmationDetails.fileDiff,
+                  }
+                : {}),
+              onConfirm: confirmationDetails
+                ? (
+                    outcome: ToolConfirmationOutcome,
+                    payload?: ToolConfirmationPayload,
+                  ) => confirmationDetails.onConfirm(outcome, payload)
+                : async () => {},
+            };
           }
 
           if (!effectiveConfirmationDetails) {

--- a/src/copilot-shell/packages/core/src/tools/tools.ts
+++ b/src/copilot-shell/packages/core/src/tools/tools.ts
@@ -560,9 +560,19 @@ export interface ToolMcpConfirmationDetails {
 export interface ToolInfoConfirmationDetails {
   type: 'info';
   title: string;
-  onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
+  onConfirm: (
+    outcome: ToolConfirmationOutcome,
+    payload?: ToolConfirmationPayload,
+  ) => Promise<void>;
   prompt: string;
   urls?: string[];
+  /**
+   * Optional diff preview — populated when the hook wraps a native 'edit'
+   * confirmation, allowing the info dialog to show the proposed change
+   * alongside the hook message.
+   */
+  fileName?: string;
+  fileDiff?: string;
 }
 
 export type ToolCallConfirmationDetails =


### PR DESCRIPTION
## Description

When a `PreToolUse` hook returns `ask`, if the target tool already has
its own native confirmation dialog (e.g. `run_shell_command` with `rm`
produces an `exec`-type dialog), the previous implementation only
appended the hook message to the dialog **title**. This made the message
effectively invisible on the first invocation — users would click
through without seeing the hook warning.

This PR unifies the `hookForceAsk` path to always synthesize an `info`
dialog, ensuring the hook message appears in the **prompt body**
regardless of the tool's native confirmation type. For `edit`-type
confirmations (file write/modify), the diff preview is preserved and
rendered below the hook message.

**Changes:**
- `coreToolScheduler.ts`: when `hookForceAsk=true`, always produce an
  `info` dialog; forward native `onConfirm` (with `payload`) to preserve
  side-effects (allowlisting, `AUTO_EDIT` mode); spread `fileName` and
  `fileDiff` from `edit`-type native confirmation.
- `tools.ts`: add optional `payload` to `ToolInfoConfirmationDetails
  .onConfirm`; add optional `fileName`/`fileDiff` fields.
- `ToolConfirmationMessage.tsx`: in the `info` branch, render
  `DiffRenderer` below the prompt when `fileDiff` is present.
- `coreToolScheduler.test.ts`: rewrite `hookForceAsk` test to assert
  `type='info'`, hook message in prompt body, and `onConfirm`
  side-effects.

## Related Issue

closes #344 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional change)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Unit tests: `coreToolScheduler.test.ts` — 38 tests pass, including the
rewritten `hookForceAsk` test that verifies `type='info'`, prompt body
content, and `ProceedAlways` side-effect (`approvalMode=AUTO_EDIT`).

Manual:
1. Configure `rm-guard.py` as a `PreToolUse` hook (matcher `.*`).
2. Ask the agent to run `rm <file>` — hook message now appears in the
   `info` dialog body on the **first** invocation.
3. Ask the agent to write a file containing `rm ` — hook message and
   diff preview are both shown in the same dialog.

## Additional Notes

Known limitation: when the tool is in `AUTO_EDIT` mode, `shouldConfirm
Execute` returns `false` and no `fileDiff` is available, so the diff
preview will not appear even if the hook triggers `ask`. This edge case
is rare and left as a follow-up.