### PR TITLE
feat(sec-core): add PIIChecker hooks for cosh and OpenClaw

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/cli.py
@@ -16,7 +16,6 @@ scanner_app = typer.Typer(
 
 _OUTPUT_FORMATS = {"json", "text"}
 _SOURCES = {"user_input", "tool_output", "manual", "unknown"}
-_DEFAULT_MAX_BYTES = 1_048_576
 _TEXT_OPTION = typer.Option(None, "--text", help="Text to scan.")
 _INPUT_OPTION = typer.Option(
     None,
@@ -59,25 +58,43 @@ _SOURCE_OPTION = typer.Option(
     ),
 )
 _MAX_BYTES_OPTION = typer.Option(
-    _DEFAULT_MAX_BYTES,
+    None,
     "--max-bytes",
-    help="Maximum bytes to scan before truncating input.",
+    help="Optional maximum bytes to scan before truncating input.",
 )
 
 
-def _read_limited_input(path: Path, max_bytes: int) -> tuple[str, bool, int]:
-    """Read at most max_bytes from a UTF-8 file before scanner-level limiting.
+def _decode_utf8_input(data: bytes, *, allow_partial_tail: bool = False) -> str:
+    """Decode UTF-8 input, optionally backing off a truncated final character."""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        if allow_partial_tail and exc.reason == "unexpected end of data":
+            return data[: exc.start].decode("utf-8")
+        raise
+
+
+def _read_limited_input(path: Path, max_bytes: int | None) -> tuple[str, bool, int]:
+    """Read a UTF-8 file, applying max_bytes only when explicitly provided.
 
     The returned byte count reflects file bytes read for scanning. When the CLI
     truncates a file, that truncation flag takes precedence over the scanner's
     string-level truncation result in the final summary.
     """
+    if max_bytes is None:
+        data = path.read_bytes()
+        return _decode_utf8_input(data), False, len(data)
+
     with path.open("rb") as handle:
         data = handle.read(max_bytes + 1)
     truncated = len(data) > max_bytes
     if truncated:
         data = data[:max_bytes]
-    return data.decode("utf-8", errors="ignore"), truncated, len(data)
+    return (
+        _decode_utf8_input(data, allow_partial_tail=truncated),
+        truncated,
+        len(data),
+    )
 
 
 def _format_text_output(data: dict[str, Any]) -> str:
@@ -124,7 +141,7 @@ def scan_pii(
     raw_evidence: bool = _RAW_EVIDENCE_OPTION,
     redact_output: bool = _REDACT_OUTPUT_OPTION,
     source: str = _SOURCE_OPTION,
-    max_bytes: int = _MAX_BYTES_OPTION,
+    max_bytes: int | None = _MAX_BYTES_OPTION,
 ) -> None:
     """Detect PII and credentials in text or a file."""
     if ctx.invoked_subcommand is not None:
@@ -138,7 +155,7 @@ def scan_pii(
             err=True,
         )
         raise typer.Exit(code=1)
-    if max_bytes <= 0:
+    if max_bytes is not None and max_bytes <= 0:
         typer.echo("Error: --max-bytes must be greater than zero.", err=True)
         raise typer.Exit(code=1)
     if (text is None and input_path is None) or (
@@ -151,9 +168,13 @@ def scan_pii(
     input_bytes_scanned = None
     scan_text = text or ""
     if input_path is not None:
-        scan_text, input_truncated, input_bytes_scanned = _read_limited_input(
-            input_path, max_bytes
-        )
+        try:
+            scan_text, input_truncated, input_bytes_scanned = _read_limited_input(
+                input_path, max_bytes
+            )
+        except UnicodeDecodeError as exc:
+            typer.echo(f"Error: --input must be valid UTF-8: {exc}.", err=True)
+            raise typer.Exit(code=1) from exc
 
     result = invoke(
         "pii_scan",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/scanner.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/scanner.py
@@ -20,12 +20,24 @@ ALLOWED_SOURCES = {"user_input", "tool_output", "manual", "unknown"}
 _MULTI_TYPE_OVERLAPS = {frozenset({"bearer_token", "jwt"})}
 
 
-def _limit_text(text: str, max_bytes: int) -> tuple[str, bool, int]:
-    """Limit text by encoded byte length."""
+def _decode_utf8_prefix(data: bytes) -> str:
+    """Decode bytes after backing off a partial UTF-8 character at the end."""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        if exc.reason != "unexpected end of data":
+            raise
+        return data[: exc.start].decode("utf-8")
+
+
+def _limit_text(text: str, max_bytes: int | None) -> tuple[str, bool, int]:
+    """Limit text by encoded byte length when a byte limit is configured."""
     encoded = text.encode("utf-8")
+    if max_bytes is None:
+        return text, False, len(encoded)
     if len(encoded) <= max_bytes:
         return text, False, len(encoded)
-    trimmed = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    trimmed = _decode_utf8_prefix(encoded[:max_bytes])
     return trimmed, True, max_bytes
 
 
@@ -70,11 +82,13 @@ class PiiScanner:
         include_low_confidence: bool = False,
         raw_evidence: bool = False,
         redact_output: bool = False,
-        max_bytes: int = DEFAULT_MAX_BYTES,
+        max_bytes: int | None = None,
     ) -> PiiScanResult:
         """Scan text and return a fixed-schema result."""
         started = time.perf_counter()
         normalized_source = source if source in ALLOWED_SOURCES else "unknown"
+        if max_bytes is not None and max_bytes <= 0:
+            raise ValueError("max_bytes must be greater than zero")
         limited_text, truncated, bytes_scanned = _limit_text(text, max_bytes)
 
         candidates = self._detect(limited_text)
@@ -213,7 +227,7 @@ def scan_text(
     include_low_confidence: bool = False,
     raw_evidence: bool = False,
     redact_output: bool = False,
-    max_bytes: int = DEFAULT_MAX_BYTES,
+    max_bytes: int | None = None,
 ) -> PiiScanResult:
     """Convenience function for one-off scans."""
     return PiiScanner(detectors=detectors).scan(

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/pii_scan.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/pii_scan.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from agent_sec_cli.pii_checker import audit as pii_audit
 from agent_sec_cli.pii_checker.models import PiiScanResult, Verdict
-from agent_sec_cli.pii_checker.scanner import DEFAULT_MAX_BYTES, PiiScanner
+from agent_sec_cli.pii_checker.scanner import PiiScanner
 from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
@@ -51,15 +51,19 @@ class PiiScanBackend(BaseBackend):
         include_low_confidence = bool(kwargs.get("include_low_confidence", False))
         raw_evidence = bool(kwargs.get("raw_evidence", False))
         redact_output = bool(kwargs.get("redact_output", False))
-        try:
-            max_bytes = int(kwargs.get("max_bytes", DEFAULT_MAX_BYTES))
-        except (TypeError, ValueError) as exc:
-            return self._to_action_result(
-                _error_result(
-                    "pii_scan error: max_bytes must be an integer",
-                    error_type=type(exc).__name__,
+        max_bytes_arg = kwargs.get("max_bytes")
+        if max_bytes_arg is None:
+            max_bytes: int | None = None
+        else:
+            try:
+                max_bytes = int(max_bytes_arg)
+            except (TypeError, ValueError) as exc:
+                return self._to_action_result(
+                    _error_result(
+                        "pii_scan error: max_bytes must be an integer",
+                        error_type=type(exc).__name__,
+                    )
                 )
-            )
         input_truncated = bool(kwargs.get("input_truncated", False))
         input_bytes_scanned = kwargs.get("input_bytes_scanned")
         if input_bytes_scanned is not None:
@@ -68,7 +72,7 @@ class PiiScanBackend(BaseBackend):
             except (TypeError, ValueError):
                 input_bytes_scanned = None
 
-        if max_bytes <= 0:
+        if max_bytes is not None and max_bytes <= 0:
             return self._to_action_result(
                 _error_result(
                     "pii_scan error: max_bytes must be greater than zero",

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -45,6 +45,13 @@
             "command": "python3 ${extensionPath}/hooks/prompt_scanner_hook.py",
             "description": "Scans user prompts for prompt injection and jailbreak attempts.",
             "timeout": 10000
+          },
+          {
+            "type": "command",
+            "name": "pii-checker",
+            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "description": "Scans user prompts for PII and credentials.",
+            "timeout": 10000
           }
         ]
       }

--- a/src/agent-sec-core/cosh-extension/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/pii_checker_hook.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Cosh hook script for PIIChecker.
+
+Reads a cosh UserPromptSubmit JSON from stdin, extracts the user prompt,
+invokes ``agent-sec-cli scan-pii`` via subprocess, and writes a cosh
+HookOutput JSON to stdout.
+
+This script is intentionally self-contained — it does NOT import any
+``agent_sec_cli`` package. All it needs is the standard library and the
+``agent-sec-cli`` binary on $PATH.
+"""
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+_DEFAULT_SOURCE = "user_input"
+_MAX_EVIDENCE_ITEMS = 3
+_MAX_EVIDENCE_CHARS = 80
+
+
+def _allow() -> str:
+    """Return a permissive cosh HookOutput JSON string."""
+    return json.dumps({"decision": "allow"})
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _shorten(value: str, limit: int = _MAX_EVIDENCE_CHARS) -> str:
+    value = " ".join(value.split())
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"
+
+
+def _format_pii_warning(verdict: str, findings: list[Any]) -> str:
+    """Build a minimal-disclosure warning from structured PII findings."""
+    typed_findings = [item for item in findings if isinstance(item, dict)]
+    count = len(typed_findings)
+    pii_types = sorted(
+        {
+            finding_type
+            for finding in typed_findings
+            if (finding_type := _safe_text(finding.get("type")))
+        }
+    )
+    severities = sorted(
+        {
+            severity
+            for finding in typed_findings
+            if (severity := _safe_text(finding.get("severity")))
+        }
+    )
+    redacted_evidence: list[str] = []
+    for finding in typed_findings:
+        evidence = _safe_text(finding.get("evidence_redacted"))
+        if evidence and evidence not in redacted_evidence:
+            redacted_evidence.append(_shorten(evidence))
+        if len(redacted_evidence) >= _MAX_EVIDENCE_ITEMS:
+            break
+
+    risk = "高风险敏感信息" if verdict == "deny" else "敏感信息"
+    parts = [
+        f"[pii-checker] 检测到 {count} 项{risk}",
+        f"类型：{', '.join(pii_types) if pii_types else 'unknown'}",
+    ]
+    if severities:
+        parts.append(f"严重级别：{', '.join(severities)}")
+    if redacted_evidence:
+        parts.append(f"脱敏示例：{', '.join(redacted_evidence)}")
+    parts.append("本轮请求将继续处理。")
+    return "；".join(parts)
+
+
+def _format_cosh(scan_result: dict[str, Any]) -> str:
+    """Convert a scan-pii result dict into a cosh HookOutput JSON string.
+
+    Mapping:
+        verdict == "pass" -> decision "allow"
+        verdict == "warn" -> decision "allow" with reason
+        verdict == "deny" -> decision "allow" with high-risk reason
+        verdict == "error" or unknown -> fail-open "allow"
+    """
+    verdict = _safe_text(scan_result.get("verdict")) or "pass"
+    findings = _as_list(scan_result.get("findings"))
+
+    if verdict == "pass" or not findings:
+        return _allow()
+
+    if verdict in {"warn", "deny"}:
+        return json.dumps(
+            {"decision": "allow", "reason": _format_pii_warning(verdict, findings)},
+            ensure_ascii=False,
+        )
+
+    return _allow()
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError, ValueError):
+        print(_allow())
+        return
+
+    prompt_text = input_data.get("prompt", "")
+    if not isinstance(prompt_text, str) or not prompt_text.strip():
+        print(_allow())
+        return
+
+    try:
+        proc = subprocess.run(
+            [
+                "agent-sec-cli",
+                "scan-pii",
+                "--text",
+                prompt_text,
+                "--format",
+                "json",
+                "--source",
+                _DEFAULT_SOURCE,
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        print(_allow())
+        return
+
+    if proc.returncode != 0:
+        print(_allow())
+        return
+
+    try:
+        scan_result = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        print(_allow())
+        return
+
+    print(_format_cosh(scan_result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -30,7 +30,7 @@ openclaw-plugin/
 │   │   ├── skill-ledger.ts     #   before_tool_call
 │   │   ├── code-scan.ts        #   before_tool_call hook
 │   │   ├── prompt-scan.ts      #   before_dispatch hook
-│   │   ├── pii-scan.ts         #   before_prompt_build + message_sending hooks
+│   │   ├── pii-scan.ts         #   before_prompt_build + reply_dispatch hooks
 │   │   └── observability.ts    #   observability hook registration
 │   └── helpers/                # Capability support code
 │       └── observability/      #   OpenClaw → agent-sec observability adapter
@@ -187,7 +187,7 @@ Source: ~/path/to/openclaw-plugin/dist/index.js
 Typed hooks:
 before_dispatch (priority 190)
 before_prompt_build (priority 0)
-message_sending (priority 0)
+reply_dispatch (priority 0)
 llm_input (priority 1000)
 model_call_started (priority 1000)
 model_call_ended (priority 1000)
@@ -234,7 +234,7 @@ AGENT_SEC_LIVE=1 npm run smoke
 | Capability         | Hook                  | Priority | Behavior                                             |
 |--------------------|-----------------------|----------|------------------------------------------------------|
 | `prompt-scan`      | `before_dispatch`     | 190      | Scans inbound messages for prompt injection attacks   |
-| `pii-scan-user-input` | `before_prompt_build`, `message_sending` | 0 (default) | Scans current user prompt for PII/credentials and prefixes a non-blocking same-run warning |
+| `pii-scan-user-input` | `before_prompt_build`, `reply_dispatch` | 0 (default) | Scans current user prompt for PII/credentials and emits a non-blocking same-run warning |
 | `scan-code`        | `before_tool_call`    | 0 (default) | Scans tool commands for security issues              |
 | `skill-ledger`     | `before_tool_call`    | 80       | Checks skill integrity when SKILL.md is read         |
 | `observability`    | selected typed hooks  | varies   | Sends observability records to agent-sec-cli          |
@@ -243,7 +243,7 @@ AGENT_SEC_LIVE=1 npm run smoke
 
 The `pii-scan-user-input` capability scans only `event.prompt` in `before_prompt_build`. It intentionally does not scan `event.messages`, because that list may include history, tool results, memory, or RAG context and can repeatedly warn on older PII that was not submitted in the current turn.
 
-`warn` and `deny` verdicts never block OpenClaw in v1. The capability caches a minimal warning under the current `runId`, then `message_sending` drains that warning and prefixes it to the same run's outgoing message. If `runId` is missing, the capability fails open and does not cache a session-level warning.
+`warn` and `deny` verdicts never block OpenClaw in v1. The capability caches a minimal warning under the current `runId`, then `reply_dispatch` reads that warning and queues it with `dispatcher.sendBlockReply({ text })` before the default agent reply flow continues. In this context, block reply means OpenClaw's intermediate reply type, not a security block. The warning is removed only after it is successfully queued. This avoids consuming the warning in a generic outbound `message_sending` hook that may not represent the final user-visible reply. If `runId` is missing, the capability fails open and does not cache a session-level warning. If OpenClaw marks the turn with `sendPolicy: "deny"` or `suppressUserDelivery: true`, the warning is dropped without display so the plugin does not override host-level delivery policy.
 
 ### Configuring `observability`
 

--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -1,6 +1,6 @@
 # agent-sec OpenClaw Plugin
 
-OpenClaw security plugin that hooks into the agent lifecycle via `agent-sec-cli`, providing code scanning, skill integrity verification, prompt analysis, and best-effort agent observability logging.
+OpenClaw security plugin that hooks into the agent lifecycle via `agent-sec-cli`, providing code scanning, skill integrity verification, prompt analysis, PII checking, and best-effort agent observability logging.
 
 ---
 
@@ -26,10 +26,11 @@ openclaw-plugin/
 │   ├── index.ts                # Plugin entry point (definePluginEntry)
 │   ├── types.ts                # SecurityCapability interface
 │   ├── utils.ts                # CLI invocation utility (callAgentSecCli)
-│   ├── capabilities/           # Four security capability entry files
+│   ├── capabilities/           # Security capability entry files
 │   │   ├── skill-ledger.ts     #   before_tool_call
 │   │   ├── code-scan.ts        #   before_tool_call hook
 │   │   ├── prompt-scan.ts      #   before_dispatch hook
+│   │   ├── pii-scan.ts         #   before_prompt_build + message_sending hooks
 │   │   └── observability.ts    #   observability hook registration
 │   └── helpers/                # Capability support code
 │       └── observability/      #   OpenClaw → agent-sec observability adapter
@@ -185,6 +186,8 @@ Source: ~/path/to/openclaw-plugin/dist/index.js
 
 Typed hooks:
 before_dispatch (priority 190)
+before_prompt_build (priority 0)
+message_sending (priority 0)
 llm_input (priority 1000)
 model_call_started (priority 1000)
 model_call_ended (priority 1000)
@@ -231,9 +234,16 @@ AGENT_SEC_LIVE=1 npm run smoke
 | Capability         | Hook                  | Priority | Behavior                                             |
 |--------------------|-----------------------|----------|------------------------------------------------------|
 | `prompt-scan`      | `before_dispatch`     | 190      | Scans inbound messages for prompt injection attacks   |
+| `pii-scan-user-input` | `before_prompt_build`, `message_sending` | 0 (default) | Scans current user prompt for PII/credentials and prefixes a non-blocking same-run warning |
 | `scan-code`        | `before_tool_call`    | 0 (default) | Scans tool commands for security issues              |
 | `skill-ledger`     | `before_tool_call`    | 80       | Checks skill integrity when SKILL.md is read         |
 | `observability`    | selected typed hooks  | varies   | Sends observability records to agent-sec-cli          |
+
+### Configuring `pii-scan-user-input`
+
+The `pii-scan-user-input` capability scans only `event.prompt` in `before_prompt_build`. It intentionally does not scan `event.messages`, because that list may include history, tool results, memory, or RAG context and can repeatedly warn on older PII that was not submitted in the current turn.
+
+`warn` and `deny` verdicts never block OpenClaw in v1. The capability caches a minimal warning under the current `runId`, then `message_sending` drains that warning and prefixes it to the same run's outgoing message. If `runId` is missing, the capability fails open and does not cache a session-level warning.
 
 ### Configuring `observability`
 
@@ -272,9 +282,13 @@ Supported OpenClaw plugin entry config:
       "agent-sec": {
         "config": {
           "promptScanBlock": false,
+          "piiScanUserInput": true,
+          "piiIncludeLowConfidence": false,
+          "piiWarningTtlMs": 300000,
           "capabilities": {
             "scan-code": { "enabled": true },
             "prompt-scan": { "enabled": true },
+            "pii-scan-user-input": { "enabled": true },
             "skill-ledger": { "enabled": true },
             "observability": { "enabled": true }
           }

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -14,6 +14,22 @@
         "type": "boolean",
         "default": false,
         "description": "检测到 DENY 时直接拦截请求，不转发给 LLM"
+      },
+      "piiScanUserInput": {
+        "type": "boolean",
+        "default": true,
+        "description": "扫描本轮用户输入中的 PII 和凭据，并以非阻断 warning 提示"
+      },
+      "piiIncludeLowConfidence": {
+        "type": "boolean",
+        "default": false,
+        "description": "是否包含低置信度 PII findings"
+      },
+      "piiWarningTtlMs": {
+        "type": "number",
+        "default": 300000,
+        "minimum": 0,
+        "description": "PII warning 按 runId 暂存的 TTL，避免未发送回复时残留"
       }
 
     }
@@ -22,6 +38,18 @@
     "promptScanBlock": {
       "label": "Prompt 扫描拦截模式",
       "description": "检测到 DENY 时直接拦截请求，不转发给 LLM"
+    },
+    "piiScanUserInput": {
+      "label": "PII 用户输入扫描",
+      "description": "扫描本轮用户输入中的 PII 和凭据，并以非阻断 warning 提示"
+    },
+    "piiIncludeLowConfidence": {
+      "label": "PII 低置信度 findings",
+      "description": "展示低置信度 PII findings"
+    },
+    "piiWarningTtlMs": {
+      "label": "PII warning TTL",
+      "description": "PII warning 按 runId 暂存的最长时间，单位毫秒"
     }
 
   }

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
@@ -71,7 +71,7 @@ function pushWarning(
   warningsByRun.set(runId, bucket);
 }
 
-function drainWarnings(
+function readWarnings(
   warningsByRun: Map<string, WarningBucket>,
   runId: string,
   warningTtlMs: number,
@@ -81,8 +81,14 @@ function drainWarnings(
   if (!bucket) {
     return [];
   }
-  warningsByRun.delete(runId);
   return [...bucket.warnings];
+}
+
+function deleteWarnings(
+  warningsByRun: Map<string, WarningBucket>,
+  runId: string,
+): void {
+  warningsByRun.delete(runId);
 }
 
 function shorten(value: string, limit = MAX_EVIDENCE_CHARS): string {
@@ -157,12 +163,12 @@ function buildScanArgs(prompt: string, includeLowConfidence: boolean): string[] 
  * 用户输入 PII / 凭据检测。
  *
  * v1 only scans event.prompt in before_prompt_build and shows non-blocking
- * warnings by prefixing the same run's outgoing message in message_sending.
+ * warnings by queueing a same-run block reply in reply_dispatch.
  */
 export const piiScan: SecurityCapability = {
   id: "pii-scan-user-input",
   name: "PII Checker",
-  hooks: ["before_prompt_build", "message_sending"],
+  hooks: ["before_prompt_build", "reply_dispatch"],
   register(api) {
     const cfg = readConfig((api.pluginConfig as Record<string, any>) ?? {});
     if (!cfg.scanUserInput) {
@@ -228,7 +234,7 @@ export const piiScan: SecurityCapability = {
     );
 
     api.on(
-      "message_sending",
+      "reply_dispatch",
       async (event: any, ctx: any) => {
         try {
           const runId = getRunId(event, ctx);
@@ -237,17 +243,25 @@ export const piiScan: SecurityCapability = {
             return undefined;
           }
 
-          const warnings = drainWarnings(warningsByRun, runId, cfg.warningTtlMs);
+          if (event?.sendPolicy === "deny" || event?.suppressUserDelivery === true) {
+            deleteWarnings(warningsByRun, runId);
+            return undefined;
+          }
+
+          const warnings = readWarnings(warningsByRun, runId, cfg.warningTtlMs);
           if (warnings.length === 0) {
             return undefined;
           }
 
-          const content = typeof event?.content === "string" ? event.content : "";
-          return {
-            content: content ? `${warnings.join("\n")}\n\n${content}` : warnings.join("\n"),
-          };
+          const queued = ctx?.dispatcher?.sendBlockReply?.({
+            text: warnings.join("\n"),
+          });
+          if (queued) {
+            deleteWarnings(warningsByRun, runId);
+          }
+          return undefined;
         } catch (error) {
-          api.logger.warn(`[pii-checker] message_sending failed open: ${error instanceof Error ? error.message : String(error)}`);
+          api.logger.warn(`[pii-checker] reply_dispatch failed open: ${error instanceof Error ? error.message : String(error)}`);
           return undefined;
         }
       },

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
@@ -1,0 +1,257 @@
+import type { SecurityCapability } from "../types.js";
+import { callAgentSecCli } from "../utils.js";
+
+const DEFAULT_WARNING_TTL_MS = 300_000;
+const CLI_TIMEOUT_MS = 10_000;
+const MAX_EVIDENCE_ITEMS = 3;
+const MAX_EVIDENCE_CHARS = 80;
+
+type WarningBucket = {
+  warnings: string[];
+  createdAt: number;
+  lastTouchedAt: number;
+};
+
+type PiiScanConfig = {
+  scanUserInput: boolean;
+  includeLowConfidence: boolean;
+  warningTtlMs: number;
+};
+
+function readConfig(pluginConfig: Record<string, any>): PiiScanConfig {
+  const ttl = Number(pluginConfig.piiWarningTtlMs);
+  return {
+    scanUserInput: pluginConfig.piiScanUserInput !== false,
+    includeLowConfidence: pluginConfig.piiIncludeLowConfidence === true,
+    warningTtlMs:
+      Number.isFinite(ttl) && ttl >= 0 ? ttl : DEFAULT_WARNING_TTL_MS,
+  };
+}
+
+function getRunId(event: any, ctx: any): string | undefined {
+  const ctxRunId = typeof ctx?.runId === "string" ? ctx.runId.trim() : "";
+  if (ctxRunId) {
+    return ctxRunId;
+  }
+  const eventRunId = typeof event?.runId === "string" ? event.runId.trim() : "";
+  return eventRunId || undefined;
+}
+
+function cleanupExpired(
+  warningsByRun: Map<string, WarningBucket>,
+  warningTtlMs: number,
+): void {
+  const now = Date.now();
+  for (const [runId, bucket] of warningsByRun) {
+    if (now - bucket.lastTouchedAt >= warningTtlMs) {
+      warningsByRun.delete(runId);
+    }
+  }
+}
+
+function pushWarning(
+  warningsByRun: Map<string, WarningBucket>,
+  runId: string,
+  warning: string,
+  warningTtlMs: number,
+): void {
+  cleanupExpired(warningsByRun, warningTtlMs);
+  const now = Date.now();
+  const bucket =
+    warningsByRun.get(runId) ??
+    {
+      warnings: [],
+      createdAt: now,
+      lastTouchedAt: now,
+    };
+  if (!bucket.warnings.includes(warning)) {
+    bucket.warnings.push(warning);
+  }
+  bucket.lastTouchedAt = now;
+  warningsByRun.set(runId, bucket);
+}
+
+function drainWarnings(
+  warningsByRun: Map<string, WarningBucket>,
+  runId: string,
+  warningTtlMs: number,
+): string[] {
+  cleanupExpired(warningsByRun, warningTtlMs);
+  const bucket = warningsByRun.get(runId);
+  if (!bucket) {
+    return [];
+  }
+  warningsByRun.delete(runId);
+  return [...bucket.warnings];
+}
+
+function shorten(value: string, limit = MAX_EVIDENCE_CHARS): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  return `${normalized.slice(0, limit - 1)}…`;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function formatPiiWarning(verdict: string, findings: unknown[]): string {
+  const typedFindings = findings.filter(
+    (finding): finding is Record<string, unknown> =>
+      typeof finding === "object" && finding !== null && !Array.isArray(finding),
+  );
+  const piiTypes = Array.from(
+    new Set(
+      typedFindings
+        .map((finding) => safeString(finding.type))
+        .filter((value) => value.length > 0),
+    ),
+  ).sort();
+  const severities = Array.from(
+    new Set(
+      typedFindings
+        .map((finding) => safeString(finding.severity))
+        .filter((value) => value.length > 0),
+    ),
+  ).sort();
+  const evidence = typedFindings
+    .map((finding) => safeString(finding.evidence_redacted))
+    .filter((value, index, arr) => value.length > 0 && arr.indexOf(value) === index)
+    .slice(0, MAX_EVIDENCE_ITEMS)
+    .map((value) => shorten(value));
+
+  const risk = verdict === "deny" ? "高风险敏感信息" : "敏感信息";
+  const parts = [
+    `[pii-checker] 检测到 ${typedFindings.length} 项${risk}`,
+    `类型：${piiTypes.length > 0 ? piiTypes.join(", ") : "unknown"}`,
+  ];
+  if (severities.length > 0) {
+    parts.push(`严重级别：${severities.join(", ")}`);
+  }
+  if (evidence.length > 0) {
+    parts.push(`脱敏示例：${evidence.join(", ")}`);
+  }
+  parts.push("本轮请求将继续处理。");
+  return parts.join("；");
+}
+
+function buildScanArgs(prompt: string, includeLowConfidence: boolean): string[] {
+  const args = [
+    "scan-pii",
+    "--text",
+    prompt,
+    "--format",
+    "json",
+    "--source",
+    "user_input",
+  ];
+  if (includeLowConfidence) {
+    args.push("--include-low-confidence");
+  }
+  return args;
+}
+
+/**
+ * 用户输入 PII / 凭据检测。
+ *
+ * v1 only scans event.prompt in before_prompt_build and shows non-blocking
+ * warnings by prefixing the same run's outgoing message in message_sending.
+ */
+export const piiScan: SecurityCapability = {
+  id: "pii-scan-user-input",
+  name: "PII Checker",
+  hooks: ["before_prompt_build", "message_sending"],
+  register(api) {
+    const cfg = readConfig((api.pluginConfig as Record<string, any>) ?? {});
+    if (!cfg.scanUserInput) {
+      api.logger.info("[pii-checker] piiScanUserInput=false, capability disabled");
+      return;
+    }
+
+    const warningsByRun = new Map<string, WarningBucket>();
+
+    api.on(
+      "before_prompt_build",
+      async (event: any, ctx: any) => {
+        try {
+          cleanupExpired(warningsByRun, cfg.warningTtlMs);
+
+          const prompt = typeof event?.prompt === "string" ? event.prompt : "";
+          if (!prompt.trim()) {
+            return undefined;
+          }
+
+          const result = await callAgentSecCli(buildScanArgs(prompt, cfg.includeLowConfidence), {
+            timeout: CLI_TIMEOUT_MS,
+          });
+          if (result.exitCode !== 0) {
+            api.logger.warn(`[pii-checker] CLI failed: ${result.stderr || result.exitCode}`);
+            return undefined;
+          }
+
+          const scanResult = JSON.parse(result.stdout) as {
+            verdict?: unknown;
+            findings?: unknown;
+          };
+          const verdict = safeString(scanResult.verdict) || "pass";
+          const findings = Array.isArray(scanResult.findings)
+            ? scanResult.findings
+            : [];
+
+          if (verdict === "pass" || findings.length === 0) {
+            api.logger.info("[pii-checker] pass");
+            return undefined;
+          }
+
+          if (verdict !== "warn" && verdict !== "deny") {
+            return undefined;
+          }
+
+          const runId = getRunId(event, ctx);
+          if (!runId) {
+            api.logger.warn("[pii-checker] missing runId, warning not cached");
+            return undefined;
+          }
+
+          const warning = formatPiiWarning(verdict, findings);
+          pushWarning(warningsByRun, runId, warning, cfg.warningTtlMs);
+          api.logger.warn(`[pii-checker] ${verdict.toUpperCase()} — warning cached for runId=${runId}`);
+          return undefined;
+        } catch (error) {
+          api.logger.warn(`[pii-checker] failed open: ${error instanceof Error ? error.message : String(error)}`);
+          return undefined;
+        }
+      },
+      { priority: 0 },
+    );
+
+    api.on(
+      "message_sending",
+      async (event: any, ctx: any) => {
+        try {
+          const runId = getRunId(event, ctx);
+          if (!runId) {
+            cleanupExpired(warningsByRun, cfg.warningTtlMs);
+            return undefined;
+          }
+
+          const warnings = drainWarnings(warningsByRun, runId, cfg.warningTtlMs);
+          if (warnings.length === 0) {
+            return undefined;
+          }
+
+          const content = typeof event?.content === "string" ? event.content : "";
+          return {
+            content: content ? `${warnings.join("\n")}\n\n${content}` : warnings.join("\n"),
+          };
+        } catch (error) {
+          api.logger.warn(`[pii-checker] message_sending failed open: ${error instanceof Error ? error.message : String(error)}`);
+          return undefined;
+        }
+      },
+      { priority: 0 },
+    );
+  },
+};

--- a/src/agent-sec-core/openclaw-plugin/src/index.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/index.ts
@@ -3,12 +3,14 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { SecurityCapability } from "./types.js";
 import { codeScan } from "./capabilities/code-scan.js";
 import { observability } from "./capabilities/observability.js";
+import { piiScan } from "./capabilities/pii-scan.js";
 import { promptScan } from "./capabilities/prompt-scan.js";
 import { skillLedger } from "./capabilities/skill-ledger.js";
 
 const capabilities: SecurityCapability[] = [
   codeScan,
   promptScan,
+  piiScan,
   skillLedger,
   observability,
 ];

--- a/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
@@ -31,10 +31,13 @@ const mockEvents: Record<string, Record<string, unknown>> = {
     prompt: "hello world",
     messages: [{ role: "user", content: "hello world" }],
   },
-  message_sending: {
+  reply_dispatch: {
     runId: "run-001",
     sessionId: "session-001",
-    content: "Hello.",
+    sendPolicy: "allow",
+    inboundAudio: false,
+    shouldRouteToOriginating: false,
+    shouldSendToolSummaries: true,
   },
   llm_input: {
     runId: "run-001",
@@ -111,8 +114,18 @@ const mockCtx: Record<string, Record<string, unknown>> = {
   before_prompt_build: {
     channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
   },
-  message_sending: {
-    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+  reply_dispatch: {
+    dispatcher: {
+      sendToolResult: () => false,
+      sendBlockReply: () => true,
+      sendFinalReply: () => false,
+      waitForIdle: async () => {},
+      getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => {},
+    },
+    recordProcessed: () => {},
+    markIdle: () => {},
   },
   llm_input: {
     channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",

--- a/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
@@ -2,6 +2,7 @@
 import { testCapability } from "./test-harness.js";
 import { codeScan } from "../src/capabilities/code-scan.js";
 import { observability } from "../src/capabilities/observability.js";
+import { piiScan } from "../src/capabilities/pii-scan.js";
 import { promptScan } from "../src/capabilities/prompt-scan.js";
 import { skillLedger } from "../src/capabilities/skill-ledger.js";
 import { _setCliMock } from "../src/utils.js";
@@ -23,6 +24,17 @@ const mockEvents: Record<string, Record<string, unknown>> = {
     body: "hello world",
     senderId: "user-123",
     isGroup: false,
+  },
+  before_prompt_build: {
+    runId: "run-001",
+    sessionId: "session-001",
+    prompt: "hello world",
+    messages: [{ role: "user", content: "hello world" }],
+  },
+  message_sending: {
+    runId: "run-001",
+    sessionId: "session-001",
+    content: "Hello.",
   },
   llm_input: {
     runId: "run-001",
@@ -96,6 +108,12 @@ const mockCtx: Record<string, Record<string, unknown>> = {
   before_dispatch: {
     channelId: "telegram", sessionKey: "sk-001", senderId: "user-123",
   },
+  before_prompt_build: {
+    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+  },
+  message_sending: {
+    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+  },
   llm_input: {
     channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
   },
@@ -116,7 +134,7 @@ const mockCtx: Record<string, Record<string, unknown>> = {
   },
 };
 
-const caps = [codeScan, promptScan, observability];
+const caps = [codeScan, promptScan, piiScan, observability];
 
 if (!process.env.AGENT_SEC_LIVE) {
   _setCliMock(async (args) => {
@@ -124,6 +142,9 @@ if (!process.env.AGENT_SEC_LIVE) {
       return { exitCode: 0, stdout: '{"verdict":"pass","findings":[]}', stderr: "" };
     }
     if (args[0] === "scan-prompt") {
+      return { exitCode: 0, stdout: '{"verdict":"pass","findings":[]}', stderr: "" };
+    }
+    if (args[0] === "scan-pii") {
       return { exitCode: 0, stdout: '{"verdict":"pass","findings":[]}', stderr: "" };
     }
     if (args[0] === "skill-ledger" && args[1] === "check") {

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
@@ -32,10 +32,10 @@ function registerHandlers(pluginConfig: Record<string, any> = {}) {
   const { api, hooks, logs } = createMockApi(pluginConfig);
   piiScan.register(api);
   const beforePromptBuild = hooks.find((hook) => hook.hookName === "before_prompt_build");
-  const messageSending = hooks.find((hook) => hook.hookName === "message_sending");
+  const replyDispatch = hooks.find((hook) => hook.hookName === "reply_dispatch");
   assert.ok(beforePromptBuild, "before_prompt_build handler should be registered");
-  assert.ok(messageSending, "message_sending handler should be registered");
-  return { beforePromptBuild, messageSending, hooks, logs };
+  assert.ok(replyDispatch, "reply_dispatch handler should be registered");
+  return { beforePromptBuild, replyDispatch, hooks, logs };
 }
 
 let lastCliArgs: string[] | undefined;
@@ -63,6 +63,23 @@ function scanResult(verdict: string, findings: unknown[]) {
   };
 }
 
+function createReplyDispatchCtx(sendBlockReply?: (payload: any) => boolean) {
+  const blockReplies: any[] = [];
+  const dispatcher = {
+    sendToolResult: () => false,
+    sendBlockReply: sendBlockReply ?? ((payload: any) => {
+      blockReplies.push(payload);
+      return true;
+    }),
+    sendFinalReply: () => false,
+    waitForIdle: async () => {},
+    getQueuedCounts: () => ({ tool: 0, block: blockReplies.length, final: 0 }),
+    getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+    markComplete: () => {},
+  };
+  return { ctx: { dispatcher }, blockReplies };
+}
+
 const warnFinding = {
   type: "email",
   severity: "warn",
@@ -80,14 +97,14 @@ describe("pii-scan-user-input", () => {
     _resetCliMock();
   });
 
-  it("registers before_prompt_build and message_sending", () => {
+  it("registers before_prompt_build and reply_dispatch", () => {
     const { hooks } = registerHandlers();
 
     assert.deepEqual(
       hooks.map((hook) => hook.hookName),
-      ["before_prompt_build", "message_sending"],
+      ["before_prompt_build", "reply_dispatch"],
     );
-    assert.deepEqual(piiScan.hooks, ["before_prompt_build", "message_sending"]);
+    assert.deepEqual(piiScan.hooks, ["before_prompt_build", "reply_dispatch"]);
   });
 
   it("does not call CLI for empty prompt", async () => {
@@ -127,35 +144,54 @@ describe("pii-scan-user-input", () => {
   });
 
   it("pass verdict does not cache a warning", async () => {
-    const { beforePromptBuild, messageSending } = registerHandlers();
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli(scanResult("pass", []));
 
     await beforePromptBuild.handler({ prompt: "hello", runId: "run-1" }, { runId: "run-1" });
-    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
 
     assert.equal(result, undefined);
+    assert.deepEqual(blockReplies, []);
   });
 
-  it("warn verdict prefixes same-run reply once and omits raw evidence", async () => {
-    const { beforePromptBuild, messageSending } = registerHandlers();
+  it("warn verdict queues a same-run block reply once and omits raw evidence", async () => {
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli(scanResult("warn", [warnFinding]));
 
     await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const first = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
-    const second = await messageSending.handler({ content: "Hello again.", runId: "run-1" }, { runId: "run-1" });
+    const first = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+    const second = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
 
-    assert.equal(typeof first?.content, "string");
-    assert.match(first.content, /\[pii-checker\]/);
-    assert.match(first.content, /email/);
-    assert.match(first.content, /a\*\*\*@example\.com/);
-    assert.doesNotMatch(first.content, /alice@example\.com/);
-    assert.doesNotMatch(first.content, /raw_evidence/);
-    assert.ok(first.content.endsWith("\n\nHello."));
+    assert.equal(first, undefined);
     assert.equal(second, undefined);
+    assert.equal(blockReplies.length, 1);
+    assert.match(blockReplies[0].text, /\[pii-checker\]/);
+    assert.match(blockReplies[0].text, /email/);
+    assert.match(blockReplies[0].text, /a\*\*\*@example\.com/);
+    assert.doesNotMatch(blockReplies[0].text, /alice@example\.com/);
+    assert.doesNotMatch(blockReplies[0].text, /raw_evidence/);
+    assert.match(blockReplies[0].text, /本轮请求将继续处理/);
   });
 
-  it("deny verdict prefixes a high-risk warning", async () => {
-    const { beforePromptBuild, messageSending } = registerHandlers();
+  it("keeps warning cached when reply_dispatch cannot queue the block reply", async () => {
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const failedCtx = createReplyDispatchCtx(() => false).ctx;
+    const { ctx, blockReplies } = createReplyDispatchCtx();
+    mockCli(scanResult("warn", [warnFinding]));
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
+    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, failedCtx);
+    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+
+    assert.equal(blockReplies.length, 1);
+    assert.match(blockReplies[0].text, /\[pii-checker\]/);
+  });
+
+  it("deny verdict queues a high-risk warning", async () => {
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli(
       scanResult("deny", [
         {
@@ -167,61 +203,89 @@ describe("pii-scan-user-input", () => {
     );
 
     await beforePromptBuild.handler({ prompt: "password=secret", runId: "run-1" }, { runId: "run-1" });
-    const result = await messageSending.handler({ content: "Done.", runId: "run-1" }, { runId: "run-1" });
+    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
 
-    assert.match(result.content, /高风险/);
-    assert.match(result.content, /credential/);
-    assert.match(result.content, /Done\./);
+    assert.equal(result, undefined);
+    assert.equal(blockReplies.length, 1);
+    assert.match(blockReplies[0].text, /高风险/);
+    assert.match(blockReplies[0].text, /credential/);
   });
 
   it("uses event.runId when ctx.runId is missing", async () => {
-    const { beforePromptBuild, messageSending } = registerHandlers();
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli(scanResult("warn", [warnFinding]));
 
     await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-event" }, {});
-    const result = await messageSending.handler({ content: "Hello.", runId: "run-event" }, {});
+    const result = await replyDispatch.handler({ runId: "run-event", sendPolicy: "allow" }, ctx);
 
-    assert.match(result.content, /\[pii-checker\]/);
+    assert.equal(result, undefined);
+    assert.equal(blockReplies.length, 1);
+    assert.match(blockReplies[0].text, /\[pii-checker\]/);
   });
 
   it("does not cache warning when runId is missing", async () => {
-    const { beforePromptBuild, messageSending, logs } = registerHandlers();
+    const { beforePromptBuild, replyDispatch, logs } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli(scanResult("warn", [warnFinding]));
 
     await beforePromptBuild.handler({ prompt: "email alice@example.com" }, { sessionKey: "session-1" });
-    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
 
     assert.equal(result, undefined);
+    assert.deepEqual(blockReplies, []);
     assert.ok(logs.some((log) => log.includes("missing runId")));
   });
 
   it("CLI nonzero fails open", async () => {
-    const { beforePromptBuild, messageSending } = registerHandlers();
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli({ exitCode: 1, stdout: "", stderr: "boom" });
 
     await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
 
     assert.equal(result, undefined);
+    assert.deepEqual(blockReplies, []);
   });
 
   it("invalid CLI JSON fails open", async () => {
-    const { beforePromptBuild, messageSending } = registerHandlers();
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli({ exitCode: 0, stdout: "not-json", stderr: "" });
 
     await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
 
     assert.equal(result, undefined);
+    assert.deepEqual(blockReplies, []);
   });
 
   it("expires undrained warnings by TTL", async () => {
-    const { beforePromptBuild, messageSending } = registerHandlers({ piiWarningTtlMs: 0 });
+    const { beforePromptBuild, replyDispatch } = registerHandlers({ piiWarningTtlMs: 0 });
+    const { ctx, blockReplies } = createReplyDispatchCtx();
     mockCli(scanResult("warn", [warnFinding]));
 
     await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
 
     assert.equal(result, undefined);
+    assert.deepEqual(blockReplies, []);
+  });
+
+  it("drops warnings without display when user delivery is suppressed or denied", async () => {
+    const { beforePromptBuild, replyDispatch } = registerHandlers();
+    const { ctx, blockReplies } = createReplyDispatchCtx();
+    mockCli(scanResult("warn", [warnFinding]));
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
+    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow", suppressUserDelivery: true }, ctx);
+    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-2" }, { runId: "run-2" });
+    await replyDispatch.handler({ runId: "run-2", sendPolicy: "deny" }, ctx);
+    await replyDispatch.handler({ runId: "run-2", sendPolicy: "allow" }, ctx);
+
+    assert.deepEqual(blockReplies, []);
   });
 });

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
@@ -1,0 +1,227 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { piiScan } from "../../src/capabilities/pii-scan.js";
+import { _setCliMock, _resetCliMock } from "../../src/utils.js";
+import type { CliResult } from "../../src/utils.js";
+
+type RegisteredHook = {
+  hookName: string;
+  handler: (event: any, ctx: any) => Promise<any>;
+  priority: number;
+};
+
+function createMockApi(pluginConfig: Record<string, any> = {}) {
+  const hooks: RegisteredHook[] = [];
+  const logs: string[] = [];
+  const api = {
+    pluginConfig,
+    logger: {
+      info: (msg: string) => logs.push(`[INFO] ${msg}`),
+      error: (msg: string) => logs.push(`[ERROR] ${msg}`),
+      warn: (msg: string) => logs.push(`[WARN] ${msg}`),
+      debug: (msg: string) => logs.push(`[DEBUG] ${msg}`),
+    },
+    on: (hookName: string, handler: any, opts?: { priority?: number }) => {
+      hooks.push({ hookName, handler, priority: opts?.priority ?? 0 });
+    },
+  };
+  return { api: api as any, hooks, logs };
+}
+
+function registerHandlers(pluginConfig: Record<string, any> = {}) {
+  const { api, hooks, logs } = createMockApi(pluginConfig);
+  piiScan.register(api);
+  const beforePromptBuild = hooks.find((hook) => hook.hookName === "before_prompt_build");
+  const messageSending = hooks.find((hook) => hook.hookName === "message_sending");
+  assert.ok(beforePromptBuild, "before_prompt_build handler should be registered");
+  assert.ok(messageSending, "message_sending handler should be registered");
+  return { beforePromptBuild, messageSending, hooks, logs };
+}
+
+let lastCliArgs: string[] | undefined;
+let lastCliOpts: { timeout?: number } | undefined;
+
+function mockCli(result: CliResult) {
+  _setCliMock(async (args, opts) => {
+    lastCliArgs = args;
+    lastCliOpts = opts;
+    return result;
+  });
+}
+
+function mockCliNoCall() {
+  _setCliMock(async () => {
+    throw new Error("CLI should not have been called");
+  });
+}
+
+function scanResult(verdict: string, findings: unknown[]) {
+  return {
+    exitCode: 0,
+    stdout: JSON.stringify({ verdict, findings }),
+    stderr: "",
+  };
+}
+
+const warnFinding = {
+  type: "email",
+  severity: "warn",
+  evidence_redacted: "a***@example.com",
+  raw_evidence: "alice@example.com",
+};
+
+describe("pii-scan-user-input", () => {
+  beforeEach(() => {
+    lastCliArgs = undefined;
+    lastCliOpts = undefined;
+  });
+
+  afterEach(() => {
+    _resetCliMock();
+  });
+
+  it("registers before_prompt_build and message_sending", () => {
+    const { hooks } = registerHandlers();
+
+    assert.deepEqual(
+      hooks.map((hook) => hook.hookName),
+      ["before_prompt_build", "message_sending"],
+    );
+    assert.deepEqual(piiScan.hooks, ["before_prompt_build", "message_sending"]);
+  });
+
+  it("does not call CLI for empty prompt", async () => {
+    const { beforePromptBuild } = registerHandlers();
+    mockCliNoCall();
+
+    const result = await beforePromptBuild.handler({ prompt: "   ", runId: "run-1" }, { runId: "run-1" });
+
+    assert.equal(result, undefined);
+  });
+
+  it("passes scan-pii args and timeout", async () => {
+    const { beforePromptBuild } = registerHandlers();
+    mockCli(scanResult("pass", []));
+
+    await beforePromptBuild.handler({ prompt: "hello", runId: "run-1" }, { runId: "run-1" });
+
+    assert.deepEqual(lastCliArgs, [
+      "scan-pii",
+      "--text",
+      "hello",
+      "--format",
+      "json",
+      "--source",
+      "user_input",
+    ]);
+    assert.equal(lastCliOpts?.timeout, 10000);
+  });
+
+  it("adds --include-low-confidence when configured", async () => {
+    const { beforePromptBuild } = registerHandlers({ piiIncludeLowConfidence: true });
+    mockCli(scanResult("pass", []));
+
+    await beforePromptBuild.handler({ prompt: "hello", runId: "run-1" }, { runId: "run-1" });
+
+    assert.ok(lastCliArgs?.includes("--include-low-confidence"));
+  });
+
+  it("pass verdict does not cache a warning", async () => {
+    const { beforePromptBuild, messageSending } = registerHandlers();
+    mockCli(scanResult("pass", []));
+
+    await beforePromptBuild.handler({ prompt: "hello", runId: "run-1" }, { runId: "run-1" });
+    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+
+    assert.equal(result, undefined);
+  });
+
+  it("warn verdict prefixes same-run reply once and omits raw evidence", async () => {
+    const { beforePromptBuild, messageSending } = registerHandlers();
+    mockCli(scanResult("warn", [warnFinding]));
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
+    const first = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+    const second = await messageSending.handler({ content: "Hello again.", runId: "run-1" }, { runId: "run-1" });
+
+    assert.equal(typeof first?.content, "string");
+    assert.match(first.content, /\[pii-checker\]/);
+    assert.match(first.content, /email/);
+    assert.match(first.content, /a\*\*\*@example\.com/);
+    assert.doesNotMatch(first.content, /alice@example\.com/);
+    assert.doesNotMatch(first.content, /raw_evidence/);
+    assert.ok(first.content.endsWith("\n\nHello."));
+    assert.equal(second, undefined);
+  });
+
+  it("deny verdict prefixes a high-risk warning", async () => {
+    const { beforePromptBuild, messageSending } = registerHandlers();
+    mockCli(
+      scanResult("deny", [
+        {
+          type: "credential",
+          severity: "deny",
+          evidence_redacted: "password=[REDACTED]",
+        },
+      ]),
+    );
+
+    await beforePromptBuild.handler({ prompt: "password=secret", runId: "run-1" }, { runId: "run-1" });
+    const result = await messageSending.handler({ content: "Done.", runId: "run-1" }, { runId: "run-1" });
+
+    assert.match(result.content, /高风险/);
+    assert.match(result.content, /credential/);
+    assert.match(result.content, /Done\./);
+  });
+
+  it("uses event.runId when ctx.runId is missing", async () => {
+    const { beforePromptBuild, messageSending } = registerHandlers();
+    mockCli(scanResult("warn", [warnFinding]));
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-event" }, {});
+    const result = await messageSending.handler({ content: "Hello.", runId: "run-event" }, {});
+
+    assert.match(result.content, /\[pii-checker\]/);
+  });
+
+  it("does not cache warning when runId is missing", async () => {
+    const { beforePromptBuild, messageSending, logs } = registerHandlers();
+    mockCli(scanResult("warn", [warnFinding]));
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com" }, { sessionKey: "session-1" });
+    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+
+    assert.equal(result, undefined);
+    assert.ok(logs.some((log) => log.includes("missing runId")));
+  });
+
+  it("CLI nonzero fails open", async () => {
+    const { beforePromptBuild, messageSending } = registerHandlers();
+    mockCli({ exitCode: 1, stdout: "", stderr: "boom" });
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
+    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+
+    assert.equal(result, undefined);
+  });
+
+  it("invalid CLI JSON fails open", async () => {
+    const { beforePromptBuild, messageSending } = registerHandlers();
+    mockCli({ exitCode: 0, stdout: "not-json", stderr: "" });
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
+    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+
+    assert.equal(result, undefined);
+  });
+
+  it("expires undrained warnings by TTL", async () => {
+    const { beforePromptBuild, messageSending } = registerHandlers({ piiWarningTtlMs: 0 });
+    mockCli(scanResult("warn", [warnFinding]));
+
+    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
+    const result = await messageSending.handler({ content: "Hello.", runId: "run-1" }, { runId: "run-1" });
+
+    assert.equal(result, undefined);
+  });
+});

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
@@ -1,0 +1,207 @@
+"""Unit tests for cosh-extension/hooks/pii_checker_hook.py."""
+
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_COSH_HOOK = str(
+    Path(__file__).resolve().parents[2]
+    / ".."
+    / "cosh-extension"
+    / "hooks"
+    / "pii_checker_hook.py"
+)
+
+sys.path.insert(0, str(Path(_COSH_HOOK).parent))
+import pii_checker_hook  # noqa: E402
+from pii_checker_hook import _format_cosh  # noqa: E402
+
+
+class TestFormatCosh:
+    def test_pass_returns_allow(self):
+        result = json.loads(_format_cosh({"verdict": "pass", "findings": []}))
+        assert result == {"decision": "allow"}
+
+    def test_warn_returns_allow_with_reason(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "warn",
+                    "findings": [
+                        {
+                            "type": "email",
+                            "severity": "warn",
+                            "evidence_redacted": "a***@example.com",
+                            "raw_evidence": "alice@example.com",
+                        }
+                    ],
+                }
+            )
+        )
+
+        assert result["decision"] == "allow"
+        assert "[pii-checker]" in result["reason"]
+        assert "email" in result["reason"]
+        assert "a***@example.com" in result["reason"]
+        assert "alice@example.com" not in result["reason"]
+        assert "raw_evidence" not in result["reason"]
+
+    def test_deny_returns_allow_with_high_risk_reason(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "deny",
+                    "findings": [
+                        {
+                            "type": "credential",
+                            "severity": "deny",
+                            "evidence_redacted": "password=[REDACTED]",
+                        }
+                    ],
+                }
+            )
+        )
+
+        assert result["decision"] == "allow"
+        assert "高风险" in result["reason"]
+        assert "credential" in result["reason"]
+
+    def test_warn_without_findings_allows(self):
+        result = json.loads(_format_cosh({"verdict": "warn", "findings": []}))
+        assert result == {"decision": "allow"}
+
+    @pytest.mark.parametrize("verdict", ["error", "unknown", ""])
+    def test_error_and_unknown_verdicts_allow(self, verdict):
+        result = json.loads(_format_cosh({"verdict": verdict, "findings": [{}]}))
+        assert result == {"decision": "allow"}
+
+
+class TestCoshHookMain:
+    def _run_main(self, monkeypatch, capsys, input_data):
+        monkeypatch.setattr(pii_checker_hook.sys, "stdin", io.StringIO(input_data))
+        pii_checker_hook.main()
+        return json.loads(capsys.readouterr().out)
+
+    def test_empty_prompt_allows_without_cli(self, monkeypatch, capsys):
+        def fail_run(*args, **kwargs):
+            raise AssertionError("CLI should not be called")
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fail_run)
+
+        output = self._run_main(monkeypatch, capsys, '{"prompt": ""}')
+        assert output == {"decision": "allow"}
+
+    def test_invalid_json_allows_without_cli(self, monkeypatch, capsys):
+        def fail_run(*args, **kwargs):
+            raise AssertionError("CLI should not be called")
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fail_run)
+
+        output = self._run_main(monkeypatch, capsys, "not-json")
+        assert output == {"decision": "allow"}
+
+    def test_missing_prompt_allows_without_cli(self, monkeypatch, capsys):
+        def fail_run(*args, **kwargs):
+            raise AssertionError("CLI should not be called")
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fail_run)
+
+        output = self._run_main(monkeypatch, capsys, '{"session_id": "abc"}')
+        assert output == {"decision": "allow"}
+
+    def test_calls_scan_pii_with_user_input_source(self, monkeypatch, capsys):
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "verdict": "warn",
+                        "findings": [
+                            {
+                                "type": "phone_cn",
+                                "severity": "warn",
+                                "evidence_redacted": "138****8000",
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fake_run)
+
+        output = self._run_main(
+            monkeypatch,
+            capsys,
+            json.dumps({"prompt": "Phone: 13800138000"}),
+        )
+
+        assert captured["args"] == [
+            "agent-sec-cli",
+            "scan-pii",
+            "--text",
+            "Phone: 13800138000",
+            "--format",
+            "json",
+            "--source",
+            "user_input",
+        ]
+        assert captured["kwargs"]["timeout"] == 10
+        assert output["decision"] == "allow"
+        assert "phone_cn" in output["reason"]
+
+    def test_cli_nonzero_allows(self, monkeypatch, capsys):
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="boom",
+            )
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fake_run)
+
+        output = self._run_main(monkeypatch, capsys, '{"prompt": "hello"}')
+        assert output == {"decision": "allow"}
+
+    def test_cli_bad_json_allows(self, monkeypatch, capsys):
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout="not-json",
+                stderr="",
+            )
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fake_run)
+
+        output = self._run_main(monkeypatch, capsys, '{"prompt": "hello"}')
+        assert output == {"decision": "allow"}
+
+
+def test_manifest_registers_only_user_prompt_submit_for_pii():
+    manifest_path = (
+        Path(__file__).resolve().parents[2]
+        / ".."
+        / "cosh-extension"
+        / "cosh-extension.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    pii_locations = []
+    for hook_name, groups in manifest["hooks"].items():
+        for group in groups:
+            for hook in group.get("hooks", []):
+                if hook.get("name") == "pii-checker":
+                    pii_locations.append(hook_name)
+
+    assert pii_locations == ["UserPromptSubmit"]

--- a/src/agent-sec-core/tests/unit-test/pii_checker/test_scanner.py
+++ b/src/agent-sec-core/tests/unit-test/pii_checker/test_scanner.py
@@ -1,5 +1,6 @@
 """Unit tests for the PII scanner."""
 
+import pytest
 from agent_sec_cli.pii_checker.detectors.base import PiiCandidate
 from agent_sec_cli.pii_checker.scanner import DEFAULT_MAX_BYTES, PiiScanner
 
@@ -181,6 +182,11 @@ def test_max_bytes_truncates_input():
     assert result["verdict"] == "pass"
 
 
+def test_invalid_max_bytes_is_rejected():
+    with pytest.raises(ValueError, match="max_bytes must be greater than zero"):
+        PiiScanner().scan("alice@example.com", max_bytes=0)
+
+
 def test_multibyte_truncation_boundary_is_safe():
     max_bytes = len("备注".encode("utf-8")) + 1
     result = _scan("备注🙂 alice@example.com", max_bytes=max_bytes, redact_output=True)
@@ -189,6 +195,26 @@ def test_multibyte_truncation_boundary_is_safe():
     assert result["summary"]["bytes_scanned"] == max_bytes
     assert result["verdict"] == "pass"
     assert result["redacted_text"] == "备注"
+
+
+def test_large_input_over_default_limit_scans_tail_by_default():
+    email = "alice@company.cn"
+    text = f"{'x' * (DEFAULT_MAX_BYTES + 10)} {email}"
+    result = _scan(text)
+
+    assert result["summary"]["truncated"] is False
+    assert result["summary"]["bytes_scanned"] == len(text.encode("utf-8"))
+    assert "email" in _types(result)
+
+
+def test_explicit_default_limit_truncates_large_input_tail():
+    email = "alice@company.cn"
+    text = f"{'x' * (DEFAULT_MAX_BYTES + 10)} {email}"
+    result = _scan(text, max_bytes=DEFAULT_MAX_BYTES)
+
+    assert result["summary"]["truncated"] is True
+    assert result["summary"]["bytes_scanned"] == DEFAULT_MAX_BYTES
+    assert "email" not in _types(result)
 
 
 def test_large_input_near_default_limit_scans_tail():

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_pii_scan_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_pii_scan_backend.py
@@ -2,6 +2,7 @@
 
 import json
 
+from agent_sec_cli.pii_checker.scanner import DEFAULT_MAX_BYTES
 from agent_sec_cli.security_middleware.backends.pii_scan import PiiScanBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 
@@ -32,6 +33,31 @@ def test_backend_redact_output():
     assert result.data["verdict"] == "deny"
     assert "redacted_text" in result.data
     assert "supersecretvalue12345" not in result.data["redacted_text"]
+
+
+def test_backend_defaults_to_unlimited_scan():
+    backend = PiiScanBackend()
+    email = "alice@company.cn"
+    text = f"{'x' * (DEFAULT_MAX_BYTES + 10)} {email}"
+    result = backend.execute(RequestContext(action="pii_scan"), text=text)
+
+    assert result.success is True
+    assert result.data["summary"]["truncated"] is False
+    assert result.data["summary"]["bytes_scanned"] == len(text.encode("utf-8"))
+    assert any(finding["type"] == "email" for finding in result.data["findings"])
+
+
+def test_backend_accepts_none_max_bytes():
+    backend = PiiScanBackend()
+    result = backend.execute(
+        RequestContext(action="pii_scan"),
+        text="email alice@company.cn",
+        max_bytes=None,
+    )
+
+    assert result.success is True
+    assert result.data["verdict"] == "warn"
+    assert result.data["summary"]["truncated"] is False
 
 
 def test_backend_rejects_invalid_max_bytes():
@@ -111,3 +137,21 @@ def test_backend_error_audit_details_omit_exception_text_with_input():
     assert sensitive not in details_text
     assert details["error"] == "pii_scan error details omitted from audit"
     assert details["error_type"] == "RuntimeError"
+
+
+def test_backend_audit_details_allow_null_max_bytes_without_input_text():
+    sensitive = "alice@example.com"
+    backend = PiiScanBackend()
+    result = backend.execute(
+        RequestContext(action="pii_scan"),
+        text=sensitive,
+        max_bytes=None,
+    )
+    details = backend.build_event_details(
+        result,
+        {"text": sensitive, "max_bytes": None},
+    )
+    details_text = json.dumps(details, ensure_ascii=False)
+
+    assert details["request"]["max_bytes"] is None
+    assert sensitive not in details_text

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -163,6 +163,7 @@ class TestScanPiiCli(unittest.TestCase):
         self.assertEqual(kwargs["text"], "alice@example.com")
         self.assertEqual(kwargs["source"], "manual")
         self.assertFalse(kwargs["raw_evidence"])
+        self.assertIsNone(kwargs["max_bytes"])
 
     @patch("agent_sec_cli.pii_checker.cli.invoke")
     def test_scan_pii_text_output(self, mock_invoke):
@@ -209,6 +210,36 @@ class TestScanPiiCli(unittest.TestCase):
         self.assertIn("--source must be one of", result.output)
 
     @patch("agent_sec_cli.pii_checker.cli.invoke")
+    def test_scan_pii_input_default_reads_full_file(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(
+            success=True,
+            exit_code=0,
+            stdout='{"ok": true, "verdict": "warn"}',
+            data={
+                "ok": True,
+                "verdict": "warn",
+                "summary": {"total": 1},
+                "findings": [],
+            },
+        )
+
+        with self.runner.isolated_filesystem():
+            text = "备注🙂 alice@example.com"
+            Path("input.txt").write_text(text, encoding="utf-8")
+
+            result = self.runner.invoke(
+                app,
+                ["scan-pii", "--input", "input.txt"],
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        _, kwargs = mock_invoke.call_args
+        self.assertEqual(kwargs["text"], text)
+        self.assertFalse(kwargs["input_truncated"])
+        self.assertEqual(kwargs["input_bytes_scanned"], len(text.encode("utf-8")))
+        self.assertIsNone(kwargs["max_bytes"])
+
+    @patch("agent_sec_cli.pii_checker.cli.invoke")
     def test_scan_pii_input_reports_file_byte_limit(self, mock_invoke):
         mock_invoke.return_value = ActionResult(
             success=True,
@@ -242,6 +273,29 @@ class TestScanPiiCli(unittest.TestCase):
         self.assertTrue(kwargs["input_truncated"])
         self.assertEqual(kwargs["input_bytes_scanned"], max_bytes)
         self.assertNotIn("\ufffd", kwargs["text"])
+
+    @patch("agent_sec_cli.pii_checker.cli.invoke")
+    def test_scan_pii_input_rejects_invalid_utf8(self, mock_invoke):
+        with self.runner.isolated_filesystem():
+            Path("input.txt").write_bytes(b"\xff")
+
+            result = self.runner.invoke(
+                app,
+                ["scan-pii", "--input", "input.txt"],
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("--input must be valid UTF-8", result.output)
+        mock_invoke.assert_not_called()
+
+    def test_scan_pii_rejects_zero_max_bytes(self):
+        result = self.runner.invoke(
+            app,
+            ["scan-pii", "--text", "hello", "--max-bytes", "0"],
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("--max-bytes must be greater than zero", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a cosh UserPromptSubmit PIIChecker hook that returns allow + reason without changing host behavior
- add an OpenClaw pii-scan-user-input capability on before_prompt_build + message_sending
- add config/docs/smoke coverage plus Python and TypeScript unit tests

## Tests
- uv run --project agent-sec-cli pytest tests/unit-test/cosh_hooks/test_pii_checker_hook.py
- uv run --project agent-sec-cli ruff check --config agent-sec-cli/pyproject.toml cosh-extension/hooks/pii_checker_hook.py tests/unit-test/cosh_hooks/test_pii_checker_hook.py
- make python-code-pretty
- npm test
- npm run smoke
- npm run build
- git diff --check

no-issue: follow-up integration for PIIChecker hook support after PR #525