### PR TITLE
fix(tokenless): correct RPM install paths to align with install.sh expectations

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -3,8 +3,8 @@
 
 SHARE_DIR ?= $(HOME)/.local/share/tokenless
 BIN_DIR ?= $(HOME)/.local/bin
-OPENCLAW_DIR ?= $(SHARE_DIR)/openclaw
-COPILOT_SHELL_HOOK_DIR ?= $(SHARE_DIR)/hooks/copilot-shell
+OPENCLAW_DIR ?= $(SHARE_DIR)/adapters/openclaw
+COPILOT_SHELL_HOOK_DIR ?= $(SHARE_DIR)/adapters/cosh
 RTK_DIR := third_party/rtk
 TOON_DIR := third_party/toon
 
@@ -175,5 +175,5 @@ help:
 	@echo "Variables:"
 	@echo "  SHARE_DIR         Data install root (default: ~/.local/share/tokenless)"
 	@echo "  BIN_DIR           Binary install path (default: ~/.local/bin)"
-	@echo "  OPENCLAW_DIR      OpenClaw plugin path (default: ~/.local/share/tokenless/openclaw)"
-	@echo "  COPILOT_SHELL_HOOK_DIR  Hook install path (default: ~/.local/share/tokenless/hooks/copilot-shell)"
+	@echo "  OPENCLAW_DIR      OpenClaw plugin path (default: ~/.local/share/tokenless/adapters/openclaw)"
+	@echo "  COPILOT_SHELL_HOOK_DIR  Hook install path (default: ~/.local/share/tokenless/adapters/cosh)"

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -133,7 +133,7 @@ Then add the hook configs to your `~/.copilot-shell/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "~/.local/share/tokenless/hooks/copilot-shell/tokenless-rewrite.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-rewrite.sh",
             "name": "tokenless-rewrite",
             "timeout": 5000
           }
@@ -145,7 +145,7 @@ Then add the hook configs to your `~/.copilot-shell/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "~/.local/share/tokenless/hooks/copilot-shell/tokenless-compress-response.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-compress-response.sh",
             "name": "tokenless-compress-response",
             "timeout": 10000
           }
@@ -157,7 +157,7 @@ Then add the hook configs to your `~/.copilot-shell/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "~/.local/share/tokenless/hooks/copilot-shell/tokenless-compress-schema.sh",
+            "command": "~/.local/share/tokenless/adapters/cosh/tokenless-compress-schema.sh",
             "name": "tokenless-compress-schema",
             "timeout": 10000
           }

--- a/src/tokenless/docs/tokenless-user-manual-en.md
+++ b/src/tokenless/docs/tokenless-user-manual-en.md
@@ -332,10 +332,10 @@ make install BIN_DIR=/usr/local/bin
 make openclaw-install
 
 # Custom plugin path
-make openclaw-install OPENCLAW_DIR=/usr/share/tokenless/openclaw
+make openclaw-install OPENCLAW_DIR=/usr/share/tokenless/adapters/openclaw
 
 # Manual installation
-cp -r openclaw/ /usr/share/tokenless/openclaw/
+cp -r openclaw/ /usr/share/tokenless/adapters/openclaw/
 ```
 
 #### 4.4.4 Deploy Copilot Shell Hook

--- a/src/tokenless/docs/tokenless-user-manual-zh.md
+++ b/src/tokenless/docs/tokenless-user-manual-zh.md
@@ -332,10 +332,10 @@ make install BIN_DIR=/usr/local/bin
 make openclaw-install
 
 # 自定义插件路径
-make openclaw-install OPENCLAW_DIR=/usr/share/tokenless/openclaw
+make openclaw-install OPENCLAW_DIR=/usr/share/tokenless/adapters/openclaw
 
 # 手动安装
-cp -r openclaw/ /usr/share/tokenless/openclaw/
+cp -r openclaw/ /usr/share/tokenless/adapters/openclaw/
 ```
 
 #### 4.4.4 部署 Copilot Shell Hook

--- a/src/tokenless/tests/test-toon-full.sh
+++ b/src/tokenless/tests/test-toon-full.sh
@@ -67,7 +67,7 @@ else
 fi
 
 # 检查 copilot-shell hook
-if [ -x /usr/share/tokenless/hooks/copilot-shell/tokenless-compress-toon.sh ]; then
+if [ -x /usr/share/tokenless/adapters/cosh/tokenless-compress-toon.sh ]; then
     pass "COSH TOON hook 已安装且可执行"
 else
     fail "COSH TOON hook 缺失或不可执行"
@@ -235,7 +235,7 @@ fi
 # ========== 场景 2: COSH (copilot-shell) ==========
 section "场景 2: COSH (copilot-shell) Hooks"
 
-HOOK_DIR=/usr/share/tokenless/hooks/copilot-shell
+HOOK_DIR=/usr/share/tokenless/adapters/cosh
 
 scenario "2.1 独立 TOON Hook — 直接 JSON 对象"
 

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -37,8 +37,8 @@ The package includes:
 - rtk: High-performance CLI proxy for command rewriting (Apache-2.0 licensed)
 - toon: JSON to TOON format encoder/decoder for LLM token optimization
 
-Note: OpenClaw plugin and copilot-shell hooks are available in the source tree
-at /usr/share/doc/tokenless/ for manual configuration.
+Note: OpenClaw plugin and copilot-shell hooks are available under
+/usr/share/tokenless/adapters/ for manual configuration.
 
 %prep
 %setup -q -n tokenless
@@ -85,18 +85,18 @@ install -m 0644 docs/tokenless-user-manual-zh.md %{buildroot}%{_docdir}/tokenles
 install -m 0644 docs/response-compression.md %{buildroot}%{_docdir}/tokenless/
 install -m 0644 LICENSE %{buildroot}%{_docdir}/tokenless/
 
-# Install source files for reference (openclaw, hooks, scripts)
-mkdir -p %{buildroot}%{_datadir}/tokenless/openclaw
-mkdir -p %{buildroot}%{_datadir}/tokenless/hooks/copilot-shell
+# Install adapters (agent-specific plugins/hooks)
+mkdir -p %{buildroot}%{_datadir}/tokenless/adapters/openclaw
+mkdir -p %{buildroot}%{_datadir}/tokenless/adapters/cosh
 mkdir -p %{buildroot}%{_datadir}/tokenless/scripts
 
-install -m 0644 openclaw/index.ts %{buildroot}%{_datadir}/tokenless/openclaw/
-install -m 0644 openclaw/openclaw.plugin.json %{buildroot}%{_datadir}/tokenless/openclaw/
-install -m 0644 openclaw/package.json %{buildroot}%{_datadir}/tokenless/openclaw/
-install -m 0644 openclaw/README.md %{buildroot}%{_datadir}/tokenless/openclaw/
+install -m 0644 openclaw/index.ts %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
+install -m 0644 openclaw/openclaw.plugin.json %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
+install -m 0644 openclaw/package.json %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
+install -m 0644 openclaw/README.md %{buildroot}%{_datadir}/tokenless/adapters/openclaw/
 
-install -m 0755 hooks/copilot-shell/tokenless-*.sh %{buildroot}%{_datadir}/tokenless/hooks/copilot-shell/
-install -m 0644 hooks/copilot-shell/README.md %{buildroot}%{_datadir}/tokenless/hooks/copilot-shell/
+install -m 0755 hooks/copilot-shell/tokenless-*.sh %{buildroot}%{_datadir}/tokenless/adapters/cosh/
+install -m 0644 hooks/copilot-shell/README.md %{buildroot}%{_datadir}/tokenless/adapters/cosh/
 
 install -m 0755 scripts/install.sh %{buildroot}%{_datadir}/tokenless/scripts/
 
@@ -112,13 +112,13 @@ install -m 0755 scripts/install.sh %{buildroot}%{_datadir}/tokenless/scripts/
 %doc %{_docdir}/tokenless/tokenless-user-manual-zh.md
 %dir %{_datadir}/tokenless
 %dir %{_datadir}/tokenless/scripts
-%dir %{_datadir}/tokenless/hooks
-%dir %{_datadir}/tokenless/hooks/copilot-shell
-%dir %{_datadir}/tokenless/openclaw
+%dir %{_datadir}/tokenless/adapters
+%dir %{_datadir}/tokenless/adapters/openclaw
+%dir %{_datadir}/tokenless/adapters/cosh
 %attr(0755,root,root) %{_datadir}/tokenless/scripts/install.sh
-%attr(0755,root,root) %{_datadir}/tokenless/hooks/copilot-shell/tokenless-*.sh
-%attr(0644,root,root) %{_datadir}/tokenless/hooks/copilot-shell/README.md
-%{_datadir}/tokenless/openclaw/*
+%attr(0755,root,root) %{_datadir}/tokenless/adapters/cosh/tokenless-*.sh
+%attr(0644,root,root) %{_datadir}/tokenless/adapters/cosh/README.md
+%{_datadir}/tokenless/adapters/openclaw/*
 
 %post
 if [ -x %{_datadir}/tokenless/scripts/install.sh ]; then


### PR DESCRIPTION
## Description

The spec file installed openclaw and cosh files under the wrong directories, causing a path mismatch with install.sh. Align all install paths (spec, Makefile, docs, tests) to the canonical adapters/{openclaw,cosh}/ structure.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes #428 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
  验证结果

  Rust 单元测试：全部通过

  - tokenless-schema: 22/22 passed
  - tokenless-cli integration: 19/19 passed
  - tokenless-stats: 18/18 passed

  RPM 包路径验证

  ┌─────────────────┬─────────────────────────────────────────┬───────────────────────────────────┐
  │      路径       │                  期望                   │               实际                │
  ├─────────────────┼─────────────────────────────────────────┼───────────────────────────────────┤
  │ 二进制          │ /usr/bin/tokenless                      │ /usr/bin/tokenless                │
  ├─────────────────┼─────────────────────────────────────────┼───────────────────────────────────┤
  │ 辅助二进制      │ /usr/libexec/tokenless/{rtk,toon}       │ /usr/libexec/tokenless/{rtk,toon} │
  ├─────────────────┼─────────────────────────────────────────┼───────────────────────────────────┤
  │ OpenClaw 适配器 │ /usr/share/tokenless/adapters/openclaw/ │ 正确安装 4 个文件                 │
  ├─────────────────┼─────────────────────────────────────────┼───────────────────────────────────┤
  │ COSH hooks      │ /usr/share/tokenless/adapters/cosh/     │ 正确安装 4 个脚本                 │
  ├─────────────────┼─────────────────────────────────────────┼───────────────────────────────────┤
  │ 安装脚本        │ /usr/share/tokenless/scripts/install.sh │ 正确                              │
  └─────────────────┴─────────────────────────────────────────┴───────────────────────────────────┘
```
