### PR TITLE
fix(cosh): filter unavailable agents in key sharing prompt

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/components/CustomAgentKeySharePrompt.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/CustomAgentKeySharePrompt.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import {
+  CustomAgentKeySharePrompt,
+  type AgentChoice,
+} from './CustomAgentKeySharePrompt.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+
+// Mock useKeypress so the component does not try to attach to a real stdin.
+vi.mock('../hooks/useKeypress.js', () => ({
+  useKeypress: vi.fn(),
+}));
+
+// Mock RadioButtonSelect so we can assert the exact item list passed in,
+// without depending on BaseSelectionList / selection hooks.
+vi.mock('./shared/RadioButtonSelect.js', () => ({
+  RadioButtonSelect: vi.fn(() => null),
+}));
+
+const MockedRadioButtonSelect = vi.mocked(
+  RadioButtonSelect,
+) as unknown as ReturnType<typeof vi.fn>;
+
+function getRenderedChoices(): AgentChoice[] {
+  const props = MockedRadioButtonSelect.mock.calls.at(-1)?.[0] as
+    | { items: Array<{ value: AgentChoice }> }
+    | undefined;
+  if (!props) {
+    throw new Error('RadioButtonSelect was not rendered');
+  }
+  return props.items.map((item) => item.value);
+}
+
+describe('CustomAgentKeySharePrompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all three choices when nothing is excluded', () => {
+    render(<CustomAgentKeySharePrompt onSelect={vi.fn()} onCancel={vi.fn()} />);
+    expect(getRenderedChoices()).toEqual(['openclaw', 'qwencode', 'none']);
+  });
+
+  it('hides qwencode when it is in excludedChoices', () => {
+    // Scenario from issue #386: ~/.qwen does not exist, so Qwen Code must
+    // not appear in the Agent Key Sharing list even though the flow itself
+    // is shown (because ~/.openclaw exists).
+    render(
+      <CustomAgentKeySharePrompt
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+        excludedChoices={['qwencode']}
+      />,
+    );
+    expect(getRenderedChoices()).toEqual(['openclaw', 'none']);
+  });
+
+  it('hides openclaw when it is in excludedChoices', () => {
+    render(
+      <CustomAgentKeySharePrompt
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+        excludedChoices={['openclaw']}
+      />,
+    );
+    expect(getRenderedChoices()).toEqual(['qwencode', 'none']);
+  });
+
+  it('hides all agent options but keeps the manual-config entry', () => {
+    render(
+      <CustomAgentKeySharePrompt
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+        excludedChoices={['openclaw', 'qwencode']}
+      />,
+    );
+    expect(getRenderedChoices()).toEqual(['none']);
+  });
+});

--- a/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
@@ -122,17 +122,6 @@ export const DialogManager = ({
     }
   }, [uiState.isAuthenticating]);
 
-  // 当 idle 状态下所有 Agent 均已失败，自动跳转到手动配置（避免在渲染期间 setState）
-  useEffect(() => {
-    if (
-      agentShareState === 'idle' &&
-      failedAgents.has('openclaw') &&
-      failedAgents.has('qwencode')
-    ) {
-      setAgentShareState('done');
-    }
-  }, [agentShareState, failedAgents]);
-
   // 在顶层缓存文件探测结果（只在对应状态激活时读取文件，避免每次重渲染触发 IO）
   const openclawConfig = useMemo(
     () => (agentShareState === 'openclaw' ? readOpenClawConfig() : null),
@@ -143,16 +132,43 @@ export const DialogManager = ({
     [agentShareState],
   );
 
-  // 静默检测配置目录是否存在，决定是否展示流程一（只检查目录，不读取 Key）
-  // 仅在进入 USE_OPENAI 认证流程时执行一次
-  const hasAnyAgentConfigDir = useMemo(
+  // 静默分别探测每个 Agent 的配置目录是否存在，用于过滤 Agent Key Sharing 列表项
+  // （只检查目录，不读取 Key）。仅在进入 USE_OPENAI 认证流程时执行一次。
+  const hasOpenclawDir = useMemo(
     () =>
       uiState.isAuthenticating &&
       uiState.pendingAuthType === AuthType.USE_OPENAI
-        ? hasOpenClawConfigDir() || hasQwenCodeConfigDir()
+        ? hasOpenClawConfigDir()
         : false,
     [uiState.isAuthenticating, uiState.pendingAuthType],
   );
+  const hasQwenCodeDir = useMemo(
+    () =>
+      uiState.isAuthenticating &&
+      uiState.pendingAuthType === AuthType.USE_OPENAI
+        ? hasQwenCodeConfigDir()
+        : false,
+    [uiState.isAuthenticating, uiState.pendingAuthType],
+  );
+  const hasAnyAgentConfigDir = hasOpenclawDir || hasQwenCodeDir;
+
+  // 当 idle 状态下所有"可探测到的" Agent 均已失败时，自动跳转到手动配置
+  // （避免在渲染期间 setState）。不可探测到的 Agent 不应计入"全部失败"的判断。
+  useEffect(() => {
+    if (agentShareState !== 'idle' || !hasAnyAgentConfigDir) return;
+    const hasRemaining =
+      (hasOpenclawDir && !failedAgents.has('openclaw')) ||
+      (hasQwenCodeDir && !failedAgents.has('qwencode'));
+    if (!hasRemaining) {
+      setAgentShareState('done');
+    }
+  }, [
+    agentShareState,
+    failedAgents,
+    hasOpenclawDir,
+    hasQwenCodeDir,
+    hasAnyAgentConfigDir,
+  ]);
 
   if (uiState.showWelcomeBackDialog && uiState.welcomeBackInfo?.hasHistory) {
     return (
@@ -381,17 +397,23 @@ export const DialogManager = ({
       if (!defaults.apiKey && hasAnyAgentConfigDir) {
         // 流程一：展示 Agent 选择列表
         if (agentShareState === 'idle') {
-          // 计算剩余可用选项（排除已失败的 Agent）
+          // 排除：1) 已探测失败的 Agent；2) 配置目录不存在的 Agent
+          const excludedChoices: AgentChoice[] = [...failedAgents];
+          if (!hasOpenclawDir) excludedChoices.push('openclaw');
+          if (!hasQwenCodeDir) excludedChoices.push('qwencode');
+          // 计算剩余可用选项（仅包含配置目录存在且未失败的 Agent）
           const availableAgents = (['openclaw', 'qwencode'] as const).filter(
-            (a) => !failedAgents.has(a),
+            (a) =>
+              (a === 'openclaw' ? hasOpenclawDir : hasQwenCodeDir) &&
+              !failedAgents.has(a),
           );
-          // 两个都失败了：use Effect 会处理并跳转到 done，此处暂返回 null 等待下一次渲染
+          // 全部已失败：useEffect 会处理并跳转到 done，此处暂返回 null 等待下一次渲染
           if (availableAgents.length === 0) {
             return null;
           }
           return (
             <CustomAgentKeySharePrompt
-              excludedChoices={[...failedAgents]}
+              excludedChoices={excludedChoices}
               onSelect={(choice: AgentChoice) => {
                 if (choice === 'none') {
                   setAgentShareState('done');


### PR DESCRIPTION
## Description

Fix the Custom Provider auth flow so the Agent Key Sharing prompt only
offers agents whose config directory actually exists on the host.

Previously the share list was hard-coded to `OpenClaw` and `Qwen Code`,
and the flow was gated by a single "any agent config dir present"
boolean. When only one of the two was installed, users still saw the
missing agent in the list (the exact scenario reported in #386 —
`~/.qwen` is absent but the Qwen Code option is shown anyway). The
auto-skip to manual config also required **both** agents to fail, so a
user with only one installed agent whose key could not be read got
stuck re-selecting the same agent instead of falling through to manual
entry.

Per-agent detection results (`hasOpenclawDir`, `hasQwenCodeDir`) are
now computed once on entering the `USE_OPENAI` flow and used both to
filter the `CustomAgentKeySharePrompt` (missing agents are added to
`excludedChoices`) and to gate the `idle → done` transition (all
**detectable** agents failed, not all agents). File I/O behavior is
unchanged: directory probing still uses `existsSync` only, no config
files are read until the user picks an agent.

## Related Issue

closes #386

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run format && npm run build && npm run lint && npm run typecheck && npm run test
# format OK, build OK, lint OK, typecheck OK
# cli:  Test Files 218 passed, Tests 3421 passed | 7 skipped
# core: Test Files 178 passed, Tests 3858 passed | 2 skipped
# Added CustomAgentKeySharePrompt.test.tsx (4 tests) covering the
# excludedChoices filter for missing agents.
```

## Additional Notes

<!-- N/A -->
