### PR TITLE
feat(ci): add ws-ckpt signing support in package-source action

### DIFF
--- a/.github/actions/package-source/action.yaml
+++ b/.github/actions/package-source/action.yaml
@@ -149,7 +149,7 @@ runs:
           -C /tmp/build "${ARCHIVE_NAME}"
 
     # -----------------------------------------------------------------
-    # Step 4: Sign archive (os-skills only)
+    # Step 4.1: Sign archive (os-skills only)
     #
     # Signing is automatically applied when component == os-skills.
     # No external sign parameter needed; the action decides internally.
@@ -174,7 +174,7 @@ runs:
         echo "::warning::SKILL_SIGN_PRIVATE_KEY is not set; os-skills archive will be published UNSIGNED."
 
     # -----------------------------------------------------------------
-    # Step 5: Sign archive (agent-sec-core only)
+    # Step 4.2: Sign archive (agent-sec-core only)
     #
     # Signing is automatically applied when component == agent-sec-core.
     # No external sign parameter needed; the action decides internally.
@@ -199,7 +199,32 @@ runs:
         echo "::warning::SKILL_SIGN_PRIVATE_KEY is not set; agent-sec-core archive will be published UNSIGNED."
 
     # -----------------------------------------------------------------
-    # Step 6: Summarize
+    # Step 4.3: Sign archive (ws-ckpt only)
+    #
+    # Signing is automatically applied when component == ws-ckpt.
+    # No external sign parameter needed; the action decides internally.
+    # -----------------------------------------------------------------
+    - name: Sign archive (ws-ckpt)
+      if: inputs.component == 'ws-ckpt' && inputs.skill-sign-private-key != ''
+      shell: bash
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.skill-sign-private-key }}
+      run: |
+        bash src/agent-sec-core/tools/sign-skill.sh --batch /tmp/build/${ARCHIVE_NAME}/src/skills
+
+        tar -czf "/tmp/archives/${ARCHIVE_FILE}" \
+          -C /tmp/build "${ARCHIVE_NAME}"
+
+        echo "ARCHIVE_SIGNED=true" >> $GITHUB_ENV
+
+    - name: Warn if ws-ckpt signing skipped
+      if: inputs.component == 'ws-ckpt' && inputs.skill-sign-private-key == ''
+      shell: bash
+      run: |
+        echo "::warning::SKILL_SIGN_PRIVATE_KEY is not set; ws-ckpt archive will be published UNSIGNED."
+
+    # -----------------------------------------------------------------
+    # Step 5: Summarize
     # -----------------------------------------------------------------
     - name: Summarize
       shell: bash
@@ -224,7 +249,7 @@ runs:
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
     # -----------------------------------------------------------------
-    # Step 7: Compute checksum
+    # Step 6: Compute checksum
     # -----------------------------------------------------------------
     - name: Compute checksum
       id: checksum
@@ -235,7 +260,7 @@ runs:
         echo "Archive SHA256: ${SHA256}"
 
     # -----------------------------------------------------------------
-    # Step 8: Upload artifact
+    # Step 7: Upload artifact
     # -----------------------------------------------------------------
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

Extend the shared `package-source` GitHub composite action to support signing `ws-ckpt` release archives using the existing `sign-skill.sh` toolchain, mirroring the flow already implemented for `os-skills` and `agent-sec-core`. The original Step 4/5 signing steps are regrouped as numbered sub-steps (4.1/4.2/4.3) to make the three signing variants read as a single logical phase, and the downstream Summarize / Compute checksum / Upload artifact steps are renumbered to 5/6/7. When `SKILL_SIGN_PRIVATE_KEY` is not provided, a warning is emitted and the archive is published unsigned, matching the behavior of the other two components.

## Related Issue

no-issue: extends existing CI signing flow to cover the `ws-ckpt` component; purely additive to the reusable composite action.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [x] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Change is limited to a reusable GitHub Actions composite action:

- YAML structure reviewed manually against the existing `os-skills` and `agent-sec-core` signing blocks for parity (condition, env, `sign-skill.sh` invocation, re-archiving, `ARCHIVE_SIGNED` flag, fallback warning).
- End-to-end verification will be performed on the next `ws-ckpt` release run that consumes this action; the unsigned fallback path is preserved when `SKILL_SIGN_PRIVATE_KEY` is absent, so existing component builds remain unaffected.

## Additional Notes

- The new block assumes `ws-ckpt` archives expose a `src/skills` directory consumable by `sign-skill.sh --batch`, consistent with the other signed components.
- Step renumbering is comment-only and does not change runtime semantics of the existing steps.
