### PR TITLE
fix(sight): use SqliteConfig for audit CLI db path

### DIFF
--- a/src/agentsight/src/bin/cli/audit.rs
+++ b/src/agentsight/src/bin/cli/audit.rs
@@ -1,6 +1,6 @@
 //! Audit query subcommand
 
-use agentsight::{AuditEventType, AuditStore};
+use agentsight::{AuditEventType, AuditStore, SqliteConfig};
 use structopt::StructOpt;
 
 /// Audit query subcommand
@@ -29,7 +29,7 @@ pub struct AuditCommand {
 
 impl AuditCommand {
     pub fn execute(&self) {
-        let db_path = AuditStore::default_path();
+        let db_path = SqliteConfig::default().db_path();
 
         if !db_path.exists() {
             eprintln!("Database file not found: {:?}", db_path);


### PR DESCRIPTION
## Description

修复 `agentsight audit` CLI 命令报错 "Database file not found" 的问题。

原因：audit CLI 使用 `AuditStore::default_path()` 获取数据库路径，该路径与实际数据库存储路径不一致。改为使用 `SqliteConfig::default().db_path()` 以获取正确的统一数据库路径。

变更内容：
- `src/bin/cli/audit.rs`: 将 `AuditStore::default_path()` 替换为 `SqliteConfig::default().db_path()`，新增 `SqliteConfig` 导入

## Related Issue

closes #396

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

`cargo test` 通过: 2 passed; 0 failed; 29 ignored

## Additional Notes

无