### PR TITLE
feat(sight): add configurable ring buffer size and async tokenizer loading

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -8,8 +8,10 @@
       {"rule": ["node*", "*/usr/bin/cosh*"], "agent_name": "Cosh"},
       {"rule": ["node*", "*/usr/bin/copliot*"], "agent_name": "Cosh"},
       {"rule": ["node*", "*copilot-shell*"], "agent_name": "Cosh"},
+      {"rule": ["*node*", "*copilot-shell*"], "agent_name": "Cosh"},
       {"rule": ["*openclaw-gatewa*"], "agent_name": "OpenClaw"},
-      {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"}
+      {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
+      {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"}
     ]
   }
 }

--- a/src/agentsight/build.rs
+++ b/src/agentsight/build.rs
@@ -6,6 +6,7 @@ fn generate_skeleton(out: &mut PathBuf, name: &str) {
     let c_path = format!("src/bpf/{name}.bpf.c");
     let rs_name = format!("{name}.skel.rs");
     out.push(&rs_name);
+
     SkeletonBuilder::new()
         .source(&c_path)
         .build_and_generate(&out)

--- a/src/agentsight/src/bpf/common.h
+++ b/src/agentsight/src/bpf/common.h
@@ -6,7 +6,7 @@
 #include <bpf/bpf_core_read.h>
 
 #ifndef RING_BUFFER_SIZE
-#define RING_BUFFER_SIZE (64 * 1024 * 1024)
+#define RING_BUFFER_SIZE (32 * 1024 * 1024)
 #endif
 
 #ifndef MAX_TRACED_PROCESSES


### PR DESCRIPTION
## Summary

- Add `ring_buffer_mb` config option (default 32MB) to control BPF ring buffer size at runtime
- Refactor MultiModelTokenizer to use LRU(3) cache with non-blocking background loading
- Add retry loop in CLI tokenizer initialization to wait for async load completion
- Update agent matching rules for Cosh and OpenClaw in agentsight.json

## Changes

| File | Description |
|------|-------------|
| `agentsight.json` | Add `ring_buffer_mb` field and new Cosh/OpenClaw matching rules |
| `config.rs` | Add `ring_buffer_mb` config parsing and `DEFAULT_RING_BUFFER_MB` constant |
| `probes.rs` / `proctrace.rs` | Thread `ring_buffer_mb` through to BPF skeleton `set_max_entries` |
| `tokenizer/multi_model.rs` | Rewrite to LRU(3) cache + async background loading via `OnceCell` |
| `token_breakdown/cli.rs` | Add retry loop for async tokenizer readiness |
| `tokenizer/mod.rs` | Simplify re-exports |
