### PR TITLE
fix(cosh): atomic stale-lock takeover and async IO in memory hooks

### DIFF
--- a/src/copilot-shell/packages/core/src/services/autoMemory/memoryService.test.ts
+++ b/src/copilot-shell/packages/core/src/services/autoMemory/memoryService.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { tryAcquireLock, isLockStale, releaseLock } from './memoryService.js';
+
+const FAR_FUTURE_PID = 2 ** 22; // Reasonably guaranteed not to be alive on POSIX.
+
+describe('memoryService lock management', () => {
+  let tmpDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memsvc-lock-test-'));
+    lockPath = path.join(tmpDir, '.extraction.lock');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('tryAcquireLock', () => {
+    it('acquires a lock on a fresh path', async () => {
+      expect(await tryAcquireLock(lockPath)).toBe(true);
+      const content = await fs.readFile(lockPath, 'utf-8');
+      const parsed = JSON.parse(content);
+      expect(parsed.pid).toBe(process.pid);
+      expect(typeof parsed.startedAt).toBe('string');
+    });
+
+    it('returns false when a live-process lock already exists', async () => {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      expect(await tryAcquireLock(lockPath)).toBe(false);
+    });
+
+    it('reclaims a stale lock whose owner PID is dead', async () => {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: FAR_FUTURE_PID,
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      expect(await tryAcquireLock(lockPath)).toBe(true);
+      const parsed = JSON.parse(await fs.readFile(lockPath, 'utf-8'));
+      expect(parsed.pid).toBe(process.pid);
+    });
+
+    it('reclaims an aged lock even when the owner PID is alive', async () => {
+      const ancient = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ pid: process.pid, startedAt: ancient }),
+      );
+      expect(await tryAcquireLock(lockPath)).toBe(true);
+      const parsed = JSON.parse(await fs.readFile(lockPath, 'utf-8'));
+      expect(new Date(parsed.startedAt).getTime()).toBeGreaterThan(
+        new Date(ancient).getTime(),
+      );
+    });
+
+    it('reclaims a lock with malformed JSON content', async () => {
+      await fs.writeFile(lockPath, 'not-json{');
+      expect(await tryAcquireLock(lockPath)).toBe(true);
+      const parsed = JSON.parse(await fs.readFile(lockPath, 'utf-8'));
+      expect(parsed.pid).toBe(process.pid);
+    });
+
+    it('does not give up the recursion budget without making progress', async () => {
+      // Live lock — single attempt, no recursion. Returns false promptly.
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      const start = Date.now();
+      expect(await tryAcquireLock(lockPath)).toBe(false);
+      expect(Date.now() - start).toBeLessThan(1000);
+    });
+  });
+
+  describe('isLockStale', () => {
+    it('returns true when the lock file does not exist', async () => {
+      expect(await isLockStale(lockPath)).toBe(true);
+    });
+
+    it('returns true when JSON is malformed', async () => {
+      await fs.writeFile(lockPath, '{not json');
+      expect(await isLockStale(lockPath)).toBe(true);
+    });
+
+    it('returns true when owner PID is dead', async () => {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: FAR_FUTURE_PID,
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      expect(await isLockStale(lockPath)).toBe(true);
+    });
+
+    it('returns true when lock age exceeds the threshold', async () => {
+      const ancient = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ pid: process.pid, startedAt: ancient }),
+      );
+      expect(await isLockStale(lockPath)).toBe(true);
+    });
+
+    it('returns false for a fresh lock owned by a live PID', async () => {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      expect(await isLockStale(lockPath)).toBe(false);
+    });
+  });
+
+  describe('releaseLock', () => {
+    it('removes the lock file', async () => {
+      await fs.writeFile(lockPath, '{}');
+      await releaseLock(lockPath);
+      await expect(fs.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('is a no-op when the lock file is already absent', async () => {
+      await releaseLock(lockPath); // should not throw
+    });
+  });
+
+  describe('takeover does not double-acquire under serial contention', () => {
+    it('only the first caller wins when both observe the same stale lock', async () => {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: FAR_FUTURE_PID,
+          startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        }),
+      );
+
+      // Run both attempts concurrently. The atomic-rename takeover guarantees
+      // at most one of them produces a fresh lock; the other must observe
+      // either EEXIST or the in-flight state and back off.
+      const results = await Promise.all([
+        tryAcquireLock(lockPath),
+        tryAcquireLock(lockPath),
+      ]);
+      const winners = results.filter(Boolean).length;
+      expect(winners).toBe(1);
+
+      const parsed = JSON.parse(await fs.readFile(lockPath, 'utf-8'));
+      expect(parsed.pid).toBe(process.pid);
+    });
+  });
+});

--- a/src/copilot-shell/packages/core/src/services/autoMemory/memoryService.ts
+++ b/src/copilot-shell/packages/core/src/services/autoMemory/memoryService.ts
@@ -15,7 +15,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { constants as fsConstants } from 'node:fs';
-import type { Dirent } from 'node:fs';
+import type { Dirent, Stats } from 'node:fs';
 import * as Diff from 'diff';
 import type { Config } from '../../config/config.js';
 import { SubAgentScope, ContextState } from '../../subagents/subagent.js';
@@ -69,6 +69,115 @@ function isLockInfo(value: unknown): value is LockInfo {
 // --- Lock management ---
 
 /**
+ * Inspects the lock file: returns its stat and whether it's stale.
+ * Returns null if the file doesn't exist or can't be read.
+ */
+async function inspectLock(
+  lockPath: string,
+): Promise<{ stat: Stats; isStale: boolean } | null> {
+  let stat: Stats;
+  let content: string;
+  try {
+    stat = await fs.stat(lockPath);
+    content = await fs.readFile(lockPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  let info: LockInfo | null = null;
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (isLockInfo(parsed)) info = parsed;
+  } catch {
+    // Malformed JSON — treat as stale below.
+  }
+
+  if (!info) {
+    return { stat, isStale: true };
+  }
+
+  try {
+    process.kill(info.pid, 0);
+  } catch {
+    return { stat, isStale: true };
+  }
+
+  const lockAge = Date.now() - new Date(info.startedAt).getTime();
+  return { stat, isStale: lockAge > LOCK_STALE_MS };
+}
+
+/**
+ * Outcome of a stale-lock takeover attempt.
+ * - 'taken'    : We renamed the stale lock away and verified its identity by inode.
+ * - 'vanished' : The lock disappeared mid-takeover (rename hit ENOENT). A
+ *                concurrent winner is mid-flight; the caller may retry the
+ *                fast-path O_EXCL safely since O_EXCL itself serializes.
+ * - 'busy'     : Either the lock isn't actually stale, another caller won the
+ *                takeover, or we accidentally moved a fresh lock and restored
+ *                it. Caller should not retry.
+ */
+type TakeoverOutcome = 'taken' | 'vanished' | 'busy';
+
+/**
+ * Atomically reclaims a stale lock without a TOCTOU window.
+ *
+ * Uses rename (which is atomic — only one caller's rename for a given source
+ * path can succeed) instead of the unsafe `unlink + create` dance. After
+ * renaming, verifies the moved file's inode matches the stale lock we observed;
+ * if a fresh lock was created during the race window we'd have moved that one
+ * instead, so we attempt to put it back via link (fails without overwriting).
+ *
+ * Platform note: relies on POSIX-style `rename` atomicity and `stat.ino`
+ * stability. Holds on Linux (ext4/btrfs/xfs), macOS (APFS), and Windows NTFS
+ * (single-volume). Pathological filesystems that report unstable or zero
+ * inodes could weaken the inode check, but the rename atomicity alone still
+ * prevents the most common double-takeover race.
+ */
+async function takeoverStaleLock(lockPath: string): Promise<TakeoverOutcome> {
+  const inspection = await inspectLock(lockPath);
+  if (!inspection || !inspection.isStale) return 'busy';
+
+  const trashPath = `${lockPath}.takeover-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  try {
+    await fs.rename(lockPath, trashPath);
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      // Another process already moved the stale lock; their O_EXCL create
+      // is racing with ours. Signal the caller to retry the fast path.
+      return 'vanished';
+    }
+    return 'busy';
+  }
+
+  let movedStat: Stats;
+  try {
+    movedStat = await fs.stat(trashPath);
+  } catch {
+    // Couldn't verify identity of what we moved — best-effort cleanup of trash
+    // and bail. We don't attempt to restore because we can't tell whether the
+    // moved file was the stale lock or a fresh one.
+    await fs.unlink(trashPath).catch(() => {});
+    return 'busy';
+  }
+
+  if (movedStat.ino !== inspection.stat.ino) {
+    // A fresh lock was created in the gap between our stat and our rename,
+    // so we accidentally moved away a legitimate live lock. Restore it via
+    // link, which fails (without overwriting) if a newer lock now exists.
+    try {
+      await fs.link(trashPath, lockPath);
+    } catch {
+      // Best-effort restore failed; leave the situation to settle naturally.
+    }
+    await fs.unlink(trashPath).catch(() => {});
+    return 'busy';
+  }
+
+  await fs.unlink(trashPath).catch(() => {});
+  return 'taken';
+}
+
+/**
  * Attempts to acquire an exclusive lock file using O_CREAT | O_EXCL.
  */
 export async function tryAcquireLock(
@@ -93,10 +202,16 @@ export async function tryAcquireLock(
     return true;
   } catch (error: unknown) {
     if (isNodeError(error) && error.code === 'EEXIST') {
-      if (retries > 0 && (await isLockStale(lockPath))) {
-        debugLogger.debug('Cleaning up stale lock file');
-        await releaseLock(lockPath);
-        return tryAcquireLock(lockPath, retries - 1);
+      if (retries > 0) {
+        const outcome = await takeoverStaleLock(lockPath);
+        if (outcome === 'taken') {
+          debugLogger.debug('Reclaimed stale lock via atomic takeover');
+          return tryAcquireLock(lockPath, retries - 1);
+        }
+        if (outcome === 'vanished') {
+          debugLogger.debug('Lock vanished mid-takeover, retrying fast path');
+          return tryAcquireLock(lockPath, retries - 1);
+        }
       }
       debugLogger.debug('Lock held by another instance, skipping');
       return false;
@@ -109,30 +224,8 @@ export async function tryAcquireLock(
  * Checks if a lock file is stale (owner PID is dead or lock is too old).
  */
 export async function isLockStale(lockPath: string): Promise<boolean> {
-  try {
-    const content = await fs.readFile(lockPath, 'utf-8');
-    const parsed: unknown = JSON.parse(content);
-    if (!isLockInfo(parsed)) {
-      return true;
-    }
-
-    // Check if PID is still alive
-    try {
-      process.kill(parsed.pid, 0);
-    } catch {
-      return true;
-    }
-
-    // Check if lock is too old
-    const lockAge = Date.now() - new Date(parsed.startedAt).getTime();
-    if (lockAge > LOCK_STALE_MS) {
-      return true;
-    }
-
-    return false;
-  } catch {
-    return true;
-  }
+  const inspection = await inspectLock(lockPath);
+  return inspection ? inspection.isStale : true;
 }
 
 /**

--- a/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.test.ts
+++ b/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.test.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { createExtractionHooks } from './skillExtractionAgent.js';
 import type { PostToolUsePayload } from '../../subagents/subagent-hooks.js';
@@ -111,5 +113,108 @@ describe('createExtractionHooks session-read tracking', () => {
       }),
     );
     expect(reads).toEqual([]);
+  });
+});
+
+describe('createExtractionHooks patch validation', () => {
+  let tmpDir: string;
+  let inboxDir: string;
+  let patchPath: string;
+
+  const validPatch = [
+    '--- /dev/null',
+    '+++ /tmp/example.md',
+    '@@ -0,0 +1,2 @@',
+    '+hello',
+    '+world',
+    '',
+  ].join('\n');
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hook-patch-test-'));
+    inboxDir = path.join(tmpDir, '.inbox', 'private');
+    await fs.mkdir(inboxDir, { recursive: true });
+    patchPath = path.join(inboxDir, 'extraction.patch');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('normalizes a valid patch file in place via async IO', async () => {
+    // Write a patch whose hunk header has the wrong line count; normalization
+    // should recompute it from the actual content.
+    const wrongCount = validPatch.replace(
+      '@@ -0,0 +1,2 @@',
+      '@@ -0,0 +1,99 @@',
+    );
+    await fs.writeFile(patchPath, wrongCount, 'utf-8');
+
+    const hooks = createExtractionHooks();
+    const result = await hooks.postToolUse?.(
+      makePayload('write_file', { file_path: patchPath }),
+    );
+
+    expect(result).toBeUndefined();
+    const finalContent = await fs.readFile(patchPath, 'utf-8');
+    expect(finalContent).toContain('@@ -0,0 +1,2 @@');
+    expect(finalContent).not.toContain('@@ -0,0 +1,99 @@');
+  });
+
+  it('returns additionalContent when the patch has no valid hunks', async () => {
+    await fs.writeFile(patchPath, 'this is not a patch\n', 'utf-8');
+
+    const hooks = createExtractionHooks();
+    const result = await hooks.postToolUse?.(
+      makePayload('write_file', { file_path: patchPath }),
+    );
+
+    expect(result?.additionalContent).toMatch(/PATCH VALIDATION FAILED/);
+  });
+
+  it('ignores write_file outside the .inbox path', async () => {
+    const outsidePath = path.join(tmpDir, 'random.patch');
+    await fs.writeFile(outsidePath, 'irrelevant', 'utf-8');
+
+    const hooks = createExtractionHooks();
+    const result = await hooks.postToolUse?.(
+      makePayload('write_file', { file_path: outsidePath }),
+    );
+    expect(result).toBeUndefined();
+
+    // File should be untouched (not normalized/rewritten).
+    expect(await fs.readFile(outsidePath, 'utf-8')).toBe('irrelevant');
+  });
+
+  it('ignores write_file for non-.patch files even inside .inbox', async () => {
+    const mdPath = path.join(inboxDir, 'note.md');
+    await fs.writeFile(mdPath, 'not a patch', 'utf-8');
+
+    const hooks = createExtractionHooks();
+    const result = await hooks.postToolUse?.(
+      makePayload('write_file', { file_path: mdPath }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the file is missing (no follow-up error)', async () => {
+    const hooks = createExtractionHooks();
+    const result = await hooks.postToolUse?.(
+      makePayload('write_file', {
+        file_path: path.join(inboxDir, 'does-not-exist.patch'),
+      }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('skips validation when the tool call did not succeed', async () => {
+    await fs.writeFile(patchPath, 'broken', 'utf-8');
+    const hooks = createExtractionHooks();
+    const result = await hooks.postToolUse?.(
+      makePayload('write_file', { file_path: patchPath }, /* success */ false),
+    );
+    expect(result).toBeUndefined();
+    // File was not rewritten.
+    expect(await fs.readFile(patchPath, 'utf-8')).toBe('broken');
   });
 });

--- a/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.ts
+++ b/src/copilot-shell/packages/core/src/services/autoMemory/skillExtractionAgent.ts
@@ -28,7 +28,7 @@ import type {
 import { normalizePatchContent } from './memoryPatchUtils.js';
 import { extractSessionIdFromChatFilePath } from './sessionAdapter.js';
 import * as Diff from 'diff';
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 
 export interface SkillExtractionAgentConfig {
   promptConfig: PromptConfig;
@@ -401,7 +401,7 @@ export function createExtractionHooks(
       // Read the written patch and validate
       let content: string;
       try {
-        content = fs.readFileSync(filePath, 'utf-8');
+        content = await fs.readFile(filePath, 'utf-8');
       } catch {
         return;
       }
@@ -420,7 +420,7 @@ export function createExtractionHooks(
           };
         }
         // Patch is valid — overwrite with normalized version to ensure it passes future validation
-        fs.writeFileSync(filePath, normalized, 'utf-8');
+        await fs.writeFile(filePath, normalized, 'utf-8');
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         return {


### PR DESCRIPTION
## Description

Fix two correctness bugs in the auto-memory background extraction system introduced in cba22cb:

1. `postToolUse` hook used sync `readFileSync` / `writeFileSync` inside an `async` callback, blocking the event loop on every patch write.
2. Stale-lock recovery in `tryAcquireLock` had a TOCTOU window between the `isLockStale` check and the `unlink + recreate` sequence, allowing two instances to both think they hold the lock.

The lock takeover now uses an atomic `rename` + `stat.ino` verification, with a `vanished` outcome that lets the caller retry the fast path safely when a concurrent takeover-winner has just moved the stale lock away. Sync FS calls in the hook are replaced with `fs/promises`.

## Related Issue

no-issue: address code-review findings on commit cba22cb

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core`
- [ ] `skill`
- [ ] `sight`
- [ ] `tokenless`
- [ ] Multiple / Project-wide

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] For \`cosh\`: tests pass (40 tests across 4 files in autoMemory)
- [ ] For \`cosh\`: Lint and type check — not run in this session

## Testing

\`\`\`bash
cd src/copilot-shell/packages/core
npx vitest run src/services/autoMemory/
\`\`\`

40 tests pass:
- \`memoryService.test.ts\` (14, new): fresh acquire, live-lock rejection, dead-PID/aged-lock takeover, malformed JSON, concurrent contention with single-winner invariant, \`isLockStale\` and \`releaseLock\` cases.
- \`skillExtractionAgent.test.ts\` (12, +6): valid patch normalized via async IO, invalid hunk → \`additionalContent\`, paths outside \`.inbox/\` ignored, non-\`.patch\` files ignored, missing file silent, upstream failure skipped.

## Additional Notes

The takeover relies on POSIX \`rename\` atomicity and \`stat.ino\` stability — holds on Linux (ext4/btrfs/xfs), macOS (APFS), and Windows NTFS within a single volume. On exotic filesystems with unstable inodes, the inode check weakens but \`rename\` atomicity alone still prevents the dominant race.