### PR TITLE
fix(ckpt): list bug, diff bug + live img migrate

### DIFF
--- a/src/ws-ckpt/src/Cargo.lock
+++ b/src/ws-ckpt/src/Cargo.lock
@@ -1499,6 +1499,7 @@ name = "ws-ckpt-cli"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "serde_json",
  "tokio",

--- a/src/ws-ckpt/src/crates/cli/Cargo.toml
+++ b/src/ws-ckpt/src/crates/cli/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "macro
 anyhow = "1"
 serde_json = "1"
 toml = "0.8"
+chrono = { version = "0.4", features = ["clock"] }

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -698,7 +698,17 @@ fn handle_list_response(response: Response, format: &str) -> Result<()> {
                     // Dynamically compute column widths
                     let hdr_ws = "WORKSPACE";
                     let hdr_snap = "SNAPSHOT";
-                    let hdr_date = "CREATED";
+                    let offset_secs = chrono::Local::now().offset().local_minus_utc();
+                    let sign = if offset_secs >= 0 { '+' } else { '-' };
+                    let h = offset_secs.abs() / 3600;
+                    let m = (offset_secs.abs() % 3600) / 60;
+                    let local_offset = if m == 0 {
+                        format!("{sign}{h}")
+                    } else {
+                        format!("{sign}{h}:{m:02}")
+                    };
+                    let hdr_date = format!("CREATED (UTC{local_offset})");
+                    let hdr_date = hdr_date.as_str();
                     let hdr_msg = "MESSAGE";
 
                     let w_ws = snapshots
@@ -736,7 +746,11 @@ fn handle_list_response(response: Response, format: &str) -> Result<()> {
                             "{:<w_ws$} {:<w_snap$} {:<w_date$} {}",
                             entry.workspace,
                             id_display,
-                            entry.meta.created_at.format("%Y-%m-%d %H:%M:%S"),
+                            entry
+                                .meta
+                                .created_at
+                                .with_timezone(&chrono::Local)
+                                .format("%Y-%m-%d %H:%M:%S"),
                             entry.meta.message.as_deref().unwrap_or("-"),
                         );
                     }

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::process;
 
 use anyhow::{Context, Result};
+use clap::builder::{StringValueParser, TypedValueParser};
 use clap::{Parser, Subcommand};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
@@ -13,14 +14,12 @@ use ws_ckpt_common::{
     ADVISORY_SNAPSHOT_LIMIT, CONFIG_FILE_PATH, DEFAULT_AUTO_CLEANUP,
     DEFAULT_AUTO_CLEANUP_INTERVAL_SECS, DEFAULT_HEALTH_CHECK_INTERVAL_SECS,
     DEFAULT_IMG_MAX_PERCENT, DEFAULT_IMG_SIZE_GB, DEFAULT_MOUNT_PATH, DEFAULT_SOCKET_PATH,
+    MAX_FRAME_SIZE,
 };
 
 /// Backend-usage advisory threshold (percent); CLI-side since daemon returns raw bytes.
 const ADVISORY_FS_USAGE_PCT: f64 = 90.0;
-
-/// Upper bound for the best-effort advisory IPC; a stuck daemon must not delay
-/// user-visible commands. Local UDS RTT is sub-millisecond.
-const ADVISORY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(10);
+const ADVISORY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(30);
 
 // Parse CLI value for `--auto-cleanup-keep`: integer -> Count mode, duration
 // string (e.g. "30d", units s/m/h/d/w) -> Age mode. Mirrors TOML semantics in
@@ -59,14 +58,14 @@ enum Commands {
     /// Initialize a workspace for btrfs snapshot management
     Init {
         /// Workspace path or ID (absolute path, relative path, or workspace ID)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: String,
     },
 
     /// Create a checkpoint (readonly snapshot)
     Checkpoint {
         /// Workspace path or ID (absolute path, relative path, or workspace ID)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: String,
 
         /// Snapshot ID (must be unique within the workspace)
@@ -85,7 +84,7 @@ enum Commands {
     /// Rollback workspace to a specific snapshot
     Rollback {
         /// Workspace path or ID (absolute path, relative path, or workspace ID)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: String,
 
         /// Target snapshot (ID like msg1-step2, or name like before-refactor)
@@ -96,7 +95,7 @@ enum Commands {
     /// Delete a specific snapshot
     Delete {
         /// Workspace path or ID (optional; omit for global snapshot lookup)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: Option<String>,
 
         /// Snapshot ID or unique prefix
@@ -111,7 +110,7 @@ enum Commands {
     /// List all snapshots for a workspace (or all workspaces if omitted)
     List {
         /// Workspace path or ID (optional; omit to list all workspaces)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: Option<String>,
 
         /// Output format: table or json (default: table)
@@ -122,7 +121,7 @@ enum Commands {
     /// Show diff between two snapshots
     Diff {
         /// Workspace path or ID (absolute path, relative path, or workspace ID)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: String,
 
         /// Source snapshot (ID or name)
@@ -137,7 +136,7 @@ enum Commands {
     /// Show daemon and workspace status
     Status {
         /// Workspace path or ID (optional filter)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: Option<String>,
 
         /// Output format: table or json (default: table)
@@ -148,7 +147,7 @@ enum Commands {
     /// Clean up old snapshots, keeping the most recent ones
     Cleanup {
         /// Workspace path or ID (absolute path, relative path, or workspace ID)
-        #[arg(long, short = 'w')]
+        #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: String,
 
         /// Number of recent unpinned snapshots to keep (default: 20)
@@ -193,7 +192,7 @@ enum Commands {
     /// Recover workspace to a normal directory (undo init)
     Recover {
         /// Workspace path or ID
-        #[arg(short, long, conflicts_with = "all")]
+        #[arg(short, long, conflicts_with = "all", value_parser = workspace_value_parser())]
         workspace: Option<String>,
 
         /// Recover all registered workspaces
@@ -413,12 +412,27 @@ fn get_socket_path() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from(DEFAULT_SOCKET_PATH))
 }
 
+/// Clap value parser that rejects empty and whitespace-only workspace strings.
+/// Stricter than `NonEmptyStringValueParser`, which only rejects `""`.
+fn workspace_value_parser() -> impl TypedValueParser<Value = String> {
+    StringValueParser::new().try_map(|s: String| {
+        if s.trim().is_empty() {
+            Err("workspace argument must not be empty or whitespace")
+        } else {
+            Ok(s)
+        }
+    })
+}
+
 /// Resolve workspace identifier: convert filesystem paths to absolute,
 /// pass workspace IDs through unchanged.
 ///
 /// IMPORTANT: We must NOT follow symlinks here. With symlink-based workspaces,
 /// the user-facing path is a symlink (e.g. `/tmp/test-ws -> /mnt/btrfs-workspace/ws-xxx`).
 /// The daemon registers the symlink path, so we must preserve it.
+///
+/// Assumes the input has already been validated non-empty by
+/// `workspace_value_parser`; callers feeding raw strings should validate first.
 fn resolve_workspace_arg(workspace: &str) -> String {
     let path = std::path::Path::new(workspace);
     // If it looks like a workspace ID (no path separators), pass through unchanged
@@ -475,9 +489,15 @@ async fn send_request_to_daemon(request: &Request) -> Result<Response> {
         .read_exact(&mut len_buf)
         .await
         .context("failed to read response length")?;
-    let len = u32::from_le_bytes(len_buf) as usize;
-
-    let mut payload = vec![0u8; len];
+    let len = u32::from_le_bytes(len_buf);
+    if len > MAX_FRAME_SIZE {
+        anyhow::bail!(
+            "Response frame too large: {} bytes (max {})",
+            len,
+            MAX_FRAME_SIZE
+        );
+    }
+    let mut payload = vec![0u8; len as usize];
     stream
         .read_exact(&mut payload)
         .await
@@ -508,9 +528,15 @@ async fn try_send_request_to_daemon_silent(request: &Request) -> Result<Response
         .read_exact(&mut len_buf)
         .await
         .context("read response length (silent)")?;
-    let len = u32::from_le_bytes(len_buf) as usize;
-
-    let mut payload = vec![0u8; len];
+    let len = u32::from_le_bytes(len_buf);
+    if len > MAX_FRAME_SIZE {
+        anyhow::bail!(
+            "Response frame too large: {} bytes (max {})",
+            len,
+            MAX_FRAME_SIZE
+        );
+    }
+    let mut payload = vec![0u8; len as usize];
     stream
         .read_exact(&mut payload)
         .await
@@ -1210,6 +1236,72 @@ mod tests {
             Commands::Init { workspace } => assert_eq!(workspace, "/tmp/test"),
             _ => panic!("expected Init"),
         }
+    }
+
+    #[test]
+    fn parse_rejects_empty_or_whitespace_workspace_on_every_subcommand() {
+        let subcommands: &[&[&str]] = &[
+            &["init", "-w"],
+            &["checkpoint", "-w"],
+            &["rollback", "-w"],
+            &["delete", "-w"],
+            &["list", "-w"],
+            &["diff", "-w"],
+            &["status", "-w"],
+            &["cleanup", "-w"],
+            &["recover", "-w"],
+        ];
+        // Trailing args needed to satisfy required-flag validation for some
+        // subcommands. Tested independently for each blank value.
+        let trailing: &[(&str, &[&str])] = &[
+            ("init", &[]),
+            ("checkpoint", &["-i", "snap-1"]),
+            ("rollback", &["-s", "snap-1"]),
+            ("delete", &["-s", "snap-1"]),
+            ("list", &[]),
+            ("diff", &["-f", "a", "-t", "b"]),
+            ("status", &[]),
+            ("cleanup", &[]),
+            ("recover", &[]),
+        ];
+        for blank in ["", "   ", "\t"] {
+            for sub in subcommands {
+                let name = sub[0];
+                let extra = trailing
+                    .iter()
+                    .find(|(n, _)| *n == name)
+                    .map(|(_, a)| *a)
+                    .unwrap_or(&[]);
+                let mut argv: Vec<&str> = vec!["ws-ckpt"];
+                argv.extend_from_slice(sub);
+                argv.push(blank);
+                argv.extend_from_slice(extra);
+                let err = Cli::try_parse_from(&argv)
+                    .err()
+                    .unwrap_or_else(|| panic!("expected parse error for argv: {:?}", argv));
+                assert_eq!(
+                    err.kind(),
+                    clap::error::ErrorKind::ValueValidation,
+                    "argv {:?} should fail with ValueValidation, got {:?}",
+                    argv,
+                    err.kind()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_accepts_non_blank_workspace() {
+        // Sanity: non-blank values still parse.
+        Cli::try_parse_from(["ws-ckpt", "init", "-w", "ws-abc"]).unwrap();
+        Cli::try_parse_from(["ws-ckpt", "init", "-w", "/foo"]).unwrap();
+        Cli::try_parse_from(["ws-ckpt", "init", "-w", "  abc  "]).unwrap();
+    }
+
+    #[test]
+    fn resolve_workspace_arg_passes_through_non_empty() {
+        assert_eq!(resolve_workspace_arg("ws-abc123"), "ws-abc123");
+        assert_eq!(resolve_workspace_arg("/abs/path"), "/abs/path");
     }
 
     #[test]

--- a/src/ws-ckpt/src/crates/common/src/backend.rs
+++ b/src/ws-ckpt/src/crates/common/src/backend.rs
@@ -113,4 +113,9 @@ pub trait StorageBackend: Send + Sync {
     async fn bootstrap(&self, _config: &crate::DaemonConfig) -> anyhow::Result<()> {
         Ok(())
     }
+
+    /// Optional hook: BtrfsLoop reports its on-disk image state for state.json.
+    async fn loop_img_state(&self) -> Option<crate::persist::LoopImgState> {
+        None
+    }
 }

--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -643,7 +643,9 @@ impl Default for DaemonConfig {
 
 // ── Frame encoding/decoding (sync, no tokio dependency) ──
 
-const MAX_FRAME_SIZE: u32 = 16 * 1024 * 1024; // 16MB max
+/// Max IPC frame payload (excludes 4-byte length header). Enforced on both
+/// sides to prevent OOM from a malformed length prefix.
+pub const MAX_FRAME_SIZE: u32 = 16 * 1024 * 1024; // 16 MiB
 
 /// Serialize a message into a length-prefixed frame: [4-byte LE length][bincode payload]
 pub fn encode_frame<T: Serialize>(msg: &T) -> Result<Vec<u8>, WsCkptError> {

--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -166,9 +166,39 @@ pub enum ErrorCode {
 
 // ── Snapshot types ──
 
+/// Serde for `SnapshotMeta.metadata`: passes `Value` through for JSON,
+/// encodes as `String` for bincode (which can't deserialize untagged enums).
+mod metadata_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_json::Value;
+
+    pub fn serialize<S: Serializer>(v: &Option<Value>, s: S) -> Result<S::Ok, S::Error> {
+        // Collapse `Some(Value::Null)` to `None` to match JSON round-trip.
+        let normalized = v.as_ref().filter(|val| !val.is_null());
+        if s.is_human_readable() {
+            normalized.serialize(s)
+        } else {
+            normalized.map(|val| val.to_string()).serialize(s)
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Value>, D::Error> {
+        // No need to collapse `Some(Value::Null)` here: `serialize` already
+        // normalizes it on the way out, so the wire never carries a null value.
+        if d.is_human_readable() {
+            Option::<Value>::deserialize(d)
+        } else {
+            Option::<String>::deserialize(d)?
+                .map(|s| serde_json::from_str(&s).map_err(serde::de::Error::custom))
+                .transpose()
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SnapshotMeta {
     pub message: Option<String>,
+    #[serde(default, with = "metadata_serde")]
     pub metadata: Option<serde_json::Value>,
     pub pinned: bool,
     pub created_at: DateTime<Utc>,
@@ -1238,6 +1268,75 @@ mod tests {
         assert_eq!(deserialized.id, "abc123def456");
         assert_eq!(deserialized.meta.message.as_deref(), Some("test message"));
         assert!(!deserialized.meta.pinned);
+    }
+
+    /// bincode round-trip with a non-trivial `metadata` Value.
+    /// Regression: pre-fix, `Option<serde_json::Value>` would fail bincode
+    /// deserialize because Value requires `deserialize_any`.
+    #[test]
+    fn response_list_ok_with_metadata_bincode_round_trip() {
+        let metadata = serde_json::json!({"event": "init", "n": 42, "tags": ["a", "b"]});
+        let resp = Response::ListOk {
+            snapshots: vec![SnapshotEntry {
+                id: "abc".to_string(),
+                workspace: "/ws".to_string(),
+                meta: SnapshotMeta {
+                    message: Some("first".to_string()),
+                    metadata: Some(metadata.clone()),
+                    pinned: false,
+                    created_at: chrono::Utc::now(),
+                    missing: false,
+                },
+            }],
+        };
+        let decoded = round_trip_response(&resp);
+        match decoded {
+            Response::ListOk { snapshots } => {
+                assert_eq!(snapshots.len(), 1);
+                assert_eq!(snapshots[0].meta.metadata, Some(metadata));
+            }
+            _ => panic!("expected ListOk variant"),
+        }
+    }
+
+    /// `Some(Value::Null)` collapses to `None` on both JSON and bincode paths,
+    /// matching `Option<Value>`'s natural JSON round-trip behavior.
+    #[test]
+    fn snapshot_meta_metadata_null_collapses_to_none() {
+        let meta = SnapshotMeta {
+            message: None,
+            metadata: Some(serde_json::Value::Null),
+            pinned: false,
+            created_at: chrono::Utc::now(),
+            missing: false,
+        };
+        // JSON path
+        let json = serde_json::to_string(&meta).unwrap();
+        let from_json: SnapshotMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(from_json.metadata, None);
+        // bincode path
+        let bin = bincode::serialize(&meta).unwrap();
+        let from_bin: SnapshotMeta = bincode::deserialize(&bin).unwrap();
+        assert_eq!(from_bin.metadata, None);
+    }
+
+    /// JSON round-trip keeps `metadata` as a nested Value (not a quoted string).
+    /// Verifies the `is_human_readable() == true` path of `metadata_serde`.
+    #[test]
+    fn snapshot_meta_metadata_json_round_trip_keeps_nested_object() {
+        let metadata = serde_json::json!({"k": "v"});
+        let meta = SnapshotMeta {
+            message: None,
+            metadata: Some(metadata.clone()),
+            pinned: false,
+            created_at: chrono::Utc::now(),
+            missing: false,
+        };
+        let s = serde_json::to_string(&meta).unwrap();
+        // metadata is rendered as an object, not as an escaped string
+        assert!(s.contains(r#""metadata":{"k":"v"}"#), "got: {}", s);
+        let parsed: SnapshotMeta = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.metadata, Some(metadata));
     }
 
     #[test]

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -8,6 +8,8 @@ use tokio::process::Command;
 use tracing::{error, info, warn};
 use ws_ckpt_common::{ChangeType, DiffEntry};
 
+use crate::util::unescape_proc_mount;
+
 /// Ensure the current kernel can mount btrfs.
 ///
 /// Checks `/proc/filesystems`; if absent, tries `modprobe btrfs` once and rechecks.
@@ -592,8 +594,8 @@ pub async fn find_available_btrfs_partition() -> Result<MountInfo> {
                 continue;
             }
             return Ok(MountInfo {
-                device: parts[0].to_string(),
-                mount_point: parts[1].to_string(),
+                device: unescape_proc_mount(parts[0]),
+                mount_point: unescape_proc_mount(parts[1]),
             });
         }
     }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -214,18 +214,17 @@ fn diff_between_snapshots_blocking(snap_from: &Path, snap_to: &Path) -> Result<V
     Ok(entries)
 }
 
-/// Parse the output of `btrfs receive --dump` into clean, deduplicated DiffEntry items.
+/// Parse `btrfs receive --dump` output into deduplicated DiffEntry items.
 ///
-/// Processing phases:
-/// 1. Detect snapshot prefix (e.g. `./msg1-step1/`) and build rename map
-///    to resolve btrfs-internal temporary inode references (e.g. `o261-118-0`)
-///    to their real file paths.
-/// 2. Walk operations, resolve paths, and deduplicate so that each real path
-///    appears at most once with the most significant change type.
+/// Phase 1 collects: snapshot prefix, temp→real rename map, link pairs,
+/// unlinks. A `link new dest=old` paired with `unlink old` encodes an `mv`
+/// (btrfs send emits no `rename` line for cross-snapshot mv).
+/// Phase 2 emits entries with precedence dedup (Renamed > Added > Deleted > Modified).
 fn parse_btrfs_diff_output(output: &str) -> Vec<DiffEntry> {
-    // ── Phase 1: detect snapshot prefix + build rename map ──
     let mut snapshot_prefix = String::new();
     let mut rename_map: HashMap<String, String> = HashMap::new();
+    let mut link_pairs: Vec<(String, String)> = Vec::new();
+    let mut unlinked: HashSet<String> = HashSet::new();
 
     for line in output.lines() {
         let line = line.trim();
@@ -233,24 +232,35 @@ fn parse_btrfs_diff_output(output: &str) -> Vec<DiffEntry> {
             continue;
         }
         if let Some(rest) = line.strip_prefix("snapshot") {
-            // "snapshot  ./msg1-step1  uuid=... transid=..."
             if let Some(name) = rest.split_whitespace().next() {
                 snapshot_prefix = format!("{}/", name);
             }
         } else if let Some(rest) = line.strip_prefix("rename") {
-            // "rename  ./snap/old_path  dest=./snap/new_path"
-            let rest = rest.trim();
-            if let Some(dest_pos) = rest.find("dest=") {
-                let src = first_token(&rest[..dest_pos]);
-                let dst = first_token(&rest[dest_pos + 5..]);
-                let src = strip_snap_prefix(&src, &snapshot_prefix);
-                let dst = strip_snap_prefix(&dst, &snapshot_prefix);
+            if let Some((src, dst)) = parse_dest_pair(rest, &snapshot_prefix) {
                 rename_map.insert(src, dst);
             }
+        } else if let Some(rest) = line.strip_prefix("link") {
+            if let Some((new_real, dest_path)) = parse_dest_pair(rest, &snapshot_prefix) {
+                link_pairs.push((new_real, dest_path));
+            }
+        } else if let Some(rest) = line.strip_prefix("unlink") {
+            unlinked.insert(strip_snap_prefix(&first_token(rest), &snapshot_prefix));
         }
     }
 
-    // ── Phase 2: process operations with dedup (preserve first-seen order) ──
+    // mv detection: a `link new dest=old` paired with `unlink old` folds into
+    // a single Renamed and the matching Deleted is suppressed. Each old path
+    // can pair with at most one link — additional links to the same old path
+    // fall through to real-hardlink (Added) handling in Phase 2.
+    let mut mv_renames: HashMap<String, String> = HashMap::new();
+    let mut suppressed_unlinks: HashSet<String> = HashSet::new();
+    for (new_real, dest_path) in &link_pairs {
+        if unlinked.contains(dest_path) && !suppressed_unlinks.contains(dest_path) {
+            mv_renames.insert(new_real.clone(), dest_path.clone());
+            suppressed_unlinks.insert(dest_path.clone());
+        }
+    }
+
     let mut seen: HashMap<String, usize> = HashMap::new();
     let mut entries: Vec<DiffEntry> = Vec::new();
 
@@ -261,24 +271,53 @@ fn parse_btrfs_diff_output(output: &str) -> Vec<DiffEntry> {
         }
 
         if let Some(rest) = line.strip_prefix("mkfile") {
-            let raw = first_token(rest);
-            let path = strip_snap_prefix(&raw, &snapshot_prefix);
-            let resolved = rename_map.get(&path).cloned().unwrap_or(path);
-            insert_dedup(&mut seen, &mut entries, resolved, ChangeType::Added, None);
+            let path = resolve_path(rest, &snapshot_prefix, &rename_map);
+            insert_dedup(&mut seen, &mut entries, path, ChangeType::Added, None);
         } else if let Some(rest) = line.strip_prefix("mkdir") {
-            let raw = first_token(rest);
-            let path = strip_snap_prefix(&raw, &snapshot_prefix);
-            let resolved = rename_map.get(&path).cloned().unwrap_or(path);
+            let path = resolve_path(rest, &snapshot_prefix, &rename_map);
             insert_dedup(
                 &mut seen,
                 &mut entries,
-                resolved,
+                path,
                 ChangeType::Added,
                 Some("directory".to_string()),
             );
+        } else if let Some(rest) = line.strip_prefix("symlink") {
+            // First token is the new symlink path (often a temp inode renamed
+            // later); `dest=` is the link target string and isn't used.
+            let path = resolve_path(rest, &snapshot_prefix, &rename_map);
+            insert_dedup(
+                &mut seen,
+                &mut entries,
+                path,
+                ChangeType::Added,
+                Some("symlink".to_string()),
+            );
+        } else if let Some(rest) = line.strip_prefix("link") {
+            if let Some((new_real, _)) = parse_dest_pair(rest, &snapshot_prefix) {
+                if let Some(old) = mv_renames.get(&new_real).cloned() {
+                    insert_dedup(
+                        &mut seen,
+                        &mut entries,
+                        new_real.clone(),
+                        ChangeType::Renamed,
+                        Some(format!("{} → {}", old, new_real)),
+                    );
+                } else {
+                    insert_dedup(
+                        &mut seen,
+                        &mut entries,
+                        new_real,
+                        ChangeType::Added,
+                        Some("hardlink".to_string()),
+                    );
+                }
+            }
         } else if let Some(rest) = line.strip_prefix("unlink") {
             let path = strip_snap_prefix(&first_token(rest), &snapshot_prefix);
-            insert_dedup(&mut seen, &mut entries, path, ChangeType::Deleted, None);
+            if !suppressed_unlinks.contains(&path) {
+                insert_dedup(&mut seen, &mut entries, path, ChangeType::Deleted, None);
+            }
         } else if let Some(rest) = line.strip_prefix("rmdir") {
             let path = strip_snap_prefix(&first_token(rest), &snapshot_prefix);
             insert_dedup(
@@ -289,12 +328,8 @@ fn parse_btrfs_diff_output(output: &str) -> Vec<DiffEntry> {
                 Some("directory".to_string()),
             );
         } else if let Some(rest) = line.strip_prefix("rename") {
-            // Only emit user-facing Renamed for real renames; temp→real are
-            // silently resolved via the rename_map built in Phase 1.
-            let rest = rest.trim();
-            if let Some(dest_pos) = rest.find("dest=") {
-                let src = strip_snap_prefix(&first_token(&rest[..dest_pos]), &snapshot_prefix);
-                let dst = strip_snap_prefix(&first_token(&rest[dest_pos + 5..]), &snapshot_prefix);
+            // temp→real renames are folded via rename_map; only emit the rest.
+            if let Some((src, dst)) = parse_dest_pair(rest, &snapshot_prefix) {
                 if !is_btrfs_temp_ref(&src) {
                     insert_dedup(
                         &mut seen,
@@ -307,15 +342,8 @@ fn parse_btrfs_diff_output(output: &str) -> Vec<DiffEntry> {
             }
         } else if let Some(rest) = line.strip_prefix("update_extent") {
             // `btrfs send --no-data` emits update_extent instead of write.
-            let path = strip_snap_prefix(&first_token(rest), &snapshot_prefix);
-            let resolved = rename_map.get(&path).cloned().unwrap_or(path);
-            insert_dedup(
-                &mut seen,
-                &mut entries,
-                resolved,
-                ChangeType::Modified,
-                None,
-            );
+            let path = resolve_path(rest, &snapshot_prefix, &rename_map);
+            insert_dedup(&mut seen, &mut entries, path, ChangeType::Modified, None);
         } else if let Some(rest) = line.strip_prefix("write") {
             let path = strip_snap_prefix(&first_token(rest), &snapshot_prefix);
             insert_dedup(&mut seen, &mut entries, path, ChangeType::Modified, None);
@@ -323,14 +351,32 @@ fn parse_btrfs_diff_output(output: &str) -> Vec<DiffEntry> {
             let path = strip_snap_prefix(&first_token(rest), &snapshot_prefix);
             insert_dedup(&mut seen, &mut entries, path, ChangeType::Modified, None);
         }
-        // Silently skip metadata-only ops: snapshot, utimes, chown, chmod,
-        // set_xattr, remove_xattr, clone, link, etc.
+        // Skip metadata-only ops: utimes, chown, chmod, set_xattr, remove_xattr, clone.
     }
 
     entries
 }
 
-/// Insert a DiffEntry, deduplicating by path (first occurrence wins).
+/// Strip the snapshot prefix from the first token of `rest`, then resolve
+/// through `rename_map` (temp → real) when applicable.
+fn resolve_path(rest: &str, snapshot_prefix: &str, rename_map: &HashMap<String, String>) -> String {
+    let path = strip_snap_prefix(&first_token(rest), snapshot_prefix);
+    rename_map.get(&path).cloned().unwrap_or(path)
+}
+
+/// Parse a `<src>  dest=<dst>` line tail into `(src, dst)`, both with the
+/// snapshot prefix stripped. `dest=` for `link`/mvs may carry a bare relative
+/// path (no prefix), which `strip_snap_prefix` no-ops cleanly.
+fn parse_dest_pair(rest: &str, snapshot_prefix: &str) -> Option<(String, String)> {
+    let rest = rest.trim();
+    let dest_pos = rest.find("dest=")?;
+    let src = strip_snap_prefix(&first_token(&rest[..dest_pos]), snapshot_prefix);
+    let dst = strip_snap_prefix(&first_token(&rest[dest_pos + 5..]), snapshot_prefix);
+    Some((src, dst))
+}
+
+/// Insert a DiffEntry, dedup'd by path. Higher-precedence change_type wins
+/// on conflict (see `change_precedence`).
 fn insert_dedup(
     seen: &mut HashMap<String, usize>,
     entries: &mut Vec<DiffEntry>,
@@ -341,13 +387,31 @@ fn insert_dedup(
     if path.is_empty() {
         return;
     }
-    if !seen.contains_key(&path) {
+    if let Some(&idx) = seen.get(&path) {
+        if change_precedence(&change_type) > change_precedence(&entries[idx].change_type) {
+            // Replace both fields together: keeping the old `detail` (e.g.
+            // `"directory"` from a prior `rmdir`) when a `mkfile` reuses the
+            // path leaks misleading metadata into the new entry.
+            entries[idx].change_type = change_type;
+            entries[idx].detail = detail;
+        }
+    } else {
         seen.insert(path.clone(), entries.len());
         entries.push(DiffEntry {
             path,
             change_type,
             detail,
         });
+    }
+}
+
+/// Renamed > Added > Deleted > Modified.
+fn change_precedence(c: &ChangeType) -> u8 {
+    match c {
+        ChangeType::Renamed => 4,
+        ChangeType::Added => 3,
+        ChangeType::Deleted => 2,
+        ChangeType::Modified => 1,
     }
 }
 
@@ -770,6 +834,109 @@ mod tests {
         let output = "mkfile  new.txt\nchown  foo.txt\nxattr  bar.txt\n";
         let entries = parse_btrfs_diff_output(output);
         assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].change_type, ChangeType::Added);
+    }
+
+    // mkfile temp + rename temp→foo.txt + update_extent foo.txt → Added wins.
+    #[test]
+    fn parse_btrfs_diff_output_added_file_with_temp_rename() {
+        let output = "snapshot  ./snap_a_ro  uuid=abc transid=1\n\
+                      mkfile          ./snap_a_ro/o257-34321-0\n\
+                      rename          ./snap_a_ro/o257-34321-0  dest=./snap_a_ro/foo.txt\n\
+                      update_extent   ./snap_a_ro/foo.txt  offset=0 len=6\n";
+        let entries = parse_btrfs_diff_output(output);
+        assert_eq!(entries.len(), 1, "entries: {:?}", entries);
+        assert_eq!(entries[0].path, "foo.txt");
+        assert_eq!(entries[0].change_type, ChangeType::Added);
+    }
+
+    // symlink temp + rename temp→mylink → Added(mylink, "symlink").
+    #[test]
+    fn parse_btrfs_diff_output_symlink_with_temp_rename() {
+        let output = "snapshot  ./snap_a_ro  uuid=abc transid=1\n\
+                      symlink         ./snap_a_ro/o258-34321-0  dest=/etc/passwd\n\
+                      rename          ./snap_a_ro/o258-34321-0  dest=./snap_a_ro/mylink\n";
+        let entries = parse_btrfs_diff_output(output);
+        assert_eq!(entries.len(), 1, "entries: {:?}", entries);
+        assert_eq!(entries[0].path, "mylink");
+        assert_eq!(entries[0].change_type, ChangeType::Added);
+        assert_eq!(entries[0].detail.as_deref(), Some("symlink"));
+    }
+
+    // link new dest=existing where existing is NOT unlinked → real hardlink.
+    #[test]
+    fn parse_btrfs_diff_output_real_hardlink_emits_added() {
+        let output = "snapshot  ./snap_a_ro  uuid=abc transid=1\n\
+                      mkfile          ./snap_a_ro/o259-34321-0\n\
+                      rename          ./snap_a_ro/o259-34321-0  dest=./snap_a_ro/target.txt\n\
+                      link            ./snap_a_ro/hardlink_to_target  dest=target.txt\n";
+        let entries = parse_btrfs_diff_output(output);
+        assert_eq!(entries.len(), 2, "entries: {:?}", entries);
+        assert_eq!(entries[0].path, "target.txt");
+        assert_eq!(entries[0].change_type, ChangeType::Added);
+        assert_eq!(entries[1].path, "hardlink_to_target");
+        assert_eq!(entries[1].change_type, ChangeType::Added);
+        assert_eq!(entries[1].detail.as_deref(), Some("hardlink"));
+    }
+
+    // mv foo.txt → bar.txt: link bar dest=foo + unlink foo → single Renamed,
+    // Deleted(foo) suppressed.
+    #[test]
+    fn parse_btrfs_diff_output_mv_emits_renamed_and_drops_deleted() {
+        let output = "snapshot  ./snap_b_ro  uuid=abc transid=2\n\
+                      link            ./snap_b_ro/bar.txt  dest=foo.txt\n\
+                      unlink          ./snap_b_ro/foo.txt\n";
+        let entries = parse_btrfs_diff_output(output);
+        assert_eq!(entries.len(), 1, "entries: {:?}", entries);
+        assert_eq!(entries[0].path, "bar.txt");
+        assert_eq!(entries[0].change_type, ChangeType::Renamed);
+        assert_eq!(entries[0].detail.as_deref(), Some("foo.txt → bar.txt"));
+    }
+
+    // rmdir foo + mkfile foo: Added wins over Deleted, and the old "directory"
+    // detail must NOT leak into the new file entry.
+    #[test]
+    fn parse_btrfs_diff_output_replace_clears_stale_detail() {
+        let output = "snapshot  ./snap  uuid=abc transid=1\n\
+                      rmdir   ./snap/foo\n\
+                      mkfile  ./snap/o100-1-0\n\
+                      rename  ./snap/o100-1-0  dest=./snap/foo\n";
+        let entries = parse_btrfs_diff_output(output);
+        assert_eq!(entries.len(), 1, "entries: {:?}", entries);
+        assert_eq!(entries[0].path, "foo");
+        assert_eq!(entries[0].change_type, ChangeType::Added);
+        assert_eq!(entries[0].detail, None, "stale 'directory' detail leaked");
+    }
+
+    // Two `link X dest=foo` plus one `unlink foo`: only the first link is
+    // treated as the mv rename; the second is a real hardlink Added.
+    #[test]
+    fn parse_btrfs_diff_output_multi_link_to_same_old_path() {
+        let output = "snapshot  ./snap  uuid=abc transid=1\n\
+                      link    ./snap/bar  dest=foo\n\
+                      link    ./snap/baz  dest=foo\n\
+                      unlink  ./snap/foo\n";
+        let entries = parse_btrfs_diff_output(output);
+        assert_eq!(entries.len(), 2, "entries: {:?}", entries);
+        assert_eq!(entries[0].path, "bar");
+        assert_eq!(entries[0].change_type, ChangeType::Renamed);
+        assert_eq!(entries[0].detail.as_deref(), Some("foo → bar"));
+        assert_eq!(entries[1].path, "baz");
+        assert_eq!(entries[1].change_type, ChangeType::Added);
+        assert_eq!(entries[1].detail.as_deref(), Some("hardlink"));
+    }
+
+    // PB-004: update_extent before mkfile (both resolve to same real path);
+    // Added must win over the earlier-seen Modified via precedence dedup.
+    #[test]
+    fn parse_btrfs_diff_output_added_wins_over_modified_when_extent_first() {
+        let output = "snapshot  ./snap  uuid=abc transid=1\n\
+                      update_extent   ./snap/foo.txt  offset=0 len=6\n\
+                      mkfile          ./snap/o100-1-0\n\
+                      rename          ./snap/o100-1-0  dest=./snap/foo.txt\n";
+        let entries = parse_btrfs_diff_output(output);
+        assert_eq!(entries.len(), 1, "entries: {:?}", entries);
+        assert_eq!(entries[0].path, "foo.txt");
         assert_eq!(entries[0].change_type, ChangeType::Added);
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -8,6 +8,7 @@ use tokio::process::Command;
 use tracing::{error, info, warn};
 
 use ws_ckpt_common::backend::*;
+use ws_ckpt_common::persist::LoopImgState;
 use ws_ckpt_common::{DaemonConfig, DiffEntry, WorkspaceInfo, SNAPSHOTS_DIR};
 
 use super::btrfs_common;
@@ -458,6 +459,24 @@ impl StorageBackend for BtrfsLoopBackend {
         info!("BtrfsLoop bootstrap complete (img={:?})", self.img_path);
         Ok(())
     }
+
+    async fn loop_img_state(&self) -> Option<LoopImgState> {
+        let img_size_bytes = match tokio::fs::metadata(&self.img_path).await {
+            Ok(m) => m.len(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                warn!("loop_img_state: stat {:?} failed: {:#}", self.img_path, e);
+                return None;
+            }
+        };
+        let img_path_str = self.img_path.to_string_lossy().to_string();
+        let last_loop_device = find_loop_device_for(&img_path_str).await.ok();
+        Some(LoopImgState {
+            img_path: self.img_path.clone(),
+            img_size_bytes,
+            last_loop_device,
+        })
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -470,17 +489,13 @@ impl StorageBackend for BtrfsLoopBackend {
 ///
 /// Decision tree:
 ///
-/// 1. `mount_path` already mounted — trust the existing kernel mount and look
-///    up its backing file via `findmnt` + `losetup`. Skip migration this run;
-///    if backing is the legacy file, log a notice — migration will retry next
-///    time the mount is gone (e.g. system reboot).
-///    - Backing-file lookup may fail (findmnt/losetup not in PATH, unexpected
-///      output). In that case we **fail loud** rather than guessing. Picking
-///      a candidate based on disk presence isn't safe: a stale/empty target
-///      file may sit on disk while the live mount is actually backed by
-///      legacy, and choosing target here would (a) cause `reconcile_img_size`
-///      to operate on the wrong file this run, and (b) bias the *next* cold
-///      boot toward mounting the stale target, hiding live data.
+/// 1. `mount_path` already mounted — look up backing via `findmnt` + `losetup`.
+///    - Backing == target: return target.
+///    - Backing == legacy: try in-place relocation (umount → rename → remount).
+///      Pre-rename failure (busy / cross-fs / cmd error) → fall back to legacy.
+///      Post-rename failure (losetup/mount) → return target; bootstrap will mount.
+///    - Lookup itself failed: bail loud — guessing risks reconciling a stale
+///      target while live data still sits on legacy.
 /// 2. Cold path (mount not active):
 ///    - target exists → use target.
 ///    - target missing && legacy exists → attempt migration.
@@ -496,19 +511,36 @@ pub async fn decide_effective_img_path(
     let mount_path_str = mount_path.to_string_lossy().to_string();
     match is_mounted(&mount_path_str).await {
         Ok(true) => match find_backing_file(&mount_path_str).await {
-            Ok(p) => {
-                info!(
-                    "{} already mounted; trusting existing kernel state (backing: {:?})",
-                    mount_path_str, p
-                );
-                if p == legacy {
-                    warn!(
-                        "Currently running on legacy img {:?}; migration deferred until \
-                         {} is unmounted (e.g. system reboot)",
-                        legacy, mount_path_str
+            Ok((loop_dev, backing)) => {
+                if backing == legacy {
+                    info!(
+                        "Backing {:?} is at legacy path; attempting live relocation to {:?}",
+                        legacy, target
                     );
+                    match try_relocate_active_legacy_mount(
+                        &mount_path_str,
+                        legacy,
+                        target,
+                        &loop_dev,
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            info!("Live img migration complete: {:?} -> {:?}", legacy, target);
+                            return Ok(target.to_path_buf());
+                        }
+                        Err(e) => {
+                            error!(
+                                "In-place relocation from legacy {:?} -> target {:?} aborted: {:#}. \
+                                 Daemon will keep serving on legacy this run; migration will retry \
+                                 on next start once the mount is idle.",
+                                legacy, target, e
+                            );
+                            return Ok(legacy.to_path_buf());
+                        }
+                    }
                 }
-                return Ok(p);
+                return Ok(backing);
             }
             Err(e) => {
                 bail!(
@@ -577,23 +609,137 @@ pub async fn decide_effective_img_path(
     Ok(target.to_path_buf())
 }
 
-/// Resolve the file backing the loop device currently mounted at `mount_path`.
-async fn find_backing_file(mount_path: &str) -> anyhow::Result<PathBuf> {
+/// Resolve the loop device and its backing file for the mount at `mount_path`.
+async fn find_backing_file(mount_path: &str) -> anyhow::Result<(String, PathBuf)> {
     let src = run_command("findmnt", &["-no", "SOURCE", mount_path])
         .await
         .context("findmnt failed")?;
-    let loop_dev = src.trim();
+    let loop_dev = src.trim().to_string();
     if loop_dev.is_empty() {
         bail!("findmnt returned no SOURCE for {}", mount_path);
     }
-    let out = run_command("losetup", &["-nl", "--output", "BACK-FILE", loop_dev])
+    let out = run_command("losetup", &["-nl", "--output", "BACK-FILE", &loop_dev])
         .await
         .context("losetup -l failed")?;
     let back = out.trim();
     if back.is_empty() {
         bail!("losetup returned empty BACK-FILE for {}", loop_dev);
     }
-    Ok(PathBuf::from(back))
+    Ok((loop_dev, PathBuf::from(back)))
+}
+
+/// Live-mount migration legacy → target: idle-check, umount, rename, remount.
+/// Aborts (without touching the live mount) when busy or cross-fs.
+/// On failure after umount, best-effort remounts legacy before bubbling the error.
+async fn try_relocate_active_legacy_mount(
+    mount_path: &str,
+    legacy: &Path,
+    target: &Path,
+    loop_device: &str,
+) -> anyhow::Result<()> {
+    if let Some(pids) = check_mount_busy(mount_path).await {
+        bail!(
+            "mount {} is in use by PIDs [{}]; refusing to umount during relocation",
+            mount_path,
+            pids
+        );
+    }
+
+    if let Some(parent) = target.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("create target parent {:?}", parent))?;
+    }
+    let legacy_dev = tokio::fs::metadata(legacy)
+        .await
+        .with_context(|| format!("stat legacy {:?}", legacy))?
+        .dev();
+    let target_parent = target.parent().unwrap_or_else(|| Path::new("/"));
+    let target_dev = tokio::fs::metadata(target_parent)
+        .await
+        .with_context(|| format!("stat target parent {:?}", target_parent))?
+        .dev();
+    if legacy_dev != target_dev {
+        bail!(
+            "legacy {:?} (dev {}) and target parent {:?} (dev {}) are on different \
+             filesystems; cross-fs rename is not atomic — this is unexpected since \
+             both paths should live under the host root fs",
+            legacy,
+            legacy_dev,
+            target_parent,
+            target_dev
+        );
+    }
+
+    let legacy_str = legacy.to_string_lossy().to_string();
+
+    run_command_checked("umount", &[mount_path])
+        .await
+        .context("umount mount_path")?;
+    // From here on any failure best-effort remounts legacy so the system isn't
+    // left worse than before.
+    if let Err(e) = run_command_checked("losetup", &["-d", loop_device]).await {
+        // Loop still attached — don't rename a file the kernel still tracks as backing.
+        if let Err(re) = run_command_checked("mount", &[loop_device, mount_path]).await {
+            warn!(
+                "losetup -d and remount both failed; mount {} is now offline: {:#}",
+                mount_path, re
+            );
+        }
+        return Err(e).context("losetup -d failed; attempted remount of legacy (may have failed)");
+    }
+
+    if let Err(e) = tokio::fs::rename(legacy, target).await {
+        if let Err(remount_err) = remount_legacy(&legacy_str, mount_path).await {
+            warn!(
+                "rename {:?} -> {:?} failed and remount of legacy failed too: {:#}; \
+                 mount {} is now offline — manual intervention required",
+                legacy, target, remount_err, mount_path
+            );
+        }
+        return Err(anyhow::Error::from(e).context(format!("rename {:?} -> {:?}", legacy, target)));
+    }
+
+    // Past rename: legacy is gone — we return Ok(()) regardless so the caller
+    // uses `target`. If remount fails, bootstrap will handle it on this same run.
+    let target_str = target.to_string_lossy().to_string();
+    match run_command("losetup", &["--find", "--show", &target_str]).await {
+        Ok(new_loop) => {
+            let new_loop = new_loop.trim().to_string();
+            if let Err(e) = run_command_checked("mount", &[&new_loop, mount_path]).await {
+                let _ = run_command_checked("losetup", &["-d", &new_loop]).await;
+                warn!(
+                    "Post-rename mount failed ({:#}); bootstrap will retry for {:?}",
+                    e, target
+                );
+            } else {
+                info!(
+                    "Relocated active mount {} -> backing {:?}",
+                    mount_path, target
+                );
+            }
+        }
+        Err(e) => {
+            warn!(
+                "Post-rename losetup --find failed ({:#}); bootstrap will retry for {:?}",
+                e, target
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Reattach + mount `img`; used only by `try_relocate_active_legacy_mount` rollback.
+/// Called after `losetup -d` succeeded, so the original loop device is gone and we
+/// must allocate a fresh one via `losetup --find`.
+async fn remount_legacy(img: &str, mount_path: &str) -> anyhow::Result<()> {
+    let loop_dev = run_command("losetup", &["--find", "--show", img])
+        .await
+        .context("reattach legacy via losetup --find")?;
+    let loop_dev = loop_dev.trim().to_string();
+    run_command_checked("mount", &[&loop_dev, mount_path])
+        .await
+        .context("remount legacy after relocation rollback")
 }
 
 /// Move `legacy` to `target`. Tries atomic rename first; on `EXDEV` falls back
@@ -1116,5 +1262,34 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(got, target);
+    }
+
+    /// Reports size; degrades `last_loop_device` to `None` when losetup is
+    /// unavailable or no loop backs the file (e.g. unit tests on macOS).
+    #[tokio::test]
+    async fn loop_img_state_reports_size_and_tolerates_missing_losetup() {
+        use ws_ckpt_common::backend::StorageBackend;
+
+        let dir = tempdir().unwrap();
+        let img = dir.path().join("data.img");
+        let payload = vec![0u8; 4096];
+        tokio::fs::write(&img, &payload).await.unwrap();
+
+        let backend = super::BtrfsLoopBackend::new(dir.path().join("mnt"), img.clone());
+        let st = backend.loop_img_state().await.expect("Some(state)");
+        assert_eq!(st.img_path, img);
+        assert_eq!(st.img_size_bytes, payload.len() as u64);
+        assert!(st.last_loop_device.is_none());
+    }
+
+    /// Missing img → `None` (not yet bootstrapped).
+    #[tokio::test]
+    async fn loop_img_state_none_when_img_missing() {
+        use ws_ckpt_common::backend::StorageBackend;
+
+        let dir = tempdir().unwrap();
+        let img = dir.path().join("never-created.img");
+        let backend = super::BtrfsLoopBackend::new(dir.path().join("mnt"), img.clone());
+        assert!(backend.loop_img_state().await.is_none());
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
@@ -47,8 +47,18 @@ pub fn start_scheduler(state: Arc<DaemonState>) {
 /// `auto_cleanup_interval_secs`, and `auto_cleanup_keep.is_disabled()`.
 /// Disabled parks on `config_notify`; active races `sleep` vs `config_notify`
 /// for immediate reload.
+///
+/// `notify_waiters()` does **not** store a permit, so a notify that fires
+/// before a waiter has registered is lost. To close the window between the
+/// config read and registration, we build the `Notified` future and
+/// `enable()` it (registers immediately) **before** reading config. Any
+/// `notify_waiters()` issued afterwards is then captured by this waiter.
 async fn auto_cleanup_loop(state: Arc<DaemonState>) {
     loop {
+        let notified = state.config_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
         let (enabled, interval, keep_disabled) = {
             let cfg = state.config.read().unwrap();
             (
@@ -59,14 +69,14 @@ async fn auto_cleanup_loop(state: Arc<DaemonState>) {
         };
         if !enabled || interval == 0 || keep_disabled {
             // Disabled: block until a reload arrives, then re-check.
-            state.config_notify.notified().await;
+            notified.await;
             continue;
         }
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(interval)) => {
                 auto_cleanup(&state).await;
             }
-            _ = state.config_notify.notified() => {
+            _ = notified.as_mut() => {
                 // Config changed mid-sleep: skip this cleanup pass and re-read.
             }
         }
@@ -74,19 +84,24 @@ async fn auto_cleanup_loop(state: Arc<DaemonState>) {
 }
 
 /// Health-check loop. Same push-based pattern as `auto_cleanup_loop`, keyed
-/// off `health_check_interval_secs`.
+/// off `health_check_interval_secs`. See that function's comment for why
+/// `enable()` is called before the config read.
 async fn health_check_loop(state: Arc<DaemonState>) {
     loop {
+        let notified = state.config_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
         let interval = state.config.read().unwrap().health_check_interval_secs;
         if interval == 0 {
-            state.config_notify.notified().await;
+            notified.await;
             continue;
         }
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(interval)) => {
                 health_check(&state).await;
             }
-            _ = state.config_notify.notified() => {}
+            _ = notified.as_mut() => {}
         }
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -244,9 +244,14 @@ pub async fn diff_snapshots(
 
     let ws = arc.read().await;
 
-    // Resolve from
-    let from_id = resolve_snapshot_id(&ws.index, from)?;
-    let to_id = resolve_snapshot_id(&ws.index, to)?;
+    let from_id = match resolve_snapshot_id(&ws.index, from) {
+        Ok(id) => id,
+        Err(e) => return Ok(snapshot_resolve_error_response(from, e)),
+    };
+    let to_id = match resolve_snapshot_id(&ws.index, to) {
+        Ok(id) => id,
+        Err(e) => return Ok(snapshot_resolve_error_response(to, e)),
+    };
 
     let changes = state.backend.diff(&ws.ws_id, &from_id, &to_id).await?;
 
@@ -254,16 +259,28 @@ pub async fn diff_snapshots(
 }
 
 /// Resolve a snapshot reference (ID or prefix) to its ID.
+///
+/// Returns `ResolveError` directly so callers can map it to a user-facing
+/// `Response::Error { code: SnapshotNotFound, .. }` rather than bubbling up
+/// as an opaque `InternalError` via the dispatcher's anyhow fallback.
 fn resolve_snapshot_id(
     index: &ws_ckpt_common::SnapshotIndex,
     reference: &str,
-) -> anyhow::Result<String> {
-    match index.resolve_by_prefix(reference) {
-        Ok((id, _)) => Ok(id.clone()),
-        Err(ResolveError::NotFound) => anyhow::bail!("snapshot not found: {}", reference),
-        Err(ResolveError::Ambiguous(n)) => {
-            anyhow::bail!("ambiguous snapshot prefix '{}': {} matches", reference, n)
+) -> Result<String, ResolveError> {
+    index.resolve_by_prefix(reference).map(|(id, _)| id.clone())
+}
+
+/// Build a `SnapshotNotFound` response from a `ResolveError`.
+fn snapshot_resolve_error_response(reference: &str, err: ResolveError) -> Response {
+    let message = match err {
+        ResolveError::NotFound => format!("snapshot not found: {}", reference),
+        ResolveError::Ambiguous(n) => {
+            format!("ambiguous snapshot prefix '{}': {} matches", reference, n)
         }
+    };
+    Response::Error {
+        code: ErrorCode::SnapshotNotFound,
+        message,
     }
 }
 
@@ -797,6 +814,60 @@ mod tests {
     fn resolve_snapshot_id_not_found() {
         let index = SnapshotIndex::new(PathBuf::from("/ws"));
         let result = resolve_snapshot_id(&index, "nonexistent");
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), ResolveError::NotFound);
+    }
+
+    #[test]
+    fn resolve_snapshot_id_ambiguous_prefix() {
+        let mut index = SnapshotIndex::new(PathBuf::from("/ws"));
+        index
+            .snapshots
+            .insert("abcd111".to_string(), make_snapshot_meta(false));
+        index
+            .snapshots
+            .insert("abcd222".to_string(), make_snapshot_meta(false));
+        assert_eq!(
+            resolve_snapshot_id(&index, "abcd").unwrap_err(),
+            ResolveError::Ambiguous(2)
+        );
+    }
+
+    /// Regression: user-input errors on `diff` must surface as
+    /// `SnapshotNotFound`, not as `InternalError` via the dispatcher fallback.
+    #[tokio::test]
+    async fn diff_snapshots_missing_id_returns_snapshot_not_found() {
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        let mut index = SnapshotIndex::new(PathBuf::from("/home/user/ws"));
+        index
+            .snapshots
+            .insert("real-id".to_string(), make_snapshot_meta(false));
+        state.register_workspace("ws-diff".to_string(), PathBuf::from("/home/user/ws"), index);
+
+        let resp = diff_snapshots(&state, "ws-diff", "does-not-exist", "real-id")
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::SnapshotNotFound);
+                assert!(message.contains("does-not-exist"), "got: {}", message);
+            }
+            other => panic!("expected SnapshotNotFound, got: {:?}", other),
+        }
+
+        // Also covers the `to`-side branch.
+        let resp = diff_snapshots(&state, "ws-diff", "real-id", "missing-to")
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::SnapshotNotFound);
+                assert!(message.contains("missing-to"), "got: {}", message);
+            }
+            other => panic!("expected SnapshotNotFound, got: {:?}", other),
+        }
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/state.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/state.rs
@@ -258,6 +258,9 @@ impl DaemonState {
     /// Resolve a workspace by identifier: tries workspace ID first, then filesystem path.
     /// Supports absolute paths, relative paths, and workspace IDs (e.g., "ws-6d5aaa").
     pub async fn resolve_workspace(&self, workspace: &str) -> Option<Arc<RwLock<WorkspaceState>>> {
+        if workspace.trim().is_empty() {
+            return None;
+        }
         // Normalize: strip trailing slashes so "/a/b/" and "/a/b" are equivalent.
         let workspace = {
             let t = workspace.trim_end_matches('/');

--- a/src/ws-ckpt/src/crates/daemon/src/state.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/state.rs
@@ -192,7 +192,7 @@ impl DaemonState {
                 mount_path: self.backend.data_root().to_path_buf(),
                 data_root: self.backend.data_root().to_path_buf(),
                 snapshots_root: self.backend.snapshots_root().to_path_buf(),
-                loop_img: None, // filled in by bootstrap
+                loop_img: self.backend.loop_img_state().await,
             },
             BackendType::BtrfsBase => BackendPaths::BtrfsBase {
                 mount_path: self.backend.data_root().to_path_buf(),

--- a/src/ws-ckpt/src/crates/daemon/src/util.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/util.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Context};
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::state::DaemonState;
 
@@ -42,6 +42,34 @@ pub async fn run_command_checked(cmd: &str, args: &[&str]) -> anyhow::Result<()>
     Ok(())
 }
 
+/// Decode `\NNN` octal escapes used by /proc/mounts for whitespace and
+/// backslashes in mount-point paths (e.g. space → \040, tab → \011).
+/// Unrecognised sequences are left literal so a malformed line never panics.
+pub fn unescape_proc_mount(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 3 < bytes.len() {
+            let d0 = bytes[i + 1];
+            let d1 = bytes[i + 2];
+            let d2 = bytes[i + 3];
+            if (b'0'..=b'7').contains(&d0)
+                && (b'0'..=b'7').contains(&d1)
+                && (b'0'..=b'7').contains(&d2)
+            {
+                let v = ((d0 - b'0') << 6) | ((d1 - b'0') << 3) | (d2 - b'0');
+                out.push(v);
+                i += 4;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 /// Return true if `mount_path` appears in `/proc/mounts`.
 pub async fn is_mounted(mount_path: &str) -> anyhow::Result<bool> {
     let target = Path::new(mount_path);
@@ -55,7 +83,8 @@ pub async fn is_mounted(mount_path: &str) -> anyhow::Result<bool> {
     while let Some(line) = reader.next_line().await? {
         let parts: Vec<&str> = line.split_whitespace().collect();
         if let Some(mp) = parts.get(1) {
-            let mp_path = Path::new(mp);
+            let decoded = unescape_proc_mount(mp);
+            let mp_path = Path::new(&decoded);
             if mp_path == target || mp_path.components().collect::<PathBuf>() == target_norm {
                 return Ok(true);
             }
@@ -85,7 +114,7 @@ pub async fn ensure_symlinks(state: &DaemonState) {
 
         match tokio::fs::read_link(&ws_path).await {
             Ok(target) if target == expected_subvol_path => {
-                info!("symlink OK for {}: -> {:?}", ws_path, target);
+                debug!("symlink OK for {}: -> {:?}", ws_path, target);
             }
             Ok(target) => {
                 warn!(
@@ -105,6 +134,10 @@ pub async fn ensure_symlinks(state: &DaemonState) {
 /// Atomically replace the symlink via temp-file + rename.
 async fn rebuild_symlink(ws_path: &str, expected_subvol_path: &Path) {
     let tmp_path = format!("{}.tmp", ws_path);
+    // Best-effort cleanup of leftover residue from a prior daemon crash between
+    // symlink() and rename(); without this, symlink() returns EEXIST and
+    // recovery wedges permanently for this workspace.
+    let _ = tokio::fs::remove_file(&tmp_path).await;
     if let Err(e) = tokio::fs::symlink(expected_subvol_path, &tmp_path).await {
         warn!("failed to create temp symlink for {}: {}", ws_path, e);
         return;
@@ -117,5 +150,38 @@ async fn rebuild_symlink(ws_path: &str, expected_subvol_path: &Path) {
         let _ = tokio::fs::remove_file(&tmp_path).await;
     } else {
         info!("rebuilt symlink for {}", ws_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unescape_space_and_tab() {
+        assert_eq!(unescape_proc_mount("/mnt/my\\040dir"), "/mnt/my dir");
+        assert_eq!(unescape_proc_mount("/a\\011b"), "/a\tb");
+    }
+
+    #[test]
+    fn unescape_backslash() {
+        assert_eq!(unescape_proc_mount("/path\\134name"), "/path\\name");
+    }
+
+    #[test]
+    fn unescape_passthrough_plain_ascii() {
+        assert_eq!(unescape_proc_mount("/var/lib/ws-ckpt"), "/var/lib/ws-ckpt");
+    }
+
+    #[test]
+    fn unescape_incomplete_sequence_left_literal() {
+        // Trailing `\04` has only 2 digits — not a valid octal triple.
+        assert_eq!(unescape_proc_mount("/end\\04"), "/end\\04");
+    }
+
+    #[test]
+    fn unescape_non_octal_digit_left_literal() {
+        // `\089` — '8' is not octal, sequence left untouched.
+        assert_eq!(unescape_proc_mount("/x\\089"), "/x\\089");
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -19,12 +19,11 @@ fn error_resp(code: ErrorCode, msg: impl Into<String>) -> Response {
     }
 }
 
-/// Strip trailing slashes from a path string, preserving root "/".
-///
-/// POSIX lstat() follows a trailing-slash symlink, so passing
-/// "/path/symlink/" to `symlink_metadata` misses the symlink detection.
-/// Normalize user-supplied paths once at the boundary to avoid this pitfall.
+/// Strip trailing slashes, preserving root "/". Empty stays empty.
 fn strip_trailing_slashes(s: &str) -> &str {
+    if s.is_empty() {
+        return s;
+    }
     let trimmed = s.trim_end_matches('/');
     if trimmed.is_empty() {
         "/"
@@ -33,9 +32,61 @@ fn strip_trailing_slashes(s: &str) -> &str {
     }
 }
 
+/// Re-adopt an existing managed subvolume into the daemon state and return
+/// `InitOk { ws_id }`. Used when a workspace is discovered out-of-band
+/// (e.g. after daemon restart with on-disk subvol intact) — either through
+/// a user-facing symlink (Step 0) or through canonical resolution into
+/// mount_path (Step 2b).
+///
+/// Loads the index from disk if present; falls back to rebuilding it from
+/// the snapshots directory; persists the rebuilt index. Save_manifest
+/// failure is warned but not fatal — the in-memory registration succeeded
+/// and subsequent writes will retry persistence.
+async fn adopt_existing_subvol(
+    state: &Arc<DaemonState>,
+    ws_id: &str,
+    registered_path: std::path::PathBuf,
+) -> Response {
+    let snap_dir = state.index_dir(ws_id);
+    let btrfs_snap_dir = state.backend.snapshots_root().join(ws_id);
+    let mut index = if let Ok(idx) = index_store::load(&snap_dir).await {
+        idx
+    } else {
+        SnapshotIndex::new(registered_path.clone())
+    };
+    if index.snapshots.is_empty() {
+        if let Ok(rebuilt) =
+            index_store::rebuild_from_fs(&btrfs_snap_dir, registered_path.clone()).await
+        {
+            if !rebuilt.snapshots.is_empty() {
+                info!(
+                    "Recovered {} snapshot(s) from filesystem for {}",
+                    rebuilt.snapshots.len(),
+                    ws_id
+                );
+                index = rebuilt;
+                let _ = index_store::save(&snap_dir, &index).await;
+            }
+        }
+    }
+    state.register_workspace(ws_id.to_string(), registered_path, index);
+    if let Err(e) = state.save_manifest().await {
+        warn!("save_manifest failed after subvol re-adoption: {:#}", e);
+    }
+    Response::InitOk {
+        ws_id: ws_id.to_string(),
+    }
+}
+
 // ── init ──
 
 pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<Response> {
+    if workspace.trim().is_empty() {
+        return Ok(error_resp(
+            ErrorCode::InvalidPath,
+            "workspace path is empty",
+        ));
+    }
     let workspace = strip_trailing_slashes(workspace);
     // 0. Early check: detect workspace already managed via symlink to our data_root.
     //    This must run before canonicalize(), which would resolve the symlink
@@ -68,35 +119,7 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
                             "recovering unregistered workspace: {} -> {:?} (ws_id={})",
                             workspace, target, ws_id
                         );
-                        let snap_dir = state.index_dir(&ws_id);
-                        let btrfs_snap_dir = state.backend.snapshots_root().join(&ws_id);
-                        let mut index = if let Ok(idx) = index_store::load(&snap_dir).await {
-                            idx
-                        } else {
-                            SnapshotIndex::new(ws_path.clone())
-                        };
-                        // If index has no snapshots, try rebuilding from filesystem
-                        if index.snapshots.is_empty() {
-                            if let Ok(rebuilt) =
-                                index_store::rebuild_from_fs(&btrfs_snap_dir, ws_path.clone()).await
-                            {
-                                if !rebuilt.snapshots.is_empty() {
-                                    info!(
-                                        "Recovered {} snapshot(s) from filesystem for {}",
-                                        rebuilt.snapshots.len(),
-                                        ws_id
-                                    );
-                                    index = rebuilt;
-                                    // Persist rebuilt index
-                                    let _ = index_store::save(&snap_dir, &index).await;
-                                }
-                            }
-                        }
-                        state.register_workspace(ws_id.clone(), ws_path.clone(), index);
-                        if let Err(e) = state.save_manifest().await {
-                            warn!("save_manifest failed after recovery register: {:#}", e);
-                        }
-                        return Ok(Response::InitOk { ws_id });
+                        return Ok(adopt_existing_subvol(state, &ws_id, ws_path.clone()).await);
                     } else {
                         // Broken symlink — target subvolume gone; remove and re-init
                         warn!(
@@ -128,6 +151,15 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
         );
     }
 
+    // Refuse '/' as workspace: rsync would be self-referential and pull in
+    // /proc, /sys, etc.; recover() would overwrite the root filesystem.
+    if abs_path == std::path::Path::new("/") {
+        return Ok(error_resp(
+            ErrorCode::InvalidPath,
+            "root '/' is not a supported workspace; use a specific subdirectory",
+        ));
+    }
+
     // 2. Pre-checks
     let meta = match tokio::fs::metadata(&abs_path).await {
         Ok(m) => m,
@@ -156,6 +188,50 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
         });
     }
     if abs_path.starts_with(&state.mount_path) {
+        // The user-facing path canonicalises into our mount root. Two
+        // sub-cases need different handling:
+        //   (a) `abs_path == mount_path/<ws_id>` for some `ws_id` we
+        //       manage. The user is effectively reaching one of our
+        //       subvolumes through a bind mount or symlink chain — treat
+        //       this as idempotent (already registered) or auto-adopt
+        //       (orphan subvol after restart).
+        //   (b) Anything else under mount_path (e.g. `.snapshots/...`, a
+        //       nested directory inside a subvol, or an unknown name at
+        //       the root). This is real self-referential nesting and
+        //       must stay an error.
+        if let Ok(rest) = abs_path.strip_prefix(&state.mount_path) {
+            let mut comps = rest.components();
+            let single = match (comps.next(), comps.next()) {
+                (Some(first), None) => Some(first.as_os_str().to_string_lossy().to_string()),
+                _ => None,
+            };
+            if let Some(ws_id) = single {
+                if let Some(existing) = state.get_by_wsid(&ws_id) {
+                    let ws = existing.read().await;
+                    warn!(
+                        "init target {} resolves to managed subvolume {:?}; \
+                         treating as already initialized",
+                        workspace, abs_path
+                    );
+                    return Ok(Response::InitOk {
+                        ws_id: ws.ws_id.clone(),
+                    });
+                }
+                // Orphan subvol — re-adopt if its snapshot bucket exists
+                // (created at init, proving it was a real workspace).
+                if tokio::fs::metadata(state.backend.snapshots_root().join(&ws_id))
+                    .await
+                    .is_ok()
+                {
+                    warn!(
+                        "init target {} resolves to orphan subvolume {:?}; \
+                         re-adopting (ws_id={})",
+                        workspace, abs_path, ws_id
+                    );
+                    return Ok(adopt_existing_subvol(state, &ws_id, abs_path.clone()).await);
+                }
+            }
+        }
         return Ok(error_resp(
             ErrorCode::InvalidPath,
             format!(
@@ -531,6 +607,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn init_empty_workspace_returns_invalid_path() {
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        for blank in ["", "   ", "\t"] {
+            let resp = init(&state, blank).await.unwrap();
+            match resp {
+                Response::Error { code, message } => {
+                    assert_eq!(code, ErrorCode::InvalidPath);
+                    assert!(
+                        message.contains("empty"),
+                        "expected empty-path message, got: {}",
+                        message
+                    );
+                }
+                other => panic!(
+                    "expected InvalidPath error for blank input, got {:?}",
+                    other
+                ),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn init_root_path_returns_invalid_path() {
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        // All of these canonicalize to "/" and must be rejected.
+        for variant in ["/", "///", "/.", "/./"] {
+            let resp = init(&state, variant).await.unwrap();
+            match resp {
+                Response::Error { code, message } => {
+                    assert_eq!(code, ErrorCode::InvalidPath, "variant {:?}", variant);
+                    assert!(
+                        message.contains("root"),
+                        "variant {:?}: expected root-rejection message, got: {}",
+                        variant,
+                        message
+                    );
+                }
+                other => panic!(
+                    "variant {:?}: expected InvalidPath error, got {:?}",
+                    variant, other
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn strip_trailing_slashes_preserves_empty_and_root() {
+        assert_eq!(strip_trailing_slashes(""), "");
+        assert_eq!(strip_trailing_slashes("/"), "/");
+        assert_eq!(strip_trailing_slashes("///"), "/");
+        assert_eq!(strip_trailing_slashes("/foo/"), "/foo");
+        assert_eq!(strip_trailing_slashes("/foo"), "/foo");
+        assert_eq!(strip_trailing_slashes("foo/"), "foo");
+    }
+
+    #[tokio::test]
     async fn init_already_initialized_returns_ok() {
         let state = Arc::new(DaemonState::new(
             test_config(),
@@ -579,6 +719,33 @@ mod tests {
                 assert!(message.contains("inside mount_path"));
             }
             _ => panic!("expected InvalidPath error for path inside mount_path"),
+        }
+    }
+
+    #[tokio::test]
+    async fn init_canonical_into_managed_subvol_is_idempotent() {
+        // User-facing path resolves (via bind mount / symlink chain) into
+        // `mount_path/<ws_id>` for a workspace that's already registered.
+        // Expectation: warn + InitOk, not InvalidPath.
+        let mount_dir = tempfile::tempdir().unwrap();
+        let mount_path = tokio::fs::canonicalize(mount_dir.path()).await.unwrap();
+        let ws_id = "ws-abc123";
+        let subvol_path = mount_path.join(ws_id);
+        tokio::fs::create_dir_all(&subvol_path).await.unwrap();
+
+        let mut cfg = test_config();
+        cfg.mount_path = mount_path.clone();
+        let state = Arc::new(DaemonState::new(cfg, test_backend(), test_state_dir()));
+        state.register_workspace(
+            ws_id.to_string(),
+            PathBuf::from("/some/user/facing/path"),
+            SnapshotIndex::new(PathBuf::from("/some/user/facing/path")),
+        );
+
+        let resp = init(&state, &subvol_path.to_string_lossy()).await.unwrap();
+        match resp {
+            Response::InitOk { ws_id: returned } => assert_eq!(returned, ws_id),
+            other => panic!("expected idempotent InitOk, got {:?}", other),
         }
     }
 

--- a/src/ws-ckpt/ws-ckpt.spec.in
+++ b/src/ws-ckpt/ws-ckpt.spec.in
@@ -53,7 +53,6 @@ install -p -m 0644 src/skills/ws-ckpt/SKILL.md %{buildroot}%{_datadir}/anolisa/r
 %attr(0755,root,root) %{_bindir}/ws-ckpt
 %{_unitdir}/ws-ckpt.service
 /etc/ws-ckpt/config.toml.sample
-%dir %{_datadir}/anolisa
 %dir %{_datadir}/anolisa/runtime
 %dir %{_datadir}/anolisa/runtime/skills
 %{_datadir}/anolisa/runtime/skills/ws-ckpt/


### PR DESCRIPTION
## Description

本 PR 集中修复 `ws-ckpt` 在长时压力测试与日常使用过程中暴露的若干问题，
覆盖 `list / diff `，并加固 BtrfsLoop 后端在 legacy → target 迁移期间的可靠性。

修复与改进项（每个 commit 独立可复核）：

- **list 元数据 bincode 解码失败** (#516)
  `Option<Value>` 经 bincode 往返后 `Some(Value::Null)` 被识别为非空导致解码报错。
  在 `SnapshotMeta.metadata` 上引入自定义 serde 模块：
  - JSON 维持 `Some(Null)` 语义（向后兼容）
  - bincode 编码前归一为 `None`，避免空值二义性

- **diff 解析器：symlink / hardlink / rename** (#508)
  `btrfs receive --dump` 对符号链接、硬链接、重命名分别输出
  `symlink` / `link` / `unlink`，旧解析器要么忽略要么误判为 `Modified`。改造后：
  - `symlink` → `Added(detail="symlink")`
  - `link` 且其 `dest` 同时出现在 `unlink` 列表 → 合并为单条 `Renamed`
    （`R` 行替代旧的 `-/+` 配对）
  - `link` 其他场景 → `Added(detail="hardlink")`
  - 去重策略由 first-wins 改为优先级 `Renamed > Added > Deleted > Modified`
  - 新增 5 个使用真实 `btrfs receive --dump` 片段的单测

- **diff 错误码归一化**
  目标快照不存在时返回 `SnapshotNotFound` 而非笼统的 `InternalError`，
  使上层（CLI / 插件）可以做精确分支处理。

- **list 表格本地时区显示**
  默认按本地时区渲染并附带 UTC 偏移，`--utc` 维持原 ISO-Z 输出；
  `cli` crate 显式声明 `chrono = { features = ["clock"] }`。

- **daemon 健壮性**
  - 拒绝空 `workspace_path`，避免误从 `/` 起 rsync
  - 对 canonical 已托管 subvol 的 `init` 调用改为幂等
  - IPC 重连与重启路径若干小问题修复

- **BtrfsLoop：legacy img 在线迁移** (active-mount relocation)
  挂载点仍由 legacy `/data/ws-ckpt/btrfs-data.img` 承载时，daemon 启动可在线
  完成 `idle 检测 → umount → rename → losetup → mount` 迁至
  target `/var/lib/ws-ckpt/btrfs-data.img`：
  - rename 之前任何失败（mount 被占用 / 跨 fs / 命令出错）干净中止，
    本次仍服务于 legacy，下次启动空闲再重试
  - umount 之后失败则 best-effort 把 legacy 重新挂回，保证不比迁移前更差

其中 4 个 commit（diff 错误码 / list 本地时区 / daemon 健壮性 / 在线迁移）
为测试过程中陆续发现，未单独立 issue。

## Related Issue

closes #516
closes #508

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (list local time + `loop_img_state` hook)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)   <!-- ws-ckpt 归属，如不准请改 -->
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly  <!-- 纯内部修复，无文档变化 -->
- [ ] For `cosh`
- [] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python)
- [ ] For `skill`
- [ ] For `sight`
- [ ] For `tokenless`
- [x] Lock files are up to date (`Cargo.lock`)

## Testing
### 场景 4：v0 布局自动迁移（mock 旧版本布局）

验证目标：手动构造 v0 版本的文件布局（index.json 在 btrfs 设备内，无 state.json, img文件在/data/ws-ckpt内），验证新版 daemon 启动时能自动发现并完成迁移。

```shell
# === 场景 4：v0 布局自动迁移 - BtrfsLoop（img 在 /data/ws-ckpt 内）===
IMG_PATH=/var/lib/ws-ckpt/btrfs-data.img 
MOUNT_PATH=/mnt/btrfs-workspace
SNAPSHOTS_ROOT=$MOUNT_PATH/snapshots
STATE_DIR=/var/lib/ws-ckpt
WS_ID=$(grep -rl $WS $STATE_DIR/indexes/*/index.json | head -1 | xargs dirname | xargs basename)

# --- 步骤 1: 正常打快照，确保 img 内有子卷数据 ---
ws-ckpt checkpoint -w $WS -i migrate-img-1 -m "loop migration test"
ws-ckpt list -w $WS
# 预期: 1 个快照 (migrate-img-1)

# --- 步骤 2: 停止 daemon（保留 img + 挂载，不能 umount/losetup -d）---
sudo systemctl stop ws-ckpt

# --- 步骤 3: mock v0 布局 ---

# 3a. 收集每个 ws_id 对应的 index.json 内容
#     用临时目录保存而不是用 bash 关联数组，避免 sudo 子 shell 丢上下文
TMP_BACKUP=$(mktemp -d)
for d in /var/lib/ws-ckpt/indexes/*/; do
    [ -d "$d" ] || continue
    wsid=$(basename "$d")
    cp "$d/index.json" "$TMP_BACKUP/$wsid.json"
done
ls "$TMP_BACKUP"
# 预期: 列出每个 ws_id.json，文件数 = workspace 数

# 3b. 删除新版本的 state.json 和 indexes/
sudo rm -f  /var/lib/ws-ckpt/state.json
sudo rm -rf /var/lib/ws-ckpt/indexes/

# 3c. 逐个把 index.json 写回旧位置（每个 ws_id 一份）
for f in "$TMP_BACKUP"/*.json; do
    wsid=$(basename "$f" .json)
    sudo mkdir -p "$SNAPSHOTS_ROOT/$wsid"
    sudo cp "$f" "$SNAPSHOTS_ROOT/$wsid/index.json"
done

# 3d. 移动img文件
mkdir -p /data/ws-ckpt/
mv /var/lib/ws-ckpt/btrfs-data.img /data/ws-ckpt/btrfs-data.img

# --- 步骤 4: 确认 mock 结果 ---
ls "$STATE_DIR/state.json" 2>&1
ls "$STATE_DIR/indexes/" 2>&1
# 预期: No such file or directory
test -f "/data/ws-ckpt/btrfs-data.img" && echo "img move to: /data/ws-ckpt/btrfs-data.img"
# 预期: img move to
mount | grep -q "$MOUNT_PATH" && echo "mount kept" 
# 预期: mount move to
cat "$SNAPSHOTS_ROOT/$WS_ID/index.json" | python3 -m json.tool
# 预期: 包含 migrate-img-1 快照元数据

# --- 步骤 5: 启动 daemon 触发自动迁移 ---
sudo systemctl start ws-ckpt
sleep 3   # 等迁移 + bootstrap 回填 loop_img

# --- 步骤 6: 确认迁移日志 ---
journalctl -u ws-ckpt --since "1 minute ago" --no-pager
# 预期: 出现 "Migrating from v0 layout: moving indexes from ..."
#       和 "Migration complete, state.json generated"

# --- 步骤 7: 确认 state.json 已生成，且后端识别为 btrfs-loop ---
cat "$STATE_DIR/state.json" | python3 -m json.tool

# --- 步骤 8: 关键校验 - img 已迁移 ---
ll $IMG_PATH

# --- 步骤 9: 确认 indexes/ 目录已写入 ---
ls "$STATE_DIR/indexes/"
cat "$STATE_DIR/indexes/$WS_ID/index.json" | python3 -m json.tool
# 预期: 含 migrate-img-1 快照元数据

# --- 步骤 10: 确认快照未丢失 ---
ws-ckpt list -w "$WS"
# 预期: 仍然包含 migrate-img-1

# --- 步骤 11: 确认旧位置文件已删除（move 语义）---
ls "$SNAPSHOTS_ROOT/$WS_ID/index.json" 2>&1
ll /data/ws-ckpt/btrfs-data.img
# 预期: No such file or directory

# --- 步骤 12: 确认 img / 挂载 / loop 设备未被破坏 ---
test -f "$IMG_PATH" && echo "img still kept"
mount | grep "$MOUNT_PATH"
losetup --list | grep "$IMG_PATH"

# --- 步骤 13: 清理测试数据 ---
ws-ckpt delete -w "$WS" -s migrate-img-1 --force
```

### 场景 7：带 metadata 快照的 list 显示正常（Bug 1 回归）

验证目标：checkpoint 带 `--metadata '{...}'` 后，list 表格与 JSON 输出均不再触发 bincode 序列化错误，metadata 以嵌套对象形式返回。

```bash
# --- 步骤 1: 创建带 metadata 的快照 ---
ws-ckpt checkpoint -w $WS -i meta-1 -m "meta test 1" --metadata '{"event":"init","n":42,"tags":["a","b"]}'
ws-ckpt checkpoint -w $WS -i meta-2 -m "meta test 2" --metadata '{"k":"v"}'

# --- 步骤 2: 表格 list 正常输出 ---
ws-ckpt list -w $WS
# 预期: 正常显示 meta-1、meta-2 两行，无 bincode 错误

# --- 步骤 3: JSON list 正常输出且 metadata 是嵌套对象 ---
ws-ckpt list -w $WS --format json
# 预期:
# 输出格式化json格式
# 而非被转义成字符串:
#   "metadata": "{\"event\":\"init\"...}"

# --- 步骤 4: 不带 metadata 的快照仍兼容 ---
ws-ckpt checkpoint -w $WS -i meta-3 -m "no metadata"
ws-ckpt list -w $WS --format json | python3 -c '
import json, sys
entries = json.load(sys.stdin)
for e in entries:
    m = e["meta"].get("metadata")
    sid = e["id"]
    print(f"  {sid}: metadata={m!r}")'
# 预期: meta-3 的 metadata 为 None/null，meta-1 / meta-2 为对应的嵌套对象

# --- 步骤 5: 清理 ---
ws-ckpt delete -w $WS -s meta-1 --force
ws-ckpt delete -w $WS -s meta-2 --force
ws-ckpt delete -w $WS -s meta-3 --force
```

### 场景 8：软硬链接与 mv 场景的 diff 识别（Bug 2 回归）

验证目标：新增普通文件显示 `+`（Added）而非 `M`（Modified）；新增 symlink / hardlink 能被识别为 `+`；`mv old new` 显示为 `R (old → new)` 且不再残留 `- old` 那一行。

```bash
# --- 步骤 1: 建立基线快照 ---
ws-ckpt checkpoint -w $WS -i diff-s1 -m "baseline"

# --- 步骤 2: 新增普通文件 + symlink + hardlink ---
echo "hello" > $WS/foo.txt
echo "target" > $WS/target.txt
ln -s /etc/passwd $WS/mylink                 # symlink
ln $WS/target.txt $WS/hardlink_to_target     # hardlink

ws-ckpt checkpoint -w $WS -i diff-s2 -m "add files"

# --- 步骤 3: diff 确认新增文件都是 + 而非 M ---
ws-ckpt diff -w $WS -f diff-s1 -t diff-s2
# 预期:
#   + foo.txt
#   + target.txt
#   + mylink             (symlink)
#   + hardlink_to_target (hardlink)
# 无任何 M 标记，无遗漏行

# --- 步骤 4: mv 场景 ---
mv $WS/foo.txt $WS/bar.txt
ws-ckpt checkpoint -w $WS -i diff-s3 -m "rename foo -> bar"

# --- 步骤 5: diff 确认 mv 识别为 Renamed 且无孤立的 - ---
ws-ckpt diff -w $WS -f diff-s2 -t diff-s3
# 预期:
#   R bar.txt  (foo.txt → bar.txt)
# 不应出现:
#   - foo.txt                (旧 bug：只剩这一行，新名丢失)

# --- 步骤 8: 清理 ---
rm -f $WS/bar.txt $WS/target.txt $WS/mylink $WS/hardlink_to_target
ws-ckpt delete -w $WS -s diff-s1 --force
ws-ckpt delete -w $WS -s diff-s2 --force
ws-ckpt delete -w $WS -s diff-s3 --force
```