### PR TITLE
feat(sec-core): correlate security events with observability events

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/cli.py
@@ -106,17 +106,31 @@ def review() -> None:
 
     # Lazy-import Textual so the hot `record` / `schema` paths don't pay its
     # import cost.
+    from agent_sec_cli.observability.correlation import (  # noqa: PLC0415
+        SecurityCorrelationService,
+    )
     from agent_sec_cli.observability.review import (  # noqa: PLC0415
         ObservabilityReviewApp,
     )
     from agent_sec_cli.observability.sqlite_reader import (  # noqa: PLC0415
         ObservabilityReader,
     )
+    from agent_sec_cli.security_events.sqlite_reader import (  # noqa: PLC0415
+        SqliteEventReader,
+    )
 
     reader = ObservabilityReader()
+    security_reader = None
     try:
-        ObservabilityReviewApp(reader=reader).run()
+        security_reader = SqliteEventReader()
+        security_correlation = SecurityCorrelationService(security_reader)
+        ObservabilityReviewApp(
+            reader=reader,
+            security_correlation=security_correlation,
+        ).run()
     finally:
+        if security_reader is not None:
+            security_reader.close()
         reader.close()
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/correlation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/correlation.py
@@ -1,19 +1,116 @@
-"""Correlate observability records to security events for review UI."""
+"""Correlate observability records to security events for review UI.
 
+Entry points:
+
+* ``SecurityCorrelationService.find_correlated(record)`` — correlate one
+  observability record.
+* ``SecurityCorrelationService.find_correlated_many(records)`` — correlate a
+  batch of records while sharing candidate reads. This is a read optimization
+  for the review event list; it must return the same per-record correlations as
+  calling ``find_correlated`` for each record independently.
+
+Preconditions
+-------------
+* Hook must be ``before_tool_call`` or ``before_agent_run``; anything else
+  returns ``[]``.
+* ``session_id`` must be present; otherwise no query is issued.
+* Candidate categories are constrained by ``SUPPORTED_SECURITY_EVENT_CATEGORIES``:
+
+  - ``before_tool_call`` → ``(code_scan, skill_ledger)``
+  - ``before_agent_run`` → ``(prompt_scan, pii_scan)``
+
+* At most one event per category is returned, in the order listed above.
+
+Matching modes (highest priority first)
+---------------------------------------
+1. **Exact (``tool_call_id``)** — triggered when the record has non-empty,
+   non-zero ``session_id + run_id + tool_call_id``. Requires the event's
+   ``session_id / run_id / tool_call_id`` to all match. No time window.
+   Yields ``match_rank=0``, ``match_reason="tool_call_id"``.
+
+2. **Run (``run_id``)** — only for hook ``before_agent_run`` with a valid
+   ``run_id``. Requires ``session_id + run_id`` to match. No time window.
+   Yields ``match_rank=0``, ``match_reason="run_id"``.
+
+3. **Fallback (``field+time``)** — when the prior two don't apply (typically
+   because the obs record's ``tool_call_id`` is missing or the all-zero UUID).
+   Two filters then per-category field matching:
+
+   a. Time window: ``|event_ts − obs_ts| ≤ FALLBACK_TIME_WINDOW_SECONDS`` (10s).
+   b. Soft ``run_id`` constraint: if the record has a real ``run_id`` the event
+      must match; if not (missing / zero), the reader is asked for events with
+      ``run_id=None``.
+   c. ``_field_match_rank`` dispatches by category:
+
+      ====================  ======================================================
+      Category              Strategy
+      ====================  ======================================================
+      ``skill_ledger``      **Skipped** — event stores a resolved absolute
+                            ``skill_dir``, obs stores the unresolved logical name;
+                            the two live at different abstraction layers, so
+                            fallback similarity matching would be misleading.
+      ``pii_scan``          Hash-only — ``sha256(obs.metrics.prompt) ==
+                            event.request.text_sha256``.
+      ``prompt_scan``       String similarity between obs
+                            ``metrics.{prompt,user_input,text,input}`` and event
+                            ``request.{text,prompt,user_input,input}``.
+      ``code_scan``         String similarity between obs
+                            ``metrics.parameters.{command,cmd,code,script,input}``
+                            and event ``request.{code,command,cmd,script}``.
+      ====================  ======================================================
+
+   ``_string_match_rank`` normalizes both sides with ``" ".join(s.split())``
+   then ranks the comparison:
+
+   - exact equality → ``match_rank=0``
+   - either side is a suffix of the other → ``match_rank=1``
+   - either side is a prefix of the other → ``match_rank=2``
+   - otherwise → no match
+
+   Yields ``match_reason="field+time"``.
+
+Batch candidate reads
+---------------------
+``find_correlated_many`` does not change the matching modes above. It groups
+records only to reduce SQLite round-trips before applying the same per-record
+selection logic:
+
+* Exact mode groups records by ``session_id + run_id + categories`` and reads
+  candidates with ``tool_call_id IN (...)``.
+* Run mode groups records by ``session_id + run_id + categories`` and reads
+  candidates once for that run.
+* Fallback mode keeps each record's ``observed_at ± 10s`` semantics. It merges
+  only overlapping windows whose total span stays within
+  ``MAX_FALLBACK_BATCH_WINDOW_SECONDS`` so long runs are not prefetched as one
+  large time range.
+
+Per-category selection
+----------------------
+When multiple candidates of one category pass matching, the smallest
+``(match_rank, |time_delta|, security_timestamp_epoch, event_id)`` wins.
+Match quality dominates, then proximity in time, then a stable tiebreak.
+
+Example: in fallback, an event whose text exactly equals the obs prompt but
+sits 5 s away beats an event that's only a suffix of the prompt at 0.1 s away:
+``(0, 5)`` < ``(1, 0.1)``.
+"""
+
+import hashlib
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Any, Iterable, Literal, Mapping, Protocol, Sequence
 
 from agent_sec_cli.security_events.schema import SecurityEvent
 
 ZERO_RUN_ID = "00000000-0000-0000-0000-000000000000"
-FALLBACK_TIME_WINDOW_SECONDS = 2.0
+FALLBACK_TIME_WINDOW_SECONDS = 10.0
+MAX_FALLBACK_BATCH_WINDOW_SECONDS = 60.0
 
 SUPPORTED_SECURITY_EVENT_CATEGORIES: dict[str, tuple[str, ...]] = {
     "before_tool_call": ("code_scan", "skill_ledger"),
     "before_agent_run": ("prompt_scan", "pii_scan"),
 }
 
-MatchReason = Literal["tool_call_id", "run_id", "rule+time"]
+MatchReason = Literal["tool_call_id", "run_id", "field+time"]
 
 
 @dataclass(frozen=True)
@@ -25,6 +122,7 @@ class ObservabilityRecordFields:
     run_id: str | None
     tool_call_id: str | None
     observed_at_epoch: float
+    metrics: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -35,6 +133,7 @@ class CorrelatedSecurityEvent:
     match_reason: MatchReason
     time_delta_seconds: float
     security_timestamp_epoch: float
+    match_rank: int = 0
 
 
 class _SecurityEventCandidate(Protocol):
@@ -50,10 +149,19 @@ class _CorrelationReader(Protocol):
         categories: tuple[str, ...],
         run_id: str | None,
         tool_call_id: str | None,
-        since_epoch: float | None,
-        until_epoch: float | None,
+        tool_call_ids: Sequence[str] | None = None,
+        since_epoch: float | None = None,
+        until_epoch: float | None = None,
     ) -> list[_SecurityEventCandidate]:
         pass
+
+
+@dataclass(frozen=True)
+class _FallbackBatchItem:
+    index: int
+    record: ObservabilityRecordFields
+    since_epoch: float
+    until_epoch: float
 
 
 class SecurityCorrelationService:
@@ -111,7 +219,129 @@ class SecurityCorrelationService:
             since_epoch=record.observed_at_epoch - FALLBACK_TIME_WINDOW_SECONDS,
             until_epoch=record.observed_at_epoch + FALLBACK_TIME_WINDOW_SECONDS,
         )
-        return self._select_by_category(record, candidates, categories, "rule+time")
+        return self._select_by_category(record, candidates, categories, "field+time")
+
+    def find_correlated_many(
+        self, records: Sequence[ObservabilityRecordFields]
+    ) -> list[list[CorrelatedSecurityEvent]]:
+        """Return correlations for many records while sharing candidate queries."""
+        results: list[list[CorrelatedSecurityEvent]] = [[] for _ in records]
+        exact_groups: dict[
+            tuple[str, tuple[str, ...], str],
+            list[tuple[int, ObservabilityRecordFields]],
+        ] = {}
+        run_groups: dict[
+            tuple[str, tuple[str, ...], str],
+            list[tuple[int, ObservabilityRecordFields]],
+        ] = {}
+        fallback_groups: dict[
+            tuple[str, tuple[str, ...], str | None],
+            list[_FallbackBatchItem],
+        ] = {}
+
+        for index, record in enumerate(records):
+            categories = SUPPORTED_SECURITY_EVENT_CATEGORIES.get(record.hook)
+            if categories is None or _missing(record.session_id):
+                continue
+
+            session_id = str(record.session_id)
+            if _has_tool_call_correlation(record):
+                exact_groups.setdefault(
+                    (session_id, categories, str(record.run_id)),
+                    [],
+                ).append((index, record))
+                continue
+
+            if _has_run_correlation(record):
+                run_groups.setdefault(
+                    (session_id, categories, str(record.run_id)),
+                    [],
+                ).append((index, record))
+                continue
+
+            run_id = None if _missing_run_id(record.run_id) else record.run_id
+            fallback_groups.setdefault((session_id, categories, run_id), []).append(
+                _FallbackBatchItem(
+                    index=index,
+                    record=record,
+                    since_epoch=record.observed_at_epoch - FALLBACK_TIME_WINDOW_SECONDS,
+                    until_epoch=record.observed_at_epoch + FALLBACK_TIME_WINDOW_SECONDS,
+                )
+            )
+
+        for (session_id, categories, run_id), items in exact_groups.items():
+            tool_call_ids = tuple(
+                sorted(
+                    {
+                        str(record.tool_call_id)
+                        for _, record in items
+                        if not _missing(record.tool_call_id)
+                    }
+                )
+            )
+            if not tool_call_ids:
+                continue
+            candidates = self._reader.query_correlation_candidates(
+                session_id=session_id,
+                categories=categories,
+                run_id=run_id,
+                tool_call_id=None,
+                tool_call_ids=tool_call_ids,
+                since_epoch=None,
+                until_epoch=None,
+            )
+            for index, record in items:
+                results[index] = self._select_by_category(
+                    record,
+                    candidates,
+                    categories,
+                    "tool_call_id",
+                )
+
+        for (session_id, categories, run_id), items in run_groups.items():
+            candidates = self._reader.query_correlation_candidates(
+                session_id=session_id,
+                categories=categories,
+                run_id=run_id,
+                tool_call_id=None,
+                since_epoch=None,
+                until_epoch=None,
+            )
+            for index, record in items:
+                results[index] = self._select_by_category(
+                    record,
+                    candidates,
+                    categories,
+                    "run_id",
+                )
+
+        for (session_id, categories, run_id), items in fallback_groups.items():
+            candidates_by_index: dict[int, list[_SecurityEventCandidate]] = {
+                item.index: [] for item in items
+            }
+            for window_items in _merge_fallback_batch_items(items):
+                since_epoch = min(item.since_epoch for item in window_items)
+                until_epoch = max(item.until_epoch for item in window_items)
+                candidates = self._reader.query_correlation_candidates(
+                    session_id=session_id,
+                    categories=categories,
+                    run_id=run_id,
+                    tool_call_id=None,
+                    since_epoch=since_epoch,
+                    until_epoch=until_epoch,
+                )
+                for item in window_items:
+                    candidates_by_index[item.index].extend(candidates)
+
+            for item in items:
+                results[item.index] = self._select_by_category(
+                    item.record,
+                    candidates_by_index[item.index],
+                    categories,
+                    "field+time",
+                )
+
+        return results
 
     def _select_by_category(
         self,
@@ -122,13 +352,20 @@ class SecurityCorrelationService:
     ) -> list[CorrelatedSecurityEvent]:
         selected: dict[str, CorrelatedSecurityEvent] = {}
         for candidate in candidates:
-            if not _candidate_matches(record, candidate, categories, match_reason):
+            match_rank = _candidate_match_rank(
+                record,
+                candidate,
+                categories,
+                match_reason,
+            )
+            if match_rank is None:
                 continue
             correlated = CorrelatedSecurityEvent(
                 event=candidate.event,
                 match_reason=match_reason,
                 time_delta_seconds=candidate.timestamp_epoch - record.observed_at_epoch,
                 security_timestamp_epoch=candidate.timestamp_epoch,
+                match_rank=match_rank,
             )
             current = selected.get(candidate.event.category)
             if current is None or _rank(correlated) < _rank(current):
@@ -137,35 +374,41 @@ class SecurityCorrelationService:
         return [selected[category] for category in categories if category in selected]
 
 
-def _candidate_matches(
+def _candidate_match_rank(
     record: ObservabilityRecordFields,
     candidate: _SecurityEventCandidate,
     categories: tuple[str, ...],
     match_reason: MatchReason,
-) -> bool:
+) -> int | None:
     event = candidate.event
     if event.category not in categories:
-        return False
+        return None
     if _missing(event.session_id) or event.session_id != record.session_id:
-        return False
+        return None
 
     if match_reason == "tool_call_id":
-        return (
+        if (
             not _missing_run_id(event.run_id)
             and event.run_id == record.run_id
             and not _missing(event.tool_call_id)
             and event.tool_call_id == record.tool_call_id
-        )
+        ):
+            return 0
+        return None
 
     if match_reason == "run_id":
-        return not _missing_run_id(event.run_id) and event.run_id == record.run_id
+        if not _missing_run_id(event.run_id) and event.run_id == record.run_id:
+            return 0
+        return None
 
     if not _missing_run_id(record.run_id) and event.run_id != record.run_id:
-        return False
-    return (
+        return None
+    if (
         abs(candidate.timestamp_epoch - record.observed_at_epoch)
-        <= FALLBACK_TIME_WINDOW_SECONDS
-    )
+        > FALLBACK_TIME_WINDOW_SECONDS
+    ):
+        return None
+    return _field_match_rank(record, event)
 
 
 def _has_tool_call_correlation(record: ObservabilityRecordFields) -> bool:
@@ -188,8 +431,175 @@ def _missing_run_id(value: str | None) -> bool:
     return _missing(value) or value == ZERO_RUN_ID
 
 
-def _rank(correlation: CorrelatedSecurityEvent) -> tuple[float, float, str]:
+def _merge_fallback_batch_items(
+    items: list[_FallbackBatchItem],
+) -> list[list[_FallbackBatchItem]]:
+    merged: list[list[_FallbackBatchItem]] = []
+    current: list[_FallbackBatchItem] = []
+    current_since = 0.0
+    current_until = 0.0
+
+    for item in sorted(items, key=lambda value: (value.since_epoch, value.until_epoch)):
+        if not current:
+            current = [item]
+            current_since = item.since_epoch
+            current_until = item.until_epoch
+            continue
+
+        next_until = max(current_until, item.until_epoch)
+        if (
+            item.since_epoch <= current_until
+            and next_until - current_since <= MAX_FALLBACK_BATCH_WINDOW_SECONDS
+        ):
+            current.append(item)
+            current_until = next_until
+            continue
+
+        merged.append(current)
+        current = [item]
+        current_since = item.since_epoch
+        current_until = item.until_epoch
+
+    if current:
+        merged.append(current)
+    return merged
+
+
+def _field_match_rank(
+    record: ObservabilityRecordFields,
+    event: SecurityEvent,
+) -> int | None:
+    # skill_ledger events store a resolved skill_dir (absolute path) while
+    # observability records carry the unresolved logical name. The two live
+    # at different abstraction layers, so fallback string-similarity matching
+    # would be misleading — only the tool_call_id exact mode can relate them.
+    if event.category == "skill_ledger":
+        return None
+
+    record_values = _observability_match_values(record, event.category)
+    if event.category == "pii_scan":
+        return _pii_hash_match_rank(record_values, event)
+
+    event_values = _security_event_match_values(event)
+    ranks = [
+        rank
+        for left in record_values
+        for right in event_values
+        if (rank := _string_match_rank(left, right)) is not None
+    ]
+
+    if not ranks:
+        return None
+    return min(ranks)
+
+
+def _observability_match_values(
+    record: ObservabilityRecordFields,
+    category: str,
+) -> list[str]:
+    metrics = record.metrics
+    if not isinstance(metrics, Mapping):
+        return []
+
+    if record.hook == "before_agent_run":
+        return _strings_from_mapping(
+            metrics,
+            ("prompt", "user_input", "text", "input"),
+        )
+
+    if record.hook != "before_tool_call":
+        return []
+
+    parameters = metrics.get("parameters")
+    if category == "code_scan":
+        return _strings_from_tool_parameters(
+            parameters,
+            ("command", "cmd", "code", "script", "input"),
+        )
+    return []
+
+
+def _security_event_match_values(event: SecurityEvent) -> list[str]:
+    request = event.details.get("request")
+    if not isinstance(request, Mapping):
+        return []
+
+    if event.category == "prompt_scan":
+        return _strings_from_mapping(
+            request,
+            ("text", "prompt", "user_input", "input"),
+        )
+    if event.category == "code_scan":
+        return _strings_from_mapping(request, ("code", "command", "cmd", "script"))
+    return []
+
+
+def _strings_from_tool_parameters(
+    value: Any,
+    keys: tuple[str, ...],
+) -> list[str]:
+    if isinstance(value, str):
+        return _non_empty_strings((value,))
+    if isinstance(value, Mapping):
+        return _strings_from_mapping(value, keys)
+    return []
+
+
+def _strings_from_mapping(
+    values: Mapping[str, Any],
+    keys: tuple[str, ...],
+) -> list[str]:
+    return _non_empty_strings(values.get(key) for key in keys)
+
+
+def _non_empty_strings(values: Iterable[Any]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            result.append(value)
+    return result
+
+
+def _string_match_rank(left: str, right: str) -> int | None:
+    normalized_left = _normalize_match_text(left)
+    normalized_right = _normalize_match_text(right)
+    if not normalized_left or not normalized_right:
+        return None
+    if normalized_left == normalized_right:
+        return 0
+    if normalized_left.endswith(normalized_right) or normalized_right.endswith(
+        normalized_left
+    ):
+        return 1
+    if normalized_left.startswith(normalized_right) or normalized_right.startswith(
+        normalized_left
+    ):
+        return 2
+    return None
+
+
+def _normalize_match_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _pii_hash_match_rank(record_values: list[str], event: SecurityEvent) -> int | None:
+    request = event.details.get("request")
+    if not isinstance(request, Mapping):
+        return None
+    expected_hash = request.get("text_sha256")
+    if not isinstance(expected_hash, str) or not expected_hash:
+        return None
+
+    for value in record_values:
+        actual_hash = hashlib.sha256(value.encode("utf-8")).hexdigest()
+        if actual_hash == expected_hash:
+            return 0
+    return None
+
+
+def _rank(correlation: CorrelatedSecurityEvent) -> tuple[int, float, float, str]:
     return (
+        correlation.match_rank,
         abs(correlation.time_delta_seconds),
         correlation.security_timestamp_epoch,
         correlation.event.event_id,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/correlation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/correlation.py
@@ -1,0 +1,206 @@
+"""Correlate observability records to security events for review UI."""
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from agent_sec_cli.security_events.schema import SecurityEvent
+
+ZERO_RUN_ID = "00000000-0000-0000-0000-000000000000"
+FALLBACK_TIME_WINDOW_SECONDS = 2.0
+
+SUPPORTED_SECURITY_EVENT_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "before_tool_call": ("code_scan", "skill_ledger"),
+    "before_agent_run": ("prompt_scan", "pii_scan"),
+}
+
+MatchReason = Literal["tool_call_id", "run_id", "rule+time"]
+
+
+@dataclass(frozen=True)
+class ObservabilityRecordFields:
+    """Plain fields required to correlate one observability record."""
+
+    hook: str
+    session_id: str | None
+    run_id: str | None
+    tool_call_id: str | None
+    observed_at_epoch: float
+
+
+@dataclass(frozen=True)
+class CorrelatedSecurityEvent:
+    """Security event plus correlation metadata computed by the service."""
+
+    event: SecurityEvent
+    match_reason: MatchReason
+    time_delta_seconds: float
+    security_timestamp_epoch: float
+
+
+class _SecurityEventCandidate(Protocol):
+    event: SecurityEvent
+    timestamp_epoch: float
+
+
+class _CorrelationReader(Protocol):
+    def query_correlation_candidates(
+        self,
+        *,
+        session_id: str,
+        categories: tuple[str, ...],
+        run_id: str | None,
+        tool_call_id: str | None,
+        since_epoch: float | None,
+        until_epoch: float | None,
+    ) -> list[_SecurityEventCandidate]:
+        pass
+
+
+class SecurityCorrelationService:
+    """Find security events correlated to one observability record."""
+
+    def __init__(self, reader: _CorrelationReader) -> None:
+        self._reader = reader
+
+    def find_correlated(
+        self, record: ObservabilityRecordFields
+    ) -> list[CorrelatedSecurityEvent]:
+        """Return sorted, category-deduplicated security-event correlations."""
+        categories = SUPPORTED_SECURITY_EVENT_CATEGORIES.get(record.hook)
+        if categories is None or _missing(record.session_id):
+            return []
+
+        if _has_tool_call_correlation(record):
+            candidates = self._reader.query_correlation_candidates(
+                session_id=str(record.session_id),
+                categories=categories,
+                run_id=record.run_id,
+                tool_call_id=record.tool_call_id,
+                since_epoch=None,
+                until_epoch=None,
+            )
+            return self._select_by_category(
+                record,
+                candidates,
+                categories,
+                "tool_call_id",
+            )
+
+        if _has_run_correlation(record):
+            candidates = self._reader.query_correlation_candidates(
+                session_id=str(record.session_id),
+                categories=categories,
+                run_id=record.run_id,
+                tool_call_id=None,
+                since_epoch=None,
+                until_epoch=None,
+            )
+            return self._select_by_category(
+                record,
+                candidates,
+                categories,
+                "run_id",
+            )
+
+        run_id = None if _missing_run_id(record.run_id) else record.run_id
+        candidates = self._reader.query_correlation_candidates(
+            session_id=str(record.session_id),
+            categories=categories,
+            run_id=run_id,
+            tool_call_id=None,
+            since_epoch=record.observed_at_epoch - FALLBACK_TIME_WINDOW_SECONDS,
+            until_epoch=record.observed_at_epoch + FALLBACK_TIME_WINDOW_SECONDS,
+        )
+        return self._select_by_category(record, candidates, categories, "rule+time")
+
+    def _select_by_category(
+        self,
+        record: ObservabilityRecordFields,
+        candidates: list[_SecurityEventCandidate],
+        categories: tuple[str, ...],
+        match_reason: MatchReason,
+    ) -> list[CorrelatedSecurityEvent]:
+        selected: dict[str, CorrelatedSecurityEvent] = {}
+        for candidate in candidates:
+            if not _candidate_matches(record, candidate, categories, match_reason):
+                continue
+            correlated = CorrelatedSecurityEvent(
+                event=candidate.event,
+                match_reason=match_reason,
+                time_delta_seconds=candidate.timestamp_epoch - record.observed_at_epoch,
+                security_timestamp_epoch=candidate.timestamp_epoch,
+            )
+            current = selected.get(candidate.event.category)
+            if current is None or _rank(correlated) < _rank(current):
+                selected[candidate.event.category] = correlated
+
+        return [selected[category] for category in categories if category in selected]
+
+
+def _candidate_matches(
+    record: ObservabilityRecordFields,
+    candidate: _SecurityEventCandidate,
+    categories: tuple[str, ...],
+    match_reason: MatchReason,
+) -> bool:
+    event = candidate.event
+    if event.category not in categories:
+        return False
+    if _missing(event.session_id) or event.session_id != record.session_id:
+        return False
+
+    if match_reason == "tool_call_id":
+        return (
+            not _missing_run_id(event.run_id)
+            and event.run_id == record.run_id
+            and not _missing(event.tool_call_id)
+            and event.tool_call_id == record.tool_call_id
+        )
+
+    if match_reason == "run_id":
+        return not _missing_run_id(event.run_id) and event.run_id == record.run_id
+
+    if not _missing_run_id(record.run_id) and event.run_id != record.run_id:
+        return False
+    return (
+        abs(candidate.timestamp_epoch - record.observed_at_epoch)
+        <= FALLBACK_TIME_WINDOW_SECONDS
+    )
+
+
+def _has_tool_call_correlation(record: ObservabilityRecordFields) -> bool:
+    return (
+        not _missing(record.session_id)
+        and not _missing_run_id(record.run_id)
+        and not _missing(record.tool_call_id)
+    )
+
+
+def _has_run_correlation(record: ObservabilityRecordFields) -> bool:
+    return record.hook == "before_agent_run" and not _missing_run_id(record.run_id)
+
+
+def _missing(value: str | None) -> bool:
+    return value is None or not value.strip()
+
+
+def _missing_run_id(value: str | None) -> bool:
+    return _missing(value) or value == ZERO_RUN_ID
+
+
+def _rank(correlation: CorrelatedSecurityEvent) -> tuple[float, float, str]:
+    return (
+        abs(correlation.time_delta_seconds),
+        correlation.security_timestamp_epoch,
+        correlation.event.event_id,
+    )
+
+
+__all__ = [
+    "CorrelatedSecurityEvent",
+    "FALLBACK_TIME_WINDOW_SECONDS",
+    "ObservabilityRecordFields",
+    "SUPPORTED_SECURITY_EVENT_CATEGORIES",
+    "SecurityCorrelationService",
+    "ZERO_RUN_ID",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/review.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/review.py
@@ -205,11 +205,13 @@ class EventListScreen(_ListScreenBase):
         )
         self._rows_by_key = {str(row.id): row for row in rows}
         security_correlation = getattr(self.app, "security_correlation", None)
+        security_results = _find_correlated_security_events_many(
+            rows,
+            security_correlation,
+        )
         self._security_results_by_key = {
-            str(row.id): _format_security_result(
-                _find_correlated_security_events(row, security_correlation)
-            )
-            for row in rows
+            str(row.id): _format_security_result(security_results[index])
+            for index, row in enumerate(rows)
         }
         return rows
 
@@ -373,18 +375,53 @@ def _find_correlated_security_events(
     if security_correlation is None:
         return []
     try:
-        return security_correlation.find_correlated(
-            ObservabilityRecordFields(
-                hook=record.hook,
-                session_id=record.session_id,
-                run_id=record.run_id,
-                tool_call_id=record.tool_call_id,
-                observed_at_epoch=record.observed_at_epoch,
-            )
-        )
+        return security_correlation.find_correlated(_record_fields(record))
     except Exception:
         # TODO(logging): warn with error type, session_id, and run_id once logging is wired.
         return []
+
+
+def _find_correlated_security_events_many(
+    records: list[ObservabilityEventRecord],
+    security_correlation: _SecurityCorrelation | None,
+) -> list[list[CorrelatedSecurityEvent]]:
+    if security_correlation is None:
+        return [[] for _ in records]
+
+    find_many = getattr(security_correlation, "find_correlated_many", None)
+    if callable(find_many):
+        try:
+            results = find_many([_record_fields(record) for record in records])
+        except Exception:
+            return [[] for _ in records]
+        if len(results) == len(records):
+            return [list(result) for result in results]
+
+    return [
+        _find_correlated_security_events(record, security_correlation)
+        for record in records
+    ]
+
+
+def _record_fields(record: ObservabilityEventRecord) -> ObservabilityRecordFields:
+    return ObservabilityRecordFields(
+        hook=record.hook,
+        session_id=record.session_id,
+        run_id=record.run_id,
+        tool_call_id=record.tool_call_id,
+        observed_at_epoch=record.observed_at_epoch,
+        metrics=_safe_metrics_dict(record.metrics_json),
+    )
+
+
+def _safe_metrics_dict(raw: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
 
 
 def _format_security_result(events: list[CorrelatedSecurityEvent]) -> str:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/review.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/review.py
@@ -10,8 +10,13 @@ module never owns the reader's lifecycle.
 
 import json
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 
+from agent_sec_cli.observability.correlation import (
+    CorrelatedSecurityEvent,
+    ObservabilityRecordFields,
+    SecurityCorrelationService,
+)
 from agent_sec_cli.observability.models import ObservabilityEventRecord
 from agent_sec_cli.observability.repositories import RunSummary, SessionSummary
 from agent_sec_cli.observability.sqlite_reader import ObservabilityReader
@@ -21,6 +26,13 @@ from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header, Static
+
+
+class _SecurityCorrelation(Protocol):
+    def find_correlated(
+        self, record: ObservabilityRecordFields
+    ) -> list[CorrelatedSecurityEvent]:
+        pass
 
 
 def _format_epoch(epoch: float) -> str:
@@ -182,15 +194,23 @@ class EventListScreen(_ListScreenBase):
         self._run_id = run_id
         # Cache rows so action_drill can recover the full record by row key.
         self._rows_by_key: dict[str, ObservabilityEventRecord] = {}
+        self._security_results_by_key: dict[str, str] = {}
 
     def _columns(self) -> tuple[str, ...]:
-        return ("Time", "Hook", "Call / Tool", "Summary")
+        return ("Time", "Hook", "Call / Tool", "Security Result")
 
     def _load_rows(self) -> list[ObservabilityEventRecord]:
         rows = self.app.reader.list_events(  # type: ignore[attr-defined]
             self._session_id, self._run_id
         )
         self._rows_by_key = {str(row.id): row for row in rows}
+        security_correlation = getattr(self.app, "security_correlation", None)
+        self._security_results_by_key = {
+            str(row.id): _format_security_result(
+                _find_correlated_security_events(row, security_correlation)
+            )
+            for row in rows
+        }
         return rows
 
     def _row_values(self, row: ObservabilityEventRecord) -> tuple[str, ...]:  # type: ignore[override]
@@ -200,7 +220,7 @@ class EventListScreen(_ListScreenBase):
             _format_epoch(row.observed_at_epoch),
             row.hook,
             _truncate(ident, 18),
-            _truncate(_summarize_metrics(row.hook, row.metrics_json), 50),
+            _truncate(self._security_results_by_key.get(str(row.id), "-"), 50),
         )
 
     def _row_key(self, row: ObservabilityEventRecord) -> str:  # type: ignore[override]
@@ -210,7 +230,12 @@ class EventListScreen(_ListScreenBase):
         record = self._rows_by_key.get(key)
         if record is None:
             return
-        self.app.push_screen(EventDetailScreen(record=record))
+        self.app.push_screen(
+            EventDetailScreen(
+                record=record,
+                security_correlation=getattr(self.app, "security_correlation", None),
+            )
+        )
 
 
 class EventDetailScreen(Screen):
@@ -221,11 +246,17 @@ class EventDetailScreen(Screen):
         Binding("q", "app.pop_screen", "Back", show=False),
     ]
 
-    def __init__(self, record: ObservabilityEventRecord) -> None:
+    def __init__(
+        self,
+        record: ObservabilityEventRecord,
+        security_correlation: _SecurityCorrelation | None = None,
+    ) -> None:
         super().__init__()
         self._record = record
+        self._security_correlation = security_correlation
 
     def compose(self) -> ComposeResult:
+        security_events = self._correlated_security_events()
         yield Header()
         with VerticalScroll():
             yield Static(self._render_header(), markup=True)
@@ -233,6 +264,9 @@ class EventDetailScreen(Screen):
             yield Static(_safe_pretty_json(self._record.metadata_json), markup=False)
             yield Static("\n[b]Metrics[/b]:", markup=True)
             yield Static(_safe_pretty_json(self._record.metrics_json), markup=False)
+            if security_events:
+                yield Static("\n[b]Security Events[/b]:", markup=True)
+                yield Static(_render_security_events(security_events), markup=False)
         yield Footer()
 
     def _render_header(self) -> str:
@@ -262,6 +296,12 @@ class EventDetailScreen(Screen):
 
         return "\n".join(header_lines)
 
+    def _correlated_security_events(self) -> list[CorrelatedSecurityEvent]:
+        return _find_correlated_security_events(
+            self._record,
+            self._security_correlation,
+        )
+
 
 class ObservabilityReviewApp(App):
     """Drill-down TUI over recorded observability events."""
@@ -269,10 +309,15 @@ class ObservabilityReviewApp(App):
     BINDINGS = [Binding("q", "quit", "Quit", show=True)]
     TITLE = "agent-sec-cli observability review"
 
-    def __init__(self, reader: ObservabilityReader) -> None:
+    def __init__(
+        self,
+        reader: ObservabilityReader,
+        security_correlation: SecurityCorrelationService | None = None,
+    ) -> None:
         super().__init__()
         # Reader is owned by the CLI entry — App must not close it.
         self.reader = reader
+        self.security_correlation = security_correlation
 
     def on_mount(self) -> None:
         self.push_screen(SessionListScreen())
@@ -319,6 +364,93 @@ def _safe_pretty_json(raw: str) -> str:
         snippet = raw[:500]
         return f"Failed to parse JSON:\n{snippet}"
     return json.dumps(parsed, indent=2, ensure_ascii=False)
+
+
+def _find_correlated_security_events(
+    record: ObservabilityEventRecord,
+    security_correlation: _SecurityCorrelation | None,
+) -> list[CorrelatedSecurityEvent]:
+    if security_correlation is None:
+        return []
+    try:
+        return security_correlation.find_correlated(
+            ObservabilityRecordFields(
+                hook=record.hook,
+                session_id=record.session_id,
+                run_id=record.run_id,
+                tool_call_id=record.tool_call_id,
+                observed_at_epoch=record.observed_at_epoch,
+            )
+        )
+    except Exception:
+        # TODO(logging): warn with error type, session_id, and run_id once logging is wired.
+        return []
+
+
+def _format_security_result(events: list[CorrelatedSecurityEvent]) -> str:
+    if not events:
+        return "-"
+    return ", ".join(
+        f"{correlated.event.category}:{_security_result_value(correlated)}"
+        for correlated in events
+    )
+
+
+def _security_result_value(correlated: CorrelatedSecurityEvent) -> str:
+    event = correlated.event
+    result = _value_from_result_object(event.details.get("result"))
+    if result is not None:
+        return result
+
+    result = _value_from_result_object(event.details)
+    if result is not None:
+        return result
+
+    return event.result
+
+
+def _value_from_result_object(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+
+    for key in ("verdict", "status"):
+        result_value = value.get(key)
+        if result_value is not None and result_value != "":
+            return str(result_value)
+
+    valid = value.get("valid")
+    if valid is True:
+        return "pass"
+    if valid is False:
+        return "fail"
+    if valid is not None and valid != "":
+        return str(valid)
+    return None
+
+
+def _render_security_events(events: list[CorrelatedSecurityEvent]) -> str:
+    lines: list[str] = []
+    for index, correlated in enumerate(events, start=1):
+        event = correlated.event
+        if index > 1:
+            lines.append("")
+        lines.append(
+            f"{index}. {event.category} / {event.event_type} result={event.result}"
+        )
+        lines.append(
+            "   "
+            f"match={correlated.match_reason} "
+            f"delta={correlated.time_delta_seconds:+.3f}s "
+            f"security_at={_format_epoch(correlated.security_timestamp_epoch)}"
+        )
+        lines.append("   details:")
+        detail_lines = json.dumps(
+            event.details,
+            indent=2,
+            ensure_ascii=False,
+        ).splitlines()
+        lines.extend(f"     {line}" for line in detail_lines)
+    return "\n".join(lines)
 
 
 __all__ = [

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -14,6 +14,8 @@ from sqlalchemy import Select, delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import SQLAlchemyError
 
+_CORRELATION_CANDIDATE_LIMIT = 1000
+
 
 @dataclass(frozen=True)
 class CorrelationCandidate:
@@ -129,10 +131,11 @@ class SecurityEventRepository:
         categories: Sequence[str],
         run_id: str | None = None,
         tool_call_id: str | None = None,
+        tool_call_ids: Sequence[str] | None = None,
         since_epoch: float | None = None,
         until_epoch: float | None = None,
     ) -> list[CorrelationCandidate]:
-        """Query read-only security event candidates for observability correlation."""
+        """Query up to 1000 read-only candidates for observability correlation."""
         if not categories:
             return []
 
@@ -142,7 +145,14 @@ class SecurityEventRepository:
         ]
         if run_id is not None:
             conditions.append(SecurityEventRecord.run_id == run_id)
-        if tool_call_id is not None:
+        if tool_call_ids is not None:
+            normalized_tool_call_ids = tuple(value for value in tool_call_ids if value)
+            if not normalized_tool_call_ids:
+                return []
+            conditions.append(
+                SecurityEventRecord.tool_call_id.in_(normalized_tool_call_ids)
+            )
+        elif tool_call_id is not None:
             conditions.append(SecurityEventRecord.tool_call_id == tool_call_id)
         if since_epoch is not None:
             conditions.append(SecurityEventRecord.timestamp_epoch >= since_epoch)
@@ -156,6 +166,7 @@ class SecurityEventRepository:
                 SecurityEventRecord.timestamp_epoch.asc(),
                 SecurityEventRecord.event_id.asc(),
             )
+            .limit(_CORRELATION_CANDIDATE_LIMIT)
         )
 
         session_factory = self._store.session_factory()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -3,8 +3,9 @@
 import json
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Sequence
 
 from agent_sec_cli.security_events.models import SecurityEventRecord
 from agent_sec_cli.security_events.orm_store import SqliteStore
@@ -12,6 +13,14 @@ from agent_sec_cli.security_events.schema import SecurityEvent
 from sqlalchemy import Select, delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import SQLAlchemyError
+
+
+@dataclass(frozen=True)
+class CorrelationCandidate:
+    """Security event row plus the original epoch used for correlation sorting."""
+
+    event: SecurityEvent
+    timestamp_epoch: float
 
 
 class SecurityEventRepository:
@@ -112,6 +121,66 @@ class SecurityEventRepository:
             if event is not None:
                 events.append(event)
         return events
+
+    def query_correlation_candidates(
+        self,
+        *,
+        session_id: str,
+        categories: Sequence[str],
+        run_id: str | None = None,
+        tool_call_id: str | None = None,
+        since_epoch: float | None = None,
+        until_epoch: float | None = None,
+    ) -> list[CorrelationCandidate]:
+        """Query read-only security event candidates for observability correlation."""
+        if not categories:
+            return []
+
+        conditions: list[Any] = [
+            SecurityEventRecord.session_id == session_id,
+            SecurityEventRecord.category.in_(tuple(categories)),
+        ]
+        if run_id is not None:
+            conditions.append(SecurityEventRecord.run_id == run_id)
+        if tool_call_id is not None:
+            conditions.append(SecurityEventRecord.tool_call_id == tool_call_id)
+        if since_epoch is not None:
+            conditions.append(SecurityEventRecord.timestamp_epoch >= since_epoch)
+        if until_epoch is not None:
+            conditions.append(SecurityEventRecord.timestamp_epoch <= until_epoch)
+
+        stmt = (
+            select(SecurityEventRecord)
+            .where(*conditions)
+            .order_by(
+                SecurityEventRecord.timestamp_epoch.asc(),
+                SecurityEventRecord.event_id.asc(),
+            )
+        )
+
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return []
+
+        try:
+            with session_factory() as session:
+                records = list(session.scalars(stmt).all())
+        except SQLAlchemyError:
+            # TODO(logging): warn with error type, session_id, and run_id once logging is wired.
+            self._store.dispose()
+            return []
+
+        candidates: list[CorrelationCandidate] = []
+        for record in records:
+            event = self._record_to_event(record)
+            if event is not None:
+                candidates.append(
+                    CorrelationCandidate(
+                        event=event,
+                        timestamp_epoch=record.timestamp_epoch,
+                    )
+                )
+        return candidates
 
     def count(
         self,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
@@ -68,15 +68,17 @@ class SqliteEventReader:
         categories: tuple[str, ...] | list[str],
         run_id: str | None = None,
         tool_call_id: str | None = None,
+        tool_call_ids: tuple[str, ...] | list[str] | None = None,
         since_epoch: float | None = None,
         until_epoch: float | None = None,
     ) -> list[CorrelationCandidate]:
-        """Query read-only security event candidates for observability correlation."""
+        """Query up to 1000 read-only candidates for observability correlation."""
         return self._repository.query_correlation_candidates(
             session_id=session_id,
             categories=categories,
             run_id=run_id,
             tool_call_id=tool_call_id,
+            tool_call_ids=tool_call_ids,
             since_epoch=since_epoch,
             until_epoch=until_epoch,
         )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 from agent_sec_cli.security_events.config import get_db_path
 from agent_sec_cli.security_events.orm_store import SqliteStore
-from agent_sec_cli.security_events.repositories import SecurityEventRepository
+from agent_sec_cli.security_events.repositories import (
+    CorrelationCandidate,
+    SecurityEventRepository,
+)
 from agent_sec_cli.security_events.schema import SecurityEvent
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -56,6 +59,26 @@ class SqliteEventReader:
             until=until,
             limit=limit,
             offset=offset,
+        )
+
+    def query_correlation_candidates(
+        self,
+        *,
+        session_id: str,
+        categories: tuple[str, ...] | list[str],
+        run_id: str | None = None,
+        tool_call_id: str | None = None,
+        since_epoch: float | None = None,
+        until_epoch: float | None = None,
+    ) -> list[CorrelationCandidate]:
+        """Query read-only security event candidates for observability correlation."""
+        return self._repository.query_correlation_candidates(
+            session_id=session_id,
+            categories=categories,
+            run_id=run_id,
+            tool_call_id=tool_call_id,
+            since_epoch=since_epoch,
+            until_epoch=until_epoch,
         )
 
     def count(

--- a/src/agent-sec-core/tests/unit-test/observability/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_cli.py
@@ -100,6 +100,46 @@ def test_record_accepts_before_llm_call_without_call_id(tmp_path: Path) -> None:
     assert records[0]["metrics"] == {"prompt": "assembled prompt"}
 
 
+def test_record_accepts_before_tool_call_with_zero_tool_call_id(
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    zero_id = "00000000-0000-0000-0000-000000000000"
+    payload = _payload(
+        hook="before_tool_call",
+        metadata={
+            "sessionId": "session-123",
+            "runId": zero_id,
+            "toolCallId": zero_id,
+        },
+        metrics={
+            "tool_name": "terminal",
+            "parameters": {"command": "ls"},
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["observability", "record", "--format", "json", "--stdin"],
+        input=json.dumps(payload),
+        env={"AGENT_SEC_DATA_DIR": str(tmp_path)},
+    )
+
+    assert result.exit_code == 0, result.output
+    records = _jsonl_records(tmp_path / "observability.jsonl")
+    assert records[0]["hook"] == "before_tool_call"
+    assert records[0]["metadata"] == {
+        "sessionId": "session-123",
+        "runId": zero_id,
+        "toolCallId": zero_id,
+    }
+    assert records[0]["metrics"] == {
+        "tool_name": "terminal",
+        "parameters": {"command": "ls"},
+    }
+    assert (tmp_path / "observability.db").exists()
+
+
 def test_record_accepts_after_agent_run_llm_output_response(tmp_path: Path) -> None:
     runner = CliRunner()
     payload = _payload(

--- a/src/agent-sec-core/tests/unit-test/observability/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_cli.py
@@ -6,8 +6,10 @@ from typing import Any
 
 import agent_sec_cli.observability as observability
 import agent_sec_cli.observability.cli as observability_cli
+import agent_sec_cli.observability.correlation as observability_correlation
 import agent_sec_cli.observability.review as observability_review
 import agent_sec_cli.observability.sqlite_reader as observability_sqlite_reader
+import agent_sec_cli.security_events.sqlite_reader as security_sqlite_reader
 import pytest
 import typer
 from agent_sec_cli.cli import app
@@ -354,9 +356,27 @@ def test_review_closes_reader_after_tui_exits(
         def close(self) -> None:
             events.append("reader-close")
 
+    class FakeSecurityReader:
+        def __init__(self) -> None:
+            events.append("security-reader-init")
+
+        def close(self) -> None:
+            events.append("security-reader-close")
+
+    class FakeCorrelationService:
+        def __init__(self, reader: FakeSecurityReader) -> None:
+            events.append(f"correlation-init:{reader.__class__.__name__}")
+
     class FakeReviewApp:
-        def __init__(self, reader: FakeReader) -> None:
-            events.append(f"app-init:{reader.__class__.__name__}")
+        def __init__(
+            self,
+            reader: FakeReader,
+            security_correlation: FakeCorrelationService | None = None,
+        ) -> None:
+            events.append(
+                f"app-init:{reader.__class__.__name__}:"
+                f"{security_correlation.__class__.__name__}"
+            )
 
         def run(self) -> None:
             events.append("app-run")
@@ -364,14 +384,23 @@ def test_review_closes_reader_after_tui_exits(
     monkeypatch.setattr(observability_cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(observability_cli.sys.stdout, "isatty", lambda: True)
     monkeypatch.setattr(observability_sqlite_reader, "ObservabilityReader", FakeReader)
+    monkeypatch.setattr(security_sqlite_reader, "SqliteEventReader", FakeSecurityReader)
+    monkeypatch.setattr(
+        observability_correlation,
+        "SecurityCorrelationService",
+        FakeCorrelationService,
+    )
     monkeypatch.setattr(observability_review, "ObservabilityReviewApp", FakeReviewApp)
 
     observability_cli.review()
 
     assert events == [
         "reader-init",
-        "app-init:FakeReader",
+        "security-reader-init",
+        "correlation-init:FakeSecurityReader",
+        "app-init:FakeReader:FakeCorrelationService",
         "app-run",
+        "security-reader-close",
         "reader-close",
     ]
 
@@ -385,9 +414,22 @@ def test_review_closes_reader_when_tui_raises(
         def close(self) -> None:
             events.append("reader-close")
 
-    class FailingReviewApp:
-        def __init__(self, reader: FakeReader) -> None:
+    class FakeSecurityReader:
+        def close(self) -> None:
+            events.append("security-reader-close")
+
+    class FakeCorrelationService:
+        def __init__(self, reader: FakeSecurityReader) -> None:
             self._reader = reader
+
+    class FailingReviewApp:
+        def __init__(
+            self,
+            reader: FakeReader,
+            security_correlation: FakeCorrelationService | None = None,
+        ) -> None:
+            self._reader = reader
+            self._security_correlation = security_correlation
 
         def run(self) -> None:
             events.append("app-run")
@@ -396,6 +438,12 @@ def test_review_closes_reader_when_tui_raises(
     monkeypatch.setattr(observability_cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(observability_cli.sys.stdout, "isatty", lambda: True)
     monkeypatch.setattr(observability_sqlite_reader, "ObservabilityReader", FakeReader)
+    monkeypatch.setattr(security_sqlite_reader, "SqliteEventReader", FakeSecurityReader)
+    monkeypatch.setattr(
+        observability_correlation,
+        "SecurityCorrelationService",
+        FakeCorrelationService,
+    )
     monkeypatch.setattr(
         observability_review, "ObservabilityReviewApp", FailingReviewApp
     )
@@ -403,4 +451,36 @@ def test_review_closes_reader_when_tui_raises(
     with pytest.raises(RuntimeError, match="tui failed"):
         observability_cli.review()
 
-    assert events == ["app-run", "reader-close"]
+    assert events == ["app-run", "security-reader-close", "reader-close"]
+
+
+def test_review_closes_reader_when_security_reader_init_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeReader:
+        def __init__(self) -> None:
+            events.append("reader-init")
+
+        def close(self) -> None:
+            events.append("reader-close")
+
+    class FailingSecurityReader:
+        def __init__(self) -> None:
+            events.append("security-reader-init")
+            raise RuntimeError("security reader failed")
+
+    monkeypatch.setattr(observability_cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(observability_cli.sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(observability_sqlite_reader, "ObservabilityReader", FakeReader)
+    monkeypatch.setattr(
+        security_sqlite_reader,
+        "SqliteEventReader",
+        FailingSecurityReader,
+    )
+
+    with pytest.raises(RuntimeError, match="security reader failed"):
+        observability_cli.review()
+
+    assert events == ["reader-init", "security-reader-init", "reader-close"]

--- a/src/agent-sec-core/tests/unit-test/observability/test_correlation.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_correlation.py
@@ -1,6 +1,8 @@
 """Unit tests for observability-to-security-event correlation."""
 
+import hashlib
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 from agent_sec_cli.observability.correlation import (
@@ -34,6 +36,7 @@ def _record(
     run_id: str | None = "run-1",
     tool_call_id: str | None = "tool-1",
     observed_at_epoch: float = 100.0,
+    metrics: dict[str, Any] | None = None,
 ) -> ObservabilityRecordFields:
     return ObservabilityRecordFields(
         hook=hook,
@@ -41,6 +44,7 @@ def _record(
         run_id=run_id,
         tool_call_id=tool_call_id,
         observed_at_epoch=observed_at_epoch,
+        metrics=metrics,
     )
 
 
@@ -52,6 +56,7 @@ def _event(
     session_id: str | None = "session-1",
     run_id: str | None = "run-1",
     tool_call_id: str | None = "tool-1",
+    details: dict[str, Any] | None = None,
 ) -> SecurityEvent:
     return SecurityEvent(
         event_id=event_id,
@@ -65,8 +70,14 @@ def _event(
         session_id=session_id,
         run_id=run_id,
         tool_call_id=tool_call_id,
-        details={"event": event_id},
+        details=details or {"event": event_id},
     )
+
+
+def _result_signatures(results: list[list[Any]]) -> list[list[tuple[str, str]]]:
+    return [
+        [(item.event.event_id, item.match_reason) for item in row] for row in results
+    ]
 
 
 @pytest.mark.parametrize(
@@ -160,6 +171,111 @@ def test_exact_mode_does_not_fallback_when_no_exact_candidates() -> None:
             "until_epoch": None,
         }
     ]
+
+
+def test_batch_exact_mode_queries_tool_call_ids_once_without_changing_results() -> None:
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(event_id="code-tool-1", category="code_scan"),
+                timestamp_epoch=100.5,
+            ),
+            _Candidate(
+                _event(
+                    event_id="skill-tool-2",
+                    category="skill_ledger",
+                    tool_call_id="tool-2",
+                ),
+                timestamp_epoch=101.0,
+            ),
+            _Candidate(
+                _event(
+                    event_id="wrong-tool",
+                    category="code_scan",
+                    tool_call_id="tool-3",
+                ),
+                timestamp_epoch=99.0,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated_many(
+        [
+            _record(tool_call_id="tool-1", observed_at_epoch=100.0),
+            _record(tool_call_id="tool-2", observed_at_epoch=100.0),
+        ]
+    )
+
+    assert reader.calls == [
+        {
+            "session_id": "session-1",
+            "categories": ("code_scan", "skill_ledger"),
+            "run_id": "run-1",
+            "tool_call_id": None,
+            "tool_call_ids": ("tool-1", "tool-2"),
+            "since_epoch": None,
+            "until_epoch": None,
+        }
+    ]
+    assert [[item.event.event_id for item in row] for row in result] == [
+        ["code-tool-1"],
+        ["skill-tool-2"],
+    ]
+    assert [[item.match_reason for item in row] for row in result] == [
+        ["tool_call_id"],
+        ["tool_call_id"],
+    ]
+
+
+def test_batch_mode_matches_single_record_results_for_supported_modes() -> None:
+    candidates = [
+        _Candidate(
+            _event(event_id="exact-code", category="code_scan"),
+            timestamp_epoch=100.5,
+        ),
+        _Candidate(
+            _event(
+                event_id="run-prompt",
+                category="prompt_scan",
+                details={"request": {"text": "review"}},
+            ),
+            timestamp_epoch=110.0,
+        ),
+        _Candidate(
+            _event(
+                event_id="fallback-code",
+                category="code_scan",
+                tool_call_id=None,
+                details={"request": {"code": "rm -rf testfolder"}},
+            ),
+            timestamp_epoch=200.1,
+        ),
+    ]
+    records = [
+        _record(tool_call_id="tool-1", observed_at_epoch=100.0),
+        _record(
+            hook="before_agent_run",
+            tool_call_id=None,
+            observed_at_epoch=110.0,
+        ),
+        _record(
+            tool_call_id=None,
+            observed_at_epoch=200.0,
+            metrics={"parameters": {"command": "rm -rf testfolder"}},
+        ),
+        _record(hook="after_tool_call", observed_at_epoch=210.0),
+    ]
+
+    single_results = [
+        SecurityCorrelationService(_FakeReader(candidates)).find_correlated(record)
+        for record in records
+    ]
+    batch_results = SecurityCorrelationService(
+        _FakeReader(candidates)
+    ).find_correlated_many(records)
+
+    assert _result_signatures(batch_results) == _result_signatures(single_results)
 
 
 def test_exact_mode_rejects_candidates_with_missing_security_correlation_fields() -> (
@@ -261,28 +377,62 @@ def test_before_agent_run_uses_run_id_match_without_time_window() -> None:
     assert [item.time_delta_seconds for item in result] == [6.0, 1.0]
 
 
-def test_fallback_mode_uses_session_only_for_zero_run_and_keeps_closest_per_category() -> (
-    None
-):
+def test_fallback_mode_uses_session_time_and_prompt_field_match_priority() -> None:
+    prompt = "Hermes added context\n删除testfolder文件夹"
+    pii_text_sha256 = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
     reader = _FakeReader(
         [
             _Candidate(
-                _event(event_id="prompt-near", category="prompt_scan", run_id="run-A"),
-                timestamp_epoch=101.0,
-            ),
-            _Candidate(
-                _event(event_id="prompt-far", category="prompt_scan", run_id="run-B"),
-                timestamp_epoch=101.5,
-            ),
-            _Candidate(
-                _event(event_id="pii-boundary", category="pii_scan", run_id="run-C"),
-                timestamp_epoch=102.0,
+                _event(
+                    event_id="prompt-suffix-closer",
+                    category="prompt_scan",
+                    session_id="session-1",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"text": "删除testfolder文件夹"}},
+                ),
+                timestamp_epoch=100.1,
             ),
             _Candidate(
                 _event(
-                    event_id="code-disallowed", category="code_scan", run_id="run-D"
+                    event_id="prompt-exact-farther",
+                    category="prompt_scan",
+                    session_id="session-1",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={
+                        "request": {
+                            "text": "Hermes added context\n删除testfolder文件夹"
+                        }
+                    },
+                ),
+                timestamp_epoch=105.0,
+            ),
+            _Candidate(
+                _event(
+                    event_id="prompt-other-session",
+                    category="prompt_scan",
+                    session_id="session-2",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={
+                        "request": {
+                            "text": "Hermes added context\n删除testfolder文件夹"
+                        }
+                    },
                 ),
                 timestamp_epoch=100.0,
+            ),
+            _Candidate(
+                _event(
+                    event_id="pii-boundary",
+                    category="pii_scan",
+                    session_id="session-1",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"text_sha256": pii_text_sha256}},
+                ),
+                timestamp_epoch=110.0,
             ),
         ]
     )
@@ -294,6 +444,7 @@ def test_fallback_mode_uses_session_only_for_zero_run_and_keeps_closest_per_cate
             run_id=ZERO_RUN_ID,
             tool_call_id=None,
             observed_at_epoch=100.0,
+            metrics={"prompt": prompt},
         )
     )
 
@@ -303,14 +454,120 @@ def test_fallback_mode_uses_session_only_for_zero_run_and_keeps_closest_per_cate
             "categories": ("prompt_scan", "pii_scan"),
             "run_id": None,
             "tool_call_id": None,
-            "since_epoch": 98.0,
-            "until_epoch": 102.0,
+            "since_epoch": 90.0,
+            "until_epoch": 110.0,
         }
     ]
-    assert [item.event.event_id for item in result] == ["prompt-near", "pii-boundary"]
-    assert [item.event.run_id for item in result] == ["run-A", "run-C"]
-    assert [item.match_reason for item in result] == ["rule+time", "rule+time"]
-    assert [item.time_delta_seconds for item in result] == [1.0, 2.0]
+    assert [item.event.event_id for item in result] == [
+        "prompt-exact-farther",
+        "pii-boundary",
+    ]
+    assert [item.match_reason for item in result] == ["field+time", "field+time"]
+    assert [item.match_rank for item in result] == [0, 0]
+    assert [item.time_delta_seconds for item in result] == [5.0, 10.0]
+
+
+def test_fallback_mode_rejects_time_only_candidates_without_field_match() -> None:
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(
+                    event_id="prompt-time-only",
+                    category="prompt_scan",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"text": "unrelated prompt"}},
+                ),
+                timestamp_epoch=100.5,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(
+            hook="before_agent_run",
+            run_id=ZERO_RUN_ID,
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+            metrics={"prompt": "删除testfolder文件夹"},
+        )
+    )
+
+    assert result == []
+
+
+def test_fallback_mode_does_not_match_pii_scan_by_raw_text_prefix_or_suffix() -> None:
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(
+                    event_id="pii-raw-suffix",
+                    category="pii_scan",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"text": "alice@example.com"}},
+                ),
+                timestamp_epoch=100.1,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(
+            hook="before_agent_run",
+            run_id=ZERO_RUN_ID,
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+            metrics={"prompt": "Hermes added context\nalice@example.com"},
+        )
+    )
+
+    assert result == []
+
+
+def test_fallback_mode_matches_pii_scan_by_request_text_hash() -> None:
+    prompt = "联系我 alice@example.com"
+    text_sha256 = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(
+                    event_id="pii-hash",
+                    category="pii_scan",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"text_sha256": text_sha256}},
+                ),
+                timestamp_epoch=99.5,
+            ),
+            _Candidate(
+                _event(
+                    event_id="prompt-without-request-text",
+                    category="prompt_scan",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"source": "user_input"}},
+                ),
+                timestamp_epoch=99.0,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(
+            hook="before_agent_run",
+            run_id=ZERO_RUN_ID,
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+            metrics={"prompt": prompt},
+        )
+    )
+
+    assert [item.event.event_id for item in result] == ["pii-hash"]
+    assert result[0].match_reason == "field+time"
 
 
 @pytest.mark.parametrize("run_id", [None, ""])
@@ -324,6 +581,8 @@ def test_fallback_mode_uses_session_only_when_run_id_is_missing(
                     event_id="cross-run-match",
                     category="code_scan",
                     run_id="security-run",
+                    tool_call_id=None,
+                    details={"request": {"code": "rm -rf testfolder"}},
                 ),
                 timestamp_epoch=100.5,
             )
@@ -332,7 +591,12 @@ def test_fallback_mode_uses_session_only_when_run_id_is_missing(
     service = SecurityCorrelationService(reader)
 
     result = service.find_correlated(
-        _record(run_id=run_id, tool_call_id=None, observed_at_epoch=100.0)
+        _record(
+            run_id=run_id,
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+            metrics={"parameters": {"command": "rm -rf testfolder"}},
+        )
     )
 
     assert reader.calls == [
@@ -341,12 +605,52 @@ def test_fallback_mode_uses_session_only_when_run_id_is_missing(
             "categories": ("code_scan", "skill_ledger"),
             "run_id": None,
             "tool_call_id": None,
-            "since_epoch": 98.0,
-            "until_epoch": 102.0,
+            "since_epoch": 90.0,
+            "until_epoch": 110.0,
         }
     ]
     assert [item.event.event_id for item in result] == ["cross-run-match"]
     assert result[0].event.run_id == "security-run"
+    assert result[0].match_reason == "field+time"
+
+
+def test_fallback_mode_matches_tool_call_fields_by_suffix_then_prefix() -> None:
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(
+                    event_id="code-prefix-closer",
+                    category="code_scan",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"code": "cd /repo"}},
+                ),
+                timestamp_epoch=100.1,
+            ),
+            _Candidate(
+                _event(
+                    event_id="code-suffix-farther",
+                    category="code_scan",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"code": "rm -rf testfolder"}},
+                ),
+                timestamp_epoch=101.0,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(
+            run_id=None,
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+            metrics={"parameters": {"command": "cd /repo && rm -rf testfolder"}},
+        )
+    )
+
+    assert [item.event.event_id for item in result] == ["code-suffix-farther"]
 
 
 def test_fallback_mode_filters_candidates_outside_time_window_from_defensive_reader() -> (
@@ -355,20 +659,110 @@ def test_fallback_mode_filters_candidates_outside_time_window_from_defensive_rea
     reader = _FakeReader(
         [
             _Candidate(
-                _event(event_id="inside", category="code_scan"),
+                _event(
+                    event_id="inside",
+                    category="code_scan",
+                    details={"request": {"code": "inside"}},
+                ),
                 timestamp_epoch=101.9,
             ),
             _Candidate(
-                _event(event_id="outside", category="skill_ledger"),
-                timestamp_epoch=102.1,
+                _event(
+                    event_id="outside",
+                    category="code_scan",
+                    details={"request": {"code": "inside"}},
+                ),
+                timestamp_epoch=110.1,
             ),
         ]
     )
     service = SecurityCorrelationService(reader)
 
     result = service.find_correlated(
-        _record(tool_call_id=None, observed_at_epoch=100.0)
+        _record(
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+            metrics={"parameters": {"command": "inside"}},
+        )
     )
 
     assert reader.calls[0]["run_id"] == "run-1"
     assert [item.event.event_id for item in result] == ["inside"]
+
+
+def test_batch_fallback_keeps_long_run_time_windows_bounded() -> None:
+    reader = _FakeReader()
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated_many(
+        [
+            _record(
+                tool_call_id=None,
+                observed_at_epoch=10.0,
+                metrics={"parameters": {"command": "first"}},
+            ),
+            _record(
+                tool_call_id=None,
+                observed_at_epoch=3500.0,
+                metrics={"parameters": {"command": "last"}},
+            ),
+        ]
+    )
+
+    assert result == [[], []]
+    assert reader.calls == [
+        {
+            "session_id": "session-1",
+            "categories": ("code_scan", "skill_ledger"),
+            "run_id": "run-1",
+            "tool_call_id": None,
+            "since_epoch": 0.0,
+            "until_epoch": 20.0,
+        },
+        {
+            "session_id": "session-1",
+            "categories": ("code_scan", "skill_ledger"),
+            "run_id": "run-1",
+            "tool_call_id": None,
+            "since_epoch": 3490.0,
+            "until_epoch": 3510.0,
+        },
+    ]
+
+
+def test_fallback_mode_skips_skill_ledger_even_when_basename_would_match() -> None:
+    """skill_ledger has no reliable field-level correlation outside exact mode.
+
+    obs records carry the unresolved skill name; events carry the resolved
+    absolute skill_dir. The two are at different abstraction layers, so the
+    fallback path must not guess via basename/suffix matching.
+    """
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(
+                    event_id="skill-basename-match",
+                    category="skill_ledger",
+                    run_id=None,
+                    tool_call_id=None,
+                    details={"request": {"skill_dir": "/abs/skills/devops/pass-skill"}},
+                ),
+                timestamp_epoch=100.5,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(
+            run_id=None,
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+            metrics={
+                "tool_name": "skill_view",
+                "parameters": {"name": "pass-skill"},
+            },
+        )
+    )
+
+    assert result == []

--- a/src/agent-sec-core/tests/unit-test/observability/test_correlation.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_correlation.py
@@ -1,0 +1,374 @@
+"""Unit tests for observability-to-security-event correlation."""
+
+from dataclasses import dataclass
+
+import pytest
+from agent_sec_cli.observability.correlation import (
+    ZERO_RUN_ID,
+    ObservabilityRecordFields,
+    SecurityCorrelationService,
+)
+from agent_sec_cli.security_events.schema import SecurityEvent
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    event: SecurityEvent
+    timestamp_epoch: float
+
+
+class _FakeReader:
+    def __init__(self, candidates: list[_Candidate] | None = None) -> None:
+        self.candidates = candidates or []
+        self.calls: list[dict[str, object]] = []
+
+    def query_correlation_candidates(self, **kwargs: object) -> list[_Candidate]:
+        self.calls.append(kwargs)
+        return self.candidates
+
+
+def _record(
+    *,
+    hook: str = "before_tool_call",
+    session_id: str | None = "session-1",
+    run_id: str | None = "run-1",
+    tool_call_id: str | None = "tool-1",
+    observed_at_epoch: float = 100.0,
+) -> ObservabilityRecordFields:
+    return ObservabilityRecordFields(
+        hook=hook,
+        session_id=session_id,
+        run_id=run_id,
+        tool_call_id=tool_call_id,
+        observed_at_epoch=observed_at_epoch,
+    )
+
+
+def _event(
+    *,
+    event_id: str,
+    category: str,
+    timestamp: str = "2026-05-20T00:00:00+00:00",
+    session_id: str | None = "session-1",
+    run_id: str | None = "run-1",
+    tool_call_id: str | None = "tool-1",
+) -> SecurityEvent:
+    return SecurityEvent(
+        event_id=event_id,
+        event_type=category,
+        category=category,
+        result="succeeded",
+        timestamp=timestamp,
+        trace_id="trace-ignored",
+        pid=1,
+        uid=1,
+        session_id=session_id,
+        run_id=run_id,
+        tool_call_id=tool_call_id,
+        details={"event": event_id},
+    )
+
+
+@pytest.mark.parametrize(
+    "hook",
+    [
+        "before_llm_call",
+        "after_llm_call",
+        "after_tool_call",
+        "after_agent_run",
+    ],
+)
+def test_unsupported_hook_returns_empty_without_reader_call(hook: str) -> None:
+    reader = _FakeReader()
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(_record(hook=hook))
+
+    assert result == []
+    assert reader.calls == []
+
+
+def test_missing_session_returns_empty_without_reader_call() -> None:
+    reader = _FakeReader()
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(_record(session_id=None))
+
+    assert result == []
+    assert reader.calls == []
+
+
+def test_exact_mode_uses_tool_call_id_without_time_window_and_orders_categories() -> (
+    None
+):
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(event_id="skill-later", category="skill_ledger"),
+                timestamp_epoch=150.0,
+            ),
+            _Candidate(
+                _event(event_id="code-far-away", category="code_scan"),
+                timestamp_epoch=1000.0,
+            ),
+            _Candidate(
+                _event(event_id="skill-nearer", category="skill_ledger"),
+                timestamp_epoch=110.0,
+            ),
+            _Candidate(
+                _event(event_id="prompt-disallowed", category="prompt_scan"),
+                timestamp_epoch=100.0,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(_record(observed_at_epoch=100.0))
+
+    assert reader.calls == [
+        {
+            "session_id": "session-1",
+            "categories": ("code_scan", "skill_ledger"),
+            "run_id": "run-1",
+            "tool_call_id": "tool-1",
+            "since_epoch": None,
+            "until_epoch": None,
+        }
+    ]
+    assert [item.event.event_id for item in result] == [
+        "code-far-away",
+        "skill-nearer",
+    ]
+    assert [item.match_reason for item in result] == ["tool_call_id", "tool_call_id"]
+    assert [item.time_delta_seconds for item in result] == [900.0, 10.0]
+
+
+def test_exact_mode_does_not_fallback_when_no_exact_candidates() -> None:
+    reader = _FakeReader()
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(_record(observed_at_epoch=100.0))
+
+    assert result == []
+    assert reader.calls == [
+        {
+            "session_id": "session-1",
+            "categories": ("code_scan", "skill_ledger"),
+            "run_id": "run-1",
+            "tool_call_id": "tool-1",
+            "since_epoch": None,
+            "until_epoch": None,
+        }
+    ]
+
+
+def test_exact_mode_rejects_candidates_with_missing_security_correlation_fields() -> (
+    None
+):
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(event_id="missing-session", category="code_scan", session_id=""),
+                timestamp_epoch=100.0,
+            ),
+            _Candidate(
+                _event(event_id="missing-run", category="code_scan", run_id=None),
+                timestamp_epoch=100.0,
+            ),
+            _Candidate(
+                _event(
+                    event_id="missing-tool", category="skill_ledger", tool_call_id=""
+                ),
+                timestamp_epoch=100.0,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(_record(observed_at_epoch=100.0))
+
+    assert result == []
+
+
+@pytest.mark.parametrize("category", ["sandbox", "hardening", "asset_verify"])
+@pytest.mark.parametrize("mode", ["exact", "fallback"])
+def test_categories_outside_security_mapping_are_filtered(
+    mode: str, category: str
+) -> None:
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(event_id=f"{mode}-{category}", category=category),
+                timestamp_epoch=100.0,
+            )
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+    record = (
+        _record(observed_at_epoch=100.0)
+        if mode == "exact"
+        else _record(tool_call_id=None, observed_at_epoch=100.0)
+    )
+
+    result = service.find_correlated(record)
+
+    assert result == []
+
+
+def test_before_agent_run_uses_run_id_match_without_time_window() -> None:
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(event_id="prompt-slow", category="prompt_scan"),
+                timestamp_epoch=106.0,
+            ),
+            _Candidate(
+                _event(event_id="pii-near", category="pii_scan"),
+                timestamp_epoch=101.0,
+            ),
+            _Candidate(
+                _event(
+                    event_id="prompt-wrong-run",
+                    category="prompt_scan",
+                    run_id="run-2",
+                ),
+                timestamp_epoch=100.5,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(
+            hook="before_agent_run",
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+        )
+    )
+
+    assert reader.calls == [
+        {
+            "session_id": "session-1",
+            "categories": ("prompt_scan", "pii_scan"),
+            "run_id": "run-1",
+            "tool_call_id": None,
+            "since_epoch": None,
+            "until_epoch": None,
+        }
+    ]
+    assert [item.event.event_id for item in result] == ["prompt-slow", "pii-near"]
+    assert [item.match_reason for item in result] == ["run_id", "run_id"]
+    assert [item.time_delta_seconds for item in result] == [6.0, 1.0]
+
+
+def test_fallback_mode_uses_session_only_for_zero_run_and_keeps_closest_per_category() -> (
+    None
+):
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(event_id="prompt-near", category="prompt_scan", run_id="run-A"),
+                timestamp_epoch=101.0,
+            ),
+            _Candidate(
+                _event(event_id="prompt-far", category="prompt_scan", run_id="run-B"),
+                timestamp_epoch=101.5,
+            ),
+            _Candidate(
+                _event(event_id="pii-boundary", category="pii_scan", run_id="run-C"),
+                timestamp_epoch=102.0,
+            ),
+            _Candidate(
+                _event(
+                    event_id="code-disallowed", category="code_scan", run_id="run-D"
+                ),
+                timestamp_epoch=100.0,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(
+            hook="before_agent_run",
+            run_id=ZERO_RUN_ID,
+            tool_call_id=None,
+            observed_at_epoch=100.0,
+        )
+    )
+
+    assert reader.calls == [
+        {
+            "session_id": "session-1",
+            "categories": ("prompt_scan", "pii_scan"),
+            "run_id": None,
+            "tool_call_id": None,
+            "since_epoch": 98.0,
+            "until_epoch": 102.0,
+        }
+    ]
+    assert [item.event.event_id for item in result] == ["prompt-near", "pii-boundary"]
+    assert [item.event.run_id for item in result] == ["run-A", "run-C"]
+    assert [item.match_reason for item in result] == ["rule+time", "rule+time"]
+    assert [item.time_delta_seconds for item in result] == [1.0, 2.0]
+
+
+@pytest.mark.parametrize("run_id", [None, ""])
+def test_fallback_mode_uses_session_only_when_run_id_is_missing(
+    run_id: str | None,
+) -> None:
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(
+                    event_id="cross-run-match",
+                    category="code_scan",
+                    run_id="security-run",
+                ),
+                timestamp_epoch=100.5,
+            )
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(run_id=run_id, tool_call_id=None, observed_at_epoch=100.0)
+    )
+
+    assert reader.calls == [
+        {
+            "session_id": "session-1",
+            "categories": ("code_scan", "skill_ledger"),
+            "run_id": None,
+            "tool_call_id": None,
+            "since_epoch": 98.0,
+            "until_epoch": 102.0,
+        }
+    ]
+    assert [item.event.event_id for item in result] == ["cross-run-match"]
+    assert result[0].event.run_id == "security-run"
+
+
+def test_fallback_mode_filters_candidates_outside_time_window_from_defensive_reader() -> (
+    None
+):
+    reader = _FakeReader(
+        [
+            _Candidate(
+                _event(event_id="inside", category="code_scan"),
+                timestamp_epoch=101.9,
+            ),
+            _Candidate(
+                _event(event_id="outside", category="skill_ledger"),
+                timestamp_epoch=102.1,
+            ),
+        ]
+    )
+    service = SecurityCorrelationService(reader)
+
+    result = service.find_correlated(
+        _record(tool_call_id=None, observed_at_epoch=100.0)
+    )
+
+    assert reader.calls[0]["run_id"] == "run-1"
+    assert [item.event.event_id for item in result] == ["inside"]

--- a/src/agent-sec-core/tests/unit-test/observability/test_review.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_review.py
@@ -69,6 +69,26 @@ class _FakeCorrelationService:
         return self.results
 
 
+class _FakeBatchCorrelationService(_FakeCorrelationService):
+    def __init__(
+        self,
+        batch_results: list[list[CorrelatedSecurityEvent]],
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__(error=error)
+        self.batch_results = batch_results
+        self.batch_calls: list[list[object]] = []
+
+    def find_correlated_many(
+        self, record_fields: list[object]
+    ) -> list[list[CorrelatedSecurityEvent]]:
+        self.batch_calls.append(record_fields)
+        if self.error is not None:
+            raise self.error
+        return self.batch_results
+
+
 def _record(
     *,
     record_id: int = 1,
@@ -435,6 +455,71 @@ def test_event_list_renders_security_result_from_correlation() -> None:
 
     assert security_result == "code_scan:warn"
     assert len(calls) == 1
+    assert getattr(calls[0], "metrics") == {"tool_name": "grep"}
+
+
+def test_event_list_uses_batch_security_correlation_when_available() -> None:
+    async def run() -> tuple[list[str], list[list[object]], list[object]]:
+        records = [
+            _record(
+                record_id=7,
+                hook="before_tool_call",
+                metrics={"tool_name": "grep"},
+                metadata={
+                    "sessionId": "session-A",
+                    "runId": "run-A",
+                    "toolCallId": "tool-call-1",
+                },
+                tool_call_id="tool-call-1",
+            ),
+            _record(
+                record_id=8,
+                hook="after_tool_call",
+                metrics={"status": "ok"},
+                metadata={
+                    "sessionId": "session-A",
+                    "runId": "run-A",
+                    "toolCallId": "tool-call-1",
+                },
+                tool_call_id="tool-call-1",
+            ),
+        ]
+        reader = _FakeReader(events_by_run={("session-A", "run-A"): records})
+        correlation = _FakeBatchCorrelationService(
+            [
+                [
+                    CorrelatedSecurityEvent(
+                        event=_security_event(details={"result": {"verdict": "warn"}}),
+                        match_reason="tool_call_id",
+                        time_delta_seconds=0.1,
+                        security_timestamp_epoch=1778932800.1,
+                    )
+                ],
+                [],
+            ]
+        )
+        app = ObservabilityReviewApp(
+            reader=reader,  # type: ignore[arg-type]
+            security_correlation=correlation,
+        )
+        async with app.run_test() as pilot:
+            await app.push_screen(
+                EventListScreen(session_id="session-A", run_id="run-A")
+            )
+            await pilot.pause()
+            table = app.screen.query_one(DataTable)
+            return (
+                [str(table.get_row_at(index)[3]) for index in range(table.row_count)],
+                correlation.batch_calls,
+                correlation.calls,
+            )
+
+    security_results, batch_calls, single_calls = asyncio.run(run())
+
+    assert security_results == ["code_scan:warn", "-"]
+    assert len(batch_calls) == 1
+    assert len(batch_calls[0]) == 2
+    assert single_calls == []
 
 
 def test_format_security_result_uses_correlated_scan_verdicts() -> None:

--- a/src/agent-sec-core/tests/unit-test/observability/test_review.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_review.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 
+from agent_sec_cli.observability.correlation import CorrelatedSecurityEvent
 from agent_sec_cli.observability.models import ObservabilityEventRecord
 from agent_sec_cli.observability.repositories import RunSummary, SessionSummary
 from agent_sec_cli.observability.review import (
@@ -11,9 +12,11 @@ from agent_sec_cli.observability.review import (
     ObservabilityReviewApp,
     SessionListScreen,
     TurnListScreen,
+    _format_security_result,
     _safe_pretty_json,
     _summarize_metrics,
 )
+from agent_sec_cli.security_events.schema import SecurityEvent
 from textual.app import App
 from textual.widgets import DataTable, Static
 
@@ -48,6 +51,24 @@ class _FakeReader:
         return self.events_by_run.get((session_id, run_id), [])
 
 
+class _FakeCorrelationService:
+    def __init__(
+        self,
+        results: list[CorrelatedSecurityEvent] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.results = results or []
+        self.error = error
+        self.calls: list[ObservabilityEventRecord] = []
+
+    def find_correlated(self, record_fields: object) -> list[CorrelatedSecurityEvent]:
+        self.calls.append(record_fields)  # type: ignore[arg-type]
+        if self.error is not None:
+            raise self.error
+        return self.results
+
+
 def _record(
     *,
     record_id: int = 1,
@@ -74,11 +95,42 @@ def _record(
     )
 
 
-def _render_detail_text(record: ObservabilityEventRecord) -> str:
+def _security_event(
+    *,
+    event_id: str = "security-event-1",
+    category: str = "code_scan",
+    event_type: str = "code_scan",
+    details: dict[str, object] | None = None,
+) -> SecurityEvent:
+    return SecurityEvent(
+        event_id=event_id,
+        event_type=event_type,
+        category=category,
+        result="succeeded",
+        timestamp="2026-05-16T12:00:01+00:00",
+        trace_id="trace-ignored",
+        pid=1,
+        uid=1,
+        session_id="session-A",
+        run_id="run-A",
+        tool_call_id="tool-call-1",
+        details=details or {"summary": "dangerous command"},
+    )
+
+
+def _render_detail_text(
+    record: ObservabilityEventRecord,
+    correlation_service: _FakeCorrelationService | None = None,
+) -> str:
     async def render() -> str:
         app = App()
         async with app.run_test() as pilot:
-            await app.push_screen(EventDetailScreen(record=record))
+            await app.push_screen(
+                EventDetailScreen(
+                    record=record,
+                    security_correlation=correlation_service,
+                )
+            )
             await pilot.pause()
             return "\n".join(
                 str(widget.render()) for widget in app.screen.query(Static)
@@ -124,6 +176,51 @@ def test_event_detail_renders_optional_call_identifiers() -> None:
 
     assert "call-1" in text
     assert "tool-call-1" in text
+
+
+def test_event_detail_renders_correlated_security_events_when_present() -> None:
+    details = {"summary": "dangerous command", "action": "scan"}
+    correlation = _FakeCorrelationService(
+        [
+            CorrelatedSecurityEvent(
+                event=_security_event(details=details),
+                match_reason="tool_call_id",
+                time_delta_seconds=1.25,
+                security_timestamp_epoch=1778932801.25,
+            )
+        ]
+    )
+
+    text = _render_detail_text(
+        _record(hook="before_tool_call", tool_call_id="tool-call-1"),
+        correlation,
+    )
+
+    assert correlation.calls
+    assert "Security Events" in text
+    assert "code_scan" in text
+    assert "tool_call_id" in text
+    assert "1.250s" in text
+    assert "security_at=" in text
+    assert "observed=" not in text
+    assert "dangerous command" in text
+    assert text.index('"summary"') < text.index('"action"')
+
+
+def test_event_detail_omits_security_events_section_when_no_correlations() -> None:
+    text = _render_detail_text(_record(), _FakeCorrelationService())
+
+    assert "Security Events" not in text
+
+
+def test_event_detail_omits_security_events_section_when_correlation_fails() -> None:
+    text = _render_detail_text(
+        _record(),
+        _FakeCorrelationService(error=RuntimeError("database unavailable")),
+    )
+
+    assert "before_agent_run" in text
+    assert "Security Events" not in text
 
 
 def test_review_app_drills_from_session_to_event_detail() -> None:
@@ -290,6 +387,103 @@ def test_event_list_ignores_stale_row_key() -> None:
             return isinstance(app.screen, EventListScreen)
 
     assert asyncio.run(run()) is True
+
+
+def test_event_list_uses_security_result_column_name() -> None:
+    screen = EventListScreen(session_id="session-A", run_id="run-A")
+
+    assert screen._columns() == ("Time", "Hook", "Call / Tool", "Security Result")
+
+
+def test_event_list_renders_security_result_from_correlation() -> None:
+    async def run() -> tuple[str, list[object]]:
+        record = _record(
+            record_id=7,
+            hook="before_tool_call",
+            metrics={"tool_name": "grep"},
+            metadata={
+                "sessionId": "session-A",
+                "runId": "run-A",
+                "toolCallId": "tool-call-1",
+            },
+            tool_call_id="tool-call-1",
+        )
+        reader = _FakeReader(events_by_run={("session-A", "run-A"): [record]})
+        correlation = _FakeCorrelationService(
+            [
+                CorrelatedSecurityEvent(
+                    event=_security_event(details={"result": {"verdict": "warn"}}),
+                    match_reason="tool_call_id",
+                    time_delta_seconds=0.1,
+                    security_timestamp_epoch=1778932800.1,
+                )
+            ]
+        )
+        app = ObservabilityReviewApp(
+            reader=reader,  # type: ignore[arg-type]
+            security_correlation=correlation,
+        )
+        async with app.run_test() as pilot:
+            await app.push_screen(
+                EventListScreen(session_id="session-A", run_id="run-A")
+            )
+            await pilot.pause()
+            table = app.screen.query_one(DataTable)
+            return str(table.get_row_at(0)[3]), correlation.calls
+
+    security_result, calls = asyncio.run(run())
+
+    assert security_result == "code_scan:warn"
+    assert len(calls) == 1
+
+
+def test_format_security_result_uses_correlated_scan_verdicts() -> None:
+    events = [
+        CorrelatedSecurityEvent(
+            event=_security_event(
+                event_id="code-scan-1",
+                category="code_scan",
+                details={"result": {"verdict": "warn"}},
+            ),
+            match_reason="tool_call_id",
+            time_delta_seconds=0.1,
+            security_timestamp_epoch=1778932800.1,
+        ),
+        CorrelatedSecurityEvent(
+            event=_security_event(
+                event_id="skill-ledger-1",
+                category="skill_ledger",
+                event_type="skill_ledger",
+                details={"result": {"status": "pass"}},
+            ),
+            match_reason="tool_call_id",
+            time_delta_seconds=0.2,
+            security_timestamp_epoch=1778932800.2,
+        ),
+    ]
+
+    assert _format_security_result(events) == "code_scan:warn, skill_ledger:pass"
+
+
+def test_format_security_result_handles_missing_or_boolean_results() -> None:
+    assert _format_security_result([]) == "-"
+    assert (
+        _format_security_result(
+            [
+                CorrelatedSecurityEvent(
+                    event=_security_event(
+                        category="skill_ledger",
+                        event_type="skill_ledger",
+                        details={"result": {"valid": False}},
+                    ),
+                    match_reason="tool_call_id",
+                    time_delta_seconds=0.1,
+                    security_timestamp_epoch=1778932800.1,
+                )
+            ]
+        )
+        == "skill_ledger:fail"
+    )
 
 
 def test_summarize_metrics_renders_hook_specific_timeline_text() -> None:

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -584,6 +584,65 @@ class TestCorrelationCandidateQuery:
             "upper-bound",
         ]
 
+    def test_candidates_filter_multiple_tool_call_ids(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        for event_id, tool_call_id in (
+            ("tool-1-match", "tool-1"),
+            ("tool-2-match", "tool-2"),
+            ("tool-3-skip", "tool-3"),
+        ):
+            writer.write(
+                _make_correlated_event(
+                    event_id=event_id,
+                    category="code_scan",
+                    timestamp_epoch=CORRELATION_BASE_EPOCH,
+                    session_id="session-1",
+                    run_id="run-1",
+                    tool_call_id=tool_call_id,
+                )
+            )
+        writer.close()
+
+        candidates = reader.query_correlation_candidates(
+            session_id="session-1",
+            categories=("code_scan",),
+            run_id="run-1",
+            tool_call_ids=("tool-1", "tool-2"),
+        )
+
+        assert [candidate.event.event_id for candidate in candidates] == [
+            "tool-1-match",
+            "tool-2-match",
+        ]
+
+    def test_candidates_are_limited_to_1000_rows(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        for index in range(1001):
+            writer.write(
+                _make_correlated_event(
+                    event_id=f"candidate-{index:04d}",
+                    category="code_scan",
+                    timestamp_epoch=CORRELATION_BASE_EPOCH + index,
+                    session_id="session-1",
+                    run_id="run-1",
+                    tool_call_id="tool-1",
+                )
+            )
+        writer.close()
+
+        candidates = reader.query_correlation_candidates(
+            session_id="session-1",
+            categories=("code_scan",),
+            run_id="run-1",
+            tool_call_id="tool-1",
+        )
+
+        assert len(candidates) == 1000
+        assert candidates[0].event.event_id == "candidate-0000"
+        assert candidates[-1].event.event_id == "candidate-0999"
+
     def test_candidates_do_not_filter_run_when_run_id_omitted(
         self, writer: SqliteEventWriter, reader: SqliteEventReader
     ) -> None:

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -13,6 +13,8 @@ from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
 from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
 
+CORRELATION_BASE_EPOCH = 1_800_000_000.0
+
 
 def _make_event(
     event_type: str = "test_event", category: str = "test", **kwargs: Any
@@ -22,6 +24,28 @@ def _make_event(
         category=category,
         details=kwargs.get("details", {"key": "value"}),
         trace_id=kwargs.get("trace_id", ""),
+    )
+
+
+def _make_correlated_event(
+    *,
+    event_id: str,
+    category: str,
+    timestamp_epoch: float,
+    session_id: str,
+    run_id: str | None = None,
+    tool_call_id: str | None = None,
+) -> SecurityEvent:
+    return SecurityEvent(
+        event_id=event_id,
+        event_type=f"{category}_event",
+        category=category,
+        timestamp=datetime.fromtimestamp(timestamp_epoch, timezone.utc).isoformat(),
+        trace_id="trace",
+        session_id=session_id,
+        run_id=run_id,
+        tool_call_id=tool_call_id,
+        details={"event_id": event_id},
     )
 
 
@@ -441,3 +465,178 @@ class TestSqliteEventReader:
         reader.close()
         assert reader._engine is None
         assert reader._session_factory is None
+
+
+class TestCorrelationCandidateQuery:
+    def test_candidates_match_session_run_tool_call_and_category(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(
+            _make_correlated_event(
+                event_id="match-code",
+                category="code_scan",
+                timestamp_epoch=CORRELATION_BASE_EPOCH,
+                session_id="session-1",
+                run_id="run-1",
+                tool_call_id="tool-1",
+            )
+        )
+        writer.write(
+            _make_correlated_event(
+                event_id="match-skill",
+                category="skill_ledger",
+                timestamp_epoch=CORRELATION_BASE_EPOCH + 1.0,
+                session_id="session-1",
+                run_id="run-1",
+                tool_call_id="tool-1",
+            )
+        )
+        writer.write(
+            _make_correlated_event(
+                event_id="wrong-tool",
+                category="code_scan",
+                timestamp_epoch=CORRELATION_BASE_EPOCH + 2.0,
+                session_id="session-1",
+                run_id="run-1",
+                tool_call_id="tool-2",
+            )
+        )
+        writer.write(
+            _make_correlated_event(
+                event_id="wrong-run",
+                category="code_scan",
+                timestamp_epoch=CORRELATION_BASE_EPOCH + 3.0,
+                session_id="session-1",
+                run_id="run-2",
+                tool_call_id="tool-1",
+            )
+        )
+        writer.write(
+            _make_correlated_event(
+                event_id="wrong-session",
+                category="code_scan",
+                timestamp_epoch=CORRELATION_BASE_EPOCH + 4.0,
+                session_id="session-2",
+                run_id="run-1",
+                tool_call_id="tool-1",
+            )
+        )
+        writer.write(
+            _make_correlated_event(
+                event_id="wrong-category",
+                category="sandbox",
+                timestamp_epoch=CORRELATION_BASE_EPOCH + 5.0,
+                session_id="session-1",
+                run_id="run-1",
+                tool_call_id="tool-1",
+            )
+        )
+        writer.close()
+
+        candidates = reader.query_correlation_candidates(
+            session_id="session-1",
+            categories=("code_scan", "skill_ledger"),
+            run_id="run-1",
+            tool_call_id="tool-1",
+        )
+
+        assert [candidate.event.event_id for candidate in candidates] == [
+            "match-code",
+            "match-skill",
+        ]
+        assert [candidate.timestamp_epoch for candidate in candidates] == [
+            CORRELATION_BASE_EPOCH,
+            CORRELATION_BASE_EPOCH + 1.0,
+        ]
+
+    def test_candidates_filter_inclusive_epoch_window(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        for event_id, timestamp_epoch in (
+            ("too-early", 997.99),
+            ("lower-bound", 998.0),
+            ("center", 1000.0),
+            ("upper-bound", 1002.0),
+            ("too-late", 1002.01),
+        ):
+            writer.write(
+                _make_correlated_event(
+                    event_id=event_id,
+                    category="prompt_scan",
+                    timestamp_epoch=CORRELATION_BASE_EPOCH + timestamp_epoch,
+                    session_id="session-1",
+                    run_id="run-1",
+                )
+            )
+        writer.close()
+
+        candidates = reader.query_correlation_candidates(
+            session_id="session-1",
+            categories=["prompt_scan"],
+            run_id="run-1",
+            since_epoch=CORRELATION_BASE_EPOCH + 998.0,
+            until_epoch=CORRELATION_BASE_EPOCH + 1002.0,
+        )
+
+        assert [candidate.event.event_id for candidate in candidates] == [
+            "lower-bound",
+            "center",
+            "upper-bound",
+        ]
+
+    def test_candidates_do_not_filter_run_when_run_id_omitted(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(
+            _make_correlated_event(
+                event_id="run-1-match",
+                category="pii_scan",
+                timestamp_epoch=CORRELATION_BASE_EPOCH,
+                session_id="session-1",
+                run_id="run-1",
+            )
+        )
+        writer.write(
+            _make_correlated_event(
+                event_id="run-2-match",
+                category="pii_scan",
+                timestamp_epoch=CORRELATION_BASE_EPOCH + 1.0,
+                session_id="session-1",
+                run_id="run-2",
+            )
+        )
+        writer.write(
+            _make_correlated_event(
+                event_id="wrong-session",
+                category="pii_scan",
+                timestamp_epoch=CORRELATION_BASE_EPOCH + 2.0,
+                session_id="session-2",
+                run_id="run-1",
+            )
+        )
+        writer.close()
+
+        candidates = reader.query_correlation_candidates(
+            session_id="session-1",
+            categories=("pii_scan",),
+            since_epoch=CORRELATION_BASE_EPOCH - 1.0,
+            until_epoch=CORRELATION_BASE_EPOCH + 2.0,
+        )
+
+        assert [candidate.event.event_id for candidate in candidates] == [
+            "run-1-match",
+            "run-2-match",
+        ]
+
+    def test_candidates_return_empty_when_schema_unavailable(
+        self, tmp_path: Path
+    ) -> None:
+        reader = SqliteEventReader(path=str(tmp_path / "missing.db"))
+
+        assert (
+            reader.query_correlation_candidates(
+                session_id="session-1",
+                categories=("code_scan",),
+            )
+            == []
+        )


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Add a correlation service that links observability records to security events
  by session/run/tool-call context. Surface correlated security events in the
  observability review detail screen, including match reason, time delta, event
  timestamp, and details.

  For before_agent_run records, match prompt/PII scan events by session_id and
  run_id when a meaningful run_id exists; fall back to the time window only when
  run_id is missing or zero. For before_tool_call records, keep exact
  tool_call_id matching.

  Also extend SQLite security-event reader queries and add unit coverage for
  correlation modes, review rendering, CLI lifecycle cleanup, and reader filters.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
