### PR TITLE
fix(sight): simplify agent_crash detection and fix multi-process dedup

### DIFF
--- a/src/agentsight/dashboard/src/pages/ConversationList.tsx
+++ b/src/agentsight/dashboard/src/pages/ConversationList.tsx
@@ -339,7 +339,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
   if (loading)
     return (
       <tr>
-        <td colSpan={8} className="px-8 py-4 text-sm text-gray-400 bg-blue-50">
+        <td colSpan={10} className="px-8 py-4 text-sm text-gray-400 bg-blue-50">
           加载 Trace 列表...
         </td>
       </tr>
@@ -347,7 +347,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
   if (error)
     return (
       <tr>
-        <td colSpan={8} className="px-8 py-4 text-sm text-red-500 bg-blue-50">
+        <td colSpan={10} className="px-8 py-4 text-sm text-red-500 bg-blue-50">
           ⚠️ {error}
         </td>
       </tr>
@@ -360,7 +360,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
     <>
       {/* Sub-header */}
       <tr className="bg-blue-50 border-t border-blue-100">
-        <td colSpan={9} className="px-4 lg:px-8 py-2">
+        <td colSpan={10} className="px-4 lg:px-8 py-2">
           <div className="grid grid-cols-[260px_274px_120px_120px_160px_80px_100px] text-xs font-semibold text-blue-700 uppercase tracking-wide min-w-[800px]">
             <div>Conversation ID</div>
             <div>用户请求</div>
@@ -375,7 +375,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
 
       {traces.length === 0 && (
         <tr className="bg-blue-50">
-          <td colSpan={9} className="px-4 lg:px-8 py-3 text-sm text-gray-400">
+          <td colSpan={10} className="px-4 lg:px-8 py-3 text-sm text-gray-400">
             该 Session 下暂无 Trace
           </td>
         </tr>
@@ -384,7 +384,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
       {pageTraces.map((tr) => (
         <React.Fragment key={tr.conversation_id}>
           <tr className="bg-blue-50 hover:bg-blue-100 transition-colors">
-            <td colSpan={9} className="px-4 lg:px-8 py-2">
+            <td colSpan={10} className="px-4 lg:px-8 py-2">
               <div className="grid grid-cols-[260px_274px_120px_120px_160px_80px_100px] items-center text-sm min-w-[800px]">
                 {/* Col 1: Conversation ID */}
                 <div className="min-w-0 pr-2">
@@ -447,7 +447,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
           {/* Trace interruption panel */}
           {expandedTracePanel === tr.trace_id && (
             <tr className="bg-blue-50">
-              <td colSpan={9} className="px-4 lg:px-8 pb-3 pt-0">
+              <td colSpan={10} className="px-4 lg:px-8 pb-3 pt-0">
                 <div className="border border-gray-200 rounded-lg overflow-hidden">
                   <InterruptionPanel
                     conversationId={tr.conversation_id}
@@ -464,7 +464,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
       {/* 分页控制 */}
       {totalPages > 1 && (
         <tr className="bg-blue-50 border-t border-blue-100">
-          <td colSpan={8} className="px-4 lg:px-8 py-2">
+          <td colSpan={10} className="px-4 lg:px-8 py-2">
             <div className="flex items-center gap-2 justify-end">
               <span className="text-xs text-gray-500">
                 {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, traces.length)} / {traces.length} 条
@@ -797,6 +797,10 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
   // Which session row is expanded to show traces
   const [expandedSession, setExpandedSession] = useState<string | null>(null);
 
+  // Session list pagination
+  const SESSION_PAGE_SIZE = 10;
+  const [sessionPage, setSessionPage] = useState(0);
+
   // Called when a single interruption event is resolved inside InterruptionPanel.
   // Decrements counts in all relevant state maps so badges update without re-query.
   const handleResolvedEvent = useCallback((info: ResolvedEventInfo) => {
@@ -927,6 +931,7 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
     setTimeseriesLoading(true);
     setError(null);
     setHasQueried(true);
+    setSessionPage(0); // reset to first page on new query
 
     const startNs = startMs * 1_000_000;
     const endNs = effectiveEnd * 1_000_000;
@@ -1193,7 +1198,10 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
                     </tr>
                   )}
 
-                  {sessions.map((sess) => {
+                  {(() => {
+                    const sessionTotalPages = Math.max(1, Math.ceil(sessions.length / SESSION_PAGE_SIZE));
+                    const pageSessions = sessions.slice(sessionPage * SESSION_PAGE_SIZE, (sessionPage + 1) * SESSION_PAGE_SIZE);
+                    return pageSessions.map((sess) => {
                     const isExpanded = expandedSession === sess.session_id;
                     return (
                       <React.Fragment key={sess.session_id}>
@@ -1302,10 +1310,49 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
                         )}
                       </React.Fragment>
                     );
-                  })}
+                  });
+                  })()}
                 </tbody>
                 </table>
               </div>
+              {/* Session pagination controls */}
+              {sessions.length > SESSION_PAGE_SIZE && (() => {
+                const sessionTotalPages = Math.ceil(sessions.length / SESSION_PAGE_SIZE);
+                return (
+                  <div className="flex items-center gap-2 justify-end px-4 py-3 border-t border-gray-100">
+                    <span className="text-xs text-gray-500">
+                      {sessionPage * SESSION_PAGE_SIZE + 1}–{Math.min((sessionPage + 1) * SESSION_PAGE_SIZE, sessions.length)} / {sessions.length} 条
+                    </span>
+                    <button
+                      onClick={() => setSessionPage((p) => Math.max(0, p - 1))}
+                      disabled={sessionPage === 0}
+                      className="px-2 py-0.5 text-xs border border-gray-300 text-gray-600 rounded hover:bg-gray-50 disabled:opacity-40 transition-colors"
+                    >
+                      &lsaquo; 上一页
+                    </button>
+                    {Array.from({ length: sessionTotalPages }, (_, i) => (
+                      <button
+                        key={i}
+                        onClick={() => setSessionPage(i)}
+                        className={`px-2 py-0.5 text-xs rounded transition-colors ${
+                          i === sessionPage
+                            ? 'bg-blue-600 text-white'
+                            : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
+                        }`}
+                      >
+                        {i + 1}
+                      </button>
+                    ))}
+                    <button
+                      onClick={() => setSessionPage((p) => Math.min(sessionTotalPages - 1, p + 1))}
+                      disabled={sessionPage === sessionTotalPages - 1}
+                      className="px-2 py-0.5 text-xs border border-gray-300 text-gray-600 rounded hover:bg-gray-50 disabled:opacity-40 transition-colors"
+                    >
+                      下一页 &rsaquo;
+                    </button>
+                  </div>
+                );
+              })()}
             </div>
           </>
         )}

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -8,11 +8,11 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::discovery::AgentScanner;
-use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore};
-use crate::interruption::{InterruptionEvent, InterruptionType};
 use super::port_detector::detect_listening_ports;
 use super::store::{AgentHealthState, AgentHealthStatus, HealthStore, now_ms};
+use crate::discovery::AgentScanner;
+use crate::interruption::{InterruptionEvent, InterruptionType};
+use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore};
 
 /// Background health checker that periodically probes discovered agents
 pub struct HealthChecker {
@@ -42,19 +42,13 @@ impl HealthChecker {
     }
 
     /// Create with an interruption store so offline events trigger `agent_crash`.
-    pub fn with_interruption_store(
-        mut self,
-        interruption_store: Arc<InterruptionStore>,
-    ) -> Self {
+    pub fn with_interruption_store(mut self, interruption_store: Arc<InterruptionStore>) -> Self {
         self.interruption_store = Some(interruption_store);
         self
     }
 
     /// Create with a GenAI store to query pending calls on agent crash.
-    pub fn with_genai_store(
-        mut self,
-        genai_store: Arc<GenAISqliteStore>,
-    ) -> Self {
+    pub fn with_genai_store(mut self, genai_store: Arc<GenAISqliteStore>) -> Self {
         self.genai_store = Some(genai_store);
         self
     }
@@ -96,8 +90,16 @@ impl HealthChecker {
             vec![]
         };
 
-        // Write agent_crash interruption events for processes that just went offline
-        // Group by conversation_id: 1 agent_crash per conversation, not per call.
+        // Write agent_crash interruption events for processes that just went offline.
+        //
+        // Deduplication strategy:
+        //   - Cosh spawns 2 node processes per session (parent + worker). LLM traffic
+        //     may be recorded under either pid. We group all pids for the same agent_name
+        //     and query them together so we see all calls in one pass.
+        //   - OpenClaw is a single-pid gateway that may serve multiple concurrent sessions.
+        //     All sessions for that pid are returned and each gets its own event.
+        //   - Deduplication key is (agent_name, session_id, conversation_id): at most one
+        //     agent_crash event is written per unique (agent, session, conversation) triple.
         if !newly_offline.is_empty() {
             if let Some(ref istore) = self.interruption_store {
                 let now_ns = std::time::SystemTime::now()
@@ -105,111 +107,101 @@ impl HealthChecker {
                     .map(|d| d.as_nanos() as i64)
                     .unwrap_or(0);
 
+                // Group newly-offline entries by agent_name so multi-process agents
+                // (e.g. Cosh) are processed together in a single DB query.
+                let mut by_agent: HashMap<String, Vec<&AgentHealthStatus>> = HashMap::new();
                 for offline in &newly_offline {
-                    let pending_calls = self.get_pending_calls_for_pid(offline.pid);
+                    by_agent
+                        .entry(offline.agent_name.clone())
+                        .or_default()
+                        .push(offline);
+                }
+
+                // Dedup key: (agent_name, session_id, conversation_id)
+                let mut seen_conv: HashSet<(String, Option<String>, Option<String>)> =
+                    HashSet::new();
+
+                for (agent_name, group) in &by_agent {
+                    let pids: Vec<i32> = group.iter().map(|o| o.pid as i32).collect();
+                    // Use the representative offline entry for metadata (pid shown in detail).
+                    // When multiple pids exist (Cosh), use the largest pid (worker) as it is
+                    // most likely the one that carried LLM traffic.
+                    let rep = group.iter().max_by_key(|o| o.pid).unwrap();
+
+                    // ── Branch A: pending (in-flight) LLM calls ──────────────────────────
+                    let pending_calls = self.get_pending_calls_for_pids(&pids);
                     if !pending_calls.is_empty() {
-                        // Group pending calls by conversation_id → 1 event per conversation
-                        let mut by_conv: HashMap<Option<String>, Vec<(String, Option<String>)>> = HashMap::new();
+                        let mut by_conv: HashMap<
+                            (Option<String>, Option<String>),
+                            Vec<(String, Option<String>)>,
+                        > = HashMap::new();
                         for (call_id, session_id, _trace_id, conversation_id) in &pending_calls {
-                            by_conv.entry(conversation_id.clone())
+                            by_conv
+                                .entry((session_id.clone(), conversation_id.clone()))
                                 .or_default()
                                 .push((call_id.clone(), session_id.clone()));
                         }
-
-                        for (conversation_id, calls) in &by_conv {
-                            let session_id = calls.first().and_then(|(_, s)| s.clone());
-                            let call_ids: Vec<&str> = calls.iter().map(|(c, _)| c.as_str()).collect();
+                        for ((session_id, conversation_id), calls) in &by_conv {
+                            let dedup_key = (
+                                agent_name.clone(),
+                                session_id.clone(),
+                                conversation_id.clone(),
+                            );
+                            if !seen_conv.insert(dedup_key) {
+                                log::debug!(
+                                    "Skipping duplicate agent_crash for {} session={:?} conversation={:?}",
+                                    agent_name,
+                                    session_id,
+                                    conversation_id
+                                );
+                                continue;
+                            }
+                            let call_ids: Vec<&str> =
+                                calls.iter().map(|(c, _)| c.as_str()).collect();
                             let detail = serde_json::json!({
-                                "pid": offline.pid,
-                                "agent_name": offline.agent_name,
-                                "exe_path": offline.exe_path.clone(),
+                                "pid": rep.pid,
+                                "agent_name": agent_name,
+                                "exe_path": rep.exe_path.clone(),
                                 "call_ids": call_ids,
                             });
                             let event = InterruptionEvent::new(
                                 InterruptionType::AgentCrash,
-                                session_id,
+                                session_id.clone(),
                                 None,
                                 conversation_id.clone(),
                                 None,
-                                Some(offline.pid as i32),
-                                Some(offline.agent_name.clone()),
+                                Some(rep.pid as i32),
+                                Some(agent_name.clone()),
                                 now_ns,
                                 Some(detail),
                             );
                             if let Err(e) = istore.insert(&event) {
-                                log::warn!("Failed to record agent_crash interruption for pid={}: {}", offline.pid, e);
-                            } else {
-                                log::info!("Recorded agent_crash for {} (pid={}, conversation={:?}, {} call(s))",
-                                    offline.agent_name, offline.pid, conversation_id, calls.len());
-                            }
-                        }
-                        self.mark_pending_interrupted(offline.pid, "agent_crash");
-                    } else {
-                        // No pending calls — check if any agentic loop was cut short
-                        let incomplete = self.get_incomplete_agentic_sessions_for_pid(offline.pid);
-                        if !incomplete.is_empty() {
-                            // Group by conversation_id
-                            let mut by_conv: HashMap<Option<String>, Vec<(String, Option<String>)>> = HashMap::new();
-                            for (call_id, session_id, _trace_id, conversation_id) in &incomplete {
-                                by_conv.entry(conversation_id.clone())
-                                    .or_default()
-                                    .push((call_id.clone(), session_id.clone()));
-                            }
-
-                            for (conversation_id, calls) in &by_conv {
-                                let session_id = calls.first().and_then(|(_, s)| s.clone());
-                                let call_ids: Vec<&str> = calls.iter().map(|(c, _)| c.as_str()).collect();
-                                let detail = serde_json::json!({
-                                    "pid": offline.pid,
-                                    "agent_name": offline.agent_name,
-                                    "exe_path": offline.exe_path.clone(),
-                                    "call_ids": call_ids,
-                                    "reason": "agentic_loop_incomplete",
-                                });
-                                let event = InterruptionEvent::new(
-                                    InterruptionType::AgentCrash,
-                                    session_id,
-                                    None,
-                                    conversation_id.clone(),
-                                    None,
-                                    Some(offline.pid as i32),
-                                    Some(offline.agent_name.clone()),
-                                    now_ns,
-                                    Some(detail),
+                                log::warn!(
+                                    "Failed to record agent_crash for pid={}: {}",
+                                    rep.pid,
+                                    e
                                 );
-                                if let Err(e) = istore.insert(&event) {
-                                    log::warn!("Failed to record agent_crash (incomplete loop) for pid={}: {}", offline.pid, e);
-                                } else {
-                                    log::info!("Recorded agent_crash (incomplete loop) for {} (pid={}, conversation={:?})",
-                                        offline.agent_name, offline.pid, conversation_id);
-                                }
-                            }
-                        } else {
-                            // Truly no in-flight activity — still record crash for observability
-                            let detail = serde_json::json!({
-                                "pid": offline.pid,
-                                "agent_name": offline.agent_name,
-                                "exe_path": offline.exe_path,
-                                "last_check_time": offline.last_check_time,
-                            });
-                            let event = InterruptionEvent::new(
-                                InterruptionType::AgentCrash,
-                                None,
-                                None,
-                                None,
-                                None,
-                                Some(offline.pid as i32),
-                                Some(offline.agent_name.clone()),
-                                now_ns,
-                                Some(detail),
-                            );
-                            if let Err(e) = istore.insert(&event) {
-                                log::warn!("Failed to record agent_crash interruption for pid={}: {}", offline.pid, e);
                             } else {
-                                log::info!("Recorded agent_crash for {} (pid={}, no pending call)",
-                                    offline.agent_name, offline.pid);
+                                log::info!(
+                                    "Recorded agent_crash for {} (pid={}, session={:?}, conversation={:?}, {} call(s))",
+                                    agent_name,
+                                    rep.pid,
+                                    session_id,
+                                    conversation_id,
+                                    calls.len()
+                                );
                             }
                         }
+                        for o in group {
+                            self.mark_pending_interrupted(o.pid, "agent_crash");
+                        }
+                    } else {
+                        // No pending calls — treat as normal/graceful shutdown.
+                        log::debug!(
+                            "Agent {} (pids={:?}) exited with no pending calls — treating as normal shutdown",
+                            agent_name,
+                            pids
+                        );
                     }
                 }
             }
@@ -319,7 +311,10 @@ impl HealthChecker {
                     }
                     log::debug!(
                         "Health probe failed for {} (pid={}) on port {}: {}",
-                        agent.agent_info.name, agent.pid, port, msg
+                        agent.agent_info.name,
+                        agent.pid,
+                        port,
+                        msg
                     );
                 }
             }
@@ -349,7 +344,10 @@ impl HealthChecker {
     /// Query pending LLM calls for a specific PID from genai_events.
     ///
     /// Returns a list of (call_id, session_id, trace_id, conversation_id) tuples.
-    fn get_pending_calls_for_pid(&self, pid: u32) -> Vec<(String, Option<String>, Option<String>, Option<String>)> {
+    fn get_pending_calls_for_pid(
+        &self,
+        pid: u32,
+    ) -> Vec<(String, Option<String>, Option<String>, Option<String>)> {
         if let Some(ref genai_store) = self.genai_store {
             match genai_store.list_pending_for_pid(pid as i32) {
                 Ok(calls) => calls,
@@ -363,27 +361,18 @@ impl HealthChecker {
         }
     }
 
-    /// Query sessions whose agentic loop was incomplete for a specific PID.
+    /// Query pending LLM calls for multiple PIDs at once.
     ///
-    /// Returns (call_id, session_id, trace_id, conversation_id) for the last
-    /// call of each (session, conversation) that ended with
-    /// finish_reason=tool_calls, indicating the agent was mid-loop when it
-    /// crashed.  Only considers calls from the last 5 minutes to avoid false
-    /// positives from historical data.
-    fn get_incomplete_agentic_sessions_for_pid(
+    /// Returns a list of (call_id, session_id, trace_id, conversation_id) tuples.
+    fn get_pending_calls_for_pids(
         &self,
-        pid: u32,
+        pids: &[i32],
     ) -> Vec<(String, Option<String>, Option<String>, Option<String>)> {
         if let Some(ref genai_store) = self.genai_store {
-            // 5-minute lookback window (in nanoseconds)
-            let since_ns = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as i64 - 300_000_000_000i64)
-                .unwrap_or(0);
-            match genai_store.list_incomplete_agentic_sessions_for_pid(pid as i32, since_ns) {
+            match genai_store.list_pending_for_pids(pids) {
                 Ok(calls) => calls,
                 Err(e) => {
-                    log::warn!("Failed to query incomplete agentic sessions for pid={}: {}", pid, e);
+                    log::warn!("Failed to query pending calls for pids={:?}: {}", pids, e);
                     vec![]
                 }
             }
@@ -396,7 +385,11 @@ impl HealthChecker {
     fn mark_pending_interrupted(&self, pid: u32, itype: &str) {
         if let Some(ref genai_store) = self.genai_store {
             if let Err(e) = genai_store.mark_pending_interrupted_for_pid(pid as i32, itype) {
-                log::warn!("Failed to mark pending calls as interrupted for pid={}: {}", pid, e);
+                log::warn!(
+                    "Failed to mark pending calls as interrupted for pid={}: {}",
+                    pid,
+                    e
+                );
             }
         }
     }
@@ -408,7 +401,8 @@ impl HealthChecker {
 fn build_restart_cmd(exe_path: &str, cmdline_args: &[String]) -> Vec<String> {
     let mut cmd = vec![exe_path.to_string()];
     // cmdline_args[0] 通常是 exe 本身（argv[0]），跳过以避免重复
-    let args: Vec<_> = cmdline_args.iter()
+    let args: Vec<_> = cmdline_args
+        .iter()
         .skip(1)
         .filter(|a| !a.is_empty())
         .cloned()

--- a/src/agentsight/src/interruption/oom_recovery.rs
+++ b/src/agentsight/src/interruption/oom_recovery.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::interruption::types::{InterruptionEvent, InterruptionType};
-use crate::storage::sqlite::InterruptionStore;
 use crate::storage::sqlite::GenAISqliteStore;
+use crate::storage::sqlite::InterruptionStore;
 
 /// A parsed OOM kill event from dmesg
 #[derive(Debug)]
@@ -66,7 +66,11 @@ pub fn recover_oom_events(
 
         // Per-event dedup: skip if already recorded with same (pid, timestamp)
         if interruption_store.oom_event_exists(ev.pid, ev.timestamp_ns) {
-            log::debug!("OOM recovery: skip duplicate pid={} ts={}", ev.pid, ev.timestamp_ns);
+            log::debug!(
+                "OOM recovery: skip duplicate pid={} ts={}",
+                ev.pid,
+                ev.timestamp_ns
+            );
             continue;
         }
 
@@ -74,30 +78,37 @@ pub fn recover_oom_events(
         let agent_name = match_agent_name(&ev.process_name);
 
         // Try to correlate with genai_events to find active session/conversation
-        // Use 5-minute lookback window to avoid false positives from old data
-        let since_ns = ev.timestamp_ns.saturating_sub(300_000_000_000) as i64;
-        let (session_id, conversation_id, active_conversations): (Option<String>, Option<String>, Vec<String>) =
-            if let Some(gstore) = genai_store {
-                match gstore.list_incomplete_agentic_sessions_for_pid(ev.pid, since_ns) {
-                    Ok(pairs) => {
-                        let primary = pairs.first();
-                        let convs: Vec<String> = pairs.iter()
-                            .filter_map(|(_, _, _, cid)| cid.clone())
-                            .collect();
-                        (
-                            primary.and_then(|(_, sid, _, _)| sid.clone()),
-                            primary.and_then(|(_, _, _, cid)| cid.clone()),
-                            convs,
-                        )
-                    }
-                    Err(e) => {
-                        log::debug!("OOM recovery: failed to query genai for pid={}: {}", ev.pid, e);
-                        (None, None, Vec::new())
-                    }
+        // via pending (in-flight) LLM calls at OOM time.
+        let (session_id, conversation_id, active_conversations): (
+            Option<String>,
+            Option<String>,
+            Vec<String>,
+        ) = if let Some(gstore) = genai_store {
+            match gstore.list_pending_for_pid(ev.pid) {
+                Ok(pairs) => {
+                    let primary = pairs.first();
+                    let convs: Vec<String> = pairs
+                        .iter()
+                        .filter_map(|(_, _, _, cid)| cid.clone())
+                        .collect();
+                    (
+                        primary.and_then(|(_, sid, _, _)| sid.clone()),
+                        primary.and_then(|(_, _, _, cid)| cid.clone()),
+                        convs,
+                    )
                 }
-            } else {
-                (None, None, Vec::new())
-            };
+                Err(e) => {
+                    log::debug!(
+                        "OOM recovery: failed to query genai for pid={}: {}",
+                        ev.pid,
+                        e
+                    );
+                    (None, None, Vec::new())
+                }
+            }
+        } else {
+            (None, None, Vec::new())
+        };
 
         let mut detail = serde_json::json!({
             "pid": ev.pid,
@@ -126,19 +137,26 @@ pub fn recover_oom_events(
             Ok(_) => {
                 log::info!(
                     "OOM recovery: wrote agent_crash for pid={} name={} at {}",
-                    ev.pid, ev.process_name, ev.timestamp_ns,
+                    ev.pid,
+                    ev.process_name,
+                    ev.timestamp_ns,
                 );
                 written += 1;
             }
             Err(e) => {
-                log::warn!("OOM recovery: failed to insert event for pid={}: {}", ev.pid, e);
+                log::warn!(
+                    "OOM recovery: failed to insert event for pid={}: {}",
+                    ev.pid,
+                    e
+                );
             }
         }
     }
 
     log::info!(
         "OOM recovery: scanned {} OOM events, wrote {} new interruption records",
-        events.len(), written,
+        events.len(),
+        written,
     );
 }
 
@@ -208,7 +226,8 @@ fn parse_killed_process(line: &str) -> Option<(i32, String)> {
 
     // Extract name between first '(' and ')'
     let name = rest
-        .split('(').nth(1)
+        .split('(')
+        .nth(1)
         .and_then(|s| s.split(')').next())
         .unwrap_or("")
         .to_string();

--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -9,13 +9,13 @@
 //! variable (default: 200 MB). When approaching 90% of the limit, old records are pruned
 //! automatically. The size check includes the main database file plus WAL and SHM files.
 
+use rusqlite::{Connection, params};
 use std::path::PathBuf;
 use std::sync::Mutex;
-use rusqlite::{params, Connection};
 
-use crate::genai::semantic::GenAISemanticEvent;
-use crate::genai::exporter::GenAIExporter;
 use super::connection::{create_connection, default_base_path};
+use crate::genai::exporter::GenAIExporter;
+use crate::genai::semantic::GenAISemanticEvent;
 
 // ─── Size limit configuration ──────────────────────────────────────────────────
 
@@ -34,7 +34,8 @@ fn get_max_db_size() -> u64 {
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(DEFAULT_MAX_DB_SIZE_MB)
-        * 1024 * 1024
+        * 1024
+        * 1024
 }
 
 /// Get prune threshold (90% of max)
@@ -221,7 +222,7 @@ impl GenAISqliteStore {
             db_path: path.to_path_buf(),
         };
         store.init_tables()?;
-        
+
         // Log current database size on startup
         let current_size = store.get_total_db_size();
         let max_size = get_max_db_size();
@@ -232,7 +233,7 @@ impl GenAISqliteStore {
             threshold / 1024 / 1024,
             max_size / 1024 / 1024
         );
-        
+
         Ok(store)
     }
 
@@ -328,9 +329,7 @@ impl GenAISqliteStore {
 
         // Query existing columns once to avoid repeated PRAGMA calls
         let existing_cols: std::collections::HashSet<String> = {
-            let mut stmt = conn.prepare(
-                "SELECT name FROM pragma_table_info('genai_events')"
-            )?;
+            let mut stmt = conn.prepare("SELECT name FROM pragma_table_info('genai_events')")?;
             stmt.query_map([], |row| row.get::<_, String>(0))?
                 .filter_map(|r| r.ok())
                 .collect()
@@ -341,42 +340,49 @@ impl GenAISqliteStore {
             // Column with no index
             ($col:literal, $def:literal) => {
                 if !existing_cols.contains($col) {
-                    conn.execute_batch(
-                        &format!("ALTER TABLE genai_events ADD COLUMN {} {};", $col, $def)
-                    )?;
+                    conn.execute_batch(&format!(
+                        "ALTER TABLE genai_events ADD COLUMN {} {};",
+                        $col, $def
+                    ))?;
                     log::info!("Migrated genai_events: added '{}' column", $col);
                 }
             };
             // Column + index
             ($col:literal, $def:literal, $idx:literal) => {
                 if !existing_cols.contains($col) {
-                    conn.execute_batch(
-                        &format!("ALTER TABLE genai_events ADD COLUMN {} {};", $col, $def)
-                    )?;
+                    conn.execute_batch(&format!(
+                        "ALTER TABLE genai_events ADD COLUMN {} {};",
+                        $col, $def
+                    ))?;
                     log::info!("Migrated genai_events: added '{}' column", $col);
                 }
                 // Always run CREATE INDEX IF NOT EXISTS — safe even if index already exists
-                conn.execute_batch(
-                    &format!("CREATE INDEX IF NOT EXISTS {} ON genai_events({});", $idx, $col)
-                )?;
+                conn.execute_batch(&format!(
+                    "CREATE INDEX IF NOT EXISTS {} ON genai_events({});",
+                    $idx, $col
+                ))?;
             };
         }
 
         // v2: Anthropic prompt-cache token counters
         ensure_col!("cache_creation_tokens", "INTEGER");
-        ensure_col!("cache_read_tokens",     "INTEGER");
+        ensure_col!("cache_read_tokens", "INTEGER");
 
         // v3: two-phase write lifecycle status
-        ensure_col!("status", "TEXT NOT NULL DEFAULT 'complete'",
-                    "idx_genai_status");
+        ensure_col!(
+            "status",
+            "TEXT NOT NULL DEFAULT 'complete'",
+            "idx_genai_status"
+        );
 
         // v4: per-call interruption type
-        ensure_col!("interruption_type", "TEXT",
-                    "idx_genai_interruption_type");
-
+        ensure_col!("interruption_type", "TEXT", "idx_genai_interruption_type");
 
         // Migration: add conversation_id column for existing databases
-        let _ = conn.execute("ALTER TABLE genai_events ADD COLUMN conversation_id TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE genai_events ADD COLUMN conversation_id TEXT",
+            [],
+        );
 
         // v5: tool_call_ids JSON array for output tool calls
         ensure_col!("tool_call_ids", "TEXT");
@@ -446,26 +452,56 @@ impl GenAISqliteStore {
                 let conn = self.conn.lock().unwrap();
                 let event_json = serde_json::to_string(event)?;
 
-                let (input_tokens, output_tokens, total_tokens) = call.token_usage.as_ref()
-                    .map(|u| (u.input_tokens as i64, u.output_tokens as i64, u.total_tokens as i64))
+                let (input_tokens, output_tokens, total_tokens) = call
+                    .token_usage
+                    .as_ref()
+                    .map(|u| {
+                        (
+                            u.input_tokens as i64,
+                            u.output_tokens as i64,
+                            u.total_tokens as i64,
+                        )
+                    })
                     .unwrap_or((0, 0, 0));
-                let cache_creation = call.token_usage.as_ref()
+                let cache_creation = call
+                    .token_usage
+                    .as_ref()
                     .and_then(|u| u.cache_creation_input_tokens.map(|v| v as i64));
-                let cache_read = call.token_usage.as_ref()
+                let cache_read = call
+                    .token_usage
+                    .as_ref()
                     .and_then(|u| u.cache_read_input_tokens.map(|v| v as i64));
 
                 let system_instructions: Option<String> = {
-                    let sys: Vec<_> = call.request.messages.iter()
-                        .filter(|m| m.role == "system").collect();
-                    if sys.is_empty() { None } else { serde_json::to_string(&sys).ok() }
+                    let sys: Vec<_> = call
+                        .request
+                        .messages
+                        .iter()
+                        .filter(|m| m.role == "system")
+                        .collect();
+                    if sys.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&sys).ok()
+                    }
                 };
                 let input_messages: Option<String> = {
-                    let non_sys: Vec<_> = call.request.messages.iter()
-                        .filter(|m| m.role != "system").collect();
+                    let non_sys: Vec<_> = call
+                        .request
+                        .messages
+                        .iter()
+                        .filter(|m| m.role != "system")
+                        .collect();
                     let latest = if let Some(idx) = non_sys.iter().rposition(|m| m.role == "user") {
                         &non_sys[idx..]
-                    } else { &non_sys[..] };
-                    if latest.is_empty() { None } else { serde_json::to_string(&latest).ok() }
+                    } else {
+                        &non_sys[..]
+                    };
+                    if latest.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&latest).ok()
+                    }
                 };
                 let output_messages: Option<String> = if call.response.messages.is_empty() {
                     None
@@ -473,23 +509,42 @@ impl GenAISqliteStore {
                     serde_json::to_string(&call.response.messages).ok()
                 };
                 let finish_reasons: Option<String> = {
-                    let reasons: Vec<_> = call.response.messages.iter()
-                        .filter_map(|m| m.finish_reason.as_deref()).collect();
-                    if reasons.is_empty() { None } else { serde_json::to_string(&reasons).ok() }
+                    let reasons: Vec<_> = call
+                        .response
+                        .messages
+                        .iter()
+                        .filter_map(|m| m.finish_reason.as_deref())
+                        .collect();
+                    if reasons.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&reasons).ok()
+                    }
                 };
 
                 let tool_call_ids: Option<String> = {
-                    let ids: Vec<String> = call.response.messages.iter()
+                    let ids: Vec<String> = call
+                        .response
+                        .messages
+                        .iter()
                         .flat_map(|m| m.parts.iter())
                         .filter_map(|p| {
-                            if let crate::genai::semantic::MessagePart::ToolCall { id: Some(tc_id), .. } = p {
+                            if let crate::genai::semantic::MessagePart::ToolCall {
+                                id: Some(tc_id),
+                                ..
+                            } = p
+                            {
                                 Some(tc_id.clone())
                             } else {
                                 None
                             }
                         })
                         .collect();
-                    if ids.is_empty() { None } else { serde_json::to_string(&ids).ok() }
+                    if ids.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&ids).ok()
+                    }
                 };
 
                 let updated = conn.execute(
@@ -549,8 +604,12 @@ impl GenAISqliteStore {
                         system_instructions,
                         input_messages,
                         output_messages,
-                        call.metadata.get("status_code").and_then(|s| s.parse::<i64>().ok()),
-                        call.metadata.get("sse_event_count").and_then(|s| s.parse::<i64>().ok()),
+                        call.metadata
+                            .get("status_code")
+                            .and_then(|s| s.parse::<i64>().ok()),
+                        call.metadata
+                            .get("sse_event_count")
+                            .and_then(|s| s.parse::<i64>().ok()),
                         event_json,
                         tool_call_ids,
                         call.call_id,
@@ -558,11 +617,17 @@ impl GenAISqliteStore {
                 )?;
 
                 if updated > 0 {
-                    log::debug!("[GenAI] Promoted pending→complete for call_id={}", call.call_id);
+                    log::debug!(
+                        "[GenAI] Promoted pending→complete for call_id={}",
+                        call.call_id
+                    );
                     return Ok(());
                 }
                 // No pending row found — fall through to plain insert below
-                log::debug!("[GenAI] No pending row for call_id={}, inserting directly", call.call_id);
+                log::debug!(
+                    "[GenAI] No pending row for call_id={}, inserting directly",
+                    call.call_id
+                );
             }
             // Fallback: store_event handles the full INSERT path
             self.store_event(event)
@@ -600,7 +665,10 @@ impl GenAISqliteStore {
             params![cutoff_ns],
         )?;
         if updated > 0 {
-            log::info!("[GenAI] Marked {} stale pending call(s) as interrupted", updated);
+            log::info!(
+                "[GenAI] Marked {} stale pending call(s) as interrupted",
+                updated
+            );
         }
         Ok(updated)
     }
@@ -629,7 +697,10 @@ impl GenAISqliteStore {
     pub fn list_pending_for_pid(
         &self,
         pid: i32,
-    ) -> Result<Vec<(String, Option<String>, Option<String>, Option<String>)>, Box<dyn std::error::Error>> {
+    ) -> Result<
+        Vec<(String, Option<String>, Option<String>, Option<String>)>,
+        Box<dyn std::error::Error>,
+    > {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT call_id, session_id, trace_id, conversation_id
@@ -638,14 +709,17 @@ impl GenAISqliteStore {
                AND status = 'pending'
                AND pid = ?1",
         )?;
-        let rows = stmt.query_map(params![pid], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, Option<String>>(1)?,
-                row.get::<_, Option<String>>(2)?,
-                row.get::<_, Option<String>>(3)?,
-            ))
-        })?.filter_map(|r| r.ok()).collect();
+        let rows = stmt
+            .query_map(params![pid], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
         Ok(rows)
     }
 
@@ -668,54 +742,59 @@ impl GenAISqliteStore {
             params![itype, pid],
         )?;
         if updated > 0 {
-            log::info!("Marked {} pending call(s) as interrupted for pid={}", updated, pid);
+            log::info!(
+                "Marked {} pending call(s) as interrupted for pid={}",
+                updated,
+                pid
+            );
         }
         Ok(updated)
     }
 
-    /// Find sessions whose agentic loop was cut short by a process crash.
-    ///
-    /// Looks for the most recent `complete` LLM call for each
-    /// (session, conversation) pair associated with the given PID where the
-    /// finish reason is `tool_calls` — meaning the model issued another tool
-    /// call and was still mid-loop when the process died.
-    ///
-    /// Returns `(call_id, session_id, trace_id, conversation_id)` tuples,
-    /// deduplicated by (session_id, conversation_id) so one interruption event
-    /// is emitted per conversation.
-    pub fn list_incomplete_agentic_sessions_for_pid(
+    /// Like `list_pending_for_pid` but accepts multiple PIDs at once.
+    pub fn list_pending_for_pids(
         &self,
-        pid: i32,
-        since_ns: i64,
-    ) -> Result<Vec<(String, Option<String>, Option<String>, Option<String>)>, Box<dyn std::error::Error>> {
+        pids: &[i32],
+    ) -> Result<
+        Vec<(String, Option<String>, Option<String>, Option<String>)>,
+        Box<dyn std::error::Error>,
+    > {
+        if pids.is_empty() {
+            return Ok(vec![]);
+        }
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let placeholders: String = pids
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
             "SELECT call_id, session_id, trace_id, conversation_id
-             FROM genai_events g1
-             WHERE g1.event_type = 'llm_call'
-               AND g1.status    = 'complete'
-               AND g1.pid       = ?1
-               AND g1.start_timestamp_ns >= ?2
-               AND g1.finish_reasons LIKE '%tool_calls%'
-               AND g1.start_timestamp_ns = (
-                   SELECT MAX(g2.start_timestamp_ns)
-                   FROM genai_events g2
-                   WHERE g2.event_type = 'llm_call'
-                     AND g2.status     = 'complete'
-                     AND g2.pid        = ?1
-                     AND g2.start_timestamp_ns >= ?2
-                     AND COALESCE(g2.session_id,      '') = COALESCE(g1.session_id,      '')
-                     AND COALESCE(g2.conversation_id,  '') = COALESCE(g1.conversation_id,  '')
-               )",
-        )?;
-        let rows = stmt.query_map(params![pid, since_ns], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, Option<String>>(1)?,
-                row.get::<_, Option<String>>(2)?,
-                row.get::<_, Option<String>>(3)?,
-            ))
-        })?.filter_map(|r| r.ok()).collect();
+             FROM genai_events
+             WHERE event_type = 'llm_call'
+               AND status = 'pending'
+               AND pid IN ({})",
+            placeholders
+        );
+        let params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = pids
+            .iter()
+            .map(|p| Box::new(*p) as Box<dyn rusqlite::types::ToSql>)
+            .collect();
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|b| b.as_ref()).collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_refs.as_slice(), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
         Ok(rows)
     }
 
@@ -1032,9 +1111,7 @@ impl GenAISqliteStore {
                AND start_timestamp_ns BETWEEN ?1 AND ?2
              ORDER BY agent_name ASC",
         )?;
-        let rows = stmt.query_map(params![start_ns, end_ns], |row| {
-            row.get::<_, String>(0)
-        })?;
+        let rows = stmt.query_map(params![start_ns, end_ns], |row| row.get::<_, String>(0))?;
         let mut result = Vec::new();
         for row in rows {
             result.push(row?);
@@ -1093,7 +1170,8 @@ impl GenAISqliteStore {
                     output_tokens: row.get(3)?,
                     total_tokens: row.get(4)?,
                 })
-            })?.collect::<Result<Vec<_>, _>>()?
+            })?
+            .collect::<Result<Vec<_>, _>>()?
         } else {
             let mut stmt = conn.prepare(sql)?;
             stmt.query_map(params![start_ns, end_ns, bucket_ns], |row| {
@@ -1103,7 +1181,8 @@ impl GenAISqliteStore {
                     output_tokens: row.get(3)?,
                     total_tokens: row.get(4)?,
                 })
-            })?.collect::<Result<Vec<_>, _>>()?
+            })?
+            .collect::<Result<Vec<_>, _>>()?
         };
 
         Ok(rows)
@@ -1156,7 +1235,8 @@ impl GenAISqliteStore {
                     model: row.get(2)?,
                     total_tokens: row.get(3)?,
                 })
-            })?.collect::<Result<Vec<_>, _>>()?
+            })?
+            .collect::<Result<Vec<_>, _>>()?
         } else {
             let mut stmt = conn.prepare(sql)?;
             stmt.query_map(params![start_ns, end_ns, bucket_ns], |row| {
@@ -1165,7 +1245,8 @@ impl GenAISqliteStore {
                     model: row.get(2)?,
                     total_tokens: row.get(3)?,
                 })
-            })?.collect::<Result<Vec<_>, _>>()?
+            })?
+            .collect::<Result<Vec<_>, _>>()?
         };
 
         Ok(rows)
@@ -1192,10 +1273,10 @@ impl GenAISqliteStore {
         )?;
         let rows = stmt.query_map([], |row| {
             Ok(AgentTokenSummary {
-                agent_name:    row.get(0)?,
-                input_tokens:  row.get(1)?,
+                agent_name: row.get(0)?,
+                input_tokens: row.get(1)?,
                 output_tokens: row.get(2)?,
-                total_tokens:  row.get(3)?,
+                total_tokens: row.get(3)?,
                 request_count: row.get(4)?,
             })
         })?;
@@ -1378,13 +1459,15 @@ impl GenAISqliteStore {
                 }
                 Err(e) => {
                     // Check if it's SQLITE_FULL (extended code 13)
-                    if let Some(rusqlite::Error::SqliteFailure(err, _)) = 
-                        e.downcast_ref::<rusqlite::Error>() {
+                    if let Some(rusqlite::Error::SqliteFailure(err, _)) =
+                        e.downcast_ref::<rusqlite::Error>()
+                    {
                         if err.extended_code == 13 && retries < MAX_PRUNE_RETRIES {
                             retries += 1;
                             log::warn!(
                                 "Database full (SQLITE_FULL), pruning old records (attempt {}/{})",
-                                retries, MAX_PRUNE_RETRIES
+                                retries,
+                                MAX_PRUNE_RETRIES
                             );
                             self.prune_old_records()?;
                             self.checkpoint()?;
@@ -1398,41 +1481,69 @@ impl GenAISqliteStore {
     }
 
     /// Try to insert an event without size check
-    fn try_insert_event(&self, event: &GenAISemanticEvent) -> Result<(), Box<dyn std::error::Error>> {
+    fn try_insert_event(
+        &self,
+        event: &GenAISemanticEvent,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();
         let event_json = serde_json::to_string(event)?;
 
         match event {
             GenAISemanticEvent::LLMCall(call) => {
-                let (input_tokens, output_tokens, total_tokens) = call.token_usage.as_ref()
-                    .map(|u| (u.input_tokens as i64, u.output_tokens as i64, u.total_tokens as i64))
+                let (input_tokens, output_tokens, total_tokens) = call
+                    .token_usage
+                    .as_ref()
+                    .map(|u| {
+                        (
+                            u.input_tokens as i64,
+                            u.output_tokens as i64,
+                            u.total_tokens as i64,
+                        )
+                    })
                     .unwrap_or((0, 0, 0));
-                let cache_creation = call.token_usage.as_ref()
+                let cache_creation = call
+                    .token_usage
+                    .as_ref()
                     .and_then(|u| u.cache_creation_input_tokens.map(|v| v as i64));
-                let cache_read = call.token_usage.as_ref()
+                let cache_read = call
+                    .token_usage
+                    .as_ref()
                     .and_then(|u| u.cache_read_input_tokens.map(|v| v as i64));
 
                 // Extract system instructions
                 let system_instructions: Option<String> = {
-                    let sys_msgs: Vec<_> = call.request.messages.iter()
+                    let sys_msgs: Vec<_> = call
+                        .request
+                        .messages
+                        .iter()
                         .filter(|m| m.role == "system")
                         .collect();
-                    if sys_msgs.is_empty() { None }
-                    else { serde_json::to_string(&sys_msgs).ok() }
+                    if sys_msgs.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&sys_msgs).ok()
+                    }
                 };
 
                 // Extract input messages (incremental: latest round only)
                 let input_messages: Option<String> = {
-                    let non_system: Vec<_> = call.request.messages.iter()
+                    let non_system: Vec<_> = call
+                        .request
+                        .messages
+                        .iter()
                         .filter(|m| m.role != "system")
                         .collect();
-                    let latest = if let Some(idx) = non_system.iter().rposition(|m| m.role == "user") {
-                        &non_system[idx..]
+                    let latest =
+                        if let Some(idx) = non_system.iter().rposition(|m| m.role == "user") {
+                            &non_system[idx..]
+                        } else {
+                            &non_system[..]
+                        };
+                    if latest.is_empty() {
+                        None
                     } else {
-                        &non_system[..]
-                    };
-                    if latest.is_empty() { None }
-                    else { serde_json::to_string(&latest).ok() }
+                        serde_json::to_string(&latest).ok()
+                    }
                 };
 
                 // Extract output messages
@@ -1446,26 +1557,43 @@ impl GenAISqliteStore {
                 let finish_reasons: Option<String> = if call.response.messages.is_empty() {
                     None
                 } else {
-                    let reasons: Vec<_> = call.response.messages.iter()
+                    let reasons: Vec<_> = call
+                        .response
+                        .messages
+                        .iter()
                         .filter_map(|m| m.finish_reason.as_deref())
                         .collect();
-                    if reasons.is_empty() { None }
-                    else { serde_json::to_string(&reasons).ok() }
+                    if reasons.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&reasons).ok()
+                    }
                 };
 
                 // Extract tool_call_ids from response messages (outgoing tool calls)
                 let tool_call_ids: Option<String> = {
-                    let ids: Vec<String> = call.response.messages.iter()
+                    let ids: Vec<String> = call
+                        .response
+                        .messages
+                        .iter()
                         .flat_map(|m| m.parts.iter())
                         .filter_map(|p| {
-                            if let crate::genai::semantic::MessagePart::ToolCall { id: Some(tc_id), .. } = p {
+                            if let crate::genai::semantic::MessagePart::ToolCall {
+                                id: Some(tc_id),
+                                ..
+                            } = p
+                            {
                                 Some(tc_id.clone())
                             } else {
                                 None
                             }
                         })
                         .collect();
-                    if ids.is_empty() { None } else { serde_json::to_string(&ids).ok() }
+                    if ids.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&ids).ok()
+                    }
                 };
 
                 // Get instance ID (same logic as SLS uploader)
@@ -1586,44 +1714,44 @@ impl GenAISqliteStore {
     /// Get total database size (main db + wal + shm)
     fn get_total_db_size(&self) -> u64 {
         let mut total = 0u64;
-        
+
         // Main database file
         if let Ok(meta) = std::fs::metadata(&self.db_path) {
             total += meta.len();
         }
-        
+
         // WAL file
         let wal_path = format!("{}-wal", self.db_path.display());
         if let Ok(meta) = std::fs::metadata(&wal_path) {
             total += meta.len();
         }
-        
+
         // SHM file
         let shm_path = format!("{}-shm", self.db_path.display());
         if let Ok(meta) = std::fs::metadata(&shm_path) {
             total += meta.len();
         }
-        
+
         total
     }
 
     /// Check database size and prune if approaching limit
-    /// 
+    ///
     /// Keeps pruning until size drops below threshold to avoid repeated triggers.
     fn check_and_prune_if_needed(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut current_size = self.get_total_db_size();
         let threshold = get_prune_threshold();
-        
+
         if current_size < threshold {
             return Ok(());
         }
-        
+
         log::info!(
             "Database size {}MB exceeding threshold {}MB, pruning old records",
             current_size / 1024 / 1024,
             threshold / 1024 / 1024
         );
-        
+
         // Keep pruning until below threshold (max 5 iterations to prevent infinite loop)
         let mut iterations = 0;
         while current_size >= threshold && iterations < 5 {
@@ -1631,7 +1759,7 @@ impl GenAISqliteStore {
             self.prune_old_records()?;
             self.checkpoint()?;
             current_size = self.get_total_db_size();
-            
+
             if current_size >= threshold {
                 log::info!(
                     "Database still {}MB (threshold {}MB), continue pruning (iteration {})",
@@ -1641,72 +1769,71 @@ impl GenAISqliteStore {
                 );
             }
         }
-        
+
         log::info!(
             "Pruning complete, database size now {}MB",
             current_size / 1024 / 1024
         );
-        
+
         Ok(())
     }
 
     /// Prune old records to free up space
-    /// 
+    ///
     /// Deletes a percentage of oldest records based on id.
     fn prune_old_records(&self) -> Result<(), Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();
-        
+
         // Get total count
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM genai_events",
-            [],
-            |row| row.get(0)
-        )?;
-        
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM genai_events", [], |row| row.get(0))?;
+
         if count == 0 {
             return Ok(());
         }
-        
+
         // Calculate how many to delete (5% of total)
         let delete_count = ((count as f64) * PRUNE_PERCENT).max(1.0) as i64;
-        
+
         log::info!(
             "Pruning {} of {} records ({:.1}%)",
-            delete_count, count, PRUNE_PERCENT * 100.0
+            delete_count,
+            count,
+            PRUNE_PERCENT * 100.0
         );
-        
+
         // Delete oldest records by id
         let deleted = conn.execute(
             "DELETE FROM genai_events WHERE id IN (
                 SELECT id FROM genai_events ORDER BY id ASC LIMIT ?1
             )",
-            params![delete_count]
+            params![delete_count],
         )?;
-        
+
         log::info!("Deleted {} records", deleted);
-        
+
         Ok(())
     }
 
     /// Execute WAL checkpoint and VACUUM to reclaim disk space
-    /// 
+    ///
     /// 1. VACUUM: rebuild database to compact data
     /// 2. Checkpoint: flush and truncate WAL file
-    /// 
+    ///
     /// Note: VACUUM in WAL mode creates a new db file, so we need to
     /// re-enable WAL and checkpoint after VACUUM.
     fn checkpoint(&self) -> Result<(), Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();
-        
+
         // VACUUM rebuilds the database (works better before checkpoint in WAL mode)
         conn.execute_batch("VACUUM;")?;
-        
+
         // Re-enable WAL mode (VACUUM may reset it)
         conn.execute_batch("PRAGMA journal_mode=WAL;")?;
-        
+
         // Checkpoint with TRUNCATE to shrink WAL file
         conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
-        
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

Fix two bugs in the `agent_crash` interruption detection logic in AgentSight:

1. **Multi-process deduplication for Cosh**: Cosh spawns two Node.js processes per session (parent + worker). Killing one process caused two separate `agent_crash` events to be emitted for the same conversation. Fix by grouping all pids sharing the same `agent_name` and querying them together in a single DB pass.

2. **Historical record re-association (Branch B removal)**: The `agentic_loop_incomplete` detection branch queried `complete + tool_calls` genai records as a crash signal. These records were never marked as consumed, so they could be re-associated with new crashes 30+ minutes later. Fix by removing Branch B entirely — only `status=pending` (in-flight) LLM calls are a reliable crash signal.

**Changes:**
- `health/checker.rs`: group pids by `agent_name`, query all pids together via `get_pending_calls_for_pids`, dedup key upgraded to `(agent_name, session_id, conversation_id)`; remove Branch B (65 lines)
- `storage/sqlite/genai.rs`: add `list_pending_for_pids` (multi-pid query); remove `list_incomplete_agentic_sessions_for_pid/pids` and `mark_incomplete_interrupted_for_call_ids` (~178 lines)
- `interruption/oom_recovery.rs`: switch to `list_pending_for_pid` (previously called deleted method)
- `dashboard/src/pages/ConversationList.tsx`: fix colSpan (→ 10) and add session pagination (10 per page)

## Related Issue

closes #389

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo fmt --check` passes
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Manually verified:
- Killing a Cosh process now produces exactly 1 `agent_crash` event per conversation (previously 2)
- No stale `complete+tool_calls` records are re-associated with new crashes
- OpenClaw (single-pid, multi-session) still produces one crash event per active session

## Additional Notes

The deduplication key `(agent_name, session_id, conversation_id)` ensures that concurrent OpenClaw sessions each get their own crash event while Cosh's multi-process setup produces only one.
