### PR TITLE
fix(sec-core): align skill signing paths

### DIFF
--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -208,7 +208,7 @@ Output example:
 
 ### Verification Flow
 
-1. Load trusted public keys from `agent-sec-cli/asset-verify/trusted-keys/*.asc`
+1. Load trusted public keys from `agent_sec_cli/asset_verify/trusted-keys/*.asc`
 2. Verify the GPG signature (`.skill-meta/.skill.sig`) of `.skill-meta/Manifest.json` in each skill directory
 3. Validate SHA-256 hashes of all files listed in the Manifest
 

--- a/src/agent-sec-core/README_CN.md
+++ b/src/agent-sec-core/README_CN.md
@@ -208,7 +208,7 @@ python3 agent-sec-cli/src/agent_sec_cli/sandbox/sandbox_policy.py --cwd "$PWD" "
 
 ### 校验流程
 
-1. 加载受信公钥（`agent-sec-cli/asset-verify/trusted-keys/*.asc`）
+1. 加载受信公钥（`agent_sec_cli/asset_verify/trusted-keys/*.asc`）
 2. 验证 Skill 目录中 `.skill-meta/Manifest.json` 的 GPG 签名（`.skill-meta/.skill.sig`）
 3. 校验 Manifest 中所有文件的 SHA-256 哈希
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf
@@ -1,5 +1,6 @@
 # Skill Verification Config
-# trusted_keys_dir = /etc/agent-sec/trusted-keys
+# Trusted keys are loaded from the packaged trusted-keys/ directory next to
+# this file.
 
 # Skills directories to verify (one per line)
 skills_dir = [

--- a/src/agent-sec-core/tools/SIGNING_GUIDE.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE.md
@@ -25,18 +25,18 @@ tools/sign-skill.sh --check
 Three commands cover the entire workflow. Step 1 is a one-time setup; step 2 should be re-run whenever skill files change.
 
 ```bash
-# 1. One-time setup — generate GPG key + export public key to trusted-keys
+# 1. One-time setup — generate GPG key + export public key to verifier package data
 tools/sign-skill.sh --init
 
-# 2. Batch-sign all deployed skills (default: ~/.copilot-shell/skills/)
-tools/sign-skill.sh --batch --force
+# 2. Batch-sign all skills in this source checkout
+tools/sign-skill.sh --batch skills --force
 
 # 3. Verify
 agent-sec-cli verify
 ```
 
 `--init` automatically generates a dedicated signing key (`ANOLISA Local Deploy Key`) and
-exports the public key to `~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/`.
+exports the public key to `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`.
 You can override the export path with `--trusted-keys-dir <DIR>`.
 
 ## Step-by-Step (Manual Key Management)
@@ -65,8 +65,10 @@ gpg --list-secret-keys me@example.com
 
 ### 2. Export the Public Key
 
-The verifier loads trusted public keys from `~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/`.
-`--init` exports there automatically. To re-export manually:
+The verifier loads trusted public keys from the packaged `agent_sec_cli/asset_verify/trusted-keys/`
+directory. When running from this source checkout, `--init` exports to
+`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/` automatically.
+To re-export manually:
 
 ```bash
 tools/sign-skill.sh --export-key
@@ -82,7 +84,7 @@ Or fully manually:
 
 ```bash
 gpg --armor --export me@example.com \
-    > ~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/me-example-com.asc
+    > agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/me-example-com.asc
 ```
 
 ### 3. Sign Skills
@@ -96,10 +98,10 @@ tools/sign-skill.sh /usr/share/anolisa/skills/my-skill --force
 Batch-sign all skills under a directory:
 
 ```bash
-# Uses the default directory (~/.copilot-shell/skills/)
-tools/sign-skill.sh --batch --force
+# Source checkout example
+tools/sign-skill.sh --batch skills --force
 
-# Or specify a custom directory
+# Custom or installed directory
 tools/sign-skill.sh --batch /usr/share/anolisa/skills --force
 ```
 
@@ -112,7 +114,10 @@ Each signed skill directory will contain:
 
 ### 4. Configure the Verifier
 
-When using `--batch`, the script automatically registers the skills directory in `config.conf`. For manual setups, make sure the skills directory is listed in the deployed `config.conf` (e.g. `~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/config.conf`):
+`--batch` signs skill directories but does not edit verifier configuration. For
+batch verification, make sure the skills root is listed in the verifier config
+packaged with the CLI (`agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf`
+in this source tree):
 
 ```ini
 skills_dir = [
@@ -179,7 +184,7 @@ tools/sign-skill.sh --batch /path/to/skills --force
 Whenever skill files are modified, the existing `.skill-meta/Manifest.json` hashes become stale. Re-sign with `--force`:
 
 ```bash
-tools/sign-skill.sh --batch --force
+tools/sign-skill.sh --batch skills --force
 ```
 
 Then verify:
@@ -206,8 +211,8 @@ agent-sec-cli verify
 | **Init** | `--init [--trusted-keys-dir DIR]` | Generate GPG key + export public key |
 | **Check** | `--check` | Verify prerequisites (gpg, jq, sha256sum) |
 | **Single** | `<skill_dir> [--force]` | Sign one skill directory |
-| **Batch** | `--batch [parent_dir] [--force]` | Sign all subdirectories under parent (default: `~/.copilot-shell/skills/`). Auto-registers the directory in `config.conf`. |
-| **Export** | `--export-key [DIR]` | Export public key (default: `~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/`) |
+| **Batch** | `--batch <parent_dir> [--force]` | Sign all subdirectories under parent. |
+| **Export** | `--export-key [DIR]` | Export public key (default: `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`) |
 
 Common options:
 

--- a/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
@@ -25,18 +25,18 @@ tools/sign-skill.sh --check
 三条命令即可完成全部流程。步骤 1 每台机器只需执行一次；步骤 2 在 skill 文件变更后需重新执行。
 
 ```bash
-# 1. 一次性初始化 — 生成 GPG 密钥并导出公钥到 trusted-keys 目录
+# 1. 一次性初始化 — 生成 GPG 密钥并导出公钥到校验器包内数据目录
 tools/sign-skill.sh --init
 
-# 2. 批量签名所有已部署的 skill（默认：~/.copilot-shell/skills/）
-tools/sign-skill.sh --batch --force
+# 2. 批量签名当前源码树中的所有 skill
+tools/sign-skill.sh --batch skills --force
 
 # 3. 验证
 agent-sec-cli verify
 ```
 
 `--init` 会自动生成专用签名密钥（`ANOLISA Local Deploy Key`），并将公钥导出到
-`~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/`。
+`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`。
 可通过 `--trusted-keys-dir <DIR>` 覆盖导出路径。
 
 ## 手动逐步操作
@@ -65,8 +65,9 @@ gpg --list-secret-keys me@example.com
 
 ### 2. 导出公钥
 
-校验器从 `~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/` 加载受信公钥，
-`--init` 会自动导出到此目录。手动重新导出：
+校验器从打包后的 `agent_sec_cli/asset_verify/trusted-keys/` 目录加载受信公钥。
+在当前源码树中运行时，`--init` 会自动导出到
+`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`。手动重新导出：
 
 ```bash
 tools/sign-skill.sh --export-key
@@ -82,7 +83,7 @@ tools/sign-skill.sh --export-key /custom/path/to/trusted-keys/
 
 ```bash
 gpg --armor --export me@example.com \
-    > ~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/me-example-com.asc
+    > agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/me-example-com.asc
 ```
 
 ### 3. 签名 Skill
@@ -96,10 +97,10 @@ tools/sign-skill.sh /usr/share/anolisa/skills/my-skill --force
 批量签名目录下所有 skill：
 
 ```bash
-# 使用默认目录（~/.copilot-shell/skills/）
-tools/sign-skill.sh --batch --force
+# 当前源码树示例
+tools/sign-skill.sh --batch skills --force
 
-# 或指定自定义目录
+# 自定义目录 / 已安装目录
 tools/sign-skill.sh --batch /usr/share/anolisa/skills --force
 ```
 
@@ -112,7 +113,9 @@ tools/sign-skill.sh --batch /usr/share/anolisa/skills --force
 
 ### 4. 配置校验器
 
-使用 `--batch` 时，脚本会自动将 skill 目录注册到 `config.conf` 中。如果手动配置，请确保 skill 目录已配置在已部署的 `config.conf` 中（如 `~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/config.conf`）：
+`--batch` 只负责签名 skill 目录，不会修改校验器配置。若要进行批量校验，请确保
+skill 根目录已配置在随 CLI 打包的校验器配置中（当前源码树中的路径为
+`agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf`）：
 
 ```ini
 skills_dir = [
@@ -179,7 +182,7 @@ tools/sign-skill.sh --batch /path/to/skills --force
 每当 skill 文件被修改，已有的 `.skill-meta/Manifest.json` 哈希值将失效。使用 `--force` 重新签名：
 
 ```bash
-tools/sign-skill.sh --batch --force
+tools/sign-skill.sh --batch skills --force
 ```
 
 然后验证：
@@ -206,8 +209,8 @@ agent-sec-cli verify
 | **初始化** | `--init [--trusted-keys-dir DIR]` | 生成 GPG 密钥 + 导出公钥 |
 | **检查** | `--check` | 检查前置依赖（gpg、jq、sha256sum） |
 | **单个签名** | `<skill_dir> [--force]` | 签名单个 skill 目录 |
-| **批量签名** | `--batch [parent_dir] [--force]` | 签名目录下所有子目录（默认：`~/.copilot-shell/skills/`）。自动将目录注册到 `config.conf`。 |
-| **导出公钥** | `--export-key [DIR]` | 导出公钥（默认：`~/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys/`） |
+| **批量签名** | `--batch <parent_dir> [--force]` | 签名目录下所有子目录。 |
+| **导出公钥** | `--export-key [DIR]` | 导出公钥（默认：`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`） |
 
 常用选项：
 

--- a/src/agent-sec-core/tools/sign-skill.sh
+++ b/src/agent-sec-core/tools/sign-skill.sh
@@ -9,7 +9,7 @@
 #
 # Usage:
 #   Single mode: ./sign-skill.sh <skill_dir> [--skill-name NAME] [--force]
-#   Batch  mode: ./sign-skill.sh --batch [parent_dir] [--force]
+#   Batch  mode: ./sign-skill.sh --batch <parent_dir> [--force]
 #   Init   mode: ./sign-skill.sh --init [--trusted-keys-dir DIR]
 #   Export key:  ./sign-skill.sh --export-key [DIR]
 #   Check deps:  ./sign-skill.sh --check
@@ -51,17 +51,10 @@ SIGN_KEY_EMAIL="anolisa-deploy@$(hostname -s 2>/dev/null || echo localhost)"
 SIGN_KEY_NAME="ANOLISA Local Deploy Key"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_SEC_CORE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Default path for deployed skills
-DEFAULT_SKILLS_DIR="$HOME/.copilot-shell/skills"
-
-# Default path for trusted public keys (verifier reads from here)
-DEFAULT_TRUSTED_KEYS_DIR="$HOME/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/trusted-keys"
-
-# Path to the deployed verifier config (inside agent-sec-core skill).
-# Batch mode auto-registers the signed directory here so that the verifier
-# picks it up without manual config.conf editing.
-DEPLOY_CONFIG_CONF="$HOME/.copilot-shell/skills/agent-sec-core/scripts/asset-verify/config.conf"
+# Default path for trusted public keys in the verifier package data.
+DEFAULT_TRUSTED_KEYS_DIR="$AGENT_SEC_CORE_DIR/agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys"
 
 # Resolve gpg binary: prefer 'gpg', fall back to 'gpg2' (RHEL/Alinux minimal)
 if command -v gpg &>/dev/null; then
@@ -175,76 +168,20 @@ sign_manifest() {
     return 0
 }
 
-# Ensure a skills directory is registered in the deployed config.conf.
-# This must be called BEFORE signing agent-sec-core, because config.conf
-# is part of that skill and will be included in its manifest hash.
-ensure_config_dir_entry() {
-    local dir_to_add="$1"
-    local config_file="$DEPLOY_CONFIG_CONF"
-
-    if [[ ! -f "$config_file" ]]; then
-        echo -e "${YELLOW}NOTE: config.conf not found at $config_file — skipping auto-register${NC}"
-        return 0
-    fi
-
-    # Already registered?  Use awk to check only inside the skills_dir
-    # array for an exact (whitespace-trimmed) match, avoiding substring
-    # false positives from grep -F.
-    if awk -v target="$dir_to_add" '
-        /skills_dir[[:space:]]*=/ { in_list=1; next }
-        in_list && /^[[:space:]]*\]/ { exit 1 }
-        in_list {
-            line=$0; gsub(/^[[:space:]]+|[[:space:],]+$/, "", line)
-            if (line == target) { found=1; exit 0 }
-        }
-        END { exit (found ? 0 : 1) }
-    ' "$config_file" 2>/dev/null; then
-        echo "Skills directory already in config.conf: $dir_to_add"
-        return 0
-    fi
-
-    # Preserve original file permissions across the temp-file swap.
-    local orig_mode
-    orig_mode=$(stat -c '%a' "$config_file" 2>/dev/null) \
-        || orig_mode=$(stat -f '%Lp' "$config_file" 2>/dev/null) \
-        || orig_mode=""
-
-    # Insert entry before the first ']' (end of skills_dir array).
-    # The pattern tolerates an optionally-indented closing bracket.
-    local tmp_file
-    tmp_file=$(mktemp)
-    awk -v entry="    $dir_to_add" '
-        /^[[:space:]]*\]/ && !done { print entry; done=1 }
-        { print }
-    ' "$config_file" > "$tmp_file" && mv "$tmp_file" "$config_file"
-
-    # Restore original permissions if we captured them.
-    if [[ -n "$orig_mode" ]]; then
-        chmod "$orig_mode" "$config_file" 2>/dev/null
-    fi
-
-    if grep -qF "$dir_to_add" "$config_file" 2>/dev/null; then
-        echo -e "${GREEN}Added skills directory to config.conf: $dir_to_add${NC}"
-    else
-        echo -e "${YELLOW}WARNING: Could not update config.conf — please add '$dir_to_add' manually${NC}"
-    fi
-}
-
 # Function to show usage
 show_usage() {
     echo -e "${BOLD}Skill Manifest and Signature Generator${NC}"
     echo ""
     echo "Usage:"
     echo "  $0 <skill_dir> [--skill-name NAME] [--force]"
-    echo "  $0 --batch [parent_dir] [--force]"
+    echo "  $0 --batch <parent_dir> [--force]"
     echo "  $0 --init [--trusted-keys-dir DIR]"
     echo "  $0 --export-key [DIR]"
     echo "  $0 --check"
     echo ""
     echo "Modes:"
     echo "  (default)           Sign a single skill directory"
-    echo "  --batch [DIR]       Sign every subdirectory under DIR"
-    echo "                      (default: $DEFAULT_SKILLS_DIR)"
+    echo "  --batch DIR         Sign every subdirectory under DIR"
     echo "  --init              One-time setup: generate GPG key + export public key"
     echo "  --export-key [DIR]  Export signing public key to DIR"
     echo "                      (default: $DEFAULT_TRUSTED_KEYS_DIR)"
@@ -259,8 +196,8 @@ show_usage() {
     echo ""
     echo "Quick Start (self-deployment):"
     echo "  $0 --init"
-    echo "  $0 --batch --force"
-    echo "  python3 /path/to/verifier.py"
+    echo "  $0 --batch /path/to/skills --force"
+    echo "  agent-sec-cli verify"
     echo ""
     echo "Environment Variables:"
     echo "  GPG_PRIVATE_KEY   ASCII-armored GPG private key (for CI/CD auto-import)"
@@ -555,13 +492,13 @@ main() {
                 ;;
             --batch)
                 batch=true
-                # Directory is optional; default to DEFAULT_SKILLS_DIR
                 if [[ -n "${2:-}" && "${2:0:1}" != "-" ]]; then
                     batch_dir="$2"
                     shift 2
                 else
-                    batch_dir=""
-                    shift
+                    echo -e "${RED}ERROR: --batch requires a parent directory${NC}" >&2
+                    show_usage
+                    exit 1
                 fi
                 ;;
             --skill-name)
@@ -614,21 +551,11 @@ main() {
     # ── Batch mode ──
 
     if [[ "$batch" == true ]]; then
-        # Default to the standard deployed skills directory
-        if [[ -z "$batch_dir" ]]; then
-            batch_dir="$DEFAULT_SKILLS_DIR"
-        fi
-
         batch_dir=$(cd "$batch_dir" 2>/dev/null && pwd) || true
         if [[ ! -d "$batch_dir" ]]; then
             echo -e "${RED}ERROR: Batch directory does not exist: $batch_dir${NC}" >&2
             exit 1
         fi
-
-        # Register the skills directory in config.conf BEFORE signing.
-        # config.conf is part of the agent-sec-core skill, so it must be
-        # updated first to ensure its manifest hash is correct.
-        ensure_config_dir_entry "$batch_dir"
 
         echo "Batch signing skills under: $batch_dir"
         echo ""


### PR DESCRIPTION
## Description

Align sec-core skill signing and asset verification path guidance with the current agent-sec-cli package layout.

Changes:
- Remove the stale `/etc` trusted key hint from asset-verify config.
- Update `sign-skill.sh` to export trusted keys to the current verifier package-data path by default.
- Require an explicit parent directory for `sign-skill.sh --batch`; no hidden default skill directory is used.
- Remove the obsolete batch auto-registration behavior that targeted the deleted agent-sec-core skill config path.
- Refresh English/Chinese signing docs and README path references.

## Related Issue

fixes #480

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `bash -n src/agent-sec-core/tools/sign-skill.sh`
- `git diff --check`
- `PYTHONPATH=src/agent-sec-core/agent-sec-cli/src src/agent-sec-core/agent-sec-cli/.venv/bin/python -m pytest src/agent-sec-core/tests/unit-test/test_run_verification.py src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py -q` (`20 passed, 2 skipped`)

## Additional Notes

Full `tests/e2e/skill-signing/e2e_test.py` was not run locally because this environment does not have `gpg`/`gpg2` and `jq` installed.
