### PR TITLE
fix(build): use Perl capabilities for eBPF deps

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -98,6 +98,15 @@ step()  { echo -e "\n${CYAN}${BOLD}==> $*${NC}"; }
 
 cmd_exists() { command -v "$1" &>/dev/null; }
 
+perl_module_exists() {
+    local module="$1"
+    cmd_exists perl && perl -M"$module" -e1 &>/dev/null
+}
+
+shell_args() {
+    printf '%q ' "$@"
+}
+
 # Extract first semver (X.Y.Z) from a string.
 # Examples: "rustc 1.91.0 (abc 2024)" -> "1.91.0", "v22.21.1" -> "22.21.1"
 extract_ver() {
@@ -1249,19 +1258,25 @@ check_ebpf_deps() {
     if ! cmd_exists llvm-config && ! cmd_exists llvm-config-*; then missing+=("llvm"); fi
 
     if [[ "$PKG_BASE" == "rpm" ]]; then
-        local pkgs=("libbpf-devel" "libbpf-static" "elfutils-libelf-devel" "zlib-devel" "openssl-devel" "perl" "perl-core" "perl-IPC-Cmd" "perl-FindBin" "pkg-config")
+        local pkgs=("libbpf-devel" "libbpf-static" "elfutils-libelf-devel" "zlib-devel" "openssl-devel" "perl" "perl-core" "pkg-config")
         local pkg
         for pkg in "${pkgs[@]}"; do
             if ! rpm -q "$pkg" &>/dev/null; then
                 missing+=("$pkg")
             fi
         done
+        if ! perl_module_exists "IPC::Cmd"; then
+            missing+=("perl(IPC::Cmd)")
+        fi
+        if ! perl_module_exists "FindBin"; then
+            missing+=("perl(FindBin)")
+        fi
 
         if [[ ${#missing[@]} -eq 0 ]]; then
             ok "All eBPF packages present"
         else
             warn "Missing eBPF packages: ${missing[*]}"
-            info "Install with: ${BOLD}sudo dnf install -y ${missing[*]}${NC}"
+            info "Install with: ${BOLD}sudo dnf install -y $(shell_args "${missing[@]}")${NC}"
 
             if $INSTALL_DEPS; then
                 info "Installing missing eBPF packages ..."


### PR DESCRIPTION
## Description

Fix `build-all.sh` eBPF dependency detection for agentsight on Alibaba
Cloud Linux 3/4.

Previously the RPM dependency list used the fixed package name
`perl-FindBin`. This works on Alibaba Cloud Linux 4, but fails on
Alibaba Cloud Linux 3 because `FindBin` is provided by
`perl-interpreter` instead of a standalone `perl-FindBin` package.

This change checks Perl module availability directly and installs RPM
capabilities when needed:

- `perl(FindBin)`
- `perl(IPC::Cmd)`

This lets dnf resolve the correct provider per distribution version.

## Related Issue

no-issue: build script compatibility fix for Alinux 3/4 dependency names

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass

## Testing

Local checks:

```bash
bash -n scripts/build-all.sh
./scripts/build-all.sh --dry-run --component sight --no-install