### PR TITLE
feat(sight): add HTTP/1.1 request body reassembly for fragmented SSL writes

### DIFF
--- a/src/agentsight/src/aggregator/http/aggregator.rs
+++ b/src/agentsight/src/aggregator/http/aggregator.rs
@@ -39,6 +39,12 @@ pub enum ConnectionState {
     RequestPending {
         request: ParsedRequest,
     },
+    /// Request body pending - body not yet complete, waiting for more data or response
+    RequestBodyPending {
+        request: ParsedRequest,
+        expected_body_len: Option<usize>,
+        body_buffer: Vec<u8>,
+    },
     /// SSE active - response headers received, body streaming
     SseActive {
         request: Option<ParsedRequest>,
@@ -84,6 +90,7 @@ impl HttpConnectionAggregator {
                     match evicted_state {
                         ConnectionState::Idle => "Idle",
                         ConnectionState::RequestPending { .. } => "RequestPending",
+                        ConnectionState::RequestBodyPending { .. } => "RequestBodyPending",
                         ConnectionState::SseActive { .. } => "SseActive",
                     },
                     self.connections.cap(),
@@ -96,19 +103,61 @@ impl HttpConnectionAggregator {
     pub fn process_request(&mut self, request: ParsedRequest) {
         let connection_id = ConnectionId::from_ssl_event(&request.source_event);
 
-        log::trace!(
-            "[HttpAggregator] State transition: -> RequestPending | conn={:?} | method={} | path={}",
-            connection_id,
-            request.method,
-            request.path,
-        );
+        // Check if body is complete by comparing with Content-Length
+        let content_length: Option<usize> = request
+            .headers
+            .get("content-length")
+            .and_then(|v| v.parse().ok());
 
-        self.insert(
-            connection_id,
-            ConnectionState::RequestPending {
-                request,
-            },
-        );
+        let body_complete = match content_length {
+            Some(cl) => request.body_len >= cl,
+            None => {
+                // No Content-Length: check for Transfer-Encoding: chunked
+                let is_chunked = request
+                    .headers
+                    .get("transfer-encoding")
+                    .map(|v| v.contains("chunked"))
+                    .unwrap_or(false);
+                if is_chunked {
+                    // Check if body contains chunked terminator
+                    let body = request.body();
+                    body.windows(5).any(|w| w == b"0\r\n\r\n")
+                } else {
+                    true // No Content-Length and not chunked → body is complete
+                }
+            }
+        };
+
+        if body_complete {
+            log::trace!(
+                "[HttpAggregator] State transition: -> RequestPending | conn={:?} | method={} | path={}",
+                connection_id,
+                request.method,
+                request.path,
+            );
+            self.insert(
+                connection_id,
+                ConnectionState::RequestPending { request },
+            );
+        } else {
+            log::debug!(
+                "[HttpAggregator] State transition: -> RequestBodyPending | conn={:?} | method={} | path={} | body_len={} | content_length={:?}",
+                connection_id,
+                request.method,
+                request.path,
+                request.body_len,
+                content_length,
+            );
+            let initial_body = request.body().to_vec();
+            self.insert(
+                connection_id,
+                ConnectionState::RequestBodyPending {
+                    request,
+                    expected_body_len: content_length,
+                    body_buffer: initial_body,
+                },
+            );
+        }
     }
 
     /// Process HTTP Response (from HTTP Parser)
@@ -122,6 +171,42 @@ impl HttpConnectionAggregator {
         let state = self.connections.pop(&connection_id)?;
         
         match state {
+            ConnectionState::RequestBodyPending {
+                request,
+                expected_body_len,
+                mut body_buffer,
+            } => {
+                // Response arrived → request must be complete (server replies only after full request)
+                log::debug!(
+                    "[HttpAggregator] State transition: RequestBodyPending -> Complete (response-driven) | conn={:?} | buffered={}",
+                    connection_id,
+                    body_buffer.len(),
+                );
+                if let Some(cl) = expected_body_len {
+                    body_buffer.truncate(cl);
+                }
+                let mut completed_request = request;
+                completed_request.reassembled_body = Some(body_buffer);
+
+                if response.is_sse() {
+                    self.insert(
+                        connection_id,
+                        ConnectionState::SseActive {
+                            request: Some(completed_request),
+                            response_headers: response,
+                            sse_events: Vec::new(),
+                        },
+                    );
+                    None
+                } else {
+                    let pair = HttpPair::from_parsed(
+                        connection_id,
+                        completed_request,
+                        response,
+                    );
+                    Some(AggregatedResult::HttpComplete(pair))
+                }
+            }
             ConnectionState::RequestPending { request } => {
                 if response.is_sse() {
                     log::trace!(
@@ -193,6 +278,72 @@ impl HttpConnectionAggregator {
                 // Response on SSE connection - shouldn't happen normally
                 // Restore state and return None
                 self.insert(connection_id, state);
+                None
+            }
+        }
+    }
+
+    /// Process raw body data (continuation bytes for an in-progress request)
+    pub fn process_raw_body_data(&mut self, ssl_event: &SslEvent) -> Option<AggregatedResult> {
+        let connection_id = ConnectionId::from_ssl_event(ssl_event);
+        let state = self.connections.pop(&connection_id)?;
+
+        match state {
+            ConnectionState::RequestBodyPending {
+                request,
+                expected_body_len,
+                mut body_buffer,
+            } => {
+                // Append new data to buffer
+                let data = &ssl_event.buf[..ssl_event.buf_size() as usize];
+                body_buffer.extend_from_slice(data);
+
+                // Check if body is now complete
+                let complete = match expected_body_len {
+                    Some(cl) => body_buffer.len() >= cl,
+                    None => {
+                        // chunked: check for terminator
+                        body_buffer.windows(5).any(|w| w == b"0\r\n\r\n")
+                    }
+                };
+
+                if complete {
+                    log::debug!(
+                        "[HttpAggregator] State transition: RequestBodyPending -> RequestPending (body complete) | conn={:?} | total_body={}",
+                        connection_id,
+                        body_buffer.len(),
+                    );
+                    if let Some(cl) = expected_body_len {
+                        body_buffer.truncate(cl);
+                    }
+                    let mut completed_request = request;
+                    completed_request.reassembled_body = Some(body_buffer);
+                    self.insert(
+                        connection_id,
+                        ConnectionState::RequestPending {
+                            request: completed_request,
+                        },
+                    );
+                } else {
+                    log::trace!(
+                        "[HttpAggregator] RequestBodyPending: buffered more data | conn={:?} | total={}",
+                        connection_id,
+                        body_buffer.len(),
+                    );
+                    self.insert(
+                        connection_id,
+                        ConnectionState::RequestBodyPending {
+                            request,
+                            expected_body_len,
+                            body_buffer,
+                        },
+                    );
+                }
+                None
+            }
+            other => {
+                // Not in RequestBodyPending state, restore and ignore
+                self.insert(connection_id, other);
                 None
             }
         }
@@ -419,6 +570,7 @@ mod tests {
             body_offset: 0,
             body_len: 0,
             source_event: event.clone(),
+            reassembled_body: None,
         };
         aggregator.process_request(request);
         
@@ -461,6 +613,7 @@ mod tests {
             body_offset: 0,
             body_len: 0,
             source_event: event.clone(),
+            reassembled_body: None,
         };
         aggregator.process_request(request);
         
@@ -483,5 +636,272 @@ mod tests {
         // SSE response should not return result immediately, but should activate SSE state
         assert!(result.is_none());
         assert!(aggregator.is_sse_active(&ConnectionId { pid: 1234, ssl_ptr: 0x1000 }));
+    }
+
+    fn create_mock_ssl_event_with_buf(pid: u32, ssl_ptr: u64, buf: Vec<u8>, rw: i32) -> Rc<SslEvent> {
+        Rc::new(SslEvent {
+            source: 0,
+            timestamp_ns: 1000,
+            delta_ns: 0,
+            pid,
+            tid: 1,
+            uid: 0,
+            len: buf.len() as u32,
+            rw,
+            comm: String::new(),
+            buf,
+            is_handshake: false,
+            ssl_ptr,
+        })
+    }
+
+    #[test]
+    fn test_request_body_aggregation_content_length() {
+        let mut aggregator = HttpConnectionAggregator::new();
+
+        // Simulate a request with Content-Length: 20 but only 5 bytes in first event
+        let headers_and_partial_body = b"POST /api HTTP/1.1\r\nContent-Length: 20\r\n\r\nhello";
+        let event1 = create_mock_ssl_event_with_buf(1234, 0x2000, headers_and_partial_body.to_vec(), 1);
+
+        // Parse as request (simulating what HttpParser would produce)
+        let header_end = headers_and_partial_body.windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .unwrap() + 4;
+        let body_len = headers_and_partial_body.len() - header_end;
+
+        let mut headers = HashMap::new();
+        headers.insert("content-length".to_string(), "20".to_string());
+
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            path: "/api".to_string(),
+            version: 1,
+            headers,
+            body_offset: header_end,
+            body_len,
+            source_event: event1,
+            reassembled_body: None,
+        };
+
+        // Process request - should enter RequestBodyPending since body_len(5) < content_length(20)
+        aggregator.process_request(request);
+        let conn_id = ConnectionId { pid: 1234, ssl_ptr: 0x2000 };
+        assert!(!aggregator.has_pending_request(&conn_id));
+
+        // Send continuation data (10 bytes)
+        let continuation1 = SslEvent {
+            source: 0, timestamp_ns: 2000, delta_ns: 0,
+            pid: 1234, tid: 1, uid: 0, len: 10, rw: 1,
+            comm: String::new(),
+            buf: b" world fir".to_vec(),
+            is_handshake: false, ssl_ptr: 0x2000,
+        };
+        let result = aggregator.process_raw_body_data(&continuation1);
+        assert!(result.is_none()); // Still incomplete (15 < 20)
+
+        // Send final continuation (5 bytes, total = 5 + 10 + 5 = 20)
+        let continuation2 = SslEvent {
+            source: 0, timestamp_ns: 3000, delta_ns: 0,
+            pid: 1234, tid: 1, uid: 0, len: 5, rw: 1,
+            comm: String::new(),
+            buf: b"st!!!".to_vec(),
+            is_handshake: false, ssl_ptr: 0x2000,
+        };
+        let result = aggregator.process_raw_body_data(&continuation2);
+        assert!(result.is_none()); // Transitioned to RequestPending
+
+        // Now the request should be in RequestPending with full body
+        assert!(aggregator.has_pending_request(&conn_id));
+
+        // Sending a response should complete the pair
+        let resp_event = create_mock_ssl_event_with_buf(1234, 0x2000,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK".to_vec(), 0);
+        let response = ParsedResponse {
+            version: 1,
+            status_code: 200,
+            reason: "OK".to_string(),
+            headers: HashMap::new(),
+            body_offset: 0,
+            body_len: 2,
+            source_event: resp_event,
+        };
+
+        let result = aggregator.process_response(response);
+        assert!(result.is_some());
+        if let Some(AggregatedResult::HttpComplete(pair)) = result {
+            assert_eq!(pair.request.method, "POST");
+            // Verify the reassembled body
+            let body = pair.request.body();
+            assert_eq!(body, b"hello world first!!!");
+            assert_eq!(body.len(), 20);
+        } else {
+            panic!("Expected HttpComplete result");
+        }
+    }
+
+    #[test]
+    fn test_request_body_aggregation_response_completion() {
+        let mut aggregator = HttpConnectionAggregator::new();
+
+        // Request with Content-Length but body will be completed by response arrival
+        let headers_and_partial = b"POST /chat HTTP/1.1\r\nContent-Length: 100\r\n\r\npartial";
+        let event = create_mock_ssl_event_with_buf(5678, 0x3000, headers_and_partial.to_vec(), 1);
+
+        let header_end = headers_and_partial.windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .unwrap() + 4;
+        let body_len = headers_and_partial.len() - header_end;
+
+        let mut headers = HashMap::new();
+        headers.insert("content-length".to_string(), "100".to_string());
+
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            path: "/chat".to_string(),
+            version: 1,
+            headers,
+            body_offset: header_end,
+            body_len,
+            source_event: event,
+            reassembled_body: None,
+        };
+
+        aggregator.process_request(request);
+
+        // Send some continuation
+        let cont = SslEvent {
+            source: 0, timestamp_ns: 2000, delta_ns: 0,
+            pid: 5678, tid: 1, uid: 0, len: 10, rw: 1,
+            comm: String::new(),
+            buf: b"_more_data".to_vec(),
+            is_handshake: false, ssl_ptr: 0x3000,
+        };
+        aggregator.process_raw_body_data(&cont);
+
+        // Response arrives before Content-Length is satisfied → force-complete
+        let resp_event = create_mock_ssl_event_with_buf(5678, 0x3000,
+            b"HTTP/1.1 200 OK\r\n\r\n{}".to_vec(), 0);
+        let response = ParsedResponse {
+            version: 1,
+            status_code: 200,
+            reason: "OK".to_string(),
+            headers: HashMap::new(),
+            body_offset: 0,
+            body_len: 2,
+            source_event: resp_event,
+        };
+
+        let result = aggregator.process_response(response);
+        assert!(result.is_some());
+        if let Some(AggregatedResult::HttpComplete(pair)) = result {
+            // Body should be truncated to content_length (100) but we only have 17 bytes
+            // Since total buffer (17) < content_length (100), truncate does nothing
+            let body = pair.request.body();
+            assert_eq!(body, b"partial_more_data");
+        } else {
+            panic!("Expected HttpComplete result");
+        }
+    }
+
+    #[test]
+    fn test_request_body_single_event_no_aggregation() {
+        let mut aggregator = HttpConnectionAggregator::new();
+
+        // Request where body fits in single event (body_len >= content_length)
+        let full_request = b"POST /api HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello";
+        let event = create_mock_ssl_event_with_buf(1234, 0x4000, full_request.to_vec(), 1);
+
+        let header_end = full_request.windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .unwrap() + 4;
+        let body_len = full_request.len() - header_end;
+
+        let mut headers = HashMap::new();
+        headers.insert("content-length".to_string(), "5".to_string());
+
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            path: "/api".to_string(),
+            version: 1,
+            headers,
+            body_offset: header_end,
+            body_len,
+            source_event: event,
+            reassembled_body: None,
+        };
+
+        // Should go directly to RequestPending (no aggregation needed)
+        aggregator.process_request(request);
+        let conn_id = ConnectionId { pid: 1234, ssl_ptr: 0x4000 };
+        assert!(aggregator.has_pending_request(&conn_id));
+    }
+
+    #[test]
+    fn test_raw_data_ignored_when_no_pending() {
+        let mut aggregator = HttpConnectionAggregator::new();
+
+        // Send raw data for a connection that has no pending body
+        let raw = SslEvent {
+            source: 0, timestamp_ns: 1000, delta_ns: 0,
+            pid: 9999, tid: 1, uid: 0, len: 5, rw: 1,
+            comm: String::new(),
+            buf: b"hello".to_vec(),
+            is_handshake: false, ssl_ptr: 0x5000,
+        };
+        let result = aggregator.process_raw_body_data(&raw);
+        assert!(result.is_none());
+        assert_eq!(aggregator.active_connections(), 0);
+    }
+
+    #[test]
+    fn test_request_body_pending_with_sse_response() {
+        let mut aggregator = HttpConnectionAggregator::new();
+
+        // Request with incomplete body
+        let partial = b"POST /stream HTTP/1.1\r\nContent-Length: 50\r\n\r\ndata";
+        let event = create_mock_ssl_event_with_buf(1234, 0x6000, partial.to_vec(), 1);
+
+        let header_end = partial.windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .unwrap() + 4;
+        let body_len = partial.len() - header_end;
+
+        let mut headers = HashMap::new();
+        headers.insert("content-length".to_string(), "50".to_string());
+
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            path: "/stream".to_string(),
+            version: 1,
+            headers,
+            body_offset: header_end,
+            body_len,
+            source_event: event,
+            reassembled_body: None,
+        };
+
+        aggregator.process_request(request);
+
+        // SSE response arrives → should force-complete body and enter SseActive
+        let resp_event = create_mock_ssl_event_with_buf(1234, 0x6000,
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n".to_vec(), 0);
+        let mut resp_headers = HashMap::new();
+        resp_headers.insert("content-type".to_string(), "text/event-stream".to_string());
+
+        let response = ParsedResponse {
+            version: 1,
+            status_code: 200,
+            reason: "OK".to_string(),
+            headers: resp_headers,
+            body_offset: 0,
+            body_len: 0,
+            source_event: resp_event,
+        };
+
+        let result = aggregator.process_response(response);
+        // SSE response should not return immediately, should enter SseActive
+        assert!(result.is_none());
+        let conn_id = ConnectionId { pid: 1234, ssl_ptr: 0x6000 };
+        assert!(aggregator.is_sse_active(&conn_id));
     }
 }

--- a/src/agentsight/src/aggregator/unified.rs
+++ b/src/agentsight/src/aggregator/unified.rs
@@ -68,6 +68,9 @@ impl Aggregator {
                     .map(AggregatedResult::Http2StreamComplete)
                     .collect()
             }
+            ParsedMessage::RawData(ssl_event) => {
+                self.http.process_raw_body_data(&ssl_event).into_iter().collect()
+            }
         }
     }
 

--- a/src/agentsight/src/parser/http/parser.rs
+++ b/src/agentsight/src/parser/http/parser.rs
@@ -90,6 +90,7 @@ impl HttpParser {
             body_offset: header_end,
             body_len,
             source_event: Rc::clone(event),
+            reassembled_body: None,
         })
     }
 

--- a/src/agentsight/src/parser/http/request.rs
+++ b/src/agentsight/src/parser/http/request.rs
@@ -17,12 +17,18 @@ pub struct ParsedRequest {
     pub body_offset: usize,          // body 在 source_event.buf 中的起始位置
     pub body_len: usize,             // body 长度
     pub source_event: Rc<SslEvent>,  // 原始 SslEvent (Rc 避免拷贝)
+    /// 重组后的完整 body（跨多事件聚合时使用）
+    pub reassembled_body: Option<Vec<u8>>,
 }
 
 impl ParsedRequest {
-    /// 获取 body 数据（零拷贝）
+    /// 获取 body 数据（零拷贝，或返回重组后的 body）
     pub fn body(&self) -> &[u8] {
-        &self.source_event.buf[self.body_offset..self.body_offset + self.body_len]
+        if let Some(ref buf) = self.reassembled_body {
+            buf
+        } else {
+            &self.source_event.buf[self.body_offset..self.body_offset + self.body_len]
+        }
     }
 
     pub fn body_str(&self) -> &str {
@@ -34,10 +40,10 @@ impl ParsedRequest {
     /// 如果 body 是有效的 UTF-8 且是有效的 JSON，返回解析后的 Value。
     /// 如果直接解析失败，会尝试剥离 HTTP chunked transfer encoding 后再解析。
     pub fn json_body(&self) -> Option<serde_json::Value> {
-        if self.body_len == 0 {
+        let body = self.body();
+        if body.is_empty() {
             return None;
         }
-        let body = self.body();
         let body_str = String::from_utf8_lossy(body);
 
         // Try direct JSON parse first
@@ -227,6 +233,7 @@ mod tests {
             body_offset: body.len() - 5,
             body_len: 5,
             source_event: event,
+            reassembled_body: None,
         };
         assert_eq!(req.body_str(), "hello");
         assert_eq!(req.body(), b"hello");
@@ -247,6 +254,7 @@ mod tests {
             body_offset,
             body_len: json_str.len(),
             source_event: event,
+            reassembled_body: None,
         };
         let val = req.json_body().unwrap();
         assert_eq!(val["key"], "value");
@@ -263,6 +271,7 @@ mod tests {
             body_offset: 0,
             body_len: 0,
             source_event: event,
+            reassembled_body: None,
         };
         assert!(req.json_body().is_none());
     }
@@ -294,6 +303,7 @@ mod tests {
             body_offset: body.len() - 7,
             body_len: 7,
             source_event: event,
+            reassembled_body: None,
         };
         let args = req.to_trace_args();
         assert_eq!(args["method"], "POST");
@@ -311,6 +321,7 @@ mod tests {
             body_offset: 0,
             body_len: 0,
             source_event: event,
+            reassembled_body: None,
         };
         let events = req.to_chrome_trace_events();
         assert_eq!(events.len(), 1);
@@ -351,6 +362,7 @@ mod tests {
             body_offset: 0,
             body_len: 0,
             source_event: event,
+            reassembled_body: None,
         };
         let debug_str = format!("{:?}", req);
         assert!(debug_str.contains("GET"));

--- a/src/agentsight/src/parser/result.rs
+++ b/src/agentsight/src/parser/result.rs
@@ -3,10 +3,12 @@
 //! This module defines the `ParsedMessage` and `ParseResult` types
 //! representing the output from parsing events.
 
+use std::rc::Rc;
 use crate::parser::http::{ParsedRequest, ParsedResponse};
 use crate::parser::sse::ParsedSseEvent;
 use crate::parser::proctrace::ParsedProcEvent;
 use crate::parser::http2::ParsedHttp2Frame;
+use crate::probes::sslsniff::SslEvent;
 
 /// Parsed message from events
 #[derive(Debug, Clone)]
@@ -21,6 +23,8 @@ pub enum ParsedMessage {
     Http2Frames(Vec<ParsedHttp2Frame>),
     /// Process Event
     ProcEvent(ParsedProcEvent),
+    /// Raw SSL data (unrecognized write-direction, used for body continuation)
+    RawData(Rc<SslEvent>),
 }
 
 impl ParsedMessage {
@@ -32,6 +36,7 @@ impl ParsedMessage {
             ParsedMessage::SseEvent(_) => "SseEvent",
             ParsedMessage::Http2Frames(_) => "Http2Frames",
             ParsedMessage::ProcEvent(_) => "ProcEvent",
+            ParsedMessage::RawData(_) => "RawData",
         }
     }
 }

--- a/src/agentsight/src/parser/unified.rs
+++ b/src/agentsight/src/parser/unified.rs
@@ -95,7 +95,19 @@ impl Parser {
             }
         }
 
-        // 3. Fallback: SSE data
+        // 3. Write-direction data that failed all protocol detection → RawData
+        // This is likely a body continuation for an in-progress HTTP/1.1 request
+        if ssl_event.rw == 1 {
+            log::debug!(
+                "parse_ssl_event: unrecognized write-direction data (len={}), emitting RawData",
+                ssl_event.buf_size()
+            );
+            return ParseResult {
+                messages: vec![ParsedMessage::RawData(ssl_event)],
+            };
+        }
+
+        // 4. Fallback: SSE data (read-direction only)
         let sse_events = self.sse_parser.parse(ssl_event.clone());
         let messages = sse_events
             .into_iter()


### PR DESCRIPTION
## Description

当前 AgentSight 的 HTTP/1.x 聚合器无法正确处理请求体跨多个 SSL_write 事件分片传输的场景。当 LLM API 请求体较大时，eBPF sslsniff 探针可能将其拆分为多个 write 事件，现有解析器只能处理完整单包请求，导致 body 丢失或解析失败。

本 PR 引入 HTTP/1.1 请求体重组机制：
- 在 HttpConnectionAggregator 中新增 RequestBodyPending 状态，跟踪尚未接收完整的请求体。
- 在 ParsedRequest 中增加 reassembled_body 字段，支持跨事件拼接 body。
- 在 Parser 中新增 RawData 消息类型，将无法识别的 write-direction 数据透传为 body continuation。
- 当 write-direction 数据无法匹配任何已知协议时，将其作为当前 pending 请求的 body 片段进行累积。

## Related Issue

closes #472

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

`cargo test` 通过（2 doc-tests passed, 0 failed）。由于本改动涉及 eBPF 探针与 HTTP 协议解析的交互，完整集成测试需要在真实 SSL 流量环境下验证。

## Additional Notes

此改动主要影响以下文件：
- src/aggregator/http/aggregator.rs
- src/aggregator/unified.rs
- src/parser/http/parser.rs
- src/parser/http/request.rs
- src/parser/result.rs
- src/parser/unified.rs
