### PR TITLE
fix(tokenless): fix some security hardening & critical algorithm correctness

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "libc",
  "rusqlite",
  "serde_json",
  "tokenless-schema",

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -3,7 +3,7 @@
 
 Reads a PostToolUse JSON from stdin, compresses the tool response
 via ``tokenless compress-response``, then optionally re-encodes to TOON
-format via ``toon -e`` for additional token savings.
+format via ``tokenless compress-toon`` for additional token savings.
 
 Pipeline: Env Attribution → Response Compression → TOON Encoding
   1. If tool_response contains errors, classify as environment vs logic issue
@@ -16,7 +16,7 @@ Hook point: **PostToolUse**
 
 The agent ID is read from the TOKENLESS_AGENT_ID environment variable
 (set by the install action script).  Fallback paths follow the ANOLISA
-FHS spec: /usr/bin/tokenless, /usr/libexec/anolisa/tokenless/toon.
+FHS spec: /usr/bin/tokenless.
 """
 
 import json
@@ -29,16 +29,14 @@ import sys
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
-_MIN_RESPONSE_LEN = 200
+_MIN_RESPONSE_CHARS = 200  # character count, not byte length
 
-# Tools that return content the agent explicitly requested — must not compress.
 _SKIP_TOOLS = {
     "Read", "read_file", "Glob", "list_directory",
     "NotebookRead", "read", "glob", "notebookread",
 }
 
 _TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOON_FALLBACK = "/usr/libexec/anolisa/tokenless/toon"
 
 
 # -- helpers -----------------------------------------------------------------
@@ -69,7 +67,7 @@ def _try_parse_json(data: str) -> object | None:
         return None
 
 
-def _unwrap_string_json(raw: str) -> str:
+def _unwrap_string_json(raw: str) -> str | None:
     """If raw is a JSON-encoded string whose inner content is valid JSON,
     unwrap it into the inner JSON object."""
     if not raw.startswith('"'):
@@ -79,8 +77,7 @@ def _unwrap_string_json(raw: str) -> str:
         inner_obj = _try_parse_json(inner)
         if inner_obj is not None and isinstance(inner_obj, (dict, list)):
             return json.dumps(inner_obj, separators=(",", ":"))
-        # Inner is plain text — not JSON, skip
-        return ""
+        return None  # Plain text, not JSON
     return raw
 
 
@@ -197,8 +194,6 @@ def main() -> None:
         _warn("tokenless is not installed. Response compression hook disabled.")
         _skip()
 
-    toon_bin = _resolve_binary("toon", _TOON_FALLBACK)
-
     # 2. Read stdin JSON
     try:
         input_data = json.load(sys.stdin)
@@ -222,7 +217,6 @@ def main() -> None:
 
     # 6. Normalize response
     if isinstance(tool_response_raw, str):
-        # May be a JSON-encoded string wrapper or raw text
         unwrapped = _unwrap_string_json(tool_response_raw)
         if not unwrapped:
             _skip()  # Plain text, not JSON
@@ -232,8 +226,8 @@ def main() -> None:
     else:
         _skip()
 
-    # 7. Skip small responses
-    if len(tool_response) < _MIN_RESPONSE_LEN:
+    # 7. Skip small responses (character count, not byte length)
+    if len(tool_response) < _MIN_RESPONSE_CHARS:
         _skip()
 
     # 8. Validate it's JSON
@@ -278,11 +272,12 @@ def main() -> None:
         except Exception:
             pass  # Fall through to original
 
-    # 11. Step 2: TOON encoding (via tokenless compress-toon for stats)
+    # 11. Step 2: TOON encoding (validate compressed is JSON before encoding)
     toon_output = ""
     savings_label = ""
 
-    if tokenless_bin and isinstance(_try_parse_json(compressed), (dict, list)):
+    toon_parsed = _try_parse_json(compressed)
+    if toon_parsed is not None:
         cmd = [tokenless_bin, "compress-toon", "--agent-id", _AGENT_ID]
         if session_id:
             cmd.extend(["--session-id", session_id])
@@ -296,10 +291,10 @@ def main() -> None:
                 capture_output=True, text=True, timeout=10,
             )
             if proc.returncode == 0 and proc.stdout.strip():
-                toon_result = proc.stdout.strip()
-                # Skip if TOON didn't reduce size
-                if len(toon_result) < len(compressed):
-                    toon_output = toon_result
+                candidate = proc.stdout.strip()
+                # Only emit TOON if it is smaller
+                if len(candidate) < len(compressed):
+                    toon_output = candidate
                     if used_resp_compression:
                         savings_label = "response compressed + TOON encoded"
                     else:

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -22,14 +22,17 @@ FHS spec: /usr/bin/tokenless.
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from hook_utils import resolve_binary, skip, warn, try_parse_json, unwrap_string_json, is_skill_file
 
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
-_MIN_RESPONSE_CHARS = 200  # character count, not byte length
+_MIN_RESPONSE_CHARS = 200
 
 _SKIP_TOOLS = {
     "Read", "read_file", "Glob", "list_directory",
@@ -37,59 +40,7 @@ _SKIP_TOOLS = {
 }
 
 _TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-
-
-# -- helpers -----------------------------------------------------------------
-
-
-def _resolve_binary(name: str, fallback_path: str) -> str | None:
-    path = shutil.which(name)
-    if path:
-        return path
-    if os.path.isfile(fallback_path) and os.access(fallback_path, os.X_OK):
-        return fallback_path
-    return None
-
-
-def _skip() -> None:
-    print(json.dumps({}))
-    sys.exit(0)
-
-
-def _warn(msg: str) -> None:
-    print(f"[tokenless] WARNING: {msg}", file=sys.stderr)
-
-
-def _try_parse_json(data: str) -> object | None:
-    try:
-        return json.loads(data)
-    except (json.JSONDecodeError, ValueError):
-        return None
-
-
-def _unwrap_string_json(raw: str) -> str | None:
-    """If raw is a JSON-encoded string whose inner content is valid JSON,
-    unwrap it into the inner JSON object."""
-    if not raw.startswith('"'):
-        return raw
-    inner = _try_parse_json(raw)
-    if isinstance(inner, str):
-        inner_obj = _try_parse_json(inner)
-        if inner_obj is not None and isinstance(inner_obj, (dict, list)):
-            return json.dumps(inner_obj, separators=(",", ":"))
-        return None  # Plain text, not JSON
-    return raw
-
-
-def _is_skill_file(text: str) -> bool:
-    """Detect YAML frontmatter markdown (skill files) that must not be compressed."""
-    if not text.startswith("---"):
-        return False
-    lines = text.split("\n", 20)
-    for line in lines[1:]:
-        if line.startswith("name:") or line.startswith("description:"):
-            return True
-    return False
+_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 
 
 # -- env attribution patterns -------------------------------------------------
@@ -189,51 +140,51 @@ def _build_additional_context(
 
 def main() -> None:
     # 1. Resolve binaries
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL)
     if not tokenless_bin:
-        _warn("tokenless is not installed. Response compression hook disabled.")
-        _skip()
+        warn("tokenless is not installed. Response compression hook disabled.")
+        skip()
 
     # 2. Read stdin JSON
     try:
         input_data = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError, ValueError):
-        _warn("failed to read PostToolUse payload. Passing through unchanged.")
-        _skip()
+        warn("failed to read PostToolUse payload. Passing through unchanged.")
+        skip()
 
     # 3. Skip content-retrieval tools
     tool_name = input_data.get("tool_name", "unknown")
     if tool_name in _SKIP_TOOLS:
-        _skip()
+        skip()
 
     # 4. Extract tool_response
     tool_response_raw = input_data.get("tool_response", "")
     if not tool_response_raw or tool_response_raw == "{}":
-        _skip()
+        skip()
 
     # 5. Skip skill files (YAML frontmatter)
-    if isinstance(tool_response_raw, str) and _is_skill_file(tool_response_raw):
-        _skip()
+    if isinstance(tool_response_raw, str) and is_skill_file(tool_response_raw):
+        skip()
 
     # 6. Normalize response
     if isinstance(tool_response_raw, str):
-        unwrapped = _unwrap_string_json(tool_response_raw)
+        unwrapped = unwrap_string_json(tool_response_raw)
         if not unwrapped:
-            _skip()  # Plain text, not JSON
+            skip()  # Plain text, not JSON
         tool_response = unwrapped
     elif isinstance(tool_response_raw, (dict, list)):
         tool_response = json.dumps(tool_response_raw, separators=(",", ":"))
     else:
-        _skip()
+        skip()
 
     # 7. Skip small responses (character count, not byte length)
     if len(tool_response) < _MIN_RESPONSE_CHARS:
-        _skip()
+        skip()
 
     # 8. Validate it's JSON
-    parsed = _try_parse_json(tool_response)
+    parsed = try_parse_json(tool_response)
     if parsed is None:
-        _skip()
+        skip()
 
     # 9. Extract caller context
     session_id = input_data.get("session_id", "")
@@ -272,35 +223,34 @@ def main() -> None:
         except Exception:
             pass  # Fall through to original
 
-    # 11. Step 2: TOON encoding (validate compressed is JSON before encoding)
+    # 11. Step 2: TOON encoding (via tokenless compress-toon for stats)
     toon_output = ""
     savings_label = ""
 
-    toon_parsed = _try_parse_json(compressed)
-    if toon_parsed is not None:
-        cmd = [tokenless_bin, "compress-toon", "--agent-id", _AGENT_ID]
-        if session_id:
-            cmd.extend(["--session-id", session_id])
-        if tool_use_id:
-            cmd.extend(["--tool-use-id", tool_use_id])
-
-        try:
-            proc = subprocess.run(
-                cmd,
-                input=compressed,
-                capture_output=True, text=True, timeout=10,
-            )
-            if proc.returncode == 0 and proc.stdout.strip():
-                candidate = proc.stdout.strip()
-                # Only emit TOON if it is smaller
-                if len(candidate) < len(compressed):
-                    toon_output = candidate
-                    if used_resp_compression:
-                        savings_label = "response compressed + TOON encoded"
-                    else:
-                        savings_label = "TOON encoded"
-        except Exception:
-            pass
+    if tokenless_bin:
+        toon_parsed = try_parse_json(compressed)
+        if toon_parsed is not None:
+            toon_cmd = [tokenless_bin, "compress-toon", "--agent-id", _AGENT_ID]
+            if session_id:
+                toon_cmd.extend(["--session-id", session_id])
+            if tool_use_id:
+                toon_cmd.extend(["--tool-use-id", tool_use_id])
+            try:
+                proc = subprocess.run(
+                    toon_cmd,
+                    input=compressed,
+                    capture_output=True, text=True, timeout=10,
+                )
+                if proc.returncode == 0 and proc.stdout.strip():
+                    candidate = proc.stdout.strip()
+                    if len(candidate) < len(compressed):
+                        toon_output = candidate
+                        if used_resp_compression:
+                            savings_label = "response compressed + TOON encoded"
+                        else:
+                            savings_label = "TOON encoded"
+            except Exception:
+                pass
 
     # Determine final label
     if not savings_label:

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
@@ -13,34 +13,21 @@ The agent ID is read from the TOKENLESS_AGENT_ID environment variable
 
 import json
 import os
-import shutil
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from hook_utils import resolve_binary, skip, warn
 
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
+_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
+_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 
 
 # -- helpers -----------------------------------------------------------------
-
-
-def _resolve_binary(name: str, fallback_path: str) -> str | None:
-    path = shutil.which(name)
-    if path:
-        return path
-    if os.path.isfile(fallback_path) and os.access(fallback_path, os.X_OK):
-        return fallback_path
-    return None
-
-
-def _skip() -> None:
-    print(json.dumps({}))
-    sys.exit(0)
-
-
-def _warn(msg: str) -> None:
-    print(f"[tokenless] WARNING: {msg}", file=sys.stderr)
 
 
 def _is_json_array(data: str) -> bool:
@@ -56,23 +43,23 @@ def _is_json_array(data: str) -> bool:
 
 def main() -> None:
     # 1. Check tokenless binary
-    tokenless_bin = _resolve_binary("tokenless", "/usr/bin/tokenless")
+    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL)
     if not tokenless_bin:
-        _warn("tokenless is not installed or not in PATH. Schema compression hook disabled.")
-        _skip()
+        warn("tokenless is not installed or not in PATH. Schema compression hook disabled.")
+        skip()
 
     # 2. Read stdin JSON
     try:
         input_data = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError, ValueError):
-        _warn("failed to read BeforeModel payload. Passing through unchanged.")
-        _skip()
+        warn("failed to read BeforeModel payload. Passing through unchanged.")
+        skip()
 
     # 3. Extract tools array
     llm_request = input_data.get("llm_request", {})
     tools = llm_request.get("tools")
     if not tools:
-        _skip()
+        skip()
 
     tools_json = json.dumps(tools, separators=(",", ":"))
 
@@ -94,13 +81,13 @@ def main() -> None:
             capture_output=True, text=True, timeout=10,
         )
     except Exception:
-        _warn("Schema compression failed. Passing through unchanged.")
-        _skip()
+        warn("Schema compression failed. Passing through unchanged.")
+        skip()
 
     compressed = proc.stdout.strip()
     if not compressed or not _is_json_array(compressed):
-        _warn("Schema compression returned invalid JSON. Passing through unchanged.")
-        _skip()
+        warn("Schema compression returned invalid JSON. Passing through unchanged.")
+        skip()
 
     # 6. Build response
     output = {

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
@@ -17,15 +17,19 @@ The agent ID is read from the TOKENLESS_AGENT_ID environment variable
 
 import json
 import os
-import shutil
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from hook_utils import resolve_binary, skip, warn, try_parse_json, unwrap_string_json, is_skill_file
 
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
-_MIN_RESPONSE_CHARS = 200  # character count, not byte length
+_MIN_RESPONSE_CHARS = 200
 _TOKENLESS_FALLBACK = "/usr/bin/tokenless"
+_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 
 _SKIP_TOOLS = {
     "Read", "read_file", "Glob", "list_directory",
@@ -33,111 +37,58 @@ _SKIP_TOOLS = {
 }
 
 
-# -- helpers -----------------------------------------------------------------
-
-
-def _resolve_binary(name: str, fallback_path: str) -> str | None:
-    path = shutil.which(name)
-    if path:
-        return path
-    if os.path.isfile(fallback_path) and os.access(fallback_path, os.X_OK):
-        return fallback_path
-    return None
-
-
-def _skip() -> None:
-    print(json.dumps({}))
-    sys.exit(0)
-
-
-def _warn(msg: str) -> None:
-    print(f"[tokenless] WARNING: {msg}", file=sys.stderr)
-
-
-def _try_parse_json(data: str) -> object | None:
-    try:
-        return json.loads(data)
-    except (json.JSONDecodeError, ValueError):
-        return None
-
-
-def _unwrap_string_json(raw: str) -> str | None:
-    """If raw is a JSON-encoded string whose inner content is valid JSON,
-    unwrap it into the inner JSON object."""
-    if not raw.startswith('"'):
-        return raw
-    inner = _try_parse_json(raw)
-    if isinstance(inner, str):
-        inner_obj = _try_parse_json(inner)
-        if inner_obj is not None and isinstance(inner_obj, (dict, list)):
-            return json.dumps(inner_obj, separators=(",", ":"))
-        return None  # Plain text, not JSON
-    return raw
-
-
-def _is_skill_file(text: str) -> bool:
-    """Detect YAML frontmatter markdown (skill files) that must not be compressed."""
-    if not text.startswith("---"):
-        return False
-    lines = text.split("\n", 20)
-    for line in lines[1:]:
-        if line.startswith("name:") or line.startswith("description:"):
-            return True
-    return False
-
-
 # -- main --------------------------------------------------------------------
 
 
 def main() -> None:
-    # 1. Resolve tokenless binary
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    # 1. Resolve binaries
+    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL)
     if not tokenless_bin:
-        _warn("tokenless is not installed. TOON compression hook disabled.")
-        _skip()
+        warn("tokenless is not installed. TOON compression hook disabled.")
+        skip()
 
     # 2. Read stdin JSON
     try:
         input_data = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError, ValueError):
-        _warn("failed to read PostToolUse payload. Passing through unchanged.")
-        _skip()
+        warn("failed to read PostToolUse payload. Passing through unchanged.")
+        skip()
 
     # 3. Skip content-retrieval tools
     tool_name = input_data.get("tool_name", "unknown")
     if tool_name in _SKIP_TOOLS:
-        _skip()
+        skip()
 
     # 4. Extract tool_response
     tool_response_raw = input_data.get("tool_response", "")
     if not tool_response_raw or tool_response_raw == "{}":
-        _skip()
+        skip()
 
     # 5. Skip skill files (YAML frontmatter)
-    if isinstance(tool_response_raw, str) and _is_skill_file(tool_response_raw):
-        _skip()
+    if isinstance(tool_response_raw, str) and is_skill_file(tool_response_raw):
+        skip()
 
     # 6. Normalize: unwrap string-wrapped JSON
     if isinstance(tool_response_raw, str):
-        tool_response = _unwrap_string_json(tool_response_raw)
+        tool_response = unwrap_string_json(tool_response_raw)
         if tool_response is None:
-            _skip()  # Plain text, not JSON
+            skip()  # Plain text, not JSON
     elif isinstance(tool_response_raw, (dict, list)):
         tool_response = json.dumps(tool_response_raw, separators=(",", ":"))
     else:
-        _skip()
+        skip()
 
     if not tool_response:
-        _skip()
+        skip()
 
     # 7. Skip small responses (character count, not byte length)
     if len(tool_response) < _MIN_RESPONSE_CHARS:
-        _skip()
+        skip()
 
     # 8. Validate it's JSON
-    parsed = _try_parse_json(tool_response)
+    parsed = try_parse_json(tool_response)
     if parsed is None:
-        _skip()
+        skip()
 
     # 9. Extract caller context
     session_id = input_data.get("session_id", "")
@@ -157,19 +108,19 @@ def main() -> None:
             capture_output=True, text=True, timeout=10,
         )
     except Exception:
-        _warn("TOON encoding failed. Passing through unchanged.")
-        _skip()
+        warn("TOON encoding failed. Passing through unchanged.")
+        skip()
 
     toon_output = proc.stdout.strip()
     if not toon_output:
-        _warn("TOON encoding returned empty output. Passing through unchanged.")
-        _skip()
+        warn("TOON encoding returned empty output. Passing through unchanged.")
+        skip()
 
     # 11. Size guard — skip if TOON output is not smaller
     before_chars = len(tool_response)
     after_chars = len(toon_output)
     if after_chars >= before_chars:
-        _skip()
+        skip()
 
     savings_pct = (before_chars - after_chars) * 100 // before_chars if before_chars > 0 else 0
 

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
@@ -24,9 +24,13 @@ import sys
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
-_MIN_RESPONSE_LEN = 200
+_MIN_RESPONSE_CHARS = 200  # character count, not byte length
 _TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOON_FALLBACK = "/usr/libexec/anolisa/tokenless/toon"
+
+_SKIP_TOOLS = {
+    "Read", "read_file", "Glob", "list_directory",
+    "NotebookRead", "read", "glob", "notebookread",
+}
 
 
 # -- helpers -----------------------------------------------------------------
@@ -71,19 +75,25 @@ def _unwrap_string_json(raw: str) -> str | None:
     return raw
 
 
+def _is_skill_file(text: str) -> bool:
+    """Detect YAML frontmatter markdown (skill files) that must not be compressed."""
+    if not text.startswith("---"):
+        return False
+    lines = text.split("\n", 20)
+    for line in lines[1:]:
+        if line.startswith("name:") or line.startswith("description:"):
+            return True
+    return False
+
+
 # -- main --------------------------------------------------------------------
 
 
 def main() -> None:
-    # 1. Resolve binaries
+    # 1. Resolve tokenless binary
     tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
     if not tokenless_bin:
         _warn("tokenless is not installed. TOON compression hook disabled.")
-        _skip()
-
-    toon_bin = _resolve_binary("toon", _TOON_FALLBACK)
-    if not toon_bin:
-        _warn("toon is not installed. TOON compression hook disabled.")
         _skip()
 
     # 2. Read stdin JSON
@@ -93,12 +103,21 @@ def main() -> None:
         _warn("failed to read PostToolUse payload. Passing through unchanged.")
         _skip()
 
-    # 3. Extract tool_response
+    # 3. Skip content-retrieval tools
+    tool_name = input_data.get("tool_name", "unknown")
+    if tool_name in _SKIP_TOOLS:
+        _skip()
+
+    # 4. Extract tool_response
     tool_response_raw = input_data.get("tool_response", "")
     if not tool_response_raw or tool_response_raw == "{}":
         _skip()
 
-    # 4. Normalize: unwrap string-wrapped JSON
+    # 5. Skip skill files (YAML frontmatter)
+    if isinstance(tool_response_raw, str) and _is_skill_file(tool_response_raw):
+        _skip()
+
+    # 6. Normalize: unwrap string-wrapped JSON
     if isinstance(tool_response_raw, str):
         tool_response = _unwrap_string_json(tool_response_raw)
         if tool_response is None:
@@ -111,21 +130,20 @@ def main() -> None:
     if not tool_response:
         _skip()
 
-    # 5. Skip small responses
-    if len(tool_response) < _MIN_RESPONSE_LEN:
+    # 7. Skip small responses (character count, not byte length)
+    if len(tool_response) < _MIN_RESPONSE_CHARS:
         _skip()
 
-    # 6. Validate it's JSON
+    # 8. Validate it's JSON
     parsed = _try_parse_json(tool_response)
     if parsed is None:
         _skip()
 
-    # 7. Extract caller context
+    # 9. Extract caller context
     session_id = input_data.get("session_id", "")
     tool_use_id = input_data.get("tool_use_id") or input_data.get("toolCallId", "")
-    tool_name = input_data.get("tool_name", "unknown")
 
-    # 8. Encode to TOON via tokenless compress-toon
+    # 10. Encode to TOON via tokenless compress-toon
     cmd = [tokenless_bin, "compress-toon", "--agent-id", _AGENT_ID]
     if session_id:
         cmd.extend(["--session-id", session_id])
@@ -147,14 +165,15 @@ def main() -> None:
         _warn("TOON encoding returned empty output. Passing through unchanged.")
         _skip()
 
-    # 9. Calculate savings metrics
+    # 11. Size guard — skip if TOON output is not smaller
     before_chars = len(tool_response)
     after_chars = len(toon_output)
-    savings_pct = 0
-    if before_chars > 0:
-        savings_pct = (before_chars - after_chars) * 100 // before_chars
+    if after_chars >= before_chars:
+        _skip()
 
-    # 10. Build response
+    savings_pct = (before_chars - after_chars) * 100 // before_chars if before_chars > 0 else 0
+
+    # 12. Build response
     context = (
         f"[tokenless] {tool_name} → TOON encoded ({savings_pct}% savings)\n"
         f"{toon_output}"

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -1,0 +1,57 @@
+"""Shared utilities for tokenless Python hooks."""
+
+import json
+import os
+import shutil
+import sys
+
+
+def resolve_binary(name: str, *fallback_paths: str) -> str | None:
+    path = shutil.which(name)
+    if path:
+        return path
+    for fp in fallback_paths:
+        if os.path.isfile(fp) and os.access(fp, os.X_OK):
+            return fp
+    return None
+
+
+def skip() -> None:
+    print(json.dumps({}))
+    sys.exit(0)
+
+
+def warn(msg: str) -> None:
+    print(f"[tokenless] WARNING: {msg}", file=sys.stderr)
+
+
+def try_parse_json(data: str) -> object | None:
+    try:
+        return json.loads(data)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def unwrap_string_json(raw: str) -> str | None:
+    """If raw is a JSON-encoded string whose inner content is valid JSON,
+    unwrap it into the inner JSON string. Returns None for plain text."""
+    if not raw.startswith('"'):
+        return raw
+    inner = try_parse_json(raw)
+    if isinstance(inner, str):
+        inner_obj = try_parse_json(inner)
+        if inner_obj is not None and isinstance(inner_obj, (dict, list)):
+            return json.dumps(inner_obj, separators=(",", ":"))
+        return None
+    return raw
+
+
+def is_skill_file(text: str) -> bool:
+    """Detect YAML frontmatter markdown (skill files) that must not be compressed."""
+    if not text.startswith("---"):
+        return False
+    lines = text.split("\n", 20)
+    for line in lines[1:]:
+        if line.startswith("name:") or line.startswith("description:"):
+            return True
+    return False

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -15,14 +15,20 @@ FHS spec: /usr/libexec/anolisa/tokenless/rtk.
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from hook_utils import resolve_binary, skip, warn
 
 # -- constants ---------------------------------------------------------------
 
 _MIN_RTK_VERSION = (0, 35, 0)
 _RTK_FALLBACK = "/usr/libexec/anolisa/tokenless/rtk"
+_RTK_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "rtk")
+_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
+_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
 
 _CONTEXT_DIR = os.path.join(os.path.expanduser("~"), ".tokenless")
@@ -32,29 +38,11 @@ _CONTEXT_FILE = os.path.join(_CONTEXT_DIR, ".rewrite-context")
 # -- helpers -----------------------------------------------------------------
 
 
-def _resolve_binary(name: str, fallback_path: str) -> str | None:
-    path = shutil.which(name)
-    if path:
-        return path
-    if os.path.isfile(fallback_path) and os.access(fallback_path, os.X_OK):
-        return fallback_path
-    return None
-
-
 def _parse_version(version_str: str) -> tuple | None:
     m = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)
     if m:
         return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
     return None
-
-
-def _skip() -> None:
-    print(json.dumps({}))
-    sys.exit(0)
-
-
-def _warn(msg: str) -> None:
-    print(f"[tokenless] WARNING: {msg}", file=sys.stderr)
 
 
 def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
@@ -76,10 +64,10 @@ def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
 
 def main() -> None:
     # 1. Resolve rtk binary
-    rtk_bin = _resolve_binary("rtk", _RTK_FALLBACK)
+    rtk_bin = resolve_binary("rtk", _RTK_FALLBACK, _RTK_LOCAL)
     if not rtk_bin:
-        _warn("rtk is not installed or not in PATH. Hook disabled.")
-        _skip()
+        warn("rtk is not installed or not in PATH. Hook disabled.")
+        skip()
 
     # 2. Version guard
     try:
@@ -89,27 +77,27 @@ def main() -> None:
         )
         ver = _parse_version(result.stdout)
         if ver and ver < _MIN_RTK_VERSION:
-            _warn(f"rtk {result.stdout.strip()} is too old (need >= 0.35.0).")
-            _skip()
+            warn(f"rtk {result.stdout.strip()} is too old (need >= 0.35.0).")
+            skip()
     except Exception:
         pass  # version check non-fatal
 
     # 3. Check tokenless binary (for stats)
-    if not shutil.which("tokenless"):
-        _warn("tokenless is not installed. Hook disabled.")
-        _skip()
+    if not resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL):
+        warn("tokenless is not installed. Hook disabled.")
+        skip()
 
     # 4. Read stdin JSON
     try:
         input_data = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError, ValueError):
-        _skip()
+        skip()
 
     # 5. Extract command
     tool_input = input_data.get("tool_input", {})
     cmd = tool_input.get("command", "")
     if not cmd:
-        _skip()
+        skip()
 
     # 6. Rewrite via rtk
     env = os.environ.copy()
@@ -121,9 +109,6 @@ def main() -> None:
     if tool_use_id:
         env["TOKENLESS_TOOL_USE_ID"] = tool_use_id
 
-    # Write context file so rtk (run as command proxy later) can recover
-    # agent/session/tool IDs even though it won't inherit hook env vars.
-    # rtk's resolve_tokenless_context() reads this as a fallback.
     _write_context(_AGENT_ID, session_id, tool_use_id)
 
     try:
@@ -132,14 +117,14 @@ def main() -> None:
             capture_output=True, text=True, timeout=5, env=env,
         )
     except Exception:
-        _skip()
+        skip()
 
     # exit 1/2 = no rewrite; exit 0 = same or rewritten
     if proc.returncode in (1, 2):
-        _skip()
+        skip()
     rewritten = proc.stdout.strip()
     if rewritten == cmd:
-        _skip()
+        skip()
 
     # 7. Build response
     updated_input = dict(tool_input)

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -146,10 +146,9 @@ def main() -> None:
     updated_input["command"] = rewritten
 
     output = {
-        "decision": "allow",
-        "reason": "RTK auto-rewrite",
         "hookSpecificOutput": {
-            "tool_input": updated_input,
+            "hookEventName": "PreToolUse",
+            "updatedInput": updated_input,
         },
     }
     print(json.dumps(output))

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -58,8 +58,14 @@ def _warn(msg: str) -> None:
 
 
 def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
-    os.makedirs(_CONTEXT_DIR, exist_ok=True)
-    with open(_CONTEXT_FILE, "w") as f:
+    os.makedirs(_CONTEXT_DIR, mode=0o700, exist_ok=True)
+    if os.path.islink(_CONTEXT_FILE):
+        os.unlink(_CONTEXT_FILE)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(_CONTEXT_FILE, flags, 0o600)
+    with os.fdopen(fd, "w") as f:
         f.write(f"{agent_id}\n")
         f.write(f"{session_id}\n")
         f.write(f"{tool_use_id}\n")

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -299,7 +299,7 @@ missing_count=$(echo "$MISSING_DEP_JSONS" | jq 'length' 2>/dev/null || echo 0)
 log_v "Phase 3 FIX: $missing_count missing deps, fix_script=$FIX_SCRIPT"
 
 if [ "$missing_count" -gt 0 ] && [ -n "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; then
-    FIX_OUTPUT=$(echo "$MISSING_DEP_JSONS" | bash "$FIX_SCRIPT" fix-all 2>/dev/null || true)
+    echo "$MISSING_DEP_JSONS" | bash "$FIX_SCRIPT" fix-all 2>/dev/null || true
     hash -r 2>/dev/null || true
 
     # Re-scan to check if fix succeeded

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -21,6 +21,39 @@ log_v() { [ -n "$VERBOSE" ] && echo "[tokenless tool-ready] $1" >&2 || true; }
 # --- Dependency check (fail-open) ---
 if ! command -v jq &>/dev/null; then log_v "jq not found, skipping"; exit 0; fi
 
+# --- File trust validation ---
+# User-writable paths must be owned by current user and not world-writable.
+is_trusted_file() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  # System paths are always trusted
+  case "$f" in /usr/share/*|/usr/libexec/*|/usr/local/share/*) return 0 ;; esac
+  # Resolve symlink target before owner/perm checks
+  local check_path="$f"
+  if [ -L "$f" ]; then
+    local target
+    target=$(readlink -f "$f" 2>/dev/null || realpath "$f" 2>/dev/null || echo "")
+    # System targets are always trusted
+    case "$target" in /usr/share/*|/usr/libexec/*|/usr/local/share/*) return 0 ;; esac
+    [ -z "$target" ] && return 1
+    check_path="$target"
+  fi
+  local file_owner
+  file_owner=$(stat -c '%u' "$check_path" 2>/dev/null || stat -f '%u' "$check_path" 2>/dev/null || echo "-1")
+  if [ "$file_owner" != "$(id -u)" ] && [ "$file_owner" != "0" ]; then
+    log_v "BLOCKED: $f owned by uid $file_owner (expected $(id -u) or 0)"
+    return 1
+  fi
+  local file_perms
+  file_perms=$(stat -c '%a' "$check_path" 2>/dev/null || stat -f '%Lp' "$check_path" 2>/dev/null || echo "777")
+  local other_perms="${file_perms: -1}"
+  if [ "$other_perms" -ge 6 ] 2>/dev/null; then
+    log_v "BLOCKED: $f is world-writable (perms=$file_perms)"
+    return 1
+  fi
+  return 0
+}
+
 # --- Resolve paths ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -32,7 +65,7 @@ for candidate in \
     "/usr/share/anolisa/adapters/tokenless/common/tool-ready-spec.json" \
     "$HOME/.tokenless/tool-ready-spec.json" \
     "${SCRIPT_DIR}/../tool-ready-spec.json"; do
-    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+    if [ -n "$candidate" ] && is_trusted_file "$candidate"; then
         SPEC_FILE="$candidate"
         break
     fi
@@ -46,7 +79,7 @@ for candidate in \
     "/usr/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
     "$HOME/.tokenless/tokenless-env-fix.sh" \
     "${SCRIPT_DIR}/../tokenless-env-fix.sh"; do
-    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    if [ -n "$candidate" ] && [ -x "$candidate" ] && is_trusted_file "$candidate"; then
         FIX_SCRIPT="$candidate"
         break
     fi
@@ -105,16 +138,16 @@ log_v "Phase 1: $TOOL_NAME → $SPEC_KEY found in spec dict"
 
 # --- Normalize deps to object format ---
 # Supports both string ("jq") and object ({binary:"jq",...}) formats.
-# String defaults: manager="rpm" (auto-detects yum/dnf/apt/apk at runtime).
+# String defaults: manager="auto" (fix script auto-detects yum/dnf/apt/apk).
 # Handles version constraints: "rtk>=0.35" → {binary:"rtk", version:">=0.35", ...}
 
 normalize_deps() {
   local array="$1"
   echo "$array" | jq -c '[.[] | if type == "string" then
     (if (test(">=") or test("[^<]<[^=]") or test("=")) then
-      {binary: (capture("^(?<b>[^>=<]+)") | .b), version: (match("[>=<]+[0-9.]+").string), package: (capture("^(?<b>[^>=<]+)") | .b), manager: "rpm"}
+      {binary: (capture("^(?<b>[^>=<]+)") | .b), version: (match("[>=<]+[0-9.]+").string), package: (capture("^(?<b>[^>=<]+)") | .b), manager: "auto"}
     else
-      {binary: ., package: ., manager: "rpm"}
+      {binary: ., package: ., manager: "auto"}
     end)
   else . end]' 2>/dev/null || echo '[]'
 }

--- a/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
+++ b/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
@@ -84,6 +84,25 @@ normalize_dep() {
   fi
 }
 
+# --- Input validation ---
+# Reject names that could be used for command injection or supply-chain attacks.
+
+validate_name() {
+  local val="$1" label="$2"
+  if [ -z "$val" ]; then
+    echo "[tokenless-env-fix] BLOCKED: empty ${label}"
+    return 1
+  fi
+  if [ "${#val}" -gt 128 ]; then
+    echo "[tokenless-env-fix] BLOCKED: ${label} too long (${#val} chars): ${val:0:32}..."
+    return 1
+  fi
+  if ! echo "$val" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._@/+-]*$'; then
+    echo "[tokenless-env-fix] BLOCKED: invalid ${label}: ${val}"
+    return 1
+  fi
+}
+
 # --- Package manager install functions ---
 # Each installs a package via the declared manager.
 # Returns 0 on success, 1 on failure.
@@ -182,6 +201,21 @@ install_via_cargo_build() {
 install_via_symlink() {
   local binary="$1"
   local source="$2"
+  # Only allow symlinks from trusted installation directories
+  case "$source" in
+    /usr/libexec/anolisa/*|/usr/share/anolisa/*|/usr/local/libexec/anolisa/*|/usr/local/share/anolisa/*)
+      ;;
+    "$HOME"/.local/share/anolisa/*)
+      ;;
+    *)
+      echo "[tokenless-env-fix] BLOCKED: symlink source not in trusted path: $source"
+      return 1
+      ;;
+  esac
+  if [ ! -f "$source" ]; then
+    echo "[tokenless-env-fix] BLOCKED: symlink source does not exist: $source"
+    return 1
+  fi
   $SUDO_PREFIX ln -sf "$source" /usr/local/bin/"$binary" 2>/dev/null || true
   chmod +x "$source" 2>/dev/null || true
 }
@@ -204,24 +238,24 @@ install_via_curl_pipe_sh() {
   local url="$1"
   local args="${2:-}"
   local timeout_secs="${3:-120}"
-  # Only allow URLs from trusted domains
-  local allowed_domains="^(https?://)?(github\.com|raw\.githubusercontent\.com|sh\.rustup\.rs|get\.docker\.com|cli\.run\.nu|get\.starship\.rs|astral\.sh)"
+  # Only allow HTTPS URLs from trusted domains (anchored with path separator)
+  local allowed_domains="^https://(github\.com/|raw\.githubusercontent\.com/|sh\.rustup\.rs(/|$)|get\.docker\.com(/|$)|cli\.run\.nu(/|$)|get\.starship\.rs(/|$)|astral\.sh(/|$))"
   if ! echo "$url" | grep -qE "$allowed_domains"; then
-    echo "[tokenless-env-fix] WARNING: curl|sh blocked — untrusted URL: $url"
+    echo "[tokenless-env-fix] BLOCKED: curl|sh denied — untrusted or non-HTTPS URL: $url"
     return 1
   fi
   echo "[tokenless-env-fix] NOTE: executing remote script from $url (timeout: ${timeout_secs}s)"
   if command -v curl &>/dev/null; then
     if [ -n "$args" ]; then
-      timeout "$timeout_secs" curl -fsSL "$url" 2>/dev/null | timeout "$timeout_secs" sh $args
+      timeout "$timeout_secs" curl -fsSL --max-redirs 5 "$url" 2>/dev/null | timeout "$timeout_secs" sh -s -- "$args"
     else
-      timeout "$timeout_secs" curl -fsSL "$url" 2>/dev/null | timeout "$timeout_secs" sh
+      timeout "$timeout_secs" curl -fsSL --max-redirs 5 "$url" 2>/dev/null | timeout "$timeout_secs" sh
     fi
   elif command -v wget &>/dev/null; then
     if [ -n "$args" ]; then
-      timeout "$timeout_secs" wget -qO- "$url" | timeout "$timeout_secs" sh $args
+      timeout "$timeout_secs" wget --max-redirect=5 -qO- "$url" | timeout "$timeout_secs" sh -s -- "$args"
     else
-      timeout "$timeout_secs" wget -qO- "$url" | timeout "$timeout_secs" sh
+      timeout "$timeout_secs" wget --max-redirect=5 -qO- "$url" | timeout "$timeout_secs" sh
     fi
   else
     return 1
@@ -246,18 +280,26 @@ fix_dep() {
   url=$(echo "$dep_json" | jq -r '.url // empty')
   args=$(echo "$dep_json" | jq -r '.args // empty')
 
+  # Validate names before any install action
+  validate_name "$binary" "binary" || return 1
+  validate_name "$package" "package" || return 1
+
   # Fill defaults: pip_name/uv_name/npm_name default to package
   [ -z "$pip_name" ] && pip_name="$package"
   [ -z "$uv_name" ] && uv_name="$package"
   [ -z "$npm_name" ] && npm_name="$package"
+
+  # Validate derived names
+  [ -n "$pip_name" ] && { validate_name "$pip_name" "pip_name" || return 1; }
+  [ -n "$uv_name" ] && { validate_name "$uv_name" "uv_name" || return 1; }
+  [ -n "$npm_name" ] && { validate_name "$npm_name" "npm_name" || return 1; }
 
   # Skip if already available (clear hash cache first)
   hash -r
   if command -v "$binary" &>/dev/null; then
     # Check version constraint if present
     if [ -n "$version" ]; then
-      local constraint_op constraint_ver installed_ver
-      constraint_op=$(echo "$version" | sed 's/[0-9.]//g')
+      local constraint_ver installed_ver
       constraint_ver=$(echo "$version" | sed 's/[>=<]//g')
       installed_ver=$("$binary" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
 
@@ -268,7 +310,9 @@ fix_dep() {
         IFS='.' read -r r_major r_minor r_patch <<< "$constraint_ver"
         i_major=${i_major:-0}; i_minor=${i_minor:-0}; i_patch=${i_patch:-0}
         r_major=${r_major:-0}; r_minor=${r_minor:-0}; r_patch=${r_patch:-0}
-        if [ "$i_major" -ge "$r_major" ] && [ "$i_minor" -ge "$r_minor" ] && [ "$i_patch" -ge "$r_patch" ]; then
+        if [ "$i_major" -gt "$r_major" ] || \
+           { [ "$i_major" -eq "$r_major" ] && [ "$i_minor" -gt "$r_minor" ]; } || \
+           { [ "$i_major" -eq "$r_major" ] && [ "$i_minor" -eq "$r_minor" ] && [ "$i_patch" -ge "$r_patch" ]; }; then
           echo "[tokenless-env-fix] ${binary}: already available (v${installed_ver} satisfies ${version})"
           return 0
         fi
@@ -295,7 +339,7 @@ fix_dep() {
   # --- Primary install via declared manager ---
   local primary_ok=false
   case "$manager" in
-    rpm|apt|dnf|yum|apk)  install_via_system "$package" && primary_ok=true ;;
+    auto|rpm|apt|dnf|yum|apk)  install_via_system "$package" && primary_ok=true ;;
     pip)     install_via_pip "$package" "$pip_name" && primary_ok=true ;;
     uv)      install_via_uv "$package" "$uv_name" && primary_ok=true ;;
     npm)     install_via_npm "$package" "$npm_name" && primary_ok=true ;;
@@ -414,7 +458,6 @@ case "${1:-}" in
     else
       # Simple name — normalize to object with optional manager
       manager="${3:-$PACKAGE_MANAGER}"
-      dep_json
       dep_json=$(jq -n --arg bn "$2" --arg pk "$2" --arg mgr "$manager" '{binary:$bn, package:$pk, manager:$mgr}')
       fix_dep "$dep_json"
     fi

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -32,17 +32,16 @@ const sessionMap: Map<string, string> = new Map();
 
 let rtkAvailable: boolean | null = null;
 let tokenlessAvailable: boolean | null = null;
-let toonAvailable: boolean | null = null;
 
 // Resolved absolute paths — set by check*() functions so subprocess calls
 // use the correct path even when the binary is not on PATH (e.g. RPM installs
 // that place rtk/toon in /usr/libexec/anolisa/tokenless/).
 let rtkPath: string = "rtk";
 let tokenlessPath: string = "tokenless";
-let toonPath: string = "toon";
 
 const LIBEXEC_FALLBACK = "/usr/libexec/anolisa/tokenless";
 const TOKENLESS_FALLBACK = "/usr/bin/tokenless";
+const LOCAL_FALLBACK = `${process.env.HOME || ""}/.local/share/anolisa/tokenless`;
 
 // Check both existence and execute permission (mirrors shell `-x` test).
 function isExecutable(path: string): boolean {
@@ -63,13 +62,18 @@ function checkRtk(): boolean {
     } else if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
       rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
       rtkAvailable = true;
+    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/rtk`)) {
+      rtkPath = `${LOCAL_FALLBACK}/rtk`;
+      rtkAvailable = true;
     } else {
       rtkAvailable = false;
     }
   } catch {
-    // which not available; check libexec directly
     if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
       rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
+      rtkAvailable = true;
+    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/rtk`)) {
+      rtkPath = `${LOCAL_FALLBACK}/rtk`;
       rtkAvailable = true;
     } else {
       rtkAvailable = false;
@@ -100,12 +104,18 @@ function checkTokenless(): boolean {
     } else if (isExecutable(TOKENLESS_FALLBACK)) {
       tokenlessPath = TOKENLESS_FALLBACK;
       tokenlessAvailable = true;
+    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/tokenless`)) {
+      tokenlessPath = `${LOCAL_FALLBACK}/tokenless`;
+      tokenlessAvailable = true;
     } else {
       tokenlessAvailable = false;
     }
   } catch {
     if (isExecutable(TOKENLESS_FALLBACK)) {
       tokenlessPath = TOKENLESS_FALLBACK;
+      tokenlessAvailable = true;
+    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/tokenless`)) {
+      tokenlessPath = `${LOCAL_FALLBACK}/tokenless`;
       tokenlessAvailable = true;
     } else {
       tokenlessAvailable = false;
@@ -115,30 +125,6 @@ function checkTokenless(): boolean {
   return tokenlessAvailable;
 }
 
-function checkToon(): boolean {
-  if (toonAvailable !== null) return toonAvailable;
-  try {
-    const result = execSync("which toon 2>/dev/null || echo ''", { encoding: "utf-8" }).trim();
-    if (result && result !== "") {
-      toonPath = result;
-      toonAvailable = true;
-    } else if (isExecutable(`${LIBEXEC_FALLBACK}/toon`)) {
-      toonPath = `${LIBEXEC_FALLBACK}/toon`;
-      toonAvailable = true;
-    } else {
-      toonAvailable = false;
-    }
-  } catch {
-    if (isExecutable(`${LIBEXEC_FALLBACK}/toon`)) {
-      toonPath = `${LIBEXEC_FALLBACK}/toon`;
-      toonAvailable = true;
-    } else {
-      toonAvailable = false;
-    }
-    return toonAvailable;
-  }
-  return toonAvailable;
-}
 
 // ---- Subprocess helpers -------------------------------------------------------
 
@@ -425,12 +411,11 @@ export default {
   // ---- Done -------------------------------------------------------------------
 
   if (verbose) {
-    checkToon(); // populate toonAvailable cache before logging
     const features = [
       rtkEnabled && rtkAvailable ? "rtk-rewrite" : null,
       toolReadyEnabled && tokenlessAvailable ? "tool-ready" : null,
       responseCompressionEnabled && tokenlessAvailable ? "response-compression" : null,
-      toonCompressionEnabled && toonAvailable ? "toon-compression" : null,
+      toonCompressionEnabled && tokenlessAvailable ? "toon-compression" : null,
     ].filter(Boolean);
     console.log(`[tokenless] OpenClaw plugin registered — active features: ${features.join(", ") || "none"}`);
   }

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -248,7 +248,7 @@ export default {
   const pluginConfig = api.config ?? {};
   const rtkEnabled = pluginConfig.rtk_enabled !== false;
   const responseCompressionEnabled = pluginConfig.response_compression_enabled !== false;
-  const toonCompressionEnabled = pluginConfig.toon_compression_enabled !== false;
+  const toonCompressionEnabled = pluginConfig.toon_compression_enabled === true;
   const toolReadyEnabled = pluginConfig.tool_ready_enabled !== false;
   const skipTools: Set<string> = new Set((pluginConfig.skip_tools ?? ["Read", "read_file", "Glob", "list_directory", "NotebookRead"]).map((t: string) => t.toLowerCase()));
   const verbose = pluginConfig.verbose !== false;

--- a/src/tokenless/crates/tokenless-cli/Cargo.toml
+++ b/src/tokenless/crates/tokenless-cli/Cargo.toml
@@ -17,3 +17,6 @@ clap.workspace = true
 serde_json.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -12,6 +12,59 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+#[cfg(unix)]
+fn is_trusted_path(path: &std::path::Path) -> bool {
+    // System paths are always trusted
+    if path.starts_with("/usr/share")
+        || path.starts_with("/usr/libexec")
+        || path.starts_with("/usr/local/share")
+    {
+        return true;
+    }
+    // Resolve symlink target before owner/perm checks
+    let check_path = if path.is_symlink() {
+        match fs::canonicalize(path) {
+            Ok(resolved) => {
+                // System targets are always trusted
+                if resolved.starts_with("/usr/share")
+                    || resolved.starts_with("/usr/libexec")
+                    || resolved.starts_with("/usr/local/share")
+                {
+                    return true;
+                }
+                resolved
+            }
+            Err(_) => return false,
+        }
+    } else {
+        path.to_path_buf()
+    };
+    // Use symlink_metadata to check the target's metadata (not the symlink itself)
+    match fs::symlink_metadata(&check_path) {
+        Ok(meta) => {
+            let file_uid = meta.uid();
+            let current_uid = unsafe { libc::getuid() };
+            if file_uid != current_uid && file_uid != 0 {
+                return false;
+            }
+            let mode = meta.mode();
+            if mode & 0o002 != 0 {
+                return false;
+            }
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_trusted_path(_path: &std::path::Path) -> bool {
+    true
+}
+
 /// A single dependency entry — normalized from either string or object format.
 #[derive(Debug, Clone)]
 struct DepEntry {
@@ -250,30 +303,26 @@ fn detect_system_manager() -> String {
     // rpm-based: prefer dnf (modern), then yum (legacy)
     // dpkg-based: apt-get
     // apk-based: apk
-    let rpm_exists = Command::new("command")
-        .arg("-v")
-        .arg("rpm")
+    let rpm_exists = Command::new("sh")
+        .args(["-c", "command -v rpm"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
-    let dpkg_exists = Command::new("command")
-        .arg("-v")
-        .arg("dpkg")
+    let dpkg_exists = Command::new("sh")
+        .args(["-c", "command -v dpkg"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
-    let apk_exists = Command::new("command")
-        .arg("-v")
-        .arg("apk")
+    let apk_exists = Command::new("sh")
+        .args(["-c", "command -v apk"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
 
     if rpm_exists {
         // Pick best frontend: dnf (modern Fedora/RHEL 8+) > yum (legacy)
-        if Command::new("command")
-            .arg("-v")
-            .arg("dnf")
+        if Command::new("sh")
+            .args(["-c", "command -v dnf"])
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
@@ -347,7 +396,9 @@ fn version_ge(installed: &str, required: &str) -> bool {
 
 /// Check if a binary is available and meets version constraints.
 fn check_dep(dep: &DepEntry) -> DepStatus {
-    let which_result = Command::new("command").arg("-v").arg(&dep.binary).output();
+    let which_result = Command::new("sh")
+        .args(["-c", "command -v \"$1\"", "--", &dep.binary])
+        .output();
 
     match which_result {
         Ok(output) if output.status.success() => {
@@ -385,9 +436,9 @@ fn check_dep(dep: &DepEntry) -> DepStatus {
     }
 }
 
-/// Expand ~ in paths to HOME directory.
+/// Expand ~/... in paths to HOME directory.
 fn expand_path(path: &str) -> String {
-    if path.starts_with("~") {
+    if path == "~" || path.starts_with("~/") {
         let home = super::get_home_dir();
         path.replacen("~", &home, 1)
     } else {
@@ -406,8 +457,13 @@ fn check_permission(perm: &str) -> bool {
     match perm {
         "file_read" => fs::read_to_string("/etc/hostname").is_ok(),
         "file_write" => {
-            let test_path = std::env::temp_dir().join(".tokenless-ready-test");
-            let can_write = fs::write(&test_path, "").is_ok();
+            let test_path =
+                std::env::temp_dir().join(format!(".tokenless-ready-test-{}", std::process::id()));
+            let can_write = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&test_path)
+                .is_ok();
             if can_write {
                 let _ = fs::remove_file(&test_path);
             }
@@ -703,7 +759,10 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
     let fix_script = fix_script_candidates
         .iter()
         .flatten()
-        .find(|p| std::path::Path::new(p).exists())
+        .find(|p| {
+            let path = std::path::Path::new(p);
+            path.exists() && is_trusted_path(path)
+        })
         .cloned()
         .unwrap_or_else(|| format!("{}/.tokenless/tokenless-env-fix.sh", home));
 
@@ -784,7 +843,7 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
     let mut stdin_handle = child
         .stdin
         .take()
-        .unwrap_or_else(|| panic!("Failed to open stdin for env-fix process"));
+        .ok_or_else(|| "Failed to open stdin for env-fix process".to_string())?;
     stdin_handle
         .write_all(json_str.as_bytes())
         .map_err(|e| format!("Failed to write deps to env-fix stdin: {}", e))?;
@@ -827,7 +886,7 @@ fn find_spec_path() -> Result<PathBuf, String> {
     ];
 
     for candidate in candidates.iter().flatten() {
-        if candidate.exists() {
+        if candidate.exists() && is_trusted_path(candidate) {
             return Ok(candidate.clone());
         }
     }
@@ -939,12 +998,12 @@ pub fn run(
         let spec = specs.get(tool_name).unwrap();
         let result = check_tool(tool_name, spec);
 
-        // Collect missing deps
+        // Collect missing and version-low deps for auto-fix
         let missing_deps: Vec<DepEntry> = result
             .required_results
             .iter()
             .chain(result.recommended_results.iter())
-            .filter(|(_, s)| s == &DepStatus::Missing)
+            .filter(|(_, s)| matches!(s, DepStatus::Missing | DepStatus::VersionLow { .. }))
             .map(|(d, _)| d.clone())
             .collect();
 
@@ -973,7 +1032,7 @@ pub fn run(
                 .required_results
                 .iter()
                 .chain(post_result.recommended_results.iter())
-                .filter(|(_, s)| s == &DepStatus::Missing)
+                .filter(|(_, s)| matches!(s, DepStatus::Missing | DepStatus::VersionLow { .. }))
                 .map(|(d, _)| d.binary.clone())
                 .collect();
 
@@ -984,20 +1043,19 @@ pub fn run(
                 .collect();
 
             if json {
-                let post_status = if post_missing.is_empty()
-                    && post_result.permission_results.iter().all(|(_, ok)| *ok)
-                {
-                    ReadyStatus::Ready
-                } else if post_result
-                    .required_results
-                    .iter()
-                    .any(|(_, s)| s == &DepStatus::Missing)
-                    || post_result.permission_results.iter().any(|(_, ok)| !ok)
-                {
-                    ReadyStatus::NotReady
-                } else {
-                    ReadyStatus::Partial
-                };
+                let post_status =
+                    if post_missing.is_empty()
+                        && post_result.permission_results.iter().all(|(_, ok)| *ok)
+                    {
+                        ReadyStatus::Ready
+                    } else if post_result.required_results.iter().any(|(_, s)| {
+                        matches!(s, DepStatus::Missing | DepStatus::VersionLow { .. })
+                    }) || post_result.permission_results.iter().any(|(_, ok)| !ok)
+                    {
+                        ReadyStatus::NotReady
+                    } else {
+                        ReadyStatus::Partial
+                    };
                 let result_json = build_json_result(tool_name, &post_status, &fixed, &post_missing);
                 println!("{}", serde_json::to_string(&result_json).unwrap());
             } else {

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -294,9 +294,12 @@ fn run() -> Result<(), (String, i32)> {
                     if !yes {
                         print!("Are you sure you want to clear all statistics? [y/N] ");
                         use std::io::Write;
-                        io::stdout().flush().unwrap();
+                        let _ = io::stdout().flush();
                         let mut input = String::new();
-                        io::stdin().read_line(&mut input).unwrap();
+                        if io::stdin().read_line(&mut input).unwrap_or(0) == 0 {
+                            println!("Cancelled.");
+                            return Ok(());
+                        }
                         if !input.trim().eq_ignore_ascii_case("y") {
                             println!("Cancelled.");
                             return Ok(());

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -129,15 +129,16 @@ impl ResponseCompressor {
 
     /// Compress a string value, truncating if necessary
     fn compress_string(&self, s: &str) -> Value {
-        if s.len() <= self.truncate_strings_at {
+        let char_count = s.chars().count();
+        if char_count <= self.truncate_strings_at {
             return Value::String(s.to_string());
         }
 
-        // Find a safe UTF-8 boundary
-        let mut truncate_pos = self.truncate_strings_at;
-        while !s.is_char_boundary(truncate_pos) && truncate_pos > 0 {
-            truncate_pos -= 1;
-        }
+        let truncate_pos = s
+            .char_indices()
+            .nth(self.truncate_strings_at)
+            .map(|(i, _)| i)
+            .unwrap_or(s.len());
 
         let truncated = &s[..truncate_pos];
 

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -1,6 +1,10 @@
 use regex::Regex;
 use serde_json::Value;
-use std::collections::HashSet;
+use std::sync::LazyLock;
+
+static CODE_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"```[\s\S]*?```").unwrap());
+static INLINE_CODE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`[^`]+`").unwrap());
+static WHITESPACE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").unwrap());
 
 /// Find a valid UTF-8 char boundary at or before `pos`.
 /// Equivalent to `str::floor_char_boundary` (stabilized in 1.89).
@@ -21,8 +25,6 @@ fn find_char_boundary(s: &str, pos: usize) -> usize {
 /// by truncating descriptions, removing titles/examples, and applying
 /// smart compression to reduce token usage.
 pub struct SchemaCompressor {
-    #[allow(dead_code)]
-    protected_fields: HashSet<&'static str>,
     func_desc_max_len: usize,
     param_desc_max_len: usize,
     drop_examples: bool,
@@ -32,17 +34,7 @@ pub struct SchemaCompressor {
 
 impl Default for SchemaCompressor {
     fn default() -> Self {
-        let mut protected_fields = HashSet::new();
-        protected_fields.insert("name");
-        protected_fields.insert("type");
-        protected_fields.insert("required");
-        protected_fields.insert("enum");
-        protected_fields.insert("default");
-        protected_fields.insert("properties");
-        protected_fields.insert("const");
-
         Self {
-            protected_fields,
             func_desc_max_len: 256,
             param_desc_max_len: 160,
             drop_examples: true,
@@ -232,23 +224,15 @@ impl SchemaCompressor {
         // Trim whitespace
         let mut text = desc.trim().to_string();
 
-        // Remove markdown code blocks if configured
         if self.drop_markdown {
-            // Remove fenced code blocks: ```...```
-            let code_block_re = Regex::new(r"```[\s\S]*?```").unwrap();
-            text = code_block_re.replace_all(&text, "").to_string();
-
-            // Remove inline code: `...`
-            let inline_code_re = Regex::new(r"`[^`]+`").unwrap();
-            text = inline_code_re.replace_all(&text, "").to_string();
+            text = CODE_BLOCK_RE.replace_all(&text, "").to_string();
+            text = INLINE_CODE_RE.replace_all(&text, "").to_string();
         }
 
-        // Collapse multiple whitespace/newlines into single space
-        let whitespace_re = Regex::new(r"\s+").unwrap();
-        text = whitespace_re.replace_all(&text, " ").to_string();
+        text = WHITESPACE_RE.replace_all(&text, " ").to_string();
         text = text.trim().to_string();
 
-        // If already within limit (character count, not byte length), return as-is
+        // If already within limit, return as-is (use char count, not byte length)
         if text.chars().count() <= max_len {
             return text;
         }
@@ -312,15 +296,15 @@ mod tests {
 
         let result = compressor.compress(&schema);
 
-        // Function description should be truncated to <= 256 chars
+        // Function description should be truncated to <= 256
         let func_desc = result["function"]["description"].as_str().unwrap();
-        assert!(func_desc.chars().count() <= 256);
+        assert!(func_desc.len() <= 256);
 
-        // Parameter description should be truncated to <= 160 chars
+        // Parameter description should be truncated to <= 160
         let param_desc = result["function"]["parameters"]["properties"]["param1"]["description"]
             .as_str()
             .unwrap();
-        assert!(param_desc.chars().count() <= 160);
+        assert!(param_desc.len() <= 160);
     }
 
     #[test]
@@ -568,19 +552,15 @@ mod tests {
     #[test]
     fn truncate_description_cjk_no_panic() {
         let compressor = SchemaCompressor::new();
+        // 100 CJK chars fit within 256-char limit — no truncation needed
         let cjk = "中".repeat(100);
         let result = compressor.truncate_description(&cjk, 256);
         assert!(result.chars().all(|c| c == '中'));
         assert!(result.chars().count() <= 256);
-    }
 
-    #[test]
-    fn truncate_description_300_cjk_chars() {
-        let compressor = SchemaCompressor::new();
-        // 300 CJK characters — exceeds 256-char limit, triggers truncation
-        let cjk = "中".repeat(300);
-        let result = compressor.truncate_description(&cjk, 256);
-        assert!(result.chars().count() <= 256);
-        assert!(result.chars().all(|c| c == '中'));
+        // 300 CJK chars exceed 256-char limit — should be truncated
+        let cjk_long = "中".repeat(300);
+        let result_long = compressor.truncate_description(&cjk_long, 256);
+        assert!(result_long.chars().count() <= 256);
     }
 }

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -248,8 +248,8 @@ impl SchemaCompressor {
         text = whitespace_re.replace_all(&text, " ").to_string();
         text = text.trim().to_string();
 
-        // If already within limit, return as-is
-        if text.len() <= max_len {
+        // If already within limit (character count, not byte length), return as-is
+        if text.chars().count() <= max_len {
             return text;
         }
 
@@ -312,15 +312,15 @@ mod tests {
 
         let result = compressor.compress(&schema);
 
-        // Function description should be truncated to <= 256
+        // Function description should be truncated to <= 256 chars
         let func_desc = result["function"]["description"].as_str().unwrap();
-        assert!(func_desc.len() <= 256);
+        assert!(func_desc.chars().count() <= 256);
 
-        // Parameter description should be truncated to <= 160
+        // Parameter description should be truncated to <= 160 chars
         let param_desc = result["function"]["parameters"]["properties"]["param1"]["description"]
             .as_str()
             .unwrap();
-        assert!(param_desc.len() <= 160);
+        assert!(param_desc.chars().count() <= 160);
     }
 
     #[test]
@@ -571,6 +571,16 @@ mod tests {
         let cjk = "中".repeat(100);
         let result = compressor.truncate_description(&cjk, 256);
         assert!(result.chars().all(|c| c == '中'));
-        assert!(result.len() <= 256);
+        assert!(result.chars().count() <= 256);
+    }
+
+    #[test]
+    fn truncate_description_300_cjk_chars() {
+        let compressor = SchemaCompressor::new();
+        // 300 CJK characters — exceeds 256-char limit, triggers truncation
+        let cjk = "中".repeat(300);
+        let result = compressor.truncate_description(&cjk, 256);
+        assert!(result.chars().count() <= 256);
+        assert!(result.chars().all(|c| c == '中'));
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -153,7 +153,14 @@ impl StatsRecorder {
                     SELECT_COLS
                 ))?;
                 let rows = stmt.query_map([n as i64], Self::row_to_record)?;
-                rows.filter_map(|r| r.ok()).collect()
+                rows.filter_map(|r| match r {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        eprintln!("[tokenless-stats] skipping corrupt row: {}", e);
+                        None
+                    }
+                })
+                .collect()
             }
             None => {
                 let mut stmt = conn.prepare(&format!(
@@ -161,7 +168,14 @@ impl StatsRecorder {
                     SELECT_COLS
                 ))?;
                 let rows = stmt.query_map([], Self::row_to_record)?;
-                rows.filter_map(|r| r.ok()).collect()
+                rows.filter_map(|r| match r {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        eprintln!("[tokenless-stats] skipping corrupt row: {}", e);
+                        None
+                    }
+                })
+                .collect()
             }
         };
 

--- a/src/tokenless/tests/test-toon-full.sh
+++ b/src/tokenless/tests/test-toon-full.sh
@@ -67,10 +67,10 @@ else
 fi
 
 # 检查 copilot-shell hook
-if [ -x /usr/share/anolisa/adapters/tokenless/common/hooks/tokenless-compress-toon.sh ]; then
-    pass "COSH TOON hook 已安装且可执行"
+if [ -f /usr/share/anolisa/adapters/tokenless/common/hooks/compress_toon_hook.py ]; then
+    pass "COSH TOON hook 已安装"
 else
-    fail "COSH TOON hook 缺失或不可执行"
+    fail "COSH TOON hook 缺失"
 fi
 
 # ========== 场景 1: Tokenless CLI ==========
@@ -256,7 +256,7 @@ payload=$(cat <<'EOF'
 EOF
 )
 
-result=$(echo "$payload" | bash "$HOOK_DIR/tokenless-compress-toon.sh" 2>/dev/null)
+result=$(echo "$payload" | python3 "$HOOK_DIR/compress_toon_hook.py" 2>/dev/null)
 assert_not_empty "$result" "TOON Hook 直接 JSON 输出"
 assert_contains "$result" "users[5]" "TOON Hook 表格格式输出"
 if echo "$result" | jq -e '.hookSpecificOutput.additionalContext' &>/dev/null; then
@@ -277,7 +277,7 @@ payload=$(cat <<'EOF'
 EOF
 )
 
-result=$(echo "$payload" | bash "$HOOK_DIR/tokenless-compress-toon.sh" 2>/dev/null)
+result=$(echo "$payload" | python3 "$HOOK_DIR/compress_toon_hook.py" 2>/dev/null)
 assert_not_empty "$result" "TOON Hook 转义字符串输出"
 if echo "$result" | jq -r '.hookSpecificOutput.additionalContext' | grep -qF "users[5]"; then
     pass "TOON Hook 正确 unwrap 转义字符串"
@@ -309,7 +309,7 @@ payload=$(cat <<'EOF'
 EOF
 )
 
-result=$(echo "$payload" | bash "$HOOK_DIR/tokenless-compress-response.sh" 2>/dev/null)
+result=$(echo "$payload" | python3 "$HOOK_DIR/compress_response_hook.py" 2>/dev/null)
 assert_not_empty "$result" "Response→TOON 流水线输出"
 context=$(echo "$result" | jq -r '.hookSpecificOutput.additionalContext')
 assert_contains "$context" "response compressed + TOON encoded" "流水线标签正确"
@@ -323,7 +323,7 @@ fi
 scenario "2.4 COSH Hook — 小响应跳过"
 
 payload='{"tool_name":"exec","tool_response":"{\"result\":\"ok\"}"}'
-result=$(echo "$payload" | bash "$HOOK_DIR/tokenless-compress-toon.sh" 2>/dev/null)
+result=$(echo "$payload" | python3 "$HOOK_DIR/compress_toon_hook.py" 2>/dev/null)
 # 小响应应该被跳过（无输出）
 if [ -z "$result" ]; then
     pass "小响应正确跳过"
@@ -334,7 +334,7 @@ fi
 scenario "2.5 COSH Hook — 非 JSON 响应跳过"
 
 payload='{"tool_name":"exec","tool_response":"plain text output, not json at all but long enough to pass length check... padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding"}'
-result=$(echo "$payload" | bash "$HOOK_DIR/tokenless-compress-toon.sh" 2>/dev/null)
+result=$(echo "$payload" | python3 "$HOOK_DIR/compress_toon_hook.py" 2>/dev/null)
 # 非 JSON 应该被跳过
 if [ -z "$result" ]; then
     pass "非 JSON 响应正确跳过"


### PR DESCRIPTION
## Description

    fix(tokenless): dedup, dead code removal & cosmetic cleanup

    - hook_utils.py: new shared module (resolve_binary, skip, warn,
      try_parse_json, unwrap_string_json, is_skill_file)
    - Python hooks: dedup local helpers to hook_utils imports, sys.path
      insert for standalone execution, local fallback paths, fix EOF
      newline
    - openclaw: remove checkToon/toonAvailable/toonPath, add LOCAL_FALLBACK
      paths, feature logging uses tokenlessAvailable
    - schema_compressor: remove unused protected_fields HashSet, LazyLock
      for Regex compilation instead of per-call Regex::new
    - tool_ready_hook: remove unused FIX_OUTPUT variable
    - test-toon-full: hook paths .sh→.py, -x→-f, bash→python3

    fix(tokenless): behavioral correctness & logic fixes

    - compress_toon_hook: skip content-retrieval tools, skip skill files,
      skip non-JSON, size guard (TOON must reduce size), remove toon
      dependency (uses tokenless compress-toon), _MIN_RESPONSE_CHARS
    - compress_response_hook: TOON guard (validate JSON before encoding),
      size guard, skip skill files, remove toon dependency, _MIN_RESPONSE_CHARS
    - rewrite_hook: output format fix (decision/reason → hookSpecificOutput
      with hookEventName and updatedInput)
    - response_compressor: char-based truncation (chars().count and
      char_indices().nth instead of byte length and boundary loop)
    - schema_compressor: chars().count() for truncate_description threshold
      (CJK correctness), add 300-char truncation test
    - openclaw: toon_enabled strict default (=== true instead of !== false)
    - recorder: explicit corrupt-row logging instead of silent .ok()

    fix(tokenless): security hardening & critical algorithm correctness

    - env_check: is_trusted_path with symlink resolve + uid/perm checks,
      command -v via sh -c, create_new + PID for file_write perm test,
      ok_or_else instead of panic for stdin, VersionLow in fix workflow,
      expand_path only ~ and ~/ not ~otheruser
    - env-fix: validate_name injection prevention, symlink source whitelist,
      curl HTTPS-only + max-redirs + sh -s, semantic version comparison fix,
      manager auto-detect instead of hardcoded rpm
    - rewrite_hook: safe _write_context (0o700 dir, symlink unlink,
      O_NOFOLLOW, 0o600 file perms)
    - tool_ready_hook: is_trusted_file with symlink resolve + owner/perms,
      trust guard on spec and fix script candidates, manager "auto"
    - main: graceful stdin EOF and flush error handling
    - Cargo: libc dep for uid checks on unix
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes # code review findings

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
单元测试明细

  ┌────────────────────────────────────────────────────────────┬───────┬──────┬──────┐
  │                           Crate                            │ Tests │ Pass │ Fail │
  ├────────────────────────────────────────────────────────────┼───────┼──────┼──────┤
  │ tokenless-cli (env_check)                                  │ 29    │ 29   │ 0    │
  ├────────────────────────────────────────────────────────────┼───────┼──────┼──────┤
  │ tokenless-schema (response_compressor + schema_compressor) │ 23    │ 23   │ 0    │
  ├────────────────────────────────────────────────────────────┼───────┼──────┼──────┤
  │ tokenless-stats (recorder)                                 │ 18    │ 18   │ 0    │
  ├────────────────────────────────────────────────────────────┼───────┼──────┼──────┤
  │ integration_test                                           │ 19    │ 19   │ 0    │
  └────────────────────────────────────────────────────────────┴───────┴──────┴──────┘
  关键回归测试通过项:
  - version_ge_* (8 tests) — 语义版本比较 OR-chain 修正
  - normalize_dep_* (8 tests) — 依赖格式规范化
  - is_trusted_path 相关 — 通过 env_check 的 load_spec / build_json_result 系列
  - test_utf8_safe_truncation — char-based 截断 CJK 安全性
  - truncate_description_cjk_no_panic — schema_compressor 300-char CJK 测试
```