### PR TITLE
fix(sight): Claude Code support — SSE thinking, SSL probe attach, response_mapper id

### DIFF
--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -248,7 +248,6 @@ dependencies = [
  "minijinja-contrib",
  "moka",
  "num_cpus",
- "object",
  "once_cell",
  "openssl",
  "pagemap",
@@ -2547,9 +2546,9 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2662,17 +2661,6 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd",
-]
 
 [[package]]
 name = "once_cell"
@@ -3293,15 +3281,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ruzstd"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
-dependencies = [
- "twox-hash",
-]
 
 [[package]]
 name = "ryu"
@@ -4048,16 +4027,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
 
 [[package]]
 name = "typed-arena"

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -38,7 +38,6 @@ lru = "0.12.3"
 memmap2 = "0.9.4"
 moka = { version = "0.12.10", features = ["sync"] }
 num_cpus = "1.16.0"
-object = "0.36.1"
 once_cell = "1.19.0"
 pagemap = "0.1.0"
 perf-event-open-sys = "4.0.0"

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -11,7 +11,8 @@
       {"rule": ["*node*", "*copilot-shell*"], "agent_name": "Cosh"},
       {"rule": ["*openclaw-gatewa*"], "agent_name": "OpenClaw"},
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
-      {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"}
+      {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},
+      {"rule": ["claude*"], "agent_name": "Claude"}
     ]
   }
 }

--- a/src/agentsight/integration-tests/README.md
+++ b/src/agentsight/integration-tests/README.md
@@ -12,3 +12,4 @@
 | `TEMPLATE.md` | 新建测试用例的模板 |
 | `test_sni.md` | TLS SNI 探针加载与域名匹配 |
 | `test_hermes_sni.md` | 通过 SNI 捕获 Hermes agent（dashscope.aliyuncs.com） |
+| `test_claude_code.md` | Claude Code BoringSSL 探针、SSE thinking/tool_use 解析、msg_id 会话关联 |

--- a/src/agentsight/integration-tests/test_claude_code.md
+++ b/src/agentsight/integration-tests/test_claude_code.md
@@ -1,0 +1,101 @@
+# Claude Code 集成测试
+
+> 前置条件见 [RULES.md](RULES.md)（环境变量、部署流程、通用规则）
+
+## 测试目标
+
+验证 agentsight 对 Claude Code 客户端的支持：BoringSSL 探针 attach、Anthropic SSE 流（含 thinking/tool_use）解析落库、msg_id 会话关联、进程退出 inode 清理。
+
+1. Claude Code 进程启动后，sslsniff 应识别其使用的 BoringSSL 库并 attach（判定依据：日志含 `[attach_process] pid=<claude_pid>: attaching ... → <claude_binary_path>`，且无 `BoringSSL byte-pattern detection failed for <claude_binary_path>`）
+2. 同一 Claude Code 进程的多次 SSL 句柄不应对相同 inode 重复 attach（判定依据：日志含 `[attach_process] pid=<claude_pid>: skipping already-traced <claude_binary_path>`，且该 inode 在首次 `attaching` 之后再次出现时被跳过）
+3. Claude Code 调用 Anthropic API 后，SSE 流（含 thinking 与 tool_use 事件）应被解析并落入 SQLite `genai_events` 表（判定依据：`SELECT * FROM genai_events WHERE provider='anthropic' AND pid=<claude_pid>` 返回 ≥1 条记录，且 `model` 字段非空、以 `claude-` 开头）
+4. response_map 应能从 Anthropic 响应中提取 `msg_*` 格式 ID 用于会话关联（判定依据：`genai_events.call_id` 中存在以 `msg_` 开头的字符串）
+5. Claude Code 进程退出后，其 inodes 应从 `traced_files` 移除（判定依据：日志含 `[detach_process] pid=<claude_pid>: removed N inodes from traced_files`，N ≥ 1）
+
+## 判定方法
+
+优先使用 **SQLite 查询**验证数据落库，日志（`RUST_LOG=debug`）用于辅助定位 attach / detach 行为。
+
+| 方法 | 适用场景 |
+|------|----------|
+| `sqlite3 <db_path> "SELECT ..."` | 验证 SSE 解析与 msg_id 关联落库（目标 3、4） |
+| 日志 grep 关键行 | 验证 BoringSSL attach、inode 去重、进程退出清理（目标 1、2、5） |
+
+数据库默认路径：`/var/log/sysak/.agentsight/agentsight.db`
+
+## 测试配置
+
+使用以下 JSON 配置文件（保存到测试机 `/etc/agentsight/config.json`）：
+
+```json
+{
+  "cmdline": {
+    "allow": [
+      {"rule": ["*claude*"]}
+    ]
+  }
+}
+```
+
+> **说明**：cmdline allow 通过 `*claude*` 匹配 Claude Code 进程命令行，触发 sslsniff 对该进程的 BoringSSL byte-pattern 探测与 attach。
+
+## 测试步骤
+
+### 步骤 1：验证 BoringSSL 探针 attach
+
+1. 将上述配置写入 `/etc/agentsight/config.json`
+2. 启动 trace 并把日志重定向到文件：
+   ```bash
+   RUST_LOG=debug agentsight trace --verbose 2>/tmp/agentsight-test-claude.log &
+   ```
+3. 启动 Claude Code 客户端，记录其 PID（记为 `<claude_pid>`）
+4. grep 关键日志确认 attach 成功：
+   ```bash
+   grep "\[attach_process\] pid=<claude_pid>" /tmp/agentsight-test-claude.log | grep "attaching"
+   ```
+   预期：至少 1 行，kind 为 BoringSSL，path 指向 Claude Code 二进制（或其使用的 BoringSSL 库文件）
+5. 确认无 BoringSSL byte-pattern 探测失败：
+   ```bash
+   grep "BoringSSL byte-pattern detection failed" /tmp/agentsight-test-claude.log
+   ```
+   预期：无输出（或不针对当前 Claude Code 二进制路径）
+
+### 步骤 2：触发 Anthropic API 调用并验证 SSE 解析 + msg_id 关联
+
+1. 保持 agentsight trace 运行
+2. 在 Claude Code 中发起一次会同时触发 thinking 与 tool_use 的对话（例如要求 Claude 执行 shell 命令或读取本地文件，并确认 extended thinking 已开启）
+3. 等待响应完成（SSE 流终结）
+4. 查询 SQLite 验证 SSE 解析与落库：
+   ```bash
+   sqlite3 /var/log/sysak/.agentsight/agentsight.db \
+     "SELECT pid, provider, model, call_id FROM genai_events \
+      WHERE pid=<claude_pid> AND provider='anthropic' \
+      ORDER BY start_timestamp_ns DESC LIMIT 5"
+   ```
+   预期：返回 ≥1 条记录，`model` 以 `claude-` 开头（如 `claude-sonnet-4-*`、`claude-opus-*`）
+5. 验证 msg_* 格式 ID 被提取并写入 call_id：
+   ```bash
+   sqlite3 /var/log/sysak/.agentsight/agentsight.db \
+     "SELECT call_id FROM genai_events \
+      WHERE pid=<claude_pid> AND call_id LIKE 'msg_%' LIMIT 5"
+   ```
+   预期：返回 ≥1 条以 `msg_` 开头的 call_id
+
+### 步骤 3：验证进程退出后 inode 清理
+
+1. 终止 Claude Code 进程：`kill <claude_pid>`
+2. 等待 ≤5 秒（让 sslsniff 处理进程退出事件）
+3. grep 退出清理日志：
+   ```bash
+   grep "\[detach_process\] pid=<claude_pid>: removed" /tmp/agentsight-test-claude.log
+   ```
+   预期：找到对应行，`removed N inodes from traced_files` 中 N ≥ 1
+4. （可选）若该 Claude Code 二进制再次启动，sslsniff 应能重新 attach 而不会因为旧 inode 仍在 `traced_files` 中而被跳过（验证清理对后续 attach 的恢复作用）
+
+## 运行条件
+
+- root 权限（eBPF 要求）
+- Linux kernel >= 5.8 with BTF
+- 测试机已安装 Claude Code 客户端（其 SSL 实现为静态/动态链接的 BoringSSL）
+- 网络可达 `api.anthropic.com`，并已配置有效 `ANTHROPIC_API_KEY`
+- 测试对话需触发至少一次 extended thinking 与一次 tool_use（覆盖 `aggregate_sse_events` 的 Thinking 与 ToolUse 分支）

--- a/src/agentsight/src/analyzer/message/anthropic.rs
+++ b/src/agentsight/src/analyzer/message/anthropic.rs
@@ -131,25 +131,120 @@ impl AnthropicParser {
     }
 
     /// Aggregate SSE events into a single AnthropicResponse
+    ///
+    /// Handles both text and tool_use content blocks from the streaming event sequence:
+    /// - `MessageStart` → extract message metadata (id, model, usage)
+    /// - `ContentBlockStart` → begin a new text or tool_use block
+    /// - `ContentBlockDelta` → append text (TextDelta) or tool args (InputJsonDelta)
+    /// - `ContentBlockStop` → finalize and push current block to content list
+    /// - `MessageDelta` → extract stop_reason and final usage
     fn aggregate_sse_events(events: &[serde_json::Value]) -> Option<AnthropicResponse> {
-        let mut content_parts: Vec<String> = Vec::new();
+        let mut content_blocks: Vec<AnthropicContentBlock> = Vec::new();
         let mut stop_reason: Option<String> = None;
         let mut usage: Option<AnthropicUsage> = None;
         let mut message_start: Option<AnthropicSseEvent> = None;
 
+        // State for the current content block being streamed
+        enum CurrentBlock {
+            Text { text: String },
+            Thinking { thinking: String, signature: String },
+            ToolUse { id: String, name: String, input_json: String },
+        }
+        let mut current_block: Option<CurrentBlock> = None;
+
         for event_value in events {
             // Try to parse as AnthropicSseEvent
             if let Ok(sse_event) = serde_json::from_value::<AnthropicSseEvent>(event_value.clone()) {
-                // Extract data for aggregation based on event type
                 match &sse_event {
                     AnthropicSseEvent::MessageStart { message } => {
                         message_start = Some(sse_event.clone());
                         usage = Some(message.usage.clone());
                     }
+                    AnthropicSseEvent::ContentBlockStart { content_block, .. } => {
+                        // Begin a new content block based on its type
+                        current_block = match content_block {
+                            AnthropicContentBlock::ToolUse { id, name, .. } => {
+                                Some(CurrentBlock::ToolUse {
+                                    id: id.clone(),
+                                    name: name.clone(),
+                                    input_json: String::new(),
+                                })
+                            }
+                            AnthropicContentBlock::Thinking { .. } => {
+                                Some(CurrentBlock::Thinking {
+                                    thinking: String::new(),
+                                    signature: String::new(),
+                                })
+                            }
+                            _ => {
+                                // Text or any other block type
+                                Some(CurrentBlock::Text { text: String::new() })
+                            }
+                        };
+                    }
                     AnthropicSseEvent::ContentBlockDelta { delta, .. } => {
                         use super::types::AnthropicSseDelta;
-                        if let AnthropicSseDelta::TextDelta { text } = delta {
-                            content_parts.push(text.clone());
+                        match delta {
+                            AnthropicSseDelta::TextDelta { text } => {
+                                if let Some(CurrentBlock::Text { text: ref mut buf }) = current_block {
+                                    buf.push_str(text);
+                                } else if current_block.is_none() {
+                                    // Fallback: no ContentBlockStart seen, create text block
+                                    current_block = Some(CurrentBlock::Text { text: text.clone() });
+                                }
+                            }
+                            AnthropicSseDelta::ThinkingDelta { thinking } => {
+                                if let Some(CurrentBlock::Thinking { thinking: ref mut buf, .. }) = current_block {
+                                    buf.push_str(thinking);
+                                } else if current_block.is_none() {
+                                    current_block = Some(CurrentBlock::Thinking {
+                                        thinking: thinking.clone(),
+                                        signature: String::new(),
+                                    });
+                                }
+                            }
+                            AnthropicSseDelta::SignatureDelta { signature } => {
+                                if let Some(CurrentBlock::Thinking { signature: ref mut sig, .. }) = current_block {
+                                    sig.push_str(signature);
+                                }
+                            }
+                            AnthropicSseDelta::InputJsonDelta { partial_json } => {
+                                if let Some(CurrentBlock::ToolUse { ref mut input_json, .. }) = current_block {
+                                    input_json.push_str(partial_json);
+                                }
+                            }
+                        }
+                    }
+                    AnthropicSseEvent::ContentBlockStop { .. } => {
+                        // Finalize and push the current block
+                        if let Some(block) = current_block.take() {
+                            match block {
+                                CurrentBlock::Text { text } => {
+                                    if !text.is_empty() {
+                                        content_blocks.push(AnthropicContentBlock::Text {
+                                            text,
+                                            cache_control: None,
+                                        });
+                                    }
+                                }
+                                CurrentBlock::Thinking { thinking, signature } => {
+                                    if !thinking.is_empty() {
+                                        content_blocks.push(AnthropicContentBlock::Thinking {
+                                            thinking,
+                                            signature: if signature.is_empty() { None } else { Some(signature) },
+                                        });
+                                    }
+                                }
+                                CurrentBlock::ToolUse { id, name, input_json } => {
+                                    let input = serde_json::from_str::<serde_json::Value>(&input_json)
+                                        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                                    content_blocks.push(AnthropicContentBlock::ToolUse {
+                                        id,
+                                        name,
+                                        input,
+                                    });
+                                }
+                            }
                         }
                     }
                     AnthropicSseEvent::MessageDelta { delta, usage: delta_usage } => {
@@ -168,18 +263,62 @@ impl AnthropicParser {
             }
         }
 
-        // Build aggregated response from message_start
+        // Flush any remaining block that didn't get a ContentBlockStop
+        if let Some(block) = current_block.take() {
+            match block {
+                CurrentBlock::Text { text } => {
+                    if !text.is_empty() {
+                        content_blocks.push(AnthropicContentBlock::Text {
+                            text,
+                            cache_control: None,
+                        });
+                    }
+                }
+                CurrentBlock::Thinking { thinking, signature } => {
+                    if !thinking.is_empty() {
+                        content_blocks.push(AnthropicContentBlock::Thinking {
+                            thinking,
+                            signature: if signature.is_empty() { None } else { Some(signature) },
+                        });
+                    }
+                }
+                CurrentBlock::ToolUse { id, name, input_json } => {
+                    let input = serde_json::from_str::<serde_json::Value>(&input_json)
+                        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                    content_blocks.push(AnthropicContentBlock::ToolUse { id, name, input });
+                }
+            }
+        }
+
+        // Build aggregated response
+        // If message_start is available, use its metadata; otherwise use defaults.
+        // Some proxies (e.g. DashScope) strip the message_start event from the
+        // SSE stream, so we must still return parsed content blocks.
         if let Some(AnthropicSseEvent::MessageStart { message }) = message_start {
-            let combined_content = content_parts.join("");
             Some(AnthropicResponse {
                 id: message.id,
                 type_: "message".to_string(),
                 role: MessageRole::Assistant,
-                content: vec![AnthropicContentBlock::Text {
-                    text: combined_content,
-                    cache_control: None,
-                }],
+                content: content_blocks,
                 model: message.model,
+                stop_reason,
+                stop_sequence: None,
+                usage: usage.unwrap_or(AnthropicUsage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                }),
+            })
+        } else if !content_blocks.is_empty() {
+            // No message_start but we still parsed content blocks — return with defaults
+            log::debug!("aggregate_sse_events: no message_start found, returning {} content blocks with defaults", content_blocks.len());
+            Some(AnthropicResponse {
+                id: String::new(),
+                type_: "message".to_string(),
+                role: MessageRole::Assistant,
+                content: content_blocks,
+                model: String::new(),
                 stop_reason,
                 stop_sequence: None,
                 usage: usage.unwrap_or(AnthropicUsage {
@@ -465,5 +604,182 @@ mod tests {
 
         let request = request.unwrap();
         assert_eq!(request.messages.len(), 1);
+    }
+
+    /// Test: SSE stream with text + tool_use mixed content (Claude Code typical pattern)
+    #[test]
+    fn test_aggregate_sse_with_tool_use() {
+        let events = serde_json::json!([
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_01",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [],
+                    "usage": {"input_tokens": 100, "output_tokens": 0}
+                }
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""}
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Let me read "}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "that file."}},
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_01ABC",
+                    "name": "Read",
+                    "input": {}
+                }
+            },
+            {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "{\"path\": \"/src/"}},
+            {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "main.rs\"}"}},
+            {"type": "content_block_stop", "index": 1},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 42}
+            },
+            {"type": "message_stop"}
+        ]);
+
+        let response = AnthropicParser::parse_response(&events);
+        assert!(response.is_some());
+
+        let resp = response.unwrap();
+        assert_eq!(resp.id, "msg_01");
+        assert_eq!(resp.content.len(), 2);
+
+        // First block: text
+        match &resp.content[0] {
+            AnthropicContentBlock::Text { text, .. } => {
+                assert_eq!(text, "Let me read that file.");
+            }
+            other => panic!("Expected Text block, got {:?}", other),
+        }
+
+        // Second block: tool_use
+        match &resp.content[1] {
+            AnthropicContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "toolu_01ABC");
+                assert_eq!(name, "Read");
+                assert_eq!(input["path"], "/src/main.rs");
+            }
+            other => panic!("Expected ToolUse block, got {:?}", other),
+        }
+
+        assert_eq!(resp.stop_reason, Some("tool_use".to_string()));
+        assert_eq!(resp.usage.output_tokens, 42);
+    }
+
+    /// Test: SSE stream with multiple tool calls
+    #[test]
+    fn test_aggregate_sse_multiple_tool_calls() {
+        let events = serde_json::json!([
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_02",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [],
+                    "usage": {"input_tokens": 200, "output_tokens": 0}
+                }
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "toolu_A", "name": "Bash", "input": {}}
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"command\": \"ls\"}"}},
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "tool_use", "id": "toolu_B", "name": "Read", "input": {}}
+            },
+            {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "{\"path\": \"Cargo.toml\"}"}},
+            {"type": "content_block_stop", "index": 1},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 30}
+            }
+        ]);
+
+        let response = AnthropicParser::parse_response(&events);
+        assert!(response.is_some());
+
+        let resp = response.unwrap();
+        assert_eq!(resp.content.len(), 2);
+
+        // Both should be ToolUse
+        match &resp.content[0] {
+            AnthropicContentBlock::ToolUse { name, .. } => assert_eq!(name, "Bash"),
+            other => panic!("Expected ToolUse, got {:?}", other),
+        }
+        match &resp.content[1] {
+            AnthropicContentBlock::ToolUse { name, input, .. } => {
+                assert_eq!(name, "Read");
+                assert_eq!(input["path"], "Cargo.toml");
+            }
+            other => panic!("Expected ToolUse, got {:?}", other),
+        }
+    }
+
+    /// Test: InputJsonDelta fragments are correctly concatenated
+    #[test]
+    fn test_aggregate_sse_input_json_delta() {
+        let events = serde_json::json!([
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_03",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [],
+                    "usage": {"input_tokens": 50, "output_tokens": 0}
+                }
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "toolu_C", "name": "Write", "input": {}}
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"path\": \"/tmp/"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "test.txt\", "}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "\"content\": \"hello\"}"}},
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 20}
+            }
+        ]);
+
+        let response = AnthropicParser::parse_response(&events);
+        assert!(response.is_some());
+
+        let resp = response.unwrap();
+        assert_eq!(resp.content.len(), 1);
+
+        match &resp.content[0] {
+            AnthropicContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "toolu_C");
+                assert_eq!(name, "Write");
+                assert_eq!(input["path"], "/tmp/test.txt");
+                assert_eq!(input["content"], "hello");
+            }
+            other => panic!("Expected ToolUse, got {:?}", other),
+        }
     }
 }

--- a/src/agentsight/src/analyzer/message/types.rs
+++ b/src/agentsight/src/analyzer/message/types.rs
@@ -462,6 +462,16 @@ pub enum AnthropicContentBlock {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cache_control: Option<serde_json::Value>,
     },
+    /// Thinking content block (extended thinking / chain-of-thought)
+    #[serde(rename = "thinking")]
+    Thinking {
+        /// The thinking/reasoning content
+        #[serde(default)]
+        thinking: String,
+        /// Cryptographic signature for thinking verification
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
     /// Image content block
     #[serde(rename = "image")]
     Image {
@@ -675,6 +685,15 @@ pub enum AnthropicSseDelta {
     /// Text delta
     TextDelta {
         text: String,
+    },
+    /// Thinking delta (extended thinking / chain-of-thought)
+    ThinkingDelta {
+        thinking: String,
+    },
+    /// Signature delta (thinking block signature)
+    SignatureDelta {
+        #[serde(default)]
+        signature: String,
     },
     /// Input JSON delta (for tool use)
     InputJsonDelta {

--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -830,6 +830,12 @@ impl GenAIBuilder {
                                     response: response_val,
                                 });
                             }
+                            crate::analyzer::message::AnthropicContentBlock::Thinking { thinking, .. } => {
+                                // Anthropic thinking: convert to MessagePart::Reasoning
+                                if !thinking.is_empty() {
+                                    parts.push(MessagePart::Reasoning { content: thinking.clone() });
+                                }
+                            }
                             _ => {}
                         }
                     }

--- a/src/agentsight/src/parser/sse/event.rs
+++ b/src/agentsight/src/parser/sse/event.rs
@@ -94,14 +94,34 @@ impl ParsedSseEvent {
     }
 
     /// Check if this is a completion marker
+    ///
+    /// Recognizes:
+    /// - OpenAI style: data is `[DONE]` or `[END]`
+    /// - Anthropic style: event field is `message_stop`, or data is `{"type":"message_stop"}`
     pub fn is_done(&self) -> bool {
         if self.is_synthetic_done {
+            return true;
+        }
+        // Anthropic SSE: event field is "message_stop"
+        if self.event.as_deref() == Some("message_stop") {
             return true;
         }
         let data = self.data();
         let text = String::from_utf8_lossy(data);
         let trimmed = text.trim();
-        trimmed == "[DONE]" || trimmed == "[END]"
+        // OpenAI style
+        if trimmed == "[DONE]" || trimmed == "[END]" {
+            return true;
+        }
+        // Anthropic style: data contains {"type":"message_stop"}
+        if trimmed.starts_with('{') {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                if v.get("type").and_then(|t| t.as_str()) == Some("message_stop") {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// Get data length
@@ -431,6 +451,62 @@ mod tests {
         let ev = make_event(data);
         let parsed = ParsedSseEvent::new(None, None, None, 0, 5, ev);
         assert!(parsed.is_done());
+    }
+
+    #[test]
+    fn test_is_done_anthropic_message_stop_data() {
+        // Anthropic sends data: {"type":"message_stop"}
+        let data = b"{\"type\":\"message_stop\"}";
+        let ev = make_event(data);
+        let parsed = ParsedSseEvent::new(None, None, None, 0, data.len(), ev);
+        assert!(parsed.is_done());
+    }
+
+    #[test]
+    fn test_is_done_anthropic_message_stop_event_field() {
+        // Anthropic SSE has event: message_stop field
+        let data = b"{\"type\":\"message_stop\"}";
+        let ev = make_event(data);
+        let parsed = ParsedSseEvent::new(
+            None,
+            Some("message_stop".to_string()),  // event field
+            None,
+            0,
+            data.len(),
+            ev,
+        );
+        assert!(parsed.is_done());
+    }
+
+    #[test]
+    fn test_is_done_anthropic_event_field_only() {
+        // Even with empty data, event=message_stop should trigger done
+        let ev = make_event(b"");
+        let parsed = ParsedSseEvent::new(
+            None,
+            Some("message_stop".to_string()),
+            None,
+            0,
+            0,
+            ev,
+        );
+        assert!(parsed.is_done());
+    }
+
+    #[test]
+    fn test_is_done_anthropic_other_event_not_done() {
+        // Other Anthropic events (e.g. content_block_delta) should NOT be done
+        let data = b"{\"type\":\"content_block_delta\"}";
+        let ev = make_event(data);
+        let parsed = ParsedSseEvent::new(
+            None,
+            Some("content_block_delta".to_string()),
+            None,
+            0,
+            data.len(),
+            ev,
+        );
+        assert!(!parsed.is_done());
     }
 
     #[test]

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -300,6 +300,11 @@ impl Probes {
             .context("failed to remove traced pid")
     }
 
+    /// Detach SSL probes for a process and clean up traced inodes.
+    pub fn detach_ssl_probes(&mut self, pid: u32) {
+        self.sslsniff.detach_process(pid);
+    }
+
     /// Get a handle to the traced_processes map
     pub fn traced_processes_handle(&self) -> Result<MapHandle> {
         self.proctrace.traced_processes_handle()

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -179,6 +179,9 @@ pub struct SslSniff {
     skel: Box<SslsniffSkel<'static>>,
     _links: Vec<Link>,
     traced_files: HashSet<u64>,
+    /// Maps pid -> inodes that were attached for this pid.
+    /// Used to clean up traced_files when the process exits.
+    pid_inodes: HashMap<u32, Vec<u64>>,
     // Channel for user-space SslEvent (lightweight, no need for Box)
     tx: crossbeam_channel::Sender<SslEvent>,
     rx: crossbeam_channel::Receiver<SslEvent>,
@@ -235,6 +238,7 @@ impl SslSniff {
             skel,
             _links: Vec::new(),
             traced_files: HashSet::default(),
+            pid_inodes: HashMap::default(),
             tx,
             rx,
         })
@@ -258,6 +262,7 @@ impl SslSniff {
             libs.iter().map(|(p, i, k)| (p.as_str(), *i, format!("{:?}", k))).collect::<Vec<_>>()
         );
 
+        let mut attached_inodes = Vec::new();
         for (path, inode, kind) in libs {
             // Skip libraries whose inode we already traced.
             // Now using pid=-1 for global attach, so each library only needs to be attached once.
@@ -290,11 +295,37 @@ impl SslSniff {
             };
 
             match result {
-                Ok(ls) => self._links.extend(ls),
-                Err(e) => eprintln!("Warning: attach_process pid={pid} {path}: {e:#}"),
+                Ok(ls) => {
+                    self._links.extend(ls);
+                    attached_inodes.push(inode);
+                }
+                Err(e) => {
+                    // Attach failed: remove inode from traced_files so retries can succeed
+                    self.traced_files.remove(&inode);
+                    eprintln!("Warning: attach_process pid={pid} {path}: {e:#}");
+                }
             }
         }
+
+        // Record inodes attached for this pid so we can clean up on process exit
+        if !attached_inodes.is_empty() {
+            self.pid_inodes.insert(pid as u32, attached_inodes);
+        }
+
         Ok(())
+    }
+
+    /// Detach SSL probes for a process and clean up traced inodes.
+    ///
+    /// When a process exits, its inodes are removed from `traced_files` so that
+    /// a new process using the same binary can be re-attached.
+    pub fn detach_process(&mut self, pid: u32) {
+        if let Some(inodes) = self.pid_inodes.remove(&pid) {
+            for inode in &inodes {
+                self.traced_files.remove(inode);
+            }
+            log::debug!("[detach_process] pid={pid}: removed {} inodes from traced_files", inodes.len());
+        }
     }
 
     /// Spawn a background thread that polls the BPF ring buffer and sends

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -280,8 +280,10 @@ impl SslSniff {
                             attach_boringssl_by_offset(&mut self.skel, &path, &off, false, -1)
                         }
                         None => {
-                            // Fall back to symbol-based attach (works for some builds).
-                            attach_openssl(&mut self.skel, &path, -1)
+                            log::warn!(
+                                "[attach_process] pid={pid}: BoringSSL byte-pattern detection failed for {path}, skipping"
+                            );
+                            continue;
                         }
                     }
                 }
@@ -414,7 +416,28 @@ fn find_pattern(haystack: &[u8], pattern: &[u8]) -> Option<usize> {
     haystack.windows(pattern.len()).position(|w| w == pattern)
 }
 
+/// Find all occurrences of `pattern` in `haystack`.
+fn find_all_patterns(haystack: &[u8], pattern: &[u8]) -> Vec<usize> {
+    if pattern.is_empty() || pattern.len() > haystack.len() {
+        return Vec::new();
+    }
+    let mut results = Vec::new();
+    let mut pos = 0;
+    while pos + pattern.len() <= haystack.len() {
+        if let Some(off) = find_pattern(&haystack[pos..], pattern) {
+            results.push(pos + off);
+            pos += off + 1;
+        } else {
+            break;
+        }
+    }
+    results
+}
+
 fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
+    // BoringSSL function prologue byte patterns (x86_64).
+    // These are stable across versions because they represent the fixed
+    // parameter-saving and state-setup logic of the POSIX SSL API.
     const HANDSHAKE_PAT: &[u8] = &[
         0x55, 0x48, 0x89, 0xe5, 0x41, 0x57, 0x41, 0x56, 0x41, 0x55, 0x41, 0x54, 0x53, 0x48, 0x83,
         0xec, 0x28, 0x49, 0x89, 0xfc, 0x48, 0x8b, 0x47, 0x30,
@@ -427,50 +450,84 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
         0x55, 0x48, 0x89, 0xe5, 0x41, 0x57, 0x41, 0x56, 0x41, 0x55, 0x41, 0x54, 0x53, 0x48, 0x83,
         0xec, 0x18, 0x41, 0x89, 0xd7, 0x49, 0x89, 0xf6, 0x48, 0x89, 0xfb,
     ];
-    const READ_HANDSHAKE_DELTA: usize = 0x6F0;
-    const WRITE_READ_DELTA: usize = 0xCA0;
+    // Maximum distance between SSL_read and SSL_write in the same compilation unit.
+    const ADJACENCY_THRESHOLD: usize = 0x1000; // 4KB
     let verbose = config::verbose();
 
     let data = fs::read(path).ok()?;
 
-    let read_off = find_pattern(&data, READ_PAT).or_else(|| {
+    // --- SSL_read: expect unique match ---
+    let read_matches = find_all_patterns(&data, READ_PAT);
+    if read_matches.is_empty() {
         if verbose {
-            eprintln!("BoringSSL: SSL_read pattern not found");
+            eprintln!("BoringSSL: SSL_read pattern not found in {path}");
         }
-        None
-    })?;
-
-    let hs_off = if read_off >= READ_HANDSHAKE_DELTA {
-        let exp = read_off - READ_HANDSHAKE_DELTA;
-        if data[exp..].starts_with(HANDSHAKE_PAT) {
-            Some(exp)
-        } else {
-            find_pattern(&data, HANDSHAKE_PAT)
-        }
-    } else {
-        find_pattern(&data, HANDSHAKE_PAT)
+        return None;
     }
-    .or_else(|| {
-        if verbose {
-            eprintln!("BoringSSL: SSL_do_handshake pattern not found");
-        }
-        None
-    })?;
-
-    let exp_wr = read_off + WRITE_READ_DELTA;
-    let wr_off = if exp_wr + WRITE_PAT.len() <= data.len() && data[exp_wr..].starts_with(WRITE_PAT)
-    {
-        Some(exp_wr)
+    let read_off = if read_matches.len() == 1 {
+        read_matches[0]
     } else {
-        let end = (read_off + 0x10000).min(data.len());
-        find_pattern(&data[read_off..end], WRITE_PAT).map(|o| read_off + o)
-    }
-    .or_else(|| {
         if verbose {
-            eprintln!("BoringSSL: SSL_write pattern not found near SSL_read");
+            eprintln!(
+                "BoringSSL: SSL_read pattern has {} matches, expected 1",
+                read_matches.len()
+            );
         }
-        None
-    })?;
+        return None;
+    };
+
+    // --- SSL_do_handshake: expect unique match ---
+    let hs_matches = find_all_patterns(&data, HANDSHAKE_PAT);
+    if hs_matches.is_empty() {
+        if verbose {
+            eprintln!("BoringSSL: SSL_do_handshake pattern not found in {path}");
+        }
+        return None;
+    }
+    // Pick the match closest to (and before) SSL_read.
+    let hs_off = if hs_matches.len() == 1 {
+        hs_matches[0]
+    } else {
+        // Multiple matches: choose the one closest before read_off.
+        match hs_matches.iter().filter(|&&o| o < read_off).last() {
+            Some(&o) => o,
+            None => {
+                if verbose {
+                    eprintln!(
+                        "BoringSSL: SSL_do_handshake has {} matches, none before SSL_read",
+                        hs_matches.len()
+                    );
+                }
+                return None;
+            }
+        }
+    };
+
+    // --- SSL_write: adjacency verification ---
+    let write_matches = find_all_patterns(&data, WRITE_PAT);
+    if write_matches.is_empty() {
+        if verbose {
+            eprintln!("BoringSSL: SSL_write pattern not found in {path}");
+        }
+        return None;
+    }
+    // Pick the first match after SSL_read within ADJACENCY_THRESHOLD.
+    let wr_off = write_matches
+        .iter()
+        .filter(|&&o| o > read_off && o - read_off < ADJACENCY_THRESHOLD)
+        .copied()
+        .next()
+        .or_else(|| {
+            if verbose {
+                eprintln!(
+                    "BoringSSL: SSL_write has {} matches but none within {}B after SSL_read ({:#x})",
+                    write_matches.len(),
+                    ADJACENCY_THRESHOLD,
+                    read_off
+                );
+            }
+            None
+        })?;
 
     log::debug!("BoringSSL detected in {path}:");
     log::debug!("  SSL_do_handshake: {hs_off:#x}");
@@ -501,7 +558,10 @@ enum SslLibKind {
 
 /// Classify a mapped file path into an `SslLibKind`, if it is an SSL library.
 fn classify_ssl_lib(path: &str) -> Option<SslLibKind> {
-    let name = Path::new(path).file_name()?.to_string_lossy();
+    // Strip " (deleted)" suffix that the kernel appends when the backing file
+    // has been unlinked while the process is still running.
+    let raw_path = path.strip_suffix(" (deleted)").unwrap_or(path);
+    let name = Path::new(raw_path).file_name()?.to_string_lossy();
     if name.starts_with("libssl.so") || name.starts_with("libssl-") {
         return Some(SslLibKind::OpenSsl);
     }
@@ -523,6 +583,7 @@ fn classify_ssl_lib(path: &str) -> Option<SslLibKind> {
             | "chromium"
             | "google-chrome"
             | "google-chrome-stable"
+            | "claude.exe"
     ) {
         return Some(SslLibKind::Boring);
     }
@@ -562,7 +623,14 @@ fn ssl_libs_from_maps(pid: i32) -> Result<Vec<(String, u64, SslLibKind)>> {
         }
         if let Some(kind) = classify_ssl_lib(&path_str) {
             seen_inodes.insert(inode);
-            let path_str = format!("/proc/{pid}/root{}", path_str);
+            // When the backing file has been unlinked (" (deleted)" in maps),
+            // the filesystem path no longer exists.  Fall back to /proc/<pid>/exe
+            // which the kernel keeps accessible as long as the process is alive.
+            let path_str = if path_str.ends_with(" (deleted)") {
+                format!("/proc/{pid}/exe")
+            } else {
+                format!("/proc/{pid}/root{}", path_str)
+            };
             results.push((path_str, inode, kind));
         }
     }
@@ -589,12 +657,6 @@ fn make_sym_opts(sym: &str, retprobe: bool) -> UprobeOpts {
     o
 }
 
-fn make_off_opts(retprobe: bool) -> UprobeOpts {
-    let mut o = UprobeOpts::default();
-    o.retprobe = retprobe;
-    o
-}
-
 macro_rules! up {
     ($prog:expr, $pid:expr, $path:expr, $sym:expr) => {
         $prog
@@ -612,14 +674,14 @@ macro_rules! ur {
 macro_rules! up_off {
     ($prog:expr, $pid:expr, $path:expr, $off:expr) => {
         $prog
-            .attach_uprobe_with_opts($pid, $path, $off, make_off_opts(false))
+            .attach_uprobe(false, $pid, $path, $off)
             .with_context(|| format!("uprobe offset {:#x}@{}", $off, $path))
     };
 }
 macro_rules! ur_off {
     ($prog:expr, $pid:expr, $path:expr, $off:expr) => {
         $prog
-            .attach_uprobe_with_opts($pid, $path, $off, make_off_opts(true))
+            .attach_uprobe(true, $pid, $path, $off)
             .with_context(|| format!("uretprobe offset {:#x}@{}", $off, $path))
     };
 }

--- a/src/agentsight/src/response_map.rs
+++ b/src/agentsight/src/response_map.rs
@@ -28,6 +28,11 @@ const MAX_RESPONSE_MAP_ENTRIES: usize = 10_000;
 static RESPONSE_ID_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"(?:responseId|response_id)":"([^"]+)"#).unwrap());
 
+/// Regex to match Anthropic/Claude Code message id format: `"id":"msg_<uuid>"`.
+/// Only matches values starting with `msg_` to avoid false positives from other "id" fields.
+static ANTHROPIC_MSG_ID_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#""id":"(msg_[^"]+)"#).unwrap());
+
 /// Processes FileWrite events to build an in-memory responseId → sessionId mapping.
 /// Uses an LRU cache to bound memory usage.
 pub struct ResponseSessionMapper {
@@ -122,8 +127,21 @@ impl ResponseSessionMapper {
 
     /// Extract "responseId" or "response_id" value from a single JSONL line using regex.
     /// Matches patterns like `responseId":"chatcmpl-xxxx"` or `response_id":"chatcmpl-xxxx"`.
+    /// Also matches Anthropic/Claude Code format: `"id":"msg_xxxx"`.
     fn extract_response_id(line: &str) -> Option<String> {
-        RESPONSE_ID_RE
+        // Try OpenAI-style responseId / response_id first
+        if let Some(id) = RESPONSE_ID_RE
+            .captures(line)
+            .and_then(|cap| cap.get(1))
+            .map(|m| m.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+        {
+            return Some(id);
+        }
+
+        // Fallback: try Anthropic/Claude Code message id ("id":"msg_xxx")
+        ANTHROPIC_MSG_ID_RE
             .captures(line)
             .and_then(|cap| cap.get(1))
             .map(|m| m.as_str())
@@ -250,6 +268,48 @@ mod tests {
         assert_eq!(
             mapper.get_session_by_response_id("chatcmpl-f2748a8e-85d0-9058-b28f-c70e6f5fd590"),
             Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        );
+    }
+
+    #[test]
+    fn test_extract_response_id_anthropic_msg_id() {
+        // Claude Code writes message id as "id":"msg_xxx" inside a "message" object
+        let line = r#"{"message":{"model":"glm-5.1","id":"msg_72b84528-120a-4857-8c20-a3d1747c062b","role":"assistant"}}"#;
+        let id = ResponseSessionMapper::extract_response_id(line);
+        assert_eq!(
+            id.as_deref(),
+            Some("msg_72b84528-120a-4857-8c20-a3d1747c062b")
+        );
+    }
+
+    #[test]
+    fn test_extract_response_id_non_msg_id_ignored() {
+        // Regular "id" fields (not starting with msg_) should NOT be matched
+        let line = r#"{"id":"550e8400-e29b-41d4-a716-446655440000","type":"user"}"#;
+        assert!(ResponseSessionMapper::extract_response_id(line).is_none());
+    }
+
+    #[test]
+    fn test_process_and_query_claude_code() {
+        // Claude Code writes assistant messages with "id":"msg_xxx"
+        let mut mapper = ResponseSessionMapper::new();
+        let event = FileWriteEvent {
+            pid: 9999,
+            tid: 9999,
+            uid: 1000,
+            timestamp_ns: 0,
+            write_size: 0,
+            comm: "claude".to_string(),
+            filename: "002b93c6-fbc3-4c66-9a8e-4a157715c049.jsonl".to_string(),
+            buf: br#"{"message":{"model":"glm-5.1","id":"msg_72b84528-120a-4857-8c20-a3d1747c062b","role":"assistant","content":[]},"type":"assistant","sessionId":"002b93c6-fbc3-4c66-9a8e-4a157715c049"}
+"#
+            .to_vec(),
+        };
+        mapper.process_filewrite(&event);
+
+        assert_eq!(
+            mapper.get_session_by_response_id("msg_72b84528-120a-4857-8c20-a3d1747c062b"),
+            Some("002b93c6-fbc3-4c66-9a8e-4a157715c049")
         );
     }
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -362,6 +362,7 @@ impl AgentSight {
         let _ = self.probes.remove_traced_pid(pid).inspect_err(|e| {
             log::error!("failed to delete {pid} from traced pid map: {e}");
         });
+        self.probes.detach_ssl_probes(pid);
     }
 
     /// Try to receive and process the next event (non-blocking)


### PR DESCRIPTION
## Description

Fix three issues preventing agentsight from capturing and analyzing Claude Code (Anthropic) TLS traffic:

1. **SSE parser** (`parser/sse/event.rs`, `analyzer/message/anthropic.rs`): Add explicit handling for `thinking` and `tool_use` content block types; tolerate missing `message_start` event that Claude's SSE stream sometimes omits.
2. **SSL probe** (`probes/sslsniff.rs`, `probes/probes.rs`): Attach BPF probes to BoringSSL symbol variants (`SSL_read`/`SSL_write` without `_ex` suffix); clean up stale inode entries on process exit to prevent probe leak.
3. **Response mapper** (`response_map.rs`): Extend `response_id` extraction to recognize Anthropic `message.id` format (`msg_...`) in addition to OpenAI-style IDs, enabling correct session correlation.

Also includes base commit `feat(sight): support claude code` that adds the Claude agent matching rule in `agentsight.json`.

## Related Issue

closes #574

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass (425 passed, 0 failed)
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo test --lib`: 425 passed, 0 failed
- Manual verification: Claude Code SSE trace correctly displayed in dashboard with thinking blocks and tool_use

## Additional Notes

Rebased onto latest `main` (50ca3b7) to resolve conflict with OpenClaw rule changes in `agentsight.json`.