### PR TITLE
Bugfix: fix(tokenless): resolve rtk/toon binary paths for RPM-installed plugins

### DIFF
--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-response.sh
@@ -27,8 +27,13 @@ if ! command -v tokenless &>/dev/null; then
 fi
 
 TOON_AVAILABLE=false
+TOON_BIN=""
 if command -v toon &>/dev/null; then
   TOON_AVAILABLE=true
+  TOON_BIN="$(command -v toon)"
+elif [ -x /usr/libexec/tokenless/toon ]; then
+  TOON_AVAILABLE=true
+  TOON_BIN=/usr/libexec/tokenless/toon
 fi
 
 # --- Read input (fail-open) ---
@@ -142,7 +147,7 @@ TOON_OUTPUT=""
 if [ "$TOON_AVAILABLE" = true ]; then
   IS_JSON=$(echo "$COMPRESSED" | jq -e '.' &>/dev/null && echo "yes" || echo "no")
   if [ "$IS_JSON" = "yes" ]; then
-    TOON_OUTPUT=$(echo "$COMPRESSED" | toon -e 2>/dev/null) || true
+    TOON_OUTPUT=$(echo "$COMPRESSED" | "$TOON_BIN" -e 2>/dev/null) || true
     if [ -n "$TOON_OUTPUT" ]; then
       AFTER_TOON_CHARS=${#TOON_OUTPUT}
       if [ "$USED_RESP_COMPRESSION" = true ]; then

--- a/src/tokenless/hooks/copilot-shell/tokenless-compress-toon.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-compress-toon.sh
@@ -20,9 +20,20 @@ if ! command -v tokenless &>/dev/null; then
   exit 0
 fi
 
+# --- Resolve toon binary path ---
+# RPM installs toon to /usr/libexec/tokenless/ (not on PATH).
+# Local installs place it in ~/.local/bin/ (on PATH).
+# Resolve: try PATH first, then fallback to libexec.
+
 if ! command -v toon &>/dev/null; then
-  echo "[tokenless] WARNING: toon is not installed or not in PATH. TOON compression hook disabled." >&2
-  exit 0
+  if [ -x /usr/libexec/tokenless/toon ]; then
+    TOON_BIN=/usr/libexec/tokenless/toon
+  else
+    echo "[tokenless] WARNING: toon is not installed or not in PATH. TOON compression hook disabled." >&2
+    exit 0
+  fi
+else
+  TOON_BIN="$(command -v toon)"
 fi
 
 # --- Read input (fail-open) ---

--- a/src/tokenless/hooks/copilot-shell/tokenless-rewrite.sh
+++ b/src/tokenless/hooks/copilot-shell/tokenless-rewrite.sh
@@ -12,13 +12,24 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
+# --- Resolve rtk binary path ---
+# RPM installs rtk to /usr/libexec/tokenless/ (not on PATH).
+# Local installs place it in ~/.local/bin/ (on PATH).
+# Resolve: try PATH first, then fallback to libexec.
+
 if ! command -v rtk &>/dev/null; then
-  echo "[tokenless] WARNING: rtk is not installed or not in PATH. Hook disabled." >&2
-  exit 0
+  if [ -x /usr/libexec/tokenless/rtk ]; then
+    RTK_BIN=/usr/libexec/tokenless/rtk
+  else
+    echo "[tokenless] WARNING: rtk is not installed or not in PATH. Hook disabled." >&2
+    exit 0
+  fi
+else
+  RTK_BIN="$(command -v rtk)"
 fi
 
 # Version guard
-RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+RTK_VERSION=$("$RTK_BIN" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 if [ -n "$RTK_VERSION" ]; then
   MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
   MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
@@ -44,7 +55,7 @@ fi
 
 # --- Use rtk to rewrite ---
 
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+REWRITTEN=$("$RTK_BIN" rewrite "$CMD" 2>/dev/null)
 REWRITE_EXIT=$?
 
 # Handle rewrite result: exit 1/2 = no rewrite, exit 0 = same or rewritten

--- a/src/tokenless/openclaw/index.ts
+++ b/src/tokenless/openclaw/index.ts
@@ -19,6 +19,7 @@
  */
 
 import { execSync, execFileSync, spawnSync } from "child_process";
+import { existsSync, statSync } from "fs";
 
 // ---- Session ID mapping --------------------------------------------------------
 // OpenClaw's tool_result_persist ctx provides sessionKey ("agent:main:main")
@@ -37,9 +38,19 @@ let toonAvailable: boolean | null = null;
 // use the correct path even when the binary is not on PATH (e.g. RPM installs
 // that place rtk/toon in /usr/libexec/tokenless/).
 let rtkPath: string = "rtk";
+let tokenlessPath: string = "tokenless";
 let toonPath: string = "toon";
 
 const LIBEXEC_FALLBACK = "/usr/libexec/tokenless";
+
+// Check both existence and execute permission (mirrors shell `-x` test).
+function isExecutable(path: string): boolean {
+  try {
+    return existsSync(path) && (statSync(path).mode & 0o111) !== 0;
+  } catch {
+    return false;
+  }
+}
 
 function checkRtk(): boolean {
   if (rtkAvailable !== null) return rtkAvailable;
@@ -48,7 +59,7 @@ function checkRtk(): boolean {
     if (result && result !== "") {
       rtkPath = result;
       rtkAvailable = true;
-    } else if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/rtk`)) {
+    } else if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
       rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
       rtkAvailable = true;
     } else {
@@ -56,16 +67,13 @@ function checkRtk(): boolean {
     }
   } catch {
     // which not available; check libexec directly
-    try {
-      if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/rtk`)) {
-        rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
-        rtkAvailable = true;
-      } else {
-        rtkAvailable = false;
-      }
-    } catch {
+    if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
+      rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
+      rtkAvailable = true;
+    } else {
       rtkAvailable = false;
     }
+    return rtkAvailable;
   }
   return rtkAvailable;
 }
@@ -84,10 +92,24 @@ function isSkillContent(message: any): boolean {
 function checkTokenless(): boolean {
   if (tokenlessAvailable !== null) return tokenlessAvailable;
   try {
-    execSync("which tokenless", { stdio: "ignore" });
-    tokenlessAvailable = true;
+    const result = execSync("which tokenless 2>/dev/null || echo ''", { encoding: "utf-8" }).trim();
+    if (result && result !== "") {
+      tokenlessPath = result;
+      tokenlessAvailable = true;
+    } else if (isExecutable(`${LIBEXEC_FALLBACK}/tokenless`)) {
+      tokenlessPath = `${LIBEXEC_FALLBACK}/tokenless`;
+      tokenlessAvailable = true;
+    } else {
+      tokenlessAvailable = false;
+    }
   } catch {
-    tokenlessAvailable = false;
+    if (isExecutable(`${LIBEXEC_FALLBACK}/tokenless`)) {
+      tokenlessPath = `${LIBEXEC_FALLBACK}/tokenless`;
+      tokenlessAvailable = true;
+    } else {
+      tokenlessAvailable = false;
+    }
+    return tokenlessAvailable;
   }
   return tokenlessAvailable;
 }
@@ -99,23 +121,20 @@ function checkToon(): boolean {
     if (result && result !== "") {
       toonPath = result;
       toonAvailable = true;
-    } else if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/toon`)) {
+    } else if (isExecutable(`${LIBEXEC_FALLBACK}/toon`)) {
       toonPath = `${LIBEXEC_FALLBACK}/toon`;
       toonAvailable = true;
     } else {
       toonAvailable = false;
     }
   } catch {
-    try {
-      if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/toon`)) {
-        toonPath = `${LIBEXEC_FALLBACK}/toon`;
-        toonAvailable = true;
-      } else {
-        toonAvailable = false;
-      }
-    } catch {
+    if (isExecutable(`${LIBEXEC_FALLBACK}/toon`)) {
+      toonPath = `${LIBEXEC_FALLBACK}/toon`;
+      toonAvailable = true;
+    } else {
       toonAvailable = false;
     }
+    return toonAvailable;
   }
   return toonAvailable;
 }
@@ -145,7 +164,7 @@ function tryCompressResponse(response: any, sessionId?: string, toolCallId?: str
     const args = ["compress-response", "--agent-id", "openclaw"];
     if (sessionId) args.push("--session-id", sessionId);
     if (toolCallId) args.push("--tool-use-id", toolCallId);
-    const result = execFileSync("tokenless", args, {
+    const result = execFileSync(tokenlessPath, args, {
       encoding: "utf-8",
       timeout: 3000,
       input,
@@ -159,7 +178,7 @@ function tryCompressResponse(response: any, sessionId?: string, toolCallId?: str
 function tryCompressSchema(schema: Record<string, unknown>): Record<string, unknown> | null {
   try {
     const input = JSON.stringify(schema);
-    const result = execFileSync("tokenless", ["compress-schema"], {
+    const result = execFileSync(tokenlessPath, ["compress-schema"], {
       encoding: "utf-8",
       timeout: 3000,
       input,

--- a/src/tokenless/openclaw/index.ts
+++ b/src/tokenless/openclaw/index.ts
@@ -33,13 +33,39 @@ let rtkAvailable: boolean | null = null;
 let tokenlessAvailable: boolean | null = null;
 let toonAvailable: boolean | null = null;
 
+// Resolved absolute paths — set by check*() functions so subprocess calls
+// use the correct path even when the binary is not on PATH (e.g. RPM installs
+// that place rtk/toon in /usr/libexec/tokenless/).
+let rtkPath: string = "rtk";
+let toonPath: string = "toon";
+
+const LIBEXEC_FALLBACK = "/usr/libexec/tokenless";
+
 function checkRtk(): boolean {
   if (rtkAvailable !== null) return rtkAvailable;
   try {
-    execSync("which rtk", { stdio: "ignore" });
-    rtkAvailable = true;
+    const result = execSync("which rtk 2>/dev/null || echo ''", { encoding: "utf-8" }).trim();
+    if (result && result !== "") {
+      rtkPath = result;
+      rtkAvailable = true;
+    } else if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/rtk`)) {
+      rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
+      rtkAvailable = true;
+    } else {
+      rtkAvailable = false;
+    }
   } catch {
-    rtkAvailable = false;
+    // which not available; check libexec directly
+    try {
+      if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/rtk`)) {
+        rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
+        rtkAvailable = true;
+      } else {
+        rtkAvailable = false;
+      }
+    } catch {
+      rtkAvailable = false;
+    }
   }
   return rtkAvailable;
 }
@@ -69,10 +95,27 @@ function checkTokenless(): boolean {
 function checkToon(): boolean {
   if (toonAvailable !== null) return toonAvailable;
   try {
-    execSync("which toon", { stdio: "ignore" });
-    toonAvailable = true;
+    const result = execSync("which toon 2>/dev/null || echo ''", { encoding: "utf-8" }).trim();
+    if (result && result !== "") {
+      toonPath = result;
+      toonAvailable = true;
+    } else if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/toon`)) {
+      toonPath = `${LIBEXEC_FALLBACK}/toon`;
+      toonAvailable = true;
+    } else {
+      toonAvailable = false;
+    }
   } catch {
-    toonAvailable = false;
+    try {
+      if (require("fs").existsSync(`${LIBEXEC_FALLBACK}/toon`)) {
+        toonPath = `${LIBEXEC_FALLBACK}/toon`;
+        toonAvailable = true;
+      } else {
+        toonAvailable = false;
+      }
+    } catch {
+      toonAvailable = false;
+    }
   }
   return toonAvailable;
 }
@@ -81,7 +124,7 @@ function checkToon(): boolean {
 
 function tryRtkRewrite(command: string): string | null {
   try {
-    const result = spawnSync("rtk", ["rewrite", command], {
+    const result = spawnSync(rtkPath, ["rewrite", command], {
       encoding: "utf-8",
       timeout: 2000,
       stdio: ["ignore", "pipe", "pipe"],
@@ -131,7 +174,7 @@ function tryCompressToon(response: any): { toonText: string; savingsPct: number 
   try {
     const input = JSON.stringify(response);
     const beforeChars = input.length;
-    const toonText = execFileSync("toon", ["-e"], {
+    const toonText = execFileSync(toonPath, ["-e"], {
       encoding: "utf-8",
       timeout: 3000,
       input,
@@ -276,7 +319,7 @@ export default {
         if (toonCompressionEnabled && checkToon()) {
           try {
             const jsonInput = JSON.stringify(currentMessage);
-            const result = execFileSync("toon", ["-e"], {
+            const result = execFileSync(toonPath, ["-e"], {
               encoding: "utf-8",
               timeout: 3000,
               input: jsonInput,

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -79,6 +79,10 @@ else
     install -m 0755 /usr/bin/toon %{buildroot}%{_libexecdir}/tokenless/toon
 fi
 
+# Create symlinks so rtk and toon are discoverable via PATH
+ln -sf %{_libexecdir}/tokenless/rtk %{buildroot}%{_bindir}/rtk
+ln -sf %{_libexecdir}/tokenless/toon %{buildroot}%{_bindir}/toon
+
 # Install documentation
 install -m 0644 docs/tokenless-user-manual-en.md %{buildroot}%{_docdir}/tokenless/
 install -m 0644 docs/tokenless-user-manual-zh.md %{buildroot}%{_docdir}/tokenless/
@@ -103,6 +107,8 @@ install -m 0755 scripts/install.sh %{buildroot}%{_datadir}/tokenless/scripts/
 %files
 %defattr(0644,root,root,0755)
 %attr(0755,root,root) %{_bindir}/tokenless
+%attr(0755,root,root) %{_bindir}/rtk
+%attr(0755,root,root) %{_bindir}/toon
 %dir %attr(0755,root,root) %{_libexecdir}/tokenless
 %attr(0755,root,root) %{_libexecdir}/tokenless/rtk
 %attr(0755,root,root) %{_libexecdir}/tokenless/toon


### PR DESCRIPTION
## Description
    RPM installs rtk/toon to /usr/libexec/tokenless/ (not on PATH), but
    cosh hooks and openclaw plugin only searched PATH. Add symlinks in
    spec and libexec fallback in hooks/plugin code.

    Replace require("fs").existsSync() with isExecutable() that checks both
    existence and execute permission, matching the shell hook `-x` behavior.
    Unify fs import to top-level ES import. Add tokenlessPath resolution
    (PATH → libexec fallback) so all subprocess calls use resolved paths
    consistently.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #443 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```c
三项测试全部通过：

  ┌────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │    测试    │                                                                        结果                                                                         │
  ├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ make build │ tokenless + rtk + toon 三个二进制编译成功（rtk 有几个无关 warning）                                                                                 │
  ├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ make test  │ 22 单元 + 19 集成 + 18 stats 测试全 pass，rtk/toon cargo check 成功                                                                                 │
  ├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ RPM 构建   │ tokenless-0.2.0-4.alnx4.x86_64.rpm 生成成功，包含 symlinks /usr/bin/rtk → /usr/libexec/tokenless/rtk 和 /usr/bin/toon → /usr/libexec/tokenless/toon │
  └────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  RPM 构建有两个 warning（symlink 的 %attr 模式无效 + 绝对路径 symlink），都是 benign 的——symlink 权限在 Linux 上总是 0777，%attr(0755) 只是声明性标记不影响功能。

```
