### PR TITLE
fix(agentsight): restore token savings display in conversation list

### DIFF
--- a/src/agentsight/dashboard/src/pages/ConversationList.tsx
+++ b/src/agentsight/dashboard/src/pages/ConversationList.tsx
@@ -16,6 +16,7 @@ import {
   fetchInterruptionStats,
   fetchInterruptionSessionCounts,
   fetchInterruptionConversationCounts,
+  fetchTokenSavings,
   SessionSummary,
   TraceSummary,
   TimeseriesBucket,
@@ -790,6 +791,9 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
   const [sessionInterruptionCounts, setSessionInterruptionCounts] = useState<Map<string, SessionInterruptionCount>>(new Map());
   const [conversationInterruptionCounts, setConversationInterruptionCounts] = useState<Map<string, ConversationInterruptionCount>>(new Map());
 
+  // Token savings per session (session_id → saved_tokens)
+  const [savingsMap, setSavingsMap] = useState<Map<string, number>>(new Map());
+
   // Which session row is expanded to show traces
   const [expandedSession, setExpandedSession] = useState<string | null>(null);
 
@@ -893,9 +897,9 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
     loadAgentNames(startMs, endMs);
   }, [startMs, endMs, loadAgentNames]);
 
-  // Shared data-fetch helper: runs all 6 parallel queries and updates state.
+  // Shared data-fetch helper: runs all 7 parallel queries and updates state.
   const runQuery = useCallback(async (startNs: number, endNs: number, agent?: string) => {
-    const [sessData, tsData, intData, iStats, iSessionCounts, iConversationCounts] = await Promise.all([
+    const [sessData, tsData, intData, iStats, iSessionCounts, iConvCounts, savingsResp] = await Promise.all([
       fetchSessions(startNs, endNs).then((data) =>
         agent ? data.filter((s) => s.agent_name === agent) : data
       ),
@@ -904,6 +908,7 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
       fetchInterruptionStats(startNs, endNs).catch(() => [] as InterruptionTypeStat[]),
       fetchInterruptionSessionCounts(startNs, endNs).catch(() => [] as SessionInterruptionCount[]),
       fetchInterruptionConversationCounts(startNs, endNs).catch(() => [] as ConversationInterruptionCount[]),
+      fetchTokenSavings(startNs, endNs, agent).catch(() => null),
     ]);
     setSessions(sessData);
     setTokenSeries(tsData.token_series);
@@ -911,7 +916,8 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
     setInterruptionCount(intData);
     setInterruptionStats(iStats);
     setSessionInterruptionCounts(new Map(iSessionCounts.map((c) => [c.session_id, c])));
-    setConversationInterruptionCounts(new Map(iConversationCounts.map((c) => [c.conversation_id, c])));
+    setConversationInterruptionCounts(new Map(iConvCounts.map((c) => [c.conversation_id, c])));
+    setSavingsMap(new Map(savingsResp?.sessions.map((s) => [s.session_id, s.saved_tokens]) ?? []));
   }, []);
 
   const handleQuery = useCallback(async () => {
@@ -1159,6 +1165,9 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide w-[110px]">
                         输入 Token
                       </th>
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide w-[100px]">
+                        节省 Token
+                      </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide w-[110px]">
                         输出 Token
                       </th>
@@ -1176,7 +1185,7 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
                 <tbody className="divide-y divide-gray-100">
                   {!loading && sessions.length === 0 && (
                     <tr>
-                      <td colSpan={8} className="px-4 lg:px-6 py-12 text-center text-gray-400">
+                      <td colSpan={10} className="px-4 lg:px-6 py-12 text-center text-gray-400">
                         <div className="text-4xl mb-2">🔍</div>
                         <p>所选时间范围内暂无 Session 数据</p>
                         <p className="text-xs mt-1">请确认 agentsight 服务已启动并有数据写入</p>
@@ -1230,6 +1239,26 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
                           </td>
                           <td className="px-4 lg:px-6 py-4 text-sm font-semibold text-blue-600">
                             {fmtTokens(sess.total_input_tokens)}
+                          </td>
+                          <td className="px-4 lg:px-6 py-4" onClick={(e) => e.stopPropagation()}>
+                            {(() => {
+                              const saved = savingsMap.get(sess.session_id);
+                              if (!saved) return <span className="text-xs text-gray-300">—</span>;
+                              const params = new URLSearchParams({
+                                session_id: sess.session_id,
+                                start: String(startMs),
+                                end: String(endMs),
+                              });
+                              if (selectedAgent) params.set('agent', selectedAgent);
+                              return (
+                                <a
+                                  href={`#/savings?${params.toString()}`}
+                                  className="text-sm font-semibold text-green-600 underline decoration-green-300 hover:text-green-800 hover:decoration-green-600 transition-colors"
+                                >
+                                  {fmtTokens(saved)}
+                                </a>
+                              );
+                            })()}
                           </td>
                           <td className="px-4 lg:px-6 py-4 text-sm font-semibold text-green-600">
                             {fmtTokens(sess.total_output_tokens)}


### PR DESCRIPTION
## Summary

Restore the token savings display feature in the ConversationList component that was removed in a previous commit.

## Changes

- **Add token savings data fetching**
  - Import fetchTokenSavings API function
  - Add savingsMap state to store per-session token savings
  - Fetch token savings in parallel with other queries (7 total API calls)
  
- **Display token savings column**
  - Add '节省 Token' column header to session table
  - Show saved token count with clickable link to savings detail page
  - Pass session_id, time range, and agent filter params to savings page
  
- **Update table layout**
  - Adjust colSpan from 8 to 10 to accommodate the new column

## Impact

- Restores visibility of token optimization savings per session
- Provides easy navigation to detailed savings analysis
- Improves user experience with direct access to savings metrics

## Related Issue

closes #363

## Type of Change

- [x] Bug fix (restoration of accidentally removed feature)

## Scope

- [x] `sight` (agentsight)