### PR TITLE
fix(cosh): add skill_context to PreToolUse hook input for resolved skill path

### DIFF
--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -834,9 +834,34 @@ export class CoreToolScheduler {
           const hookSystem = this.config.getHookSystem();
           if (hookSystem) {
             try {
+              // For Skill tool, resolve the skill file path so hooks can
+              // locate the skill on disk even when the SKILL.md `name`
+              // differs from the directory name.
+              let skillContext:
+                | import('../hooks/types.js').SkillToolContext
+                | undefined;
+              if (
+                reqInfo.name === ToolNames.SKILL &&
+                typeof reqInfo.args['skill'] === 'string'
+              ) {
+                const skillTool = this.toolRegistry.getTool(ToolNames.SKILL);
+                if (skillTool instanceof SkillTool) {
+                  const skillConfig = await skillTool.resolveSkillConfig(
+                    reqInfo.args['skill'],
+                  );
+                  if (skillConfig) {
+                    skillContext = {
+                      skill_name: skillConfig.name,
+                      file_path: skillConfig.filePath,
+                    };
+                  }
+                }
+              }
+
               const hookOutput = await hookSystem.firePreToolUseEvent(
                 reqInfo.name,
                 reqInfo.args,
+                skillContext,
               );
 
               if (hookOutput) {

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.test.ts
@@ -275,4 +275,67 @@ describe('HookEventHandler', () => {
       expect(result.errors[0].message).toBe('Runner error');
     });
   });
+
+  describe('firePreToolUseEvent', () => {
+    it('should include skill_context in hook input when provided', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      const skillContext = {
+        skill_name: 'linux-admin',
+        file_path: '/home/user/.copilot-shell/skills/alinux-admin/SKILL.md',
+      };
+      await hookEventHandler.firePreToolUseEvent(
+        'Skill',
+        { skill: 'linux-admin' },
+        skillContext,
+      );
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as {
+        tool_name: string;
+        tool_input: Record<string, unknown>;
+        skill_context?: { skill_name: string; file_path: string };
+      };
+      expect(input.tool_name).toBe('Skill');
+      expect(input.tool_input).toEqual({ skill: 'linux-admin' });
+      expect(input.skill_context).toEqual(skillContext);
+    });
+
+    it('should omit skill_context from hook input when not provided', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.firePreToolUseEvent('Bash', {
+        command: 'ls',
+      });
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as Record<string, unknown>;
+      expect(input['tool_name']).toBe('Bash');
+      expect(input).not.toHaveProperty('skill_context');
+    });
+  });
 });

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
@@ -85,6 +85,7 @@ export class HookEventHandler {
   async firePreToolUseEvent(
     toolName: string,
     toolInput: Record<string, unknown>,
+    skillContext?: import('./types.js').SkillToolContext,
   ): Promise<AggregatedHookResult> {
     debugLogger.info(
       `[Hook Debug] hookEventHandler.firePreToolUseEvent: tool=${toolName}`,
@@ -93,6 +94,7 @@ export class HookEventHandler {
       ...this.createBaseInput(HookEventName.PreToolUse),
       tool_name: toolName,
       tool_input: toolInput,
+      ...(skillContext && { skill_context: skillContext }),
     };
 
     const result = await this.executeHooks(HookEventName.PreToolUse, input);

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -110,6 +110,7 @@ export class HookSystem {
   async firePreToolUseEvent(
     toolName: string,
     toolInput: Record<string, unknown>,
+    skillContext?: import('./types.js').SkillToolContext,
   ): Promise<PreToolUseHookOutput | undefined> {
     debugLogger.info(
       `[Hook Debug] hookSystem.firePreToolUseEvent: entering facade, tool=${toolName}`,
@@ -117,6 +118,7 @@ export class HookSystem {
     const result = await this.hookEventHandler.firePreToolUseEvent(
       toolName,
       toolInput,
+      skillContext,
     );
     const output = result.finalOutput
       ? (createHookOutput(

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -399,11 +399,22 @@ export interface McpToolContext {
   tcp?: string; // For WebSocket transport
 }
 
+/**
+ * Context for Skill tool executions.
+ * Contains the resolved skill metadata so hooks can locate the skill on disk
+ * even when the SKILL.md `name` differs from the directory name.
+ */
+export interface SkillToolContext {
+  skill_name: string;
+  file_path: string;
+}
+
 export interface PreToolUseInput extends HookInput {
   permission_mode?: PermissionMode;
   tool_name: string;
   tool_input: Record<string, unknown>;
   mcp_context?: McpToolContext;
+  skill_context?: SkillToolContext;
   original_request_name?: string;
 }
 

--- a/src/copilot-shell/packages/core/src/tools/skill.ts
+++ b/src/copilot-shell/packages/core/src/tools/skill.ts
@@ -192,6 +192,22 @@ ${skillDescriptions}
   getAvailableSkillNames(): string[] {
     return this.availableSkills.map((skill) => skill.name);
   }
+
+  /**
+   * Resolve a skill name to its SkillConfig for PreToolUse hook enrichment.
+   * Returns undefined if the skill cannot be found.
+   */
+  async resolveSkillConfig(
+    skillName: string,
+  ): Promise<SkillConfig | undefined> {
+    try {
+      return (
+        (await this.skillManager.loadSkillForRuntime(skillName)) ?? undefined
+      );
+    } catch {
+      return undefined;
+    }
+  }
 }
 
 class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {


### PR DESCRIPTION
## Summary

- Adds `skill_context` (with `skill_name` and `file_path`) to `PreToolUseInput`, symmetric with existing `mcp_context` for MCP tools
- When the Skill tool fires PreToolUse, coreToolScheduler now resolves the skill via `SkillManager` and attaches the resolved path to the hook input
- Hooks can now locate skill directories on disk even when the SKILL.md `name` differs from the directory name

## Type of Change

- [x] Bug fix

## Related Issue

Closes #381

## Testing

```bash
cd src/copilot-shell
npm run build && npm run test && npm run lint && npm run typecheck
# 125 hook tests passed, build succeeded, lint clean, typecheck clean
```

## Changed Files

| File | Change |
|------|--------|
| `hooks/types.ts` | Add `SkillToolContext` interface and `skill_context?` field to `PreToolUseInput` |
| `hooks/hookEventHandler.ts` | Forward optional `skillContext` parameter |
| `hooks/hookSystem.ts` | Forward optional `skillContext` parameter in facade |
| `core/coreToolScheduler.ts` | Resolve skill path before PreToolUse hook fire |
| `tools/skill.ts` | Add `resolveSkillConfig()` method to `SkillTool` |
| `hooks/hookEventHandler.test.ts` | 2 new tests for skill_context inclusion/omission |