### PR TITLE
fix(sec-core): detect scan-pii module mode via subprocess

### DIFF
--- a/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
@@ -4,7 +4,6 @@ import json
 import os
 import subprocess
 import sys
-from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
@@ -14,12 +13,14 @@ _MODES = ("binary", "module")
 
 
 def _module_mode_available() -> bool:
-    try:
-        return find_spec("agent_sec_cli") is not None and (
-            find_spec("agent_sec_cli.cli") is not None
-        )
-    except ModuleNotFoundError:
-        return False
+    result = subprocess.run(
+        [sys.executable, "-c", "import agent_sec_cli.cli"],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+    return result.returncode == 0
 
 
 def _command(mode: str) -> list[str]:


### PR DESCRIPTION
## Summary
- make scan-pii e2e module-mode detection use the same subprocess import path that the test later executes
- skip module mode in RPM environments where only the installed agent-sec-cli binary is importable

## Tests
- uv run --project agent-sec-cli ruff check --config agent-sec-cli/pyproject.toml tests/e2e/cli/test_scan_pii_e2e.py
- uv run --project agent-sec-cli pytest tests/e2e/cli/test_scan_pii_e2e.py -v
- git diff --check

no-issue: CI fix split out from PIIChecker hook PR #539