### PR TITLE
feat(sight): add uid field to SLS logs and fix OpenClaw matcher

### DIFF
--- a/src/agentsight/src/discovery/agents/openclaw.rs
+++ b/src/agentsight/src/discovery/agents/openclaw.rs
@@ -47,7 +47,13 @@ impl AgentMatcher for OpenClawMatcher {
         }
 
         // Case 2: Node runtime with "openclaw" and "gateway" in cmdline args
-        let is_node = match_name_with_version_suffix(&comm_lower, "node");
+        // Note: Node.js apps can change process.title (e.g., to "MainThread"),
+        // so we also check if cmdline_args[0] (the actual executable) contains "node".
+        let is_node = match_name_with_version_suffix(&comm_lower, "node")
+            || ctx.cmdline_args.first().map_or(false, |arg| {
+                let basename = arg.rsplit('/').next().unwrap_or(arg);
+                match_name_with_version_suffix(&basename.to_lowercase(), "node")
+            });
         if is_node {
             let has_openclaw = ctx.cmdline_args.iter().any(|arg| {
                 arg.to_lowercase().contains("openclaw")

--- a/src/agentsight/src/genai/instance_id.rs
+++ b/src/agentsight/src/genai/instance_id.rs
@@ -2,14 +2,70 @@
 //!
 //! Provides a shared function to resolve the current machine's instance ID,
 //! used by both SLS PutLogs uploader and Logtail file exporter.
+//!
+//! Both `get_instance_id()` and `get_owner_account_id()` are cached via
+//! `OnceLock` — the metadata HTTP call is only made once per process lifetime.
 
-/// 获取实例ID：优先请求阿里云 ECS metadata（超时1秒），失败则回退到 hostname
-pub fn get_instance_id() -> String {
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// ECS metadata 请求超时（连接 + 读取均为 1 秒）
+const METADATA_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// 全局缓存：owner-account-id
+static OWNER_ACCOUNT_ID: OnceLock<String> = OnceLock::new();
+/// 全局缓存：instance-id
+static INSTANCE_ID: OnceLock<String> = OnceLock::new();
+
+/// 构建带有显式 connect timeout 的 ureq agent，避免非 ECS 环境 TCP SYN 重试卡死
+fn metadata_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(METADATA_TIMEOUT)
+        .timeout(METADATA_TIMEOUT)
+        .build()
+}
+
+/// 获取 owner account ID（带缓存）：首次调用请求阿里云 ECS metadata（超时1秒），
+/// 失败返回空字符串。后续调用直接返回缓存值。
+pub fn get_owner_account_id() -> &'static str {
+    OWNER_ACCOUNT_ID.get_or_init(|| {
+        fetch_owner_account_id()
+    })
+}
+
+/// 实际请求 owner-account-id
+fn fetch_owner_account_id() -> String {
+    let agent = metadata_agent();
+    match agent.get("http://100.100.100.200/latest/meta-data/owner-account-id").call() {
+        Ok(resp) => {
+            if let Ok(body) = resp.into_string() {
+                let uid = body.trim().to_string();
+                if !uid.is_empty() {
+                    log::info!("Got ECS owner-account-id: {}", uid);
+                    return uid;
+                }
+            }
+        }
+        Err(e) => {
+            log::warn!("ECS owner-account-id not available: {}", e);
+        }
+    }
+    String::new()
+}
+
+/// 获取实例ID（带缓存）：首次调用请求阿里云 ECS metadata（超时1秒），
+/// 失败则回退到 hostname。后续调用直接返回缓存值。
+pub fn get_instance_id() -> &'static str {
+    INSTANCE_ID.get_or_init(|| {
+        fetch_instance_id()
+    })
+}
+
+/// 实际请求 instance-id
+fn fetch_instance_id() -> String {
     // 尝试从 ECS metadata service 获取 instance-id
-    match ureq::get("http://100.100.100.200/latest/meta-data/instance-id")
-        .timeout(std::time::Duration::from_secs(1))
-        .call()
-    {
+    let agent = metadata_agent();
+    match agent.get("http://100.100.100.200/latest/meta-data/instance-id").call() {
         Ok(resp) => {
             if let Ok(body) = resp.into_string() {
                 let id = body.trim().to_string();

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -114,6 +114,7 @@ impl GenAIExporter for LogtailExporter {
 /// 此函数被 Logtail 文件导出器使用，由 iLogtail 采集后上传到 SLS。
 pub fn events_to_flat_records(events: &[GenAISemanticEvent]) -> Vec<BTreeMap<String, String>> {
     let hostname = instance_id::get_instance_id();
+    let uid = instance_id::get_owner_account_id();
     let mut records = Vec::with_capacity(events.len());
 
     for event in events {
@@ -122,11 +123,16 @@ pub fn events_to_flat_records(events: &[GenAISemanticEvent]) -> Vec<BTreeMap<Str
 
         // iLogtail 保留字段
         m.insert("__time__".to_string(), timestamp.to_string());
-        m.insert("__source__".to_string(), hostname.clone());
+        m.insert("__source__".to_string(), hostname.to_string());
         m.insert("__topic__".to_string(), "agentsight".to_string());
 
         // 每条日志都写入 instance
-        m.insert("instance".to_string(), hostname.clone());
+        m.insert("instance".to_string(), hostname.to_string());
+
+        // 写入 uid (owner-account-id)
+        if !uid.is_empty() {
+            m.insert("uid".to_string(), uid.to_string());
+        }
 
         match event {
             GenAISemanticEvent::LLMCall(call) => {

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -158,7 +158,16 @@ impl AgentSight {
         // When SLS_LOGTAIL_FILE is set, use Logtail file exporter only (skip local storage)
         // — the Logtail file will be collected by iLogtail and uploaded to SLS.
         if let Some(exporter) = LogtailExporter::new() {
-            log::info!("Logtail file exporter enabled ({})", exporter.path().display());
+            // SLS 模式必须能获取到 uid (owner-account-id)，否则拒绝启动
+            let uid = crate::genai::instance_id::get_owner_account_id();
+            if uid.is_empty() {
+                anyhow::bail!(
+                    "SLS Logtail exporter is enabled (SLS_LOGTAIL_FILE set) but failed to \
+                     fetch owner-account-id from ECS metadata service. \
+                     Cannot upload logs without uid. Aborting."
+                );
+            }
+            log::info!("Logtail file exporter enabled ({}), uid={}", exporter.path().display(), uid);
             genai_exporters.push(Box::new(exporter));
         } else {
             // No Logtail: use local JSONL + SQLite


### PR DESCRIPTION
## Description

为 AgentSight 新增两项改进：

1. **SLS 日志新增 uid 字段**：通过 OnceLock 缓存元数据服务获取的 owner-account-id，启动时校验可用性，确保日志可关联用户维度数据。
2. **修复 OpenClaw matcher**：处理 Node.js 环境下 process.title 变更导致的进程匹配失败问题。

## Related Issue

closes #498

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo test` 通过（2 passed, 0 failed, 29 ignored）
- OpenClaw matcher 逻辑验证：Node.js process.title 变更场景下正确匹配

## Additional Notes

分支名 `console` 未遵循 `feature/sight/<desc>` 命名规范（CI Warning 级别）。
