### PR TITLE
feat(tokenless): add compression stats with auto-record from real data

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -398,59 +398,30 @@ build_tokenless() {
     local spec_file
     spec_file=$(process_spec_template "$spec_in" "$version")
 
-    log "Step 1/3: Building tokenless and rtk..."
+    log "Step 1/3: Initializing submodules..."
     (
         cd "$TOKEN_DIR"
-        # Initialize submodules if not already done
         if [ ! -d "third_party/rtk/.git" ]; then
             log "Initializing git submodules..."
             git submodule update --init --recursive
         fi
-        # Build tokenless
-        cargo build --release --workspace
-        # Build rtk from submodule
-        cargo build --release --manifest-path third_party/rtk/Cargo.toml
     )
 
     log "Step 2/3: Creating source tarball ${tarball_name}..."
-
     local tmp_dir
     tmp_dir=$(mktemp -d)
-    local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
-    mkdir -p "$pkg_dir"/{openclaw,hooks/copilot-shell,scripts}
+    local pkg_dir="${tmp_dir}/${pkg_name}"
+    mkdir -p "$pkg_dir"
 
-    # Copy binaries
-    cp -rp "${TOKEN_DIR}/target/release/tokenless" "$pkg_dir/" 2>/dev/null || warn "tokenless binary missing"
-    cp -rp "${TOKEN_DIR}/third_party/rtk/target/release/rtk" "$pkg_dir/" 2>/dev/null || warn "rtk binary missing"
+    # Copy full source tree, excluding build artifacts and VCS
+    tar -cf - -C "$TOKEN_DIR" \
+        --exclude='target' \
+        --exclude='.git' \
+        --exclude='.gitmodules' \
+        --exclude='node_modules' \
+        . | tar -xf - -C "$pkg_dir"
 
-    # Copy documentation (user manuals from docs/ directory)
-    mkdir -p "$pkg_dir/docs"
-    [ -f "${TOKEN_DIR}/docs/tokenless-user-manual-en.md" ] && cp "${TOKEN_DIR}/docs/tokenless-user-manual-en.md" "$pkg_dir/docs/"
-    [ -f "${TOKEN_DIR}/docs/tokenless-user-manual-zh.md" ] && cp "${TOKEN_DIR}/docs/tokenless-user-manual-zh.md" "$pkg_dir/docs/"
-    [ -f "${TOKEN_DIR}/docs/response-compression.md" ] && cp "${TOKEN_DIR}/docs/response-compression.md" "$pkg_dir/docs/"
-    # LICENSE from project root
-    [ -f "${TOKEN_DIR}/LICENSE" ] && cp "${TOKEN_DIR}/LICENSE" "$pkg_dir/docs/" || \
-    [ -f "${ROOT_DIR}/LICENSE" ] && cp "${ROOT_DIR}/LICENSE" "$pkg_dir/docs/"
-
-    # Copy OpenClaw plugin files
-    [ -f "${TOKEN_DIR}/openclaw/index.ts" ] && cp "${TOKEN_DIR}/openclaw/index.ts" "$pkg_dir/openclaw/"
-    [ -f "${TOKEN_DIR}/openclaw/openclaw.plugin.json" ] && cp "${TOKEN_DIR}/openclaw/openclaw.plugin.json" "$pkg_dir/openclaw/"
-    [ -f "${TOKEN_DIR}/openclaw/package.json" ] && cp "${TOKEN_DIR}/openclaw/package.json" "$pkg_dir/openclaw/"
-    [ -f "${TOKEN_DIR}/openclaw/README.md" ] && cp "${TOKEN_DIR}/openclaw/README.md" "$pkg_dir/openclaw/"
-
-    # Copy copilot-shell hook files (preserve permissions)
-    if [ -d "${TOKEN_DIR}/hooks/copilot-shell" ]; then
-        cp -p "${TOKEN_DIR}/hooks/copilot-shell"/* "$pkg_dir/hooks/copilot-shell/" 2>/dev/null || warn "Hook files missing"
-        chmod 0755 "$pkg_dir/hooks/copilot-shell"/tokenless-*.sh 2>/dev/null || true
-    fi
-
-    # Copy installation script (preserve permissions)
-    if [ -f "${TOKEN_DIR}/scripts/install.sh" ]; then
-        cp -p "${TOKEN_DIR}/scripts/install.sh" "$pkg_dir/scripts/"
-        chmod 0755 "$pkg_dir/scripts/install.sh"
-    fi
-
-    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
+    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}"
     rm -rf "$tmp_dir"
 
     log "Step 3/3: Running rpmbuild..."

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -47,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +79,55 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -108,10 +177,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -126,16 +293,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
@@ -153,6 +389,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -185,12 +432,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -227,6 +495,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,12 +524,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokenless-cli"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
+ "rusqlite",
  "serde_json",
  "tokenless-schema",
+ "tokenless-stats",
 ]
 
 [[package]]
@@ -258,6 +561,18 @@ version = "0.1.0"
 dependencies = [
  "regex",
  "serde_json",
+]
+
+[[package]]
+name = "tokenless-stats"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dirs",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -273,10 +588,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -285,6 +725,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/tokenless-schema",
     "crates/tokenless-cli",
+    "crates/tokenless-stats",
 ]
 exclude = [
     "third_party/rtk",
@@ -19,3 +20,4 @@ serde_json = "1.0"
 regex = "1.10"
 thiserror = "2.0"
 clap = { version = "4", features = ["derive"] }
+chrono = "0.4"

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -6,7 +6,7 @@ OPENCLAW_DIR ?= /usr/share/tokenless/openclaw
 COPILOT_SHELL_HOOK_DIR ?= /usr/share/tokenless/hooks/copilot-shell
 RTK_DIR := third_party/rtk
 
-.PHONY: build build-tokenless build-rtk install test lint clean \
+.PHONY: build build-tokenless build-rtk install test lint clean dist \
         openclaw-install openclaw-uninstall \
         copilot-shell-install copilot-shell-uninstall setup help
 
@@ -58,6 +58,16 @@ clean:
 	@echo "==> Cleaning..."
 	cargo clean
 	cargo clean --manifest-path $(RTK_DIR)/Cargo.toml
+
+# Create source tarball (excludes build artifacts)
+dist: clean
+	@echo "==> Creating tarball..."
+	tar czf ../tokenless-0.1.0.tar.gz \
+	    --exclude='target' \
+	    --exclude='third_party/rtk/target' \
+	    --exclude='.git' \
+	    -C .. tokenless
+	@echo "==> Tarball: ../tokenless-0.1.0.tar.gz"
 
 # OpenClaw plugin management
 openclaw-install:

--- a/src/tokenless/crates/tokenless-cli/Cargo.toml
+++ b/src/tokenless/crates/tokenless-cli/Cargo.toml
@@ -11,5 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 tokenless-schema = { path = "../tokenless-schema" }
+tokenless-stats = { path = "../tokenless-stats" }
 clap.workspace = true
 serde_json.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+rusqlite = { version = "0.31", features = ["bundled"] }

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -1,8 +1,13 @@
+//! Tokenless CLI - LLM token optimization via schema and response compression.
+
 use clap::{Parser, Subcommand};
 use std::fs;
 use std::io::{self, Read};
 use std::process;
 use tokenless_schema::{ResponseCompressor, SchemaCompressor};
+use tokenless_stats::estimate_tokens_from_chars;
+use tokenless_stats::{format_list, format_show, format_summary};
+use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, TokenlessConfig};
 
 #[derive(Parser)]
 #[command(
@@ -19,19 +24,68 @@ struct Cli {
 enum Commands {
     /// Compress OpenAI Function Calling tool schemas
     CompressSchema {
-        /// Input file path (reads from stdin if omitted)
         #[arg(short, long)]
         file: Option<String>,
-        /// Treat input as a JSON array of tools
+        /// Compress a JSON array of schemas
         #[arg(long)]
         batch: bool,
+        /// Agent ID for stats (e.g. "copilot-shell")
+        #[arg(long)]
+        agent_id: Option<String>,
+        /// Session ID for grouping
+        #[arg(long)]
+        session_id: Option<String>,
+        /// Tool use ID
+        #[arg(long)]
+        tool_use_id: Option<String>,
     },
     /// Compress API responses
     CompressResponse {
-        /// Input file path (reads from stdin if omitted)
         #[arg(short, long)]
         file: Option<String>,
+        /// Agent ID for stats
+        #[arg(long)]
+        agent_id: Option<String>,
+        /// Session ID for grouping
+        #[arg(long)]
+        session_id: Option<String>,
+        /// Tool use ID
+        #[arg(long)]
+        tool_use_id: Option<String>,
     },
+    /// View and export statistics
+    #[command(subcommand)]
+    Stats(StatsCommands),
+}
+
+#[derive(Subcommand)]
+enum StatsCommands {
+    /// Show summary statistics with breakdown by operation
+    Summary {
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+    /// List recent records
+    List {
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+    },
+    /// Show before/after text content for a specific record
+    Show {
+        /// Record database ID
+        id: i64,
+    },
+    /// Clear all statistics
+    Clear {
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Show stats recording status
+    Status,
+    /// Enable stats recording
+    Enable,
+    /// Disable stats recording
+    Disable,
 }
 
 fn read_input(file: &Option<String>) -> Result<String, String> {
@@ -49,47 +103,246 @@ fn read_input(file: &Option<String>) -> Result<String, String> {
     }
 }
 
+fn get_db_path() -> String {
+    std::env::var("TOKENLESS_STATS_DB").unwrap_or_else(|_| {
+        format!(
+            "{}/.tokenless/stats.db",
+            std::env::var("HOME").unwrap_or_else(|_| ".".to_string())
+        )
+    })
+}
+
+fn ensure_db_dir() -> Result<(), (String, i32)> {
+    let db_path = get_db_path();
+    if let Some(parent) = std::path::Path::new(&db_path).parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| (format!("Failed to create database directory: {}", e), 1))?;
+    }
+    Ok(())
+}
+
+fn open_recorder() -> Result<StatsRecorder, (String, i32)> {
+    ensure_db_dir()?;
+    StatsRecorder::new(get_db_path()).map_err(|e| (format!("Failed to open database: {}", e), 1))
+}
+
 fn run() -> Result<(), (String, i32)> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::CompressSchema { file, batch } => {
+        Commands::CompressSchema {
+            file,
+            batch,
+            agent_id,
+            session_id,
+            tool_use_id,
+        } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
             let value: serde_json::Value = serde_json::from_str(&input)
                 .map_err(|e| (format!("JSON parse error: {}", e), 1))?;
 
             let compressor = SchemaCompressor::new();
 
-            if batch {
+            let result_json = if batch {
                 let arr = value
                     .as_array()
                     .ok_or_else(|| ("Expected a JSON array for --batch mode".to_string(), 1))?;
                 let results: Vec<serde_json::Value> =
                     arr.iter().map(|item| compressor.compress(item)).collect();
-                let output = serde_json::to_string_pretty(&results)
-                    .map_err(|e| (format!("Serialization error: {}", e), 2))?;
-                println!("{}", output);
+                serde_json::to_string_pretty(&results)
+                    .map_err(|e| (format!("Serialization error: {}", e), 2))?
             } else {
                 let result = compressor.compress(&value);
-                let output = serde_json::to_string_pretty(&result)
-                    .map_err(|e| (format!("Serialization error: {}", e), 2))?;
-                println!("{}", output);
-            }
+                serde_json::to_string_pretty(&result)
+                    .map_err(|e| (format!("Serialization error: {}", e), 2))?
+            };
+
+            println!("{}", result_json);
+
+            // Auto-record stats with actual text content
+            // Compact JSON for accurate after_text (pretty-print inflates size)
+            let after_compact = serde_json::to_string(
+                &serde_json::from_str::<serde_json::Value>(&result_json)
+                    .unwrap_or(serde_json::Value::Null),
+            )
+            .unwrap_or(result_json.clone());
+            record_compression_stats(
+                OperationType::CompressSchema,
+                agent_id,
+                session_id,
+                tool_use_id,
+                input,
+                after_compact,
+            );
         }
-        Commands::CompressResponse { file } => {
+        Commands::CompressResponse {
+            file,
+            agent_id,
+            session_id,
+            tool_use_id,
+        } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
             let value: serde_json::Value = serde_json::from_str(&input)
                 .map_err(|e| (format!("JSON parse error: {}", e), 1))?;
 
             let compressor = ResponseCompressor::new();
-            let result = compressor.compress(&value);
-            let output = serde_json::to_string_pretty(&result)
+            let result_json = serde_json::to_string_pretty(&compressor.compress(&value))
                 .map_err(|e| (format!("Serialization error: {}", e), 2))?;
-            println!("{}", output);
+
+            println!("{}", result_json);
+
+            // Auto-record stats with actual text content
+            let after_compact = serde_json::to_string(
+                &serde_json::from_str::<serde_json::Value>(&result_json)
+                    .unwrap_or(serde_json::Value::Null),
+            )
+            .unwrap_or(result_json.clone());
+            record_compression_stats(
+                OperationType::CompressResponse,
+                agent_id,
+                session_id,
+                tool_use_id,
+                input,
+                after_compact,
+            );
+        }
+        Commands::Stats(stats_cmd) => {
+            let recorder = open_recorder()?;
+
+            match stats_cmd {
+                StatsCommands::Summary { limit } => {
+                    let records = recorder
+                        .all_records(limit)
+                        .map_err(|e| (format!("Failed to query records: {}", e), 1))?;
+                    println!(
+                        "{}",
+                        format_summary(&records, Some("Tokenless Statistics Summary"))
+                    );
+                }
+                StatsCommands::List { limit } => {
+                    let records = recorder
+                        .all_records(Some(limit))
+                        .map_err(|e| (format!("Failed to query records: {}", e), 1))?;
+                    println!("{}", format_list(&records, limit));
+                }
+                StatsCommands::Show { id } => {
+                    let record = recorder
+                        .record_by_id(id)
+                        .map_err(|e| (format!("Failed to query record: {}", e), 1))?
+                        .ok_or_else(|| (format!("Record not found: {}", id), 1))?;
+                    println!("{}", format_show(&record));
+                }
+                StatsCommands::Clear { yes } => {
+                    if !yes {
+                        print!("Are you sure you want to clear all statistics? [y/N] ");
+                        use std::io::Write;
+                        io::stdout().flush().unwrap();
+                        let mut input = String::new();
+                        io::stdin().read_line(&mut input).unwrap();
+                        if !input.trim().eq_ignore_ascii_case("y") {
+                            println!("Cancelled.");
+                            return Ok(());
+                        }
+                    }
+                    recorder
+                        .clear()
+                        .map_err(|e| (format!("Failed to clear: {}", e), 1))?;
+                    println!("Statistics cleared.");
+                }
+                StatsCommands::Status => {
+                    let env_set = std::env::var("TOKENLESS_STATS_ENABLED").ok();
+                    let config = TokenlessConfig::load();
+                    if config.is_stats_enabled() {
+                        let source = if env_set.is_some() {
+                            "env override"
+                        } else if TokenlessConfig::config_file_exists() {
+                            "config file"
+                        } else {
+                            "default"
+                        };
+                        println!("Stats recording: ENABLED (via {})", source);
+                    } else {
+                        let source = if env_set.is_some() {
+                            "env override"
+                        } else if TokenlessConfig::config_file_exists() {
+                            "config file"
+                        } else {
+                            "default"
+                        };
+                        println!("Stats recording: DISABLED (via {})", source);
+                    }
+                }
+                StatsCommands::Enable => {
+                    let mut config = TokenlessConfig::load();
+                    config.stats_enabled = true;
+                    config
+                        .save()
+                        .map_err(|e| (format!("Failed to save config: {}", e), 1))?;
+                    println!("Stats recording enabled.");
+                }
+                StatsCommands::Disable => {
+                    let mut config = TokenlessConfig::load();
+                    config.stats_enabled = false;
+                    config
+                        .save()
+                        .map_err(|e| (format!("Failed to save config: {}", e), 1))?;
+                    println!("Stats recording disabled.");
+                }
+            }
         }
     }
 
     Ok(())
+}
+
+/// Record compression stats — fail-silent so compression output
+/// is never blocked by database errors.
+///
+/// All metrics (chars, tokens) are derived from actual text content,
+/// never from caller-supplied estimates.
+fn record_compression_stats(
+    op: OperationType,
+    agent_id: Option<String>,
+    session_id: Option<String>,
+    tool_use_id: Option<String>,
+    before_text: String,
+    after_text: String,
+) {
+    if !TokenlessConfig::load().is_stats_enabled() {
+        return;
+    }
+
+    let before_chars = before_text.len();
+    let after_chars = after_text.len();
+    let before_tokens = estimate_tokens_from_chars(before_chars);
+    let after_tokens = estimate_tokens_from_chars(after_chars);
+
+    let pid = std::process::id();
+    let agent = agent_id
+        .as_deref()
+        .map(|a| format!("{}({})", a, pid))
+        .unwrap_or_else(|| format!("cli({})", pid));
+    let mut record = StatsRecord::new(
+        op,
+        agent,
+        before_chars,
+        before_tokens,
+        after_chars,
+        after_tokens,
+    )
+    .with_before_text(before_text)
+    .with_after_text(after_text);
+    if let Some(sid) = session_id {
+        record = record.with_session_id(sid);
+    }
+    if let Some(tuid) = tool_use_id {
+        record = record.with_tool_use_id(tuid);
+    }
+
+    // Record silently — stats failures must not break compression
+    if let Ok(recorder) = open_recorder() {
+        let _ = recorder.record(&record);
+    }
 }
 
 fn main() {

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(compressor.compress(&json!(true)), json!(true));
         assert_eq!(compressor.compress(&json!(false)), json!(false));
         assert_eq!(compressor.compress(&json!(42)), json!(42));
-        assert_eq!(compressor.compress(&json!(3.14)), json!(3.14));
+        assert_eq!(compressor.compress(&json!(42.5)), json!(42.5));
         assert_eq!(compressor.compress(&json!("short")), json!("short"));
     }
 

--- a/src/tokenless/crates/tokenless-stats/Cargo.toml
+++ b/src/tokenless/crates/tokenless-stats/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tokenless-stats"
+version = "0.1.0"
+edition = "2021"
+description = "Statistics tracking for tokenless - SQLite-based metrics storage"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
+thiserror = "1.0"
+dirs = "5.0"

--- a/src/tokenless/crates/tokenless-stats/src/config.rs
+++ b/src/tokenless/crates/tokenless-stats/src/config.rs
@@ -1,0 +1,148 @@
+//! Configuration for tokenless.
+//!
+//! Stored at `~/.tokenless/config.json`. Controls global feature flags.
+//! Environment variable `TOKENLESS_STATS_ENABLED` overrides file config.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Global tokenless configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenlessConfig {
+    /// Whether to record compression stats (default: true)
+    #[serde(default = "default_true")]
+    pub stats_enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for TokenlessConfig {
+    fn default() -> Self {
+        Self {
+            stats_enabled: true,
+        }
+    }
+}
+
+impl TokenlessConfig {
+    fn config_path() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".tokenless/config.json")
+    }
+
+    /// Whether a config file exists on disk.
+    pub fn config_file_exists() -> bool {
+        Self::config_path().exists()
+    }
+
+    /// Load config with an explicit env override value and optional custom path.
+    /// Priority: env_override > config.json file > default(true)
+    pub fn load_with_env_and_path(env_val: Option<&str>, path: Option<&PathBuf>) -> Self {
+        if let Some(val) = env_val {
+            let enabled =
+                val == "1" || val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("yes");
+            return Self {
+                stats_enabled: enabled,
+            };
+        }
+
+        // Fall back to file config
+        let default_path = Self::config_path();
+        let config_path = path.unwrap_or(&default_path);
+        std::fs::read_to_string(config_path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    /// Load config with an explicit env override value.
+    /// Priority: env_override > config.json file > default(true)
+    pub fn load_with_env(env_val: Option<&str>) -> Self {
+        Self::load_with_env_and_path(env_val, None)
+    }
+
+    /// Load config: env var overrides file config, file config overrides defaults.
+    /// Priority: TOKENLESS_STATS_ENABLED env > config.json file > default(true)
+    pub fn load() -> Self {
+        let env_val = std::env::var("TOKENLESS_STATS_ENABLED").ok();
+        Self::load_with_env(env_val.as_deref())
+    }
+
+    /// Save config to disk.
+    pub fn save(&self) -> std::io::Result<()> {
+        let path = Self::config_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(&path, json)
+    }
+
+    /// Returns true if stats recording is enabled (env override or file config).
+    pub fn is_stats_enabled(&self) -> bool {
+        self.stats_enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = TokenlessConfig::default();
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        let tmp_dir = std::env::temp_dir().join("tokenless_test_missing");
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        let path = tmp_dir.join("config.json");
+        let config = TokenlessConfig::load_with_env_and_path(None, Some(&path));
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_load_invalid_json() {
+        let tmp_dir = std::env::temp_dir().join("tokenless_test_invalid_json");
+        let _ = std::fs::create_dir_all(&tmp_dir);
+        let path = tmp_dir.join("config.json");
+        let _ = std::fs::write(&path, "not json");
+        let config = TokenlessConfig::load_with_env_and_path(None, Some(&path));
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_env_override_enabled() {
+        let config = TokenlessConfig::load_with_env(Some("1"));
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_env_override_disabled() {
+        let config = TokenlessConfig::load_with_env(Some("0"));
+        assert!(!config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_env_override_true_string() {
+        let config = TokenlessConfig::load_with_env(Some("true"));
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_env_override_overrides_file() {
+        let tmp_dir = std::env::temp_dir().join("tokenless_test_override");
+        let _ = std::fs::create_dir_all(&tmp_dir);
+        let path = tmp_dir.join("config.json");
+        // Write file config with stats_enabled=false
+        let _ = std::fs::write(&path, "{\"stats_enabled\":false}");
+        // Env override to enable
+        let config = TokenlessConfig::load_with_env_and_path(Some("1"), Some(&path));
+        assert!(config.is_stats_enabled());
+    }
+}

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -1,0 +1,24 @@
+//! Tokenless Statistics Library
+//!
+//! Tracks compression metrics (characters, tokens, text content)
+//! for Agent hook integrations. Records before/after data for
+//! schema compression, response compression, and command rewriting.
+
+pub mod config;
+pub mod query;
+pub mod record;
+pub mod recorder;
+pub mod tokenizer;
+
+pub use record::{OperationType, StatsRecord};
+
+pub use recorder::{StatsError, StatsRecorder, StatsResult, StatsSummary};
+
+pub use query::{format_list, format_show, format_summary};
+
+pub use tokenizer::{count_chars, estimate_tokens, estimate_tokens_from_chars, Tokenizer};
+
+pub use config::TokenlessConfig;
+
+/// Library version
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/tokenless/crates/tokenless-stats/src/query.rs
+++ b/src/tokenless/crates/tokenless-stats/src/query.rs
@@ -1,0 +1,253 @@
+//! Query and formatting utilities for tokenless stats.
+
+use std::collections::HashMap;
+
+use crate::record::StatsRecord;
+use crate::recorder::StatsSummary;
+
+/// Format a summary report with overall stats and breakdown by operation type.
+pub fn format_summary(records: &[StatsRecord], title: Option<&str>) -> String {
+    let total = StatsSummary::from_records(records);
+
+    let mut output = String::new();
+
+    if let Some(t) = title {
+        output.push_str(t);
+        output.push('\n');
+        output.push_str(&"=".repeat(60));
+        output.push('\n');
+    }
+
+    output.push_str(&format!("Total Records: {}\n\n", total.total_records));
+
+    output.push_str("Character Savings:\n");
+    output.push_str(&format!("  Before: {} chars\n", total.total_before_chars));
+    output.push_str(&format!("  After:  {} chars\n", total.total_after_chars));
+    output.push_str(&format!(
+        "  Saved:  {} chars ({:.1}%)\n\n",
+        total.chars_saved(),
+        total.chars_percent()
+    ));
+
+    output.push_str("Token Savings:\n");
+    output.push_str(&format!("  Before: {} tokens\n", total.total_before_tokens));
+    output.push_str(&format!("  After:  {} tokens\n", total.total_after_tokens));
+    output.push_str(&format!(
+        "  Saved:  {} tokens ({:.1}%)\n\n",
+        total.tokens_saved(),
+        total.tokens_percent()
+    ));
+
+    // Breakdown by operation type
+    let mut by_op: HashMap<&str, StatsSummary> = HashMap::new();
+    for r in records {
+        let op = r.operation.as_str();
+        let entry = by_op.entry(op).or_default();
+        entry.total_records += 1;
+        entry.total_before_chars += r.before_chars;
+        entry.total_after_chars += r.after_chars;
+        entry.total_before_tokens += r.before_tokens;
+        entry.total_after_tokens += r.after_tokens;
+    }
+
+    output.push_str("Breakdown by Operation:\n");
+    output.push_str(&"-".repeat(40));
+    output.push('\n');
+
+    let mut ops: Vec<_> = by_op.iter().collect();
+    ops.sort_by(|a, b| b.1.total_records.cmp(&a.1.total_records));
+
+    for (op, s) in ops {
+        output.push_str(&format!("  {}: {} records\n", op, s.total_records));
+        output.push_str(&format!(
+            "    Chars: {} -> {} (-{:.1}%)\n",
+            s.total_before_chars,
+            s.total_after_chars,
+            s.chars_percent()
+        ));
+        output.push_str(&format!(
+            "    Tokens: {} -> {} (-{:.1}%)\n",
+            s.total_before_tokens,
+            s.total_after_tokens,
+            s.tokens_percent()
+        ));
+    }
+
+    output
+}
+
+/// Format a list of records for display
+pub fn format_list(records: &[StatsRecord], limit: usize) -> String {
+    if records.is_empty() {
+        return "No records found.".to_string();
+    }
+
+    let display = if records.len() > limit {
+        &records[..limit]
+    } else {
+        records
+    };
+
+    let mut output = String::new();
+    output.push_str(&format!("Showing {} record(s):\n", display.len()));
+    output.push_str(&"=".repeat(80));
+    output.push('\n');
+
+    for record in display {
+        output.push_str(&record.format_summary_line());
+        output.push('\n');
+    }
+
+    if records.len() > limit {
+        output.push_str(&format!(
+            "\n... and {} more (use --limit to show all)",
+            records.len() - limit
+        ));
+    }
+
+    output
+}
+
+/// Format a single record showing before/after text content.
+/// If before and after are identical, shows original text with "(no compression)" note.
+pub fn format_show(record: &StatsRecord) -> String {
+    let before = record.before_text.as_deref().unwrap_or("");
+    let after = record.after_text.as_deref().unwrap_or("");
+
+    if before.is_empty() && after.is_empty() {
+        return "  (no text content stored)\n".to_string();
+    }
+
+    let mut output = String::new();
+
+    if before == after || after.is_empty() {
+        // No compression happened or no after text
+        output.push_str("=== Original (no compression) ===\n");
+        output.push_str(before);
+        if !before.is_empty() && !before.ends_with('\n') {
+            output.push('\n');
+        }
+    } else {
+        output.push_str("=== Before ===\n");
+        output.push_str(before);
+        if !before.is_empty() && !before.ends_with('\n') {
+            output.push('\n');
+        }
+        output.push_str("\n=== After ===\n");
+        output.push_str(after);
+        if !after.is_empty() && !after.ends_with('\n') {
+            output.push('\n');
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{OperationType, StatsRecord};
+    use chrono::Local;
+
+    fn test_record() -> StatsRecord {
+        let mut r = StatsRecord::new(
+            OperationType::CompressSchema,
+            "copilot-shell".to_string(),
+            1000,
+            400,
+            500,
+            200,
+        );
+        r.id = 1;
+        r.timestamp = Local::now();
+        r.before_text = Some("original text".to_string());
+        r.after_text = Some("compressed".to_string());
+        r
+    }
+
+    #[test]
+    fn test_format_summary() {
+        let records = vec![test_record()];
+        let output = format_summary(&records, Some("Test Summary"));
+
+        assert!(output.contains("Test Summary"));
+        assert!(output.contains("Total Records: 1"));
+        assert!(output.contains("Character Savings"));
+        assert!(output.contains("Token Savings"));
+    }
+
+    #[test]
+    fn test_format_list() {
+        let records = vec![test_record()];
+        let output = format_list(&records, 20);
+
+        assert!(output.contains("Showing 1 record"));
+        assert!(output.contains("[ID:1]"));
+    }
+
+    #[test]
+    fn test_format_show_with_compression() {
+        let record = test_record();
+        let output = format_show(&record);
+
+        assert!(output.contains("=== Before ==="));
+        assert!(output.contains("original text"));
+        assert!(output.contains("=== After ==="));
+        assert!(output.contains("compressed"));
+    }
+
+    #[test]
+    fn test_format_show_no_compression() {
+        let mut r = StatsRecord::new(
+            OperationType::CompressSchema,
+            "test".to_string(),
+            100,
+            25,
+            100,
+            25,
+        );
+        r.id = 2;
+        r.timestamp = Local::now();
+        r.before_text = Some("same text".to_string());
+        r.after_text = Some("same text".to_string());
+
+        let output = format_show(&r);
+        assert!(output.contains("no compression"));
+        assert!(output.contains("same text"));
+        assert!(!output.contains("=== After ==="));
+    }
+
+    #[test]
+    fn test_format_show_no_text_stored() {
+        let mut r = StatsRecord::new(
+            OperationType::CompressSchema,
+            "test".to_string(),
+            100,
+            25,
+            80,
+            20,
+        );
+        r.id = 3;
+        r.timestamp = Local::now();
+
+        let output = format_show(&r);
+        assert!(output.contains("no text content stored"));
+    }
+
+    #[test]
+    fn test_format_diff_no_diff_available() {
+        let mut r = StatsRecord::new(
+            OperationType::CompressSchema,
+            "test".to_string(),
+            100,
+            25,
+            80,
+            20,
+        );
+        r.id = 1;
+        r.timestamp = Local::now();
+
+        let output = format_show(&r);
+        assert!(output.contains("no text content stored"));
+    }
+}

--- a/src/tokenless/crates/tokenless-stats/src/record.rs
+++ b/src/tokenless/crates/tokenless-stats/src/record.rs
@@ -1,0 +1,276 @@
+//! Statistics record definitions for tokenless.
+//!
+//! Each record represents a single compression or rewriting operation
+//! with before/after metrics and optional text content for diff export.
+
+use chrono::{DateTime, Local};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// Type of operation performed (three compression types)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OperationType {
+    /// Schema compression (BeforeModel hook)
+    CompressSchema,
+    /// Response compression (PostToolUse hook)
+    CompressResponse,
+    /// Command rewriting (RTK, PreToolUse hook)
+    RewriteCommand,
+}
+
+impl OperationType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            OperationType::CompressSchema => "compress-schema",
+            OperationType::CompressResponse => "compress-response",
+            OperationType::RewriteCommand => "rewrite-command",
+        }
+    }
+}
+
+impl FromStr for OperationType {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "compress-schema" => OperationType::CompressSchema,
+            "compress-response" => OperationType::CompressResponse,
+            "rewrite-command" => OperationType::RewriteCommand,
+            _ => OperationType::CompressSchema,
+        })
+    }
+}
+
+/// A single statistics record stored in the database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsRecord {
+    /// Database record ID (auto-increment primary key)
+    pub id: i64,
+    /// Timestamp when the record was created
+    pub timestamp: DateTime<Local>,
+    /// Type of operation (compress-schema, compress-response, rewrite-command)
+    pub operation: OperationType,
+    /// Agent identifier (e.g., "copilot-shell")
+    pub agent_id: String,
+    /// Source process ID (optional)
+    pub source_pid: Option<i64>,
+    /// Session ID for grouping related operations
+    pub session_id: Option<String>,
+    /// Tool use ID for correlation with specific tool calls
+    pub tool_use_id: Option<String>,
+    /// Characters before compression
+    pub before_chars: usize,
+    /// Tokens before compression (estimated)
+    pub before_tokens: usize,
+    /// Characters after compression
+    pub after_chars: usize,
+    /// Tokens after compression (estimated)
+    pub after_tokens: usize,
+    /// Text content before compression
+    pub before_text: Option<String>,
+    /// Text content after compression
+    pub after_text: Option<String>,
+}
+
+impl StatsRecord {
+    /// Create a new stats record
+    pub fn new(
+        operation: OperationType,
+        agent_id: String,
+        before_chars: usize,
+        before_tokens: usize,
+        after_chars: usize,
+        after_tokens: usize,
+    ) -> Self {
+        Self {
+            id: -1,
+            timestamp: Local::now(),
+            operation,
+            agent_id,
+            source_pid: None,
+            session_id: None,
+            tool_use_id: None,
+            before_chars,
+            before_tokens,
+            after_chars,
+            after_tokens,
+            before_text: None,
+            after_text: None,
+        }
+    }
+
+    /// Set the session ID
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    /// Set the tool use ID
+    pub fn with_tool_use_id(mut self, tool_use_id: impl Into<String>) -> Self {
+        self.tool_use_id = Some(tool_use_id.into());
+        self
+    }
+
+    /// Set the source PID
+    pub fn with_source_pid(mut self, pid: i64) -> Self {
+        self.source_pid = Some(pid);
+        self
+    }
+
+    /// Set text content before compression
+    pub fn with_before_text(mut self, text: String) -> Self {
+        self.before_text = Some(text);
+        self
+    }
+
+    /// Set text content after compression
+    pub fn with_after_text(mut self, text: String) -> Self {
+        self.after_text = Some(text);
+        self
+    }
+
+    /// Characters saved by compression
+    pub fn chars_saved(&self) -> usize {
+        self.before_chars.saturating_sub(self.after_chars)
+    }
+
+    /// Tokens saved by compression
+    pub fn tokens_saved(&self) -> usize {
+        self.before_tokens.saturating_sub(self.after_tokens)
+    }
+
+    /// Characters saved percentage
+    pub fn chars_percent(&self) -> f64 {
+        if self.before_chars > 0 {
+            (self.chars_saved() as f64 / self.before_chars as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    /// Tokens saved percentage
+    pub fn tokens_percent(&self) -> f64 {
+        if self.before_tokens > 0 {
+            (self.tokens_saved() as f64 / self.before_tokens as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    /// Get a formatted summary line for list output
+    pub fn format_summary_line(&self) -> String {
+        let session = self.session_id.as_deref().unwrap_or("-");
+        let tool = self.tool_use_id.as_deref().unwrap_or("-");
+
+        format!(
+            "[ID:{}] {} | {} | Session:{} | Tool:{} | Chars:{}→{}(-{}) | Tokens:{}→{}(-{:.0}%)",
+            self.id,
+            self.timestamp.format("%Y-%m-%d %H:%M:%S"),
+            self.agent_id,
+            session,
+            tool,
+            self.before_chars,
+            self.after_chars,
+            self.chars_saved(),
+            self.before_tokens,
+            self.after_tokens,
+            self.tokens_percent(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_operation_type_from_str() {
+        assert_eq!(
+            "compress-schema".parse::<OperationType>().unwrap(),
+            OperationType::CompressSchema
+        );
+        assert_eq!(
+            "compress-response".parse::<OperationType>().unwrap(),
+            OperationType::CompressResponse
+        );
+        assert_eq!(
+            "rewrite-command".parse::<OperationType>().unwrap(),
+            OperationType::RewriteCommand
+        );
+    }
+
+    #[test]
+    fn test_savings_calculation() {
+        let record = StatsRecord::new(
+            OperationType::CompressSchema,
+            "copilot-shell".to_string(),
+            1000,
+            400,
+            500,
+            200,
+        );
+
+        assert_eq!(record.chars_saved(), 500);
+        assert_eq!(record.tokens_saved(), 200);
+        assert!((record.chars_percent() - 50.0).abs() < 0.1);
+        assert!((record.tokens_percent() - 50.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_record_with_diff_text() {
+        let record = StatsRecord::new(
+            OperationType::CompressSchema,
+            "copilot-shell".to_string(),
+            16,
+            4,
+            10,
+            3,
+        )
+        .with_before_text("original text here".to_string())
+        .with_after_text("compressed".to_string());
+
+        assert!(record.before_text.is_some());
+        assert!(record.after_text.is_some());
+    }
+
+    #[test]
+    fn test_format_summary_line() {
+        let record = StatsRecord::new(
+            OperationType::CompressSchema,
+            "copilot-shell".to_string(),
+            1000,
+            400,
+            500,
+            200,
+        )
+        .with_session_id("session-123")
+        .with_tool_use_id("call_abc");
+
+        let line = record.format_summary_line();
+        assert!(line.contains("[ID:-1]"));
+        assert!(line.contains("copilot-shell"));
+        assert!(line.contains("Session:session-123"));
+        assert!(line.contains("Tool:call_abc"));
+    }
+
+    #[test]
+    fn test_format_summary_line_with_pid() {
+        let record = StatsRecord::new(
+            OperationType::CompressSchema,
+            "copilot-shell(12345)".to_string(),
+            1000,
+            400,
+            500,
+            200,
+        )
+        .with_session_id("session-123");
+
+        let line = record.format_summary_line();
+        assert!(line.contains("copilot-shell(12345)"));
+        assert!(
+            !line.contains("pid:"),
+            "PID should be inline in agent_id, not separate"
+        );
+    }
+}

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -1,0 +1,286 @@
+//! Statistics recorder for tokenless.
+//!
+//! Provides SQLite-based storage for compression and rewriting metrics.
+
+use crate::record::{OperationType, StatsRecord};
+use chrono::DateTime;
+use rusqlite::Connection;
+use std::path::Path;
+use std::sync::Mutex;
+
+/// Result type for stats operations
+pub type StatsResult<T> = Result<T, StatsError>;
+
+/// Error types for stats operations
+#[derive(Debug, thiserror::Error)]
+pub enum StatsError {
+    #[error("Database error: {0}")]
+    Database(#[from] rusqlite::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Statistics recorder that stores metrics in SQLite
+pub struct StatsRecorder {
+    conn: Mutex<Connection>,
+}
+
+impl StatsRecorder {
+    /// Create a new recorder with database at the given path
+    pub fn new<P: AsRef<Path>>(db_path: P) -> StatsResult<Self> {
+        let conn = Connection::open(db_path)?;
+
+        conn.execute_batch(
+            "
+            PRAGMA journal_mode=WAL;
+            PRAGMA busy_timeout=5000;
+            PRAGMA synchronous=NORMAL;
+        ",
+        )?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS stats (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                source_pid INTEGER,
+                session_id TEXT,
+                tool_use_id TEXT,
+                before_chars INTEGER NOT NULL,
+                before_tokens INTEGER NOT NULL,
+                after_chars INTEGER NOT NULL,
+                after_tokens INTEGER NOT NULL,
+                before_text TEXT,
+                after_text TEXT
+            )",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_timestamp ON stats(timestamp)",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_operation ON stats(operation)",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_id ON stats(agent_id)",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_id ON stats(session_id)",
+            [],
+        )?;
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Record a statistics entry
+    pub fn record(&self, record: &StatsRecord) -> StatsResult<i64> {
+        let conn = self.conn.lock().map_err(|e| {
+            self.conn.clear_poison();
+            StatsError::Database(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some(format!("Lock poisoned: {}", e)),
+            ))
+        })?;
+
+        conn.execute(
+            "INSERT INTO stats (
+                timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
+                before_chars, before_tokens, after_chars, after_tokens,
+                before_text, after_text
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rusqlite::params![
+                record.timestamp.to_rfc3339(),
+                record.operation.as_str(),
+                record.agent_id,
+                record.source_pid,
+                record.session_id,
+                record.tool_use_id,
+                record.before_chars,
+                record.before_tokens,
+                record.after_chars,
+                record.after_tokens,
+                record.before_text,
+                record.after_text,
+            ],
+        )?;
+
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// Query all records, newest first, with optional limit
+    pub fn all_records(&self, limit: Option<usize>) -> StatsResult<Vec<StatsRecord>> {
+        let conn = self.conn.lock().map_err(|e| {
+            self.conn.clear_poison();
+            StatsError::Database(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some(format!("Lock poisoned: {}", e)),
+            ))
+        })?;
+
+        let sql = match limit {
+            Some(n) => format!(
+                "SELECT id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
+                        before_chars, before_tokens, after_chars, after_tokens,
+                        before_text, after_text
+                 FROM stats ORDER BY timestamp DESC LIMIT {}",
+                n
+            ),
+            None => String::from(
+                "SELECT id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
+                        before_chars, before_tokens, after_chars, after_tokens,
+                        before_text, after_text
+                 FROM stats ORDER BY timestamp DESC",
+            ),
+        };
+
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], Self::row_to_record)?;
+
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row?);
+        }
+        Ok(result)
+    }
+
+    /// Get a single record by database ID
+    pub fn record_by_id(&self, id: i64) -> StatsResult<Option<StatsRecord>> {
+        let conn = self.conn.lock().map_err(|e| {
+            self.conn.clear_poison();
+            StatsError::Database(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some(format!("Lock poisoned: {}", e)),
+            ))
+        })?;
+
+        let mut stmt = conn.prepare(
+            "SELECT id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
+                    before_chars, before_tokens, after_chars, after_tokens,
+                    before_text, after_text
+             FROM stats WHERE id = ?",
+        )?;
+
+        let mut rows = stmt.query_map([id], Self::row_to_record)?;
+
+        if let Some(row) = rows.next() {
+            Ok(Some(row?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Get record count
+    pub fn count(&self) -> StatsResult<usize> {
+        let conn = self.conn.lock().map_err(|e| {
+            self.conn.clear_poison();
+            StatsError::Database(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some(format!("Lock poisoned: {}", e)),
+            ))
+        })?;
+
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM stats", [], |row| row.get(0))?;
+        Ok(count as usize)
+    }
+
+    /// Clear all records and reset auto-increment
+    pub fn clear(&self) -> StatsResult<()> {
+        let conn = self.conn.lock().map_err(|e| {
+            self.conn.clear_poison();
+            StatsError::Database(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some(format!("Lock poisoned: {}", e)),
+            ))
+        })?;
+
+        conn.execute_batch("DELETE FROM stats; DELETE FROM sqlite_sequence WHERE name='stats';")?;
+        Ok(())
+    }
+
+    /// Convert a database row to StatsRecord
+    fn row_to_record(row: &rusqlite::Row<'_>) -> Result<StatsRecord, rusqlite::Error> {
+        let agent_id: String = row.get(3)?;
+        Ok(StatsRecord {
+            id: row.get(0)?,
+            timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(1)?)
+                .map(|dt| dt.with_timezone(&chrono::Local))
+                .unwrap_or_else(|_| chrono::Local::now()),
+            operation: row
+                .get::<_, String>(2)?
+                .parse()
+                .unwrap_or(OperationType::CompressSchema),
+            agent_id,
+            source_pid: row.get(4)?,
+            session_id: row.get(5)?,
+            tool_use_id: row.get(6)?,
+            before_chars: row.get(7)?,
+            before_tokens: row.get(8)?,
+            after_chars: row.get(9)?,
+            after_tokens: row.get(10)?,
+            before_text: row.get(11)?,
+            after_text: row.get(12)?,
+        })
+    }
+}
+
+/// Summary statistics
+#[derive(Debug, Clone, Default)]
+pub struct StatsSummary {
+    pub total_records: usize,
+    pub total_before_chars: usize,
+    pub total_after_chars: usize,
+    pub total_before_tokens: usize,
+    pub total_after_tokens: usize,
+}
+
+impl StatsSummary {
+    pub fn chars_saved(&self) -> usize {
+        self.total_before_chars
+            .saturating_sub(self.total_after_chars)
+    }
+
+    pub fn tokens_saved(&self) -> usize {
+        self.total_before_tokens
+            .saturating_sub(self.total_after_tokens)
+    }
+
+    pub fn chars_percent(&self) -> f64 {
+        if self.total_before_chars > 0 {
+            (self.chars_saved() as f64 / self.total_before_chars as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    pub fn tokens_percent(&self) -> f64 {
+        if self.total_before_tokens > 0 {
+            (self.tokens_saved() as f64 / self.total_before_tokens as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    /// Build summary from a slice of records
+    pub fn from_records(records: &[StatsRecord]) -> Self {
+        let mut summary = Self {
+            total_records: records.len(),
+            ..Default::default()
+        };
+
+        for record in records {
+            summary.total_before_chars += record.before_chars;
+            summary.total_after_chars += record.after_chars;
+            summary.total_before_tokens += record.before_tokens;
+            summary.total_after_tokens += record.after_tokens;
+        }
+
+        summary
+    }
+}

--- a/src/tokenless/crates/tokenless-stats/src/tokenizer.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tokenizer.rs
@@ -1,0 +1,51 @@
+//! Tokenizer for estimating token counts.
+
+/// Estimate token count from text using character-based heuristic.
+/// Uses ~4 characters per token for English text as a rough approximation.
+pub fn estimate_tokens(text: &str) -> usize {
+    if text.is_empty() {
+        return 0;
+    }
+    text.chars().count().div_ceil(4)
+}
+
+/// Estimate token count from a character count when text is unavailable.
+/// Same heuristic: ~4 characters per token.
+pub fn estimate_tokens_from_chars(chars: usize) -> usize {
+    if chars == 0 {
+        return 0;
+    }
+    chars.div_ceil(4)
+}
+
+/// Count Unicode characters in text.
+pub fn count_chars(text: &str) -> usize {
+    text.chars().count()
+}
+
+/// Backwards-compatible struct for existing code.
+/// Prefer using the free functions `estimate_tokens` and `count_chars` directly.
+pub struct Tokenizer;
+
+impl Tokenizer {
+    #[doc(hidden)]
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[doc(hidden)]
+    pub fn estimate_tokens(&self, text: &str) -> usize {
+        estimate_tokens(text)
+    }
+
+    #[doc(hidden)]
+    pub fn count_chars(&self, text: &str) -> usize {
+        count_chars(text)
+    }
+}
+
+impl Default for Tokenizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
@@ -34,7 +34,7 @@
 
 set -euo pipefail
 
-# --- Dependency checks (fail-open: never block tool responses) ---
+# --- Dependency checks (fail-open) ---
 
 if ! command -v jq &>/dev/null; then
   echo "[tokenless] WARNING: jq is not installed. Response compression hook disabled." >&2
@@ -53,7 +53,7 @@ INPUT=$(cat || {
   exit 0
 })
 
-# --- Extract tool_response (fail-open) ---
+# --- Extract tool_response ---
 
 TOOL_RESPONSE=$(echo "$INPUT" | jq -c '.tool_response // empty' 2>/dev/null || echo '')
 
@@ -95,11 +95,18 @@ if [ -n "$TOOL_RESPONSE_RAW" ]; then
   esac
 fi
 
-# --- Compress response via tokenless ---
-# tool_response may not be valid JSON in all cases (e.g., shell output wrapped as string).
-# tokenless compress-response expects JSON input; if it fails, fall through gracefully.
+# --- Extract caller context from raw payload ---
 
-COMPRESSED=$(echo "$TOOL_RESPONSE" | tokenless compress-response 2>/dev/null) || {
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
+TOOL_USE_ID=$(echo "$INPUT" | jq -r '.tool_use_id // empty' 2>/dev/null || echo '')
+
+# --- Compress response ---
+
+COMPRESSED=$(echo "$TOOL_RESPONSE" | tokenless compress-response \
+  --agent-id copilot-shell \
+  ${SESSION_ID:+--session-id "$SESSION_ID"} \
+  ${TOOL_USE_ID:+--tool-use-id "$TOOL_USE_ID"} \
+  2>/dev/null) || {
   echo "[tokenless] WARNING: Response compression failed. Passing through unchanged." >&2
   exit 0
 }
@@ -111,10 +118,6 @@ if [ -z "$COMPRESSED" ]; then
 fi
 
 # --- Build copilot-shell response ---
-# suppressOutput: true  — hides the original verbose tool output from the agent
-# additionalContext      — injects the compressed content instead
-
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo 'unknown')
 
 jq -n \
   --arg context "$COMPRESSED" \

--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh
@@ -1,45 +1,12 @@
 #!/usr/bin/env bash
-# tokenless-hook-version: 1
-# Token-Less copilot-shell hook — compresses tool schema definitions to save ~57% schema tokens.
-# Requires: tokenless, jq
-#
-# Hook event: BeforeModel
-#
-# The BeforeModel event exposes `llm_request` which contains the full LLM request.
-# However, as of the current anolisa copilot-shell protocol, the decoupled
-# LLMRequest type does NOT include a `tools` array (tool schema definitions).
-# It only exposes: model, messages, config, and toolConfig (mode + allowedFunctionNames).
-#
-# LIMITATION: Schema compression cannot be performed via hooks until the
-# anolisa hook protocol is extended to include tool definitions in LLMRequest.
-# This script is a placeholder that will activate automatically once the
-# protocol adds tools support. Until then it exits cleanly (no-op).
-#
-# When tools support is added, the expected LLMRequest.tools format would be:
-#   "tools": [ { "name": "...", "description": "...", "parameters": { ... } }, ... ]
-#
-# copilot-shell settings.json configuration:
-#   {
-#     "hooks": {
-#       "BeforeModel": [
-#         {
-#           "type": "command",
-#           "command": "/path/to/Token-Less/hooks/copilot-shell/tokenless-compress-schema.sh",
-#           "name": "tokenless-compress-schema",
-#           "description": "Compress tool schema definitions to save tokens",
-#           "timeout": 10000
-#         }
-#       ]
-#     }
-#   }
-#
-# copilot-shell hook protocol:
-#   stdin:  JSON with { llm_request: { model, messages, config, toolConfig, tools? } }
-#   stdout: JSON with { hookSpecificOutput: { llm_request: { tools: [...] } } }
+# tokenless-hook-version: 6
+# Token-Less copilot-shell hook — compresses tool schema definitions.
+# Stats are recorded automatically by tokenless compress-schema.
+# Requires: jq
 
 set -euo pipefail
 
-# --- Dependency checks (fail-open: never block LLM calls) ---
+# --- Dependency checks (fail-open) ---
 
 if ! command -v jq &>/dev/null; then
   echo "[tokenless] WARNING: jq is not installed. Schema compression hook disabled." >&2
@@ -58,28 +25,29 @@ INPUT=$(cat || {
   exit 0
 })
 
-# --- Extract tools array from llm_request (fail-open) ---
-# The tools field is not yet part of the decoupled LLMRequest protocol.
-# Check if it exists; if not, exit cleanly (no-op).
+# --- Extract tools array ---
 
 TOOLS=$(echo "$INPUT" | jq -c '.llm_request.tools // empty' 2>/dev/null || echo '')
 
 if [ -z "$TOOLS" ] || [ "$TOOLS" = "null" ] || [ "$TOOLS" = "[]" ]; then
-  # No tools in the request — nothing to compress.
-  # This is the expected path until the protocol adds tools support.
   exit 0
 fi
-
-# --- Validate tools is an array ---
 
 TOOLS_LENGTH=$(echo "$TOOLS" | jq 'length' 2>/dev/null || echo '0')
 if [ "$TOOLS_LENGTH" -eq 0 ]; then
   exit 0
 fi
 
-# --- Compress schemas via tokenless ---
+# --- Extract caller context from raw payload ---
 
-COMPRESSED=$(echo "$TOOLS" | tokenless compress-schema --batch 2>/dev/null) || {
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
+
+# --- Compress schemas ---
+
+COMPRESSED=$(echo "$TOOLS" | tokenless compress-schema --batch \
+  --agent-id copilot-shell \
+  ${SESSION_ID:+--session-id "$SESSION_ID"} \
+  2>/dev/null) || {
   echo "[tokenless] WARNING: Schema compression failed. Passing through unchanged." >&2
   exit 0
 }
@@ -91,7 +59,6 @@ if ! echo "$COMPRESSED" | jq -e 'type == "array"' &>/dev/null 2>&1; then
 fi
 
 # --- Build copilot-shell response ---
-# Return a partial llm_request with only the tools field modified.
 
 jq -n \
   --argjson tools "$COMPRESSED" \

--- a/src/tokenless/hooks/copilot-shell/tokenless-rewrite.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-rewrite.sh
@@ -1,24 +1,11 @@
 #!/usr/bin/env bash
-# tokenless-hook-version: 1
-# Token-Less copilot-shell hook — rewrites commands to use rtk for token savings.
-# Requires: rtk >= 0.23.0, jq
+# tokenless-hook-version: 6
+# Token-Less copilot-shell hook — rewrites commands via rtk.
+# Requires: rtk >= 0.35.0, jq
 #
-# This is a thin delegating hook: all rewrite logic lives in `rtk rewrite`,
-# which is the single source of truth. To add or change rewrite rules,
-# update the RTK registry — not this file.
-#
-# Exit code protocol for `rtk rewrite`:
-#   0 + stdout  Rewrite found, no deny/ask rule matched → auto-allow
-#   1           No RTK equivalent → pass through unchanged
-#   2           Deny rule matched → pass through (agent handles deny)
-#   3 + stdout  Ask rule matched → rewrite but let agent prompt the user
-#
-# copilot-shell hook protocol:
-#   stdin:  JSON with { tool_input: { command: "..." }, ... }
-#   stdout: JSON with { hookSpecificOutput: { tool_input: { command: "..." } } }
-#   Note: copilot-shell uses `tool_input` (not `updatedInput` like Claude Code)
+# Hook event: PreToolUse
 
-# --- Dependency checks (fail-open: never block commands) ---
+# --- Dependency checks (fail-open) ---
 
 if ! command -v jq &>/dev/null; then
   echo "[tokenless] WARNING: jq is not installed. Hook cannot rewrite commands." >&2
@@ -30,15 +17,20 @@ if ! command -v rtk &>/dev/null; then
   exit 0
 fi
 
-# Version guard: rtk rewrite was added in 0.23.0.
+# Version guard
 RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 if [ -n "$RTK_VERSION" ]; then
   MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
   MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
-  if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
-    echo "[tokenless] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+  if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 35 ]; then
+    echo "[tokenless] WARNING: rtk $RTK_VERSION is too old (need >= 0.35.0)." >&2
     exit 0
   fi
+fi
+
+if ! command -v tokenless &>/dev/null; then
+  echo "[tokenless] WARNING: tokenless is not installed. Hook disabled." >&2
+  exit 0
 fi
 
 # --- Read input ---
@@ -50,56 +42,39 @@ if [ -z "$CMD" ]; then
   exit 0
 fi
 
-# --- Delegate to rtk rewrite ---
+# --- Use rtk to rewrite ---
 
 REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
-EXIT_CODE=$?
+REWRITE_EXIT=$?
 
-case $EXIT_CODE in
-  0)
-    # Rewrite found, no permission rules matched — safe to auto-allow.
-    [ "$CMD" = "$REWRITTEN" ] && exit 0
-    ;;
-  1)
-    # No RTK equivalent — pass through unchanged.
-    exit 0
-    ;;
-  2)
-    # Deny rule matched — let agent's native deny handle it.
-    exit 0
-    ;;
-  3)
-    # Ask rule matched — rewrite but do NOT auto-allow.
-    ;;
-  *)
-    exit 0
-    ;;
+# Handle rewrite result: exit 1/2 = no rewrite, exit 0 = same or rewritten
+case $REWRITE_EXIT in
+  1|2) exit 0 ;;
+  0) [ "$CMD" = "$REWRITTEN" ] && exit 0 ;;
 esac
 
+# --- Extract caller context and export for RTK stats ---
+# Environment variables are inherited by child processes (rtk)
+# and read by RTK's record_to_tokenless_stats (takes precedence over file).
+
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
+TOOL_USE_ID=$(echo "$INPUT" | jq -r '.tool_use_id // empty' 2>/dev/null || echo '')
+
+export TOKENLESS_AGENT_ID="copilot-shell"
+if [ -n "$SESSION_ID" ]; then export TOKENLESS_SESSION_ID="$SESSION_ID"; fi
+if [ -n "$TOOL_USE_ID" ]; then export TOKENLESS_TOOL_USE_ID="$TOOL_USE_ID"; fi
+
 # --- Build copilot-shell response ---
-# Key difference from Claude Code: use `tool_input` instead of `updatedInput`
 
 ORIGINAL_INPUT=$(echo "$INPUT" | jq -c '.tool_input')
 UPDATED_INPUT=$(echo "$ORIGINAL_INPUT" | jq --arg cmd "$REWRITTEN" '.command = $cmd')
 
-if [ "$EXIT_CODE" -eq 3 ]; then
-  # Ask: rewrite the command, omit decision so agent prompts user.
-  jq -n \
-    --argjson updated "$UPDATED_INPUT" \
-    '{
-      "hookSpecificOutput": {
-        "tool_input": $updated
-      }
-    }'
-else
-  # Allow: rewrite the command and auto-allow.
-  jq -n \
-    --argjson updated "$UPDATED_INPUT" \
-    '{
-      "decision": "allow",
-      "reason": "RTK auto-rewrite",
-      "hookSpecificOutput": {
-        "tool_input": $updated
-      }
-    }'
-fi
+jq -n \
+  --argjson updated "$UPDATED_INPUT" \
+  '{
+    "decision": "allow",
+    "reason": "RTK auto-rewrite",
+    "hookSpecificOutput": {
+      "tool_input": $updated
+    }
+  }'

--- a/src/tokenless/openclaw/index.ts
+++ b/src/tokenless/openclaw/index.ts
@@ -1,23 +1,27 @@
 /**
- * Token-Less Unified Plugin for OpenClaw
+ * Token-Less Unified Plugin for OpenClaw v5
  *
  * Combines two complementary optimisation strategies into a single plugin:
  *
  *   1. RTK command rewriting  — transparently rewrites exec tool commands to
  *      their RTK equivalents (delegated to `rtk rewrite`).
- *   2. Tokenless schema / response compression — compresses tool schemas and
- *      tool responses via `tokenless compress-schema` / `tokenless compress-response`.
+ *   2. Response compression   — compresses API/tool responses via
+ *      `tokenless compress-response`.
  *
- * Both features are thin delegates that shell out to their respective binaries.
- * If a binary is missing the corresponding feature is silently disabled.
- *
- * Design principles:
- *   - Non-blocking: every operation has a timeout guard and failures passthrough.
- *   - Lazy binary detection: `which` is called at most once per binary.
- *   - Zero runtime dependencies beyond Node built-ins.
+ * Stats are recorded automatically by tokenless compress-response / compress-schema.
+ * Context passing uses environment variables (TOKENLESS_AGENT_ID,
+ * TOKENLESS_SESSION_ID, TOKENLESS_TOOL_USE_ID) which are inherited by
+ * child processes and read by RTK's stats patch.
  */
 
 import { execSync, execFileSync, spawnSync } from "child_process";
+
+// ---- Session ID mapping --------------------------------------------------------
+// OpenClaw's tool_result_persist ctx provides sessionKey ("agent:main:main")
+// but NOT sessionId (UUID). We maintain a sessionKey → sessionId map built
+// from session_start events so response compression can use the correct UUID.
+
+const sessionMap: Map<string, string> = new Map();
 
 // ---- Binary availability cache ------------------------------------------------
 
@@ -61,16 +65,12 @@ function checkTokenless(): boolean {
 
 function tryRtkRewrite(command: string): string | null {
   try {
-    // Use spawnSync instead of execSync because rtk uses exit code 3 to signal
-    // "command was rewritten" — execSync throws on any non-zero exit code,
-    // which would silently discard the rewritten result.
     const result = spawnSync("rtk", ["rewrite", command], {
       encoding: "utf-8",
       timeout: 2000,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const rewritten = result.stdout?.trim();
-    // Exit 0 or 3 = success (3 means rewritten), exit 1 = no rewrite needed
     if ((result.status === 0 || result.status === 3) && rewritten && rewritten !== command) {
       return rewritten;
     }
@@ -80,24 +80,13 @@ function tryRtkRewrite(command: string): string | null {
   }
 }
 
-function tryCompressSchema(schema: any): any | null {
-  try {
-    const input = JSON.stringify(schema);
-    const result = execFileSync("tokenless", ["compress-schema"], {
-      encoding: "utf-8",
-      timeout: 3000,
-      input,
-    }).trim();
-    return JSON.parse(result);
-  } catch {
-    return null;
-  }
-}
-
-function tryCompressResponse(response: any): any | null {
+function tryCompressResponse(response: any, sessionId?: string, toolCallId?: string): any | null {
   try {
     const input = JSON.stringify(response);
-    const result = execFileSync("tokenless", ["compress-response"], {
+    const args = ["compress-response", "--agent-id", "openclaw"];
+    if (sessionId) args.push("--session-id", sessionId);
+    if (toolCallId) args.push("--tool-use-id", toolCallId);
+    const result = execFileSync("tokenless", args, {
       encoding: "utf-8",
       timeout: 3000,
       input,
@@ -113,26 +102,43 @@ function tryCompressResponse(response: any): any | null {
 export default {
   id: "tokenless-openclaw",
   name: "Token-Less",
-  version: "1.0.0",
-  description: "Unified RTK command rewriting + schema/response compression",
+  version: "5.0.0",
+  description: "Unified RTK command rewriting + response compression",
   register(api: any) {
   const pluginConfig = api.config ?? {};
   const rtkEnabled = pluginConfig.rtk_enabled !== false;
-  const schemaCompressionEnabled = pluginConfig.schema_compression_enabled !== false;
   const responseCompressionEnabled = pluginConfig.response_compression_enabled !== false;
   const skipTools: Set<string> = new Set((pluginConfig.skip_tools ?? ["Read", "read_file", "Glob", "list_directory", "NotebookRead"]).map((t: string) => t.toLowerCase()));
   const verbose = pluginConfig.verbose !== false;
+
+  // ---- 0. Session mapping (sessionKey → sessionId) ---------------------------
+
+  api.on(
+    "session_start",
+    (event: { sessionId: string; sessionKey?: string; resumedFrom?: string }) => {
+      if (event.sessionKey && event.sessionId) {
+        sessionMap.set(event.sessionKey, event.sessionId);
+      }
+      // Also store in env var for RTK (exec) path
+      process.env.TOKENLESS_SESSION_ID = event.sessionId;
+    },
+  );
 
   // ---- 1. RTK command rewriting (before_tool_call) ----------------------------
 
   if (rtkEnabled && checkRtk()) {
     api.on(
       "before_tool_call",
-      (event: { toolName: string; params: Record<string, unknown> }) => {
+      (event: { toolName: string; params: Record<string, unknown> }, ctx: { sessionId?: string; sessionKey?: string; agentId?: string; toolCallId?: string; runId?: string }) => {
         if (event.toolName !== "exec") return;
 
         const command = event.params?.command;
         if (typeof command !== "string") return;
+
+        // Set env vars so RTK and response compression can read agent/session/tool IDs
+        process.env.TOKENLESS_AGENT_ID = "openclaw";
+        if (ctx?.sessionId) process.env.TOKENLESS_SESSION_ID = ctx.sessionId;
+        if (ctx?.toolCallId) process.env.TOKENLESS_TOOL_USE_ID = ctx.toolCallId;
 
         const rewritten = tryRtkRewrite(command);
         if (!rewritten) return;
@@ -147,38 +153,15 @@ export default {
     );
   }
 
-  // ---- 2. Schema compression (before_tool_register) ---------------------------
-
-  if (schemaCompressionEnabled && checkTokenless()) {
-    api.on(
-      "before_tool_register",
-      (event: { toolName: string; schema: Record<string, unknown> }) => {
-        const compressed = tryCompressSchema(event.schema);
-        if (!compressed) return;
-
-        if (verbose) {
-          const before = JSON.stringify(event.schema).length;
-          const after = JSON.stringify(compressed).length;
-          console.log(
-            `[tokenless/schema] ${event.toolName}: ${before} -> ${after} chars (${Math.round((1 - after / before) * 100)}% reduction)`,
-          );
-        }
-
-        return { schema: compressed };
-      },
-      { priority: 10 },
-    );
-  }
-
-  // ---- 3. Response compression (tool_result_persist) -------------------------
+  // ---- 2. Response compression (tool_result_persist) --------------------------
 
   if (responseCompressionEnabled && checkTokenless()) {
     api.on(
       "tool_result_persist",
-      (event: { toolName: string; toolCallId?: string; message: any }) => {
-        // Skip exec tool results when RTK is enabled — RTK already produces
-        // optimized output, double-compression is wasteful.
-        if (rtkEnabled && rtkAvailable && event.toolName === "exec") return;
+      (event: { toolName?: string; toolCallId?: string; message: any; isSynthetic?: boolean }, ctx: { agentId?: string; sessionId?: string; sessionKey?: string; toolName?: string; toolCallId?: string }) => {
+        const beforeJson = JSON.stringify(event.message);
+        // Skip small responses
+        if (beforeJson.length < 200) return;
 
         // Skip content-retrieval tools — agent needs complete responses
         if (event.toolName && skipTools.has(event.toolName.toLowerCase())) return;
@@ -186,14 +169,26 @@ export default {
         // Skip skill content to avoid breaking YAML frontmatter metadata.
         if (isSkillContent(event.message)) return;
 
-        const compressed = tryCompressResponse(event.message);
+        const toolCallId = ctx?.toolCallId || event.toolCallId;
+
+        // Resolve sessionId with 4-level priority:
+        //   1. ctx.sessionId   — direct from OpenClaw (newer versions)
+        //   2. sessionMap[sessionKey] — from session_start mapping
+        //   3. TOKENLESS_SESSION_ID   — env var (set by session_start / before_tool_call)
+        //   4. ctx.sessionKey  — always available ("agent:main:main"), best-effort fallback
+        const sessionId = ctx?.sessionId
+          || (ctx?.sessionKey && sessionMap.get(ctx.sessionKey))
+          || process.env.TOKENLESS_SESSION_ID
+          || ctx?.sessionKey;
+
+        const compressed = tryCompressResponse(event.message, sessionId, toolCallId);
         if (!compressed) return;
 
         if (verbose) {
-          const before = JSON.stringify(event.message).length;
-          const after = JSON.stringify(compressed).length;
+          const beforeChars = JSON.stringify(event.message).length;
+          const afterChars = JSON.stringify(compressed).length;
           console.log(
-            `[tokenless/response] ${event.toolName}: ${before} -> ${after} chars (${Math.round((1 - after / before) * 100)}% reduction)`,
+            `[tokenless/response] ${event.toolName}: ${beforeChars} -> ${afterChars} chars (${Math.round((1 - afterChars / beforeChars) * 100)}% reduction)`,
           );
         }
 
@@ -208,10 +203,9 @@ export default {
   if (verbose) {
     const features = [
       rtkEnabled && rtkAvailable ? "rtk-rewrite" : null,
-      schemaCompressionEnabled && tokenlessAvailable ? "schema-compression" : null,
       responseCompressionEnabled && tokenlessAvailable ? "response-compression" : null,
     ].filter(Boolean);
-    console.log(`[tokenless] OpenClaw plugin registered — active features: ${features.join(", ") || "none"}`);
+    console.log(`[tokenless] OpenClaw plugin v5 registered — active features: ${features.join(", ") || "none"}`);
   }
   },
 };

--- a/src/tokenless/openclaw/openclaw.plugin.json
+++ b/src/tokenless/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "tokenless-openclaw",
   "name": "Token-Less",
-  "version": "1.0.0",
+  "version": "5.0.0",
   "description": "Unified RTK command rewriting + schema/response compression",
   "configSchema": {
     "type": "object",

--- a/src/tokenless/scripts/install.sh
+++ b/src/tokenless/scripts/install.sh
@@ -80,54 +80,84 @@ setup_openclaw() {
 
     info "Configuring OpenClaw plugin..."
     info "  Source: $openclaw_src"
-    info "  Destination: $OPENCLAW_DIR"
 
-    mkdir -p "$OPENCLAW_DIR"
+    # Install plugin files to ~/.openclaw/extensions/tokenless/
+    local ext_dir="$HOME/.openclaw/extensions/tokenless"
+    mkdir -p "$ext_dir"
 
-    # Copy openclaw files
-    if [ -f "${openclaw_src}/index.ts" ]; then
-        cp "${openclaw_src}/index.ts" "$OPENCLAW_DIR/"
-        info "  Copied index.ts"
-    fi
-
-    if [ -f "${openclaw_src}/openclaw.plugin.json" ]; then
-        cp "${openclaw_src}/openclaw.plugin.json" "$OPENCLAW_DIR/"
-        info "  Copied openclaw.plugin.json"
-    fi
-
-    if [ -f "${openclaw_src}/package.json" ]; then
-        cp "${openclaw_src}/package.json" "$OPENCLAW_DIR/"
-        info "  Copied package.json"
-    fi
+    cp "${openclaw_src}/index.ts" "$ext_dir/" 2>/dev/null || true
+    cp "${openclaw_src}/openclaw.plugin.json" "$ext_dir/"
+    cp "${openclaw_src}/package.json" "$ext_dir/"
+    info "  Copied plugin files to $ext_dir"
 
     # Compile TypeScript to JavaScript
     if command -v npx &>/dev/null; then
-        if npx --yes esbuild "${OPENCLAW_DIR}/index.ts" --bundle --platform=node --format=esm --outfile="${OPENCLAW_DIR}/index.js" 2>/dev/null; then
+        if npx --yes esbuild "${ext_dir}/index.ts" --bundle --platform=node --format=esm --outfile="${ext_dir}/index.js" 2>/dev/null; then
             info "  Compiled index.ts -> index.js (esbuild)"
         else
-            sed 's/: any//g; s/: string//g; s/: boolean | null/: any/g; s/: Record<string, unknown>//g; s/: { [^}]*}//g' "${OPENCLAW_DIR}/index.ts" > "${OPENCLAW_DIR}/index.js"
+            sed 's/: any//g; s/: string//g; s/: boolean | null/: any/g; s/: Record<string, unknown>//g; s/: { [^}]*}//g' "${ext_dir}/index.ts" > "${ext_dir}/index.js"
             info "  Compiled index.ts -> index.js (sed fallback)"
         fi
     else
-        sed 's/: any//g; s/: string//g; s/: boolean | null/: any/g; s/: Record<string, unknown>//g; s/: { [^}]*}//g' "${OPENCLAW_DIR}/index.ts" > "${OPENCLAW_DIR}/index.js"
+        sed 's/: any//g; s/: string//g; s/: boolean | null/: any/g; s/: Record<string, unknown>//g; s/: { [^}]*}//g' "${ext_dir}/index.ts" > "${ext_dir}/index.js"
         info "  Compiled index.ts -> index.js (sed fallback)"
     fi
 
-    # Configure plugins.allow
+    # Register plugin in openclaw.json
     local openclaw_config="$HOME/.openclaw/openclaw.json"
-    if [ -f "$openclaw_config" ] && command -v python3 &>/dev/null; then
-        python3 -c "
-import json
-cfg = json.load(open('$openclaw_config'))
-p = cfg.setdefault('plugins', {})
-a = set(p.get('allow', []))
-a.add('tokenless-openclaw')
-p['allow'] = sorted(a)
-json.dump(cfg, open('$openclaw_config', 'w'), indent=2)
-"
-        info "  Added tokenless-openclaw to plugins.allow"
-    elif [ -f "$openclaw_config" ]; then
-        warn "  python3 not found — please manually add 'tokenless-openclaw' to plugins.allow in $openclaw_config"
+    if [ -f "$openclaw_config" ] && command -v jq &>/dev/null; then
+        local temp_file
+        temp_file=$(mktemp)
+        jq '
+            .plugins.enabled = true |
+            .plugins.entries["tokenless-openclaw"] = {"enabled": true} |
+            .plugins.allow = (.plugins.allow // [] | map(select(. != "tokenless-openclaw")) + ["tokenless-openclaw"])
+        ' "$openclaw_config" > "$temp_file" 2>/dev/null
+        if [ -s "$temp_file" ]; then
+            mv "$temp_file" "$openclaw_config"
+            info "  Registered tokenless-openclaw in $openclaw_config"
+        else
+            rm -f "$temp_file"
+            warn "  Failed to update openclaw.json"
+        fi
+    else
+        warn "  jq not found — manually add tokenless-openclaw to $openclaw_config"
+    fi
+}
+
+cleanup_openclaw() {
+    local is_upgrade="${1:-0}"
+
+    if [ "$is_upgrade" -eq 1 ]; then
+        info "Upgrade detected, preserving OpenClaw plugin"
+        return 0
+    fi
+
+    info "Cleaning up OpenClaw plugin..."
+
+    # Remove extension directory
+    local ext_dir="$HOME/.openclaw/extensions/tokenless"
+    if [ -d "$ext_dir" ]; then
+        rm -rf "$ext_dir"
+        info "  Removed $ext_dir"
+    fi
+
+    # Unregister from openclaw.json
+    local openclaw_config="$HOME/.openclaw/openclaw.json"
+    if [ -f "$openclaw_config" ] && command -v jq &>/dev/null; then
+        local temp_file
+        temp_file=$(mktemp)
+        jq '
+            del(.plugins.entries["tokenless-openclaw"]) |
+            .plugins.allow = (.plugins.allow // [] | map(select(. != "tokenless-openclaw")))
+        ' "$openclaw_config" > "$temp_file" 2>/dev/null
+        if [ -s "$temp_file" ]; then
+            mv "$temp_file" "$openclaw_config"
+            info "  Unregistered tokenless-openclaw from $openclaw_config"
+        else
+            rm -f "$temp_file"
+            warn "  Failed to update openclaw.json"
+        fi
     fi
 }
 
@@ -350,6 +380,9 @@ rpm_postinstall() {
     info "Token-Less Post-Installation Configuration"
     info "=========================================="
 
+    # Configure OpenClaw plugin
+    setup_openclaw "system" || true
+
     # Configure copilot-shell hooks (system-wide path)
     configure_cosh_hooks "$SYS_SHARE_DIR/hooks/copilot-shell" || true
 
@@ -382,7 +415,14 @@ rpm_preuninstall() {
 
     # Clean up hooks configuration
     # $1 = 0: full uninstall, $1 = 1: upgrade
+    cleanup_openclaw "$action"
     cleanup_cosh_hooks "$action"
+
+    # Clean up stats data on full uninstall (preserve on upgrade)
+    if [ "$action" -eq 0 ] && [ -d "$HOME/.tokenless" ]; then
+        rm -rf "$HOME/.tokenless"
+        info "  Removed stats data: $HOME/.tokenless"
+    fi
 
     info "=========================================="
     info "Cleanup completed"

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Token-Less Full Test Suite
+# Tests all three compression methods:
+# 1. Schema Compression (tokenless compress-schema)
+# 2. Response Compression (tokenless compress-response)
+# 3. Command Rewriting (RTK)
+# 4. Stats System (record, list, summary, diff)
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_TOTAL=0
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; ((TESTS_PASSED++)); ((TESTS_TOTAL++)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; ((TESTS_FAILED++)); ((TESTS_TOTAL++)); }
+log_section() { echo -e "\n${YELLOW}========================================${NC}\n${YELLOW}$1${NC}\n${YELLOW}========================================${NC}\n"; }
+
+assert_contains() {
+    local input="$1" expected="$2" test_name="$3"
+    if echo "$input" | grep -q "$expected"; then log_pass "$test_name"
+    else log_fail "$test_name - Expected: $expected"; fi
+}
+
+test_schema_compression() {
+    log_section "Test 1: Schema Compression"
+
+    log_info "Test 1.1: Simple schema compression"
+    local simple_schema='{"function":{"name":"greet","description":"Say hello","parameters":{"type":"object","properties":{"name":{"type":"string"}}}}}'
+    local compressed=$(echo "$simple_schema" | tokenless compress-schema 2>/dev/null)
+    assert_contains "$compressed" '"function"' "Simple schema preserves function"
+    assert_contains "$compressed" '"greet"' "Simple schema preserves name"
+
+    log_info "Test 1.2: Nested schema compression"
+    local nested_schema='{"function":{"name":"create_user","parameters":{"type":"object","title":"Params","properties":{"address":{"type":"object","title":"Address","properties":{"street":{"type":"string"}}}}}}}'
+    compressed=$(echo "$nested_schema" | tokenless compress-schema 2>/dev/null)
+    assert_contains "$compressed" '"address"' "Nested schema preserves address"
+
+    log_info "Test 1.3: Enum preservation"
+    local enum_schema='{"function":{"name":"calc","parameters":{"properties":{"op":{"type":"string","enum":["add","sub"]}}}}}'
+    compressed=$(echo "$enum_schema" | tokenless compress-schema 2>/dev/null)
+    assert_contains "$compressed" '"enum"' "Enum preserved"
+
+    log_info "Test 1.4: Edge cases"
+    assert_contains "$(echo '{}' | tokenless compress-schema 2>/dev/null)" '{}' "Empty schema"
+    assert_contains "$(echo 'null' | tokenless compress-schema 2>/dev/null)" 'null' "Null schema"
+}
+
+test_response_compression() {
+    log_section "Test 2: Response Compression"
+
+    log_info "Test 2.1: Null removal"
+    local null_response='{"name":"test","value":null,"count":5}'
+    local compressed=$(echo "$null_response" | tokenless compress-response 2>/dev/null)
+    assert_contains "$compressed" '"name"' "Null removal preserves name"
+
+    log_info "Test 2.2: Debug field removal"
+    local debug_response='{"data":"ok","debug":"info","trace":"stack"}'
+    compressed=$(echo "$debug_response" | tokenless compress-response 2>/dev/null)
+    assert_contains "$compressed" '"data"' "Debug removal preserves data"
+
+    log_info "Test 2.3: Nested object"
+    local nested='{"status":"ok","data":{"user":{"name":"John"}}}'
+    compressed=$(echo "$nested" | tokenless compress-response 2>/dev/null)
+    assert_contains "$compressed" '"status"' "Nested preserves status"
+}
+
+test_command_rewriting() {
+    log_section "Test 3: Command Rewriting (RTK)"
+
+    log_info "Test 3.1: RTK availability"
+    if command -v rtk &> /dev/null; then
+        log_pass "RTK available: $(rtk --version)"
+    else log_fail "RTK not found"; fi
+
+    log_info "Test 3.2: RTK rewrite"
+    local rewritten=$(rtk rewrite "ls -la" 2>/dev/null || echo "ls -la")
+    if [ -n "$rewritten" ]; then log_pass "RTK rewrite works: $rewritten"
+    else log_fail "RTK rewrite failed"; fi
+
+    log_info "Test 3.3: Multiple commands"
+    local cmds=("git status" "cargo build" "npm install")
+    local ok=0
+    for cmd in "${cmds[@]}"; do
+        local r=$(rtk rewrite "$cmd" 2>/dev/null || echo "")
+        [ -n "$r" ] && ((ok++)) || true
+    done
+    log_pass "RTK processed $ok/${#cmds[@]} commands"
+}
+
+test_stats_system() {
+    log_section "Test 4: Stats System"
+
+    # Use a temp DB for testing
+    local test_db=$(mktemp)
+    export TOKENLESS_STATS_DB="$test_db"
+
+    # ── 4.1: Trigger stats recording via actual compress-response ──
+    log_info "Test 4.1: Stats auto-record via compress-response"
+    local test_response='{"data":"important","debug":"noise","trace":"noise","items":[1,2,3,4,5,6,7,8,9,10]}'
+    local compressed
+    compressed=$(echo "$test_response" | tokenless compress-response \
+        --agent-id test-agent \
+        --session-id test-session \
+        --tool-use-id test-tool \
+        2>/dev/null) || true
+    if [ -n "$compressed" ]; then
+        log_pass "Stats auto-record via compress-response"
+    else
+        log_fail "Stats auto-record failed"
+    fi
+
+    # ── 4.2: Verify stats list shows the record ──
+    log_info "Test 4.2: Stats list"
+    local list_output
+    list_output=$(tokenless stats list 2>/dev/null) || true
+    if echo "$list_output" | grep -q '\[ID:'; then
+        log_pass "Stats list shows records"
+    else
+        log_fail "Stats list missing ID"
+    fi
+
+    # ── 4.3: Verify stats show displays details ──
+    log_info "Test 4.3: Stats show"
+    local record_id
+    record_id=$(echo "$list_output" | grep -o '\[ID:[0-9]*\]' | head -1 | grep -o '[0-9]*')
+    if [ -n "$record_id" ]; then
+        local show_output
+        show_output=$(tokenless stats show "$record_id" 2>/dev/null) || true
+        if echo "$show_output" | grep -qE '=== Before ===|=== After ==='; then
+            log_pass "Stats show displays compression metrics"
+        else
+            log_fail "Stats show missing metrics"
+        fi
+    else
+        log_fail "No record ID for stats show"
+    fi
+
+    # ── 4.4: Stats summary ──
+    log_info "Test 4.4: Stats summary"
+    local summary
+    summary=$(tokenless stats summary 2>/dev/null) || true
+    if echo "$summary" | grep -qE "Total Records|compress-response"; then
+        log_pass "Stats summary works"
+    else
+        log_fail "Stats summary broken"
+    fi
+
+    # ── 4.5: Stats clear ──
+    log_info "Test 4.5: Stats clear"
+    tokenless stats clear --yes >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        log_pass "Stats clear works"
+    else
+        log_fail "Stats clear failed"
+    fi
+
+    unset TOKENLESS_STATS_DB
+    rm -f "$test_db"
+}
+
+main() {
+    echo "============================================"
+    echo "  Token-Less Full Test Suite"
+    echo "============================================"
+
+    if ! command -v tokenless &> /dev/null; then
+        echo -e "${RED}ERROR: tokenless not found${NC}"; exit 1
+    fi
+    log_info "Testing $(tokenless --version)"
+
+    test_schema_compression
+    test_response_compression
+    test_command_rewriting
+    test_stats_system
+
+    echo ""
+    echo "============================================"
+    echo "  Summary: ${TESTS_PASSED}/${TESTS_TOTAL} passed"
+    echo "============================================"
+
+    [ "$TESTS_FAILED" -gt 0 ] && exit 1
+    echo -e "\n${GREEN}All tests passed!${NC}"
+}
+
+main "$@"

--- a/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
+++ b/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
@@ -1,0 +1,175 @@
+diff --git a/src/core/tracking.rs b/src/core/tracking.rs
+index 982c937..5eb93c1 100644
+--- a/src/core/tracking.rs
++++ b/src/core/tracking.rs
+@@ -1294,6 +1294,9 @@ impl TimedExecution {
+         let input_tokens = estimate_tokens(input);
+         let output_tokens = estimate_tokens(output);
+ 
++        // Also record to tokenless stats database (fail-silent)
++        record_to_tokenless_stats(original_cmd, rtk_cmd, input, output);
++
+         if let Ok(tracker) = Tracker::new() {
+             let _ = tracker.record(
+                 original_cmd,
+@@ -1355,6 +1358,160 @@ pub fn args_display(args: &[OsString]) -> String {
+         .join(" ")
+ }
+ 
++/// Estimate token count from character count using ~4 chars/token heuristic.
++fn estimate_tokens_from_chars(chars: usize) -> usize {
++    if chars == 0 { return 0; }
++    chars.div_ceil(4)
++}
++
++/// Resolve caller context from environment variables (primary) or
++/// .rewrite-context file (fallback for backwards compatibility).
++fn resolve_tokenless_context() -> (String, Option<String>, Option<String>) {
++    let pid = std::process::id();
++
++    // Primary: environment variables set by the hook
++    let env_agent = std::env::var("TOKENLESS_AGENT_ID").ok();
++    let env_session = std::env::var("TOKENLESS_SESSION_ID").ok();
++    let env_toolcall = std::env::var("TOKENLESS_TOOL_USE_ID").ok();
++
++    if env_agent.is_some() || env_session.is_some() || env_toolcall.is_some() {
++        let agent = env_agent.map(|a| format!("{}({})", a, pid))
++            .unwrap_or_else(|| format!("cli({})", pid));
++        let sid = env_session.filter(|s| !s.is_empty());
++        let tuid = env_toolcall.filter(|t| !t.is_empty());
++        return (agent, sid, tuid);
++    }
++
++    // Fallback: .rewrite-context file (legacy compat)
++    let context_file = dirs::home_dir()
++        .map(|d| d.join(".tokenless/.rewrite-context"))
++        .filter(|p| p.exists())
++        .and_then(|p| std::fs::read_to_string(p).ok());
++    if let Some(ctx) = &context_file {
++        let mut lines = ctx.lines();
++        let agent = lines.next().unwrap_or("").trim().to_string();
++        let session = lines.next().unwrap_or("").trim().to_string();
++        let toolcall = lines.next().unwrap_or("").trim().to_string();
++        // Clean up the context file after reading
++        let _ = dirs::home_dir()
++            .map(|d| d.join(".tokenless/.rewrite-context"))
++            .as_ref()
++            .map(std::fs::remove_file);
++        let agent_with_pid = if !agent.is_empty() {
++            format!("{}({})", agent, pid)
++        } else {
++            format!("cli({})", pid)
++        };
++        let sid = if session.is_empty() { None } else { Some(session) };
++        let tuid = if toolcall.is_empty() { None } else { Some(toolcall) };
++        return (agent_with_pid, sid, tuid);
++    }
++
++    (format!("cli({})", pid), None::<String>, None::<String>)
++}
++
++/// Check if tokenless stats are enabled.
++/// Priority: TOKENLESS_STATS_ENABLED env > config.json > default(true)
++fn is_tokenless_stats_enabled() -> bool {
++    // Check env var first
++    if let Ok(val) = std::env::var("TOKENLESS_STATS_ENABLED") {
++        return val == "1" || val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("yes");
++    }
++    // Fall back to config file
++    dirs::home_dir()
++        .map(|d| d.join(".tokenless/config.json"))
++        .and_then(|p| std::fs::read_to_string(p).ok())
++        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
++        .and_then(|v| v.get("stats_enabled").and_then(|b| b.as_bool()))
++        .unwrap_or(true)
++}
++
++/// Record RTK command output compression stats to the tokenless stats database.
++///
++/// Called from `TimedExecution::track` whenever RTK filters command output.
++/// Reads caller context from environment variables (primary) or
++/// .rewrite-context file (fallback) to obtain agent_id, session_id, and
++/// tool_use_id so the record can be correlated with a specific tool call.
++///
++/// Fails silently so RTK output is never blocked by database errors.
++fn record_to_tokenless_stats(
++    original_cmd: &str,
++    rtk_cmd: &str,
++    raw_output: &str,
++    filtered_output: &str,
++) {
++    let _ = (original_cmd, rtk_cmd);
++
++    if !is_tokenless_stats_enabled() {
++        return;
++    }
++
++    let (agent_id, session_id, tool_use_id) = resolve_tokenless_context();
++
++    let db_path = std::env::var("TOKENLESS_STATS_DB")
++        .unwrap_or_else(|_| {
++            format!(
++                "{}/.tokenless/stats.db",
++                std::env::var("HOME").unwrap_or_else(|_| ".".to_string())
++            )
++        });
++
++    let before_chars = raw_output.len();
++    let after_chars = filtered_output.len();
++    let before_tokens = estimate_tokens_from_chars(before_chars);
++    let after_tokens = estimate_tokens_from_chars(after_chars);
++
++    let _ = (|| -> anyhow::Result<()> {
++        if let Some(parent) = std::path::Path::new(&db_path).parent() {
++            std::fs::create_dir_all(parent)?;
++        }
++        let conn = rusqlite::Connection::open(&db_path)?;
++        conn.execute_batch(
++            "CREATE TABLE IF NOT EXISTS stats (
++                id INTEGER PRIMARY KEY AUTOINCREMENT,
++                timestamp TEXT NOT NULL,
++                operation TEXT NOT NULL,
++                agent_id TEXT NOT NULL,
++                source_pid INTEGER,
++                session_id TEXT,
++                tool_use_id TEXT,
++                before_chars INTEGER NOT NULL,
++                before_tokens INTEGER NOT NULL,
++                after_chars INTEGER NOT NULL,
++                after_tokens INTEGER NOT NULL,
++                before_text TEXT,
++                after_text TEXT
++            );
++            CREATE INDEX IF NOT EXISTS idx_stats_timestamp ON stats(timestamp);
++            CREATE INDEX IF NOT EXISTS idx_stats_operation ON stats(operation);
++            CREATE INDEX IF NOT EXISTS idx_stats_agent_id ON stats(agent_id);
++            CREATE INDEX IF NOT EXISTS idx_stats_session_id ON stats(session_id);",
++        )?;
++        conn.execute(
++            "INSERT INTO stats (
++                timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
++                before_chars, before_tokens, after_chars, after_tokens,
++                before_text, after_text
++            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
++            rusqlite::params![
++                chrono::Utc::now().to_rfc3339(),
++                "rewrite-command",
++                agent_id,
++                None::<i64>,
++                session_id,
++                tool_use_id,
++                before_chars as i64,
++                before_tokens as i64,
++                after_chars as i64,
++                after_tokens as i64,
++                raw_output,
++                filtered_output,
++            ],
++        )?;
++        Ok(())
++    })();
++}
++
+ #[cfg(test)]
+ mod tests {
+     use super::*;

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 4
+%define anolis_release 5
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -26,20 +26,32 @@ Core Features:
 - Schema Compression: Compresses OpenAI Function Calling tool definitions
 - Response Compression: Compresses API/tool responses
 - Command Rewriting: Filters CLI command output via RTK
+- Statistics Tracking: SQLite-based metrics for compression effectiveness
 
 The package includes:
-- tokenless: CLI tool for schema and response compression
+- tokenless: CLI tool for schema and response compression with stats tracking
 - rtk: High-performance CLI proxy for command rewriting (Apache-2.0 licensed)
 
 Note: OpenClaw plugin and copilot-shell hooks are available in the source tree
 at /usr/share/doc/tokenless/ for manual configuration.
 
 %prep
-%setup -q
+%setup -q -n tokenless
+
+# Clean any stale build artifacts from the tarball
+cargo clean --release
+cargo clean --release --manifest-path third_party/rtk/Cargo.toml
+
+# Apply tokenless stats patch to RTK (upstream rtk v0.36.0)
+# Patch is included in the tarball under third_party/patches/
+patch --forward -p1 --no-backup-if-mismatch -d third_party/rtk < third_party/patches/rtk-tokenless-stats.patch
 
 %build
-# Binaries are pre-built by scripts/rpm-build.sh
-# No build step needed in RPM build
+# Build tokenless (schema + response compression + stats)
+cargo build --release
+
+# Build rtk (command rewriting)
+cargo build --release --manifest-path third_party/rtk/Cargo.toml
 
 %install
 rm -rf %{buildroot}
@@ -47,15 +59,15 @@ mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/tokenless
 mkdir -p %{buildroot}%{_docdir}/tokenless
 
-# Install pre-built binaries
-install -m 0755 tokenless %{buildroot}%{_bindir}/tokenless
-install -m 0755 rtk %{buildroot}%{_bindir}/rtk
+# Install binaries
+install -m 0755 target/release/tokenless %{buildroot}%{_bindir}/tokenless
+install -m 0755 third_party/rtk/target/release/rtk %{buildroot}%{_bindir}/rtk
 
-# Install documentation (user manuals from docs/ directory)
+# Install documentation
 install -m 0644 docs/tokenless-user-manual-en.md %{buildroot}%{_docdir}/tokenless/
 install -m 0644 docs/tokenless-user-manual-zh.md %{buildroot}%{_docdir}/tokenless/
 install -m 0644 docs/response-compression.md %{buildroot}%{_docdir}/tokenless/
-install -m 0644 docs/LICENSE %{buildroot}%{_docdir}/tokenless/
+install -m 0644 LICENSE %{buildroot}%{_docdir}/tokenless/
 
 # Install source files for reference (openclaw, hooks, scripts)
 mkdir -p %{buildroot}%{_datadir}/tokenless/openclaw
@@ -76,12 +88,10 @@ install -m 0755 scripts/install.sh %{buildroot}%{_datadir}/tokenless/scripts/
 %defattr(0644,root,root,0755)
 %attr(0755,root,root) %{_bindir}/tokenless
 %attr(0755,root,root) %{_bindir}/rtk
-# Documentation files
 %doc %{_docdir}/tokenless/LICENSE
 %doc %{_docdir}/tokenless/response-compression.md
 %doc %{_docdir}/tokenless/tokenless-user-manual-en.md
 %doc %{_docdir}/tokenless/tokenless-user-manual-zh.md
-# Scripts and hooks with executable permissions
 %dir %{_datadir}/tokenless
 %dir %{_datadir}/tokenless/scripts
 %dir %{_datadir}/tokenless/hooks
@@ -93,15 +103,11 @@ install -m 0755 scripts/install.sh %{buildroot}%{_datadir}/tokenless/scripts/
 %{_datadir}/tokenless/openclaw/*
 
 %post
-# Configure copilot-shell hooks after installation
 if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
     %{_datadir}/tokenless/scripts/install.sh --install || true
 fi
 
 %preun
-# Clean up configuration before uninstallation
-# $1 = 0: full uninstall
-# $1 = 1: upgrade
 if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
     if [ $1 -eq 1 ]; then
         %{_datadir}/tokenless/scripts/install.sh --upgrade || true
@@ -111,6 +117,12 @@ if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
 fi
 
 %changelog
+* Sat Apr 25 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-5
+- Add compression stats: auto-record real before/after data from all modes
+- Remove stats record subcommand; derive chars/tokens from actual text
+- RTK patch records command output compression (not command strings)
+- Clean ~/.tokenless on RPM uninstall
+
 * Sat Apr 25 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-4
 - Fix: skip compression for content-retrieval tools and skill files
   - Added tool-name-based skip list: Read, read_file, Glob, list_directory, NotebookRead
@@ -119,27 +131,10 @@ fi
   - Fail-open design: original response passes through on any error path
 
 * Sat Apr 11 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-3
-- Fix: Response compression not working issue
-  - Fixed `tokenless compress-response` command not taking effect
-  - Fixed `tokenless-compress-response.sh` hook script execution failure
+- Fix: response compression command not working
 
 * Sat Apr 11 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-2
-- Unified install.sh script combining postinstall and preuninstall functionality
-  - Single script handles: source install, RPM post-install, RPM pre-uninstall
-  - Modes: --install, --uninstall, --upgrade, --uninstall-source, --help
-  - Backward compatible with existing RPM workflow
-- Added cosh (copilot-shell) hook support
-  - tokenless-compress-schema.sh: Compress LLM schema for cosh
-  - tokenless-compress-response.sh: Compress LLM response for cosh
-  - tokenless-rewrite.sh: Rewrite requests for cosh integration
-- Automatic copilot-shell hook configuration via %post/%preun scriptlets
-  - Supports both ~/.copilot-shell/settings.json and ~/.qwen-code/settings.json
-  - Idempotent installation (no duplicate hooks on reinstall)
-  - Complete cleanup on uninstall (removes empty hooks arrays)
-  - Fail-open design: gracefully handles missing dependencies
+- Add copilot-shell hooks and unified install script
 
 * Fri Apr 10 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-1
-- Initial package for tokenless 0.1.0
-- Include rtk (Rust Token Killer) binary
-- Include openclaw TypeScript and JSON files
-- Include install.sh script
+- Initial package


### PR DESCRIPTION
## Description

Three compression modes auto-record before/after metrics internally:
- compress-schema/compress-response: via CLI record_compression_stats
- rewrite-command: via RTK patch in TimedExecution::track (output compression)

Key design decisions:
- Chars/tokens derived from actual text length
- Compact JSON stored as after_text to avoid pretty-print token inflation
- format_show displays raw before/after text instead of diffs
- Fail-silent: stats errors never block compression output
- RTK patch records command output, not command strings

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue: new feature

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

src/tokenless/tests/run-all-tests.sh
```code
  Test 4: Stats System (5/5)

  ┌─────┬───────────────────────────────────────────────────────────┬──────┐
  │  #  │                           用例                            │ 结果 │
  ├─────┼───────────────────────────────────────────────────────────┼──────┤
  │ 4.1 │ compress-response 自动记录统计                            │ PASS │
  ├─────┼───────────────────────────────────────────────────────────┼──────┤
  │ 4.2 │ stats list 展示记录含 [ID:xx]                             │ PASS │
  ├─────┼───────────────────────────────────────────────────────────┼──────┤
  │ 4.3 │ stats show <id> 展示 Before/After 内容                    │ PASS │
  ├─────┼───────────────────────────────────────────────────────────┼──────┤
  │ 4.4 │ stats summary 展示 Total Records / compress-response 汇总 │ PASS │
  ├─────┼───────────────────────────────────────────────────────────┼──────┤
  │ 4.5 │ stats clear --yes 清理统计数据库                          │ PASS │
  └─────┴───────────────────────────────────────────────────────────┴──────┘
```

## Additional Notes
