### PR TITLE
fix(cosh): preserve user dirs in auto-memory workspace cleanup

### DIFF
--- a/src/copilot-shell/packages/core/src/services/autoMemory/memoryService.ts
+++ b/src/copilot-shell/packages/core/src/services/autoMemory/memoryService.ts
@@ -558,14 +558,17 @@ export async function startAutoMemoryExtraction(
     );
 
     // Add chats and memory directories to workspace context so the extraction
-    // agent can read session files and write patches/skills via tools
+    // agent can read session files and write patches/skills via tools.
+    // Track each successfully added directory so cleanup removes only what we
+    // added, leaving any user-added directories (e.g. via /directory) intact.
     const workspaceContext = config.getWorkspaceContext();
-    let addedExtraDirs = false;
+    const extraDirs: string[] = [];
     try {
       workspaceContext.addDirectory(chatsDir);
+      extraDirs.push(chatsDir);
       await fs.mkdir(memoryDir, { recursive: true });
       workspaceContext.addDirectory(memoryDir);
-      addedExtraDirs = true;
+      extraDirs.push(memoryDir);
     } catch {
       debugLogger.warn(
         `Could not add chats/memory directories to workspace context`,
@@ -606,11 +609,16 @@ export async function startAutoMemoryExtraction(
       await subagent.runNonInteractive(context, abortController.signal);
     } finally {
       chatRecordingService?.removeExcludedPromptIdPrefix(excludePrefix);
-      // Remove the temporarily added directories
-      if (addedExtraDirs) {
-        workspaceContext.setDirectories(
-          workspaceContext.getInitialDirectories(),
-        );
+      // Remove only the directories we added; never touch directories that
+      // were already present or added by the user during this run.
+      for (const dir of extraDirs) {
+        try {
+          workspaceContext.removeDirectory(dir);
+        } catch (e) {
+          debugLogger.warn(
+            `Failed to remove auto-memory directory ${dir} from workspace context: ${e}`,
+          );
+        }
       }
     }
 

--- a/src/copilot-shell/packages/core/src/utils/workspaceContext.test.ts
+++ b/src/copilot-shell/packages/core/src/utils/workspaceContext.test.ts
@@ -97,6 +97,69 @@ describe('WorkspaceContext with real filesystem', () => {
     });
   });
 
+  describe('removing directories', () => {
+    it('should remove a previously added directory', () => {
+      const workspaceContext = new WorkspaceContext(cwd);
+      workspaceContext.addDirectory(otherDir);
+      workspaceContext.removeDirectory(otherDir);
+
+      expect(workspaceContext.getDirectories()).toEqual([cwd]);
+    });
+
+    it('should leave initial directories intact', () => {
+      const workspaceContext = new WorkspaceContext(cwd, [otherDir]);
+      const extra = path.join(tempDir, 'extra');
+      fs.mkdirSync(extra, { recursive: true });
+      workspaceContext.addDirectory(extra);
+      workspaceContext.removeDirectory(extra);
+
+      expect(workspaceContext.getDirectories()).toEqual([cwd, otherDir]);
+    });
+
+    it('should be a no-op when the directory is not in the set', () => {
+      const workspaceContext = new WorkspaceContext(cwd);
+      const listener = vi.fn();
+      workspaceContext.onDirectoriesChanged(listener);
+
+      workspaceContext.removeDirectory(otherDir);
+
+      expect(workspaceContext.getDirectories()).toEqual([cwd]);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should resolve symlinks before removing', () => {
+      const realDir = path.join(tempDir, 'real');
+      fs.mkdirSync(realDir, { recursive: true });
+      const symlinkDir = path.join(tempDir, 'symlink-to-real');
+      fs.symlinkSync(realDir, symlinkDir, 'dir');
+      const workspaceContext = new WorkspaceContext(cwd);
+      workspaceContext.addDirectory(realDir);
+      workspaceContext.removeDirectory(symlinkDir);
+
+      expect(workspaceContext.getDirectories()).toEqual([cwd]);
+    });
+
+    it('should notify listeners when a removal mutates the set', () => {
+      const workspaceContext = new WorkspaceContext(cwd);
+      workspaceContext.addDirectory(otherDir);
+      const listener = vi.fn();
+      workspaceContext.onDirectoriesChanged(listener);
+
+      workspaceContext.removeDirectory(otherDir);
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+
+    it('should throw for a non-existent path', () => {
+      const workspaceContext = new WorkspaceContext(cwd);
+      const ghost = path.join(tempDir, 'never-existed');
+
+      expect(() => workspaceContext.removeDirectory(ghost)).toThrow(
+        /does not exist/,
+      );
+    });
+  });
+
   describe('path validation', () => {
     it('should accept paths within workspace directories', () => {
       const workspaceContext = new WorkspaceContext(cwd, [otherDir]);

--- a/src/copilot-shell/packages/core/src/utils/workspaceContext.ts
+++ b/src/copilot-shell/packages/core/src/utils/workspaceContext.ts
@@ -78,6 +78,19 @@ export class WorkspaceContext {
     this.notifyDirectoriesChanged();
   }
 
+  /**
+   * Removes a directory from the workspace.
+   * @param directory The directory path to remove (can be relative or absolute)
+   * @param basePath Optional base path for resolving relative paths (defaults to cwd)
+   */
+  removeDirectory(directory: string, basePath: string = process.cwd()): void {
+    const resolved = this.resolveAndValidateDir(directory, basePath);
+    if (!this.directories.delete(resolved)) {
+      return;
+    }
+    this.notifyDirectoriesChanged();
+  }
+
   private resolveAndValidateDir(
     directory: string,
     basePath: string = process.cwd(),


### PR DESCRIPTION
## Description

The auto-memory background extraction adds `chatsDir` and `memoryDir` to
the shared `WorkspaceContext`, then on cleanup calls
`setDirectories(getInitialDirectories())`. `initialDirectories` is a
snapshot frozen at constructor time and is never updated, so any
directory the user added at runtime via the `/directory` slash command
gets wiped when the background extraction finishes — and any subsequent
file access in those user directories silently fails the workspace
boundary check.

This change introduces `WorkspaceContext.removeDirectory(path)` and
makes the cleanup remove only the two directories auto-memory itself
added, leaving every other directory in the context untouched. The
extracted directories are tracked individually as they are added, which
also closes a partial-add leak: previously, if `addDirectory(chatsDir)`
succeeded but the subsequent `mkdir`/`addDirectory(memoryDir)` threw,
`addedExtraDirs` stayed `false` and the `chatsDir` entry leaked.

## Related Issue

no-issue: bug fix surfaced during review of cba22cb

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

`workspaceContext.test.ts` gains six TDD-driven tests covering
`removeDirectory`: removal, leaving initial directories intact, no-op
on non-member, symlink resolution, listener notification, and throwing
on a non-existent path. Red-green confirmed: all six tests fail with
`removeDirectory is not a function` before the implementation, and pass
after. Full suite for the touched modules: 60/60 pass
(`workspaceContext` 40 + `autoMemory/*` 20).

## Additional Notes

This fix is independent of #547 (the `read_file`/`absolute_path` arg-key
bug); both issues live in the auto-memory subsystem introduced in
cba22cb but touch disjoint files.