### PR TITLE
fix(tokenless): auto-record stats with real tool_use_id from hook payload

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -419,8 +419,8 @@ fn record_compression_stats(
     let pid = std::process::id();
     let agent = agent_id
         .as_deref()
-        .map(|a| format!("{}({})", a, pid))
-        .unwrap_or_else(|| format!("cli({})", pid));
+        .map(|a| a.to_string())
+        .unwrap_or_else(|| "cli".to_string());
     let mut record = StatsRecord::new(
         op,
         agent,
@@ -437,6 +437,7 @@ fn record_compression_stats(
     if let Some(tuid) = tool_use_id {
         record = record.with_tool_use_id(tuid);
     }
+    record = record.with_source_pid(pid as i64);
 
     // Record silently — stats failures must not break compression
     if let Ok(recorder) = open_recorder() {

--- a/src/tokenless/docs/tokenless-user-manual-en.md
+++ b/src/tokenless/docs/tokenless-user-manual-en.md
@@ -248,7 +248,7 @@ sudo rpm -ivh tokenless-0.1.0-3.alnx4.x86_64.rpm
 After RPM installation, the following configurations are performed automatically:
 
 1. **Binaries**: Installed to `/usr/bin/tokenless` and `/usr/bin/rtk`
-2. **Hook Scripts**: Installed to `/usr/share/tokenless/hooks/copilot-shell/`
+2. **Hook Scripts**: Installed to `/usr/share/tokenless/adapters/cosh/`
 3. **OpenClaw Plugin**: Auto-detected and configured (if OpenClaw is installed)
 4. **Copilot Shell**: Auto-detected and configured (if Copilot Shell is installed)
 
@@ -261,7 +261,7 @@ which tokenless
 tokenless --version
 
 # Check hook scripts (RPM installation path)
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 
 # Check OpenClaw plugin configuration
 cat ~/.openclaw/openclaw.json | jq '.plugins.allow'
@@ -292,6 +292,12 @@ make setup
 
 # Uninstall cleanup
 ./scripts/install.sh --uninstall
+
+# Manual OpenClaw plugin setup only
+./scripts/install.sh --openclaw
+
+# Manual copilot-shell hooks setup only
+./scripts/install.sh --cosh
 ```
 
 ### 4.4 Method 4: Step-by-Step Installation
@@ -339,9 +345,9 @@ cp -r openclaw/ /usr/share/tokenless/openclaw/
 make copilot-shell-install
 
 # Manual installation
-mkdir -p /usr/share/tokenless/hooks/copilot-shell
-cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/hooks/copilot-shell/
-chmod +x /usr/share/tokenless/hooks/copilot-shell/tokenless-*.sh
+mkdir -p /usr/share/tokenless/adapters/cosh
+cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/adapters/cosh/
+chmod +x /usr/share/tokenless/adapters/cosh/tokenless-*.sh
 ```
 
 ---
@@ -415,8 +421,12 @@ After RPM installation, the installation script automatically detects and config
 If reconfiguration is needed after RPM installation, run:
 
 ```bash
-# Use system path configuration
+# Full auto-detection and configuration
 /usr/share/tokenless/scripts/install.sh --install
+
+# Or configure individual platforms only
+/usr/share/tokenless/scripts/install.sh --cosh      # copilot-shell hooks only
+/usr/share/tokenless/scripts/install.sh --openclaw  # OpenClaw plugin only
 ```
 
 #### 5.2.3 Verify Auto-Configuration
@@ -431,7 +441,7 @@ cat ~/.copilot-shell/settings.json | jq '.hooks | keys'
 # Should contain PreToolUse, PostToolUse, BeforeModel
 
 # Check hook scripts
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 ```
 
 ### 5.3 Copilot Shell Configuration
@@ -442,8 +452,8 @@ Hook script locations depend on the installation method:
 
 | Installation Method | Hook Script Location |
 |---------------------|---------------------|
-| RPM Installation | `/usr/share/tokenless/hooks/copilot-shell/` |
-| Source Installation | `/usr/share/tokenless/hooks/copilot-shell/` |
+| RPM Installation | `/usr/share/tokenless/adapters/cosh/` |
+| Source Installation | `/usr/share/tokenless/adapters/cosh/` |
 
 | Script | Function | Hook Event |
 |--------|----------|------------|
@@ -465,7 +475,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -477,7 +487,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -489,7 +499,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -510,7 +520,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -522,7 +532,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -534,7 +544,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -707,7 +717,7 @@ echo '{"tool_name":"Shell","tool_response":"{\"stdout\":\"lots of verbose output
 echo '{"llm_request":{"tools":[{"name":"test","description":"A test tool","parameters":{}}]}}' | bash hooks/copilot-shell/tokenless-compress-schema.sh
 
 # Test installed hook (RPM installation)
-echo '{"tool_input":{"command":"cargo test"}}' | bash /usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh
+echo '{"tool_input":{"command":"cargo test"}}' | bash /usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh
 ```
 
 ### 6.2 CLI Testing
@@ -747,10 +757,10 @@ tokenless --version
 rtk --version
 
 # Check hook scripts (RPM installation)
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 
 # Check hook scripts (Source installation)
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 ```
 
 ---

--- a/src/tokenless/docs/tokenless-user-manual-zh.md
+++ b/src/tokenless/docs/tokenless-user-manual-zh.md
@@ -248,7 +248,7 @@ sudo rpm -ivh tokenless-0.1.0-3.alnx4.x86_64.rpm
 RPM 包安装后会自动执行以下配置：
 
 1. **二进制文件**：安装到 `/usr/bin/tokenless` 和 `/usr/bin/rtk`
-2. **Hook 脚本**：安装到 `/usr/share/tokenless/hooks/copilot-shell/`
+2. **Hook 脚本**：安装到 `/usr/share/tokenless/adapters/cosh/`
 3. **OpenClaw 插件**：自动检测并配置（如果已安装 OpenClaw）
 4. **Copilot Shell**：自动检测并配置（如果已安装 Copilot Shell）
 
@@ -261,7 +261,7 @@ which tokenless
 tokenless --version
 
 # 检查 Hook 脚本（RPM 安装位置）
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 
 # 检查 OpenClaw 插件配置
 cat ~/.openclaw/openclaw.json | jq '.plugins.allow'
@@ -292,6 +292,12 @@ make setup
 
 # 卸载清理
 ./scripts/install.sh --uninstall
+
+# 仅手动配置 OpenClaw 插件
+./scripts/install.sh --openclaw
+
+# 仅手动配置 copilot-shell hooks
+./scripts/install.sh --cosh
 ```
 
 ### 4.4 方法四：分步安装
@@ -339,9 +345,9 @@ cp -r openclaw/ /usr/share/tokenless/openclaw/
 make copilot-shell-install
 
 # 手动安装
-mkdir -p /usr/share/tokenless/hooks/copilot-shell
-cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/hooks/copilot-shell/
-chmod +x /usr/share/tokenless/hooks/copilot-shell/tokenless-*.sh
+mkdir -p /usr/share/tokenless/adapters/cosh
+cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/adapters/cosh/
+chmod +x /usr/share/tokenless/adapters/cosh/tokenless-*.sh
 ```
 
 ---
@@ -415,8 +421,12 @@ RPM 包安装后，安装脚本会自动检测并配置已安装的平台。
 如果 RPM 安装后需要重新配置，运行：
 
 ```bash
-# 使用系统路径的配置
+# 完整自动检测和配置
 /usr/share/tokenless/scripts/install.sh --install
+
+# 或仅配置单个平台
+/usr/share/tokenless/scripts/install.sh --cosh      # 仅 copilot-shell hooks
+/usr/share/tokenless/scripts/install.sh --openclaw  # 仅 OpenClaw 插件
 ```
 
 #### 5.2.3 验证自动配置
@@ -431,7 +441,7 @@ cat ~/.copilot-shell/settings.json | jq '.hooks | keys'
 # 应包含 PreToolUse, PostToolUse, BeforeModel
 
 # 检查 Hook 脚本
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 ```
 
 ### 5.3 Copilot Shell 配置
@@ -442,8 +452,8 @@ ls -la /usr/share/tokenless/hooks/copilot-shell/
 
 | 安装方式 | Hook 脚本位置 |
 |---------|--------------|
-| RPM 安装 | `/usr/share/tokenless/hooks/copilot-shell/` |
-| 源码安装 | `/usr/share/tokenless/hooks/copilot-shell/` |
+| RPM 安装 | `/usr/share/tokenless/adapters/cosh/` |
+| 源码安装 | `/usr/share/tokenless/adapters/cosh/` |
 
 | 脚本 | 功能 | Hook 事件 |
 |------|------|----------|
@@ -465,7 +475,7 @@ ls -la /usr/share/tokenless/hooks/copilot-shell/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -477,7 +487,7 @@ ls -la /usr/share/tokenless/hooks/copilot-shell/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -489,7 +499,7 @@ ls -la /usr/share/tokenless/hooks/copilot-shell/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -510,7 +520,7 @@ ls -la /usr/share/tokenless/hooks/copilot-shell/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -522,7 +532,7 @@ ls -la /usr/share/tokenless/hooks/copilot-shell/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -534,7 +544,7 @@ ls -la /usr/share/tokenless/hooks/copilot-shell/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -707,7 +717,7 @@ echo '{"tool_name":"Shell","tool_response":"{\"stdout\":\"lots of verbose output
 echo '{"llm_request":{"tools":[{"name":"test","description":"A test tool","parameters":{}}]}}' | bash hooks/copilot-shell/tokenless-compress-schema.sh
 
 # 测试已安装的 Hook（RPM 安装）
-echo '{"tool_input":{"command":"cargo test"}}' | bash /usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh
+echo '{"tool_input":{"command":"cargo test"}}' | bash /usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh
 ```
 
 ### 6.2 测试 CLI
@@ -747,10 +757,10 @@ tokenless --version
 rtk --version
 
 # 检查 Hook 脚本（RPM 安装）
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 
 # 检查 Hook 脚本（源码安装）
-ls -la /usr/share/tokenless/hooks/copilot-shell/
+ls -la /usr/share/tokenless/adapters/cosh/
 ```
 
 ---

--- a/src/tokenless/hooks/copilot-shell/README.md
+++ b/src/tokenless/hooks/copilot-shell/README.md
@@ -63,7 +63,14 @@ All hooks are **fail-open**: if dependencies are missing or processing fails, th
 
 ## Installation
 
-### Automatic
+### Automatic (via install script)
+
+```bash
+# RPM post-install or manual configuration
+bash /usr/share/tokenless/scripts/install.sh --cosh
+```
+
+### Via Makefile
 
 ```bash
 make copilot-shell-install
@@ -73,9 +80,9 @@ make copilot-shell-install
 
 1. Copy the hook scripts:
 ```bash
-mkdir -p /usr/share/tokenless/hooks/copilot-shell
-cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/hooks/copilot-shell/
-chmod +x /usr/share/tokenless/hooks/copilot-shell/tokenless-*.sh
+mkdir -p /usr/share/tokenless/adapters/cosh
+cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/adapters/cosh/
+chmod +x /usr/share/tokenless/adapters/cosh/tokenless-*.sh
 ```
 
 2. Add the following to your settings file (`~/.copilot-shell/settings.json` or `~/.qwen-code/settings.json`):
@@ -88,7 +95,7 @@ chmod +x /usr/share/tokenless/hooks/copilot-shell/tokenless-*.sh
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -100,7 +107,7 @@ chmod +x /usr/share/tokenless/hooks/copilot-shell/tokenless-*.sh
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -112,7 +119,7 @@ chmod +x /usr/share/tokenless/hooks/copilot-shell/tokenless-*.sh
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
+            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -131,13 +138,13 @@ Test each hook manually:
 
 ```bash
 # Command rewriting
-echo '{"tool_input":{"command":"cargo test"}}' | bash hooks/copilot-shell/tokenless-rewrite.sh
+echo '{"tool_input":{"command":"cargo test"}}' | bash /usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh
 
 # Response compression → TOON pipeline
-echo '{"tool_name":"Shell","tool_response":"{\"users\":[{\"id\":1,\"name\":\"Alice\"},{\"id\":2,\"name\":\"Bob\"}],\"debug\":\"info\"}"}' | bash hooks/copilot-shell/tokenless-compress-response.sh
+echo '{"tool_name":"Shell","tool_response":"{\"users\":[{\"id\":1,\"name\":\"Alice\"},{\"id\":2,\"name\":\"Bob\"}],\"debug\":\"info\"}"}' | bash /usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh
 
 # Schema compression (currently no-op until protocol adds tools support)
-echo '{"llm_request":{"tools":[{"name":"test","description":"A test tool","parameters":{}}]}}' | bash hooks/copilot-shell/tokenless-compress-schema.sh
+echo '{"llm_request":{"tools":[{"name":"test","description":"A test tool","parameters":{}}]}}' | bash /usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh
 ```
 
 ## Token Savings Examples

--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tokenless-hook-version: 7
+# tokenless-hook-version: 11
 # Token-Less copilot-shell hook — compresses tool call responses,
 # then optionally re-encodes to TOON format for additional token savings.
 #
@@ -106,6 +106,11 @@ if [ "$RESPONSE_LEN" -lt 200 ]; then
   exit 0
 fi
 
+# --- Extract caller context for auto-stats ---
+
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
+TOOL_USE_ID=$(echo "$INPUT" | jq -r '.tool_use_id // .toolCallId // empty' 2>/dev/null || echo '')
+
 # --- Step 1: Response Compression ---
 # tokenless compress-response expects a JSON object/array. If TOOL_RESPONSE
 # is a JSON string (plain text), compression will fail — we skip to TOON.
@@ -113,7 +118,11 @@ fi
 COMPRESSED=""
 USED_RESP_COMPRESSION=false
 if echo "$TOOL_RESPONSE" | jq -e 'type == "object" or type == "array"' &>/dev/null 2>&1; then
-  COMPRESSED=$(echo "$TOOL_RESPONSE" | tokenless compress-response 2>/dev/null) || true
+  COMPRESSED=$(echo "$TOOL_RESPONSE" | tokenless compress-response \
+    --agent-id copilot-shell \
+    ${SESSION_ID:+--session-id "$SESSION_ID"} \
+    ${TOOL_USE_ID:+--tool-use-id "$TOOL_USE_ID"} \
+    2>/dev/null) || true
   if [ -n "$COMPRESSED" ]; then
     USED_RESP_COMPRESSION=true
   fi
@@ -168,34 +177,6 @@ fi
 BEFORE_CHARS=$RESPONSE_LEN
 BEFORE_TOKENS=$(( (BEFORE_CHARS + 3) / 4 ))
 AFTER_TOKENS=$(( (AFTER_CHARS + 3) / 4 ))
-
-# --- Record statistics ---
-
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo 'unknown')
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
-TOOL_USE_ID=$(echo "$INPUT" | jq -r '.tool_use_id // empty' 2>/dev/null || echo '')
-AGENT_ID="copilot-shell"
-AGENT_PID=$$
-
-if command -v tokenless &>/dev/null; then
-  RECORD_CMD=(
-    tokenless stats record
-    --operation compress-response
-    --agent-id "$AGENT_ID"
-    --before-chars "$BEFORE_CHARS"
-    --before-tokens "$BEFORE_TOKENS"
-    --after-chars "$AFTER_CHARS"
-    --after-tokens "$AFTER_TOKENS"
-    --pid "$AGENT_PID"
-    --before-text "$TOOL_RESPONSE"
-    --after-text "$FINAL_OUTPUT"
-  )
-
-  [ -n "$SESSION_ID" ] && RECORD_CMD+=(--session-id "$SESSION_ID")
-  [ -n "$TOOL_USE_ID" ] && RECORD_CMD+=(--tool-use-id "$TOOL_USE_ID")
-
-  "${RECORD_CMD[@]}" 2>/dev/null || true
-fi
 
 # --- Build copilot-shell response ---
 

--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tokenless-hook-version: 6
+# tokenless-hook-version: 10
 # Token-Less copilot-shell hook — compresses tool schema definitions.
 # Stats are recorded automatically by tokenless compress-schema.
 # Requires: jq
@@ -41,12 +41,14 @@ fi
 # --- Extract caller context from raw payload ---
 
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
+TOOL_USE_ID=$(echo "$INPUT" | jq -r '.tool_use_id // .toolCallId // empty' 2>/dev/null || echo '')
 
 # --- Compress schemas ---
 
 COMPRESSED=$(echo "$TOOLS" | tokenless compress-schema --batch \
   --agent-id copilot-shell \
   ${SESSION_ID:+--session-id "$SESSION_ID"} \
+  ${TOOL_USE_ID:+--tool-use-id "$TOOL_USE_ID"} \
   2>/dev/null) || {
   echo "[tokenless] WARNING: Schema compression failed. Passing through unchanged." >&2
   exit 0

--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-toon.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-toon.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# tokenless-hook-version: 3
+# tokenless-hook-version: 7
 # Token-Less copilot-shell hook — compresses JSON tool responses to TOON format.
-# Requires: toon, jq
+# Stats are recorded automatically by tokenless compress-toon.
+# Requires: tokenless, toon, jq
 #
 # Hook event: PostToolUse
-# Records: timestamp, Agent(pid), sessionID, toolCallID, before/after chars & tokens, before/after text
 
 set -euo pipefail
 
@@ -15,16 +15,14 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
-if ! command -v toon &>/dev/null; then
-  echo "[tokenless] WARNING: toon is not installed or not in PATH. TOON compression hook disabled." >&2
+if ! command -v tokenless &>/dev/null; then
+  echo "[tokenless] WARNING: tokenless is not installed. TOON compression hook disabled." >&2
   exit 0
 fi
 
-if ! command -v tokenless &>/dev/null; then
-  echo "[tokenless] WARNING: tokenless is not installed. Stats recording disabled." >&2
-  TOKENLESS_AVAILABLE=false
-else
-  TOKENLESS_AVAILABLE=true
+if ! command -v toon &>/dev/null; then
+  echo "[tokenless] WARNING: toon is not installed or not in PATH. TOON compression hook disabled." >&2
+  exit 0
 fi
 
 # --- Read input (fail-open) ---
@@ -66,21 +64,21 @@ if ! echo "$TOOL_RESPONSE" | jq -e '.' &>/dev/null 2>&1; then
   exit 0
 fi
 
-# --- Calculate before metrics ---
+# --- Extract caller context for auto-stats ---
 
-BEFORE_CHARS=$RESPONSE_LEN
-BEFORE_TOKENS=$(( (BEFORE_CHARS + 3) / 4 ))
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
+TOOL_USE_ID=$(echo "$INPUT" | jq -r '.tool_use_id // .toolCallId // empty' 2>/dev/null || echo '')
 
 # --- Encode JSON to TOON ---
 
-START_TIME=$(date +%s%3N 2>/dev/null || echo "0")
-
-TOON_OUTPUT=$(echo "$TOOL_RESPONSE" | toon -e 2>/dev/null) || {
+TOON_OUTPUT=$(echo "$TOOL_RESPONSE" | tokenless compress-toon \
+  --agent-id copilot-shell \
+  ${SESSION_ID:+--session-id "$SESSION_ID"} \
+  ${TOOL_USE_ID:+--tool-use-id "$TOOL_USE_ID"} \
+  2>/dev/null) || {
   echo "[tokenless] WARNING: TOON encoding failed. Passing through unchanged." >&2
   exit 0
 }
-
-END_TIME=$(date +%s%3N 2>/dev/null || echo "0")
 
 # Validate non-empty output
 if [ -z "$TOON_OUTPUT" ]; then
@@ -93,33 +91,8 @@ fi
 AFTER_CHARS=${#TOON_OUTPUT}
 AFTER_TOKENS=$(( (AFTER_CHARS + 3) / 4 ))
 
-# --- Record statistics ---
-
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo 'unknown')
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo '')
-TOOL_USE_ID=$(echo "$INPUT" | jq -r '.tool_use_id // empty' 2>/dev/null || echo '')
-AGENT_ID="copilot-shell"
-AGENT_PID=$$
-
-if [ "$TOKENLESS_AVAILABLE" = true ]; then
-  RECORD_CMD=(
-    tokenless stats record
-    --operation compress-toon
-    --agent-id "$AGENT_ID"
-    --before-chars "$BEFORE_CHARS"
-    --before-tokens "$BEFORE_TOKENS"
-    --after-chars "$AFTER_CHARS"
-    --after-tokens "$AFTER_TOKENS"
-    --pid "$AGENT_PID"
-    --before-text "$TOOL_RESPONSE"
-    --after-text "$TOON_OUTPUT"
-  )
-
-  [ -n "$SESSION_ID" ] && RECORD_CMD+=(--session-id "$SESSION_ID")
-  [ -n "$TOOL_USE_ID" ] && RECORD_CMD+=(--tool-use-id "$TOOL_USE_ID")
-
-  "${RECORD_CMD[@]}" 2>/dev/null || true
-fi
+BEFORE_CHARS=$RESPONSE_LEN
 
 # --- Build copilot-shell response ---
 

--- a/src/tokenless/scripts/install.sh
+++ b/src/tokenless/scripts/install.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 #   ./install.sh --uninstall        # RPM pre-uninstall cleanup (full removal)
 #   ./install.sh --upgrade          # RPM pre-uninstall cleanup (upgrade — no-op)
 #   ./install.sh --openclaw         # Manually install OpenClaw plugin
-#   ./install.sh --hooks            # Manually install copilot-shell hooks
+#   ./install.sh --cosh              # Manually install copilot-shell hooks
 #   ./install.sh --help             # Show help
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -529,7 +529,7 @@ OPTIONS:
     --uninstall       RPM pre-uninstallation cleanup
     --upgrade         RPM pre-uninstallation cleanup (upgrade scenario)
     --openclaw        Manually setup OpenClaw plugin only
-    --hooks           Manually setup copilot-shell hooks only
+    --cosh             Manually setup copilot-shell hooks only
     --help, -h        Show this help message
 
 EXAMPLES:
@@ -578,7 +578,7 @@ main() {
         --openclaw)
             setup_openclaw "$(detect_installation_source)"
             ;;
-        --hooks)
+        --cosh)
             if [ -f "$HOME/.copilot-shell/settings.json" ] || [ -f "$HOME/.qwen-code/settings.json" ]; then
                 configure_cosh_hooks "$SYS_SHARE_DIR/adapters/cosh"
             else

--- a/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
+++ b/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
@@ -12,7 +12,7 @@ index 982c937..5eb93c1 100644
          if let Ok(tracker) = Tracker::new() {
              let _ = tracker.record(
                  original_cmd,
-@@ -1355,6 +1358,160 @@ pub fn args_display(args: &[OsString]) -> String {
+@@ -1355,6 +1358,157 @@ pub fn args_display(args: &[OsString]) -> String {
          .join(" ")
  }
  
@@ -25,16 +25,13 @@ index 982c937..5eb93c1 100644
 +/// Resolve caller context from environment variables (primary) or
 +/// .rewrite-context file (fallback for backwards compatibility).
 +fn resolve_tokenless_context() -> (String, Option<String>, Option<String>) {
-+    let pid = std::process::id();
-+
 +    // Primary: environment variables set by the hook
 +    let env_agent = std::env::var("TOKENLESS_AGENT_ID").ok();
 +    let env_session = std::env::var("TOKENLESS_SESSION_ID").ok();
 +    let env_toolcall = std::env::var("TOKENLESS_TOOL_USE_ID").ok();
 +
 +    if env_agent.is_some() || env_session.is_some() || env_toolcall.is_some() {
-+        let agent = env_agent.map(|a| format!("{}({})", a, pid))
-+            .unwrap_or_else(|| format!("cli({})", pid));
++        let agent = env_agent.unwrap_or_else(|| "cli".to_string());
 +        let sid = env_session.filter(|s| !s.is_empty());
 +        let tuid = env_toolcall.filter(|t| !t.is_empty());
 +        return (agent, sid, tuid);
@@ -55,17 +52,17 @@ index 982c937..5eb93c1 100644
 +            .map(|d| d.join(".tokenless/.rewrite-context"))
 +            .as_ref()
 +            .map(std::fs::remove_file);
-+        let agent_with_pid = if !agent.is_empty() {
-+            format!("{}({})", agent, pid)
++        let agent = if !agent.is_empty() {
++            agent
 +        } else {
-+            format!("cli({})", pid)
++            "cli".to_string()
 +        };
 +        let sid = if session.is_empty() { None } else { Some(session) };
 +        let tuid = if toolcall.is_empty() { None } else { Some(toolcall) };
-+        return (agent_with_pid, sid, tuid);
++        return (agent, sid, tuid);
 +    }
 +
-+    (format!("cli({})", pid), None::<String>, None::<String>)
++    ("cli".to_string(), None::<String>, None::<String>)
 +}
 +
 +/// Check if tokenless stats are enabled.
@@ -155,7 +152,7 @@ index 982c937..5eb93c1 100644
 +                chrono::Utc::now().to_rfc3339(),
 +                "rewrite-command",
 +                agent_id,
-+                None::<i64>,
++                Some(std::process::id() as i64),
 +                session_id,
 +                tool_use_id,
 +                before_chars as i64,

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 2
+%define anolis_release 3
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -127,6 +127,13 @@ if [ $1 -eq 0 ] && [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
 fi
 
 %changelog
+* Tue Apr 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-3
+- fix: remove duplicate PID from agent_id, use source_pid exclusively
+- fix: RTK patch now records source_pid (was NULL) and clean agent_id
+- fix: copilot-shell PostToolUse now passes tool_use_id to hook payload
+- fix: copilot-shell BeforeModel now passes tool_use_id to hook payload
+- refactor: rename install.sh --hooks to --cosh for clarity
+
 * Mon Apr 27 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-2
 - Restructure dirs: /usr/share/tokenless/{core,adapters/{openclaw,cosh}}
 


### PR DESCRIPTION
## Description

- Set source_pid in auto-recorded stats (was always NULL)
- Fix hook scripts to extract and pass real tool_use_id from copilot-shell payload (was synthesizing timestamps as fallback)
- Use .tool_use_id // .toolCallId fallback for backward compat with openclaw


<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes #407

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
# tokenless stats list
Showing 9 record(s):
================================================================================
[ID:9] 2026-04-29 12:04:19 | openclaw pid:1786181 | Session:e13ef799-5bb0-4891-bc93-8c748ff42947 | Tool:call_1ba03a6c01e94e5fae779a80 | Chars:3240→1342(-1898) | Tokens:810→336(-59%)
[ID:8] 2026-04-29 12:04:19 | openclaw pid:1786179 | Session:e13ef799-5bb0-4891-bc93-8c748ff42947 | Tool:call_1c09333692284094a19cf008 | Chars:1080→1080(-0) | Tokens:270→270(-0%)
[ID:5] 2026-04-29 12:03:22 | copilot-shell pid:1786079 | Session:4b90cd3f-4c84-4dd1-8f9e-f0327d462349 | Tool:call_589e6399050f4576b9c6817b | Chars:4605→1104(-3501) | Tokens:1152→276(-76%)
[ID:2] 2026-04-29 11:59:21 | copilot-shell pid:1785705 | Session:4b90cd3f-4c84-4dd1-8f9e-f0327d462349 | Tool:call_75d290d5f2174930986a4eca | Chars:7018→1104(-5914) | Tokens:1755→276(-84%)
[ID:7] 2026-04-29 12:04:19 | openclaw pid:1786149 | Session:e13ef799-5bb0-4891-bc93-8c748ff42947 | Tool:call_1ba03a6c01e94e5fae779a80 | Chars:1494→1369(-125) | Tokens:374→343(-8%)
[ID:6] 2026-04-29 12:04:19 | openclaw pid:1786147 | Session:e13ef799-5bb0-4891-bc93-8c748ff42947 | Tool:call_1ba03a6c01e94e5fae779a80 | Chars:1231→289(-942) | Tokens:308→73(-76%)
[ID:4] 2026-04-29 12:03:22 | cli pid:1786049 | Session:- | Tool:- | Chars:2285→2160(-125) | Tokens:572→540(-6%)
[ID:3] 2026-04-29 11:59:29 | cli pid:1785757 | Session:- | Tool:- | Chars:3670→3471(-199) | Tokens:918→868(-5%)
[ID:1] 2026-04-29 11:59:21 | cli pid:1785675 | Session:- | Tool:- | Chars:3562→3348(-214) | Tokens:891→837(-6%)
```

