### PR TITLE
fix(sight): standardize call_id, add tool_call_ids column

### DIFF
--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -165,15 +165,11 @@ impl GenAIBuilder {
         let body_str = if request.body_len > 0 { Some(request.body_str().to_string()) } else { None };
         let body_match = !path_match && Self::is_sysom_pop_request(&body_str);
         if !path_match && !body_match {
-            print!("[GenAI] build_pending: skip non-LLM path={} body_len={}\n",
-                request.path, request.body_len);
             return None;
         }
 
         let call_id = self.generate_id();
         let body = request.json_body();
-        print!("[GenAI] build_pending: path={} body_parsed={} body_len={}\n",
-            request.path, body.is_some(), request.body_len);
 
         // Determine if streaming
         let is_sse = body.as_ref()
@@ -186,27 +182,6 @@ impl GenAIBuilder {
         let (session_id, conversation_id, user_query, input_messages, system_instructions) =
             if let Some(ref v) = body {
                 if let Some(messages) = v.get("messages").and_then(|m| m.as_array()) {
-                    // Diagnostic: dump message roles and content types
-                    let total = messages.len();
-                    let user_count = messages.iter()
-                        .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
-                        .count();
-                    print!("[GenAI] build_pending: messages.len={} user_count={}\n", total, user_count);
-                    // Print first 3 user messages' content type
-                    for (i, m) in messages.iter()
-                        .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
-                        .take(3)
-                        .enumerate()
-                    {
-                        let ctype = match m.get("content") {
-                            Some(c) if c.is_string() => format!("string(len={})", c.as_str().unwrap_or("").len()),
-                            Some(c) if c.is_array() => format!("array(len={})", c.as_array().unwrap().len()),
-                            Some(c) if c.is_null() => "null".to_string(),
-                            Some(_) => "other".to_string(),
-                            None => "missing".to_string(),
-                        };
-                        print!("[GenAI] build_pending: user_msg[{}] content_type={}\n", i, ctype);
-                    }
                     // Helper: extract text from "content" which can be either
                     // a plain string or an array of content blocks:
                     //   "content": "text"
@@ -287,14 +262,9 @@ impl GenAIBuilder {
                     (session_id, conversation_id, user_query, input_messages, system_instructions)
                 } else {
                     // messages key missing or not an array
-                    let keys: Vec<_> = v.as_object()
-                        .map(|o| o.keys().take(10).cloned().collect::<Vec<_>>())
-                        .unwrap_or_default();
-                    print!("[GenAI] build_pending: no 'messages' array, top-level keys={:?}\n", keys);
                     (None, None, None, None, None)
                 }
             } else {
-                print!("[GenAI] build_pending: body is None (json parse failed)\n");
                 (None, None, None, None, None)
             };
 
@@ -311,12 +281,6 @@ impl GenAIBuilder {
         // Resolve agent_name from comm using known_agents registry
         // (PID is dead so /proc is gone, but comm is still available from the captured request)
         let agent_name = Self::resolve_agent_name_from_comm(&request.source_event.comm);
-
-        print!("[GenAI] build_pending: pid={} session_id={:?} conversation_id={:?} user_query={:?} model={:?} provider={:?} agent={:?}\n",
-            conn_id.pid, session_id, conversation_id,
-            user_query.as_deref().map(|s| if s.len() > 100 { &s[..100] } else { s }),
-            model, provider, agent_name,
-        );
 
         Some(PendingCallInfo {
             call_id,
@@ -421,9 +385,6 @@ impl GenAIBuilder {
 
         let event_count = sse_events.len() as i64;
 
-        print!("[GenAI] extract_sse_enrichment: events={} model={:?} trace_id={:?} content_len={} input_tokens={:?} output_tokens={:?}\n",
-            event_count, model, trace_id, content_buf.len(), input_tokens, output_tokens);
-
         Some(SseEnrichment {
             model,
             trace_id,
@@ -466,7 +427,7 @@ impl GenAIBuilder {
             return None;
         }
 
-        let call_id = self.generate_id();
+        let internal_id = self.generate_id();
 
         // Build request from parsed message or HTTP record
         let request = self.build_request(&parsed_message, &http);
@@ -510,8 +471,11 @@ impl GenAIBuilder {
             .unwrap_or_else(|| Self::compute_session_id(&request));
 
         // 提取 LLM API 的 response_id（如 chatcmpl-xxx），用作 trace_id
-        let response_id = Self::extract_response_id(&parsed_message, &http)
-            .unwrap_or_else(|| call_id.clone());
+        // 同时作为 call_id 的首选值：trace_id 有值时直接复用，避免两套 ID；
+        // SysOM / 解析失败等无 response_id 的场景 fallback 到内部生成的 internal_id。
+        let response_id = Self::extract_response_id(&parsed_message, &http);
+        let call_id = response_id.clone().unwrap_or_else(|| internal_id.clone());
+        let response_id = response_id.unwrap_or_else(|| call_id.clone());
 
         // Extract error message from response body when status_code >= 400
         let error = if http.status_code >= 400 {

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -979,10 +979,12 @@ pub async fn get_token_savings(
         std::collections::HashMap::new()
     };
 
-    // Step 3.5: Build call_id → turn_index map so we can determine
-    // at which turn each tool_use_id was invoked.
+    // Step 3.5: Build tool_call_id → turn_index map so we can determine
+    // at which turn each tool_use_id was invoked. Uses the tool_call_ids
+    // column (JSON array) from genai_events, with backward compatibility
+    // for stats.db entries that still store call_id.
     let turn_indices = match GenAISqliteStore::new_with_path(db_path) {
-        Ok(store) => store.get_call_turn_indices(&session_ids).unwrap_or_default(),
+        Ok(store) => store.get_tool_call_turn_indices(&session_ids).unwrap_or_default(),
         Err(_) => std::collections::HashMap::new(),
     };
 

--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -926,6 +926,52 @@ impl GenAISqliteStore {
         Ok(result)
     }
 
+    /// Build a mapping from `tool_call_id` to the turn index of the LLM call
+    /// that issued it.
+    ///
+    /// Reads the `tool_call_ids` JSON array column from `genai_events` and
+    /// expands it so that each individual tool_call_id maps to the turn index
+    /// (1-based) of its parent LLM call.
+    pub fn get_tool_call_turn_indices(
+        &self,
+        session_ids: &[&str],
+    ) -> Result<std::collections::HashMap<String, usize>, Box<dyn std::error::Error>> {
+        let conn = self.conn.lock().unwrap();
+        let mut result = std::collections::HashMap::new();
+
+        for sid in session_ids {
+            let sql = "SELECT call_id, tool_call_ids FROM genai_events \
+                       WHERE event_type = 'llm_call' AND session_id = ?1 \
+                       ORDER BY start_timestamp_ns ASC";
+            let mut stmt = conn.prepare(sql)?;
+            let rows = stmt.query_map(params![sid], |row| {
+                let call_id: String = row.get(0)?;
+                let tool_call_ids: Option<String> = row.get(1)?;
+                Ok((call_id, tool_call_ids))
+            })?;
+
+            for (idx, row) in rows.enumerate() {
+                let (call_id, tool_call_ids_json) = row?;
+                let turn = idx + 1; // 1-based
+
+                // Also map the call_id itself (for backward compat with
+                // stats.db that may still store call_id as tool_use_id)
+                result.insert(call_id.clone(), turn);
+
+                // Expand each tool_call_id in the JSON array
+                if let Some(json_str) = tool_call_ids_json {
+                    if let Ok(ids) = serde_json::from_str::<Vec<String>>(&json_str) {
+                        for tc_id in ids {
+                            result.insert(tc_id, turn);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
     /// List all conversations under a given session, with aggregated token stats.
     pub fn list_traces_by_session(
         &self,

--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -315,7 +315,7 @@ impl GenAISqliteStore {
             CREATE INDEX IF NOT EXISTS idx_genai_trace_timestamp ON genai_events(trace_id, start_timestamp_ns);
             CREATE INDEX IF NOT EXISTS idx_genai_conversation_timestamp ON genai_events(conversation_id, start_timestamp_ns);
             CREATE INDEX IF NOT EXISTS idx_genai_pid_timestamp ON genai_events(pid, start_timestamp_ns);
-            CREATE INDEX IF NOT EXISTS idx_genai_instance_timestamp ON genai_events(instance, start_timestamp_ns);",
+            CREATE INDEX IF NOT EXISTS idx_genai_instance_timestamp ON genai_events(instance, start_timestamp_ns)",
             // NOTE: idx_genai_status and idx_genai_interruption_type are NOT created here
             // because they depend on columns added via migration. They are created in the
             // migration blocks below, which guarantees the columns exist first.
@@ -377,6 +377,9 @@ impl GenAISqliteStore {
 
         // Migration: add conversation_id column for existing databases
         let _ = conn.execute("ALTER TABLE genai_events ADD COLUMN conversation_id TEXT", []);
+
+        // v5: tool_call_ids JSON array for output tool calls
+        ensure_col!("tool_call_ids", "TEXT");
 
         Ok(())
     }
@@ -475,6 +478,20 @@ impl GenAISqliteStore {
                     if reasons.is_empty() { None } else { serde_json::to_string(&reasons).ok() }
                 };
 
+                let tool_call_ids: Option<String> = {
+                    let ids: Vec<String> = call.response.messages.iter()
+                        .flat_map(|m| m.parts.iter())
+                        .filter_map(|p| {
+                            if let crate::genai::semantic::MessagePart::ToolCall { id: Some(tc_id), .. } = p {
+                                Some(tc_id.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    if ids.is_empty() { None } else { serde_json::to_string(&ids).ok() }
+                };
+
                 let updated = conn.execute(
                     "UPDATE genai_events SET
                         status = 'complete',
@@ -503,8 +520,9 @@ impl GenAISqliteStore {
                         output_messages     = ?23,
                         status_code         = ?24,
                         sse_event_count     = ?25,
-                        event_json          = ?26
-                    WHERE call_id = ?27 AND status = 'pending'",
+                        event_json          = ?26,
+                        tool_call_ids       = ?27
+                    WHERE call_id = ?28 AND status = 'pending'",
                     params![
                         call.metadata.get("response_id"),
                         call.metadata.get("conversation_id"),
@@ -532,6 +550,7 @@ impl GenAISqliteStore {
                         call.metadata.get("status_code").and_then(|s| s.parse::<i64>().ok()),
                         call.metadata.get("sse_event_count").and_then(|s| s.parse::<i64>().ok()),
                         event_json,
+                        tool_call_ids,
                         call.call_id,
                     ],
                 )?;
@@ -1386,6 +1405,21 @@ impl GenAISqliteStore {
                     else { serde_json::to_string(&reasons).ok() }
                 };
 
+                // Extract tool_call_ids from response messages (outgoing tool calls)
+                let tool_call_ids: Option<String> = {
+                    let ids: Vec<String> = call.response.messages.iter()
+                        .flat_map(|m| m.parts.iter())
+                        .filter_map(|p| {
+                            if let crate::genai::semantic::MessagePart::ToolCall { id: Some(tc_id), .. } = p {
+                                Some(tc_id.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    if ids.is_empty() { None } else { serde_json::to_string(&ids).ok() }
+                };
+
                 // Get instance ID (same logic as SLS uploader)
                 let instance = crate::genai::sls::SlsUploader::get_instance_id();
 
@@ -1400,12 +1434,12 @@ impl GenAISqliteStore {
                         cache_creation_tokens, cache_read_tokens,
                         system_instructions, input_messages, output_messages,
                         user_query, http_method, http_path, status_code,
-                        is_sse, sse_event_count, event_json
+                        is_sse, sse_event_count, event_json, tool_call_ids
                     ) VALUES (
                         ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
                         ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22,
                         ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32,
-                        ?33, ?34, ?35, ?36, ?37, ?38, ?39
+                        ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40
                     )",
                     params![
                         "llm_call",
@@ -1447,6 +1481,7 @@ impl GenAISqliteStore {
                         call.metadata.get("is_sse").map(|s| if s == "true" { 1i64 } else { 0 }),
                         call.metadata.get("sse_event_count").and_then(|s| s.parse::<i64>().ok()),
                         event_json,
+                        tool_call_ids,
                     ],
                 )?;
             }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -592,9 +592,6 @@ impl AgentSight {
             return;
         }
 
-        print!("[DrainCheck] Found {} dead-PID connection(s) to persist\n",
-            drained.len());
-
         use crate::aggregator::ConnectionState;
         use crate::genai::GenAIBuilder;
 
@@ -610,21 +607,15 @@ impl AgentSight {
                 _ => continue,
             };
 
-            print!("[DrainCheck] dead-PID conn: pid={} ssl_ptr={:#x} state={} path={} sse_events={}\n",
-                conn_id.pid, conn_id.ssl_ptr, state_name, request.path, sse_events.len());
-
             if let Some(pending) = self.genai_builder.build_pending_from_request(&request, &conn_id) {
                 if let Some(ref store) = self.genai_sqlite_store {
                     let call_id = pending.call_id.clone();
                     let pid = pending.pid;
 
                     if let Err(e) = store.insert_pending(&pending) {
-                        print!("[DrainCheck] FAIL persist: {}\n", e);
+                        log::warn!("[DrainCheck] FAIL persist: {}", e);
                         continue;
                     }
-                    print!("[DrainCheck] OK persisted: pid={} call_id={} session_id={:?} conversation_id={:?}\n",
-                        conn_id.pid, call_id, pending.session_id, pending.conversation_id);
-
                     // ── Session ID reconciliation ──────────────────────────
                     // The drain path computes session_id via SHA256 hash fallback,
                     // but normal flow uses ResponseSessionMapper (agent .jsonl UUID).
@@ -633,18 +624,13 @@ impl AgentSight {
                         Ok(Some(ref real_session_id)) => {
                             if pending.session_id.as_deref() != Some(real_session_id.as_str()) {
                                 if let Err(e) = store.update_session_id(&call_id, real_session_id) {
-                                    print!("[DrainCheck] FAIL update session_id: {}\n", e);
-                                } else {
-                                    print!("[DrainCheck] session_id reconciled: {:?} -> {}\n",
-                                        pending.session_id, real_session_id);
+                                    log::warn!("[DrainCheck] FAIL update session_id: {}", e);
                                 }
                             }
                         }
-                        Ok(None) => {
-                            print!("[DrainCheck] no completed session found for pid={}, keeping hash fallback\n", pid);
-                        }
+                        Ok(None) => {}
                         Err(e) => {
-                            print!("[DrainCheck] FAIL lookup session: {}\n", e);
+                            log::warn!("[DrainCheck] FAIL lookup session: {}", e);
                         }
                     }
 
@@ -726,21 +712,18 @@ impl AgentSight {
                                         }
                                     }
                                 } else {
-                                    print!("[DrainCheck] tokenizer unavailable for model {:?}, skipping token computation\n",
+                                    log::warn!("[DrainCheck] tokenizer unavailable for model {:?}, skipping token computation",
                                         enrichment.model.as_deref().or(pending.model.as_deref()));
                                 }
                             }
                             if let Err(e) = store.enrich_pending_from_sse(&call_id, &enrichment) {
-                                print!("[DrainCheck] FAIL enrich SSE: {}\n", e);
-                            } else {
-                                print!("[DrainCheck] SSE enriched: model={:?} trace_id={:?} input_tokens={:?} output_tokens={:?}\n",
-                                    enrichment.model, enrichment.trace_id, enrichment.input_tokens, enrichment.output_tokens);
+                                log::warn!("[DrainCheck] FAIL enrich SSE: {}", e);
                             }
                         }
                     }
                 }
             } else {
-                print!("[DrainCheck] build_pending returned None: pid={} path={} body_len={}\n",
+                log::debug!("[DrainCheck] build_pending returned None: pid={} path={} body_len={}",
                     conn_id.pid, request.path, request.body_len);
             }
         }


### PR DESCRIPTION

- Use LLM API response_id as call_id when available (e.g. chatcmpl-xxx), fall back to internal generated ID for providers without response_id (closes #349)

- Add tool_call_ids TEXT column (JSON array) to genai_events table, populated from MessagePart::ToolCall.id in response messages

- Fix store_event INSERT path to also write tool_call_ids (was missing in fallback path, causing NULL values)

- Remove debug print! statements from builder.rs (8 statements) and diagnostic cases to log::debug

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue #349

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #349 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
