### PR TITLE
fix(sec-core): stabilize Hermes skill-ledger warnings

### DIFF
--- a/src/agent-sec-core/hermes-plugin/src/capabilities/skill_ledger.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/skill_ledger.py
@@ -19,7 +19,8 @@ _SKILL_MANIFEST = "SKILL.md"
 _DEFAULT_HERMES_SKILLS_DIR = Path("~/.hermes/skills")
 _DEFAULT_BLOCK_STATUSES = ["none", "drifted", "deny", "tampered"]
 _SKIP_DIRS = frozenset({".git", ".github", ".hub", ".archive", ".skill-meta"})
-_CONTEXT_KEY_FIELDS = ("session_id", "task_id", "run_id", "conversation_id")
+_CONTEXT_KEY_FIELDS = ("session_id", "task_id", "run_id")
+_HERMES_SESSION_ENV = "HERMES_SESSION_ID"
 
 _STATUS_MESSAGES = {
     "none": "Skill has not been security-scanned yet.",
@@ -136,16 +137,21 @@ class SkillLedgerCapability(AgentSecCoreCapability):
         self._remember_warning(kwargs, skill_name, skill_dir, status, message)
         return None
 
-    def _on_transform_llm_output(self, response=None, **kwargs):
+    def _on_transform_llm_output(
+        self,
+        response_text: str = "",
+        session_id: str = "",
+        **kwargs,
+    ):
         """Prepend user-visible skill-ledger warnings to the final response."""
         if self._enable_block:
             return None
         if self._max_warnings_per_turn == 0:
             return None
-        if not isinstance(response, str):
+        if not isinstance(response_text, str) or not response_text:
             return None
 
-        warnings = self._pop_warnings(kwargs)
+        warnings = self._pop_warnings({"session_id": session_id, **kwargs})
         if not warnings:
             return None
 
@@ -162,7 +168,7 @@ class SkillLedgerCapability(AgentSecCoreCapability):
                 f"- ... {len(warnings) - self._max_warnings_per_turn} more warning(s)"
             )
         lines.append("")
-        lines.append(response)
+        lines.append(response_text)
         return "\n".join(lines)
 
     def _resolve_skill_dir(self, args: dict[str, Any]) -> Path | None:
@@ -314,10 +320,29 @@ class SkillLedgerCapability(AgentSecCoreCapability):
 
     @staticmethod
     def _context_key(kwargs: dict[str, Any]) -> str | None:
+        runtime_session_id = SkillLedgerCapability._runtime_session_id()
+        if runtime_session_id is not None:
+            return f"session_id:{runtime_session_id}"
+
         for field in _CONTEXT_KEY_FIELDS:
             value = kwargs.get(field)
             if isinstance(value, str) and value.strip():
                 return f"{field}:{value}"
+        return None
+
+    @staticmethod
+    def _runtime_session_id() -> str | None:
+        try:
+            from gateway.session_context import get_session_env
+        except Exception:
+            return None
+
+        try:
+            value = get_session_env(_HERMES_SESSION_ENV, "")
+        except Exception:
+            return None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
         return None
 
     @staticmethod

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_skill_ledger.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_skill_ledger.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
@@ -58,6 +60,20 @@ def _cli_status(status: str, *, exit_code: int = 0) -> CliResult:
     return CliResult(
         stdout=json.dumps({"status": status}), stderr="", exit_code=exit_code
     )
+
+
+def _install_gateway_session_context(monkeypatch, session_id: str) -> None:
+    gateway_module = ModuleType("gateway")
+    session_context_module = ModuleType("gateway.session_context")
+
+    def get_session_env(name: str, default: str = "") -> str:
+        assert name == "HERMES_SESSION_ID"
+        return session_id or default
+
+    session_context_module.get_session_env = get_session_env
+    gateway_module.session_context = session_context_module
+    monkeypatch.setitem(sys.modules, "gateway", gateway_module)
+    monkeypatch.setitem(sys.modules, "gateway.session_context", session_context_module)
 
 
 class TestSkillLedgerHooks:
@@ -114,12 +130,83 @@ class TestSkillLedgerHooks:
         mock_cli.return_value = _cli_status(status, exit_code=1)
 
         result = cap._on_pre_tool_call("skill_view", {"name": "risky"}, task_id="t1")
-        output = cap._on_transform_llm_output("assistant response", task_id="t1")
+        output = cap._on_transform_llm_output(
+            response_text="assistant response", task_id="t1"
+        )
 
         assert result is None
         assert output.startswith("[agent-sec-core skill-ledger warning]")
         assert f"status={status}" in output
         assert output.endswith("assistant response")
+
+    @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
+    def test_drifted_warning_uses_response_text_and_logs_status(
+        self, mock_cli, tmp_path, caplog
+    ):
+        root = tmp_path / "skills"
+        _make_skill(root, "devops/drifted")
+        cap = _make_capability(root)
+        mock_cli.return_value = _cli_status("drifted", exit_code=1)
+        caplog.set_level(logging.WARNING, logger="agent-sec-core")
+
+        result = cap._on_pre_tool_call(
+            "skill_view", {"name": "drifted"}, session_id="s1"
+        )
+        output = cap._on_transform_llm_output(
+            response_text="assistant response", session_id="s1"
+        )
+
+        assert result is None
+        assert output.startswith("[agent-sec-core skill-ledger warning]")
+        assert "status=drifted" in output
+        assert output.endswith("assistant response")
+        assert any("status=drifted" in record.message for record in caplog.records)
+
+    @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
+    def test_runtime_hermes_session_context_bridges_missing_pre_session_id(
+        self, mock_cli, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "skills"
+        _make_skill(root, "devops/risky")
+        cap = _make_capability(root)
+        mock_cli.return_value = _cli_status("drifted", exit_code=1)
+        _install_gateway_session_context(monkeypatch, "hermes-session-1")
+
+        cap._on_pre_tool_call(
+            "skill_view", {"name": "risky"}, session_id="", task_id="t1"
+        )
+
+        assert list(cap._warnings_by_context) == ["session_id:hermes-session-1"]
+        output = cap._on_transform_llm_output(
+            response_text="assistant response", session_id="hermes-session-1"
+        )
+        second = cap._on_transform_llm_output(
+            response_text="assistant response", session_id="hermes-session-1"
+        )
+
+        assert output.startswith("[agent-sec-core skill-ledger warning]")
+        assert output.endswith("assistant response")
+        assert second is None
+
+    @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
+    def test_mismatched_keys_do_not_use_pending_warning_fallback(
+        self, mock_cli, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "skills"
+        _make_skill(root, "devops/risky")
+        cap = _make_capability(root)
+        mock_cli.return_value = _cli_status("drifted", exit_code=1)
+        _install_gateway_session_context(monkeypatch, "")
+
+        cap._on_pre_tool_call(
+            "skill_view", {"name": "risky"}, session_id="", task_id="t1"
+        )
+        output = cap._on_transform_llm_output(
+            response_text="assistant response", session_id="s1"
+        )
+
+        assert output is None
+        assert list(cap._warnings_by_context) == ["task_id:t1"]
 
     @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
     def test_enable_block_blocks_configured_status_without_warning(


### PR DESCRIPTION
## Description

Fix Hermes skill-ledger warning delivery so non-pass skill checks are reliably visible to users in the final response.

Changes:
- Use Hermes core's `response_text` argument in `transform_llm_output`.
- Prefer Hermes runtime `HERMES_SESSION_ID` from `gateway.session_context.get_session_env()` when correlating cached warnings.
- Fall back only to explicit hook ids (`session_id`, `task_id`, `run_id`) and avoid pending-bucket guessing.
- Keep pass skills silent while preserving drifted/non-pass status logging and user-visible warnings.

## Related Issue

no-issue: hotfix validated from Hermes runtime behavior; no public issue was provided.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make -C src/agent-sec-core python-code-pretty`
- `src/agent-sec-core/agent-sec-cli/.venv/bin/pytest src/agent-sec-core/tests/unit-test/hermes-plugin/test_skill_ledger.py` (`31 passed`)
- `make -C src/agent-sec-core python-lint` currently fails on existing repository-wide ruff findings unrelated to this PR (`231 errors`, including import ordering and lazy-import rules in pre-existing files).

## Additional Notes

This is a hook-only fix. Hermes core is unchanged. If Hermes does not expose a runtime session id, skill-ledger still fails safe and does not guess from unrelated pending warning buckets.
