### PR TITLE
fix(sight): cache agent name by pid for dead process resolution

### DIFF
--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -77,12 +77,13 @@ impl GenAIBuilder {
         &self,
         results: &[AnalysisResult],
         response_mapper: &ResponseSessionMapper,
+        pid_agent_name_cache: &std::collections::HashMap<u32, String>,
     ) -> (BuildOutput, Option<PendingCallInfo>) {
         let mut events = Vec::new();
         let mut pending: Option<PendingCallInfo> = None;
         let mut pending_response_id = None;
 
-        if let Some(llm_call) = self.build_llm_call(results, response_mapper) {
+        if let Some(llm_call) = self.build_llm_call(results, response_mapper, pid_agent_name_cache) {
             // Build PendingCallInfo from the same LLMCall before moving it
             let http_record = results.iter().find_map(|r| match r {
                 AnalysisResult::Http(h) => Some(h.clone()),
@@ -161,6 +162,7 @@ impl GenAIBuilder {
         &self,
         request: &ParsedRequest,
         conn_id: &ConnectionId,
+        pid_agent_name_cache: &std::collections::HashMap<u32, String>,
     ) -> Option<PendingCallInfo> {
         // Only process known LLM API paths
         let path_match = self.is_llm_api_path(&request.path);
@@ -280,9 +282,8 @@ impl GenAIBuilder {
         // Extract provider from request path
         let provider = self.extract_provider_from_path(&request.path);
 
-        // Resolve agent_name from comm using known_agents registry
-        // (PID is dead so /proc is gone, but comm is still available from the captured request)
-        let agent_name = Self::resolve_agent_name_from_comm(&request.source_event.comm);
+        // Resolve agent_name: check pid→name cache first (works for dead PIDs), then comm-based fallback
+        let agent_name = Self::resolve_agent_name_from_comm(&request.source_event.comm, conn_id.pid as u32, pid_agent_name_cache);
 
         Some(PendingCallInfo {
             call_id,
@@ -401,7 +402,7 @@ impl GenAIBuilder {
     /// Build LLMCall from analysis results
     ///
     /// Combines data from TokenRecord, HttpRecord, and ParsedApiMessage
-    fn build_llm_call(&self, results: &[AnalysisResult], response_mapper: &ResponseSessionMapper) -> Option<LLMCall> {
+    fn build_llm_call(&self, results: &[AnalysisResult], response_mapper: &ResponseSessionMapper, pid_agent_name_cache: &std::collections::HashMap<u32, String>) -> Option<LLMCall> {
         // Extract components from analysis results
         let token_record = results.iter().find_map(|r| match r {
             AnalysisResult::Token(t) => Some(t.clone()),
@@ -547,7 +548,7 @@ impl GenAIBuilder {
             error,
             pid: http.pid as i32,
             process_name: http.comm.clone(),
-            agent_name: Self::resolve_agent_name(&http.comm, http.pid),
+            agent_name: Self::resolve_agent_name(&http.comm, http.pid, pid_agent_name_cache),
             metadata: {
                 let mut meta = HashMap::new();
                 meta.insert("method".to_string(), http.method);
@@ -1209,7 +1210,11 @@ impl GenAIBuilder {
 
     /// Resolve agent name from comm string only (no /proc access).
     /// Used for dead-PID drain where the process is already gone.
-    fn resolve_agent_name_from_comm(comm: &str) -> Option<String> {
+    fn resolve_agent_name_from_comm(comm: &str, pid: u32, cache: &std::collections::HashMap<u32, String>) -> Option<String> {
+        // First check the pid→agent_name cache (works even for dead processes)
+        if let Some(name) = cache.get(&pid) {
+            return Some(name.clone());
+        }
         let ctx = ProcessContext {
             comm: comm.to_string(),
             cmdline_args: vec![],
@@ -1222,7 +1227,11 @@ impl GenAIBuilder {
     }
 
     /// 通过进程名匹配 agent registry，返回已知 agent 名称
-    fn resolve_agent_name(comm: &str, pid: u32) -> Option<String> {
+    fn resolve_agent_name(comm: &str, pid: u32, cache: &std::collections::HashMap<u32, String>) -> Option<String> {
+        // First check the pid→agent_name cache (works even for dead processes)
+        if let Some(name) = cache.get(&pid) {
+            return Some(name.clone());
+        }
         // Read cmdline from /proc/{pid}/cmdline for accurate agent matching
         let cmdline_args = std::fs::read(format!("/proc/{}/cmdline", pid))
             .ok()

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -19,6 +19,7 @@
 //! ```
 
 use anyhow::{Context, Result};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -90,6 +91,8 @@ pub struct AgentSight {
     ffi_sender: Option<FfiEventSender>,
     /// Rate-limiter for dead-PID connection drain (at most once per second)
     last_drain_check: std::time::Instant,
+    /// Cache of pid → agent_name, persists after process exit for deferred resolution
+    pid_agent_name_cache: HashMap<u32, String>,
 }
 
 /// GenAI events waiting for session_id resolution via ResponseSessionMapper.
@@ -134,6 +137,12 @@ impl AgentSight {
         // Attach SSL probes to already-running agents
         for agent in &existing_agents {
             Self::attach_process_internal(&mut probes, agent.pid, &agent.agent_info.name);
+        }
+
+        // Build pid → agent_name cache from existing agents (persists after process exit)
+        let mut pid_agent_name_cache = HashMap::new();
+        for agent in &existing_agents {
+            pid_agent_name_cache.insert(agent.pid, agent.agent_info.name.clone());
         }
 
         // Start polling (non-blocking)
@@ -267,6 +276,7 @@ impl AgentSight {
             pending_genai: Vec::new(),
             ffi_sender: None,
             last_drain_check: std::time::Instant::now(),
+            pid_agent_name_cache,
         })
     }
 
@@ -366,7 +376,7 @@ impl AgentSight {
             let analysis_results = self.analyzer.analyze_aggregated(agg_result);
 
             // Build GenAI semantic events AND pending info in one pass
-            let (output, pending_info) = self.genai_builder.build_with_pending(&analysis_results, &self.response_mapper);
+            let (output, pending_info) = self.genai_builder.build_with_pending(&analysis_results, &self.response_mapper, &self.pid_agent_name_cache);
 
             if !output.events.is_empty() {
                 if output.pending_response_id.is_some() {
@@ -442,6 +452,7 @@ impl AgentSight {
                 // Check if this is a known agent and start tracking
                 if let Some(agent) = self.scanner.on_process_create(*pid, comm) {
                     let agent_name = agent.agent_info.name.clone();
+                    self.pid_agent_name_cache.insert(*pid, agent_name.clone());
                     self.attach_process(*pid, &agent_name);
                 }
             }
@@ -607,7 +618,7 @@ impl AgentSight {
                 _ => continue,
             };
 
-            if let Some(pending) = self.genai_builder.build_pending_from_request(&request, &conn_id) {
+            if let Some(pending) = self.genai_builder.build_pending_from_request(&request, &conn_id, &self.pid_agent_name_cache) {
                 if let Some(ref store) = self.genai_sqlite_store {
                     let call_id = pending.call_id.clone();
                     let pid = pending.pid;


### PR DESCRIPTION
## Description

修复当 Agent 进程退出后（dead PID），GenAIBuilder 无法正确解析 agent_name 的问题。

之前在进程退出后尝试通过 /proc/{pid}/cmdline 读取进程信息进行 agent 名称匹配，但进程已消失导致 /proc 目录不可访问。本次变更有两个改进：

1. 在 AgentSight 中新增 ，在进程创建（Agent 发现）时就缓存 pid → agent_name 映射。
2.  和  优先从 cache 中查询，即使进程已退出也能正确解析 agent_name。

## Related Issue

closes #263

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

`cargo test` 全部通过（141 tests passed）。

## Additional Notes

变更涉及文件：
- `src/genai/builder.rs`：为相关函数添加 `pid_agent_name_cache` 参数，优先从 cache 解析 agent_name。
- `src/unified.rs`：初始化 cache，在进程创建时写入缓存，并传递给 GenAIBuilder。