### PR TITLE
chore(ci): adapt CI workflows for ws-ckpt component

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,6 +19,7 @@ body:
         - skill
         - sight
         - tokenless
+        - ckpt
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -20,6 +20,7 @@ body:
         - skill
         - sight
         - tokenless
+        - ckpt
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -19,6 +19,7 @@ body:
         - skill
         - sight
         - tokenless
+        - ckpt
         - other
   - type: textarea
     id: question

--- a/.github/actions/package-source/action.yaml
+++ b/.github/actions/package-source/action.yaml
@@ -51,6 +51,7 @@ runs:
           agentsight)     SRC_DIR="src/agentsight" ;;
           tokenless)     SRC_DIR="src/tokenless" ;;
           os-skills)      SRC_DIR="src/os-skills" ;;
+          ws-ckpt)        SRC_DIR="src/ws-ckpt" ;;
           *)
             echo "ERROR: Unknown component: $COMPONENT"
             exit 1

--- a/.github/workflows/_rpm-build.yaml
+++ b/.github/workflows/_rpm-build.yaml
@@ -59,6 +59,9 @@ jobs:
             tokenless)
               dnf install -y rust cargo jq
               ;;
+            ws-ckpt)
+              dnf install -y rust cargo btrfs-progs rsync systemd-rpm-macros
+              ;;
             os-skills)
               # noarch, no extra build deps
               ;;
@@ -120,11 +123,13 @@ jobs:
           EXPECTED_TAR="${COMPONENT}-${VERSION}.tar.gz"
           cp "$SOURCE_TAR" ~/rpmbuild/SOURCES/"${EXPECTED_TAR}"
 
-          # Copy vendor tarball if present
+          # Copy vendor tarball if present, renaming to match spec Source1:
+          # %{name}-%{version}-vendor.tar.gz (strip any artifact suffix).
           if [ -d "/tmp/vendor/" ]; then
             VENDOR_TAR=$(find /tmp/vendor/ -name "*.tar.gz" | head -1)
             if [ -n "$VENDOR_TAR" ]; then
-              cp "$VENDOR_TAR" ~/rpmbuild/SOURCES/
+              EXPECTED_VENDOR_TAR="${COMPONENT}-${VERSION}-vendor.tar.gz"
+              cp "$VENDOR_TAR" ~/rpmbuild/SOURCES/"${EXPECTED_VENDOR_TAR}"
             fi
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_ws_ckpt:
+        description: 'Force run ws-ckpt tests (ignore change detection)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -43,6 +48,7 @@ jobs:
       agent_sec_core: ${{ steps.changes.outputs.agent_sec_core }}
       agentsight: ${{ steps.changes.outputs.agentsight }}
       tokenless: ${{ steps.changes.outputs.tokenless }}
+      ws_ckpt: ${{ steps.changes.outputs.ws_ckpt }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,6 +73,7 @@ jobs:
           AGENT_SEC=false
           AGENTSIGHT=false
           TOKENLESS=false
+          WS_CKPT=false
 
           # Path-based detection
           if echo "$CHANGED" | grep -q "^src/copilot-shell/"; then
@@ -80,6 +87,9 @@ jobs:
           fi
           if echo "$CHANGED" | grep -q "^src/tokenless/"; then
             TOKENLESS=true
+          fi
+          if echo "$CHANGED" | grep -q "^src/ws-ckpt/"; then
+            WS_CKPT=true
           fi
 
           # Manual override via workflow_dispatch
@@ -95,11 +105,15 @@ jobs:
           if [[ "${{ inputs.run_tokenless }}" == "true" ]]; then
             TOKENLESS=true
           fi
+          if [[ "${{ inputs.run_ws_ckpt }}" == "true" ]]; then
+            WS_CKPT=true
+          fi
 
           echo "copilot_shell=$COPILOT_SHELL" >> $GITHUB_OUTPUT
           echo "agent_sec_core=$AGENT_SEC" >> $GITHUB_OUTPUT
           echo "agentsight=$AGENTSIGHT" >> $GITHUB_OUTPUT
           echo "tokenless=$TOKENLESS" >> $GITHUB_OUTPUT
+          echo "ws_ckpt=$WS_CKPT" >> $GITHUB_OUTPUT
 
           echo "### Change Detection Results" >> $GITHUB_STEP_SUMMARY
           echo "| Component | Changed |" >> $GITHUB_STEP_SUMMARY
@@ -108,6 +122,7 @@ jobs:
           echo "| agent-sec-core | $AGENT_SEC |" >> $GITHUB_STEP_SUMMARY
           echo "| agentsight | $AGENTSIGHT |" >> $GITHUB_STEP_SUMMARY
           echo "| tokenless | $TOKENLESS |" >> $GITHUB_STEP_SUMMARY
+          echo "| ws-ckpt | $WS_CKPT |" >> $GITHUB_STEP_SUMMARY
 
   # =========================================================================
   # Step 2: Build & Lint copilot-shell
@@ -321,4 +336,43 @@ jobs:
       - name: Run tests
         run: |
           cd src/tokenless
+          cargo test --workspace
+
+  # =========================================================================
+  # Step 7: Test ws-ckpt
+  # =========================================================================
+  test-ws-ckpt:
+    name: Test ws-ckpt
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ws_ckpt == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: 'rustfmt, clippy'
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/ws-ckpt/src
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y btrfs-progs rsync
+
+      - name: Check formatting
+        run: |
+          cd src/ws-ckpt/src
+          cargo fmt --all --check
+
+      - name: Lint
+        run: |
+          cd src/ws-ckpt/src
+          cargo clippy --workspace -- -D warnings
+
+      - name: Run tests
+        run: |
+          cd src/ws-ckpt/src
           cargo test --workspace

--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -33,6 +33,7 @@ jobs:
       # TODO: uncomment when agentsight is integrated
       # sight-version: ${{ steps.sight.outputs.version }}
       tokenless-version: ${{ steps.tokenless.outputs.version }}
+      ws-ckpt-version: ${{ steps.ws-ckpt.outputs.version }}
       image-version: ${{ steps.image.outputs.version }}
       image-version-tag: ${{ steps.image.outputs.version_tag }}
     steps:
@@ -92,6 +93,12 @@ jobs:
         with:
           tag-match: "tokenless/v*"
 
+      - name: "Version: ws-ckpt"
+        id: ws-ckpt
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-match: "ckpt/v*"
+
       - name: Summary
         run: |
           echo "## Component Versions" >> $GITHUB_STEP_SUMMARY
@@ -102,6 +109,7 @@ jobs:
           echo "| agent-sec-core | \`${{ steps.sec-core.outputs.version || '_skipped (no release branch)_' }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| agentsight | _TODO_ |" >> $GITHUB_STEP_SUMMARY
           echo "| tokenless | \`${{ steps.tokenless.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| ws-ckpt | \`${{ steps.ws-ckpt.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **image** | \`${{ steps.image.outputs.version }}\` (tag: \`${{ steps.image.outputs.version_tag }}\`) |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -155,6 +163,29 @@ jobs:
         with:
           component: tokenless
           version: ${{ needs.versions.outputs.tokenless-version }}
+          artifact-suffix: ".nightly"
+          retention-days: "7"
+
+  package-ws-ckpt:
+    name: "Package: ws-ckpt"
+    runs-on: ubuntu-22.04
+    needs: versions
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/package-source
+        with:
+          component: ws-ckpt
+          version: ${{ needs.versions.outputs.ws-ckpt-version }}
+          artifact-suffix: ".nightly"
+          retention-days: "7"
+
+      - name: Package vendor archive
+        uses: ./.github/actions/package-vendor
+        with:
+          component: ws-ckpt
+          version: ${{ needs.versions.outputs.ws-ckpt-version }}
           artifact-suffix: ".nightly"
           retention-days: "7"
 
@@ -271,6 +302,21 @@ jobs:
       source-artifact: "tokenless-${{ needs.versions.outputs.tokenless-version }}.nightly"
       artifact-suffix: ".nightly"
 
+  rpm-ws-ckpt:
+    name: "RPM: ws-ckpt (${{ matrix.arch }})"
+    needs: [versions, package-ws-ckpt]
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    uses: ./.github/workflows/_rpm-build.yaml
+    with:
+      component: ws-ckpt
+      version: ${{ needs.versions.outputs.ws-ckpt-version }}
+      arch: ${{ matrix.arch }}
+      source-artifact: "ws-ckpt-${{ needs.versions.outputs.ws-ckpt-version }}.nightly"
+      vendor-artifact: "ws-ckpt-${{ needs.versions.outputs.ws-ckpt-version }}.nightly-vendor"
+      artifact-suffix: ".nightly"
+
   # ===========================================================================
   # Job 4: Build and push Docker image
   # ===========================================================================
@@ -283,6 +329,7 @@ jobs:
       - rpm-skill
       - rpm-sec-core
       - rpm-tokenless
+      - rpm-ws-ckpt
       # TODO: uncomment when agentsight is integrated
       # - rpm-sight
     steps:
@@ -387,6 +434,7 @@ jobs:
           echo "| agent-sec-core | \`${{ needs.versions.outputs.sec-core-version || '_skipped_' }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| agentsight | _TODO_ |" >> $GITHUB_STEP_SUMMARY
           echo "| tokenless | \`${{ needs.versions.outputs.tokenless-version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| ws-ckpt | \`${{ needs.versions.outputs.ws-ckpt-version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Images" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.GHCR_IMAGE }}:${IMAGE_TAG}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prelint.yml
+++ b/.github/workflows/prelint.yml
@@ -79,8 +79,8 @@ jobs:
             if (scopeMatch) {
               const scope = scopeMatch[1].slice(1, -1);
               const validScopes = [
-                'cosh', 'sec-core', 'skill', 'sight',
-                'agent-sec-core', 'agentsight', 'os-skills', // legacy aliases
+                'cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt',
+                'agent-sec-core', 'agentsight', 'os-skills', 'ws-ckpt', // legacy aliases
                 'deps', 'ci', 'docs', 'chore'
               ];
               if (!validScopes.includes(scope)) {
@@ -125,7 +125,7 @@ jobs:
             }
 
             // Valid scopes — short names preferred; legacy long names accepted for forward compatibility
-            const validScopes = ['cosh', 'sec-core', 'skill', 'sight', 'agent-sec-core', 'agentsight', 'os-skills', 'ci', 'docs', 'deps'];
+            const validScopes = ['cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt', 'agent-sec-core', 'agentsight', 'os-skills', 'ws-ckpt', 'ci', 'docs', 'deps'];
             const scopePattern = validScopes.join('|');
 
             // Valid branch patterns per development spec

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -19,6 +19,7 @@ on:
           - agentsight
           - os-skills
           - tokenless
+          - ws-ckpt
       version:
         description: 'Version (e.g. 2.1.0, without v prefix)'
         required: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       - 'sight/v*'
       - 'skill/v*'
       - 'tokenless/v*'
+      - 'ckpt/v*'
 
 permissions:
   contents: write
@@ -45,6 +46,7 @@ jobs:
             sight)    COMPONENT="agentsight" ;;
             skill)    COMPONENT="os-skills" ;;
             tokenless) COMPONENT="tokenless" ;;
+            ckpt)     COMPONENT="ws-ckpt" ;;
             *)
               echo "Unknown scope: $SCOPE"
               exit 1
@@ -140,6 +142,7 @@ jobs:
             agentsight)     PREFIX="sight/v" ;;
             os-skills)      PREFIX="skill/v" ;;
             tokenless)      PREFIX="tokenless/v" ;;
+            ws-ckpt)        PREFIX="ckpt/v" ;;
           esac
 
           PREV_TAG=$(git tag --list "${PREFIX}*" --sort=-version:refname | grep -v "^${TAG}$" | head -1)

--- a/src/ws-ckpt/docs/RPM-PACKAGING.md
+++ b/src/ws-ckpt/docs/RPM-PACKAGING.md
@@ -22,7 +22,7 @@ rpm -ivh ws-ckpt-0.1.0-1.x86_64.rpm
 ```
 
 安装过程会自动：
-- 将 `ws-ckpt` 二进制部署到 `/usr/local/bin/`
+- 将 `ws-ckpt` 二进制部署到 `/usr/bin/`
 - 安装 systemd 服务文件到 `/etc/systemd/system/`
 - 创建运行时目录（`/run/ws-ckpt`、`/data/ws-ckpt`、`/mnt/btrfs-workspace`）
 - 执行 `systemctl daemon-reload` 并 `enable` 服务

--- a/src/ws-ckpt/src/systemd/ws-ckpt.service
+++ b/src/ws-ckpt/src/systemd/ws-ckpt.service
@@ -10,7 +10,7 @@ After=local-fs.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/ws-ckpt daemon
+ExecStart=/usr/bin/ws-ckpt daemon
 Restart=on-failure
 RestartSec=5
 Environment=RUST_LOG=info

--- a/src/ws-ckpt/ws-ckpt.spec.in
+++ b/src/ws-ckpt/ws-ckpt.spec.in
@@ -9,82 +9,87 @@ Summary:        AI-oriented workspace snapshot tool based on btrfs
 License:        Apache-2.0
 URL:            https://github.com/alibaba/anolisa
 Source0:        %{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.gz
 
-Requires:       rsync btrfs-progs
+BuildRequires:  cargo >= 1.70
+BuildRequires:  rust >= 1.70
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  pkgconfig
+BuildRequires:  systemd-rpm-macros
+
+Requires:       rsync
+Requires:       btrfs-progs
 
 %description
-ws-ckpt 是一个为 AI 助手设计的文件系统快照工具。
-支持工作区初始化、快照创建、秒级回滚等功能。
-支持多后端架构（btrfs-base / btrfs-loop / overlayfs），
-通过三级自动探测选择最优存储后端，实现高效快照管理。
+ws-ckpt is an AI-oriented filesystem snapshot tool. It supports workspace
+initialization, snapshot creation and second-level rollback. Its
+multi-backend architecture (btrfs-base / btrfs-loop / overlayfs) with
+three-tier auto detection picks the optimal backend for efficient
+snapshots.
 
 %prep
-%setup -q
+%setup -q -a 1
 
 %build
-# 二进制由 build-rpm.sh 预先编译并打包进 Source0 tarball，此处无需额外编译步骤。
+cd src
+cargo build --release --offline
 
 %install
 rm -rf $RPM_BUILD_ROOT
-install -d -m 0755 %{buildroot}/usr/local/bin
+install -d -m 0755 %{buildroot}%{_bindir}
 install -d -m 0755 %{buildroot}%{_unitdir}
 install -d -m 0755 %{buildroot}/etc/ws-ckpt
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/runtime/skills/ws-ckpt
 
-# 安装二进制文件
-install -p -m 0755 ws-ckpt %{buildroot}/usr/local/bin/ws-ckpt
-
-# 安装 systemd 服务文件
-install -p -m 0644 ws-ckpt.service %{buildroot}%{_unitdir}/ws-ckpt.service
-
-# 安装默认配置文件
-install -p -m 0644 config.toml %{buildroot}/etc/ws-ckpt/config.toml
+install -p -m 0755 src/target/release/ws-ckpt %{buildroot}%{_bindir}/ws-ckpt
+install -p -m 0644 src/systemd/ws-ckpt.service %{buildroot}%{_unitdir}/ws-ckpt.service
+install -p -m 0644 src/config.toml %{buildroot}/etc/ws-ckpt/config.toml
+install -p -m 0644 src/skills/ws-ckpt/SKILL.md %{buildroot}%{_datadir}/anolisa/runtime/skills/ws-ckpt/SKILL.md
 
 %files
-%attr(0755,root,root) /usr/local/bin/ws-ckpt
+%license LICENSE
+%doc README.md
+%attr(0755,root,root) %{_bindir}/ws-ckpt
 %{_unitdir}/ws-ckpt.service
 %config(noreplace) /etc/ws-ckpt/config.toml
+%dir %{_datadir}/anolisa
+%dir %{_datadir}/anolisa/runtime
+%dir %{_datadir}/anolisa/runtime/skills
+%{_datadir}/anolisa/runtime/skills/ws-ckpt/
 
 %pre
-# 安装前：确保 btrfs 内核模块已加载，创建必要的运行时目录
-modprobe btrfs 2>/dev/null || { echo "错误：内核不支持 btrfs，无法安装 ws-ckpt"; exit 1; }
-mkdir -p /run/ws-ckpt
-mkdir -p /data/ws-ckpt
-mkdir -p /mnt/btrfs-workspace
-mkdir -p /etc/ws-ckpt
+modprobe btrfs 2>/dev/null || { echo "ERROR: kernel does not support btrfs"; exit 1; }
+mkdir -p /run/ws-ckpt /data/ws-ckpt /mnt/btrfs-workspace /etc/ws-ckpt
 
 %post
 systemctl daemon-reload
 systemctl enable ws-ckpt.service
 systemctl start ws-ckpt.service 2>/dev/null || true
-echo "ws-ckpt 已安装、已启动、已设置为开机自启。"
-echo "运行 'systemctl status ws-ckpt' 查看服务状态。"
-echo "运行 'ws-ckpt --help' 查看使用帮助。"
+echo "ws-ckpt installed, started and enabled at boot."
+echo "Run 'systemctl status ws-ckpt' to check service status."
+echo "Run 'ws-ckpt --help' for usage."
 
 %preun
-# 卸载前（仅在完全卸载时，$1 == 0）
 if [ $1 -eq 0 ]; then
-    # 1. 先还原所有工作区（daemon 此时仍在运行）
-    if [ -x /usr/local/bin/ws-ckpt ]; then
-        /usr/local/bin/ws-ckpt recover --all --force 2>&1 || \
+    # Recover workspaces before stopping the daemon
+    if [ -x %{_bindir}/ws-ckpt ]; then
+        %{_bindir}/ws-ckpt recover --all --force 2>&1 || \
             echo "WARNING: recover workspaces failed"
     fi
-    # 2. 再停止并禁用服务
     systemctl stop ws-ckpt.service 2>/dev/null || true
     systemctl disable ws-ckpt.service 2>/dev/null || true
 fi
 
 %postun
-# 卸载后：清理运行时资源并重新加载 systemd（仅在完全卸载时）
 if [ $1 -eq 0 ]; then
-    # BtrfsLoop 后端: umount + 释放 loop + 删除 img
+    # BtrfsLoop backend: umount + release loop + remove img
     if [ -f "/data/ws-ckpt/btrfs-data.img" ]; then
         umount /mnt/btrfs-workspace 2>/dev/null || true
         losetup -j /data/ws-ckpt/btrfs-data.img 2>/dev/null | \
             cut -d: -f1 | xargs -r losetup -d 2>/dev/null || true
         rm -f /data/ws-ckpt/btrfs-data.img 2>/dev/null || true
     fi
-    # BtrfsBase 后端: 无需 umount（原生分区由系统管理）
-    # 清理 %pre 创建的运行时目录（rmdir 仅删空目录，残留数据会自动保护）
     rmdir /mnt/btrfs-workspace 2>/dev/null || true
     rmdir /data/ws-ckpt 2>/dev/null || true
     rmdir /run/ws-ckpt 2>/dev/null || true
@@ -92,5 +97,5 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Thu Apr 23 2026 ws-ckpt ziqi02<ziqi02@alibaba-inc.com> - 0.1.0-1
+* Thu Apr 23 2026 ziqi02 <ziqi02@alibaba-inc.com> - 0.1.0-1
 - Initial release


### PR DESCRIPTION
## Description

Integrate the newly-introduced `ws-ckpt` subproject (Rust cargo workspace under `src/ws-ckpt/`) into the unified ANOLISA CI/CD pipeline so it rides the same source-packaging, vendor-packaging, RPM build, nightly Docker image, GitHub Release and issue/label flows as other components.

Key changes:

- `.github/actions/package-source/action.yaml`: add `ws-ckpt` -> `src/ws-ckpt` mapping.
- `.github/workflows/_rpm-build.yaml`: add `ws-ckpt` dep block (`cargo`, `rust`, `btrfs-progs`, `rsync`, `systemd-rpm-macros`); rename vendor tarball to `${component}-${version}-vendor.tar.gz` so spec files can reference it as `Source1: %{name}-%{version}-vendor.tar.gz`.
- `.github/workflows/ci.yaml`: add `run_ws_ckpt` input, path-driven detection for `^src/ws-ckpt/`, and a new `test-ws-ckpt` job running `fmt` / `clippy` / `cargo test` against the workspace.
- `.github/workflows/release.yaml`: register `ckpt/v*` tag trigger plus scope-prefix mapping (`ckpt` -> `ws-ckpt`).
- `.github/workflows/release-preview.yaml`: add `ws-ckpt` to the component dropdown.
- `.github/workflows/docker-nightly.yaml`: add version calculation, `package-ws-ckpt` (source + vendor in the same job), `rpm-ws-ckpt` (amd64/arm64 with `vendor-artifact` wired), and plug it into `docker-build-push.needs`.
- `.github/workflows/prelint.yml`: add `ckpt` (and `tokenless`, `ws-ckpt`) to both `validScopes` lists.
- `.github/ISSUE_TEMPLATE/*.yml`: add `ckpt` to the component dropdown in bug / feature / question templates.
- `src/ws-ckpt/ws-ckpt.spec.in`: rewrite for offline RPM build. Declare `Source1: %{name}-%{version}-vendor.tar.gz`, use `%setup -q -a 1` to place `src/vendor/` and `src/.cargo/config.toml` at the cargo workspace root, add `BuildRequires: systemd-rpm-macros` (stop hard-coding `%global _unitdir`), switch `%build` to `cargo build --release --offline`, tidy comments to English and prune noise.

## Related Issue

no-issue: follow-up of #343 (ws-ckpt introduction) to wire it into the shared CI/CD surface.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] CI/CD or build changes

## Scope

- [x] `ckpt` (ws-ckpt)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Workflow-only changes. Recommended validation path:

1. Run `Release Preview` with `component=ws-ckpt`, `version=0.1.0` to verify source tarball, vendor tarball and RPM build succeed end-to-end.
2. Trigger `Docker Nightly` (dry-run) to confirm `package-ws-ckpt` emits the vendor artifact and `rpm-ws-ckpt` consumes it.

## Additional Notes

- `ws-ckpt` now strictly requires a vendor tarball at RPM build time; local `rpmbuild` without a prior `cargo vendor` step will fail on `Source1`. Consider extending `src/ws-ckpt/build-rpm.sh` to produce the vendor tarball too if local offline builds become a frequent path.
- Vendor tarball rename is applied generically inside `_rpm-build.yaml`, so other Rust components (e.g. `tokenless`, `agentsight`) can opt into offline RPM builds later by simply declaring `Source1` in their spec files.
