### PR TITLE
fix(cosh): set run_id before UserPromptSubmit hook fires

### DIFF
--- a/src/copilot-shell/packages/core/src/core/client.test.ts
+++ b/src/copilot-shell/packages/core/src/core/client.test.ts
@@ -2536,6 +2536,170 @@ Other open files:
         expect(mockCheckNextSpeaker).toHaveBeenCalledTimes(2);
         expect(userPromptSubmitCallCount(mockMessageBus)).toBe(1);
       });
+
+      it('sets currentRunId before firing UserPromptSubmit so hook input has the right run_id', async () => {
+        // Arrange: enable hooks + messageBus
+        const mockMessageBus = createMockMessageBus();
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        // PreCompact hook uses hookSystem; return undefined so it short-circuits.
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'Hello' };
+          })(),
+        );
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-runid',
+        );
+        for await (const _ of stream) {
+          // drain
+        }
+
+        // Assert: setCurrentRunId('prompt-id-runid') was invoked before the
+        // UserPromptSubmit hook request hit the bus, so hookEventHandler can
+        // read the right run_id when constructing the hook input.
+        const setRunIdCall = vi
+          .mocked(mockConfig.setCurrentRunId)
+          .mock.calls.findIndex((call) => call[0] === 'prompt-id-runid');
+        expect(setRunIdCall).toBeGreaterThanOrEqual(0);
+        const setRunIdOrder = vi.mocked(mockConfig.setCurrentRunId).mock
+          .invocationCallOrder[setRunIdCall];
+
+        const userPromptSubmitOrder = mockMessageBus.request.mock.calls
+          .map((call, i) => ({
+            order: mockMessageBus.request.mock.invocationCallOrder[i],
+            eventName: (call[0] as HookExecutionRequest).eventName,
+          }))
+          .find((entry) => entry.eventName === 'UserPromptSubmit')?.order;
+
+        expect(userPromptSubmitOrder).toBeDefined();
+        expect(setRunIdOrder).toBeLessThan(userPromptSubmitOrder!);
+      });
+
+      it('exposes the current run_id to hook handlers at UserPromptSubmit request time', async () => {
+        // Arrange: link setCurrentRunId / getCurrentRunId so the bus subscriber
+        // observes whatever sendMessageStream wrote — mirroring the real path
+        // hookEventHandler.createBaseInput() takes via config.getCurrentRunId().
+        let currentRunId: string | undefined;
+        vi.mocked(mockConfig.setCurrentRunId).mockImplementation((id) => {
+          currentRunId = id;
+        });
+        (mockConfig as unknown as { getCurrentRunId: Mock }).getCurrentRunId =
+          vi.fn(() => currentRunId);
+
+        // Capture run_id at the moment a HOOK_EXECUTION_REQUEST hits the bus,
+        // which is exactly when createBaseInput() would read it.
+        let runIdSeenByHookRunner: string | undefined;
+        const mockMessageBus = {
+          request: vi
+            .fn()
+            .mockImplementation(async (req: HookExecutionRequest) => {
+              if (req.eventName === 'UserPromptSubmit') {
+                runIdSeenByHookRunner = mockConfig.getCurrentRunId();
+              }
+              return {
+                type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+                correlationId: 'test-correlation-id',
+                success: true,
+              };
+            }),
+        };
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'Hello' };
+          })(),
+        );
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-hook-input-runid',
+        );
+        for await (const _ of stream) {
+          // drain
+        }
+
+        // Assert: at hook-handling time getCurrentRunId() returns the new id,
+        // i.e. the run_id that createBaseInput() will inject is correct.
+        expect(runIdSeenByHookRunner).toBe('prompt-id-hook-input-runid');
+      });
+
+      it('keeps the original run_id during a continuation call', async () => {
+        // Arrange: link set/get like the previous test.
+        let currentRunId: string | undefined = 'pre-existing-run-id';
+        vi.mocked(mockConfig.setCurrentRunId).mockImplementation((id) => {
+          currentRunId = id;
+        });
+        (mockConfig as unknown as { getCurrentRunId: Mock }).getCurrentRunId =
+          vi.fn(() => currentRunId);
+
+        const mockMessageBus = createMockMessageBus();
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'after tool' };
+          })(),
+        );
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        const stream = client.sendMessageStream(
+          [{ text: 'tool result' }],
+          new AbortController().signal,
+          'continuation-prompt-id',
+          { isContinuation: true },
+        );
+        for await (const _ of stream) {
+          // drain
+        }
+
+        // Assert: continuations must NOT overwrite the active run_id.
+        expect(mockConfig.setCurrentRunId).not.toHaveBeenCalled();
+        expect(mockConfig.getCurrentRunId()).toBe('pre-existing-run-id');
+      });
     });
   });
 

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -534,6 +534,13 @@ export class GeminiClient {
     // user submits a prompt") only apply to the first, non-continuation call.
     const isContinuation = options?.isContinuation === true;
 
+    // Promote prompt_id to the current run id BEFORE firing UserPromptSubmit
+    // so hookEventHandler.createBaseInput() can populate run_id correctly.
+    // Continuations keep the run id from the original prompt — don't overwrite.
+    if (!isContinuation) {
+      this.config.setCurrentRunId(prompt_id);
+    }
+
     // Fire UserPromptSubmit hook through MessageBus (only if hooks are enabled)
     const hooksEnabled = this.config.getEnableHooks();
     const messageBus = this.config.getMessageBus();
@@ -623,7 +630,6 @@ export class GeminiClient {
     if (!isContinuation) {
       this.loopDetector.reset(prompt_id);
       this.lastPromptId = prompt_id;
-      this.config.setCurrentRunId(prompt_id);
 
       // record user message for session management
       this.config.getChatRecordingService()?.recordUserMessage(request);


### PR DESCRIPTION
## Description

`UserPromptSubmit` hook input was carrying a stale `run_id` (or `undefined`
on the very first prompt). `GeminiClient.sendMessageStream()` used to fire
the hook through `messageBus.request` BEFORE calling
`config.setCurrentRunId(prompt_id)`, so when
`hookEventHandler.createBaseInput()` read `config.getCurrentRunId()` it
saw the previous prompt's value.

Fix:

- Promote `setCurrentRunId(prompt_id)` to run right after the
  `isContinuation` guard, before any `UserPromptSubmit` hook activity.
- Remove the now-duplicate `setCurrentRunId` from the later non-continuation
  initialization block.
- Continuations (tool-result follow-ups, Stop hook, next-speaker
  `Please continue.`) still skip the call so they keep the original
  prompt's run_id, consistent with the #530 fix.

`recordUserMessage` and `stripThoughtsFromHistory` are intentionally NOT
moved earlier — block / ask / additionalContext semantics on
`UserPromptSubmit` must keep working.

## Related Issue

closes #531

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Three new regression tests in
`src/core/client.test.ts → sendMessageStream → UserPromptSubmit hook firing semantics`:

1. `sets currentRunId before firing UserPromptSubmit so hook input has the right run_id` —
   Uses `invocationCallOrder` to assert `setCurrentRunId(prompt_id)` runs
   before the `UserPromptSubmit` request hits the bus.
2. `exposes the current run_id to hook handlers at UserPromptSubmit request time` —
   Links `setCurrentRunId` / `getCurrentRunId` and has the bus subscriber
   capture `getCurrentRunId()` exactly as `createBaseInput()` would,
   asserting the captured id equals the prompt id.
3. `keeps the original run_id during a continuation call` — Pre-seeds the
   run id, calls with `{ isContinuation: true }`, asserts
   `setCurrentRunId` is not invoked and the run id is untouched.

Commands run:

```
cd src/copilot-shell && npm run test --workspace=packages/core -- src/core/client.test.ts
# 56/56 tests pass
```

## Additional Notes

Only `client.ts` and `client.test.ts` are changed. No `dist/`,
`coverage/`, `package.json`, or `package-lock.json` modifications.
This stacks on top of the #530 fix  as
`0764474 fix(cosh): fire UserPromptSubmit hook only on real user prompts`.