### PR TITLE
feat(cosh): surface UserPromptSubmit and PostToolUse hook reason in UI

### DIFF
--- a/src/copilot-shell/packages/core/src/core/client.test.ts
+++ b/src/copilot-shell/packages/core/src/core/client.test.ts
@@ -30,6 +30,7 @@ import {
   GeminiEventType,
   Turn,
   type ChatCompressionInfo,
+  type ServerGeminiStreamEvent,
 } from './turn.js';
 import { getCoreSystemPrompt } from './prompts.js';
 import { DEFAULT_QWEN_FLASH_MODEL } from '../config/models.js';
@@ -2699,6 +2700,269 @@ Other open files:
         // Assert: continuations must NOT overwrite the active run_id.
         expect(mockConfig.setCurrentRunId).not.toHaveBeenCalled();
         expect(mockConfig.getCurrentRunId()).toBe('pre-existing-run-id');
+      });
+
+      // ─────────────────────────────────────────────────────────────────
+      // Regression: Issue #535 — UserPromptSubmit allow/approve `reason`
+      //   was not surfaced to the terminal UI. Non-blocking decisions now
+      //   yield a HookSystemMessage event so users can see informational
+      //   warnings ("policy check passed with a warning") that hooks
+      //   surface alongside an allow decision.
+      // ─────────────────────────────────────────────────────────────────
+      it('emits HookSystemMessage when UserPromptSubmit allow decision carries a reason', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({
+            type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+            correlationId: 'test-correlation-id',
+            success: true,
+            output: {
+              decision: 'allow',
+              reason: 'Prompt accepted, but policy check found a warning',
+            },
+          }),
+        };
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'ok' };
+          })(),
+        );
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-allow-reason',
+        );
+        const events = [];
+        for await (const e of stream) {
+          events.push(e);
+        }
+
+        const hookMessages = events.filter(
+          (e) => e.type === GeminiEventType.HookSystemMessage,
+        );
+        expect(hookMessages).toEqual([
+          {
+            type: GeminiEventType.HookSystemMessage,
+            value: 'Prompt accepted, but policy check found a warning',
+          },
+        ]);
+      });
+
+      it('prefers systemMessage over reason when both are present on allow', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({
+            type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+            correlationId: 'test-correlation-id',
+            success: true,
+            output: {
+              decision: 'allow',
+              systemMessage: 'explicit system message',
+              reason: 'fallback reason',
+            },
+          }),
+        };
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'ok' };
+          })(),
+        );
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-systemmsg-priority',
+        );
+        const events = [];
+        for await (const e of stream) {
+          events.push(e);
+        }
+
+        const hookMessages = events.filter(
+          (e) => e.type === GeminiEventType.HookSystemMessage,
+        );
+        expect(hookMessages).toEqual([
+          {
+            type: GeminiEventType.HookSystemMessage,
+            value: 'explicit system message',
+          },
+        ]);
+      });
+
+      it('does not emit HookSystemMessage when blocking — Error event already carries the reason', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({
+            type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+            correlationId: 'test-correlation-id',
+            success: true,
+            output: {
+              decision: 'block',
+              reason: 'blocked by policy',
+            },
+          }),
+        };
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-block',
+        );
+        const events = [];
+        for await (const e of stream) {
+          events.push(e);
+        }
+
+        // Block path: an Error event is yielded with the reason; no separate
+        // HookSystemMessage should be emitted.
+        const errorEvents = events.filter(
+          (e) => e.type === GeminiEventType.Error,
+        );
+        expect(errorEvents).toHaveLength(1);
+        const hookMessages = events.filter(
+          (e) => e.type === GeminiEventType.HookSystemMessage,
+        );
+        expect(hookMessages).toEqual([]);
+      });
+
+      it('does not emit HookSystemMessage when ask — UserPromptConfirmation already carries the reason', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({
+            type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+            correlationId: 'test-correlation-id',
+            success: true,
+            output: {
+              decision: 'ask',
+              reason: 'please confirm',
+            },
+          }),
+        };
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        // Ask path awaits a confirmation resolve(); abort to unblock.
+        const abortController = new AbortController();
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          abortController.signal,
+          'prompt-id-ask',
+        );
+        const events: ServerGeminiStreamEvent[] = [];
+        const collect = (async () => {
+          for await (const e of stream) {
+            events.push(e);
+            if (e.type === GeminiEventType.UserPromptConfirmation) {
+              abortController.abort();
+            }
+          }
+        })();
+        await collect;
+
+        const confirmations = events.filter(
+          (e) => e.type === GeminiEventType.UserPromptConfirmation,
+        );
+        expect(confirmations).toHaveLength(1);
+        const hookMessages = events.filter(
+          (e) => e.type === GeminiEventType.HookSystemMessage,
+        );
+        expect(hookMessages).toEqual([]);
+      });
+
+      it('does not emit HookSystemMessage when allow has no message at all', async () => {
+        const mockMessageBus = createMockMessageBus();
+        // Override default: empty `output` with neither systemMessage nor reason.
+        mockMessageBus.request = vi.fn().mockResolvedValue({
+          type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+          correlationId: 'test-correlation-id',
+          success: true,
+          output: { decision: 'allow' },
+        });
+        vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        (mockConfig as unknown as { getHookSystem: Mock }).getHookSystem = vi
+          .fn()
+          .mockReturnValue(undefined);
+
+        const mockChat: Partial<GeminiChat> = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+
+        mockTurnRunFn.mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'content', value: 'ok' };
+          })(),
+        );
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-allow-empty',
+        );
+        const events = [];
+        for await (const e of stream) {
+          events.push(e);
+        }
+
+        const hookMessages = events.filter(
+          (e) => e.type === GeminiEventType.HookSystemMessage,
+        );
+        expect(hookMessages).toEqual([]);
       });
     });
   });

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -619,6 +619,25 @@ export class GeminiClient {
         }
       }
 
+      // Non-blocking allow/approve path: surface systemMessage (or reason as
+      // fallback) to the terminal UI. Block uses Error event above; ask uses
+      // UserPromptConfirmation, both of which already render the message — so
+      // this branch only runs when no other UI path was taken.
+      if (
+        hookOutput &&
+        !hookOutput.isBlockingDecision() &&
+        !hookOutput.shouldStopExecution() &&
+        !hookOutput.isAskDecision()
+      ) {
+        const message = hookOutput.systemMessage ?? hookOutput.reason;
+        if (message) {
+          yield {
+            type: GeminiEventType.HookSystemMessage,
+            value: message,
+          };
+        }
+      }
+
       // Add additional context from hooks to the request
       const additionalContext = hookOutput?.getAdditionalContext();
       if (additionalContext) {

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
@@ -2613,6 +2613,259 @@ describe('CoreToolScheduler Sequential Execution', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
+  // Regression: Issue #535 — PostToolUse hook reason was not surfaced to UI.
+  //   The aggregator already produces notifications[]; the scheduler must
+  //   forward them via outputUpdateHandler so the terminal renders the same
+  //   per-hook box style used for PreToolUse.
+  // ─────────────────────────────────────────────────────────────────────────
+  it('PostToolUse allow decision with reason should emit a structured notification to outputUpdateHandler', async () => {
+    const executeFn = vi.fn().mockResolvedValue({
+      llmContent: 'tool ran',
+      returnDisplay: 'tool ran',
+    });
+    const postAllowTool = new MockTool({
+      name: 'postAllowTool',
+      execute: executeFn,
+      shouldConfirmExecute: vi.fn().mockResolvedValue(false),
+    });
+
+    const postAllowHookOutput = {
+      decision: 'allow' as const,
+      isBlockingDecision: () => false,
+      shouldStopExecution: () => false,
+      isAskDecision: () => false,
+      systemMessage: undefined,
+      reason: 'Tool output passed compliance review',
+      getEffectiveReason: () => 'Tool output passed compliance review',
+      getAdditionalContext: () => undefined,
+      notifications: [
+        {
+          hookName: 'compliance-reviewer',
+          message: 'Tool output passed compliance review',
+          decision: 'allow' as const,
+        },
+      ],
+    };
+    const mockHookPostAllow = {
+      firePreToolUseEvent: vi.fn().mockResolvedValue(undefined),
+      firePostToolUseEvent: vi.fn().mockResolvedValue(postAllowHookOutput),
+    };
+
+    const toolRegistryPostAllow = {
+      getTool: () => postAllowTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => postAllowTool,
+      getToolByDisplayName: () => postAllowTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsCompletePostAllow = vi.fn();
+    const outputUpdateHandlerPostAllow = vi.fn();
+
+    const mockConfigPostAllow = {
+      getSessionId: () => 'test-session-post-allow',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getAllowedTools: () => [],
+      getToolRegistry: () => toolRegistryPostAllow,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getUseSmartEdit: () => false,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      isInteractive: () => true,
+      getExperimentalZedIntegration: () => false,
+      getEnableHooks: () => true,
+      getHookSystem: () => mockHookPostAllow,
+    } as unknown as Config;
+
+    const schedulerPostAllow = new CoreToolScheduler({
+      config: mockConfigPostAllow,
+      onAllToolCallsComplete: onAllToolCallsCompletePostAllow,
+      onToolCallsUpdate: vi.fn(),
+      outputUpdateHandler: outputUpdateHandlerPostAllow,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortControllerPostAllow = new AbortController();
+    await schedulerPostAllow.schedule(
+      [
+        {
+          callId: 'post-allow-1',
+          name: 'postAllowTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'p-post-allow',
+        },
+      ],
+      abortControllerPostAllow.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsCompletePostAllow).toHaveBeenCalled();
+    });
+
+    // Notification must surface to the UI even though the decision is allow.
+    expect(outputUpdateHandlerPostAllow).toHaveBeenCalledWith('post-allow-1', {
+      hookName: 'compliance-reviewer',
+      hookMessage: 'Tool output passed compliance review',
+      decision: 'allow',
+      mergedDecision: 'allow',
+    });
+
+    const completedCalls = onAllToolCallsCompletePostAllow.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('success');
+  });
+
+  it('PostToolUse block decision should emit notification AND replace tool response', async () => {
+    const executeFn = vi.fn().mockResolvedValue({
+      llmContent: 'tool ran',
+      returnDisplay: 'tool ran',
+    });
+    const postBlockTool = new MockTool({
+      name: 'postBlockTool',
+      execute: executeFn,
+      shouldConfirmExecute: vi.fn().mockResolvedValue(false),
+    });
+
+    const postBlockHookOutput = {
+      decision: 'block' as const,
+      isBlockingDecision: () => true,
+      shouldStopExecution: () => false,
+      isAskDecision: () => false,
+      systemMessage: undefined,
+      reason: 'Output requires follow-up review before continuing',
+      getEffectiveReason: () =>
+        'Output requires follow-up review before continuing',
+      getAdditionalContext: () => undefined,
+      notifications: [
+        {
+          hookName: 'compliance-reviewer',
+          message: 'Output requires follow-up review before continuing',
+          decision: 'block' as const,
+        },
+      ],
+    };
+    const mockHookPostBlock = {
+      firePreToolUseEvent: vi.fn().mockResolvedValue(undefined),
+      firePostToolUseEvent: vi.fn().mockResolvedValue(postBlockHookOutput),
+    };
+
+    const toolRegistryPostBlock = {
+      getTool: () => postBlockTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => postBlockTool,
+      getToolByDisplayName: () => postBlockTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsCompletePostBlock = vi.fn();
+    const outputUpdateHandlerPostBlock = vi.fn();
+
+    const mockConfigPostBlock = {
+      getSessionId: () => 'test-session-post-block',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getAllowedTools: () => [],
+      getToolRegistry: () => toolRegistryPostBlock,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getUseSmartEdit: () => false,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      isInteractive: () => true,
+      getExperimentalZedIntegration: () => false,
+      getEnableHooks: () => true,
+      getHookSystem: () => mockHookPostBlock,
+    } as unknown as Config;
+
+    const schedulerPostBlock = new CoreToolScheduler({
+      config: mockConfigPostBlock,
+      onAllToolCallsComplete: onAllToolCallsCompletePostBlock,
+      onToolCallsUpdate: vi.fn(),
+      outputUpdateHandler: outputUpdateHandlerPostBlock,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortControllerPostBlock = new AbortController();
+    await schedulerPostBlock.schedule(
+      [
+        {
+          callId: 'post-block-1',
+          name: 'postBlockTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'p-post-block',
+        },
+      ],
+      abortControllerPostBlock.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsCompletePostBlock).toHaveBeenCalled();
+    });
+
+    // Block path: mergedDecision is 'block' so the per-hook box can dim.
+    expect(outputUpdateHandlerPostBlock).toHaveBeenCalledWith('post-block-1', {
+      hookName: 'compliance-reviewer',
+      hookMessage: 'Output requires follow-up review before continuing',
+      decision: 'block',
+      mergedDecision: 'block',
+    });
+
+    // Tool execution still completes (status success); only the responseParts
+    // sent back to the LLM are replaced with the hook reason.
+    const completedCalls = onAllToolCallsCompletePostBlock.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('success');
+    const responseParts = (
+      completedCalls[0] as { response: { responseParts: unknown } }
+    ).response.responseParts;
+    expect(JSON.stringify(responseParts)).toContain(
+      'Output requires follow-up review before continuing',
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
   // hook-ask command forwarding: safe shell command (echo)
   //   When shouldConfirmExecute() returns false (safe command like `echo`)
   //   but a hook forces ask, the scheduler must extract the shell command

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -1512,6 +1512,42 @@ export class CoreToolScheduler {
                   );
 
                   if (postToolOutput) {
+                    // Compute mergedDecision once so every notification shares
+                    // the same context. Mirrors the PreToolUse path: blocking
+                    // (block/deny or continue=false) wins over ask, which
+                    // wins over the per-hook decision used for individual
+                    // notification dimming.
+                    const isBlockingPost =
+                      postToolOutput.isBlockingDecision() ||
+                      postToolOutput.shouldStopExecution();
+                    const isAskPost = postToolOutput.isAskDecision();
+                    const mergedDecisionPost: HookDecision | undefined =
+                      isBlockingPost
+                        ? postToolOutput.decision === 'deny'
+                          ? 'deny'
+                          : 'block'
+                        : isAskPost
+                          ? 'ask'
+                          : postToolOutput.decision;
+
+                    // Emit per-hook notifications BEFORE applying the merged
+                    // decision so every hook's reason/systemMessage surfaces
+                    // in the UI even when the overall outcome later replaces
+                    // the tool response.
+                    if (
+                      this.outputUpdateHandler &&
+                      postToolOutput.notifications?.length
+                    ) {
+                      for (const n of postToolOutput.notifications) {
+                        this.outputUpdateHandler(callId, {
+                          hookName: n.hookName,
+                          hookMessage: n.message,
+                          decision: n.decision,
+                          mergedDecision: mergedDecisionPost,
+                        });
+                      }
+                    }
+
                     // If hook denies, replace tool result with reason
                     if (postToolOutput.isBlockingDecision()) {
                       const reason = postToolOutput.getEffectiveReason();

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.test.ts
@@ -63,6 +63,7 @@ describe('HookSystem', () => {
     mockHookEventHandler = {
       fireUserPromptSubmitEvent: vi.fn(),
       fireStopEvent: vi.fn(),
+      firePostToolUseEvent: vi.fn(),
     } as unknown as HookEventHandler;
 
     vi.mocked(HookRegistry).mockImplementation(() => mockHookRegistry);
@@ -323,6 +324,93 @@ describe('HookSystem', () => {
 
       expect(result).toBeDefined();
       expect(result?.getAdditionalContext()).toBe('Some additional context');
+    });
+  });
+
+  describe('firePostToolUseEvent', () => {
+    it('should attach aggregator notifications to the returned output', async () => {
+      const notifications = [
+        {
+          hookName: 'audit-hook',
+          message: 'Tool output flagged for follow-up review',
+          decision: 'allow' as HookDecision,
+        },
+      ];
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 12,
+        finalOutput: {
+          decision: 'allow' as HookDecision,
+          reason: 'Tool output flagged for follow-up review',
+        },
+        notifications,
+      };
+      vi.mocked(mockHookEventHandler.firePostToolUseEvent).mockResolvedValue(
+        mockResult,
+      );
+
+      const result = await hookSystem.firePostToolUseEvent(
+        'shell',
+        { command: 'ls' },
+        { llmContent: 'output' },
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.notifications).toEqual(notifications);
+    });
+
+    it('should leave notifications undefined when aggregator emits none', async () => {
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 12,
+        finalOutput: {
+          decision: 'allow' as HookDecision,
+        },
+      };
+      vi.mocked(mockHookEventHandler.firePostToolUseEvent).mockResolvedValue(
+        mockResult,
+      );
+
+      const result = await hookSystem.firePostToolUseEvent(
+        'shell',
+        { command: 'ls' },
+        { llmContent: 'output' },
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.notifications).toBeUndefined();
+    });
+
+    it('should return undefined when no final output', async () => {
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 0,
+        finalOutput: undefined,
+        notifications: [
+          {
+            hookName: 'audit-hook',
+            message: 'noise that should be discarded',
+            decision: 'allow' as HookDecision,
+          },
+        ],
+      };
+      vi.mocked(mockHookEventHandler.firePostToolUseEvent).mockResolvedValue(
+        mockResult,
+      );
+
+      const result = await hookSystem.firePostToolUseEvent(
+        'shell',
+        { command: 'ls' },
+        { llmContent: 'output' },
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -197,6 +197,11 @@ export class HookSystem {
           result.finalOutput,
         ) as PostToolUseHookOutput)
       : undefined;
+    // Carry per-hook notifications from the aggregator so the scheduler can
+    // emit them as structured data to the UI layer (mirrors PreToolUse).
+    if (output && result.notifications?.length) {
+      output.notifications = result.notifications;
+    }
     debugLogger.info(
       `[Hook Debug] hookSystem.firePostToolUseEvent: facade returning, hasOutput=${!!output}`,
     );


### PR DESCRIPTION
## Description

Follow-up to #421. `UserPromptSubmit` and `PostToolUse` hooks could return
a `reason` (or `systemMessage`) on non-blocking decisions, but the
terminal UI never showed it — leaving informational warnings invisible.

This PR mirrors the #421 PreToolUse path:

- `firePostToolUseEvent()` now carries aggregator `notifications[]` on
  the returned output, and `coreToolScheduler` emits each one via
  `outputUpdateHandler(callId, {hookName, hookMessage, decision, mergedDecision})`
  before applying the merged block / ask / allow outcome.
- `UserPromptSubmit` non-blocking allow / approve now yields a
  `HookSystemMessage` event using `systemMessage ?? reason`. Block
  (`Error` event) and ask (`UserPromptConfirmation`) paths are unchanged
  because they already render the message.
- `additionalContext` LLM injection is unchanged — the new path is
  UI-only.

## Related Issue

closes #535

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (\`package-lock.json\` / \`Cargo.lock\`)

## Testing

\`\`\`
npx vitest run packages/core/src/core/client.test.ts \
                packages/core/src/core/coreToolScheduler.test.ts \
                packages/core/src/hooks/hookSystem.test.ts
→ 3 files passed, 122/122 tests passed
\`\`\`

Type check on the three changed test files is clean (pre-existing
third-party \`@types\` errors for \`simple-git\` / \`google-auth-library\` /
\`@opentelemetry/exporter-metrics-otlp-http\` are unrelated to this PR).

Manual verification scenarios:

- \`UserPromptSubmit\` returning \`{decision: "allow", reason: "..."}\` —
  reason now renders in the terminal as a \`HookSystemMessage\`.
- \`PostToolUse\` returning \`{decision: "allow", reason: "..."}\` —
  reason renders as a per-hook notification on the existing tool
  message UI; tool still completes successfully.
- \`PostToolUse\` returning \`{decision: "block", reason: "..."}\` —
  notification renders with \`mergedDecision: "block"\` *and* the
  response sent to the LLM is replaced with the reason.

## Additional Notes

The non-interactive JSON output adapter
(\`BaseJsonOutputAdapter.processEvent\` handling of \`HookSystemMessage\`)
is intentionally deferred; #535 scopes to the terminal UI.