### PR TITLE
fix(cosh): block initial chat on skill/subagent first-load discovery

### DIFF
--- a/src/copilot-shell/packages/core/src/config/config.ts
+++ b/src/copilot-shell/packages/core/src/config/config.ts
@@ -1833,6 +1833,26 @@ export class Config {
       registerCoreTool(LspTool, this);
     }
 
+    // Wait for SkillTool / TaskTool first-load to settle so that the
+    // initial chat request sees populated skill/subagent descriptions
+    // instead of the "Loading available skills..." placeholder.
+    const skillToolInstance = registry.getTool(SkillTool.Name);
+    if (skillToolInstance instanceof SkillTool) {
+      try {
+        await skillToolInstance.initPromise;
+      } catch (error) {
+        console.warn('[Config] SkillTool initial discovery failed:', error);
+      }
+    }
+    const taskToolInstance = registry.getTool(TaskTool.Name);
+    if (taskToolInstance instanceof TaskTool) {
+      try {
+        await taskToolInstance.initPromise;
+      } catch (error) {
+        console.warn('[Config] TaskTool initial discovery failed:', error);
+      }
+    }
+
     await registry.discoverAllTools();
     console.debug('ToolRegistry created', registry.getAllToolNames());
     return registry;

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -46,6 +46,7 @@ import {
 import { LoopDetectionService } from '../services/loopDetectionService.js';
 
 // Tools
+import { SkillTool } from '../tools/skill.js';
 import { TaskTool } from '../tools/task.js';
 
 // Telemetry
@@ -220,6 +221,28 @@ export class GeminiClient {
     this.hasFailedCompressionAttempt = false;
 
     const toolRegistry = this.config.getToolRegistry();
+
+    // Defensive: ensure SkillTool / TaskTool first-load completes before
+    // building the function declarations. createToolRegistry already awaits
+    // these, but startChat may also be reached through paths that bypass it
+    // (e.g. resetChat / tryCompressChat / session resume).
+    const skillToolInstance = toolRegistry.getTool(SkillTool.Name);
+    if (skillToolInstance instanceof SkillTool) {
+      try {
+        await skillToolInstance.initPromise;
+      } catch {
+        // Already logged inside SkillTool; continue with whatever is loaded.
+      }
+    }
+    const taskToolInstance = toolRegistry.getTool(TaskTool.Name);
+    if (taskToolInstance instanceof TaskTool) {
+      try {
+        await taskToolInstance.initPromise;
+      } catch {
+        // Already logged inside TaskTool; continue with whatever is loaded.
+      }
+    }
+
     const toolDeclarations = toolRegistry.getFunctionDeclarations();
     const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
 

--- a/src/copilot-shell/packages/core/src/skills/remote-skill-registry.ts
+++ b/src/copilot-shell/packages/core/src/skills/remote-skill-registry.ts
@@ -70,7 +70,8 @@ interface IndexCache {
 }
 
 const DEFAULT_CACHE_TTL = 3600000; // 1 hour
-const DEFAULT_TIMEOUT = 30000; // 30 seconds
+const DEFAULT_INDEX_TIMEOUT = 10000; // 10 seconds, used for fast metadata calls
+const DEFAULT_DOWNLOAD_TIMEOUT = 60000; // 60 seconds, used for skill package downloads
 const COPILOT_CONFIG_DIR = '.copilot-shell';
 const REMOTE_SKILLS_DIR = 'remote-skills';
 const INDEX_CACHE_FILE = 'index.json';
@@ -88,7 +89,8 @@ export class RemoteSkillRegistry {
   private readonly baseUrl: string;
   private readonly cacheDir: string;
   private readonly cacheTTL: number;
-  private readonly timeout: number;
+  private readonly indexTimeout: number;
+  private readonly downloadTimeout: number;
   private readonly authToken?: string;
 
   private indexCache: IndexCache | null = null;
@@ -99,7 +101,17 @@ export class RemoteSkillRegistry {
       config.cacheDir ??
       path.join(os.homedir(), COPILOT_CONFIG_DIR, REMOTE_SKILLS_DIR);
     this.cacheTTL = config.cacheTTL ?? DEFAULT_CACHE_TTL;
-    this.timeout = config.timeout ?? DEFAULT_TIMEOUT;
+    // When `timeout` is explicitly provided, honour it for both phases to
+    // preserve backward compatibility. Otherwise, use a short timeout for
+    // metadata calls (index/readme) and a longer one for downloads so that a
+    // slow Skill-OS server cannot block the cold-start path for 30s.
+    if (config.timeout !== undefined) {
+      this.indexTimeout = config.timeout;
+      this.downloadTimeout = config.timeout;
+    } else {
+      this.indexTimeout = DEFAULT_INDEX_TIMEOUT;
+      this.downloadTimeout = DEFAULT_DOWNLOAD_TIMEOUT;
+    }
     this.authToken = config.authToken;
   }
 
@@ -140,7 +152,7 @@ export class RemoteSkillRegistry {
     } catch (error) {
       const isAbort = error instanceof Error && error.name === 'AbortError';
       const message = isAbort
-        ? `Remote skill server timed out after ${this.timeout}ms. The server may be unreachable.`
+        ? `Remote skill server timed out after ${this.indexTimeout}ms. The server may be unreachable.`
         : `Failed to connect to remote skill server: ${error instanceof Error ? error.message : String(error)}`;
       throw new Error(message);
     }
@@ -224,7 +236,9 @@ export class RemoteSkillRegistry {
     const zipPath = path.join(skillDir, 'skill.zip');
     const downloadUrl = `${this.baseUrl}/skills/api/v1/skills/${skillPath}/download`;
 
-    const response = await this.fetchWithTimeout(downloadUrl);
+    const response = await this.fetchWithTimeout(downloadUrl, {
+      timeoutOverride: this.downloadTimeout,
+    });
     if (!response.ok) {
       throw new Error(`Failed to download skill: ${response.status}`);
     }
@@ -357,10 +371,14 @@ export class RemoteSkillRegistry {
     return path.join(this.cacheDir, skillPath);
   }
 
-  private async fetchWithTimeout(url: string): Promise<Response> {
+  private async fetchWithTimeout(
+    url: string,
+    options: { timeoutOverride?: number } = {},
+  ): Promise<Response> {
     console.debug(`[RemoteSkillRegistry] Fetching: ${url}`);
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    const timeoutMs = options.timeoutOverride ?? this.indexTimeout;
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
       const headers: Record<string, string> = {

--- a/src/copilot-shell/packages/core/src/skills/skill-manager.ts
+++ b/src/copilot-shell/packages/core/src/skills/skill-manager.ts
@@ -124,7 +124,11 @@ export class SkillManager {
 
     // Initialize cache if it doesn't exist or we're forcing a refresh
     if (!shouldUseCache) {
-      await this.refreshCache();
+      // Suppress notification when refresh is triggered from listSkills:
+      // the caller (typically SkillTool / TaskTool) is already in the middle
+      // of consuming the new state, so a re-entrant notify would just queue
+      // a redundant refreshSkills() round-trip.
+      await this.refreshCache(false);
     }
 
     // Pre-load disabled state once when excludeDisabled is requested
@@ -325,8 +329,13 @@ export class SkillManager {
 
   /**
    * Refreshes the skills cache by loading all skills from disk.
+   *
+   * @param notify - When true (default), invokes registered change listeners
+   *   after the cache is rebuilt. Pass `false` for internal call sites that
+   *   are themselves reacting to a listener invocation, to avoid re-entrant
+   *   refresh storms.
    */
-  async refreshCache(): Promise<void> {
+  async refreshCache(notify: boolean = true): Promise<void> {
     const skillsCache = new Map<SkillLevel, SkillConfig[]>();
     this.parseErrors.clear();
 
@@ -338,13 +347,18 @@ export class SkillManager {
       'system',
     ];
 
+    // Scan levels sequentially. They touch disjoint directories, but tests
+    // assert deterministic readdir ordering, and per-level latency is small
+    // enough that parallelism is not worth the contract change.
     for (const level of levels) {
       const levelSkills = await this.listSkillsAtLevel(level);
       skillsCache.set(level, levelSkills);
     }
 
     this.skillsCache = skillsCache;
-    this.notifyChangeListeners();
+    if (notify) {
+      this.notifyChangeListeners();
+    }
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/tools/skill.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/skill.test.ts
@@ -169,6 +169,53 @@ describe('SkillTool', () => {
     });
   });
 
+  describe('cold-start race conditions', () => {
+    it('should expose initPromise that resolves after first load completes', async () => {
+      vi.mocked(mockSkillManager.listSkills).mockResolvedValue(mockSkills);
+      const tool = new SkillTool(config);
+
+      expect(tool.initPromise).toBeInstanceOf(Promise);
+      await tool.initPromise;
+      await vi.runAllTimersAsync();
+
+      // After awaiting initPromise, the description must already contain
+      // real skill metadata, not the placeholder string.
+      expect(tool.description).not.toContain('Loading available skills');
+      expect(tool.description).toContain('code-review');
+    });
+
+    it('should call listSkills with includeRemote=false on cold start', async () => {
+      vi.mocked(mockSkillManager.listSkills).mockResolvedValue(mockSkills);
+      const tool = new SkillTool(config);
+      await tool.initPromise;
+
+      // The very first call must be local-only so a slow remote registry
+      // never blocks the cold-start path.
+      const firstCallArgs = vi.mocked(mockSkillManager.listSkills).mock
+        .calls[0]?.[0];
+      expect(firstCallArgs).toMatchObject({ includeRemote: false });
+    });
+
+    it('should preserve previously loaded skills when a refresh fails', async () => {
+      vi.mocked(mockSkillManager.listSkills).mockResolvedValue(mockSkills);
+      const tool = new SkillTool(config);
+      await tool.initPromise;
+      await vi.runAllTimersAsync();
+      expect(tool.description).toContain('code-review');
+
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(mockSkillManager.listSkills).mockRejectedValue(
+        new Error('transient failure'),
+      );
+      await tool.refreshSkills({ includeRemote: true });
+
+      // The transient failure must NOT wipe out the previously loaded
+      // skills, otherwise the next request would see an empty description.
+      expect(tool.description).toContain('code-review');
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe('schema generation', () => {
     it('should expose static schema without dynamic enums', () => {
       const schema = skillTool.schema;

--- a/src/copilot-shell/packages/core/src/tools/skill.ts
+++ b/src/copilot-shell/packages/core/src/tools/skill.ts
@@ -28,6 +28,31 @@ export class SkillTool extends BaseDeclarativeTool<SkillParams, ToolResult> {
   private skillManager: SkillManager;
   private availableSkills: SkillConfig[] = [];
 
+  /**
+   * Monotonic counter used to discard stale `refreshSkills` results when a
+   * newer refresh starts before an older one resolves (e.g. a watcher
+   * debounce burst on slow disks).
+   */
+  private refreshSeq = 0;
+
+  /**
+   * Tracks whether the initial discovery has produced a result at least
+   * once. Once `true`, transient failures will keep the last-known-good
+   * `availableSkills` instead of clobbering it with an empty list.
+   */
+  private hasLoadedOnce = false;
+
+  /**
+   * Resolves once the *local* skill discovery has completed. Remote skills
+   * are loaded in the background AFTER this resolves so the CLI cold start
+   * is never blocked by the remote registry's network round-trip.
+   *
+   * Callers that need an accurate tool description for the very first LLM
+   * request (e.g. `Config.createToolRegistry`, `GeminiClient.startChat`)
+   * MUST await this promise before reading `tool.schema`.
+   */
+  readonly initPromise: Promise<void>;
+
   constructor(private readonly config: Config) {
     // Initialize with a basic schema first
     const initialSchema = {
@@ -55,35 +80,76 @@ export class SkillTool extends BaseDeclarativeTool<SkillParams, ToolResult> {
 
     this.skillManager = config.getSkillManager()!;
     this.skillManager.addChangeListener(() => {
-      void this.refreshSkills();
+      // Watcher / state-toggle triggered: refresh both local + remote.
+      void this.refreshSkills({ includeRemote: true });
     });
 
-    // Initialize the tool asynchronously
-    this.refreshSkills();
+    // Cold start path:
+    //   1. First load LOCAL skills only (fast, never blocks on network).
+    //   2. After initPromise resolves, asynchronously enrich with REMOTE
+    //      skills so the LLM can see them on subsequent requests.
+    this.initPromise = this.refreshSkills({ includeRemote: false }).then(() => {
+      // Fire-and-forget remote enrichment; failures are swallowed inside.
+      void this.refreshSkills({ includeRemote: true });
+    });
   }
 
   /**
    * Asynchronously initializes the tool by loading available skills
    * and updating the description and schema.
+   *
+   * Race-safe: if invoked multiple times concurrently (e.g. by the change
+   * listener during a watcher burst), only the LATEST invocation is allowed
+   * to overwrite `availableSkills` / description.
    */
-  async refreshSkills(): Promise<void> {
+  async refreshSkills(
+    options: { includeRemote?: boolean } = { includeRemote: true },
+  ): Promise<void> {
+    const seq = ++this.refreshSeq;
     try {
-      // Include remote skills in the listing so agent knows about them
-      // Exclude disabled skills so they are hidden from the LLM
-      this.availableSkills = await this.skillManager.listSkills({
-        includeRemote: true,
+      // Exclude disabled skills so they are hidden from the LLM.
+      const skills = await this.skillManager.listSkills({
+        includeRemote: options.includeRemote ?? true,
         excludeDisabled: true,
       });
+
+      // Stale guard: a newer refresh has started; drop our result.
+      if (seq !== this.refreshSeq) {
+        return;
+      }
+
+      // Defensive: a misbehaving SkillManager (or a test mock that has
+      // been cleared by `vi.clearAllMocks`) may return undefined; never let
+      // that propagate into `availableSkills`, which every consumer expects
+      // to be an array.
+      this.availableSkills = skills ?? [];
+      this.hasLoadedOnce = true;
       this.updateDescriptionAndSchema();
     } catch (error) {
       console.warn('Failed to load skills for Skills tool:', error);
-      this.availableSkills = [];
-      this.updateDescriptionAndSchema();
+      if (seq !== this.refreshSeq) {
+        return;
+      }
+      // IMPORTANT: do NOT clobber a previously-good list with an empty one.
+      // Only on the very first load do we initialize to [] so the description
+      // gets a proper "No skills are currently configured" message.
+      if (!this.hasLoadedOnce) {
+        this.availableSkills = [];
+        this.hasLoadedOnce = true;
+        this.updateDescriptionAndSchema();
+      }
     } finally {
-      // Update the client with the new tools
+      // Update the client with the new tools. setTools() is cheap and safe
+      // to call as soon as a chat exists; if the chat isn't ready yet,
+      // startChat() will pick up the latest description by reading
+      // tool.schema directly.
       const geminiClient = this.config.getGeminiClient();
       if (geminiClient && geminiClient.isInitialized()) {
-        await geminiClient.setTools();
+        try {
+          await geminiClient.setTools();
+        } catch (error) {
+          console.warn('Failed to push refreshed tools to chat:', error);
+        }
       }
     }
   }

--- a/src/copilot-shell/packages/core/src/tools/task.ts
+++ b/src/copilot-shell/packages/core/src/tools/task.ts
@@ -52,6 +52,27 @@ export class TaskTool extends BaseDeclarativeTool<TaskParams, ToolResult> {
   private subagentManager: SubagentManager;
   private availableSubagents: SubagentConfig[] = [];
 
+  /**
+   * Monotonic counter to discard stale `refreshSubagents` results when a
+   * newer refresh starts before an older one resolves.
+   */
+  private refreshSeq = 0;
+
+  /**
+   * Tracks whether the initial discovery has produced a result at least
+   * once. Once `true`, transient failures will keep the last-known-good
+   * `availableSubagents` instead of clobbering it with an empty list.
+   */
+  private hasLoadedOnce = false;
+
+  /**
+   * Resolves once the initial subagent discovery has completed.
+   * Callers that need an accurate tool description for the very first LLM
+   * request (e.g. `Config.createToolRegistry`, `GeminiClient.startChat`)
+   * MUST await this promise before reading `tool.schema`.
+   */
+  readonly initPromise: Promise<void>;
+
   constructor(private readonly config: Config) {
     // Initialize with a basic schema first
     const initialSchema = {
@@ -90,27 +111,48 @@ export class TaskTool extends BaseDeclarativeTool<TaskParams, ToolResult> {
       void this.refreshSubagents();
     });
 
-    // Initialize the tool asynchronously
-    this.refreshSubagents();
+    // Initialize the tool asynchronously, exposed via initPromise so the
+    // tool registry creation can block on it (mirrors SkillTool).
+    this.initPromise = this.refreshSubagents();
   }
 
   /**
    * Asynchronously initializes the tool by loading available subagents
    * and updating the description and schema.
+   *
+   * Race-safe: if invoked multiple times concurrently (e.g. by the change
+   * listener), only the LATEST invocation overwrites `availableSubagents`.
    */
   async refreshSubagents(): Promise<void> {
+    const seq = ++this.refreshSeq;
     try {
-      this.availableSubagents = await this.subagentManager.listSubagents();
+      const subagents = await this.subagentManager.listSubagents();
+      if (seq !== this.refreshSeq) return;
+      // Defensive: a misbehaving SubagentManager (or a test mock that has
+      // been cleared by `vi.clearAllMocks`) may return undefined; never let
+      // that propagate into `availableSubagents`, which is required to be
+      // an array by every consumer (`getAvailableSubagentNames`, etc.).
+      this.availableSubagents = subagents ?? [];
+      this.hasLoadedOnce = true;
       this.updateDescriptionAndSchema();
     } catch (error) {
       console.warn('Failed to load subagents for Task tool:', error);
-      this.availableSubagents = [];
-      this.updateDescriptionAndSchema();
+      if (seq !== this.refreshSeq) return;
+      // Keep the last-known-good list on transient errors.
+      if (!this.hasLoadedOnce) {
+        this.availableSubagents = [];
+        this.hasLoadedOnce = true;
+        this.updateDescriptionAndSchema();
+      }
     } finally {
-      // Update the client with the new tools
+      // Update the client with the new tools (best-effort).
       const geminiClient = this.config.getGeminiClient();
       if (geminiClient && geminiClient.isInitialized()) {
-        await geminiClient.setTools();
+        try {
+          await geminiClient.setTools();
+        } catch (error) {
+          console.warn('Failed to push refreshed tools to chat:', error);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

On small instances (e.g. 2c2g), the very first request sent to the model contained the placeholder description `Loading available skills...` instead of the real skill list, so the model never invoked any skill. Root cause: `SkillTool` (and `TaskTool`) kicked off their first `refreshSkills()` / `refreshSubagents()` in fire-and-forget fashion in the constructor. When disk IO was slow or the remote Skill-OS server was unreachable, the tool function declarations were emitted before the list was populated.

This PR makes the cold-start path deterministic by:

1. Exposing a public `initPromise` on both tools and awaiting it from `Config.createToolRegistry` and `GeminiClient.startChat` (covers every chat-creation path).
2. Adding a monotonic `refreshSeq` race guard plus a `hasLoadedOnce` flag so transient errors no longer overwrite a previously-good list with `[]`.
3. Switching `SkillTool` to local-first cold start (remote skills are fetched in the background after `initPromise` resolves), so a slow Skill-OS server cannot block startup.
4. Splitting the single 30s `RemoteSkillRegistry` timeout into a 10s metadata timeout and a 60s download timeout.
5. Adding a `notify` flag to `SkillManager.refreshCache` to suppress re-entrant change-listener storms when `listSkills` lazily refreshes its own cache.
6. Defensive `?? []` guards so a misbehaving manager (or test mock cleared by `vi.clearAllMocks`) cannot leave `availableSkills` / `availableSubagents` as `undefined`.

## Related Issue

no-issue: discovered during 2c2g instance smoke test; reproduced via network capture showing the placeholder description in the very first function declaration sent to the model.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```
cd src/copilot-shell
npm run format         # prettier clean
npm run build          # 3 packages built
npm run lint           # eslint clean
npm run typecheck      # tsc clean
npm run test           # 178 test files / 3863 tests / 0 failed
```

Three new regression tests under `packages/core/src/tools/skill.test.ts > cold-start race conditions`:
- `should expose initPromise that resolves after first load completes` — guarantees the description is no longer the placeholder once `initPromise` resolves.
- `should call listSkills with includeRemote=false on cold start` — locks in the local-first contract.
- `should preserve previously loaded skills when a refresh fails` — protects against transient IO errors clobbering the list.

## Additional Notes

The original sequential `Promise.all` parallelization in `SkillManager.refreshCache` was reverted because an existing test (`should load skills from multiple custom directories`) relies on `readdir` call ordering. The race-condition fix does not depend on it; per-level scan latency is small compared to the network and disk waits we already removed from the cold-start path.
