### PR TITLE
fix(cosh): correct read_file arg key in auto-memory session hook

### DIFF
--- a/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.test.ts
+++ b/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.test.ts
@@ -37,7 +37,7 @@ describe('createExtractionHooks session-read tracking', () => {
     });
     await hooks.postToolUse?.(
       makePayload('read_file', {
-        absolute_path: path.join(chatsDir, `${uuidA}.jsonl`),
+        file_path: path.join(chatsDir, `${uuidA}.jsonl`),
       }),
     );
     expect(reads).toEqual([uuidA]);
@@ -68,7 +68,7 @@ describe('createExtractionHooks session-read tracking', () => {
       onSessionRead: (sid) => reads.push(sid),
     });
     await hooks.postToolUse?.(
-      makePayload('read_file', { absolute_path: '/etc/passwd' }),
+      makePayload('read_file', { file_path: '/etc/passwd' }),
     );
     expect(reads).toEqual([]);
   });
@@ -82,7 +82,7 @@ describe('createExtractionHooks session-read tracking', () => {
     await hooks.postToolUse?.(
       makePayload(
         'read_file',
-        { absolute_path: path.join(chatsDir, `${uuidA}.jsonl`) },
+        { file_path: path.join(chatsDir, `${uuidA}.jsonl`) },
         /* success */ false,
       ),
     );
@@ -94,7 +94,7 @@ describe('createExtractionHooks session-read tracking', () => {
     // Should simply not throw, and not observe any side-effect.
     await hooks.postToolUse?.(
       makePayload('read_file', {
-        absolute_path: path.join(chatsDir, `${uuidA}.jsonl`),
+        file_path: path.join(chatsDir, `${uuidA}.jsonl`),
       }),
     );
   });

--- a/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.ts
+++ b/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.ts
@@ -382,7 +382,7 @@ export function createExtractionHooks(
       // Track session reads (best-effort, never blocks validation).
       if (payload.success && chatsDir && onSessionRead) {
         if (payload.toolName === 'read_file') {
-          reportSessionRead(payload.args['absolute_path']);
+          reportSessionRead(payload.args['file_path']);
         } else if (payload.toolName === 'read_many_files') {
           const paths = payload.args['paths'];
           if (Array.isArray(paths)) {


### PR DESCRIPTION
## Description

The auto-memory extraction subagent's `postToolUse` hook reads
`payload.args['absolute_path']` to track which chat session files were
actually consumed, but the `read_file` tool's real schema uses `file_path`
(see `tools/read-file.ts`). The wrong key returns `undefined`, so
`onSessionRead` never fires for `read_file` reads. The
`actuallyReadSessions` set in `memoryService.ts` stays empty, and the
"only mark processed after read" logic causes the same candidate sessions
to be retried run after run until `MAX_ATTEMPTS_BEFORE_SKIP` — burning LLM
calls. This was likely inherited from gemini-cli where the tool used
`absolute_path`. The accompanying test fed the mock payload with the same
wrong key, so it stayed green and missed the regression.

## Related Issue

no-issue: trivial bug fix surfaced during review of cba22cb

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Red-green verification on `skillExtractionAgent.test.ts`:

1. Apply the test fix only (mock payloads use `file_path`) — the
   `reports sessionId when read_file reads a chat session file` test
   FAILS, asserting `[]` instead of `[uuidA]`. This proves the test
   would have caught the original bug.
2. Apply the source fix — all 6 tests in
   `skillExtractionAgent.test.ts` pass.

## Additional Notes

The `read_many_files` branch on the next line (`payload.args['paths']`)
was already correct — only the `read_file` branch had the wrong key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)