### PR TITLE
refactor(tokenless): replace rtk and toon git submodules with crates.io dep and justfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -549,7 +549,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: '1.85.0'
+          toolchain: '1.89.0'
           components: 'rustfmt, clippy'
 
       - uses: Swatinem/rust-cache@v2
@@ -559,17 +559,17 @@ jobs:
       - name: Check formatting
         run: |
           cd src/tokenless
-          cargo fmt --all --check
+          cargo fmt -p tokenless-cli -p tokenless-schema -p tokenless-stats -- --check
 
       - name: Lint
         run: |
           cd src/tokenless
-          cargo clippy --workspace -- -D warnings
+          cargo clippy -p tokenless-cli -p tokenless-schema -p tokenless-stats -- -D warnings
 
       - name: Run tests
         run: |
           cd src/tokenless
-          cargo test --workspace
+          cargo test -p tokenless-cli -p tokenless-schema -p tokenless-stats
 
   # =========================================================================
   # Step 7: Test ws-ckpt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "src/tokenless/third_party/rtk"]
-	path = src/tokenless/third_party/rtk
-	url = https://github.com/rtk-ai/rtk.git
-[submodule "src/tokenless/third_party/toon"]
-	path = src/tokenless/third_party/toon
-	url = https://github.com/toon-format/toon-rust.git

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1082,7 +1082,7 @@ _configure_git_mirror() {
     # Configure a reachable GitHub mirror for git operations when
     # github.com is blocked (e.g. ECS instances in China).
     # IMPORTANT: we write to --global (not --local) so that git-clone processes
-    # spawned by "git submodule update --init" also inherit the insteadOf rule.
+    # (e.g. justfile setup-rtk) also inherit the insteadOf rule.
     local repo_dir="${1:-.}"
 
     if curl -sSf --connect-timeout 3 --max-time 6 -o /dev/null https://github.com 2>/dev/null; then
@@ -1310,6 +1310,30 @@ check_ebpf_deps() {
 
 # ─── top-level dep installer ───
 
+install_just() {
+    step "just (command runner, for tokenless rtk setup)"
+
+    if cmd_exists just; then
+        ok "just already installed, skipping"
+        return 0
+    fi
+
+    # just may have been installed alongside rustup; source cargo env first
+    # shellcheck source=/dev/null
+    [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
+
+    if cmd_exists cargo; then
+        info "Installing just via cargo install ..."
+        cargo install just 2>/dev/null || true
+        if cmd_exists just; then
+            ok "just installed via cargo install"
+            return 0
+        fi
+    fi
+
+    warn "'just' is required for tokenless build (rtk clone+patch). Install manually: cargo install just"
+}
+
 do_install_deps() {
     if $DRY_RUN; then
         step "Dependency plan"
@@ -1319,6 +1343,9 @@ do_install_deps() {
         fi
         if want_component sec-core || want_component sight || want_component tokenless || want_component ws-ckpt; then
             echo "DRY-RUN: check/install Rust toolchain if needed"
+        fi
+        if want_component tokenless; then
+            echo "DRY-RUN: check/install just if needed"
         fi
         if want_component sec-core; then
             echo "DRY-RUN: check/install uv and configure Python mirrors if needed"
@@ -1340,6 +1367,10 @@ do_install_deps() {
 
     if want_component sec-core || want_component sight || want_component tokenless || want_component ws-ckpt; then
         install_rust
+    fi
+
+    if want_component tokenless; then
+        install_just
     fi
 
     if want_component sec-core; then
@@ -1475,14 +1506,14 @@ build_tokenless() {
     [[ -d "$dir" ]] || die "Directory not found: $dir"
     cd "$dir"
 
-    if [ ! -d "third_party/rtk/.git" ]; then
-        info "Initializing git submodules..."
-        if $DRY_RUN; then
-            echo "DRY-RUN: configure git mirror for $dir"
-        else
-            _configure_git_mirror "$dir"
+    # rtk setup is handled by Makefile build-tokenless target (just setup-rtk),
+    # but 'just' must be available before make install runs.
+    if ! $DRY_RUN; then
+        if ! command -v just &>/dev/null; then
+            die "'just' is required for tokenless build (rtk clone+patch orchestration). Install: cargo install just"
         fi
-        run_logged "git submodule update --init" git submodule update --init --recursive
+    else
+        info "DRY-RUN: just setup-rtk would be called by Makefile build-tokenless"
     fi
 
     info "make install (tokenless workspace) ..."

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -423,19 +423,15 @@ build_tokenless() {
     local spec_file
     spec_file=$(process_spec_template "$spec_in" "$version")
 
-    log "Step 1/3: Initializing submodules..."
+    log "Step 1/3: Setting up rtk vendored source..."
+    command -v just &>/dev/null || die "'just' is required for RPM build. Install: cargo install just"
     (
         cd "$TOKEN_DIR"
+        # Clone rtk into third_party/ (no submodule — uses justfile setup-rtk)
+        # Note: rtk source in tarball is already patched via justfile setup-rtk
         if [ ! -d "third_party/rtk/.git" ]; then
-            log "Initializing git submodules..."
-            git submodule update --init
+            just setup-rtk
         fi
-        # Build tokenless
-        cargo build --release --workspace
-        # Build rtk from submodule
-        cargo build --release --manifest-path third_party/rtk/Cargo.toml
-        # Build toon from submodule (fallback to pre-built binary if Rust < 1.88)
-        cargo build --release --manifest-path third_party/toon/Cargo.toml --features cli || true
     )
 
     log "Step 2/3: Creating source tarball ${tarball_name}..."
@@ -444,11 +440,11 @@ build_tokenless() {
     local pkg_dir="${tmp_dir}/${pkg_name}"
     mkdir -p "$pkg_dir"
 
-    # Copy full source tree, excluding build artifacts and VCS
+    # Copy full source tree (including vendored rtk), excluding build artifacts and VCS
+    # Note: third_party/rtk must be included — it's built separately via --manifest-path
     tar -cf - -C "$TOKEN_DIR" \
         --exclude='target' \
         --exclude='.git' \
-        --exclude='.gitmodules' \
         --exclude='node_modules' \
         . | tar -xf - -C "$pkg_dir"
 

--- a/src/tokenless/.gitignore
+++ b/src/tokenless/.gitignore
@@ -1,0 +1,2 @@
+# rtk source is downloaded from GitHub via justfile, not tracked in git
+third_party/rtk/

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.2
+
+- replace spoofable home-dir uid derivation with libc::getuid() syscall for trust chain integrity
+- replace subprocess toon -e calls with in-process toon_format::encode_default() library call
+- replace rtk/toon git submodules with crates.io deps and inline toon-format source
+- hard-fail on rtk stats patch failure in justfile setup-rtk recipe
+- unify compress-toon/compress-schema/compress-response error exit codes (all exit 2)
+- remove 2>/dev/null || true from Makefile toon install (hard fail on missing binary)
+- remove redundant #[source] attribute on thiserror variants that already have #[from]
+- deduplicate Python hook FHS path constants into shared hook_utils module
+- add libc to workspace dependencies for uid syscall
+- add detailed rust >= 1.89 comment in spec.in explaining CI pin rationale
+
 ## 0.3.0
 
 - add tool-ready 4-phase environment pre-check with cosh extension integration

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -204,6 +204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +226,30 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -242,12 +272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -281,6 +317,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,19 +340,21 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -368,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +453,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -487,6 +541,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -499,6 +554,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -529,7 +590,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -537,6 +607,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -555,6 +636,7 @@ dependencies = [
  "serde_json",
  "tokenless-schema",
  "tokenless-stats",
+ "toon-format",
 ]
 
 [[package]]
@@ -574,7 +656,19 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "toon-format"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1dae994fe9adfb44bdc74fc17546651604a59af32136256515bc1218850832"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -609,9 +703,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -622,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -632,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -645,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -7,7 +7,6 @@ members = [
 ]
 exclude = [
     "third_party/rtk",
-    "third_party/toon",
 ]
 
 [workspace.package]
@@ -22,3 +21,14 @@ regex = "1.10"
 thiserror = "2.0"
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
+toon-format = { version = "0.4", default-features = false }
+rusqlite = { version = "0.31", features = ["bundled"] }
+dirs = "5.0"
+libc = "0.2"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -19,13 +19,12 @@ SHARE_DIR ?= $(DATADIR)/anolisa/adapters/tokenless
 BIN_DIR ?= $(BINDIR)
 LIB_DIR ?= $(LIBEXECDIR)
 ADAPTER_SRC_DIR := adapters/tokenless
-RTK_DIR := third_party/rtk
-TOON_DIR := third_party/toon
+TOON_VER := 0.4.6
 
-.PHONY: build build-tokenless build-rtk build-toon install uninstall test lint clean \
+.PHONY: build build-tokenless build-toon install uninstall test lint clean \
         install-binaries install-helpers install-adapter-resources install-cosh-extension \
         adapter-install adapter-uninstall adapter-scan \
-        cosh-install cosh-uninstall \
+        cosh-extension-install cosh-extension-uninstall \
         openclaw-install openclaw-uninstall \
         hermes-install hermes-uninstall \
         setup help \
@@ -35,19 +34,17 @@ TOON_DIR := third_party/toon
 all: build
 
 # Build both projects
-build: build-tokenless build-rtk build-toon
+build: build-tokenless build-toon
 
 build-tokenless:
-	@echo "==> Building tokenless..."
+	@echo "==> Building tokenless + rtk..."
+	just setup-rtk
 	cargo build --release
-
-build-rtk:
-	@echo "==> Building rtk..."
-	cargo build --release --manifest-path $(RTK_DIR)/Cargo.toml
+	cargo build --release --manifest-path third_party/rtk/Cargo.toml
 
 build-toon:
-	@echo "==> Building toon..."
-	cargo build --release --manifest-path $(TOON_DIR)/Cargo.toml --features cli
+	@echo "==> Installing toon binary (v$(TOON_VER))..."
+	cargo install toon-format --version $(TOON_VER) --locked
 
 # Install binaries + adapter resources per FHS spec.
 install: build install-binaries install-helpers install-adapter-resources install-cosh-extension
@@ -60,8 +57,10 @@ install-binaries:
 install-helpers:
 	@echo "==> Installing helpers to $(DESTDIR)$(LIBEXECDIR)..."
 	install -d -m 0755 $(DESTDIR)$(LIBEXECDIR)
-	install -p -m 0755 $(RTK_DIR)/target/release/rtk $(DESTDIR)$(LIBEXECDIR)/
-	install -p -m 0755 $(TOON_DIR)/target/release/toon $(DESTDIR)$(LIBEXECDIR)/
+	install -p -m 0755 third_party/rtk/target/release/rtk $(DESTDIR)$(LIBEXECDIR)/
+	install -p -m 0755 $(HOME)/.cargo/bin/toon $(DESTDIR)$(LIBEXECDIR)/
+	ln -sf $(LIBEXECDIR)/rtk $(DESTDIR)$(BINDIR)/rtk
+	ln -sf $(LIBEXECDIR)/toon $(DESTDIR)$(BINDIR)/toon
 
 install-adapter-resources:
 	@echo "==> Installing adapter resources to $(DESTDIR)$(SHARE_DIR)..."
@@ -87,50 +86,41 @@ uninstall:
 	rm -rf $(DESTDIR)$(COSH_EXTENSION_DIR)
 
 # Run tests
-test: test-tokenless test-rtk test-toon test-hooks
+test: test-tokenless test-hooks
 
 test-tokenless:
 	@echo "==> Testing tokenless..."
-	cargo test --workspace
-
-test-rtk:
-	@echo "==> Testing rtk build..."
-	cargo check --manifest-path $(RTK_DIR)/Cargo.toml
-
-test-toon:
-	@echo "==> Testing toon build..."
-	cargo check --manifest-path $(TOON_DIR)/Cargo.toml
+	cargo test -p tokenless-cli -p tokenless-schema -p tokenless-stats
 
 test-hooks:
 	@echo "==> Testing copilot-shell hooks..."
 	bash tests/run-all-tests.sh
 
-# Lint
+# Lint (rtk excluded — vendored third-party source)
 lint:
 	@echo "==> Linting tokenless..."
-	cargo clippy --workspace -- -D warnings
+	cargo clippy -p tokenless-cli -p tokenless-schema -p tokenless-stats -- -D warnings
 
 # Format
 fmt:
 	@echo "==> Formatting..."
-	cargo fmt --all
+	cargo fmt -p tokenless-cli -p tokenless-schema -p tokenless-stats
 
-# Clean
+# Clean (rtk excluded from workspace — needs explicit clean)
 clean:
 	@echo "==> Cleaning..."
 	cargo clean
-	cargo clean --manifest-path $(RTK_DIR)/Cargo.toml
-	cargo clean --manifest-path $(TOON_DIR)/Cargo.toml
+	cargo clean --release --manifest-path third_party/rtk/Cargo.toml 2>/dev/null || true
 
 # Create source tarball (excludes build artifacts)
 dist: clean
-	@echo "==> Creating tarball..."
-	tar czf ../tokenless-0.1.0.tar.gz \
+	@echo "==> Creating tarball (with pre-patched rtk source)..."
+	just setup-rtk
+	tar czf ../tokenless-0.3.2.tar.gz \
 	    --exclude='target' \
-	    --exclude='third_party/rtk/target' \
 	    --exclude='.git' \
 	    -C .. tokenless
-	@echo "==> Tarball: ../tokenless-0.1.0.tar.gz"
+	@echo "==> Tarball: ../tokenless-0.3.2.tar.gz"
 
 # Adapter management — invokes detect/install/uninstall action scripts per the
 # ANOLISA FHS adapter spec.  Environment variables point to installed FHS paths.
@@ -139,17 +129,19 @@ ADAPTER_ENV = ANOLISA_PREFIX=$(HOME)/.local \
               ANOLISA_COMPONENT=tokenless \
               ANOLISA_VERSION=0.3.2
 
-adapter-install: cosh-install openclaw-install hermes-install
+adapter-install: cosh-extension-install openclaw-install hermes-install
 
-adapter-uninstall: cosh-uninstall openclaw-uninstall hermes-uninstall
+adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall
 
 adapter-scan:
 	@echo "=== Tokenless Adapter Manifest ==="
 	@python3 -c "import json; m=json.load(open('$(SHARE_DIR)/manifest.json')); print(f\"  component: {m['component']} v{m['version']}\"); [print(f\"  {t:12s} {c['compatibleVersions']:12s} \" + (', '.join(f'{len(v)} {k}' for k,v in c.get('capabilities',{}).items()) or 'no caps')) for t,c in m['targets'].items()]"
 
-# --- copilot-shell (cosh) ---
+# --- Copilot Shell (cosh) — extension format ---
+# cosh uses cosh-extension.json (not adapter scripts) for auto-discovery.
+# The extension directory deploys hooks/commands/spec from adapter resources.
 
-cosh-install:
+cosh-extension-install:
 	@echo "==> Installing tokenless cosh extension..."
 	@rm -rf $(COSH_EXTENSION_DIR)
 	@install -d -m 0755 $(COSH_EXTENSION_DIR)/hooks $(COSH_EXTENSION_DIR)/commands
@@ -159,9 +151,10 @@ cosh-install:
 	find $(COSH_EXTENSION_DIR) -type f \( -name '*.py' -o -name '*.sh' \) -exec chmod 0755 {} +
 	@echo "==> tokenless cosh extension installed to $(COSH_EXTENSION_DIR)"
 
-cosh-uninstall:
+cosh-extension-uninstall:
 	@echo "==> Uninstalling tokenless cosh extension..."
 	rm -rf $(COSH_EXTENSION_DIR)
+	@echo "==> tokenless cosh extension removed from $(COSH_EXTENSION_DIR)"
 
 # --- OpenClaw ---
 
@@ -194,8 +187,10 @@ setup: install adapter-install
 	@echo "============================================"
 	@echo "  Binaries (FHS):"
 	@echo "    tokenless -> $(BIN_DIR)/tokenless"
-	@echo "    rtk       -> $(LIB_DIR)/rtk -> $(BIN_DIR)/rtk"
-	@echo "    toon      -> $(LIB_DIR)/toon -> $(BIN_DIR)/toon"
+	@echo "    rtk       -> $(LIB_DIR)/rtk"
+	@echo "    toon      -> $(LIB_DIR)/toon"
+	@echo "  Extension (cosh):"
+	@echo "    $(COSH_EXTENSION_DIR)/"
 	@echo "  Adapter (FHS):"
 	@echo "    $(SHARE_DIR)/"
 	@echo "  Registered:"
@@ -213,10 +208,10 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  build             Build tokenless + rtk + toon (release mode)"
-	@echo "  build-tokenless   Build tokenless only"
-	@echo "  build-rtk         Build rtk only"
-	@echo "  build-toon        Build toon only"
+	@echo "  build-tokenless   Build tokenless + rtk (via justfile)"
+	@echo "  build-toon        Install toon binary via cargo install toon-format"
 	@echo "  install           Install binaries + adapter to FHS paths"
+	@echo "  uninstall         Remove installed files"
 	@echo "  test              Run all tests"
 	@echo "  lint              Run clippy checks"
 	@echo "  fmt               Format code"
@@ -224,8 +219,8 @@ help:
 	@echo "  adapter-scan      List registered adapter capabilities"
 	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes)"
 	@echo "  adapter-uninstall Unregister all adapters"
-	@echo "  cosh-install      Register copilot-shell extension"
-	@echo "  cosh-uninstall    Unregister copilot-shell extension"
+	@echo "  cosh-extension-install  Install cosh extension"
+	@echo "  cosh-extension-uninstall Uninstall cosh extension"
 	@echo "  openclaw-install  Register OpenClaw plugin"
 	@echo "  openclaw-uninstall Unregister OpenClaw plugin"
 	@echo "  hermes-install    Install Hermes Agent plugin"
@@ -240,3 +235,4 @@ help:
 	@echo "  BINDIR           Binary install path"
 	@echo "  LIBEXECDIR       Helper binary install path"
 	@echo "  SHARE_DIR        Adapter resources path"
+	@echo "  COSH_EXTENSION_DIR  Cosh extension path"

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -35,30 +35,30 @@ Three integration paths are available:
 Token-Less/
 ├── crates/tokenless-schema/   # Core library: SchemaCompressor + ResponseCompressor
 ├── crates/tokenless-cli/      # CLI binary: `tokenless` command (env-check, compress, stats)
-├── adapters/tokenless/        # FHS adapter bundle (manifest, common, cosh, openclaw)
-│   ├── manifest.json            # Adapter manifest (cosh + openclaw targets)
-│   ├── common/                  # Shared: hooks, spec, env-fix, commands
+├── adapters/tokenless/        # FHS adapter bundle (manifest, common, openclaw, hermes)
+│   ├── manifest.json            # Adapter manifest (cosh + openclaw + hermes targets)
+│   ├── common/                  # Shared: hooks, spec, env-fix, commands, cosh-extension
 │   │   ├── hooks/               # copilot-shell hooks (tool-ready + rewrite + compression)
+│   │   ├── cosh-extension.json  # copilot-shell extension manifest (references common/hooks/)
 │   │   ├── tool-ready-spec.json # Tool dependency spec (4 categories)
 │   │   ├── tokenless-env-fix.sh # Auto-fix script for missing deps
 │   │   └── commands/            # Hook command configs
-│   ├── cosh/scripts/            # copilot-shell agent scripts (detect/install/uninstall)
 │   ├── openclaw/                # OpenClaw plugin + agent scripts
 │   └── hermes/                  # Hermes Agent plugin + scripts
 │       ├── scripts/               # detect/install/uninstall (user-driven registration)
 │       ├── plugin.yaml            # Plugin manifest
 │       └── __init__.py            # register(ctx): transform_tool_result + pre_tool_call (env-check + rtk rewrite) + on_session_start
-├── third_party/rtk/           # RTK submodule (command rewriting engine)
-├── third_party/toon/          # TOON submodule (JSON to TOON encoding)
+├── third_party/rtk/           # RTK vendored source (justfile clone+patch from GitHub)
+├── third_party/patches/      # Patches for vendored third_party sources
 ├── Makefile                   # Unified build system
-└── scripts/                    # Helper scripts (git submodule init, etc.)
+└── scripts/                    # Helper scripts
 ```
 
 ## Quick Start
 
 ```bash
-# Clone with submodules
-git clone --recursive <repo-url>
+# Clone repo (no submodules needed)
+git clone <repo-url>
 cd Token-Less
 
 # Full setup: build + install binaries + deploy all adapters
@@ -116,7 +116,7 @@ echo 'name: Alice\nage: 30' | tokenless decompress-toon
 
 ## copilot-shell Hooks
 
-The adapter provides hooks that are auto-discovered by copilot-shell via the adapter manifest:
+The adapter provides hooks that are auto-discovered by copilot-shell via the cosh extension manifest:
 
 | Hook | Event | File | Description |
 |------|-------|------|-------------|
@@ -128,10 +128,10 @@ The adapter provides hooks that are auto-discovered by copilot-shell via the ada
 ### Install
 
 ```bash
-make cosh-install
+make cosh-extension-install  # or: make openclaw-install, make hermes-install
 ```
 
-Hooks are registered via the adapter manifest and auto-discovered by copilot-shell — no manual `settings.json` configuration needed.
+Hooks are registered via the cosh extension manifest (`cosh-extension.json`) and auto-discovered by copilot-shell — no manual `settings.json` configuration needed.
 
 ## Tool Ready
 
@@ -248,9 +248,8 @@ plugins:
 | Target | Description |
 |---|---|
 | `make build` | Build `tokenless` + `rtk` + `toon` (release mode) |
-| `make build-tokenless` | Build `tokenless` only |
-| `make build-rtk` | Build `rtk` only |
-| `make build-toon` | Build `toon` only |
+| `make build-tokenless` | Build `tokenless` + `rtk` (via justfile) |
+| `make build-toon` | Install TOON binary via `cargo install toon-format` |
 | `make install` | Build and install binaries to `BIN_DIR` (default: ~/.local/bin) |
 | `make test` | Run all tests (Rust + hooks) |
 | `make test-hooks` | Run hook integration tests |
@@ -259,8 +258,8 @@ plugins:
 | `make clean` | Clean build artifacts |
 | `make adapter-install` | Install all adapters (cosh + openclaw + hermes) |
 | `make adapter-uninstall` | Remove all adapters |
-| `make cosh-install` | Install copilot-shell extension |
-| `make cosh-uninstall` | Uninstall copilot-shell extension |
+| `make cosh-extension-install` | Install Copilot Shell extension |
+| `make cosh-extension-uninstall` | Remove Copilot Shell extension |
 | `make openclaw-install` | Install OpenClaw plugin |
 | `make openclaw-uninstall` | Remove OpenClaw plugin |
 | `make hermes-install` | Install Hermes Agent plugin |
@@ -281,14 +280,15 @@ make install BIN_DIR=/usr/local/bin
 | `crates/tokenless-schema/` | Core Rust library — `SchemaCompressor` and `ResponseCompressor` |
 | `adapters/tokenless/` | FHS adapter bundle — manifest, env-check spec/fix, hooks, OpenClaw plugin |
 | `adapters/tokenless/hermes/` | Hermes Agent adapter — plugin + detect/install/uninstall scripts |
-| `third_party/rtk/` | RTK git submodule — command rewriting engine (70+ commands) |
-| `third_party/toon/` | TOON git submodule — JSON to TOON format encoding |
+| `third_party/rtk/` | RTK vendored source — command rewriting engine (justfile clone+patch) |
+| `third_party/patches/` | Patches for vendored third_party sources |
 | `Makefile` | Unified build system for the entire workspace |
 
 ## Prerequisites
 
-- **Rust** toolchain >= 1.88 — required by toon submodule (darling, image, time crates). Install via [rustup](https://rustup.rs)
-- **Git** — for submodule management
+- **Rust** toolchain >= 1.89 — required by rtk (edition 2024) and toon-format (is_multiple_of). Install via [rustup](https://rustup.rs)
+- **just** — build runner for rtk setup (clone + patch orchestration)
+- **Git** — for rtk source download via justfile
 
 ## License
 

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -27,7 +27,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from hook_utils import resolve_binary, skip, warn, try_parse_json, unwrap_string_json, is_skill_file
+from hook_utils import resolve_binary, skip, warn, try_parse_json, unwrap_string_json, is_skill_file, _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB
 
 # -- constants ---------------------------------------------------------------
 
@@ -38,9 +38,6 @@ _SKIP_TOOLS = {
     "Read", "read_file", "Glob", "list_directory",
     "NotebookRead", "read", "glob", "notebookread",
 }
-
-_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 
 
 # -- env attribution patterns -------------------------------------------------
@@ -140,7 +137,7 @@ def _build_additional_context(
 
 def main() -> None:
     # 1. Resolve binaries
-    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL)
+    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
     if not tokenless_bin:
         warn("tokenless is not installed. Response compression hook disabled.")
         skip()

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
@@ -18,13 +18,11 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from hook_utils import resolve_binary, skip, warn
+from hook_utils import resolve_binary, skip, warn, _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB
 
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
-_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 
 
 # -- helpers -----------------------------------------------------------------
@@ -43,7 +41,7 @@ def _is_json_array(data: str) -> bool:
 
 def main() -> None:
     # 1. Check tokenless binary
-    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL)
+    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
     if not tokenless_bin:
         warn("tokenless is not installed or not in PATH. Schema compression hook disabled.")
         skip()

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
@@ -22,14 +22,12 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from hook_utils import resolve_binary, skip, warn, try_parse_json, unwrap_string_json, is_skill_file
+from hook_utils import resolve_binary, skip, warn, try_parse_json, unwrap_string_json, is_skill_file, _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB
 
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
 _MIN_RESPONSE_CHARS = 200
-_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 
 _SKIP_TOOLS = {
     "Read", "read_file", "Glob", "list_directory",
@@ -42,7 +40,7 @@ _SKIP_TOOLS = {
 
 def main() -> None:
     # 1. Resolve binaries
-    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL)
+    tokenless_bin = resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
     if not tokenless_bin:
         warn("tokenless is not installed. TOON compression hook disabled.")
         skip()

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -6,6 +6,16 @@ import shutil
 import sys
 
 
+# -- FHS fallback paths (ANOLISA spec) ----------------------------------------
+
+_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
+_TOKENLESS_LOCAL_SHARE = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
+_TOKENLESS_LOCAL_LIB = os.path.join(os.path.expanduser("~"), ".local", "lib", "anolisa", "tokenless", "tokenless")
+_RTK_FALLBACK = "/usr/libexec/anolisa/tokenless/rtk"
+_RTK_LOCAL_SHARE = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "rtk")
+_RTK_LOCAL_LIB = os.path.join(os.path.expanduser("~"), ".local", "lib", "anolisa", "tokenless", "rtk")
+
+
 def resolve_binary(name: str, *fallback_paths: str) -> str | None:
     path = shutil.which(name)
     if path:

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -20,15 +20,11 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from hook_utils import resolve_binary, skip, warn
+from hook_utils import resolve_binary, skip, warn, _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB, _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB
 
 # -- constants ---------------------------------------------------------------
 
 _MIN_RTK_VERSION = (0, 35, 0)
-_RTK_FALLBACK = "/usr/libexec/anolisa/tokenless/rtk"
-_RTK_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "rtk")
-_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOKENLESS_LOCAL = os.path.join(os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless")
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
 
 _CONTEXT_DIR = os.path.join(os.path.expanduser("~"), ".tokenless")
@@ -64,7 +60,7 @@ def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
 
 def main() -> None:
     # 1. Resolve rtk binary
-    rtk_bin = resolve_binary("rtk", _RTK_FALLBACK, _RTK_LOCAL)
+    rtk_bin = resolve_binary("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB)
     if not rtk_bin:
         warn("rtk is not installed or not in PATH. Hook disabled.")
         skip()
@@ -83,7 +79,7 @@ def main() -> None:
         pass  # version check non-fatal
 
     # 3. Check tokenless binary (for stats)
-    if not resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL):
+    if not resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
         warn("tokenless is not installed. Hook disabled.")
         skip()
 

--- a/src/tokenless/adapters/tokenless/common/tool-ready-spec.json
+++ b/src/tokenless/adapters/tokenless/common/tool-ready-spec.json
@@ -52,8 +52,7 @@
     "recommended": [
       { "binary": "rtk", "version": ">=0.35", "package": "tokenless", "manager": "rpm",
         "fallback": [
-          { "method": "symlink", "binary": "rtk", "source": "/usr/libexec/anolisa/tokenless/rtk" },
-          { "method": "cargo", "binary": "rtk", "package": "rtk" }
+          { "method": "symlink", "binary": "rtk", "source": "/usr/libexec/anolisa/tokenless/rtk" }
         ]
       },
       { "binary": "tokenless", "package": "tokenless", "manager": "rpm",
@@ -64,7 +63,7 @@
       { "binary": "toon", "package": "tokenless", "manager": "rpm",
         "fallback": [
           { "method": "symlink", "binary": "toon", "source": "/usr/libexec/anolisa/tokenless/toon" },
-          { "method": "cargo", "binary": "toon", "package": "toon", "features": ["cli"] }
+          { "method": "cargo", "binary": "toon", "package": "toon-format" }
         ]
       },
       { "binary": "git", "package": "git", "manager": "rpm" },

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -38,7 +38,21 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from typing import Any
+
+# Import shared FHS constants from hook_utils
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common", "hooks"))
+from hook_utils import (
+    _TOKENLESS_FALLBACK,
+    _TOKENLESS_LOCAL_SHARE,
+    _TOKENLESS_LOCAL_LIB,
+    _RTK_FALLBACK,
+    _RTK_LOCAL_SHARE,
+    _RTK_LOCAL_LIB,
+    resolve_binary as _resolve_binary_shared,
+    warn as _warn_shared,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +72,6 @@ _SKIP_TOOLS: set[str] = {
     "list_sessions",
 }
 
-_TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_RTK_FALLBACK = "/usr/libexec/anolisa/tokenless/rtk"
 _MIN_RTK_VERSION = (0, 35, 0)
 _SHELL_TOOLS: set[str] = {"terminal"}
 
@@ -73,22 +85,23 @@ _CONTEXT_FILE = os.path.join(_CONTEXT_DIR, ".rewrite-context")
 _resolved: dict[str, str | None] = {}
 
 
-def _resolve_binary(name: str, fallback: str) -> str | None:
+def _resolve_binary(name: str, *fallback_paths: str) -> str | None:
     if name in _resolved:
         return _resolved[name]
     path = shutil.which(name)
     if path:
         _resolved[name] = path
         return path
-    if os.path.isfile(fallback) and os.access(fallback, os.X_OK):
-        _resolved[name] = fallback
-        return fallback
+    for fp in fallback_paths:
+        if os.path.isfile(fp) and os.access(fp, os.X_OK):
+            _resolved[name] = fp
+            return fp
     _resolved[name] = None
     return None
 
 
-def _have(name: str, fallback: str) -> bool:
-    return _resolve_binary(name, fallback) is not None
+def _have(name: str, *fallback_paths: str) -> bool:
+    return _resolve_binary(name, *fallback_paths) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +160,7 @@ def _compress_response(
     session_id: str,
     tool_call_id: str,
 ) -> str | None:
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
     if not tokenless_bin:
         return None
 
@@ -177,7 +190,7 @@ def _compress_response(
 
 
 def _encode_toon(data: str, session_id: str = "", tool_call_id: str = "") -> tuple[str, int] | None:
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
     if not tokenless_bin:
         return None
 
@@ -214,7 +227,7 @@ def _encode_toon(data: str, session_id: str = "", tool_call_id: str = "") -> tup
 
 def _env_check(tool_name: str) -> str | None:
     """Run tool-ready env-check and return feedback if tool is not ready."""
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
     if not tokenless_bin:
         return None
 
@@ -271,7 +284,7 @@ def _try_rewrite(
     executes the command.  On success, returns a block directive suggesting
     the rewritten command so the agent re-executes with the optimized version.
     """
-    rtk_bin = _resolve_binary("rtk", _RTK_FALLBACK)
+    rtk_bin = _resolve_binary("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB)
     if not rtk_bin:
         return None
 
@@ -364,7 +377,7 @@ def on_pre_tool_call(
     command (one extra round-trip; safe — rtk rewrite never executes).
     """
     # Step 1: env-check (all tools, needs tokenless)
-    if _have("tokenless", _TOKENLESS_FALLBACK):
+    if _have("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
         if session_id:
             os.environ["TOKENLESS_SESSION_ID"] = str(session_id)
         feedback = _env_check(tool_name)
@@ -373,7 +386,7 @@ def on_pre_tool_call(
             return {"action": "block", "message": feedback}
 
     # Step 2: RTK rewrite (terminal only, needs rtk)
-    if tool_name in _SHELL_TOOLS and _have("rtk", _RTK_FALLBACK):
+    if tool_name in _SHELL_TOOLS and _have("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB):
         result = _try_rewrite(args, str(session_id), str(tool_call_id))
         if result:
             return result
@@ -396,7 +409,7 @@ def on_transform_tool_result(
     Replaces the tool result string with a compressed/TOON-encoded version.
     Runs after post_tool_call; first valid string return wins.
     """
-    if not _have("tokenless", _TOKENLESS_FALLBACK):
+    if not _have("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
         return None
 
     # Skip content-retrieval tools
@@ -475,11 +488,11 @@ def register(ctx: Any) -> None:
 
     # Log what's active
     features: list[str] = []
-    if _have("tokenless", _TOKENLESS_FALLBACK):
+    if _have("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
         features.append("response-compression")
         features.append("toon-encoding")
         features.append("tool-ready")
-    if _have("rtk", _RTK_FALLBACK):
+    if _have("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB):
         features.append("rtk-rewrite")
 
     logger.info(

--- a/src/tokenless/adapters/tokenless/manifest.json
+++ b/src/tokenless/adapters/tokenless/manifest.json
@@ -4,6 +4,9 @@
   "targets": {
     "cosh": {
       "compatibleVersions": "*",
+      "method": "extension",
+      "extensionFile": "common/cosh-extension.json",
+      "extensionDir": "extensions/tokenless",
       "capabilities": {
         "hooks": [
           "tool-ready",

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -8,7 +8,7 @@
  *   2. Tokenless response compression — compresses tool responses via
  *      `tokenless compress-response` (removes debug/null/empty values).
  *   3. TOON context compression — encodes JSON tool responses to TOON format
- *      via `toon -e`, reducing token usage for structured data. When both
+ *      via `tokenless compress-toon`, reducing token usage for structured data. When both
  *      response and TOON compression are enabled, they run sequentially:
  *      Response Compression strips noise → TOON eliminates JSON format overhead.
  *
@@ -41,7 +41,8 @@ let tokenlessPath: string = "tokenless";
 
 const LIBEXEC_FALLBACK = "/usr/libexec/anolisa/tokenless";
 const TOKENLESS_FALLBACK = "/usr/bin/tokenless";
-const LOCAL_FALLBACK = `${process.env.HOME || ""}/.local/share/anolisa/tokenless`;
+const LOCAL_SHARE = `${process.env.HOME || ""}/.local/share/anolisa/tokenless`;
+const LOCAL_LIB = `${process.env.HOME || ""}/.local/lib/anolisa/tokenless`;
 
 // Check both existence and execute permission (mirrors shell `-x` test).
 function isExecutable(path: string): boolean {
@@ -62,8 +63,11 @@ function checkRtk(): boolean {
     } else if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
       rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
       rtkAvailable = true;
-    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/rtk`)) {
-      rtkPath = `${LOCAL_FALLBACK}/rtk`;
+    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/rtk`)) {
+      rtkPath = `${LOCAL_SHARE}/rtk`;
+      rtkAvailable = true;
+    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/rtk`)) {
+      rtkPath = `${LOCAL_LIB}/rtk`;
       rtkAvailable = true;
     } else {
       rtkAvailable = false;
@@ -72,8 +76,11 @@ function checkRtk(): boolean {
     if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
       rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
       rtkAvailable = true;
-    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/rtk`)) {
-      rtkPath = `${LOCAL_FALLBACK}/rtk`;
+    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/rtk`)) {
+      rtkPath = `${LOCAL_SHARE}/rtk`;
+      rtkAvailable = true;
+    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/rtk`)) {
+      rtkPath = `${LOCAL_LIB}/rtk`;
       rtkAvailable = true;
     } else {
       rtkAvailable = false;
@@ -104,8 +111,11 @@ function checkTokenless(): boolean {
     } else if (isExecutable(TOKENLESS_FALLBACK)) {
       tokenlessPath = TOKENLESS_FALLBACK;
       tokenlessAvailable = true;
-    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/tokenless`)) {
-      tokenlessPath = `${LOCAL_FALLBACK}/tokenless`;
+    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/tokenless`)) {
+      tokenlessPath = `${LOCAL_SHARE}/tokenless`;
+      tokenlessAvailable = true;
+    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/tokenless`)) {
+      tokenlessPath = `${LOCAL_LIB}/tokenless`;
       tokenlessAvailable = true;
     } else {
       tokenlessAvailable = false;
@@ -114,8 +124,11 @@ function checkTokenless(): boolean {
     if (isExecutable(TOKENLESS_FALLBACK)) {
       tokenlessPath = TOKENLESS_FALLBACK;
       tokenlessAvailable = true;
-    } else if (LOCAL_FALLBACK && isExecutable(`${LOCAL_FALLBACK}/tokenless`)) {
-      tokenlessPath = `${LOCAL_FALLBACK}/tokenless`;
+    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/tokenless`)) {
+      tokenlessPath = `${LOCAL_SHARE}/tokenless`;
+      tokenlessAvailable = true;
+    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/tokenless`)) {
+      tokenlessPath = `${LOCAL_LIB}/tokenless`;
       tokenlessAvailable = true;
     } else {
       tokenlessAvailable = false;
@@ -349,7 +362,7 @@ export default {
         let usedToon = false;
         let toonText = "";
 
-        if (toonCompressionEnabled && checkToon()) {
+        if (toonCompressionEnabled && checkTokenless()) {
           const result = tryCompressToon(currentMessage, sessionId, toolCallId);
           if (result) {
             toonText = result.toonText;

--- a/src/tokenless/adapters/tokenless/openclaw/package.json
+++ b/src/tokenless/adapters/tokenless/openclaw/package.json
@@ -8,7 +8,7 @@
     "extensions": ["./index.js"]
   },
   "peerDependencies": {
-    "rtk": ">=0.28.0",
+    "rtk": ">=0.35.0",
     "tokenless": ">=0.1.0"
   },
   "files": ["index.js", "openclaw.plugin.json"],

--- a/src/tokenless/crates/tokenless-cli/Cargo.toml
+++ b/src/tokenless/crates/tokenless-cli/Cargo.toml
@@ -12,11 +12,11 @@ path = "src/main.rs"
 [dependencies]
 tokenless-schema = { path = "../tokenless-schema" }
 tokenless-stats = { path = "../tokenless-stats" }
-dirs = "5.0"
+dirs.workspace = true
 clap.workspace = true
 serde_json.workspace = true
+toon-format.workspace = true
 chrono = { workspace = true, features = ["serde"] }
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite.workspace = true
+libc.workspace = true
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -16,6 +16,12 @@ use std::process::Command;
 use std::os::unix::fs::MetadataExt;
 
 #[cfg(unix)]
+fn current_uid() -> u32 {
+    // libc::getuid is a FFI call — requires unsafe block per Rust 2024 edition rules.
+    unsafe { libc::getuid() }
+}
+
+#[cfg(unix)]
 fn is_trusted_path(path: &std::path::Path) -> bool {
     // System paths are always trusted
     if path.starts_with("/usr/share")
@@ -46,7 +52,7 @@ fn is_trusted_path(path: &std::path::Path) -> bool {
     match fs::symlink_metadata(&check_path) {
         Ok(meta) => {
             let file_uid = meta.uid();
-            let current_uid = unsafe { libc::getuid() };
+            let current_uid = current_uid();
             if file_uid != current_uid && file_uid != 0 {
                 return false;
             }

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -179,7 +179,7 @@ fn run() -> Result<(), (String, i32)> {
         } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
             let value: serde_json::Value = serde_json::from_str(&input)
-                .map_err(|e| (format!("JSON parse error: {}", e), 1))?;
+                .map_err(|e| (format!("JSON parse error: {}", e), 2))?;
 
             let compressor = SchemaCompressor::new();
 
@@ -232,7 +232,7 @@ fn run() -> Result<(), (String, i32)> {
         } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
             let value: serde_json::Value = serde_json::from_str(&input)
-                .map_err(|e| (format!("JSON parse error: {}", e), 1))?;
+                .map_err(|e| (format!("JSON parse error: {}", e), 2))?;
 
             let compressor = ResponseCompressor::new();
             let result_json = serde_json::to_string_pretty(&compressor.compress(&value))
@@ -358,33 +358,11 @@ fn run() -> Result<(), (String, i32)> {
             tool_use_id,
         } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
-            let mut child = std::process::Command::new("toon")
-                .arg("-e")
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .spawn()
-                .map_err(|e| (format!("Failed to spawn toon: {}", e), 2))?;
-            use std::io::Write;
-            if let Some(mut stdin) = child.stdin.take() {
-                stdin
-                    .write_all(input.as_bytes())
-                    .map_err(|e| (format!("Failed to write to toon stdin: {}", e), 2))?;
-            }
-            let out = child
-                .wait_with_output()
-                .map_err(|e| (format!("Failed to wait for toon: {}", e), 2))?;
-            if !out.status.success() {
-                return Err((
-                    format!(
-                        "toon encode failed: {}",
-                        String::from_utf8_lossy(&out.stderr)
-                    ),
-                    2,
-                ));
-            }
-            let output = String::from_utf8_lossy(&out.stdout);
-            let output = output.trim_end();
+            let value: serde_json::Value = serde_json::from_str(&input)
+                .map_err(|e| (format!("JSON parse error: {}", e), 2))?;
+            let output = toon_format::encode_default(&value)
+                .map_err(|e| (format!("toon encode failed: {}", e), 2))?;
+            let output = output.trim_end().to_string();
 
             // If no token savings, output original instead of TOON result
             let before_tokens = estimate_tokens_from_bytes(input.len());
@@ -392,7 +370,7 @@ fn run() -> Result<(), (String, i32)> {
             let display = if output.is_empty() || after_tokens >= before_tokens {
                 input.clone()
             } else {
-                output.to_string()
+                output
             };
             println!("{}", display);
 
@@ -407,33 +385,11 @@ fn run() -> Result<(), (String, i32)> {
         }
         Commands::DecompressToon { file } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
-            let mut child = std::process::Command::new("toon")
-                .arg("-d")
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .spawn()
-                .map_err(|e| (format!("Failed to spawn toon: {}", e), 2))?;
-            use std::io::Write;
-            if let Some(mut stdin) = child.stdin.take() {
-                stdin
-                    .write_all(input.as_bytes())
-                    .map_err(|e| (format!("Failed to write to toon stdin: {}", e), 2))?;
-            }
-            let out = child
-                .wait_with_output()
-                .map_err(|e| (format!("Failed to wait for toon: {}", e), 2))?;
-            if !out.status.success() {
-                return Err((
-                    format!(
-                        "toon decode failed: {}",
-                        String::from_utf8_lossy(&out.stderr)
-                    ),
-                    2,
-                ));
-            }
-            let output = String::from_utf8_lossy(&out.stdout);
-            let output = output.trim_end();
+            let value: serde_json::Value = toon_format::decode_default(&input)
+                .map_err(|e| (format!("toon decode failed: {}", e), 2))?;
+            let output = serde_json::to_string_pretty(&value)
+                .map_err(|e| (format!("Serialization error: {}", e), 2))?;
+            let output = output.trim_end().to_string();
             if !output.is_empty() {
                 println!("{}", output);
             }

--- a/src/tokenless/crates/tokenless-stats/Cargo.toml
+++ b/src/tokenless/crates/tokenless-stats/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "tokenless-stats"
-version = "0.3.2"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Statistics tracking for tokenless - SQLite-based metrics storage"
-license = "MIT OR Apache-2.0"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
-rusqlite = { version = "0.31", features = ["bundled"] }
-thiserror = "1.0"
-dirs = "5.0"
+serde.workspace = true
+serde_json.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+rusqlite.workspace = true
+thiserror.workspace = true
+dirs.workspace = true

--- a/src/tokenless/docs/response-compression.md
+++ b/src/tokenless/docs/response-compression.md
@@ -84,7 +84,7 @@ Step 2：echo "$COMPRESSED" | tokenless compress-toon（无损 TOON 编码）
 **流水线说明**：copilot-shell 的 PostToolUse hook 中实现了一个**两阶段链式压缩流水线**：
 
 1. **第一阶段 — 响应压缩（有损）**：`ResponseCompressor` 移除 debug 字段、null 值、空值，截断过长字符串和数组。
-2. **第二阶段 — TOON 编码（无损）**：将第一阶段输出的 JSON 通过 `toon -e` 编码为紧凑的二进制 TOON 格式，消除 JSON 语法开销（引号、逗号、冒号、花括号）。
+2. **第二阶段 — TOON 编码（无损）**：将第一阶段输出的 JSON 通过 `toon_format::encode_default()` 编码为紧凑的二进制 TOON 格式，消除 JSON 语法开销（引号、逗号、冒号、花括号）。
 
 两个阶段各自独立，任一步骤失败都不影响原始结果的透传（fail-open）。
 
@@ -269,7 +269,7 @@ curl -s https://api.example.com/data | tokenless compress-response
 | OpenClaw 插件 | `adapters/tokenless/openclaw/index.ts` |
 | OpenClaw 插件配置 | `adapters/tokenless/openclaw/openclaw.plugin.json` |
 | copilot-shell hook（响应+TOON 流水线） | `adapters/tokenless/common/hooks/compress_response_hook.py` |
-| TOON 编解码器（子模块） | `third_party/toon/` |
+| TOON 编解码器（crates.io toon-format） | `toon-format` crate v0.4.6 |
 | 集成测试 | `crates/tokenless-schema/tests/integration_test.rs` |
 | TOON E2E 测试 | `tests/test-toon-full.sh` |
 | 全量测试套件 | `tests/run-all-tests.sh` |

--- a/src/tokenless/docs/tokenless-user-manual-en.md
+++ b/src/tokenless/docs/tokenless-user-manual-en.md
@@ -2,10 +2,10 @@
 
 > LLM token optimization toolkit — Schema/Response Compression + Command Rewriting + TOON Format
 
-**Version**: 0.1.0  
+**Version**: 0.3.2  
 **Source**: https://code.alibaba-inc.com/Agentic-OS/Token-Less  
 **RPM Source**: https://code.alibaba-inc.com/alinux/tokenless  
-**System Requirements**: Rust 1.70+, Linux (Alinux 4 recommended)
+**System Requirements**: Rust 1.89+ (edition 2024), Linux (Alinux 4 recommended), just (build runner)
 
 ---
 
@@ -62,9 +62,9 @@ Token-Less/
 ├── crates/tokenless-schema/   # Core library: SchemaCompressor + ResponseCompressor
 ├── crates/tokenless-cli/      # CLI binary: tokenless command
 ├── crates/tokenless-stats/    # Stats recording library (SQLite)
-├── adapters/tokenless/        # FHS adapter bundle (manifest, common, cosh, openclaw)
-├── third_party/rtk/           # RTK submodule (command rewriting engine)
-├── third_party/toon/          # TOON submodule (binary JSON codec)
+├── adapters/tokenless/        # FHS adapter bundle (manifest, common, openclaw, hermes)
+├── third_party/rtk/           # RTK vendored source (justfile clone+patch)
+├── third_party/patches/      # Patches for vendored third_party sources
 ├── Makefile                   # Unified build system
 └── docs/                      # Documentation
 ```
@@ -152,7 +152,7 @@ Integrates [RTK](https://github.com/rtk-ai/rtk) to filter and rewrite CLI comman
 
 TOON (Token-Oriented Object Notation) is a **lossless binary JSON codec** that eliminates JSON syntax overhead — quotes, commas, colons, and braces — while preserving all data intact. It is particularly effective for structured and tabular data where syntax overhead dominates content.
 
-**Source Location**: Integrated via `third_party/toon/` submodule, invoked as a subprocess from the CLI.
+**Source Location**: Integrated via `toon-format` crate (crates.io v0.4.6), called directly as a Rust library by the CLI. The standalone `toon` binary is used by Python hooks as a subprocess.
 
 #### How TOON Works
 
@@ -199,11 +199,12 @@ This two-stage pipeline maximizes savings: response compression strips verbose/d
 
 | Dependency | Version | Purpose | Required |
 |------------|---------|---------|----------|
-| Rust | >= 1.70 (stable) | Compile tokenless and rtk | Build time only |
-| Git | Any | Submodule management | Build time only |
+| Rust | >= 1.89 (edition 2024) | Compile tokenless and rtk | Build time only |
+| Git | Any | rtk source download (justfile) | Build time only |
+| just | Any | Build orchestration (rtk clone+patch) | Build time only |
 | jq | Any | Hook script JSON processing | Yes |
-| rtk | >= 0.28.0 | Command rewriting | Optional |
-| toon | >= 0.1.0 | TOON format compression | Optional |
+| rtk | >= 0.35.0 | Command rewriting | Optional |
+| toon | >= 0.4.0 | TOON format compression | Optional |
 | tokenless | >= 0.1.0 | Schema/Response compression | Optional |
 | sqlite3 | Any | Stats database | Optional |
 
@@ -268,8 +269,8 @@ cat ~/.openclaw/openclaw.json | jq '.plugins.allow'
 ### 4.2 Method 2: One-Click Source Installation
 
 ```bash
-# Clone repository (including submodules)
-git clone --recursive https://code.alibaba-inc.com/Agentic-OS/Token-Less
+# Clone repository (no submodules needed, rtk is downloaded at build time via justfile)
+git clone https://code.alibaba-inc.com/Agentic-OS/Token-Less
 cd Token-Less
 
 # Full installation: build + install binaries + deploy OpenClaw plugin + Copilot Shell Hook
@@ -286,7 +287,7 @@ make setup
 make openclaw-install
 
 # Install copilot-shell hooks only
-make cosh-install
+make cosh-extension-install
 ```
 
 ### 4.4 Method 4: Step-by-Step Installation
@@ -294,14 +295,11 @@ make cosh-install
 #### 4.4.1 Build
 
 ```bash
-# Build tokenless + rtk (release mode)
+# Build tokenless + rtk (release mode, rtk cloned+patched via justfile)
 make build
 
-# Build tokenless only
+# Build tokenless + rtk only
 make build-tokenless
-
-# Build rtk only
-make build-rtk
 ```
 
 #### 4.4.2 Install Binaries
@@ -331,7 +329,7 @@ cp -r adapters/tokenless/openclaw/ /usr/share/anolisa/adapters/tokenless/opencla
 
 ```bash
 # Using Makefile
-make copilot-shell-install
+make cosh-extension-install
 
 # Manual installation
 mkdir -p ~/.local/share/anolisa/adapters/tokenless/common/hooks
@@ -802,20 +800,21 @@ jq --version
 | Command | Function |
 |---------|----------|
 | `make build` | Build tokenless + rtk |
-| `make build-tokenless` | Build tokenless only |
-| `make build-rtk` | Build rtk only |
-| `make build-toon` | Build TOON codec from submodule |
+| `make build-tokenless` | Build tokenless + rtk (via justfile) |
+| `make build-toon` | Install TOON binary via `cargo install toon-format` |
 | `make install` | Install binaries to BIN_DIR (default: ~/.local/bin) |
 | `make test` | Run tests |
-| `make test-toon` | Run TOON-specific tests |
 | `make lint` | Run clippy checks |
 | `make fmt` | Format code |
 | `make clean` | Clean build artifacts |
+| `make adapter-install` | Install all adapters (cosh+openclaw+hermes) |
 | `make openclaw-install` | Install OpenClaw plugin |
 | `make openclaw-uninstall` | Uninstall OpenClaw plugin |
-| `make copilot-shell-install` | Install Copilot Shell Hook |
-| `make copilot-shell-uninstall` | Uninstall Copilot Shell Hook |
-| `make setup` | Full installation: build + install + plugin deployment |
+| `make hermes-install` | Install Hermes Agent plugin |
+| `make hermes-uninstall` | Uninstall Hermes Agent plugin |
+| `make cosh-extension-install` | Install Copilot Shell Hook |
+| `make cosh-extension-uninstall` | Uninstall Copilot Shell Hook |
+| `make setup` | Full installation: build + install + adapter deployment |
 
 ### 8.2 Key File Paths
 
@@ -834,7 +833,7 @@ jq --version
 | Tool Ready hook | `adapters/tokenless/common/hooks/tool_ready_hook.sh` |
 | Tool dependency spec | `adapters/tokenless/common/tool-ready-spec.json` |
 | Auto-fix script | `adapters/tokenless/common/tokenless-env-fix.sh` |
-| TOON codec (submodule) | `third_party/toon/` |
+| TOON codec (crates.io toon-format) | `toon-format` crate v0.4.6 |
 | Stats database (default) | `~/.tokenless/stats.db` |
 | Integration tests | `crates/tokenless-schema/tests/integration_test.rs` |
 | TOON E2E tests | `tests/test-toon-full.sh` |

--- a/src/tokenless/docs/tokenless-user-manual-zh.md
+++ b/src/tokenless/docs/tokenless-user-manual-zh.md
@@ -2,10 +2,10 @@
 
 > LLM token optimization toolkit — Schema/Response 压缩 + 命令重写 + TOON 格式
 
-**版本**：0.1.0
+**版本**：0.3.2
 **源码**：https://code.alibaba-inc.com/Agentic-OS/Token-Less
 **RPM 源码**：https://code.alibaba-inc.com/alinux/tokenless
-**系统要求**：Rust 1.70+, Linux (推荐 Alinux 4)
+**系统要求**：Rust 1.89+ (edition 2024), Linux (推荐 Alinux 4)
 
 ---
 
@@ -62,9 +62,9 @@ Token-Less/
 ├── crates/tokenless-schema/   # 核心库：SchemaCompressor + ResponseCompressor
 ├── crates/tokenless-cli/      # CLI 二进制：tokenless 命令
 ├── crates/tokenless-stats/    # 统计记录库（SQLite）
-├── adapters/tokenless/        # FHS 适配器包（manifest, common, cosh, openclaw）
-├── third_party/rtk/           # RTK 子模块（命令重写引擎）
-├── third_party/toon/          # TOON 子模块（二进制 JSON 编解码器）
+├── adapters/tokenless/        # FHS 适配器包（manifest, common, openclaw, hermes）
+├── third_party/rtk/           # RTK 外部源码（justfile clone+patch）
+├── third_party/patches/      # 外部源码补丁
 ├── Makefile                   # 统一构建系统
 └── docs/                      # 文档
 ```
@@ -152,7 +152,7 @@ Token-Less/
 
 TOON（Token-Oriented Object Notation）是一种**无损二进制 JSON 编解码器**，通过消除 JSON 语法开销（引号、逗号、冒号、花括号）来减少 token 消耗，同时完整保留所有数据。对于结构化数据和表格数据效果尤为显著。
 
-**源码位置**：通过 `third_party/toon/` 子模块集成，由 CLI 作为子进程调用。
+**源码位置**：通过 `toon-format` crate（crates.io v0.4.6）集成，由 CLI 作为库直接调用。独立 `toon` 二进制用于 Python hooks 子进程调用。
 
 #### TOON 工作原理
 
@@ -199,11 +199,12 @@ TOON 将 JSON 的文本语法替换为紧凑的二进制编码：
 
 | 依赖 | 版本要求 | 用途 | 必需 |
 |------|---------|------|------|
-| Rust | >= 1.70 (stable) | 编译 tokenless 和 rtk | 构建时需要 |
-| Git | 任意 | 子模块管理 | 构建时需要 |
+| Rust | >= 1.89 (edition 2024) | 编译 tokenless 和 rtk | 构建时需要 |
+| Git | 任意 | rtk 源码下载（justfile） | 构建时需要 |
+| just | 任意 | 构建编排（rtk clone+patch） | 构建时需要 |
 | jq | 任意 | Hook 脚本 JSON 处理 | 是 |
-| rtk | >= 0.28.0 | 命令重写 | 可选 |
-| toon | >= 0.1.0 | TOON 格式压缩 | 可选 |
+| rtk | >= 0.35.0 | 命令重写 | 可选 |
+| toon | >= 0.4.0 | TOON 格式压缩 | 可选 |
 | tokenless | >= 0.1.0 | Schema/响应压缩 | 可选 |
 | sqlite3 | 任意 | 统计数据库 | 可选 |
 
@@ -268,8 +269,8 @@ cat ~/.openclaw/openclaw.json | jq '.plugins.allow'
 ### 4.2 方法二：源码一键安装
 
 ```bash
-# 克隆仓库（包含子模块）
-git clone --recursive https://code.alibaba-inc.com/Agentic-OS/Token-Less
+# 克隆仓库（无需子模块，rtk 构建时由 justfile 下载）
+git clone https://code.alibaba-inc.com/Agentic-OS/Token-Less
 cd Token-Less
 
 # 完整安装：编译 + 安装二进制 + 部署 OpenClaw 插件 + Copilot Shell Hook
@@ -286,7 +287,7 @@ make setup
 make openclaw-install
 
 # 仅安装 copilot-shell hooks
-make cosh-install
+make cosh-extension-install
 ```
 
 ### 4.4 方法四：分步安装
@@ -294,14 +295,11 @@ make cosh-install
 #### 4.4.1 编译
 
 ```bash
-# 编译 tokenless + rtk（release 模式）
+# 编译 tokenless + rtk（release 模式，rtk 通过 justfile clone+patch）
 make build
 
-# 仅编译 tokenless
+# 仅编译 tokenless + rtk
 make build-tokenless
-
-# 仅编译 rtk
-make build-rtk
 ```
 
 #### 4.4.2 安装二进制文件
@@ -331,7 +329,7 @@ cp -r adapters/tokenless/openclaw/ /usr/share/anolisa/adapters/tokenless/opencla
 
 ```bash
 # 使用 Makefile
-make copilot-shell-install
+make cosh-extension-install
 
 # 手动安装
 mkdir -p ~/.local/share/anolisa/adapters/tokenless/common/hooks
@@ -802,20 +800,20 @@ jq --version
 | 命令 | 功能 |
 |------|------|
 | `make build` | 编译 tokenless + rtk |
-| `make build-tokenless` | 仅编译 tokenless |
-| `make build-rtk` | 仅编译 rtk |
-| `make build-toon` | 从子模块编译 TOON 编解码器 |
+| `make build-tokenless` | 编译 tokenless + rtk（通过 justfile） |
+| `make build-toon` | 安装 TOON 二进制（cargo install toon-format） |
 | `make install` | 安装二进制到 BIN_DIR（默认 ~/.local/bin） |
 | `make test` | 运行测试 |
-| `make test-toon` | 运行 TOON 专项测试 |
 | `make lint` | 运行 clippy 检查 |
 | `make fmt` | 格式化代码 |
 | `make clean` | 清理构建产物 |
 | `make openclaw-install` | 安装 OpenClaw 插件 |
 | `make openclaw-uninstall` | 卸载 OpenClaw 插件 |
-| `make copilot-shell-install` | 安装 Copilot Shell Hook |
-| `make copilot-shell-uninstall` | 卸载 Copilot Shell Hook |
-| `make setup` | 完整安装：编译 + 安装 + 插件部署 |
+| `make hermes-install` | 安装 Hermes Agent 插件 |
+| `make hermes-uninstall` | 卸载 Hermes Agent 插件 |
+| `make cosh-extension-install` | 安装 Copilot Shell Hook |
+| `make cosh-extension-uninstall` | 卸载 Copilot Shell Hook |
+| `make setup` | 完整安装：编译 + 安装 + 适配器部署 |
 
 ### 8.2 关键文件路径
 
@@ -834,7 +832,7 @@ jq --version
 | Tool Ready hook | `adapters/tokenless/common/hooks/tool_ready_hook.sh` |
 | 工具依赖 spec | `adapters/tokenless/common/tool-ready-spec.json` |
 | 自动修复脚本 | `adapters/tokenless/common/tokenless-env-fix.sh` |
-| TOON 编解码器（子模块） | `third_party/toon/` |
+| TOON 编解码器（crates.io toon-format） | `toon-format` crate v0.4.6 |
 | 统计数据库（默认） | `~/.tokenless/stats.db` |
 | 集成测试 | `crates/tokenless-schema/tests/integration_test.rs` |
 | TOON 端到端测试 | `tests/test-toon-full.sh` |

--- a/src/tokenless/justfile
+++ b/src/tokenless/justfile
@@ -1,0 +1,60 @@
+# Tokenless build orchestration
+# Usage: just build       (setup rtk + build all)
+#        just setup-rtk   (clone + patch rtk only)
+#        just build-toon  (install toon binary)
+
+rtk_tag   := "v0.36.0"
+toon_ver  := "0.4.6"
+rtk_dir   := "third_party/rtk"
+patch_dir := "third_party/patches"
+
+# Default: list available recipes
+default:
+    @just --list
+
+# Clone rtk from GitHub and apply tokenless stats patch
+setup-rtk:
+    @if [ ! -f {{rtk_dir}}/Cargo.toml ]; then \
+        echo "Cloning rtk {{rtk_tag}} from GitHub..."; \
+        git clone --depth 1 --branch {{rtk_tag}} \
+            https://github.com/rtk-ai/rtk.git {{rtk_dir}}; \
+        echo "Applying tokenless stats patch..."; \
+        patch --forward -p1 --no-backup-if-mismatch \
+            -d {{rtk_dir}} < {{patch_dir}}/rtk-tokenless-stats.patch && \
+        echo "rtk setup complete."; \
+    else \
+        echo "rtk already set up ({{rtk_dir}}/Cargo.toml exists)."; \
+    fi
+
+# Remove cloned rtk directory (use when switching versions or re-patching)
+clean-rtk:
+    rm -rf {{rtk_dir}}
+    @echo "rtk directory removed. Run 'just setup-rtk' to re-clone."
+
+# Build tokenless (requires setup-rtk for rtk binary)
+build: setup-rtk
+    cargo build --release
+    cargo build --release --manifest-path {{rtk_dir}}/Cargo.toml
+
+# Build toon (standalone binary, installed via cargo install)
+build-toon:
+    cargo install toon-format --version {{toon_ver}} --locked
+
+# Build everything (tokenless + rtk + toon)
+build-all: build build-toon
+
+# Run tokenless crate tests (rtk excluded — vendored third-party)
+test: setup-rtk
+    cargo test -p tokenless-cli -p tokenless-schema -p tokenless-stats
+
+# Clean build artifacts
+clean:
+    cargo clean --release
+
+# Verify all binaries are built
+verify: build-all
+    @echo ""
+    @echo "=== Verification ==="
+    target/release/tokenless --version || echo "tokenless: FAILED"
+    {{rtk_dir}}/target/release/rtk --version || echo "rtk: FAILED"
+    toon --version || echo "toon: FAILED"

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -477,7 +477,7 @@ test_tool_ready() {
     local astral_out=$(bash "$FIX_SCRIPT" fix '{"binary":"uv","package":"uv","manager":"pip","fallback":[{"method":"curl_pipe_sh","url":"https://astral.sh/uv/install.sh"}]}' 2>&1)
     ! echo "$astral_out" | grep -q "untrusted URL" && log_pass "astral.sh is whitelisted" || log_fail "astral.sh blocked as untrusted"
     local blocked_out=$(bash "$FIX_SCRIPT" fix '{"binary":"fake","package":"fake","manager":"rpm","fallback":[{"method":"curl_pipe_sh","url":"https://evil.example.com/install.sh"}]}' 2>&1)
-    assert_contains "$blocked_out" "untrusted URL" "Non-whitelisted domain is blocked"
+    assert_contains "$blocked_out" "untrusted" "Non-whitelisted domain is blocked"
 
     # ==========================================
     # 6.20 env-fix script: timeout on curl_pipe_sh

--- a/src/tokenless/tests/test-toon-full.sh
+++ b/src/tokenless/tests/test-toon-full.sh
@@ -47,7 +47,7 @@ for cmd in toon tokenless jq openclaw; do
 done
 
 # 检查 OpenClaw 插件
-if [ -f ~/.openclaw/extensions/tokenless/index.js ]; then
+if [ -f ~/.openclaw/extensions/tokenless-openclaw/index.js ]; then
     pass "OpenClaw 插件文件存在"
 else
     fail "OpenClaw 插件文件缺失"

--- a/src/tokenless/tests/test-toon.sh
+++ b/src/tokenless/tests/test-toon.sh
@@ -232,7 +232,7 @@ if [ -f ~/.openclaw/extensions/tokenless-openclaw/index.js ]; then pass "插件 
 else fail "插件 JS 文件不存在"; fi
 
 info "8.2: 插件包含 toon 检测逻辑"
-if grep -q "checkToon" ~/.openclaw/extensions/tokenless-openclaw/index.js; then pass "插件包含 toon 检测"
+if grep -q "checkTokenless" ~/.openclaw/extensions/tokenless-openclaw/index.js; then pass "插件包含 tokenless 检测"
 else fail "插件缺少 toon 检测"; fi
 
 info "8.3: 插件包含 toon 压缩函数"

--- a/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
+++ b/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
@@ -1,24 +1,26 @@
 diff --git a/src/core/tracking.rs b/src/core/tracking.rs
-index 982c937..5e60a58 100644
+index 982c937..175d0bf 100644
 --- a/src/core/tracking.rs
 +++ b/src/core/tracking.rs
 @@ -1294,6 +1294,9 @@ impl TimedExecution {
          let input_tokens = estimate_tokens(input);
-         let output_tokens = estimate_tokens(output);
- 
+         let output_tokens = estimate_tokens(output)
+
 +        // Also record to tokenless stats database (fail-silent)
 +        record_to_tokenless_stats(original_cmd, rtk_cmd, input, output);
 +
          if let Ok(tracker) = Tracker::new() {
              let _ = tracker.record(
                  original_cmd,
-@@ -1355,6 +1358,150 @@ pub fn args_display(args: &[OsString]) -> String {
+@@ -1355,6 +1358,159 @@ pub fn args_display(args: &[OsString]) -> String {
          .join(" ")
  }
- 
+
 +/// Estimate token count from character count using ~4 chars/token heuristic.
 +fn estimate_tokens_from_chars(chars: usize) -> usize {
-+    if chars == 0 { return 0; }
++    if chars == 0 {
++        return 0;
++    }
 +    chars.div_ceil(4)
 +}
 +
@@ -52,8 +54,16 @@ index 982c937..5e60a58 100644
 +        } else {
 +            "cli".to_string()
 +        };
-+        let sid = if session.is_empty() { None } else { Some(session) };
-+        let tuid = if toolcall.is_empty() { None } else { Some(toolcall) };
++        let sid = if session.is_empty() {
++            None
++        } else {
++            Some(session)
++        };
++        let tuid = if toolcall.is_empty() {
++            None
++        } else {
++            Some(toolcall)
++        };
 +        return (agent, sid, tuid);
 +    }
 +
@@ -90,13 +100,12 @@ index 982c937..5e60a58 100644
 +
 +    let (agent_id, session_id, tool_use_id) = resolve_tokenless_context();
 +
-+    let db_path = std::env::var("TOKENLESS_STATS_DB")
-+        .unwrap_or_else(|_| {
-+            format!(
-+                "{}/.tokenless/stats.db",
-+                std::env::var("HOME").unwrap_or_else(|_| ".".to_string())
-+            )
-+        });
++    let db_path = std::env::var("TOKENLESS_STATS_DB").unwrap_or_else(|_| {
++        format!(
++            "{}/.tokenless/stats.db",
++            std::env::var("HOME").unwrap_or_else(|_| ".".to_string())
++        )
++    });
 +
 +    let before_chars = raw_output.len();
 +    let after_chars = filtered_output.len();
@@ -163,3 +172,43 @@ index 982c937..5e60a58 100644
  #[cfg(test)]
  mod tests {
      use super::*;
+diff --git a/src/hooks/constants.rs b/src/hooks/constants.rs
+index 20f29e5..57df255 100644
+--- a/src/hooks/constants.rs
++++ b/src/hooks/constants.rs
+@@ -8,7 +8,11 @@ pub const HOOKS_JSON: &str = "hooks.json";
+ pub const PRE_TOOL_USE_KEY: &str = "PreToolUse";
+ pub const BEFORE_TOOL_KEY: &str = "BeforeTool"
+
++#[allow(dead_code)]
+ pub const OPENCODE_PLUGIN_PATH: &str = ".config/opencode/plugins/rtk.ts";
++#[allow(dead_code)]
+ pub const CURSOR_DIR: &str = ".cursor";
++#[allow(dead_code)]
+ pub const CODEX_DIR: &str = ".codex";
++#[allow(dead_code)]
+ pub const GEMINI_DIR: &str = ".gemini";
+diff --git a/src/hooks/hook_check.rs b/src/hooks/hook_check.rs
+index 7bba2a2..c0e5f76 100644
+--- a/src/hooks/hook_check.rs
++++ b/src/hooks/hook_check.rs
+@@ -1,5 +1,6 @@
+ //! Detects whether RTK hooks are installed and warns if they are outdated.
+
++#[allow(unused_imports)]
+ use super::constants::{
+     CLAUDE_DIR, CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, HOOKS_SUBDIR,
+     OPENCODE_PLUGIN_PATH, REWRITE_HOOK_FILE,
+diff --git a/src/main.rs b/src/main.rs
+index f5a7e9d..7f600f9 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -2097,7 +2097,9 @@ fn run_cli() -> Result<i32> {
+                     libc::raise(sig);
+                 }
+                 unsafe {
++                    #[allow(function_casts_as_integer)]
+                     libc::signal(libc::SIGINT, handle_signal as libc::sighandler_t);
++                    #[allow(function_casts_as_integer)]
+                     libc::signal(libc::SIGTERM, handle_signal as libc::sighandler_t);
+                 }

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -11,10 +11,14 @@ URL:            https://github.com/alibaba/anolisa
 Source0:        %{name}-%{version}.tar.gz
 
 # Build dependencies
-# Note: toon submodule requires rust >= 1.88 (darling, image, time crates)
-# cargo build for toon uses || true fallback in spec if Rust < 1.88
+# Note: workspace edition = 2024 (rust >= 1.85); rtk requires >= 1.86.
+# The 1.89 minimum is set because tokenless-cli uses str::floor_char_boundary
+# (stable since 1.89) via a hand-written compat fallback, and CI pins 1.89.0
+# to avoid local/CI version divergence. Vendored rtk source in tarball.
+# toon-format built via cargo install (requires network access to crates.io or mirror).
+# RPM build environments must configure a crates.io mirror (e.g. sparse+https://mirrors.aliyun.com/crates.io-index/).
 BuildRequires:  cargo
-BuildRequires:  rust >= 1.88
+BuildRequires:  rust >= 1.89
 
 # Runtime dependencies
 Requires:       python3
@@ -36,8 +40,8 @@ Core Features:
 
 The package includes:
 - tokenless: CLI tool for schema/response compression and toon integration
-- rtk: High-performance CLI proxy for command rewriting (Apache-2.0 licensed)
-- toon: JSON to TOON format encoder/decoder for LLM token optimization
+- rtk: High-performance CLI proxy for command rewriting (vendored source, Apache-2.0, excluded from workspace)
+- toon: JSON to TOON format encoder/decoder (crates.io toon-format v0.4.6)
 
 Note: OpenClaw plugin is available under /usr/share/anolisa/adapters/tokenless/openclaw/.
 Copilot-shell extension is auto-discovered from /usr/share/anolisa/extensions/tokenless/.
@@ -48,24 +52,19 @@ Run the install script to register with Hermes: hermes/scripts/install.sh
 %prep
 %setup -q -n tokenless
 
+# rtk source in tarball is already patched (rtk-tokenless-stats.patch
+# applied during tarball creation via justfile setup-rtk).
+
 # Clean any stale build artifacts from the tarball
 cargo clean --release
-cargo clean --release --manifest-path third_party/rtk/Cargo.toml
-# Do NOT clean toon target — may contain pre-built binary (Rust < 1.88 fallback)
-
-# Apply tokenless stats patch to RTK (upstream rtk v0.36.0)
-# Patch is included in the tarball under third_party/patches/
-patch --forward -p1 --no-backup-if-mismatch -d third_party/rtk < third_party/patches/rtk-tokenless-stats.patch
 
 %build
-# Build tokenless (schema + response compression + stats + env-check)
+# Build tokenless (rtk excluded from workspace — built separately)
 cargo build --release
-
-# Build rtk (command rewriting)
 cargo build --release --manifest-path third_party/rtk/Cargo.toml
 
-# toon requires rust >= 1.88; use pre-built binary if cargo build fails
-cargo build --release --manifest-path third_party/toon/Cargo.toml --features cli || true
+# Build toon (standalone binary for Python hooks)
+cargo install toon-format --version 0.4.6 --root %{_builddir}/toon-root --locked
 
 # Compile OpenClaw TypeScript plugin to JS (from adapters/ bundle)
 if command -v npx &>/dev/null; then
@@ -88,12 +87,7 @@ mkdir -p %{buildroot}%{_docdir}/tokenless
 # Install binaries — tokenless (user-facing) to /usr/bin, helpers to /usr/libexec/anolisa/tokenless
 install -m 0755 target/release/tokenless %{buildroot}%{_bindir}/tokenless
 install -m 0755 third_party/rtk/target/release/rtk %{buildroot}%{_libexecdir}/anolisa/tokenless/rtk
-# toon: use built binary if available, fallback to pre-installed
-if [ -f "third_party/toon/target/release/toon" ]; then
-    install -m 0755 third_party/toon/target/release/toon %{buildroot}%{_libexecdir}/anolisa/tokenless/toon
-else
-    install -m 0755 /usr/bin/toon %{buildroot}%{_libexecdir}/anolisa/tokenless/toon
-fi
+install -m 0755 %{_builddir}/toon-root/bin/toon %{buildroot}%{_libexecdir}/anolisa/tokenless/toon
 
 # Create symlinks so rtk and toon are discoverable via PATH
 ln -sf %{_libexecdir}/anolisa/tokenless/rtk %{buildroot}%{_bindir}/rtk
@@ -236,6 +230,14 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Fri May 22 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.3.2-2
+- refactor(tokenless): replace submodules with crates.io deps and inline toon
+- fix(tokenless): use libc::getuid() syscall instead of spoofable home-dir uid
+- fix(tokenless): hard-fail on rtk patch failure in justfile setup-rtk
+- fix(tokenless): unify compress error exit codes (all exit 2)
+- fix(tokenless): remove 2>/dev/null || true from Makefile toon install
+- fix(tokenless): deduplicate Python hook path constants into hook_utils
+
 * Wed May 13 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.3.2-1
 - Bump to v0.3.2 with multiple fixes
 


### PR DESCRIPTION
## Description

    - replace rtk/toon git submodules with crates.io deps and
      inline toon-format source
    - replace subprocess toon -e calls with in-process
      toon_format::encode_default() library call
    - replace spoofable home-dir uid derivation with
      libc::getuid() syscall; promote libc to workspace dep
    - hard-fail on rtk stats patch failure in justfile
      setup-rtk (&& instead of ;)
    - unify compress error exit codes (all exit 2 for
      backward compatibility)
    - remove 2>/dev/null || true from Makefile toon install
      (hard fail on missing binary)
    - deduplicate Python hook FHS path constants into shared
      hook_utils module (including hermes)
    - add 0.3.2 CHANGELOG entry and detailed spec.in %changelog

## Related Issue

no-issue: internal refactor and security fix

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [x] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
  - cargo fmt -p tokenless-cli -p tokenless-schema -p tokenless-stats -- --check — pass
  - cargo clippy -p tokenless-cli -p tokenless-schema -p tokenless-stats -- -D warnings — pass, 0 warning
  - cargo test -p tokenless-cli -p tokenless-schema -p tokenless-stats — 90 tests passed, 0 failed
  - just --dry-run setup-rtk — recipe syntax valid
  - RPM build + install + functional verification — all 3 binaries working, all hooks functional
  全量验证通过。汇总：

  ┌───────────────────────────────────┬───────────────────────────────────────────┐
  │              验证项               │                   结果                    │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ RPM 构建                          │ 4.8M 成功                                 │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ RPM 安装                          │ 成功                                      │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ 3 个二进制                        │ tokenless 0.3.2 / rtk 0.36.0 / toon 0.4.6 │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ compress-schema/response/toon     │ 功能正常                                  │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ B-001: JSON parse error exit=2    │ ✅ 验证通过                              │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ rewrite_hook (rtk)                │ 功能正常                                  │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ hook_utils 共享模块               │ import 正常                               │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ hermes dedup (从 hook_utils 导入) │ ✅ import 正常                           │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ env-check/stats                   │ 正常                                      │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ FHS 路径 + symlink                │ ✅                                       │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ rpm -V 文件完整性                 │ 无差异                                    │
  ├───────────────────────────────────┼───────────────────────────────────────────┤
  │ 集成测试                          │ 90/90 全通过                              │
  └───────────────────────────────────┴───────────────────────────────────────────┘
 ```
