### PR TITLE
fix(tokenless): preserve tool result message structure in TOON encoding

### DIFF
--- a/src/tokenless/openclaw/index.ts
+++ b/src/tokenless/openclaw/index.ts
@@ -303,7 +303,20 @@ export default {
           savingsLabel = usedResponseCompression
             ? "response compressed + TOON encoded"
             : "TOON encoded";
-          finalMessage = `[TOON format, ${totalSavingsPct}% token savings]\n${toonText}`;
+          // Wrap TOON text in the original tool result message structure.
+          // If we return a raw string, OpenClaw's tool_result_persist hook
+          // replaces the entire message body, dropping role/toolCallId/toolName.
+          // That causes session-transcript-repair to inject a synthetic
+          // "missing tool result" error on the next run, breaking the session.
+          const toonWrapped = `[TOON format, ${totalSavingsPct}% token savings]\n${toonText}`;
+          if (typeof event.message === "object" && event.message?.role === "toolResult") {
+            finalMessage = {
+              ...event.message,
+              content: [{ type: "text" as const, text: toonWrapped }],
+            };
+          } else {
+            finalMessage = toonWrapped;
+          }
         } else {
           const before = JSON.stringify(event.message).length;
           const after = JSON.stringify(currentMessage).length;

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 3
+%define anolis_release 4
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -135,12 +135,11 @@ if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then
 fi
 
 %changelog
+* Wed Apr 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-4
+- fix: preserve tool result message structure in TOON encoding
+
 * Wed Apr 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-3
 - build: align install paths with FHS
-  - Makefile defaults: ~/.local/{bin,share/tokenless} for local build (XDG convention)
-  - install.sh: auto-detect install root (RPM -> /usr, make -> ~/.local)
-  - build-all.sh: fallback from /usr/local/bin to $HOME/.local/bin
-  - RPM: rtk/toon helpers moved from /usr/bin to /usr/libexec/tokenless
 
 * Mon Apr 27 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-2
 - feat(hook): add copilot-shell hooks for command rewriting and compression


### PR DESCRIPTION
## Description

The tool_result_persist hook was replacing the entire tool result message with a raw TOON string, dropping role/toolCallId/toolName. This caused session-transcript-repair to inject a synthetic "missing tool result" error on the next run, silently breaking subsequent sessions.

Fix: wrap TOON text inside the original message structure so the session guard can correctly match toolCallId when loading history.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes #420

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
测试用例已就绪：

  测试数据：/tmp/toon-tui-test.json（772 chars，包含 server/services/metrics/alerts 等嵌套结构，模拟真实 tool result）

  TUI 测试步骤：

  1. 当前 stats 共 14 条记录
  2. 在 TUI 中输入：Run: cat /tmp/toon-tui-test.json
    - 模型会调用 exec 工具，返回 772 字符的 JSON
    - 触发 pipeline：Response Compress → TOON Encode
    - TOON 预计节省 60-75% tokens
  3. 紧接着发送：What's 2+2?
    - 验证关键点：如果 fix 正确，TUI 回复 4；如果结构被破坏，TUI 冻结无响应
  4. 检查 sqlite3 /root/.tokenless/stats.db "SELECT COUNT(*) FROM stats;" — 应增长
 ```
