### PR TITLE
feat(sec-core): persist observability record to sqldb

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/README.md
+++ b/src/agent-sec-core/agent-sec-cli/README.md
@@ -110,7 +110,10 @@ agent-sec-cli observability schema
 ### Observability Records
 
 `agent-sec-cli observability record` accepts one JSON object from stdin and writes
-validated hook telemetry to the independent `observability.jsonl` stream.
+validated hook telemetry to the independent `observability.jsonl` stream plus an
+internal `observability.db` SQLite index. The SQLite index is an implementation
+detail for retention and future local reads; this command does not expose a
+public query API.
 
 Required wire fields:
 
@@ -264,14 +267,17 @@ ROTATION_COUNT = 5
 ### Observability
 
 Observability records use the same data directory resolver as security events,
-but write to a separate stream:
+but write to separate files:
 
 - default system path: `/var/log/agent-sec/observability.jsonl`
+- default SQLite index: `/var/log/agent-sec/observability.db`
 - user fallback: `~/.agent-sec-core/observability.jsonl`
+- user SQLite fallback: `~/.agent-sec-core/observability.db`
 - test/dev override: `AGENT_SEC_DATA_DIR=/path/to/dir`
 
-The observability stream uses its own JSONL file, lock file, rotation limit, and
-backup count; it does not write to `security-events.jsonl`.
+The observability stream uses its own JSONL file, lock file, SQLite database,
+rotation limit, backup count, and 7-day SQLite retention policy; it does not
+write to `security-events.jsonl` or `security-events.db`.
 
 ---
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/__init__.py
@@ -1,15 +1,47 @@
 """Observability payload schema and metric definitions."""
 
+import atexit
+
 from agent_sec_cli.observability.metrics import HOOK_METRIC_ALLOWLIST
 from agent_sec_cli.observability.schema import (
     ObservabilityMetadata,
     ObservabilityRecord,
 )
-from agent_sec_cli.observability.writer_jsonl import get_writer
+from agent_sec_cli.observability.sqlite_writer import ObservabilitySqliteWriter
+from agent_sec_cli.observability.writer import ObservabilityWriter
+
+_writer: ObservabilityWriter | None = None
+_sqlite_writer: ObservabilitySqliteWriter | None = None
+
+
+def get_writer() -> ObservabilityWriter:
+    """Return the module-level JSONL writer (created lazily)."""
+    global _writer  # noqa: PLW0603
+    if _writer is None:
+        _writer = ObservabilityWriter()
+    return _writer
+
+
+def get_sqlite_writer() -> ObservabilitySqliteWriter:
+    """Return the module-level SQLite writer (created lazily)."""
+    global _sqlite_writer  # noqa: PLW0603
+    if _sqlite_writer is None:
+        _sqlite_writer = ObservabilitySqliteWriter()
+        atexit.register(_sqlite_writer.close)
+    return _sqlite_writer
+
+
+def record_observability(record: ObservabilityRecord) -> None:
+    """Persist *record* to JSONL and the SQLite index."""
+    get_writer().write(record)
+    get_sqlite_writer().write(record)
+
 
 __all__ = [
     "HOOK_METRIC_ALLOWLIST",
     "ObservabilityMetadata",
     "ObservabilityRecord",
     "get_writer",
+    "get_sqlite_writer",
+    "record_observability",
 ]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/cli.py
@@ -5,12 +5,12 @@ import sys
 from typing import Any
 
 import typer
+from agent_sec_cli.observability import record_observability
 from agent_sec_cli.observability.schema import (
     ObservabilityRecord,
     observability_record_json_schema,
     validate_observability_record,
 )
-from agent_sec_cli.observability.writer_jsonl import get_writer
 from pydantic import ValidationError
 
 app = typer.Typer(help="Record observability metrics.")
@@ -75,7 +75,7 @@ def record(
         raise typer.Exit(code=1)
 
     try:
-        get_writer().write(record_payload)
+        record_observability(record_payload)
     except Exception as exc:  # noqa: BLE001
         typer.echo(f"Error: failed to write observability record: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/config.py
@@ -1,0 +1,29 @@
+"""Configuration helpers for observability persistence."""
+
+from agent_sec_cli.security_events.config import (
+    get_stream_db_path,
+    get_stream_log_path,
+)
+
+OBSERVABILITY_STREAM = "observability"
+OBSERVABILITY_LOG_PREFIX = "[observability]"
+DEFAULT_OBSERVABILITY_RETENTION_DAYS = 7
+
+
+def get_observability_log_path() -> str:
+    """Return the JSONL path for the observability stream."""
+    return get_stream_log_path(OBSERVABILITY_STREAM)
+
+
+def get_observability_db_path() -> str:
+    """Return the SQLite path for the observability stream."""
+    return get_stream_db_path(OBSERVABILITY_STREAM)
+
+
+__all__ = [
+    "DEFAULT_OBSERVABILITY_RETENTION_DAYS",
+    "OBSERVABILITY_LOG_PREFIX",
+    "OBSERVABILITY_STREAM",
+    "get_observability_db_path",
+    "get_observability_log_path",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/models.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/models.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy ORM models for observability indexes."""
+
+from agent_sec_cli.security_events.orm_base import Base
+from sqlalchemy import Float, Index, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+OBSERVABILITY_SQLITE_SCHEMA_VERSION = 1
+
+
+class ObservabilityEventRecord(Base):
+    """ORM mapping for the queryable observability event index."""
+
+    __tablename__ = "observability_events"
+    __table_args__ = (
+        Index("idx_observability_observed_at_epoch", "observed_at_epoch"),
+        Index("idx_observability_hook_observed_at_epoch", "hook", "observed_at_epoch"),
+        Index(
+            "idx_observability_session_observed_at_epoch",
+            "session_id",
+            "observed_at_epoch",
+        ),
+        Index("idx_observability_run_observed_at_epoch", "run_id", "observed_at_epoch"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    hook: Mapped[str] = mapped_column(Text, nullable=False)
+    observed_at: Mapped[str] = mapped_column(Text, nullable=False)
+    observed_at_epoch: Mapped[float] = mapped_column(Float, nullable=False)
+    session_id: Mapped[str] = mapped_column(Text, nullable=False)
+    run_id: Mapped[str] = mapped_column(Text, nullable=False)
+    metrics_json: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[str] = mapped_column(Text, nullable=False)
+    call_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tool_call_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+ORM_MODELS = (ObservabilityEventRecord,)
+
+
+__all__ = [
+    "OBSERVABILITY_SQLITE_SCHEMA_VERSION",
+    "ORM_MODELS",
+    "ObservabilityEventRecord",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/repositories.py
@@ -1,0 +1,129 @@
+"""Typed repository for observability SQLite indexing."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_sec_cli.observability.config import OBSERVABILITY_LOG_PREFIX
+from agent_sec_cli.observability.models import ObservabilityEventRecord
+from agent_sec_cli.observability.schema import ObservabilityRecord
+from agent_sec_cli.security_events.orm_store import SqliteStore
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.exc import SQLAlchemyError
+
+
+class ObservabilityEventRepository:
+    """Repository for observability insert/count/prune operations."""
+
+    def __init__(self, store: SqliteStore) -> None:
+        self._store = store
+
+    def insert(self, record: ObservabilityRecord) -> bool:
+        """Insert an observability record. Returns False for skipped writes."""
+        try:
+            values = self._record_values(record)
+        except (ValueError, TypeError) as exc:
+            print(
+                f"{OBSERVABILITY_LOG_PREFIX} invalid event params: {exc}",
+                file=sys.stderr,
+            )
+            return False
+
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return False
+
+        with session_factory.begin() as session:
+            session.add(ObservabilityEventRecord(**values))
+        return True
+
+    def count(self) -> int:
+        """Return the number of indexed observability records."""
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return 0
+
+        try:
+            with session_factory() as session:
+                return int(
+                    session.execute(
+                        select(func.count()).select_from(ObservabilityEventRecord)
+                    ).scalar_one()
+                )
+        except SQLAlchemyError:
+            self._store.dispose()
+            return 0
+
+    def prune(
+        self,
+        max_age_days: int,
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        """Delete rows older than max_age_days by observed_at_epoch."""
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return
+
+        cutoff = _epoch(now or datetime.now(timezone.utc)) - (max_age_days * 86400)
+        try:
+            with session_factory.begin() as session:
+                session.execute(
+                    delete(ObservabilityEventRecord).where(
+                        ObservabilityEventRecord.observed_at_epoch < cutoff
+                    )
+                )
+        except SQLAlchemyError:
+            pass
+
+    def checkpoint(self) -> None:
+        """Run a best-effort WAL checkpoint on the current engine."""
+        engine = self._store.engine
+        if engine is None:
+            return
+        try:
+            with engine.connect() as conn:
+                conn.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+        except Exception:  # noqa: BLE001
+            pass
+
+    @staticmethod
+    def _record_values(record: ObservabilityRecord) -> dict[str, object]:
+        """Build the ORM values dict for INSERT."""
+        wire_record = record.to_record()
+        metrics = _ensure_mapping(wire_record["metrics"], "metrics")
+        metadata = _ensure_mapping(wire_record["metadata"], "metadata")
+
+        return {
+            "hook": record.hook,
+            "observed_at": str(wire_record["observedAt"]),
+            "observed_at_epoch": record.observed_at.timestamp(),
+            "session_id": str(metadata["sessionId"]),
+            "run_id": str(metadata["runId"]),
+            "metrics_json": json.dumps(metrics, ensure_ascii=False),
+            "metadata_json": json.dumps(metadata, ensure_ascii=False),
+            "call_id": _optional_str(metadata.get("callId")),
+            "tool_call_id": _optional_str(metadata.get("toolCallId")),
+        }
+
+
+def _ensure_mapping(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{name} must be an object")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _epoch(value: datetime) -> float:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.timestamp()
+
+
+__all__ = ["ObservabilityEventRepository"]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/repositories.py
@@ -75,7 +75,7 @@ class ObservabilityEventRepository:
                     )
                 )
         except SQLAlchemyError:
-            pass
+            self._store.dispose()
 
     def checkpoint(self) -> None:
         """Run a best-effort WAL checkpoint on the current engine."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_writer.py
@@ -1,0 +1,100 @@
+"""SQLAlchemy-backed writer for observability records."""
+
+from pathlib import Path
+
+from agent_sec_cli.observability.config import (
+    DEFAULT_OBSERVABILITY_RETENTION_DAYS,
+    OBSERVABILITY_LOG_PREFIX,
+    get_observability_db_path,
+)
+from agent_sec_cli.observability.models import (
+    OBSERVABILITY_SQLITE_SCHEMA_VERSION,
+    ORM_MODELS,
+)
+from agent_sec_cli.observability.repositories import (
+    ObservabilityEventRepository,
+)
+from agent_sec_cli.observability.schema import ObservabilityRecord
+from agent_sec_cli.security_events.orm_store import (
+    SqliteStore,
+    is_sqlite_corruption_error,
+    is_sqlite_schema_error,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import DatabaseError, SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+
+
+class ObservabilitySqliteWriter:
+    """Best-effort SQLite index writer for observability records."""
+
+    def __init__(
+        self,
+        path: str | Path | None = None,
+        max_age_days: int = DEFAULT_OBSERVABILITY_RETENTION_DAYS,
+    ) -> None:
+        self._store = SqliteStore(
+            path or get_observability_db_path(),
+            models=ORM_MODELS,
+            schema_version=OBSERVABILITY_SQLITE_SCHEMA_VERSION,
+            log_prefix=OBSERVABILITY_LOG_PREFIX,
+        )
+        self._repository = ObservabilityEventRepository(self._store)
+        self._max_age_days = max_age_days
+
+    @property
+    def _engine(self) -> Engine | None:
+        return self._store.engine
+
+    @property
+    def _session_factory(self) -> sessionmaker[Session] | None:
+        return self._store.cached_session_factory
+
+    @property
+    def _disabled(self) -> bool:
+        return self._store.disabled
+
+    def write(self, record: ObservabilityRecord) -> None:
+        """Insert *record* into SQLite. Fire-and-forget index writes never raise."""
+        if self._store.disabled:
+            return
+
+        try:
+            self._repository.insert(record)
+        except DatabaseError as exc:
+            if not is_sqlite_corruption_error(exc):
+                if is_sqlite_schema_error(exc):
+                    self._store.request_schema_repair()
+                return
+            self._store.handle_corruption(exc)
+            if self._store.disabled:
+                return
+            try:
+                self._repository.insert(record)
+            except Exception:  # noqa: BLE001
+                pass
+        except (SQLAlchemyError, OSError):
+            self._store.dispose()
+
+    def close(self) -> None:
+        """Best-effort WAL checkpoint and dispose pooled connections."""
+        if self._store.engine is None:
+            return
+        self._repository.prune(self._max_age_days)
+        self._repository.checkpoint()
+        self._store.close()
+
+    def _ensure_session_factory(self) -> sessionmaker[Session] | None:
+        """Return the lazily initialized session factory."""
+        return self._store.session_factory()
+
+    def _dispose_engine(self) -> None:
+        """Dispose SQLAlchemy engine state and clear session factory."""
+        self._store.dispose()
+
+    def _handle_corruption(self, exc: Exception) -> None:
+        """Delete a corrupt database and prepare for a fresh start."""
+        self._store.handle_corruption(exc)
+
+
+__all__ = ["ObservabilitySqliteWriter"]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_writer.py
@@ -20,6 +20,9 @@ from agent_sec_cli.security_events.orm_store import (
     is_sqlite_corruption_error,
     is_sqlite_schema_error,
 )
+from agent_sec_cli.security_events.sqlite_maintenance import (
+    run_sqlite_maintenance_if_due,
+)
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import DatabaseError, SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
@@ -77,24 +80,18 @@ class ObservabilitySqliteWriter:
             self._store.dispose()
 
     def close(self) -> None:
-        """Best-effort WAL checkpoint and dispose pooled connections."""
+        """Best-effort gated prune/WAL checkpoint and dispose pooled connections."""
         if self._store.engine is None:
             return
+        try:
+            run_sqlite_maintenance_if_due(self._store.path, self._run_maintenance)
+        finally:
+            self._store.close()
+
+    def _run_maintenance(self) -> None:
+        """Run low-frequency SQLite maintenance for this writer."""
         self._repository.prune(self._max_age_days)
         self._repository.checkpoint()
-        self._store.close()
-
-    def _ensure_session_factory(self) -> sessionmaker[Session] | None:
-        """Return the lazily initialized session factory."""
-        return self._store.session_factory()
-
-    def _dispose_engine(self) -> None:
-        """Dispose SQLAlchemy engine state and clear session factory."""
-        self._store.dispose()
-
-    def _handle_corruption(self, exc: Exception) -> None:
-        """Delete a corrupt database and prepare for a fresh start."""
-        self._store.handle_corruption(exc)
 
 
 __all__ = ["ObservabilitySqliteWriter"]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/writer.py
@@ -1,19 +1,20 @@
-"""JSONL persistence for observability records."""
+"""JSONL writer for observability records."""
 
 from pathlib import Path
 
+from agent_sec_cli.observability.config import (
+    OBSERVABILITY_LOG_PREFIX,
+    OBSERVABILITY_STREAM,
+    get_observability_log_path,
+)
 from agent_sec_cli.observability.schema import ObservabilityRecord
-from agent_sec_cli.security_events.config import get_stream_log_path
 from agent_sec_cli.security_events.writer import JsonlEventWriter
 
-OBSERVABILITY_STREAM = "observability"
 DEFAULT_OBSERVABILITY_MAX_BYTES = 256 * 1024 * 1024
 DEFAULT_OBSERVABILITY_BACKUP_COUNT = 3
 
-_writer: "ObservabilityJsonlWriter | None" = None
 
-
-class ObservabilityJsonlWriter:
+class ObservabilityWriter:
     """Append observability records to the independent observability JSONL stream."""
 
     def __init__(
@@ -23,10 +24,10 @@ class ObservabilityJsonlWriter:
         backup_count: int = DEFAULT_OBSERVABILITY_BACKUP_COUNT,
     ) -> None:
         self._writer = JsonlEventWriter(
-            path=path or get_stream_log_path(OBSERVABILITY_STREAM),
+            path=path or get_observability_log_path(),
             max_bytes=max_bytes,
             backup_count=backup_count,
-            error_prefix="[observability]",
+            error_prefix=OBSERVABILITY_LOG_PREFIX,
         )
 
     def write(self, record: ObservabilityRecord) -> None:
@@ -34,18 +35,9 @@ class ObservabilityJsonlWriter:
         self._writer.write_or_raise(record.to_record())
 
 
-def get_writer() -> ObservabilityJsonlWriter:
-    """Return the module-level singleton observability JSONL writer."""
-    global _writer  # noqa: PLW0603
-    if _writer is None:
-        _writer = ObservabilityJsonlWriter()
-    return _writer
-
-
 __all__ = [
     "DEFAULT_OBSERVABILITY_BACKUP_COUNT",
     "DEFAULT_OBSERVABILITY_MAX_BYTES",
     "OBSERVABILITY_STREAM",
-    "ObservabilityJsonlWriter",
-    "get_writer",
+    "ObservabilityWriter",
 ]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/orm_store.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/orm_store.py
@@ -4,8 +4,9 @@ import re
 import sqlite3
 import sys
 import threading
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import Any
 
 from agent_sec_cli.security_events.orm_base import Base
 from sqlalchemy import create_engine, event, inspect, text
@@ -29,6 +30,7 @@ _SQLITE_SCHEMA_ERROR_MARKERS = (
 _IDENTIFIER_RE = re.compile(r"^[a-z_]+$")
 
 OrmModel = type[Base]
+SchemaMigration = Callable[[Connection, int, int, tuple[OrmModel, ...], str], None]
 _DEFAULT_MODELS: tuple[OrmModel, ...] = ()
 
 
@@ -55,7 +57,10 @@ def create_sqlite_engine(path: Path, *, read_only: bool = False) -> Engine:
     )
 
     @event.listens_for(engine, "connect")
-    def _configure_connection(dbapi_connection, _connection_record) -> None:  # type: ignore[no-untyped-def]
+    def _configure_connection(
+        dbapi_connection: sqlite3.Connection,
+        _connection_record: Any,
+    ) -> None:
         cursor = dbapi_connection.cursor()
         try:
             cursor.execute("PRAGMA busy_timeout=200")
@@ -90,19 +95,25 @@ def _coerce_models(models: Iterable[OrmModel] | None) -> tuple[OrmModel, ...]:
     return _require_models(tuple(models) if models is not None else _DEFAULT_MODELS)
 
 
-def _warn_newer_schema_version(version: int) -> None:
+def _warn_newer_schema_version(
+    version: int,
+    supported_version: int,
+    log_prefix: str = "[security_events]",
+) -> None:
     print(
-        f"[security_events] sqlite schema version {version} is newer than "
-        f"this binary supports ({_SCHEMA_VERSION}); skipping schema migration",
+        f"{log_prefix} sqlite schema version {version} is newer than "
+        f"this binary supports ({supported_version}); skipping schema migration",
         file=sys.stderr,
     )
 
 
 def _schema_readiness(
-    conn: Connection, models: tuple[OrmModel, ...]
+    conn: Connection,
+    models: tuple[OrmModel, ...],
+    schema_version: int,
 ) -> tuple[int, list[str]]:
     version = int(conn.execute(text("PRAGMA user_version")).scalar_one())
-    if version > _SCHEMA_VERSION:
+    if version > schema_version:
         return version, []
 
     inspector = inspect(conn)
@@ -118,18 +129,34 @@ def _schema_version(conn: Connection) -> int:
     return int(conn.execute(text("PRAGMA user_version")).scalar_one())
 
 
-def ensure_schema(engine: Engine, models: Iterable[OrmModel] | None = None) -> None:
+def ensure_schema(
+    engine: Engine,
+    models: Iterable[OrmModel] | None = None,
+    *,
+    schema_version: int = _SCHEMA_VERSION,
+    schema_migrations: SchemaMigration | None = None,
+    log_prefix: str = "[security_events]",
+) -> None:
     """Create model tables/indexes and apply convergent column migrations."""
     model_tuple = _coerce_models(models)
     with engine.connect() as conn:
         conn.execute(text("PRAGMA journal_mode=WAL"))
     with engine.begin() as conn:
         version = conn.execute(text("PRAGMA user_version")).scalar_one()
-        if version > _SCHEMA_VERSION:
-            _warn_newer_schema_version(int(version))
+        if version > schema_version:
+            _warn_newer_schema_version(int(version), schema_version, log_prefix)
             return
 
         conn.execute(text("PRAGMA auto_vacuum = INCREMENTAL"))
+        if version < schema_version and schema_migrations is not None:
+            schema_migrations(
+                conn,
+                int(version),
+                schema_version,
+                model_tuple,
+                log_prefix,
+            )
+
         for model in model_tuple:
             table = model.__table__
             conn.execute(CreateTable(table, if_not_exists=True))
@@ -150,8 +177,8 @@ def ensure_schema(engine: Engine, models: Iterable[OrmModel] | None = None) -> N
             for index in table.indexes:
                 conn.execute(CreateIndex(index, if_not_exists=True))
 
-        if version < _SCHEMA_VERSION:
-            conn.execute(text(f"PRAGMA user_version = {_SCHEMA_VERSION}"))
+        if version < schema_version:
+            conn.execute(text(f"PRAGMA user_version = {schema_version}"))
 
 
 def ensure_schema_if_needed(
@@ -159,35 +186,48 @@ def ensure_schema_if_needed(
     models: Iterable[OrmModel] | None = None,
     *,
     force: bool = False,
+    schema_version: int = _SCHEMA_VERSION,
+    schema_migrations: SchemaMigration | None = None,
+    log_prefix: str = "[security_events]",
 ) -> None:
     """Run full schema convergence only when version changes or repair is forced."""
     model_tuple = _coerce_models(models)
     with engine.connect() as conn:
         version = _schema_version(conn)
-        if version > _SCHEMA_VERSION:
-            _warn_newer_schema_version(int(version))
+        if version > schema_version:
+            _warn_newer_schema_version(int(version), schema_version, log_prefix)
             return
 
-        if version == _SCHEMA_VERSION and not force:
+        if version == schema_version and not force:
             return
 
-    ensure_schema(engine, model_tuple)
+    ensure_schema(
+        engine,
+        model_tuple,
+        schema_version=schema_version,
+        schema_migrations=schema_migrations,
+        log_prefix=log_prefix,
+    )
 
 
 def warn_readonly_schema_readiness(
-    engine: Engine, models: Iterable[OrmModel] | None = None
+    engine: Engine,
+    models: Iterable[OrmModel] | None = None,
+    *,
+    schema_version: int = _SCHEMA_VERSION,
+    log_prefix: str = "[security_events]",
 ) -> None:
     """Warn about read-only schema drift without creating or migrating anything."""
     model_tuple = _coerce_models(models)
     with engine.connect() as conn:
-        version, missing_tables = _schema_readiness(conn, model_tuple)
+        version, missing_tables = _schema_readiness(conn, model_tuple, schema_version)
 
-    if version > _SCHEMA_VERSION:
-        _warn_newer_schema_version(int(version))
-    elif version < _SCHEMA_VERSION or missing_tables:
+    if version > schema_version:
+        _warn_newer_schema_version(int(version), schema_version, log_prefix)
+    elif version < schema_version or missing_tables:
         print(
-            f"[security_events] sqlite schema not ready for read-only access: "
-            f"version={version}, expected={_SCHEMA_VERSION}, "
+            f"{log_prefix} sqlite schema not ready for read-only access: "
+            f"version={version}, expected={schema_version}, "
             f"missing_tables={missing_tables}",
             file=sys.stderr,
         )
@@ -235,10 +275,16 @@ class SqliteStore:
         *,
         read_only: bool = False,
         models: Iterable[OrmModel] | None = None,
+        schema_version: int = _SCHEMA_VERSION,
+        schema_migrations: SchemaMigration | None = None,
+        log_prefix: str = "[security_events]",
     ) -> None:
         self.path = normalize_sqlite_path(path)
         self.read_only = read_only
         self.models = _coerce_models(models)
+        self.schema_version = schema_version
+        self.schema_migrations = schema_migrations
+        self._log_prefix = log_prefix
         self._engine_lock = threading.Lock()
         self._engine: Engine | None = None
         self._session_factory: sessionmaker[Session] | None = None
@@ -296,7 +342,7 @@ class SqliteStore:
             except DatabaseError as exc:
                 if self.read_only or not is_sqlite_corruption_error(exc):
                     print(
-                        f"[security_events] schema init failure: {exc}",
+                        f"{self._log_prefix} schema init failure: {exc}",
                         file=sys.stderr,
                     )
                     return None
@@ -307,13 +353,13 @@ class SqliteStore:
                     self._open_session_factory(None)
                 except (SQLAlchemyError, OSError) as rebuild_exc:
                     print(
-                        f"[security_events] corruption rebuild failed: {rebuild_exc}",
+                        f"{self._log_prefix} corruption rebuild failed: {rebuild_exc}",
                         file=sys.stderr,
                     )
                     return None
             except (SQLAlchemyError, OSError) as exc:
                 print(
-                    f"[security_events] schema init failure: {exc}",
+                    f"{self._log_prefix} schema init failure: {exc}",
                     file=sys.stderr,
                 )
                 return None
@@ -343,7 +389,7 @@ class SqliteStore:
     def handle_corruption(self, exc: Exception) -> None:
         """Delete a corrupt expendable SQLite query index and clear state."""
         print(
-            f"[security_events] corrupt DB detected, recreating: {exc}",
+            f"{self._log_prefix} corrupt DB detected, recreating: {exc}",
             file=sys.stderr,
         )
         self.dispose()
@@ -353,7 +399,7 @@ class SqliteStore:
         except OSError as delete_exc:
             self._disabled = True
             print(
-                f"[security_events] cannot delete corrupt db, "
+                f"{self._log_prefix} cannot delete corrupt db, "
                 f"writer disabled: {delete_exc}",
                 file=sys.stderr,
             )
@@ -366,12 +412,20 @@ class SqliteStore:
         engine = create_sqlite_engine(self.path, read_only=self.read_only)
         try:
             if self.read_only:
-                warn_readonly_schema_readiness(engine, self.models)
+                warn_readonly_schema_readiness(
+                    engine,
+                    self.models,
+                    schema_version=self.schema_version,
+                    log_prefix=self._log_prefix,
+                )
             else:
                 ensure_schema_if_needed(
                     engine,
                     self.models,
                     force=force_schema,
+                    schema_version=self.schema_version,
+                    schema_migrations=self.schema_migrations,
+                    log_prefix=self._log_prefix,
                 )
             self._engine = engine
             self._db_identity = db_identity
@@ -432,6 +486,7 @@ __all__ = [
     "is_sqlite_schema_error",
     "normalize_sqlite_path",
     "register_orm_models",
+    "SchemaMigration",
     "sqlite_database_files",
     "warn_readonly_schema_readiness",
 ]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -207,7 +207,7 @@ class SecurityEventRepository:
                     )
                 )
         except SQLAlchemyError:
-            pass
+            self._store.dispose()
 
     def checkpoint(self) -> None:
         """Run a best-effort WAL checkpoint on the current engine."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_maintenance.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_maintenance.py
@@ -1,0 +1,114 @@
+"""Cross-process gate for low-frequency SQLite maintenance."""
+
+import fcntl
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+DEFAULT_SQLITE_MAINTENANCE_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+def run_sqlite_maintenance_if_due(
+    db_path: str | Path,
+    maintenance: Callable[[], None],
+    *,
+    interval_seconds: float = DEFAULT_SQLITE_MAINTENANCE_INTERVAL_SECONDS,
+    now: float | None = None,
+) -> bool:
+    """Run maintenance once per DB path when its marker is older than interval."""
+    path = Path(db_path)
+    marker_path = _maintenance_marker_path(path)
+    lock_path = _maintenance_lock_path(path)
+    current_time = _current_time(now)
+
+    if not _maintenance_due(marker_path, interval_seconds, current_time):
+        return False
+
+    lock_fd = _try_acquire_lock(lock_path)
+    if lock_fd is None:
+        return False
+
+    try:
+        current_time = _current_time(now)
+        if not _maintenance_due(marker_path, interval_seconds, current_time):
+            return False
+
+        try:
+            maintenance()
+        except Exception:  # noqa: BLE001
+            return False
+
+        # Only a durable marker write advances the gate. If this fails, the
+        # idempotent maintenance may run again on the next short-lived CLI exit.
+        _mark_maintenance_complete(marker_path, current_time)
+        return True
+    except OSError:
+        return False
+    finally:
+        _release_lock(lock_fd)
+
+
+def _maintenance_marker_path(db_path: Path) -> Path:
+    return Path(f"{db_path}.maintenance")
+
+
+def _maintenance_lock_path(db_path: Path) -> Path:
+    return Path(f"{db_path}.maintenance.lock")
+
+
+def _current_time(now: float | None) -> float:
+    if now is not None:
+        return now
+    return time.time()
+
+
+def _maintenance_due(marker_path: Path, interval_seconds: float, now: float) -> bool:
+    if interval_seconds <= 0:
+        return True
+
+    last_run = _read_last_maintenance(marker_path)
+    if last_run is None or last_run > now:
+        return True
+    return now - last_run >= interval_seconds
+
+
+def _read_last_maintenance(marker_path: Path) -> float | None:
+    try:
+        return float(marker_path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _mark_maintenance_complete(marker_path: Path, now: float) -> None:
+    tmp_path = marker_path.with_name(f"{marker_path.name}.{os.getpid()}.tmp")
+    tmp_path.write_text(f"{now:.6f}\n", encoding="utf-8")
+    try:
+        tmp_path.chmod(0o600)
+    except OSError:
+        pass
+    tmp_path.replace(marker_path)
+
+
+def _try_acquire_lock(lock_path: Path) -> int | None:
+    try:
+        # Keep the lock file on disk; flock state belongs to the open file
+        # descriptor, and unlinking lock files can create cross-process races.
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR | os.O_CLOEXEC, 0o600)
+    except OSError:
+        return None
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        return None
+    return fd
+
+
+def _release_lock(lock_fd: int) -> None:
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    except OSError:
+        pass
+    os.close(lock_fd)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
@@ -14,6 +14,9 @@ from agent_sec_cli.security_events.orm_store import (
 )
 from agent_sec_cli.security_events.repositories import SecurityEventRepository
 from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.sqlite_maintenance import (
+    run_sqlite_maintenance_if_due,
+)
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import DatabaseError, SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
@@ -66,21 +69,15 @@ class SqliteEventWriter:
             self._store.dispose()
 
     def close(self) -> None:
-        """Best-effort prune, WAL checkpoint, and dispose pooled connections."""
+        """Best-effort gated prune/WAL checkpoint and dispose pooled connections."""
         if self._store.engine is None:
             return
+        try:
+            run_sqlite_maintenance_if_due(self._store.path, self._run_maintenance)
+        finally:
+            self._store.close()
+
+    def _run_maintenance(self) -> None:
+        """Run low-frequency SQLite maintenance for this writer."""
         self._repository.prune(self._max_age_days)
         self._repository.checkpoint()
-        self._store.close()
-
-    def _ensure_session_factory(self) -> sessionmaker[Session] | None:
-        """Return the lazily initialized session factory."""
-        return self._store.session_factory()
-
-    def _dispose_engine(self) -> None:
-        """Dispose SQLAlchemy engine state and clear session factory."""
-        self._store.dispose()
-
-    def _handle_corruption(self, exc: Exception) -> None:
-        """Delete a corrupt database and prepare for a fresh start."""
-        self._store.handle_corruption(exc)

--- a/src/agent-sec-core/tests/e2e/cli/test_observability_record_sqlite_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_observability_record_sqlite_e2e.py
@@ -1,0 +1,60 @@
+"""E2E tests for agent-sec-cli observability record SQLite indexing."""
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+from .conftest import run_cli
+
+
+def test_observability_record_json_creates_observability_sqlite_index() -> None:
+    data_dir = Path(os.environ["AGENT_SEC_DATA_DIR"])
+    payload = {
+        "hook": "after_tool_call",
+        "observedAt": "2026-05-11T12:00:00Z",
+        "metadata": {
+            "sessionId": "session-e2e",
+            "runId": "run-e2e",
+            "callId": "call-e2e",
+            "toolCallId": "tool-call-e2e",
+        },
+        "metrics": {
+            "result": {"ok": True},
+            "duration_ms": 25,
+            "result_size_bytes": 128,
+        },
+    }
+
+    result = run_cli(
+        "observability",
+        "record",
+        "--format",
+        "json",
+        "--stdin",
+        input_text=json.dumps(payload),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert (data_dir / "observability.jsonl").exists()
+    assert (data_dir / "observability.db").exists()
+    assert not (data_dir / "security-events.db").exists()
+
+    conn = sqlite3.connect(data_dir / "observability.db")
+    try:
+        row = conn.execute("""
+            SELECT hook, session_id, run_id, call_id, tool_call_id, metrics_json
+            FROM observability_events
+            """).fetchone()
+    finally:
+        conn.close()
+
+    assert row[0:5] == (
+        "after_tool_call",
+        "session-e2e",
+        "run-e2e",
+        "call-e2e",
+        "tool-call-e2e",
+    )
+    assert json.loads(row[5])["result_size_bytes"] == 128

--- a/src/agent-sec-core/tests/unit-test/observability/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_cli.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-import agent_sec_cli.observability.writer_jsonl as writer_jsonl
+import agent_sec_cli.observability as observability
 import pytest
 from agent_sec_cli.cli import app
 from agent_sec_cli.observability.metrics import HOOK_METRIC_ALLOWLIST
@@ -13,7 +13,8 @@ from typer.testing import CliRunner
 
 @pytest.fixture(autouse=True)
 def reset_observability_writer(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(writer_jsonl, "_writer", None, raising=False)
+    monkeypatch.setattr(observability, "_writer", None, raising=False)
+    monkeypatch.setattr(observability, "_sqlite_writer", None, raising=False)
 
 
 def _payload(**overrides: Any) -> dict[str, Any]:
@@ -41,7 +42,7 @@ def _jsonl_records(path: Path) -> list[dict[str, Any]]:
     ]
 
 
-def test_record_json_stdin_writes_observability_jsonl_only(tmp_path: Path) -> None:
+def test_record_json_stdin_writes_observability_stores_only(tmp_path: Path) -> None:
     runner = CliRunner()
 
     result = runner.invoke(
@@ -58,7 +59,9 @@ def test_record_json_stdin_writes_observability_jsonl_only(tmp_path: Path) -> No
     assert "schemaVersion" not in records[0]
     assert records[0]["hook"] == "before_agent_run"
     assert records[0]["metadata"]["sessionId"] == "session-123"
+    assert (tmp_path / "observability.db").exists()
     assert not (tmp_path / "security-events.jsonl").exists()
+    assert not (tmp_path / "security-events.db").exists()
 
 
 def test_record_accepts_before_llm_call_without_call_id(tmp_path: Path) -> None:

--- a/src/agent-sec-core/tests/unit-test/observability/test_retention.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_retention.py
@@ -1,0 +1,62 @@
+"""Unit tests for observability SQLite retention."""
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agent_sec_cli.observability.models import (
+    OBSERVABILITY_SQLITE_SCHEMA_VERSION,
+    ObservabilityEventRecord,
+)
+from agent_sec_cli.observability.repositories import (
+    ObservabilityEventRepository,
+)
+from agent_sec_cli.observability.schema import validate_observability_record
+from agent_sec_cli.security_events.orm_store import SqliteStore
+
+
+def test_retention_prunes_by_observed_at_epoch(tmp_path: Path) -> None:
+    store = SqliteStore(
+        tmp_path / "observability.db",
+        models=(ObservabilityEventRecord,),
+        schema_version=OBSERVABILITY_SQLITE_SCHEMA_VERSION,
+        log_prefix="[observability]",
+    )
+    repository = ObservabilityEventRepository(store)
+    now = datetime(2026, 5, 11, 12, 0, tzinfo=timezone.utc)
+
+    stale_by_observed_at = validate_observability_record(
+        {
+            "hook": "before_agent_run",
+            "observedAt": "2026-05-01T12:00:00Z",
+            "metadata": {"sessionId": "old-session", "runId": "old-run"},
+            "metrics": {"prompt": "old"},
+        }
+    )
+    fresh_by_observed_at = validate_observability_record(
+        {
+            "hook": "before_agent_run",
+            "observedAt": "2026-05-10T12:00:00Z",
+            "metadata": {"sessionId": "new-session", "runId": "new-run"},
+            "metrics": {"prompt": "new"},
+        }
+    )
+
+    assert repository.insert(stale_by_observed_at)
+    assert repository.insert(fresh_by_observed_at)
+
+    repository.prune(7, now=now)
+
+    assert repository.count() == 1
+    conn = sqlite3.connect(tmp_path / "observability.db")
+    try:
+        rows = conn.execute("""
+            SELECT session_id
+            FROM observability_events
+            ORDER BY observed_at_epoch
+            """).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [("new-session",)]
+    store.close()

--- a/src/agent-sec-core/tests/unit-test/observability/test_retention.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_retention.py
@@ -4,6 +4,7 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 from agent_sec_cli.observability.models import (
     OBSERVABILITY_SQLITE_SCHEMA_VERSION,
     ObservabilityEventRecord,
@@ -13,6 +14,7 @@ from agent_sec_cli.observability.repositories import (
 )
 from agent_sec_cli.observability.schema import validate_observability_record
 from agent_sec_cli.security_events.orm_store import SqliteStore
+from sqlalchemy.exc import SQLAlchemyError
 
 
 def test_retention_prunes_by_observed_at_epoch(tmp_path: Path) -> None:
@@ -60,3 +62,31 @@ def test_retention_prunes_by_observed_at_epoch(tmp_path: Path) -> None:
 
     assert rows == [("new-session",)]
     store.close()
+
+
+def test_observability_prune_disposes_store_on_sqlalchemy_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FailingSessionFactory:
+        def begin(self):
+            raise SQLAlchemyError("prune failed")
+
+    store = SqliteStore(
+        tmp_path / "observability.db",
+        models=(ObservabilityEventRecord,),
+        schema_version=OBSERVABILITY_SQLITE_SCHEMA_VERSION,
+        log_prefix="[observability]",
+    )
+    repository = ObservabilityEventRepository(store)
+    disposed = False
+
+    def fake_dispose() -> None:
+        nonlocal disposed
+        disposed = True
+
+    monkeypatch.setattr(store, "session_factory", lambda: FailingSessionFactory())
+    monkeypatch.setattr(store, "dispose", fake_dispose)
+
+    repository.prune(30)
+
+    assert disposed

--- a/src/agent-sec-core/tests/unit-test/observability/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_writer.py
@@ -1,0 +1,332 @@
+"""Unit tests for observability dual persistence."""
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import agent_sec_cli.observability as observability
+import agent_sec_cli.security_events.orm_store as orm_store
+import pytest
+from agent_sec_cli.observability import record_observability
+from agent_sec_cli.observability.models import (
+    OBSERVABILITY_SQLITE_SCHEMA_VERSION,
+)
+from agent_sec_cli.observability.schema import validate_observability_record
+from agent_sec_cli.observability.sqlite_writer import ObservabilitySqliteWriter
+from agent_sec_cli.observability.writer import ObservabilityWriter
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "hook": "before_agent_run",
+        "observedAt": "2026-05-11T12:00:00Z",
+        "metadata": {
+            "sessionId": "session-123",
+            "runId": "run-123",
+        },
+        "metrics": {
+            "prompt": "Summarize ./README.md",
+            "model_id": "qwen3",
+            "model_provider": "dashscope",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _jsonl_records(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _sqlite_columns(path: Path) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {
+            row[1] for row in conn.execute("PRAGMA table_info(observability_events)")
+        }
+    finally:
+        conn.close()
+
+
+def _sqlite_user_version(path: Path) -> int:
+    conn = sqlite3.connect(path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _sqlite_row_count(path: Path) -> int:
+    conn = sqlite3.connect(path)
+    try:
+        return int(
+            conn.execute("SELECT count(*) FROM observability_events").fetchone()[0]
+        )
+    finally:
+        conn.close()
+
+
+def test_observability_jsonl_writer_only_writes_jsonl(
+    tmp_path: Path,
+) -> None:
+    record = validate_observability_record(_payload())
+    writer = ObservabilityWriter(path=tmp_path / "observability.jsonl")
+
+    writer.write(record)
+
+    records = _jsonl_records(tmp_path / "observability.jsonl")
+    assert records[0]["hook"] == "before_agent_run"
+    assert records[0]["metadata"]["sessionId"] == "session-123"
+    assert not (tmp_path / "observability.db").exists()
+    assert not (tmp_path / "security-events.jsonl").exists()
+    assert not (tmp_path / "security-events.db").exists()
+
+
+def test_observability_sqlite_writer_only_writes_independent_sqlite_index(
+    tmp_path: Path,
+) -> None:
+    record = validate_observability_record(_payload())
+    writer = ObservabilitySqliteWriter(path=tmp_path / "observability.db")
+
+    writer.write(record)
+    writer.close()
+
+    assert not (tmp_path / "observability.jsonl").exists()
+    assert not (tmp_path / "security-events.jsonl").exists()
+    assert not (tmp_path / "security-events.db").exists()
+
+    conn = sqlite3.connect(tmp_path / "observability.db")
+    try:
+        row = conn.execute("""
+            SELECT id, hook, observed_at, session_id, run_id, metrics_json,
+                   metadata_json, call_id, tool_call_id
+            FROM observability_events
+            """).fetchone()
+        indexes = {
+            item[1]
+            for item in conn.execute(
+                "PRAGMA index_list(observability_events)"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row[0] == 1
+    assert row[1] == "before_agent_run"
+    assert row[2] == "2026-05-11T12:00:00Z"
+    assert row[3] == "session-123"
+    assert row[4] == "run-123"
+    assert json.loads(row[5])["prompt"] == "Summarize ./README.md"
+    assert json.loads(row[6]) == {"sessionId": "session-123", "runId": "run-123"}
+    assert row[7] is None
+    assert row[8] is None
+    assert {
+        "idx_observability_observed_at_epoch",
+        "idx_observability_hook_observed_at_epoch",
+        "idx_observability_session_observed_at_epoch",
+        "idx_observability_run_observed_at_epoch",
+    }.issubset(indexes)
+    assert _sqlite_user_version(tmp_path / "observability.db") == (
+        OBSERVABILITY_SQLITE_SCHEMA_VERSION
+    )
+
+
+def test_observability_sqlite_columns_are_core_index_and_correlation_only(
+    tmp_path: Path,
+) -> None:
+    record = validate_observability_record(_payload())
+    writer = ObservabilitySqliteWriter(path=tmp_path / "observability.db")
+
+    writer.write(record)
+    writer.close()
+
+    columns = _sqlite_columns(tmp_path / "observability.db")
+    assert columns == {
+        "id",
+        "hook",
+        "observed_at",
+        "observed_at_epoch",
+        "session_id",
+        "run_id",
+        "metrics_json",
+        "metadata_json",
+        "call_id",
+        "tool_call_id",
+    }
+
+
+def test_observability_sqlite_writer_prunes_on_close_not_write(
+    tmp_path: Path,
+) -> None:
+    now = datetime.now(timezone.utc)
+    stale_record = validate_observability_record(
+        _payload(
+            observedAt=(now - timedelta(days=8)).isoformat(),
+            metadata={"sessionId": "stale-session", "runId": "stale-run"},
+        )
+    )
+    fresh_record = validate_observability_record(
+        _payload(
+            observedAt=now.isoformat(),
+            metadata={"sessionId": "fresh-session", "runId": "fresh-run"},
+        )
+    )
+    writer = ObservabilitySqliteWriter(
+        path=tmp_path / "observability.db",
+        max_age_days=7,
+    )
+
+    writer.write(stale_record)
+    writer.write(fresh_record)
+
+    assert _sqlite_row_count(tmp_path / "observability.db") == 2
+
+    writer.close()
+
+    conn = sqlite3.connect(tmp_path / "observability.db")
+    try:
+        rows = conn.execute("""
+            SELECT session_id
+            FROM observability_events
+            ORDER BY observed_at_epoch
+            """).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [("fresh-session",)]
+
+
+def test_observability_sqlite_writer_uses_schema_version_fast_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "observability.db"
+    writer = ObservabilitySqliteWriter(path=db_path)
+    writer.write(validate_observability_record(_payload()))
+    writer.close()
+
+    assert _sqlite_user_version(db_path) == OBSERVABILITY_SQLITE_SCHEMA_VERSION
+
+    def fail_full_schema(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("current observability schema should use the fast path")
+
+    monkeypatch.setattr(orm_store, "ensure_schema", fail_full_schema)
+
+    writer = ObservabilitySqliteWriter(path=db_path)
+    writer.write(
+        validate_observability_record(
+            _payload(metadata={"sessionId": "session-456", "runId": "run-456"})
+        )
+    )
+    writer.close()
+
+    assert _sqlite_row_count(db_path) == 2
+
+
+def test_record_observability_dual_writes_jsonl_and_sqlite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(observability, "_writer", None, raising=False)
+    monkeypatch.setattr(observability, "_sqlite_writer", None, raising=False)
+    record = validate_observability_record(_payload())
+
+    record_observability(record)
+    observability.get_sqlite_writer().close()
+
+    assert _jsonl_records(tmp_path / "observability.jsonl")[0]["hook"] == (
+        "before_agent_run"
+    )
+    assert (tmp_path / "observability.db").exists()
+    assert not (tmp_path / "security-events.jsonl").exists()
+    assert not (tmp_path / "security-events.db").exists()
+
+
+def test_observability_writer_indexes_llm_call_correlation_only(
+    tmp_path: Path,
+) -> None:
+    record = validate_observability_record(
+        _payload(
+            hook="after_llm_call",
+            metadata={
+                "sessionId": "session-123",
+                "runId": "run-123",
+                "callId": "call-123",
+            },
+            metrics={
+                "latency_ms": 125.5,
+                "outcome": "failure",
+                "response": {"error": "timeout"},
+            },
+        )
+    )
+    writer = ObservabilitySqliteWriter(path=tmp_path / "observability.db")
+
+    writer.write(record)
+    writer.close()
+
+    conn = sqlite3.connect(tmp_path / "observability.db")
+    try:
+        row = conn.execute("""
+            SELECT call_id, tool_call_id, metrics_json
+            FROM observability_events
+            """).fetchone()
+    finally:
+        conn.close()
+
+    assert row[0] == "call-123"
+    assert row[1] is None
+    assert json.loads(row[2]) == {
+        "latency_ms": 125.5,
+        "outcome": "failure",
+        "response": {"error": "timeout"},
+    }
+
+
+def test_observability_writer_indexes_tool_call_correlation_only(
+    tmp_path: Path,
+) -> None:
+    record = validate_observability_record(
+        _payload(
+            hook="after_tool_call",
+            metadata={
+                "sessionId": "session-123",
+                "runId": "run-123",
+                "callId": "call-123",
+                "toolCallId": "tool-call-123",
+            },
+            metrics={
+                "result": {"ok": True},
+                "duration_ms": 25,
+                "result_size_bytes": 128,
+            },
+        )
+    )
+    writer = ObservabilitySqliteWriter(path=tmp_path / "observability.db")
+
+    writer.write(record)
+    writer.close()
+
+    conn = sqlite3.connect(tmp_path / "observability.db")
+    try:
+        row = conn.execute("""
+            SELECT call_id, tool_call_id, metrics_json
+            FROM observability_events
+            """).fetchone()
+    finally:
+        conn.close()
+
+    assert row[0] == "call-123"
+    assert row[1] == "tool-call-123"
+    assert json.loads(row[2]) == {
+        "result": {"ok": True},
+        "duration_ms": 25,
+        "result_size_bytes": 128,
+    }

--- a/src/agent-sec-core/tests/unit-test/observability/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_writer.py
@@ -2,11 +2,13 @@
 
 import json
 import sqlite3
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 import agent_sec_cli.observability as observability
+import agent_sec_cli.observability.sqlite_writer as observability_sqlite_writer_module
 import agent_sec_cli.security_events.orm_store as orm_store
 import pytest
 from agent_sec_cli.observability import record_observability
@@ -201,6 +203,40 @@ def test_observability_sqlite_writer_prunes_on_close_not_write(
         conn.close()
 
     assert rows == [("fresh-session",)]
+
+
+def test_observability_sqlite_writer_closes_through_maintenance_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "observability.db"
+    writer = ObservabilitySqliteWriter(path=db_path)
+    writer.write(validate_observability_record(_payload()))
+    gated_paths: list[Path] = []
+
+    def fake_run_sqlite_maintenance_if_due(
+        db_path_arg: str | Path,
+        maintenance: Callable[[], None],
+        *,
+        interval_seconds: float = 0,
+        now: float | None = None,
+    ) -> bool:
+        gated_paths.append(Path(db_path_arg))
+        maintenance()
+        return True
+
+    monkeypatch.setattr(
+        observability_sqlite_writer_module,
+        "run_sqlite_maintenance_if_due",
+        fake_run_sqlite_maintenance_if_due,
+        raising=False,
+    )
+
+    writer.close()
+
+    assert gated_paths == [db_path.resolve()]
+    assert writer._engine is None
+    assert writer._session_factory is None
 
 
 def test_observability_sqlite_writer_uses_schema_version_fast_path(

--- a/src/agent-sec-core/tests/unit-test/security_events/test_orm_store.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_orm_store.py
@@ -282,10 +282,23 @@ def test_ensure_schema_if_needed_runs_full_schema_when_version_mismatch(
     called = False
     original_ensure_schema = orm_store.ensure_schema
 
-    def wrapped_ensure_schema(engine_arg, models=None):  # type: ignore[no-untyped-def]
+    def wrapped_ensure_schema(
+        engine_arg,
+        models=None,
+        *,
+        schema_version=orm_store._SCHEMA_VERSION,
+        schema_migrations=None,
+        log_prefix="[security_events]",
+    ):  # type: ignore[no-untyped-def]
         nonlocal called
         called = True
-        original_ensure_schema(engine_arg, models)
+        original_ensure_schema(
+            engine_arg,
+            models,
+            schema_version=schema_version,
+            schema_migrations=schema_migrations,
+            log_prefix=log_prefix,
+        )
 
     monkeypatch.setattr(orm_store, "ensure_schema", wrapped_ensure_schema)
 
@@ -392,6 +405,27 @@ def test_readonly_store_warns_without_migrating_unready_schema(
         }
     finally:
         conn.close()
+
+
+def test_sqlite_store_uses_custom_error_prefix(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = tmp_path / "observability.db"
+    conn = sqlite3.connect(db_path)
+    conn.close()
+
+    store = SqliteStore(
+        db_path,
+        read_only=True,
+        models=(SecurityEventRecord,),
+        log_prefix="[observability]",
+    )
+    try:
+        assert store.session_factory() is not None
+    finally:
+        store.close()
+
+    assert "[observability] sqlite schema not ready" in capsys.readouterr().err
 
 
 def test_store_corruption_cleanup_resets_state_and_allows_reinit(

--- a/src/agent-sec-core/tests/unit-test/security_events/test_orm_store.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_orm_store.py
@@ -355,6 +355,29 @@ def test_sqlite_store_reuses_session_factory_across_repositories(
         store.close()
 
 
+def test_security_event_prune_disposes_store_on_sqlalchemy_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FailingSessionFactory:
+        def begin(self):
+            raise SQLAlchemyError("prune failed")
+
+    store = SqliteStore(tmp_path / "events.db")
+    repository = SecurityEventRepository(store)
+    disposed = False
+
+    def fake_dispose() -> None:
+        nonlocal disposed
+        disposed = True
+
+    monkeypatch.setattr(store, "session_factory", lambda: FailingSessionFactory())
+    monkeypatch.setattr(store, "dispose", fake_dispose)
+
+    repository.prune(30)
+
+    assert disposed
+
+
 def test_readonly_store_does_not_create_missing_db(tmp_path: Path) -> None:
     missing_db = tmp_path / "missing.db"
     store = SqliteStore(missing_db, read_only=True)

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_maintenance.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_maintenance.py
@@ -1,0 +1,107 @@
+"""Unit tests for cross-process SQLite maintenance gating."""
+
+import fcntl
+import os
+from pathlib import Path
+
+from agent_sec_cli.security_events.sqlite_maintenance import (
+    run_sqlite_maintenance_if_due,
+)
+
+
+def test_sqlite_maintenance_runs_once_per_interval(tmp_path: Path) -> None:
+    db_path = tmp_path / "events.db"
+    calls: list[str] = []
+
+    def maintenance() -> None:
+        calls.append("run")
+
+    assert run_sqlite_maintenance_if_due(
+        db_path,
+        maintenance,
+        interval_seconds=10,
+        now=100.0,
+    )
+    assert not run_sqlite_maintenance_if_due(
+        db_path,
+        maintenance,
+        interval_seconds=10,
+        now=109.0,
+    )
+    assert run_sqlite_maintenance_if_due(
+        db_path,
+        maintenance,
+        interval_seconds=10,
+        now=110.0,
+    )
+
+    assert calls == ["run", "run"]
+    marker_path = Path(f"{db_path}.maintenance")
+    assert float(marker_path.read_text(encoding="utf-8").strip()) == 110.0
+
+
+def test_sqlite_maintenance_skips_when_another_process_holds_lock(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "events.db"
+    lock_path = Path(f"{db_path}.maintenance.lock")
+    calls: list[str] = []
+
+    def maintenance() -> None:
+        calls.append("run")
+
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        assert not run_sqlite_maintenance_if_due(
+            db_path,
+            maintenance,
+            interval_seconds=10,
+            now=100.0,
+        )
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+    assert calls == []
+    assert not Path(f"{db_path}.maintenance").exists()
+
+
+def test_sqlite_maintenance_retries_after_callback_failure(tmp_path: Path) -> None:
+    db_path = tmp_path / "events.db"
+    calls: list[str] = []
+
+    def failing_maintenance() -> None:
+        calls.append("fail")
+        raise RuntimeError("maintenance failed")
+
+    assert not run_sqlite_maintenance_if_due(
+        db_path,
+        failing_maintenance,
+        interval_seconds=10,
+        now=100.0,
+    )
+
+    assert calls == ["fail"]
+    assert not Path(f"{db_path}.maintenance").exists()
+
+
+def test_sqlite_maintenance_treats_invalid_marker_as_due(tmp_path: Path) -> None:
+    db_path = tmp_path / "events.db"
+    marker_path = Path(f"{db_path}.maintenance")
+    marker_path.write_text("not-a-timestamp\n", encoding="utf-8")
+    calls: list[str] = []
+
+    def maintenance() -> None:
+        calls.append("run")
+
+    assert run_sqlite_maintenance_if_due(
+        db_path,
+        maintenance,
+        interval_seconds=10,
+        now=100.0,
+    )
+
+    assert calls == ["run"]
+    assert float(marker_path.read_text(encoding="utf-8").strip()) == 100.0

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -7,12 +7,14 @@ import stat
 import sys
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import agent_sec_cli.security_events.sqlite_writer as sqlite_writer_module
 import pytest
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
@@ -491,6 +493,62 @@ class TestSqliteEventWriter:
         assert writer._engine is None
         assert writer._session_factory is None
 
+    def test_close_runs_prune_and_checkpoint_through_maintenance_gate(
+        self,
+        db_path: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        writer.write(_make_event())
+        gated_paths: list[Path] = []
+
+        def fake_run_sqlite_maintenance_if_due(
+            db_path_arg: str | Path,
+            maintenance: Callable[[], None],
+            *,
+            interval_seconds: float = 0,
+            now: float | None = None,
+        ) -> bool:
+            gated_paths.append(Path(db_path_arg))
+            maintenance()
+            return True
+
+        monkeypatch.setattr(
+            sqlite_writer_module,
+            "run_sqlite_maintenance_if_due",
+            fake_run_sqlite_maintenance_if_due,
+            raising=False,
+        )
+
+        writer.close()
+
+        assert gated_paths == [Path(db_path).resolve()]
+        assert writer._engine is None
+        assert writer._session_factory is None
+
+    def test_close_skips_repeated_maintenance_for_same_db_path(
+        self,
+        db_path: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        first_writer = SqliteEventWriter(path=db_path)
+        first_writer.write(_make_event())
+        first_writer.close()
+
+        second_writer = SqliteEventWriter(path=db_path)
+        second_writer.write(_make_event(event_type="second_event"))
+
+        def fail_if_maintenance_runs() -> None:
+            raise AssertionError("maintenance should be skipped while marker is fresh")
+
+        monkeypatch.setattr(
+            second_writer,
+            "_run_maintenance",
+            fail_if_maintenance_runs,
+        )
+
+        second_writer.close()
+
     def test_disabled_after_delete_failure(self, db_path: str) -> None:
         writer = SqliteEventWriter(path=db_path)
         writer.write(_make_event())
@@ -511,18 +569,6 @@ class TestSqliteEventWriter:
 
         # Subsequent writes should be no-ops
         writer2.write(_make_event())
-
-    def test_store_helpers_delegate_to_store(self, db_path: str) -> None:
-        writer = SqliteEventWriter(path=db_path)
-        writer.write(_make_event())
-        assert writer._engine is not None
-        assert writer._session_factory is not None
-        assert writer._ensure_session_factory() is writer._session_factory
-        assert not writer._disabled
-
-        writer._dispose_engine()
-        assert writer._engine is None
-        assert writer._session_factory is None
 
     def test_write_retries_after_corruption_error(
         self, db_path: str, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
- add observability SQLite writer/repository/schema versioning
- align retention and writer behavior with security events
- add focused observability SQLite/unit/e2e coverage
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
