### PR TITLE
feat(sight): add tcpsniff probe for plain HTTP traffic capture

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -1,11 +1,5 @@
 {
   "tcp_targets": [":8080"],
-  "user_agent": [
-    {"pattern": "*anthropic*", "agent_name": "Anthropic SDK"},
-    {"pattern": "*openai*", "agent_name": "OpenAI SDK"},
-    {"pattern": "*langchain*", "agent_name": "LangChain"},
-    {"pattern": "*cursor*", "agent_name": "Cursor"}
-  ],
   "cmdline": {
     "allow": [
       {"rule": ["hermes*"], "agent_name": "Hermes"},

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -1,4 +1,5 @@
 {
+  "tcp_ports": [8080],
   "cmdline": {
     "allow": [
       {"rule": ["hermes*"], "agent_name": "Hermes"},

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -1,5 +1,5 @@
 {
-  "tcp_targets": [":8080"],
+  "tcp_targets": [],
   "cmdline": {
     "allow": [
       {"rule": ["hermes*"], "agent_name": "Hermes"},

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -1,5 +1,11 @@
 {
-  "tcp_ports": [8080],
+  "tcp_targets": [":8080"],
+  "user_agent": [
+    {"pattern": "*anthropic*", "agent_name": "Anthropic SDK"},
+    {"pattern": "*openai*", "agent_name": "OpenAI SDK"},
+    {"pattern": "*langchain*", "agent_name": "LangChain"},
+    {"pattern": "*cursor*", "agent_name": "Cursor"}
+  ],
   "cmdline": {
     "allow": [
       {"rule": ["hermes*"], "agent_name": "Hermes"},

--- a/src/agentsight/build.rs
+++ b/src/agentsight/build.rs
@@ -58,6 +58,9 @@ fn main() {
     // Generate udpdns skeleton and bindings
     generate_skeleton(&mut out, "udpdns");
     generate_header(&mut out, "udpdns");
+
+    // Generate tcpsniff skeleton (no header — reuses sslsniff.h event format)
+    generate_skeleton(&mut out, "tcpsniff");
     
     // generate_header(&mut out, "frametypes");
     // generate_header(&mut out, "errors");

--- a/src/agentsight/integration-tests/test_tcpsniff.md
+++ b/src/agentsight/integration-tests/test_tcpsniff.md
@@ -1,0 +1,41 @@
+# TCP Plain-Text Capture (tcpsniff) 集成测试
+
+> 前置条件见 [RULES.md](RULES.md)（环境变量、部署流程、通用规则）
+
+## 测试目标
+
+### 探针加载与内核适配
+
+1. 配置含 `tcp_targets` 时，tcpsniff BPF 探针应被加载并 attach（日志含 "TcpSniff: attached 3 BPF programs"）
+2. 配置 `tcp_targets` 为空或不存在时，tcpsniff 探针不应被加载（日志含 "TcpSniff probe disabled"）
+3. 在 kernel 5.18+ 上，应使用新签名（日志含 "loaded with new tcp_recvmsg signature (5.18+)"）
+4. 在 kernel 5.8–5.17 上，应自动回退到旧签名（日志含 "loaded with old tcp_recvmsg signature (5.8-5.17)"）
+
+### 请求捕获 (tcp_sendmsg)
+
+5. 向目标 IP/端口发送 HTTP 请求时，应捕获并解析为 Request 事件（日志含 "Aggregating parsed results(1): Request"）
+6. 捕获的 Request 应包含完整 HTTP headers + body（判定：GenAI 事件中 `input_messages` 非空，`raw_body` 不含 `\x00\x00` 前缀乱码）
+7. 非目标的 TCP 流量不应被捕获（配置 `tcp_targets: [":8080"]`，向其他端口发请求不应产生事件）
+
+### 响应捕获 (tcp_recvmsg)
+
+8. 目标 IP/端口的 HTTP 响应应被捕获并解析为 Response 事件（日志含 "Aggregating parsed results(1): Response"）
+9. SSE 流式响应应被正确拆分为多个 SseEvent（日志含 "SseEvent, SseEvent, SseEvent"）
+10. 响应内容不应出现乱码/重复/交错（判定：GenAI 事件中 `output_messages` 内容完整且无重复字符）
+
+### 端到端数据正确性
+
+11. 捕获的 LLM 调用应提取到正确的 token 用量（判定：`/api/sessions` 返回 `total_input_tokens > 0` 且 `total_output_tokens > 0`）
+12. 不同用户请求应分配不同的 `conversation_id`（判定：`/api/sessions/{id}/traces` 返回多条 trace，每条有独立 `conversation_id`）
+13. `user_query` 应从请求 body 的 messages 数组中正确提取（判定：`/api/sessions/{id}/traces` 中 `user_query` 字段与实际发送内容匹配）
+
+### 配置
+
+14. JSON 配置文件中 `"tcp_targets": [":8080", "10.0.0.1:9090"]` 应正确设置目标（支持仅端口、仅 IP、IP+端口三种格式）
+15. `tcp_targets` 支持三级匹配：精确 IP+端口 → 仅 IP → 仅端口
+
+## 运行条件
+
+- root 权限
+- Linux kernel >= 5.8 with BTF（`/sys/kernel/btf/vmlinux` 存在）
+- 目标 IP/端口上有可接收 HTTP 请求的服务运行（如 Higress gateway 或简单 HTTP echo server）

--- a/src/agentsight/src/analyzer/audit/analyzer.rs
+++ b/src/agentsight/src/analyzer/audit/analyzer.rs
@@ -6,6 +6,7 @@ use crate::aggregator::HttpPair;
 use crate::aggregator::AggregatedProcess;
 use crate::aggregator::AggregatedResult;
 use crate::analyzer::HttpRecord;
+use crate::analyzer::token::TokenRecord;
 use super::record::{AuditEventType, AuditExtra, AuditRecord};
 
 /// Analyzes aggregated results and extracts audit records
@@ -41,7 +42,7 @@ impl AuditAnalyzer {
     /// Only creates llm_call for SSE responses, which are LLM streaming API calls.
     /// Non-SSE requests (like npm package queries) are filtered out.
     /// This method works for both HTTP/1.1 and HTTP/2 uniformly.
-    pub fn analyze_http(&self, http_record: &HttpRecord) -> Option<AuditRecord> {
+    pub fn analyze_http(&self, http_record: &HttpRecord, token_record: Option<&TokenRecord>) -> Option<AuditRecord> {
         // Only create llm_call for SSE responses
         if !http_record.is_sse {
             return None;
@@ -52,6 +53,17 @@ impl AuditAnalyzer {
             .as_ref()
             .and_then(|body| serde_json::from_str::<serde_json::Value>(body).ok())
             .and_then(|json| json.get("model")?.as_str().map(|s| s.to_string()));
+
+        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens) =
+            match token_record {
+                Some(t) => (
+                    t.input_tokens,
+                    t.output_tokens,
+                    t.cache_creation_tokens.unwrap_or(0),
+                    t.cache_read_tokens.unwrap_or(0),
+                ),
+                None => (0, 0, 0, 0),
+            };
 
         Some(AuditRecord {
             id: None,
@@ -67,10 +79,10 @@ impl AuditAnalyzer {
                 request_method: Some(http_record.method.clone()),
                 request_path: Some(http_record.path.clone()),
                 response_status: Some(http_record.status_code),
-                input_tokens: 0,
-                output_tokens: 0,
-                cache_creation_tokens: 0,
-                cache_read_tokens: 0,
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
                 is_sse: true,
             },
         })

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -459,11 +459,6 @@ impl Analyzer {
 
         // 4. HTTP data export - extract raw HTTP request/response data
         if let Some(http_record) = self.extract_http_record(result) {
-            // Extract audit from HttpRecord (only for SSE responses / LLM calls)
-            if let Some(audit_record) = self.audit.analyze_http(&http_record) {
-                results.push(AnalysisResult::Audit(audit_record));
-            }
-
             if token_result.is_none() && http_record.is_sse {
                 if let Some(body) = &http_record.response_body {
                     if let Ok(x) = serde_json::from_str::<Vec<serde_json::Value>>(body) {
@@ -489,8 +484,14 @@ impl Analyzer {
                     }
                 }
             }
-            results.push(AnalysisResult::Http(http_record));
 
+            // Extract audit from HttpRecord (only for SSE responses / LLM calls)
+            // Pass token_result so audit record gets populated token counts
+            if let Some(audit_record) = self.audit.analyze_http(&http_record, token_result.as_ref()) {
+                results.push(AnalysisResult::Audit(audit_record));
+            }
+
+            results.push(AnalysisResult::Http(http_record));
         }
 
 

--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -22,6 +22,11 @@ pub struct TraceCommand {
     #[structopt(long)]
     pub enable_filewatch: bool,
 
+    /// Capture plain-text TCP traffic on these ports (comma-separated, e.g. 8080,8443).
+    /// Useful when the agent routes through a local gateway (e.g. Higress) via HTTP.
+    #[structopt(long, use_delimiter = true)]
+    pub tcp_ports: Vec<u16>,
+
     /// Path to JSON configuration file
     #[structopt(short, long, default_value = "/etc/agentsight/config.json")]
     pub config: String,
@@ -63,9 +68,14 @@ impl TraceCommand {
     /// Run the actual tracing logic using AgentSight
     fn run_tracing(&self) {
         // Build AgentSight config (empty target_pids means trace all processes)
-        let config = AgentsightConfig::new()
+        let mut config = AgentsightConfig::new()
             .set_verbose(self.verbose)
             .set_enable_filewatch(self.enable_filewatch);
+
+        // Only override tcp_target_ports if explicitly specified on CLI
+        if !self.tcp_ports.is_empty() {
+            config = config.set_tcp_target_ports(self.tcp_ports.clone());
+        }
 
         // Set config_path for unified loading in AgentSight::new()
         let config = config.set_config_path(std::path::PathBuf::from(&self.config));

--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -22,11 +22,6 @@ pub struct TraceCommand {
     #[structopt(long)]
     pub enable_filewatch: bool,
 
-    /// Capture plain-text TCP traffic on these ports (comma-separated, e.g. 8080,8443).
-    /// Useful when the agent routes through a local gateway (e.g. Higress) via HTTP.
-    #[structopt(long, use_delimiter = true)]
-    pub tcp_ports: Vec<u16>,
-
     /// Path to JSON configuration file
     #[structopt(short, long, default_value = "/etc/agentsight/config.json")]
     pub config: String,
@@ -68,17 +63,10 @@ impl TraceCommand {
     /// Run the actual tracing logic using AgentSight
     fn run_tracing(&self) {
         // Build AgentSight config (empty target_pids means trace all processes)
-        let mut config = AgentsightConfig::new()
+        let config = AgentsightConfig::new()
             .set_verbose(self.verbose)
-            .set_enable_filewatch(self.enable_filewatch);
-
-        // Only override tcp_target_ports if explicitly specified on CLI
-        if !self.tcp_ports.is_empty() {
-            config = config.set_tcp_target_ports(self.tcp_ports.clone());
-        }
-
-        // Set config_path for unified loading in AgentSight::new()
-        let config = config.set_config_path(std::path::PathBuf::from(&self.config));
+            .set_enable_filewatch(self.enable_filewatch)
+            .set_config_path(std::path::PathBuf::from(&self.config));
         
         // Create AgentSight (auto-attaches probes and starts polling)
         let mut sight = match AgentSight::new(config) {

--- a/src/agentsight/src/bpf/tcpsniff.bpf.c
+++ b/src/agentsight/src/bpf/tcpsniff.bpf.c
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// TCP plain-text traffic capture BPF program.
+// Hooks tcp_sendmsg (fentry) and tcp_recvmsg (fentry+fexit) to capture
+// HTTP traffic on configurable ports. Emits probe_SSL_data_t events
+// (same format as sslsniff) so the entire downstream pipeline works unchanged.
+
+#include "vmlinux.h"
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_endian.h>
+#include "sslsniff.h"
+#include "common.h"
+
+// MSG_PEEK is a socket flag not exported by vmlinux.h
+#ifndef MSG_PEEK
+#define MSG_PEEK 2
+#endif
+
+// --- CO-RE compatibility for iov_iter fields ---
+// Kernel 6.4+ renamed iov_iter.iov to iov_iter.__iov.
+struct iov_iter___new {
+    const struct iovec *__iov;
+};
+
+// Kernel 6.0+ added ITER_UBUF: read()/write() on sockets use ubuf instead of iov.
+struct iov_iter___ubuf {
+    void *ubuf;
+    u8 iter_type;
+};
+
+// ITER_UBUF = 5 in kernel 6.0+ (ITER_IOVEC=0, ITER_KVEC=1, ITER_BVEC=2, ...)
+#define ITER_UBUF_TYPE 5
+
+// Result of extracting user buffer from msghdr
+struct msg_buf_info {
+    void *buf;   // user-space buffer pointer
+    u64 len;     // length of THIS buffer (not total msg size)
+};
+
+// Extract user-space buffer pointer and length from msghdr's iov_iter.
+// For ITER_UBUF: returns ubuf pointer and iter->count (contiguous).
+// For ITER_IOVEC: returns iov[0].iov_base and iov[0].iov_len (first segment only).
+//   writev() scatters data across iovecs; we capture only the first segment
+//   to avoid reading beyond its boundary into unrelated memory.
+static __always_inline struct msg_buf_info get_msg_buf_info(struct msghdr *msg)
+{
+    struct msg_buf_info info = { .buf = NULL, .len = 0 };
+    struct iov_iter *iter = &msg->msg_iter;
+
+    // Try ITER_UBUF first (kernel 6.0+, used by read()/write() on sockets)
+    struct iov_iter___ubuf *ubuf_iter = (void *)iter;
+    if (bpf_core_field_exists(ubuf_iter->ubuf)) {
+        u8 type = BPF_CORE_READ(ubuf_iter, iter_type);
+        if (type == ITER_UBUF_TYPE) {
+            info.buf = BPF_CORE_READ(ubuf_iter, ubuf);
+            info.len = BPF_CORE_READ(iter, count);
+            return info;
+        }
+    }
+
+    // Fall back to ITER_IOVEC (sendmsg/recvmsg/writev syscalls)
+    struct iov_iter___new *new_iter = (void *)iter;
+    const struct iovec *iov;
+    if (bpf_core_field_exists(new_iter->__iov)) {
+        iov = BPF_CORE_READ(new_iter, __iov);
+    } else {
+        iov = BPF_CORE_READ(iter, iov);
+    }
+    if (!iov)
+        return info;
+    info.buf = BPF_CORE_READ(iov, iov_base);
+    info.len = BPF_CORE_READ(iov, iov_len);
+    return info;
+}
+
+// --- Port filter map (populated from userspace) ---
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 64);
+    __type(key, __u16);   // port in network byte order
+    __type(value, __u8);  // dummy
+} tcp_target_ports SEC(".maps");
+
+// --- Stash map for tcp_recvmsg entry → exit ---
+struct tcp_recv_args {
+    u64 sk;           // struct sock * as u64
+    u64 user_buf;     // user-space buffer pointer captured at fentry
+    u64 buf_len;      // buffer capacity captured at fentry
+    u64 start_ns;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1024);
+    __type(key, u32);   // tid
+    __type(value, struct tcp_recv_args);
+} tcp_recv_stash SEC(".maps");
+
+// Check if destination port is in the target list
+static __always_inline bool is_target_port(struct sock *sk)
+{
+    __u16 dport = BPF_CORE_READ(sk, __sk_common.skc_dport);
+    return bpf_map_lookup_elem(&tcp_target_ports, &dport) != NULL;
+}
+
+// Emit a probe_SSL_data_t event given a pre-resolved user buffer pointer.
+static __always_inline int emit_tcp_event_buf(
+    struct sock *sk,
+    void *user_buf,
+    u32 data_len,
+    int rw,           // 1=send(request), 0=recv(response)
+    u64 start_ns,
+    u32 ns_pid)
+{
+    if (data_len == 0 || !user_buf)
+        return 0;
+
+    // Reserve ring buffer event (same struct as sslsniff)
+    struct probe_SSL_data_t *data = bpf_ringbuf_reserve(&rb, sizeof(*data), 0);
+    if (!data)
+        return 0;
+
+    u64 now = bpf_ktime_get_ns();
+
+    data->source = EVENT_SOURCE_SSL;  // reuse SSL source for seamless pipeline
+    data->timestamp_ns = now;
+    data->delta_ns = (start_ns > 0) ? (now - start_ns) : 0;
+    data->pid = ns_pid;
+    data->tid = (u32)bpf_get_current_pid_tgid();
+    data->uid = bpf_get_current_uid_gid();
+    data->len = data_len;
+    data->rw = rw;
+    data->is_handshake = false;
+    data->ssl_ptr = (u64)sk;  // use sock pointer as connection identifier
+
+    // Clamp buffer size for verifier
+    u32 buf_copy_size = data_len & 0xFFFFF;
+    if (buf_copy_size > MAX_BUF_SIZE)
+        buf_copy_size = MAX_BUF_SIZE;
+
+    bpf_get_current_comm(&data->comm, sizeof(data->comm));
+
+    int ret = bpf_probe_read_user(&data->buf, buf_copy_size, user_buf);
+    if (ret == 0) {
+        data->buf_filled = 1;
+        data->buf_size = buf_copy_size;
+    } else {
+        data->buf_filled = 0;
+        data->buf_size = 0;
+    }
+
+    bpf_ringbuf_submit(data, 0);
+    return 0;
+}
+
+// Get the iov pointer from iov_iter (CO-RE safe)
+static __always_inline const struct iovec *get_iov_ptr(struct iov_iter *iter)
+{
+    struct iov_iter___new *new_iter = (void *)iter;
+    if (bpf_core_field_exists(new_iter->__iov))
+        return BPF_CORE_READ(new_iter, __iov);
+    return BPF_CORE_READ(iter, iov);
+}
+
+// --- tcp_sendmsg: capture outgoing data (HTTP requests) ---
+// For writev() (ITER_IOVEC), data is scattered across multiple iovecs.
+// Node.js typically uses writev with iov[0]=HTTP headers, iov[1]=JSON body.
+// We read both segments into the event buffer for correct parsing.
+// For write() (ITER_UBUF), data is contiguous — single copy.
+SEC("fentry/tcp_sendmsg")
+int BPF_PROG(trace_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = pid_tgid >> 32;
+
+    u32 ns_pid = is_pid_traced(pid);
+    if (!ns_pid)
+        return 0;
+
+    if (!is_target_port(sk))
+        return 0;
+
+    struct iov_iter *iter = &msg->msg_iter;
+
+    // Check if ITER_UBUF (contiguous buffer from write() syscall)
+    struct iov_iter___ubuf *ubuf_iter = (void *)iter;
+    if (bpf_core_field_exists(ubuf_iter->ubuf)) {
+        u8 type = BPF_CORE_READ(ubuf_iter, iter_type);
+        if (type == ITER_UBUF_TYPE) {
+            void *ubuf = BPF_CORE_READ(ubuf_iter, ubuf);
+            u32 count = (u32)BPF_CORE_READ(iter, count);
+            if (count > (u32)size)
+                count = (u32)size;
+            return emit_tcp_event_buf(sk, ubuf, count, 1, 0, ns_pid);
+        }
+    }
+
+    // ITER_IOVEC: scatter-gather from writev()/sendmsg()
+    // Read iov[0] and iov[1] into the event buffer concatenated.
+    const struct iovec *iov = get_iov_ptr(iter);
+    if (!iov)
+        return 0;
+
+    void *iov0_base = BPF_CORE_READ(iov, iov_base);
+    u64 iov0_len = BPF_CORE_READ(iov, iov_len);
+    if (!iov0_base || iov0_len == 0)
+        return 0;
+
+    // Reserve ring buffer event
+    struct probe_SSL_data_t *data = bpf_ringbuf_reserve(&rb, sizeof(*data), 0);
+    if (!data)
+        return 0;
+
+    u64 now = bpf_ktime_get_ns();
+    data->source = EVENT_SOURCE_SSL;
+    data->timestamp_ns = now;
+    data->delta_ns = 0;
+    data->pid = ns_pid;
+    data->tid = (u32)bpf_get_current_pid_tgid();
+    data->uid = bpf_get_current_uid_gid();
+    data->len = (u32)size;
+    data->rw = 1;
+    data->is_handshake = false;
+    data->ssl_ptr = (u64)sk;
+    bpf_get_current_comm(&data->comm, sizeof(data->comm));
+
+    // Copy iov[0] (HTTP headers)
+    u32 iov0_copy = (u32)iov0_len & 0xFFFFF;
+    if (iov0_copy > MAX_BUF_SIZE)
+        iov0_copy = MAX_BUF_SIZE;
+
+    int ret = bpf_probe_read_user(&data->buf[0], iov0_copy, iov0_base);
+    if (ret != 0) {
+        data->buf_filled = 0;
+        data->buf_size = 0;
+        bpf_ringbuf_submit(data, 0);
+        return 0;
+    }
+
+    u32 total_copied = iov0_copy;
+
+    // Try to also copy iov[1] (JSON body) if there's space
+    u32 nr_segs = (u32)BPF_CORE_READ(iter, nr_segs);
+    if (nr_segs >= 2 && total_copied < MAX_BUF_SIZE) {
+        const struct iovec *iov1 = &iov[1];
+        void *iov1_base = BPF_CORE_READ(iov1, iov_base);
+        u64 iov1_len = BPF_CORE_READ(iov1, iov_len);
+
+        if (iov1_base && iov1_len > 0) {
+            u32 remaining = MAX_BUF_SIZE - total_copied;
+            u32 iov1_copy = (u32)iov1_len & 0xFFFFF;
+            if (iov1_copy > remaining)
+                iov1_copy = remaining;
+
+            // Verifier needs bounded offset
+            u32 offset = total_copied & 0xFFFFF;
+            if (offset + iov1_copy <= MAX_BUF_SIZE) {
+                ret = bpf_probe_read_user(&data->buf[offset], iov1_copy, iov1_base);
+                if (ret == 0)
+                    total_copied += iov1_copy;
+            }
+        }
+    }
+
+    data->buf_filled = 1;
+    data->buf_size = total_copied;
+    bpf_ringbuf_submit(data, 0);
+    return 0;
+}
+
+// --- tcp_recvmsg entry: stash user_buf pointer for fexit ---
+SEC("fentry/tcp_recvmsg")
+int BPF_PROG(trace_tcp_recvmsg_entry, struct sock *sk, struct msghdr *msg,
+             size_t size, int flags)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = pid_tgid >> 32;
+
+    u32 ns_pid = is_pid_traced(pid);
+    if (!ns_pid)
+        return 0;
+
+    if (!is_target_port(sk))
+        return 0;
+
+    // Peek flag means data won't be consumed — skip
+    if (flags & MSG_PEEK)
+        return 0;
+
+    // Capture user buffer pointer NOW, before kernel advances iov_iter
+    struct msg_buf_info bi = get_msg_buf_info(msg);
+    if (!bi.buf)
+        return 0;
+
+    u32 tid = (u32)pid_tgid;
+    struct tcp_recv_args args = {
+        .sk = (u64)sk,
+        .user_buf = (u64)bi.buf,
+        .buf_len = bi.len,
+        .start_ns = bpf_ktime_get_ns(),
+    };
+    bpf_map_update_elem(&tcp_recv_stash, &tid, &args, BPF_ANY);
+    return 0;
+}
+
+// --- tcp_recvmsg exit: read received data using stashed buffer pointer ---
+SEC("fexit/tcp_recvmsg")
+int BPF_PROG(trace_tcp_recvmsg_exit, struct sock *sk, struct msghdr *msg,
+             size_t size, int flags, int *addr_len, int ret)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
+    struct tcp_recv_args *args = bpf_map_lookup_elem(&tcp_recv_stash, &tid);
+    if (!args) 
+        return 0;
+
+    u64 stashed_sk = args->sk;
+    u64 stashed_buf = args->user_buf;
+    u64 stashed_len = args->buf_len;
+    u64 start_ns = args->start_ns;
+    bpf_map_delete_elem(&tcp_recv_stash, &tid);
+
+    if (ret <= 0)
+        return 0;
+
+    u32 ns_pid = is_pid_traced(pid);
+    if (!ns_pid)
+        return 0;
+
+    // Clamp ret to buffer capacity
+    u32 copy_len = (u32)ret;
+    if ((u64)ret > stashed_len)
+        copy_len = (u32)stashed_len;
+
+    return emit_tcp_event_buf(
+        (struct sock *)stashed_sk,
+        (void *)stashed_buf,
+        copy_len, 0, start_ns, ns_pid);
+}
+
+// --- Kernel 5.8–5.17 variants ---
+// tcp_recvmsg had an extra `int nonblock` parameter before 5.18 (commit ec095263a965).
+// Signature: int tcp_recvmsg(struct sock *sk, struct msghdr *msg, size_t len,
+//                            int nonblock, int flags, int *addr_len)
+// Userspace tries the new (5.18+) programs first; falls back to these on older kernels.
+
+SEC("fentry/tcp_recvmsg")
+int BPF_PROG(trace_tcp_recvmsg_entry_old, struct sock *sk, struct msghdr *msg,
+             size_t size, int nonblock, int flags)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = pid_tgid >> 32;
+
+    u32 ns_pid = is_pid_traced(pid);
+    if (!ns_pid)
+        return 0;
+
+    if (!is_target_port(sk))
+        return 0;
+
+    if (flags & MSG_PEEK)
+        return 0;
+
+    struct msg_buf_info bi = get_msg_buf_info(msg);
+    if (!bi.buf)
+        return 0;
+
+    u32 tid = (u32)pid_tgid;
+    struct tcp_recv_args args = {
+        .sk = (u64)sk,
+        .user_buf = (u64)bi.buf,
+        .buf_len = bi.len,
+        .start_ns = bpf_ktime_get_ns(),
+    };
+    bpf_map_update_elem(&tcp_recv_stash, &tid, &args, BPF_ANY);
+    return 0;
+}
+
+SEC("fexit/tcp_recvmsg")
+int BPF_PROG(trace_tcp_recvmsg_exit_old, struct sock *sk, struct msghdr *msg,
+             size_t size, int nonblock, int flags, int *addr_len, int ret)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
+    struct tcp_recv_args *args = bpf_map_lookup_elem(&tcp_recv_stash, &tid);
+    if (!args)
+        return 0;
+
+    u64 stashed_sk = args->sk;
+    u64 stashed_buf = args->user_buf;
+    u64 stashed_len = args->buf_len;
+    u64 start_ns = args->start_ns;
+    bpf_map_delete_elem(&tcp_recv_stash, &tid);
+
+    if (ret <= 0)
+        return 0;
+
+    u32 ns_pid = is_pid_traced(pid);
+    if (!ns_pid)
+        return 0;
+
+    u32 copy_len = (u32)ret;
+    if ((u64)ret > stashed_len)
+        copy_len = (u32)stashed_len;
+
+    return emit_tcp_event_buf(
+        (struct sock *)stashed_sk,
+        (void *)stashed_buf,
+        copy_len, 0, start_ns, ns_pid);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/agentsight/src/bpf/tcpsniff.bpf.c
+++ b/src/agentsight/src/bpf/tcpsniff.bpf.c
@@ -3,9 +3,11 @@
 //
 // TCP plain-text traffic capture BPF program.
 // Hooks tcp_sendmsg (fentry) and tcp_recvmsg (fentry+fexit) to capture
-// HTTP traffic on configurable ports. Emits probe_SSL_data_t events
+// HTTP traffic on configurable IP/port targets. Emits probe_SSL_data_t events
 // (same format as sslsniff) so the entire downstream pipeline works unchanged.
+// Filters by destination IP/port only; no process-level filtering.
 
+#define NO_TRACED_PROCESSES_MAP
 #include "vmlinux.h"
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
@@ -76,13 +78,20 @@ static __always_inline struct msg_buf_info get_msg_buf_info(struct msghdr *msg)
     return info;
 }
 
-// --- Port filter map (populated from userspace) ---
+// --- IP/port filter map (populated from userspace) ---
+// Key: destination IP + port, 0 = wildcard (any IP or any port).
+struct tcp_target_key {
+    __be32 ip;    // destination IPv4, network byte order; 0 = any IP
+    __be16 port;  // destination port, network byte order; 0 = any port
+    __u16  pad;   // alignment padding
+};
+
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 64);
-    __type(key, __u16);   // port in network byte order
-    __type(value, __u8);  // dummy
-} tcp_target_ports SEC(".maps");
+    __type(key, struct tcp_target_key);
+    __type(value, __u8);
+} tcp_targets SEC(".maps");
 
 // --- Stash map for tcp_recvmsg entry → exit ---
 struct tcp_recv_args {
@@ -99,11 +108,32 @@ struct {
     __type(value, struct tcp_recv_args);
 } tcp_recv_stash SEC(".maps");
 
-// Check if destination port is in the target list
-static __always_inline bool is_target_port(struct sock *sk)
+// Check if the connection's destination matches any configured target.
+// Lookup priority (most-specific first):
+//   1. exact ip+port match
+//   2. ip-only match (port=0 means any port)
+//   3. port-only match (ip=0 means any ip)
+static __always_inline bool is_target_conn(struct sock *sk)
 {
-    __u16 dport = BPF_CORE_READ(sk, __sk_common.skc_dport);
-    return bpf_map_lookup_elem(&tcp_target_ports, &dport) != NULL;
+    struct tcp_target_key key = {};
+    __be32 daddr = BPF_CORE_READ(sk, __sk_common.skc_daddr);
+    __be16 dport = BPF_CORE_READ(sk, __sk_common.skc_dport);
+
+    // 1. exact ip+port
+    key.ip = daddr;
+    key.port = dport;
+    if (bpf_map_lookup_elem(&tcp_targets, &key))
+        return true;
+
+    // 2. ip-only (port wildcard)
+    key.port = 0;
+    if (bpf_map_lookup_elem(&tcp_targets, &key))
+        return true;
+
+    // 3. port-only (ip wildcard)
+    key.ip = 0;
+    key.port = dport;
+    return bpf_map_lookup_elem(&tcp_targets, &key) != NULL;
 }
 
 // Emit a probe_SSL_data_t event given a pre-resolved user buffer pointer.
@@ -112,8 +142,7 @@ static __always_inline int emit_tcp_event_buf(
     void *user_buf,
     u32 data_len,
     int rw,           // 1=send(request), 0=recv(response)
-    u64 start_ns,
-    u32 ns_pid)
+    u64 start_ns)
 {
     if (data_len == 0 || !user_buf)
         return 0;
@@ -124,12 +153,13 @@ static __always_inline int emit_tcp_event_buf(
         return 0;
 
     u64 now = bpf_ktime_get_ns();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
 
     data->source = EVENT_SOURCE_SSL;  // reuse SSL source for seamless pipeline
     data->timestamp_ns = now;
     data->delta_ns = (start_ns > 0) ? (now - start_ns) : 0;
-    data->pid = ns_pid;
-    data->tid = (u32)bpf_get_current_pid_tgid();
+    data->pid = (u32)(pid_tgid >> 32);
+    data->tid = (u32)pid_tgid;
     data->uid = bpf_get_current_uid_gid();
     data->len = data_len;
     data->rw = rw;
@@ -173,14 +203,7 @@ static __always_inline const struct iovec *get_iov_ptr(struct iov_iter *iter)
 SEC("fentry/tcp_sendmsg")
 int BPF_PROG(trace_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = pid_tgid >> 32;
-
-    u32 ns_pid = is_pid_traced(pid);
-    if (!ns_pid)
-        return 0;
-
-    if (!is_target_port(sk))
+    if (!is_target_conn(sk))
         return 0;
 
     struct iov_iter *iter = &msg->msg_iter;
@@ -194,7 +217,7 @@ int BPF_PROG(trace_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
             u32 count = (u32)BPF_CORE_READ(iter, count);
             if (count > (u32)size)
                 count = (u32)size;
-            return emit_tcp_event_buf(sk, ubuf, count, 1, 0, ns_pid);
+            return emit_tcp_event_buf(sk, ubuf, count, 1, 0);
         }
     }
 
@@ -215,11 +238,12 @@ int BPF_PROG(trace_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
         return 0;
 
     u64 now = bpf_ktime_get_ns();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
     data->source = EVENT_SOURCE_SSL;
     data->timestamp_ns = now;
     data->delta_ns = 0;
-    data->pid = ns_pid;
-    data->tid = (u32)bpf_get_current_pid_tgid();
+    data->pid = (u32)(pid_tgid >> 32);
+    data->tid = (u32)pid_tgid;
     data->uid = bpf_get_current_uid_gid();
     data->len = (u32)size;
     data->rw = 1;
@@ -276,14 +300,7 @@ SEC("fentry/tcp_recvmsg")
 int BPF_PROG(trace_tcp_recvmsg_entry, struct sock *sk, struct msghdr *msg,
              size_t size, int flags)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = pid_tgid >> 32;
-
-    u32 ns_pid = is_pid_traced(pid);
-    if (!ns_pid)
-        return 0;
-
-    if (!is_target_port(sk))
+    if (!is_target_conn(sk))
         return 0;
 
     // Peek flag means data won't be consumed — skip
@@ -295,7 +312,7 @@ int BPF_PROG(trace_tcp_recvmsg_entry, struct sock *sk, struct msghdr *msg,
     if (!bi.buf)
         return 0;
 
-    u32 tid = (u32)pid_tgid;
+    u32 tid = (u32)bpf_get_current_pid_tgid();
     struct tcp_recv_args args = {
         .sk = (u64)sk,
         .user_buf = (u64)bi.buf,
@@ -311,83 +328,7 @@ SEC("fexit/tcp_recvmsg")
 int BPF_PROG(trace_tcp_recvmsg_exit, struct sock *sk, struct msghdr *msg,
              size_t size, int flags, int *addr_len, int ret)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = pid_tgid >> 32;
-    u32 tid = (u32)pid_tgid;
-
-    struct tcp_recv_args *args = bpf_map_lookup_elem(&tcp_recv_stash, &tid);
-    if (!args) 
-        return 0;
-
-    u64 stashed_sk = args->sk;
-    u64 stashed_buf = args->user_buf;
-    u64 stashed_len = args->buf_len;
-    u64 start_ns = args->start_ns;
-    bpf_map_delete_elem(&tcp_recv_stash, &tid);
-
-    if (ret <= 0)
-        return 0;
-
-    u32 ns_pid = is_pid_traced(pid);
-    if (!ns_pid)
-        return 0;
-
-    // Clamp ret to buffer capacity
-    u32 copy_len = (u32)ret;
-    if ((u64)ret > stashed_len)
-        copy_len = (u32)stashed_len;
-
-    return emit_tcp_event_buf(
-        (struct sock *)stashed_sk,
-        (void *)stashed_buf,
-        copy_len, 0, start_ns, ns_pid);
-}
-
-// --- Kernel 5.8–5.17 variants ---
-// tcp_recvmsg had an extra `int nonblock` parameter before 5.18 (commit ec095263a965).
-// Signature: int tcp_recvmsg(struct sock *sk, struct msghdr *msg, size_t len,
-//                            int nonblock, int flags, int *addr_len)
-// Userspace tries the new (5.18+) programs first; falls back to these on older kernels.
-
-SEC("fentry/tcp_recvmsg")
-int BPF_PROG(trace_tcp_recvmsg_entry_old, struct sock *sk, struct msghdr *msg,
-             size_t size, int nonblock, int flags)
-{
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = pid_tgid >> 32;
-
-    u32 ns_pid = is_pid_traced(pid);
-    if (!ns_pid)
-        return 0;
-
-    if (!is_target_port(sk))
-        return 0;
-
-    if (flags & MSG_PEEK)
-        return 0;
-
-    struct msg_buf_info bi = get_msg_buf_info(msg);
-    if (!bi.buf)
-        return 0;
-
-    u32 tid = (u32)pid_tgid;
-    struct tcp_recv_args args = {
-        .sk = (u64)sk,
-        .user_buf = (u64)bi.buf,
-        .buf_len = bi.len,
-        .start_ns = bpf_ktime_get_ns(),
-    };
-    bpf_map_update_elem(&tcp_recv_stash, &tid, &args, BPF_ANY);
-    return 0;
-}
-
-SEC("fexit/tcp_recvmsg")
-int BPF_PROG(trace_tcp_recvmsg_exit_old, struct sock *sk, struct msghdr *msg,
-             size_t size, int nonblock, int flags, int *addr_len, int ret)
-{
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = pid_tgid >> 32;
-    u32 tid = (u32)pid_tgid;
+    u32 tid = (u32)bpf_get_current_pid_tgid();
 
     struct tcp_recv_args *args = bpf_map_lookup_elem(&tcp_recv_stash, &tid);
     if (!args)
@@ -402,8 +343,65 @@ int BPF_PROG(trace_tcp_recvmsg_exit_old, struct sock *sk, struct msghdr *msg,
     if (ret <= 0)
         return 0;
 
-    u32 ns_pid = is_pid_traced(pid);
-    if (!ns_pid)
+    // Clamp ret to buffer capacity
+    u32 copy_len = (u32)ret;
+    if ((u64)ret > stashed_len)
+        copy_len = (u32)stashed_len;
+
+    return emit_tcp_event_buf(
+        (struct sock *)stashed_sk,
+        (void *)stashed_buf,
+        copy_len, 0, start_ns);
+}
+
+// --- Kernel 5.8–5.17 variants ---
+// tcp_recvmsg had an extra `int nonblock` parameter before 5.18 (commit ec095263a965).
+// Signature: int tcp_recvmsg(struct sock *sk, struct msghdr *msg, size_t len,
+//                            int nonblock, int flags, int *addr_len)
+// Userspace tries the new (5.18+) programs first; falls back to these on older kernels.
+
+SEC("fentry/tcp_recvmsg")
+int BPF_PROG(trace_tcp_recvmsg_entry_old, struct sock *sk, struct msghdr *msg,
+             size_t size, int nonblock, int flags)
+{
+    if (!is_target_conn(sk))
+        return 0;
+
+    if (flags & MSG_PEEK)
+        return 0;
+
+    struct msg_buf_info bi = get_msg_buf_info(msg);
+    if (!bi.buf)
+        return 0;
+
+    u32 tid = (u32)bpf_get_current_pid_tgid();
+    struct tcp_recv_args args = {
+        .sk = (u64)sk,
+        .user_buf = (u64)bi.buf,
+        .buf_len = bi.len,
+        .start_ns = bpf_ktime_get_ns(),
+    };
+    bpf_map_update_elem(&tcp_recv_stash, &tid, &args, BPF_ANY);
+    return 0;
+}
+
+SEC("fexit/tcp_recvmsg")
+int BPF_PROG(trace_tcp_recvmsg_exit_old, struct sock *sk, struct msghdr *msg,
+             size_t size, int nonblock, int flags, int *addr_len, int ret)
+{
+    u32 tid = (u32)bpf_get_current_pid_tgid();
+
+    struct tcp_recv_args *args = bpf_map_lookup_elem(&tcp_recv_stash, &tid);
+    if (!args)
+        return 0;
+
+    u64 stashed_sk = args->sk;
+    u64 stashed_buf = args->user_buf;
+    u64 stashed_len = args->buf_len;
+    u64 start_ns = args->start_ns;
+    bpf_map_delete_elem(&tcp_recv_stash, &tid);
+
+    if (ret <= 0)
         return 0;
 
     u32 copy_len = (u32)ret;
@@ -413,7 +411,7 @@ int BPF_PROG(trace_tcp_recvmsg_exit_old, struct sock *sk, struct msghdr *msg,
     return emit_tcp_event_buf(
         (struct sock *)stashed_sk,
         (void *)stashed_buf,
-        copy_len, 0, start_ns, ns_pid);
+        copy_len, 0, start_ns);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -141,6 +141,8 @@ struct JsonFullConfig {
     cmdline: Option<JsonCmdline>,
     #[serde(default)]
     domain: Option<Vec<JsonDomainGroup>>,
+    #[serde(default)]
+    tcp_ports: Option<Vec<u16>>,
 }
 
 #[derive(serde::Deserialize)]
@@ -282,6 +284,8 @@ pub struct AgentsightConfig {
     pub poll_timeout_ms: u64,
     /// Enable file watch probe (monitors .jsonl file opens from traced processes)
     pub enable_filewatch: bool,
+    /// TCP target ports for plain HTTP capture (empty = disabled)
+    pub tcp_target_ports: Vec<u16>,
 
     // --- HTTP/Aggregation Configuration ---
     /// LRU cache capacity for HTTP connections
@@ -336,6 +340,7 @@ impl Default for AgentsightConfig {
             target_uid: None,
             poll_timeout_ms: DEFAULT_POLL_TIMEOUT_MS,
             enable_filewatch: false,
+            tcp_target_ports: vec![8080],
 
             // HTTP/Aggregation defaults
             connection_capacity: DEFAULT_CONNECTION_CAPACITY,
@@ -418,6 +423,12 @@ impl AgentsightConfig {
         self
     }
 
+    /// Set TCP target ports for plain HTTP traffic capture
+    pub fn set_tcp_target_ports(mut self, ports: Vec<u16>) -> Self {
+        self.tcp_target_ports = ports;
+        self
+    }
+
     /// Set connection capacity
     pub fn set_connection_capacity(mut self, capacity: usize) -> Self {
         self.connection_capacity = capacity;
@@ -441,6 +452,9 @@ impl AgentsightConfig {
         }
         if let Some(p) = parsed.log_path.take() {
             self.log_path = Some(p);
+        }
+        if let Some(ports) = parsed.tcp_ports.take() {
+            self.tcp_target_ports = ports;
         }
 
         let (cmdline_rules, domain_rules) = extract_rules(parsed);

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -123,15 +123,6 @@ pub struct DomainRule {
     pub pattern: String,
 }
 
-/// User-Agent header matching rule for agent identification
-#[derive(Debug, Clone)]
-pub struct UserAgentRule {
-    /// Glob pattern matched against the User-Agent header value (case-insensitive)
-    pub pattern: String,
-    /// Agent name to assign when matched
-    pub agent_name: String,
-}
-
 // ==================== Agent Discovery Configuration ====================
 
 /// Default agents configuration JSON (embedded in binary).
@@ -203,8 +194,6 @@ struct JsonFullConfig {
     #[serde(default)]
     domain: Option<Vec<JsonDomainGroup>>,
     #[serde(default)]
-    user_agent: Option<Vec<JsonUserAgentEntry>>,
-    #[serde(default)]
     tcp_ports: Option<Vec<u16>>,
     #[serde(default)]
     tcp_targets: Option<Vec<String>>,
@@ -230,17 +219,10 @@ struct JsonDomainGroup {
     rule: Vec<String>,
 }
 
-#[derive(serde::Deserialize)]
-struct JsonUserAgentEntry {
-    pattern: String,
-    agent_name: String,
-}
-
-/// Extract cmdline, domain, and user-agent rules from a parsed JsonFullConfig.
-fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>, Vec<UserAgentRule>) {
+/// Extract cmdline and domain rules from a parsed JsonFullConfig.
+fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>) {
     let mut cmdline_rules = Vec::new();
     let mut domain_rules = Vec::new();
-    let mut user_agent_rules = Vec::new();
 
     if let Some(cmdline) = parsed.cmdline {
         if let Some(allow_list) = cmdline.allow {
@@ -277,24 +259,13 @@ fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>, 
         }
     }
 
-    if let Some(ua_entries) = parsed.user_agent {
-        for entry in ua_entries {
-            if !entry.pattern.is_empty() {
-                user_agent_rules.push(UserAgentRule {
-                    pattern: entry.pattern,
-                    agent_name: entry.agent_name,
-                });
-            }
-        }
-    }
-
-    (cmdline_rules, domain_rules, user_agent_rules)
+    (cmdline_rules, domain_rules)
 }
 
-/// Parse a JSON config string into cmdline rules, domain rules, and user-agent rules.
+/// Parse a JSON config string into cmdline rules and domain rules.
 ///
 /// This is the shared parser for both the config file and FFI's `load_config()`.
-pub fn parse_json_rules(json: &str) -> Result<(Vec<CmdlineRule>, Vec<DomainRule>, Vec<UserAgentRule>), String> {
+pub fn parse_json_rules(json: &str) -> Result<(Vec<CmdlineRule>, Vec<DomainRule>), String> {
     let parsed: JsonFullConfig = serde_json::from_str(json)
         .map_err(|e| format!("JSON parse error: {}", e))?;
     Ok(extract_rules(parsed))
@@ -321,14 +292,7 @@ pub fn ensure_default_agents_config(path: &Path) -> anyhow::Result<()> {
 
 /// Load default cmdline rules (embedded), without touching the filesystem.
 pub fn default_cmdline_rules() -> Vec<CmdlineRule> {
-    let (rules, _, _) = parse_json_rules(DEFAULT_AGENTS_JSON)
-        .expect("embedded DEFAULT_AGENTS_JSON is valid");
-    rules
-}
-
-/// Load default user-agent rules (embedded), without touching the filesystem.
-pub fn default_user_agent_rules() -> Vec<UserAgentRule> {
-    let (_, _, rules) = parse_json_rules(DEFAULT_AGENTS_JSON)
+    let (rules, _) = parse_json_rules(DEFAULT_AGENTS_JSON)
         .expect("embedded DEFAULT_AGENTS_JSON is valid");
     rules
 }
@@ -409,8 +373,6 @@ pub struct AgentsightConfig {
     pub cmdline_rules: Vec<CmdlineRule>,
     /// User-defined domain rules for DNS-based SSL attachment
     pub domain_rules: Vec<DomainRule>,
-    /// User-Agent header matching rules for agent identification
-    pub user_agent_rules: Vec<UserAgentRule>,
 
     // --- Config File Path ---
     /// Path to JSON configuration file
@@ -456,7 +418,6 @@ impl Default for AgentsightConfig {
             // FFI Rule defaults
             cmdline_rules: Vec::new(),
             domain_rules: Vec::new(),
-            user_agent_rules: Vec::new(),
 
             // Config file path default
             config_path: None,
@@ -564,10 +525,9 @@ impl AgentsightConfig {
                 .collect();
         }
 
-        let (cmdline_rules, domain_rules, user_agent_rules) = extract_rules(parsed);
+        let (cmdline_rules, domain_rules) = extract_rules(parsed);
         self.cmdline_rules.extend(cmdline_rules);
         self.domain_rules.extend(domain_rules);
-        self.user_agent_rules.extend(user_agent_rules);
         Ok(())
     }
 
@@ -865,10 +825,9 @@ mod tests {
     #[test]
     fn test_default_agents_json_valid() {
         // Verify the embedded JSON is valid and parses correctly
-        let (cmdline_rules, domain_rules, user_agent_rules) = parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
+        let (cmdline_rules, domain_rules) = parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
         assert!(!cmdline_rules.is_empty());
         assert!(domain_rules.is_empty()); // no domain rules in default config
-        assert!(!user_agent_rules.is_empty()); // has default user-agent rules
     }
 
     #[test]
@@ -879,7 +838,7 @@ mod tests {
                 "deny": [{"rule": ["node", "*webpack*"]}]
             }
         }"#;
-        let (cmdline_rules, domain_rules, _) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, domain_rules) = parse_json_rules(json).unwrap();
         assert_eq!(cmdline_rules.len(), 2);
         assert!(cmdline_rules[0].allow);
         assert_eq!(cmdline_rules[0].agent_name, Some("Claude Code".to_string()));
@@ -891,7 +850,7 @@ mod tests {
     #[test]
     fn test_parse_json_rules_domain() {
         let json = r#"{"domain": [{"rule": ["*.openai.com", "*.anthropic.com"]}]}"#;
-        let (cmdline_rules, domain_rules, _) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, domain_rules) = parse_json_rules(json).unwrap();
         assert!(cmdline_rules.is_empty());
         assert_eq!(domain_rules.len(), 2);
     }
@@ -905,7 +864,7 @@ mod tests {
     #[test]
     fn test_parse_json_rules_empty_rule_skipped() {
         let json = r#"{"cmdline":{"allow":[{"rule":[],"agent_name":"Skipped"},{"rule":["node"],"agent_name":"Kept"}]}}"#;
-        let (cmdline_rules, _, _) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, _) = parse_json_rules(json).unwrap();
         assert_eq!(cmdline_rules.len(), 1);
         assert_eq!(cmdline_rules[0].agent_name, Some("Kept".to_string()));
     }

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -1,4 +1,6 @@
+use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use anyhow::Context;
 
@@ -121,6 +123,15 @@ pub struct DomainRule {
     pub pattern: String,
 }
 
+/// User-Agent header matching rule for agent identification
+#[derive(Debug, Clone)]
+pub struct UserAgentRule {
+    /// Glob pattern matched against the User-Agent header value (case-insensitive)
+    pub pattern: String,
+    /// Agent name to assign when matched
+    pub agent_name: String,
+}
+
 // ==================== Agent Discovery Configuration ====================
 
 /// Default agents configuration JSON (embedded in binary).
@@ -128,6 +139,56 @@ pub struct DomainRule {
 /// Uses the same format as FFI's `agentsight_config_load_config()`:
 /// `cmdline.allow` entries with `rule` and `agent_name`.
 const DEFAULT_AGENTS_JSON: &str = include_str!("../agentsight.json");
+
+// ==================== TCP Target Configuration ====================
+
+/// A single TCP traffic capture target.
+///
+/// Filters captured plain-HTTP traffic by destination IP and/or port.
+/// `ip = None` means any destination IP; `port = None` means any port.
+///
+/// String format (used in JSON config and CLI):
+///   `":8080"`          → port-only (any IP, port 8080)
+///   `"10.0.0.1"`       → IP-only   (IP 10.0.0.1, any port)
+///   `"10.0.0.1:8080"`  → exact     (IP 10.0.0.1, port 8080)
+#[derive(Debug, Clone, PartialEq)]
+pub struct TcpTarget {
+    pub ip: Option<Ipv4Addr>,
+    pub port: Option<u16>,
+}
+
+impl FromStr for TcpTarget {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.starts_with(':') {
+            // ":port" — port-only
+            let port: u16 = s[1..]
+                .parse()
+                .map_err(|_| format!("invalid port in '{}'", s))?;
+            Ok(TcpTarget { ip: None, port: Some(port) })
+        } else if s.contains(':') {
+            // "ip:port"
+            let mut parts = s.rsplitn(2, ':');
+            let port_str = parts.next().unwrap();
+            let ip_str = parts.next().unwrap();
+            let ip: Ipv4Addr = ip_str
+                .parse()
+                .map_err(|_| format!("invalid IP in '{}'", s))?;
+            let port: u16 = port_str
+                .parse()
+                .map_err(|_| format!("invalid port in '{}'", s))?;
+            Ok(TcpTarget { ip: Some(ip), port: Some(port) })
+        } else {
+            // "ip" — IP-only
+            let ip: Ipv4Addr = s
+                .parse()
+                .map_err(|_| format!("invalid IP address '{}'", s))?;
+            Ok(TcpTarget { ip: Some(ip), port: None })
+        }
+    }
+}
 
 
 /// Internal JSON structures for parsing the config file (same format as FFI).
@@ -142,7 +203,11 @@ struct JsonFullConfig {
     #[serde(default)]
     domain: Option<Vec<JsonDomainGroup>>,
     #[serde(default)]
+    user_agent: Option<Vec<JsonUserAgentEntry>>,
+    #[serde(default)]
     tcp_ports: Option<Vec<u16>>,
+    #[serde(default)]
+    tcp_targets: Option<Vec<String>>,
 }
 
 #[derive(serde::Deserialize)]
@@ -165,10 +230,17 @@ struct JsonDomainGroup {
     rule: Vec<String>,
 }
 
-/// Extract cmdline and domain rules from a parsed JsonFullConfig.
-fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>) {
+#[derive(serde::Deserialize)]
+struct JsonUserAgentEntry {
+    pattern: String,
+    agent_name: String,
+}
+
+/// Extract cmdline, domain, and user-agent rules from a parsed JsonFullConfig.
+fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>, Vec<UserAgentRule>) {
     let mut cmdline_rules = Vec::new();
     let mut domain_rules = Vec::new();
+    let mut user_agent_rules = Vec::new();
 
     if let Some(cmdline) = parsed.cmdline {
         if let Some(allow_list) = cmdline.allow {
@@ -205,13 +277,24 @@ fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>) 
         }
     }
 
-    (cmdline_rules, domain_rules)
+    if let Some(ua_entries) = parsed.user_agent {
+        for entry in ua_entries {
+            if !entry.pattern.is_empty() {
+                user_agent_rules.push(UserAgentRule {
+                    pattern: entry.pattern,
+                    agent_name: entry.agent_name,
+                });
+            }
+        }
+    }
+
+    (cmdline_rules, domain_rules, user_agent_rules)
 }
 
-/// Parse a JSON config string into cmdline rules and domain rules.
+/// Parse a JSON config string into cmdline rules, domain rules, and user-agent rules.
 ///
 /// This is the shared parser for both the config file and FFI's `load_config()`.
-pub fn parse_json_rules(json: &str) -> Result<(Vec<CmdlineRule>, Vec<DomainRule>), String> {
+pub fn parse_json_rules(json: &str) -> Result<(Vec<CmdlineRule>, Vec<DomainRule>, Vec<UserAgentRule>), String> {
     let parsed: JsonFullConfig = serde_json::from_str(json)
         .map_err(|e| format!("JSON parse error: {}", e))?;
     Ok(extract_rules(parsed))
@@ -238,7 +321,14 @@ pub fn ensure_default_agents_config(path: &Path) -> anyhow::Result<()> {
 
 /// Load default cmdline rules (embedded), without touching the filesystem.
 pub fn default_cmdline_rules() -> Vec<CmdlineRule> {
-    let (rules, _) = parse_json_rules(DEFAULT_AGENTS_JSON)
+    let (rules, _, _) = parse_json_rules(DEFAULT_AGENTS_JSON)
+        .expect("embedded DEFAULT_AGENTS_JSON is valid");
+    rules
+}
+
+/// Load default user-agent rules (embedded), without touching the filesystem.
+pub fn default_user_agent_rules() -> Vec<UserAgentRule> {
+    let (_, _, rules) = parse_json_rules(DEFAULT_AGENTS_JSON)
         .expect("embedded DEFAULT_AGENTS_JSON is valid");
     rules
 }
@@ -284,8 +374,9 @@ pub struct AgentsightConfig {
     pub poll_timeout_ms: u64,
     /// Enable file watch probe (monitors .jsonl file opens from traced processes)
     pub enable_filewatch: bool,
-    /// TCP target ports for plain HTTP capture (empty = disabled)
-    pub tcp_target_ports: Vec<u16>,
+    /// TCP capture targets for plain HTTP capture (empty = disabled).
+    /// Each entry specifies destination IP, port, or both.
+    pub tcp_targets: Vec<TcpTarget>,
 
     // --- HTTP/Aggregation Configuration ---
     /// LRU cache capacity for HTTP connections
@@ -318,6 +409,8 @@ pub struct AgentsightConfig {
     pub cmdline_rules: Vec<CmdlineRule>,
     /// User-defined domain rules for DNS-based SSL attachment
     pub domain_rules: Vec<DomainRule>,
+    /// User-Agent header matching rules for agent identification
+    pub user_agent_rules: Vec<UserAgentRule>,
 
     // --- Config File Path ---
     /// Path to JSON configuration file
@@ -340,7 +433,7 @@ impl Default for AgentsightConfig {
             target_uid: None,
             poll_timeout_ms: DEFAULT_POLL_TIMEOUT_MS,
             enable_filewatch: false,
-            tcp_target_ports: vec![8080],
+            tcp_targets: Vec::new(),
 
             // HTTP/Aggregation defaults
             connection_capacity: DEFAULT_CONNECTION_CAPACITY,
@@ -363,6 +456,7 @@ impl Default for AgentsightConfig {
             // FFI Rule defaults
             cmdline_rules: Vec::new(),
             domain_rules: Vec::new(),
+            user_agent_rules: Vec::new(),
 
             // Config file path default
             config_path: None,
@@ -423,9 +517,9 @@ impl AgentsightConfig {
         self
     }
 
-    /// Set TCP target ports for plain HTTP traffic capture
-    pub fn set_tcp_target_ports(mut self, ports: Vec<u16>) -> Self {
-        self.tcp_target_ports = ports;
+    /// Set TCP capture targets for plain HTTP traffic capture
+    pub fn set_tcp_targets(mut self, targets: Vec<TcpTarget>) -> Self {
+        self.tcp_targets = targets;
         self
     }
 
@@ -453,13 +547,27 @@ impl AgentsightConfig {
         if let Some(p) = parsed.log_path.take() {
             self.log_path = Some(p);
         }
-        if let Some(ports) = parsed.tcp_ports.take() {
-            self.tcp_target_ports = ports;
+        if let Some(targets) = parsed.tcp_targets.take() {
+            let mut result = Vec::new();
+            for s in &targets {
+                match s.parse::<TcpTarget>() {
+                    Ok(t) => result.push(t),
+                    Err(e) => log::warn!("Ignoring invalid tcp_targets entry '{}': {}", s, e),
+                }
+            }
+            self.tcp_targets = result;
+        } else if let Some(ports) = parsed.tcp_ports.take() {
+            // backward compat: "tcp_ports": [8080] → port-only targets
+            self.tcp_targets = ports
+                .into_iter()
+                .map(|p| TcpTarget { ip: None, port: Some(p) })
+                .collect();
         }
 
-        let (cmdline_rules, domain_rules) = extract_rules(parsed);
+        let (cmdline_rules, domain_rules, user_agent_rules) = extract_rules(parsed);
         self.cmdline_rules.extend(cmdline_rules);
         self.domain_rules.extend(domain_rules);
+        self.user_agent_rules.extend(user_agent_rules);
         Ok(())
     }
 
@@ -757,9 +865,10 @@ mod tests {
     #[test]
     fn test_default_agents_json_valid() {
         // Verify the embedded JSON is valid and parses correctly
-        let (cmdline_rules, domain_rules) = parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
+        let (cmdline_rules, domain_rules, user_agent_rules) = parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
         assert!(!cmdline_rules.is_empty());
         assert!(domain_rules.is_empty()); // no domain rules in default config
+        assert!(!user_agent_rules.is_empty()); // has default user-agent rules
     }
 
     #[test]
@@ -770,7 +879,7 @@ mod tests {
                 "deny": [{"rule": ["node", "*webpack*"]}]
             }
         }"#;
-        let (cmdline_rules, domain_rules) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, domain_rules, _) = parse_json_rules(json).unwrap();
         assert_eq!(cmdline_rules.len(), 2);
         assert!(cmdline_rules[0].allow);
         assert_eq!(cmdline_rules[0].agent_name, Some("Claude Code".to_string()));
@@ -782,7 +891,7 @@ mod tests {
     #[test]
     fn test_parse_json_rules_domain() {
         let json = r#"{"domain": [{"rule": ["*.openai.com", "*.anthropic.com"]}]}"#;
-        let (cmdline_rules, domain_rules) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, domain_rules, _) = parse_json_rules(json).unwrap();
         assert!(cmdline_rules.is_empty());
         assert_eq!(domain_rules.len(), 2);
     }
@@ -796,7 +905,7 @@ mod tests {
     #[test]
     fn test_parse_json_rules_empty_rule_skipped() {
         let json = r#"{"cmdline":{"allow":[{"rule":[],"agent_name":"Skipped"},{"rule":["node"],"agent_name":"Kept"}]}}"#;
-        let (cmdline_rules, _) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, _, _) = parse_json_rules(json).unwrap();
         assert_eq!(cmdline_rules.len(), 1);
         assert_eq!(cmdline_rules[0].agent_name, Some("Kept".to_string()));
     }

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -63,24 +63,6 @@ pub fn match_domain_glob(domain: &str, patterns: &[String]) -> bool {
     false
 }
 
-/// Match a User-Agent header value against configured rules.
-/// Returns the agent_name of the first matching rule, or None.
-pub fn match_user_agent(user_agent: &str, rules: &[crate::config::UserAgentRule]) -> Option<String> {
-    let ua_lower = user_agent.to_lowercase();
-    for rule in rules {
-        let pat_lower = rule.pattern.to_lowercase();
-        match Pattern::new(&pat_lower) {
-            Ok(p) => {
-                if p.matches(&ua_lower) {
-                    return Some(rule.agent_name.clone());
-                }
-            }
-            Err(_) => continue,
-        }
-    }
-    None
-}
-
 /// Matcher based on cmdline glob patterns (config-driven).
 pub struct CmdlineGlobMatcher {
     info: AgentInfo,
@@ -281,28 +263,5 @@ mod tests {
             allow: true,
         };
         assert!(CmdlineGlobMatcher::from_deny_rule(&rule).is_none());
-    }
-
-    #[test]
-    fn test_match_user_agent() {
-        let rules = vec![
-            crate::config::UserAgentRule {
-                pattern: "*anthropic*".to_string(),
-                agent_name: "Anthropic SDK".to_string(),
-            },
-            crate::config::UserAgentRule {
-                pattern: "*openai*".to_string(),
-                agent_name: "OpenAI SDK".to_string(),
-            },
-        ];
-        assert_eq!(
-            match_user_agent("anthropic-python/0.30.0", &rules),
-            Some("Anthropic SDK".to_string())
-        );
-        assert_eq!(
-            match_user_agent("OpenAI/Node 4.52.0", &rules),
-            Some("OpenAI SDK".to_string())
-        );
-        assert_eq!(match_user_agent("curl/7.81.0", &rules), None);
     }
 }

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -63,6 +63,24 @@ pub fn match_domain_glob(domain: &str, patterns: &[String]) -> bool {
     false
 }
 
+/// Match a User-Agent header value against configured rules.
+/// Returns the agent_name of the first matching rule, or None.
+pub fn match_user_agent(user_agent: &str, rules: &[crate::config::UserAgentRule]) -> Option<String> {
+    let ua_lower = user_agent.to_lowercase();
+    for rule in rules {
+        let pat_lower = rule.pattern.to_lowercase();
+        match Pattern::new(&pat_lower) {
+            Ok(p) => {
+                if p.matches(&ua_lower) {
+                    return Some(rule.agent_name.clone());
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
 /// Matcher based on cmdline glob patterns (config-driven).
 pub struct CmdlineGlobMatcher {
     info: AgentInfo,
@@ -263,5 +281,28 @@ mod tests {
             allow: true,
         };
         assert!(CmdlineGlobMatcher::from_deny_rule(&rule).is_none());
+    }
+
+    #[test]
+    fn test_match_user_agent() {
+        let rules = vec![
+            crate::config::UserAgentRule {
+                pattern: "*anthropic*".to_string(),
+                agent_name: "Anthropic SDK".to_string(),
+            },
+            crate::config::UserAgentRule {
+                pattern: "*openai*".to_string(),
+                agent_name: "OpenAI SDK".to_string(),
+            },
+        ];
+        assert_eq!(
+            match_user_agent("anthropic-python/0.30.0", &rules),
+            Some("Anthropic SDK".to_string())
+        );
+        assert_eq!(
+            match_user_agent("OpenAI/Node 4.52.0", &rules),
+            Some("OpenAI SDK".to_string())
+        );
+        assert_eq!(match_user_agent("curl/7.81.0", &rules), None);
     }
 }

--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -9,8 +9,8 @@ use crate::analyzer::{
 use crate::analyzer::message::types::OpenAIChatMessage;
 use crate::aggregator::{ConnectionId, ParsedRequest};
 use crate::analyzer::token::TokenParser;
-use crate::discovery::matcher::{ProcessContext, CmdlineGlobMatcher, match_user_agent};
-use crate::config::{default_cmdline_rules, UserAgentRule};
+use crate::discovery::matcher::{ProcessContext, CmdlineGlobMatcher};
+use crate::config::default_cmdline_rules;
 use crate::parser::sse::ParsedSseEvent;
 use crate::response_map::ResponseSessionMapper;
 use crate::storage::sqlite::{PendingCallInfo, SseEnrichment};
@@ -39,8 +39,6 @@ pub struct GenAIBuilder {
     session_prefix: String,
     /// Counter for generating unique IDs within a session
     call_counter: AtomicU64,
-    /// User-Agent header matching rules for agent identification fallback
-    user_agent_rules: Vec<UserAgentRule>,
 }
 
 impl Default for GenAIBuilder {
@@ -60,14 +58,7 @@ impl GenAIBuilder {
         GenAIBuilder {
             session_prefix: format!("{:x}_{:x}", ts, pid),
             call_counter: AtomicU64::new(0),
-            user_agent_rules: Vec::new(),
         }
-    }
-
-    /// Set user-agent rules for HTTP-header-based agent detection
-    pub fn with_user_agent_rules(mut self, rules: Vec<UserAgentRule>) -> Self {
-        self.user_agent_rules = rules;
-        self
     }
 
     /// Build GenAI semantic events AND a `PendingCallInfo` to be written to DB
@@ -86,7 +77,7 @@ impl GenAIBuilder {
         &self,
         results: &[AnalysisResult],
         response_mapper: &ResponseSessionMapper,
-        pid_agent_name_cache: &mut std::collections::HashMap<u32, String>,
+        pid_agent_name_cache: &std::collections::HashMap<u32, String>,
     ) -> (BuildOutput, Option<PendingCallInfo>) {
         let mut events = Vec::new();
         let mut pending: Option<PendingCallInfo> = None;
@@ -291,12 +282,9 @@ impl GenAIBuilder {
         // Extract provider from request path
         let provider = self.extract_provider_from_path(&request.path);
 
-        // Resolve agent_name: check pid→name cache first (works for dead PIDs), then comm-based fallback, then User-Agent
+        // Resolve agent_name: check pid→name cache first, then comm-based matching, then comm as fallback
         let agent_name = Self::resolve_agent_name_from_comm(&request.source_event.comm, conn_id.pid as u32, pid_agent_name_cache)
-            .or_else(|| {
-                request.headers.get("user-agent")
-                    .and_then(|ua| match_user_agent(ua, &self.user_agent_rules))
-            });
+            .or_else(|| Some(request.source_event.comm_str()));
 
         Some(PendingCallInfo {
             call_id,
@@ -415,7 +403,7 @@ impl GenAIBuilder {
     /// Build LLMCall from analysis results
     ///
     /// Combines data from TokenRecord, HttpRecord, and ParsedApiMessage
-    fn build_llm_call(&self, results: &[AnalysisResult], response_mapper: &ResponseSessionMapper, pid_agent_name_cache: &mut std::collections::HashMap<u32, String>) -> Option<LLMCall> {
+    fn build_llm_call(&self, results: &[AnalysisResult], response_mapper: &ResponseSessionMapper, pid_agent_name_cache: &std::collections::HashMap<u32, String>) -> Option<LLMCall> {
         // Extract components from analysis results
         let token_record = results.iter().find_map(|r| match r {
             AnalysisResult::Token(t) => Some(t.clone()),
@@ -561,18 +549,8 @@ impl GenAIBuilder {
             error,
             pid: http.pid as i32,
             process_name: http.comm.clone(),
-            agent_name: {
-                let name = Self::resolve_agent_name(
-                    &http.comm, http.pid, pid_agent_name_cache,
-                    Some(&http.request_headers), &self.user_agent_rules,
-                );
-                if let Some(ref n) = name {
-                    if http.pid > 0 {
-                        pid_agent_name_cache.entry(http.pid).or_insert_with(|| n.clone());
-                    }
-                }
-                name
-            },
+            agent_name: Self::resolve_agent_name(&http.comm, http.pid, pid_agent_name_cache)
+                .or_else(|| Some(http.comm.clone())),
             metadata: {
                 let mut meta = HashMap::new();
                 meta.insert("method".to_string(), http.method);
@@ -1262,13 +1240,7 @@ impl GenAIBuilder {
     }
 
     /// 通过进程名匹配 agent registry，返回已知 agent 名称
-    fn resolve_agent_name(
-        comm: &str,
-        pid: u32,
-        cache: &std::collections::HashMap<u32, String>,
-        request_headers: Option<&str>,
-        user_agent_rules: &[UserAgentRule],
-    ) -> Option<String> {
+    fn resolve_agent_name(comm: &str, pid: u32, cache: &std::collections::HashMap<u32, String>) -> Option<String> {
         // First check the pid→agent_name cache (works even for dead processes)
         if let Some(name) = cache.get(&pid) {
             return Some(name.clone());
@@ -1294,27 +1266,11 @@ impl GenAIBuilder {
             cmdline_args,
             exe_path,
         };
-        if let Some(name) = default_cmdline_rules()
+        default_cmdline_rules()
             .iter()
             .filter_map(|rule| CmdlineGlobMatcher::from_config(rule))
             .find(|m| m.matches(&ctx))
             .map(|m| m.info().name.clone())
-        {
-            return Some(name);
-        }
-
-        // Fallback: match User-Agent header
-        if let Some(headers_json) = request_headers {
-            if let Ok(headers) = serde_json::from_str::<HashMap<String, String>>(headers_json) {
-                if let Some(ua) = headers.get("user-agent") {
-                    if let Some(name) = match_user_agent(ua, user_agent_rules) {
-                        return Some(name);
-                    }
-                }
-            }
-        }
-
-        None
     }
 
     /// Convert OpenAI ChatMessage to parts-based InputMessage

--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -9,8 +9,8 @@ use crate::analyzer::{
 use crate::analyzer::message::types::OpenAIChatMessage;
 use crate::aggregator::{ConnectionId, ParsedRequest};
 use crate::analyzer::token::TokenParser;
-use crate::discovery::matcher::{ProcessContext, CmdlineGlobMatcher};
-use crate::config::default_cmdline_rules;
+use crate::discovery::matcher::{ProcessContext, CmdlineGlobMatcher, match_user_agent};
+use crate::config::{default_cmdline_rules, UserAgentRule};
 use crate::parser::sse::ParsedSseEvent;
 use crate::response_map::ResponseSessionMapper;
 use crate::storage::sqlite::{PendingCallInfo, SseEnrichment};
@@ -39,6 +39,8 @@ pub struct GenAIBuilder {
     session_prefix: String,
     /// Counter for generating unique IDs within a session
     call_counter: AtomicU64,
+    /// User-Agent header matching rules for agent identification fallback
+    user_agent_rules: Vec<UserAgentRule>,
 }
 
 impl Default for GenAIBuilder {
@@ -58,7 +60,14 @@ impl GenAIBuilder {
         GenAIBuilder {
             session_prefix: format!("{:x}_{:x}", ts, pid),
             call_counter: AtomicU64::new(0),
+            user_agent_rules: Vec::new(),
         }
+    }
+
+    /// Set user-agent rules for HTTP-header-based agent detection
+    pub fn with_user_agent_rules(mut self, rules: Vec<UserAgentRule>) -> Self {
+        self.user_agent_rules = rules;
+        self
     }
 
     /// Build GenAI semantic events AND a `PendingCallInfo` to be written to DB
@@ -77,7 +86,7 @@ impl GenAIBuilder {
         &self,
         results: &[AnalysisResult],
         response_mapper: &ResponseSessionMapper,
-        pid_agent_name_cache: &std::collections::HashMap<u32, String>,
+        pid_agent_name_cache: &mut std::collections::HashMap<u32, String>,
     ) -> (BuildOutput, Option<PendingCallInfo>) {
         let mut events = Vec::new();
         let mut pending: Option<PendingCallInfo> = None;
@@ -282,8 +291,12 @@ impl GenAIBuilder {
         // Extract provider from request path
         let provider = self.extract_provider_from_path(&request.path);
 
-        // Resolve agent_name: check pid→name cache first (works for dead PIDs), then comm-based fallback
-        let agent_name = Self::resolve_agent_name_from_comm(&request.source_event.comm, conn_id.pid as u32, pid_agent_name_cache);
+        // Resolve agent_name: check pid→name cache first (works for dead PIDs), then comm-based fallback, then User-Agent
+        let agent_name = Self::resolve_agent_name_from_comm(&request.source_event.comm, conn_id.pid as u32, pid_agent_name_cache)
+            .or_else(|| {
+                request.headers.get("user-agent")
+                    .and_then(|ua| match_user_agent(ua, &self.user_agent_rules))
+            });
 
         Some(PendingCallInfo {
             call_id,
@@ -402,7 +415,7 @@ impl GenAIBuilder {
     /// Build LLMCall from analysis results
     ///
     /// Combines data from TokenRecord, HttpRecord, and ParsedApiMessage
-    fn build_llm_call(&self, results: &[AnalysisResult], response_mapper: &ResponseSessionMapper, pid_agent_name_cache: &std::collections::HashMap<u32, String>) -> Option<LLMCall> {
+    fn build_llm_call(&self, results: &[AnalysisResult], response_mapper: &ResponseSessionMapper, pid_agent_name_cache: &mut std::collections::HashMap<u32, String>) -> Option<LLMCall> {
         // Extract components from analysis results
         let token_record = results.iter().find_map(|r| match r {
             AnalysisResult::Token(t) => Some(t.clone()),
@@ -548,7 +561,18 @@ impl GenAIBuilder {
             error,
             pid: http.pid as i32,
             process_name: http.comm.clone(),
-            agent_name: Self::resolve_agent_name(&http.comm, http.pid, pid_agent_name_cache),
+            agent_name: {
+                let name = Self::resolve_agent_name(
+                    &http.comm, http.pid, pid_agent_name_cache,
+                    Some(&http.request_headers), &self.user_agent_rules,
+                );
+                if let Some(ref n) = name {
+                    if http.pid > 0 {
+                        pid_agent_name_cache.entry(http.pid).or_insert_with(|| n.clone());
+                    }
+                }
+                name
+            },
             metadata: {
                 let mut meta = HashMap::new();
                 meta.insert("method".to_string(), http.method);
@@ -1238,7 +1262,13 @@ impl GenAIBuilder {
     }
 
     /// 通过进程名匹配 agent registry，返回已知 agent 名称
-    fn resolve_agent_name(comm: &str, pid: u32, cache: &std::collections::HashMap<u32, String>) -> Option<String> {
+    fn resolve_agent_name(
+        comm: &str,
+        pid: u32,
+        cache: &std::collections::HashMap<u32, String>,
+        request_headers: Option<&str>,
+        user_agent_rules: &[UserAgentRule],
+    ) -> Option<String> {
         // First check the pid→agent_name cache (works even for dead processes)
         if let Some(name) = cache.get(&pid) {
             return Some(name.clone());
@@ -1264,11 +1294,27 @@ impl GenAIBuilder {
             cmdline_args,
             exe_path,
         };
-        default_cmdline_rules()
+        if let Some(name) = default_cmdline_rules()
             .iter()
             .filter_map(|rule| CmdlineGlobMatcher::from_config(rule))
             .find(|m| m.matches(&ctx))
             .map(|m| m.info().name.clone())
+        {
+            return Some(name);
+        }
+
+        // Fallback: match User-Agent header
+        if let Some(headers_json) = request_headers {
+            if let Ok(headers) = serde_json::from_str::<HashMap<String, String>>(headers_json) {
+                if let Some(ua) = headers.get("user-agent") {
+                    if let Some(name) = match_user_agent(ua, user_agent_rules) {
+                        return Some(name);
+                    }
+                }
+            }
+        }
+
+        None
     }
 
     /// Convert OpenAI ChatMessage to parts-based InputMessage

--- a/src/agentsight/src/probes/mod.rs
+++ b/src/agentsight/src/probes/mod.rs
@@ -6,6 +6,7 @@ pub mod procmon;
 pub mod filewatch;
 pub mod filewrite;
 pub mod udpdns;
+pub mod tcpsniff;
 pub mod probes;
 
 // Re-export commonly used types
@@ -16,3 +17,4 @@ pub use procmon::{ProcMon, ProcMonEvent, Event as ProcMonEventExt};
 pub use filewatch::{FileWatch, FileWatchEvent};
 pub use filewrite::{FileWrite as FileWriteProbe, FileWriteEvent};
 pub use udpdns::{UdpDns, UdpDnsEvent};
+pub use tcpsniff::TcpSniff;

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -22,6 +22,7 @@ use super::procmon::{ProcMon, ProcMonEvent};
 use super::filewatch::{FileWatch, RawFileWatchEvent};
 use super::filewrite::{FileWrite as FileWriteProbe, RawFileWriteEvent};
 use super::udpdns::{UdpDns, RawUdpDnsEvent};
+use super::tcpsniff::TcpSniff;
 
 const POLL_TIMEOUT_MS: u64 = 100;
 
@@ -53,6 +54,8 @@ pub struct Probes {
     filewrite: FileWriteProbe,
     /// UDP DNS probe (reuses ring buffer, captures domains from DNS queries, optional)
     udpdns: Option<UdpDns>,
+    /// TCP sniff probe (captures plain HTTP traffic on configured ports, optional)
+    tcpsniff: Option<TcpSniff>,
     /// Shared ring buffer handle (cloned from proctrace) for polling
     rb_handle: MapHandle,
     /// Unified event channel - events are converted to Event type inside the poller
@@ -66,7 +69,7 @@ impl Probes {
     /// # Arguments
     /// * `target_pids` - Initial PIDs to trace (empty means trace all matching UID)
     /// * `target_uid` - Optional UID filter
-    pub fn new(target_pids: &[u32], target_uid: Option<u32>, enable_filewatch: bool, enable_udpdns: bool) -> Result<Self> {
+    pub fn new(target_pids: &[u32], target_uid: Option<u32>, enable_filewatch: bool, enable_udpdns: bool, tcp_target_ports: &[u16]) -> Result<Self> {
         // Create proctrace first - it will own the traced_processes map and ring buffer
         let proctrace = ProcTrace::new_with_target(target_pids, target_uid)
             .context("failed to create proctrace")?;
@@ -110,6 +113,18 @@ impl Probes {
             None
         };
 
+        // Optionally create tcpsniff - captures plain HTTP traffic on configured ports
+        let tcpsniff = if !tcp_target_ports.is_empty() {
+            let mut tcp = TcpSniff::new_with_maps(&map_handle, &rb_handle)
+                .context("failed to create tcpsniff")?;
+            tcp.set_target_ports(tcp_target_ports)
+                .context("failed to set tcp target ports")?;
+            Some(tcp)
+        } else {
+            log::info!("TcpSniff probe disabled (no tcp_target_ports configured)");
+            None
+        };
+
         let (event_tx, event_rx) = crossbeam_channel::unbounded();
         
         Ok(Self {
@@ -119,6 +134,7 @@ impl Probes {
             filewatch,
             filewrite,
             udpdns,
+            tcpsniff,
             rb_handle,
             event_tx,
             event_rx,
@@ -143,6 +159,11 @@ impl Probes {
         if let Some(ref mut dns) = self.udpdns {
             dns.attach()
                 .context("failed to attach udpdns")?;
+        }
+        // Attach tcpsniff for plain HTTP traffic capture (if enabled)
+        if let Some(ref mut tcp) = self.tcpsniff {
+            tcp.attach()
+                .context("failed to attach tcpsniff")?;
         }
         // sslsniff uses uprobes attached per-process via attach_process()
         Ok(())

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -22,6 +22,7 @@ use super::procmon::{ProcMon, ProcMonEvent};
 use super::filewatch::{FileWatch, RawFileWatchEvent};
 use super::filewrite::{FileWrite as FileWriteProbe, RawFileWriteEvent};
 use super::udpdns::{UdpDns, RawUdpDnsEvent};
+use crate::config::TcpTarget;
 use super::tcpsniff::TcpSniff;
 
 const POLL_TIMEOUT_MS: u64 = 100;
@@ -69,7 +70,7 @@ impl Probes {
     /// # Arguments
     /// * `target_pids` - Initial PIDs to trace (empty means trace all matching UID)
     /// * `target_uid` - Optional UID filter
-    pub fn new(target_pids: &[u32], target_uid: Option<u32>, enable_filewatch: bool, enable_udpdns: bool, tcp_target_ports: &[u16]) -> Result<Self> {
+    pub fn new(target_pids: &[u32], target_uid: Option<u32>, enable_filewatch: bool, enable_udpdns: bool, tcp_targets: &[TcpTarget]) -> Result<Self> {
         // Create proctrace first - it will own the traced_processes map and ring buffer
         let proctrace = ProcTrace::new_with_target(target_pids, target_uid)
             .context("failed to create proctrace")?;
@@ -113,15 +114,15 @@ impl Probes {
             None
         };
 
-        // Optionally create tcpsniff - captures plain HTTP traffic on configured ports
-        let tcpsniff = if !tcp_target_ports.is_empty() {
-            let mut tcp = TcpSniff::new_with_maps(&map_handle, &rb_handle)
+        // Optionally create tcpsniff - captures plain HTTP traffic to configured IP/port targets
+        let tcpsniff = if !tcp_targets.is_empty() {
+            let mut tcp = TcpSniff::new_with_maps(&rb_handle)
                 .context("failed to create tcpsniff")?;
-            tcp.set_target_ports(tcp_target_ports)
-                .context("failed to set tcp target ports")?;
+            tcp.set_targets(tcp_targets)
+                .context("failed to set tcp targets")?;
             Some(tcp)
         } else {
-            log::info!("TcpSniff probe disabled (no tcp_target_ports configured)");
+            log::info!("TcpSniff probe disabled (no tcp_targets configured)");
             None
         };
 

--- a/src/agentsight/src/probes/tcpsniff.rs
+++ b/src/agentsight/src/probes/tcpsniff.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// TCP plain-text traffic probe - captures HTTP traffic on configurable ports
+// by hooking tcp_sendmsg (fentry) and tcp_recvmsg (fentry+fexit).
+//
+// Emits probe_SSL_data_t events (same format as sslsniff) so the entire
+// downstream pipeline (parser, aggregator, analyzer, storage) works unchanged.
+//
+// Multi-kernel support:
+//   - Kernel 5.18+: tcp_recvmsg(sk, msg, size, flags, addr_len)
+//   - Kernel 5.8–5.17: tcp_recvmsg(sk, msg, size, nonblock, flags, addr_len)
+//   Userspace tries the new signature first and falls back to old on attach failure.
+
+use crate::config;
+use anyhow::{Context, Result};
+use libbpf_rs::{
+    Link, MapHandle, MapFlags,
+    skel::{OpenSkel, SkelBuilder},
+};
+use std::{
+    mem::MaybeUninit,
+    os::fd::AsFd,
+};
+
+// --- Generated skeleton ---
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/tcpsniff.skel.rs"));
+}
+use bpf::*;
+
+/// TCP plain-text traffic probe
+pub struct TcpSniff {
+    _open_object: Box<MaybeUninit<libbpf_rs::OpenObject>>,
+    skel: Box<TcpsniffSkel<'static>>,
+    _links: Vec<Link>,
+    use_old_sig: bool,
+}
+
+impl TcpSniff {
+    /// Build and load the BPF skeleton, selecting the correct tcp_recvmsg
+    /// program variant for the running kernel.
+    ///
+    /// `use_old_sig`: true → load old (5.8-5.17) programs, false → new (5.18+)
+    fn load_skel(
+        traced_processes: &MapHandle,
+        rb: &MapHandle,
+        use_old_sig: bool,
+    ) -> Result<(
+        Box<MaybeUninit<libbpf_rs::OpenObject>>,
+        Box<TcpsniffSkel<'static>>,
+    )> {
+        let mut builder = TcpsniffSkelBuilder::default();
+        builder.obj_builder.debug(config::verbose());
+
+        let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
+        let mut open_skel = builder.open().context("failed to open tcpsniff BPF object")?;
+
+        // Reuse external maps
+        open_skel
+            .maps_mut()
+            .traced_processes()
+            .reuse_fd(traced_processes.as_fd())
+            .context("failed to reuse traced_processes map for tcpsniff")?;
+        open_skel
+            .maps_mut()
+            .rb()
+            .reuse_fd(rb.as_fd())
+            .context("failed to reuse rb map for tcpsniff")?;
+
+        // Selectively enable programs:
+        // tcp_sendmsg fentry: always enabled (signature unchanged across kernels)
+        // tcp_recvmsg fentry + fexit: enable either new or old variant
+        if use_old_sig {
+            // Disable new-signature programs
+            open_skel
+                .progs_mut()
+                .trace_tcp_recvmsg_entry()
+                .set_autoload(false)
+                .context("failed to disable new recvmsg fentry")?;
+            open_skel
+                .progs_mut()
+                .trace_tcp_recvmsg_exit()
+                .set_autoload(false)
+                .context("failed to disable new recvmsg fexit")?;
+        } else {
+            // Disable old-signature programs
+            open_skel
+                .progs_mut()
+                .trace_tcp_recvmsg_entry_old()
+                .set_autoload(false)
+                .context("failed to disable old recvmsg fentry")?;
+            open_skel
+                .progs_mut()
+                .trace_tcp_recvmsg_exit_old()
+                .set_autoload(false)
+                .context("failed to disable old recvmsg fexit")?;
+        }
+
+        let skel = open_skel.load().context("failed to load tcpsniff BPF object")?;
+
+        // SAFETY: skel borrows open_object which lives in a Box<MaybeUninit>
+        let skel =
+            unsafe { Box::from_raw(Box::into_raw(Box::new(skel)) as *mut TcpsniffSkel<'static>) };
+
+        Ok((open_object, skel))
+    }
+
+    /// Create a new TcpSniff that reuses existing traced_processes and ring buffer maps.
+    /// Automatically detects the tcp_recvmsg signature for the running kernel.
+    pub fn new_with_maps(traced_processes: &MapHandle, rb: &MapHandle) -> Result<Self> {
+        // Try new signature first (5.18+), fall back to old (5.8-5.17) on load failure
+        let (open_object, skel, use_old_sig) = match Self::load_skel(traced_processes, rb, false) {
+            Ok((obj, skel)) => {
+                log::info!("TcpSniff: loaded with new tcp_recvmsg signature (5.18+)");
+                (obj, skel, false)
+            }
+            Err(e) => {
+                log::info!(
+                    "TcpSniff: new tcp_recvmsg signature failed ({}), trying old (5.8-5.17)",
+                    e
+                );
+                let (obj, skel) = Self::load_skel(traced_processes, rb, true)
+                    .context("failed to load tcpsniff with old tcp_recvmsg signature")?;
+                log::info!("TcpSniff: loaded with old tcp_recvmsg signature (5.8-5.17)");
+                (obj, skel, true)
+            }
+        };
+
+        Ok(Self {
+            _open_object: open_object,
+            skel,
+            _links: Vec::new(),
+            use_old_sig,
+        })
+    }
+
+    /// Populate the BPF tcp_target_ports map with the given ports.
+    /// Must be called after new_with_maps() and before attach().
+    pub fn set_target_ports(&mut self, ports: &[u16]) -> Result<()> {
+        let binding = self.skel.maps();
+        let map = binding.tcp_target_ports();
+        let dummy: u8 = 1;
+        for &port in ports {
+            let net_port = port.to_be(); // convert to network byte order
+            map.update(
+                &net_port.to_ne_bytes(),
+                &[dummy],
+                MapFlags::ANY,
+            )
+            .with_context(|| format!("failed to add port {} to tcp_target_ports map", port))?;
+        }
+        log::info!("TcpSniff: configured {} target port(s): {:?}", ports.len(), ports);
+        Ok(())
+    }
+
+    /// Attach fentry/fexit hooks for tcp_sendmsg and tcp_recvmsg.
+    /// Attaches whichever tcp_recvmsg variant was loaded.
+    pub fn attach(&mut self) -> Result<()> {
+        let mut links = Vec::new();
+
+        // tcp_sendmsg fentry — always present
+        let link = self
+            .skel
+            .progs_mut()
+            .trace_tcp_sendmsg()
+            .attach()
+            .context("failed to attach tcp_sendmsg fentry")?;
+        links.push(link);
+
+        // tcp_recvmsg — attach the variant that was loaded
+        if self.use_old_sig {
+            let entry_link = self
+                .skel
+                .progs_mut()
+                .trace_tcp_recvmsg_entry_old()
+                .attach()
+                .context("failed to attach tcp_recvmsg fentry (old signature)")?;
+            links.push(entry_link);
+
+            let exit_link = self
+                .skel
+                .progs_mut()
+                .trace_tcp_recvmsg_exit_old()
+                .attach()
+                .context("failed to attach tcp_recvmsg fexit (old signature)")?;
+            links.push(exit_link);
+        } else {
+            let entry_link = self
+                .skel
+                .progs_mut()
+                .trace_tcp_recvmsg_entry()
+                .attach()
+                .context("failed to attach tcp_recvmsg fentry")?;
+            links.push(entry_link);
+
+            let exit_link = self
+                .skel
+                .progs_mut()
+                .trace_tcp_recvmsg_exit()
+                .attach()
+                .context("failed to attach tcp_recvmsg fexit")?;
+            links.push(exit_link);
+        }
+
+        let n = links.len();
+        self._links = links;
+        log::info!(
+            "TcpSniff: attached {} BPF programs (tcp_sendmsg fentry, tcp_recvmsg fentry+fexit)",
+            n
+        );
+        Ok(())
+    }
+}

--- a/src/agentsight/src/probes/tcpsniff.rs
+++ b/src/agentsight/src/probes/tcpsniff.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 // Copyright (c) 2025 AgentSight Project
 //
-// TCP plain-text traffic probe - captures HTTP traffic on configurable ports
+// TCP plain-text traffic probe - captures HTTP traffic to configured IP/port targets
 // by hooking tcp_sendmsg (fentry) and tcp_recvmsg (fentry+fexit).
 //
+// Filters by destination IP/port only (no process-level filtering).
 // Emits probe_SSL_data_t events (same format as sslsniff) so the entire
 // downstream pipeline (parser, aggregator, analyzer, storage) works unchanged.
 //
@@ -12,7 +13,7 @@
 //   - Kernel 5.8–5.17: tcp_recvmsg(sk, msg, size, nonblock, flags, addr_len)
 //   Userspace tries the new signature first and falls back to old on attach failure.
 
-use crate::config;
+use crate::config::{self, TcpTarget};
 use anyhow::{Context, Result};
 use libbpf_rs::{
     Link, MapHandle, MapFlags,
@@ -20,6 +21,7 @@ use libbpf_rs::{
 };
 use std::{
     mem::MaybeUninit,
+    net::Ipv4Addr,
     os::fd::AsFd,
 };
 
@@ -43,7 +45,6 @@ impl TcpSniff {
     ///
     /// `use_old_sig`: true → load old (5.8-5.17) programs, false → new (5.18+)
     fn load_skel(
-        traced_processes: &MapHandle,
         rb: &MapHandle,
         use_old_sig: bool,
     ) -> Result<(
@@ -56,12 +57,7 @@ impl TcpSniff {
         let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
         let mut open_skel = builder.open().context("failed to open tcpsniff BPF object")?;
 
-        // Reuse external maps
-        open_skel
-            .maps_mut()
-            .traced_processes()
-            .reuse_fd(traced_processes.as_fd())
-            .context("failed to reuse traced_processes map for tcpsniff")?;
+        // Reuse the shared ring buffer
         open_skel
             .maps_mut()
             .rb()
@@ -106,11 +102,12 @@ impl TcpSniff {
         Ok((open_object, skel))
     }
 
-    /// Create a new TcpSniff that reuses existing traced_processes and ring buffer maps.
+    /// Create a new TcpSniff that reuses the shared ring buffer map.
     /// Automatically detects the tcp_recvmsg signature for the running kernel.
-    pub fn new_with_maps(traced_processes: &MapHandle, rb: &MapHandle) -> Result<Self> {
+    /// Does NOT require traced_processes — filtering is by destination IP/port only.
+    pub fn new_with_maps(rb: &MapHandle) -> Result<Self> {
         // Try new signature first (5.18+), fall back to old (5.8-5.17) on load failure
-        let (open_object, skel, use_old_sig) = match Self::load_skel(traced_processes, rb, false) {
+        let (open_object, skel, use_old_sig) = match Self::load_skel(rb, false) {
             Ok((obj, skel)) => {
                 log::info!("TcpSniff: loaded with new tcp_recvmsg signature (5.18+)");
                 (obj, skel, false)
@@ -120,7 +117,7 @@ impl TcpSniff {
                     "TcpSniff: new tcp_recvmsg signature failed ({}), trying old (5.8-5.17)",
                     e
                 );
-                let (obj, skel) = Self::load_skel(traced_processes, rb, true)
+                let (obj, skel) = Self::load_skel(rb, true)
                     .context("failed to load tcpsniff with old tcp_recvmsg signature")?;
                 log::info!("TcpSniff: loaded with old tcp_recvmsg signature (5.8-5.17)");
                 (obj, skel, true)
@@ -135,22 +132,39 @@ impl TcpSniff {
         })
     }
 
-    /// Populate the BPF tcp_target_ports map with the given ports.
+    /// Populate the BPF tcp_targets map with the given targets.
     /// Must be called after new_with_maps() and before attach().
-    pub fn set_target_ports(&mut self, ports: &[u16]) -> Result<()> {
+    ///
+    /// Key layout (8 bytes): ip (4 bytes BE) | port (2 bytes BE) | pad (2 bytes zero)
+    pub fn set_targets(&mut self, targets: &[TcpTarget]) -> Result<()> {
         let binding = self.skel.maps();
-        let map = binding.tcp_target_ports();
+        let map = binding.tcp_targets();
         let dummy: u8 = 1;
-        for &port in ports {
-            let net_port = port.to_be(); // convert to network byte order
-            map.update(
-                &net_port.to_ne_bytes(),
-                &[dummy],
-                MapFlags::ANY,
-            )
-            .with_context(|| format!("failed to add port {} to tcp_target_ports map", port))?;
+
+        for target in targets {
+            let ip_be: u32 = match target.ip {
+                Some(Ipv4Addr::UNSPECIFIED) | None => 0u32,
+                Some(ip) => u32::from(ip).to_be(),
+            };
+            let port_be: u16 = match target.port {
+                None => 0u16,
+                Some(p) => p.to_be(),
+            };
+            // Serialize key as [ip_be(4)] [port_be(2)] [pad(2)]
+            let mut key = [0u8; 8];
+            key[0..4].copy_from_slice(&ip_be.to_ne_bytes());
+            key[4..6].copy_from_slice(&port_be.to_ne_bytes());
+            // key[6..8] = 0 (pad)
+
+            map.update(&key, &[dummy], MapFlags::ANY)
+                .with_context(|| format!("failed to add target {:?} to tcp_targets map", target))?;
         }
-        log::info!("TcpSniff: configured {} target port(s): {:?}", ports.len(), ports);
+
+        log::info!(
+            "TcpSniff: configured {} target(s): {:?}",
+            targets.len(),
+            targets
+        );
         Ok(())
     }
 

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -323,8 +323,7 @@ impl AgentSight {
             parser: Parser::new(),
             aggregator: Aggregator::new(),
             analyzer,
-            genai_builder: GenAIBuilder::new()
-                .with_user_agent_rules(config.user_agent_rules.clone()),
+            genai_builder: GenAIBuilder::new(),
             genai_exporters,
             genai_sqlite_store,
             interruption_detector: InterruptionDetector::new(DetectorConfig::default()),
@@ -468,16 +467,15 @@ impl AgentSight {
             let (output, pending_info) = self.genai_builder.build_with_pending(
                 &analysis_results,
                 &self.response_mapper,
-                &mut self.pid_agent_name_cache,
+                &self.pid_agent_name_cache,
             );
 
-            // Backfill TokenRecord.agent from pid_agent_name_cache
+            // Backfill TokenRecord.agent from pid_agent_name_cache, falling back to comm
             for ar in &mut analysis_results {
                 if let crate::analyzer::AnalysisResult::Token(t) = ar {
                     if t.agent.is_none() {
-                        if let Some(name) = self.pid_agent_name_cache.get(&t.pid) {
-                            t.agent = Some(name.clone());
-                        }
+                        t.agent = self.pid_agent_name_cache.get(&t.pid).cloned()
+                            .or_else(|| Some(t.comm.clone()));
                     }
                 }
             }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -156,13 +156,8 @@ impl AgentSight {
 
         // Create probes - agent discovery is handled by AgentScanner via ProcMon events
         let enable_udpdns = !config.domain_rules.is_empty();
-        let mut probes = Probes::new(
-            &[],
-            config.target_uid,
-            config.enable_filewatch,
-            enable_udpdns,
-        )
-        .context("Failed to create probes")?;
+        let mut probes =
+            Probes::new(&[], config.target_uid, config.enable_filewatch, enable_udpdns, &config.tcp_target_ports).context("Failed to create probes")?;
 
         // Attach procmon for process monitoring
         probes.attach().context("Failed to attach probes")?;

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -157,7 +157,7 @@ impl AgentSight {
         // Create probes - agent discovery is handled by AgentScanner via ProcMon events
         let enable_udpdns = !config.domain_rules.is_empty();
         let mut probes =
-            Probes::new(&[], config.target_uid, config.enable_filewatch, enable_udpdns, &config.tcp_target_ports).context("Failed to create probes")?;
+            Probes::new(&[], config.target_uid, config.enable_filewatch, enable_udpdns, &config.tcp_targets).context("Failed to create probes")?;
 
         // Attach procmon for process monitoring
         probes.attach().context("Failed to attach probes")?;
@@ -323,7 +323,8 @@ impl AgentSight {
             parser: Parser::new(),
             aggregator: Aggregator::new(),
             analyzer,
-            genai_builder: GenAIBuilder::new(),
+            genai_builder: GenAIBuilder::new()
+                .with_user_agent_rules(config.user_agent_rules.clone()),
             genai_exporters,
             genai_sqlite_store,
             interruption_detector: InterruptionDetector::new(DetectorConfig::default()),
@@ -461,14 +462,25 @@ impl AgentSight {
 
         // Analyze and store results
         for agg_result in &aggregated_results {
-            let analysis_results = self.analyzer.analyze_aggregated(agg_result);
+            let mut analysis_results = self.analyzer.analyze_aggregated(agg_result);
 
             // Build GenAI semantic events AND pending info in one pass
             let (output, pending_info) = self.genai_builder.build_with_pending(
                 &analysis_results,
                 &self.response_mapper,
-                &self.pid_agent_name_cache,
+                &mut self.pid_agent_name_cache,
             );
+
+            // Backfill TokenRecord.agent from pid_agent_name_cache
+            for ar in &mut analysis_results {
+                if let crate::analyzer::AnalysisResult::Token(t) = ar {
+                    if t.agent.is_none() {
+                        if let Some(name) = self.pid_agent_name_cache.get(&t.pid) {
+                            t.agent = Some(name.clone());
+                        }
+                    }
+                }
+            }
 
             if !output.events.is_empty() {
                 if output.pending_response_id.is_some() {


### PR DESCRIPTION
## Description

Add tcpsniff eBPF probe for capturing plain HTTP traffic, enabling observation of unencrypted HTTP requests/responses for LLM API calls that don't use TLS (e.g., local proxies, internal services).

## Related Issue

closes #588

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Tested tcpsniff probe attachment and plain HTTP traffic capture manually on alinux3 with kernel 5.10+.

## Additional Notes

This probe complements the existing SSL probe by capturing unencrypted HTTP traffic for complete LLM API observability.
