### PR TITLE
feat(sec-core): prompt scanner hook ask user on missing model instead of fail-open

### DIFF
--- a/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
@@ -41,6 +41,10 @@ def _allow() -> str:
     return json.dumps({"decision": "allow"})
 
 
+# Keyword used by model_manager.py in the ModelLoadError message.
+_WARMUP_HINT = "agent-sec-cli scan-prompt warmup"
+
+
 def _format_cosh(scan_result: dict) -> str:
     """Convert a ScanResult dict into a cosh HookOutput JSON string.
 
@@ -48,7 +52,9 @@ def _format_cosh(scan_result: dict) -> str:
         verdict == "pass"  -> decision "allow"
         verdict == "warn"  -> decision "ask"  (let user decide)
         verdict == "deny"  -> decision "ask"  (let user decide)
-        otherwise          -> fail-open "allow"
+        verdict == "error"
+          + model not downloaded -> decision "ask" with warmup instructions
+          otherwise              -> fail-open "allow"
     """
     verdict = scan_result.get("verdict", "pass")
 
@@ -72,7 +78,23 @@ def _format_cosh(scan_result: dict) -> str:
             {"decision": "ask", "reason": msg},
             ensure_ascii=False,
         )
-    # error or unknown -> fail-open
+    # error verdict — check whether it is a "model not downloaded" error.
+    # Use "ask" so the user can still send the prompt; the reason text makes
+    # it clear this is a setup reminder, not a security block.
+    if verdict == "error" and _WARMUP_HINT in summary:
+        warmup_msg = (
+            "[prompt-scanner] ⚠️  安全扫描组件尚未完成初始化，本次 prompt 未经安全检测。\n"
+            "需要一次性下载本地检测小模型才能启用扫描功能。\n"
+            "请在终端执行以下命令完成下载，之后无需再次操作：\n"
+            "  agent-sec-cli scan-prompt warmup\n"
+            "\n"
+            "你仍可以选择继续发送（Yes），或取消（No）后先完成下载。"
+        )
+        return json.dumps(
+            {"decision": "ask", "reason": warmup_msg},
+            ensure_ascii=False,
+        )
+    # other error or unknown verdict -> fail-open
     return json.dumps({"decision": "allow"})
 
 

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_prompt_scanner_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_prompt_scanner_hook.py
@@ -1,0 +1,186 @@
+"""Unit tests for cosh-extension/hooks/prompt_scanner_hook.py.
+
+The hook is self-contained (no agent_sec_cli imports), so we test it
+by importing the _format_cosh helper directly and piping JSON via
+subprocess for integration-style tests.
+
+Tests cover:
+1. verdict → decision mapping (pass, warn, deny, error, unknown)
+2. Warmup detection via string matching in summary
+3. Non-warmup error verdict still fails open
+4. Subprocess integration: pipe JSON into the hook and verify stdout
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path to the standalone cosh hook script
+_COSH_HOOK = str(
+    Path(__file__).resolve().parents[2]
+    / ".."
+    / "cosh-extension"
+    / "hooks"
+    / "prompt_scanner_hook.py"
+)
+
+# Import _format_cosh for direct unit testing
+sys.path.insert(0, str(Path(_COSH_HOOK).parent))
+from prompt_scanner_hook import _WARMUP_HINT, _format_cosh
+
+# ---------------------------------------------------------------------------
+# Unit tests: _format_cosh
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCoshPass:
+    """verdict=pass → decision=allow."""
+
+    def test_pass_returns_allow(self):
+        result = json.loads(_format_cosh({"verdict": "pass"}))
+        assert result["decision"] == "allow"
+
+    def test_pass_ignores_summary(self):
+        result = json.loads(_format_cosh({"verdict": "pass", "summary": "anything"}))
+        assert result["decision"] == "allow"
+
+
+class TestFormatCoshWarn:
+    """verdict=warn → decision=ask with reason."""
+
+    def test_warn_returns_ask(self):
+        result = json.loads(
+            _format_cosh({"verdict": "warn", "summary": "suspicious prompt"})
+        )
+        assert result["decision"] == "ask"
+        assert "suspicious prompt" in result["reason"]
+        assert "[prompt-scanner]" in result["reason"]
+
+    def test_warn_uses_threat_type_when_no_summary(self):
+        result = json.loads(
+            _format_cosh({"verdict": "warn", "threat_type": "direct_injection"})
+        )
+        assert result["decision"] == "ask"
+        assert "direct_injection" in result["reason"]
+
+    def test_warn_uses_default_when_no_summary_no_threat_type(self):
+        result = json.loads(_format_cosh({"verdict": "warn"}))
+        assert result["decision"] == "ask"
+        assert "Prompt rejected by security policy" in result["reason"]
+
+
+class TestFormatCoshDeny:
+    """verdict=deny → decision=ask with reason."""
+
+    def test_deny_returns_ask(self):
+        result = json.loads(
+            _format_cosh({"verdict": "deny", "summary": "jailbreak detected"})
+        )
+        assert result["decision"] == "ask"
+        assert "jailbreak detected" in result["reason"]
+
+
+class TestFormatCoshErrorWarmup:
+    """verdict=error + summary contains warmup hint → decision=ask with warmup message."""
+
+    def test_error_with_warmup_hint_in_summary_returns_ask(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "error",
+                    "summary": f"Scanner error: Model not found. Run {_WARMUP_HINT}",
+                }
+            )
+        )
+        assert result["decision"] == "ask"
+        assert "warmup" in result["reason"]
+        assert "agent-sec-cli scan-prompt warmup" in result["reason"]
+
+    def test_warmup_message_contains_chinese_instructions(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "error",
+                    "summary": f"Model not available. {_WARMUP_HINT}",
+                }
+            )
+        )
+        assert result["decision"] == "ask"
+        assert "agent-sec-cli scan-prompt warmup" in result["reason"]
+
+
+class TestFormatCoshErrorOther:
+    """verdict=error without warmup hint → fail-open allow."""
+
+    def test_error_without_warmup_hint_returns_allow(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "error",
+                    "summary": "internal scanner failure",
+                }
+            )
+        )
+        assert result["decision"] == "allow"
+
+    def test_error_with_empty_summary_returns_allow(self):
+        result = json.loads(_format_cosh({"verdict": "error"}))
+        assert result["decision"] == "allow"
+
+
+class TestFormatCoshUnknown:
+    """Unknown verdict → fail-open allow."""
+
+    def test_unknown_verdict_returns_allow(self):
+        result = json.loads(_format_cosh({"verdict": "unknown"}))
+        assert result["decision"] == "allow"
+
+    def test_missing_verdict_defaults_to_allow(self):
+        """When verdict key is missing, default is 'pass' → allow."""
+        result = json.loads(_format_cosh({}))
+        assert result["decision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: subprocess (pipe JSON into hook, verify stdout)
+# ---------------------------------------------------------------------------
+
+
+class TestCoshHookSubprocess:
+    """Integration tests: pipe JSON into prompt_scanner_hook.py and verify stdout."""
+
+    def _run_hook(self, input_data: dict) -> dict:
+        proc = subprocess.run(
+            [sys.executable, _COSH_HOOK],
+            input=json.dumps(input_data),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        # Hook always exits 0
+        assert proc.returncode == 0, f"Hook stderr: {proc.stderr}"
+        return json.loads(proc.stdout)
+
+    def test_empty_prompt_allows(self):
+        output = self._run_hook({"prompt": ""})
+        assert output["decision"] == "allow"
+
+    def test_invalid_json_allows(self):
+        """Malformed stdin should fail-open with allow."""
+        proc = subprocess.run(
+            [sys.executable, _COSH_HOOK],
+            input="not-json",
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert proc.returncode == 0
+        output = json.loads(proc.stdout)
+        assert output["decision"] == "allow"
+
+    def test_missing_prompt_key_allows(self):
+        output = self._run_hook({"session_id": "abc"})
+        assert output["decision"] == "allow"


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

和cosh 配合的效果如下：

<img width="1097" height="411" alt="image" src="https://github.com/user-attachments/assets/bf609744-b0ed-4efd-8d49-e82d4f997f9f" />


## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
