### PR TITLE
fix(sec-core): expand home paths for skill-ledger

### DIFF
--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
@@ -74,6 +74,16 @@ function keysExist(): boolean {
 // Helpers
 // ---------------------------------------------------------------------------
 
+function expandHomePath(filePath: string): string {
+  if (filePath === "~") {
+    return homedir();
+  }
+  if (filePath.startsWith("~/")) {
+    return homedir() + filePath.slice(1);
+  }
+  return filePath;
+}
+
 /** Extract the file path from a before_tool_call event, or undefined if not a read-SKILL.md call. */
 function extractSkillPath(
   event: { toolName: string; params: Record<string, unknown> },
@@ -91,7 +101,7 @@ function extractSkillPath(
   if (!filePath) return undefined;
 
   // Resolve to canonical absolute path to neutralize ".." traversal
-  const resolved = resolve(filePath);
+  const resolved = resolve(expandHomePath(filePath));
 
   if (!resolved.endsWith("/SKILL.md")) return undefined;
 

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { skillLedger } from "../../src/capabilities/skill-ledger.js";
 import { _resetCliMock, _setCliMock } from "../../src/utils.js";
@@ -275,6 +275,36 @@ describe("skill-ledger", () => {
 
     assert.equal(checkCallCount, 1);
     assert.ok(lastCheckArgs?.includes("/skills/alpha"));
+  });
+
+  it("expands leading ~/ before invoking skill-ledger check", async () => {
+    mockSkillLedgerStatus("pass");
+    const { beforeToolCall } = registerHandlers();
+
+    await beforeToolCall.handler(
+      readSkillEvent("~/openclaw/skills/session-logs/SKILL.md"),
+      {},
+    );
+
+    const expectedSkillDir = resolve(homedir(), "openclaw/skills/session-logs");
+    assert.equal(checkCallCount, 1);
+    assert.ok(lastCheckArgs?.includes(expectedSkillDir));
+    assert.ok(!lastCheckArgs?.some((arg) => arg.includes("/~/")));
+  });
+
+  it("keeps home prefix when ~/ is followed by repeated slashes", async () => {
+    mockSkillLedgerStatus("pass");
+    const { beforeToolCall } = registerHandlers();
+
+    await beforeToolCall.handler(
+      readSkillEvent("~//openclaw/skills/session-logs/SKILL.md"),
+      {},
+    );
+
+    const expectedSkillDir = resolve(homedir(), "openclaw/skills/session-logs");
+    assert.equal(checkCallCount, 1);
+    assert.ok(lastCheckArgs?.includes(expectedSkillDir));
+    assert.ok(!lastCheckArgs?.includes("/openclaw/skills/session-logs"));
   });
 
   it("passes hook trace context to skill-ledger check", async () => {


### PR DESCRIPTION
## Description

Fixes OpenClaw skill-ledger path normalization for `read` calls that pass `~/.../SKILL.md`.

The hook now expands leading `~` / `~/` to the current user's home directory before applying `path.resolve()`, so skill-ledger checks no longer receive paths like `$cwd/~/openclaw/...`. The implementation intentionally does not expand `~user/...` or non-leading `~` segments.

## Related Issue

closes #593

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cd src/agent-sec-core && make python-code-pretty`
- `cd src/agent-sec-core/openclaw-plugin && npm run build`
- Added OpenClaw skill-ledger unit coverage for `~/openclaw/.../SKILL.md` and `~//openclaw/.../SKILL.md`.
- Attempted `cd src/agent-sec-core/openclaw-plugin && npm test`, but the local Node/tsx test runner exits with code 137 in this environment before running assertions. The same command previously hit sandbox IPC restrictions with `listen EPERM`.

## Additional Notes

`src/agent-sec-core/Makefile` does not currently define `pretty` or `code` targets; the existing sec-core formatter target is `python-code-pretty`.
