### PR TITLE
fix(cosh): add auto-completion for /statusline subcommands

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1514,6 +1514,16 @@ export default {
     '↑↓ or j/k to navigate · 1/2/3 select · Enter confirm · Esc cancel',
   "Set up Copilot Shell's status line UI":
     "Set up Copilot Shell's status line UI",
+  'Show current status line configuration':
+    'Show current status line configuration',
+  'Clear status line configuration': 'Clear status line configuration',
+  'Current status line command: {{command}}':
+    'Current status line command: {{command}}',
+  'No status line command is currently set.':
+    'No status line command is currently set.',
+  'Status line command cleared.': 'Status line command cleared.',
+  'Status line command set to: {{command}}':
+    'Status line command set to: {{command}}',
   'Toggle compact mode': 'Toggle compact mode',
   'Hide tool output and thinking for a cleaner view (toggle with Ctrl+O)':
     'Hide tool output and thinking for a cleaner view (toggle with Ctrl+O)',

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -1344,6 +1344,12 @@ export default {
   '↑↓ or j/k to navigate · 1/2/3 select · Enter confirm · Esc cancel':
     '↑↓ 或 j/k 导航 · 1/2/3 选择 · Enter 确认 · Esc 取消',
   "Set up Copilot Shell's status line UI": '设置 Copilot Shell 的状态栏 UI',
+  'Show current status line configuration': '显示当前状态栏配置',
+  'Clear status line configuration': '清除状态栏配置',
+  'Current status line command: {{command}}': '当前状态栏命令：{{command}}',
+  'No status line command is currently set.': '当前未设置状态栏命令。',
+  'Status line command cleared.': '状态栏命令已清除。',
+  'Status line command set to: {{command}}': '状态栏命令已设置为：{{command}}',
   'Toggle compact mode': '切换紧凑模式',
   'Hide tool output and thinking for a cleaner view (toggle with Ctrl+O)':
     '隐藏工具输出和思考过程，获得更清晰的视图（通过 Ctrl+O 切换）',

--- a/src/copilot-shell/packages/cli/src/ui/commands/statuslineCommand.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/statuslineCommand.test.ts
@@ -4,15 +4,148 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { statuslineCommand } from './statuslineCommand.js';
+import { CommandKind } from './types.js';
 
 describe('statuslineCommand', () => {
   it('should have the correct name and description', () => {
     expect(statuslineCommand.name).toBe('statusline');
     expect(statuslineCommand.description).toBeDefined();
+    expect(statuslineCommand.kind).toBe(CommandKind.BUILT_IN);
   });
 
-  // Other tests are temporarily disabled due to complex type mismatches
-  // that are unrelated to the status line feature changes
+  it('should register show and clear subCommands', () => {
+    expect(statuslineCommand.subCommands).toBeDefined();
+    expect(statuslineCommand.subCommands).toHaveLength(2);
+
+    const names = statuslineCommand.subCommands!.map((sc) => sc.name);
+    expect(names).toContain('show');
+    expect(names).toContain('clear');
+  });
+
+  it('clear subCommand should have "off" as altName', () => {
+    const clearCmd = statuslineCommand.subCommands!.find(
+      (sc) => sc.name === 'clear',
+    );
+    expect(clearCmd).toBeDefined();
+    expect(clearCmd!.altNames).toContain('off');
+  });
+
+  it('subCommands should have descriptions', () => {
+    for (const sub of statuslineCommand.subCommands!) {
+      expect(sub.description).toBeDefined();
+      expect(sub.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('subCommands should have actions', () => {
+    for (const sub of statuslineCommand.subCommands!) {
+      expect(sub.action).toBeDefined();
+      expect(typeof sub.action).toBe('function');
+    }
+  });
+
+  it('show subCommand should return current config when set', () => {
+    const showCmd = statuslineCommand.subCommands!.find(
+      (sc) => sc.name === 'show',
+    );
+    const context = {
+      services: {
+        settings: {
+          merged: {
+            ui: { statusLine: { command: 'echo hello' } },
+          },
+        },
+      },
+    };
+    const result = showCmd!.action!(context as never, '');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('echo hello'),
+    });
+  });
+
+  it('show subCommand should report no config when unset', () => {
+    const showCmd = statuslineCommand.subCommands!.find(
+      (sc) => sc.name === 'show',
+    );
+    const context = {
+      services: {
+        settings: {
+          merged: { ui: {} },
+        },
+      },
+    };
+    const result = showCmd!.action!(context as never, '');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('No status line'),
+    });
+  });
+
+  it('clear subCommand should clear the config', async () => {
+    const clearCmd = statuslineCommand.subCommands!.find(
+      (sc) => sc.name === 'clear',
+    );
+    const setValue = vi.fn();
+    const context = {
+      services: {
+        settings: {
+          setValue,
+          merged: { ui: { statusLine: { command: 'echo hello' } } },
+        },
+      },
+    };
+    const result = await clearCmd!.action!(context as never, '');
+    expect(setValue).toHaveBeenCalledWith('User', 'ui.statusLine', undefined);
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('cleared'),
+    });
+  });
+
+  it('parent action with no args should delegate to show', async () => {
+    const context = {
+      services: {
+        settings: {
+          merged: { ui: {} },
+        },
+      },
+    };
+    const result = await statuslineCommand.action!(context as never, '');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('No status line'),
+    });
+  });
+
+  it('parent action with args should set the command', async () => {
+    const setValue = vi.fn();
+    const context = {
+      services: {
+        settings: {
+          setValue,
+          merged: { ui: {} },
+        },
+      },
+    };
+    const result = await statuslineCommand.action!(
+      context as never,
+      'echo "test"',
+    );
+    expect(setValue).toHaveBeenCalledWith('User', 'ui.statusLine', {
+      type: 'command',
+      command: 'echo "test"',
+    });
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('echo "test"'),
+    });
+  });
 });

--- a/src/copilot-shell/packages/cli/src/ui/commands/statuslineCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/statuslineCommand.ts
@@ -16,57 +16,70 @@ type StatusLineActionReturn =
       content: Array<{ text: string }>;
     };
 
+const showSubCommand: SlashCommand = {
+  name: 'show',
+  get description() {
+    return t('Show current status line configuration');
+  },
+  kind: CommandKind.BUILT_IN,
+  action: (context): StatusLineActionReturn => {
+    const currentConfig = context.services.settings.merged.ui?.statusLine as
+      | { command: string }
+      | undefined;
+    if (currentConfig) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: t('Current status line command: {{command}}', {
+          command: currentConfig.command,
+        }),
+      };
+    }
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: t('No status line command is currently set.'),
+    };
+  },
+};
+
+const clearSubCommand: SlashCommand = {
+  name: 'clear',
+  altNames: ['off'],
+  get description() {
+    return t('Clear status line configuration');
+  },
+  kind: CommandKind.BUILT_IN,
+  action: async (context): Promise<StatusLineActionReturn> => {
+    await context.services.settings.setValue(
+      SettingScope.User,
+      'ui.statusLine',
+      undefined,
+    );
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: t('Status line command cleared.'),
+    };
+  },
+};
+
 export const statuslineCommand: SlashCommand = {
   name: 'statusline',
   get description() {
     return t("Set up Copilot Shell's status line UI");
   },
   kind: CommandKind.BUILT_IN,
+  subCommands: [showSubCommand, clearSubCommand],
   action: async (context, args): Promise<StatusLineActionReturn> => {
-    // Split the command and arguments
     const trimmedArgs = args.trim();
 
-    // If no arguments, show current status or usage info
+    // No arguments: show current configuration
     if (!trimmedArgs) {
-      // Show current status line configuration
-      const currentConfig = context.services.settings.merged.ui?.statusLine as
-        | { command: string }
-        | undefined;
-      if (currentConfig) {
-        return {
-          type: 'message',
-          messageType: 'info',
-          content: t('Current status line command: {{command}}', {
-            command: currentConfig.command,
-          }),
-        };
-      } else {
-        return {
-          type: 'message',
-          messageType: 'info',
-          content: t('No status line command is currently set.'),
-        };
-      }
+      return showSubCommand.action!(context, '') as StatusLineActionReturn;
     }
 
-    // Check if the command is 'clear' or 'off' to remove the configuration
-    if (
-      trimmedArgs.toLowerCase() === 'clear' ||
-      trimmedArgs.toLowerCase() === 'off'
-    ) {
-      await context.services.settings.setValue(
-        SettingScope.User,
-        'ui.statusLine',
-        undefined,
-      );
-      return {
-        type: 'message',
-        messageType: 'info',
-        content: t('Status line command cleared.'),
-      };
-    }
-
-    // Otherwise, set the status line command
+    // Set the status line command
     const statusLineConfig = {
       type: 'command',
       command: trimmedArgs,


### PR DESCRIPTION
## Description

Refactored the `/statusline` command to use the `SlashCommand` subcommand registration pattern. Previously, `/statusline` parsed arguments manually with string matching, which meant the auto-completion framework had no awareness of its `show` and `clear` subcommands. Now these are registered as proper `subCommands`, enabling the existing completion engine to suggest them automatically when users type `/statusline`.

## Related Issue

closes #406

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run build && npm run test && npm run lint && npm run typecheck
# All 178 test files passed (3858 tests), lint clean, typecheck clean
```

## Additional Notes

- `clear` subcommand retains `off` as an `altName` for backward compatibility
- Parent action still handles arbitrary command strings (e.g., `/statusline echo "hello"`) for setting the status line command
- No public API or configuration format changes
