### PR TITLE
fix(sec-core): respect trace-id filter in count

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -582,6 +582,7 @@ def events(
         result = reader.count(
             event_type=event_type,
             category=category,
+            trace_id=trace_id,
             since=resolved_since,
             until=resolved_until,
             offset=offset,
@@ -600,7 +601,13 @@ def events(
             raise typer.Exit(code=1)
 
         result = reader.count_by(
-            count_by, since=resolved_since, until=resolved_until, offset=offset
+            count_by,
+            event_type=event_type,
+            category=category,
+            trace_id=trace_id,
+            since=resolved_since,
+            until=resolved_until,
+            offset=offset,
         )
         typer.echo(json.dumps(result, ensure_ascii=False, indent=2))
         raise typer.Exit(code=0)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -197,6 +197,7 @@ class SecurityEventRepository:
         self,
         event_type: str | None = None,
         category: str | None = None,
+        trace_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
         offset: int = 0,
@@ -205,6 +206,7 @@ class SecurityEventRepository:
         conditions = self._build_filters(
             event_type=event_type,
             category=category,
+            trace_id=trace_id,
             since=since,
             until=until,
         )
@@ -236,6 +238,9 @@ class SecurityEventRepository:
     def count_by(
         self,
         group_field: str,
+        event_type: str | None = None,
+        category: str | None = None,
+        trace_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
         offset: int = 0,
@@ -248,7 +253,13 @@ class SecurityEventRepository:
                 "Must be one of: category, event_type, trace_id"
             )
 
-        conditions = self._build_filters(since=since, until=until)
+        conditions = self._build_filters(
+            event_type=event_type,
+            category=category,
+            trace_id=trace_id,
+            since=since,
+            until=until,
+        )
         if offset == 0:
             stmt = select(column, func.count()).where(*conditions).group_by(column)
         else:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
@@ -87,6 +87,7 @@ class SqliteEventReader:
         self,
         event_type: str | None = None,
         category: str | None = None,
+        trace_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
         offset: int = 0,
@@ -95,6 +96,7 @@ class SqliteEventReader:
         return self._repository.count(
             event_type=event_type,
             category=category,
+            trace_id=trace_id,
             since=since,
             until=until,
             offset=offset,
@@ -103,6 +105,9 @@ class SqliteEventReader:
     def count_by(
         self,
         group_field: str,
+        event_type: str | None = None,
+        category: str | None = None,
+        trace_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
         offset: int = 0,
@@ -110,6 +115,9 @@ class SqliteEventReader:
         """Count events grouped by a specific field."""
         return self._repository.count_by(
             group_field,
+            event_type=event_type,
+            category=category,
+            trace_id=trace_id,
             since=since,
             until=until,
             offset=offset,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/summary.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/summary.py
@@ -33,8 +33,20 @@ class SummaryBackend(BaseBackend):
             since=since_iso,
             until=until_iso,
         )
-        by_category = reader.count_by("category", since=since_iso, until=until_iso)
-        by_event_type = reader.count_by("event_type", since=since_iso, until=until_iso)
+        by_category = reader.count_by(
+            "category",
+            category=category,
+            event_type=event_type,
+            since=since_iso,
+            until=until_iso,
+        )
+        by_event_type = reader.count_by(
+            "event_type",
+            category=category,
+            event_type=event_type,
+            since=since_iso,
+            until=until_iso,
+        )
 
         # Build summary data
         data = {

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -286,6 +286,15 @@ class TestSqliteEventReader:
         writer.write(_make_event(category="hardening"))
         assert reader.count(category="sandbox") == 2
 
+    def test_count_filter_by_trace_id(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(trace_id="trace-abc"))
+        writer.write(_make_event(trace_id="trace-abc"))
+        writer.write(_make_event(trace_id="trace-xyz"))
+
+        assert reader.count(trace_id="trace-abc") == 2
+
     def test_count_by_category(
         self, writer: SqliteEventWriter, reader: SqliteEventReader
     ) -> None:
@@ -305,6 +314,34 @@ class TestSqliteEventReader:
         result = reader.count_by("event_type")
         assert result["alpha"] == 2
         assert result["beta"] == 1
+
+    def test_count_by_filter_by_trace_id(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(category="sandbox", trace_id="trace-abc"))
+        writer.write(_make_event(category="hardening", trace_id="trace-abc"))
+        writer.write(_make_event(category="sandbox", trace_id="trace-xyz"))
+
+        result = reader.count_by("category", trace_id="trace-abc")
+
+        assert result == {"hardening": 1, "sandbox": 1}
+
+    def test_count_by_filter_by_event_type_and_category(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(
+            _make_event(event_type="alpha", category="sandbox", trace_id="trace-1")
+        )
+        writer.write(
+            _make_event(event_type="alpha", category="hardening", trace_id="trace-2")
+        )
+        writer.write(
+            _make_event(event_type="beta", category="sandbox", trace_id="trace-3")
+        )
+
+        result = reader.count_by("trace_id", event_type="alpha", category="sandbox")
+
+        assert result == {"trace-1": 1}
 
     def test_count_by_invalid_field_raises(self, reader: SqliteEventReader) -> None:
         with pytest.raises(ValueError):

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_summary_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_summary_backend.py
@@ -1,7 +1,6 @@
 """Unit tests for security_middleware.backends.summary — SummaryBackend."""
 
 import tempfile
-import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -53,6 +52,24 @@ class TestSummaryBackend(unittest.TestCase):
         self.assertEqual(result.data["by_category"]["sandbox"], 5)
         self.assertEqual(result.data["by_category"]["hardening"], 3)
         self.assertIn("Total events: 8", result.stdout)
+
+    @patch("agent_sec_cli.security_middleware.backends.summary.get_reader")
+    def test_summary_breakdowns_respect_filters(self, mock_get_reader):
+        self.writer.write(_make_event(category="sandbox", event_type="alpha"))
+        self.writer.write(_make_event(category="sandbox", event_type="alpha"))
+        self.writer.write(_make_event(category="hardening", event_type="alpha"))
+        self.writer.write(_make_event(category="sandbox", event_type="beta"))
+
+        mock_get_reader.return_value = self.reader
+
+        backend = SummaryBackend()
+        ctx = RequestContext(action="summary")
+        result = backend.execute(ctx, hours=24, category="sandbox", event_type="alpha")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["total_events"], 2)
+        self.assertEqual(result.data["by_category"], {"sandbox": 2})
+        self.assertEqual(result.data["by_event_type"], {"alpha": 2})
 
     @patch("agent_sec_cli.security_middleware.backends.summary.get_reader")
     def test_summary_empty_db(self, mock_get_reader):

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -229,6 +229,93 @@ def test_main_invalid_trace_context_exits_before_app(mock_app, monkeypatch, caps
     mock_app.assert_not_called()
 
 
+def test_events_count_forwards_trace_id_filter():
+    captured = {}
+
+    class Reader:
+        def count(
+            self,
+            *,
+            event_type=None,
+            category=None,
+            trace_id=None,
+            since=None,
+            until=None,
+            offset=0,
+        ):
+            captured.update(
+                {
+                    "event_type": event_type,
+                    "category": category,
+                    "trace_id": trace_id,
+                    "since": since,
+                    "until": until,
+                    "offset": offset,
+                }
+            )
+            return 2
+
+    with patch("agent_sec_cli.cli.get_reader", return_value=Reader()):
+        result = CliRunner().invoke(
+            app, ["events", "--trace-id", "trace-abc", "--count"]
+        )
+
+    assert result.exit_code == 0
+    assert result.output == "2\n"
+    assert captured["trace_id"] == "trace-abc"
+
+
+def test_events_count_by_forwards_filters():
+    captured = {}
+
+    class Reader:
+        def count_by(
+            self,
+            group_field,
+            *,
+            event_type=None,
+            category=None,
+            trace_id=None,
+            since=None,
+            until=None,
+            offset=0,
+        ):
+            captured.update(
+                {
+                    "group_field": group_field,
+                    "event_type": event_type,
+                    "category": category,
+                    "trace_id": trace_id,
+                    "since": since,
+                    "until": until,
+                    "offset": offset,
+                }
+            )
+            return {"sandbox": 1}
+
+    with patch("agent_sec_cli.cli.get_reader", return_value=Reader()):
+        result = CliRunner().invoke(
+            app,
+            [
+                "events",
+                "--count-by",
+                "category",
+                "--event-type",
+                "alpha",
+                "--category",
+                "sandbox",
+                "--trace-id",
+                "trace-abc",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert captured["group_field"] == "category"
+    assert captured["event_type"] == "alpha"
+    assert captured["category"] == "sandbox"
+    assert captured["trace_id"] == "trace-abc"
+
+
 class TestHardenCli(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Fixed following issues
- agent-sec-cli events --trace-id X --count where trace-id is missed
- agent-sec-cli events --trace-id X --count-by category where trace-id is missed
- agent-sec-cli events --event-type T --count-by category where event-type is missed 
- agent-sec-cli events --category C --count-by event_type where category is missed

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
