### PR TITLE
fix(cosh): mitigate JavaScript heap out of memory during long sessions

### DIFF
--- a/src/copilot-shell/packages/cli/src/config/settingsSchema.ts
+++ b/src/copilot-shell/packages/cli/src/config/settingsSchema.ts
@@ -1119,7 +1119,7 @@ const SETTINGS_SCHEMA = {
         label: 'Auto Configure Max Old Space Size',
         category: 'Advanced',
         requiresRestart: true,
-        default: false,
+        default: true,
         description: 'Automatically configure Node.js memory limits',
         showInDialog: false,
       },

--- a/src/copilot-shell/packages/core/src/core/client.test.ts
+++ b/src/copilot-shell/packages/core/src/core/client.test.ts
@@ -647,6 +647,61 @@ describe('Gemini Client (client.ts)', () => {
       });
     });
 
+    it('does not permanently latch after an empty summary failure', async () => {
+      // Call 1: Setup to produce EMPTY_SUMMARY (summaryText = '')
+      const { client } = setup({
+        originalTokenCount: 100,
+        summaryText: '',
+        compressionInputTokenCount: 1600,
+        compressionOutputTokenCount: 50,
+      });
+
+      // Mock contextWindowSize to ensure compression is triggered
+      vi.spyOn(client['config'], 'getContentGeneratorConfig').mockReturnValue({
+        model: 'test-model',
+        apiKey: 'test-key',
+        vertexai: false,
+        authType: AuthType.USE_GEMINI,
+        contextWindowSize: 100,
+      });
+
+      const firstResult = await client.tryCompressChat(
+        'prompt-id-empty',
+        false,
+      );
+
+      expect(firstResult.compressionStatus).toBe(
+        CompressionStatus.COMPRESSION_FAILED_EMPTY_SUMMARY,
+      );
+
+      // Call 2: Re-setup with a valid summary to verify compression is retried
+      setup({
+        originalTokenCount: 100,
+        summaryText: 'A valid summary this time.',
+        compressionInputTokenCount: 1600,
+        compressionOutputTokenCount: 50,
+      });
+
+      vi.spyOn(client['config'], 'getContentGeneratorConfig').mockReturnValue({
+        model: 'test-model',
+        apiKey: 'test-key',
+        vertexai: false,
+        authType: AuthType.USE_GEMINI,
+        contextWindowSize: 100,
+      });
+
+      const secondResult = await client.tryCompressChat(
+        'prompt-id-retry',
+        false,
+      );
+
+      // Should NOT be NOOP — empty summary failure is transient
+      expect(secondResult.compressionStatus).not.toBe(CompressionStatus.NOOP);
+      expect(secondResult.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+      // generateContent should have been called twice (once per attempt)
+      expect(mockGenerateContentFn).toHaveBeenCalledTimes(2);
+    });
+
     it('should not trigger summarization if token count is below threshold', async () => {
       const MOCKED_TOKEN_LIMIT = 1000;
       vi.spyOn(client['config'], 'getContentGeneratorConfig').mockReturnValue({

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -160,7 +160,7 @@ export class GeminiClient {
     return this.chat !== undefined;
   }
 
-  getHistory(): Content[] {
+  getHistory(): readonly Content[] {
     return this.getChat().getHistory();
   }
 
@@ -934,11 +934,10 @@ export class GeminiClient {
       }
     } else if (
       info.compressionStatus ===
-        CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT ||
-      info.compressionStatus ===
-        CompressionStatus.COMPRESSION_FAILED_EMPTY_SUMMARY
+      CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT
     ) {
-      // Track failed attempts (only mark as failed if not forced)
+      // Only latch on inflated token count failure. Empty summary is a
+      // transient condition that may succeed on the next attempt.
       if (!force) {
         this.hasFailedCompressionAttempt = true;
       }

--- a/src/copilot-shell/packages/core/src/core/geminiChat.ts
+++ b/src/copilot-shell/packages/core/src/core/geminiChat.ts
@@ -285,7 +285,7 @@ export class GeminiChat {
 
     // Add user content to history ONCE before any attempts.
     this.history.push(userContent);
-    const requestContents = this.getHistory(true);
+    const requestContents = extractCuratedHistory(this.history);
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
@@ -554,13 +554,13 @@ export class GeminiChat {
    * @return History contents alternating between user and model for the entire
    * chat session.
    */
-  getHistory(curated: boolean = false): Content[] {
+  getHistory(curated: boolean = false): readonly Content[] {
     const history = curated
       ? extractCuratedHistory(this.history)
       : this.history;
-    // Deep copy the history to avoid mutating the history outside of the
-    // chat session.
-    return structuredClone(history);
+    // Shallow copy the history to avoid mutating the array outside of the
+    // chat session. Callers must not mutate individual Content elements.
+    return [...history];
   }
 
   /**

--- a/src/copilot-shell/packages/core/src/services/chatCompressionService.ts
+++ b/src/copilot-shell/packages/core/src/services/chatCompressionService.ts
@@ -34,7 +34,7 @@ export const COMPRESSION_PRESERVE_THRESHOLD = 0.3;
  * Exported for testing purposes.
  */
 export function findCompressSplitPoint(
-  contents: Content[],
+  contents: readonly Content[],
   fraction: number,
 ): number {
   if (fraction <= 0 || fraction >= 1) {

--- a/src/copilot-shell/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/src/copilot-shell/packages/core/src/utils/nextSpeakerChecker.ts
@@ -86,7 +86,6 @@ export async function checkNextSpeaker(
     lastComprehensiveMessage.parts &&
     lastComprehensiveMessage.parts.length === 0
   ) {
-    lastComprehensiveMessage.parts.push({ text: '' });
     return {
       reasoning:
         'The last message was a filler model message with no content (nothing for user to act on), model should speak next.',


### PR DESCRIPTION
## Description

Mitigate JavaScript heap out of memory crashes during long-running agentic sessions by backporting three upstream gemini-cli memory management patches:

1. **Enable `autoConfigureMemory` by default** — automatically raises the V8 heap limit to 50% of system RAM on machines where this exceeds the current limit, protected by the existing `>` guard in `gemini.tsx`.
2. **Replace `structuredClone` with shallow copy** — eliminates O(N) deep-copy memory pressure per conversation turn by returning `[...history]` with a `readonly Content[]` type constraint. The only mutation point (`nextSpeakerChecker.ts:89 parts.push`) was already a dead write on the deep copy and has been removed.
3. **Fix compression failure permanent latch** — only latch `hasFailedCompressionAttempt` on `INFLATED` status; `EMPTY_SUMMARY` is a transient condition that may succeed on retry.

## Related Issue

closes #273

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run test -- packages/core/src/core/geminiChat.test.ts        # 28/28 passed
npm run test -- packages/core/src/utils/nextSpeakerChecker.test.ts  # 10/10 passed
npm run test -- packages/core/src/services/chatCompressionService.test.ts  # 19/19 passed
npm run test -- packages/core/src/core/client.test.ts            # 49/49 passed (includes new EMPTY_SUMMARY non-latch test)
npm run test -- packages/core/src/services/loopDetectionService.test.ts  # 37/37 passed
npm run test -- packages/cli/src/config                          # 326/326 passed
```

TypeScript type check passes with zero errors related to changed files (pre-existing `QWEN_OAUTH` errors are unrelated).

## Additional Notes

- The `readonly Content[]` return type is a compile-time constraint only; it does not affect runtime behavior for callers that only read history (all verified callers).
- `autoConfigureMemory` only takes effect when 50% RAM exceeds the current heap limit, so small-memory machines are unaffected.
