### PR TITLE
fix(sec-core): limit skill-ledger hook scope

### DIFF
--- a/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
@@ -2,7 +2,7 @@
 """Cosh hook script for skill-ledger.
 
 Reads a cosh PreToolUse JSON from stdin, resolves the skill directory
-from the skill name, invokes ``agent-sec-cli skill-ledger check`` via
+from the skill context or skill name, invokes ``agent-sec-cli skill-ledger check`` via
 subprocess, and writes a cosh HookOutput JSON to stdout.
 
 Hook point: **PreToolUse** — matcher: ``skill``
@@ -82,10 +82,99 @@ def _allow_with_reason(reason: str) -> str:
     return json.dumps({"decision": "allow", "reason": reason}, ensure_ascii=False)
 
 
+def _debug(message: str) -> None:
+    """Write debug-only hook details to stderr."""
+    print(f"[skill-ledger debug] {message}", file=sys.stderr)
+
+
+def _supported_skill_bases(cwd: str) -> list[Path]:
+    """Return the skill roots currently covered by this hook.
+
+    Current scope is intentionally limited to:
+    project (.copilot-shell/skills/) → user (~/.copilot-shell/skills/)
+    → system (/usr/share/anolisa/skills/).
+    """
+    return [
+        Path(cwd) / ".copilot-shell" / "skills",
+        Path.home() / ".copilot-shell" / "skills",
+        Path("/usr/share/anolisa/skills"),
+    ]
+
+
+def _resolve_supported_skill_bases(cwd: str, skill_name: str) -> list[Path]:
+    """Resolve supported skill roots, skipping only roots that fail."""
+    supported_bases: list[Path] = []
+    for base in _supported_skill_bases(cwd):
+        try:
+            supported_bases.append(base.resolve())
+        except (OSError, ValueError) as exc:
+            _debug(
+                "Skill '{}' check skipped for base '{}': failed to resolve: {}".format(
+                    skill_name, base, exc
+                )
+            )
+    return supported_bases
+
+
+def _resolve_skill_dir_from_context(
+    input_data: dict, cwd: str, skill_name: str
+) -> tuple[str | None, bool]:
+    """Resolve the skill dir from ``skill_context.file_path`` when available.
+
+    Returns ``(skill_dir, handled)``.  ``handled`` is True whenever a
+    well-formed ``skill_context.file_path`` was present, even if the path is
+    outside the supported project/user/system scope.  In that case the caller
+    should fail open without falling back to name-based lookup, because the
+    context identifies the actual skill that copilot-shell resolved.
+    """
+    skill_context = input_data.get("skill_context")
+    if not isinstance(skill_context, dict):
+        return None, False
+
+    file_path = skill_context.get("file_path")
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None, False
+
+    try:
+        skill_file = Path(file_path).expanduser().resolve()
+    except (OSError, ValueError) as exc:
+        _debug(
+            "Skill '{}' check skipped: invalid skill_context.file_path '{}': {}".format(
+                skill_name, file_path, exc
+            )
+        )
+        return None, True
+
+    supported_bases = _resolve_supported_skill_bases(cwd, skill_name)
+    if not supported_bases:
+        _debug(
+            "Skill '{}' check skipped: no supported skill bases could be resolved".format(
+                skill_name
+            )
+        )
+        return None, True
+
+    if not any(skill_file.is_relative_to(base) for base in supported_bases):
+        _debug(
+            "Skill '{}' at '{}' is outside current skill-ledger hook scope "
+            "(project/user/system); check skipped".format(skill_name, skill_file)
+        )
+        return None, True
+
+    if skill_file.name != "SKILL.md" or not skill_file.is_file():
+        _debug(
+            "Skill '{}' check skipped: skill_context.file_path '{}' does not "
+            "point to an existing SKILL.md".format(skill_name, skill_file)
+        )
+        return None, True
+
+    return str(skill_file.parent), True
+
+
 def _resolve_skill_dir(skill_name: str, cwd: str) -> tuple[str | None, bool]:
     """Resolve a skill name to its on-disk directory.
 
-    Search order mirrors copilot-shell's SkillManager priority:
+    Current hook scope is intentionally limited to:
     project (.copilot-shell/skills/) → user (~/.copilot-shell/skills/)
     → system (/usr/share/anolisa/skills/).
 
@@ -95,18 +184,15 @@ def _resolve_skill_dir(skill_name: str, cwd: str) -> tuple[str | None, bool]:
     - ``(None, False)`` — not found (remote or unknown skill).
     """
     traversal_detected = False
-    bases = [
-        Path(cwd) / ".copilot-shell" / "skills",
-        Path.home() / ".copilot-shell" / "skills",
-        Path("/usr/share/anolisa/skills"),
-    ]
+    bases = _supported_skill_bases(cwd)
     for base in bases:
         candidate = base / skill_name
         try:
+            resolved_base = base.resolve()
             resolved = candidate.resolve()
         except (OSError, ValueError):
             continue
-        if not resolved.is_relative_to(base.resolve()):
+        if not resolved.is_relative_to(resolved_base):
             traversal_detected = True
             continue  # path-traversal attempt — skip this base
         if resolved.is_dir() and (resolved / "SKILL.md").is_file():
@@ -198,9 +284,21 @@ def main() -> None:
         )
         return
 
-    # 3. Resolve skill directory
+    # 3. Resolve skill directory.  Prefer copilot-shell's resolved file path
+    # when present so SKILL.md names may differ from directory names, but only
+    # within the current project/user/system scope.
     cwd = input_data.get("cwd", os.environ.get("COPILOT_SHELL_PROJECT_DIR", "."))
-    skill_dir, traversal = _resolve_skill_dir(skill_name, cwd)
+    skill_dir, context_handled = _resolve_skill_dir_from_context(
+        input_data, cwd, skill_name
+    )
+    if context_handled:
+        if skill_dir is None:
+            print(_allow())
+            return
+        traversal = False
+    else:
+        skill_dir, traversal = _resolve_skill_dir(skill_name, cwd)
+
     if traversal:
         reason = "\U0001f6a8 Skill '{}' rejected: path traversal detected".format(
             skill_name
@@ -208,7 +306,7 @@ def main() -> None:
         print(_allow_with_reason(reason))
         return
     if skill_dir is None:
-        # Not found in any location (project/user/system) — remote or unknown → fail-open
+        # Not found in any supported location (project/user/system) → fail-open
         reason = (
             "\u26a0\ufe0f Skill '{}' not found on disk \u2014 check skipped".format(
                 skill_name

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
@@ -618,8 +618,11 @@ skill-ledger 需适配两个宿主系统，两者 Skill 模型和 Hook 机制存
 }
 ```
 
-**Skill 目录定位**：`tool_input` 仅含 skill 名称，hook 脚本按 project → custom → user → extension → system 优先级自行查找。project 级路径通过 event 的 `cwd` 字段推断。
+**Skill 目录定位（当前版本范围）**：copilot-shell hook 仅覆盖 project → user → system 三类 skill：
+- project：`<cwd>/.copilot-shell/skills/<skill>/`
+- user：`~/.copilot-shell/skills/<skill>/`
+- system：`/usr/share/anolisa/skills/<skill>/`
 
-**extension Skills**：读取 `~/.copilot-shell/extensions/<ext>/` 下的 `cosh-extension.json` 配置，按 `skills` 字段确定 skill 基目录，支持 `link` 类型安装（跟随 `.qwen-extension-install.json` 中的 `source` 路径）。extension skill 与其他级别 skill 享有相同的安全检查。
+当 PreToolUse 事件包含 `skill_context.file_path` 时，hook 优先使用该路径解决 `SKILL.md` 中 `name` 与目录名不一致的问题；但该路径仍必须落在上述 project/user/system 根目录内。若路径落在 custom、extension、remote 或其他目录，当前版本不执行 skill-ledger 检查，hook fail-open，并仅写入 debug 日志说明该 skill 不在当前 hook 支持范围内。
 
-**remote Skills**：首次下载的 remote skill 无 `.skill-meta/`，hook 返回 `unscanned`，输出告警但不阻断。
+**custom / extension / remote Skills**：当前版本的 copilot-shell hook 不覆盖这些来源。未来若扩展覆盖范围，需要单独补充目录解析、信任边界和测试用例。

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
@@ -39,7 +39,7 @@ _COSH_HOOK = str(
 # ---------------------------------------------------------------------------
 
 
-def _run_hook(input_data, *, env_override=None):
+def _run_hook(input_data, *, env_override=None, return_stderr=False):
     """Run the hook as a subprocess with *input_data* as stdin JSON.
 
     Returns the parsed JSON output dict.
@@ -56,28 +56,38 @@ def _run_hook(input_data, *, env_override=None):
         env=env,
     )
     assert proc.returncode == 0, f"Hook stderr: {proc.stderr}"
-    return json.loads(proc.stdout)
+    output = json.loads(proc.stdout)
+    if return_stderr:
+        return output, proc.stderr
+    return output
 
 
-def _make_skill_event(skill_name, cwd="."):
+def _make_skill_event(skill_name, cwd=".", skill_file_path=None):
     """Build a minimal PreToolUse event for the skill tool."""
-    return {
+    event = {
         "hook_event_name": "PreToolUse",
         "tool_name": "skill",
         "tool_input": {"skill": skill_name},
         "cwd": cwd,
     }
+    if skill_file_path is not None:
+        event["skill_context"] = {
+            "skill_name": skill_name,
+            "file_path": str(skill_file_path),
+        }
+    return event
 
 
-def _create_skill_dir(parent, name="test-skill"):
+def _create_skill_dir(parent, name="test-skill", manifest_name=None):
     """Create a minimal skill directory with a SKILL.md file.
 
     Returns the absolute path to ``<parent>/.copilot-shell/skills/<name>/``.
     """
+    manifest_name = manifest_name or name
     skill_dir = Path(parent) / ".copilot-shell" / "skills" / name
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\nname: test-skill\ndescription: A test skill\n---\nHello\n"
+        f"---\nname: {manifest_name}\ndescription: A test skill\n---\nHello\n"
     )
     return str(skill_dir)
 
@@ -185,6 +195,91 @@ class TestSkillDirResolution:
         )
         assert output["decision"] == "allow"
         assert "reason" in output, "Skill dir not found — CLI was never called"
+
+    def test_skill_context_resolves_name_directory_mismatch(self, mock_cli_env):
+        """skill_context.file_path should locate project skills by real path.
+
+        This covers the case where the Skill tool receives the frontmatter
+        name, but the on-disk directory uses a different name.
+        """
+        skill_dir = _create_skill_dir(
+            mock_cli_env["cwd"],
+            name="directory-name",
+            manifest_name="frontmatter-name",
+        )
+        env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        output = _run_hook(
+            _make_skill_event(
+                "frontmatter-name",
+                mock_cli_env["cwd"],
+                Path(skill_dir) / "SKILL.md",
+            ),
+            env_override=env,
+        )
+        assert output["decision"] == "allow"
+        assert "low-risk" in output["reason"]
+
+    def test_skill_context_skips_only_unresolvable_supported_base(self, mock_cli_env):
+        """A bad project base should not discard user/system base checks."""
+        home = Path(mock_cli_env["cwd"]).parent / "home"
+        skill_dir = home / ".copilot-shell" / "skills" / "user-dir"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text(
+            "---\nname: user-skill\ndescription: A user skill\n---\nHello\n"
+        )
+
+        env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        env["HOME"] = str(home)
+        output = _run_hook(
+            _make_skill_event("user-skill", "\0bad-project", skill_file),
+            env_override=env,
+        )
+
+        assert output["decision"] == "allow"
+        assert "low-risk" in output["reason"]
+
+    @pytest.mark.parametrize("scope_name", ["custom", "extension", "remote"])
+    def test_skill_context_outside_supported_scope_debug_skips(
+        self, tmp_path, scope_name
+    ):
+        """custom/extension/remote paths are out of scope for this hook."""
+        home = tmp_path / "home"
+        project = tmp_path / "project"
+        home.mkdir()
+        project.mkdir()
+
+        if scope_name == "custom":
+            skill_dir = tmp_path / "custom-skills" / "custom-skill"
+        elif scope_name == "extension":
+            skill_dir = (
+                home
+                / ".copilot-shell"
+                / "extensions"
+                / "test-ext"
+                / "skills"
+                / "extension-skill"
+            )
+        else:
+            skill_dir = (
+                home / ".copilot-shell" / "remote-skills" / "system" / "remote-skill"
+            )
+
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text(
+            f"---\nname: {scope_name}-skill\ndescription: A test skill\n---\n"
+        )
+
+        output, stderr = _run_hook(
+            _make_skill_event(f"{scope_name}-skill", str(project), skill_file),
+            env_override={"HOME": str(home)},
+            return_stderr=True,
+        )
+
+        assert output == {"decision": "allow"}
+        assert "outside current skill-ledger hook scope" in stderr
+        assert "project/user/system" in stderr
 
     def test_missing_skill_md_not_found(self):
         """Directory exists but no SKILL.md → not recognized as a skill."""


### PR DESCRIPTION
## Description

Limit the copilot-shell skill-ledger hook to the currently supported project/user/system skill roots. The hook now uses `skill_context.file_path` only when the resolved file is inside those roots, which preserves support for SKILL.md names that differ from directory names without expanding the supported trust boundary.

custom, extension, remote, and other out-of-scope skill paths now fail open with debug-only stderr diagnostics instead of user-visible warnings. The design document has been updated to describe the current scope explicitly.

## Related Issue

no-issue: aligns hook behavior and design documentation with the intended current skill-ledger scope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `src/agent-sec-core/agent-sec-cli/.venv/bin/python -m ruff format --check src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py`
- `src/agent-sec-core/agent-sec-cli/.venv/bin/python -m pytest src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py -q`

## Additional Notes

The debug message is written to stderr so stdout remains a valid HookOutput JSON protocol response. The hook still exits successfully and returns `{"decision": "allow"}` for unsupported skill sources.
