### PR TITLE
ci(agent-sec-core): pass skill signing keys in nightly build

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -228,6 +228,8 @@ jobs:
           version: ${{ needs.versions.outputs.sec-core-version }}
           artifact-suffix: ".nightly"
           retention-days: "7"
+          skill-sign-private-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}
+          skill-sign-public-key: ${{ vars.SKILL_SIGN_PUBLIC_KEY }}
 
   # ===========================================================================
   # Job 3: Build RPMs


### PR DESCRIPTION
## Description

Wire the `SKILL_SIGN_PRIVATE_KEY` secret and `SKILL_SIGN_PUBLIC_KEY` variable into the `package-source` action invocation for the `package-sec-core` job in `docker-nightly.yaml`. This aligns `sec-core` with `cosh` / `os-skills` so that its bundled skills are GPG-signed in nightly artifacts, matching the behavior of `release.yaml` and `release-preview.yaml`.

## Related Issue

no-issue: follow-up of nightly signing alignment across components

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core) CI integration

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] Change is limited to CI workflow wiring, no runtime code touched
- [x] Lock files are up to date (no dependency changes)

## Testing

Workflow-level wiring change; will be validated on the next scheduled/dispatch run of `docker-nightly.yaml`. The `package-source` action already gates signing on the presence of `skill-sign-private-key`, so absence of the secret degrades gracefully to the existing "signing skipped" warning path.

## Additional Notes

<!-- N/A -->
