### PR TITLE
fix(sight): hide Cosh from agent health UI and remove keepalive support

### DIFF
--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -219,8 +219,13 @@ impl HealthChecker {
 
         for agent in &agents {
             let ports = detect_listening_ports(agent.pid);
-            // 构造重启命令：exe + 原始 cmdline args
-            let restart_cmd = build_restart_cmd(&agent.exe_path, &agent.cmdline_args);
+            // Cosh has no daemon process and does not support keepalive/restart.
+            // Build restart_cmd only for agents that support it.
+            let restart_cmd = if agent.agent_info.name == "Cosh" {
+                None
+            } else {
+                Some(build_restart_cmd(&agent.exe_path, &agent.cmdline_args))
+            };
             let status = if ports.is_empty() {
                 AgentHealthStatus {
                     pid: agent.pid,
@@ -232,7 +237,7 @@ impl HealthChecker {
                     last_check_time: now_ms(),
                     latency_ms: None,
                     error_message: None,
-                    restart_cmd: Some(restart_cmd),
+                    restart_cmd,
                 }
             } else {
                 self.probe_agent(agent, &ports, restart_cmd)
@@ -254,7 +259,7 @@ impl HealthChecker {
         &self,
         agent: &crate::discovery::DiscoveredAgent,
         ports: &[u16],
-        restart_cmd: Vec<String>,
+        restart_cmd: Option<Vec<String>>,
     ) -> AgentHealthStatus {
         let mut last_error = String::new();
         // 标记是否遇到了超时错误（区分 hung vs unreachable）
@@ -285,7 +290,7 @@ impl HealthChecker {
                         last_check_time: now_ms(),
                         latency_ms: Some(latency),
                         error_message: None,
-                        restart_cmd: Some(restart_cmd),
+                        restart_cmd,
                     };
                 }
                 Err(ureq::Error::Status(_code, _resp)) => {
@@ -300,7 +305,7 @@ impl HealthChecker {
                         last_check_time: now_ms(),
                         latency_ms: Some(latency),
                         error_message: None,
-                        restart_cmd: Some(restart_cmd),
+                        restart_cmd,
                     };
                 }
                 Err(ureq::Error::Transport(e)) => {
@@ -337,7 +342,7 @@ impl HealthChecker {
             last_check_time: now_ms(),
             latency_ms: None,
             error_message: Some(last_error),
-            restart_cmd: Some(restart_cmd),
+            restart_cmd,
         }
     }
 

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -316,11 +316,19 @@ pub struct AgentHealthResponse {
 /// GET /api/agent-health
 ///
 /// Returns the latest health check results for all discovered agent processes.
+/// Cosh is excluded from the response: it has no HTTP port and no daemon process,
+/// so there is nothing meaningful to display in the UI. Agent-crash interruption
+/// detection for Cosh still works via the health checker background scan.
 #[get("/api/agent-health")]
 pub async fn get_agent_health(data: web::Data<AppState>) -> impl Responder {
     let store = data.health_store.read().unwrap();
+    let agents = store
+        .all_agents()
+        .into_iter()
+        .filter(|a| a.agent_name != "Cosh")
+        .collect();
     HttpResponse::Ok().json(AgentHealthResponse {
-        agents: store.all_agents(),
+        agents,
         last_scan_time: store.last_scan_time,
     })
 }


### PR DESCRIPTION
## Description

Cosh has no daemon process and no listening HTTP port, so it does not benefit from the agent health status display or restart/keepalive logic. Displaying Cosh in the Agent Status sidebar caused two related issues:

1. Each cosh session spawns 2 node processes, both shown as separate agents (both offline/no_port since cosh has no HTTP server)
2. Every time a cosh process exits, an offline record is retained in the store, causing the sidebar to accumulate a large number of "offline" entries over time

Changes:
- `health/checker.rs`: set `restart_cmd=None` for Cosh agents, removing the keepalive/restart button from the Web UI
- `server/handlers.rs`: filter Cosh entries out of `GET /api/agent-health` response so they no longer appear in the Agent Status sidebar (fixes both the duplicate-process display and the accumulated offline records)

Agent-crash interruption detection for Cosh is **preserved**: `CoshMatcher` remains in `known_agents()` so the health checker still tracks process lifecycle and correlates crashes with in-flight LLM calls.

## Related Issue

closes #390
closes #398

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Verified `cargo build` compiles without errors. The Cosh agent is still tracked internally by the health checker (visible in logs), but excluded from the API response to the frontend.

## Additional Notes

The root cause of both issues is that cosh spawns 2 node processes per session with no HTTP port, and the store accumulates offline entries on every exit. By filtering Cosh from the health API response, the Agent Status sidebar shows only meaningful agents (e.g. OpenClaw) while crash detection remains intact.
