### PR TITLE
feat(sec-core): add OpenClaw enableBlock hook policies

### DIFF
--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -27,10 +27,10 @@ openclaw-plugin/
 │   ├── types.ts                # SecurityCapability interface
 │   ├── utils.ts                # CLI invocation utility (callAgentSecCli)
 │   ├── capabilities/           # Security capability entry files
-│   │   ├── skill-ledger.ts     #   before_tool_call + reply_dispatch hooks
+│   │   ├── skill-ledger.ts     #   before_tool_call hook
 │   │   ├── code-scan.ts        #   before_tool_call hook
 │   │   ├── prompt-scan.ts      #   before_dispatch hook
-│   │   ├── pii-scan.ts         #   before_prompt_build + reply_dispatch hooks
+│   │   ├── pii-scan.ts         #   before_dispatch hook
 │   │   └── observability.ts    #   observability hook registration
 │   └── helpers/                # Capability support code
 │       └── observability/      #   OpenClaw → agent-sec observability adapter
@@ -185,9 +185,8 @@ Version: 0.x.y
 Source: ~/path/to/openclaw-plugin/dist/index.js
 
 Typed hooks:
+before_dispatch (priority 200)
 before_dispatch (priority 190)
-before_prompt_build (priority 0)
-reply_dispatch (priority 0)
 llm_input (priority 1000)
 model_call_started (priority 1000)
 model_call_ended (priority 1000)
@@ -233,10 +232,10 @@ AGENT_SEC_LIVE=1 npm run smoke
 
 | Capability         | Hook                  | Priority | Behavior                                             |
 |--------------------|-----------------------|----------|------------------------------------------------------|
+| `pii-scan-user-input` | `before_dispatch` | 200 | Scans inbound user text for PII/credentials before prompt-scan and optionally blocks on `deny` |
 | `prompt-scan`      | `before_dispatch`     | 190      | Scans inbound messages for prompt injection attacks   |
-| `pii-scan-user-input` | `before_prompt_build`, `reply_dispatch` | 0 (default) | Scans current user prompt for PII/credentials and emits a non-blocking same-run warning |
 | `scan-code`        | `before_tool_call`    | 0 (default) | Scans tool commands for security issues              |
-| `skill-ledger`     | `before_tool_call`, `reply_dispatch` | 80 / 0 | Checks skill integrity when SKILL.md is read and emits configurable warnings or approval requests |
+| `skill-ledger`     | `before_tool_call`    | 80       | Checks skill integrity when SKILL.md is read and optionally asks on risky states |
 | `observability`    | selected typed hooks  | varies   | Sends observability records to agent-sec-cli          |
 
 ### Configuring `code-scan`
@@ -251,9 +250,9 @@ openclaw config set plugins.entries.agent-sec.config.codeScanRequireApproval tru
 
 ### Configuring `pii-scan-user-input`
 
-The `pii-scan-user-input` capability scans only `event.prompt` in `before_prompt_build`. It intentionally does not scan `event.messages`, because that list may include history, tool results, memory, or RAG context and can repeatedly warn on older PII that was not submitted in the current turn.
+The `pii-scan-user-input` capability scans the current inbound user text in `before_dispatch`, preferring `event.content` and falling back to `event.body`. It intentionally does not scan assembled prompt history, tool results, memory, or RAG context, so older PII does not trigger repeated warnings on later turns.
 
-`warn` and `deny` verdicts never block OpenClaw in v1. The capability caches a minimal warning under the current `runId`, then `reply_dispatch` reads that warning and queues it with `dispatcher.sendBlockReply({ text })` before the default agent reply flow continues. In this context, block reply means OpenClaw's intermediate reply type, not a security block. The warning is removed only after it is successfully queued. This avoids consuming the warning in a generic outbound `message_sending` hook that may not represent the final user-visible reply. If `runId` is missing, the capability fails open and does not cache a session-level warning. If OpenClaw marks the turn with `sendPolicy: "deny"` or `suppressUserDelivery: true`, the warning is dropped without display so the plugin does not override host-level delivery policy.
+By default, `capabilities["pii-scan-user-input"].enableBlock` is `false`, so `warn` and `deny` verdicts are logged and the turn continues. Set `enableBlock: true` to block `deny` verdicts before prompt-scan runs by returning `{ handled: true, text }`. `warn` verdicts are always logged only. The block text uses redacted evidence and never includes raw PII values.
 
 ### Configuring `observability`
 
@@ -293,16 +292,13 @@ Supported OpenClaw plugin entry config:
         "config": {
           "promptScanBlock": false,
           "codeScanRequireApproval": false,
-          "skillLedgerRequireApproval": false,
-          "skillLedgerWarningTtlMs": 300000,
           "piiScanUserInput": true,
           "piiIncludeLowConfidence": false,
-          "piiWarningTtlMs": 300000,
           "capabilities": {
             "scan-code": { "enabled": true },
             "prompt-scan": { "enabled": true },
-            "pii-scan-user-input": { "enabled": true },
-            "skill-ledger": { "enabled": true },
+            "pii-scan-user-input": { "enabled": true, "enableBlock": false },
+            "skill-ledger": { "enabled": true, "enableBlock": true },
             "observability": { "enabled": true }
           }
         },
@@ -316,6 +312,7 @@ Supported OpenClaw plugin entry config:
 ```
 
 Set a capability's `enabled` value to `false` to skip registering only that capability while keeping the rest of the `agent-sec` plugin active.
+Set `enableBlock` on supported capabilities to control whether matching security findings block or ask the user for approval.
 
 `llm_input`, `llm_output`, and `agent_end` require OpenClaw to allow conversation access for this external plugin with `plugins.entries.agent-sec.hooks.allowConversationAccess=true`. Without that OpenClaw setting, those hooks are blocked by OpenClaw before this plugin sees them.
 
@@ -323,15 +320,13 @@ Set a capability's `enabled` value to `false` to skip registering only that capa
 
 The `skill-ledger` capability checks skill integrity by invoking `agent-sec-cli skill-ledger check` when the agent reads a `SKILL.md` file. It automatically initializes signing keys on first use.
 
-By default, `skillLedgerRequireApproval` is `false`. In this mode, `none`, `drifted`, `deny`, and `tampered` statuses do not block the read. Instead, the capability caches a same-run warning under the current `runId`, then `reply_dispatch` queues it with `dispatcher.sendBlockReply({ text })` before the normal agent reply continues. `warn`, `error`, and unknown statuses are logged only.
+By default, `capabilities["skill-ledger"].enableBlock` is `true`. In this mode, `none`, `drifted`, `deny`, and `tampered` statuses return an OpenClaw approval request. `warn`, `error`, and unknown statuses are logged only.
 
-Set `skillLedgerRequireApproval: true` to restore approval-card behavior for `none`, `drifted`, `deny`, and `tampered` statuses:
+Set `enableBlock: false` to log all non-`pass` statuses without asking:
 
 ```bash
-openclaw config set plugins.entries.agent-sec.config.skillLedgerRequireApproval true
+openclaw config set 'plugins.entries.agent-sec.config.capabilities.skill-ledger.enableBlock' false
 ```
-
-`skillLedgerWarningTtlMs` controls how long an undelivered warning remains cached. If `runId` is missing, the warning is not cached. If OpenClaw sets `sendPolicy: "deny"` or `suppressUserDelivery: true`, cached warnings are dropped without display.
 
 **Prerequisites**: `agent-sec-cli skill-ledger check` must be available. Signing keys are auto-initialized (no passphrase) if not present.
 

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -18,36 +18,64 @@
       "piiScanUserInput": {
         "type": "boolean",
         "default": true,
-        "description": "扫描本轮用户输入中的 PII 和凭据，并以非阻断 warning 提示"
+        "description": "扫描本轮用户输入中的 PII 和凭据"
       },
       "piiIncludeLowConfidence": {
         "type": "boolean",
         "default": false,
         "description": "是否包含低置信度 PII findings"
       },
-      "piiWarningTtlMs": {
-        "type": "number",
-        "default": 300000,
-        "minimum": 0,
-        "description": "PII warning 按 runId 暂存的 TTL，避免未发送回复时残留"
-      },
       "codeScanRequireApproval": {
         "type": "boolean",
         "default": false,
         "description": "代码扫描检测到安全问题时是否要求用户审批（默认仅记录日志并放行）"
       },
-      "skillLedgerRequireApproval": {
-        "type": "boolean",
-        "default": false,
-        "description": "检测到未扫描、漂移、高风险或签名异常 skill 时是否要求用户确认"
-      },
-      "skillLedgerWarningTtlMs": {
-        "type": "number",
-        "default": 300000,
-        "minimum": 0,
-        "description": "skill-ledger warning 按 runId 暂存的最长时间，单位毫秒"
+      "capabilities": {
+        "type": "object",
+        "description": "按能力配置启用状态和阻断策略",
+        "properties": {
+          "scan-code": {
+            "type": "object",
+            "properties": {
+              "enabled": { "type": "boolean", "default": true }
+            }
+          },
+          "prompt-scan": {
+            "type": "object",
+            "properties": {
+              "enabled": { "type": "boolean", "default": true }
+            }
+          },
+          "pii-scan-user-input": {
+            "type": "object",
+            "properties": {
+              "enabled": { "type": "boolean", "default": true },
+              "enableBlock": {
+                "type": "boolean",
+                "default": false,
+                "description": "检测到 deny 级别 PII/凭据时是否直接阻断本轮请求"
+              }
+            }
+          },
+          "skill-ledger": {
+            "type": "object",
+            "properties": {
+              "enabled": { "type": "boolean", "default": true },
+              "enableBlock": {
+                "type": "boolean",
+                "default": true,
+                "description": "检测到 none、drifted、deny 或 tampered skill 状态时是否要求用户确认"
+              }
+            }
+          },
+          "observability": {
+            "type": "object",
+            "properties": {
+              "enabled": { "type": "boolean", "default": true }
+            }
+          }
+        }
       }
-
     }
   },
   "uiHints": {
@@ -57,28 +85,19 @@
     },
     "piiScanUserInput": {
       "label": "PII 用户输入扫描",
-      "description": "扫描本轮用户输入中的 PII 和凭据，并以非阻断 warning 提示"
+      "description": "扫描本轮用户输入中的 PII 和凭据"
     },
     "piiIncludeLowConfidence": {
       "label": "PII 低置信度 findings",
       "description": "展示低置信度 PII findings"
     },
-    "piiWarningTtlMs": {
-      "label": "PII warning TTL",
-      "description": "PII warning 按 runId 暂存的最长时间，单位毫秒"
-    },
     "codeScanRequireApproval": {
       "label": "代码扫描审批模式",
       "description": "启用后，代码扫描检测到安全问题时在 Dashboard 上弹出审批卡片；关闭则仅记录日志并放行"
     },
-    "skillLedgerRequireApproval": {
-      "label": "Skill Ledger 审批模式",
-      "description": "启用后，未扫描、漂移、高风险或签名异常 skill 会要求用户确认；关闭则发送同轮告警并继续处理"
-    },
-    "skillLedgerWarningTtlMs": {
-      "label": "Skill Ledger warning TTL",
-      "description": "skill-ledger warning 按 runId 暂存的最长时间，单位毫秒"
+    "capabilities": {
+      "label": "能力配置",
+      "description": "配置各安全能力的启用状态和阻断策略"
     }
-
   }
 }

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
@@ -1,94 +1,25 @@
 import type { SecurityCapability } from "../types.js";
 import { callAgentSecCli } from "../utils.js";
 
-const DEFAULT_WARNING_TTL_MS = 300_000;
 const CLI_TIMEOUT_MS = 10_000;
 const MAX_EVIDENCE_ITEMS = 3;
 const MAX_EVIDENCE_CHARS = 80;
-
-type WarningBucket = {
-  warnings: string[];
-  createdAt: number;
-  lastTouchedAt: number;
-};
+const BEFORE_DISPATCH_PRIORITY = 200;
 
 type PiiScanConfig = {
   scanUserInput: boolean;
   includeLowConfidence: boolean;
-  warningTtlMs: number;
+  enableBlock: boolean;
 };
 
 function readConfig(pluginConfig: Record<string, any>): PiiScanConfig {
-  const ttl = Number(pluginConfig.piiWarningTtlMs);
+  const capabilityConfig =
+    pluginConfig.capabilities?.["pii-scan-user-input"] ?? {};
   return {
     scanUserInput: pluginConfig.piiScanUserInput !== false,
     includeLowConfidence: pluginConfig.piiIncludeLowConfidence === true,
-    warningTtlMs:
-      Number.isFinite(ttl) && ttl >= 0 ? ttl : DEFAULT_WARNING_TTL_MS,
+    enableBlock: capabilityConfig.enableBlock === true,
   };
-}
-
-function getRunId(event: any, ctx: any): string | undefined {
-  const ctxRunId = typeof ctx?.runId === "string" ? ctx.runId.trim() : "";
-  if (ctxRunId) {
-    return ctxRunId;
-  }
-  const eventRunId = typeof event?.runId === "string" ? event.runId.trim() : "";
-  return eventRunId || undefined;
-}
-
-function cleanupExpired(
-  warningsByRun: Map<string, WarningBucket>,
-  warningTtlMs: number,
-): void {
-  const now = Date.now();
-  for (const [runId, bucket] of warningsByRun) {
-    if (now - bucket.lastTouchedAt >= warningTtlMs) {
-      warningsByRun.delete(runId);
-    }
-  }
-}
-
-function pushWarning(
-  warningsByRun: Map<string, WarningBucket>,
-  runId: string,
-  warning: string,
-  warningTtlMs: number,
-): void {
-  cleanupExpired(warningsByRun, warningTtlMs);
-  const now = Date.now();
-  const bucket =
-    warningsByRun.get(runId) ??
-    {
-      warnings: [],
-      createdAt: now,
-      lastTouchedAt: now,
-    };
-  if (!bucket.warnings.includes(warning)) {
-    bucket.warnings.push(warning);
-  }
-  bucket.lastTouchedAt = now;
-  warningsByRun.set(runId, bucket);
-}
-
-function readWarnings(
-  warningsByRun: Map<string, WarningBucket>,
-  runId: string,
-  warningTtlMs: number,
-): string[] {
-  cleanupExpired(warningsByRun, warningTtlMs);
-  const bucket = warningsByRun.get(runId);
-  if (!bucket) {
-    return [];
-  }
-  return [...bucket.warnings];
-}
-
-function deleteWarnings(
-  warningsByRun: Map<string, WarningBucket>,
-  runId: string,
-): void {
-  warningsByRun.delete(runId);
 }
 
 function shorten(value: string, limit = MAX_EVIDENCE_CHARS): string {
@@ -103,7 +34,11 @@ function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
-function formatPiiWarning(verdict: string, findings: unknown[]): string {
+function formatPiiWarning(
+  verdict: string,
+  findings: unknown[],
+  finalMessage = "本轮请求将继续处理。",
+): string {
   const typedFindings = findings.filter(
     (finding): finding is Record<string, unknown> =>
       typeof finding === "object" && finding !== null && !Array.isArray(finding),
@@ -139,7 +74,7 @@ function formatPiiWarning(verdict: string, findings: unknown[]): string {
   if (evidence.length > 0) {
     parts.push(`脱敏示例：${evidence.join(", ")}`);
   }
-  parts.push("本轮请求将继续处理。");
+  parts.push(finalMessage);
   return parts.join("；");
 }
 
@@ -158,16 +93,24 @@ function buildScanArgs(includeLowConfidence: boolean): string[] {
   return args;
 }
 
+function getInboundText(event: any): string {
+  const content = typeof event?.content === "string" ? event.content : "";
+  if (content.trim()) {
+    return content;
+  }
+  return typeof event?.body === "string" ? event.body : "";
+}
+
 /**
  * 用户输入 PII / 凭据检测。
  *
- * v1 only scans event.prompt in before_prompt_build and shows non-blocking
- * warnings by queueing a same-run block reply in reply_dispatch.
+ * Scans the current inbound user text before dispatch. When enableBlock is
+ * true, a deny verdict handles the turn with a user-visible block message.
  */
 export const piiScan: SecurityCapability = {
   id: "pii-scan-user-input",
   name: "PII Checker",
-  hooks: ["before_prompt_build", "reply_dispatch"],
+  hooks: ["before_dispatch"],
   register(api) {
     const cfg = readConfig((api.pluginConfig as Record<string, any>) ?? {});
     if (!cfg.scanUserInput) {
@@ -175,22 +118,18 @@ export const piiScan: SecurityCapability = {
       return;
     }
 
-    const warningsByRun = new Map<string, WarningBucket>();
-
     api.on(
-      "before_prompt_build",
-      async (event: any, ctx: any) => {
+      "before_dispatch",
+      async (event: any) => {
         try {
-          cleanupExpired(warningsByRun, cfg.warningTtlMs);
-
-          const prompt = typeof event?.prompt === "string" ? event.prompt : "";
-          if (!prompt.trim()) {
+          const text = getInboundText(event);
+          if (!text.trim()) {
             return undefined;
           }
 
           const result = await callAgentSecCli(buildScanArgs(cfg.includeLowConfidence), {
             timeout: CLI_TIMEOUT_MS,
-            stdin: prompt,
+            stdin: text,
           });
           if (result.exitCode !== 0) {
             api.logger.warn(`[pii-checker] CLI failed: ${result.stderr || result.exitCode}`);
@@ -215,57 +154,29 @@ export const piiScan: SecurityCapability = {
             return undefined;
           }
 
-          const runId = getRunId(event, ctx);
-          if (!runId) {
-            api.logger.warn("[pii-checker] missing runId, warning not cached");
-            return undefined;
-          }
-
-          const warning = formatPiiWarning(verdict, findings);
-          pushWarning(warningsByRun, runId, warning, cfg.warningTtlMs);
-          api.logger.warn(`[pii-checker] ${verdict.toUpperCase()} — warning cached for runId=${runId}`);
-          return undefined;
-        } catch (error) {
-          api.logger.warn(`[pii-checker] failed open: ${error instanceof Error ? error.message : String(error)}`);
-          return undefined;
-        }
-      },
-      { priority: 0 },
-    );
-
-    api.on(
-      "reply_dispatch",
-      async (event: any, ctx: any) => {
-        try {
-          const runId = getRunId(event, ctx);
-          if (!runId) {
-            cleanupExpired(warningsByRun, cfg.warningTtlMs);
-            return undefined;
-          }
-
-          if (event?.sendPolicy === "deny" || event?.suppressUserDelivery === true) {
-            deleteWarnings(warningsByRun, runId);
-            return undefined;
-          }
-
-          const warnings = readWarnings(warningsByRun, runId, cfg.warningTtlMs);
-          if (warnings.length === 0) {
-            return undefined;
-          }
-
-          const queued = ctx?.dispatcher?.sendBlockReply?.({
-            text: warnings.join("\n"),
-          });
-          if (queued) {
-            deleteWarnings(warningsByRun, runId);
+          const warning = formatPiiWarning(
+            verdict,
+            findings,
+            verdict === "deny" && cfg.enableBlock ? "本轮请求已被阻断。" : undefined,
+          );
+          api.logger.warn(
+            `[pii-checker] ${verdict.toUpperCase()} (enableBlock=${cfg.enableBlock}) — ${warning}`,
+          );
+          if (verdict === "deny" && cfg.enableBlock) {
+            return {
+              handled: true,
+              text: warning,
+            };
           }
           return undefined;
         } catch (error) {
-          api.logger.warn(`[pii-checker] reply_dispatch failed open: ${error instanceof Error ? error.message : String(error)}`);
+          api.logger.warn(
+            `[pii-checker] failed open: ${error instanceof Error ? error.message : String(error)}`,
+          );
           return undefined;
         }
       },
-      { priority: 0 },
+      { priority: BEFORE_DISPATCH_PRIORITY },
     );
   },
 };

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
@@ -20,14 +20,7 @@ type CheckResult = {
 };
 
 type SkillLedgerConfig = {
-  requireApproval: boolean;
-  warningTtlMs: number;
-};
-
-type WarningBucket = {
-  warnings: string[];
-  createdAt: number;
-  lastTouchedAt: number;
+  enableBlock: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -37,7 +30,6 @@ type WarningBucket = {
 const READ_TOOL_NAMES = ["read"];
 const PATH_PARAM_NAMES = ["file_path", "path"];
 const DEFAULT_TIMEOUT_MS = 5_000;
-const DEFAULT_WARNING_TTL_MS = 300_000;
 
 // ---------------------------------------------------------------------------
 // Status messages and confirmation policy
@@ -122,70 +114,10 @@ function confirmationSeverity(status: string): "warning" | "critical" | undefine
 }
 
 function readConfig(pluginConfig: Record<string, any>): SkillLedgerConfig {
-  const ttl = Number(pluginConfig.skillLedgerWarningTtlMs);
+  const capabilityConfig = pluginConfig.capabilities?.["skill-ledger"] ?? {};
   return {
-    requireApproval: pluginConfig.skillLedgerRequireApproval === true,
-    warningTtlMs:
-      Number.isFinite(ttl) && ttl >= 0 ? ttl : DEFAULT_WARNING_TTL_MS,
+    enableBlock: capabilityConfig.enableBlock !== false,
   };
-}
-
-function getRunId(event: any, ctx: any): string | undefined {
-  const ctxRunId = typeof ctx?.runId === "string" ? ctx.runId.trim() : "";
-  if (ctxRunId) return ctxRunId;
-  const eventRunId = typeof event?.runId === "string" ? event.runId.trim() : "";
-  return eventRunId || undefined;
-}
-
-function cleanupExpired(
-  warningsByRun: Map<string, WarningBucket>,
-  warningTtlMs: number,
-): void {
-  const now = Date.now();
-  for (const [runId, bucket] of warningsByRun) {
-    if (now - bucket.lastTouchedAt >= warningTtlMs) {
-      warningsByRun.delete(runId);
-    }
-  }
-}
-
-function pushWarning(
-  warningsByRun: Map<string, WarningBucket>,
-  runId: string,
-  warning: string,
-  warningTtlMs: number,
-): void {
-  cleanupExpired(warningsByRun, warningTtlMs);
-  const now = Date.now();
-  const bucket =
-    warningsByRun.get(runId) ??
-    {
-      warnings: [],
-      createdAt: now,
-      lastTouchedAt: now,
-    };
-  if (!bucket.warnings.includes(warning)) {
-    bucket.warnings.push(warning);
-  }
-  bucket.lastTouchedAt = now;
-  warningsByRun.set(runId, bucket);
-}
-
-function readWarnings(
-  warningsByRun: Map<string, WarningBucket>,
-  runId: string,
-  warningTtlMs: number,
-): string[] {
-  cleanupExpired(warningsByRun, warningTtlMs);
-  const bucket = warningsByRun.get(runId);
-  return bucket ? [...bucket.warnings] : [];
-}
-
-function deleteWarnings(
-  warningsByRun: Map<string, WarningBucket>,
-  runId: string,
-): void {
-  warningsByRun.delete(runId);
 }
 
 // ---------------------------------------------------------------------------
@@ -195,10 +127,9 @@ function deleteWarnings(
 export const skillLedger: SecurityCapability = {
   id: "skill-ledger",
   name: "Skill Ledger",
-  hooks: ["before_tool_call", "reply_dispatch"],
+  hooks: ["before_tool_call"],
   register(api) {
     const cfg = readConfig((api.pluginConfig as Record<string, any>) ?? {});
-    const warningsByRun = new Map<string, WarningBucket>();
 
     /** Ensure signing keys exist; auto-init if missing. */
     let ensureKeysPromise: Promise<void> | null = null;
@@ -209,7 +140,9 @@ export const skillLedger: SecurityCapability = {
       ensureKeysPromise = (async () => {
         if (keysExist()) return;
 
-        api.logger.info("[skill-ledger] signing keys not found — running init --no-baseline");
+        api.logger.info(
+          "[skill-ledger] signing keys not found — running init --no-baseline",
+        );
         const result = await callAgentSecCli(
           ["skill-ledger", "init", "--no-baseline"],
           { timeout: DEFAULT_TIMEOUT_MS, traceContext },
@@ -218,7 +151,9 @@ export const skillLedger: SecurityCapability = {
         if (result.exitCode === 0) {
           api.logger.info("[skill-ledger] signing keys initialized successfully");
         } else if (!keysExist()) {
-          api.logger.warn(`[skill-ledger] init --no-baseline failed: ${result.stderr}`);
+          api.logger.warn(
+            `[skill-ledger] init --no-baseline failed: ${result.stderr}`,
+          );
           ensureKeysPromise = null; // allow retry on next call
         }
       })().catch(() => {
@@ -232,120 +167,82 @@ export const skillLedger: SecurityCapability = {
     ensureKeys().catch(() => {});
 
     // ── Hook handlers ───────────────────────────────────────────────
-    api.on("before_tool_call", async (event: any, ctx: any) => {
-      try {
-        if (!cfg.requireApproval) {
-          cleanupExpired(warningsByRun, cfg.warningTtlMs);
-        }
-
-        const skillMdPath = extractSkillPath(event);
-        if (!skillMdPath) return undefined;
-
-        const skillDir = resolveSkillDir(skillMdPath);
-        const skillName = basename(skillDir);
-        const traceContext = buildTraceContext(event, ctx);
-
-        // Ensure keys are ready
-        await ensureKeys(traceContext);
-
-        // Invoke CLI
-        const result = await callAgentSecCli(
-          ["skill-ledger", "check", skillDir],
-          { timeout: DEFAULT_TIMEOUT_MS, traceContext },
-        );
-
-        // Parse JSON output — CLI may return exit code 1 for deny/tampered states,
-        // but stdout still contains valid check result with status field.
-        // We should parse stdout even if exit code is non-zero.
-        let checkResult: CheckResult;
+    api.on(
+      "before_tool_call",
+      async (event: any, ctx: any) => {
         try {
-          checkResult = JSON.parse(result.stdout) as CheckResult;
-        } catch {
-          // Only log warning if parsing fails AND exit code is non-zero
-          if (result.exitCode !== 0) {
-            api.logger.warn(`[skill-ledger] CLI error (exit ${result.exitCode}): ${result.stderr}`);
-          } else {
-            api.logger.warn(`[skill-ledger] failed to parse CLI output: ${result.stdout}`);
-          }
-          return undefined;
-        }
+          const skillMdPath = extractSkillPath(event);
+          if (!skillMdPath) return undefined;
 
-        const status = checkResult.status ?? "unknown";
+          const skillDir = resolveSkillDir(skillMdPath);
+          const skillName = basename(skillDir);
+          const traceContext = buildTraceContext(event, ctx);
 
-        if (status === "pass") {
-          return undefined;
-        }
+          // Ensure keys are ready
+          await ensureKeys(traceContext);
 
-        const message = formatSkillLedgerMessage(status, skillName);
-        api.logger.warn(`[skill-ledger] ${message}`);
+          // Invoke CLI
+          const result = await callAgentSecCli(
+            ["skill-ledger", "check", skillDir],
+            { timeout: DEFAULT_TIMEOUT_MS, traceContext },
+          );
 
-        const severity = confirmationSeverity(status);
-        if (severity) {
-          if (cfg.requireApproval) {
-            return {
-              requireApproval: {
-                title: "Skill Ledger Security Check",
-                description: message,
-                severity,
-              },
-            };
-          }
-
-          const runId = getRunId(event, ctx);
-          if (!runId) {
-            api.logger.warn("[skill-ledger] missing runId, warning not cached");
-            return undefined;
-          }
-
-          pushWarning(warningsByRun, runId, `[skill-ledger] status=${status}; ${message}`, cfg.warningTtlMs);
-          api.logger.warn(`[skill-ledger] ${status.toUpperCase()} — warning cached for runId=${runId}`);
-        }
-
-        // For warn/error/unknown states, log and allow. Fail-open behavior for
-        // CLI/runtime failures remains handled by the catch/parse branches.
-        return undefined;
-      } catch (err) {
-        // Fail-open: uncaught errors must never block tool calls
-        api.logger.warn(`[skill-ledger] error: ${err}`);
-        return undefined;
-      }
-    }, { priority: 80 });
-
-    if (!cfg.requireApproval) {
-      api.on(
-        "reply_dispatch",
-        async (event: any, ctx: any) => {
+          // Parse JSON output. CLI may return exit code 1 for risky states,
+          // but stdout still contains valid check result with status field.
+          // We should parse stdout even if exit code is non-zero.
+          let checkResult: CheckResult;
           try {
-            const runId = getRunId(event, ctx);
-            if (!runId) {
-              cleanupExpired(warningsByRun, cfg.warningTtlMs);
-              return undefined;
+            checkResult = JSON.parse(result.stdout) as CheckResult;
+          } catch {
+            // Only log warning if parsing fails AND exit code is non-zero
+            if (result.exitCode !== 0) {
+              api.logger.warn(
+                `[skill-ledger] CLI error (exit ${result.exitCode}): ${result.stderr}`,
+              );
+            } else {
+              api.logger.warn(
+                `[skill-ledger] failed to parse CLI output: ${result.stdout}`,
+              );
             }
-
-            if (event?.sendPolicy === "deny" || event?.suppressUserDelivery === true) {
-              deleteWarnings(warningsByRun, runId);
-              return undefined;
-            }
-
-            const warnings = readWarnings(warningsByRun, runId, cfg.warningTtlMs);
-            if (warnings.length === 0) {
-              return undefined;
-            }
-
-            const queued = ctx?.dispatcher?.sendBlockReply?.({
-              text: `${warnings.join("\n")}\n本轮请求将继续处理。`,
-            });
-            if (queued) {
-              deleteWarnings(warningsByRun, runId);
-            }
-            return undefined;
-          } catch (err) {
-            api.logger.warn(`[skill-ledger] reply_dispatch failed open: ${err instanceof Error ? err.message : String(err)}`);
             return undefined;
           }
-        },
-        { priority: 0 },
-      );
-    }
+
+          const status = checkResult.status ?? "unknown";
+
+          if (status === "pass") {
+            return undefined;
+          }
+
+          const message = formatSkillLedgerMessage(status, skillName);
+          api.logger.warn(`[skill-ledger] ${message}`);
+
+          const severity = confirmationSeverity(status);
+          if (severity) {
+            if (cfg.enableBlock) {
+              return {
+                requireApproval: {
+                  title: "Skill Ledger Security Check",
+                  description: message,
+                  severity,
+                },
+              };
+            }
+
+            api.logger.warn(
+              `[skill-ledger] ${status.toUpperCase()} (enableBlock=false) — allowing`,
+            );
+          }
+
+          // For warn/error/unknown states, log and allow. Fail-open behavior for
+          // CLI/runtime failures remains handled by the catch/parse branches.
+          return undefined;
+        } catch (err) {
+          // Fail-open: uncaught errors must never block tool calls
+          api.logger.warn(`[skill-ledger] error: ${err}`);
+          return undefined;
+        }
+      },
+      { priority: 80 },
+    );
   },
 };

--- a/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/smoke-test.ts
@@ -106,13 +106,22 @@ const mockEvents: Record<string, Record<string, unknown>> = {
 // 每个 hook 的 mock ctx（提供代表性字段值）
 const mockCtx: Record<string, Record<string, unknown>> = {
   before_tool_call: {
-    sessionKey: "sk-001", sessionId: "session-001", runId: "run-001", toolName: "exec", toolCallId: "tc-001",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
+    toolName: "exec",
+    toolCallId: "tc-001",
   },
   before_dispatch: {
-    channelId: "telegram", sessionKey: "sk-001", senderId: "user-123",
+    channelId: "telegram",
+    sessionKey: "sk-001",
+    senderId: "user-123",
   },
   before_prompt_build: {
-    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+    channelId: "telegram",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
   },
   reply_dispatch: {
     dispatcher: {
@@ -128,22 +137,41 @@ const mockCtx: Record<string, Record<string, unknown>> = {
     markIdle: () => {},
   },
   llm_input: {
-    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+    channelId: "telegram",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
   },
   model_call_started: {
-    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+    channelId: "telegram",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
   },
   model_call_ended: {
-    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+    channelId: "telegram",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
   },
   llm_output: {
-    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+    channelId: "telegram",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
   },
   agent_end: {
-    channelId: "telegram", sessionKey: "sk-001", sessionId: "session-001", runId: "run-001",
+    channelId: "telegram",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
   },
   after_tool_call: {
-    sessionKey: "sk-001", sessionId: "session-001", runId: "run-001", toolName: "exec", toolCallId: "tc-001",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-001",
+    toolName: "exec",
+    toolCallId: "tc-001",
   },
 };
 
@@ -151,16 +179,36 @@ const caps = [codeScan, promptScan, piiScan, observability];
 
 if (!process.env.AGENT_SEC_LIVE) {
   _setCliMock(async (args) => {
-    if (args[0] === "scan-code") {
-      return { exitCode: 0, stdout: '{"verdict":"pass","findings":[]}', stderr: "" };
+    const offset = args[0] === "--trace-context" ? 2 : 0;
+    if (args[offset] === "scan-code") {
+      return {
+        exitCode: 0,
+        stdout: '{"verdict":"pass","findings":[]}',
+        stderr: "",
+      };
     }
-    if (args[0] === "scan-prompt") {
-      return { exitCode: 0, stdout: '{"verdict":"pass","findings":[]}', stderr: "" };
+    if (args[offset] === "scan-prompt") {
+      return {
+        exitCode: 0,
+        stdout: '{"verdict":"pass","findings":[]}',
+        stderr: "",
+      };
     }
-    if (args[0] === "scan-pii") {
-      return { exitCode: 0, stdout: '{"verdict":"pass","findings":[]}', stderr: "" };
+    if (args[offset] === "scan-pii") {
+      return {
+        exitCode: 0,
+        stdout: '{"verdict":"pass","findings":[]}',
+        stderr: "",
+      };
     }
-    if (args[0] === "skill-ledger" && args[1] === "check") {
+    if (
+      args[offset] === "skill-ledger" &&
+      args[offset + 1] === "init" &&
+      args[offset + 2] === "--no-baseline"
+    ) {
+      return { exitCode: 0, stdout: '{"fingerprint":"mock"}', stderr: "" };
+    }
+    if (args[offset] === "skill-ledger" && args[offset + 1] === "check") {
       return { exitCode: 0, stdout: '{"status":"pass"}', stderr: "" };
     }
     return { exitCode: 0, stdout: "", stderr: "" };
@@ -189,7 +237,11 @@ const skillLedgerMockEvents: Record<string, Record<string, unknown>> = {
 const skillLedgerMockCtx: Record<string, Record<string, unknown>> = {
   ...mockCtx,
   before_tool_call: {
-    sessionKey: "sk-001", sessionId: "session-001", runId: "run-002", toolName: "read", toolCallId: "tc-002",
+    sessionKey: "sk-001",
+    sessionId: "session-001",
+    runId: "run-002",
+    toolName: "read",
+    toolCallId: "tc-002",
   },
   reply_dispatch: {
     ...mockCtx.reply_dispatch,
@@ -200,7 +252,9 @@ const skillLedgerMockCtx: Record<string, Record<string, unknown>> = {
 };
 
 console.log("=== Agent-Sec Smoke Test ===");
-console.log(`Mode: ${process.env.AGENT_SEC_LIVE ? "LIVE (real CLI)" : "MOCK (no CLI needed)"}\n`);
+console.log(
+  `Mode: ${process.env.AGENT_SEC_LIVE ? "LIVE (real CLI)" : "MOCK (no CLI needed)"}\n`,
+);
 
 for (const cap of caps) {
   console.log(`[${cap.id}] hooks: [${cap.hooks.join(", ")}]`);
@@ -208,17 +262,26 @@ for (const cap of caps) {
   for (const r of results) {
     const status = r.error ? `FAIL: ${r.error.message}` : "OK";
     const detail = r.result ? ` → ${JSON.stringify(r.result)}` : "";
-    console.log(`  ${r.hookName}: ${status} (${r.durationMs.toFixed(0)}ms)${detail}`);
+    console.log(
+      `  ${r.hookName}: ${status} (${r.durationMs.toFixed(0)}ms)${detail}`,
+    );
   }
   console.log();
 }
 
 // ── skill-ledger (separate mock events) ──────────────────────────
 console.log(`[${skillLedger.id}] hooks: [${skillLedger.hooks.join(", ")}]`);
-const slResults = await testCapability(skillLedger, skillLedgerMockEvents, undefined, skillLedgerMockCtx);
+const slResults = await testCapability(
+  skillLedger,
+  skillLedgerMockEvents,
+  undefined,
+  skillLedgerMockCtx,
+);
 for (const r of slResults) {
   const status = r.error ? `FAIL: ${r.error.message}` : "OK";
   const detail = r.result ? ` → ${JSON.stringify(r.result)}` : "";
-  console.log(`  ${r.hookName}: ${status} (${r.durationMs.toFixed(0)}ms)${detail}`);
+  console.log(
+    `  ${r.hookName}: ${status} (${r.durationMs.toFixed(0)}ms)${detail}`,
+  );
 }
 console.log();

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
@@ -6,7 +6,7 @@ import type { CliResult } from "../../src/utils.js";
 
 type RegisteredHook = {
   hookName: string;
-  handler: (event: any, ctx: any) => Promise<any>;
+  handler: (event: any, ctx?: any) => Promise<any>;
   priority: number;
 };
 
@@ -31,11 +31,17 @@ function createMockApi(pluginConfig: Record<string, any> = {}) {
 function registerHandlers(pluginConfig: Record<string, any> = {}) {
   const { api, hooks, logs } = createMockApi(pluginConfig);
   piiScan.register(api);
-  const beforePromptBuild = hooks.find((hook) => hook.hookName === "before_prompt_build");
-  const replyDispatch = hooks.find((hook) => hook.hookName === "reply_dispatch");
-  assert.ok(beforePromptBuild, "before_prompt_build handler should be registered");
-  assert.ok(replyDispatch, "reply_dispatch handler should be registered");
-  return { beforePromptBuild, replyDispatch, hooks, logs };
+  const beforeDispatch = hooks.find((hook) => hook.hookName === "before_dispatch");
+  assert.ok(beforeDispatch, "before_dispatch handler should be registered");
+  return { beforeDispatch, hooks, logs };
+}
+
+function enableBlockConfig(enableBlock: boolean): Record<string, any> {
+  return {
+    capabilities: {
+      "pii-scan-user-input": { enableBlock },
+    },
+  };
 }
 
 let lastCliArgs: string[] | undefined;
@@ -63,28 +69,18 @@ function scanResult(verdict: string, findings: unknown[]) {
   };
 }
 
-function createReplyDispatchCtx(sendBlockReply?: (payload: any) => boolean) {
-  const blockReplies: any[] = [];
-  const dispatcher = {
-    sendToolResult: () => false,
-    sendBlockReply: sendBlockReply ?? ((payload: any) => {
-      blockReplies.push(payload);
-      return true;
-    }),
-    sendFinalReply: () => false,
-    waitForIdle: async () => {},
-    getQueuedCounts: () => ({ tool: 0, block: blockReplies.length, final: 0 }),
-    getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
-    markComplete: () => {},
-  };
-  return { ctx: { dispatcher }, blockReplies };
-}
-
 const warnFinding = {
   type: "email",
   severity: "warn",
   evidence_redacted: "a***@example.com",
   raw_evidence: "alice@example.com",
+};
+
+const denyFinding = {
+  type: "credential",
+  severity: "deny",
+  evidence_redacted: "password=[REDACTED]",
+  raw_evidence: "password=secret",
 };
 
 describe("pii-scan-user-input", () => {
@@ -97,30 +93,31 @@ describe("pii-scan-user-input", () => {
     _resetCliMock();
   });
 
-  it("registers before_prompt_build and reply_dispatch", () => {
+  it("registers only before_dispatch before prompt-scan priority", () => {
     const { hooks } = registerHandlers();
 
     assert.deepEqual(
       hooks.map((hook) => hook.hookName),
-      ["before_prompt_build", "reply_dispatch"],
+      ["before_dispatch"],
     );
-    assert.deepEqual(piiScan.hooks, ["before_prompt_build", "reply_dispatch"]);
+    assert.deepEqual(piiScan.hooks, ["before_dispatch"]);
+    assert.equal(hooks[0].priority, 200);
   });
 
-  it("does not call CLI for empty prompt", async () => {
-    const { beforePromptBuild } = registerHandlers();
+  it("does not call CLI for empty inbound text", async () => {
+    const { beforeDispatch } = registerHandlers();
     mockCliNoCall();
 
-    const result = await beforePromptBuild.handler({ prompt: "   ", runId: "run-1" }, { runId: "run-1" });
+    const result = await beforeDispatch.handler({ content: "   ", body: "   " });
 
     assert.equal(result, undefined);
   });
 
   it("passes scan-pii args and timeout", async () => {
-    const { beforePromptBuild } = registerHandlers();
+    const { beforeDispatch } = registerHandlers();
     mockCli(scanResult("pass", []));
 
-    await beforePromptBuild.handler({ prompt: "hello", runId: "run-1" }, { runId: "run-1" });
+    await beforeDispatch.handler({ content: "hello", body: "fallback" });
 
     assert.deepEqual(lastCliArgs, [
       "scan-pii",
@@ -134,158 +131,89 @@ describe("pii-scan-user-input", () => {
     assert.equal(lastCliOpts?.stdin, "hello");
   });
 
-  it("adds --include-low-confidence when configured", async () => {
-    const { beforePromptBuild } = registerHandlers({ piiIncludeLowConfidence: true });
+  it("falls back to body when content is empty", async () => {
+    const { beforeDispatch } = registerHandlers();
     mockCli(scanResult("pass", []));
 
-    await beforePromptBuild.handler({ prompt: "hello", runId: "run-1" }, { runId: "run-1" });
+    await beforeDispatch.handler({ content: "   ", body: "hello from body" });
+
+    assert.equal(lastCliOpts?.stdin, "hello from body");
+  });
+
+  it("adds --include-low-confidence when configured", async () => {
+    const { beforeDispatch } = registerHandlers({ piiIncludeLowConfidence: true });
+    mockCli(scanResult("pass", []));
+
+    await beforeDispatch.handler({ content: "hello" });
 
     assert.ok(lastCliArgs?.includes("--include-low-confidence"));
   });
 
-  it("pass verdict does not cache a warning", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
+  it("pass verdict allows silently", async () => {
+    const { beforeDispatch } = registerHandlers();
     mockCli(scanResult("pass", []));
 
-    await beforePromptBuild.handler({ prompt: "hello", runId: "run-1" }, { runId: "run-1" });
-    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+    const result = await beforeDispatch.handler({ content: "hello" });
 
     assert.equal(result, undefined);
-    assert.deepEqual(blockReplies, []);
   });
 
-  it("warn verdict queues a same-run block reply once and omits raw evidence", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-    mockCli(scanResult("warn", [warnFinding]));
+  for (const enableBlock of [false, true]) {
+    it(`warn verdict logs and allows when enableBlock=${enableBlock}`, async () => {
+      const { beforeDispatch, logs } = registerHandlers(enableBlockConfig(enableBlock));
+      mockCli(scanResult("warn", [warnFinding]));
 
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const first = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-    const second = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+      const result = await beforeDispatch.handler({ content: "email alice@example.com" });
 
-    assert.equal(first, undefined);
-    assert.equal(second, undefined);
-    assert.equal(blockReplies.length, 1);
-    assert.match(blockReplies[0].text, /\[pii-checker\]/);
-    assert.match(blockReplies[0].text, /email/);
-    assert.match(blockReplies[0].text, /a\*\*\*@example\.com/);
-    assert.doesNotMatch(blockReplies[0].text, /alice@example\.com/);
-    assert.doesNotMatch(blockReplies[0].text, /raw_evidence/);
-    assert.match(blockReplies[0].text, /本轮请求将继续处理/);
-  });
+      assert.equal(result, undefined);
+      assert.ok(logs.some((log) => log.includes("[pii-checker] WARN")));
+      assert.ok(logs.some((log) => log.includes("a***@example.com")));
+      assert.ok(!logs.some((log) => log.includes("alice@example.com")));
+    });
+  }
 
-  it("keeps warning cached when reply_dispatch cannot queue the block reply", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const failedCtx = createReplyDispatchCtx(() => false).ctx;
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-    mockCli(scanResult("warn", [warnFinding]));
+  it("deny verdict defaults to log and allow", async () => {
+    const { beforeDispatch, logs } = registerHandlers();
+    mockCli(scanResult("deny", [denyFinding]));
 
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, failedCtx);
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    assert.equal(blockReplies.length, 1);
-    assert.match(blockReplies[0].text, /\[pii-checker\]/);
-  });
-
-  it("deny verdict queues a high-risk warning", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-    mockCli(
-      scanResult("deny", [
-        {
-          type: "credential",
-          severity: "deny",
-          evidence_redacted: "password=[REDACTED]",
-        },
-      ]),
-    );
-
-    await beforePromptBuild.handler({ prompt: "password=secret", runId: "run-1" }, { runId: "run-1" });
-    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+    const result = await beforeDispatch.handler({ content: "password=secret" });
 
     assert.equal(result, undefined);
-    assert.equal(blockReplies.length, 1);
-    assert.match(blockReplies[0].text, /高风险/);
-    assert.match(blockReplies[0].text, /credential/);
+    assert.ok(logs.some((log) => log.includes("[pii-checker] DENY")));
+    assert.ok(logs.some((log) => log.includes("enableBlock=false")));
   });
 
-  it("uses event.runId when ctx.runId is missing", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-    mockCli(scanResult("warn", [warnFinding]));
+  it("deny verdict blocks when enableBlock=true and omits raw evidence", async () => {
+    const { beforeDispatch } = registerHandlers(enableBlockConfig(true));
+    mockCli(scanResult("deny", [denyFinding]));
 
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-event" }, {});
-    const result = await replyDispatch.handler({ runId: "run-event", sendPolicy: "allow" }, ctx);
+    const result = await beforeDispatch.handler({ content: "password=secret" });
 
-    assert.equal(result, undefined);
-    assert.equal(blockReplies.length, 1);
-    assert.match(blockReplies[0].text, /\[pii-checker\]/);
-  });
-
-  it("does not cache warning when runId is missing", async () => {
-    const { beforePromptBuild, replyDispatch, logs } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-    mockCli(scanResult("warn", [warnFinding]));
-
-    await beforePromptBuild.handler({ prompt: "email alice@example.com" }, { sessionKey: "session-1" });
-    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    assert.equal(result, undefined);
-    assert.deepEqual(blockReplies, []);
-    assert.ok(logs.some((log) => log.includes("missing runId")));
+    assert.equal(result?.handled, true);
+    assert.match(result?.text, /\[pii-checker\]/);
+    assert.match(result?.text, /高风险/);
+    assert.match(result?.text, /credential/);
+    assert.match(result?.text, /password=\[REDACTED\]/);
+    assert.match(result?.text, /本轮请求已被阻断/);
+    assert.doesNotMatch(result?.text, /password=secret/);
+    assert.doesNotMatch(result?.text, /raw_evidence/);
   });
 
   it("CLI nonzero fails open", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
+    const { beforeDispatch } = registerHandlers(enableBlockConfig(true));
     mockCli({ exitCode: 1, stdout: "", stderr: "boom" });
 
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+    const result = await beforeDispatch.handler({ content: "email alice@example.com" });
 
     assert.equal(result, undefined);
-    assert.deepEqual(blockReplies, []);
   });
 
   it("invalid CLI JSON fails open", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
+    const { beforeDispatch } = registerHandlers(enableBlockConfig(true));
     mockCli({ exitCode: 0, stdout: "not-json", stderr: "" });
 
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
+    const result = await beforeDispatch.handler({ content: "email alice@example.com" });
 
     assert.equal(result, undefined);
-    assert.deepEqual(blockReplies, []);
-  });
-
-  it("expires undrained warnings by TTL", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers({ piiWarningTtlMs: 0 });
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-    mockCli(scanResult("warn", [warnFinding]));
-
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    const result = await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    assert.equal(result, undefined);
-    assert.deepEqual(blockReplies, []);
-  });
-
-  it("drops warnings without display when user delivery is suppressed or denied", async () => {
-    const { beforePromptBuild, replyDispatch } = registerHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-    mockCli(scanResult("warn", [warnFinding]));
-
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-1" }, { runId: "run-1" });
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow", suppressUserDelivery: true }, ctx);
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    await beforePromptBuild.handler({ prompt: "email alice@example.com", runId: "run-2" }, { runId: "run-2" });
-    await replyDispatch.handler({ runId: "run-2", sendPolicy: "deny" }, ctx);
-    await replyDispatch.handler({ runId: "run-2", sendPolicy: "allow" }, ctx);
-
-    assert.deepEqual(blockReplies, []);
   });
 });

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
@@ -37,18 +37,15 @@ function registerHandlers(pluginConfig: Record<string, any> = {}) {
   const { api, hooks, logs } = createMockApi(pluginConfig);
   skillLedger.register(api);
   const beforeToolCall = hooks.find((hook) => hook.hookName === "before_tool_call");
-  const replyDispatch = hooks.find((hook) => hook.hookName === "reply_dispatch");
   assert.ok(beforeToolCall, "before_tool_call handler should be registered");
-  return { beforeToolCall, replyDispatch, hooks, logs };
+  return { beforeToolCall, hooks, logs };
 }
 
-function registerWarningHandlers(
-  pluginConfig: Record<string, any> = {},
-): ReturnType<typeof registerHandlers> & { replyDispatch: RegisteredHook } {
-  const handlers = registerHandlers(pluginConfig);
-  assert.ok(handlers.replyDispatch, "reply_dispatch handler should be registered");
-  return handlers as ReturnType<typeof registerHandlers> & {
-    replyDispatch: RegisteredHook;
+function enableBlockConfig(enableBlock: boolean): Record<string, any> {
+  return {
+    capabilities: {
+      "skill-ledger": { enableBlock },
+    },
   };
 }
 
@@ -130,25 +127,6 @@ function readSkillEvent(path = "/skills/risky/SKILL.md", runId = "run-1") {
   };
 }
 
-function createReplyDispatchCtx(sendBlockReply?: (payload: any) => boolean) {
-  const blockReplies: any[] = [];
-  const dispatcher = {
-    sendToolResult: () => false,
-    sendBlockReply:
-      sendBlockReply ??
-      ((payload: any) => {
-        blockReplies.push(payload);
-        return true;
-      }),
-    sendFinalReply: () => false,
-    waitForIdle: async () => {},
-    getQueuedCounts: () => ({ tool: 0, block: blockReplies.length, final: 0 }),
-    getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
-    markComplete: () => {},
-  };
-  return { ctx: { dispatcher }, blockReplies };
-}
-
 describe("skill-ledger", () => {
   beforeEach(() => {
     checkCallCount = 0;
@@ -160,17 +138,16 @@ describe("skill-ledger", () => {
     _resetCliMock();
   });
 
-  it("registers before_tool_call and reply_dispatch", () => {
+  it("registers only before_tool_call", () => {
     mockSkillLedgerStatus("pass");
-    const { hooks } = registerWarningHandlers();
+    const { hooks } = registerHandlers();
 
     assert.deepEqual(
       hooks.map((hook) => hook.hookName),
-      ["before_tool_call", "reply_dispatch"],
+      ["before_tool_call"],
     );
     assert.equal(hooks[0].priority, 80);
-    assert.equal(hooks[1].priority, 0);
-    assert.deepEqual(skillLedger.hooks, ["before_tool_call", "reply_dispatch"]);
+    assert.deepEqual(skillLedger.hooks, ["before_tool_call"]);
   });
 
   it("logs key init failures without blocking registration", async () => {
@@ -358,168 +335,59 @@ describe("skill-ledger", () => {
 
   it("pass allows silently", async () => {
     mockSkillLedgerStatus("pass");
-    const { beforeToolCall, replyDispatch } = registerWarningHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
+    const { beforeToolCall } = registerHandlers();
 
     assert.equal(await beforeToolCall.handler(readSkillEvent(), { runId: "run-1" }), undefined);
-    assert.equal(
-      await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx),
-      undefined,
-    );
-
-    assert.deepEqual(blockReplies, []);
   });
 
   for (const status of ["none", "drifted", "deny", "tampered"]) {
-    it(`${status} defaults to non-blocking same-run user warning`, async () => {
+    it(`${status} asks for approval by default`, async () => {
       mockSkillLedgerStatus(status, status === "none" ? 0 : 1);
-      const { beforeToolCall, replyDispatch } = registerWarningHandlers();
-      const { ctx, blockReplies } = createReplyDispatchCtx();
+      const { beforeToolCall } = registerHandlers();
 
       const result = await beforeToolCall.handler(
         readSkillEvent(`/skills/${status}/SKILL.md`, "run-1"),
         { runId: "run-1" },
       );
-      const firstDispatch = await replyDispatch.handler(
-        { runId: "run-1", sendPolicy: "allow" },
-        ctx,
-      );
-      const secondDispatch = await replyDispatch.handler(
-        { runId: "run-1", sendPolicy: "allow" },
-        ctx,
-      );
 
-      assert.equal(result, undefined);
-      assert.equal(firstDispatch, undefined);
-      assert.equal(secondDispatch, undefined);
-      assert.equal(blockReplies.length, 1);
-      assert.match(blockReplies[0].text, /\[skill-ledger\]/);
-      assert.match(blockReplies[0].text, new RegExp(status));
-      assert.match(blockReplies[0].text, /本轮请求将继续处理/);
+      assert.equal(result?.requireApproval?.title, "Skill Ledger Security Check");
+      assert.match(result?.requireApproval?.description, new RegExp(status));
+      assert.equal(
+        result?.requireApproval?.severity,
+        status === "deny" || status === "tampered" ? "critical" : "warning",
+      );
     });
   }
 
-  it("skillLedgerRequireApproval=true preserves approval behavior", async () => {
-    const cases: Array<[string, "warning" | "critical"]> = [
-      ["none", "warning"],
-      ["drifted", "warning"],
-      ["deny", "critical"],
-      ["tampered", "critical"],
-    ];
-
-    for (const [status, severity] of cases) {
+  for (const status of ["none", "drifted", "deny", "tampered"]) {
+    it(`${status} logs and allows when enableBlock=false`, async () => {
       mockSkillLedgerStatus(status, status === "none" ? 0 : 1);
-      const { beforeToolCall, replyDispatch, hooks } = registerHandlers({
-        skillLedgerRequireApproval: true,
-      });
+      const { beforeToolCall, logs } = registerHandlers(enableBlockConfig(false));
 
       const result = await beforeToolCall.handler(
         readSkillEvent(`/skills/${status}/SKILL.md`, "run-1"),
         { runId: "run-1" },
       );
 
-      assert.deepEqual(
-        hooks.map((hook) => hook.hookName),
-        ["before_tool_call"],
-      );
-      assert.equal(replyDispatch, undefined);
-      assert.equal(result?.requireApproval?.title, "Skill Ledger Security Check");
-      assert.equal(result?.requireApproval?.severity, severity);
-    }
-  });
+      assert.equal(result, undefined);
+      assert.ok(logs.some((log) => log.includes(`[skill-ledger] ${status.toUpperCase()} (enableBlock=false)`)));
+    });
+  }
 
   for (const status of ["warn", "error", "mystery"]) {
-    it(`${status} logs only in default and approval modes`, async () => {
-      for (const pluginConfig of [{}, { skillLedgerRequireApproval: true }]) {
+    it(`${status} logs only in default and enableBlock=false modes`, async () => {
+      for (const pluginConfig of [{}, enableBlockConfig(false)]) {
         mockSkillLedgerStatus(status, status === "error" ? 1 : 0);
-        const { beforeToolCall, replyDispatch, logs } = registerHandlers(pluginConfig);
-        const { ctx, blockReplies } = createReplyDispatchCtx();
+        const { beforeToolCall, logs } = registerHandlers(pluginConfig);
 
         const result = await beforeToolCall.handler(
           readSkillEvent(`/skills/${status}/SKILL.md`, "run-1"),
           { runId: "run-1" },
         );
 
-        if (pluginConfig.skillLedgerRequireApproval === true) {
-          assert.equal(replyDispatch, undefined);
-        } else {
-          assert.ok(replyDispatch);
-          await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-        }
-
         assert.equal(result, undefined);
-        assert.deepEqual(blockReplies, []);
         assert.ok(logs.some((log) => log.includes("[skill-ledger]")));
       }
     });
   }
-
-  it("does not cache a user warning when runId is missing", async () => {
-    mockSkillLedgerStatus("none");
-    const { beforeToolCall, replyDispatch, logs } = registerWarningHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-
-    await beforeToolCall.handler(
-      { toolName: "read", params: { file_path: "/skills/none/SKILL.md" } },
-      {},
-    );
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    assert.deepEqual(blockReplies, []);
-    assert.ok(logs.some((log) => log.includes("missing runId")));
-  });
-
-  it("retains warnings when sendBlockReply fails", async () => {
-    mockSkillLedgerStatus("drifted", 1);
-    const { beforeToolCall, replyDispatch } = registerWarningHandlers();
-    const failedCtx = createReplyDispatchCtx(() => false).ctx;
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-
-    await beforeToolCall.handler(readSkillEvent("/skills/drifted/SKILL.md", "run-1"), {
-      runId: "run-1",
-    });
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, failedCtx);
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    assert.equal(blockReplies.length, 1);
-    assert.match(blockReplies[0].text, /drifted/);
-  });
-
-  it("drops warnings when delivery is denied or suppressed", async () => {
-    mockSkillLedgerStatus("deny", 1);
-    const { beforeToolCall, replyDispatch } = registerWarningHandlers();
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-
-    await beforeToolCall.handler(readSkillEvent("/skills/deny/SKILL.md", "run-1"), {
-      runId: "run-1",
-    });
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "deny" }, ctx);
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    await beforeToolCall.handler(readSkillEvent("/skills/deny/SKILL.md", "run-2"), {
-      runId: "run-2",
-    });
-    await replyDispatch.handler(
-      { runId: "run-2", sendPolicy: "allow", suppressUserDelivery: true },
-      ctx,
-    );
-    await replyDispatch.handler({ runId: "run-2", sendPolicy: "allow" }, ctx);
-
-    assert.deepEqual(blockReplies, []);
-  });
-
-  it("expires undrained warnings by TTL", async () => {
-    mockSkillLedgerStatus("none");
-    const { beforeToolCall, replyDispatch } = registerWarningHandlers({
-      skillLedgerWarningTtlMs: 0,
-    });
-    const { ctx, blockReplies } = createReplyDispatchCtx();
-
-    await beforeToolCall.handler(readSkillEvent("/skills/none/SKILL.md", "run-1"), {
-      runId: "run-1",
-    });
-    await replyDispatch.handler({ runId: "run-1", sendPolicy: "allow" }, ctx);
-
-    assert.deepEqual(blockReplies, []);
-  });
 });


### PR DESCRIPTION
## Description

This PR updates the OpenClaw `agent-sec` plugin blocking strategy for `skill-ledger` and `pii-scan-user-input`.

- Switches `skill-ledger` to `before_tool_call` only, with `capabilities["skill-ledger"].enableBlock` defaulting to `true`; `none`, `drifted`, `deny`, and `tampered` now return OpenClaw `requireApproval`.
- Moves `pii-scan-user-input` to `before_dispatch` at priority `200`, ahead of prompt-scan priority `190`; `capabilities["pii-scan-user-input"].enableBlock` defaults to `false`, and `deny` only returns `{ handled: true, text }` when enabled.
- Removes the previous runId warning cache / `reply_dispatch` strategy for both capabilities and updates config schema, README, smoke test coverage, and unit tests.

## Related Issue

no-issue: user-requested OpenClaw hook blocking policy alignment

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make python-code-pretty` from `src/agent-sec-core` passed; black/isort reported 237 files unchanged.
- `npm run build` from `src/agent-sec-core/openclaw-plugin` passed.
- `git diff --check upstream/main...HEAD` passed.
- Verified built hook registration from `dist`: `pii-scan-user-input` registers `before_dispatch` priority `200`, `prompt-scan` registers `before_dispatch` priority `190`, and `skill-ledger` registers `before_tool_call` priority `80`.

`npm test` and `npm run smoke` could not complete in this local Codex worktree environment: inside the sandbox, `tsx` cannot create its IPC pipe (`listen EPERM`); outside the sandbox, the local esbuild binary used by `tsx` is terminated with `SIGKILL`/exit `137`.

## Additional Notes

This PR only changes OpenClaw plugin behavior. Cosh and Hermes hook behavior is unchanged.
