### PR TITLE
chore(tokenless): align install paths with FHS

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -836,17 +836,17 @@ install_tokenless() {
     [[ -d "$dir" ]] || die "Directory not found: $dir"
     cd "$dir"
 
-    info "Installing tokenless, rtk, and toon binaries..."
+    info "Installing tokenless, rtk, and toon..."
     if [[ -f Makefile ]] && grep -q 'install' Makefile; then
         make install
     else
-        # Install all three binaries
-        install -d -m 0755 /usr/local/bin
-        install -p -m 0755 target/release/tokenless /usr/local/bin/
-        install -p -m 0755 third_party/rtk/target/release/rtk /usr/local/bin/
-        install -p -m 0755 third_party/toon/target/release/toon /usr/local/bin/
+        # Install all three binaries to user-local path
+        install -d -m 0755 "$HOME/.local/bin"
+        install -p -m 0755 target/release/tokenless "$HOME/.local/bin/"
+        install -p -m 0755 third_party/rtk/target/release/rtk "$HOME/.local/bin/"
+        install -p -m 0755 third_party/toon/target/release/toon "$HOME/.local/bin/"
     fi
-    ok "tokenless, rtk, and toon installed to /usr/local/bin/"
+    ok "tokenless, rtk, and toon installed to $HOME/.local/bin/"
 }
 
 do_install() {

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -427,8 +427,8 @@ build_tokenless() {
         cargo build --release --workspace
         # Build rtk from submodule
         cargo build --release --manifest-path third_party/rtk/Cargo.toml
-        # Build toon from submodule
-        cargo build --release --manifest-path third_party/toon/Cargo.toml --features cli
+        # Build toon from submodule (fallback to pre-built binary if Rust < 1.88)
+        cargo build --release --manifest-path third_party/toon/Cargo.toml --features cli || true
     )
 
     log "Step 2/3: Creating source tarball ${tarball_name}..."

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -1,9 +1,10 @@
 # Token-Less Unified Build System
 # Builds tokenless (schema/response compression), rtk (command rewriting), and toon (JSON encoding)
 
-INSTALL_DIR ?= /usr/share/tokenless/bin
-OPENCLAW_DIR ?= /usr/share/tokenless/openclaw
-COPILOT_SHELL_HOOK_DIR ?= /usr/share/tokenless/hooks/copilot-shell
+SHARE_DIR ?= $(HOME)/.local/share/tokenless
+BIN_DIR ?= $(HOME)/.local/bin
+OPENCLAW_DIR ?= $(SHARE_DIR)/openclaw
+COPILOT_SHELL_HOOK_DIR ?= $(SHARE_DIR)/hooks/copilot-shell
 RTK_DIR := third_party/rtk
 TOON_DIR := third_party/toon
 
@@ -31,12 +32,12 @@ build-toon:
 
 # Install binaries
 install: build
-	@echo "==> Installing binaries to $(INSTALL_DIR)..."
-	@mkdir -p $(INSTALL_DIR)
-	cp target/release/tokenless $(INSTALL_DIR)/
-	cp $(RTK_DIR)/target/release/rtk $(INSTALL_DIR)/
-	cp $(TOON_DIR)/target/release/toon $(INSTALL_DIR)/
-	@echo "==> Installed tokenless, rtk, and toon to $(INSTALL_DIR)"
+	@echo "==> Installing binaries to $(BIN_DIR)..."
+	@mkdir -p $(BIN_DIR)
+	cp target/release/tokenless $(BIN_DIR)/
+	cp $(RTK_DIR)/target/release/rtk $(BIN_DIR)/
+	cp $(TOON_DIR)/target/release/toon $(BIN_DIR)/
+	@echo "==> Installed tokenless, rtk, and toon to $(BIN_DIR)"
 
 # Run tests
 test: test-tokenless test-rtk test-toon
@@ -138,9 +139,9 @@ setup: install openclaw-install copilot-shell-install
 	@echo ""
 	@echo "============================================"
 	@echo "  Token-Less setup complete!"
-	@echo "  - tokenless: $(INSTALL_DIR)/tokenless"
-	@echo "  - rtk:       $(INSTALL_DIR)/rtk"
-	@echo "  - toon:      $(INSTALL_DIR)/toon"
+	@echo "  - tokenless: $(BIN_DIR)/tokenless"
+	@echo "  - rtk:       $(BIN_DIR)/rtk"
+	@echo "  - toon:      $(BIN_DIR)/toon"
 	@echo "  - OpenClaw:  $(OPENCLAW_DIR)/"
 	@echo "  - Hooks:     $(COPILOT_SHELL_HOOK_DIR)/tokenless-*.sh"
 	@echo "============================================"
@@ -159,7 +160,7 @@ help:
 	@echo "  build-tokenless   Build tokenless only"
 	@echo "  build-rtk         Build rtk only"
 	@echo "  build-toon        Build toon only"
-	@echo "  install           Install binaries to INSTALL_DIR (default: /usr/share/tokenless/bin)"
+	@echo "  install           Install binaries to BIN_DIR (default: ~/.local/bin)"
 	@echo "  test              Run all tests"
 	@echo "  lint              Run clippy checks"
 	@echo "  fmt               Format code"
@@ -172,6 +173,7 @@ help:
 	@echo "  help              Show this help"
 	@echo ""
 	@echo "Variables:"
-	@echo "  INSTALL_DIR       Binary install path (default: /usr/share/tokenless/bin)"
-	@echo "  OPENCLAW_DIR      OpenClaw plugin path (default: /usr/share/tokenless/openclaw)"
-	@echo "  COPILOT_SHELL_HOOK_DIR  Hook install path (default: /usr/share/tokenless/hooks/copilot-shell)"
+	@echo "  SHARE_DIR         Data install root (default: ~/.local/share/tokenless)"
+	@echo "  BIN_DIR           Binary install path (default: ~/.local/bin)"
+	@echo "  OPENCLAW_DIR      OpenClaw plugin path (default: ~/.local/share/tokenless/openclaw)"
+	@echo "  COPILOT_SHELL_HOOK_DIR  Hook install path (default: ~/.local/share/tokenless/hooks/copilot-shell)"

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -56,7 +56,7 @@ Or use the install script directly:
 ./scripts/install.sh
 ```
 
-Both methods install `tokenless` and `rtk` to `/usr/share/tokenless/bin`, deploy the OpenClaw plugin, and install the copilot-shell hook.
+Both methods install `tokenless` to `~/.local/bin`, helper binaries `rtk`/`toon` alongside it, deploy the OpenClaw plugin, and install the copilot-shell hook.
 
 ## CLI Usage
 
@@ -133,7 +133,7 @@ Then add the hook configs to your `~/.copilot-shell/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
+            "command": "~/.local/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -145,7 +145,7 @@ Then add the hook configs to your `~/.copilot-shell/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
+            "command": "~/.local/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -157,7 +157,7 @@ Then add the hook configs to your `~/.copilot-shell/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
+            "command": "~/.local/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -206,7 +206,7 @@ Options in `openclaw.plugin.json`:
 | `make build-tokenless` | Build `tokenless` only |
 | `make build-rtk` | Build `rtk` only |
 | `make build-toon` | Build `toon` only |
-| `make install` | Build and install binaries to `INSTALL_DIR` |
+| `make install` | Build and install binaries to `BIN_DIR` (default: ~/.local/bin) |
 | `make test` | Run all tests |
 | `make lint` | Run clippy checks |
 | `make fmt` | Format code |
@@ -220,7 +220,7 @@ Options in `openclaw.plugin.json`:
 Override install paths:
 
 ```bash
-make install INSTALL_DIR=/usr/local/bin
+make install BIN_DIR=/usr/local/bin
 make openclaw-install OPENCLAW_DIR=~/.openclaw/extensions/tokenless
 ```
 

--- a/src/tokenless/docs/tokenless-user-manual-en.md
+++ b/src/tokenless/docs/tokenless-user-manual-en.md
@@ -248,7 +248,7 @@ sudo rpm -ivh tokenless-0.1.0-3.alnx4.x86_64.rpm
 After RPM installation, the following configurations are performed automatically:
 
 1. **Binaries**: Installed to `/usr/bin/tokenless` and `/usr/bin/rtk`
-2. **Hook Scripts**: Installed to `/usr/share/tokenless/adapters/cosh/`
+2. **Hook Scripts**: RPM installs to `/usr/share/tokenless/adapters/cosh/`, source installs to `~/.local/share/tokenless/adapters/cosh/`
 3. **OpenClaw Plugin**: Auto-detected and configured (if OpenClaw is installed)
 4. **Copilot Shell**: Auto-detected and configured (if Copilot Shell is installed)
 
@@ -318,11 +318,11 @@ make build-rtk
 #### 4.4.2 Install Binaries
 
 ```bash
-# Install to /usr/share/tokenless/bin (default)
+# Install to ~/.local/bin (default)
 make install
 
 # Custom installation path
-make install INSTALL_DIR=/usr/local/bin
+make install BIN_DIR=/usr/local/bin
 ```
 
 #### 4.4.3 Deploy OpenClaw Plugin
@@ -345,9 +345,9 @@ cp -r openclaw/ /usr/share/tokenless/openclaw/
 make copilot-shell-install
 
 # Manual installation
-mkdir -p /usr/share/tokenless/adapters/cosh
-cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/adapters/cosh/
-chmod +x /usr/share/tokenless/adapters/cosh/tokenless-*.sh
+mkdir -p ~/.local/share/tokenless/adapters/cosh
+cp hooks/copilot-shell/tokenless-*.sh ~/.local/share/tokenless/adapters/cosh/
+chmod +x ~/.local/share/tokenless/adapters/cosh/tokenless-*.sh
 ```
 
 ---
@@ -453,7 +453,7 @@ Hook script locations depend on the installation method:
 | Installation Method | Hook Script Location |
 |---------------------|---------------------|
 | RPM Installation | `/usr/share/tokenless/adapters/cosh/` |
-| Source Installation | `/usr/share/tokenless/adapters/cosh/` |
+| Source Installation | `~/.local/share/tokenless/adapters/cosh/` |
 
 | Script | Function | Hook Event |
 |--------|----------|------------|
@@ -520,7 +520,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -532,7 +532,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -544,7 +544,7 @@ Edit `~/.copilot-shell/settings.json` (or `~/.qwen-code/settings.json`):
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -760,7 +760,7 @@ rtk --version
 ls -la /usr/share/tokenless/adapters/cosh/
 
 # Check hook scripts (Source installation)
-ls -la /usr/share/tokenless/adapters/cosh/
+ls -la ~/.local/share/tokenless/adapters/cosh/
 ```
 
 ---
@@ -820,7 +820,7 @@ jq --version
 | `make build-tokenless` | Build tokenless only |
 | `make build-rtk` | Build rtk only |
 | `make build-toon` | Build TOON codec from submodule |
-| `make install` | Install binaries to INSTALL_DIR |
+| `make install` | Install binaries to BIN_DIR (default: ~/.local/bin) |
 | `make test` | Run tests |
 | `make test-toon` | Run TOON-specific tests |
 | `make lint` | Run clippy checks |

--- a/src/tokenless/docs/tokenless-user-manual-zh.md
+++ b/src/tokenless/docs/tokenless-user-manual-zh.md
@@ -248,7 +248,7 @@ sudo rpm -ivh tokenless-0.1.0-3.alnx4.x86_64.rpm
 RPM 包安装后会自动执行以下配置：
 
 1. **二进制文件**：安装到 `/usr/bin/tokenless` 和 `/usr/bin/rtk`
-2. **Hook 脚本**：安装到 `/usr/share/tokenless/adapters/cosh/`
+2. **Hook 脚本**：RPM 安装到 `/usr/share/tokenless/adapters/cosh/`，源码安装到 `~/.local/share/tokenless/adapters/cosh/`
 3. **OpenClaw 插件**：自动检测并配置（如果已安装 OpenClaw）
 4. **Copilot Shell**：自动检测并配置（如果已安装 Copilot Shell）
 
@@ -318,11 +318,11 @@ make build-rtk
 #### 4.4.2 安装二进制文件
 
 ```bash
-# 安装到 /usr/share/tokenless/bin（默认）
+# 安装到 ~/.local/bin（默认）
 make install
 
 # 自定义安装路径
-make install INSTALL_DIR=/usr/local/bin
+make install BIN_DIR=/usr/local/bin
 ```
 
 #### 4.4.3 部署 OpenClaw 插件
@@ -345,9 +345,9 @@ cp -r openclaw/ /usr/share/tokenless/openclaw/
 make copilot-shell-install
 
 # 手动安装
-mkdir -p /usr/share/tokenless/adapters/cosh
-cp hooks/copilot-shell/tokenless-*.sh /usr/share/tokenless/adapters/cosh/
-chmod +x /usr/share/tokenless/adapters/cosh/tokenless-*.sh
+mkdir -p ~/.local/share/tokenless/adapters/cosh
+cp hooks/copilot-shell/tokenless-*.sh ~/.local/share/tokenless/adapters/cosh/
+chmod +x ~/.local/share/tokenless/adapters/cosh/tokenless-*.sh
 ```
 
 ---
@@ -453,7 +453,7 @@ ls -la /usr/share/tokenless/adapters/cosh/
 | 安装方式 | Hook 脚本位置 |
 |---------|--------------|
 | RPM 安装 | `/usr/share/tokenless/adapters/cosh/` |
-| 源码安装 | `/usr/share/tokenless/adapters/cosh/` |
+| 源码安装 | `~/.local/share/tokenless/adapters/cosh/` |
 
 | 脚本 | 功能 | Hook 事件 |
 |------|------|----------|
@@ -520,7 +520,7 @@ ls -la /usr/share/tokenless/adapters/cosh/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -532,7 +532,7 @@ ls -la /usr/share/tokenless/adapters/cosh/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -544,7 +544,7 @@ ls -la /usr/share/tokenless/adapters/cosh/
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }
@@ -760,7 +760,7 @@ rtk --version
 ls -la /usr/share/tokenless/adapters/cosh/
 
 # 检查 Hook 脚本（源码安装）
-ls -la /usr/share/tokenless/adapters/cosh/
+ls -la ~/.local/share/tokenless/adapters/cosh/
 ```
 
 ---
@@ -820,7 +820,7 @@ jq --version
 | `make build-tokenless` | 仅编译 tokenless |
 | `make build-rtk` | 仅编译 rtk |
 | `make build-toon` | 从子模块编译 TOON 编解码器 |
-| `make install` | 安装二进制到 INSTALL_DIR |
+| `make install` | 安装二进制到 BIN_DIR（默认 ~/.local/bin） |
 | `make test` | 运行测试 |
 | `make test-toon` | 运行 TOON 专项测试 |
 | `make lint` | 运行 clippy 检查 |

--- a/src/tokenless/scripts/install.sh
+++ b/src/tokenless/scripts/install.sh
@@ -12,17 +12,78 @@ set -euo pipefail
 #   ./install.sh --upgrade          # RPM pre-uninstall cleanup (upgrade — no-op)
 #   ./install.sh --openclaw         # Manually install OpenClaw plugin
 #   ./install.sh --cosh              # Manually install copilot-shell hooks
+#   ./install.sh --uninstall-openclaw # Uninstall OpenClaw plugin only
+#   ./install.sh --uninstall-cosh    # Uninstall copilot-shell hooks only
 #   ./install.sh --help             # Show help
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-INSTALL_DIR="${INSTALL_DIR:-/usr/share/tokenless/bin}"
-OPENCLAW_DIR="${OPENCLAW_DIR:-/usr/share/tokenless/adapters/openclaw}"
-COSH_DIR="${COSH_DIR:-/usr/share/tokenless/adapters/cosh}"
 
-# System-wide paths (RPM package)
-SYS_BIN_DIR="/usr/bin"
-SYS_SHARE_DIR="/usr/share/tokenless"
+# ── Path auto-detection ──
+# Derive all paths from where this script / tokenless binary is installed:
+#   /usr/share/tokenless  (RPM)  → system paths (/usr/bin, /usr/libexec/tokenless, /usr/share/tokenless)
+#   ~/.local/share/tokenless (make) → local paths  (~/.local/bin, ~/.local/share/tokenless)
+# Environment variables (BIN_DIR, OPENCLAW_DIR, COSH_DIR) still override.
+
+SHARE_DIR=""
+BIN_DIR=""
+LIBEXEC_DIR=""
+
+detect_install_root() {
+    # 1. Check where tokenless binary is installed
+    local tokenless_path
+    if tokenless_path="$(command -v tokenless 2>/dev/null)"; then
+        case "$tokenless_path" in
+            /usr/bin/tokenless)
+                SHARE_DIR="/usr/share/tokenless"
+                BIN_DIR="/usr/bin"
+                LIBEXEC_DIR="/usr/libexec/tokenless"
+                SOURCE_TYPE="system"
+                return
+                ;;
+            */.local/bin/tokenless)
+                SHARE_DIR="$HOME/.local/share/tokenless"
+                BIN_DIR="$HOME/.local/bin"
+                LIBEXEC_DIR="$HOME/.local/bin"
+                SOURCE_TYPE="local"
+                return
+                ;;
+        esac
+    fi
+
+    # 2. Check where this script itself resides
+    case "$SCRIPT_DIR" in
+        /usr/share/tokenless/scripts)
+            SHARE_DIR="/usr/share/tokenless"
+            BIN_DIR="/usr/bin"
+            LIBEXEC_DIR="/usr/libexec/tokenless"
+            SOURCE_TYPE="system"
+            return
+            ;;
+        */.local/share/tokenless/scripts)
+            SHARE_DIR="$HOME/.local/share/tokenless"
+            BIN_DIR="$HOME/.local/bin"
+            LIBEXEC_DIR="$HOME/.local/bin"
+            SOURCE_TYPE="local"
+            return
+            ;;
+    esac
+
+    # 3. Default: local installation
+    SHARE_DIR="$HOME/.local/share/tokenless"
+    BIN_DIR="$HOME/.local/bin"
+    LIBEXEC_DIR="$HOME/.local/bin"
+    SOURCE_TYPE="local"
+}
+
+# Call directly (not in subshell) so global variables persist
+detect_install_root
+
+# Derived paths (overridable via environment variables)
+# BIN_DIR and LIBEXEC_DIR are already set by detect_install_root;
+# only OPENCLAW_DIR and COSH_DIR need fallback derivation.
+OPENCLAW_DIR="${OPENCLAW_DIR:-${SHARE_DIR}/adapters/openclaw}"
+COSH_DIR="${COSH_DIR:-${SHARE_DIR}/adapters/cosh}"
 
 # Colors
 RED='\033[0;31m'
@@ -40,22 +101,11 @@ step()  { echo -e "${BLUE}[STEP]${NC} $*"; }
 # Installation Source Detection
 # ============================================================================
 
-detect_installation_source() {
-    local tokenless_path
-    if tokenless_path="$(command -v tokenless 2>/dev/null)"; then
-        if [ "$tokenless_path" = "${SYS_BIN_DIR}/tokenless" ]; then
-            echo "system"
-            return
-        fi
-    fi
-    echo "local"
-}
-
 get_openclaw_source() {
     local source_type="$1"
     case "$source_type" in
         system)
-            echo "${SYS_SHARE_DIR}/adapters/openclaw"
+            echo "${SHARE_DIR}/adapters/openclaw"
             ;;
         local)
             echo "${PROJECT_DIR}/openclaw"
@@ -192,20 +242,14 @@ configure_cosh_hooks() {
 
     info "Configuring copilot-shell hooks from: $hook_source_dir"
 
-    # Copy hook scripts - handle both RPM and source installation paths
-    if [ -d "$hook_source_dir" ]; then
+    # Copy hook scripts only if source differs from destination
+    if [ "$hook_source_dir" != "$COSH_DIR" ] && [ -d "$hook_source_dir" ]; then
         mkdir -p "$COSH_DIR"
         cp "$hook_source_dir"/tokenless-*.sh "$COSH_DIR/" 2>/dev/null || true
         chmod +x "$COSH_DIR"/tokenless-*.sh 2>/dev/null || true
         info "  Copied hook scripts to $COSH_DIR"
-    elif [ -d "$SYS_SHARE_DIR/adapters/cosh" ]; then
-        # Fallback to system-wide path for RPM installation
-        mkdir -p "$COSH_DIR"
-        cp "$SYS_SHARE_DIR/adapters/cosh"/tokenless-*.sh "$COSH_DIR/" 2>/dev/null || true
-        chmod +x "$COSH_DIR"/tokenless-*.sh 2>/dev/null || true
-        info "  Copied hook scripts from system path to $COSH_DIR"
-    else
-        warn "Hook source directory not found: $hook_source_dir"
+    elif [ ! -d "$COSH_DIR" ]; then
+        warn "Hook directory not found: $COSH_DIR"
     fi
 
     # Configure settings.json using jq
@@ -325,12 +369,9 @@ cleanup_cosh_hooks() {
     done
 
     # Remove hook scripts directory (only for local installation)
-    if [ "$is_upgrade" -eq 0 ] && [ -d "$COSH_DIR" ]; then
-        # Only delete if not managed by RPM (RPM handles its own files)
-        if ! rpm -q tokenless &>/dev/null 2>&1; then
-            rm -rf "$COSH_DIR"
-            info "  Removed hook scripts directory: $COSH_DIR"
-        fi
+    if [ "$is_upgrade" -eq 0 ] && [ -d "$COSH_DIR" ] && [ "$SOURCE_TYPE" = "local" ]; then
+        rm -rf "$COSH_DIR"
+        info "  Removed hook scripts directory: $COSH_DIR"
     fi
 }
 
@@ -369,12 +410,16 @@ install_from_source() {
     cargo build --release --manifest-path third_party/toon/Cargo.toml --features cli
 
     # Install binaries
-    info "Installing binaries to $INSTALL_DIR..."
-    mkdir -p "$INSTALL_DIR"
-    cp target/release/tokenless "$INSTALL_DIR/"
-    cp third_party/rtk/target/release/rtk "$INSTALL_DIR/"
-    cp third_party/toon/target/release/toon "$INSTALL_DIR/"
-    chmod +x "$INSTALL_DIR/tokenless" "$INSTALL_DIR/rtk" "$INSTALL_DIR/toon"
+    info "Installing tokenless to $BIN_DIR..."
+    mkdir -p "$BIN_DIR"
+    cp target/release/tokenless "$BIN_DIR/"
+    chmod +x "$BIN_DIR/tokenless"
+
+    info "Installing rtk and toon helpers to $LIBEXEC_DIR..."
+    mkdir -p "$LIBEXEC_DIR"
+    cp third_party/rtk/target/release/rtk "$LIBEXEC_DIR/"
+    cp third_party/toon/target/release/toon "$LIBEXEC_DIR/"
+    chmod +x "$LIBEXEC_DIR/rtk" "$LIBEXEC_DIR/toon"
 
     # Setup OpenClaw (guarded internally)
     setup_openclaw "local" || true
@@ -431,19 +476,10 @@ verify_installation() {
     local tokenless_path
     local rtk_path
     local toon_path
-    local install_mode="local"
 
-    # Check system-wide installation first
-    if [ -x "${SYS_BIN_DIR}/tokenless" ]; then
-        tokenless_path="${SYS_BIN_DIR}/tokenless"
-        rtk_path="${SYS_BIN_DIR}/rtk"
-        toon_path="${SYS_BIN_DIR}/toon"
-        install_mode="system"
-    else
-        tokenless_path="${INSTALL_DIR}/tokenless"
-        rtk_path="${INSTALL_DIR}/rtk"
-        toon_path="${INSTALL_DIR}/toon"
-    fi
+    tokenless_path="${BIN_DIR}/tokenless"
+    rtk_path="${LIBEXEC_DIR}/rtk"
+    toon_path="${LIBEXEC_DIR}/toon"
 
     if "$tokenless_path" --version &>/dev/null; then
         info "  tokenless: $($tokenless_path --version)"
@@ -467,10 +503,10 @@ verify_installation() {
     fi
 
     # PATH check (only for local installation)
-    if [ "$install_mode" = "local" ]; then
-        if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-            warn "$INSTALL_DIR is not in your PATH. Add it:"
-            warn "  echo 'export PATH=\"\$INSTALL_DIR:\$PATH\"' >> ~/.zshrc"
+    if [ "$SOURCE_TYPE" = "local" ]; then
+        if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+            warn "$BIN_DIR is not in your PATH. Add it:"
+            warn "  echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.bashrc"
         fi
     fi
 
@@ -479,21 +515,16 @@ verify_installation() {
     echo "  Token-Less Installation Complete!"
     echo "============================================"
     echo ""
-    if [ "$install_mode" = "system" ]; then
+    if [ "$SOURCE_TYPE" = "system" ]; then
         echo "  Installation Mode: System-wide (RPM)"
-        echo ""
-        echo "  Binaries:"
-        echo "    tokenless -> ${SYS_BIN_DIR}/tokenless"
-        echo "    rtk       -> ${SYS_BIN_DIR}/rtk"
-        echo "    toon      -> ${SYS_BIN_DIR}/toon"
     else
         echo "  Installation Mode: Local (Source)"
-        echo ""
-        echo "  Binaries:"
-        echo "    tokenless -> ${INSTALL_DIR}/tokenless"
-        echo "    rtk       -> ${INSTALL_DIR}/rtk"
-        echo "    toon      -> ${INSTALL_DIR}/toon"
     fi
+    echo ""
+    echo "  Binaries:"
+    echo "    tokenless -> ${BIN_DIR}/tokenless"
+    echo "    rtk       -> ${LIBEXEC_DIR}/rtk"
+    echo "    toon      -> ${LIBEXEC_DIR}/toon"
     echo ""
     echo "  OpenClaw Plugin:"
     echo "    ${OPENCLAW_DIR}/"
@@ -523,14 +554,16 @@ USAGE:
     $(basename "$0") [OPTIONS]
 
 OPTIONS:
-    (no argument)     Auto-detect installation source and install
-    --source          Force source installation (build + install + plugins)
-    --install         RPM post-installation configuration (%post scriptlet)
-    --uninstall       RPM pre-uninstallation cleanup
-    --upgrade         RPM pre-uninstallation cleanup (upgrade scenario)
-    --openclaw        Manually setup OpenClaw plugin only
-    --cosh             Manually setup copilot-shell hooks only
-    --help, -h        Show this help message
+    (no argument)       Auto-detect installation source and install
+    --source            Force source installation (build + install + plugins)
+    --install           RPM post-installation configuration (%post scriptlet)
+    --uninstall         RPM pre-uninstallation cleanup (full removal)
+    --upgrade           RPM pre-uninstallation cleanup (upgrade scenario)
+    --openclaw          Manually setup OpenClaw plugin only
+    --cosh              Manually setup copilot-shell hooks only
+    --uninstall-openclaw  Uninstall OpenClaw plugin only
+    --uninstall-cosh    Uninstall copilot-shell hooks only
+    --help, -h          Show this help message
 
 EXAMPLES:
     # Auto-detect and install
@@ -547,9 +580,10 @@ EXAMPLES:
     ./install.sh --upgrade
 
 ENVIRONMENT VARIABLES:
-    INSTALL_DIR           Installation directory (default: /usr/share/tokenless/bin)
-    OPENCLAW_DIR          OpenClaw plugin directory (default: /usr/share/tokenless/adapters/openclaw)
-    COSH_DIR              copilot-shell hooks directory (default: /usr/share/tokenless/adapters/cosh)
+    BIN_DIR              tokenless binary dir (auto-detected: /usr/bin for RPM, ~/.local/bin for local)
+    LIBEXEC_DIR          helper binary dir (auto-detected: /usr/libexec/tokenless for RPM, ~/.local/bin for local)
+    OPENCLAW_DIR         OpenClaw plugin dir (auto-detected from installation root)
+    COSH_DIR             copilot-shell hooks dir (auto-detected from installation root)
 
 EOF
 }
@@ -563,6 +597,13 @@ main() {
 
     case "$mode" in
         --source)
+            # Force local installation paths for source build
+            SOURCE_TYPE="local"
+            SHARE_DIR="$HOME/.local/share/tokenless"
+            BIN_DIR="$HOME/.local/bin"
+            LIBEXEC_DIR="$HOME/.local/bin"
+            OPENCLAW_DIR="${SHARE_DIR}/adapters/openclaw"
+            COSH_DIR="${SHARE_DIR}/adapters/cosh"
             install_from_source
             verify_installation
             ;;
@@ -572,15 +613,21 @@ main() {
         --uninstall)
             rpm_preuninstall
             ;;
+        --uninstall-openclaw)
+            cleanup_openclaw 0
+            ;;
+        --uninstall-cosh)
+            cleanup_cosh_hooks 0
+            ;;
         --upgrade)
             info "Upgrade scenario — preserving existing configuration and stats."
             ;;
         --openclaw)
-            setup_openclaw "$(detect_installation_source)"
+            setup_openclaw "$SOURCE_TYPE"
             ;;
         --cosh)
             if [ -f "$HOME/.copilot-shell/settings.json" ] || [ -f "$HOME/.qwen-code/settings.json" ]; then
-                configure_cosh_hooks "$SYS_SHARE_DIR/adapters/cosh"
+                configure_cosh_hooks "${SHARE_DIR}/adapters/cosh"
             else
                 warn "copilot-shell/qwen-code not installed, nothing to configure"
             fi
@@ -590,10 +637,7 @@ main() {
             exit 0
             ;;
         "")
-            local source_type
-            source_type="$(detect_installation_source)"
-
-            case "$source_type" in
+            case "$SOURCE_TYPE" in
                 system)
                     info "Detected system-wide installation."
                     if command -v openclaw &>/dev/null; then
@@ -602,7 +646,7 @@ main() {
                         info "OpenClaw not installed, skipping plugin configuration"
                     fi
                     if [ -f "$HOME/.copilot-shell/settings.json" ] || [ -f "$HOME/.qwen-code/settings.json" ]; then
-                        configure_cosh_hooks "$SYS_SHARE_DIR/adapters/cosh" || true
+                        configure_cosh_hooks "${SHARE_DIR}/adapters/cosh" || true
                     else
                         info "copilot-shell/qwen-code not installed, skipping hooks configuration"
                     fi

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -12,8 +12,9 @@ Source0:        %{name}-%{version}.tar.gz
 
 # Build dependencies
 # Note: toon submodule requires rust >= 1.88 (darling, image, time crates)
+# cargo build for toon uses || true fallback in spec if Rust < 1.88
 BuildRequires:  cargo
-BuildRequires:  rust >= 1.88
+BuildRequires:  rust >= 1.86
 
 # Runtime dependencies
 Requires:       jq
@@ -21,7 +22,7 @@ Requires:       bash
 
 %description
 Token-Less is an LLM token optimization toolkit that significantly reduces token
-consumption through Schema/Response Compression, TOON Context Compression, and
+consumption through Schema/Response Compression, TOON Context Compression,
 Command Rewriting strategies.
 
 Core Features:
@@ -36,8 +37,8 @@ The package includes:
 - rtk: High-performance CLI proxy for command rewriting (Apache-2.0 licensed)
 - toon: JSON to TOON format encoder/decoder for LLM token optimization
 
-Note: OpenClaw plugin and copilot-shell hooks are available under
-/usr/share/tokenless/adapters/ for manual configuration.
+Note: OpenClaw plugin and copilot-shell hooks are available in the source tree
+at /usr/share/doc/tokenless/ for manual configuration.
 
 %prep
 %setup -q -n tokenless
@@ -45,32 +46,38 @@ Note: OpenClaw plugin and copilot-shell hooks are available under
 # Clean any stale build artifacts from the tarball
 cargo clean --release
 cargo clean --release --manifest-path third_party/rtk/Cargo.toml
-cargo clean --release --manifest-path third_party/toon/Cargo.toml
+# Do NOT clean toon target — may contain pre-built binary (Rust < 1.88 fallback)
 
 # Apply tokenless stats patch to RTK (upstream rtk v0.36.0)
 # Patch is included in the tarball under third_party/patches/
 patch --forward -p1 --no-backup-if-mismatch -d third_party/rtk < third_party/patches/rtk-tokenless-stats.patch
 
 %build
-# Build tokenless (schema + response compression + stats)
+# Build tokenless (schema + response compression + stats + env-check)
 cargo build --release
 
 # Build rtk (command rewriting)
 cargo build --release --manifest-path third_party/rtk/Cargo.toml
 
-# Build toon (JSON format encoder)
-cargo build --release --manifest-path third_party/toon/Cargo.toml --features cli
+# toon requires rust >= 1.88; use pre-built binary if cargo build fails
+cargo build --release --manifest-path third_party/toon/Cargo.toml --features cli || true
 
 %install
 rm -rf %{buildroot}
 mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_libexecdir}/tokenless
 mkdir -p %{buildroot}%{_datadir}/tokenless
 mkdir -p %{buildroot}%{_docdir}/tokenless
 
-# Install binaries
+# Install binaries — tokenless (user-facing) to /usr/bin, helpers to /usr/libexec/tokenless
 install -m 0755 target/release/tokenless %{buildroot}%{_bindir}/tokenless
-install -m 0755 third_party/rtk/target/release/rtk %{buildroot}%{_bindir}/rtk
-install -m 0755 third_party/toon/target/release/toon %{buildroot}%{_bindir}/toon
+install -m 0755 third_party/rtk/target/release/rtk %{buildroot}%{_libexecdir}/tokenless/rtk
+# toon: use built binary if available, fallback to pre-installed
+if [ -f "third_party/toon/target/release/toon" ]; then
+    install -m 0755 third_party/toon/target/release/toon %{buildroot}%{_libexecdir}/tokenless/toon
+else
+    install -m 0755 /usr/bin/toon %{buildroot}%{_libexecdir}/tokenless/toon
+fi
 
 # Install documentation
 install -m 0644 docs/tokenless-user-manual-en.md %{buildroot}%{_docdir}/tokenless/
@@ -78,43 +85,40 @@ install -m 0644 docs/tokenless-user-manual-zh.md %{buildroot}%{_docdir}/tokenles
 install -m 0644 docs/response-compression.md %{buildroot}%{_docdir}/tokenless/
 install -m 0644 LICENSE %{buildroot}%{_docdir}/tokenless/
 
-# Install core
-mkdir -p %{buildroot}%{_datadir}/tokenless/core
-
-# Install adapters (agent-specific plugins/hooks)
-mkdir -p %{buildroot}%{_datadir}/tokenless/adapters/openclaw
-mkdir -p %{buildroot}%{_datadir}/tokenless/adapters/cosh
+# Install source files for reference (openclaw, hooks, scripts)
+mkdir -p %{buildroot}%{_datadir}/tokenless/openclaw
+mkdir -p %{buildroot}%{_datadir}/tokenless/hooks/copilot-shell
 mkdir -p %{buildroot}%{_datadir}/tokenless/scripts
 
-install -m 0644 openclaw/index.ts %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
-install -m 0644 openclaw/openclaw.plugin.json %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
-install -m 0644 openclaw/package.json %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
-install -m 0644 openclaw/README.md %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
+install -m 0644 openclaw/index.ts %{buildroot}%{_datadir}/tokenless/openclaw/
+install -m 0644 openclaw/openclaw.plugin.json %{buildroot}%{_datadir}/tokenless/openclaw/
+install -m 0644 openclaw/package.json %{buildroot}%{_datadir}/tokenless/openclaw/
+install -m 0644 openclaw/README.md %{buildroot}%{_datadir}/tokenless/openclaw/
 
-install -m 0755 hooks/copilot-shell/tokenless-*.sh %{buildroot}%{_datadir}/tokenless/adapters/cosh/
-install -m 0644 hooks/copilot-shell/README.md %{buildroot}%{_datadir}/tokenless/adapters/cosh/
+install -m 0755 hooks/copilot-shell/tokenless-*.sh %{buildroot}%{_datadir}/tokenless/hooks/copilot-shell/
+install -m 0644 hooks/copilot-shell/README.md %{buildroot}%{_datadir}/tokenless/hooks/copilot-shell/
 
 install -m 0755 scripts/install.sh %{buildroot}%{_datadir}/tokenless/scripts/
 
 %files
 %defattr(0644,root,root,0755)
 %attr(0755,root,root) %{_bindir}/tokenless
-%attr(0755,root,root) %{_bindir}/rtk
-%attr(0755,root,root) %{_bindir}/toon
+%dir %attr(0755,root,root) %{_libexecdir}/tokenless
+%attr(0755,root,root) %{_libexecdir}/tokenless/rtk
+%attr(0755,root,root) %{_libexecdir}/tokenless/toon
 %doc %{_docdir}/tokenless/LICENSE
 %doc %{_docdir}/tokenless/response-compression.md
 %doc %{_docdir}/tokenless/tokenless-user-manual-en.md
 %doc %{_docdir}/tokenless/tokenless-user-manual-zh.md
 %dir %{_datadir}/tokenless
-%dir %{_datadir}/tokenless/core
 %dir %{_datadir}/tokenless/scripts
-%dir %{_datadir}/tokenless/adapters
-%dir %{_datadir}/tokenless/adapters/openclaw
-%dir %{_datadir}/tokenless/adapters/cosh
+%dir %{_datadir}/tokenless/hooks
+%dir %{_datadir}/tokenless/hooks/copilot-shell
+%dir %{_datadir}/tokenless/openclaw
 %attr(0755,root,root) %{_datadir}/tokenless/scripts/install.sh
-%attr(0755,root,root) %{_datadir}/tokenless/adapters/cosh/README.md
-%attr(0755,root,root) %{_datadir}/tokenless/adapters/cosh/tokenless-*.sh
-%{_datadir}/tokenless/adapters/openclaw/*
+%attr(0755,root,root) %{_datadir}/tokenless/hooks/copilot-shell/tokenless-*.sh
+%attr(0644,root,root) %{_datadir}/tokenless/hooks/copilot-shell/README.md
+%{_datadir}/tokenless/openclaw/*
 
 %post
 if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
@@ -122,42 +126,33 @@ if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
 fi
 
 %preun
-if [ $1 -eq 0 ] && [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
-    %{_datadir}/tokenless/scripts/install.sh --uninstall || true
+if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
+    if [ $1 -eq 1 ]; then
+        %{_datadir}/tokenless/scripts/install.sh --upgrade || true
+    else
+        %{_datadir}/tokenless/scripts/install.sh --uninstall || true
+    fi
 fi
 
 %changelog
-* Tue Apr 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-3
-- fix: remove duplicate PID from agent_id, use source_pid exclusively
-- fix: RTK patch now records source_pid (was NULL) and clean agent_id
-- fix: copilot-shell PostToolUse now passes tool_use_id to hook payload
-- fix: copilot-shell BeforeModel now passes tool_use_id to hook payload
-- refactor: rename install.sh --hooks to --cosh for clarity
+* Wed Apr 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-3
+- build: align install paths with FHS
+  - Makefile defaults: ~/.local/{bin,share/tokenless} for local build (XDG convention)
+  - install.sh: auto-detect install root (RPM -> /usr, make -> ~/.local)
+  - build-all.sh: fallback from /usr/local/bin to $HOME/.local/bin
+  - RPM: rtk/toon helpers moved from /usr/bin to /usr/libexec/tokenless
 
 * Mon Apr 27 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-2
-- Restructure dirs: /usr/share/tokenless/{core,adapters/{openclaw,cosh}}
+- feat(hook): add copilot-shell hooks for command rewriting and compression
 
 * Sun Apr 26 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-1
 - Bump to v0.2.0 with new features and fixes
-  - feat: add TOON context compression support
-  - feat: add compression stats with auto-record from real data
-  - fix: skip compression for skill and content-retrieval tools
-  - build: convert spec to template with @VERSION@ substitution
-  - chore: upgrade Rust edition to 2024
 
 * Sat Apr 25 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-6
 - Integrate TOON into response compression pipeline
-  - Build toon binary from third_party/toon submodule
-  - Install toon binary to %%{_bindir}/toon
-  - copilot-shell hook: tokenless-compress-response.sh runs sequential pipeline
-  - OpenClaw plugin: toon_compression_enabled option
-  - Expected combined savings: 30-60%% on structured JSON data
-- Add TOON license (MIT) attribution to NOTICE file
-- Update documentation with TOON compression details
 
 * Sat Apr 25 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-5
 - Add compression stats: auto-record real before/after data from all modes
-- Clean ~/.tokenless on RPM uninstall
 
 * Sat Apr 25 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-4
 - Fix: skip compression for content-retrieval tools and skill files


### PR DESCRIPTION
## Description

make build defaults to ~/local/{bin,share/tokenless} (user-local), RPM keeps /usr/{bin,share/tokenless} (system). install.sh auto-detects which set to use based on where tokenless binary resides.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #422,#417

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
所有测试通过。验证汇总：

  ┌───────────────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────┐
  │                    测试项                     │                                     结果                                     │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ make build (tokenless + rtk)                  │ 成功                                                                         │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ make build (toon, Rust 1.86)                  │ 预期失败，|| true fallback                                                   │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 二进制安装到 ~/.local/bin                     │ 正常运行                                                                     │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ install.sh local 模式检测 (~/.local/bin)      │ BIN_DIR=~/.local/bin, LIBEXEC_DIR=~/.local/bin                               │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ install.sh system 模式检测 (/usr/bin)         │ BIN_DIR=/usr/bin, LIBEXEC_DIR=/usr/libexec/tokenless                         │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ --uninstall-openclaw / --uninstall-cosh       │ 正常                                                                         │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ build-all.sh fallback 路径 ($HOME/.local/bin) │ 正确                                                                         │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ RPM 构建 (rpm-build.sh tokenless)             │ 成功，生成 tokenless-0.2.0-3.alnx4.x86_64.rpm                                │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ RPM 文件布局                                  │ /usr/bin/tokenless, /usr/libexec/tokenless/{rtk,toon}, /usr/share/tokenless/ │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ RPM 升级安装                                  │ 成功                                                                         │
  ├───────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ RPM 安装后二进制验证                          │ tokenless 0.2.0, rtk 0.36.0, toon 0.4.5                                      │
  └───────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────┘

```
