### PR TITLE
docs(cosh): clarify systemMessage vs reason in hook docs

### DIFF
--- a/src/copilot-shell/hooks/docs/reference.md
+++ b/src/copilot-shell/hooks/docs/reference.md
@@ -38,15 +38,15 @@ All hooks receive these common fields via `stdin`:
 
 Most hooks support these fields in their `stdout` JSON:
 
-| Field                | Type      | Description                                                        |
-| :------------------- | :-------- | :----------------------------------------------------------------- |
-| `systemMessage`      | `string`  | Displayed immediately to the user in the terminal.                 |
-| `suppressOutput`     | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.       |
-| `continue`           | `boolean` | If `false`, stops the entire agent loop immediately.               |
-| `stopReason`         | `string`  | Displayed to the user when `continue` is `false`.                  |
-| `decision`           | `string`  | `"allow"`, `"deny"` (alias `"block"`), `"ask"`, or `"approve"`.    |
-| `reason`             | `string`  | The feedback/error message provided when a `decision` is `"deny"`. |
-| `hookSpecificOutput` | `object`  | Event-specific output fields (see individual event sections).      |
+| Field                | Type      | Description                                                                                                                                              |
+| :------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `systemMessage`      | `string`  | Displayed immediately to the user in the terminal.                                                                                                       |
+| `suppressOutput`     | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                                                                                             |
+| `continue`           | `boolean` | If `false`, stops the entire agent loop immediately.                                                                                                     |
+| `stopReason`         | `string`  | Displayed to the user when `continue` is `false`.                                                                                                        |
+| `decision`           | `string`  | `"allow"`, `"deny"` (alias `"block"`), `"ask"`, or `"approve"`.                                                                                          |
+| `reason`             | `string`  | The feedback/error message used for `"deny"`/`"block"` decisions and stop-like flows. For user-visible allow/approve/ask messaging, use `systemMessage`. |
+| `hookSpecificOutput` | `object`  | Event-specific output fields (see individual event sections).                                                                                            |
 
 ---
 
@@ -64,10 +64,17 @@ and parameter rewriting.
   - `original_request_name`: (`string`) The original name if this is a tail call.
 - **Relevant Output Fields**:
   - `decision`: Set to `"deny"` (or `"block"`) to prevent tool execution.
-  - `reason`: Required if denied. Sent to the agent as a tool error.
+  - `systemMessage`: Use this for any informational or warning text that
+    should be shown to the user when execution continues, including
+    `"allow"`, `"approve"`, and `"ask"` flows.
+  - `reason`: Required if denied. Sent to the agent as a tool error. Do not
+    rely on `reason` alone for user-visible allow/ask messaging.
   - `hookSpecificOutput.tool_input`: An object that **merges with and
     overrides** the model's arguments before execution.
   - `continue`: Set to `false` to **kill the entire agent loop**.
+- **Allow/Approve/Ask note**: If you want the user to see a warning or prompt
+  while the tool is still allowed or awaiting confirmation, put that text in
+  `systemMessage`.
 - **Exit Code 2 (Block Tool)**: Prevents execution. Uses `stderr` as reason.
 
 ### `PostToolUse`

--- a/src/copilot-shell/hooks/docs/writing-hooks.md
+++ b/src/copilot-shell/hooks/docs/writing-hooks.md
@@ -88,6 +88,10 @@ echo '{"decision": "allow"}'
 exit 0
 ```
 
+For `PreToolUse`, use `systemMessage` for any warning or informational text you
+want users to see on `allow`, `approve`, or `ask` paths. Reserve `reason` for
+deny or block outcomes.
+
 **Configuration:**
 
 ```json


### PR DESCRIPTION
## Description

The hook documentation previously only described `reason` as the
feedback field for `"deny"` decisions. With the recent systemMessage
merge feature, hooks can now surface user-visible messages on
`"allow"`, `"approve"`, and `"ask"` paths via `systemMessage`.

This PR updates both the reference and writing-hooks docs to:
- Broaden the `reason` field description to cover deny/block and
  stop-like flows
- Add `systemMessage` as the recommended field for informational
  text on non-deny paths
- Add usage notes in the PreToolUse section and writing guide

Closes #421

## Related Issue

- [x] Related issue linked (recommended for new features and non-trivial changes)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

N/A — documentation-only changes.

## Additional Notes

Complements the systemMessage concatenation feature (bd03f8b) by
ensuring hook authors know which field to use for each decision path.