### PR TITLE
feat(skill): add Hermes Agent install SKILL

### DIFF
--- a/src/os-skills/ai/install-hermes/SKILL.md
+++ b/src/os-skills/ai/install-hermes/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: install-hermes
+description: One-click installation and configuration of Hermes Agent by Nous Research. Handles installing Hermes from scratch, adding LLM providers (OpenRouter, Anthropic, OpenAI, z.ai/GLM, Kimi, DeepSeek, Alibaba Qwen, Ollama, etc.), setting up messaging platforms (Telegram, Discord, Slack, DingTalk, Feishu/Lark, Weixin, WeCom), installing Hermes Workspace web UI, and migrating from OpenClaw. Use when the user asks about installing Hermes, setting up a provider, configuring a messaging platform, adding a bot, or any Hermes setup task.
+---
+
+# Hermes Agent 一键安装与配置
+**操作系统**: Linux / macOS / WSL2 / Android(Termux)。不支持原生 Windows。
+
+## 意图识别与行动映射
+
+当用户表达以下意图时，按对应工作流执行：
+
+| 用户说 | 对应工作流 |
+|--------|-----------|
+| "安装 Hermes" / "从零开始" | [工作流 1: 全新安装](#工作流-1-全新安装) |
+| "安装 [Provider 名]" / "配置 [模型名]" / "接入 [供应商]" | [工作流 2: 添加 Provider](#工作流-2-添加-provider) |
+| "接入 [平台名]" / "配置 [Telegram/钉钉/飞书/微信]" / "安装 Bot" | [工作流 3: 添加消息平台](#工作流-3-添加消息平台) |
+| "安装 Workspace" / "Web UI" / "可视化界面" | [工作流 4: 安装 Hermes Workspace](#工作流-4-安装-hermes-workspace-web-ui) |
+| "从 OpenClaw 迁移" | [工作流 5: OpenClaw 迁移](#工作流-5-从-openclaw-迁移) |
+| "检查配置" / "出问题" / "不能用" | [工作流 6: 诊断与修复](#工作流-6-诊断与修复) |
+
+---
+
+## 工作流 1: 全新安装
+
+### 前提检查
+
+```bash
+git --version   # 必须可用
+```
+
+### 执行安装
+
+```bash
+bash ./scripts/install.sh
+source ~/.bashrc   # 或 source ~/.zshrc
+hermes doctor      # 验证
+```
+
+> **安装过程说明**：
+> - 脚本默认**最小安装**（跳过 daytona/playwright/WhatsApp 等重型组件），安装速度快
+> - 需要完整功能（浏览器工具、WhatsApp 等）时加 `--full` 参数
+> - 脚本默认**跳过**交互式配置向导，安装完后运行 `hermes setup` 再配置
+> - 如需安装时直接配置，加 `--with-setup` 参数
+> - CI/自动化场景直接运行即可，不会出现任何交互阻塞
+
+**安装参数说明**：
+
+| 参数 | 说明 |
+|------|------|
+| （无参数） | 最小安装，仅核心包，速度最快（**推荐新手**） |
+| `--full` | 安装所有 extras（daytona、playwright、WhatsApp 等） |
+| `--with-setup` | 安装完后启动配置向导 |
+
+### 首次配置
+
+```bash
+hermes model       # 选择 Provider 和模型
+hermes             # 启动首次对话验证
+```
+
+---
+
+## 工作流 2: 添加 Provider
+
+> 用户意图："我要安装 OpenRouter"、"接入 DeepSeek"、"用 Claude"、"配置 Kimi" 等。
+
+### Step 1: 确定 Provider 类型
+
+从以下速查表识别用户指定的 Provider：
+
+| Provider | 环境变量名 | 交互式命令 | 详细配置参考 |
+|----------|-----------|-----------|-------------|
+| Alibaba / 通义千问 | `DASHSCOPE_API_KEY` | `hermes model` | [model.md](references/model.md) |
+| DeepSeek | `DEEPSEEK_API_KEY` | `hermes model` | [model.md](references/model.md) |
+| z.ai / 智谱 GLM | `GLM_API_KEY` | `hermes model` | [model.md](references/model.md) |
+| Kimi / Moonshot 中国版 | `KIMI_CN_API_KEY` | `hermes model` | [model.md](references/model.md) |
+| MiniMax 中国 | `MINIMAX_CN_API_KEY` | `hermes model` | [model.md](references/model.md) |
+| Ollama (本地) | 无需密钥 | `hermes model` | [model.md](references/model.md) |
+
+### Step 2: 收集必要信息
+
+向用户询问 Provider 所需的凭证：
+
+- **API Key 类型**: 绝大多数 Provider 只需要一个 API Key
+- **OAuth 类型**（Nous Portal / Codex / GitHub Copilot / Anthropic / Google Gemini）: 终端会显示扫码或浏览器链接，用户按提示完成授权
+- **本地模型**（Ollama）: 确认 Ollama 已运行且模型已加载
+
+### Step 3: 一键配置
+
+**推荐方式 — 交互式向导**：
+
+```bash
+hermes model
+# 按提示选择 Provider → 粘贴 API Key / 扫码授权 → 选择模型
+```
+
+**脚本方式 — 已知 API Key 时**：
+
+```bash
+hermes config set <ENV_VAR_NAME> <api-key-value>
+hermes config set model <provider>/<model-id>
+```
+
+例如配置 DeepSeek：
+
+```bash
+hermes config set DEEPSEEK_API_KEY sk-xxx
+hermes config set model deepseek/deepseek-chat
+```
+
+### Step 4: 验证
+
+```bash
+hermes doctor
+hermes          # 启动对话，确认 banner 显示正确模型
+```
+
+> **模型最低要求**: 64K token 上下文窗口。不足 64K 的模型会在启动时被拒绝。
+> **辅助模型**: 即使主模型已配置，部分工具（视觉、网页摘要）默认使用 OpenRouter 上的 Gemini Flash。建议同时配置 `OPENROUTER_API_KEY` 以解锁完整工具能力。
+
+---
+
+## 工作流 3: 添加消息平台
+
+> 用户意图："接入钉钉"、"配置飞书 Bot"、"微信机器人"、"Telegram Bot" 等。
+
+### Step 1: 确定平台
+
+| 平台 | 凭证要求 | 连接方式 | 详细配置参考 |
+|------|---------|---------|-------------|
+| 钉钉 | Client ID + Client Secret + User ID | Stream Mode (WebSocket) | [cn-messaging-platforms.md](references/cn-messaging-platforms.md) |
+| 飞书 / Lark | App ID + App Secret | WebSocket / Webhook | [cn-messaging-platforms.md](references/cn-messaging-platforms.md) |
+| 微信 | 扫码登录（无手动密钥） | 长轮询 | [cn-messaging-platforms.md](references/cn-messaging-platforms.md) |
+| 企业微信 | Bot ID + Secret（或扫码） | WebSocket | [cn-messaging-platforms.md](references/cn-messaging-platforms.md) |
+| Telegram | Bot Token | HTTP 长轮询 | `hermes gateway setup` |
+| Discord | Bot Token | WebSocket Gateway | `hermes gateway setup` |
+| Slack | Bot Token + Signing Secret | HTTP 事件 | `hermes gateway setup` |
+| WhatsApp | 无需密钥（扫码） | WhatsApp Web 桥接 | `hermes gateway setup` |
+| Signal | 无需密钥 | Signal 桥接 | `hermes gateway setup` |
+
+### Step 2: 收集凭证
+
+**中国平台凭证收集清单**：
+
+| 平台 | 需要用户提供 | 获取方式 |
+|------|-------------|---------|
+| 钉钉 | Client ID, Client Secret, 允许的用户 ID | [钉钉开发者后台](https://open-dev.dingtalk.com/) |
+| 飞书 | App ID, App Secret | [飞书开放平台](https://open.feishu.cn/) |
+| 微信 | 无需凭证，扫码即可 | 微信手机 App 扫码 |
+| 企微 | Bot ID, Secret（或扫码） | 企微管理后台 |
+
+### Step 3: 一键配置
+
+**交互式配置（推荐）**：
+
+```bash
+hermes gateway setup
+# 选择平台 → 按提示输入凭证 / 扫码 → 完成
+```
+
+对于中国平台，交互式向导支持**扫码自动创建应用**（飞书、企微）或**扫码授权**（钉钉）。
+
+**手动配置**（已知凭证时）：
+
+编辑 `~/.hermes/.env`，写入对应环境变量：
+
+```bash
+# 钉钉
+DINGTALK_CLIENT_ID=your-app-key
+DINGTALK_CLIENT_SECRET=your-app-secret
+DINGTALK_ALLOWED_USERS=user-id-1
+
+# 飞书
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=secret_xxx
+FEISHU_CONNECTION_MODE=websocket
+FEISHU_ALLOWED_USERS=ou_xxx
+
+# 企微
+WECOM_BOT_ID=your-bot-id
+WECOM_SECRET=your-secret
+```
+
+### Step 4: 启动与验证
+
+```bash
+hermes gateway          # 启动网关
+hermes gateway status   # 检查各平台状态
+```
+
+向 Bot 发送一条测试消息验证连通性。
+
+---
+
+## 工作流 4: 安装 Hermes Workspace (Web UI)
+
+> 用户意图："安装可视化界面"、"Web UI"、"Workspace"、"Web 控制台"。
+
+Hermes Workspace 是一个基于 Web 的可视化管理界面，支持聊天、记忆浏览、技能管理、终端操作。
+
+### 前提
+
+- Node.js 22+（`node --version`）
+- Hermes Agent 已安装且 gateway 可访问
+
+### 一键安装
+
+```bash
+git clone https://github.com/outsourc-e/hermes-workspace.git
+cd hermes-workspace
+pnpm install
+cp .env.example .env
+```
+
+### 连接到现有 Hermes
+
+```bash
+# 编辑 .env
+echo 'HERMES_API_URL=http://127.0.0.1:8642' >> .env
+echo 'HERMES_DASHBOARD_URL=http://127.0.0.1:9119' >> .env
+
+# 启动
+pnpm dev    # http://localhost:3000
+```
+
+### Docker 一键启动（含 Agent + Workspace）
+
+```bash
+git clone https://github.com/outsourc-e/hermes-workspace.git
+cd hermes-workspace
+cp .env.example .env
+# 编辑 .env，至少添加一个 Provider API Key
+docker compose up
+# 打开 http://localhost:3000
+```
+
+### 验证
+
+```bash
+curl http://127.0.0.1:8642/health         # gateway 健康
+curl http://127.0.0.1:9119/api/status     # dashboard 状态
+```
+
+---
+
+## 工作流 5: 从 OpenClaw 迁移
+
+> 用户意图："从 OpenClaw 迁移"、"导入 OpenClaw 数据"。
+
+### 自动检测
+
+首次运行 `hermes setup` 时，若检测到 `~/.openclaw` 会自动提示迁移。
+
+### 手动迁移
+
+```bash
+hermes claw migrate --dry-run    # 预览
+hermes claw migrate              # 执行迁移
+```
+
+### 迁移内容
+
+SOUL.md、记忆、技能、命令白名单、平台配置、API 密钥、TTS 资源、AGENTS.md。
+
+---
+
+## 工作流 6: 诊断与修复
+
+当用户说"出问题了"、"不能用"、"报错"时，按此顺序执行：
+
+```bash
+hermes doctor          # 1. 诊断环境和配置
+hermes model           # 2. 重选/修复 Provider
+hermes setup           # 3. 完整设置向导
+hermes sessions list   # 4. 检查会话
+hermes --continue      # 5. 恢复会话
+hermes gateway status  # 6. 检查网关
+```
+
+### 常见问题速查
+
+| 症状 | 原因 | 修复 |
+|------|------|------|
+| `hermes: command not found` | Shell 未重载 | `source ~/.bashrc` |
+| 空白/错误回复 | Provider 认证错误 | `hermes model` 重配 |
+| 自定义端点乱码 | 错误的 base URL | 独立客户端验证端点 |
+| 网关启动但无消息 | Bot token/allowlist 不完整 | `hermes gateway setup` |
+| `--continue` 无旧会话 | Profile 不匹配 | `hermes sessions list` 检查 |
+| Alibaba 401 错误 | 使用了国际版端点 | 设置 `DASHSCOPE_BASE_URL`，见坑位 #8 |
+| `Unknown TERMINAL_ENV 'auto'` | terminal.backend 未显式设置 | `hermes config set terminal.backend local` |
+| 钉钉 `Unauthorized user` | ALLOWED_USERS 填了工号而非真实 ID | 从网关日志获取 `sender_id`，见坑位 #9 |
+
+---
+
+## 安装踩坑速查
+
+### 坑 1：Python 依赖安装超时（pip 回溯卡死）
+
+**内置脚本**：
+- 默认改用 `uv pip install`
+- 默认最小安装（不含重型 extras），需要完整功能时加 `--full`：
+  ```bash
+  bash install.sh --full
+  ```
+
+### 坑 2：Python venv 重复安装（已内置优化）
+
+脚本已内置检查：若 venv 存在且 `pip check` 通过，自动跳过重建和依赖安装，无需手动处理。
+
+### npm 默认源超时（已内置优化）
+
+**默认最小安装会完全跳过 Node.js 依赖**，npm 超时问题在默认模式下不存在。
+
+若使用 `--full` 安装浏览器工具时遇到 npm 超时：脚本已自动设置 npmmirror 镜像，所有 `npm install` 均使用 `--registry=https://registry.npmmirror.com`。
+
+若遇到 `ENOTEMPTY` 报错（上次安装中断留有残留），清理后重试：
+```bash
+rm -rf ~/.hermes/hermes-agent/node_modules
+npm install --registry=https://registry.npmmirror.com --prefix ~/.hermes/hermes-agent
+```
+
+### 坑 4：Playwright 下载超时（已内置优化）
+
+脚本已设置 `PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright`，并统一改为 `npx --yes playwright install chromium` 跳过交互确认。
+
+手动重试：
+```bash
+export PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright
+cd ~/.hermes/hermes-agent && npx --yes playwright install chromium
+```
+
+### 坑 5：WhatsApp Bridge GitHub 依赖卡死（已内置 timeout）
+
+部分依赖直接从 GitHub 拉取，脚本已加 `timeout 120`。
+
+需要 WhatsApp 时，等 GitHub 可访问后手动安装：
+```bash
+cd ~/.hermes/hermes-agent/scripts/whatsapp-bridge && npm install
+```
+
+### 坑 6：安装结束弹出交互向导（已默认跳过）
+
+脚本默认 `RUN_SETUP=false`，全程无交互阻塞。需要向导时显式开启：
+```bash
+bash install.sh --with-setup
+```
+
+### 坑 7：terminal.backend 报错
+
+`config.yaml` 默认值 `auto` 会触发报错 `Unknown TERMINAL_ENV 'auto'`。
+
+修复（安装后必做）：
+```bash
+hermes config set terminal.backend local
+```
+
+### 坑 8：通义千问（Alibaba/DashScope）完整配置步骤
+
+Hermes 默认调用**国际版**端点 `dashscope-intl.aliyuncs.com`，中国区 Key 会出现 401。且 provider 必须显式设为 `alibaba`（不能用 `custom`），API Key 必须写入 `.env` 而非 `config.yaml`。
+
+**Step 1：在 `~/.hermes/.env` 中添加**：
+```bash
+DASHSCOPE_API_KEY=sk-xxxxxxxxxxxx
+DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+```
+
+**Step 2：在 `~/.hermes/config.yaml` 中设置**：
+```yaml
+model:
+  provider: "alibaba"
+  default: "qwen-plus"  # qwen-max 只有 32K 上下文，不满足 Hermes 64K 最低要求！
+                        # qwen-plus / qwen-turbo / qwen-long 均有 131K+ 上下文，可正常使用
+```
+
+**Step 3：验证**：
+```bash
+hermes doctor   # 应显示 ✓ Alibaba/DashScope
+hermes          # 启动对话验证
+```
+
+> **常见错误**：
+> - 使用 `provider: custom` 会报 "not a recognised provider"（虽然 doctor 不报错，但行为异常）
+> - 把 `api_key` 写在 `config.yaml` 的 `model:` 块下无效，必须通过 `DASHSCOPE_API_KEY` 环境变量
+> - **`qwen-max` 不可用**：上下文窗口仅 32K，低于 Hermes 64K 最低要求，启动时报错
+> - 推荐使用 `qwen-plus`（131K）、`qwen-turbo`（131K）或 `qwen-long`（10M）
+
+### 坑 9：钉钉 ALLOWED_USERS 填工号无效
+
+`DINGTALK_ALLOWED_USERS` 需要的是钉钉系统内的 **User ID**（格式如 `$:LWCP_v1:$xxxx`），与员工工号不同。
+
+**获取方法**：
+1. 暂不设置 `DINGTALK_ALLOWED_USERS`，启动网关
+2. 从钉钉给 Bot 发一条消息
+3. 在日志中找到：
+   ```
+   WARNING gateway.run: Unauthorized user: $:LWCP_v1:$MJqzUSC2... (姓名) on dingtalk
+   ```
+4. 把这个 ID 填入 `~/.hermes/.env`：
+   ```bash
+   DINGTALK_ALLOWED_USERS=$:LWCP_v1:$MJqzUSC2TvsmFU4Pp/Q2osUNJaBYAh1P
+   ```
+5. 重启网关：`hermes gateway stop && hermes gateway run &`
+
+---
+
+## 配置文件速查
+
+| 文件 | 用途 | 典型内容 |
+|------|------|---------|
+| `~/.hermes/.env` | 密钥和 Token | API Key、Bot Token |
+| `~/.hermes/config.yaml` | 非密钥配置 | 模型、终端后端、平台设置 |
+| `~/.hermes/auth.json` | OAuth 凭证 | 自动刷新 token |
+
+### 常用 CLI 命令
+
+| 命令 | 说明 |
+|------|------|
+| `hermes` | 启动对话 |
+| `hermes --tui` | 现代 TUI 界面 |
+| `hermes model` | 选择/配置 Provider |
+| `hermes setup` | 完整设置向导 |
+| `hermes doctor` | 诊断问题 |
+| `hermes update` | 更新到最新版本 |
+| `hermes gateway` | 消息网关管理 |
+| `hermes config set` | 设置配置项 |
+| `hermes tools` | 配置工具 |
+| `hermes skills` | 浏览/安装技能 |
+| `hermes claw migrate` | 从 OpenClaw 迁移 |
+
+---
+
+## 参考文档
+
+- **Provider 详细配置**（含国产模型 z.ai/GLM、Kimi、DeepSeek、Alibaba Qwen、MiniMax 及国际 Provider）: [references/model.md](references/model.md)
+- **中国消息平台接入**（钉钉 Stream Mode、飞书 WebSocket/Webhook、微信 iLink Bot、企微 AI Bot）: [references/cn-messaging-platforms.md](references/cn-messaging-platforms.md)
+- **通用配置参考**（终端后端、MCP、技能、语音等）: [references/quickstart-reference.md](references/quickstart-reference.md)
+- **官方文档**: https://hermes-agent.nousresearch.com/docs
+- **GitHub**: https://github.com/NousResearch/hermes-agent

--- a/src/os-skills/ai/install-hermes/references/cn-messaging-platforms.md
+++ b/src/os-skills/ai/install-hermes/references/cn-messaging-platforms.md
@@ -1,0 +1,342 @@
+# Hermes Agent 中国消息平台接入指南
+
+本文档覆盖钉钉、飞书/Lark、微信、企业微信四大平台的完整接入流程。
+
+---
+
+## 钉钉（DingTalk）
+
+### 行为模型
+
+| 场景 | 行为 |
+|------|------|
+| 私聊（1:1） | 自动回复所有消息，无需 @mention |
+| 群聊 | 仅在被 @mention 时回复 |
+| 多人群聊 | 默认按用户隔离会话历史 |
+
+会话隔离控制（`config.yaml`）：
+
+```yaml
+group_sessions_per_user: true   # false = 群内共享一个对话
+```
+
+### 前置依赖
+
+默认**最小安装**内已包含核心依赖。若使用 `--full` 安装或需要单独补装：
+
+```bash
+uv pip install --no-config -e ".[dingtalk]" -i https://mirrors.aliyun.com/pypi/simple/
+# 或单独安装依赖：
+uv pip install --no-config dingtalk-stream httpx alibabacloud-dingtalk -i https://mirrors.aliyun.com/pypi/simple/
+```
+
+### Step 1: 创建钉钉应用
+
+1. 登录 [钉钉开发者后台](https://open-dev.dingtalk.com/)
+2. **应用开发 → 自建应用 → H5 微应用**（或机器人）
+3. 获取 **Client ID (AppKey)** 和 **Client Secret (AppSecret)**
+
+> Client Secret 仅显示一次，丢失需重新生成。
+
+### Step 2: 启用机器人能力
+
+1. 应用设置 → **添加能力 → 机器人**
+2. 消息接收模式选择 **Stream Mode**（推荐，无需公网 URL）
+
+### Step 3: 获取钉钉 User ID
+
+> ❗员工工号 ≠ 钉钉 User ID，两者格式完全不同。
+
+**推荐方法 — 通过网关日志获取**：
+
+1. **先不设置** `DINGTALK_ALLOWED_USERS`，启动网关：`hermes gateway run &`
+2. 从钉钉给 Bot 发一条消息
+3. 查看日志 `~/.hermes/logs/agent.log`，找到这一行：
+   ```
+   WARNING gateway.run: Unauthorized user: $:LWCP_v1:$xxxx... (姓名) on dingtalk
+   ```
+4. 把 `$:LWCP_v1:$xxxx...` 这个完整字符串填入配置
+
+**备选方法**：找组织管理员在钉钉通讯录查询成员的系统 ID。
+
+### Step 4: 配置
+
+**方式 A: 交互式配置（推荐）**
+
+```bash
+hermes gateway setup    # 选择 DingTalk
+```
+
+支持两种授权方式：
+- **扫码授权**（推荐）：终端显示二维码，钉钉扫码自动写入凭证
+- **手动粘贴**：直接输入 Client ID / Secret / 用户 ID
+
+**方式 B: 手动配置**
+
+`~/.hermes/.env`：
+
+```bash
+DINGTALK_CLIENT_ID=your-app-key
+DINGTALK_CLIENT_SECRET=your-app-secret
+DINGTALK_ALLOWED_USERS=user-id-1,user-id-2
+```
+
+### 启动
+
+```bash
+hermes gateway
+```
+
+### AI 卡片（可选）
+
+在 `config.yaml` 中配置卡片模板 ID 可启用富文本流式卡片：
+
+```yaml
+platforms:
+  dingtalk:
+    enabled: true
+    extra:
+      card_template_id: "your-card-template-id"
+```
+
+### 显示设置
+
+```yaml
+display:
+  platforms:
+    dingtalk:
+      show_reasoning: false
+      streaming: true
+      tool_progress: all        # all | new | off
+      interim_assistant_messages: true
+```
+
+### 故障排查
+
+| 问题 | 修复 |
+|------|------|
+| Bot 不回复 | 检查机器人能力已启用 + Stream Mode + ALLOWED_USERS 包含你的 ID |
+| `dingtalk-stream not installed` | `pip install dingtalk-stream httpx` |
+| 凭证缺失错误 | 检查 `.env` 中 CLIENT_ID 和 CLIENT_SECRET |
+| Stream 断连重连循环 | 检查网络和凭证有效性，自动指数退避重连 |
+| `No session_webhook` | 发新消息即可（钉钉 webhook 有时效限制） |
+
+---
+
+## 飞书 / Lark（Feishu）
+
+### 行为模型
+
+| 场景 | 行为 |
+|------|------|
+| 私聊 | 自动回复所有消息 |
+| 群聊 | 仅在被 @mention 时回复 |
+| 多人群聊 | 默认按用户隔离会话 |
+
+### 连接模式
+
+| 模式 | 说明 | 适用场景 |
+|------|------|---------|
+| `websocket`（推荐） | SDK 维护的长连接，自动重连 | 无公网环境 |
+| `webhook` | HTTP 端点接收推送 | 已有公网 HTTP 服务 |
+
+### Step 1: 创建飞书应用
+
+**扫码创建（推荐）**：
+
+```bash
+hermes gateway setup    # 选择 Feishu / Lark，扫码自动创建
+```
+
+**手动创建**：
+1. 飞书：https://open.feishu.cn/ ｜ Lark：https://open.larksuite.com/
+2. 创建应用 → 获取 **App ID** 和 **App Secret**
+3. 启用 Bot 能力
+
+### Step 2: 配置
+
+**交互式**：`hermes gateway setup` → 选 Feishu / Lark
+
+**手动配置** `~/.hermes/.env`：
+
+```bash
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=secret_xxx
+FEISHU_DOMAIN=feishu              # feishu | lark
+FEISHU_CONNECTION_MODE=websocket  # websocket | webhook
+FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
+FEISHU_HOME_CHANNEL=oc_xxx        # 可选：cron/通知输出频道
+```
+
+Webhook 模式额外配置：
+
+```bash
+FEISHU_WEBHOOK_HOST=127.0.0.1
+FEISHU_WEBHOOK_PORT=8765
+FEISHU_WEBHOOK_PATH=/feishu/webhook
+FEISHU_ENCRYPT_KEY=your-encrypt-key        # Webhook 签名验证
+FEISHU_VERIFICATION_TOKEN=your-token       # 额外认证层
+```
+
+### 启动
+
+```bash
+hermes gateway
+```
+
+### 群消息策略
+
+```bash
+FEISHU_GROUP_POLICY=allowlist   # open | allowlist | disabled
+```
+
+### 交互卡片
+
+支持按钮点击回调，用于命令审批（Allow/Deny）。需在开发者后台配置：
+1. 订阅 `card.action.trigger` 事件
+2. 启用 Bot 的交互卡片能力
+3. Webhook 模式需配置卡片请求 URL
+
+### 文档评论智能回复
+
+在飞书文档中 @mention Bot，Hermes 会读取文档内容和评论上下文，直接在评论区回复。
+
+---
+
+## 微信（Weixin / WeChat）
+
+> 适用于个人微信账号。企业微信请看下方 WeCom 部分。
+
+### 前置依赖
+
+默认**最小安装**内已包含核心依赖。若需要单独补装：
+
+```bash
+uv pip install --no-config aiohttp cryptography -i https://mirrors.aliyun.com/pypi/simple/
+```
+
+### 配置流程
+
+```bash
+hermes gateway setup    # 选择 Weixin
+```
+
+向导会：
+1. 请求二维码 → 终端显示
+2. 用微信扫码确认登录
+3. 自动保存凭证到 `~/.hermes/weixin/accounts/`
+
+手动配置 `~/.hermes/.env`：
+
+```bash
+WEIXIN_ACCOUNT_ID=your-account-id
+WEIXIN_DM_POLICY=open                    # open | allowlist | disabled | pairing
+WEIXIN_ALLOWED_USERS=user_id_1,user_id_2
+WEIXIN_HOME_CHANNEL=chat_id
+```
+
+### 连接方式
+
+HTTP 长轮询（非 WebSocket），无需公网端点。
+
+### 特性
+
+- AES-128-ECB 加密 CDN 媒体自动加解密
+- Markdown 原生渲染
+- 智能消息分块（4000 字符限制，逻辑边界拆分）
+- 输入中指示器（"正在输入..."）
+- 消息去重（5 分钟滑动窗口）
+- 上下文 Token 持久化（重启后恢复回复连续性）
+
+### 访问策略
+
+| DM 策略 | 行为 |
+|---------|------|
+| `open` | 任何人可私聊（默认） |
+| `allowlist` | 仅 allow_from 列表中用户 |
+| `disabled` | 忽略所有私聊 |
+
+群策略默认 `disabled`（个人微信可能在很多群中）。
+
+---
+
+## 企业微信（WeCom）
+
+### 前置依赖
+
+默认**最小安装**内已包含核心依赖。若需要单独补装：
+
+```bash
+uv pip install --no-config aiohttp httpx cryptography -i https://mirrors.aliyun.com/pypi/simple/
+```
+
+### 配置流程
+
+**扫码创建（推荐）**：
+
+```bash
+hermes gateway setup    # 选择 WeCom，扫码自动创建 AI Bot
+```
+
+**手动配置** `~/.hermes/.env`：
+
+```bash
+WECOM_BOT_ID=your-bot-id
+WECOM_SECRET=your-secret
+WECOM_ALLOWED_USERS=user_id_1,user_id_2
+WECOM_HOME_CHANNEL=chat_id
+```
+
+### 连接方式
+
+WebSocket 长连接（`wss://openws.work.weixin.qq.com`），无需公网端点。自动心跳 + 指数退避重连。
+
+### 访问策略
+
+```bash
+WECOM_DM_POLICY=open        # open | allowlist | disabled | pairing
+WECOM_GROUP_POLICY=open     # open | allowlist | disabled
+```
+
+支持**按群精细控制**发言者白名单：
+
+```yaml
+platforms:
+  wecom:
+    enabled: true
+    extra:
+      bot_id: "your-bot-id"
+      secret: "your-secret"
+      group_policy: "allowlist"
+      group_allow_from: ["group_id_1", "group_id_2"]
+      groups:
+        group_id_1:
+          allow_from: ["user_alice", "user_bob"]
+        "*":
+          allow_from: ["user_admin"]
+```
+
+### 媒体支持
+
+| 类型 | 入站 | 出站限制 |
+|------|------|---------|
+| 图片 | URL / base64，自动缓存 | 10 MB |
+| 文件 | 自动缓存，保留文件名 | 20 MB |
+| 语音 | 文字转写提取 | 2 MB（AMR） |
+| 视频 | 下载缓存 | 10 MB |
+
+超限自动降级为通用文件附件发送。入站 AES-256-CBC 加密媒体自动解密。
+
+---
+
+## 四平台对比速查
+
+| 特性 | 钉钉 | 飞书 | 微信 | 企微 |
+|------|------|------|------|------|
+| 连接方式 | Stream (WebSocket) | WebSocket / Webhook | 长轮询 | WebSocket |
+| 需要公网 | 否 | Webhook 模式需要 | 否 | 否 |
+| 扫码配置 | 支持 | 支持 | 支持 | 支持 |
+| AI 卡片 | 支持 | 支持（交互按钮） | 不支持 | 不支持 |
+| 媒体加密 | 无 | 无 | AES-128-ECB | AES-256-CBC |
+| 群策略默认 | @mention | @mention | disabled | open |
+| 文档评论回复 | 不支持 | 支持 | 不支持 | 不支持 |

--- a/src/os-skills/ai/install-hermes/references/model.md
+++ b/src/os-skills/ai/install-hermes/references/model.md
@@ -1,0 +1,264 @@
+# Hermes Agent 模型提供商配置指南（国内版）
+
+---
+
+## Provider 速查总表
+
+| Provider | 环境变量 | Provider ID | 推荐模型 |
+|----------|---------|-------------|---------|
+| **Alibaba / 通义千问** | `DASHSCOPE_API_KEY` | `alibaba` | `qwen-turbo` / `qwen-plus` |
+| **DeepSeek** | `DEEPSEEK_API_KEY` | `deepseek` | `deepseek-chat` |
+| **z.ai / 智谱 GLM** | `GLM_API_KEY` | `zai` | `glm-4-plus` |
+| **Kimi / Moonshot（中国）** | `KIMI_CN_API_KEY` | `kimi-coding-cn` | `kimi-k2.5` |
+| **MiniMax（中国）** | `MINIMAX_CN_API_KEY` | `minimax-cn` | `MiniMax-M2.7` |
+| **Ollama（本地）** | 无需密钥 | `custom` | 按本地已拉取模型 |
+
+### 快速配置命令
+
+```bash
+# 设置 API Key + 模型（二合一）
+hermes config set <ENV_VAR> <your-api-key>
+hermes config set model <provider-id>/<model-name>
+
+# 示例：配置通义千问
+hermes config set DASHSCOPE_API_KEY sk-xxx
+hermes config set DASHSCOPE_BASE_URL https://dashscope.aliyuncs.com/compatible-mode/v1
+hermes config set model alibaba/qwen-turbo
+
+# 交互式配置（推荐初次使用）
+hermes model
+```
+
+### 通用命令速查
+
+```bash
+hermes model              # 交互式添加/切换 Provider
+/model                    # 在会话内快速切换（仅限已配置）
+hermes config set model <provider>/<model>    # 直接设置默认模型
+hermes doctor             # 诊断 Provider 配置
+```
+
+---
+
+## Alibaba Cloud / 通义千问（DashScope）
+
+阿里云的通义千问（Qwen）系列模型，通过 DashScope 平台提供。
+
+### 前置准备
+
+1. 注册 [阿里云百炼](https://bailian.console.aliyun.com/) 账号
+2. 创建 API Key
+
+### 配置步骤
+
+```bash
+hermes config set DASHSCOPE_API_KEY sk-xxxxxxxxxxxxxxxx
+hermes config set DASHSCOPE_BASE_URL https://dashscope.aliyuncs.com/compatible-mode/v1
+hermes config set model alibaba/qwen-turbo
+```
+
+> ⚠️ **中国大陆必须设置 `DASHSCOPE_BASE_URL`**
+>
+> Hermes 默认使用国际版端点 `dashscope-intl.aliyuncs.com`，中国区 Key 会返回 401。
+> 必须在 `~/.hermes/.env` 中追加：
+> ```bash
+> DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+> ```
+
+### 可用模型
+
+| 模型 | 上下文窗口 | 特点 | 适用场景 |
+|------|-----------|------|----------|
+| `qwen3-235b-a22b` | 131K | 最强旗舰 | 复杂推理 |
+| `qwen3.5-plus` | 131K | 最新增强版 | 代码、推理 |
+| `qwen-plus` ⭐ | 131K | 性价比首选 | 日常使用（**推荐**） |
+| `qwen-turbo` | 131K | 快速版 | 高并发 |
+| `qwen-long` | 10M | 超长文本 | 文档分析 |
+
+> ⚠️ **`qwen-max` 不可用**：上下文窗口仅 32K，低于 Hermes Agent 64K 最低要求，启动时报错。请使用 `qwen-plus` 或 `qwen-turbo`（均为 131K）。
+
+### 完整 .env 示例
+
+```bash
+DASHSCOPE_API_KEY=sk-xxxxxxxxxxxxxxxx
+DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+```
+
+---
+
+## DeepSeek
+
+### 前置准备
+
+1. 注册 [DeepSeek 开放平台](https://platform.deepseek.com/)
+2. 创建 API Key
+
+### 配置步骤
+
+```bash
+hermes config set DEEPSEEK_API_KEY sk-xxx
+hermes config set model deepseek/deepseek-chat
+```
+
+### 可用模型
+
+| 模型 | 特点 |
+|------|------|
+| `deepseek-chat` | 通用对话，平衡性能 |
+| `deepseek-reasoner` | 强化推理，适合数学/逻辑 |
+| `deepseek-coder` | 代码专用 |
+
+---
+
+## z.ai / 智谱 GLM
+
+### 前置准备
+
+1. 注册 [智谱 AI 开放平台](https://open.bigmodel.cn/)
+2. 在控制台创建 API Key
+
+### 配置步骤
+
+```bash
+hermes config set GLM_API_KEY your-glm-api-key
+hermes config set model zai/glm-4-plus
+```
+
+### 可用模型
+
+| 模型 | 特点 | 适用场景 |
+|------|------|---------|
+| `glm-4-plus` | 平衡性能与成本 | 日常对话、文本分析 |
+| `glm-4-air` | 轻量快速 | 简单任务、高并发 |
+| `glm-4-flash` | 极速响应 | 实时交互 |
+
+---
+
+## Kimi / Moonshot（中国版）
+
+针对中国大陆用户的优化版本，使用国内 API 端点。
+
+### 前置准备
+
+1. 注册 [Moonshot AI](https://platform.moonshot.cn/) 账号（国内站）
+2. 创建 API Key
+
+### 配置步骤
+
+```bash
+hermes config set KIMI_CN_API_KEY your-kimi-cn-api-key
+hermes config set model kimi-coding-cn/kimi-k2.5
+```
+
+### 可用模型
+
+| 模型 | 说明 |
+|------|------|
+| `kimi-k2.5` | Kimi 2.5，性能优化版 |
+| `kimi-k2` | Kimi 2.0 稳定版 |
+| `moonshot-v1-128k` | 128K 超长上下文 |
+
+---
+
+## MiniMax（中国版）
+
+### 前置准备
+
+1. 注册 [MiniMax 开放平台](https://platform.minimaxi.com/)
+2. 创建 API Key
+
+### 配置步骤
+
+```bash
+hermes config set MINIMAX_CN_API_KEY your-minimax-cn-api-key
+hermes config set model minimax-cn/MiniMax-M2.7
+```
+
+### 可用模型
+
+| 模型 | 特点 |
+|------|------|
+| `MiniMax-M2.7` | 最新旗舰模型 |
+| `abab6.5-chat` | 通用对话模型 |
+| `abab6.5s-chat` | 快速响应版本 |
+
+---
+
+## Ollama（本地模型）
+
+适合离线场景或需要数据隐私的场景。
+
+### 前置准备
+
+1. 安装 [Ollama](https://ollama.com/)
+2. 拉取模型：`ollama pull qwen2.5:7b`（推荐国内可用模型）
+
+### 配置步骤
+
+```bash
+hermes model
+# → 选择 "Custom endpoint"
+# → 输入 http://127.0.0.1:11434/v1
+# → 选择已拉取的模型
+```
+
+---
+
+## 多 Provider 故障转移
+
+```yaml
+# ~/.hermes/config.yaml
+model:
+  provider: "alibaba"
+  default: "qwen-plus"
+
+  fallback_providers:
+    - provider: "deepseek"
+      model: "deepseek-chat"
+    - provider: "zai"
+      model: "glm-4-plus"
+```
+
+---
+
+## 常见问题
+
+### Q: 通义千问配置后返回 401？
+
+必须设置国内端点，见上方 Alibaba 节的说明。
+
+### Q: 如何切换已配置的 Provider？
+
+```bash
+hermes model     # 交互式切换
+/model           # 在会话中快速切换
+```
+
+### Q: API Key 存储在哪里？
+
+所有 API Key 存储在 `~/.hermes/.env`，权限 600，仅当前用户可读。
+
+### Q: 如何验证配置是否生效？
+
+```bash
+hermes doctor    # 诊断配置
+hermes           # 启动对话测试
+```
+
+### Q: 如何查看用量和配额？
+
+- 阿里云：https://dashscope.console.aliyun.com/usage
+- DeepSeek：https://platform.deepseek.com/usage
+- 智谱 AI：https://open.bigmodel.cn/usercenter/apikeys
+- Moonshot：https://platform.moonshot.cn/console/usage
+- MiniMax：https://platform.minimaxi.com/user-center/billing
+
+---
+
+## 最佳实践
+
+1. 首次使用从 `hermes model` 交互式配置开始，避免手动编辑出错
+2. 通义千问务必设置 `DASHSCOPE_BASE_URL`，否则必然 401
+3. 建议同时配置 2 个 Provider 做故障转移（如 Alibaba + DeepSeek）
+4. 定期在各平台控制台检查用量，避免超额
+5. 定期备份 `~/.hermes/.env` 和 `~/.hermes/config.yaml`

--- a/src/os-skills/ai/install-hermes/references/quickstart-reference.md
+++ b/src/os-skills/ai/install-hermes/references/quickstart-reference.md
@@ -1,0 +1,174 @@
+# Hermes Agent 详细参考
+
+本文档为 SKILL.md 的补充参考，包含更详细的配置说明和使用场景。
+
+## 安装器详细行为
+
+安装器自动完成以下工作：
+
+1. 检测操作系统和架构（Linux/macOS/WSL2/Termux）
+2. 安装 **uv**
+3. 通过 uv 安装 **Python 3.11**
+4. 安装 **Node.js v22**（浏览器自动化和 WhatsApp 桥接）
+5. 安装 **ripgrep**（快速文件搜索）和 **ffmpeg**（音频转换）
+6. 克隆 hermes-agent 仓库
+7. 创建虚拟环境并安装依赖
+8. 配置全局 `hermes` 命令
+9. 引导 LLM Provider 配置
+
+## config.yaml 配置结构
+
+Hermes 将配置分为两个文件：
+
+### ~/.hermes/.env（密钥）
+
+```env
+OPENROUTER_API_KEY=sk-or-xxxxx
+ANTHROPIC_API_KEY=sk-ant-xxxxx
+OPENAI_API_KEY=sk-xxxxx
+TELEGRAM_BOT_TOKEN=xxxxx
+DISCORD_BOT_TOKEN=xxxxx
+ELEVENLABS_API_KEY=xxxxx
+```
+
+### ~/.hermes/config.yaml（非密钥设置）
+
+```yaml
+model:
+  provider: "alibaba"          # 使用的 Provider：alibaba / deepseek / zai / openrouter ...
+  default: "qwen-plus"         # 默认模型（需满足 64K 上下文要求）
+
+terminal:
+  backend: local          # local | docker | ssh | daytona | singularity | modal
+
+# MCP 服务器集成
+mcp_servers:
+  github:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxx"
+  filesystem:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+```
+
+### 配置管理 CLI
+
+```bash
+hermes config set model anthropic/claude-opus-4.6    # 设置模型
+hermes config set terminal.backend docker             # 设置终端后端
+hermes config set OPENROUTER_API_KEY sk-or-...        # 设置 API Key（自动写入 .env）
+hermes config check                                    # 检查配置
+hermes config migrate                                  # 迁移旧配置格式
+```
+
+## 终端后端详解
+
+Hermes 支持 6 种终端后端，决定智能体在哪里执行命令：
+
+| 后端 | 说明 | 适用场景 |
+|------|------|---------|
+| `local` | 直接在本机执行 | 开发、个人使用 |
+| `docker` | Docker 容器隔离 | 安全沙箱 |
+| `ssh` | 远程服务器执行 | 远程开发 |
+| `daytona` | Serverless 持久化 | 闲时休眠，按需唤醒 |
+| `singularity` | HPC 容器 | GPU 集群 |
+| `modal` | Serverless GPU | GPU 推理、闲时近零成本 |
+
+## 消息网关平台支持
+
+完整的 15+ 平台列表：
+
+| 平台 | 说明 |
+|------|------|
+| Telegram | 最完善支持 |
+| Discord | 包含语音频道支持 |
+| Slack | 工作团队 |
+| WhatsApp | 需 Node.js |
+| Signal | 安全通信 |
+| Email | 邮件交互 |
+| Matrix | 开源协议 |
+| Mattermost | 自托管团队 |
+| SMS | 短信 |
+| DingTalk（钉钉） | 企业通信 |
+| Feishu（飞书） | 企业通信 |
+| WeCom（企微） | 企业微信 |
+| BlueBubbles | iMessage 桥接 |
+| Home Assistant | 智能家居 |
+
+### 网关管理命令
+
+```bash
+hermes gateway setup     # 交互式配置（选择平台、填入 token）
+hermes gateway start     # 启动网关进程
+hermes gateway stop      # 停止网关
+hermes gateway status    # 查看各平台连接状态
+```
+
+## Slash 命令参考
+
+### CLI 和消息平台通用
+
+| 命令 | 说明 |
+|------|------|
+| `/new` 或 `/reset` | 新建对话 |
+| `/model [provider:model]` | 切换模型 |
+| `/personality [name]` | 设置性格 |
+| `/retry` | 重试上一轮 |
+| `/undo` | 撤销上一轮 |
+| `/compress` | 压缩上下文 |
+| `/usage` | 查看 token 使用 |
+| `/insights [--days N]` | 使用洞察 |
+| `/skills` | 浏览技能 |
+| `/tools` | 查看可用工具 |
+| `/help` | 帮助 |
+| `/save` | 保存对话 |
+| `/voice on` | 开启语音模式 |
+
+### CLI 专用
+
+- **多行输入**: `Alt+Enter` 或 `Ctrl+J` 换行
+- **中断**: 输入新消息按 Enter，或 `Ctrl+C`
+- **语音录制**: `Ctrl+B`
+
+## OpenClaw 迁移详情
+
+### 迁移预设
+
+| 预设 | 包含内容 |
+|------|---------|
+| `full`（默认） | 所有内容（包括密钥） |
+| `user-data` | 用户数据（不含密钥） |
+
+### 迁移选项
+
+```bash
+hermes claw migrate --help              # 查看所有选项
+hermes claw migrate --dry-run           # 预览（不执行）
+hermes claw migrate --overwrite         # 覆盖已有冲突
+hermes claw migrate --workspace-target  # 包含 AGENTS.md 等工作区文件
+```
+
+### 迁移内容清单
+
+- **SOUL.md** → 人格文件
+- **MEMORY.md / USER.md** → 记忆条目
+- **用户技能** → `~/.hermes/skills/openclaw-imports/`
+- **命令白名单** → approval patterns
+- **消息平台配置** → 平台 config、allowed users、工作目录
+- **API 密钥** → Telegram, OpenRouter, OpenAI, Anthropic, ElevenLabs
+- **TTS 资源** → 工作区音频文件
+- **AGENTS.md** → 需 `--workspace-target` 参数
+
+## 更新与维护
+
+```bash
+hermes update     # 更新到最新版本
+hermes doctor     # 诊断环境问题
+```
+
+## 相关链接
+
+- 完整文档: https://hermes-agent.nousresearch.com/docs
+- GitHub: https://github.com/NousResearch/hermes-agent

--- a/src/os-skills/ai/install-hermes/scripts/install.sh
+++ b/src/os-skills/ai/install-hermes/scripts/install.sh
@@ -1,0 +1,1549 @@
+#!/bin/bash
+# Hermes Agent Installer
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+MAGENTA='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+# Configuration
+REPO_URL_SSH="git@gitcode.com:GitHub_Trending/he/hermes-agent.git"
+REPO_URL_HTTPS="https://gitcode.com/GitHub_Trending/he/hermes-agent.git"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+INSTALL_DIR="${HERMES_INSTALL_DIR:-$HERMES_HOME/hermes-agent}"
+PYTHON_VERSION="3.11"
+NODE_VERSION="22"
+NPM_REGISTRY="https://registry.npmmirror.com"
+
+# Options
+USE_VENV=true
+RUN_SETUP=false
+BRANCH="main"
+INSTALL_MINIMAL=true   # Default: minimal install (no heavy extras like daytona/playwright/whatsapp)
+
+# Detect non-interactive mode (e.g. curl | bash)
+# When stdin is not a terminal, read -p will fail with EOF,
+# causing set -e to silently abort the entire script.
+if [ -t 0 ]; then
+    IS_INTERACTIVE=true
+else
+    IS_INTERACTIVE=false
+fi
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-venv)
+            USE_VENV=false
+            shift
+            ;;
+        --skip-setup)
+            RUN_SETUP=false
+            shift
+            ;;
+        --with-setup)
+            RUN_SETUP=true
+            shift
+            ;;
+        --branch)
+            BRANCH="$2"
+            shift 2
+            ;;
+        --dir)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --hermes-home)
+            HERMES_HOME="$2"
+            shift 2
+            ;;
+        --full)
+            INSTALL_MINIMAL=false
+            shift
+            ;;
+        -h|--help)
+            echo "Hermes Agent Installer"
+            echo ""
+            echo "Usage: install.sh [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --no-venv      Don't create virtual environment"
+            echo "  --with-setup   Run interactive setup wizard after install"
+            echo "  --skip-setup   Skip interactive setup wizard (default)"
+            echo "  --full         Install all extras (daytona, playwright, whatsapp, etc.)"
+            echo "                 Default: minimal install for faster setup"
+            echo "  --branch NAME  Git branch to install (default: main)"
+            echo "  --dir PATH     Installation directory (default: ~/.hermes/hermes-agent)"
+            echo "  --hermes-home PATH  Data directory (default: ~/.hermes, or \$HERMES_HOME)"
+            echo "  -h, --help     Show this help"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# ============================================================================
+# Helper functions
+# ============================================================================
+
+print_banner() {
+    echo ""
+    echo -e "${MAGENTA}${BOLD}"
+    echo "┌─────────────────────────────────────────────────────────┐"
+    echo "│             ⚕ Hermes Agent Installer                    │"
+    echo "├─────────────────────────────────────────────────────────┤"
+    echo "│  An open source AI agent by Nous Research.              │"
+    echo "└─────────────────────────────────────────────────────────┘"
+    echo -e "${NC}"
+}
+
+log_info() {
+    echo -e "${CYAN}→${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+prompt_yes_no() {
+    local question="$1"
+    local default="${2:-yes}"
+    local prompt_suffix
+    local answer=""
+
+    # Use case patterns (not ${var,,}) so this works on bash 3.2 (macOS /bin/bash).
+    case "$default" in
+        [yY]|[yY][eE][sS]|[tT][rR][uU][eE]|1) prompt_suffix="[Y/n]" ;;
+        *) prompt_suffix="[y/N]" ;;
+    esac
+
+    if [ "$IS_INTERACTIVE" = true ]; then
+        read -r -p "$question $prompt_suffix " answer || answer=""
+    elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        printf "%s %s " "$question" "$prompt_suffix" > /dev/tty
+        IFS= read -r answer < /dev/tty || answer=""
+    else
+        answer=""
+    fi
+
+    answer="${answer#"${answer%%[![:space:]]*}"}"
+    answer="${answer%"${answer##*[![:space:]]}"}"
+
+    if [ -z "$answer" ]; then
+        case "$default" in
+            [yY]|[yY][eE][sS]|[tT][rR][uU][eE]|1) return 0 ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    case "$answer" in
+        [yY]|[yY][eE][sS]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_termux() {
+    [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
+}
+
+get_command_link_dir() {
+    if is_termux && [ -n "${PREFIX:-}" ]; then
+        echo "$PREFIX/bin"
+    else
+        echo "$HOME/.local/bin"
+    fi
+}
+
+get_command_link_display_dir() {
+    if is_termux && [ -n "${PREFIX:-}" ]; then
+        echo '$PREFIX/bin'
+    else
+        echo '~/.local/bin'
+    fi
+}
+
+get_hermes_command_path() {
+    local link_dir
+    link_dir="$(get_command_link_dir)"
+    if [ -x "$link_dir/hermes" ]; then
+        echo "$link_dir/hermes"
+    else
+        echo "hermes"
+    fi
+}
+
+# ============================================================================
+# System detection
+# ============================================================================
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux*)
+            if is_termux; then
+                OS="android"
+                DISTRO="termux"
+            else
+                OS="linux"
+                if [ -f /etc/os-release ]; then
+                    . /etc/os-release
+                    DISTRO="$ID"
+                else
+                    DISTRO="unknown"
+                fi
+            fi
+            ;;
+        Darwin*)
+            OS="macos"
+            DISTRO="macos"
+            ;;
+        CYGWIN*|MINGW*|MSYS*)
+            OS="windows"
+            DISTRO="windows"
+            log_error "Windows detected. Please use the PowerShell installer:"
+            log_info "  irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex"
+            exit 1
+            ;;
+        *)
+            OS="unknown"
+            DISTRO="unknown"
+            log_warn "Unknown operating system"
+            ;;
+    esac
+
+    log_success "Detected: $OS ($DISTRO)"
+}
+
+# ============================================================================
+# Dependency checks
+# ============================================================================
+
+install_uv() {
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Termux detected — using Python's stdlib venv + pip instead of uv"
+        UV_CMD=""
+        return 0
+    fi
+
+    log_info "Checking for uv package manager..."
+
+    # Check common locations for uv
+    if command -v uv &> /dev/null; then
+        UV_CMD="uv"
+        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        log_success "uv found ($UV_VERSION)"
+        return 0
+    fi
+
+    # Check ~/.local/bin (default uv install location) even if not on PATH yet
+    if [ -x "$HOME/.local/bin/uv" ]; then
+        UV_CMD="$HOME/.local/bin/uv"
+        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        log_success "uv found at ~/.local/bin ($UV_VERSION)"
+        return 0
+    fi
+
+    # Check ~/.cargo/bin (alternative uv install location)
+    if [ -x "$HOME/.cargo/bin/uv" ]; then
+        UV_CMD="$HOME/.cargo/bin/uv"
+        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        log_success "uv found at ~/.cargo/bin ($UV_VERSION)"
+        return 0
+    fi
+
+    # Install uv
+    log_info "Installing uv (fast Python package manager)..."
+    if curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null; then
+        # uv installs to ~/.local/bin by default
+        if [ -x "$HOME/.local/bin/uv" ]; then
+            UV_CMD="$HOME/.local/bin/uv"
+        elif [ -x "$HOME/.cargo/bin/uv" ]; then
+            UV_CMD="$HOME/.cargo/bin/uv"
+        elif command -v uv &> /dev/null; then
+            UV_CMD="uv"
+        else
+            log_error "uv installed but not found on PATH"
+            log_info "Try adding ~/.local/bin to your PATH and re-running"
+            exit 1
+        fi
+        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        log_success "uv installed ($UV_VERSION)"
+    else
+        log_error "Failed to install uv"
+        log_info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
+        exit 1
+    fi
+}
+
+check_python() {
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Checking Termux Python..."
+        if command -v python >/dev/null 2>&1; then
+            PYTHON_PATH="$(command -v python)"
+            if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+                PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+                log_success "Python found: $PYTHON_FOUND_VERSION"
+                return 0
+            fi
+        fi
+
+        log_info "Installing Python via pkg..."
+        pkg install -y python >/dev/null
+        PYTHON_PATH="$(command -v python)"
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+        log_success "Python installed: $PYTHON_FOUND_VERSION"
+        return 0
+    fi
+
+    log_info "Checking Python $PYTHON_VERSION..."
+
+    # Let uv handle Python — it can download and manage Python versions
+    # First check if a suitable Python is already available
+    if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION" 2>/dev/null)"; then
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+        log_success "Python found: $PYTHON_FOUND_VERSION"
+        return 0
+    fi
+
+    # Python not found — use uv to install it (no sudo needed!)
+    log_info "Python $PYTHON_VERSION not found, installing via uv..."
+    if "$UV_CMD" python install "$PYTHON_VERSION"; then
+        PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION")"
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+        log_success "Python installed: $PYTHON_FOUND_VERSION"
+    else
+        log_error "Failed to install Python $PYTHON_VERSION"
+        log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
+        exit 1
+    fi
+}
+
+check_git() {
+    log_info "Checking Git..."
+
+    if command -v git &> /dev/null; then
+        GIT_VERSION=$(git --version | awk '{print $3}')
+        log_success "Git $GIT_VERSION found"
+        return 0
+    fi
+
+    log_error "Git not found"
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Installing Git via pkg..."
+        pkg install -y git >/dev/null
+        if command -v git >/dev/null 2>&1; then
+            GIT_VERSION=$(git --version | awk '{print $3}')
+            log_success "Git $GIT_VERSION installed"
+            return 0
+        fi
+    fi
+
+    log_info "Please install Git:"
+
+    case "$OS" in
+        linux)
+            case "$DISTRO" in
+                ubuntu|debian)
+                    log_info "  sudo apt update && sudo apt install git"
+                    ;;
+                fedora)
+                    log_info "  sudo dnf install git"
+                    ;;
+                arch)
+                    log_info "  sudo pacman -S git"
+                    ;;
+                *)
+                    log_info "  Use your package manager to install git"
+                    ;;
+            esac
+            ;;
+        android)
+            log_info "  pkg install git"
+            ;;
+        macos)
+            log_info "  xcode-select --install"
+            log_info "  Or: brew install git"
+            ;;
+    esac
+
+    exit 1
+}
+
+check_node() {
+    log_info "Checking Node.js (for browser tools)..."
+
+    if command -v node &> /dev/null; then
+        local found_ver=$(node --version)
+        log_success "Node.js $found_ver found"
+        HAS_NODE=true
+        return 0
+    fi
+
+    # Check our own managed install from a previous run
+    if [ -x "$HERMES_HOME/node/bin/node" ]; then
+        export PATH="$HERMES_HOME/node/bin:$PATH"
+        local found_ver=$("$HERMES_HOME/node/bin/node" --version)
+        log_success "Node.js $found_ver found (Hermes-managed)"
+        HAS_NODE=true
+        return 0
+    fi
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Node.js not found — installing Node.js via pkg..."
+    else
+        log_info "Node.js not found — installing Node.js $NODE_VERSION LTS..."
+    fi
+    install_node
+}
+
+install_node() {
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Installing Node.js via pkg..."
+        if pkg install -y nodejs >/dev/null; then
+            local installed_ver
+            installed_ver=$(node --version 2>/dev/null)
+            log_success "Node.js $installed_ver installed via pkg"
+            HAS_NODE=true
+        else
+            log_warn "Failed to install Node.js via pkg"
+            HAS_NODE=false
+        fi
+        return 0
+    fi
+
+    local arch=$(uname -m)
+    local node_arch
+    case "$arch" in
+        x86_64)        node_arch="x64"    ;;
+        aarch64|arm64) node_arch="arm64"  ;;
+        armv7l)        node_arch="armv7l" ;;
+        *)
+            log_warn "Unsupported architecture ($arch) for Node.js auto-install"
+            log_info "Install manually: https://nodejs.org/en/download/"
+            HAS_NODE=false
+            return 0
+            ;;
+    esac
+
+    local node_os
+    case "$OS" in
+        linux) node_os="linux"  ;;
+        macos) node_os="darwin" ;;
+        *)
+            log_warn "Unsupported OS for Node.js auto-install"
+            HAS_NODE=false
+            return 0
+            ;;
+    esac
+
+    # Resolve the latest v22.x.x tarball name from the index page
+    local index_url="https://nodejs.org/dist/latest-v${NODE_VERSION}.x/"
+    local tarball_name
+    tarball_name=$(curl -fsSL "$index_url" \
+        | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
+        | head -1)
+
+    # Fallback to .tar.gz if .tar.xz not available
+    if [ -z "$tarball_name" ]; then
+        tarball_name=$(curl -fsSL "$index_url" \
+            | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz" \
+            | head -1)
+    fi
+
+    if [ -z "$tarball_name" ]; then
+        log_warn "Could not find Node.js $NODE_VERSION binary for $node_os-$node_arch"
+        log_info "Install manually: https://nodejs.org/en/download/"
+        HAS_NODE=false
+        return 0
+    fi
+
+    local download_url="${index_url}${tarball_name}"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    log_info "Downloading $tarball_name..."
+    if ! curl -fsSL "$download_url" -o "$tmp_dir/$tarball_name"; then
+        log_warn "Download failed"
+        rm -rf "$tmp_dir"
+        HAS_NODE=false
+        return 0
+    fi
+
+    log_info "Extracting to ~/.hermes/node/..."
+    if [[ "$tarball_name" == *.tar.xz ]]; then
+        tar xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+    else
+        tar xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+    fi
+
+    local extracted_dir
+    extracted_dir=$(ls -d "$tmp_dir"/node-v* 2>/dev/null | head -1)
+
+    if [ ! -d "$extracted_dir" ]; then
+        log_warn "Extraction failed"
+        rm -rf "$tmp_dir"
+        HAS_NODE=false
+        return 0
+    fi
+
+    # Place into ~/.hermes/node/ and symlink binaries to ~/.local/bin/
+    rm -rf "$HERMES_HOME/node"
+    mkdir -p "$HERMES_HOME"
+    mv "$extracted_dir" "$HERMES_HOME/node"
+    rm -rf "$tmp_dir"
+
+    mkdir -p "$HOME/.local/bin"
+    ln -sf "$HERMES_HOME/node/bin/node" "$HOME/.local/bin/node"
+    ln -sf "$HERMES_HOME/node/bin/npm"  "$HOME/.local/bin/npm"
+    ln -sf "$HERMES_HOME/node/bin/npx"  "$HOME/.local/bin/npx"
+
+    export PATH="$HERMES_HOME/node/bin:$PATH"
+
+    local installed_ver
+    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null)
+    log_success "Node.js $installed_ver installed to ~/.hermes/node/"
+    HAS_NODE=true
+}
+
+install_system_packages() {
+    # Detect what's missing
+    HAS_RIPGREP=false
+    HAS_FFMPEG=false
+    local need_ripgrep=false
+    local need_ffmpeg=false
+
+    log_info "Checking ripgrep (fast file search)..."
+    if command -v rg &> /dev/null; then
+        log_success "$(rg --version | head -1) found"
+        HAS_RIPGREP=true
+    else
+        need_ripgrep=true
+    fi
+
+    log_info "Checking ffmpeg (TTS voice messages)..."
+    if command -v ffmpeg &> /dev/null; then
+        local ffmpeg_ver=$(ffmpeg -version 2>/dev/null | head -1 | awk '{print $3}')
+        log_success "ffmpeg $ffmpeg_ver found"
+        HAS_FFMPEG=true
+    else
+        need_ffmpeg=true
+    fi
+
+    # Termux always needs the Android build toolchain for the tested pip path,
+    # even when ripgrep/ffmpeg are already present.
+    if [ "$DISTRO" = "termux" ]; then
+        local termux_pkgs=(clang rust make pkg-config libffi openssl)
+        if [ "$need_ripgrep" = true ]; then
+            termux_pkgs+=("ripgrep")
+        fi
+        if [ "$need_ffmpeg" = true ]; then
+            termux_pkgs+=("ffmpeg")
+        fi
+
+        log_info "Installing Termux packages: ${termux_pkgs[*]}"
+        if pkg install -y "${termux_pkgs[@]}" >/dev/null; then
+            [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+            [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+            log_success "Termux build dependencies installed"
+            return 0
+        fi
+
+        log_warn "Could not auto-install all Termux packages"
+        log_info "Install manually: pkg install ${termux_pkgs[*]}"
+        return 0
+    fi
+
+    # Nothing to install — done
+    if [ "$need_ripgrep" = false ] && [ "$need_ffmpeg" = false ]; then
+        return 0
+    fi
+
+    # Build a human-readable description + package list
+    local desc_parts=()
+    local pkgs=()
+    if [ "$need_ripgrep" = true ]; then
+        desc_parts+=("ripgrep for faster file search")
+        pkgs+=("ripgrep")
+    fi
+    if [ "$need_ffmpeg" = true ]; then
+        desc_parts+=("ffmpeg for TTS voice messages")
+        pkgs+=("ffmpeg")
+    fi
+    local description
+    description=$(IFS=" and "; echo "${desc_parts[*]}")
+
+    # ── macOS: brew ──
+    if [ "$OS" = "macos" ]; then
+        if command -v brew &> /dev/null; then
+            log_info "Installing ${pkgs[*]} via Homebrew..."
+            if brew install "${pkgs[@]}"; then
+                [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+                [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                return 0
+            fi
+        fi
+        log_warn "Could not auto-install (brew not found or install failed)"
+        log_info "Install manually: brew install ${pkgs[*]}"
+        return 0
+    fi
+
+    # ── Linux: resolve package manager command ──
+    local pkg_install=""
+    case "$DISTRO" in
+        ubuntu|debian) pkg_install="apt install -y"   ;;
+        fedora)        pkg_install="dnf install -y"   ;;
+        arch)          pkg_install="pacman -S --noconfirm" ;;
+    esac
+
+    if [ -n "$pkg_install" ]; then
+        local install_cmd="$pkg_install ${pkgs[*]}"
+
+        # Prevent needrestart/whiptail dialogs from blocking non-interactive installs
+        case "$DISTRO" in
+            ubuntu|debian) export DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a ;;
+        esac
+
+        # Already root — just install
+        if [ "$(id -u)" -eq 0 ]; then
+            log_info "Installing ${pkgs[*]}..."
+            if $install_cmd; then
+                [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+                [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                return 0
+            fi
+        # Passwordless sudo — just install
+        elif command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
+            log_info "Installing ${pkgs[*]}..."
+            if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd; then
+                [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+                [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                return 0
+            fi
+        # sudo needs password — ask once for everything
+        elif command -v sudo &> /dev/null; then
+            if [ "$IS_INTERACTIVE" = true ]; then
+                echo ""
+                log_info "sudo is needed ONLY to install optional system packages (${pkgs[*]}) via your package manager."
+                log_info "Hermes Agent itself does not require or retain root access."
+                if prompt_yes_no "Install ${description}? (requires sudo)" "no"; then
+                    if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd; then
+                        [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+                        [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                        return 0
+                    fi
+                fi
+            elif [ -e /dev/tty ]; then
+                # Non-interactive (e.g. curl | bash) but a terminal is available.
+                # Read the prompt from /dev/tty (same approach the setup wizard uses).
+                echo ""
+                log_info "sudo is needed ONLY to install optional system packages (${pkgs[*]}) via your package manager."
+                log_info "Hermes Agent itself does not require or retain root access."
+                if prompt_yes_no "Install ${description}?" "yes"; then
+                    if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd < /dev/tty; then
+                        [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+                        [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                        return 0
+                    fi
+                fi
+            else
+                log_warn "Non-interactive mode and no terminal available — cannot install system packages"
+                log_info "Install manually after setup completes: sudo $install_cmd"
+            fi
+        fi
+    fi
+
+    # ── Fallback for ripgrep: cargo ──
+    if [ "$need_ripgrep" = true ] && [ "$HAS_RIPGREP" = false ]; then
+        if command -v cargo &> /dev/null; then
+            log_info "Trying cargo install ripgrep (no sudo needed)..."
+            if cargo install ripgrep; then
+                log_success "ripgrep installed via cargo"
+                HAS_RIPGREP=true
+            fi
+        fi
+    fi
+
+    # ── Show manual instructions for anything still missing ──
+    if [ "$HAS_RIPGREP" = false ] && [ "$need_ripgrep" = true ]; then
+        log_warn "ripgrep not installed (file search will use grep fallback)"
+        show_manual_install_hint "ripgrep"
+    fi
+    if [ "$HAS_FFMPEG" = false ] && [ "$need_ffmpeg" = true ]; then
+        log_warn "ffmpeg not installed (TTS voice messages will be limited)"
+        show_manual_install_hint "ffmpeg"
+    fi
+}
+
+show_manual_install_hint() {
+    local pkg="$1"
+    log_info "To install $pkg manually:"
+    case "$OS" in
+        linux)
+            case "$DISTRO" in
+                ubuntu|debian) log_info "  sudo apt install $pkg" ;;
+                fedora)        log_info "  sudo dnf install $pkg" ;;
+                arch)          log_info "  sudo pacman -S $pkg"   ;;
+                *)             log_info "  Use your package manager or visit the project homepage" ;;
+            esac
+            ;;
+        android)
+            log_info "  pkg install $pkg"
+            ;;
+        macos) log_info "  brew install $pkg" ;;
+    esac
+}
+
+# ============================================================================
+# Venv dependency check
+# ============================================================================
+
+# Global flag: set to true when venv already has all deps satisfied
+VENV_DEPS_OK=false
+
+check_venv_deps_satisfied() {
+    # Returns 0 (true) if the venv exists and all Python dependencies are intact.
+    # Returns 1 (false) if anything is missing or broken.
+    if [ "$USE_VENV" = false ]; then
+        return 1
+    fi
+
+    local venv_python="$INSTALL_DIR/venv/bin/python"
+    local venv_hermes="$INSTALL_DIR/venv/bin/hermes"
+
+    # venv python must be executable
+    [ -x "$venv_python" ] || return 1
+
+    # hermes entry point must exist
+    [ -x "$venv_hermes" ] || return 1
+
+    # main package must be importable
+    if ! "$venv_python" -c "import hermes_cli" 2>/dev/null; then
+        return 1
+    fi
+
+    # no broken dependency conflicts
+    if ! "$venv_python" -m pip check 2>/dev/null; then
+        return 1
+    fi
+
+    return 0
+}
+
+# ============================================================================
+# Installation
+# ============================================================================
+
+clone_repo() {
+    log_info "Installing to $INSTALL_DIR..."
+
+    if [ -d "$INSTALL_DIR" ]; then
+        if [ -d "$INSTALL_DIR/.git" ]; then
+            log_info "Existing installation found, updating..."
+            cd "$INSTALL_DIR"
+
+            local autostash_ref=""
+            if [ -n "$(git status --porcelain)" ]; then
+                local stash_name
+                stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
+                log_info "Local changes detected, stashing before update..."
+                git stash push --include-untracked -m "$stash_name"
+                autostash_ref="$(git rev-parse --verify refs/stash)"
+            fi
+
+            git fetch origin
+            git checkout "$BRANCH"
+            git pull --ff-only origin "$BRANCH"
+
+            if [ -n "$autostash_ref" ]; then
+                local restore_now="yes"
+                if [ -t 0 ] && [ -t 1 ]; then
+                    echo
+                    log_warn "Local changes were stashed before updating."
+                    log_warn "Restoring them may reapply local customizations onto the updated codebase."
+                    printf "Restore local changes now? [Y/n] "
+                    read -r restore_answer
+                    case "$restore_answer" in
+                        ""|y|Y|yes|YES|Yes) restore_now="yes" ;;
+                        *) restore_now="no" ;;
+                    esac
+                fi
+
+                if [ "$restore_now" = "yes" ]; then
+                    log_info "Restoring local changes..."
+                    if git stash apply "$autostash_ref"; then
+                        git stash drop "$autostash_ref" >/dev/null
+                        log_warn "Local changes were restored on top of the updated codebase."
+                        log_warn "Review git diff / git status if Hermes behaves unexpectedly."
+                    else
+                        log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
+                        log_info "Resolve manually with: git stash apply $autostash_ref"
+                        exit 1
+                    fi
+                else
+                    log_info "Skipped restoring local changes."
+                    log_info "Your changes are still preserved in git stash."
+                    log_info "Restore manually with: git stash apply $autostash_ref"
+                fi
+            fi
+        else
+            log_error "Directory exists but is not a git repository: $INSTALL_DIR"
+            log_info "Remove it or choose a different directory with --dir"
+            exit 1
+        fi
+    else
+        # Try SSH first (for private repo access), fall back to HTTPS
+        # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
+        # so SSH fails fast instead of hanging when no key is configured.
+        log_info "Trying SSH clone..."
+        if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
+           git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+            log_success "Cloned via SSH"
+        else
+            rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
+            log_info "SSH failed, trying HTTPS..."
+            if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+                log_success "Cloned via HTTPS"
+            else
+                log_error "Failed to clone repository"
+                exit 1
+            fi
+        fi
+    fi
+
+    cd "$INSTALL_DIR"
+
+    log_success "Repository ready"
+}
+
+setup_venv() {
+    if [ "$USE_VENV" = false ]; then
+        log_info "Skipping virtual environment (--no-venv)"
+        return 0
+    fi
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Creating virtual environment with Termux Python..."
+
+        if [ -d "venv" ]; then
+            if check_venv_deps_satisfied; then
+                log_success "Virtual environment already exists and dependencies are satisfied, skipping recreation"
+                VENV_DEPS_OK=true
+                return 0
+            fi
+            log_info "Virtual environment exists but dependencies need updating, recreating..."
+            rm -rf venv
+        fi
+
+        "$PYTHON_PATH" -m venv venv
+        log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null))"
+        return 0
+    fi
+
+    log_info "Creating virtual environment with Python $PYTHON_VERSION..."
+
+    if [ -d "venv" ]; then
+        if check_venv_deps_satisfied; then
+            log_success "Virtual environment already exists and dependencies are satisfied, skipping recreation"
+            VENV_DEPS_OK=true
+            return 0
+        fi
+        log_info "Virtual environment exists but dependencies need updating, recreating..."
+        rm -rf venv
+    fi
+
+    # Use uv venv for faster creation (no pip bootstrap overhead)
+    # --seed installs pip/setuptools/wheel so the pip fallback path works if uv pip fails
+    if "$UV_CMD" venv venv --python "$PYTHON_VERSION" --seed 2>/dev/null; then
+        log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null))"
+    else
+        # Fallback to standard Python venv
+        log_warn "uv venv failed, falling back to python -m venv..."
+        "$PYTHON_PATH" -m venv venv
+        log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null))"
+    fi
+}
+
+install_deps() {
+    # Skip if the venv was already verified as up-to-date by setup_venv
+    if [ "$VENV_DEPS_OK" = true ]; then
+        log_success "Dependencies already satisfied, skipping installation"
+        return 0
+    fi
+
+    log_info "Installing dependencies..."
+
+    if [ "$DISTRO" = "termux" ]; then
+        if [ "$USE_VENV" = true ]; then
+            export VIRTUAL_ENV="$INSTALL_DIR/venv"
+            PIP_PYTHON="$INSTALL_DIR/venv/bin/python"
+        else
+            PIP_PYTHON="$PYTHON_PATH"
+        fi
+
+        if [ -z "${ANDROID_API_LEVEL:-}" ]; then
+            ANDROID_API_LEVEL="$(getprop ro.build.version.sdk 2>/dev/null || true)"
+            if [ -z "$ANDROID_API_LEVEL" ]; then
+                ANDROID_API_LEVEL=24
+            fi
+            export ANDROID_API_LEVEL
+            log_info "Using ANDROID_API_LEVEL=$ANDROID_API_LEVEL for Android wheel builds"
+        fi
+
+        "$PIP_PYTHON" -m pip install --upgrade pip setuptools wheel >/dev/null
+        if ! "$PIP_PYTHON" -m pip install -e '.[termux]' -c constraints-termux.txt; then
+            log_warn "Termux feature install (.[termux]) failed, trying base install..."
+            if ! "$PIP_PYTHON" -m pip install -e '.' -c constraints-termux.txt; then
+                log_error "Package installation failed on Termux."
+                log_info "Ensure these packages are installed: pkg install clang rust make pkg-config libffi openssl"
+                log_info "Then re-run: cd $INSTALL_DIR && python -m pip install -e '.[termux]' -c constraints-termux.txt"
+                exit 1
+            fi
+        fi
+
+        log_success "Main package installed"
+        log_info "Termux note: browser/WhatsApp tooling is not installed by default; see the Termux guide for optional follow-up steps."
+
+        if [ -d "tinker-atropos" ] && [ -f "tinker-atropos/pyproject.toml" ]; then
+            log_info "tinker-atropos submodule found — skipping install (optional, for RL training)"
+            log_info "  To install later: $PIP_PYTHON -m pip install -e \"./tinker-atropos\""
+        fi
+
+        log_success "All dependencies installed"
+        return 0
+    fi
+
+    if [ "$USE_VENV" = true ]; then
+        # Tell uv to install into our venv (no need to activate)
+        export VIRTUAL_ENV="$INSTALL_DIR/venv"
+    fi
+
+    # On Debian/Ubuntu (including WSL), some Python packages need build tools.
+    # Check and offer to install them if missing.
+    if [ "$DISTRO" = "ubuntu" ] || [ "$DISTRO" = "debian" ]; then
+        local need_build_tools=false
+        for pkg in gcc python3-dev libffi-dev; do
+            if ! dpkg -s "$pkg" &>/dev/null; then
+                need_build_tools=true
+                break
+            fi
+        done
+        if [ "$need_build_tools" = true ]; then
+            log_info "Some build tools may be needed for Python packages..."
+            if command -v sudo &> /dev/null; then
+                if sudo -n true 2>/dev/null; then
+                    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1 || true
+                    log_success "Build tools installed"
+                else
+                    log_info "sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt."
+                    log_info "Hermes Agent itself does not require or retain root access."
+                    if prompt_yes_no "Install build tools?" "yes"; then
+                        sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1 || true
+                        log_success "Build tools installed"
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+    # Install the main package.
+    # Use uv pip install (Rust-based resolver, no backtracking) for significantly faster installs.
+    # Default: minimal install without heavy optional extras (daytona, playwright, whatsapp, etc.).
+    # Pass --full to install everything: bash install.sh --full
+    if [ "$USE_VENV" = true ]; then
+        PIP_PYTHON="$INSTALL_DIR/venv/bin/python"
+        export VIRTUAL_ENV="$INSTALL_DIR/venv"
+    else
+        PIP_PYTHON="$PYTHON_PATH"
+    fi
+
+    if [ "$INSTALL_MINIMAL" = true ]; then
+        INSTALL_EXTRAS="."
+        log_info "Installing package (minimal, no heavy extras) with uv..."
+        log_info "Tip: use --full flag to also install daytona/playwright/whatsapp extras"
+    else
+        INSTALL_EXTRAS=".[all]"
+        log_info "Installing package with all extras (.[all]) with uv..."
+    fi
+
+    if ! "$UV_CMD" pip install -e "$INSTALL_EXTRAS" \
+        --no-config \
+        --index-url https://mirrors.aliyun.com/pypi/simple/ \
+        --python "$PIP_PYTHON"; then
+        log_warn "uv pip install failed, falling back to pip..."
+        log_info "Upgrading pip..."
+        "$PIP_PYTHON" -m pip install --upgrade pip setuptools wheel -q
+        if ! "$PIP_PYTHON" -m pip install -e "$INSTALL_EXTRAS" -i https://mirrors.aliyun.com/pypi/simple/; then
+            # Last resort: base install without any extras
+            log_warn "Install with extras failed, trying base install..."
+            if ! "$PIP_PYTHON" -m pip install -e "." -i https://mirrors.aliyun.com/pypi/simple/; then
+                log_error "Package installation failed."
+                log_info "Check that build tools are installed: sudo apt install build-essential python3-dev"
+                log_info "Then re-run: cd $INSTALL_DIR && source venv/bin/activate && pip install -e '.' -i https://mirrors.aliyun.com/pypi/simple/"
+                exit 1
+            fi
+        fi
+    fi
+
+    log_success "Main package installed"
+
+    # tinker-atropos (RL training) is optional — skip by default.
+    # To enable RL tools: git submodule update --init tinker-atropos && pip install -e "./tinker-atropos"
+    if [ -d "tinker-atropos" ] && [ -f "tinker-atropos/pyproject.toml" ]; then
+        log_info "tinker-atropos submodule found — skipping install (optional, for RL training)"
+        log_info "  To install: $PIP_PYTHON -m pip install -e \"./tinker-atropos\" -i https://mirrors.aliyun.com/pypi/simple/"
+    fi
+
+    log_success "All dependencies installed"
+}
+
+setup_path() {
+    log_info "Setting up hermes command..."
+
+    if [ "$USE_VENV" = true ]; then
+        HERMES_BIN="$INSTALL_DIR/venv/bin/hermes"
+    else
+        HERMES_BIN="$(which hermes 2>/dev/null || echo "")"
+        if [ -z "$HERMES_BIN" ]; then
+            log_warn "hermes not found on PATH after install"
+            return 0
+        fi
+    fi
+
+    # Verify the entry point script was actually generated
+    if [ ! -x "$HERMES_BIN" ]; then
+        log_warn "hermes entry point not found at $HERMES_BIN"
+        log_info "This usually means the pip install didn't complete successfully."
+        if [ "$DISTRO" = "termux" ]; then
+            log_info "Try: cd $INSTALL_DIR && python -m pip install -e '.[termux]' -c constraints-termux.txt"
+        else
+            log_info "Try: cd $INSTALL_DIR && uv pip install -e '.[all]'"
+        fi
+        return 0
+    fi
+
+    local command_link_dir
+    local command_link_display_dir
+    command_link_dir="$(get_command_link_dir)"
+    command_link_display_dir="$(get_command_link_display_dir)"
+
+    # Create a user-facing shim for the hermes command.
+    mkdir -p "$command_link_dir"
+    ln -sf "$HERMES_BIN" "$command_link_dir/hermes"
+    log_success "Symlinked hermes → $command_link_display_dir/hermes"
+
+    if [ "$DISTRO" = "termux" ]; then
+        export PATH="$command_link_dir:$PATH"
+        log_info "$command_link_display_dir is the native Termux command path"
+        log_success "hermes command ready"
+        return 0
+    fi
+
+    # Check if ~/.local/bin is on PATH; if not, add it to shell config.
+    # Detect the user's actual login shell (not the shell running this script,
+    # which is always bash when piped from curl).
+    if ! echo "$PATH" | tr ':' '\n' | grep -q "^$command_link_dir$"; then
+        SHELL_CONFIGS=()
+        IS_FISH=false
+        LOGIN_SHELL="$(basename "${SHELL:-/bin/bash}")"
+        case "$LOGIN_SHELL" in
+            zsh)
+                [ -f "$HOME/.zshrc" ] && SHELL_CONFIGS+=("$HOME/.zshrc")
+                [ -f "$HOME/.zprofile" ] && SHELL_CONFIGS+=("$HOME/.zprofile")
+                # If neither exists, create ~/.zshrc (common on fresh macOS installs)
+                if [ ${#SHELL_CONFIGS[@]} -eq 0 ]; then
+                    touch "$HOME/.zshrc"
+                    SHELL_CONFIGS+=("$HOME/.zshrc")
+                fi
+                ;;
+            bash)
+                [ -f "$HOME/.bashrc" ] && SHELL_CONFIGS+=("$HOME/.bashrc")
+                [ -f "$HOME/.bash_profile" ] && SHELL_CONFIGS+=("$HOME/.bash_profile")
+                ;;
+            fish)
+                # fish uses ~/.config/fish/config.fish and fish_add_path — not export PATH=
+                IS_FISH=true
+                FISH_CONFIG="$HOME/.config/fish/config.fish"
+                mkdir -p "$(dirname "$FISH_CONFIG")"
+                touch "$FISH_CONFIG"
+                ;;
+            *)
+                [ -f "$HOME/.bashrc" ] && SHELL_CONFIGS+=("$HOME/.bashrc")
+                [ -f "$HOME/.zshrc" ] && SHELL_CONFIGS+=("$HOME/.zshrc")
+                ;;
+        esac
+        # Also ensure ~/.profile has it (sourced by login shells on
+        # Ubuntu/Debian/WSL even when ~/.bashrc is skipped)
+        [ "$IS_FISH" = "false" ] && [ -f "$HOME/.profile" ] && SHELL_CONFIGS+=("$HOME/.profile")
+
+        PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+
+        for SHELL_CONFIG in "${SHELL_CONFIGS[@]}"; do
+            if ! grep -v '^[[:space:]]*#' "$SHELL_CONFIG" 2>/dev/null | grep -qE 'PATH=.*\.local/bin'; then
+                echo "" >> "$SHELL_CONFIG"
+                echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG"
+                echo "$PATH_LINE" >> "$SHELL_CONFIG"
+                log_success "Added ~/.local/bin to PATH in $SHELL_CONFIG"
+            fi
+        done
+
+        # fish uses fish_add_path instead of export PATH=...
+        if [ "$IS_FISH" = "true" ]; then
+            if ! grep -q 'fish_add_path.*\.local/bin' "$FISH_CONFIG" 2>/dev/null; then
+                echo "" >> "$FISH_CONFIG"
+                echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$FISH_CONFIG"
+                echo 'fish_add_path "$HOME/.local/bin"' >> "$FISH_CONFIG"
+                log_success "Added ~/.local/bin to PATH in $FISH_CONFIG"
+            fi
+        fi
+
+        if [ "$IS_FISH" = "false" ] && [ ${#SHELL_CONFIGS[@]} -eq 0 ]; then
+            log_warn "Could not detect shell config file to add ~/.local/bin to PATH"
+            log_info "Add manually: $PATH_LINE"
+        fi
+    else
+        log_info "~/.local/bin already on PATH"
+    fi
+
+    # Export for current session so hermes works immediately
+    export PATH="$command_link_dir:$PATH"
+
+    log_success "hermes command ready"
+}
+
+copy_config_templates() {
+    log_info "Setting up configuration files..."
+
+    # Create ~/.hermes directory structure (config at top level, code in subdir)
+    mkdir -p "$HERMES_HOME"/{cron,sessions,logs,pairing,hooks,image_cache,audio_cache,memories,skills}
+
+    # Create .env at ~/.hermes/.env (top level, easy to find)
+    if [ ! -f "$HERMES_HOME/.env" ]; then
+        if [ -f "$INSTALL_DIR/.env.example" ]; then
+            cp "$INSTALL_DIR/.env.example" "$HERMES_HOME/.env"
+            log_success "Created ~/.hermes/.env from template"
+        else
+            touch "$HERMES_HOME/.env"
+            log_success "Created ~/.hermes/.env"
+        fi
+    else
+        log_info "~/.hermes/.env already exists, keeping it"
+    fi
+
+    # Create config.yaml at ~/.hermes/config.yaml (top level, easy to find)
+    if [ ! -f "$HERMES_HOME/config.yaml" ]; then
+        if [ -f "$INSTALL_DIR/cli-config.yaml.example" ]; then
+            cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
+            log_success "Created ~/.hermes/config.yaml from template"
+        fi
+    else
+        log_info "~/.hermes/config.yaml already exists, keeping it"
+    fi
+
+    # Create SOUL.md if it doesn't exist (global persona file)
+    if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
+        cat > "$HERMES_HOME/SOUL.md" << 'SOUL_EOF'
+# Hermes Agent Persona
+
+<!--
+This file defines the agent's personality and tone.
+The agent will embody whatever you write here.
+Edit this to customize how Hermes communicates with you.
+
+Examples:
+  - "You are a warm, playful assistant who uses kaomoji occasionally."
+  - "You are a concise technical expert. No fluff, just facts."
+  - "You speak like a friendly coworker who happens to know everything."
+
+This file is loaded fresh each message -- no restart needed.
+Delete the contents (or this file) to use the default personality.
+-->
+SOUL_EOF
+        log_success "Created ~/.hermes/SOUL.md (edit to customize personality)"
+    fi
+
+    log_success "Configuration directory ready: ~/.hermes/"
+
+    # Seed bundled skills into ~/.hermes/skills/ (manifest-based, one-time per skill)
+    log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
+    if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
+        log_success "Skills synced to ~/.hermes/skills/"
+    else
+        # Fallback: simple directory copy if Python sync fails
+        if [ -d "$INSTALL_DIR/skills" ] && [ ! "$(ls -A "$HERMES_HOME/skills/" 2>/dev/null | grep -v '.bundled_manifest')" ]; then
+            cp -r "$INSTALL_DIR/skills/"* "$HERMES_HOME/skills/" 2>/dev/null || true
+            log_success "Skills copied to ~/.hermes/skills/"
+        fi
+    fi
+}
+
+install_node_deps() {
+    if [ "$HAS_NODE" = false ]; then
+        log_info "Skipping Node.js dependencies (Node not installed)"
+        return 0
+    fi
+
+    if [ "$INSTALL_MINIMAL" = true ]; then
+        log_info "Skipping Node.js/browser dependencies (minimal install)"
+        log_info "Tip: use --full flag to install browser tools, Playwright, WhatsApp bridge, TUI"
+        return 0
+    fi
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Skipping automatic Node/browser dependency setup on Termux"
+        log_info "Browser automation is not part of the tested Termux install path yet."
+        log_info "If you want to experiment manually later, run: cd $INSTALL_DIR && npm install"
+        return 0
+    fi
+
+    if [ -f "$INSTALL_DIR/package.json" ]; then
+        log_info "Configuring npm registry to $NPM_REGISTRY ..."
+        npm config set registry "$NPM_REGISTRY" 2>/dev/null || true
+
+        log_info "Installing Node.js dependencies (browser tools)..."
+        cd "$INSTALL_DIR"
+        npm install --registry="$NPM_REGISTRY" --silent 2>/dev/null || {
+            log_warn "npm install failed (browser tools may not work)"
+            log_info "Retry manually: cd $INSTALL_DIR && npm install --registry=$NPM_REGISTRY"
+        }
+        log_success "Node.js dependencies installed"
+
+        # Install WhatsApp Bridge dependencies if present.
+        # NOTE: @whiskeysockets/baileys is fetched directly from GitHub (not npm registry),
+        # so --registry mirror does NOT help. We use a timeout to avoid hanging.
+        if [ -f "$INSTALL_DIR/scripts/whatsapp-bridge/package.json" ]; then
+            log_info "Installing WhatsApp Bridge dependencies (timeout 120s)..."
+            log_warn "Note: WhatsApp Bridge has a GitHub dependency (@whiskeysockets/baileys)."
+            log_warn "This step may be slow or fail in environments with restricted GitHub access."
+            cd "$INSTALL_DIR/scripts/whatsapp-bridge"
+            if timeout 60 npm install --registry="$NPM_REGISTRY" --silent 2>/dev/null; then
+                log_success "WhatsApp Bridge dependencies installed"
+            else
+                log_warn "WhatsApp Bridge npm install timed out or failed (WhatsApp tools will not work)"
+                log_info "To install manually when GitHub is accessible:"
+                log_info "  cd $INSTALL_DIR/scripts/whatsapp-bridge && npm install"
+            fi
+            cd "$INSTALL_DIR"
+        fi
+
+        # Install Playwright browser + system dependencies.
+        # Playwright's --with-deps only supports apt-based systems natively.
+        # For Arch/Manjaro we install the system libs via pacman first.
+        # Other systems must install Chromium dependencies manually.
+        export PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright
+        log_info "Using Playwright mirror: $PLAYWRIGHT_DOWNLOAD_HOST"
+        log_info "Installing browser engine (Playwright Chromium)..."
+        case "$DISTRO" in
+            ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
+                log_info "Playwright may request sudo to install browser system dependencies (shared libraries)."
+                log_info "This is standard Playwright setup — Hermes itself does not require root access."
+                cd "$INSTALL_DIR" && npx --yes playwright install --with-deps chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — browser tools will not work."
+                    log_warn "Try running manually: cd $INSTALL_DIR && npx --yes playwright install --with-deps chromium"
+                }
+                ;;
+            arch|manjaro)
+                if command -v pacman &> /dev/null; then
+                    log_info "Arch/Manjaro detected — installing Chromium system dependencies via pacman..."
+                    if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
+                        sudo NEEDRESTART_MODE=a pacman -S --noconfirm --needed \
+                            nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib >/dev/null 2>&1 || true
+                    elif [ "$(id -u)" -eq 0 ]; then
+                        pacman -S --noconfirm --needed \
+                            nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib >/dev/null 2>&1 || true
+                    else
+                        log_warn "Cannot install browser deps without sudo. Run manually:"
+                        log_warn "  sudo pacman -S nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib"
+                    fi
+                fi
+                cd "$INSTALL_DIR" && npx --yes playwright install chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — browser tools will not work."
+                }
+                ;;
+            fedora|rhel|centos|rocky|alma|alinux)
+                log_warn "Playwright does not support automatic dependency installation on RPM-based systems."
+                log_info "Install Chromium system dependencies manually before using browser tools:"
+                log_info "  sudo dnf install nss atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm pango cairo alsa-lib"
+                cd "$INSTALL_DIR" && npx --yes playwright install chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — install dependencies above and retry."
+                    log_info "Retry: export PLAYWRIGHT_DOWNLOAD_HOST=$PLAYWRIGHT_DOWNLOAD_HOST && cd $INSTALL_DIR && npx --yes playwright install chromium"
+                }
+                ;;
+            opensuse*|sles)
+                log_warn "Playwright does not support automatic dependency installation on zypper-based systems."
+                log_info "Install Chromium system dependencies manually before using browser tools:"
+                log_info "  sudo zypper install mozilla-nss libatk-1_0-0 at-spi2-core cups-libs libdrm2 libxkbcommon0 Mesa-libgbm1 pango cairo libasound2"
+                cd "$INSTALL_DIR" && npx --yes playwright install chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — install dependencies above and retry."
+                }
+                ;;
+            *)
+                log_warn "Playwright does not support automatic dependency installation on $DISTRO."
+                log_info "Install Chromium/browser system dependencies for your distribution, then run:"
+                log_info "  cd $INSTALL_DIR && npx --yes playwright install chromium"
+                log_info "Browser tools will not work until dependencies are installed."
+                cd "$INSTALL_DIR" && npx --yes playwright install chromium 2>/dev/null || true
+                ;;
+        esac
+        log_success "Browser engine setup complete"
+    fi
+
+    # Install TUI dependencies
+    if [ -f "$INSTALL_DIR/ui-tui/package.json" ]; then
+        log_info "Installing TUI dependencies..."
+        cd "$INSTALL_DIR/ui-tui"
+        npm install --registry="$NPM_REGISTRY" --silent 2>/dev/null || {
+            log_warn "TUI npm install failed (hermes --tui may not work)"
+            log_info "Retry manually: cd $INSTALL_DIR/ui-tui && npm install --registry=$NPM_REGISTRY"
+        }
+        log_success "TUI dependencies installed"
+    fi
+
+
+}
+
+run_setup_wizard() {
+    if [ "$RUN_SETUP" = false ]; then
+        log_info "Setup wizard skipped (run with --with-setup to configure interactively, or run 'hermes setup' later)"
+        return 0
+    fi
+
+    # The setup wizard reads from /dev/tty, so it works even when the
+    # install script itself is piped (curl | bash). Only skip if no
+    # terminal is available at all (e.g. Docker build, CI).
+    if ! [ -e /dev/tty ]; then
+        log_info "Setup wizard skipped (no terminal available). Run 'hermes setup' after install."
+        return 0
+    fi
+
+    echo ""
+    log_info "Starting setup wizard..."
+    echo ""
+
+    cd "$INSTALL_DIR"
+
+    # Run hermes setup using the venv Python directly (no activation needed).
+    # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
+    if [ "$USE_VENV" = true ]; then
+        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
+    else
+        python -m hermes_cli.main setup < /dev/tty
+    fi
+}
+
+maybe_start_gateway() {
+    # Check if any messaging platform tokens were configured
+    ENV_FILE="$HERMES_HOME/.env"
+    if [ ! -f "$ENV_FILE" ]; then
+        return 0
+    fi
+
+    HAS_MESSAGING=false
+    for VAR in TELEGRAM_BOT_TOKEN DISCORD_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN WHATSAPP_ENABLED; do
+        VAL=$(grep "^${VAR}=" "$ENV_FILE" 2>/dev/null | cut -d'=' -f2-)
+        if [ -n "$VAL" ] && [ "$VAL" != "your-token-here" ]; then
+            HAS_MESSAGING=true
+            break
+        fi
+    done
+
+    if [ "$HAS_MESSAGING" = false ]; then
+        return 0
+    fi
+
+    echo ""
+    log_info "Messaging platform token detected!"
+    log_info "The gateway needs to be running for Hermes to send/receive messages."
+
+    # If WhatsApp is enabled and no session exists yet, run foreground first for QR scan
+    WHATSAPP_VAL=$(grep "^WHATSAPP_ENABLED=" "$ENV_FILE" 2>/dev/null | cut -d'=' -f2-)
+    WHATSAPP_SESSION="$HERMES_HOME/whatsapp/session/creds.json"
+    if [ "$WHATSAPP_VAL" = "true" ] && [ ! -f "$WHATSAPP_SESSION" ]; then
+        if [ "$IS_INTERACTIVE" = true ]; then
+            echo ""
+            log_info "WhatsApp is enabled but not yet paired."
+            log_info "Running 'hermes whatsapp' to pair via QR code..."
+            echo ""
+            if prompt_yes_no "Pair WhatsApp now?" "yes"; then
+                HERMES_CMD="$(get_hermes_command_path)"
+                $HERMES_CMD whatsapp || true
+            fi
+        else
+            log_info "WhatsApp pairing skipped (non-interactive). Run 'hermes whatsapp' to pair."
+        fi
+    fi
+
+    if ! [ -e /dev/tty ]; then
+        log_info "Gateway setup skipped (no terminal available). Run 'hermes gateway install' later."
+        return 0
+    fi
+
+    echo ""
+    local should_install_gateway=false
+    if [ "$DISTRO" = "termux" ]; then
+        if prompt_yes_no "Would you like to start the gateway in the background?" "yes"; then
+            should_install_gateway=true
+        fi
+    else
+        if prompt_yes_no "Would you like to install the gateway as a background service?" "yes"; then
+            should_install_gateway=true
+        fi
+    fi
+
+    if [ "$should_install_gateway" = true ]; then
+        HERMES_CMD="$(get_hermes_command_path)"
+
+        if [ "$DISTRO" != "termux" ] && command -v systemctl &> /dev/null; then
+            log_info "Installing systemd service..."
+            if $HERMES_CMD gateway install 2>/dev/null; then
+                log_success "Gateway service installed"
+                if $HERMES_CMD gateway start 2>/dev/null; then
+                    log_success "Gateway started! Your bot is now online."
+                else
+                    log_warn "Service installed but failed to start. Try: hermes gateway start"
+                fi
+            else
+                log_warn "Systemd install failed. You can start manually: hermes gateway"
+            fi
+        else
+            if [ "$DISTRO" = "termux" ]; then
+                log_info "Termux detected — starting gateway in best-effort background mode..."
+            else
+                log_info "systemd not available — starting gateway in background..."
+            fi
+            nohup $HERMES_CMD gateway > "$HERMES_HOME/logs/gateway.log" 2>&1 &
+            GATEWAY_PID=$!
+            log_success "Gateway started (PID $GATEWAY_PID). Logs: ~/.hermes/logs/gateway.log"
+            log_info "To stop: kill $GATEWAY_PID"
+            log_info "To restart later: hermes gateway"
+            if [ "$DISTRO" = "termux" ]; then
+                log_warn "Android may stop background processes when Termux is suspended or the system reclaims resources."
+            fi
+        fi
+    else
+        log_info "Skipped. Start the gateway later with: hermes gateway"
+    fi
+}
+
+print_success() {
+    echo ""
+    echo -e "${GREEN}${BOLD}"
+    echo "┌─────────────────────────────────────────────────────────┐"
+    echo "│              ✓ Installation Complete!                   │"
+    echo "└─────────────────────────────────────────────────────────┘"
+    echo -e "${NC}"
+    echo ""
+
+    # Show file locations
+    echo -e "${CYAN}${BOLD}📁 Your files (all in ~/.hermes/):${NC}"
+    echo ""
+    echo -e "   ${YELLOW}Config:${NC}    ~/.hermes/config.yaml"
+    echo -e "   ${YELLOW}API Keys:${NC}  ~/.hermes/.env"
+    echo -e "   ${YELLOW}Data:${NC}      ~/.hermes/cron/, sessions/, logs/"
+    echo -e "   ${YELLOW}Code:${NC}      ~/.hermes/hermes-agent/"
+    echo ""
+
+    echo -e "${CYAN}─────────────────────────────────────────────────────────${NC}"
+    echo ""
+    echo -e "${CYAN}${BOLD}🚀 Commands:${NC}"
+    echo ""
+    echo -e "   ${GREEN}hermes${NC}              Start chatting"
+    echo -e "   ${GREEN}hermes setup${NC}        Configure API keys & settings"
+    echo -e "   ${GREEN}hermes config${NC}       View/edit configuration"
+    echo -e "   ${GREEN}hermes config edit${NC}  Open config in editor"
+    echo -e "   ${GREEN}hermes gateway install${NC} Install gateway service (messaging + cron)"
+    echo -e "   ${GREEN}hermes update${NC}       Update to latest version"
+    echo ""
+
+    echo -e "${CYAN}─────────────────────────────────────────────────────────${NC}"
+    echo ""
+    if [ "$DISTRO" = "termux" ]; then
+        echo -e "${YELLOW}⚡ 'hermes' was linked into $(get_command_link_display_dir), which is already on PATH in Termux.${NC}"
+        echo ""
+    else
+        echo -e "${YELLOW}⚡ Reload your shell to use 'hermes' command:${NC}"
+        echo ""
+        LOGIN_SHELL="$(basename "${SHELL:-/bin/bash}")"
+        if [ "$LOGIN_SHELL" = "zsh" ]; then
+            echo "   source ~/.zshrc"
+        elif [ "$LOGIN_SHELL" = "bash" ]; then
+            echo "   source ~/.bashrc"
+        elif [ "$LOGIN_SHELL" = "fish" ]; then
+            echo "   source ~/.config/fish/config.fish"
+        else
+            echo "   source ~/.bashrc   # or ~/.zshrc"
+        fi
+        echo ""
+    fi
+
+    # Show Node.js warning if auto-install failed
+    if [ "$HAS_NODE" = false ]; then
+        echo -e "${YELLOW}"
+        echo "Note: Node.js could not be installed automatically."
+        echo "Browser tools need Node.js. Install manually:"
+        if [ "$DISTRO" = "termux" ]; then
+            echo "  pkg install nodejs"
+        else
+            echo "  https://nodejs.org/en/download/"
+        fi
+        echo -e "${NC}"
+    fi
+
+    # Show ripgrep note if not installed
+    if [ "$HAS_RIPGREP" = false ]; then
+        echo -e "${YELLOW}"
+        echo "Note: ripgrep (rg) was not found. File search will use"
+        echo "grep as a fallback. For faster search in large codebases,"
+        if [ "$DISTRO" = "termux" ]; then
+            echo "install ripgrep: pkg install ripgrep"
+        else
+            echo "install ripgrep: sudo apt install ripgrep (or brew install ripgrep)"
+        fi
+        echo -e "${NC}"
+    fi
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+main() {
+    print_banner
+
+    detect_os
+    install_uv
+    check_python
+    check_git
+    check_node
+    install_system_packages
+
+    clone_repo
+    setup_venv
+    install_deps
+    install_node_deps
+    setup_path
+    copy_config_templates
+    run_setup_wizard
+    maybe_start_gateway
+
+    print_success
+}
+
+main


### PR DESCRIPTION

## Description

Add China mainland optimizations and pitfall documentation to the
`install-hermes` os-skill, based on real installation experience.

**New in `install.sh`:**
- Minimal install mode by default: skips heavy extras
  (daytona/playwright/WhatsApp/Node.js npm deps); `--full` flag for
  full install
- `uv pip install --no-config` replaces pip to avoid Aliyun mirror's
  missing upload timestamps triggering `exclude-newer` — cuts
  dependency resolution from 30+ min to ~4s

**New in docs:**
- Complete 3-step DashScope/Qwen setup guide (provider, env var,
  CN endpoint) with common mistakes called out
- Context window column in model table; `qwen-max` 32K warning;
  `qwen-plus` (131K) as recommended default
- Updated config.yaml example to current `model.provider` +
  `model.default` format
- `uv pip install` + Aliyun mirror for CN messaging platform deps

## Related Issue

no-issue: skill-only addition based on real CN env install experience

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Performance improvement

## Scope

- [x] `skill` (os-skills)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have updated the documentation accordingly
- [x] For `skill`: Skill directory structure is valid and shell scripts
      pass syntax check

## Testing

End-to-end on Alibaba Cloud Linux 4(alinux4):

```bash
cosh
user: 帮我安装hermes
# 58 packages resolved in 341ms, installed in 31ms; npm step skipped
user: bailian api key  is sk-xxxxx

hermes doctor   # ✓ Alibaba/DashScope
```
<img width="932" height="394" alt="image" src="https://github.com/user-attachments/assets/e6d60140-dc70-4efa-966b-f5df06d76048" />

## Additional Notes

Root cause of the pip hang: hermes-agent's `pyproject.toml` sets
`[tool.uv] exclude-newer`; Aliyun PyPI mirror omits upload timestamps,
so uv treats all packages as newer than the cutoff and filters them.
`--no-config` skips this project-level setting.
