### PR TITLE
feat(tokenless): add hermes agent plugin

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -12,6 +12,7 @@ TOON_DIR := third_party/toon
         adapter-install adapter-uninstall adapter-scan \
         cosh-install cosh-uninstall \
         openclaw-install openclaw-uninstall \
+        hermes-install hermes-uninstall \
         setup help \
         test-hooks
 
@@ -45,7 +46,8 @@ install: build
 	@echo "==> Installed tokenless to $(BIN_DIR), rtk/toon to $(LIB_DIR) (symlinked to $(BIN_DIR))"
 	@echo "==> Installing adapter resources to $(SHARE_DIR)..."
 	@mkdir -p $(SHARE_DIR)/common/hooks $(SHARE_DIR)/common/commands \
-	           $(SHARE_DIR)/cosh/scripts $(SHARE_DIR)/openclaw/scripts
+	           $(SHARE_DIR)/cosh/scripts $(SHARE_DIR)/openclaw/scripts \
+	           $(SHARE_DIR)/hermes/scripts
 	cp $(ADAPTER_DIR)/manifest.json $(SHARE_DIR)/
 	cp $(ADAPTER_DIR)/common/tool-ready-spec.json $(SHARE_DIR)/common/
 	cp $(ADAPTER_DIR)/common/tokenless-env-fix.sh $(SHARE_DIR)/common/
@@ -60,6 +62,11 @@ install: build
 	cp $(ADAPTER_DIR)/openclaw/scripts/uninstall.sh $(SHARE_DIR)/openclaw/scripts/
 	cp $(ADAPTER_DIR)/openclaw/openclaw.plugin.json $(SHARE_DIR)/openclaw/
 	cp $(ADAPTER_DIR)/openclaw/package.json $(SHARE_DIR)/openclaw/
+	cp $(ADAPTER_DIR)/hermes/__init__.py $(SHARE_DIR)/hermes/
+	cp $(ADAPTER_DIR)/hermes/plugin.yaml $(SHARE_DIR)/hermes/
+	cp $(ADAPTER_DIR)/hermes/scripts/detect.sh $(SHARE_DIR)/hermes/scripts/
+	cp $(ADAPTER_DIR)/hermes/scripts/install.sh $(SHARE_DIR)/hermes/scripts/
+	cp $(ADAPTER_DIR)/hermes/scripts/uninstall.sh $(SHARE_DIR)/hermes/scripts/
 	@echo "==> Adapter resources installed to $(SHARE_DIR)"
 
 # Run tests
@@ -115,9 +122,9 @@ ADAPTER_ENV = ANOLISA_PREFIX=$(HOME)/.local \
               ANOLISA_COMPONENT=tokenless \
               ANOLISA_VERSION=0.3.2
 
-adapter-install: cosh-install openclaw-install
+adapter-install: cosh-install openclaw-install hermes-install
 
-adapter-uninstall: cosh-uninstall openclaw-uninstall
+adapter-uninstall: cosh-uninstall openclaw-uninstall hermes-uninstall
 
 adapter-scan:
 	@echo "=== Tokenless Adapter Manifest ==="
@@ -144,8 +151,20 @@ openclaw-uninstall:
 	@echo "==> Uninstalling tokenless OpenClaw plugin..."
 	@$(ADAPTER_ENV) ANOLISA_TARGET=openclaw bash $(SHARE_DIR)/openclaw/scripts/uninstall.sh
 
+# --- Hermes Agent ---
+HERMES_ADAPTER_DIR = $(SHARE_DIR)/hermes
+
+hermes-install:
+	@echo "==> Installing Hermes Agent plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=hermes bash $(HERMES_ADAPTER_DIR)/scripts/detect.sh || true
+	@$(ADAPTER_ENV) ANOLISA_TARGET=hermes bash $(HERMES_ADAPTER_DIR)/scripts/install.sh
+
+hermes-uninstall:
+	@echo "==> Uninstalling Hermes Agent plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=hermes bash $(HERMES_ADAPTER_DIR)/scripts/uninstall.sh
+
 # One-step setup: build + install + all adapters
-setup: install adapter-install
+setup: install adapter-install hermes-install
 	@echo ""
 	@echo "============================================"
 	@echo "  Token-Less setup complete!"
@@ -157,7 +176,7 @@ setup: install adapter-install
 	@echo "  Adapter (FHS):"
 	@echo "    $(SHARE_DIR)/"
 	@echo "  Registered:"
-	@echo "    cosh, openclaw"
+	@echo "    cosh, openclaw, hermes"
 	@echo ""
 	@echo "Verify:"
 	@echo "  tokenless --version"
@@ -186,6 +205,8 @@ help:
 	@echo "  cosh-uninstall    Unregister copilot-shell extension"
 	@echo "  openclaw-install  Register OpenClaw plugin"
 	@echo "  openclaw-uninstall Unregister OpenClaw plugin"
+	@echo "  hermes-install    Install Hermes Agent plugin"
+	@echo "  hermes-uninstall  Uninstall Hermes Agent plugin"
 	@echo "  setup             Full setup: build + install + register adapters"
 	@echo "  help              Show this help"
 	@echo ""

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -9,10 +9,11 @@ Token-Less combines complementary strategies to minimize LLM token consumption:
 - **Command Rewriting** — Integrates [RTK](https://github.com/rtk-ai/rtk) to filter and rewrite CLI command output, eliminating noise that would otherwise waste 60–90% of tokens.
 - **Tool Ready** — Pre-checks tool execution environments (binaries, configs, permissions, network), auto-fixes missing dependencies, and classifies execution failures as environment issues vs logic errors — reducing wasted retry tokens.
 
-Two integration paths are available:
+Three integration paths are available:
 
 - **OpenClaw plugin** — covers command rewriting, response compression, and schema compression in one plugin.
 - **copilot-shell hook** — intercepts Shell commands via a PreToolUse hook and delegates to RTK for command rewriting + output filtering.
+- **Hermes Agent plugin** — response compression, TOON encoding, command rewriting (block + suggest), and Tool Ready environment pre-check via Hermes's native plugin system.
 
 ## Features
 
@@ -25,6 +26,7 @@ Two integration paths are available:
 | Tool Ready | reduces retry waste | Pre-check env, auto-fix deps, failure attribution |
 | OpenClaw plugin | — | Command rewriting ✅, Response compression ✅, Schema compression ✅ |
 | copilot-shell hooks | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ✅ |
+| Hermes Agent plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ⏳ |
 | Zero runtime deps | — | Pure Rust, single static binary |
 
 ## Architecture
@@ -41,7 +43,11 @@ Token-Less/
 │   │   ├── tokenless-env-fix.sh # Auto-fix script for missing deps
 │   │   └── commands/            # Hook command configs
 │   ├── cosh/scripts/            # copilot-shell agent scripts (detect/install/uninstall)
-│   └── openclaw/                # OpenClaw plugin + agent scripts
+│   ├── openclaw/                # OpenClaw plugin + agent scripts
+│   └── hermes/                  # Hermes Agent plugin + scripts
+│       ├── scripts/               # detect/install/uninstall (user-driven registration)
+│       ├── plugin.yaml            # Plugin manifest
+│       └── __init__.py            # register(ctx): transform_tool_result + pre_tool_call (env-check + rtk rewrite) + on_session_start
 ├── third_party/rtk/           # RTK submodule (command rewriting engine)
 ├── third_party/toon/          # TOON submodule (JSON to TOON encoding)
 ├── Makefile                   # Unified build system
@@ -59,7 +65,7 @@ cd Token-Less
 make setup
 ```
 
-Both methods install `tokenless` to `~/.local/bin`, helper binaries `rtk`/`toon` alongside it, and deploy the adapters (hooks + OpenClaw plugin).
+Both methods install `tokenless` to `~/.local/bin`, helper binaries `rtk`/`toon` alongside it, and deploy the adapters (hooks + OpenClaw plugin + Hermes plugin).
 
 ## CLI Usage
 
@@ -200,6 +206,43 @@ Options in `openclaw.plugin.json`:
 | `response_compression_enabled` | `true` | Enable tool response compression via `tool_result_persist` |
 | `verbose` | `true` | Log detailed rewrite/compression info |
 
+## Hermes Agent Plugin
+
+The plugin registers hooks at three Hermes events, covering five strategies:
+
+| Strategy | Event | Action | Status |
+|---|---|---|---|
+| Tool Ready | `pre_tool_call` | Environment readiness pre-check with auto-fix and skip-retry feedback | ✅ Active |
+| Command rewriting | `pre_tool_call` | Blocks original command, suggests `rtk`-rewritten version (one extra round-trip) | ✅ Active |
+| Response compression | `transform_tool_result` | Compresses tool results via `tokenless compress-response` | ✅ Active |
+| TOON encoding | `transform_tool_result` | Pipeline step after response compression — encodes JSON to TOON format | ✅ Active |
+| Session tracking | `on_session_start` | Propagates agent/session IDs for stats recording | ✅ Active |
+| Schema compression | — | Not supported by Hermes hook system (no hook exposes tool schemas) | ⏳ Blocked |
+
+**How command rewriting works in Hermes**: Hermes's `pre_tool_call` hook can only block tool execution (not modify arguments), so the plugin blocks the original shell command and returns a message suggesting the RTK-rewritten version. The agent then re-executes with the optimized command, adding one extra tool-call round-trip. This is safe — `rtk rewrite` only does text substitution and never executes the command.
+
+Each hook degrades gracefully — if the corresponding binary is not installed, that hook is silently skipped.
+
+### Install
+
+```bash
+make hermes-install
+```
+
+Enable the plugin:
+
+```bash
+hermes plugins enable tokenless
+```
+
+Or add to `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - tokenless
+```
+
 ## Build
 
 | Target | Description |
@@ -220,6 +263,8 @@ Options in `openclaw.plugin.json`:
 | `make cosh-uninstall` | Uninstall copilot-shell extension |
 | `make openclaw-install` | Install OpenClaw plugin |
 | `make openclaw-uninstall` | Remove OpenClaw plugin |
+| `make hermes-install` | Install Hermes Agent plugin |
+| `make hermes-uninstall` | Remove Hermes Agent plugin |
 | `make setup` | Full setup: build + install + all adapters |
 
 Override install paths:
@@ -235,6 +280,7 @@ make install BIN_DIR=/usr/local/bin
 | `crates/tokenless-cli/` | CLI binary — `tokenless` command (compress, stats, env-check) |
 | `crates/tokenless-schema/` | Core Rust library — `SchemaCompressor` and `ResponseCompressor` |
 | `adapters/tokenless/` | FHS adapter bundle — manifest, env-check spec/fix, hooks, OpenClaw plugin |
+| `adapters/tokenless/hermes/` | Hermes Agent adapter — plugin + detect/install/uninstall scripts |
 | `third_party/rtk/` | RTK git submodule — command rewriting engine (70+ commands) |
 | `third_party/toon/` | TOON git submodule — JSON to TOON format encoding |
 | `Makefile` | Unified build system for the entire workspace |

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -1,0 +1,488 @@
+"""Token-Less Plugin for Hermes Agent.
+
+Combines multiple context-compression strategies into a single plugin:
+
+  1. **Response compression** — ``transform_tool_result`` : compresses tool
+     results via ``tokenless compress-response``, stripping debug fields,
+     nulls, empty values, and truncating long strings/arrays.
+  2. **TOON encoding** — ``transform_tool_result`` : pipeline step after
+     response compression; re-encodes JSON results to TOON format via
+     ``tokenless compress-toon`` for additional token savings (15-40%)
+     with proper stats recording and size check.
+  3. **Tool Ready** — ``pre_tool_call`` : environment readiness pre-check
+     with auto-fix and skip-retry feedback for missing dependencies.
+  4. **Command rewriting** — ``pre_tool_call`` : blocks shell commands
+     and suggests RTK-rewritten equivalents.  Hermes's hook cannot modify
+     arguments, so the agent must re-execute with the suggested command
+     (one extra round-trip).  Safe: ``rtk rewrite`` only does text
+     substitution, never executes the command.
+  5. **Session tracking** — ``on_session_start`` : propagates agent/session
+     IDs to tokenless stats recording.
+
+Not available in Hermes: schema compression (Hermes hooks do not expose
+tool schemas).
+
+Every hook degrades gracefully: if ``tokenless`` is not installed, all
+hooks are silently skipped.
+
+Activation is controlled by the Hermes plugin system — list ``tokenless`` in
+``plugins.enabled`` in ``config.yaml``, or enable via
+``hermes plugins enable tokenless``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+AGENT_ID = "hermes-agent"
+_MIN_RESPONSE_LEN = 200
+
+_SKIP_TOOLS: set[str] = {
+    "read_file",
+    "list_directory",
+    "glob",
+    "notebook_read",
+    "session_search",
+    "list_sessions",
+}
+
+_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
+_RTK_FALLBACK = "/usr/libexec/anolisa/tokenless/rtk"
+_MIN_RTK_VERSION = (0, 35, 0)
+_SHELL_TOOLS: set[str] = {"terminal"}
+
+_CONTEXT_DIR = os.path.join(os.path.expanduser("~"), ".tokenless")
+_CONTEXT_FILE = os.path.join(_CONTEXT_DIR, ".rewrite-context")
+
+# ---------------------------------------------------------------------------
+# Binary resolution (with caching)
+# ---------------------------------------------------------------------------
+
+_resolved: dict[str, str | None] = {}
+
+
+def _resolve_binary(name: str, fallback: str) -> str | None:
+    if name in _resolved:
+        return _resolved[name]
+    path = shutil.which(name)
+    if path:
+        _resolved[name] = path
+        return path
+    if os.path.isfile(fallback) and os.access(fallback, os.X_OK):
+        _resolved[name] = fallback
+        return fallback
+    _resolved[name] = None
+    return None
+
+
+def _have(name: str, fallback: str) -> bool:
+    return _resolve_binary(name, fallback) is not None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _try_parse_json(data: str) -> Any:
+    try:
+        return json.loads(data)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _is_skill_file(text: str) -> bool:
+    if not isinstance(text, str) or not text.startswith("---"):
+        return False
+    for line in text.split("\n", 20)[1:]:
+        if line.startswith("name:") or line.startswith("description:"):
+            return True
+    return False
+
+
+def _run(args: list[str], input_data: str, timeout: int = 10) -> subprocess.CompletedProcess | None:
+    try:
+        return subprocess.run(
+            args, input=input_data, capture_output=True, text=True, timeout=timeout,
+        )
+    except Exception:
+        return None
+
+
+def _parse_version(version_str: str) -> tuple | None:
+    m = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)
+    if m:
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    return None
+
+
+def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
+    os.makedirs(_CONTEXT_DIR, exist_ok=True)
+    with open(_CONTEXT_FILE, "w") as f:
+        f.write(f"{agent_id}\n")
+        f.write(f"{session_id}\n")
+        f.write(f"{tool_use_id}\n")
+
+
+# ---------------------------------------------------------------------------
+# 1. Response Compression (via tokenless compress-response)
+# ---------------------------------------------------------------------------
+
+
+def _compress_response(
+    tool_name: str,
+    result: str,
+    session_id: str,
+    tool_call_id: str,
+) -> str | None:
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    if not tokenless_bin:
+        return None
+
+    parsed = _try_parse_json(result)
+    if not isinstance(parsed, (dict, list)):
+        return None
+
+    cmd = [tokenless_bin, "compress-response", "--agent-id", AGENT_ID]
+    if session_id:
+        cmd.extend(["--session-id", session_id])
+    if tool_call_id:
+        cmd.extend(["--tool-use-id", tool_call_id])
+
+    proc = _run(cmd, result)
+    if not proc or proc.returncode != 0 or not proc.stdout.strip():
+        return None
+
+    compressed = proc.stdout.strip()
+    if compressed == result:
+        return None
+    return compressed
+
+
+# ---------------------------------------------------------------------------
+# 2. TOON Encoding (via tokenless compress-toon)
+# ---------------------------------------------------------------------------
+
+
+def _encode_toon(data: str, session_id: str = "", tool_call_id: str = "") -> tuple[str, int] | None:
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    if not tokenless_bin:
+        return None
+
+    parsed = _try_parse_json(data)
+    if not isinstance(parsed, (dict, list)):
+        return None
+
+    cmd = [tokenless_bin, "compress-toon", "--agent-id", AGENT_ID]
+    if session_id:
+        cmd.extend(["--session-id", session_id])
+    if tool_call_id:
+        cmd.extend(["--tool-use-id", tool_call_id])
+
+    proc = _run(cmd, data)
+    if not proc or proc.returncode != 0 or not proc.stdout.strip():
+        return None
+
+    toon_text = proc.stdout.strip()
+    # Skip if TOON didn't reduce size
+    if toon_text == data or len(toon_text) > len(data):
+        return None
+
+    savings_pct = 0
+    if len(data) > 0:
+        savings_pct = (len(data) - len(toon_text)) * 100 // len(data)
+
+    return toon_text, savings_pct
+
+
+# ---------------------------------------------------------------------------
+# 3. Tool Ready (via tokenless env-check)
+# ---------------------------------------------------------------------------
+
+
+def _env_check(tool_name: str) -> str | None:
+    """Run tool-ready env-check and return feedback if tool is not ready."""
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    if not tokenless_bin:
+        return None
+
+    proc = _run([tokenless_bin, "env-check", "--tool", tool_name, "--json"], "", timeout=5)
+    if not proc or not proc.stdout.strip():
+        return None
+
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+
+    status = parsed.get("status", "UNKNOWN")
+    if status in ("UNKNOWN", "READY"):
+        return None
+
+    # Attempt auto-fix
+    proc = _run([tokenless_bin, "env-check", "--tool", tool_name, "--fix", "--json"], "", timeout=10)
+    if not proc or not proc.stdout.strip():
+        return _not_ready_msg(tool_name)
+
+    try:
+        fix_parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return _not_ready_msg(tool_name)
+
+    if fix_parsed.get("status") == "READY":
+        return None
+
+    diagnostic = fix_parsed.get("diagnostic", "")
+    return diagnostic or _not_ready_msg(tool_name)
+
+
+def _not_ready_msg(tool_name: str) -> str:
+    return (
+        f"[tokenless tool-ready] {tool_name}: NOT_READY — "
+        f"environment issue. Skip retry, this is not a logic error."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Command Rewriting (via rtk rewrite)
+# ---------------------------------------------------------------------------
+
+
+def _try_rewrite(
+    args: Any,
+    session_id: str,
+    tool_call_id: str,
+) -> dict[str, str] | None:
+    """Attempt RTK command rewrite for terminal tool calls.
+
+    Calls ``rtk rewrite <command>`` — a pure text substitution that never
+    executes the command.  On success, returns a block directive suggesting
+    the rewritten command so the agent re-executes with the optimized version.
+    """
+    rtk_bin = _resolve_binary("rtk", _RTK_FALLBACK)
+    if not rtk_bin:
+        return None
+
+    if not isinstance(args, dict):
+        return None
+
+    command = args.get("command", "")
+    if not command:
+        return None
+
+    # Version guard — non-fatal
+    try:
+        ver_proc = subprocess.run(
+            [rtk_bin, "--version"], capture_output=True, text=True, timeout=3,
+        )
+        ver = _parse_version(ver_proc.stdout)
+        if ver and ver < _MIN_RTK_VERSION:
+            logger.warning("tokenless: rtk %s too old (need >= 0.35.0), rewrite skipped", ver_proc.stdout.strip())
+            return None
+    except Exception:
+        pass
+
+    # Write context file so rtk (running as proxy later) can recover IDs
+    _write_context(AGENT_ID, session_id, tool_call_id)
+
+    # Set env vars for rtk stats context
+    env = os.environ.copy()
+    env["TOKENLESS_AGENT_ID"] = AGENT_ID
+    if session_id:
+        env["TOKENLESS_SESSION_ID"] = session_id
+    if tool_call_id:
+        env["TOKENLESS_TOOL_USE_ID"] = tool_call_id
+
+    proc = subprocess.run(
+        [rtk_bin, "rewrite", command],
+        capture_output=True, text=True, timeout=5, env=env,
+    )
+
+    # Exit code protocol (from rtk rewrite_cmd.rs):
+    #   0 = rewrite available (stdout = rewritten command)
+    #   1 = no RTK equivalent (passthrough)
+    #   2 = deny rule matched (let Hermes handle)
+    #   3 = ask rule matched (let Hermes handle)
+    if proc.returncode == 1 or proc.returncode == 2 or proc.returncode == 3:
+        return None
+    if proc.returncode != 0:
+        return None
+
+    rewritten = proc.stdout.strip()
+    if not rewritten or rewritten == command:
+        return None
+
+    logger.info("tokenless: rtk rewrite %s → %s", command, rewritten)
+    return {
+        "action": "block",
+        "message": (
+            f"[tokenless] Command rewritten for token savings.\n"
+            f"Original: {command}\n"
+            f"Optimized: {rewritten}\n"
+            f"Re-execute with the optimized command to save 60-90% tokens."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hook callbacks
+# ---------------------------------------------------------------------------
+
+
+def on_session_start(**kwargs: Any) -> None:
+    """Record session mapping for stats context."""
+    session_id = kwargs.get("session_id", "")
+    if session_id:
+        os.environ["TOKENLESS_SESSION_ID"] = str(session_id)
+        logger.debug("tokenless: session_start session_id=%s", session_id)
+
+
+def on_pre_tool_call(
+    tool_name: str = "",
+    args: Any = None,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    **kwargs: Any,
+) -> dict[str, str] | None:
+    """Tool Ready + RTK rewrite pre-check.
+
+    Step 1: env-check blocks when the tool's environment is not ready.
+    Step 2: for ``terminal`` calls, blocks and suggests RTK-rewritten
+    command (one extra round-trip; safe — rtk rewrite never executes).
+    """
+    # Step 1: env-check (all tools, needs tokenless)
+    if _have("tokenless", _TOKENLESS_FALLBACK):
+        if session_id:
+            os.environ["TOKENLESS_SESSION_ID"] = str(session_id)
+        feedback = _env_check(tool_name)
+        if feedback:
+            logger.info("tokenless: tool-ready blocking %s — %s", tool_name, feedback)
+            return {"action": "block", "message": feedback}
+
+    # Step 2: RTK rewrite (terminal only, needs rtk)
+    if tool_name in _SHELL_TOOLS and _have("rtk", _RTK_FALLBACK):
+        result = _try_rewrite(args, str(session_id), str(tool_call_id))
+        if result:
+            return result
+
+    return None
+
+
+def on_transform_tool_result(
+    tool_name: str = "",
+    args: Any = None,
+    result: str = "",
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+    **kwargs: Any,
+) -> str | None:
+    """Response compression + TOON encoding pipeline.
+
+    Replaces the tool result string with a compressed/TOON-encoded version.
+    Runs after post_tool_call; first valid string return wins.
+    """
+    if not _have("tokenless", _TOKENLESS_FALLBACK):
+        return None
+
+    # Skip content-retrieval tools
+    if tool_name in _SKIP_TOOLS:
+        return None
+
+    if not result or result in ("{}", "[]"):
+        return None
+
+    # Skip skill files (YAML frontmatter)
+    if _is_skill_file(result):
+        return None
+
+    # Skip small responses
+    if len(result) < _MIN_RESPONSE_LEN:
+        return None
+
+    # Validate it's JSON
+    parsed = _try_parse_json(result)
+    if parsed is None:
+        return None
+
+    # Normalize: result is already a JSON string (Hermes tool contract)
+    original = result
+    original_len = len(original)
+
+    # Step 1: Response compression
+    compressed = _compress_response(tool_name, result,
+                                     str(session_id), str(tool_call_id))
+    current = compressed if compressed else result
+
+    # Step 2: TOON encoding
+    toon_result = _encode_toon(current, str(session_id), str(tool_call_id))
+    used_compression = compressed is not None
+    used_toon = toon_result is not None
+
+    if not used_compression and not used_toon:
+        return None
+
+    # Build final output
+    if used_toon:
+        toon_text, savings_pct = toon_result
+        final_len = len(toon_text)
+        savings_label = (
+            "response compressed + TOON encoded"
+            if used_compression
+            else "TOON encoded"
+        )
+        # Wrap TOON so the model sees the format hint
+        final = f"[TOON format, {savings_pct}% token savings]\n{toon_text}"
+    else:
+        final = current  # type: ignore[assignment]
+        final_len = len(final)
+        savings_pct = (original_len - final_len) * 100 // original_len if original_len else 0
+        savings_label = "response compressed"
+
+    logger.info(
+        "tokenless: %s %s: %d -> %d chars (%d%% reduction)",
+        savings_label, tool_name, original_len, final_len, savings_pct,
+    )
+
+    return final
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Register all tokenless hooks with the Hermes plugin system."""
+
+    ctx.register_hook("on_session_start", on_session_start)
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("transform_tool_result", on_transform_tool_result)
+
+    # Log what's active
+    features: list[str] = []
+    if _have("tokenless", _TOKENLESS_FALLBACK):
+        features.append("response-compression")
+        features.append("toon-encoding")
+        features.append("tool-ready")
+    if _have("rtk", _RTK_FALLBACK):
+        features.append("rtk-rewrite")
+
+    logger.info(
+        "tokenless: Hermes plugin registered — active features: %s",
+        ", ".join(features) if features else "none (install tokenless/rtk binary)",
+    )

--- a/src/tokenless/adapters/tokenless/hermes/plugin.yaml
+++ b/src/tokenless/adapters/tokenless/hermes/plugin.yaml
@@ -1,0 +1,9 @@
+name: tokenless
+version: "0.3.2"
+description: "Token-Less context compression for Hermes Agent — response compression, TOON encoding, command rewriting, and Tool Ready environment pre-check"
+author: ANOLISA
+requires_env: []
+provides_hooks:
+  - transform_tool_result
+  - pre_tool_call
+  - on_session_start

--- a/src/tokenless/adapters/tokenless/hermes/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/hermes/scripts/detect.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# detect.sh — Check if Hermes Agent is installed and compatible.
+# Exit 0 = ready to install, non-0 = not available.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-hermes}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+
+if [ -d "$HOME/.hermes/plugins" ]; then
+    echo "[${COMPONENT}] ${AGENT}: detected ~/.hermes/plugins directory"
+    exit 0
+fi
+
+if command -v hermes &>/dev/null; then
+    echo "[${COMPONENT}] ${AGENT}: detected hermes binary"
+    exit 0
+fi
+
+echo "[${COMPONENT}] ${AGENT}: not detected (neither ~/.hermes/plugins nor hermes binary found)" >&2
+exit 1

--- a/src/tokenless/adapters/tokenless/hermes/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/hermes/scripts/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# install.sh — Install tokenless plugin into Hermes Agent via symlink + enable.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-hermes}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+PLUGIN_SRC="$ADAPTER_DIR/hermes"
+PLUGIN_DST="$HOME/.hermes/plugins/tokenless"
+
+echo "[${COMPONENT}] Installing ${AGENT} plugin..."
+
+if [ ! -d "$PLUGIN_SRC" ]; then
+    echo "[${COMPONENT}] Plugin source not found: $PLUGIN_SRC"
+    exit 1
+fi
+
+if [ ! -f "$PLUGIN_SRC/plugin.yaml" ] || [ ! -f "$PLUGIN_SRC/__init__.py" ]; then
+    echo "[${COMPONENT}] Missing plugin.yaml or __init__.py in $PLUGIN_SRC"
+    exit 1
+fi
+
+mkdir -p "$PLUGIN_DST"
+
+# Use symlinks so plugin stays synced with system install
+ln -sfn "$PLUGIN_SRC/__init__.py" "$PLUGIN_DST/__init__.py"
+ln -sfn "$PLUGIN_SRC/plugin.yaml" "$PLUGIN_DST/plugin.yaml"
+
+echo "[${COMPONENT}] ${AGENT} plugin linked to $PLUGIN_DST (from $PLUGIN_SRC)."
+
+# Enable via hermes CLI if available (adds to plugins.enabled in config.yaml)
+if command -v hermes &>/dev/null; then
+    echo "[${COMPONENT}] Enabling ${AGENT} plugin..."
+    hermes plugins enable tokenless || {
+        echo "[${COMPONENT}] Warning: hermes plugins enable failed — enable manually via config.yaml."
+    }
+else
+    echo "[${COMPONENT}] hermes CLI not found — add 'tokenless' to plugins.enabled in ~/.hermes/config.yaml."
+fi

--- a/src/tokenless/adapters/tokenless/hermes/scripts/uninstall.sh
+++ b/src/tokenless/adapters/tokenless/hermes/scripts/uninstall.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# uninstall.sh — Disable and remove tokenless plugin from Hermes Agent.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-hermes}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+
+PLUGIN_DST="$HOME/.hermes/plugins/tokenless"
+
+echo "[${COMPONENT}] Uninstalling ${AGENT} plugin..."
+
+# Disable via hermes CLI if available (removes from plugins.enabled in config.yaml)
+if command -v hermes &>/dev/null; then
+    hermes plugins disable tokenless || true
+    hermes plugins remove tokenless || true
+else
+    # Manually remove symlinks/directory when hermes CLI is unavailable
+    if [ -d "$PLUGIN_DST" ]; then
+        rm -f "$PLUGIN_DST/__init__.py" "$PLUGIN_DST/plugin.yaml" 2>/dev/null || true
+        rmdir "$PLUGIN_DST" 2>/dev/null || true
+    fi
+fi
+
+echo "[${COMPONENT}] ${AGENT} plugin uninstalled."

--- a/src/tokenless/adapters/tokenless/manifest.json
+++ b/src/tokenless/adapters/tokenless/manifest.json
@@ -25,6 +25,22 @@
         "install":   "openclaw/scripts/install.sh",
         "uninstall": "openclaw/scripts/uninstall.sh"
       }
+    },
+    "hermes": {
+      "compatibleVersions": ">=1.0.0",
+      "capabilities": {
+        "hooks": [
+          "compress-response",
+          "compress-toon",
+          "rtk-rewrite",
+          "tool-ready"
+        ]
+      },
+      "actions": {
+        "detect":    "hermes/scripts/detect.sh",
+        "install":   "hermes/scripts/install.sh",
+        "uninstall": "hermes/scripts/uninstall.sh"
+      }
     }
   }
 }

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -41,6 +41,9 @@ The package includes:
 
 Note: OpenClaw plugin is available under /usr/share/anolisa/adapters/tokenless/openclaw/.
 Copilot-shell extension is auto-discovered from /usr/share/anolisa/extensions/tokenless/.
+Hermes Agent plugin (response compression, TOON encoding, command rewriting via RTK,
+and Tool Ready) is available under /usr/share/anolisa/adapters/tokenless/hermes/.
+Run the install script to register with Hermes: hermes/scripts/install.sh
 
 %prep
 %setup -q -n tokenless
@@ -79,6 +82,7 @@ mkdir -p %{buildroot}%{_libexecdir}/anolisa/tokenless
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/common/hooks
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/common/commands
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/scripts
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts
 mkdir -p %{buildroot}%{_docdir}/tokenless
 
 # Install binaries — tokenless (user-facing) to /usr/bin, helpers to /usr/libexec/anolisa/tokenless
@@ -116,6 +120,13 @@ install -m 0644 adapters/tokenless/openclaw/index.js %{buildroot}%{_datadir}/ano
 install -m 0644 adapters/tokenless/openclaw/openclaw.plugin.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/
 install -m 0644 adapters/tokenless/openclaw/package.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/
 
+# Install Hermes Agent plugin (Python hooks + install scripts)
+install -m 0755 adapters/tokenless/hermes/__init__.py %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/
+install -m 0644 adapters/tokenless/hermes/plugin.yaml %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/
+install -m 0755 adapters/tokenless/hermes/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
+install -m 0755 adapters/tokenless/hermes/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
+install -m 0755 adapters/tokenless/hermes/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
+
 # Install cosh extension for auto-discovery at /usr/share/anolisa/extensions/tokenless/
 mkdir -p %{buildroot}%{_datadir}/anolisa/extensions/tokenless/hooks
 mkdir -p %{buildroot}%{_datadir}/anolisa/extensions/tokenless/commands
@@ -146,6 +157,8 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %dir %{_datadir}/anolisa/adapters/tokenless/common/commands
 %dir %{_datadir}/anolisa/adapters/tokenless/openclaw
 %dir %{_datadir}/anolisa/adapters/tokenless/openclaw/scripts
+%dir %{_datadir}/anolisa/adapters/tokenless/hermes
+%dir %{_datadir}/anolisa/adapters/tokenless/hermes/scripts
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/manifest.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/common/tool-ready-spec.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/common/cosh-extension.json
@@ -159,6 +172,11 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/index.js
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/openclaw.plugin.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/package.json
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/__init__.py
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/plugin.yaml
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/detect.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/install.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/uninstall.sh
 # Cosh extension — auto-discovered from /usr/share/anolisa/extensions/
 %dir %{_datadir}/anolisa/extensions
 %dir %{_datadir}/anolisa/extensions/tokenless
@@ -184,6 +202,9 @@ rmdir "$HOME/.local/lib/anolisa" 2>/dev/null || true
 rmdir "$HOME/.local/lib" 2>/dev/null || true
 # Remove stale user-level cosh extension (system-level takes priority)
 rm -rf "$HOME/.copilot-shell/extensions/tokenless" 2>/dev/null || true
+# Clean up stale hermes-plugin dir (renamed to hermes/ with scripts)
+rm -rf "/usr/share/anolisa/adapters/tokenless/hermes-plugin" 2>/dev/null || true
+rm -rf "$HOME/.local/share/anolisa/adapters/tokenless/hermes-plugin" 2>/dev/null || true
 hash -r 2>/dev/null || true
 
 %preun
@@ -204,6 +225,13 @@ if [ $1 -eq 0 ]; then
             (.plugins.entries // {} | del(.["tokenless-openclaw"])) as $entries |
             .plugins.allow = $allow | .plugins.entries = $entries' \
             "$OPENCLAW_CFG" > "${OPENCLAW_CFG}.tmp" && mv "${OPENCLAW_CFG}.tmp" "$OPENCLAW_CFG"
+    fi
+    # Uninstall hermes plugin (disable + remove via hermes CLI or manual cleanup)
+    HERMES_SCRIPT="%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/uninstall.sh"
+    if [ -f "$HERMES_SCRIPT" ]; then
+        bash "$HERMES_SCRIPT" || true
+    elif [ -d "$HOME/.hermes/plugins/tokenless" ]; then
+        rm -rf "$HOME/.hermes/plugins/tokenless" 2>/dev/null || true
     fi
 fi
 


### PR DESCRIPTION
## Description

Hooks into Hermes via three events:
- transform_tool_result: response compression + TOON encoding
- pre_tool_call: tool-ready env-check + rtk command rewrite (block+suggest)
- on_session_start: session ID propagation for stats

RTK rewrite blocks the original command and suggests the rewritten version for re-execution (one extra round-trip; rtk rewrite is pure text substitution). Schema compression is blocked — Hermes hooks cannot modify tool definitions.

Adapter pattern mirrors openclaw: plugin under adapters/tokenless/hermes/ with detect/install/uninstall scripts for user-driven registration (not auto-installed in RPM %post).

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

feat # Hermes Agent support

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
  - CI: fmt ✅、clippy ✅、71 tests ✅
  - 语法: Python + 3 shell scripts ✅
  - detect.sh: 检测到 ~/.hermes/plugins 目录 ✅
  - install.sh: symlink 创建 + hermes plugins enable tokenless 自动启用 ✅（hermes ls 显示 enabled）
  - uninstall.sh: hermes plugins disable + hermes plugins remove 完整清理 ✅（目录已删除）
  - 版本: plugin.yaml 显示 0.3.2 ✅
```
