### PR TITLE
fix(cosh): emit allow decision reason to UI when systemMessage is absent

### DIFF
--- a/src/copilot-shell/hooks/docs/reference.md
+++ b/src/copilot-shell/hooks/docs/reference.md
@@ -38,15 +38,15 @@ All hooks receive these common fields via `stdin`:
 
 Most hooks support these fields in their `stdout` JSON:
 
-| Field                | Type      | Description                                                                                                                                              |
-| :------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `systemMessage`      | `string`  | Displayed immediately to the user in the terminal.                                                                                                       |
-| `suppressOutput`     | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                                                                                             |
-| `continue`           | `boolean` | If `false`, stops the entire agent loop immediately.                                                                                                     |
-| `stopReason`         | `string`  | Displayed to the user when `continue` is `false`.                                                                                                        |
-| `decision`           | `string`  | `"allow"`, `"deny"` (alias `"block"`), `"ask"`, or `"approve"`.                                                                                          |
-| `reason`             | `string`  | The feedback/error message used for `"deny"`/`"block"` decisions and stop-like flows. For user-visible allow/approve/ask messaging, use `systemMessage`. |
-| `hookSpecificOutput` | `object`  | Event-specific output fields (see individual event sections).                                                                                            |
+| Field                | Type      | Description                                                                                                                                                                                                                         |
+| :------------------- | :-------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `systemMessage`      | `string`  | Shown to the user as a per-hook notification box labeled with the hook name, independent of the tool confirmation dialog.                                                                                                           |
+| `suppressOutput`     | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                                                                                                                                                                        |
+| `continue`           | `boolean` | If `false`, stops the entire agent loop immediately.                                                                                                                                                                                |
+| `stopReason`         | `string`  | Displayed to the user when `continue` is `false`.                                                                                                                                                                                   |
+| `decision`           | `string`  | `"allow"`, `"deny"` (alias `"block"`), `"ask"`, or `"approve"`.                                                                                                                                                                     |
+| `reason`             | `string`  | The feedback/error message used for `"deny"`/`"block"` decisions and stop-like flows. For user-visible allow/approve/ask messaging, prefer `systemMessage`; if omitted, `reason` is used as the fallback text for the notification. |
+| `hookSpecificOutput` | `object`  | Event-specific output fields (see individual event sections).                                                                                                                                                                       |
 
 ---
 
@@ -64,17 +64,22 @@ and parameter rewriting.
   - `original_request_name`: (`string`) The original name if this is a tail call.
 - **Relevant Output Fields**:
   - `decision`: Set to `"deny"` (or `"block"`) to prevent tool execution.
-  - `systemMessage`: Use this for any informational or warning text that
-    should be shown to the user when execution continues, including
-    `"allow"`, `"approve"`, and `"ask"` flows.
-  - `reason`: Required if denied. Sent to the agent as a tool error. Do not
-    rely on `reason` alone for user-visible allow/ask messaging.
+  - `systemMessage`: Any informational or warning text you want the user to
+    see. It is rendered as a separate, per-hook notification box (labeled
+    with the hook name) above the tool confirmation dialog, regardless of
+    the final decision. When the overall outcome is `block`/`deny`, per-hook
+    boxes whose own `decision` is not blocking are dimmed so they do not
+    visually conflict with the denied outcome.
+  - `reason`: Required if denied. Sent to the agent as a tool error. Also
+    used as the fallback notification text when `systemMessage` is omitted.
   - `hookSpecificOutput.tool_input`: An object that **merges with and
     overrides** the model's arguments before execution.
   - `continue`: Set to `false` to **kill the entire agent loop**.
-- **Allow/Approve/Ask note**: If you want the user to see a warning or prompt
-  while the tool is still allowed or awaiting confirmation, put that text in
-  `systemMessage`.
+- **Ask-dialog note**: When `decision` is `"ask"`, the tool confirmation
+  dialog always uses a fixed prompt — `A hook requires your confirmation to
+proceed.` — instead of the hook's `systemMessage`. The hook's
+  `systemMessage` is still shown as a separate notification box above the
+  dialog, so users see both the reason and the confirmation choice.
 - **Exit Code 2 (Block Tool)**: Prevents execution. Uses `stderr` as reason.
 
 ### `PostToolUse`

--- a/src/copilot-shell/hooks/docs/writing-hooks.md
+++ b/src/copilot-shell/hooks/docs/writing-hooks.md
@@ -88,9 +88,11 @@ echo '{"decision": "allow"}'
 exit 0
 ```
 
-For `PreToolUse`, use `systemMessage` for any warning or informational text you
-want users to see on `allow`, `approve`, or `ask` paths. Reserve `reason` for
-deny or block outcomes.
+For `PreToolUse`, put any user-facing text in `systemMessage` — it is rendered
+as a per-hook notification box labeled with the hook name, independent of the
+final decision. Use `reason` for the denial/error message on `deny` or `block`
+outcomes; if `systemMessage` is omitted, `reason` is used as the fallback text
+for the notification.
 
 **Configuration:**
 

--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1602,4 +1602,6 @@ export default {
   // ============================================================================
   '⚠️  **Hook Safety Check**': '⚠️  **Hook Safety Check**',
   'Send this prompt or cancel?': 'Send this prompt or cancel?',
+  'A hook requires your confirmation to proceed.':
+    'A hook requires your confirmation to proceed.',
 };

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -1419,4 +1419,6 @@ export default {
   // ============================================================================
   '⚠️  **Hook Safety Check**': '⚠️  **Hook 安全检查提示**',
   'Send this prompt or cancel?': '是否继续发送这条 prompt？',
+  'A hook requires your confirmation to proceed.':
+    '有 Hook 需要您的确认方可继续。',
 };

--- a/src/copilot-shell/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -330,7 +330,7 @@ export const ToolConfirmationMessage: React.FC<
     bodyContent = (
       <Box flexDirection="column" paddingX={1} marginLeft={1}>
         <Text color={theme.text.link}>
-          <RenderInline text={infoProps.prompt} />
+          <RenderInline text={t(infoProps.prompt)} />
         </Text>
         {displayUrls && infoProps.urls && infoProps.urls.length > 0 && (
           <Box flexDirection="column" marginTop={1}>

--- a/src/copilot-shell/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -20,6 +20,7 @@ import type {
   PlanResultDisplay,
   AnsiOutput,
   Config,
+  HookDecision,
 } from '@copilot-shell/core';
 import { AgentExecutionDisplay } from '../subagents/index.js';
 import { PlanSummaryDisplay } from '../PlanSummaryDisplay.js';
@@ -37,6 +38,47 @@ const STATIC_HEIGHT = 1;
 const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
 const STATUS_INDICATOR_WIDTH = 3;
 const MIN_LINES_SHOWN = 2; // show at least this many lines
+
+/**
+ * Map a hook decision to a (color token, leading icon) pair so that the hook
+ * notification block can be color-coded by outcome:
+ *   allow / approve  → success (green)  ✓
+ *   ask              → warning (yellow) ?
+ *   block / deny     → error   (red)    ✗
+ *   undefined        → neutral (dim)    ●  (pure informational)
+ *
+ * When `mergedDecision` (the aggregated final decision across all hooks)
+ * indicates block/deny, any per-hook box whose own decision is NOT block/deny
+ * is dimmed to neutral gray. This avoids the visual conflict of a green
+ * “allow” box sitting alongside a red “deny” box when the overall execution
+ * is rejected. merged=ask does not trigger dimming — ask is not a rejection.
+ */
+function decisionToStyle(
+  decision?: HookDecision,
+  mergedDecision?: HookDecision,
+): {
+  color: string;
+  icon: string;
+} {
+  const mergedIsBlocking =
+    mergedDecision === 'block' || mergedDecision === 'deny';
+  const selfIsBlocking = decision === 'block' || decision === 'deny';
+  if (mergedIsBlocking && !selfIsBlocking) {
+    return { color: theme.text.secondary, icon: '●' };
+  }
+  switch (decision) {
+    case 'allow':
+    case 'approve':
+      return { color: theme.status.success, icon: '✓' };
+    case 'ask':
+      return { color: theme.status.warning, icon: '?' };
+    case 'block':
+    case 'deny':
+      return { color: theme.status.error, icon: '✗' };
+    default:
+      return { color: theme.text.secondary, icon: '●' };
+  }
+}
 
 // Large threshold to ensure we don't cause performance issues for very large
 // outputs that will get truncated further MaxSizedBox anyway.
@@ -237,6 +279,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   name,
   description,
   resultDisplay,
+  hookNotification,
   status,
   availableTerminalHeight,
   contentWidth,
@@ -327,6 +370,43 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         )}
         {emphasis === 'high' && <TrailingIndicator />}
       </Box>
+      {hookNotification && hookNotification.length > 0 && (
+        <Box
+          paddingLeft={STATUS_INDICATOR_WIDTH}
+          marginTop={1}
+          flexDirection="column"
+        >
+          {hookNotification.map((item, i) => {
+            const { color, icon } = decisionToStyle(
+              item.decision,
+              item.mergedDecision,
+            );
+            return (
+              <Box
+                key={i}
+                borderStyle="single"
+                borderTop={false}
+                borderRight={false}
+                borderBottom={false}
+                borderLeft={true}
+                borderColor={color}
+                paddingLeft={1}
+                marginTop={i === 0 ? 0 : 1}
+                flexDirection="column"
+              >
+                <Text color={color} bold>
+                  {icon} {item.hookName}
+                </Text>
+                {item.message && (
+                  <Box paddingLeft={2} flexDirection="column">
+                    <Text color={theme.text.primary}>{item.message}</Text>
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
+        </Box>
+      )}
       {displayRenderer.type !== 'none' && (
         <Box paddingLeft={STATUS_INDICATOR_WIDTH} width="100%" marginTop={1}>
           <Box flexDirection="column">

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -20,12 +20,14 @@ import type {
   Status as CoreStatus,
   EditorType,
   SandboxBypassApprovalRequest,
+  HookNotificationDisplay,
 } from '@copilot-shell/core';
 import { CoreToolScheduler } from '@copilot-shell/core';
-import { useCallback, useState, useMemo } from 'react';
+import { useCallback, useState, useMemo, useRef } from 'react';
 import type {
   HistoryItemToolGroup,
   IndividualToolCallDisplay,
+  HookNotificationItem,
 } from '../types.js';
 import { ToolCallStatus } from '../types.js';
 
@@ -37,28 +39,28 @@ export type MarkToolsAsSubmittedFn = (callIds: string[]) => void;
 
 export type TrackedScheduledToolCall = ScheduledToolCall & {
   responseSubmittedToGemini?: boolean;
-  hookSystemMessage?: string;
+  hookSystemMessage?: HookNotificationItem[];
 };
 export type TrackedValidatingToolCall = ValidatingToolCall & {
   responseSubmittedToGemini?: boolean;
-  hookSystemMessage?: string;
+  hookSystemMessage?: HookNotificationItem[];
 };
 export type TrackedWaitingToolCall = WaitingToolCall & {
   responseSubmittedToGemini?: boolean;
-  hookSystemMessage?: string;
+  hookSystemMessage?: HookNotificationItem[];
 };
 export type TrackedExecutingToolCall = ExecutingToolCall & {
   responseSubmittedToGemini?: boolean;
   pid?: number;
-  hookSystemMessage?: string;
+  hookSystemMessage?: HookNotificationItem[];
 };
 export type TrackedCompletedToolCall = CompletedToolCall & {
   responseSubmittedToGemini?: boolean;
-  hookSystemMessage?: string;
+  hookSystemMessage?: HookNotificationItem[];
 };
 export type TrackedCancelledToolCall = CancelledToolCall & {
   responseSubmittedToGemini?: boolean;
-  hookSystemMessage?: string;
+  hookSystemMessage?: HookNotificationItem[];
 };
 
 export type TrackedToolCall =
@@ -68,6 +70,18 @@ export type TrackedToolCall =
   | TrackedExecutingToolCall
   | TrackedCompletedToolCall
   | TrackedCancelledToolCall;
+
+/**
+ * Type guard: checks if an outputChunk is a structured HookNotificationDisplay.
+ */
+function isHookNotification(chunk: unknown): chunk is HookNotificationDisplay {
+  return (
+    typeof chunk === 'object' &&
+    chunk !== null &&
+    'hookName' in chunk &&
+    'hookMessage' in chunk
+  );
+}
 
 export function useReactToolScheduler(
   onComplete: (tools: CompletedToolCall[]) => Promise<void>,
@@ -83,22 +97,49 @@ export function useReactToolScheduler(
     TrackedToolCall[]
   >([]);
 
+  // Synchronous registry of hook notifications keyed by callId.
+  // React state updates (setToolCallsForDisplay) are asynchronous, so when
+  // allToolCallsCompleteHandler fires it may see stale state. This ref is
+  // updated synchronously inside outputUpdateHandler and is always current
+  // when the history snapshot is created.
+  const hookNotificationsRef = useRef<Map<string, HookNotificationItem[]>>(
+    new Map(),
+  );
+
   const outputUpdateHandler: OutputUpdateHandler = useCallback(
     (toolCallId, outputChunk) => {
+      // Structured hook notification from the core scheduler.
+      if (isHookNotification(outputChunk)) {
+        const item: HookNotificationItem = {
+          hookName: outputChunk.hookName,
+          message: outputChunk.hookMessage,
+          decision: outputChunk.decision,
+          mergedDecision: outputChunk.mergedDecision,
+        };
+        // Synchronous ref update for history snapshots.
+        const existing = hookNotificationsRef.current.get(toolCallId) ?? [];
+        hookNotificationsRef.current.set(toolCallId, [...existing, item]);
+        // React state update for live display.
+        setToolCallsForDisplay((prevCalls) =>
+          prevCalls.map((tc) => {
+            if (tc.request.callId === toolCallId) {
+              return {
+                ...tc,
+                hookSystemMessage: [...(tc.hookSystemMessage ?? []), item],
+              } as typeof tc;
+            }
+            return tc;
+          }),
+        );
+        return;
+      }
+
+      // Live streaming output (executing phase).
       setToolCallsForDisplay((prevCalls) =>
         prevCalls.map((tc) => {
-          if (tc.request.callId === toolCallId) {
-            if (tc.status === 'executing') {
-              const executingTc = tc as TrackedExecutingToolCall;
-              return { ...executingTc, liveOutput: outputChunk };
-            }
-            // Hook systemMessage is emitted during the 'validating' phase,
-            // before execution starts. Store as hookSystemMessage so it
-            // persists across state transitions (validating -> awaiting_approval).
-            if (tc.status === 'validating' && typeof outputChunk === 'string') {
-              const validatingTc = tc as TrackedValidatingToolCall;
-              return { ...validatingTc, hookSystemMessage: outputChunk.trim() };
-            }
+          if (tc.request.callId === toolCallId && tc.status === 'executing') {
+            const executingTc = tc as TrackedExecutingToolCall;
+            return { ...executingTc, liveOutput: outputChunk };
           }
           return tc;
         }),
@@ -109,7 +150,19 @@ export function useReactToolScheduler(
 
   const allToolCallsCompleteHandler: AllToolCallsCompleteHandler = useCallback(
     async (completedToolCalls) => {
-      await onComplete(completedToolCalls);
+      // completedToolCalls comes from the core scheduler (CompletedToolCall[])
+      // and does NOT carry the UI-only hookSystemMessage field. Enrich each
+      // entry from the synchronous ref before handing off to onComplete so
+      // that the history snapshot preserves hook notifications.
+      const enriched = completedToolCalls.map((tc) => ({
+        ...tc,
+        hookSystemMessage: hookNotificationsRef.current.get(tc.request.callId),
+      }));
+      // Clean up processed entries to avoid unbounded growth.
+      completedToolCalls.forEach((tc) =>
+        hookNotificationsRef.current.delete(tc.request.callId),
+      );
+      await onComplete(enriched as CompletedToolCall[]);
     },
     [onComplete],
   );
@@ -276,6 +329,9 @@ export function mapToDisplay(
             resultDisplay: trackedCall.response.resultDisplay,
             confirmationDetails: undefined,
             outputFile: trackedCall.response.outputFile,
+            hookNotification: trackedCall.hookSystemMessage?.length
+              ? trackedCall.hookSystemMessage
+              : undefined,
           };
         case 'error':
           return {
@@ -283,6 +339,9 @@ export function mapToDisplay(
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
             resultDisplay: trackedCall.response.resultDisplay,
             confirmationDetails: undefined,
+            hookNotification: trackedCall.hookSystemMessage?.length
+              ? trackedCall.hookSystemMessage
+              : undefined,
           };
         case 'cancelled':
           return {
@@ -290,36 +349,48 @@ export function mapToDisplay(
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
             resultDisplay: trackedCall.response.resultDisplay,
             confirmationDetails: undefined,
+            hookNotification: trackedCall.hookSystemMessage?.length
+              ? trackedCall.hookSystemMessage
+              : undefined,
           };
         case 'awaiting_approval':
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
-            resultDisplay:
-              (trackedCall as TrackedWaitingToolCall).hookSystemMessage ??
-              undefined,
+            resultDisplay: undefined,
             confirmationDetails: trackedCall.confirmationDetails,
+            hookNotification: (trackedCall as TrackedWaitingToolCall)
+              .hookSystemMessage?.length
+              ? (trackedCall as TrackedWaitingToolCall).hookSystemMessage
+              : undefined,
           };
         case 'executing':
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
+            // Show live streaming output if available. The hook pre-execution
+            // notification is rendered separately via hookNotification so it
+            // remains visible alongside live output.
             resultDisplay:
               (trackedCall as TrackedExecutingToolCall).liveOutput ?? undefined,
             confirmationDetails: undefined,
             ptyId: (trackedCall as TrackedExecutingToolCall).pid,
+            hookNotification: trackedCall.hookSystemMessage?.length
+              ? trackedCall.hookSystemMessage
+              : undefined,
           };
         case 'validating': // Fallthrough
         case 'scheduled':
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
-            resultDisplay:
-              trackedCall.status === 'validating'
-                ? ((trackedCall as TrackedValidatingToolCall).liveOutput ??
-                  undefined)
-                : undefined,
+            resultDisplay: undefined,
             confirmationDetails: undefined,
+            // Hook pre-execution notification shown via hookNotification so it
+            // persists through all subsequent states.
+            hookNotification: trackedCall.hookSystemMessage?.length
+              ? trackedCall.hookSystemMessage
+              : undefined,
           };
         default: {
           const exhaustiveCheck: never = trackedCall;

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -12,6 +12,7 @@ import {
   useReactToolScheduler,
   mapToDisplay,
 } from './useReactToolScheduler.js';
+import type { TrackedToolCall } from './useReactToolScheduler.js';
 import type { PartUnion, FunctionResponse } from '@google/genai';
 import type {
   Config,
@@ -780,5 +781,94 @@ describe('mapToDisplay', () => {
     expect(display.tools[1].status).toBe(ToolCallStatus.Executing);
     expect(display.tools[1].resultDisplay).toBe('markdown output');
     expect(display.tools[1].renderOutputAsMarkdown).toBe(true);
+  });
+
+  it('should render hookSystemMessage as hookNotification for validating status', () => {
+    // Regression: hook pre-execution notifications (e.g. "signature could not
+    // be verified") must be visible even for auto-allowed tools that never
+    // enter awaiting_approval. The notification now lives in hookNotification
+    // (not resultDisplay) so it persists after the tool completes.
+    // Each hook's message is stored as a separate structured element for
+    // independent box rendering.
+    const toolCall = {
+      request: baseRequest,
+      status: 'validating',
+      tool: baseTool,
+      invocation: baseInvocation,
+      hookSystemMessage: [
+        {
+          hookName: 'my-hook',
+          message: 'Warning: skill signature could not be verified',
+        },
+      ],
+    } as unknown as TrackedToolCall;
+
+    const display = mapToDisplay(toolCall);
+    expect(display.tools[0].status).toBe(ToolCallStatus.Executing);
+    expect(display.tools[0].resultDisplay).toBeUndefined();
+    expect(display.tools[0].hookNotification).toEqual([
+      {
+        hookName: 'my-hook',
+        message: 'Warning: skill signature could not be verified',
+      },
+    ]);
+  });
+
+  it('should show hookNotification independently of liveOutput for executing tool', () => {
+    // Both liveOutput and hookNotification are now independent fields.
+    // A tool with no streaming output still shows the hook warning via hookNotification.
+    const toolCall = {
+      request: baseRequest,
+      status: 'executing',
+      tool: baseTool,
+      invocation: baseInvocation,
+      liveOutput: undefined,
+      hookSystemMessage: [
+        {
+          hookName: 'my-hook',
+          message: 'Warning: skill signature could not be verified',
+        },
+      ],
+    } as unknown as TrackedToolCall;
+
+    const display = mapToDisplay(toolCall);
+    expect(display.tools[0].status).toBe(ToolCallStatus.Executing);
+    expect(display.tools[0].resultDisplay).toBeUndefined();
+    expect(display.tools[0].hookNotification).toEqual([
+      {
+        hookName: 'my-hook',
+        message: 'Warning: skill signature could not be verified',
+      },
+    ]);
+  });
+
+  it('should show both liveOutput and hookNotification simultaneously for executing tool', () => {
+    // liveOutput (real-time streaming) and hook notification are now both
+    // visible at the same time — hookNotification no longer falls back to
+    // liveOutput; they are rendered as separate UI elements.
+    const toolCall = {
+      request: baseRequest,
+      status: 'executing',
+      tool: baseTool,
+      invocation: baseInvocation,
+      liveOutput: 'streaming output...',
+      hookSystemMessage: [
+        {
+          hookName: 'hook-a',
+          message: 'Warning: skill signature could not be verified',
+        },
+        { hookName: 'hook-b', message: 'Another hook message' },
+      ],
+    } as unknown as TrackedToolCall;
+
+    const display = mapToDisplay(toolCall);
+    expect(display.tools[0].resultDisplay).toBe('streaming output...');
+    expect(display.tools[0].hookNotification).toEqual([
+      {
+        hookName: 'hook-a',
+        message: 'Warning: skill signature could not be verified',
+      },
+      { hookName: 'hook-b', message: 'Another hook message' },
+    ]);
   });
 });

--- a/src/copilot-shell/packages/cli/src/ui/types.ts
+++ b/src/copilot-shell/packages/cli/src/ui/types.ts
@@ -6,6 +6,7 @@
 
 import type {
   CompressionStatus,
+  HookDecision,
   MCPServerConfig,
   ThoughtSummary,
   ToolCallConfirmationDetails,
@@ -49,6 +50,23 @@ export enum ToolCallStatus {
   Error = 'Error',
 }
 
+/** A single hook notification with the hook's display name and message. */
+export interface HookNotificationItem {
+  hookName: string;
+  message: string;
+  /**
+   * This single hook's original decision. Drives the per-box color / icon
+   * (allow/approve → success, ask → warning, block/deny → error, undef → neutral).
+   */
+  decision?: HookDecision;
+  /**
+   * Aggregated final decision across all hooks fired for this event. When it
+   * is block/deny while `decision` is not, the UI dims this box to neutral
+   * to avoid “green allow box + rejected execution” visual conflict.
+   */
+  mergedDecision?: HookDecision;
+}
+
 export interface ToolCallEvent {
   type: 'tool_call';
   status: ToolCallStatus;
@@ -69,6 +87,13 @@ export interface IndividualToolCallDisplay {
   renderOutputAsMarkdown?: boolean;
   ptyId?: number;
   outputFile?: string;
+  /**
+   * Hook pre-execution notifications (from PreToolUse hook's systemMessage / reason).
+   * Each element represents one hook's notification with its name and message.
+   * Persists across all tool call states so notifications remain visible after completion.
+   * Rendered as separate bordered boxes, one per hook.
+   */
+  hookNotification?: HookNotificationItem[];
 }
 
 export interface CompressionProps {

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
@@ -2326,12 +2326,14 @@ describe('CoreToolScheduler Sequential Execution', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // Regression: hookForceAsk must always synthesize an 'info' dialog that
-  //   shows the hook message in the prompt body (not just the title), while
-  //   still forwarding the original onConfirm so native side-effects
-  //   (e.g. setApprovalMode, allowlisting) are preserved.
+  // Regression: hookForceAsk must always synthesize an 'info' dialog with a
+  //   fixed confirmation prompt, while still forwarding the original
+  //   onConfirm so native side-effects (e.g. setApprovalMode, allowlisting)
+  //   are preserved. The per-hook messages are rendered separately as
+  //   structured HookNotificationDisplay boxes above the dialog, so the
+  //   dialog prompt no longer embeds the hook's systemMessage.
   // ─────────────────────────────────────────────────────────────────────────
-  it('hookForceAsk should synthesize an info dialog with hook message in prompt, preserving original onConfirm side-effects', async () => {
+  it('hookForceAsk should synthesize an info dialog with a fixed prompt, preserving original onConfirm side-effects', async () => {
     let approvalMode = ApprovalMode.DEFAULT;
 
     // Hook always returns 'ask'
@@ -2441,14 +2443,17 @@ describe('CoreToolScheduler Sequential Execution', () => {
     });
 
     // ── Key assertions ──────────────────────────────────────────────────────
-    // 1. Confirmation type must be 'info' — hook message shown in prompt body,
-    //    not buried in a title augmented onto the native 'edit' dialog.
+    // 1. Confirmation type must be 'info' — dialog simply asks the user to
+    //    decide; the per-hook messages render separately as notification
+    //    boxes above this dialog.
     expect(capturedWaitingCall!.confirmationDetails.type).toBe('info');
 
-    // 2. The hook warning must appear in the prompt (not just the title).
+    // 2. The prompt should be the fixed confirmation ask, NOT the merged
+    //    hook systemMessage (which would duplicate the notification boxes).
+    //    The English string here is also used as the i18n key on the UI side.
     expect(
       (capturedWaitingCall!.confirmationDetails as { prompt?: string }).prompt,
-    ).toContain('Hook inspection required');
+    ).toBe('A hook requires your confirmation to proceed.');
 
     // 3. The title should be the generic hook header.
     expect(capturedWaitingCall!.confirmationDetails.title).toBe(
@@ -2473,6 +2478,138 @@ describe('CoreToolScheduler Sequential Execution', () => {
         .calls[0][0] as ToolCall[];
       expect(completedCalls[0].status).toBe('success');
     });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Regression: Bug #421 — PreToolUse allow decision reason field is silently
+  //   ignored and not displayed in UI.
+  //   After the structured-notification refactor, aggregator always produces
+  //   `notifications[]` when any hook supplies systemMessage or reason, and
+  //   the scheduler emits those as HookNotificationDisplay objects.
+  // ─────────────────────────────────────────────────────────────────────────
+  it('allow decision with reason should emit a structured notification to outputUpdateHandler', async () => {
+    const executeFn = vi.fn().mockResolvedValue({
+      llmContent: 'done',
+      returnDisplay: 'done',
+    });
+    const allowReasonTool = new MockTool({
+      name: 'allowReasonTool',
+      execute: executeFn,
+      shouldConfirmExecute: vi.fn().mockResolvedValue(false),
+    });
+
+    // Hook returns allow with reason. Aggregator would forward this as one
+    // entry in notifications[]; we mock the aggregated shape directly.
+    const hookAllowReasonOutput = {
+      decision: 'allow' as const,
+      isBlockingDecision: () => false,
+      shouldStopExecution: () => false,
+      isAskDecision: () => false,
+      systemMessage: undefined,
+      reason: 'Warning: skill signature could not be verified',
+      getModifiedToolInput: () => null,
+      getEffectiveReason: () =>
+        'Warning: skill signature could not be verified',
+      notifications: [
+        {
+          hookName: 'skill-verifier',
+          message: 'Warning: skill signature could not be verified',
+          decision: 'allow' as const,
+        },
+      ],
+    };
+    const mockHookAllowReason = {
+      firePreToolUseEvent: vi.fn().mockResolvedValue(hookAllowReasonOutput),
+      firePostToolUseEvent: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const toolRegistryAllowReason = {
+      getTool: () => allowReasonTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => allowReasonTool,
+      getToolByDisplayName: () => allowReasonTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsCompleteAllowReason = vi.fn();
+    const outputUpdateHandlerMock = vi.fn();
+
+    const mockConfigAllowReason = {
+      getSessionId: () => 'test-session-allow-reason',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getAllowedTools: () => [],
+      getToolRegistry: () => toolRegistryAllowReason,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getUseSmartEdit: () => false,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      isInteractive: () => true,
+      getExperimentalZedIntegration: () => false,
+      getEnableHooks: () => true,
+      getHookSystem: () => mockHookAllowReason,
+    } as unknown as Config;
+
+    const schedulerAllowReason = new CoreToolScheduler({
+      config: mockConfigAllowReason,
+      onAllToolCallsComplete: onAllToolCallsCompleteAllowReason,
+      onToolCallsUpdate: vi.fn(),
+      outputUpdateHandler: outputUpdateHandlerMock,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortControllerAllowReason = new AbortController();
+    await schedulerAllowReason.schedule(
+      [
+        {
+          callId: 'allow-reason-1',
+          name: 'allowReasonTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'p-allow-reason',
+        },
+      ],
+      abortControllerAllowReason.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsCompleteAllowReason).toHaveBeenCalled();
+    });
+
+    // The notification must have been emitted via outputUpdateHandler as a
+    // structured HookNotificationDisplay so that the terminal UI renders it
+    // with the hook's name, icon and color.
+    expect(outputUpdateHandlerMock).toHaveBeenCalledWith('allow-reason-1', {
+      hookName: 'skill-verifier',
+      hookMessage: 'Warning: skill signature could not be verified',
+      decision: 'allow',
+      mergedDecision: 'allow',
+    });
+
+    // The tool must still execute successfully — allow means proceed.
+    const completedCalls = onAllToolCallsCompleteAllowReason.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('success');
   });
 });
 

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -32,6 +32,7 @@ import {
   SkillTool,
 } from '../index.js';
 import type { SandboxBypassApprovalRequest } from '../index.js';
+import type { HookDecision } from '../hooks/types.js';
 import type {
   FunctionResponse,
   FunctionResponsePart,
@@ -66,8 +67,6 @@ export type ValidatingToolCall = {
   invocation: AnyToolInvocation;
   startTime?: number;
   outcome?: ToolConfirmationOutcome;
-  /** Hook systemMessage emitted during pre-execution validation phase */
-  liveOutput?: ToolResultDisplay;
 };
 
 export type ScheduledToolCall = {
@@ -865,11 +864,46 @@ export class CoreToolScheduler {
               );
 
               if (hookOutput) {
-                // Block: abort the tool call immediately
-                if (
+                // Compute the merged decision once so every notification shares
+                // the same context. 'block'/'deny'/'ask' come from the hook
+                // decision itself; shouldStopExecution() (continue=false) is
+                // also treated as a blocking context for UI dimming purposes.
+                const isBlocking =
                   hookOutput.isBlockingDecision() ||
-                  hookOutput.shouldStopExecution()
+                  hookOutput.shouldStopExecution();
+                const isAsk = hookOutput.isAskDecision();
+                const mergedDecision: HookDecision | undefined = isBlocking
+                  ? hookOutput.decision === 'deny'
+                    ? 'deny'
+                    : 'block'
+                  : isAsk
+                    ? 'ask'
+                    : hookOutput.decision;
+
+                // Emit hook notifications FIRST, regardless of the final
+                // decision, so every hook's voice is preserved in the UI
+                // (principle: “expose as much as possible unless denied”).
+                // UI uses mergedDecision to dim per-hook boxes when the
+                // overall outcome is block/deny, avoiding “green allow box
+                // + rejected execution” visual conflict.
+                if (
+                  this.outputUpdateHandler &&
+                  hookOutput.notifications?.length
                 ) {
+                  for (const n of hookOutput.notifications) {
+                    this.outputUpdateHandler(reqInfo.callId, {
+                      hookName: n.hookName,
+                      hookMessage: n.message,
+                      decision: n.decision,
+                      mergedDecision,
+                    });
+                  }
+                }
+
+                // Block: abort the tool call immediately. Execution rule
+                // block > ask > allow is preserved (this branch runs after
+                // notifications are already emitted above).
+                if (isBlocking) {
                   const reason = hookOutput.getEffectiveReason();
                   this.setStatusInternal(
                     reqInfo.callId,
@@ -884,7 +918,7 @@ export class CoreToolScheduler {
                 }
 
                 // Ask: force user confirmation regardless of YOLO/allowlist
-                if (hookOutput.isAskDecision()) {
+                if (isAsk) {
                   hookForceAsk = true;
                   hookAskMessage = hookOutput.systemMessage;
                 }
@@ -912,19 +946,6 @@ export class CoreToolScheduler {
                     }
                     this.notifyToolCallsUpdate();
                   }
-                }
-
-                // Emit systemMessage notification to UI (only for non-ask decisions;
-                // for ask decisions the message is shown in the confirmation dialog)
-                if (
-                  hookOutput.systemMessage &&
-                  !hookForceAsk &&
-                  this.outputUpdateHandler
-                ) {
-                  this.outputUpdateHandler(
-                    reqInfo.callId,
-                    hookOutput.systemMessage + '\n',
-                  );
                 }
               }
             } catch (error) {
@@ -965,9 +986,18 @@ export class CoreToolScheduler {
             | ToolCallConfirmationDetails
             | false = confirmationDetails;
           if (hookForceAsk) {
-            const askPrompt =
-              hookAskMessage ||
-              'A hook has requested confirmation before executing this tool.';
+            // Fixed prompt text. The actual per-hook messages are already
+            // rendered above the dialog as structured HookNotificationDisplay
+            // boxes (emitted before this point, regardless of decision). The
+            // dialog only needs to ask the user to make a decision; showing
+            // the merged systemMessage here would duplicate those boxes.
+            // `hookAskMessage` is intentionally unused in the prompt body.
+            void hookAskMessage;
+            // NOTE: This English string is used as a stable i18n key on the UI
+            // side (see ToolConfirmationMessage.tsx, which wraps `prompt` with
+            // t()). Keep both locales/en.js and locales/zh.js entries in sync
+            // when editing this text.
+            const askPrompt = 'A hook requires your confirmation to proceed.';
             // Always synthesize an 'info' dialog so the hook message is shown
             // prominently in the prompt body rather than buried in the title.
             // If the tool has a native confirmation, forward its onConfirm so

--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
@@ -20,6 +20,7 @@ import type {
   HookConfig,
   HookExecutionResult,
   BeforeToolSelectionOutput,
+  HookDecision,
 } from './types.js';
 
 /**
@@ -48,6 +49,17 @@ function getHookDisplayName(config: HookConfig | undefined): string {
 }
 
 /**
+ * Per-hook notification for UI display (hookName + message pair).
+ * The optional `decision` field lets the UI choose color and icon based on
+ * the hook's outcome (allow / approve / ask / block / deny / undefined).
+ */
+export interface HookNotification {
+  hookName: string;
+  message: string;
+  decision?: HookDecision;
+}
+
+/**
  * Aggregated result from multiple hook executions
  */
 export interface AggregatedHookResult {
@@ -56,6 +68,8 @@ export interface AggregatedHookResult {
   errors: Error[];
   totalDuration: number;
   finalOutput?: HookOutput;
+  /** Per-hook UI notifications (hookName + message). */
+  notifications?: HookNotification[];
 }
 
 /**
@@ -96,12 +110,29 @@ export class HookAggregator {
     const success = errors.length === 0;
     const finalOutput = this.mergeOutputs(namedOutputs, eventName);
 
+    // Build per-hook notifications for UI display. Each hook that provides a
+    // systemMessage (or falls back to reason) gets its own notification entry
+    // so the UI can render them as independent visual elements with the hook
+    // name clearly attributed.
+    const notifications: HookNotification[] = [];
+    for (const { name, output } of namedOutputs) {
+      const msg = output.systemMessage ?? output.reason;
+      if (msg) {
+        notifications.push({
+          hookName: name,
+          message: msg,
+          decision: output.decision,
+        });
+      }
+    }
+
     return {
       success,
       allOutputs,
       errors,
       totalDuration,
       finalOutput,
+      notifications: notifications.length > 0 ? notifications : undefined,
     };
   }
 
@@ -226,6 +257,10 @@ export class HookAggregator {
     }
 
     // Set merged decision
+    // Note: 'approve' is a Claude-Code-compatible single-hook value that no
+    // merge branch produces here; it is treated as equivalent to 'allow' at
+    // the scheduler level (neither blocking nor ask). Per-hook 'approve' is
+    // still forwarded verbatim in notifications so the UI can render it.
     if (hasBlock) {
       merged.decision = 'block';
     } else if (hasAsk) {

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -126,6 +126,11 @@ export class HookSystem {
           result.finalOutput,
         ) as PreToolUseHookOutput)
       : undefined;
+    // Carry per-hook notifications from the aggregator so the scheduler can
+    // emit them as structured data to the UI layer.
+    if (output && result.notifications?.length) {
+      output.notifications = result.notifications;
+    }
     debugLogger.info(
       `[Hook Debug] hookSystem.firePreToolUseEvent: facade returning, hasOutput=${!!output}`,
     );

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -161,6 +161,12 @@ export class DefaultHookOutput implements HookOutput {
   decision?: HookDecision;
   reason?: string;
   hookSpecificOutput?: Record<string, unknown>;
+  /** Per-hook UI notifications passed through from the aggregator. */
+  notifications?: Array<{
+    hookName: string;
+    message: string;
+    decision?: HookDecision;
+  }>;
 
   constructor(data: Partial<HookOutput> = {}) {
     this.continue = data.continue;

--- a/src/copilot-shell/packages/core/src/tools/tools.ts
+++ b/src/copilot-shell/packages/core/src/tools/tools.ts
@@ -11,6 +11,7 @@ import type { ShellExecutionConfig } from '../services/shellExecutionService.js'
 import { SchemaValidator } from '../utils/schemaValidator.js';
 import { type SubagentStatsSummary } from '../subagents/subagent-statistics.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
+import type { HookDecision } from '../hooks/types.js';
 
 /**
  * Represents a validated and ready-to-execute tool call.
@@ -468,13 +469,34 @@ export interface AnsiOutputDisplay {
   ansiOutput: AnsiOutput;
 }
 
+/**
+ * Structured hook notification for UI display.
+ * Sent via OutputUpdateHandler during the validating phase so that the UI can
+ * render the hook name and message as distinct visual elements.
+ *
+ * Two decision fields:
+ *  - `decision`: this single hook's original decision. Drives the per-box
+ *    color / icon (allow=green, ask=yellow, deny/block=red, undef=neutral).
+ *  - `mergedDecision`: the aggregated final decision across all hooks fired
+ *    for this event. When it is block/deny while this hook's decision is
+ *    not, the UI dims this box to neutral to avoid “green box + rejected
+ *    execution” visual conflict.
+ */
+export interface HookNotificationDisplay {
+  hookName: string;
+  hookMessage: string;
+  decision?: HookDecision;
+  mergedDecision?: HookDecision;
+}
+
 export type ToolResultDisplay =
   | string
   | FileDiff
   | TodoResultDisplay
   | PlanResultDisplay
   | TaskResultDisplay
-  | AnsiOutputDisplay;
+  | AnsiOutputDisplay
+  | HookNotificationDisplay;
 
 export interface FileDiff {
   fileDiff: string;


### PR DESCRIPTION
## Description

### Problem

`PreToolUse` hook messages reached the terminal through a single merged string. This caused four concrete regressions:

- `{ decision: "allow", reason }` without `systemMessage` → message silently dropped.
- Auto-approved tools (`SkillTool`, YOLO mode) → notification stored but never rendered.
- Multiple hooks on one call → messages concatenated into one blob, losing per-hook attribution.
- `decision: "ask"` → the dialog reused the first hook's `systemMessage` as its prompt, letting hooks override system-level UX copy.

All four share the same root cause: the display layer tries to reconstruct per-hook context from a post-merge blob, after the information it needs has already been flattened away.

### Changes

The fix is a structured, per-hook notification channel that replaces the merged string end-to-end. The unchanged parts of the pipeline — hook matching, execution, decision evaluation, tool invocation — are untouched.

**1. Aggregator — produce structured notifications (`hookAggregator.ts`, `hooks/types.ts`)**
Introduce `HookNotification { hookName, message, decision? }` and have `aggregateResults()` return a `notifications: HookNotification[]` alongside the merged decision. Each entry's `message` resolves as `systemMessage ?? reason`, so `allow + reason` is preserved without any special-casing downstream. Hooks with neither field are omitted.

**2. Scheduler — emit early, expose to dialog (`coreToolScheduler.ts`, `tools/tools.ts`)**
Emit the notifications list via `outputUpdateHandler` as a structured `HookNotificationDisplay` chunk *before* the merged decision is applied, so delivery no longer depends on the final state transition. `ToolConfirmationInfo` gains `hookNotifications` and `mergedDecision` fields so the same data is available when a dialog is shown. The dead `liveOutput` field on `ValidatingToolCall` is removed.

**3. CLI propagation — sticky across every state (`useReactToolScheduler.ts`, `ui/types.ts`)**
A type guard recognizes the structured chunk and appends it to a per-tool-call list on both a synchronous ref (for history snapshots) and React state (for live display). The list is carried as a sticky field across `validating` / `scheduled` / `waiting` / `executing` / `completed` / `cancelled`, which is what finally closes the gap for tools that never enter `awaiting_approval`.

**4. Terminal rendering — per-hook boxes with merged-decision dimming (`ToolMessage.tsx`)**
Each entry renders as a standalone box between the tool header and the tool output / confirmation dialog: left-side colored border, icon + bold hook name, indented message. Colors go through `decisionToStyle(item.decision, item.mergedDecision)`: when the merged outcome is `block`/`deny`, non-blocking hook boxes are dimmed so they don't visually compete with the denied outcome, while blocking hooks keep full color and all messages stay readable.

**5. Ask-dialog — fixed, localized prompt (`ToolConfirmationMessage.tsx`, `i18n/locales/*.js`)**
The dialog always shows `A hook requires your confirmation to proceed.`, wrapped in `t()` for i18n (zh: `有 Hook 需要您的确认方可继续。`). The hook's own `systemMessage` is no longer pulled into the dialog — it surfaces above the dialog as a regular per-hook box, keeping the same display contract as the allow / deny paths.

**6. Docs (`hooks/docs/reference.md`, `hooks/docs/writing-hooks.md`)**
Align `systemMessage` / `reason` semantics with the new rendering model, and document the fixed ask-dialog prompt plus the merged-decision dimming rule.

## Related Issue

closes #421

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run format && npm run build && npm run lint && npm run typecheck
npm test
# All tests pass, including new regression coverage for:
# - hookAggregator: per-hook notifications carry hookName + decision; message falls back to reason when systemMessage is absent
# - coreToolScheduler: notifications emit before the merged decision applies (allow / ask / block paths)
# - coreToolScheduler: ask-dialog uses the fixed prompt regardless of the hook's systemMessage
# - useToolScheduler: hookNotifications propagate as a sticky field across validating / executing / completed states
# - useToolScheduler: mergedDecision=block dims non-blocking per-hook boxes while keeping blocking ones fully colored
```

## Additional Notes

Hook protocol is unchanged — hooks that only set `systemMessage` behave as before. The difference is that every hook now gets its own labeled, independently-colored box instead of a merged string, and `allow + reason` is no longer silently dropped.
