### PR TITLE
docs(sight): fix stale API endpoint table in AGENTS.md

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -132,6 +132,7 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/sessions` | GET | 会话列表 |
 | `/api/sessions/{id}/traces` | GET | 会话下的 trace |
 | `/api/traces/{id}` | GET | trace 详情 |
+| `/api/conversations/{id}` | GET | conversation 事件详情 |
 | `/api/agent-names` | GET | Agent 名称列表 |
 | `/api/timeseries` | GET | 时序 Token 统计 |
 | `/api/agent-health` | GET | Agent 健康状态 |
@@ -139,15 +140,17 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/agent-health/{pid}/restart` | POST | 重启 Agent |
 | `/api/export/atif/trace/{id}` | GET | ATIF trace 导出 |
 | `/api/export/atif/session/{id}` | GET | ATIF session 导出 |
+| `/api/export/atif/conversation/{id}` | GET | ATIF conversation 导出 |
+| `/api/token-savings` | GET | Token 节省统计（`start_ns`, `end_ns`, `agent_name`） |
 | `/api/interruptions` | GET | 中断事件列表（`start_ns`, `end_ns`, `agent_name`, `type`, `severity`, `resolved`, `limit`） |
 | `/api/interruptions/count` | GET | 中断计数按严重级别（`start_ns`, `end_ns`） |
 | `/api/interruptions/stats` | GET | 中断按类型统计（`start_ns`, `end_ns`） |
 | `/api/interruptions/session-counts` | GET | 按 session 分组的中断计数（`start_ns`, `end_ns`） |
-| `/api/interruptions/trace-counts` | GET | 按 trace 分组的中断计数（`start_ns`, `end_ns`） |
+| `/api/interruptions/conversation-counts` | GET | 按 conversation 分组的中断计数（`start_ns`, `end_ns`） |
 | `/api/interruptions/{id}` | GET | 单个中断事件详情 |
 | `/api/interruptions/{id}/resolve` | POST | 标记中断为已解决 |
 | `/api/sessions/{id}/interruptions` | GET | 指定 session 的所有中断 |
-| `/api/traces/{id}/interruptions` | GET | 指定 trace 的所有中断 |
+| `/api/conversations/{id}/interruptions` | GET | 指定 conversation 的所有中断 |
 
 ## 8. Frontend
 


### PR DESCRIPTION
## Summary

Fix stale API endpoint documentation in `AGENTS.md` that listed two endpoints removed during the `trace_id → conversation_id` naming migration (commit `c24f647`).

## Changes

- **Remove** stale endpoints that no longer exist:
  - `GET /api/interruptions/trace-counts`
  - `GET /api/traces/{id}/interruptions`

- **Add** their replacements introduced in the same migration:
  - `GET /api/interruptions/conversation-counts`
  - `GET /api/conversations/{id}/interruptions`

- **Add** missing endpoints not previously documented:
  - `GET /api/conversations/{id}` — conversation event detail
  - `GET /api/export/atif/conversation/{id}` — ATIF conversation export
  - `GET /api/token-savings` — token savings statistics

## Root Cause

The two trace-based endpoints (`/api/interruptions/trace-counts` and `/api/traces/{id}/interruptions`) were intentionally removed in `c24f647` as part of renaming `trace_id` to `conversation_id`. The documentation was not updated at the time, causing the endpoints to appear as available in `AGENTS.md` while returning 404 in practice.

## Related Issue

closes #388

## Type of Change

- [x] Documentation update

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
