### PR TITLE
fix(sight): remove custom db path and use default paths

### DIFF
--- a/src/agentsight/src/bin/cli/audit.rs
+++ b/src/agentsight/src/bin/cli/audit.rs
@@ -1,6 +1,6 @@
 //! Audit query subcommand
 
-use agentsight::{AuditEventType, AuditStore, SqliteConfig};
+use agentsight::{AuditEventType, AuditStore};
 use structopt::StructOpt;
 
 /// Audit query subcommand
@@ -25,18 +25,16 @@ pub struct AuditCommand {
     /// Show summary statistics
     #[structopt(long)]
     pub summary: bool,
-
-    /// Custom audit database path
-    #[structopt(long)]
-    pub db: Option<String>,
 }
 
 impl AuditCommand {
     pub fn execute(&self) {
-        let db_path = self.db
-            .as_ref()
-            .map(|p| std::path::PathBuf::from(p))
-            .unwrap_or_else(|| SqliteConfig::default().db_path());
+        let db_path = AuditStore::default_path();
+
+        if !db_path.exists() {
+            eprintln!("Database file not found: {:?}", db_path);
+            std::process::exit(1);
+        }
 
         let store = match AuditStore::new(&db_path) {
             Ok(s) => s,

--- a/src/agentsight/src/bin/cli/interruption.rs
+++ b/src/agentsight/src/bin/cli/interruption.rs
@@ -9,7 +9,6 @@
 //! # Database
 //!
 //! Default path: `/var/log/sysak/.agentsight/interruption_events.db`
-//! Override with `--db <PATH>`.
 //!
 //! # Interruption Types
 //!
@@ -54,9 +53,6 @@
 //!
 //! # Output as JSON (for programmatic consumption)
 //! agentsight interruption list --last 24 --json
-//!
-//! # Use a custom database path
-//! agentsight interruption list --db /path/to/interruption_events.db --last 24
 //! ```
 
 use agentsight::storage::sqlite::{GenAISqliteStore, InterruptionStore, InterruptionRecord};
@@ -73,11 +69,6 @@ use structopt::StructOpt;
 /// Severity levels: critical, high, medium, low
 #[derive(Debug, StructOpt, Clone)]
 pub struct InterruptionCommand {
-    /// Custom interruption database path.
-    /// Default: /var/log/sysak/.agentsight/interruption_events.db
-    #[structopt(long, global = true)]
-    pub db: Option<String>,
-
     #[structopt(subcommand)]
     pub action: InterruptionAction,
 }
@@ -222,7 +213,13 @@ pub enum InterruptionAction {
 
 impl InterruptionCommand {
     pub fn execute(&self) {
-        let db_path = self.db_path();
+        let db_path = default_db_path();
+
+        if !db_path.exists() {
+            eprintln!("Database file not found: {:?}", db_path);
+            std::process::exit(1);
+        }
+
         let store = match InterruptionStore::new_with_path(&db_path) {
             Ok(s) => s,
             Err(e) => {
@@ -420,22 +417,17 @@ impl InterruptionCommand {
             }
         }
     }
-
-    /// Determine the database path.
-    /// Priority: --db flag > default derived from GenAISqliteStore::default_path()
-    fn db_path(&self) -> std::path::PathBuf {
-        if let Some(ref p) = self.db {
-            std::path::PathBuf::from(p)
-        } else {
-            GenAISqliteStore::default_path()
-                .parent()
-                .unwrap_or(std::path::Path::new("/var/log/sysak/.agentsight"))
-                .join("interruption_events.db")
-        }
-    }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Default database path for interruption events.
+fn default_db_path() -> std::path::PathBuf {
+    GenAISqliteStore::default_path()
+        .parent()
+        .unwrap_or(std::path::Path::new("/var/log/sysak/.agentsight"))
+        .join("interruption_events.db")
+}
 
 /// Compute (start_ns, end_ns) for the last N hours from now.
 fn time_range_ns(hours: u64) -> (i64, i64) {

--- a/src/agentsight/src/bin/cli/metrics.rs
+++ b/src/agentsight/src/bin/cli/metrics.rs
@@ -5,19 +5,16 @@ use structopt::StructOpt;
 
 /// Print per-agent token usage metrics in Prometheus text format
 #[derive(Debug, StructOpt, Clone)]
-pub struct MetricsCommand {
-    /// Custom database path (defaults to the genai_events.db written by `agentsight trace`)
-    #[structopt(long)]
-    pub db: Option<String>,
-}
+pub struct MetricsCommand {}
 
 impl MetricsCommand {
     pub fn execute(&self) {
-        let db_path = self
-            .db
-            .as_ref()
-            .map(|p| std::path::PathBuf::from(p))
-            .unwrap_or_else(GenAISqliteStore::default_path);
+        let db_path = GenAISqliteStore::default_path();
+
+        if !db_path.exists() {
+            eprintln!("Database file not found: {:?}", db_path);
+            std::process::exit(1);
+        }
 
         let store = match GenAISqliteStore::new_with_path(&db_path) {
             Ok(s) => s,

--- a/src/os-skills/devops/sysom-agentsight/SKILL.md
+++ b/src/os-skills/devops/sysom-agentsight/SKILL.md
@@ -99,7 +99,7 @@ Top commands:
 
 # 会话中断查询
 
-数据库：`/var/log/sysak/.agentsight/interruption_events.db`，可通过 `--db <PATH>` 覆盖。
+数据库：`/var/log/sysak/.agentsight/interruption_events.db`
 
 中断类型：`llm_error`、`sse_truncated`、`context_overflow`、`agent_crash`、`token_limit`
 严重级别：`critical` > `high` > `medium` > `low`


### PR DESCRIPTION
## Description

Remove the custom `--db` flag from audit, interruption, and metrics CLI subcommands. All three commands now consistently use their respective default database paths:

- `audit`: `AuditStore::default_path()`
- `interruption`: `GenAISqliteStore::default_path()` parent + `interruption_events.db`
- `metrics`: `GenAISqliteStore::default_path()`

Additionally, each command now checks whether the database file exists before opening it and exits with a clear error message if not found.

This change fixes inconsistent database path handling and aligns the CLI behavior with the documented defaults.

## Related Issue

closes #260

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

`cargo test` passes locally (2 passed, 29 ignored).

## Additional Notes

The SKILL.md documentation was also updated to reflect the removal of the `--db` override option for the interruption subcommand.