### PR TITLE
feat(sec-core): support build from scratch

### DIFF
--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -25,7 +25,7 @@ jobs:
           sed -i -e "s/cloud.aliyuncs/aliyun/g" /etc/yum.repos.d/*.repo
           dnf install -y tar git rpm-build gcc make clang llvm \
                          openssl-devel libseccomp-devel bubblewrap \
-                         python3-pip
+                         python3-pip gnupg2 jq
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -106,7 +106,7 @@ jobs:
           print(f'All {len(reqs) - skipped} dependencies verified ({skipped} skipped due to platform markers).')
           PYEOF
 
-      - name: Verify all Python imports
+      - name: Verify cli Python imports
         run: |
           export PYTHONPATH=/opt/agent-sec/lib/python3.11/site-packages${PYTHONPATH:+:$PYTHONPATH}
           python3 << 'PYEOF'
@@ -145,8 +145,43 @@ jobs:
           print('All modules imported successfully')
           PYEOF
 
-      - name: Install E2E test dependencies
-        run: dnf install -y jq
+      - name: Verify cosh hook Python imports
+        run: |
+          python3 << 'PYEOF'
+          import importlib.util, pathlib, sys
+
+          hooks_dir = pathlib.Path('/usr/share/anolisa/extensions/agent-sec-core/hooks')
+          print(f'Hooks directory: {hooks_dir.resolve()}')
+
+          py_files = sorted(hooks_dir.glob('*.py'))
+          if not py_files:
+              print('ERROR: no hook .py files found', file=sys.stderr)
+              sys.exit(1)
+
+          failed = []
+          for pyfile in py_files:
+              mod_name = pyfile.stem.replace('-', '_')
+              spec = importlib.util.spec_from_file_location(mod_name, pyfile)
+              if spec is None:
+                  print(f'  {pyfile.name} ... FAILED: cannot create module spec')
+                  failed.append((pyfile.name, 'cannot create module spec'))
+                  continue
+              try:
+                  mod = importlib.util.module_from_spec(spec)
+                  spec.loader.exec_module(mod)
+                  print(f'  {pyfile.name} ... OK')
+              except Exception as e:
+                  print(f'  {pyfile.name} ... FAILED: {e}')
+                  failed.append((pyfile.name, str(e)))
+
+          print(f'\nTotal: {len(py_files)} hooks, {len(failed)} failed')
+          if failed:
+              print('\nFailed hooks:', file=sys.stderr)
+              for name, err in failed:
+                  print(f'  - {name}: {err}', file=sys.stderr)
+              sys.exit(1)
+          print('All hook scripts imported successfully')
+          PYEOF
 
       - name: Uninstall skills package before E2E tests
         run: rpm -e agent-sec-skills --nodeps

--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -25,7 +25,7 @@ jobs:
           sed -i -e "s/cloud.aliyuncs/aliyun/g" /etc/yum.repos.d/*.repo
           dnf install -y tar git rpm-build gcc make clang llvm \
                          openssl-devel libseccomp-devel bubblewrap \
-                         python3-pip gnupg2 jq
+                         python3-pip
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sec-core-source-code-build.yaml
+++ b/.github/workflows/sec-core-source-code-build.yaml
@@ -1,0 +1,60 @@
+name: sec-core-source-code-build
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/agent-sec-core/**'
+    paths:
+      - 'src/agent-sec-core/**'
+      - 'scripts/build-all.sh'
+      - '.github/workflows/sec-core-source-code-build.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu 22.04
+            runner: ubuntu-22.04
+            container: ''
+          - name: Alinux4
+            runner: ubuntu-22.04
+            container: alibaba-cloud-linux-4-registry.cn-hangzhou.cr.aliyuncs.com/alinux4/alinux4:latest
+    continue-on-error: true
+    name: Source Build (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container || '' }}
+    steps:
+      - name: Configure mirrors and install base tools (Alinux4)
+        if: matrix.container != ''
+        run: |
+          sed -i -e "s/cloud.aliyuncs/aliyun/g" /etc/yum.repos.d/*.repo
+          dnf install -y tar git sudo
+          # Fix sudo PAM in container: replace with permissive config
+          cat > /etc/pam.d/sudo <<'EOF'
+          #%PAM-1.0
+          auth       sufficient   pam_rootok.so
+          account    sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+          EOF
+      - uses: actions/checkout@v4
+      - name: Build and install
+        run: ./scripts/build-all.sh --component sec-core
+      - name: Verify CLI
+        run: |
+          agent-sec-cli --version
+          agent-sec-cli --help
+      - name: Verify sandbox
+        run: linux-sandbox --help
+      - name: Verify deployment
+        run: |
+          ls /usr/share/anolisa/skills/
+          ls /usr/share/anolisa/extensions/agent-sec-core/
+      - name: Run E2E tests
+        run: make -C src/agent-sec-core test-e2e-source-build

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -13,7 +13,7 @@
 # Components (build order):
 #   cosh     copilot-shell      (Node.js / TypeScript)
 #   skills   os-skills          (Markdown skill definitions, no compilation)
-#   sec-core agent-sec-core     (Rust sandbox, Linux only)
+#   sec-core agent-sec-core     (Security CLI + sandbox + hooks)
 #   sight    agentsight         (eBPF / Rust, Linux only, NOT built by default)
 #   tokenless tokenless         (Rust compression library, cross-platform)
 # ──────────────────────────────────────────────────────────────────
@@ -642,6 +642,8 @@ do_install_deps() {
     fi
 
     if want_component sec-core; then
+        install_node          # openclaw-plugin needs Node.js
+        install_build_tools   # gcc + make
         install_uv
     fi
 
@@ -702,26 +704,25 @@ build_skills() {
 }
 
 build_sec_core() {
-    step "Building agent-sec-core (linux-sandbox)"
+    step "Building agent-sec-core"
     local dir="$PROJECT_ROOT/src/agent-sec-core"
     [[ -d "$dir" ]] || die "Directory not found: $dir"
     cd "$dir"
 
-    info "cargo build --release (linux-sandbox) ..."
-    if [[ -f Makefile ]] && grep -q 'build-sandbox' Makefile; then
-        make build-sandbox
-    else
-        cd linux-sandbox && cargo build --release && cd ..
-    fi
+    # build-all = build-sandbox + build-cli + build-openclaw-plugin
+    info "make build-all ..."
+    make build-all
 
-    local bin="linux-sandbox/target/release/linux-sandbox"
-    if [[ -f "$bin" ]]; then
-        ARTIFACT_NAMES+=("agent-sec-core")
-        ARTIFACT_PATHS+=("src/agent-sec-core/$bin")
-        ok "agent-sec-core built successfully"
-    else
-        warn "Expected artifact $bin not found"
-    fi
+    # Track artifacts
+    local sandbox_bin="linux-sandbox/target/release/linux-sandbox"
+    local wheel
+    wheel=$(ls agent-sec-cli/target/wheels/agent_sec_cli-*.whl 2>/dev/null | head -1)
+    local plugin_entry="openclaw-plugin/dist/index.js"
+
+    [[ -f "$sandbox_bin" ]] && ARTIFACT_NAMES+=("linux-sandbox") && ARTIFACT_PATHS+=("src/agent-sec-core/$sandbox_bin")
+    [[ -n "$wheel" ]] && ARTIFACT_NAMES+=("agent-sec-cli") && ARTIFACT_PATHS+=("src/agent-sec-core/$wheel")
+    [[ -f "$plugin_entry" ]] && ARTIFACT_NAMES+=("openclaw-plugin") && ARTIFACT_PATHS+=("src/agent-sec-core/openclaw-plugin/dist/")
+    ok "agent-sec-core built successfully"
 }
 
 build_sight() {
@@ -814,9 +815,46 @@ install_sec_core() {
     [[ -d "$dir" ]] || die "Directory not found: $dir"
     cd "$dir"
 
-    info "sudo make install-sandbox ..."
-    sudo make install-sandbox
-    ok "agent-sec-core (linux-sandbox) installed to /usr/local/bin/"
+    local venv_dir="/opt/agent-sec/venv"
+
+    # 1. Create isolated venv (uv auto-downloads Python 3.11.6 if needed)
+    info "Creating Python venv at $venv_dir ..."
+    sudo mkdir -p "$venv_dir"
+    sudo chown "$(id -u):$(id -g)" "$venv_dir"
+    uv venv --python "3.11.6" "$venv_dir"
+
+    # 2. Install deps from uv.lock into venv (uv sync understands [tool.uv.sources])
+    #    UV_PROJECT_ENVIRONMENT tells uv to use our venv instead of .venv
+    #    --no-install-project: only install deps, not the project itself
+    info "Installing agent-sec-cli dependencies (from uv.lock) ..."
+    (cd agent-sec-cli && UV_PROJECT_ENVIRONMENT="$venv_dir" uv sync --frozen --no-dev --no-install-project)
+
+    # 3. Install pre-built wheel into venv (no-deps since deps are already installed)
+    uv pip install --python "$venv_dir/bin/python" --no-deps \
+        agent-sec-cli/target/wheels/agent_sec_cli-*.whl
+
+    # 4. Symlink CLI command to /usr/local/bin/
+    sudo ln -sf "$venv_dir/bin/agent-sec-cli" /usr/local/bin/agent-sec-cli
+    ok "agent-sec-cli installed ($venv_dir + symlink to /usr/local/bin/)"
+
+    # 5. Install non-Python components (sandbox, hooks, plugin, skills)
+    info "Installing sandbox + hooks + plugin + skills ..."
+    sudo make install-cosh-hook install-openclaw-plugin install-skills install-tool
+    ok "cosh-hook + openclaw-plugin + skills installed"
+
+    # 6. Runtime dependencies
+    if ! cmd_exists bwrap; then
+        info "Installing runtime dependency: bubblewrap ..."
+        sudo $PKG_INSTALL bubblewrap || warn "bubblewrap not installed (linux-sandbox runtime dep)"
+    fi
+    if ! cmd_exists gpg && ! cmd_exists gpg2; then
+        info "Installing runtime dependency: gnupg2 ..."
+        sudo $PKG_INSTALL gnupg2 || warn "gnupg2 not installed (skill signature verification)"
+    fi
+    if ! cmd_exists jq; then
+        info "Installing runtime dependency: jq ..."
+        sudo $PKG_INSTALL jq || warn "jq not installed (openclaw-plugin deploy)"
+    fi
 }
 
 install_sight() {
@@ -906,7 +944,7 @@ $(echo -e "${BOLD}Examples:${NC}")
 $(echo -e "${BOLD}Components:${NC}")
   cosh     copilot-shell      Node.js / TypeScript AI terminal assistant       [default]
   skills   os-skills          Markdown skill definitions (deploy only)          [default]
-  sec-core agent-sec-core     Rust secure sandbox (Linux only)                  [default]
+  sec-core agent-sec-core     Security CLI + sandbox + hooks                    [default]
   sight    agentsight         eBPF observability/audit agent (Linux only)        [optional]
   tokenless tokenless         Rust token compression library (cross-platform)   [default]
 

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -67,14 +67,12 @@ test-e2e-rpm: ## Run E2E tests against RPM-installed agent-sec-cli binary
 	python3 -m pytest tests/e2e/ \
 		--import-mode=importlib \
 		--ignore=tests/e2e/skill-ledger \
-		--ignore=tests/e2e/skill-signing \
 		--ignore=tests/e2e/linux-sandbox \
 		--ignore=tests/e2e/prompt-scanner \
 		-k 'not test_error_event_writes_to_sqlite' \
 		-v --tb=short
 	@# standalone-script e2e suites (not pytest-compatible)
 	python3 tests/e2e/skill-ledger/e2e_test.py
-	@# skill-signing e2e skipped: imports Python source code
 	@# linux-sandbox e2e skipped: requires privileged container
 
 VENV_PYTHON ?= /opt/agent-sec/venv/bin/python
@@ -87,13 +85,11 @@ test-e2e-source-build: ## Run E2E tests against source-build-installed agent-sec
 	$(VENV_PYTHON) -m pytest tests/e2e/ \
 		--import-mode=importlib \
 		--ignore=tests/e2e/skill-ledger \
-		--ignore=tests/e2e/skill-signing \
 		--ignore=tests/e2e/linux-sandbox \
 		--ignore=tests/e2e/prompt-scanner \
 		-k 'not test_error_event_writes_to_sqlite' \
 		-v --tb=short
 	@# skill-ledger e2e skipped: installed system skills affect G6/G8 expected results
-	@# skill-signing e2e skipped: imports Python source code
 	@# linux-sandbox e2e skipped: requires privileged container
 
 .PHONY: test-python-coverage

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -77,6 +77,25 @@ test-e2e-rpm: ## Run E2E tests against RPM-installed agent-sec-cli binary
 	@# skill-signing e2e skipped: imports Python source code
 	@# linux-sandbox e2e skipped: requires privileged container
 
+VENV_PYTHON ?= /opt/agent-sec/venv/bin/python
+
+.PHONY: test-e2e-source-build
+test-e2e-source-build: ## Run E2E tests against source-build-installed agent-sec-cli
+	@echo "🧪 Running E2E tests on source build..."
+	@command -v agent-sec-cli >/dev/null 2>&1 || { echo "ERROR: agent-sec-cli not found on PATH"; exit 1; }
+	@$(VENV_PYTHON) -m pytest --version >/dev/null 2>&1 || uv pip install --python $(VENV_PYTHON) --quiet pytest
+	$(VENV_PYTHON) -m pytest tests/e2e/ \
+		--import-mode=importlib \
+		--ignore=tests/e2e/skill-ledger \
+		--ignore=tests/e2e/skill-signing \
+		--ignore=tests/e2e/linux-sandbox \
+		--ignore=tests/e2e/prompt-scanner \
+		-k 'not test_error_event_writes_to_sqlite' \
+		-v --tb=short
+	@# skill-ledger e2e skipped: installed system skills affect G6/G8 expected results
+	@# skill-signing e2e skipped: imports Python source code
+	@# linux-sandbox e2e skipped: requires privileged container
+
 .PHONY: test-python-coverage
 test-python-coverage: ## Run Python tests with coverage report
 	@echo "🧪 Running Python tests with coverage..."

--- a/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
@@ -28,6 +28,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 REPO_ROOT = Path(__file__).resolve().parents[3]  # agent-sec-core/
+PROJECT_ROOT = Path(__file__).resolve().parents[5]  # repository root
 SIGN_SKILL_SH = REPO_ROOT / "tools" / "sign-skill.sh"
 SOURCE_PYTHONPATH = REPO_ROOT / "agent-sec-cli" / "src"
 
@@ -88,6 +89,7 @@ def require_passwordless_sudo() -> None:
 def run_command(
     args: Iterable[str | Path],
     *,
+    cwd: Optional[Path] = None,
     env: Optional[dict[str, str]] = None,
     input_text: Optional[str] = None,
     timeout: int = 120,
@@ -96,6 +98,7 @@ def run_command(
         [str(arg) for arg in args],
         capture_output=True,
         text=True,
+        cwd=str(cwd) if cwd else None,
         env=env,
         input=input_text,
         timeout=timeout,
@@ -280,6 +283,101 @@ def test_batch_sign_registers_explicit_config_and_verifies(
         ok, name = verify_skill(str(batch_root / skill_name), keys)
         assert ok, f"verify_skill failed for {skill_name}"
         assert name == skill_name
+
+
+def test_legacy_ci_batch_invocation_with_private_key(signing_ws: Workspace) -> None:
+    """Package-source CI's historical --batch call remains compatible."""
+    archive_skills = signing_ws.root / "tmp_build" / "anolisa-ci" / "skills"
+    archive_skills.mkdir(parents=True)
+    for skill_name, content in [("ci-alpha", "A"), ("ci-beta", "B")]:
+        make_skill(archive_skills, skill_name, {"SKILL.md": f"# {content}\n"})
+
+    ci_key_home = signing_ws.root / "ci_key_gpg"
+    ci_key_home.mkdir(mode=0o700)
+    env = signing_ws.env()
+    generate = run_command(
+        ["gpg", "--homedir", ci_key_home, "--batch", "--gen-key"],
+        env=env,
+        input_text=(
+            "Key-Type: RSA\n"
+            "Key-Length: 2048\n"
+            "Name-Real: CI Signing Key\n"
+            "Name-Email: ci-sign@test.local\n"
+            "Expire-Date: 0\n"
+            "%no-protection\n"
+            "%commit\n"
+        ),
+    )
+    assert_success(generate, "generate CI signing key")
+
+    private_key = run_command(
+        [
+            "gpg",
+            "--homedir",
+            ci_key_home,
+            "--armor",
+            "--export-secret-keys",
+            "ci-sign@test.local",
+        ],
+        env=env,
+    )
+    assert_success(private_key, "export CI private key")
+
+    public_key = run_command(
+        ["gpg", "--homedir", ci_key_home, "--armor", "--export", "ci-sign@test.local"],
+        env=env,
+    )
+    assert_success(public_key, "export CI public key")
+    ci_trusted_keys = signing_ws.root / "ci_trusted_keys"
+    ci_trusted_keys.mkdir()
+    (ci_trusted_keys / "ci-sign.asc").write_text(public_key.stdout)
+
+    blank_home = signing_ws.root / "legacy_ci_gpg"
+    blank_home.mkdir(mode=0o700)
+    ci_env = signing_ws.env(
+        {
+            "GNUPGHOME": str(blank_home),
+            "GPG_PRIVATE_KEY": private_key.stdout,
+        }
+    )
+
+    installed_config = Path(
+        "/opt/agent-sec/venv/lib/python3.11/site-packages/"
+        "agent_sec_cli/asset_verify/config.conf"
+    )
+    original_installed_config = (
+        installed_config.read_text()
+        if installed_config.is_file() and os.access(installed_config, os.W_OK)
+        else None
+    )
+
+    try:
+        result = run_command(
+            [
+                "bash",
+                "src/agent-sec-core/tools/sign-skill.sh",
+                "--batch",
+                archive_skills,
+            ],
+            cwd=PROJECT_ROOT,
+            env=ci_env,
+            timeout=180,
+        )
+        assert_success(result, "legacy CI batch invocation")
+        assert "GPG private key imported and trusted" in result.stdout + result.stderr
+        assert "2/2 skills signed successfully" in result.stdout + result.stderr
+
+        keys = load_trusted_keys(ci_trusted_keys)
+        for skill_name in ("ci-alpha", "ci-beta"):
+            skill_dir = archive_skills / skill_name
+            assert (skill_dir / SIGNING_DIR / "Manifest.json").is_file()
+            assert (skill_dir / SIGNING_DIR / ".skill.sig").is_file()
+            ok, name = verify_skill(str(skill_dir), keys)
+            assert ok
+            assert name == skill_name
+    finally:
+        if original_installed_config is not None:
+            installed_config.write_text(original_installed_config)
 
 
 def test_force_overwrite(signing_ws: Workspace) -> None:

--- a/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
-"""End-to-end tests for skill signing (sign-skill.sh) and verification (verifier.py).
+"""Pytest E2E tests for skill signing and verification.
 
-Exercises the full pipeline:
-  1. sign-skill.sh --init   → GPG key generation + public key export
-  2. sign-skill.sh <dir>    → single skill signing
-  3. sign-skill.sh --batch  → batch skill signing
-  4. verifier.py             → signature + hash verification
+The default tests exercise the source-tree ``sign-skill.sh`` against temporary
+skills, trusted keys, and verifier config.  When a source-build installation is
+detected, the installed-path test also runs the user workflow:
 
-All GPG operations use an isolated GNUPGHOME so the host keyring is never
-touched.
-
-Prerequisites: gpg, jq, python3
+  /usr/local/bin/sign-skill.sh --init
+  /usr/local/bin/sign-skill.sh --batch /usr/share/anolisa/skills --force
+  agent-sec-cli verify
 """
 
 import json
@@ -19,158 +16,214 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, field
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
-# ── Paths ──────────────────────────────────────────────────────────────────
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path and import resolution
+# ---------------------------------------------------------------------------
 
 REPO_ROOT = Path(__file__).resolve().parents[3]  # agent-sec-core/
 SIGN_SKILL_SH = REPO_ROOT / "tools" / "sign-skill.sh"
-VERIFIER_DIR = REPO_ROOT / "agent-sec-cli" / "src" / "agent_sec_cli" / "asset_verify"
-VERIFIER_PY = VERIFIER_DIR / "verifier.py"
+SOURCE_PYTHONPATH = REPO_ROOT / "agent-sec-cli" / "src"
 
 SIGNING_DIR = ".skill-meta"
 
-# Make verifier importable
-sys.path.insert(0, str(VERIFIER_DIR))
+# Prefer the source-tree package, even when pytest is launched from the
+# installed source-build venv or an RPM test environment.
+sys.path.insert(0, str(SOURCE_PYTHONPATH))
 
-from errors import (  # noqa: E402
+from agent_sec_cli.asset_verify.errors import (  # noqa: E402
     ErrHashMismatch,
     ErrSigInvalid,
     ErrSigMissing,
     ErrUnexpectedFile,
 )
-from verifier import load_trusted_keys, verify_skill  # noqa: E402
-
-# ── Colours ────────────────────────────────────────────────────────────────
-
-RED = "\033[0;31m"
-GREEN = "\033[0;32m"
-YELLOW = "\033[1;33m"
-BLUE = "\033[0;34m"
-BOLD = "\033[1m"
-NC = "\033[0m"
-
-
-# ── Result tracker ─────────────────────────────────────────────────────────
+from agent_sec_cli.asset_verify.verifier import (  # noqa: E402
+    load_trusted_keys,
+    verify_skill,
+)
 
 
 @dataclass
-class Results:
-    passed: int = 0
-    failed: int = 0
-    errors: list = field(default_factory=list)
+class Workspace:
+    """Shared source-tree signing workspace."""
+
+    root: Path
+    gnupg_home: Path
+    trusted_keys: Path
+    skills_dir: Path
+    config_file: Path
+
+    def env(self, extra: Optional[dict[str, str]] = None) -> dict[str, str]:
+        env = os.environ.copy()
+        env["GNUPGHOME"] = str(self.gnupg_home)
+        env["LC_ALL"] = "C"
+        env["LANG"] = "C"
+        if extra:
+            env.update(extra)
+        return env
 
 
-results = Results()
+def require_tools(*tools: str) -> None:
+    missing = [tool for tool in tools if shutil.which(tool) is None]
+    if missing:
+        pytest.skip(f"missing required tool(s): {', '.join(missing)}")
 
 
-# ── Helpers ────────────────────────────────────────────────────────────────
+def require_passwordless_sudo() -> None:
+    sudo_bin = shutil.which("sudo")
+    if not sudo_bin:
+        pytest.skip("installed paths require sudo, but sudo is not available")
+
+    probe = run_command([sudo_bin, "-n", "true"], timeout=10)
+    if probe.returncode != 0:
+        pytest.skip("installed paths require sudo, but sudo -n is not available")
+
+
+def run_command(
+    args: Iterable[str | Path],
+    *,
+    env: Optional[dict[str, str]] = None,
+    input_text: Optional[str] = None,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(arg) for arg in args],
+        capture_output=True,
+        text=True,
+        env=env,
+        input=input_text,
+        timeout=timeout,
+    )
 
 
 def run_sign_skill(
     args: list[str],
-    env_extra: Optional[dict] = None,
+    *,
+    ws: Optional[Workspace] = None,
+    env_extra: Optional[dict[str, str]] = None,
+    script: Path = SIGN_SKILL_SH,
+    timeout: int = 120,
 ) -> subprocess.CompletedProcess:
-    """Run sign-skill.sh with the given arguments in the isolated env."""
-    env = os.environ.copy()
-    if env_extra:
-        env.update(env_extra)
-    cmd = ["bash", str(SIGN_SKILL_SH)] + args
-    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+    """Run sign-skill.sh with an isolated environment when a workspace is given."""
+    env = ws.env(env_extra) if ws else os.environ.copy()
+    return run_command(["bash", script, *args], env=env, timeout=timeout)
+
+
+def run_maybe_sudo(
+    args: Iterable[str | Path],
+    *,
+    env: Optional[dict[str, str]] = None,
+    sudo: bool = False,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess:
+    cmd = [str(arg) for arg in args]
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+
+    if sudo and os.geteuid() != 0:
+        sudo_bin = shutil.which("sudo")
+        if not sudo_bin:
+            pytest.fail("sudo is required for installed skill signing e2e")
+        preserved = [
+            f"{key}={run_env[key]}"
+            for key in ("GNUPGHOME", "PATH", "LC_ALL", "LANG")
+            if key in run_env
+        ]
+        cmd = [sudo_bin, "-n", "env", *preserved, *cmd]
+        run_env = os.environ.copy()
+
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=run_env,
+        timeout=timeout,
+    )
 
 
 def make_skill(parent: Path, name: str, files: dict[str, str]) -> Path:
-    """Create a fake skill directory with the given files.
-
-    ``files`` maps relative path → content.
-    Returns the skill directory path.
-    """
+    """Create a fake skill directory with the given files."""
     skill_dir = parent / name
-    for rel, content in files.items():
-        p = skill_dir / rel
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(content)
+    for rel_path, content in files.items():
+        path = skill_dir / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
     return skill_dir
 
 
-def test(name: str, fn):
-    """Run a single named test, catch exceptions, record results."""
-    print(f"\n{BLUE}--- {name} ---{NC}")
-    try:
-        fn()
-        print(f"{GREEN}✓ PASS{NC}")
-        results.passed += 1
-    except AssertionError as exc:
-        print(f"{RED}✗ FAIL  {exc}{NC}")
-        results.failed += 1
-        results.errors.append((name, exc))
-    except Exception as exc:
-        print(f"{RED}✗ ERROR {exc}{NC}")
-        results.failed += 1
-        results.errors.append((name, exc))
-
-
-# We reuse a single temp workspace across all tests so the GPG key only
-# needs to be generated once.
-
-
-class Workspace:
-    """Shared test workspace: isolated GNUPGHOME, trusted-keys dir, etc."""
-
-    def __init__(self):
-        self.root = Path(tempfile.mkdtemp(prefix="e2e_sign_"))
-        self.gnupg_home = self.root / "gnupg"
-        self.gnupg_home.mkdir(mode=0o700)
-        self.trusted_keys = self.root / "trusted-keys"
-        self.trusted_keys.mkdir()
-        self.skills_dir = self.root / "skills"
-        self.skills_dir.mkdir()
-
-        # Propagate isolated GNUPGHOME to all child processes
-        os.environ["GNUPGHOME"] = str(self.gnupg_home)
-
-    def cleanup(self):
-        if "GNUPGHOME" in os.environ:
-            del os.environ["GNUPGHOME"]
-        shutil.rmtree(self.root, ignore_errors=True)
-
-
-# ── Test cases ─────────────────────────────────────────────────────────────
-
-
-def test_check(ws: Workspace):
-    """--check should report all prerequisites OK."""
-    r = run_sign_skill(["--check"])
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
-    combined = r.stdout + r.stderr
-    assert "All prerequisites satisfied" in combined, combined
-
-
-def test_init(ws: Workspace):
-    """--init generates a GPG key and exports the public key."""
-    r = run_sign_skill(
-        [
-            "--init",
-            "--trusted-keys-dir",
-            str(ws.trusted_keys),
-        ]
+def assert_success(result: subprocess.CompletedProcess, context: str) -> None:
+    assert result.returncode == 0, (
+        f"{context} failed with exit {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
     )
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stdout}\n{r.stderr}"
 
-    # Public key file must exist
-    asc_files = list(ws.trusted_keys.glob("*.asc"))
-    assert (
-        len(asc_files) >= 1
-    ), f"No .asc in {ws.trusted_keys}: {list(ws.trusted_keys.iterdir())}"
+
+@pytest.fixture(scope="module")
+def signing_ws(tmp_path_factory: pytest.TempPathFactory) -> Workspace:
+    """Initialize one isolated source-tree signing workspace for the module."""
+    require_tools("gpg", "jq")
+    assert SIGN_SKILL_SH.exists(), f"{SIGN_SKILL_SH} not found"
+
+    tmp_root = Path(os.environ.get("ANOLISA_E2E_TMPDIR", "/tmp"))
+    if not tmp_root.is_dir():
+        tmp_root = tmp_path_factory.mktemp("e2e_sign_root")
+    root = Path(tempfile.mkdtemp(prefix="agent-sec-e2e-sign-", dir=tmp_root))
+    gnupg_home = root / "gnupg"
+    gnupg_home.mkdir(mode=0o700)
+    trusted_keys = root / "trusted-keys"
+    trusted_keys.mkdir()
+    skills_dir = root / "skills"
+    skills_dir.mkdir()
+    config_file = root / "config.conf"
+    config_file.write_text("skills_dir = [\n]\n")
+
+    ws = Workspace(
+        root=root,
+        gnupg_home=gnupg_home,
+        trusted_keys=trusted_keys,
+        skills_dir=skills_dir,
+        config_file=config_file,
+    )
+
+    result = run_sign_skill(
+        ["--init", "--trusted-keys-dir", str(ws.trusted_keys)],
+        ws=ws,
+    )
+    assert_success(result, "--init")
+
+    try:
+        yield ws
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_check_reports_prerequisites() -> None:
+    """--check should report all prerequisites OK."""
+    require_tools("gpg", "jq")
+    result = run_sign_skill(["--check"])
+    assert_success(result, "--check")
+    assert "All prerequisites satisfied" in result.stdout + result.stderr
+
+
+def test_init_exports_public_key(signing_ws: Workspace) -> None:
+    """The module fixture should generate and export a signing public key."""
+    asc_files = list(signing_ws.trusted_keys.glob("*.asc"))
+    assert asc_files, f"No .asc in {signing_ws.trusted_keys}"
     assert asc_files[0].stat().st_size > 0, "Exported .asc is empty"
 
 
-def test_single_sign_and_verify(ws: Workspace):
+def test_single_sign_and_verify(signing_ws: Workspace) -> None:
     """Sign a single skill, then verify with the verifier module."""
     skill = make_skill(
-        ws.skills_dir,
+        signing_ws.skills_dir,
         "skill-a",
         {
             "main.py": "print('hello')\n",
@@ -178,114 +231,135 @@ def test_single_sign_and_verify(ws: Workspace):
         },
     )
 
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stdout}\n{r.stderr}"
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "single sign")
 
-    # Manifest and signature must exist inside .skill-meta/
     signing = skill / SIGNING_DIR
     assert (signing / "Manifest.json").exists(), ".skill-meta/Manifest.json missing"
     assert (signing / ".skill.sig").exists(), ".skill-meta/.skill.sig missing"
 
-    # Manifest must contain our files
     manifest = json.loads((signing / "Manifest.json").read_text())
-    paths_in_manifest = {f["path"] for f in manifest["files"]}
-    assert (
-        "main.py" in paths_in_manifest
-    ), f"main.py not in manifest: {paths_in_manifest}"
-    assert (
-        "README.md" in paths_in_manifest
-    ), f"README.md not in manifest: {paths_in_manifest}"
-    # .skill-meta/ contents should NOT be in manifest
+    paths_in_manifest = {file_entry["path"] for file_entry in manifest["files"]}
+    assert "main.py" in paths_in_manifest
+    assert "README.md" in paths_in_manifest
     assert "Manifest.json" not in paths_in_manifest
     assert ".skill.sig" not in paths_in_manifest
-    signing_paths = [p for p in paths_in_manifest if p.startswith(".skill-meta")]
-    assert not signing_paths, f".skill-meta paths should be excluded: {signing_paths}"
+    assert not [path for path in paths_in_manifest if path.startswith(".skill-meta")]
 
-    # Verify with verifier
-    keys = load_trusted_keys(ws.trusted_keys)
+    keys = load_trusted_keys(signing_ws.trusted_keys)
     ok, name = verify_skill(str(skill), keys)
-    assert ok, "verify_skill returned False"
+    assert ok
     assert name == "skill-a"
 
 
-def test_batch_sign_and_verify(ws: Workspace):
-    """Batch-sign multiple skills, then verify each."""
-    batch_root = ws.root / "batch_skills"
+def test_batch_sign_registers_explicit_config_and_verifies(
+    signing_ws: Workspace,
+) -> None:
+    """Batch-sign multiple skills and register only the temporary config."""
+    batch_root = signing_ws.root / "batch_skills"
     batch_root.mkdir()
-    for sname, content in [("alpha", "A"), ("beta", "B"), ("gamma", "C")]:
-        make_skill(batch_root, sname, {"data.txt": content})
+    for skill_name, content in [("alpha", "A"), ("beta", "B"), ("gamma", "C")]:
+        make_skill(batch_root, skill_name, {"data.txt": content})
 
-    r = run_sign_skill(["--batch", str(batch_root), "--force"])
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stdout}\n{r.stderr}"
-    assert "3/3" in r.stdout, f"Expected 3/3 in output: {r.stdout}"
+    result = run_sign_skill(
+        [
+            "--batch",
+            str(batch_root),
+            "--force",
+            "--config-file",
+            str(signing_ws.config_file),
+        ],
+        ws=signing_ws,
+    )
+    assert_success(result, "batch sign")
+    assert "3/3" in result.stdout
+    assert str(batch_root.resolve()) in signing_ws.config_file.read_text()
 
-    keys = load_trusted_keys(ws.trusted_keys)
-    for sname in ("alpha", "beta", "gamma"):
-        ok, name = verify_skill(str(batch_root / sname), keys)
-        assert ok, f"verify_skill failed for {sname}"
-        assert name == sname
+    keys = load_trusted_keys(signing_ws.trusted_keys)
+    for skill_name in ("alpha", "beta", "gamma"):
+        ok, name = verify_skill(str(batch_root / skill_name), keys)
+        assert ok, f"verify_skill failed for {skill_name}"
+        assert name == skill_name
 
 
-def test_force_overwrite(ws: Workspace):
+def test_force_overwrite(signing_ws: Workspace) -> None:
     """--force overwrites existing manifest and signature."""
-    skill = make_skill(ws.skills_dir, "skill-force", {"f.txt": "v1"})
+    skill = make_skill(signing_ws.skills_dir, "skill-force", {"f.txt": "v1"})
 
-    r1 = run_sign_skill([str(skill), "--force"])
-    assert r1.returncode == 0
+    first = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(first, "initial sign")
     sig1 = (skill / SIGNING_DIR / ".skill.sig").read_text()
 
-    # Change content and re-sign
     (skill / "f.txt").write_text("v2")
-    r2 = run_sign_skill([str(skill), "--force"])
-    assert r2.returncode == 0
+    second = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(second, "re-sign")
     sig2 = (skill / SIGNING_DIR / ".skill.sig").read_text()
 
     assert sig1 != sig2, "Signature should differ after content change"
 
-    # Verify new signature
-    keys = load_trusted_keys(ws.trusted_keys)
+    keys = load_trusted_keys(signing_ws.trusted_keys)
     ok, _ = verify_skill(str(skill), keys)
     assert ok
 
 
-def test_no_force_rejects(ws: Workspace):
+def test_no_force_rejects_existing(signing_ws: Workspace) -> None:
     """Without --force, existing manifest/sig blocks signing."""
-    skill = make_skill(ws.skills_dir, "skill-noforce", {"x.txt": "x"})
+    skill = make_skill(signing_ws.skills_dir, "skill-noforce", {"x.txt": "x"})
 
-    r1 = run_sign_skill([str(skill)])
-    assert r1.returncode == 0
+    first = run_sign_skill([str(skill)], ws=signing_ws)
+    assert_success(first, "initial sign")
 
-    # Second run without --force should fail
-    r2 = run_sign_skill([str(skill)])
-    assert r2.returncode != 0, "Expected non-zero exit without --force"
-    assert "already exists" in r2.stdout + r2.stderr
+    second = run_sign_skill([str(skill)], ws=signing_ws)
+    assert second.returncode != 0, "Expected non-zero exit without --force"
+    assert "already exists" in second.stdout + second.stderr
 
 
-def test_export_key_default_and_custom(ws: Workspace):
+def test_no_secret_key_error_is_actionable(signing_ws: Workspace) -> None:
+    """Signing without a secret key should fail before creating .skill.sig."""
+    blank_home = signing_ws.root / "no_key_gpg"
+    blank_home.mkdir(mode=0o700)
+    skill = make_skill(signing_ws.skills_dir, "skill-no-key", {"x.txt": "x"})
+
+    result = run_sign_skill(
+        [str(skill), "--force"],
+        ws=signing_ws,
+        env_extra={"GNUPGHOME": str(blank_home)},
+    )
+
+    assert result.returncode != 0, "Expected signing to fail without a secret key"
+    combined = result.stdout + result.stderr
+    assert "No GPG secret key" in combined
+    assert "--init" in combined
+    assert "GPG_PRIVATE_KEY" in combined
+    assert not (skill / SIGNING_DIR / ".skill.sig").exists()
+
+
+def test_export_key_to_custom_dir(signing_ws: Workspace) -> None:
     """--export-key exports to a specified directory."""
-    custom_dir = ws.root / "custom_keys"
-    r = run_sign_skill(["--export-key", str(custom_dir)])
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stdout}\n{r.stderr}"
+    custom_dir = signing_ws.root / "custom_keys"
+    result = run_sign_skill(["--export-key", str(custom_dir)], ws=signing_ws)
+    assert_success(result, "--export-key custom")
     asc_files = list(custom_dir.glob("*.asc"))
-    assert len(asc_files) >= 1, f"No .asc in {custom_dir}"
+    assert asc_files, f"No .asc in {custom_dir}"
 
 
-def test_skill_name_override(ws: Workspace):
+def test_skill_name_override(signing_ws: Workspace) -> None:
     """--skill-name overrides the skill name in the manifest."""
-    skill = make_skill(ws.skills_dir, "skill-rename", {"a.txt": "a"})
-    r = run_sign_skill([str(skill), "--skill-name", "custom-name", "--force"])
-    assert r.returncode == 0
+    skill = make_skill(signing_ws.skills_dir, "skill-rename", {"a.txt": "a"})
+    result = run_sign_skill(
+        [str(skill), "--skill-name", "custom-name", "--force"],
+        ws=signing_ws,
+    )
+    assert_success(result, "skill name override")
 
     manifest = json.loads((skill / SIGNING_DIR / "Manifest.json").read_text())
-    assert (
-        manifest["skill_name"] == "custom-name"
-    ), f"Expected 'custom-name', got '{manifest['skill_name']}'"
+    assert manifest["skill_name"] == "custom-name"
 
 
-def test_hidden_files_excluded(ws: Workspace):
+def test_hidden_files_excluded(signing_ws: Workspace) -> None:
     """Hidden files and directories are excluded from the manifest."""
     skill = make_skill(
-        ws.skills_dir,
+        signing_ws.skills_dir,
         "skill-hidden",
         {
             "visible.txt": "ok",
@@ -293,190 +367,182 @@ def test_hidden_files_excluded(ws: Workspace):
             ".hidden_dir/inner.txt": "secret2",
         },
     )
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "hidden file sign")
 
     manifest = json.loads((skill / SIGNING_DIR / "Manifest.json").read_text())
-    paths = {f["path"] for f in manifest["files"]}
+    paths = {file_entry["path"] for file_entry in manifest["files"]}
     assert "visible.txt" in paths
-    assert ".hidden_file" not in paths, f".hidden_file should be excluded: {paths}"
-    assert (
-        ".hidden_dir/inner.txt" not in paths
-    ), f".hidden_dir should be excluded: {paths}"
-    # .skill-meta dir itself should not appear
-    meta_paths = [p for p in paths if p.startswith(".skill-meta")]
-    assert not meta_paths, f".skill-meta paths should be excluded: {meta_paths}"
+    assert ".hidden_file" not in paths
+    assert ".hidden_dir/inner.txt" not in paths
+    assert not [path for path in paths if path.startswith(".skill-meta")]
 
 
-def test_tampered_file_detected(ws: Workspace):
+def test_tampered_file_detected(signing_ws: Workspace) -> None:
     """Verifier detects file content tampering after signing."""
-    skill = make_skill(ws.skills_dir, "skill-tamper", {"payload.txt": "original"})
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0
+    skill = make_skill(
+        signing_ws.skills_dir, "skill-tamper", {"payload.txt": "original"}
+    )
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "tamper setup sign")
 
-    # Tamper with the file
     (skill / "payload.txt").write_text("TAMPERED")
 
-    keys = load_trusted_keys(ws.trusted_keys)
-    try:
+    keys = load_trusted_keys(signing_ws.trusted_keys)
+    with pytest.raises(ErrHashMismatch):
         verify_skill(str(skill), keys)
-        assert False, "Expected ErrHashMismatch"
-    except ErrHashMismatch:
-        pass  # expected
 
 
-def test_unsigned_reference_file_detected(ws: Workspace):
+def test_unsigned_reference_file_detected(signing_ws: Workspace) -> None:
     """Verifier detects new files added under references after signing."""
     skill = make_skill(
-        ws.skills_dir,
+        signing_ws.skills_dir,
         "skill-extra-file",
         {
             "SKILL.md": "# Skill\n",
             "references/original.md": "signed\n",
         },
     )
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "extra file setup sign")
 
-    # Empty files are still unsigned payloads when they are absent from Manifest.json.
     (skill / "references" / "a.md").write_text("")
 
-    keys = load_trusted_keys(ws.trusted_keys)
-    try:
+    keys = load_trusted_keys(signing_ws.trusted_keys)
+    with pytest.raises(ErrUnexpectedFile) as exc_info:
         verify_skill(str(skill), keys)
-        assert False, "Expected ErrUnexpectedFile"
-    except ErrUnexpectedFile as exc:
-        assert "references/a.md" in str(exc)
+    assert "references/a.md" in str(exc_info.value)
 
 
-def test_missing_sig_detected(ws: Workspace):
+def test_missing_sig_detected(signing_ws: Workspace) -> None:
     """Verifier raises ErrSigMissing when .skill.sig is deleted."""
-    skill = make_skill(ws.skills_dir, "skill-nosig", {"f.txt": "f"})
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0
+    skill = make_skill(signing_ws.skills_dir, "skill-nosig", {"f.txt": "f"})
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "missing sig setup sign")
 
     (skill / SIGNING_DIR / ".skill.sig").unlink()
 
-    keys = load_trusted_keys(ws.trusted_keys)
-    try:
+    keys = load_trusted_keys(signing_ws.trusted_keys)
+    with pytest.raises(ErrSigMissing):
         verify_skill(str(skill), keys)
-        assert False, "Expected ErrSigMissing"
-    except ErrSigMissing:
-        pass
 
 
-def test_wrong_key_rejected(ws: Workspace):
+def test_wrong_key_rejected(signing_ws: Workspace) -> None:
     """Signature made with key A is rejected when verified with key B only."""
-    # Generate a completely separate key pair in a different GNUPGHOME
-    alt_dir = ws.root / "alt_gpg"
+    alt_dir = signing_ws.root / "alt_gpg"
     alt_dir.mkdir(mode=0o700)
-    alt_keys = ws.root / "alt_keys"
+    alt_keys = signing_ws.root / "alt_keys"
     alt_keys.mkdir()
+    env = signing_ws.env()
 
-    # Generate alt key
-    subprocess.run(
-        ["gpg", "--homedir", str(alt_dir), "--batch", "--gen-key"],
-        input=(
-            "Key-Type: RSA\nKey-Length: 2048\nName-Real: Alt Key\n"
-            "Name-Email: alt@test.local\nExpire-Date: 0\n%no-protection\n%commit\n"
-        ).encode(),
-        capture_output=True,
+    generate = run_command(
+        ["gpg", "--homedir", alt_dir, "--batch", "--gen-key"],
+        env=env,
+        input_text=(
+            "Key-Type: RSA\n"
+            "Key-Length: 2048\n"
+            "Name-Real: Alt Key\n"
+            "Name-Email: alt@test.local\n"
+            "Expire-Date: 0\n"
+            "%no-protection\n"
+            "%commit\n"
+        ),
     )
+    assert_success(generate, "generate alt key")
+
+    export_alt = run_command(
+        ["gpg", "--homedir", alt_dir, "--armor", "--export", "alt@test.local"],
+        env=env,
+    )
+    assert_success(export_alt, "export alt public key")
     alt_pub = alt_keys / "alt.asc"
-    with open(alt_pub, "w") as f:
-        subprocess.run(
-            ["gpg", "--homedir", str(alt_dir), "--armor", "--export", "alt@test.local"],
-            stdout=f,
-        )
+    alt_pub.write_text(export_alt.stdout)
     assert alt_pub.stat().st_size > 0, "Failed to export alt public key"
 
-    # Skill was signed with the INIT key (ws GNUPGHOME), but verify with ALT
-    # key only → should fail
-    skill = make_skill(ws.skills_dir, "skill-wrongkey", {"z.txt": "z"})
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0
+    skill = make_skill(signing_ws.skills_dir, "skill-wrongkey", {"z.txt": "z"})
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "wrong key setup sign")
 
     alt_trusted = load_trusted_keys(alt_keys)
-    try:
+    with pytest.raises(ErrSigInvalid):
         verify_skill(str(skill), alt_trusted)
-        assert False, "Expected ErrSigInvalid"
-    except ErrSigInvalid:
-        pass
 
 
-def test_gpg_private_key_env(ws: Workspace):
+def test_gpg_private_key_env(signing_ws: Workspace) -> None:
     """GPG_PRIVATE_KEY env var import + signing works end-to-end."""
-    # Create a fresh GNUPGHOME with a new key
-    env_dir = ws.root / "env_gpg"
+    env_dir = signing_ws.root / "env_gpg"
     env_dir.mkdir(mode=0o700)
-    subprocess.run(
-        ["gpg", "--homedir", str(env_dir), "--batch", "--gen-key"],
-        input=(
-            "Key-Type: RSA\nKey-Length: 2048\nName-Real: Env Key\n"
-            "Name-Email: env@test.local\nExpire-Date: 0\n%no-protection\n%commit\n"
-        ).encode(),
-        capture_output=True,
-    )
+    env = signing_ws.env()
 
-    # Export private key
-    priv = subprocess.run(
+    generate = run_command(
+        ["gpg", "--homedir", env_dir, "--batch", "--gen-key"],
+        env=env,
+        input_text=(
+            "Key-Type: RSA\n"
+            "Key-Length: 2048\n"
+            "Name-Real: Env Key\n"
+            "Name-Email: env@test.local\n"
+            "Expire-Date: 0\n"
+            "%no-protection\n"
+            "%commit\n"
+        ),
+    )
+    assert_success(generate, "generate env key")
+
+    private_key = run_command(
         [
             "gpg",
             "--homedir",
-            str(env_dir),
+            env_dir,
             "--armor",
             "--export-secret-keys",
             "env@test.local",
         ],
-        capture_output=True,
-        text=True,
+        env=env,
     )
-    assert priv.returncode == 0 and len(priv.stdout) > 100, "Private key export failed"
+    assert_success(private_key, "export env private key")
+    assert len(private_key.stdout) > 100, "Private key export was unexpectedly short"
 
-    # Export public key for verification
-    env_keys = ws.root / "env_keys"
+    env_keys = signing_ws.root / "env_keys"
     env_keys.mkdir()
-    pub_path = env_keys / "env.asc"
-    with open(pub_path, "w") as f:
-        subprocess.run(
-            ["gpg", "--homedir", str(env_dir), "--armor", "--export", "env@test.local"],
-            stdout=f,
-        )
+    public_key = run_command(
+        ["gpg", "--homedir", env_dir, "--armor", "--export", "env@test.local"],
+        env=env,
+    )
+    assert_success(public_key, "export env public key")
+    (env_keys / "env.asc").write_text(public_key.stdout)
 
-    # Use a blank GNUPGHOME so the only way sign-skill.sh can sign is via import
-    blank_home = ws.root / "blank_gpg"
+    blank_home = signing_ws.root / "blank_gpg"
     blank_home.mkdir(mode=0o700)
 
-    skill = make_skill(ws.skills_dir, "skill-envkey", {"e.txt": "env"})
-    r = run_sign_skill(
+    skill = make_skill(signing_ws.skills_dir, "skill-envkey", {"e.txt": "env"})
+    result = run_sign_skill(
         [str(skill), "--force"],
+        ws=signing_ws,
         env_extra={
             "GNUPGHOME": str(blank_home),
-            "GPG_PRIVATE_KEY": priv.stdout,
+            "GPG_PRIVATE_KEY": private_key.stdout,
         },
     )
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stdout}\n{r.stderr}"
-    assert (
-        "imported and trusted" in r.stdout + r.stderr
-    ), f"Expected import message: {r.stdout}\n{r.stderr}"
+    assert_success(result, "GPG_PRIVATE_KEY sign")
+    assert "imported and trusted" in result.stdout + result.stderr
 
-    # Verify
     env_trusted = load_trusted_keys(env_keys)
     ok, _ = verify_skill(str(skill), env_trusted)
     assert ok
 
 
-def test_manifest_structure(ws: Workspace):
+def test_manifest_structure(signing_ws: Workspace) -> None:
     """Manifest JSON has the expected schema fields."""
     skill = make_skill(
-        ws.skills_dir,
+        signing_ws.skills_dir,
         "skill-schema",
         {
             "script.sh": "#!/bin/bash\necho hi\n",
         },
     )
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "manifest schema sign")
 
     manifest = json.loads((skill / SIGNING_DIR / "Manifest.json").read_text())
     for key in ("version", "skill_name", "algorithm", "created_at", "files"):
@@ -486,13 +552,13 @@ def test_manifest_structure(ws: Workspace):
     assert manifest["skill_name"] == "skill-schema"
     assert len(manifest["files"]) == 1
     assert manifest["files"][0]["path"] == "script.sh"
-    assert len(manifest["files"][0]["hash"]) == 64  # SHA256 hex
+    assert len(manifest["files"][0]["hash"]) == 64
 
 
-def test_subdirectory_files(ws: Workspace):
+def test_subdirectory_files(signing_ws: Workspace) -> None:
     """Files in nested subdirectories are included in the manifest."""
     skill = make_skill(
-        ws.skills_dir,
+        signing_ws.skills_dir,
         "skill-nested",
         {
             "top.txt": "top",
@@ -500,91 +566,123 @@ def test_subdirectory_files(ws: Workspace):
             "sub/deeper/leaf.txt": "leaf",
         },
     )
-    r = run_sign_skill([str(skill), "--force"])
-    assert r.returncode == 0
+    result = run_sign_skill([str(skill), "--force"], ws=signing_ws)
+    assert_success(result, "nested files sign")
 
     manifest = json.loads((skill / SIGNING_DIR / "Manifest.json").read_text())
-    paths = {f["path"] for f in manifest["files"]}
-    assert paths == {"top.txt", "sub/deep.txt", "sub/deeper/leaf.txt"}, paths
+    paths = {file_entry["path"] for file_entry in manifest["files"]}
+    assert paths == {"top.txt", "sub/deep.txt", "sub/deeper/leaf.txt"}
 
-    keys = load_trusted_keys(ws.trusted_keys)
+    keys = load_trusted_keys(signing_ws.trusted_keys)
     ok, _ = verify_skill(str(skill), keys)
     assert ok
 
 
-# ── Main ───────────────────────────────────────────────────────────────────
+def test_source_build_installed_signing_and_verify() -> None:
+    """Sign installed source-build skills and verify through agent-sec-cli."""
+    require_tools("gpg", "jq")
 
+    installed_script = Path(
+        os.environ.get("ANOLISA_INSTALLED_SIGN_SKILL", "/usr/local/bin/sign-skill.sh")
+    )
+    skills_root = Path(
+        os.environ.get("ANOLISA_INSTALLED_SKILLS_DIR", "/usr/share/anolisa/skills")
+    )
+    venv_python = Path(os.environ.get("VENV_PYTHON", "/opt/agent-sec/venv/bin/python"))
+    agent_sec_cli = shutil.which("agent-sec-cli") or "/usr/local/bin/agent-sec-cli"
 
-def main():
-    # Pre-flight
-    if not shutil.which("gpg"):
-        print(f"{RED}ERROR: gpg not found – cannot run e2e tests{NC}")
-        sys.exit(1)
-    if not shutil.which("jq"):
-        print(f"{RED}ERROR: jq not found – cannot run e2e tests{NC}")
-        sys.exit(1)
-    if not SIGN_SKILL_SH.exists():
-        print(f"{RED}ERROR: {SIGN_SKILL_SH} not found{NC}")
-        sys.exit(1)
+    if not installed_script.exists() and not venv_python.exists():
+        pytest.skip("source-build installed sign-skill.sh and venv are not present")
 
-    ws = Workspace()
+    assert installed_script.exists(), f"missing installed script: {installed_script}"
+    assert skills_root.is_dir(), f"missing installed skills root: {skills_root}"
+    assert venv_python.exists(), f"missing installed verifier python: {venv_python}"
+    assert Path(
+        agent_sec_cli
+    ).exists(), f"missing agent-sec-cli binary: {agent_sec_cli}"
+
+    verifier_paths = run_command(
+        [
+            venv_python,
+            "-c",
+            (
+                "from agent_sec_cli.asset_verify import verifier\n"
+                "print(verifier.DEFAULT_TRUSTED_KEYS_DIR)\n"
+                "print(verifier.DEFAULT_CONFIG)\n"
+            ),
+        ],
+    )
+    assert_success(verifier_paths, "resolve installed verifier paths")
+    trusted_keys_dir, config_file = [
+        Path(line.strip()) for line in verifier_paths.stdout.splitlines()[:2]
+    ]
+    assert trusted_keys_dir.is_dir(), f"missing trusted-keys dir: {trusted_keys_dir}"
+    assert config_file.is_file(), f"missing verifier config: {config_file}"
+
+    expected_skills = {"code-scanner", "prompt-scanner", "skill-ledger"}
+    for skill_name in expected_skills:
+        assert (
+            skills_root / skill_name
+        ).is_dir(), f"missing installed skill: {skill_name}"
+
+    needs_sudo = os.geteuid() != 0 and (
+        not os.access(skills_root, os.W_OK)
+        or not os.access(trusted_keys_dir, os.W_OK)
+        or not os.access(config_file, os.W_OK)
+    )
+    if needs_sudo and os.geteuid() != 0:
+        require_passwordless_sudo()
+
+    gnupg_home = Path("/tmp") / f"agent-sec-pytest-gnupg-{uuid.uuid4().hex}"
+    env = {
+        "GNUPGHOME": str(gnupg_home),
+        "LC_ALL": "C",
+        "LANG": "C",
+        "PATH": os.environ.get("PATH", ""),
+    }
+
     try:
-        print("=" * 60)
-        print(f"{BOLD}Skill Signing E2E Tests{NC}")
-        print(f"  sign-skill.sh : {SIGN_SKILL_SH}")
-        print(f"  verifier.py   : {VERIFIER_PY}")
-        print(f"  workspace     : {ws.root}")
-        print("=" * 60)
+        if needs_sudo and os.geteuid() != 0:
+            setup_home = run_maybe_sudo(
+                ["sh", "-c", f"rm -rf '{gnupg_home}' && mkdir -m 700 '{gnupg_home}'"],
+                sudo=True,
+            )
+            assert_success(setup_home, "create root GNUPGHOME")
+        else:
+            shutil.rmtree(gnupg_home, ignore_errors=True)
+            gnupg_home.mkdir(mode=0o700)
 
-        # Run --init first; most subsequent tests depend on the generated key
-        test("Prerequisites check (--check)", lambda: test_check(ws))
-        test("Init: generate key + export (--init)", lambda: test_init(ws))
-
-        # Signing & verification
-        test("Single sign + verify", lambda: test_single_sign_and_verify(ws))
-        test("Batch sign + verify", lambda: test_batch_sign_and_verify(ws))
-        test("Force overwrite re-sign", lambda: test_force_overwrite(ws))
-        test("No --force rejects existing", lambda: test_no_force_rejects(ws))
-        test("Export key to custom dir", lambda: test_export_key_default_and_custom(ws))
-        test("Skill name override", lambda: test_skill_name_override(ws))
-        test("Hidden files excluded", lambda: test_hidden_files_excluded(ws))
-
-        # Negative / security tests
-        test("Tampered file detected", lambda: test_tampered_file_detected(ws))
-        test(
-            "Unsigned reference file detected",
-            lambda: test_unsigned_reference_file_detected(ws),
+        init = run_maybe_sudo(
+            ["bash", installed_script, "--init"],
+            env=env,
+            sudo=needs_sudo,
+            timeout=180,
         )
-        test("Missing .skill.sig detected", lambda: test_missing_sig_detected(ws))
-        test("Wrong key rejected", lambda: test_wrong_key_rejected(ws))
+        assert_success(init, "installed --init")
+        assert str(trusted_keys_dir) in init.stdout + init.stderr
 
-        # Environment variable key import
-        test("GPG_PRIVATE_KEY env import", lambda: test_gpg_private_key_env(ws))
+        batch = run_maybe_sudo(
+            ["bash", installed_script, "--batch", skills_root, "--force"],
+            env=env,
+            sudo=needs_sudo,
+            timeout=180,
+        )
+        assert_success(batch, "installed --batch")
+        assert "3/3 skills signed successfully" in batch.stdout + batch.stderr
 
-        # Schema / structure
-        test("Manifest JSON structure", lambda: test_manifest_structure(ws))
-        test("Subdirectory files in manifest", lambda: test_subdirectory_files(ws))
-
+        verify = run_command([agent_sec_cli, "verify"], timeout=180)
+        assert_success(verify, "agent-sec-cli verify")
+        assert "VERIFICATION PASSED" in verify.stdout
+        for skill_name in expected_skills:
+            assert f"[OK] {skill_name}" in verify.stdout
+            assert (skills_root / skill_name / SIGNING_DIR / "Manifest.json").is_file()
+            assert (skills_root / skill_name / SIGNING_DIR / ".skill.sig").is_file()
     finally:
-        ws.cleanup()
-
-    # Summary
-    print()
-    print("=" * 60)
-    total = results.passed + results.failed
-    print(f"{BOLD}Results: {results.passed}/{total} passed{NC}")
-    if results.errors:
-        for name, exc in results.errors:
-            print(f"  {RED}FAIL{NC} {name}: {exc}")
-    print("=" * 60)
-
-    if results.failed:
-        print(f"{RED}{results.failed} test(s) failed{NC}")
-        sys.exit(1)
-    else:
-        print(f"{GREEN}All tests passed!{NC}")
-        sys.exit(0)
+        if needs_sudo and os.geteuid() != 0:
+            run_maybe_sudo(["rm", "-rf", gnupg_home], sudo=True)
+        else:
+            shutil.rmtree(gnupg_home, ignore_errors=True)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(pytest.main([__file__]))

--- a/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-signing/e2e_test.py
@@ -16,7 +16,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
@@ -149,6 +148,25 @@ def run_maybe_sudo(
         env=run_env,
         timeout=timeout,
     )
+
+
+def resolve_installed_asset_verify_dir() -> Optional[Path]:
+    """Resolve installed verifier package data without importing agent_sec_cli."""
+    search_roots = [
+        Path("/opt/agent-sec/venv/lib"),
+        Path("/opt/agent-sec/lib"),
+    ]
+
+    for root in search_roots:
+        if not root.is_dir():
+            continue
+        for asset_dir in sorted(
+            root.glob("python*/site-packages/agent_sec_cli/asset_verify")
+        ):
+            if asset_dir.is_dir() and (asset_dir / "config.conf").is_file():
+                return asset_dir
+
+    return None
 
 
 def make_skill(parent: Path, name: str, files: dict[str, str]) -> Path:
@@ -341,13 +359,17 @@ def test_legacy_ci_batch_invocation_with_private_key(signing_ws: Workspace) -> N
         }
     )
 
-    installed_config = Path(
-        "/opt/agent-sec/venv/lib/python3.11/site-packages/"
-        "agent_sec_cli/asset_verify/config.conf"
+    installed_asset_verify_dir = resolve_installed_asset_verify_dir()
+    installed_config = (
+        installed_asset_verify_dir / "config.conf"
+        if installed_asset_verify_dir is not None
+        else None
     )
     original_installed_config = (
         installed_config.read_text()
-        if installed_config.is_file() and os.access(installed_config, os.W_OK)
+        if installed_config is not None
+        and installed_config.is_file()
+        and os.access(installed_config, os.W_OK)
         else None
     )
 
@@ -376,7 +398,7 @@ def test_legacy_ci_batch_invocation_with_private_key(signing_ws: Workspace) -> N
             assert ok
             assert name == skill_name
     finally:
-        if original_installed_config is not None:
+        if original_installed_config is not None and installed_config is not None:
             installed_config.write_text(original_installed_config)
 
 
@@ -686,35 +708,22 @@ def test_source_build_installed_signing_and_verify() -> None:
     skills_root = Path(
         os.environ.get("ANOLISA_INSTALLED_SKILLS_DIR", "/usr/share/anolisa/skills")
     )
-    venv_python = Path(os.environ.get("VENV_PYTHON", "/opt/agent-sec/venv/bin/python"))
+    asset_verify_dir = resolve_installed_asset_verify_dir()
     agent_sec_cli = shutil.which("agent-sec-cli") or "/usr/local/bin/agent-sec-cli"
 
-    if not installed_script.exists() and not venv_python.exists():
-        pytest.skip("source-build installed sign-skill.sh and venv are not present")
+    if not installed_script.exists() or asset_verify_dir is None:
+        pytest.skip(
+            "source-build installed sign-skill.sh and verifier asset paths are not present"
+        )
 
     assert installed_script.exists(), f"missing installed script: {installed_script}"
     assert skills_root.is_dir(), f"missing installed skills root: {skills_root}"
-    assert venv_python.exists(), f"missing installed verifier python: {venv_python}"
     assert Path(
         agent_sec_cli
     ).exists(), f"missing agent-sec-cli binary: {agent_sec_cli}"
 
-    verifier_paths = run_command(
-        [
-            venv_python,
-            "-c",
-            (
-                "from agent_sec_cli.asset_verify import verifier\n"
-                "print(verifier.DEFAULT_TRUSTED_KEYS_DIR)\n"
-                "print(verifier.DEFAULT_CONFIG)\n"
-            ),
-        ],
-    )
-    assert_success(verifier_paths, "resolve installed verifier paths")
-    trusted_keys_dir, config_file = [
-        Path(line.strip()) for line in verifier_paths.stdout.splitlines()[:2]
-    ]
-    assert trusted_keys_dir.is_dir(), f"missing trusted-keys dir: {trusted_keys_dir}"
+    trusted_keys_dir = asset_verify_dir / "trusted-keys"
+    config_file = asset_verify_dir / "config.conf"
     assert config_file.is_file(), f"missing verifier config: {config_file}"
 
     expected_skills = {"code-scanner", "prompt-scanner", "skill-ledger"}
@@ -723,15 +732,20 @@ def test_source_build_installed_signing_and_verify() -> None:
             skills_root / skill_name
         ).is_dir(), f"missing installed skill: {skill_name}"
 
+    trusted_keys_write_target = (
+        trusted_keys_dir if trusted_keys_dir.exists() else trusted_keys_dir.parent
+    )
     needs_sudo = os.geteuid() != 0 and (
         not os.access(skills_root, os.W_OK)
-        or not os.access(trusted_keys_dir, os.W_OK)
+        or not os.access(trusted_keys_write_target, os.W_OK)
         or not os.access(config_file, os.W_OK)
     )
     if needs_sudo and os.geteuid() != 0:
         require_passwordless_sudo()
 
-    gnupg_home = Path("/tmp") / f"agent-sec-pytest-gnupg-{uuid.uuid4().hex}"
+    gnupg_home = Path(
+        tempfile.mkdtemp(prefix="agent-sec-pytest-gnupg-", dir=tempfile.gettempdir())
+    )
     env = {
         "GNUPGHOME": str(gnupg_home),
         "LC_ALL": "C",
@@ -747,8 +761,7 @@ def test_source_build_installed_signing_and_verify() -> None:
             )
             assert_success(setup_home, "create root GNUPGHOME")
         else:
-            shutil.rmtree(gnupg_home, ignore_errors=True)
-            gnupg_home.mkdir(mode=0o700)
+            gnupg_home.chmod(0o700)
 
         init = run_maybe_sudo(
             ["bash", installed_script, "--init"],
@@ -758,6 +771,9 @@ def test_source_build_installed_signing_and_verify() -> None:
         )
         assert_success(init, "installed --init")
         assert str(trusted_keys_dir) in init.stdout + init.stderr
+        assert (
+            trusted_keys_dir.is_dir()
+        ), f"trusted-keys dir was not created: {trusted_keys_dir}"
 
         batch = run_maybe_sudo(
             ["bash", installed_script, "--batch", skills_root, "--force"],

--- a/src/agent-sec-core/tools/SIGNING_GUIDE.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE.md
@@ -50,16 +50,20 @@ After running the unified source build, use the installed script and verifier:
 #    directory used by agent-sec-cli verify.
 /usr/local/bin/sign-skill.sh --init
 
-# 2. Sign the installed agent-sec-core skills.
+# 2. Sign the installed agent-sec-core skills. Replace this path if your
+#    SKILL_DIR or package layout installs skills elsewhere.
 /usr/local/bin/sign-skill.sh --batch /usr/share/anolisa/skills --force
 
 # 3. Verify all configured skill directories.
 agent-sec-cli verify
 ```
 
-For the default source-build install, `agent-sec-cli verify` already reads
-`/usr/share/anolisa/skills` from its packaged `config.conf`, so no verification
-directory argument is required.
+For the default source-build install, `/usr/share/anolisa/skills` is the
+installed skills root and `agent-sec-cli verify` already reads it from the
+packaged `config.conf`, so no verification directory argument is required. If a
+custom `SKILL_DIR` or package layout is used, pass the actual skills directory
+to `--batch`; for non-default verifier layouts, pass the matching verifier
+`config.conf` with `--config-file`.
 
 ## Step-by-Step (Manual Key Management)
 
@@ -89,8 +93,8 @@ gpg --list-secret-keys me@example.com
 
 The verifier loads trusted public keys from the packaged `agent_sec_cli/asset_verify/trusted-keys/`
 directory. When `agent-sec-cli` is installed, `sign-skill.sh` auto-detects this
-directory from `agent_sec_cli.asset_verify.verifier`. When running only from this
-source checkout, it falls back to
+directory by probing the installed package data under `/opt/agent-sec`. When
+running only from this source checkout, it falls back to
 `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`.
 To re-export manually:
 
@@ -138,11 +142,12 @@ Each signed skill directory will contain:
 
 ### 4. Configure the Verifier
 
-For installed `agent-sec-cli`, `--batch` uses the detected verifier
-`config.conf` and registers the skills root before signing. For source-tree-only
-or custom layouts, make sure the skills root is listed in the verifier config
-packaged with the CLI (`agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf`
-in this source tree). You can also choose the config file explicitly:
+For installed `agent-sec-cli`, `--batch` uses the detected installed verifier
+`config.conf` and registers the skills root before signing. Source-tree fallback
+does not modify the source checkout's `config.conf` automatically. For
+source-tree-only or custom layouts, make sure the actual skills root is listed
+in the verifier config packaged with the CLI, or choose the config file
+explicitly:
 
 ```bash
 tools/sign-skill.sh --batch /custom/skills --force \

--- a/src/agent-sec-core/tools/SIGNING_GUIDE.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE.md
@@ -39,6 +39,28 @@ agent-sec-cli verify
 exports the public key to `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`.
 You can override the export path with `--trusted-keys-dir <DIR>`.
 
+## After Source Build Installation
+
+After running the unified source build, use the installed script and verifier:
+
+```bash
+./scripts/build-all.sh --component sec-core
+
+# 1. One-time setup. The installed script auto-detects the trusted-keys
+#    directory used by agent-sec-cli verify.
+/usr/local/bin/sign-skill.sh --init
+
+# 2. Sign the installed agent-sec-core skills.
+/usr/local/bin/sign-skill.sh --batch /usr/share/anolisa/skills --force
+
+# 3. Verify all configured skill directories.
+agent-sec-cli verify
+```
+
+For the default source-build install, `agent-sec-cli verify` already reads
+`/usr/share/anolisa/skills` from its packaged `config.conf`, so no verification
+directory argument is required.
+
 ## Step-by-Step (Manual Key Management)
 
 If you prefer full control over GPG key management instead of using `--init`:
@@ -66,8 +88,10 @@ gpg --list-secret-keys me@example.com
 ### 2. Export the Public Key
 
 The verifier loads trusted public keys from the packaged `agent_sec_cli/asset_verify/trusted-keys/`
-directory. When running from this source checkout, `--init` exports to
-`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/` automatically.
+directory. When `agent-sec-cli` is installed, `sign-skill.sh` auto-detects this
+directory from `agent_sec_cli.asset_verify.verifier`. When running only from this
+source checkout, it falls back to
+`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`.
 To re-export manually:
 
 ```bash
@@ -114,10 +138,16 @@ Each signed skill directory will contain:
 
 ### 4. Configure the Verifier
 
-`--batch` signs skill directories but does not edit verifier configuration. For
-batch verification, make sure the skills root is listed in the verifier config
+For installed `agent-sec-cli`, `--batch` uses the detected verifier
+`config.conf` and registers the skills root before signing. For source-tree-only
+or custom layouts, make sure the skills root is listed in the verifier config
 packaged with the CLI (`agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf`
-in this source tree):
+in this source tree). You can also choose the config file explicitly:
+
+```bash
+tools/sign-skill.sh --batch /custom/skills --force \
+    --config-file /path/to/agent_sec_cli/asset_verify/config.conf
+```
 
 ```ini
 skills_dir = [
@@ -212,7 +242,7 @@ agent-sec-cli verify
 | **Check** | `--check` | Verify prerequisites (gpg, jq, sha256sum) |
 | **Single** | `<skill_dir> [--force]` | Sign one skill directory |
 | **Batch** | `--batch <parent_dir> [--force]` | Sign all subdirectories under parent. |
-| **Export** | `--export-key [DIR]` | Export public key (default: `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`) |
+| **Export** | `--export-key [DIR]` | Export public key (default: auto-detected verifier `trusted-keys/`, then source-tree fallback) |
 
 Common options:
 
@@ -221,3 +251,4 @@ Common options:
 | `--force` | Overwrite existing `.skill-meta/Manifest.json` and `.skill-meta/.skill.sig` |
 | `--skill-name NAME` | Override the skill name in the manifest (default: directory name) |
 | `--trusted-keys-dir DIR` | Override the public key export directory (used with `--init`) |
+| `--config-file FILE` | Override the verifier config updated by `--batch` |

--- a/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
@@ -39,6 +39,27 @@ agent-sec-cli verify
 `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`。
 可通过 `--trusted-keys-dir <DIR>` 覆盖导出路径。
 
+## 源码构建安装后的用法
+
+执行统一源码构建后，使用已安装的脚本和校验器：
+
+```bash
+./scripts/build-all.sh --component sec-core
+
+# 1. 一次性初始化。已安装脚本会自动识别 agent-sec-cli verify 使用的
+#    trusted-keys 目录。
+/usr/local/bin/sign-skill.sh --init
+
+# 2. 签名已安装的 agent-sec-core skills。
+/usr/local/bin/sign-skill.sh --batch /usr/share/anolisa/skills --force
+
+# 3. 验证所有已配置的 skill 目录。
+agent-sec-cli verify
+```
+
+默认源码构建安装场景下，`agent-sec-cli verify` 已经从随包安装的
+`config.conf` 读取 `/usr/share/anolisa/skills`，因此不需要再指定验签目录。
+
 ## 手动逐步操作
 
 如果你希望完全控制 GPG 密钥管理，而不使用 `--init`：
@@ -66,8 +87,10 @@ gpg --list-secret-keys me@example.com
 ### 2. 导出公钥
 
 校验器从打包后的 `agent_sec_cli/asset_verify/trusted-keys/` 目录加载受信公钥。
-在当前源码树中运行时，`--init` 会自动导出到
-`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`。手动重新导出：
+当 `agent-sec-cli` 已安装时，`sign-skill.sh` 会从
+`agent_sec_cli.asset_verify.verifier` 自动识别该目录；仅在源码树中运行时，
+会回退到 `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`。
+手动重新导出：
 
 ```bash
 tools/sign-skill.sh --export-key
@@ -113,9 +136,15 @@ tools/sign-skill.sh --batch /usr/share/anolisa/skills --force
 
 ### 4. 配置校验器
 
-`--batch` 只负责签名 skill 目录，不会修改校验器配置。若要进行批量校验，请确保
+当使用已安装的 `agent-sec-cli` 时，`--batch` 会使用自动识别到的 verifier
+`config.conf`，并在签名前注册 skill 根目录。对于仅源码树运行或自定义布局，请确保
 skill 根目录已配置在随 CLI 打包的校验器配置中（当前源码树中的路径为
-`agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf`）：
+`agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf`）。也可以显式指定配置文件：
+
+```bash
+tools/sign-skill.sh --batch /custom/skills --force \
+    --config-file /path/to/agent_sec_cli/asset_verify/config.conf
+```
 
 ```ini
 skills_dir = [
@@ -210,7 +239,7 @@ agent-sec-cli verify
 | **检查** | `--check` | 检查前置依赖（gpg、jq、sha256sum） |
 | **单个签名** | `<skill_dir> [--force]` | 签名单个 skill 目录 |
 | **批量签名** | `--batch <parent_dir> [--force]` | 签名目录下所有子目录。 |
-| **导出公钥** | `--export-key [DIR]` | 导出公钥（默认：`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`） |
+| **导出公钥** | `--export-key [DIR]` | 导出公钥（默认：自动识别 verifier 的 `trusted-keys/`，失败后回退源码树路径） |
 
 常用选项：
 
@@ -219,3 +248,4 @@ agent-sec-cli verify
 | `--force` | 覆盖已有的 `.skill-meta/Manifest.json` 和 `.skill-meta/.skill.sig` |
 | `--skill-name NAME` | 覆盖 Manifest 中的 skill 名称（默认：目录名） |
 | `--trusted-keys-dir DIR` | 覆盖公钥导出目录（配合 `--init` 使用） |
+| `--config-file FILE` | 覆盖 `--batch` 更新的 verifier 配置文件 |

--- a/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
+++ b/src/agent-sec-core/tools/SIGNING_GUIDE_CN.md
@@ -50,15 +50,19 @@ agent-sec-cli verify
 #    trusted-keys 目录。
 /usr/local/bin/sign-skill.sh --init
 
-# 2. 签名已安装的 agent-sec-core skills。
+# 2. 签名已安装的 agent-sec-core skills。若自定义了 SKILL_DIR 或安装布局，
+#    请替换为实际 skill 目录。
 /usr/local/bin/sign-skill.sh --batch /usr/share/anolisa/skills --force
 
 # 3. 验证所有已配置的 skill 目录。
 agent-sec-cli verify
 ```
 
-默认源码构建安装场景下，`agent-sec-cli verify` 已经从随包安装的
-`config.conf` 读取 `/usr/share/anolisa/skills`，因此不需要再指定验签目录。
+默认源码构建安装场景下，`/usr/share/anolisa/skills` 是已安装的 skill 根目录，
+`agent-sec-cli verify` 已经从随包安装的 `config.conf` 读取该目录，因此不需要
+再指定验签目录。若使用自定义 `SKILL_DIR` 或不同的包布局，请将实际 skill 目录
+传给 `--batch`；非默认 verifier 布局可通过 `--config-file` 指定对应的
+`config.conf`。
 
 ## 手动逐步操作
 
@@ -87,9 +91,9 @@ gpg --list-secret-keys me@example.com
 ### 2. 导出公钥
 
 校验器从打包后的 `agent_sec_cli/asset_verify/trusted-keys/` 目录加载受信公钥。
-当 `agent-sec-cli` 已安装时，`sign-skill.sh` 会从
-`agent_sec_cli.asset_verify.verifier` 自动识别该目录；仅在源码树中运行时，
-会回退到 `agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`。
+当 `agent-sec-cli` 已安装时，`sign-skill.sh` 会通过文件系统探测 `/opt/agent-sec`
+下的包内数据目录；仅在源码树中运行时，会回退到
+`agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys/`。
 手动重新导出：
 
 ```bash
@@ -136,10 +140,10 @@ tools/sign-skill.sh --batch /usr/share/anolisa/skills --force
 
 ### 4. 配置校验器
 
-当使用已安装的 `agent-sec-cli` 时，`--batch` 会使用自动识别到的 verifier
-`config.conf`，并在签名前注册 skill 根目录。对于仅源码树运行或自定义布局，请确保
-skill 根目录已配置在随 CLI 打包的校验器配置中（当前源码树中的路径为
-`agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf`）。也可以显式指定配置文件：
+当使用已安装的 `agent-sec-cli` 时，`--batch` 会使用自动识别到的已安装 verifier
+`config.conf`，并在签名前注册 skill 根目录。源码树 fallback 不会自动修改源码树中的
+`config.conf`。对于仅源码树运行或自定义布局，请确保实际 skill 根目录已配置在随 CLI
+打包的校验器配置中；也可以显式指定配置文件：
 
 ```bash
 tools/sign-skill.sh --batch /custom/skills --force \

--- a/src/agent-sec-core/tools/sign-skill.sh
+++ b/src/agent-sec-core/tools/sign-skill.sh
@@ -55,6 +55,9 @@ AGENT_SEC_CORE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Default path for trusted public keys in the verifier package data.
 DEFAULT_TRUSTED_KEYS_DIR="$AGENT_SEC_CORE_DIR/agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys"
+DEFAULT_CONFIG_FILE="$AGENT_SEC_CORE_DIR/agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf"
+VERIFIER_PATH_SOURCE="source"
+VERIFIER_PATHS_RESOLVED=false
 
 # Resolve gpg binary: prefer 'gpg', fall back to 'gpg2' (RHEL/Alinux minimal)
 if command -v gpg &>/dev/null; then
@@ -68,6 +71,45 @@ fi
 # Resolved GPG key identifier used for signing.  Set after key generation
 # or GPG_PRIVATE_KEY import; empty means "let gpg pick its default".
 GPG_SIGN_KEY=""
+
+resolve_verifier_paths() {
+    if [[ "$VERIFIER_PATHS_RESOLVED" == true ]]; then
+        return 0
+    fi
+    VERIFIER_PATHS_RESOLVED=true
+
+    local py
+    local out
+    local trusted_keys_dir
+    local config_file
+    local candidates=("/opt/agent-sec/venv/bin/python" "python3")
+
+    for py in "${candidates[@]}"; do
+        if [[ "$py" == */* ]]; then
+            [[ -x "$py" ]] || continue
+        else
+            command -v "$py" &>/dev/null || continue
+        fi
+
+        out=$("$py" - <<'PY' 2>/dev/null || true
+from agent_sec_cli.asset_verify import verifier
+print(verifier.DEFAULT_TRUSTED_KEYS_DIR)
+print(verifier.DEFAULT_CONFIG)
+PY
+)
+        trusted_keys_dir=$(printf '%s\n' "$out" | sed -n '1p')
+        config_file=$(printf '%s\n' "$out" | sed -n '2p')
+
+        if [[ -n "$trusted_keys_dir" && -n "$config_file" ]]; then
+            DEFAULT_TRUSTED_KEYS_DIR="$trusted_keys_dir"
+            DEFAULT_CONFIG_FILE="$config_file"
+            VERIFIER_PATH_SOURCE="$py"
+            return 0
+        fi
+    done
+
+    return 0
+}
 
 # Function to compute SHA256 hash of a file
 compute_file_hash() {
@@ -139,6 +181,21 @@ sign_manifest() {
     local manifest_path="$1"
     local signature_path="$2"
 
+    local secret_key_query="${GPG_SIGN_KEY:-}"
+    if [[ -n "$secret_key_query" ]]; then
+        if ! "$GPG" --list-secret-keys --with-colons "$secret_key_query" 2>/dev/null | grep -q '^sec'; then
+            echo -e "${RED}ERROR: No GPG secret key found for '$secret_key_query'.${NC}" >&2
+            echo "Run '$0 --init' first, or set GPG_PRIVATE_KEY before signing." >&2
+            return 1
+        fi
+    else
+        if ! "$GPG" --list-secret-keys --with-colons 2>/dev/null | grep -q '^sec'; then
+            echo -e "${RED}ERROR: No GPG secret key is available for signing.${NC}" >&2
+            echo "Run '$0 --init' first, or set GPG_PRIVATE_KEY before signing." >&2
+            return 1
+        fi
+    fi
+
     local cmd=("$GPG" --batch --yes --armor --detach-sign --output "$signature_path")
 
     # Pin signing key so the correct key is used when multiple exist
@@ -153,23 +210,85 @@ sign_manifest() {
 
     cmd+=("$manifest_path")
 
+    local gpg_err
+    gpg_err=$(mktemp)
     if [[ -n "${GPG_PASSPHRASE:-}" ]]; then
-        if ! "${cmd[@]}" <<<"$GPG_PASSPHRASE" 2>/dev/null; then
+        if ! "${cmd[@]}" <<<"$GPG_PASSPHRASE" 2>"$gpg_err"; then
             echo -e "${RED}ERROR: Failed to sign manifest${NC}" >&2
+            sed 's/^/  gpg: /' "$gpg_err" >&2
+            rm -f "$gpg_err"
             return 1
         fi
     else
-        if ! "${cmd[@]}" 2>/dev/null; then
+        if ! "${cmd[@]}" 2>"$gpg_err"; then
             echo -e "${RED}ERROR: Failed to sign manifest${NC}" >&2
+            sed 's/^/  gpg: /' "$gpg_err" >&2
+            rm -f "$gpg_err"
             return 1
         fi
     fi
+    rm -f "$gpg_err"
 
     return 0
 }
 
+ensure_config_dir_entry() {
+    local dir_to_add="$1"
+    local config_file="$2"
+
+    if [[ -z "$config_file" ]]; then
+        return 0
+    fi
+    if [[ ! -f "$config_file" ]]; then
+        echo -e "${YELLOW}NOTE: verifier config not found at $config_file; skipping skills_dir registration${NC}"
+        return 0
+    fi
+    if [[ ! -w "$config_file" ]]; then
+        echo -e "${YELLOW}NOTE: verifier config is not writable at $config_file; skipping skills_dir registration${NC}"
+        return 0
+    fi
+
+    if awk -v target="$dir_to_add" '
+        /skills_dir[[:space:]]*=/ { in_list=1; next }
+        in_list && /^[[:space:]]*\]/ { exit 1 }
+        in_list {
+            line=$0; gsub(/^[[:space:]]+|[[:space:],]+$/, "", line)
+            if (line == target) { found=1; exit 0 }
+        }
+        END { exit (found ? 0 : 1) }
+    ' "$config_file" 2>/dev/null; then
+        echo "Skills directory already registered in config.conf: $dir_to_add"
+        return 0
+    fi
+
+    local orig_mode
+    orig_mode=$(stat -c '%a' "$config_file" 2>/dev/null) \
+        || orig_mode=$(stat -f '%Lp' "$config_file" 2>/dev/null) \
+        || orig_mode=""
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    if ! awk -v entry="    $dir_to_add" '
+        /skills_dir[[:space:]]*=/ { in_list=1 }
+        in_list && /^[[:space:]]*\]/ && !done { print entry; done=1 }
+        { print }
+        END { exit (done ? 0 : 1) }
+    ' "$config_file" > "$tmp_file"; then
+        rm -f "$tmp_file"
+        echo -e "${YELLOW}WARNING: Could not update config.conf; please add '$dir_to_add' manually${NC}"
+        return 0
+    fi
+
+    mv "$tmp_file" "$config_file"
+    if [[ -n "$orig_mode" ]]; then
+        chmod "$orig_mode" "$config_file" 2>/dev/null || true
+    fi
+    echo -e "${GREEN}Added skills directory to config.conf: $dir_to_add${NC}"
+}
+
 # Function to show usage
 show_usage() {
+    resolve_verifier_paths
     echo -e "${BOLD}Skill Manifest and Signature Generator${NC}"
     echo ""
     echo "Usage:"
@@ -192,6 +311,8 @@ show_usage() {
     echo "  --force                 Overwrite existing manifest and signature files"
     echo "  --trusted-keys-dir DIR  Where to export the public key (used with --init)"
     echo "                          (default: $DEFAULT_TRUSTED_KEYS_DIR)"
+    echo "  --config-file FILE      Verifier config.conf updated by --batch"
+    echo "                          (default: $DEFAULT_CONFIG_FILE)"
     echo "  -h, --help              Show this help message"
     echo ""
     echo "Quick Start (self-deployment):"
@@ -379,9 +500,10 @@ GPGEOF
 
 do_export_key() {
     local output_dir="${1:-$DEFAULT_TRUSTED_KEYS_DIR}"
+    local key_to_export="${GPG_SIGN_KEY:-$SIGN_KEY_EMAIL}"
 
-    if ! "$GPG" --list-secret-keys "$SIGN_KEY_EMAIL" &>/dev/null 2>&1; then
-        echo -e "${RED}ERROR: No GPG secret key found for '$SIGN_KEY_EMAIL'.${NC}" >&2
+    if ! "$GPG" --list-secret-keys --with-colons "$key_to_export" 2>/dev/null | grep -q '^sec'; then
+        echo -e "${RED}ERROR: No GPG secret key found for '$key_to_export'.${NC}" >&2
         echo "Run '$0 --init' first to generate a signing key." >&2
         return 1
     fi
@@ -389,15 +511,15 @@ do_export_key() {
     mkdir -p "$output_dir"
 
     local safe_name
-    safe_name=$(echo "$SIGN_KEY_EMAIL" | tr '@.' '-')
+    safe_name=$(echo "$key_to_export" | tr '@.:' '---')
     local output_file="$output_dir/${safe_name}.asc"
 
-    "$GPG" --armor --export "$SIGN_KEY_EMAIL" > "$output_file"
+    "$GPG" --armor --export "$key_to_export" > "$output_file"
 
     if [[ -s "$output_file" ]]; then
         echo -e "${GREEN}Public key exported: $output_file${NC}"
     else
-        echo -e "${RED}ERROR: Failed to export public key for $SIGN_KEY_EMAIL${NC}" >&2
+        echo -e "${RED}ERROR: Failed to export public key for $key_to_export${NC}" >&2
         rm -f "$output_file"
         return 1
     fi
@@ -414,6 +536,8 @@ main() {
     local mode=""            # "", "init", "export-key", "check"
     local trusted_keys_dir=""
     local export_key_dir=""
+    local config_file=""
+    local config_file_explicit=false
 
     # Import GPG private key from environment variable if provided
     if [[ -n "${GPG_PRIVATE_KEY:-}" ]]; then
@@ -490,6 +614,12 @@ main() {
                 trusted_keys_dir="$2"
                 shift 2
                 ;;
+            --config-file)
+                [[ -n "${2:-}" ]] || { echo -e "${RED}ERROR: --config-file requires a file path${NC}" >&2; exit 1; }
+                config_file="$2"
+                config_file_explicit=true
+                shift 2
+                ;;
             --batch)
                 batch=true
                 if [[ -n "${2:-}" && "${2:0:1}" != "-" ]]; then
@@ -531,6 +661,14 @@ main() {
         esac
     done
 
+    resolve_verifier_paths
+    if [[ -z "$trusted_keys_dir" ]]; then
+        trusted_keys_dir="$DEFAULT_TRUSTED_KEYS_DIR"
+    fi
+    if [[ -z "$config_file" ]]; then
+        config_file="$DEFAULT_CONFIG_FILE"
+    fi
+
     # ── Mode dispatch ──
 
     if [[ "$mode" == "check" ]]; then
@@ -544,6 +682,9 @@ main() {
     fi
 
     if [[ "$mode" == "export-key" ]]; then
+        if [[ -z "$export_key_dir" ]]; then
+            export_key_dir="$DEFAULT_TRUSTED_KEYS_DIR"
+        fi
         do_export_key "$export_key_dir"
         exit $?
     fi
@@ -555,6 +696,10 @@ main() {
         if [[ ! -d "$batch_dir" ]]; then
             echo -e "${RED}ERROR: Batch directory does not exist: $batch_dir${NC}" >&2
             exit 1
+        fi
+
+        if $config_file_explicit || [[ "$config_file" != "$AGENT_SEC_CORE_DIR/"* ]]; then
+            ensure_config_dir_entry "$batch_dir" "$config_file"
         fi
 
         echo "Batch signing skills under: $batch_dir"

--- a/src/agent-sec-core/tools/sign-skill.sh
+++ b/src/agent-sec-core/tools/sign-skill.sh
@@ -54,8 +54,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENT_SEC_CORE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Default path for trusted public keys in the verifier package data.
-DEFAULT_TRUSTED_KEYS_DIR="$AGENT_SEC_CORE_DIR/agent-sec-cli/src/agent_sec_cli/asset_verify/trusted-keys"
-DEFAULT_CONFIG_FILE="$AGENT_SEC_CORE_DIR/agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf"
+SOURCE_ASSET_VERIFY_DIR="$AGENT_SEC_CORE_DIR/agent-sec-cli/src/agent_sec_cli/asset_verify"
+DEFAULT_TRUSTED_KEYS_DIR="$SOURCE_ASSET_VERIFY_DIR/trusted-keys"
+DEFAULT_CONFIG_FILE="$SOURCE_ASSET_VERIFY_DIR/config.conf"
 VERIFIER_PATH_SOURCE="source"
 VERIFIER_PATHS_RESOLVED=false
 
@@ -72,41 +73,42 @@ fi
 # or GPG_PRIVATE_KEY import; empty means "let gpg pick its default".
 GPG_SIGN_KEY=""
 
+try_verifier_asset_dir() {
+    local asset_dir="$1"
+
+    if [[ ! -d "$asset_dir" || ! -f "$asset_dir/config.conf" ]]; then
+        return 1
+    fi
+
+    DEFAULT_TRUSTED_KEYS_DIR="$asset_dir/trusted-keys"
+    DEFAULT_CONFIG_FILE="$asset_dir/config.conf"
+    VERIFIER_PATH_SOURCE="$asset_dir"
+    return 0
+}
+
 resolve_verifier_paths() {
     if [[ "$VERIFIER_PATHS_RESOLVED" == true ]]; then
         return 0
     fi
     VERIFIER_PATHS_RESOLVED=true
 
-    local py
-    local out
-    local trusted_keys_dir
-    local config_file
-    local candidates=("/opt/agent-sec/venv/bin/python" "python3")
+    local asset_dir
 
-    for py in "${candidates[@]}"; do
-        if [[ "$py" == */* ]]; then
-            [[ -x "$py" ]] || continue
-        else
-            command -v "$py" &>/dev/null || continue
-        fi
-
-        out=$("$py" - <<'PY' 2>/dev/null || true
-from agent_sec_cli.asset_verify import verifier
-print(verifier.DEFAULT_TRUSTED_KEYS_DIR)
-print(verifier.DEFAULT_CONFIG)
-PY
-)
-        trusted_keys_dir=$(printf '%s\n' "$out" | sed -n '1p')
-        config_file=$(printf '%s\n' "$out" | sed -n '2p')
-
-        if [[ -n "$trusted_keys_dir" && -n "$config_file" ]]; then
-            DEFAULT_TRUSTED_KEYS_DIR="$trusted_keys_dir"
-            DEFAULT_CONFIG_FILE="$config_file"
-            VERIFIER_PATH_SOURCE="$py"
+    for asset_dir in /opt/agent-sec/venv/lib/python*/site-packages/agent_sec_cli/asset_verify; do
+        if try_verifier_asset_dir "$asset_dir"; then
             return 0
         fi
     done
+
+    for asset_dir in /opt/agent-sec/lib/python*/site-packages/agent_sec_cli/asset_verify; do
+        if try_verifier_asset_dir "$asset_dir"; then
+            return 0
+        fi
+    done
+
+    if try_verifier_asset_dir "$SOURCE_ASSET_VERIFY_DIR"; then
+        VERIFIER_PATH_SOURCE="source"
+    fi
 
     return 0
 }


### PR DESCRIPTION
## Description

1.   更新build-all脚本，支持从源码构建并安装sec-core完整能力（除loongshield）
2.  增加github ci， 在alinux4和ubuntu22.04环境下完成sec-core build from scratch的e2e测试
3.  更新sign-skill, 修复相关问题。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
