### PR TITLE
fix(cosh): pass tool_use_id in PostToolUse hook event

### DIFF
--- a/src/copilot-shell/hooks/docs/reference.md
+++ b/src/copilot-shell/hooks/docs/reference.md
@@ -76,6 +76,7 @@ Fires after a tool executes. Used for result auditing, context injection, or
 hiding sensitive output from the agent.
 
 - **Input Fields**:
+  - `tool_use_id`: (`string`) Optional unique identifier for the tool use.
   - `tool_name`: (`string`)
   - `tool_input`: (`object`) The original arguments.
   - `tool_response`: (`object`) The result.

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -1461,6 +1461,9 @@ export class CoreToolScheduler {
                           ? toolResult.returnDisplay
                           : undefined,
                     },
+                    undefined,
+                    undefined,
+                    callId,
                   );
 
                   if (postToolOutput) {

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
@@ -155,6 +155,7 @@ export class HookEventHandler {
     toolResponse: Record<string, unknown>,
     mcpContext?: McpToolContext,
     originalRequestName?: string,
+    toolUseId?: string,
   ): Promise<AggregatedHookResult> {
     debugLogger.info(
       `[Hook Debug] hookEventHandler.firePostToolUseEvent: tool=${toolName}`,
@@ -168,6 +169,7 @@ export class HookEventHandler {
       ...(originalRequestName && {
         original_request_name: originalRequestName,
       }),
+      ...(toolUseId && { tool_use_id: toolUseId }),
     };
 
     const context: HookEventContext = { toolName };

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -173,6 +173,7 @@ export class HookSystem {
     toolResponse: Record<string, unknown>,
     mcpContext?: McpToolContext,
     originalRequestName?: string,
+    toolUseId?: string,
   ): Promise<PostToolUseHookOutput | undefined> {
     debugLogger.info(
       `[Hook Debug] hookSystem.firePostToolUseEvent: entering facade, tool=${toolName}`,
@@ -183,6 +184,7 @@ export class HookSystem {
       toolResponse,
       mcpContext,
       originalRequestName,
+      toolUseId,
     );
     const output = result.finalOutput
       ? (createHookOutput(

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -432,6 +432,7 @@ export interface PreToolUseOutput extends HookOutput {
  * PostToolUse hook input
  */
 export interface PostToolUseInput extends HookInput {
+  tool_use_id?: string; // Unique identifier for the tool use
   tool_name: string;
   tool_input: Record<string, unknown>;
   tool_response: Record<string, unknown>;


### PR DESCRIPTION
## Description

`PostToolUseInput` was missing the `tool_use_id` field that is already
present in `PostToolUseFailureInput`. This caused hook scripts receiving
`PostToolUse` events to be unable to correlate the event back to a
specific tool call. The fix threads `callId` (already available in
`coreToolScheduler`) through the hook system and exposes it as
`tool_use_id` in the hook input payload.

## Related Issue

closes #413

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my
      feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Manual verification: confirm `tool_use_id` appears in the hook input
JSON when a `PostToolUse` hook is triggered.
Unit tests for the hook event handler pipeline can be run via:
  cd src/copilot-shell && npm test

## Additional Notes

`tool_use_id` is marked optional (`?`) to maintain backward
compatibility with any existing hook scripts that do not read the field.