### PR TITLE
fix(cosh): route UserPromptSubmit through safety-priority merge

### DIFF
--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.test.ts
@@ -354,6 +354,143 @@ describe('HookAggregator', () => {
     });
   });
 
+  describe('mergeWithOrLogic - UserPromptSubmit safety-priority', () => {
+    it('should keep ask when ask precedes allow (ask + allow => ask)', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'prompt_scanner.py',
+            name: 'prompt-scanner',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'ask', reason: 'jailbreak detected' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'pii_checker.py',
+            name: 'pii-checker',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'allow', reason: 'no pii found' },
+          duration: 10,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.UserPromptSubmit,
+      );
+      expect(result.finalOutput?.decision).toBe('ask');
+      expect(result.finalOutput?.reason).toBe(
+        'jailbreak detected\nno pii found',
+      );
+    });
+
+    it('should keep ask when allow precedes ask (allow + ask => ask)', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'pii_checker.py',
+            name: 'pii-checker',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'allow', reason: 'no pii found' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'prompt_scanner.py',
+            name: 'prompt-scanner',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'ask', reason: 'jailbreak detected' },
+          duration: 10,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.UserPromptSubmit,
+      );
+      expect(result.finalOutput?.decision).toBe('ask');
+    });
+
+    it('should keep block when block precedes allow (block + allow => block)', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'prompt_scanner.py',
+            name: 'prompt-scanner',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'block', reason: 'forbidden content' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'pii_checker.py',
+            name: 'pii-checker',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'allow', reason: 'clean' },
+          duration: 10,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.UserPromptSubmit,
+      );
+      expect(result.finalOutput?.decision).toBe('block');
+    });
+
+    it('should concatenate ask reason and allow reason', () => {
+      const results: HookExecutionResult[] = [
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'prompt_scanner.py',
+            name: 'prompt-scanner',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'ask', reason: 'jailbreak suspected' },
+          duration: 10,
+        },
+        {
+          hookConfig: {
+            type: HookType.Command,
+            command: 'pii_checker.py',
+            name: 'pii-checker',
+          },
+          eventName: HookEventName.UserPromptSubmit,
+          success: true,
+          output: { decision: 'allow', reason: 'no pii' },
+          duration: 10,
+        },
+      ];
+
+      const result = aggregator.aggregateResults(
+        results,
+        HookEventName.UserPromptSubmit,
+      );
+      expect(result.finalOutput?.reason).toBe('jailbreak suspected\nno pii');
+    });
+  });
+
   describe('mergePermissionRequestOutputs', () => {
     it('should prioritize deny over allow', () => {
       const outputs: HookOutput[] = [

--- a/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookAggregator.ts
@@ -159,6 +159,7 @@ export class HookAggregator {
     let merged: HookOutput;
 
     switch (eventName) {
+      case HookEventName.UserPromptSubmit:
       case HookEventName.PreToolUse:
       case HookEventName.PostToolUse:
       case HookEventName.PostToolUseFailure:


### PR DESCRIPTION
## Description

`HookAggregator` previously routed `UserPromptSubmit` through the default
`mergeSimple` strategy, where the last hook's `decision` field overwrote
earlier ones. With both `prompt-scanner` (returning `ask` on jailbreak) and
`pii-checker` (returning `allow`) registered, the trailing `allow` silently
clobbered `ask` and the confirmation prompt never surfaced.

This PR adds `HookEventName.UserPromptSubmit` to the `mergeWithOrLogic`
switch branch so it shares the safety-priority precedence already used by
`PreToolUse` (`block/deny > ask > allow > undefined`), with `reason` and
`additionalContext` concatenated across hooks. `BeforeModel` / `AfterModel`
keep their `mergeWithFieldReplacement` semantics — they sit in a separate,
terminated switch branch and are unaffected.

## Related Issue

closes #592

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `npx vitest run src/hooks/hookAggregator.test.ts` — 32 passed (4 new)
- `npx vitest run src/hooks/` — 137 passed across the hooks suite

## Additional Notes

The fix is one switch-case line; the bulk of the diff is the 4 new test
cases verifying `ask+allow→ask`, `allow+ask→ask`, `block+allow→block`,
and reason concatenation for the `UserPromptSubmit` event.