### PR TITLE
fix(cosh): fire UserPromptSubmit hook only on real user prompts

### DIFF
--- a/src/copilot-shell/packages/core/src/core/client.test.ts
+++ b/src/copilot-shell/packages/core/src/core/client.test.ts
@@ -37,6 +37,10 @@ import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { setSimulate429 } from '../utils/testUtils.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
+import {
+  MessageBusType,
+  type HookExecutionRequest,
+} from '../confirmation-bus/types.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -2401,6 +2405,137 @@ Other open files:
       // Assert - loop detection methods should not be called when skipLoopDetection is true
       expect(ldMock.turnStarted).not.toHaveBeenCalled();
       expect(ldMock.addAndCheck).not.toHaveBeenCalled();
+    });
+
+    describe('UserPromptSubmit hook firing semantics', () => {
+      function createMockMessageBus() {
+        return {
+          request: vi.fn().mockResolvedValue({
+            type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+            correlationId: 'test-correlation-id',
+            success: true,
+          }),
+        };
+      }
+
+      function userPromptSubmitCallCount(bus: { request: Mock }): number {
+        return bus.request.mock.calls.filter(
+          (call) =>
+            (call[0] as HookExecutionRequest).eventName === 'UserPromptSubmit',
+        ).length;
+      }
+
+      it('does not refire UserPromptSubmit on continuation calls (e.g. tool response, Stop hook)', async () => {
+        // Arrange: enable hooks + provide messageBus
+        const mockMessageBus = createMockMessageBus();
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        // PreCompact hook uses hookSystem; return undefined so it short-circuits.
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        // Initial user prompt
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'Hello' };
+          })(),
+        );
+        const initialStream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-dedup',
+        );
+        for await (const _ of initialStream) {
+          // drain
+        }
+
+        // Continuation (e.g. tool result follow-up) with the same prompt id
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'After tool' };
+          })(),
+        );
+        const continuationStream = client.sendMessageStream(
+          [{ text: 'tool result' }],
+          new AbortController().signal,
+          'prompt-id-dedup',
+          { isContinuation: true },
+        );
+        for await (const _ of continuationStream) {
+          // drain
+        }
+
+        // Assert: UserPromptSubmit fired exactly once across both calls.
+        expect(userPromptSubmitCallCount(mockMessageBus)).toBe(1);
+      });
+
+      it('does not refire UserPromptSubmit when next-speaker recursion sends "Please continue."', async () => {
+        // Arrange: enable hooks + messageBus
+        const mockMessageBus = createMockMessageBus();
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        // PreCompact hook uses hookSystem; return undefined so it short-circuits.
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        // First check: model should continue. Second: stop.
+        const { checkNextSpeaker } =
+          await import('../utils/nextSpeakerChecker.js');
+        const mockCheckNextSpeaker = vi.mocked(checkNextSpeaker);
+        mockCheckNextSpeaker
+          .mockResolvedValueOnce({
+            next_speaker: 'model',
+            reasoning: 'continue',
+          })
+          .mockResolvedValueOnce(null);
+
+        // Both turn.run() invocations need a fresh stream.
+        mockTurnRunFn
+          .mockReturnValueOnce(
+            (async function* () {
+              yield { type: 'content', value: 'first half' };
+            })(),
+          )
+          .mockReturnValueOnce(
+            (async function* () {
+              yield { type: 'content', value: 'second half' };
+            })(),
+          );
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-nextspeaker',
+        );
+        for await (const _ of stream) {
+          // drain
+        }
+
+        // Assert: recursion fired (checkNextSpeaker called twice) but
+        // UserPromptSubmit fired exactly once for this user prompt.
+        expect(mockCheckNextSpeaker).toHaveBeenCalledTimes(2);
+        expect(userPromptSubmitCallCount(mockMessageBus)).toBe(1);
+      });
     });
   });
 

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -528,10 +528,16 @@ export class GeminiClient {
     options?: { isContinuation: boolean },
     turns: number = MAX_TURNS,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
+    // A continuation is any internal re-entry into this method for the same
+    // user prompt: tool-response follow-ups, Stop-hook continuation, and the
+    // next-speaker auto-continue path. UserPromptSubmit semantics ("when the
+    // user submits a prompt") only apply to the first, non-continuation call.
+    const isContinuation = options?.isContinuation === true;
+
     // Fire UserPromptSubmit hook through MessageBus (only if hooks are enabled)
     const hooksEnabled = this.config.getEnableHooks();
     const messageBus = this.config.getMessageBus();
-    if (hooksEnabled && messageBus) {
+    if (hooksEnabled && messageBus && !isContinuation) {
       const promptText = partToString(request);
       const response = await messageBus.request<
         HookExecutionRequest,
@@ -614,7 +620,7 @@ export class GeminiClient {
       }
     }
 
-    if (!options?.isContinuation) {
+    if (!isContinuation) {
       this.loopDetector.reset(prompt_id);
       this.lastPromptId = prompt_id;
       this.config.setCurrentRunId(prompt_id);
@@ -704,7 +710,7 @@ export class GeminiClient {
 
     // append system reminders to the request
     let requestToSent = await flatMapTextParts(request, async (text) => [text]);
-    if (!options?.isContinuation) {
+    if (!isContinuation) {
       const systemReminders = [];
 
       // add subagent system reminder if there are subagents
@@ -829,12 +835,14 @@ export class GeminiClient {
       if (nextSpeakerCheck?.next_speaker === 'model') {
         const nextRequest = [{ text: 'Please continue.' }];
         // This recursive call's events will be yielded out, and the final
-        // turn object from the recursive call will be returned.
+        // turn object from the recursive call will be returned. Mark it as a
+        // continuation so UserPromptSubmit (and other once-per-prompt setup)
+        // does not fire for the synthesized "Please continue." message.
         return yield* this.sendMessageStream(
           nextRequest,
           signal,
           prompt_id,
-          options,
+          { ...options, isContinuation: true },
           boundedTurns - 1,
         );
       }


### PR DESCRIPTION
## Description

Fix UserPromptSubmit hook being fired multiple times within a single user
prompt. `GeminiClient.sendMessageStream()` is re-entered for tool-result
follow-ups, Stop-hook continuations, and next-speaker auto-continue, all
of which used to refire `UserPromptSubmit` even though the semantics are
"when the user submits a prompt".

The CLI side (`useGeminiStream.ts`) already passes
`{ isContinuation: true }` for tool responses, but core never honored it
for the hook gate. This change:

- Defines a single `isContinuation` flag at the top of
  `sendMessageStream()` and gates the entire `UserPromptSubmit`
  block (block / ask / additionalContext) on `!isContinuation`.
- Unifies the two existing `!options?.isContinuation` checks (currentRunId
  / system reminders) on the same flag to avoid semantic drift.
- Forwards `isContinuation: true` on the next-speaker recursion so the
  synthesized `Please continue.` prompt does not refire the hook.

`PreToolUse`, `PostToolUse`, and `Stop` hook behavior is unchanged.

## Related Issue

closes #530

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Added two regression tests under
`src/core/client.test.ts → sendMessageStream → UserPromptSubmit hook firing semantics`:

1. Initial prompt then continuation call with the same `prompt_id`:
   `UserPromptSubmit` fires exactly once (filtered on `eventName`
   to ignore the Stop hook also flowing through `messageBus`).
2. `checkNextSpeaker` mocked to return `{ next_speaker: 'model' }` then
   `null`: recursion runs (`checkNextSpeaker` called twice) but
   `UserPromptSubmit` still fires only once.

Commands run:

```
cd src/copilot-shell && npm run test --workspace=packages/core -- src/core/client.test.ts
# 53/53 tests pass

cd src/copilot-shell && npm run typecheck --workspace=packages/core
# No new errors in client.ts / client.test.ts
# (pre-existing TS7016 errors in unrelated files: simple-git,
#  google-auth-library, @opentelemetry/exporter-metrics-otlp-http)
```

## Additional Notes

Only `client.ts` and `client.test.ts` are changed. No `dist/`,
`coverage/`, `package.json`, or `package-lock.json` modifications.