### PR TITLE
test(sec-core): include skill-ledger e2e in install flows

### DIFF
--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -66,13 +66,10 @@ test-e2e-rpm: ## Run E2E tests against RPM-installed agent-sec-cli binary
 	@command -v pytest >/dev/null 2>&1 || pip3 install --quiet pytest
 	python3 -m pytest tests/e2e/ \
 		--import-mode=importlib \
-		--ignore=tests/e2e/skill-ledger \
 		--ignore=tests/e2e/linux-sandbox \
 		--ignore=tests/e2e/prompt-scanner \
 		-k 'not test_error_event_writes_to_sqlite' \
 		-v --tb=short
-	@# standalone-script e2e suites (not pytest-compatible)
-	python3 tests/e2e/skill-ledger/e2e_test.py
 	@# linux-sandbox e2e skipped: requires privileged container
 
 VENV_PYTHON ?= $(HOME)/.local/lib/anolisa/sec-core/venv/bin/python
@@ -84,12 +81,10 @@ test-e2e-source-build: ## Run E2E tests against source-build-installed agent-sec
 	@$(VENV_PYTHON) -m pytest --version >/dev/null 2>&1 || uv pip install --python $(VENV_PYTHON) --quiet pytest
 	$(VENV_PYTHON) -m pytest tests/e2e/ \
 		--import-mode=importlib \
-		--ignore=tests/e2e/skill-ledger \
 		--ignore=tests/e2e/linux-sandbox \
 		--ignore=tests/e2e/prompt-scanner \
 		-k 'not test_error_event_writes_to_sqlite' \
 		-v --tb=short
-	@# skill-ledger e2e skipped: installed system skills affect G6/G8 expected results
 	@# linux-sandbox e2e skipped: requires privileged container
 
 .PHONY: test-python-coverage

--- a/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
@@ -140,8 +140,8 @@ def write_findings_file(parent: Path, name: str, findings: list | dict) -> Path:
     return path
 
 
-def test(name: str, fn):
-    """Run a single named test, catch exceptions, record results."""
+def run_case(name: str, fn):
+    """Run a single named E2E case, catch exceptions, record results."""
     print(f"\n{BLUE}--- {name} ---{NC}")
     try:
         fn()
@@ -169,6 +169,12 @@ class Workspace:
         self.xdg_config = self.root / "xdg_config"
         self.xdg_data.mkdir()
         self.xdg_config.mkdir()
+        config_dir = self.xdg_config / "agent-sec" / "skill-ledger"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(
+            json.dumps({"enableDefaultSkillDirs": False, "managedSkillDirs": []}),
+            encoding="utf-8",
+        )
         self.skills_dir = self.root / "skills"
         self.skills_dir.mkdir()
         self.fixtures = self.root / "fixtures"
@@ -199,7 +205,7 @@ class Workspace:
 # ── G1: Pre-flight & help ─────────────────────────────────────────────────
 
 
-def test_help_available(ws: Workspace):
+def case_help_available(ws: Workspace):
     """``agent-sec-cli skill-ledger --help`` → exit 0."""
     r = run_skill_ledger(["--help"], env_extra=ws.env())
     assert r.returncode == 0, f"--help returned {r.returncode}: {r.stderr}"
@@ -211,7 +217,7 @@ def test_help_available(ws: Workspace):
 # ── G2: init-keys ─────────────────────────────────────────────────────────
 
 
-def test_init_keys_no_passphrase(ws: Workspace):
+def case_init_keys_no_passphrase(ws: Workspace):
     """init-keys without passphrase → exit 0, encrypted: false."""
     r = run_skill_ledger(["init-keys"], env_extra=ws.env())
     assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
@@ -220,7 +226,7 @@ def test_init_keys_no_passphrase(ws: Workspace):
     assert out.get("fingerprint", "").startswith("sha256:"), f"bad fingerprint: {out}"
 
 
-def test_init_keys_json_structure(ws: Workspace):
+def case_init_keys_json_structure(ws: Workspace):
     """JSON output must contain all 4 expected fields."""
     r = run_skill_ledger(["init-keys", "--force"], env_extra=ws.env())
     assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
@@ -232,7 +238,7 @@ def test_init_keys_json_structure(ws: Workspace):
     assert len(out["privateKeyPath"]) > 0
 
 
-def test_init_keys_reject_duplicate(ws: Workspace):
+def case_init_keys_reject_duplicate(ws: Workspace):
     """Second init-keys without --force → exit 1."""
     alt_data = ws.root / "alt_data"
     alt_data.mkdir()
@@ -247,7 +253,7 @@ def test_init_keys_reject_duplicate(ws: Workspace):
     ), f"Expected 'already exists' message: stdout={r2.stdout}, stderr={r2.stderr}"
 
 
-def test_init_keys_force_overwrite(ws: Workspace):
+def case_init_keys_force_overwrite(ws: Workspace):
     """--force overwrites existing keys and produces a new fingerprint."""
     alt_data = ws.root / "force_data"
     alt_data.mkdir()
@@ -262,7 +268,7 @@ def test_init_keys_force_overwrite(ws: Workspace):
     assert fp1 != fp2, f"Fingerprint should change after --force: {fp1}"
 
 
-def test_init_keys_with_passphrase_env(ws: Workspace):
+def case_init_keys_with_passphrase_env(ws: Workspace):
     """SKILL_LEDGER_PASSPHRASE env var → encrypted: true."""
     alt_data = ws.root / "pass_data"
     alt_data.mkdir()
@@ -281,7 +287,7 @@ def test_init_keys_with_passphrase_env(ws: Workspace):
 # ── G3: Happy-path lifecycle ──────────────────────────────────────────────
 
 
-def test_full_lifecycle_pass(ws: Workspace):
+def case_full_lifecycle_pass(ws: Workspace):
     """init-keys → check (none) → certify (pass) → check (pass) → audit (valid)."""
     skill = make_skill(
         ws.skills_dir,
@@ -318,7 +324,7 @@ def test_full_lifecycle_pass(ws: Workspace):
     assert out["valid"] is True, f"expected valid=true, got {out}"
 
 
-def test_multi_version_lifecycle(ws: Workspace):
+def case_multi_version_lifecycle(ws: Workspace):
     """certify → modify file → certify → audit validates 2-version chain."""
     skill = make_skill(ws.skills_dir, "multi-ver", {"data.txt": "v1"})
     env = ws.env()
@@ -351,7 +357,7 @@ def test_multi_version_lifecycle(ws: Workspace):
     assert out["versions_checked"] == 2, f"expected 2, got {out['versions_checked']}"
 
 
-def test_lifecycle_with_warn_findings(ws: Workspace):
+def case_lifecycle_with_warn_findings(ws: Workspace):
     """certify with warn findings → check returns warn, exit 0."""
     skill = make_skill(ws.skills_dir, "lifecycle-warn", {"app.sh": "#!/bin/bash\n"})
     env = ws.env()
@@ -383,7 +389,7 @@ def test_lifecycle_with_warn_findings(ws: Workspace):
 # ── G4: check state machine ──────────────────────────────────────────────
 
 
-def test_check_no_manifest_auto_creates(ws: Workspace):
+def case_check_no_manifest_auto_creates(ws: Workspace):
     """First check on new skill → auto-create manifest, status=none."""
     skill = make_skill(ws.skills_dir, "check-new", {"f.txt": "hello"})
     env = ws.env()
@@ -395,7 +401,7 @@ def test_check_no_manifest_auto_creates(ws: Workspace):
     assert latest.exists(), f"latest.json not created: {list(skill.rglob('*'))}"
 
 
-def test_check_after_file_add_drifted(ws: Workspace):
+def case_check_after_file_add_drifted(ws: Workspace):
     """Adding a file after certify → status=drifted."""
     skill = make_skill(ws.skills_dir, "check-add", {"original.txt": "content"})
     env = ws.env()
@@ -415,7 +421,7 @@ def test_check_after_file_add_drifted(ws: Workspace):
     assert "new_file.txt" in out.get("added", [])
 
 
-def test_check_after_file_modify_drifted(ws: Workspace):
+def case_check_after_file_modify_drifted(ws: Workspace):
     """Modifying a file after certify → status=drifted."""
     skill = make_skill(ws.skills_dir, "check-modify", {"data.txt": "original"})
     env = ws.env()
@@ -435,7 +441,7 @@ def test_check_after_file_modify_drifted(ws: Workspace):
     assert "data.txt" in out.get("modified", [])
 
 
-def test_check_after_file_remove_drifted(ws: Workspace):
+def case_check_after_file_remove_drifted(ws: Workspace):
     """Removing a file after certify → status=drifted."""
     skill = make_skill(
         ws.skills_dir,
@@ -459,7 +465,7 @@ def test_check_after_file_remove_drifted(ws: Workspace):
     assert "delete_me.txt" in out.get("removed", [])
 
 
-def test_check_tampered_manifest_hash(ws: Workspace):
+def case_check_tampered_manifest_hash(ws: Workspace):
     """Tamper with latest.json without re-hashing → status=tampered, exit 1."""
     skill = make_skill(ws.skills_dir, "check-tamper", {"f.txt": "safe"})
     env = ws.env()
@@ -481,7 +487,7 @@ def test_check_tampered_manifest_hash(ws: Workspace):
     assert out["status"] == "tampered", f"expected tampered, got {out}"
 
 
-def test_check_deny_exit_code_1(ws: Workspace):
+def case_check_deny_exit_code_1(ws: Workspace):
     """Certify with deny findings → check returns deny with exit 1."""
     skill = make_skill(ws.skills_dir, "check-deny", {"danger.sh": "rm -rf /"})
     env = ws.env()
@@ -502,7 +508,7 @@ def test_check_deny_exit_code_1(ws: Workspace):
 # ── G5: certify command ──────────────────────────────────────────────────
 
 
-def test_certify_external_findings_bare_array(ws: Workspace):
+def case_certify_external_findings_bare_array(ws: Workspace):
     """--findings with bare JSON array → exit 0, correct scanStatus."""
     skill = make_skill(ws.skills_dir, "certify-bare", {"a.txt": "a"})
     env = ws.env()
@@ -522,7 +528,7 @@ def test_certify_external_findings_bare_array(ws: Workspace):
     assert out["scanStatus"] == "warn"
 
 
-def test_certify_external_findings_wrapped(ws: Workspace):
+def case_certify_external_findings_wrapped(ws: Workspace):
     """--findings with {"findings": [...]} wrapper → exit 0."""
     skill = make_skill(ws.skills_dir, "certify-wrap", {"b.txt": "b"})
     env = ws.env()
@@ -539,7 +545,7 @@ def test_certify_external_findings_wrapped(ws: Workspace):
     assert out["scanStatus"] == "pass"
 
 
-def test_certify_deny_finding_produces_deny(ws: Workspace):
+def case_certify_deny_finding_produces_deny(ws: Workspace):
     """deny-level finding → scanStatus=deny."""
     skill = make_skill(ws.skills_dir, "certify-deny", {"c.txt": "c"})
     env = ws.env()
@@ -559,7 +565,7 @@ def test_certify_deny_finding_produces_deny(ws: Workspace):
     assert out["scanStatus"] == "deny"
 
 
-def test_certify_missing_findings_file(ws: Workspace):
+def case_certify_missing_findings_file(ws: Workspace):
     """--findings pointing to nonexistent file → exit 1."""
     skill = make_skill(ws.skills_dir, "certify-missing", {"d.txt": "d"})
     env = ws.env()
@@ -570,7 +576,7 @@ def test_certify_missing_findings_file(ws: Workspace):
     assert r.returncode == 1, f"expected exit 1, got {r.returncode}"
 
 
-def test_certify_invalid_json_findings(ws: Workspace):
+def case_certify_invalid_json_findings(ws: Workspace):
     """--findings with invalid JSON → exit 1."""
     skill = make_skill(ws.skills_dir, "certify-badjson", {"e.txt": "e"})
     env = ws.env()
@@ -582,7 +588,7 @@ def test_certify_invalid_json_findings(ws: Workspace):
     assert r.returncode == 1, f"expected exit 1 for invalid JSON, got {r.returncode}"
 
 
-def test_scan_auto_invoke_default_scanners(ws: Workspace):
+def case_scan_auto_invoke_default_scanners(ws: Workspace):
     """scan runs default built-in scanners."""
     skill = make_skill(
         ws.skills_dir,
@@ -606,7 +612,7 @@ def test_scan_auto_invoke_default_scanners(ws: Workspace):
     assert scans["static-scanner"]["status"] == "pass"
 
 
-def test_certify_no_skill_dir_no_all(ws: Workspace):
+def case_certify_no_skill_dir_no_all(ws: Workspace):
     """certify without skill_dir and without --all → exit 1."""
     env = ws.env()
     r = run_skill_ledger(["certify"], env_extra=env)
@@ -620,7 +626,7 @@ def test_certify_no_skill_dir_no_all(ws: Workspace):
 # ── G6: scan --all ───────────────────────────────────────────────────────
 
 
-def test_scan_all_multiple_skills(ws: Workspace):
+def case_scan_all_multiple_skills(ws: Workspace):
     """--all scans all skills from config.json managedSkillDirs."""
     env = ws.env()
     batch_root = ws.root / "batch_skills"
@@ -646,7 +652,7 @@ def test_scan_all_multiple_skills(ws: Workspace):
     assert len(out["results"]) == 3, f"Expected 3 results, got {len(out['results'])}"
 
 
-def test_scan_all_no_skill_dirs(ws: Workspace):
+def case_scan_all_no_skill_dirs(ws: Workspace):
     """--all with default dirs disabled and empty managedSkillDirs → exit 1."""
     env = ws.env()
     config_dir = ws.xdg_config / "agent-sec" / "skill-ledger"
@@ -664,7 +670,7 @@ def test_scan_all_no_skill_dirs(ws: Workspace):
 # ── G7: audit command ────────────────────────────────────────────────────
 
 
-def test_audit_valid_chain(ws: Workspace):
+def case_audit_valid_chain(ws: Workspace):
     """Multi-version audit → valid=true, exit 0."""
     skill = make_skill(ws.skills_dir, "audit-valid", {"a.txt": "a"})
     env = ws.env()
@@ -687,7 +693,7 @@ def test_audit_valid_chain(ws: Workspace):
     assert out["versions_checked"] >= 2
 
 
-def test_audit_no_versions(ws: Workspace):
+def case_audit_no_versions(ws: Workspace):
     """Skill with no .skill-meta → valid=true, 0 versions checked."""
     skill = make_skill(ws.skills_dir, "audit-none", {"x.txt": "x"})
     env = ws.env()
@@ -698,7 +704,7 @@ def test_audit_no_versions(ws: Workspace):
     assert out["versions_checked"] == 0
 
 
-def test_audit_tampered_version_file(ws: Workspace):
+def case_audit_tampered_version_file(ws: Workspace):
     """Tamper with a version JSON → valid=false, exit 1."""
     skill = make_skill(ws.skills_dir, "audit-tamper", {"f.txt": "f"})
     env = ws.env()
@@ -724,7 +730,7 @@ def test_audit_tampered_version_file(ws: Workspace):
     assert len(out["errors"]) > 0
 
 
-def test_audit_verify_snapshots(ws: Workspace):
+def case_audit_verify_snapshots(ws: Workspace):
     """--verify-snapshots validates snapshot file hashes match manifest."""
     skill = make_skill(ws.skills_dir, "audit-snap", {"s.txt": "snapshot-test"})
     env = ws.env()
@@ -745,7 +751,7 @@ def test_audit_verify_snapshots(ws: Workspace):
 # ── G8: status command ───────────────────────────────────────────────────
 
 
-def test_status_human_readable_output(ws: Workspace):
+def case_status_human_readable_output(ws: Workspace):
     """status returns ledger-wide overview with keys, config, skills sections."""
     env = ws.env()
 
@@ -785,7 +791,7 @@ def test_status_human_readable_output(ws: Workspace):
     assert "results" not in out, f"results should not appear without --verbose: {out}"
 
 
-def test_status_drifted_shows_details(ws: Workspace):
+def case_status_drifted_shows_details(ws: Workspace):
     """status health reflects drifted when a certified skill is modified."""
     env = ws.env()
 
@@ -828,7 +834,7 @@ def test_status_drifted_shows_details(ws: Workspace):
 # ── G9: stubs & edge cases ───────────────────────────────────────────────
 
 
-def test_set_policy_stub(ws: Workspace):
+def case_set_policy_stub(ws: Workspace):
     """set-policy → exit 0, 'coming soon' in output."""
     skill = make_skill(ws.skills_dir, "stub-policy", {"x.txt": "x"})
     r = run_skill_ledger(
@@ -838,14 +844,14 @@ def test_set_policy_stub(ws: Workspace):
     assert "coming soon" in r.stdout.lower()
 
 
-def test_rotate_keys_stub(ws: Workspace):
+def case_rotate_keys_stub(ws: Workspace):
     """rotate-keys → exit 0, 'coming soon' in output."""
     r = run_skill_ledger(["rotate-keys"], env_extra=ws.env())
     assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
     assert "coming soon" in r.stdout.lower()
 
 
-def test_list_scanners(ws: Workspace):
+def case_list_scanners(ws: Workspace):
     """list-scanners → exit 0, JSON with default scanners."""
     r = run_skill_ledger(["list-scanners"], env_extra=ws.env())
     assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
@@ -857,7 +863,7 @@ def test_list_scanners(ws: Workspace):
     assert "static-scanner" in names, f"Expected static-scanner in scanners: {names}"
 
 
-def test_certify_empty_skill_dir(ws: Workspace):
+def case_certify_empty_skill_dir(ws: Workspace):
     """Certify a skill dir with no SKILL.md → exit 1."""
     skill = ws.skills_dir / "empty-skill"
     skill.mkdir(parents=True, exist_ok=True)
@@ -869,7 +875,7 @@ def test_certify_empty_skill_dir(ws: Workspace):
 # ── G10: SKILL.md contract assertions ────────────────────────────────────
 
 
-def test_contract_init_keys_empty_passphrase_env(ws: Workspace):
+def case_contract_init_keys_empty_passphrase_env(ws: Workspace):
     """SKILL_LEDGER_PASSPHRASE="" → passphrase-free init."""
     alt_data = ws.root / "contract_keys"
     alt_data.mkdir()
@@ -884,7 +890,7 @@ def test_contract_init_keys_empty_passphrase_env(ws: Workspace):
     assert key_pub.exists(), f"key.pub not at expected path: {key_pub}"
 
 
-def test_contract_check_output_schema(ws: Workspace):
+def case_contract_check_output_schema(ws: Workspace):
     """check output is JSON with ``status`` field for every outcome."""
     env = ws.env()
 
@@ -914,7 +920,7 @@ def test_contract_check_output_schema(ws: Workspace):
         assert diff_key in out, f"drifted output missing '{diff_key}': {out}"
 
 
-def test_contract_certify_explicit_scanner_flags(ws: Workspace):
+def case_contract_certify_explicit_scanner_flags(ws: Workspace):
     """certify with explicit --scanner and --scanner-version flags."""
     skill = make_skill(ws.skills_dir, "contract-flags", {"run.sh": "echo hi"})
     env = ws.env()
@@ -941,7 +947,7 @@ def test_contract_certify_explicit_scanner_flags(ws: Workspace):
     assert out.get("scanStatus") == "pass"
 
 
-def test_contract_certify_output_fields(ws: Workspace):
+def case_contract_certify_output_fields(ws: Workspace):
     """certify output JSON contains versionId and scanStatus."""
     skill = make_skill(ws.skills_dir, "contract-output", {"data.py": "x = 1"})
     env = ws.env()
@@ -969,7 +975,7 @@ def test_contract_certify_output_fields(ws: Workspace):
     ), f"Unexpected scanStatus '{out['scanStatus']}'"
 
 
-def test_contract_manifest_path(ws: Workspace):
+def case_contract_manifest_path(ws: Workspace):
     """After certify, manifest exists at <SKILL_DIR>/.skill-meta/latest.json."""
     skill = make_skill(ws.skills_dir, "contract-path", {"f.txt": "content"})
     env = ws.env()
@@ -988,7 +994,7 @@ def test_contract_manifest_path(ws: Workspace):
         assert field in data, f"Missing '{field}' in manifest"
 
 
-def test_contract_check_status_values_complete(ws: Workspace):
+def case_contract_check_status_values_complete(ws: Workspace):
     """All 6 triage statuses are reachable: none, pass, drifted, warn, deny, tampered."""
     env = ws.env()
     observed: set[str] = set()
@@ -1055,7 +1061,7 @@ def test_contract_check_status_values_complete(ws: Workspace):
 # ── G11: Passphrase-protected key lifecycle ──────────────────────────────
 
 
-def test_passphrase_full_lifecycle(ws: Workspace):
+def case_passphrase_full_lifecycle(ws: Workspace):
     """Encrypted key: init → check → certify → check → audit — all work."""
     pp_data = ws.root / "pp_data"
     pp_data.mkdir()
@@ -1098,7 +1104,7 @@ def test_passphrase_full_lifecycle(ws: Workspace):
     assert out["valid"] is True
 
 
-def test_passphrase_missing_env_fails(ws: Workspace):
+def case_passphrase_missing_env_fails(ws: Workspace):
     """Encrypted key without SKILL_LEDGER_PASSPHRASE → certify fails gracefully."""
     pp_data = ws.root / "pp_noenv"
     pp_data.mkdir()
@@ -1193,13 +1199,13 @@ def _make_cosh_event(skill_name: str, cwd: str) -> dict:
     }
 
 
-def test_hook_invalid_json_allows():
+def case_hook_invalid_json_allows():
     """Malformed stdin → fail-open allow."""
     output = _run_hook("not-json")
     assert output == {"decision": "allow"}
 
 
-def test_hook_wrong_tool_allows():
+def case_hook_wrong_tool_allows():
     """Non-skill tool → allow."""
     output = _run_hook(
         {
@@ -1210,14 +1216,14 @@ def test_hook_wrong_tool_allows():
     assert output == {"decision": "allow"}
 
 
-def test_hook_unknown_skill_warns():
+def case_hook_unknown_skill_warns():
     """Skill not found on disk → allow with warning."""
     output = _run_hook(_make_cosh_event("nonexistent-skill-xyz", "/tmp"))
     assert output["decision"] == "allow"
     assert "not found" in output.get("reason", "").lower()
 
 
-def test_hook_pass_status_silent(ws: Workspace):
+def case_hook_pass_status_silent(ws: Workspace):
     """Hook on a pass-status skill → silent allow (no reason)."""
     skill = make_skill(ws.hook_skills_dir, "hook-pass", {"m.txt": "main"})
     env = ws.env()
@@ -1237,7 +1243,7 @@ def test_hook_pass_status_silent(ws: Workspace):
     assert "reason" not in output, f"Expected silent allow, got reason: {output}"
 
 
-def test_hook_drifted_requires_confirmation(ws: Workspace):
+def case_hook_drifted_requires_confirmation(ws: Workspace):
     """Hook on a drifted skill → ask with warning reason."""
     skill = make_skill(ws.hook_skills_dir, "hook-drift", {"f.txt": "original"})
     env = ws.env()
@@ -1261,7 +1267,7 @@ def test_hook_drifted_requires_confirmation(ws: Workspace):
     )
 
 
-def test_hook_path_traversal_rejected(ws: Workspace):
+def case_hook_path_traversal_rejected(ws: Workspace):
     """Path traversal in skill name → rejected with reason."""
     output = _run_hook(
         _make_cosh_event("../../etc/passwd", "/tmp"),
@@ -1275,7 +1281,7 @@ def test_hook_path_traversal_rejected(ws: Workspace):
 # ── G13: Full pipeline (vetter → ledger → hook) ─────────────────────────
 
 
-def test_full_pipeline_vetter_to_hook(ws: Workspace):
+def case_full_pipeline_vetter_to_hook(ws: Workspace):
     """End-to-end: create → check(none) → certify(pass) → hook(silent allow)."""
     skill = make_skill(ws.hook_skills_dir, "pipeline-full", {"app.py": "print(1)\n"})
     env = ws.env()
@@ -1322,7 +1328,7 @@ def test_full_pipeline_vetter_to_hook(ws: Workspace):
 # ── G14: Key rotation ────────────────────────────────────────────────────
 
 
-def test_key_rotation_old_sigs_verifiable(ws: Workspace):
+def case_key_rotation_old_sigs_verifiable(ws: Workspace):
     """After init-keys --force, old signatures must still pass ``check``."""
     env = ws.env()
 
@@ -1363,7 +1369,11 @@ def test_key_rotation_old_sigs_verifiable(ws: Workspace):
 # ── Main ───────────────────────────────────────────────────────────────────
 
 
-def main():
+def run_all_cases() -> int:
+    """Run the script-style E2E suite and return a process-style exit code."""
+    global results
+    results = Results()
+
     # Pre-flight
     if not CLI_BIN:
         print(f"{RED}ERROR: agent-sec-cli not found on PATH{NC}")
@@ -1371,7 +1381,7 @@ def main():
             "Install the RPM package or ensure the binary is on PATH.\n"
             "  rpm -q agent-sec-core  # check installation"
         )
-        sys.exit(1)
+        return 1
 
     hook_available = HOOK_SCRIPT is not None
 
@@ -1385,149 +1395,171 @@ def main():
         print("=" * 60)
 
         # G1: Pre-flight & help
-        test("G1: --help available", lambda: test_help_available(ws))
+        run_case("G1: --help available", lambda: case_help_available(ws))
 
         # G2: init-keys (run first — all subsequent tests need keys)
-        test("G2: init-keys no passphrase", lambda: test_init_keys_no_passphrase(ws))
-        test("G2: init-keys JSON structure", lambda: test_init_keys_json_structure(ws))
-        test(
+        run_case(
+            "G2: init-keys no passphrase", lambda: case_init_keys_no_passphrase(ws)
+        )
+        run_case(
+            "G2: init-keys JSON structure", lambda: case_init_keys_json_structure(ws)
+        )
+        run_case(
             "G2: init-keys reject duplicate",
-            lambda: test_init_keys_reject_duplicate(ws),
+            lambda: case_init_keys_reject_duplicate(ws),
         )
-        test(
+        run_case(
             "G2: init-keys --force overwrite",
-            lambda: test_init_keys_force_overwrite(ws),
+            lambda: case_init_keys_force_overwrite(ws),
         )
-        test(
+        run_case(
             "G2: init-keys passphrase env",
-            lambda: test_init_keys_with_passphrase_env(ws),
+            lambda: case_init_keys_with_passphrase_env(ws),
         )
 
         # G3: Happy-path lifecycle
-        test("G3: full pass lifecycle", lambda: test_full_lifecycle_pass(ws))
-        test("G3: multi-version chain", lambda: test_multi_version_lifecycle(ws))
-        test(
-            "G3: warn findings lifecycle", lambda: test_lifecycle_with_warn_findings(ws)
+        run_case("G3: full pass lifecycle", lambda: case_full_lifecycle_pass(ws))
+        run_case("G3: multi-version chain", lambda: case_multi_version_lifecycle(ws))
+        run_case(
+            "G3: warn findings lifecycle", lambda: case_lifecycle_with_warn_findings(ws)
         )
 
         # G4: check state machine
-        test(
+        run_case(
             "G4: no manifest → auto-create",
-            lambda: test_check_no_manifest_auto_creates(ws),
+            lambda: case_check_no_manifest_auto_creates(ws),
         )
-        test("G4: file added → drifted", lambda: test_check_after_file_add_drifted(ws))
-        test(
+        run_case(
+            "G4: file added → drifted", lambda: case_check_after_file_add_drifted(ws)
+        )
+        run_case(
             "G4: file modified → drifted",
-            lambda: test_check_after_file_modify_drifted(ws),
+            lambda: case_check_after_file_modify_drifted(ws),
         )
-        test(
+        run_case(
             "G4: file removed → drifted",
-            lambda: test_check_after_file_remove_drifted(ws),
+            lambda: case_check_after_file_remove_drifted(ws),
         )
-        test("G4: tampered → exit 1", lambda: test_check_tampered_manifest_hash(ws))
-        test("G4: deny → exit 1", lambda: test_check_deny_exit_code_1(ws))
+        run_case("G4: tampered → exit 1", lambda: case_check_tampered_manifest_hash(ws))
+        run_case("G4: deny → exit 1", lambda: case_check_deny_exit_code_1(ws))
 
         # G5: certify command
-        test(
+        run_case(
             "G5: bare array findings",
-            lambda: test_certify_external_findings_bare_array(ws),
+            lambda: case_certify_external_findings_bare_array(ws),
         )
-        test("G5: wrapped findings", lambda: test_certify_external_findings_wrapped(ws))
-        test("G5: deny finding", lambda: test_certify_deny_finding_produces_deny(ws))
-        test(
-            "G5: missing findings file", lambda: test_certify_missing_findings_file(ws)
+        run_case(
+            "G5: wrapped findings", lambda: case_certify_external_findings_wrapped(ws)
         )
-        test("G5: invalid JSON", lambda: test_certify_invalid_json_findings(ws))
-        test(
+        run_case(
+            "G5: deny finding", lambda: case_certify_deny_finding_produces_deny(ws)
+        )
+        run_case(
+            "G5: missing findings file", lambda: case_certify_missing_findings_file(ws)
+        )
+        run_case("G5: invalid JSON", lambda: case_certify_invalid_json_findings(ws))
+        run_case(
             "G5: scan auto-invoke mode",
-            lambda: test_scan_auto_invoke_default_scanners(ws),
+            lambda: case_scan_auto_invoke_default_scanners(ws),
         )
-        test("G5: no skill_dir no --all", lambda: test_certify_no_skill_dir_no_all(ws))
+        run_case(
+            "G5: no skill_dir no --all", lambda: case_certify_no_skill_dir_no_all(ws)
+        )
 
         # G6: scan --all
-        test("G6: --all multiple skills", lambda: test_scan_all_multiple_skills(ws))
-        test("G6: --all no skill dirs", lambda: test_scan_all_no_skill_dirs(ws))
+        run_case("G6: --all multiple skills", lambda: case_scan_all_multiple_skills(ws))
+        run_case("G6: --all no skill dirs", lambda: case_scan_all_no_skill_dirs(ws))
 
         # G7: audit
-        test("G7: valid chain", lambda: test_audit_valid_chain(ws))
-        test("G7: no versions", lambda: test_audit_no_versions(ws))
-        test("G7: tampered version file", lambda: test_audit_tampered_version_file(ws))
-        test("G7: --verify-snapshots", lambda: test_audit_verify_snapshots(ws))
+        run_case("G7: valid chain", lambda: case_audit_valid_chain(ws))
+        run_case("G7: no versions", lambda: case_audit_no_versions(ws))
+        run_case(
+            "G7: tampered version file", lambda: case_audit_tampered_version_file(ws)
+        )
+        run_case("G7: --verify-snapshots", lambda: case_audit_verify_snapshots(ws))
 
         # G8: status
-        test("G8: human-readable output", lambda: test_status_human_readable_output(ws))
-        test("G8: drifted details", lambda: test_status_drifted_shows_details(ws))
+        run_case(
+            "G8: human-readable output", lambda: case_status_human_readable_output(ws)
+        )
+        run_case("G8: drifted details", lambda: case_status_drifted_shows_details(ws))
 
         # G9: stubs & edge cases
-        test("G9: set-policy stub", lambda: test_set_policy_stub(ws))
-        test("G9: rotate-keys stub", lambda: test_rotate_keys_stub(ws))
-        test("G9: list-scanners", lambda: test_list_scanners(ws))
-        test("G9: certify empty skill dir", lambda: test_certify_empty_skill_dir(ws))
+        run_case("G9: set-policy stub", lambda: case_set_policy_stub(ws))
+        run_case("G9: rotate-keys stub", lambda: case_rotate_keys_stub(ws))
+        run_case("G9: list-scanners", lambda: case_list_scanners(ws))
+        run_case(
+            "G9: certify empty skill dir", lambda: case_certify_empty_skill_dir(ws)
+        )
 
         # G10: contract assertions
-        test(
+        run_case(
             "G10: empty passphrase env",
-            lambda: test_contract_init_keys_empty_passphrase_env(ws),
+            lambda: case_contract_init_keys_empty_passphrase_env(ws),
         )
-        test("G10: check output schema", lambda: test_contract_check_output_schema(ws))
-        test(
+        run_case(
+            "G10: check output schema", lambda: case_contract_check_output_schema(ws)
+        )
+        run_case(
             "G10: certify --scanner flags",
-            lambda: test_contract_certify_explicit_scanner_flags(ws),
+            lambda: case_contract_certify_explicit_scanner_flags(ws),
         )
-        test(
+        run_case(
             "G10: certify output fields",
-            lambda: test_contract_certify_output_fields(ws),
+            lambda: case_contract_certify_output_fields(ws),
         )
-        test("G10: manifest path", lambda: test_contract_manifest_path(ws))
-        test(
+        run_case("G10: manifest path", lambda: case_contract_manifest_path(ws))
+        run_case(
             "G10: all 6 statuses reachable",
-            lambda: test_contract_check_status_values_complete(ws),
+            lambda: case_contract_check_status_values_complete(ws),
         )
 
         # G11: passphrase-protected lifecycle
-        test(
-            "G11: passphrase full lifecycle", lambda: test_passphrase_full_lifecycle(ws)
+        run_case(
+            "G11: passphrase full lifecycle", lambda: case_passphrase_full_lifecycle(ws)
         )
-        test(
+        run_case(
             "G11: missing passphrase fails",
-            lambda: test_passphrase_missing_env_fails(ws),
+            lambda: case_passphrase_missing_env_fails(ws),
         )
 
         # G12: cosh hook integration
         if hook_available:
-            test(
+            run_case(
                 "G12: hook invalid JSON → allow",
-                lambda: test_hook_invalid_json_allows(),
+                lambda: case_hook_invalid_json_allows(),
             )
-            test("G12: hook wrong tool → allow", lambda: test_hook_wrong_tool_allows())
-            test(
-                "G12: hook unknown skill warns", lambda: test_hook_unknown_skill_warns()
+            run_case(
+                "G12: hook wrong tool → allow", lambda: case_hook_wrong_tool_allows()
             )
-            test(
+            run_case(
+                "G12: hook unknown skill warns", lambda: case_hook_unknown_skill_warns()
+            )
+            run_case(
                 "G12: hook pass → silent allow",
-                lambda: test_hook_pass_status_silent(ws),
+                lambda: case_hook_pass_status_silent(ws),
             )
-            test(
+            run_case(
                 "G12: hook drifted → ask",
-                lambda: test_hook_drifted_requires_confirmation(ws),
+                lambda: case_hook_drifted_requires_confirmation(ws),
             )
-            test(
+            run_case(
                 "G12: hook path traversal",
-                lambda: test_hook_path_traversal_rejected(ws),
+                lambda: case_hook_path_traversal_rejected(ws),
             )
         else:
             print(f"\n{YELLOW}SKIP G12: cosh hook script not found{NC}")
 
         # G13: full pipeline
-        test(
+        run_case(
             "G13: vetter→ledger→hook pipeline",
-            lambda: test_full_pipeline_vetter_to_hook(ws),
+            lambda: case_full_pipeline_vetter_to_hook(ws),
         )
 
         # G14: key rotation
-        test(
+        run_case(
             "G14: old sigs verifiable after rotation",
-            lambda: test_key_rotation_old_sigs_verifiable(ws),
+            lambda: case_key_rotation_old_sigs_verifiable(ws),
         )
 
     finally:
@@ -1544,18 +1576,31 @@ def main():
     print("=" * 60)
 
     if results.failed:
-        print(f"{RED}{results.failed} test(s) failed{NC}")
-        sys.exit(1)
-    else:
-        print(f"{GREEN}All tests passed!{NC}")
-        sys.exit(0)
+        print(f"{RED}{results.failed} case(s) failed{NC}")
+        return 1
+
+    print(f"{GREEN}All tests passed!{NC}")
+    return 0
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the standalone script runner."""
+    global VERBOSE
+
     import argparse
 
     parser = argparse.ArgumentParser(description="skill-ledger CLI E2E tests (RPM)")
     parser.add_argument("-v", "--verbose", action="store_true", help="Show CLI output")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     VERBOSE = args.verbose
-    main()
+    return run_all_cases()
+
+
+def test_skill_ledger_e2e():
+    """Pytest entry point for the script-style skill-ledger E2E suite."""
+    exit_code = run_all_cases()
+    assert exit_code == 0, f"skill-ledger E2E failed with exit code {exit_code}"
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Enable the skill-ledger E2E suite to run through pytest so the installed RPM and source-build E2E targets collect it as part of their main pytest flow. The script runner is still supported for direct `python3 e2e_test.py` usage, while pytest now sees a single entrypoint that executes the same G1-G14 cases.

The E2E workspace also writes an isolated skill-ledger config with `enableDefaultSkillDirs=false` and empty `managedSkillDirs`, keeping installed system skills out of scan/status expectations.

## Related Issue

no-issue: test workflow maintenance

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make -C src/agent-sec-core python-code-pretty`
- `python3 -m pytest tests/e2e/skill-ledger/e2e_test.py --collect-only -q`
- `env PYTHONPATH=agent-sec-cli/src agent-sec-cli/.venv/bin/python -m pytest tests/unit-test/skill_ledger/test_config.py -q`
- `env PATH=/Users/daniel/workspace/anolisa/src/agent-sec-core/agent-sec-cli/.venv/bin:/opt/homebrew/bin:/usr/bin:/bin PYTHONPATH=agent-sec-cli/src agent-sec-cli/.venv/bin/python -m pytest tests/e2e/skill-ledger/e2e_test.py -q --tb=short`
- `make -n test-e2e-rpm`
- `make -n test-e2e-source-build`
- `git diff --check`

## Additional Notes

`test-python-coverage` continues to ignore skill-ledger E2E intentionally; this PR only changes the installed E2E targets.