### PR TITLE
fix(sec-core): skip sqldb prune in unit tests

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_writer.py
@@ -34,7 +34,7 @@ class ObservabilitySqliteWriter:
     def __init__(
         self,
         path: str | Path | None = None,
-        max_age_days: int = DEFAULT_OBSERVABILITY_RETENTION_DAYS,
+        max_age_days: int | None = DEFAULT_OBSERVABILITY_RETENTION_DAYS,
     ) -> None:
         self._store = SqliteStore(
             path or get_observability_db_path(),
@@ -90,7 +90,8 @@ class ObservabilitySqliteWriter:
 
     def _run_maintenance(self) -> None:
         """Run low-frequency SQLite maintenance for this writer."""
-        self._repository.prune(self._max_age_days)
+        if self._max_age_days is not None:
+            self._repository.prune(self._max_age_days)
         self._repository.checkpoint()
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
@@ -28,7 +28,7 @@ class SqliteEventWriter:
     def __init__(
         self,
         path: str | Path | None = None,
-        max_age_days: int = 30,
+        max_age_days: int | None = 30,
     ) -> None:
         self._store = SqliteStore(path or get_db_path())
         self._repository = SecurityEventRepository(self._store)
@@ -79,5 +79,6 @@ class SqliteEventWriter:
 
     def _run_maintenance(self) -> None:
         """Run low-frequency SQLite maintenance for this writer."""
-        self._repository.prune(self._max_age_days)
+        if self._max_age_days is not None:
+            self._repository.prune(self._max_age_days)
         self._repository.checkpoint()

--- a/src/agent-sec-core/tests/unit-test/observability/test_repository_read.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_repository_read.py
@@ -60,7 +60,9 @@ def db_path(tmp_path: Path) -> str:
 
 @pytest.fixture()
 def writer(db_path: str) -> ObservabilitySqliteWriter:
-    w = ObservabilitySqliteWriter(path=db_path)
+    # max_age_days=None disables retention prune so hardcoded-timestamp tests
+    # don't depend on the wall clock at run time.
+    w = ObservabilitySqliteWriter(path=db_path, max_age_days=None)
     yield w
     w.close()
 

--- a/src/agent-sec-core/tests/unit-test/observability/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_sqlite_reader.py
@@ -35,7 +35,7 @@ def _seed(writer: ObservabilitySqliteWriter, **kwargs: Any) -> None:
 
 def test_observability_reader_lists_sessions_runs_and_events(tmp_path: Path) -> None:
     db_path = tmp_path / "observability.db"
-    writer = ObservabilitySqliteWriter(path=db_path)
+    writer = ObservabilitySqliteWriter(path=db_path, max_age_days=None)
     _seed(writer, observed_at="2026-05-16T12:00:00Z")
     _seed(
         writer,
@@ -64,7 +64,7 @@ def test_observability_reader_lists_sessions_runs_and_events(tmp_path: Path) -> 
 
 def test_observability_reader_close_disposes_store(tmp_path: Path) -> None:
     db_path = tmp_path / "observability.db"
-    writer = ObservabilitySqliteWriter(path=db_path)
+    writer = ObservabilitySqliteWriter(path=db_path, max_age_days=None)
     _seed(writer)
     writer.close()
 

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -38,7 +38,9 @@ def tilde_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
 
 @pytest.fixture()
 def writer(db_path: str) -> SqliteEventWriter:
-    w = SqliteEventWriter(path=db_path)
+    # max_age_days=None disables retention prune so hardcoded-timestamp tests
+    # don't depend on the wall clock at run time.
+    w = SqliteEventWriter(path=db_path, max_age_days=None)
     yield w
     w.close()
 

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -106,7 +106,7 @@ class TestSqliteEventWriter:
         This is a critical data integrity test — validates the entire
         SecurityEvent conversion and INSERT correctness.
         """
-        writer = SqliteEventWriter(path=db_path)
+        writer = SqliteEventWriter(path=db_path, max_age_days=None)
 
         # Create a comprehensive event with all fields
         evt = SecurityEvent(


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Widen `max_age_days` on SqliteEventWriter / ObservabilitySqliteWriter
  from `int` to `int | None`, treating `None` as "disable prune".
  Defaults (30 / 7) and `=0` ("prune everything") semantics unchanged.
  Update affected test fixtures to pass `max_age_days=None`.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
