### PR TITLE
feat(sec-core): add PIIChecker scan CLI and middleware

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import typer
 from agent_sec_cli.observability.cli import app as observability_app
+from agent_sec_cli.pii_checker.cli import scanner_app as pii_scanner_app
 from agent_sec_cli.prompt_scanner.cli import scanner_app
 from agent_sec_cli.security_events import get_reader
 from agent_sec_cli.security_events.summary_formatter import format_summary
@@ -101,6 +102,8 @@ def _with_default_harden_args(args: list[str]) -> list[str]:
 
 # Register prompt scanner sub-command
 app.add_typer(scanner_app, name="scan-prompt")
+# Register PII scanner sub-command
+app.add_typer(pii_scanner_app, name="scan-pii")
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +136,7 @@ def log_sandbox(
         "--cwd",
         help="Current working directory",
     ),
-):
+) -> None:
     """Internal: Record sandbox prehook decision (called by sandbox-guard.py)."""
     result = invoke(
         "sandbox_prehook",
@@ -169,7 +172,7 @@ def harden(
         "--downstream-help",
         help="Show full `loongshield seharden` help and exit.",
     ),
-):
+) -> None:
     """Scan or reinforce the system against a security baseline."""
     if help_flag:
         typer.echo(_HARDEN_HELP_TEXT.rstrip())
@@ -197,7 +200,7 @@ def verify(
         "--skill",
         help="Path to specific skill for verification",
     ),
-):
+) -> None:
     """Skill integrity verification."""
     result = invoke("verify", skill=skill)
     if result.stdout:
@@ -413,7 +416,7 @@ def events(
             "Incompatible with --count, --count-by, --output."
         ),
     ),
-):
+) -> None:
     """Query security events from the local SQLite store."""
     # TODO: Support paging with limit and continue
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/__init__.py
@@ -1,0 +1,14 @@
+"""PII and credential scanner public API."""
+
+from agent_sec_cli.pii_checker.detectors.base import PiiCandidate, PiiDetector
+from agent_sec_cli.pii_checker.models import PiiFinding, PiiScanResult
+from agent_sec_cli.pii_checker.scanner import PiiScanner, scan_text
+
+__all__ = [
+    "PiiCandidate",
+    "PiiDetector",
+    "PiiFinding",
+    "PiiScanResult",
+    "PiiScanner",
+    "scan_text",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/audit.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/audit.py
@@ -1,0 +1,81 @@
+"""Audit sanitization helpers for pii_scan middleware events."""
+
+import copy
+import hashlib
+from typing import Any
+
+_AUDIT_ERROR_MESSAGE = "pii_scan error details omitted from audit"
+
+
+def _hash_text(text: str) -> str:
+    """Return a SHA-256 digest for audit correlation without storing text."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _sanitize_request(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Remove raw PII scan inputs from audit details."""
+    text = kwargs.get("text", "")
+    text_length = len(text) if isinstance(text, str) else 0
+    return {
+        "source": kwargs.get("source", "unknown"),
+        "text_length": text_length,
+        "text_sha256": _hash_text(text) if isinstance(text, str) else "",
+        "max_bytes": kwargs.get("max_bytes"),
+        "include_low_confidence": bool(kwargs.get("include_low_confidence", False)),
+        "redact_output": bool(kwargs.get("redact_output", False)),
+        "input_truncated": bool(kwargs.get("input_truncated", False)),
+    }
+
+
+def _sanitize_result(data: dict[str, Any]) -> dict[str, Any]:
+    """Keep only audit-safe PII scan result fields."""
+    findings = data.get("findings", [])
+    safe_findings: list[dict[str, Any]] = []
+    if isinstance(findings, list):
+        for item in findings:
+            if not isinstance(item, dict):
+                continue
+            safe_findings.append(
+                {
+                    "type": item.get("type"),
+                    "category": item.get("category"),
+                    "severity": item.get("severity"),
+                    "confidence": item.get("confidence"),
+                    "evidence_redacted": item.get("evidence_redacted"),
+                    "span": item.get("span"),
+                    "metadata": copy.deepcopy(item.get("metadata", {})),
+                }
+            )
+
+    summary = copy.deepcopy(data.get("summary", {}))
+    if isinstance(summary, dict) and summary.get("error"):
+        summary["error"] = _AUDIT_ERROR_MESSAGE
+
+    return {
+        "ok": data.get("ok"),
+        "verdict": data.get("verdict"),
+        "summary": summary if isinstance(summary, dict) else {},
+        "findings": safe_findings,
+        "elapsed_ms": data.get("elapsed_ms"),
+    }
+
+
+def build_audit_details(
+    result_data: dict[str, Any], kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Build audit-safe details for a successful pii_scan invocation."""
+    return {
+        "request": _sanitize_request(kwargs),
+        "result": _sanitize_result(result_data),
+    }
+
+
+def build_error_audit_details(
+    exception: Exception, kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Build audit-safe details for a failed pii_scan invocation."""
+    return {
+        "request": _sanitize_request(kwargs),
+        "error": _AUDIT_ERROR_MESSAGE,
+        "error_type": type(exception).__name__,
+    }

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/cli.py
@@ -1,0 +1,177 @@
+"""CLI entry point for the PII checker (scan-pii command)."""
+
+from pathlib import Path
+from typing import Any
+
+import typer
+from agent_sec_cli.security_middleware import invoke
+
+scanner_app = typer.Typer(
+    name="scan-pii",
+    help=(
+        "Detect PII and credentials, printing verdict, findings, and summary. "
+        "Use --redact-output to also emit redacted_text."
+    ),
+)
+
+_OUTPUT_FORMATS = {"json", "text"}
+_SOURCES = {"user_input", "tool_output", "manual", "unknown"}
+_DEFAULT_MAX_BYTES = 1_048_576
+_TEXT_OPTION = typer.Option(None, "--text", help="Text to scan.")
+_INPUT_OPTION = typer.Option(
+    None,
+    "--input",
+    exists=True,
+    file_okay=True,
+    dir_okay=False,
+    readable=True,
+    resolve_path=True,
+    help="Path to a UTF-8 text file to scan.",
+)
+_FORMAT_OPTION = typer.Option("json", "--format", help="Output format: json or text.")
+_INCLUDE_LOW_OPTION = typer.Option(
+    False,
+    "--include-low-confidence",
+    help="Include findings below the default confidence threshold.",
+)
+_RAW_EVIDENCE_OPTION = typer.Option(
+    False,
+    "--raw-evidence",
+    help=(
+        "Include raw evidence in local CLI output for debugging. "
+        "Raw evidence is never written to security events."
+    ),
+)
+_REDACT_OUTPUT_OPTION = typer.Option(
+    False,
+    "--redact-output",
+    help=(
+        "Also include redacted_text in output. "
+        "This does not rewrite input files or local data."
+    ),
+)
+_SOURCE_OPTION = typer.Option(
+    "unknown",
+    "--source",
+    help=(
+        "Audit and policy context label: user_input, tool_output, manual, or "
+        "unknown. This does not modify input content."
+    ),
+)
+_MAX_BYTES_OPTION = typer.Option(
+    _DEFAULT_MAX_BYTES,
+    "--max-bytes",
+    help="Maximum bytes to scan before truncating input.",
+)
+
+
+def _read_limited_input(path: Path, max_bytes: int) -> tuple[str, bool, int]:
+    """Read at most max_bytes from a UTF-8 file before scanner-level limiting.
+
+    The returned byte count reflects file bytes read for scanning. When the CLI
+    truncates a file, that truncation flag takes precedence over the scanner's
+    string-level truncation result in the final summary.
+    """
+    with path.open("rb") as handle:
+        data = handle.read(max_bytes + 1)
+    truncated = len(data) > max_bytes
+    if truncated:
+        data = data[:max_bytes]
+    return data.decode("utf-8", errors="ignore"), truncated, len(data)
+
+
+def _format_text_output(data: dict[str, Any]) -> str:
+    """Render a scan result as human-readable text without raw evidence."""
+    lines = [
+        f"Verdict: {data.get('verdict', 'unknown')}",
+        f"Findings: {data.get('summary', {}).get('total', 0)}",
+    ]
+    summary = data.get("summary", {})
+    if isinstance(summary, dict):
+        source = summary.get("source")
+        if source:
+            lines.append(f"Source: {source}")
+
+    findings = data.get("findings", [])
+    if isinstance(findings, list) and findings:
+        lines.append("")
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            lines.append(
+                "- {type} ({severity}, confidence={confidence}): {evidence}".format(
+                    type=finding.get("type", "unknown"),
+                    severity=finding.get("severity", "unknown"),
+                    confidence=finding.get("confidence", "?"),
+                    evidence=finding.get("evidence_redacted", "[REDACTED]"),
+                )
+            )
+
+    redacted_text = data.get("redacted_text")
+    if isinstance(redacted_text, str):
+        lines.extend(["", "Redacted text:", redacted_text])
+
+    return "\n".join(lines) + "\n"
+
+
+@scanner_app.callback(invoke_without_command=True)
+def scan_pii(
+    ctx: typer.Context,
+    text: str | None = _TEXT_OPTION,
+    input_path: Path | None = _INPUT_OPTION,
+    output_format: str = _FORMAT_OPTION,
+    include_low_confidence: bool = _INCLUDE_LOW_OPTION,
+    raw_evidence: bool = _RAW_EVIDENCE_OPTION,
+    redact_output: bool = _REDACT_OUTPUT_OPTION,
+    source: str = _SOURCE_OPTION,
+    max_bytes: int = _MAX_BYTES_OPTION,
+) -> None:
+    """Detect PII and credentials in text or a file."""
+    if ctx.invoked_subcommand is not None:
+        return
+    if output_format not in _OUTPUT_FORMATS:
+        typer.echo("Error: --format must be one of: json, text.", err=True)
+        raise typer.Exit(code=1)
+    if source not in _SOURCES:
+        typer.echo(
+            "Error: --source must be one of: user_input, tool_output, manual, unknown.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if max_bytes <= 0:
+        typer.echo("Error: --max-bytes must be greater than zero.", err=True)
+        raise typer.Exit(code=1)
+    if (text is None and input_path is None) or (
+        text is not None and input_path is not None
+    ):
+        typer.echo("Error: provide exactly one of --text or --input.", err=True)
+        raise typer.Exit(code=1)
+
+    input_truncated = False
+    input_bytes_scanned = None
+    scan_text = text or ""
+    if input_path is not None:
+        scan_text, input_truncated, input_bytes_scanned = _read_limited_input(
+            input_path, max_bytes
+        )
+
+    result = invoke(
+        "pii_scan",
+        text=scan_text,
+        source=source,
+        include_low_confidence=include_low_confidence,
+        raw_evidence=raw_evidence,
+        redact_output=redact_output,
+        max_bytes=max_bytes,
+        input_truncated=input_truncated,
+        input_bytes_scanned=input_bytes_scanned,
+    )
+
+    if output_format == "json":
+        typer.echo(result.stdout)
+    else:
+        typer.echo(_format_text_output(result.data), nl=False)
+
+    if result.error:
+        typer.echo(result.error, err=True)
+    raise typer.Exit(code=result.exit_code)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/__init__.py
@@ -1,0 +1,6 @@
+"""PII detector interfaces and built-in detectors."""
+
+from agent_sec_cli.pii_checker.detectors.base import PiiCandidate, PiiDetector
+from agent_sec_cli.pii_checker.detectors.regex import RegexPiiDetector
+
+__all__ = ["PiiCandidate", "PiiDetector", "RegexPiiDetector"]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/base.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/base.py
@@ -1,0 +1,30 @@
+"""Detector interfaces for the PII checker."""
+
+from typing import Protocol
+
+from pydantic import BaseModel, Field
+
+
+class PiiCandidate(BaseModel):
+    """Raw detector output before scanner-level filtering and redaction."""
+
+    pii_type: str
+    category: str
+    severity: str
+    confidence: float
+    value: str
+    span: tuple[int, int]
+    metadata: dict[str, object] = Field(default_factory=dict)
+    detector: str = "unknown"
+    engine: str = "unknown"
+
+
+class PiiDetector(Protocol):
+    """Protocol for regex, rules, or model-backed PII detectors."""
+
+    name: str
+    engine: str
+
+    def detect(self, text: str) -> list[PiiCandidate]:
+        """Return raw PII candidates for *text*."""
+        pass

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/regex.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/regex.py
@@ -1,0 +1,346 @@
+"""Built-in regex and validator based PII detector."""
+
+import re
+
+from agent_sec_cli.pii_checker.detectors.base import PiiCandidate
+from agent_sec_cli.pii_checker.models import PiiCategory, PiiSeverity
+from agent_sec_cli.pii_checker.validators import (
+    luhn_check,
+    validate_cn_id,
+    validate_jwt,
+)
+
+_CONTEXT_WINDOW_RADIUS = 64
+_CONTEXT_POSITIVE_DELTA = 0.12
+_CONTEXT_NEGATIVE_DELTA = -0.35
+_MAX_PRIVATE_KEY_CHARS = 16_384
+_PRIVATE_KEY_EVIDENCE_PLACEHOLDER = "[PRIVATE_KEY_OMITTED]"
+
+# Confidence model (v1 fixed heuristic; values are not calibrated probabilities):
+#
+# | Signal class                        | Base |
+# | ----------------------------------- | ---- |
+# | private_key                         | 1.00 |
+# | jwt                                 | 0.94 |
+# | cn_id                               | 0.93 |
+# | bearer_token, aliyun_access_key_id  | 0.92 |
+# | credit_card with Luhn validation    | 0.92 |
+# | api_key prefix patterns             | 0.86 |
+# | generic_secret_field, email         | 0.82 |
+# | phone_cn                            | 0.78 |
+# | reserved .invalid email             | 0.35 |
+#
+# Context adjustment uses a 64-character window around each match. Security
+# keywords raise credential-like matches by +0.12; fixture/example markers lower
+# likely test data by -0.35. Scanner-level thresholding hides low-confidence
+# findings unless include_low_confidence is enabled.
+_BASE_CONFIDENCE: dict[str, float] = {
+    "private_key": 1.0,
+    "jwt": 0.94,
+    "cn_id": 0.93,
+    "bearer_token": 0.92,
+    "aliyun_access_key_id": 0.92,
+    "credit_card": 0.92,
+    "api_key": 0.86,
+    "generic_secret_field": 0.82,
+    "email": 0.82,
+    "phone_cn": 0.78,
+    "email_reserved_invalid": 0.35,
+}
+
+_POSITIVE_CONTEXT = (
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "accesskeysecret",
+    "access_key_secret",
+    "密码",
+    "口令",
+    "密钥",
+    "令牌",
+    "授权",
+    "访问密钥",
+)
+_NEGATIVE_CONTEXT = ("example", "dummy", "test", "sample", ".invalid")
+
+_EMAIL_RE = re.compile(
+    r"(?<![\w.+-])[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]+\.[A-Za-z]{2,63}(?![\w.-])"
+)
+_PHONE_CN_RE = re.compile(
+    r"(?<!\d)(?:\+?86[-\s]?)?1[3-9]\d[-\s]?\d{4}[-\s]?\d{4}(?!\d)"
+)
+_CREDIT_CARD_RE = re.compile(r"(?<!\d)(?:\d[ -]?){13,19}(?!\d)")
+_CN_ID_RE = re.compile(r"(?<!\d)\d{17}[\dXx](?!\w)")
+_JWT_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?![A-Za-z0-9_-])"
+)
+_API_KEY_RE = re.compile(
+    r"\b(?:sk|pk|rk|gh[pousr]|xox[baprs])[-_][A-Za-z0-9_=-]{16,}\b"
+)
+_BEARER_RE = re.compile(r"\bBearer\s+([A-Za-z0-9._~+/=-]{16,})", re.IGNORECASE)
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]+?-----END \1-----"
+)
+_ALIYUN_ACCESS_KEY_ID_RE = re.compile(r"\bLTAI[A-Za-z0-9]{12,30}\b")
+_SECRET_FIELD_RE = re.compile(
+    r"(?i)(?<![\w\u4e00-\u9fff])(?P<name>password|passwd|secret|token|"
+    r"api[_-]?key|apikey|access[_-]?key[_-]?secret|accessKeySecret|"
+    r"client[_-]?secret|authorization|密码|口令|密钥|令牌|授权|访问密钥)"
+    r"\s*[:=：]\s*(?P<quoted_value>\"(?P<double_value>[^\s\"',;，；：]{8,})\"|"
+    r"'(?P<single_value>[^\s\"',;，；：]{8,})'|"
+    r"(?P<bare_value>[^\s\"',;，；：]{8,}))"
+)
+
+
+def _context_window(
+    text: str, start: int, end: int, radius: int = _CONTEXT_WINDOW_RADIUS
+) -> str:
+    """Return lowercase context around a match."""
+    return text[max(0, start - radius) : min(len(text), end + radius)].lower()
+
+
+def _score_with_context(text: str, start: int, end: int, base: float) -> float:
+    """Adjust confidence up/down based on surrounding context."""
+    context = _context_window(text, start, end)
+    score = base
+    compact_context = context.replace("-", "_")
+    if any(marker in compact_context for marker in _POSITIVE_CONTEXT):
+        score += _CONTEXT_POSITIVE_DELTA
+    if any(marker in compact_context for marker in _NEGATIVE_CONTEXT):
+        score += _CONTEXT_NEGATIVE_DELTA
+    return max(0.0, min(1.0, score))
+
+
+def _severity_for(pii_type: str) -> tuple[str, str]:
+    """Return category and severity for a finding type."""
+    if pii_type in {"email", "phone_cn", "credit_card", "cn_id"}:
+        return PiiCategory.PERSONAL_DATA.value, PiiSeverity.WARN.value
+    return PiiCategory.CREDENTIAL.value, PiiSeverity.DENY.value
+
+
+class RegexPiiDetector:
+    """Built-in detector using regexes, validators, and context scoring."""
+
+    name = "regex"
+    engine = "regex_v1"
+
+    def detect(self, text: str) -> list[PiiCandidate]:
+        """Run all regex-backed detectors and return raw candidates."""
+        candidates: list[PiiCandidate] = []
+        self._detect_private_keys(text, candidates)
+        self._detect_bearer_tokens(text, candidates)
+        self._detect_secret_fields(text, candidates)
+        self._detect_api_keys(text, candidates)
+        self._detect_aliyun_access_key_ids(text, candidates)
+        self._detect_jwts(text, candidates)
+        self._detect_credit_cards(text, candidates)
+        self._detect_cn_ids(text, candidates)
+        self._detect_phone_numbers(text, candidates)
+        self._detect_emails(text, candidates)
+        return candidates
+
+    def _add_candidate(
+        self,
+        candidates: list[PiiCandidate],
+        *,
+        pii_type: str,
+        value: str,
+        span: tuple[int, int],
+        confidence: float,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        """Append a candidate with type-derived category and severity."""
+        category, severity = _severity_for(pii_type)
+        candidates.append(
+            PiiCandidate(
+                pii_type=pii_type,
+                category=category,
+                severity=severity,
+                confidence=confidence,
+                value=value,
+                span=span,
+                metadata=metadata or {},
+                detector=self.name,
+                engine=self.engine,
+            )
+        )
+
+    def _detect_private_keys(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _PRIVATE_KEY_RE.finditer(text):
+            span = match.span()
+            if span[1] - span[0] > _MAX_PRIVATE_KEY_CHARS:
+                self._add_candidate(
+                    candidates,
+                    pii_type="private_key",
+                    value=_PRIVATE_KEY_EVIDENCE_PLACEHOLDER,
+                    span=span,
+                    confidence=_BASE_CONFIDENCE["private_key"],
+                    metadata={
+                        "validator": "pem_private_key",
+                        "evidence_omitted": True,
+                    },
+                )
+                continue
+
+            value = match.group(0)
+            self._add_candidate(
+                candidates,
+                pii_type="private_key",
+                value=value,
+                span=span,
+                confidence=_BASE_CONFIDENCE["private_key"],
+                metadata={"validator": "pem_private_key"},
+            )
+
+    def _detect_bearer_tokens(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _BEARER_RE.finditer(text):
+            value = match.group(1)
+            span = match.span(1)
+            self._add_candidate(
+                candidates,
+                pii_type="bearer_token",
+                value=value,
+                span=span,
+                confidence=_score_with_context(
+                    text, *span, _BASE_CONFIDENCE["bearer_token"]
+                ),
+                metadata={"context": "bearer"},
+            )
+
+    def _detect_secret_fields(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _SECRET_FIELD_RE.finditer(text):
+            field_name = match.group("name")
+            value = (
+                match.group("double_value")
+                or match.group("single_value")
+                or match.group("bare_value")
+            )
+            evidence_value = match.group("quoted_value")
+            if value is None:
+                continue
+            if len(value) < 12 and not field_name.lower().startswith("accesskey"):
+                continue
+            normalized_name = field_name.lower().replace("-", "_")
+            compact_name = normalized_name.replace("_", "")
+            if compact_name == "accesskeysecret":
+                pii_type = "aliyun_access_key_secret"
+            elif compact_name in {"apikey", "api_key"}:
+                pii_type = "api_key"
+            else:
+                pii_type = "generic_secret_field"
+            span = match.span("quoted_value")
+            self._add_candidate(
+                candidates,
+                pii_type=pii_type,
+                value=evidence_value,
+                span=span,
+                confidence=_score_with_context(
+                    text, *span, _BASE_CONFIDENCE["generic_secret_field"]
+                ),
+                metadata={"field": field_name},
+            )
+
+    def _detect_api_keys(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _API_KEY_RE.finditer(text):
+            self._add_candidate(
+                candidates,
+                pii_type="api_key",
+                value=match.group(0),
+                span=match.span(),
+                confidence=_score_with_context(
+                    text, *match.span(), _BASE_CONFIDENCE["api_key"]
+                ),
+                metadata={"pattern": "token_prefix"},
+            )
+
+    def _detect_aliyun_access_key_ids(
+        self, text: str, candidates: list[PiiCandidate]
+    ) -> None:
+        for match in _ALIYUN_ACCESS_KEY_ID_RE.finditer(text):
+            self._add_candidate(
+                candidates,
+                pii_type="aliyun_access_key_id",
+                value=match.group(0),
+                span=match.span(),
+                confidence=_score_with_context(
+                    text, *match.span(), _BASE_CONFIDENCE["aliyun_access_key_id"]
+                ),
+            )
+
+    def _detect_jwts(self, text: str, candidates: list[PiiCandidate]) -> None:
+        if text.count(".") < 2:
+            return
+        for match in _JWT_RE.finditer(text):
+            value = match.group(0)
+            if validate_jwt(value):
+                self._add_candidate(
+                    candidates,
+                    pii_type="jwt",
+                    value=value,
+                    span=match.span(),
+                    confidence=_score_with_context(
+                        text, *match.span(), _BASE_CONFIDENCE["jwt"]
+                    ),
+                    metadata={"validator": "jwt_structure"},
+                )
+
+    def _detect_credit_cards(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _CREDIT_CARD_RE.finditer(text):
+            value = match.group(0)
+            if luhn_check(value):
+                self._add_candidate(
+                    candidates,
+                    pii_type="credit_card",
+                    value=value,
+                    span=match.span(),
+                    confidence=_score_with_context(
+                        text, *match.span(), _BASE_CONFIDENCE["credit_card"]
+                    ),
+                    metadata={"validator": "luhn"},
+                )
+
+    def _detect_cn_ids(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _CN_ID_RE.finditer(text):
+            value = match.group(0)
+            if validate_cn_id(value):
+                self._add_candidate(
+                    candidates,
+                    pii_type="cn_id",
+                    value=value,
+                    span=match.span(),
+                    confidence=_score_with_context(
+                        text, *match.span(), _BASE_CONFIDENCE["cn_id"]
+                    ),
+                    metadata={"validator": "cn_id_checksum"},
+                )
+
+    def _detect_phone_numbers(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _PHONE_CN_RE.finditer(text):
+            value = match.group(0)
+            self._add_candidate(
+                candidates,
+                pii_type="phone_cn",
+                value=value,
+                span=match.span(),
+                confidence=_score_with_context(
+                    text, *match.span(), _BASE_CONFIDENCE["phone_cn"]
+                ),
+            )
+
+    def _detect_emails(self, text: str, candidates: list[PiiCandidate]) -> None:
+        for match in _EMAIL_RE.finditer(text):
+            value = match.group(0)
+            base = _BASE_CONFIDENCE["email"]
+            if value.lower().endswith(".invalid"):
+                base = _BASE_CONFIDENCE["email_reserved_invalid"]
+            self._add_candidate(
+                candidates,
+                pii_type="email",
+                value=value,
+                span=match.span(),
+                confidence=_score_with_context(text, *match.span(), base),
+            )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/models.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/models.py
@@ -1,0 +1,85 @@
+"""Data models for the PII checker."""
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Verdict(StrEnum):
+    """Aggregated PII scan verdict."""
+
+    PASS = "pass"
+    WARN = "warn"
+    DENY = "deny"
+    ERROR = "error"
+
+
+class PiiSeverity(StrEnum):
+    """Finding severity used by policy consumers."""
+
+    WARN = "warn"
+    DENY = "deny"
+
+
+class PiiCategory(StrEnum):
+    """High-level finding category."""
+
+    PERSONAL_DATA = "personal_data"
+    CREDENTIAL = "credential"
+
+
+class PiiFinding(BaseModel):
+    """Single PII or credential finding."""
+
+    type: str
+    category: str
+    severity: str
+    confidence: float
+    evidence_redacted: str
+    span: tuple[int, int]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    raw_evidence: str | None = None
+
+    def to_dict(self, *, include_raw_evidence: bool = False) -> dict[str, Any]:
+        """Return the fixed finding schema."""
+        data: dict[str, Any] = {
+            "type": self.type,
+            "category": self.category,
+            "severity": self.severity,
+            "confidence": round(self.confidence, 3),
+            "evidence_redacted": self.evidence_redacted,
+            "span": {"start": self.span[0], "end": self.span[1]},
+            "metadata": dict(self.metadata),
+        }
+        if include_raw_evidence and self.raw_evidence is not None:
+            data["raw_evidence"] = self.raw_evidence
+        return data
+
+
+class PiiScanResult(BaseModel):
+    """Structured PII scan result."""
+
+    ok: bool
+    verdict: str
+    summary: dict[str, Any]
+    findings: list[PiiFinding]
+    elapsed_ms: int
+    include_raw_evidence: bool = False
+    redacted_text: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the fixed public output schema."""
+        data: dict[str, Any] = {
+            "ok": self.ok,
+            "verdict": self.verdict,
+            "summary": dict(self.summary),
+            "findings": [
+                finding.to_dict(include_raw_evidence=self.include_raw_evidence)
+                for finding in self.findings
+            ],
+            "elapsed_ms": self.elapsed_ms,
+        }
+        if self.redacted_text is not None:
+            data["redacted_text"] = self.redacted_text
+        return data

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/redactor.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/redactor.py
@@ -1,0 +1,73 @@
+"""Redaction helpers for PII findings."""
+
+import re
+
+from agent_sec_cli.pii_checker.models import PiiFinding
+
+
+def _mask_middle(value: str, *, prefix: int = 4, suffix: int = 4) -> str:
+    """Keep a short safe prefix/suffix and mask the middle."""
+    if len(value) <= prefix + suffix:
+        return "[REDACTED]"
+    return f"{value[:prefix]}...[REDACTED]...{value[-suffix:]}"
+
+
+def redact_value(value: str, pii_type: str) -> str:
+    """Return a model-safe redaction for a detected value."""
+    if pii_type == "email":
+        local, _, domain = value.partition("@")
+        if not domain:
+            return "[REDACTED_EMAIL]"
+        safe_local = local[:1] + "***" if local else "***"
+        return f"{safe_local}@{domain}"
+
+    if pii_type == "phone_cn":
+        digits = re.sub(r"\D", "", value)
+        if len(digits) >= 11:
+            core = digits[-11:]
+            return f"{core[:3]}****{core[-4:]}"
+        return "[REDACTED_PHONE]"
+
+    if pii_type == "credit_card":
+        digits = re.sub(r"\D", "", value)
+        return (
+            f"[REDACTED_CARD:{digits[-4:]}]" if len(digits) >= 4 else "[REDACTED_CARD]"
+        )
+
+    if pii_type == "cn_id":
+        return (
+            f"{value[:3]}***********{value[-4:]}"
+            if len(value) >= 7
+            else "[REDACTED_CN_ID]"
+        )
+
+    if pii_type == "private_key":
+        return "[REDACTED_PRIVATE_KEY]"
+
+    if pii_type in {
+        "api_key",
+        "bearer_token",
+        "jwt",
+        "aliyun_access_key_id",
+        "aliyun_access_key_secret",
+        "generic_secret_field",
+    }:
+        return _mask_middle(value)
+
+    return "[REDACTED]"
+
+
+def redact_text(text: str, findings: list[PiiFinding]) -> str:
+    """Replace finding spans with their redacted evidence."""
+    redacted = text
+    replaced_spans: list[tuple[int, int]] = []
+    for finding in sorted(findings, key=lambda item: item.span[0], reverse=True):
+        start, end = finding.span
+        if any(
+            start < prior_end and prior_start < end
+            for prior_start, prior_end in replaced_spans
+        ):
+            continue
+        redacted = redacted[:start] + finding.evidence_redacted + redacted[end:]
+        replaced_spans.append((start, end))
+    return redacted

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/scanner.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/scanner.py
@@ -1,0 +1,226 @@
+"""Detector orchestration for the PII checker."""
+
+import time
+from collections import Counter
+from collections.abc import Sequence
+
+from agent_sec_cli.pii_checker.detectors.base import PiiCandidate, PiiDetector
+from agent_sec_cli.pii_checker.detectors.regex import RegexPiiDetector
+from agent_sec_cli.pii_checker.models import (
+    PiiFinding,
+    PiiScanResult,
+    PiiSeverity,
+    Verdict,
+)
+from agent_sec_cli.pii_checker.redactor import redact_text, redact_value
+
+DEFAULT_MAX_BYTES = 1_048_576
+LOW_CONFIDENCE_THRESHOLD = 0.5
+ALLOWED_SOURCES = {"user_input", "tool_output", "manual", "unknown"}
+_MULTI_TYPE_OVERLAPS = {frozenset({"bearer_token", "jwt"})}
+
+
+def _limit_text(text: str, max_bytes: int) -> tuple[str, bool, int]:
+    """Limit text by encoded byte length."""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text, False, len(encoded)
+    trimmed = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return trimmed, True, max_bytes
+
+
+def _aggregate_verdict(findings: list[PiiFinding]) -> str:
+    """Aggregate findings into pass/warn/deny."""
+    if any(finding.severity == PiiSeverity.DENY.value for finding in findings):
+        return Verdict.DENY.value
+    if findings:
+        return Verdict.WARN.value
+    return Verdict.PASS.value
+
+
+def _overlaps(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    """Return whether two spans overlap."""
+    return left[0] < right[1] and right[0] < left[1]
+
+
+def _should_drop_overlapping(candidate: PiiCandidate, existing: PiiCandidate) -> bool:
+    """Return whether an overlapping candidate is redundant."""
+    if not _overlaps(candidate.span, existing.span):
+        return False
+    pair = frozenset({candidate.pii_type, existing.pii_type})
+    if candidate.span == existing.span and pair in _MULTI_TYPE_OVERLAPS:
+        return False
+    return True
+
+
+class PiiScanner:
+    """PII scanner that orchestrates one or more detector implementations."""
+
+    def __init__(self, detectors: Sequence[PiiDetector] | None = None) -> None:
+        """Create a scanner with built-in regex detection unless overridden."""
+        self._detectors = (
+            list(detectors) if detectors is not None else [RegexPiiDetector()]
+        )
+
+    def scan(
+        self,
+        text: str,
+        *,
+        source: str = "unknown",
+        include_low_confidence: bool = False,
+        raw_evidence: bool = False,
+        redact_output: bool = False,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+    ) -> PiiScanResult:
+        """Scan text and return a fixed-schema result."""
+        started = time.perf_counter()
+        normalized_source = source if source in ALLOWED_SOURCES else "unknown"
+        limited_text, truncated, bytes_scanned = _limit_text(text, max_bytes)
+
+        candidates = self._detect(limited_text)
+        findings = self._build_findings(
+            candidates,
+            include_low_confidence=include_low_confidence,
+            raw_evidence=raw_evidence,
+        )
+        verdict = _aggregate_verdict(findings)
+        summary = self._build_summary(
+            findings,
+            source=normalized_source,
+            bytes_scanned=bytes_scanned,
+            truncated=truncated,
+        )
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+        return PiiScanResult(
+            ok=True,
+            verdict=verdict,
+            summary=summary,
+            findings=findings,
+            elapsed_ms=elapsed_ms,
+            include_raw_evidence=raw_evidence,
+            redacted_text=(
+                redact_text(limited_text, findings) if redact_output else None
+            ),
+        )
+
+    def _detect(self, text: str) -> list[PiiCandidate]:
+        """Run configured detectors and return deduplicated raw candidates."""
+        candidates: list[PiiCandidate] = []
+        for detector in self._detectors:
+            detector_name = getattr(detector, "name", "unknown")
+            detector_engine = getattr(detector, "engine", detector_name)
+            for candidate in detector.detect(text):
+                if candidate.detector != "unknown" and candidate.engine != "unknown":
+                    candidates.append(candidate)
+                    continue
+                candidates.append(
+                    candidate.model_copy(
+                        update={
+                            "detector": (
+                                detector_name
+                                if candidate.detector == "unknown"
+                                else candidate.detector
+                            ),
+                            "engine": (
+                                detector_engine
+                                if candidate.engine == "unknown"
+                                else candidate.engine
+                            ),
+                        }
+                    )
+                )
+        return self._dedupe(candidates)
+
+    def _dedupe(self, candidates: list[PiiCandidate]) -> list[PiiCandidate]:
+        """Drop redundant overlaps while preserving meaningful type enrichment."""
+        ordered = sorted(
+            candidates,
+            key=lambda item: (
+                item.severity != PiiSeverity.DENY.value,
+                -item.confidence,
+                item.span[0],
+                -(item.span[1] - item.span[0]),
+            ),
+        )
+        kept: list[PiiCandidate] = []
+        for candidate in ordered:
+            if any(_should_drop_overlapping(candidate, existing) for existing in kept):
+                continue
+            kept.append(candidate)
+        return sorted(kept, key=lambda item: item.span[0])
+
+    def _build_findings(
+        self,
+        candidates: list[PiiCandidate],
+        *,
+        include_low_confidence: bool,
+        raw_evidence: bool,
+    ) -> list[PiiFinding]:
+        """Convert candidates to public findings."""
+        findings: list[PiiFinding] = []
+        for candidate in candidates:
+            if (
+                not include_low_confidence
+                and candidate.confidence < LOW_CONFIDENCE_THRESHOLD
+            ):
+                continue
+            metadata = dict(candidate.metadata)
+            metadata.setdefault("detector", candidate.detector)
+            metadata.setdefault("engine", candidate.engine)
+            findings.append(
+                PiiFinding(
+                    type=candidate.pii_type,
+                    category=candidate.category,
+                    severity=candidate.severity,
+                    confidence=candidate.confidence,
+                    evidence_redacted=redact_value(candidate.value, candidate.pii_type),
+                    span=candidate.span,
+                    metadata=metadata,
+                    raw_evidence=candidate.value if raw_evidence else None,
+                )
+            )
+        return findings
+
+    def _build_summary(
+        self,
+        findings: list[PiiFinding],
+        *,
+        source: str,
+        bytes_scanned: int,
+        truncated: bool,
+    ) -> dict[str, object]:
+        """Build aggregate summary data."""
+        by_type = Counter(finding.type for finding in findings)
+        by_category = Counter(finding.category for finding in findings)
+        by_severity = Counter(finding.severity for finding in findings)
+        return {
+            "total": len(findings),
+            "by_type": dict(sorted(by_type.items())),
+            "by_category": dict(sorted(by_category.items())),
+            "by_severity": dict(sorted(by_severity.items())),
+            "source": source,
+            "bytes_scanned": bytes_scanned,
+            "truncated": truncated,
+        }
+
+
+def scan_text(
+    text: str,
+    *,
+    detectors: Sequence[PiiDetector] | None = None,
+    source: str = "unknown",
+    include_low_confidence: bool = False,
+    raw_evidence: bool = False,
+    redact_output: bool = False,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> PiiScanResult:
+    """Convenience function for one-off scans."""
+    return PiiScanner(detectors=detectors).scan(
+        text,
+        source=source,
+        include_low_confidence=include_low_confidence,
+        raw_evidence=raw_evidence,
+        redact_output=redact_output,
+        max_bytes=max_bytes,
+    )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/validators.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/validators.py
@@ -1,0 +1,70 @@
+"""Validators used to reduce false positives in PII detection."""
+
+import base64
+import binascii
+import re
+from datetime import datetime
+
+
+def luhn_check(value: str) -> bool:
+    """Validate a payment card number with the Luhn checksum."""
+    digits = [int(ch) for ch in re.sub(r"\D", "", value)]
+    if len(digits) < 13 or len(digits) > 19:
+        return False
+
+    total = 0
+    parity = len(digits) % 2
+    for idx, digit in enumerate(digits):
+        current = digit
+        if idx % 2 == parity:
+            current *= 2
+            if current > 9:
+                current -= 9
+        total += current
+    return total % 10 == 0
+
+
+def validate_cn_id(value: str) -> bool:
+    """Validate an 18-digit Chinese Resident Identity Card number."""
+    normalized = value.strip().upper()
+    if not re.fullmatch(r"\d{17}[\dX]", normalized):
+        return False
+
+    birth_date = normalized[6:14]
+    try:
+        datetime.strptime(birth_date, "%Y%m%d")
+    except ValueError:
+        return False
+
+    weights = [7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2]
+    checks = "10X98765432"
+    total = sum(int(normalized[i]) * weights[i] for i in range(17))
+    return normalized[-1] == checks[total % 11]
+
+
+def validate_jwt(value: str) -> bool:
+    """Validate the structural shape of a JWT."""
+    parts = value.split(".")
+    if len(parts) != 3 or not all(parts):
+        return False
+    if not all(re.fullmatch(r"[A-Za-z0-9_-]+", part) for part in parts):
+        return False
+
+    for part in parts[:2]:
+        padded = part + "=" * (-len(part) % 4)
+        try:
+            decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+        except (binascii.Error, ValueError):
+            return False
+        if not decoded.strip():
+            return False
+    return True
+
+
+def validate_pem_private_key(value: str) -> bool:
+    """Validate that a PEM private key has matching BEGIN/END markers."""
+    match = re.search(
+        r"-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]+?-----END \1-----",
+        value.strip(),
+    )
+    return match is not None

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
@@ -42,6 +42,7 @@ def format_summary(events: list[SecurityEvent], time_label: str) -> str:
     code_scan_events = by_category.get("code_scan", [])
     sandbox_events = by_category.get("sandbox", [])
     prompt_scan_events = by_category.get("prompt_scan", [])
+    pii_scan_events = by_category.get("pii_scan", [])
     skill_ledger_events = by_category.get("skill_ledger", [])
 
     if harden_events:
@@ -54,6 +55,8 @@ def format_summary(events: list[SecurityEvent], time_label: str) -> str:
         sections.append(_summarize_sandbox(sandbox_events))
     if prompt_scan_events:
         sections.append(_summarize_prompt_scan(prompt_scan_events))
+    if pii_scan_events:
+        sections.append(_summarize_pii_scan(pii_scan_events))
     if skill_ledger_events:
         sections.append(_summarize_skill_ledger(skill_ledger_events))
 
@@ -67,6 +70,7 @@ def format_summary(events: list[SecurityEvent], time_label: str) -> str:
         harden_events,
         asset_events,
         prompt_scan_events,
+        pii_scan_events,
         ledger_statuses,
         time_label,
     )
@@ -349,6 +353,42 @@ def _summarize_prompt_scan(events: list[SecurityEvent]) -> str:
     return "\n".join(lines)
 
 
+def _summarize_pii_scan(events: list[SecurityEvent]) -> str:
+    """Summarize pii_scan category events."""
+    lines = ["--- PII Scan ---"]
+
+    ok_count = 0
+    verdict_counts: dict[str, int] = defaultdict(int)
+    type_counts: dict[str, int] = defaultdict(int)
+
+    for e in events:
+        if e.result == "succeeded":
+            ok_count += 1
+            result = _get_result(e)
+            verdict_counts[result.get("verdict", "unknown")] += 1
+            summary = result.get("summary", {})
+            by_type = summary.get("by_type", {}) if isinstance(summary, dict) else {}
+            if isinstance(by_type, dict):
+                for pii_type, count in by_type.items():
+                    if isinstance(count, int):
+                        type_counts[str(pii_type)] += count
+
+    fail_count = len(events) - ok_count
+    lines.append(
+        f"  Scans performed: {len(events)} (succeeded: {ok_count}, failed: {fail_count})"
+    )
+
+    if verdict_counts:
+        parts = [f"{v}: {c}" for v, c in sorted(verdict_counts.items())]
+        lines.append(f"  Verdict breakdown: {', '.join(parts)}")
+
+    if type_counts:
+        parts = [f"{t}: {c}" for t, c in sorted(type_counts.items())]
+        lines.append(f"  Finding types: {', '.join(parts)}")
+
+    return "\n".join(lines)
+
+
 def _summarize_skill_ledger(events: list[SecurityEvent]) -> str:
     """Summarize skill_ledger category events.
 
@@ -473,6 +513,7 @@ def _compute_posture(
     hardening_events: list[SecurityEvent],
     verify_events: list[SecurityEvent],
     prompt_scan_events: list[SecurityEvent],
+    pii_scan_events: list[SecurityEvent],
     ledger_statuses: dict[str, int],
     time_label: str,
 ) -> str:
@@ -513,6 +554,14 @@ def _compute_posture(
 
     # --- Prompt Scan (any DENY verdict) ---
     for e in prompt_scan_events:
+        if e.result == "succeeded":
+            result = _get_result(e)
+            if result.get("verdict") == "deny":
+                needs_attention = True
+                break
+
+    # --- PII Scan (any DENY verdict) ---
+    for e in pii_scan_events:
         if e.result == "succeeded":
             result = _get_result(e)
             if result.get("verdict") == "deny":

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
@@ -54,8 +54,9 @@ def invoke(action: str, **kwargs: Any) -> ActionResult:
     """Sole public entry point for all security capabilities.
 
     1. Builds a :class:`RequestContext` (auto ``trace_id``, ``timestamp``).
-    2. Calls ``pre_action`` (no-op under the single-event model).
-    3. Routes to the appropriate backend and calls ``execute(ctx, **kwargs)``.
+    2. Routes to the appropriate backend.
+    3. Calls ``pre_action`` (no-op under the single-event model), then
+       ``execute(ctx, **kwargs)``.
     4. Logs a single ``<action>`` completion event (post-hook) with
        ``result="succeeded"``, or logs the same event type with
        ``result="failed"`` on failure (on_error). Each event contains both
@@ -67,16 +68,17 @@ def invoke(action: str, **kwargs: Any) -> ActionResult:
     # TODO: inherit trace_id and session_id from parent context, if any
     ctx = RequestContext(action=action, caller=_detect_caller())
 
+    backend = router.get_backend(action)
+
     lifecycle.pre_action(ctx, kwargs)
 
     try:
-        backend = router.get_backend(action)
         result = backend.execute(ctx, **kwargs)
     except Exception as exc:
-        lifecycle.on_error(ctx, exc, kwargs)
+        lifecycle.on_error(ctx, exc, kwargs, backend)
         raise
 
-    lifecycle.post_action(ctx, result, kwargs)
+    lifecycle.post_action(ctx, result, kwargs, backend)
     return result
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/base.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/base.py
@@ -1,5 +1,6 @@
 """Abstract base class for all security middleware backends."""
 
+import copy
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -14,3 +15,22 @@ class BaseBackend(ABC):
     def execute(self, ctx: RequestContext, **kwargs: Any) -> ActionResult:
         """Execute the backend action and return a unified ActionResult."""
         pass
+
+    def build_event_details(
+        self, result: ActionResult, kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build success audit details for the lifecycle event."""
+        return {
+            "request": copy.deepcopy(kwargs),
+            "result": copy.deepcopy(result.data),
+        }
+
+    def build_error_details(
+        self, exception: Exception, kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build failure audit details for the lifecycle event."""
+        return {
+            "request": copy.deepcopy(kwargs),
+            "error": str(exception),
+            "error_type": type(exception).__name__,
+        }

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/pii_scan.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/pii_scan.py
@@ -1,0 +1,122 @@
+"""PII scan backend."""
+
+import json
+from typing import Any
+
+from agent_sec_cli.pii_checker import audit as pii_audit
+from agent_sec_cli.pii_checker.models import PiiScanResult, Verdict
+from agent_sec_cli.pii_checker.scanner import DEFAULT_MAX_BYTES, PiiScanner
+from agent_sec_cli.security_middleware.backends.base import BaseBackend
+from agent_sec_cli.security_middleware.context import RequestContext
+from agent_sec_cli.security_middleware.result import ActionResult
+
+
+def _error_result(message: str, *, error_type: str = "PiiScanError") -> PiiScanResult:
+    """Build a fixed-schema error result."""
+    return PiiScanResult(
+        ok=False,
+        verdict=Verdict.ERROR.value,
+        summary={
+            "total": 0,
+            "by_type": {},
+            "by_category": {},
+            "by_severity": {},
+            "source": "unknown",
+            "bytes_scanned": 0,
+            "truncated": False,
+            "error": message,
+            "error_type": error_type,
+        },
+        findings=[],
+        elapsed_ms=0,
+    )
+
+
+class PiiScanBackend(BaseBackend):
+    """Scan text for PII and credentials."""
+
+    def execute(self, ctx: RequestContext, **kwargs: Any) -> ActionResult:
+        text = kwargs.get("text", "")
+        if text is None:
+            text = ""
+        if not isinstance(text, str):
+            return self._to_action_result(
+                _error_result(
+                    "pii_scan error: text must be a string",
+                    error_type="TypeError",
+                )
+            )
+
+        source = str(kwargs.get("source", "unknown"))
+        include_low_confidence = bool(kwargs.get("include_low_confidence", False))
+        raw_evidence = bool(kwargs.get("raw_evidence", False))
+        redact_output = bool(kwargs.get("redact_output", False))
+        try:
+            max_bytes = int(kwargs.get("max_bytes", DEFAULT_MAX_BYTES))
+        except (TypeError, ValueError) as exc:
+            return self._to_action_result(
+                _error_result(
+                    "pii_scan error: max_bytes must be an integer",
+                    error_type=type(exc).__name__,
+                )
+            )
+        input_truncated = bool(kwargs.get("input_truncated", False))
+        input_bytes_scanned = kwargs.get("input_bytes_scanned")
+        if input_bytes_scanned is not None:
+            try:
+                input_bytes_scanned = int(input_bytes_scanned)
+            except (TypeError, ValueError):
+                input_bytes_scanned = None
+
+        if max_bytes <= 0:
+            return self._to_action_result(
+                _error_result(
+                    "pii_scan error: max_bytes must be greater than zero",
+                    error_type="ValueError",
+                )
+            )
+
+        try:
+            result = PiiScanner().scan(
+                text,
+                source=source,
+                include_low_confidence=include_low_confidence,
+                raw_evidence=raw_evidence,
+                redact_output=redact_output,
+                max_bytes=max_bytes,
+            )
+            if input_truncated:
+                result.summary["truncated"] = True
+                if input_bytes_scanned is not None and input_bytes_scanned >= 0:
+                    result.summary["bytes_scanned"] = input_bytes_scanned
+        except Exception as exc:  # noqa: BLE001
+            result = _error_result(
+                f"pii_scan error: {exc}",
+                error_type=type(exc).__name__,
+            )
+
+        return self._to_action_result(result)
+
+    def _to_action_result(self, result: PiiScanResult) -> ActionResult:
+        """Convert scanner output to middleware ActionResult."""
+        data = result.to_dict()
+        is_error = result.verdict == Verdict.ERROR.value
+        return ActionResult(
+            success=not is_error,
+            data=data,
+            stdout=json.dumps(data, indent=2, ensure_ascii=False),
+            error="" if not is_error else str(result.summary.get("error", "")),
+            exit_code=1 if is_error else 0,
+        )
+
+    def build_event_details(
+        self, result: ActionResult, kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build sanitized pii_scan success audit details."""
+        return pii_audit.build_audit_details(result.data, kwargs)
+
+    def build_error_details(
+        self, exception: Exception, kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build sanitized pii_scan failure audit details."""
+        return pii_audit.build_error_audit_details(exception, kwargs)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
@@ -1,9 +1,9 @@
 """Lifecycle hooks — transparent pre/post/error logging via security_events."""
 
-import copy
 from typing import Any
 
 from agent_sec_cli.security_events import SecurityEvent, log_event
+from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
 
@@ -18,6 +18,7 @@ _ACTION_CATEGORY: dict[str, str] = {
     "summary": "summary",
     "code_scan": "code_scan",
     "prompt_scan": "prompt_scan",
+    "pii_scan": "pii_scan",
     "skill_ledger": "skill_ledger",
 }
 
@@ -44,7 +45,10 @@ def pre_action(ctx: RequestContext, kwargs: dict[str, Any]) -> None:
 
 
 def post_action(
-    ctx: RequestContext, result: ActionResult, kwargs: dict[str, Any]
+    ctx: RequestContext,
+    result: ActionResult,
+    kwargs: dict[str, Any],
+    backend: BaseBackend,
 ) -> None:
     """Log the single completion event after the backend completes.
 
@@ -52,10 +56,7 @@ def post_action(
     single event so the full request/response context is captured in one record.
     """
     try:
-        details: dict[str, Any] = {
-            "request": copy.deepcopy(kwargs),
-            "result": copy.deepcopy(result.data),
-        }
+        details = backend.build_event_details(result, kwargs)
         event = SecurityEvent(
             event_type=ctx.action,
             category=_category_for(ctx.action),
@@ -68,18 +69,19 @@ def post_action(
         pass
 
 
-def on_error(ctx: RequestContext, exception: Exception, kwargs: dict[str, Any]) -> None:
+def on_error(
+    ctx: RequestContext,
+    exception: Exception,
+    kwargs: dict[str, Any],
+    backend: BaseBackend,
+) -> None:
     """Log the single error event when the backend raises.
 
     Merges *kwargs* (request inputs) and error details into a single event so
     the full request context is captured alongside the failure.
     """
     try:
-        details: dict[str, Any] = {
-            "request": copy.deepcopy(kwargs),
-            "error": str(exception),
-            "error_type": type(exception).__name__,
-        }
+        details = backend.build_error_details(exception, kwargs)
         event = SecurityEvent(
             event_type=ctx.action,
             category=_category_for(ctx.action),

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/router.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/router.py
@@ -9,6 +9,7 @@ from agent_sec_cli.security_middleware.backends.code_scan import CodeScanBackend
 from agent_sec_cli.security_middleware.backends.hardening import (
     HardeningBackend,
 )
+from agent_sec_cli.security_middleware.backends.pii_scan import PiiScanBackend
 from agent_sec_cli.security_middleware.backends.prompt_scan import (
     PromptScanBackend,
 )
@@ -29,6 +30,7 @@ _BACKEND_CLASSES: dict[str, type] = {
     "summary": SummaryBackend,
     "code_scan": CodeScanBackend,
     "prompt_scan": PromptScanBackend,
+    "pii_scan": PiiScanBackend,
     "skill_ledger": SkillLedgerBackend,
 }
 

--- a/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
@@ -1,0 +1,189 @@
+"""Self-contained e2e tests for the scan-pii CLI."""
+
+import json
+import os
+import subprocess
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MODES = ("binary", "module")
+
+
+def _module_mode_available() -> bool:
+    try:
+        return find_spec("agent_sec_cli") is not None and (
+            find_spec("agent_sec_cli.cli") is not None
+        )
+    except ModuleNotFoundError:
+        return False
+
+
+def _command(mode: str) -> list[str]:
+    if mode == "binary":
+        return ["agent-sec-cli"]
+    if mode == "module":
+        if not _module_mode_available():
+            pytest.skip(
+                "module mode requires agent_sec_cli importable by this Python; "
+                "RPM e2e validates the installed agent-sec-cli binary"
+            )
+        return [sys.executable, "-m", "agent_sec_cli.cli"]
+    raise AssertionError(f"unknown CLI mode: {mode}")
+
+
+def _run_cli(
+    mode: str,
+    *args: str,
+    data_dir: Path,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["AGENT_SEC_DATA_DIR"] = str(data_dir)
+    try:
+        return subprocess.run(
+            [*_command(mode), *args],
+            capture_output=True,
+            text=True,
+            input=input_text,
+            check=False,
+            timeout=30,
+            env=env,
+        )
+    except FileNotFoundError as exc:
+        raise AssertionError("agent-sec-cli binary not found on PATH") from exc
+
+
+def _load_json(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert isinstance(data, dict)
+    return data
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_scan_pii_text_json(mode: str, tmp_path: Path) -> None:
+    result = _run_cli(
+        mode,
+        "scan-pii",
+        "--text",
+        "Contact alice@securecorp.cn for help.",
+        "--source",
+        "manual",
+        "--format",
+        "json",
+        data_dir=tmp_path / mode / "text-json",
+    )
+    data = _load_json(result)
+
+    assert data["ok"] is True
+    assert data["verdict"] == "warn"
+    assert data["summary"]["source"] == "manual"
+    assert any(finding["type"] == "email" for finding in data["findings"])
+    assert "redacted_text" not in data
+    assert all("raw_evidence" not in finding for finding in data["findings"])
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_scan_pii_input_file_json(mode: str, tmp_path: Path) -> None:
+    input_path = tmp_path / mode / "input.txt"
+    input_path.parent.mkdir(parents=True, exist_ok=True)
+    input_path.write_text("Phone: 13800138000\n", encoding="utf-8")
+
+    result = _run_cli(
+        mode,
+        "scan-pii",
+        "--input",
+        str(input_path),
+        "--source",
+        "manual",
+        "--format",
+        "json",
+        data_dir=tmp_path / mode / "input-json",
+    )
+    data = _load_json(result)
+
+    assert data["ok"] is True
+    assert data["verdict"] == "warn"
+    assert any(finding["type"] == "phone_cn" for finding in data["findings"])
+    assert all("raw_evidence" not in finding for finding in data["findings"])
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_scan_pii_redact_output_adds_redacted_text(mode: str, tmp_path: Path) -> None:
+    secret = "password=supersecretvalue12345"
+    result = _run_cli(
+        mode,
+        "scan-pii",
+        "--text",
+        secret,
+        "--source",
+        "manual",
+        "--format",
+        "json",
+        "--redact-output",
+        data_dir=tmp_path / mode / "redact-output",
+    )
+    data = _load_json(result)
+
+    assert data["verdict"] == "deny"
+    assert "redacted_text" in data
+    assert "supersecretvalue12345" not in data["redacted_text"]
+    assert "password=" in data["redacted_text"]
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_scan_pii_raw_evidence_stays_out_of_security_events(
+    mode: str, tmp_path: Path
+) -> None:
+    token = "abcdefghijklmnopqrstuvwx12345678"
+    text = f"Authorization: Bearer {token}"
+    data_dir = tmp_path / mode / "events-sanitized"
+
+    scan_result = _run_cli(
+        mode,
+        "scan-pii",
+        "--text",
+        text,
+        "--source",
+        "tool_output",
+        "--format",
+        "json",
+        "--raw-evidence",
+        "--redact-output",
+        data_dir=data_dir,
+    )
+    scan_data = _load_json(scan_result)
+    assert any("raw_evidence" in finding for finding in scan_data["findings"])
+
+    events_result = _run_cli(
+        mode,
+        "events",
+        "--category",
+        "pii_scan",
+        "--output",
+        "json",
+        data_dir=data_dir,
+    )
+    assert events_result.returncode == 0, events_result.stderr
+    events = json.loads(events_result.stdout)
+    assert isinstance(events, list)
+    assert len(events) == 1
+
+    event = events[0]
+    details = event["details"]
+    details_text = json.dumps(details, ensure_ascii=False)
+    assert event["category"] == "pii_scan"
+    assert details["request"]["source"] == "tool_output"
+    assert "text" not in details["request"]
+    assert "text_sha256" in details["request"]
+    assert "redacted_text" not in details["result"]
+    assert all(
+        "raw_evidence" not in finding for finding in details["result"]["findings"]
+    )
+    assert text not in details_text
+    assert token not in details_text

--- a/src/agent-sec-core/tests/unit-test/pii_checker/__init__.py
+++ b/src/agent-sec-core/tests/unit-test/pii_checker/__init__.py
@@ -1,0 +1,1 @@
+"""PII checker tests."""

--- a/src/agent-sec-core/tests/unit-test/pii_checker/test_scanner.py
+++ b/src/agent-sec-core/tests/unit-test/pii_checker/test_scanner.py
@@ -1,0 +1,213 @@
+"""Unit tests for the PII scanner."""
+
+from agent_sec_cli.pii_checker.detectors.base import PiiCandidate
+from agent_sec_cli.pii_checker.scanner import DEFAULT_MAX_BYTES, PiiScanner
+
+
+def _scan(text: str, **kwargs):
+    return PiiScanner().scan(text, **kwargs).to_dict()
+
+
+def _types(result: dict) -> set[str]:
+    return {finding["type"] for finding in result["findings"]}
+
+
+def test_pass_when_no_findings():
+    result = _scan("hello world")
+    assert result["ok"] is True
+    assert result["verdict"] == "pass"
+    assert result["findings"] == []
+
+
+def test_personal_data_findings_are_warn():
+    result = _scan(
+        "Contact alice@company.cn, 13800138000, id 11010519491231002X, card 4111111111111111."
+    )
+    assert result["verdict"] == "warn"
+    assert {"email", "phone_cn", "cn_id", "credit_card"}.issubset(_types(result))
+    assert {finding["severity"] for finding in result["findings"]} == {"warn"}
+
+
+def test_cn_id_with_lowercase_x_is_detected():
+    result = _scan("id 11010519491231002x")
+
+    assert result["verdict"] == "warn"
+    assert "cn_id" in _types(result)
+
+
+def test_credentials_are_deny():
+    token = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+    result = _scan(
+        "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456\n"
+        f"jwt={token}\n"
+        "api_key=sk-abcdefghijklmnopqrstuvwxyz123456\n"
+        "accessKeySecret=abcdefghijklmnopqrstuvwxyz123456\n"
+        "id=LTAI5tQnKxExampleToken12"
+    )
+    assert result["verdict"] == "deny"
+    assert {"bearer_token", "jwt", "api_key", "aliyun_access_key_secret"}.issubset(
+        _types(result)
+    )
+
+
+def test_bearer_jwt_preserves_both_types():
+    token = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+    result = _scan(f"Authorization: Bearer {token}", redact_output=True)
+
+    assert {"bearer_token", "jwt"}.issubset(_types(result))
+    assert result["summary"]["by_type"]["bearer_token"] == 1
+    assert result["summary"]["by_type"]["jwt"] == 1
+    assert token not in result["redacted_text"]
+
+
+def test_chinese_secret_field_is_detected_with_high_confidence():
+    result = _scan("密码=abcdefghijklmnopqrstuvwxyz123456")
+
+    assert result["verdict"] == "deny"
+    assert result["findings"][0]["type"] == "generic_secret_field"
+    assert result["findings"][0]["confidence"] >= 0.9
+    assert result["findings"][0]["metadata"]["detector"] == "regex"
+    assert result["findings"][0]["metadata"]["engine"] == "regex_v1"
+
+
+def test_custom_detector_can_be_injected():
+    class LocalModelDetector:
+        name = "local_model"
+        engine = "tiny_pii_v0"
+
+        def detect(self, text: str):
+            start = text.index("bob@example.com")
+            return [
+                PiiCandidate(
+                    pii_type="email",
+                    category="personal_data",
+                    severity="warn",
+                    confidence=0.99,
+                    value="bob@example.com",
+                    span=(start, start + len("bob@example.com")),
+                    metadata={"model": "tiny-pii"},
+                )
+            ]
+
+    result = (
+        PiiScanner(detectors=[LocalModelDetector()])
+        .scan("contact bob@example.com")
+        .to_dict()
+    )
+
+    assert result["verdict"] == "warn"
+    assert result["findings"][0]["type"] == "email"
+    assert result["findings"][0]["metadata"]["detector"] == "local_model"
+    assert result["findings"][0]["metadata"]["engine"] == "tiny_pii_v0"
+    assert result["findings"][0]["metadata"]["model"] == "tiny-pii"
+
+
+def test_private_key_detected_and_redacted():
+    pem = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0testbody
+-----END RSA PRIVATE KEY-----"""
+    result = _scan(pem, redact_output=True)
+    assert result["verdict"] == "deny"
+    assert result["findings"][0]["type"] == "private_key"
+    assert result["redacted_text"] == "[REDACTED_PRIVATE_KEY]"
+
+
+def test_large_private_key_omits_raw_candidate_value():
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        + ("A" * 20_000)
+        + "\n-----END RSA PRIVATE KEY-----"
+    )
+    result = _scan(pem, raw_evidence=True)
+    finding = result["findings"][0]
+
+    assert finding["type"] == "private_key"
+    assert finding["raw_evidence"] == "[PRIVATE_KEY_OMITTED]"
+    assert finding["metadata"]["evidence_omitted"] is True
+    assert "A" * 100 not in finding["raw_evidence"]
+
+
+def test_low_confidence_hidden_by_default_and_included_on_request():
+    hidden = _scan("example email test@example.invalid")
+    shown = _scan("example email test@example.invalid", include_low_confidence=True)
+
+    assert hidden["verdict"] == "pass"
+    assert hidden["findings"] == []
+    assert shown["verdict"] == "warn"
+    assert shown["findings"][0]["type"] == "email"
+
+
+def test_raw_evidence_default_off_and_opt_in():
+    text = "email alice@company.cn"
+    default = _scan(text)
+    raw = _scan(text, raw_evidence=True)
+
+    assert "raw_evidence" not in default["findings"][0]
+    assert raw["findings"][0]["raw_evidence"] == "alice@company.cn"
+
+
+def test_redacted_text_keeps_structure_without_sensitive_values():
+    secret = "password=supersecretvalue12345"
+    result = _scan(secret, redact_output=True, raw_evidence=True)
+
+    assert "password=" in result["redacted_text"]
+    assert "supersecretvalue12345" not in result["redacted_text"]
+    assert "supersecretvalue12345" in result["findings"][0]["raw_evidence"]
+
+
+def test_quoted_secret_span_keeps_quote_boundaries_balanced():
+    secret = 'password="supersecretvalue12345"'
+    result = _scan(secret, redact_output=True, raw_evidence=True)
+    finding = result["findings"][0]
+    span = finding["span"]
+
+    assert secret[span["start"] : span["end"]] == '"supersecretvalue12345"'
+    assert result["redacted_text"].startswith('password="')
+    assert result["redacted_text"].endswith('"')
+    assert "supersecretvalue12345" not in result["redacted_text"]
+
+
+def test_max_bytes_truncates_input():
+    result = _scan("alice@example.com trailing", max_bytes=5)
+    assert result["summary"]["truncated"] is True
+    assert result["verdict"] == "pass"
+
+
+def test_multibyte_truncation_boundary_is_safe():
+    max_bytes = len("备注".encode("utf-8")) + 1
+    result = _scan("备注🙂 alice@example.com", max_bytes=max_bytes, redact_output=True)
+
+    assert result["summary"]["truncated"] is True
+    assert result["summary"]["bytes_scanned"] == max_bytes
+    assert result["verdict"] == "pass"
+    assert result["redacted_text"] == "备注"
+
+
+def test_large_input_near_default_limit_scans_tail():
+    email = "alice@company.cn"
+    padding = "x" * (DEFAULT_MAX_BYTES - len(email.encode("utf-8")) - 1)
+    result = _scan(f"{padding} {email}")
+
+    assert result["summary"]["truncated"] is False
+    assert result["summary"]["bytes_scanned"] == DEFAULT_MAX_BYTES
+    assert "email" in _types(result)
+
+
+def test_malformed_private_key_stress_does_not_backtrack_slowly():
+    text = (
+        "-----BEGIN RSA PRIVATE KEY-----"
+        + ("A" * 10_000)
+        + "-----END EC PRIVATE KEY-----"
+    )
+
+    result = _scan(text)
+
+    assert "private_key" not in _types(result)

--- a/src/agent-sec-core/tests/unit-test/pii_checker/test_validators.py
+++ b/src/agent-sec-core/tests/unit-test/pii_checker/test_validators.py
@@ -1,0 +1,59 @@
+"""Unit tests for pii_checker validators."""
+
+from agent_sec_cli.pii_checker.validators import (
+    luhn_check,
+    validate_cn_id,
+    validate_jwt,
+    validate_pem_private_key,
+)
+
+
+def test_luhn_valid_card():
+    assert luhn_check("4111 1111 1111 1111")
+
+
+def test_luhn_invalid_card():
+    assert not luhn_check("4111 1111 1111 1112")
+
+
+def test_cn_id_valid_checksum_and_date():
+    assert validate_cn_id("11010519491231002X")
+
+
+def test_cn_id_accepts_lowercase_x_checksum():
+    assert validate_cn_id("11010519491231002x")
+
+
+def test_cn_id_invalid_date():
+    assert not validate_cn_id("11010519490231002X")
+
+
+def test_cn_id_invalid_checksum():
+    assert not validate_cn_id("110105194912310021")
+
+
+def test_jwt_valid_structure():
+    token = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+    assert validate_jwt(token)
+
+
+def test_jwt_invalid_structure():
+    assert not validate_jwt("not.a.jwt")
+
+
+def test_pem_private_key_matching_markers():
+    pem = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0testbody
+-----END RSA PRIVATE KEY-----"""
+    assert validate_pem_private_key(pem)
+
+
+def test_pem_private_key_mismatched_markers():
+    pem = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0testbody
+-----END EC PRIVATE KEY-----"""
+    assert not validate_pem_private_key(pem)

--- a/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
@@ -1487,3 +1487,40 @@ class TestSkillLedgerMixed:
         harden_pos = output.index("--- Hardening ---")
         ledger_pos = output.index("--- Skill Ledger ---")
         assert harden_pos < ledger_pos
+
+
+# ---------------------------------------------------------------------------
+# Test: pii_scan summary
+# ---------------------------------------------------------------------------
+
+
+class TestPiiScanSummary:
+    def test_pii_scan_section_and_deny_posture(self):
+        events = [
+            _make_event(
+                event_type="pii_scan",
+                category="pii_scan",
+                result="succeeded",
+                details={
+                    "request": {"source": "tool_output", "text_length": 32},
+                    "result": {
+                        "ok": True,
+                        "verdict": "deny",
+                        "summary": {
+                            "total": 1,
+                            "by_type": {"api_key": 1},
+                            "by_category": {"credential": 1},
+                            "by_severity": {"deny": 1},
+                        },
+                        "findings": [],
+                    },
+                },
+            )
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert "System Status: Needs attention" in output
+        assert "--- PII Scan ---" in output
+        assert "Verdict breakdown: deny: 1" in output
+        assert "Finding types: api_key: 1" in output

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_pii_scan_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_pii_scan_backend.py
@@ -1,0 +1,113 @@
+"""Unit tests for security_middleware.backends.pii_scan."""
+
+import json
+
+from agent_sec_cli.security_middleware.backends.pii_scan import PiiScanBackend
+from agent_sec_cli.security_middleware.context import RequestContext
+
+
+def test_backend_returns_json_result():
+    backend = PiiScanBackend()
+    result = backend.execute(
+        RequestContext(action="pii_scan"),
+        text="email alice@company.cn",
+        source="manual",
+    )
+
+    assert result.success is True
+    assert result.exit_code == 0
+    parsed = json.loads(result.stdout)
+    assert parsed == result.data
+    assert parsed["verdict"] == "warn"
+
+
+def test_backend_redact_output():
+    backend = PiiScanBackend()
+    result = backend.execute(
+        RequestContext(action="pii_scan"),
+        text="password=supersecretvalue12345",
+        redact_output=True,
+    )
+
+    assert result.data["verdict"] == "deny"
+    assert "redacted_text" in result.data
+    assert "supersecretvalue12345" not in result.data["redacted_text"]
+
+
+def test_backend_rejects_invalid_max_bytes():
+    backend = PiiScanBackend()
+    result = backend.execute(RequestContext(action="pii_scan"), text="x", max_bytes=0)
+
+    assert result.success is False
+    assert result.exit_code == 1
+    assert result.data["verdict"] == "error"
+    assert result.data["summary"]["error_type"] == "ValueError"
+
+
+def test_backend_rejects_non_integer_max_bytes():
+    backend = PiiScanBackend()
+    result = backend.execute(
+        RequestContext(action="pii_scan"),
+        text="x",
+        max_bytes="not-an-int",
+    )
+
+    assert result.success is False
+    assert result.exit_code == 1
+    assert result.data["summary"]["error_type"] == "ValueError"
+
+
+def test_backend_error_preserves_error_type_without_traceback(monkeypatch):
+    def fail_scan(self, text, **kwargs):
+        raise RuntimeError("scanner failed")
+
+    monkeypatch.setattr(
+        "agent_sec_cli.security_middleware.backends.pii_scan.PiiScanner.scan",
+        fail_scan,
+    )
+
+    backend = PiiScanBackend()
+    result = backend.execute(RequestContext(action="pii_scan"), text="hello")
+
+    assert result.success is False
+    assert result.exit_code == 1
+    assert result.data["summary"]["error_type"] == "RuntimeError"
+    assert result.error == "pii_scan error: scanner failed"
+    assert "Traceback" not in result.stdout
+
+
+def test_backend_audit_details_omit_exception_text_with_input(monkeypatch):
+    sensitive = "alice@example.com"
+
+    def fail_scan(self, text, **kwargs):
+        raise RuntimeError(f"scanner failed on {sensitive}")
+
+    monkeypatch.setattr(
+        "agent_sec_cli.security_middleware.backends.pii_scan.PiiScanner.scan",
+        fail_scan,
+    )
+
+    backend = PiiScanBackend()
+    result = backend.execute(RequestContext(action="pii_scan"), text=sensitive)
+    details = backend.build_event_details(result, {"text": sensitive})
+    details_text = json.dumps(details, ensure_ascii=False)
+
+    assert sensitive not in details_text
+    assert details["result"]["summary"]["error"] == (
+        "pii_scan error details omitted from audit"
+    )
+    assert details["result"]["summary"]["error_type"] == "RuntimeError"
+
+
+def test_backend_error_audit_details_omit_exception_text_with_input():
+    sensitive = "alice@example.com"
+    backend = PiiScanBackend()
+    details = backend.build_error_details(
+        RuntimeError(f"router failed on {sensitive}"),
+        {"text": sensitive},
+    )
+    details_text = json.dumps(details, ensure_ascii=False)
+
+    assert sensitive not in details_text
+    assert details["error"] == "pii_scan error details omitted from audit"
+    assert details["error_type"] == "RuntimeError"

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -1,8 +1,11 @@
 """Unit tests for security_middleware.lifecycle — pre/post/error hooks."""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import patch
 
+from agent_sec_cli.security_middleware.backends.base import BaseBackend
+from agent_sec_cli.security_middleware.backends.pii_scan import PiiScanBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.lifecycle import (
     _category_for,
@@ -11,6 +14,11 @@ from agent_sec_cli.security_middleware.lifecycle import (
     pre_action,
 )
 from agent_sec_cli.security_middleware.result import ActionResult
+
+
+class DummyBackend(BaseBackend):
+    def execute(self, ctx: RequestContext, **kwargs: Any) -> ActionResult:
+        return ActionResult(success=True, data={})
 
 
 class TestCategoryMapping(unittest.TestCase):
@@ -25,6 +33,9 @@ class TestCategoryMapping(unittest.TestCase):
 
     def test_summary_maps_to_summary(self):
         self.assertEqual(_category_for("summary"), "summary")
+
+    def test_pii_scan_maps_to_pii_scan(self):
+        self.assertEqual(_category_for("pii_scan"), "pii_scan")
 
     def test_unknown_action_falls_back_to_action_name(self):
         self.assertEqual(_category_for("custom_thing"), "custom_thing")
@@ -43,7 +54,7 @@ class TestPostAction(unittest.TestCase):
     def test_post_action_logs_event(self, mock_log):
         ctx = RequestContext(action="harden", trace_id="t-123")
         result = ActionResult(success=True, data={"passed": 5})
-        post_action(ctx, result, {"mode": "scan"})
+        post_action(ctx, result, {"mode": "scan"}, DummyBackend())
 
         mock_log.assert_called_once()
         event = mock_log.call_args[0][0]
@@ -53,13 +64,61 @@ class TestPostAction(unittest.TestCase):
         self.assertIn("request", event.details)
         self.assertIn("result", event.details)
 
+    @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
+    def test_pii_scan_event_redacts_request_and_result(self, mock_log):
+        ctx = RequestContext(action="pii_scan", trace_id="t-pii")
+        result = ActionResult(
+            success=True,
+            data={
+                "ok": True,
+                "verdict": "deny",
+                "summary": {"total": 1},
+                "findings": [
+                    {
+                        "type": "api_key",
+                        "category": "credential",
+                        "severity": "deny",
+                        "confidence": 0.99,
+                        "evidence_redacted": "sk-a...[REDACTED]...7890",
+                        "span": {"start": 8, "end": 40},
+                        "metadata": {"field": "api_key"},
+                        "raw_evidence": "sk-abcdefghijklmnopqrstuvwxyz7890",
+                    }
+                ],
+                "redacted_text": "api_key=sk-a...[REDACTED]...7890",
+                "elapsed_ms": 1,
+            },
+        )
+        post_action(
+            ctx,
+            result,
+            {
+                "text": "api_key=sk-abcdefghijklmnopqrstuvwxyz7890",
+                "source": "manual",
+                "raw_evidence": True,
+            },
+            PiiScanBackend(),
+        )
+
+        event = mock_log.call_args[0][0]
+        details = event.details
+        self.assertNotIn("text", details["request"])
+        self.assertEqual(details["request"]["source"], "manual")
+        self.assertIn("text_sha256", details["request"])
+        self.assertNotIn("redacted_text", details["result"])
+        self.assertNotIn("raw_evidence", details["result"]["findings"][0])
+        self.assertNotIn(
+            "sk-abcdefghijklmnopqrstuvwxyz7890",
+            str(details),
+        )
+
 
 class TestOnError(unittest.TestCase):
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_on_error_logs_event(self, mock_log):
         ctx = RequestContext(action="verify", trace_id="t-456")
         exc = RuntimeError("test error")
-        on_error(ctx, exc, {"skill": "/path"})
+        on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
 
         mock_log.assert_called_once()
         event = mock_log.call_args[0][0]
@@ -69,6 +128,21 @@ class TestOnError(unittest.TestCase):
         self.assertIn("error", event.details)
         self.assertEqual(event.details["error"], "test error")
         self.assertEqual(event.details["error_type"], "RuntimeError")
+
+    @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
+    def test_pii_scan_error_redacts_request(self, mock_log):
+        ctx = RequestContext(action="pii_scan", trace_id="t-pii-error")
+        exc = RuntimeError("boom")
+        on_error(
+            ctx,
+            exc,
+            {"text": "alice@example.com", "source": "user_input"},
+            PiiScanBackend(),
+        )
+
+        event = mock_log.call_args[0][0]
+        self.assertNotIn("text", event.details["request"])
+        self.assertNotIn("alice@example.com", str(event.details))
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_router.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_router.py
@@ -25,6 +25,7 @@ def test_all_registered_actions_work():
         "summary",
         "code_scan",
         "prompt_scan",
+        "pii_scan",
         "skill_ledger",
     ]
     for action in actions:

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -1,6 +1,7 @@
 """Unit tests for the top-level CLI entry points."""
 
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from agent_sec_cli.cli import app
@@ -129,6 +130,118 @@ class TestHardenCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, "seharden help\n")
         mock_invoke.assert_called_once_with("harden", args=["--help"])
+
+
+class TestScanPiiCli(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch("agent_sec_cli.pii_checker.cli.invoke")
+    def test_scan_pii_text_json(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(
+            success=True,
+            exit_code=0,
+            stdout='{"ok": true, "verdict": "warn"}',
+            data={
+                "ok": True,
+                "verdict": "warn",
+                "summary": {"total": 1},
+                "findings": [],
+            },
+        )
+
+        result = self.runner.invoke(
+            app,
+            ["scan-pii", "--text", "alice@example.com", "--source", "manual"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('"verdict": "warn"', result.output)
+        mock_invoke.assert_called_once()
+        _, kwargs = mock_invoke.call_args
+        self.assertEqual(mock_invoke.call_args.args[0], "pii_scan")
+        self.assertEqual(kwargs["text"], "alice@example.com")
+        self.assertEqual(kwargs["source"], "manual")
+        self.assertFalse(kwargs["raw_evidence"])
+
+    @patch("agent_sec_cli.pii_checker.cli.invoke")
+    def test_scan_pii_text_output(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(
+            success=True,
+            exit_code=0,
+            data={
+                "ok": True,
+                "verdict": "deny",
+                "summary": {"total": 1, "source": "manual"},
+                "findings": [
+                    {
+                        "type": "api_key",
+                        "severity": "deny",
+                        "confidence": 0.99,
+                        "evidence_redacted": "sk-a...[REDACTED]...7890",
+                    }
+                ],
+            },
+        )
+
+        result = self.runner.invoke(
+            app,
+            ["scan-pii", "--text", "api_key=secret", "--format", "text"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Verdict: deny", result.output)
+        self.assertIn("api_key", result.output)
+
+    def test_scan_pii_requires_one_input(self):
+        result = self.runner.invoke(app, ["scan-pii"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("provide exactly one", result.output)
+
+    def test_scan_pii_rejects_invalid_source(self):
+        result = self.runner.invoke(
+            app,
+            ["scan-pii", "--text", "hello", "--source", "browser"],
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("--source must be one of", result.output)
+
+    @patch("agent_sec_cli.pii_checker.cli.invoke")
+    def test_scan_pii_input_reports_file_byte_limit(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(
+            success=True,
+            exit_code=0,
+            stdout='{"ok": true, "verdict": "pass"}',
+            data={
+                "ok": True,
+                "verdict": "pass",
+                "summary": {"total": 0},
+                "findings": [],
+            },
+        )
+
+        with self.runner.isolated_filesystem():
+            Path("input.txt").write_bytes("备注🙂 alice".encode("utf-8"))
+            max_bytes = len("备注".encode("utf-8")) + 1
+
+            result = self.runner.invoke(
+                app,
+                [
+                    "scan-pii",
+                    "--input",
+                    "input.txt",
+                    "--max-bytes",
+                    str(max_bytes),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        _, kwargs = mock_invoke.call_args
+        self.assertTrue(kwargs["input_truncated"])
+        self.assertEqual(kwargs["input_bytes_scanned"], max_bytes)
+        self.assertNotIn("\ufffd", kwargs["text"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Add PIIChecker v1 for `agent-sec-core` without implementing the Cosh/OpenClaw hook integrations yet.

This PR adds:

- `agent-sec-cli scan-pii` with text/file input, JSON/text output, low-confidence controls, raw-evidence opt-in, redacted output, source labeling, and max-byte limiting.
- A Python PIIChecker API with detector orchestration, a default regex/validator detector, redaction helpers, validators, and fixed result models.
- A `pii_scan` security middleware backend plus audit-safe lifecycle details that avoid writing raw text, tool output, file contents, or raw evidence to `security_events`.
- `pii_scan` router/lifecycle/category and security summary formatter support.
- Unit coverage for detectors, validators, CLI behavior, middleware routing/backend behavior, audit sanitization, and summary formatting.

## Related Issue

no-issue: PIIChecker v1 implementation requested during development; no existing issue number was provided.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cd src/agent-sec-core && make python-code-pretty`
- `cd src/agent-sec-core && uv run --project agent-sec-cli pytest tests/unit-test -q`
  - `1354 passed, 2 subtests passed`
- `cd src/agent-sec-core && uv run --project agent-sec-cli pytest tests/e2e/cli -q`
  - `54 passed, 2 skipped`
- `git diff --check`

## Additional Notes

- The Cosh and OpenClaw hook integrations described in the broader PIIChecker plan are intentionally not included in this PR.
- The detector layer is structured so future local-model or alternate detector engines can be injected without changing the CLI, backend, audit, or output schema.
- Local `ruff check` still hits the repository's existing `isort`/ruff import-group mismatch on CLI modules after `make python-code-pretty`; this PR keeps the Makefile formatting output as the source of truth.
