### PR TITLE
feat(cosh): concatenate hook systemMessages with [name] prefix

### DIFF
--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.test.ts
@@ -203,6 +203,157 @@ describe('HookAggregator', () => {
     });
   });
 
+  describe('mergeWithOrLogic - systemMessage concatenation', () => {
+    it('should pass through single systemMessage untouched (fast path)', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: '/path/to/guard.py',
+            name: 'rm-guard',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'ask', systemMessage: 'danger detected' },
+          duration: 100,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.PreToolUse,
+      );
+      // Single hook keeps its original systemMessage, no `[name]` prefix.
+      expect(result.finalOutput?.systemMessage).toBe('danger detected');
+    });
+
+    it('should concatenate multiple systemMessages with [name] prefixes', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: './guard.py',
+            name: 'rm-guard',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'ask', systemMessage: 'rm detected' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: './audit.py',
+            name: 'audit',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'allow', systemMessage: 'logged' },
+          duration: 10,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.PreToolUse,
+      );
+      // ask wins over allow for decision; both systemMessages are retained.
+      expect(result.finalOutput?.decision).toBe('ask');
+      expect(result.finalOutput?.systemMessage).toBe(
+        '[rm-guard] rm detected\n[audit] logged',
+      );
+    });
+
+    it('should fall back to command basename when name is missing', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: '/usr/local/bin/guard.py --strict',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'ask', systemMessage: 'blocked' },
+          duration: 10,
+        },
+        {
+          hookConfig: { type: HookType.Command, command: 'audit.sh' },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'allow', systemMessage: 'ok' },
+          duration: 10,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.PreToolUse,
+      );
+      expect(result.finalOutput?.systemMessage).toBe(
+        '[guard.py] blocked\n[audit.sh] ok',
+      );
+    });
+
+    it('should skip hooks with empty or undefined systemMessage', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'a',
+            name: 'A',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'ask', systemMessage: 'A says ask' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'b',
+            name: 'B',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'allow' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'c',
+            name: 'C',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'allow', systemMessage: '' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'd',
+            name: 'D',
+          },
+          eventName: HookEventName.PreToolUse,
+          success: true,
+          output: { decision: 'allow', systemMessage: 'D note' },
+          duration: 10,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.PreToolUse,
+      );
+      // Only A and D contribute; B (undefined) and C (empty) are skipped.
+      expect(result.finalOutput?.decision).toBe('ask');
+      expect(result.finalOutput?.systemMessage).toBe(
+        '[A] A says ask\n[D] D note',
+      );
+    });
+  });
+
   describe('mergePermissionRequestOutputs', () => {
     it('should prioritize deny over allow', () => {
       const outputs: HookOutput[] = [

--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
@@ -17,9 +17,35 @@ import {
 } from './types.js';
 import type {
   HookOutput,
+  HookConfig,
   HookExecutionResult,
   BeforeToolSelectionOutput,
 } from './types.js';
+
+/**
+ * A hook output paired with the display name of the hook that produced it.
+ * Used by merge strategies that need to attribute messages to their source
+ * (e.g. prefixing systemMessage with `[name]` when multiple hooks contribute).
+ */
+interface NamedHookOutput {
+  name: string;
+  output: HookOutput;
+}
+
+/**
+ * Derive a human-readable display name for a hook. Prefers the explicit `name`
+ * field; falls back to the command basename if name is absent.
+ */
+function getHookDisplayName(config: HookConfig | undefined): string {
+  if (!config) return 'hook';
+  if (config.name && config.name.trim().length > 0) return config.name;
+  const cmd = (config.command || '').trim();
+  if (!cmd) return 'hook';
+  // Take the first token (command binary) and strip path.
+  const firstToken = cmd.split(/\s+/)[0] ?? '';
+  const basename = firstToken.split('/').pop() ?? '';
+  return basename || 'hook';
+}
 
 /**
  * Aggregated result from multiple hook executions
@@ -47,6 +73,7 @@ export class HookAggregator {
     eventName: HookEventName,
   ): AggregatedHookResult {
     const allOutputs: HookOutput[] = [];
+    const namedOutputs: NamedHookOutput[] = [];
     const errors: Error[] = [];
     let totalDuration = 0;
 
@@ -59,11 +86,15 @@ export class HookAggregator {
 
       if (result.output) {
         allOutputs.push(result.output);
+        namedOutputs.push({
+          name: getHookDisplayName(result.hookConfig),
+          output: result.output,
+        });
       }
     }
 
     const success = errors.length === 0;
-    const finalOutput = this.mergeOutputs(allOutputs, eventName);
+    const finalOutput = this.mergeOutputs(namedOutputs, eventName);
 
     return {
       success,
@@ -78,16 +109,21 @@ export class HookAggregator {
    * Merge multiple hook outputs based on event type
    */
   private mergeOutputs(
-    outputs: HookOutput[],
+    named: NamedHookOutput[],
     eventName: HookEventName,
   ): HookOutput | undefined {
-    if (outputs.length === 0) {
+    if (named.length === 0) {
       return undefined;
     }
 
-    if (outputs.length === 1) {
-      return this.createSpecificHookOutput(outputs[0], eventName);
+    if (named.length === 1) {
+      // Single-hook fast path: pass through without `[name]` prefixing to
+      // preserve backward-compatible output for the common case.
+      return this.createSpecificHookOutput(named[0].output, eventName);
     }
+
+    // For merge strategies that don't need hook names, strip them once.
+    const outputs = named.map((n) => n.output);
 
     let merged: HookOutput;
 
@@ -96,7 +132,7 @@ export class HookAggregator {
       case HookEventName.PostToolUse:
       case HookEventName.PostToolUseFailure:
       case HookEventName.Stop:
-        merged = this.mergeWithOrLogic(outputs);
+        merged = this.mergeWithOrLogic(named);
         break;
       case HookEventName.PermissionRequest:
         merged = this.mergePermissionRequestOutputs(outputs);
@@ -123,20 +159,26 @@ export class HookAggregator {
    * Rules:
    * - Any "block" or "deny" decision results in blocking (most restrictive wins)
    * - Reasons are concatenated with newlines
+   * - systemMessage values from multiple hooks are concatenated as
+   *   `[hookName] message` on separate lines, so users can see which hook
+   *   contributed which message (fixes the pre-existing "last write wins"
+   *   ambiguity where the triggering hook's message could be silently
+   *   overridden by a later allow hook).
    * - continue=false takes precedence over continue=true
    * - Additional context is concatenated
    */
-  private mergeWithOrLogic(outputs: HookOutput[]): HookOutput {
+  private mergeWithOrLogic(named: NamedHookOutput[]): HookOutput {
     const merged: HookOutput = {};
     const reasons: string[] = [];
     const additionalContexts: string[] = [];
+    const systemMessages: string[] = [];
     let hasBlock = false;
     let hasAsk = false;
     let hasContinueFalse = false;
     let stopReason: string | undefined;
     const otherHookSpecificFields: Record<string, unknown> = {};
 
-    for (const output of outputs) {
+    for (const { name, output } of named) {
       // Check for blocking decisions
       if (output.decision === 'block' || output.decision === 'deny') {
         hasBlock = true;
@@ -176,8 +218,10 @@ export class HookAggregator {
       if (output.suppressOutput !== undefined) {
         merged.suppressOutput = output.suppressOutput;
       }
-      if (output.systemMessage !== undefined) {
-        merged.systemMessage = output.systemMessage;
+      // systemMessage is accumulated with hook-name attribution rather than
+      // last-write-wins, so users see every hook's voice.
+      if (output.systemMessage !== undefined && output.systemMessage !== '') {
+        systemMessages.push(`[${name}] ${output.systemMessage}`);
       }
     }
 
@@ -186,13 +230,18 @@ export class HookAggregator {
       merged.decision = 'block';
     } else if (hasAsk) {
       merged.decision = 'ask';
-    } else if (outputs.some((o) => o.decision === 'allow')) {
+    } else if (named.some(({ output }) => output.decision === 'allow')) {
       merged.decision = 'allow';
     }
 
     // Set merged reason
     if (reasons.length > 0) {
       merged.reason = reasons.join('\n');
+    }
+
+    // Set merged systemMessage (concatenated with hook name prefixes)
+    if (systemMessages.length > 0) {
+      merged.systemMessage = systemMessages.join('\n');
     }
 
     // Set continue flag


### PR DESCRIPTION

## Description

Previously, when multiple hooks returned `systemMessage` for the same event
(e.g. `PreToolUse`), `HookAggregator.mergeWithOrLogic` used last-write-wins
semantics — the final message was overwritten by whichever hook ran last,
even if that hook didn't trigger the `ask` / `block` decision.

This caused a confusing UX where hook A raised `ask` with message "A", but
a later allow-hook C silently replaced the message with "C", so the user
saw "C" in the confirmation dialog without any hint that A was the one
that actually triggered the prompt.

This PR changes the aggregation rule to **concatenate** every non-empty
`systemMessage` as `[hookName] message` on separate lines, so users can
see exactly which hook contributed which message. The change applies
uniformly to both parallel and sequential hook execution since both
paths funnel into the same `aggregateResults` entry point.

## Related Issue

no-issue: internal UX polish for hook message attribution

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Added 4 new unit tests under
`mergeWithOrLogic - systemMessage concatenation` in hookAggregator.test.ts:

- Single hook fast path: passes through message untouched (no `[name]`
  prefix), preserving backward compatibility.
- Multiple hooks: messages concatenated as `[rm-guard] rm detected\n[audit] logged`;
  `decision=ask` wins over `allow`.
- Missing `name` field: falls back to the command basename, e.g.
  `/usr/local/bin/guard.py --strict` → `[guard.py] ...`.
- Skip rules: hooks with `systemMessage === undefined` or `''` do not
  contribute to the concatenation.

Run:

```
cd src/copilot-shell/packages/core
npx vitest run src/hooks/hookAggregator.test.ts
```

Result: **28/28 passed** (4 new + 24 existing).
Type check: `npx tsc --noEmit` clean.

## Additional Notes

- Single-hook behavior is unchanged (no `[name]` prefix) to keep existing
  UX identical for the most common case.
- Behavior is identical for parallel and sequential hook execution — the
  aggregator is the single merge point; `hookRunner` differences don't
  affect message attribution.
- Name resolution priority: `hookConfig.name` → basename of the first
  token in `command` → fallback `'hook'`.
