### PR TITLE
fix(cosh): restore bash option after canceling from provider screen

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { Config } from '@copilot-shell/core';
+import { AuthType } from '@copilot-shell/core';
+import type { LoadedSettings } from '../../config/settings.js';
+import { useAuthCommand } from './useAuth.js';
+
+vi.mock('../hooks/useQwenAuth.js', () => ({
+  useQwenAuth: () => ({
+    qwenAuthState: undefined,
+    cancelQwenAuth: vi.fn(),
+  }),
+}));
+
+describe('useAuthCommand', () => {
+  const createMockSettings = (): LoadedSettings =>
+    ({
+      merged: {
+        security: {
+          auth: {},
+        },
+      },
+      setValue: vi.fn(),
+    }) as unknown as LoadedSettings;
+
+  const createMockConfig = (): Config =>
+    ({
+      getAuthType: vi.fn(() => undefined),
+      getModelsConfig: vi.fn(() => ({})),
+      refreshAuth: vi.fn(),
+      getContentGenerator: vi.fn(() => undefined),
+      getContentGeneratorConfig: vi.fn(() => undefined),
+      updateCredentials: vi.fn(),
+      getUsageStatisticsEnabled: vi.fn(() => false),
+    }) as unknown as Config;
+
+  it('restores bash option after canceling OpenAI auth when startup allows bash', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    const addItem = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, true),
+    );
+
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+
+    expect(result.current.showBashOptionInAuthDialog).toBe(false);
+    expect(result.current.isAuthenticating).toBe(true);
+
+    act(() => {
+      result.current.cancelAuthentication();
+    });
+
+    expect(result.current.isAuthenticating).toBe(false);
+    expect(result.current.isAuthDialogOpen).toBe(true);
+    expect(result.current.showBashOptionInAuthDialog).toBe(true);
+  });
+
+  it('keeps bash option hidden after cancel when startup does not allow bash', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    const addItem = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, false),
+    );
+
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+
+    act(() => {
+      result.current.cancelAuthentication();
+    });
+
+    expect(result.current.isAuthDialogOpen).toBe(true);
+    expect(result.current.showBashOptionInAuthDialog).toBe(false);
+  });
+});

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -422,9 +422,9 @@ export const useAuthCommand = (
   );
 
   const openAuthDialog = useCallback(() => {
-    setShowBashOptionInAuthDialog(false);
+    setShowBashOptionInAuthDialog(showBashOptionOnStartup);
     setIsAuthDialogOpen(true);
-  }, []);
+  }, [showBashOptionOnStartup]);
 
   const handleContinueToBash = useCallback(() => {
     setAuthError(null);
@@ -450,10 +450,16 @@ export const useAuthCommand = (
 
     // Do not reset pendingAuthType here, persist the previously selected type.
     setIsAuthenticating(false);
-    setShowBashOptionInAuthDialog(false);
+    setShowBashOptionInAuthDialog(showBashOptionOnStartup);
     setIsAuthDialogOpen(true);
     setAuthError(null);
-  }, [isAuthenticating, pendingAuthType, cancelQwenAuth, config]);
+  }, [
+    isAuthenticating,
+    pendingAuthType,
+    cancelQwenAuth,
+    config,
+    showBashOptionOnStartup,
+  ]);
 
   /**
    /**


### PR DESCRIPTION


## Description

When a user enters the Custom Provider screen without making changes and
presses Escape to go back, the "Continue to Bash" option disappears from
the authorization dialog. The root cause is that `cancelAuthentication`
unconditionally sets `showBashOptionInAuthDialog` to `false`. The fix
restores it to its initial value (`showBashOptionOnStartup`) so the bash
option reappears after cancellation. The same fix is applied to
`openAuthDialog`.

## Related Issue

fixes #385

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

1. Start cosh without auth configured — verify "Continue to Bash" visible
2. Select "Custom Provider", press Escape without entering credentials
3. Verify "Continue to Bash" option is still visible
4. `make format` — passes
5. `npm run lint:ci` — passes
6. `make test` — 396 files, 7278 tests all pass

## Additional Notes

Changes: `useAuth.ts` (fix) + `useAuth.test.ts` (new tests)