### PR TITLE
chore(sight): update Cargo.lock for v0.3.0 release

### DIFF
--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentsight"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "actix-cors",
  "actix-web",


### PR DESCRIPTION
## Summary

Update `Cargo.lock` for AgentSight v0.3.0 release.

This patch completes the v0.3.0 release by including the updated `Cargo.lock` file that was missing from the initial release PR (#368).

closes #356

## Changes
- Update `src/agentsight/Cargo.lock` to reflect v0.3.0 dependency state
