### PR TITLE
feat(cosh): expose run_id in HookInput for per-run event correlation

### DIFF
--- a/src/copilot-shell/hooks/docs/reference.md
+++ b/src/copilot-shell/hooks/docs/reference.md
@@ -25,12 +25,22 @@ All hooks receive these common fields via `stdin`:
 ```json
 {
   "session_id": "string",
+  "run_id": "string | undefined",
   "transcript_path": "string",
   "cwd": "string",
   "hook_event_name": "string",
   "timestamp": "string (ISO 8601)"
 }
 ```
+
+| Field             | Type                  | Description                                                                                                                                                                                                                                                        |
+| :---------------- | :-------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session_id`      | `string`              | Unique identifier for the CLI session (1 session = N runs).                                                                                                                                                                                                        |
+| `run_id`          | `string \| undefined` | Unique identifier for the current agent run (1 run = 1 user prompt → complete response). Format: `{sessionId}########{counter}`. Undefined for session-level events (`SessionStart`, `SessionEnd`) and for `UserPromptSubmit` (which fires before the run begins). |
+| `transcript_path` | `string`              | Path to the session's JSONL transcript file.                                                                                                                                                                                                                       |
+| `cwd`             | `string`              | Current working directory.                                                                                                                                                                                                                                         |
+| `hook_event_name` | `string`              | The event that triggered this hook.                                                                                                                                                                                                                                |
+| `timestamp`       | `string`              | ISO 8601 timestamp of when the event fired.                                                                                                                                                                                                                        |
 
 ---
 

--- a/src/copilot-shell/hooks/docs/writing-hooks.md
+++ b/src/copilot-shell/hooks/docs/writing-hooks.md
@@ -267,6 +267,38 @@ else:
     print("{}")
 ```
 
+### Audit Trail with run_id (PostToolUse)
+
+Use `run_id` to correlate all tool calls within a single agent run for auditing.
+
+**`.copilot-shell/hooks/audit-trail.py`:**
+
+```python
+#!/usr/bin/env python3
+import sys, json, datetime
+
+input_data = json.load(sys.stdin)
+
+entry = {
+    "timestamp": datetime.datetime.now().isoformat(),
+    "session_id": input_data["session_id"],
+    "run_id": input_data.get("run_id"),
+    "event": input_data["hook_event_name"],
+    "tool": input_data.get("tool_name", ""),
+}
+
+with open(".copilot-shell/audit.jsonl", "a") as f:
+    f.write(json.dumps(entry) + "\n")
+
+print("{}")
+```
+
+Query all actions from a specific run:
+
+```bash
+jq 'select(.run_id == "sess########3")' .copilot-shell/audit.jsonl
+```
+
 ### Response Logger (AfterModel)
 
 Log all LLM responses for auditing.

--- a/src/copilot-shell/packages/core/src/config/config.test.ts
+++ b/src/copilot-shell/packages/core/src/config/config.test.ts
@@ -1527,3 +1527,39 @@ describe('Custom Skill Paths Configuration', () => {
     expect(resolved).toEqual(['/absolute/path']);
   });
 });
+
+describe('currentRunId', () => {
+  const baseParams: ConfigParameters = {
+    cwd: '/tmp',
+    embeddingModel: 'test-embedding-model',
+    targetDir: '/path/to/target',
+    debugMode: false,
+    usageStatisticsEnabled: false,
+    overrideExtensions: [],
+  };
+
+  it('should return undefined before any run_id is set', () => {
+    const config = new Config({ ...baseParams });
+    expect(config.getCurrentRunId()).toBeUndefined();
+  });
+
+  it('should store and retrieve a run_id', () => {
+    const config = new Config({ ...baseParams });
+    config.setCurrentRunId('session-123########1');
+    expect(config.getCurrentRunId()).toBe('session-123########1');
+  });
+
+  it('should overwrite the previous run_id', () => {
+    const config = new Config({ ...baseParams });
+    config.setCurrentRunId('run-1');
+    config.setCurrentRunId('run-2');
+    expect(config.getCurrentRunId()).toBe('run-2');
+  });
+
+  it('should be cleared when startNewSession is called', () => {
+    const config = new Config({ ...baseParams });
+    config.setCurrentRunId('run-from-old-session');
+    config.startNewSession();
+    expect(config.getCurrentRunId()).toBeUndefined();
+  });
+});

--- a/src/copilot-shell/packages/core/src/config/config.ts
+++ b/src/copilot-shell/packages/core/src/config/config.ts
@@ -954,6 +954,16 @@ export class Config {
     return this.sessionId;
   }
 
+  private currentRunId: string | undefined = undefined;
+
+  setCurrentRunId(runId: string): void {
+    this.currentRunId = runId;
+  }
+
+  getCurrentRunId(): string | undefined {
+    return this.currentRunId;
+  }
+
   /**
    * Releases resources owned by the config instance.
    */
@@ -971,6 +981,7 @@ export class Config {
     sessionData?: ResumedSessionData,
   ): string {
     this.sessionId = sessionId ?? randomUUID();
+    this.currentRunId = undefined;
     this.sessionData = sessionData;
     this.chatRecordingService = this.chatRecordingEnabled
       ? new ChatRecordingService(this)

--- a/src/copilot-shell/packages/core/src/core/client.test.ts
+++ b/src/copilot-shell/packages/core/src/core/client.test.ts
@@ -316,6 +316,7 @@ describe('Gemini Client (client.ts)', () => {
       getUserMemory: vi.fn().mockReturnValue(''),
       getFullContext: vi.fn().mockReturnValue(false),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      setCurrentRunId: vi.fn(),
       getProxy: vi.fn().mockReturnValue(undefined),
       getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
       getFileService: vi.fn().mockReturnValue(fileService),
@@ -1145,6 +1146,49 @@ describe('Gemini Client (client.ts)', () => {
         });
       },
     );
+
+    it('should set currentRunId on config when not a continuation', async () => {
+      // Arrange
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      // Act
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'test-prompt-id-42',
+      );
+      await fromAsync(stream);
+
+      // Assert
+      expect(mockConfig.setCurrentRunId).toHaveBeenCalledWith(
+        'test-prompt-id-42',
+      );
+    });
+
+    it('should not set currentRunId on config when isContinuation is true', async () => {
+      // Arrange
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      // Act
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'test-prompt-id-42',
+        { isContinuation: true },
+      );
+      await fromAsync(stream);
+
+      // Assert
+      expect(mockConfig.setCurrentRunId).not.toHaveBeenCalled();
+    });
 
     it('should include editor context when ideMode is enabled', async () => {
       // Arrange

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -617,6 +617,7 @@ export class GeminiClient {
     if (!options?.isContinuation) {
       this.loopDetector.reset(prompt_id);
       this.lastPromptId = prompt_id;
+      this.config.setCurrentRunId(prompt_id);
 
       // record user message for session management
       this.config.getChatRecordingService()?.recordUserMessage(request);

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.test.ts
@@ -26,6 +26,7 @@ describe('HookEventHandler', () => {
   beforeEach(() => {
     mockConfig = {
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getCurrentRunId: vi.fn().mockReturnValue('test-run-id'),
       getTranscriptPath: vi.fn().mockReturnValue('/test/transcript'),
       getWorkingDir: vi.fn().mockReturnValue('/test/cwd'),
     } as unknown as Config;
@@ -69,6 +70,55 @@ describe('HookEventHandler', () => {
     errors: [],
     totalDuration: 100,
     finalOutput,
+  });
+
+  describe('createBaseInput run_id', () => {
+    it('should include run_id from config in hook input', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireUserPromptSubmitEvent('test');
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as { session_id: string; run_id: string };
+      expect(input.session_id).toBe('test-session-id');
+      expect(input.run_id).toBe('test-run-id');
+    });
+
+    it('should include undefined run_id when not set', async () => {
+      vi.mocked(mockConfig.getCurrentRunId).mockReturnValue(undefined);
+
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireUserPromptSubmitEvent('test');
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as { run_id?: string };
+      expect(input.run_id).toBeUndefined();
+    });
   });
 
   describe('fireUserPromptSubmitEvent', () => {

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
@@ -435,6 +435,7 @@ export class HookEventHandler {
 
     return {
       session_id: this.config.getSessionId(),
+      run_id: this.config.getCurrentRunId(),
       transcript_path: transcriptPath,
       cwd: this.config.getWorkingDir(),
       hook_event_name: eventName,

--- a/src/copilot-shell/packages/core/src/hooks/types.ts
+++ b/src/copilot-shell/packages/core/src/hooks/types.ts
@@ -101,6 +101,7 @@ export type HookDecision = 'ask' | 'block' | 'deny' | 'approve' | 'allow';
  */
 export interface HookInput {
   session_id: string;
+  run_id?: string;
   transcript_path: string;
   cwd: string;
   hook_event_name: string;

--- a/src/copilot-shell/packages/core/src/services/chatRecordingService.test.ts
+++ b/src/copilot-shell/packages/core/src/services/chatRecordingService.test.ts
@@ -40,6 +40,7 @@ describe('ChatRecordingService', () => {
 
     mockConfig = {
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getCurrentRunId: vi.fn().mockReturnValue('test-run-id'),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
       getCliVersion: vi.fn().mockReturnValue('1.0.0'),
       storage: {

--- a/src/copilot-shell/packages/core/src/services/chatRecordingService.ts
+++ b/src/copilot-shell/packages/core/src/services/chatRecordingService.ts
@@ -41,6 +41,8 @@ export interface ChatRecord {
   parentUuid: string | null;
   /** Session identifier - groups records into a logical conversation */
   sessionId: string;
+  /** Run identifier - correlates records within a single agent run */
+  runId?: string;
   /** ISO 8601 timestamp of when the record was created */
   timestamp: string;
   /**
@@ -255,6 +257,7 @@ export class ChatRecordingService {
       uuid: randomUUID(),
       parentUuid: this.lastRecordUuid,
       sessionId: this.getSessionId(),
+      runId: this.config.getCurrentRunId(),
       timestamp: new Date().toISOString(),
       type,
       cwd: this.config.getProjectRoot(),


### PR DESCRIPTION

## Description

Exposes `run_id` in `HookInput` so hook scripts can correlate all events
(PreToolUse, PostToolUse, Stop, UserPromptSubmit, etc.) belonging to the
same agent run.

Previously, `HookInput` only carried `session_id`, which spans the entire
CLI process lifetime (1 session = N runs). This was too coarse-grained for
security monitoring and observability — hook scripts had no way to group
tool-call events within a single "user prompt → full agent response" cycle.

The implementation reuses the existing internal `prompt_id` value
(`{sessionId}########{counter}`) as `run_id`. `prompt_id` was already
tracked inside `GeminiClient`; this change plumbs it through `Config` so
that `HookEventHandler.createBaseInput()` can inject it into every hook
event automatically, with no per-event changes required.

`run_id` is an optional field — session-level events (SessionStart /
SessionEnd) leave it `undefined`, preserving full backward compatibility
with existing hook scripts.

`ChatRecord` in `chatRecordingService` also gains a `runId` field,
enabling run-level queries on transcript JSONL files.

## Related Issue

closes #481

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
# Unit tests covering the new behavior
cd src/copilot-shell
npm test -- --testPathPattern="config|client|hookEventHandler"
```

## Additional Notes

`run_id` is identical to `prompt_id` in value. A separate UUID was
considered but rejected to avoid maintaining two IDs with identical
semantics. Session-level events (SessionStart/SessionEnd) intentionally
omit `run_id` since they do not belong to any single run.