### PR TITLE
fix(tokenless): build OpenClaw plugin to dist/index.js

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -19,9 +19,11 @@ SHARE_DIR ?= $(DATADIR)/anolisa/adapters/tokenless
 BIN_DIR ?= $(BINDIR)
 LIB_DIR ?= $(LIBEXECDIR)
 ADAPTER_SRC_DIR := adapters/tokenless
+OPENCLAW_PLUGIN_SRC_DIR := $(ADAPTER_SRC_DIR)/openclaw
 TOON_VER := 0.4.6
 
-.PHONY: build build-tokenless build-toon install uninstall test lint clean \
+.PHONY: build build-tokenless build-toon build-openclaw-plugin \
+        install uninstall test lint clean \
         install-binaries install-helpers install-adapter-resources install-cosh-extension \
         adapter-install adapter-uninstall adapter-scan \
         cosh-extension-install cosh-extension-uninstall \
@@ -34,7 +36,7 @@ TOON_VER := 0.4.6
 all: build
 
 # Build both projects
-build: build-tokenless build-toon
+build: build-tokenless build-toon build-openclaw-plugin
 
 build-tokenless:
 	@echo "==> Building tokenless + rtk..."
@@ -45,6 +47,18 @@ build-tokenless:
 build-toon:
 	@echo "==> Installing toon binary (v$(TOON_VER))..."
 	cargo install toon-format --version $(TOON_VER) --locked
+
+# Build the tokenless OpenClaw plugin (TypeScript -> dist/index.js).
+# Produces $(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js, which install-adapter-resources
+# then copies into $(SHARE_DIR)/openclaw/dist/index.js. This file is referenced by
+# the plugin's package.json ("main" / "openclaw.extensions") and must be present
+# for `openclaw plugins install` to succeed.
+build-openclaw-plugin:
+	@echo "==> Building tokenless OpenClaw plugin..."
+	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm install --legacy-peer-deps --no-audit --no-fund --package-lock=false
+	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm run build
+	@test -f $(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js \
+	    || { echo "ERROR: $(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js was not produced"; exit 1; }
 
 # Install binaries + adapter resources per FHS spec.
 install: build install-binaries install-helpers install-adapter-resources install-cosh-extension
@@ -62,12 +76,17 @@ install-helpers:
 	ln -sf $(LIBEXECDIR)/rtk $(DESTDIR)$(BINDIR)/rtk
 	ln -sf $(LIBEXECDIR)/toon $(DESTDIR)$(BINDIR)/toon
 
-install-adapter-resources:
+install-adapter-resources: build-openclaw-plugin
 	@echo "==> Installing adapter resources to $(DESTDIR)$(SHARE_DIR)..."
 	rm -rf $(DESTDIR)$(SHARE_DIR)
 	install -d -m 0755 $(DESTDIR)$(SHARE_DIR)
 	cp -pr $(ADAPTER_SRC_DIR)/. $(DESTDIR)$(SHARE_DIR)/
+	# Strip build-only artifacts from the installed plugin tree.
+	rm -rf $(DESTDIR)$(SHARE_DIR)/openclaw/node_modules
+	rm -f  $(DESTDIR)$(SHARE_DIR)/openclaw/package-lock.json
 	find $(DESTDIR)$(SHARE_DIR) -type f \( -name '*.py' -o -name '*.sh' \) -exec chmod 0755 {} +
+	@test -f $(DESTDIR)$(SHARE_DIR)/openclaw/dist/index.js \
+	    || { echo "ERROR: $(DESTDIR)$(SHARE_DIR)/openclaw/dist/index.js missing after install-adapter-resources"; exit 1; }
 
 install-cosh-extension:
 	@echo "==> Installing tokenless cosh extension to $(DESTDIR)$(COSH_EXTENSION_DIR)..."
@@ -111,6 +130,8 @@ clean:
 	@echo "==> Cleaning..."
 	cargo clean
 	cargo clean --release --manifest-path third_party/rtk/Cargo.toml 2>/dev/null || true
+	rm -rf $(OPENCLAW_PLUGIN_SRC_DIR)/dist $(OPENCLAW_PLUGIN_SRC_DIR)/node_modules
+	rm -f  $(OPENCLAW_PLUGIN_SRC_DIR)/package-lock.json
 
 # Create source tarball (excludes build artifacts)
 dist: clean
@@ -207,9 +228,10 @@ help:
 	@echo "Token-Less Build System"
 	@echo ""
 	@echo "Targets:"
-	@echo "  build             Build tokenless + rtk + toon (release mode)"
+	@echo "  build             Build tokenless + rtk + toon + openclaw plugin"
 	@echo "  build-tokenless   Build tokenless + rtk (via justfile)"
 	@echo "  build-toon        Install toon binary via cargo install toon-format"
+	@echo "  build-openclaw-plugin  Compile OpenClaw plugin TS -> dist/index.js"
 	@echo "  install           Install binaries + adapter to FHS paths"
 	@echo "  uninstall         Remove installed files"
 	@echo "  test              Run all tests"

--- a/src/tokenless/adapters/tokenless/openclaw/.gitignore
+++ b/src/tokenless/adapters/tokenless/openclaw/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+package-lock.json

--- a/src/tokenless/adapters/tokenless/openclaw/package.json
+++ b/src/tokenless/adapters/tokenless/openclaw/package.json
@@ -3,14 +3,22 @@
   "version": "1.0.0",
   "description": "Unified OpenClaw plugin — RTK command rewriting + tokenless schema/response compression for 60-90% LLM token savings",
   "type": "module",
-  "main": "index.js",
+  "main": "dist/index.js",
   "openclaw": {
-    "extensions": ["./index.js"]
+    "extensions": ["./dist/index.js"]
+  },
+  "scripts": {
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "npm run clean && tsc --project tsconfig.json"
   },
   "peerDependencies": {
     "rtk": ">=0.35.0",
     "tokenless": ">=0.1.0"
   },
-  "files": ["index.js", "openclaw.plugin.json"],
+  "devDependencies": {
+    "@types/node": ">=22",
+    "typescript": "^5.8.0"
+  },
+  "files": ["dist/", "openclaw.plugin.json", "scripts/"],
   "license": "MIT"
 }

--- a/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
@@ -1,31 +1,56 @@
 #!/usr/bin/env bash
-# install.sh — Install tokenless plugin into OpenClaw via official CLI.
+# install.sh — Deploy the tokenless OpenClaw plugin via the openclaw CLI.
+#
+# Responsibility boundary (mirrors sec-core/openclaw-plugin/scripts/deploy.sh):
+#   - This script ONLY deploys an already-built plugin.
+#   - Compilation (index.ts -> dist/index.js) is the Makefile's job:
+#       make -C src/tokenless build-openclaw-plugin
+#     which `make install` runs automatically before `install-adapter-resources`
+#     copies the result into $SHARE_DIR/openclaw.
+#   - If dist/index.js is missing, exit with a clear error pointing at the
+#     Makefile target. Do NOT compile here — adapters shouldn't invoke npm at
+#     deploy time.
 set -euo pipefail
 
 AGENT="${ANOLISA_TARGET:-openclaw}"
 COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
 ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
+# Allow the orchestrator (or a packaging script) to inject a specific openclaw
+# binary. Defaults to whatever `openclaw` resolves to on PATH.
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+
 PLUGIN_SRC="$ADAPTER_DIR/openclaw"
 
 echo "[${COMPONENT}] Installing ${AGENT} plugin..."
 
-if ! command -v openclaw &>/dev/null; then
-    echo "[${COMPONENT}] openclaw CLI not found — skipping plugin installation."
+if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
+    echo "[${COMPONENT}] openclaw CLI not found (OPENCLAW_BIN=${OPENCLAW_BIN}) — skipping plugin installation."
     echo "[${COMPONENT}] Install OpenClaw first, then run this script again."
     exit 0
 fi
 
 if [ ! -d "$PLUGIN_SRC" ]; then
-    echo "[${COMPONENT}] Plugin source not found: $PLUGIN_SRC"
+    echo "[${COMPONENT}] Plugin source not found: $PLUGIN_SRC" >&2
     exit 1
 fi
 
-# Use openclaw CLI for registration (handles file copy, TS compilation, config update)
-openclaw plugins install "$PLUGIN_SRC" --force --dangerously-force-unsafe-install || {
-    echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0"
+if [ ! -f "$PLUGIN_SRC/dist/index.js" ]; then
+    echo "[${COMPONENT}] ERROR: $PLUGIN_SRC/dist/index.js is missing." >&2
+    echo "[${COMPONENT}]        Build the plugin first:" >&2
+    echo "[${COMPONENT}]            make -C src/tokenless build-openclaw-plugin" >&2
+    echo "[${COMPONENT}]        (run by 'make install' automatically; only an issue when" >&2
+    echo "[${COMPONENT}]         deploying a hand-assembled adapter directory)." >&2
+    exit 1
+fi
+
+# Unset OPENCLAW_HOME for the CLI call so a stray value (e.g. already pointing
+# at ~/.openclaw) doesn't cause the plugin to land in ~/.openclaw/.openclaw/...
+env -u OPENCLAW_HOME "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" \
+    --force --dangerously-force-unsafe-install || {
+    echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
     exit 1
 }
 
 echo "[${COMPONENT}] ${AGENT} plugin installed via openclaw CLI."
-echo "[${COMPONENT}] Run 'openclaw gateway restart' to activate."
+echo "[${COMPONENT}] Run '${OPENCLAW_BIN} gateway restart' to activate."

--- a/src/tokenless/adapters/tokenless/openclaw/tsconfig.json
+++ b/src/tokenless/adapters/tokenless/openclaw/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -19,6 +19,11 @@ Source0:        %{name}-%{version}.tar.gz
 # RPM build environments must configure a crates.io mirror (e.g. sparse+https://mirrors.aliyun.com/crates.io-index/).
 BuildRequires:  cargo
 BuildRequires:  rust >= 1.89
+# nodejs/npm are required to compile the OpenClaw TS plugin -> dist/index.js
+# via `make build-openclaw-plugin`. Provided by CI; declared here for chroot
+# builds where they are not pre-installed.
+BuildRequires:  nodejs
+BuildRequires:  npm
 
 # Runtime dependencies
 Requires:       python3
@@ -66,13 +71,11 @@ cargo build --release --manifest-path third_party/rtk/Cargo.toml
 # Build toon (standalone binary for Python hooks)
 cargo install toon-format --version 0.4.6 --root %{_builddir}/toon-root --locked
 
-# Compile OpenClaw TypeScript plugin to JS (from adapters/ bundle)
-if command -v npx &>/dev/null; then
-    npx --yes esbuild adapters/tokenless/openclaw/index.ts --bundle --platform=node --format=esm --outfile=adapters/tokenless/openclaw/index.js 2>/dev/null || \
-    sed 's/: any//g; s/: string//g; s/: boolean | null/: any/g; s/: Record<string, unknown>//g; s/: { [^}]*}//g' adapters/tokenless/openclaw/index.ts > adapters/tokenless/openclaw/index.js
-else
-    sed 's/: any//g; s/: string//g; s/: boolean | null/: any/g; s/: Record<string, unknown>//g; s/: { [^}]*}//g' adapters/tokenless/openclaw/index.ts > adapters/tokenless/openclaw/index.js
-fi
+# Compile the OpenClaw TS plugin via the project Makefile.
+# Produces adapters/tokenless/openclaw/dist/index.js, which package.json
+# declares as both "main" and openclaw.extensions. Mirroring sec-core's
+# build-openclaw-plugin pattern — never hand-roll tsc/esbuild here.
+make build-openclaw-plugin
 
 %install
 rm -rf %{buildroot}
@@ -81,6 +84,7 @@ mkdir -p %{buildroot}%{_libexecdir}/anolisa/tokenless
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/common/hooks
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/common/commands
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/scripts
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/dist
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts
 mkdir -p %{buildroot}%{_docdir}/tokenless
 
@@ -110,7 +114,10 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 install -m 0755 adapters/tokenless/openclaw/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/scripts/
 install -m 0755 adapters/tokenless/openclaw/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/scripts/
 install -m 0755 adapters/tokenless/openclaw/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/scripts/
-install -m 0644 adapters/tokenless/openclaw/index.js %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/
+# Install the compiled dist tree produced by `make build-openclaw-plugin`.
+# package.json declares main/openclaw.extensions = ./dist/index.js; OpenClaw
+# `plugins install` reads from this directory and requires dist/index.js to exist.
+install -m 0644 adapters/tokenless/openclaw/dist/index.js %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/dist/
 install -m 0644 adapters/tokenless/openclaw/openclaw.plugin.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/
 install -m 0644 adapters/tokenless/openclaw/package.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/
 
@@ -151,6 +158,7 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %dir %{_datadir}/anolisa/adapters/tokenless/common/commands
 %dir %{_datadir}/anolisa/adapters/tokenless/openclaw
 %dir %{_datadir}/anolisa/adapters/tokenless/openclaw/scripts
+%dir %{_datadir}/anolisa/adapters/tokenless/openclaw/dist
 %dir %{_datadir}/anolisa/adapters/tokenless/hermes
 %dir %{_datadir}/anolisa/adapters/tokenless/hermes/scripts
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/manifest.json
@@ -163,7 +171,7 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/scripts/uninstall.sh
-%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/index.js
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/dist/index.js
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/openclaw.plugin.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/openclaw/package.json
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/__init__.py


### PR DESCRIPTION
## Description

The tokenless OpenClaw plugin shipped without its compiled entrypoint:
`package.json` declares `main`/`openclaw.extensions = ./dist/index.js`,
but the Makefile only built Rust artifacts and copied `adapters/tokenless`
verbatim, so `$SHARE_DIR/openclaw/dist/index.js` never existed and the RPM's
`%build` resorted to an `npx esbuild` / `sed` fallback.

This PR converges on the same boundary as `sec-core/openclaw-plugin`:
the Makefile compiles TS to `dist/`, the spec/install steps only deliver
the compiled tree, and `install.sh` is deploy-only.

- `src/tokenless/Makefile`: new `build-openclaw-plugin` target
  (`npm install --legacy-peer-deps --no-audit --no-fund --package-lock=false`
  then `npm run build`); wired into `build` and as a prerequisite of
  `install-adapter-resources`, which now also strips `node_modules` /
  `package-lock.json` from the install tree and asserts
  `$SHARE_DIR/openclaw/dist/index.js` exists.
- `adapters/tokenless/openclaw/package.json`: `main` and
  `openclaw.extensions` now point to `dist/index.js`; added `scripts.build`
  and `devDependencies` (`typescript`, `@types/node`).
- New `adapters/tokenless/openclaw/tsconfig.json` (ES2022 / Node16,
  `outDir: dist`).
- `tokenless.spec.in`: `%build` calls `make build-openclaw-plugin`; `%install`
  and `%files` declare `openclaw/dist/index.js` instead of `openclaw/index.js`;
  added `BuildRequires: nodejs npm`.
- `adapters/tokenless/openclaw/scripts/install.sh`: removed the ad-hoc
  compile path; deploys only an already-built plugin. Honors
  `OPENCLAW_BIN` for orchestrator injection and runs the CLI under
  `env -u OPENCLAW_HOME` to avoid `~/.openclaw/.openclaw/...` nesting.
  If `dist/index.js` is missing, exits with a clear instruction to run
  `make -C src/tokenless build-openclaw-plugin`.
- `adapters/tokenless/openclaw/index.ts`: one-char fix — undefined
  `checkToon()` -> `checkTokenless()` (the `compress-toon` subcommand is
  hosted by the `tokenless` binary; this blocked TS compilation).
- New `adapters/tokenless/openclaw/.gitignore`: `dist/`, `node_modules/`,
  `package-lock.json`.

`scripts/build-all.sh` is untouched — `build-all` continues to invoke each
component's own `make install`, which now produces a complete tokenless
adapter on its own.

## Related Issue

no-issue: internal build/packaging fix; converges tokenless OpenClaw plugin
on the sec-core build boundary

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Verified locally with a staged DESTDIR:

```bash
rm -rf src/tokenless/adapters/tokenless/openclaw/{dist,node_modules,package-lock.json}
make -C src/tokenless build-openclaw-plugin
test -f src/tokenless/adapters/tokenless/openclaw/dist/index.js   # OK

TMP=$(mktemp -d)
make -C src/tokenless install-adapter-resources \
    DESTDIR="$TMP" INSTALL_PROFILE=user PREFIX="$HOME/.local"
test -f "$TMP$HOME/.local/share/anolisa/adapters/tokenless/openclaw/dist/index.js"  # OK
! test -e "$TMP$HOME/.local/share/anolisa/adapters/tokenless/openclaw/node_modules"        # OK
! test -e "$TMP$HOME/.local/share/anolisa/adapters/tokenless/openclaw/package-lock.json"   # OK