### PR TITLE
fix(sec-core): detect unsigned skill files

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/__init__.py
@@ -7,6 +7,7 @@ from agent_sec_cli.asset_verify.errors import (
     ErrNoTrustedKeys,
     ErrSigInvalid,
     ErrSigMissing,
+    ErrUnexpectedFile,
 )
 from agent_sec_cli.asset_verify.verifier import (
     compute_file_hash,
@@ -25,6 +26,7 @@ __all__ = [
     "ErrNoTrustedKeys",
     "ErrSigInvalid",
     "ErrSigMissing",
+    "ErrUnexpectedFile",
     "compute_file_hash",
     "load_config",
     "load_trusted_keys",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
@@ -47,6 +47,15 @@ class ErrHashMismatch(SkillVerifyError):
         )
 
 
+class ErrUnexpectedFile(SkillVerifyError):
+    code = 14
+
+    def __init__(self, skill_name: str, file_path: str) -> None:
+        super().__init__(
+            f"ERR_UNEXPECTED_FILE: Unsigned file '{file_path}' present in '{skill_name}'"
+        )
+
+
 class ErrConfigMissing(SkillVerifyError):
     code = 20
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/verifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/verifier.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -22,6 +23,7 @@ from agent_sec_cli.asset_verify.errors import (
     ErrNoTrustedKeys,
     ErrSigInvalid,
     ErrSigMissing,
+    ErrUnexpectedFile,
 )
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -99,6 +101,43 @@ def compute_file_hash(file_path: str) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             sha256.update(chunk)
     return sha256.hexdigest()
+
+
+def _is_hidden_manifest_path(rel_path: str) -> bool:
+    """Return True if a manifest-relative path contains a hidden component."""
+    return any(part.startswith(".") for part in Path(rel_path).parts)
+
+
+def collect_signed_file_paths(skill_dir: str) -> set[str]:
+    """Collect files that should be covered by a skill manifest.
+
+    This mirrors ``sign-skill.sh``: regular files are included recursively, while
+    hidden files and files in hidden directories such as ``.skill-meta`` are
+    ignored.
+    """
+    signed_paths: set[str] = set()
+    root = Path(skill_dir)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if not name.startswith(".")]
+
+        for filename in filenames:
+            if filename.startswith("."):
+                continue
+
+            file_path = Path(dirpath) / filename
+            try:
+                if not stat.S_ISREG(os.lstat(file_path).st_mode):
+                    continue
+            except OSError:
+                continue
+
+            rel_path = file_path.relative_to(root).as_posix()
+            if _is_hidden_manifest_path(rel_path):
+                continue
+            signed_paths.add(rel_path)
+
+    return signed_paths
 
 
 def verify_signature_gpg(
@@ -185,10 +224,13 @@ def verify_signature(
 
 
 def verify_manifest_hashes(skill_dir: str, manifest: dict, skill_name: str) -> None:
-    """Verify all file hashes in manifest"""
+    """Verify manifest hashes and reject unsigned files."""
+    manifest_paths: set[str] = set()
+
     for file_entry in manifest.get("files", []):
         rel_path = file_entry["path"]
         expected_hash = file_entry["hash"]
+        manifest_paths.add(rel_path)
 
         full_path = os.path.join(skill_dir, rel_path)
         if not os.path.exists(full_path):
@@ -197,6 +239,9 @@ def verify_manifest_hashes(skill_dir: str, manifest: dict, skill_name: str) -> N
         actual_hash = compute_file_hash(full_path)
         if actual_hash != expected_hash:
             raise ErrHashMismatch(skill_name, rel_path, expected_hash, actual_hash)
+
+    for rel_path in sorted(collect_signed_file_paths(skill_dir) - manifest_paths):
+        raise ErrUnexpectedFile(skill_name, rel_path)
 
 
 def verify_skill(skill_dir: str, trusted_keys: list) -> tuple[bool, str]:
@@ -298,10 +343,10 @@ def main() -> int:
             print(f"[ERROR] {item['name']}")
             print(f"  {item['error']}")
 
-        print(f"\n{'='*50}")
+        print(f"\n{'=' * 50}")
         print(f"PASSED: {len(results['passed'])}")
         print(f"FAILED: {len(results['failed'])}")
-        print(f"{'='*50}")
+        print(f"{'=' * 50}")
 
         if results["failed"]:
             print("VERIFICATION FAILED")

--- a/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
@@ -35,7 +35,12 @@ SIGNING_DIR = ".skill-meta"
 # Make verifier importable
 sys.path.insert(0, str(VERIFIER_DIR))
 
-from errors import ErrHashMismatch, ErrSigInvalid, ErrSigMissing  # noqa: E402
+from errors import (  # noqa: E402
+    ErrHashMismatch,
+    ErrSigInvalid,
+    ErrSigMissing,
+    ErrUnexpectedFile,
+)
 from verifier import load_trusted_keys, verify_skill  # noqa: E402
 
 # ── Colours ────────────────────────────────────────────────────────────────
@@ -320,6 +325,30 @@ def test_tampered_file_detected(ws: Workspace):
         pass  # expected
 
 
+def test_unsigned_reference_file_detected(ws: Workspace):
+    """Verifier detects new files added under references after signing."""
+    skill = make_skill(
+        ws.skills_dir,
+        "skill-extra-file",
+        {
+            "SKILL.md": "# Skill\n",
+            "references/original.md": "signed\n",
+        },
+    )
+    r = run_sign_skill([str(skill), "--force"])
+    assert r.returncode == 0
+
+    # Empty files are still unsigned payloads when they are absent from Manifest.json.
+    (skill / "references" / "a.md").write_text("")
+
+    keys = load_trusted_keys(ws.trusted_keys)
+    try:
+        verify_skill(str(skill), keys)
+        assert False, "Expected ErrUnexpectedFile"
+    except ErrUnexpectedFile as exc:
+        assert "references/a.md" in str(exc)
+
+
 def test_missing_sig_detected(ws: Workspace):
     """Verifier raises ErrSigMissing when .skill.sig is deleted."""
     skill = make_skill(ws.skills_dir, "skill-nosig", {"f.txt": "f"})
@@ -522,6 +551,10 @@ def main():
 
         # Negative / security tests
         test("Tampered file detected", lambda: test_tampered_file_detected(ws))
+        test(
+            "Unsigned reference file detected",
+            lambda: test_unsigned_reference_file_detected(ws),
+        )
         test("Missing .skill.sig detected", lambda: test_missing_sig_detected(ws))
         test("Wrong key rejected", lambda: test_wrong_key_rejected(ws))
 

--- a/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
+++ b/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
@@ -25,6 +25,7 @@ from agent_sec_cli.asset_verify.errors import (
     ErrManifestMissing,
     ErrNoTrustedKeys,
     ErrSigMissing,
+    ErrUnexpectedFile,
 )
 from agent_sec_cli.asset_verify.verifier import (
     compute_file_hash,
@@ -81,6 +82,39 @@ class TestVerifyManifestHashes(unittest.TestCase):
         with self.assertRaises(ErrHashMismatch) as ctx:
             verify_manifest_hashes(self.tmpdir, manifest, "test_skill")
         self.assertIn("FILE_MISSING", str(ctx.exception))
+
+    def test_unexpected_file(self):
+        extra_file = os.path.join(self.tmpdir, "references", "a.md")
+        os.makedirs(os.path.dirname(extra_file), exist_ok=True)
+        with open(extra_file, "w") as f:
+            f.write("")
+
+        manifest = {"files": [{"path": "main.py", "hash": self.file_hash}]}
+        with self.assertRaises(ErrUnexpectedFile) as ctx:
+            verify_manifest_hashes(self.tmpdir, manifest, "test_skill")
+        self.assertIn("references/a.md", str(ctx.exception))
+
+    def test_unexpected_root_file(self):
+        extra_file = os.path.join(self.tmpdir, "a.md")
+        with open(extra_file, "w") as f:
+            f.write("")
+
+        manifest = {"files": [{"path": "main.py", "hash": self.file_hash}]}
+        with self.assertRaises(ErrUnexpectedFile) as ctx:
+            verify_manifest_hashes(self.tmpdir, manifest, "test_skill")
+        self.assertIn("a.md", str(ctx.exception))
+
+    def test_hidden_files_are_ignored(self):
+        hidden_file = os.path.join(self.tmpdir, ".hidden.md")
+        hidden_dir_file = os.path.join(self.tmpdir, ".skill-meta", "Manifest.json")
+        os.makedirs(os.path.dirname(hidden_dir_file), exist_ok=True)
+        with open(hidden_file, "w") as f:
+            f.write("ignored")
+        with open(hidden_dir_file, "w") as f:
+            f.write("ignored")
+
+        manifest = {"files": [{"path": "main.py", "hash": self.file_hash}]}
+        verify_manifest_hashes(self.tmpdir, manifest, "test_skill")
 
 
 class TestVerifySkill(unittest.TestCase):

--- a/src/agent-sec-core/tools/SIGNING_GUIDE.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE.md
@@ -197,6 +197,7 @@ agent-sec-cli verify
 | 11 | Missing `.skill-meta/Manifest.json` | Skill was never signed |
 | 12 | Invalid signature | Signed with a key not in `trusted-keys/` |
 | 13 | Hash mismatch | Skill files changed after signing |
+| 14 | Unexpected file | Unsigned file added after signing |
 
 ## sign-skill.sh Command Reference
 

--- a/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
@@ -197,6 +197,7 @@ agent-sec-cli verify
 | 11 | 缺失 `.skill-meta/Manifest.json` | skill 从未签名 |
 | 12 | 签名无效 | 签名密钥不在 `trusted-keys/` 中 |
 | 13 | 哈希不匹配 | 签名后 skill 文件被修改 |
+| 14 | 存在未签名文件 | 签名后新增了未写入 manifest 的文件 |
 
 ## sign-skill.sh 命令参考
 


### PR DESCRIPTION
## Description

This PR fixes sec-core skill verification so files that are present in a skill directory but absent from the signed manifest are reported as verification failures. This covers the #480 case where an unsigned empty file such as `a.md` could be added under a skill or its `references/` directory without failing verify.

Hidden files and hidden directories continue to be skipped as before, including `.skill-meta/`.

## Related Issue

Fixes #480

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `PYTHONPATH=agent-sec-cli/src agent-sec-cli/.venv/bin/python -m pytest tests/integration-test/asset-verify/test_verifier.py::TestVerifyManifestHashes tests/unit-test/test_run_verification.py` — 10 passed
- `make python-code-pretty` — passed locally after applying black/isort changes
- `agent-sec-cli/.venv/bin/black --check --force-exclude "backend-skill/templates/" tests/e2e/skill-signing/e2e_test.py` — passed
- `git diff --check` — passed

## Additional Notes

- The path/config/key layout changes were split into a separate PR: #486.
- The sec-core Rust, cosh, sight, tokenless, and os-skills checklist items are not applicable to this PR.