### PR TITLE
fix(tokenless): support Debian/Ubuntu FHS paths and harden binary resolution

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -27,14 +27,14 @@ is_trusted_file() {
   local f="$1"
   [ -f "$f" ] || return 1
   # System paths are always trusted
-  case "$f" in /usr/share/*|/usr/libexec/*|/usr/local/share/*) return 0 ;; esac
+  case "$f" in /usr/share/*|/usr/libexec/*|/usr/lib/anolisa/*|/usr/local/share/*) return 0 ;; esac
   # Resolve symlink target before owner/perm checks
   local check_path="$f"
   if [ -L "$f" ]; then
     local target
     target=$(readlink -f "$f" 2>/dev/null || realpath "$f" 2>/dev/null || echo "")
     # System targets are always trusted
-    case "$target" in /usr/share/*|/usr/libexec/*|/usr/local/share/*) return 0 ;; esac
+    case "$target" in /usr/share/*|/usr/libexec/*|/usr/lib/anolisa/*|/usr/local/share/*) return 0 ;; esac
     [ -z "$target" ] && return 1
     check_path="$target"
   fi
@@ -185,7 +185,18 @@ version_ge() {
   return 0
 }
 
-# --- Check a single dep (normalized object) ---
+# --- Resolve binary path ---
+# Tries command -v first, then known install paths.
+resolve_binary() {
+  local name="$1"
+  local found
+  found=$(command -v "$name" 2>/dev/null || true)
+  if [ -n "$found" ]; then echo "$found"; return 0; fi
+  for candidate in "$HOME/.local/bin/$name" "$HOME/.local/lib/anolisa/tokenless/$name"; do
+    if [ -x "$candidate" ]; then echo "$candidate"; return 0; fi
+  done
+  return 1
+}
 # Output: "available", "missing", "version_low:<installed>:<required>"
 check_dep() {
   local dep_json="$1"
@@ -193,10 +204,12 @@ check_dep() {
   binary=$(echo "$dep_json" | jq -r '.binary')
   version=$(echo "$dep_json" | jq -r '.version // empty')
 
-  if ! command -v "$binary" &>/dev/null; then
+  local resolved
+  if ! resolved=$(resolve_binary "$binary"); then
     echo "missing"
     return
   fi
+  binary="$resolved"
 
   if [ -z "$version" ]; then
     echo "available"
@@ -307,7 +320,7 @@ if [ "$missing_count" -gt 0 ] && [ -n "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; t
     HAS_REQUIRED_MISSING=false
     for i in $(seq 0 $((missing_count - 1))); do
         binary=$(echo "$MISSING_DEP_JSONS" | jq -r ".[$i].binary")
-        if ! command -v "$binary" &>/dev/null; then
+        if ! resolve_binary "$binary" >/dev/null 2>&1; then
             STILL_MISSING="${STILL_MISSING} ${binary}"
             HAS_REQUIRED_MISSING=true
         fi

--- a/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
+++ b/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
@@ -39,6 +39,9 @@ elif command -v apk &>/dev/null; then
   PACKAGE_MANAGER="apk"
 fi
 
+# Guard to avoid repeated apt-get update across multiple install_via_system calls
+_APT_UPDATED=false
+
 # --- Logging helpers ---
 
 log_fix() {
@@ -109,6 +112,10 @@ validate_name() {
 
 install_via_system() {
   local package="$1"
+  # Refresh package index before first install on apt-based systems
+  case "$PACKAGE_MANAGER" in
+    apt)  if [ "$_APT_UPDATED" != true ]; then $SUDO_PREFIX apt-get update -qq 2>/dev/null || log_fix "apt-get update failed (network issue?)"; _APT_UPDATED=true; fi ;;
+  esac
   # Try detected system manager first, then others as fallback (Alinux dnf/yum > apt > apk)
   case "$PACKAGE_MANAGER" in
     dnf)  $SUDO_PREFIX dnf install -y "$package" 2>/dev/null || $SUDO_PREFIX yum install -y "$package" 2>/dev/null || $SUDO_PREFIX apt-get install -y "$package" 2>/dev/null || $SUDO_PREFIX apk add "$package" 2>/dev/null ;;
@@ -203,7 +210,7 @@ install_via_symlink() {
   local source="$2"
   # Only allow symlinks from trusted installation directories
   case "$source" in
-    /usr/libexec/anolisa/*|/usr/share/anolisa/*|/usr/local/libexec/anolisa/*|/usr/local/share/anolisa/*)
+    /usr/lib/anolisa/*|/usr/libexec/anolisa/*|/usr/share/anolisa/*|/usr/local/lib/anolisa/*|/usr/local/libexec/anolisa/*|/usr/local/share/anolisa/*)
       ;;
     "$HOME"/.local/share/anolisa/*)
       ;;
@@ -271,6 +278,11 @@ fix_dep() {
 
   binary=$(echo "$dep_json" | jq -r '.binary // empty')
   package=$(echo "$dep_json" | jq -r '.package // empty')
+  # Resolve per-manager package overrides: apt_package/apk_package
+  case "$PACKAGE_MANAGER" in
+    apt)  apt_pkg=$(echo "$dep_json" | jq -r '.apt_package // empty'); [ -n "$apt_pkg" ] && package="$apt_pkg" ;;
+    apk)  apk_pkg=$(echo "$dep_json" | jq -r '.apk_package // empty'); [ -n "$apk_pkg" ] && package="$apk_pkg" ;;
+  esac
   manager=$(echo "$dep_json" | jq -r '.manager // "rpm"')
   version=$(echo "$dep_json" | jq -r '.version // empty')
   pip_name=$(echo "$dep_json" | jq -r '.pip_name // empty')
@@ -346,7 +358,7 @@ fix_dep() {
     npx)     install_via_npx "$package" && primary_ok=true ;;
     cargo)   install_via_cargo "$package" && primary_ok=true ;;
     symlink) local src; src=$(echo "$dep_json" | jq -r '.source // empty'); install_via_symlink "$binary" "$src" && primary_ok=true ;;
-    path)    local pdir; pdir=$(echo "$dep_json" | jq -r '.source // "/usr/libexec/anolisa/tokenless"'); install_via_path "$pdir" && primary_ok=true ;;
+    path)    local pdir; pdir=$(echo "$dep_json" | jq -r '.source // "/usr/libexec/anolisa/tokenless"'); if [ ! -d "$pdir" ]; then pdir="/usr/lib/anolisa/tokenless"; fi; install_via_path "$pdir" && primary_ok=true ;;
     dir)     local dpath; dpath=$(echo "$dep_json" | jq -r '.source // empty'); install_via_dir "$dpath" && primary_ok=true ;;
     curl_pipe_sh) [ -n "$url" ] && install_via_curl_pipe_sh "$url" "$args" && primary_ok=true ;;
     *)
@@ -392,7 +404,7 @@ fix_dep() {
         cargo)   [ -n "$fb_package" ] && install_via_cargo "$fb_package" && fb_ok=true ;;
         cargo_build) [ -n "$fb_manifest" ] && install_via_cargo_build "$fb_manifest" "$fb_binary" "$fb_features" && fb_ok=true ;;
         symlink) [ -n "$fb_source" ] && install_via_symlink "$fb_binary" "$fb_source" && fb_ok=true ;;
-        path)    install_via_path "${fb_source:-/usr/libexec/anolisa/tokenless}" && fb_ok=true ;;
+        path)    local _fb_pdir="${fb_source:-/usr/libexec/anolisa/tokenless}"; if [ ! -d "$_fb_pdir" ]; then _fb_pdir="/usr/lib/anolisa/tokenless"; fi; install_via_path "$_fb_pdir" && fb_ok=true ;;
         dir)     [ -n "$fb_source" ] && install_via_dir "$fb_source" && fb_ok=true ;;
         curl_pipe_sh) [ -n "$fb_url" ] && install_via_curl_pipe_sh "$fb_url" "$fb_args" && fb_ok=true ;;
         *) echo "[tokenless-env-fix] ${binary}: unknown fallback method '${fb_method}'" ;;

--- a/src/tokenless/adapters/tokenless/common/tool-ready-spec.json
+++ b/src/tokenless/adapters/tokenless/common/tool-ready-spec.json
@@ -15,6 +15,8 @@
         "binary": "CLI tool name for command -v detection",
         "version": "Version constraint, e.g. >=0.35",
         "package": "Package name in the manager",
+        "apt_package": "Override package name when detected manager is apt (Debian/Ubuntu). Optional; defaults to package.",
+        "apk_package": "Override package name when detected manager is apk (Alpine). Optional; defaults to package.",
         "manager": "Package manager type. Default rpm (auto-detects yum/dnf/apt/apk at runtime)",
         "pip_name": "pip package name (default = package)",
         "uv_name": "uv package name (default = package)",
@@ -50,30 +52,19 @@
       { "binary": "jq", "package": "jq", "manager": "rpm" }
     ],
     "recommended": [
-      { "binary": "rtk", "version": ">=0.35", "package": "tokenless", "manager": "rpm",
-        "fallback": [
-          { "method": "symlink", "binary": "rtk", "source": "/usr/libexec/anolisa/tokenless/rtk" }
-        ]
-      },
-      { "binary": "tokenless", "package": "tokenless", "manager": "rpm",
-        "fallback": [
-          { "method": "cargo", "binary": "tokenless", "package": "tokenless" }
-        ]
-      },
-      { "binary": "toon", "package": "tokenless", "manager": "rpm",
-        "fallback": [
-          { "method": "symlink", "binary": "toon", "source": "/usr/libexec/anolisa/tokenless/toon" },
-          { "method": "cargo", "binary": "toon", "package": "toon-format" }
-        ]
-      },
       { "binary": "git", "package": "git", "manager": "rpm" },
-      { "binary": "ssh", "package": "openssh-clients", "manager": "rpm" },
-      { "binary": "docker", "package": "docker-ce", "manager": "rpm",
+      { "binary": "ssh", "package": "openssh-clients", "apt_package": "openssh-client", "manager": "rpm" },
+      { "binary": "docker", "package": "docker-ce", "apt_package": "docker.io", "manager": "rpm",
         "fallback": [
           { "method": "rpm", "binary": "docker", "package": "docker" }
         ]
       },
-      { "binary": "uv", "package": "uv", "manager": "pip", "pip_name": "uv" },
+      { "binary": "uv", "package": "uv", "manager": "pip", "pip_name": "uv",
+        "fallback": [
+          { "method": "curl_pipe_sh", "binary": "uv", "url": "https://astral.sh/uv/install.sh" },
+          { "method": "cargo", "binary": "uv", "package": "uv" }
+        ]
+      },
       { "binary": "python3", "package": "python3", "manager": "rpm" },
       { "binary": "cargo", "package": "cargo", "manager": "rpm" },
       { "binary": "rustc", "package": "rustc", "manager": "rpm" }

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -41,8 +41,11 @@ import subprocess
 import sys
 from typing import Any
 
-# Import shared FHS constants from hook_utils
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common", "hooks"))
+# Import shared FHS constants from hook_utils.
+# realpath needed because install.sh symlinks __init__.py into
+# ~/.hermes/plugins/, and plain __file__ points to the symlink
+# path — resolving .. from there hits a nonexistent directory.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "common", "hooks"))
 from hook_utils import (
     _TOKENLESS_FALLBACK,
     _TOKENLESS_LOCAL_SHARE,
@@ -75,6 +78,9 @@ _SKIP_TOOLS: set[str] = {
 _MIN_RTK_VERSION = (0, 35, 0)
 _SHELL_TOOLS: set[str] = {"terminal"}
 
+# Debian/Ubuntu install path (RPM uses /usr/libexec, Debian uses /usr/lib)
+_RTK_LIB_FALLBACK = "/usr/lib/anolisa/tokenless/rtk"
+
 _CONTEXT_DIR = os.path.join(os.path.expanduser("~"), ".tokenless")
 _CONTEXT_FILE = os.path.join(_CONTEXT_DIR, ".rewrite-context")
 
@@ -85,23 +91,27 @@ _CONTEXT_FILE = os.path.join(_CONTEXT_DIR, ".rewrite-context")
 _resolved: dict[str, str | None] = {}
 
 
-def _resolve_binary(name: str, *fallback_paths: str) -> str | None:
+def _resolve_binary(name: str, fallback: str) -> str | None:
     if name in _resolved:
         return _resolved[name]
     path = shutil.which(name)
     if path:
         _resolved[name] = path
         return path
-    for fp in fallback_paths:
-        if os.path.isfile(fp) and os.access(fp, os.X_OK):
-            _resolved[name] = fp
-            return fp
+    # Try fallback paths in order (RPM uses /usr/libexec, Debian uses /usr/lib)
+    for fb in (fallback, _RTK_LIB_FALLBACK if name == "rtk" else "",
+               os.path.join(os.path.expanduser("~"), ".local", "bin", name),
+               _TOKENLESS_LOCAL_LIB if name != "rtk" else _RTK_LOCAL_LIB,
+               _TOKENLESS_LOCAL_SHARE if name != "rtk" else _RTK_LOCAL_SHARE):
+        if fb and os.path.isfile(fb) and os.access(fb, os.X_OK):
+            _resolved[name] = fb
+            return fb
     _resolved[name] = None
     return None
 
 
-def _have(name: str, *fallback_paths: str) -> bool:
-    return _resolve_binary(name, *fallback_paths) is not None
+def _have(name: str, fallback: str) -> bool:
+    return _resolve_binary(name, fallback) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -142,8 +152,14 @@ def _parse_version(version_str: str) -> tuple | None:
 
 
 def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
-    os.makedirs(_CONTEXT_DIR, exist_ok=True)
-    with open(_CONTEXT_FILE, "w") as f:
+    os.makedirs(_CONTEXT_DIR, mode=0o700, exist_ok=True)
+    if os.path.islink(_CONTEXT_FILE):
+        os.unlink(_CONTEXT_FILE)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(_CONTEXT_FILE, flags, 0o600)
+    with os.fdopen(fd, "w") as f:
         f.write(f"{agent_id}\n")
         f.write(f"{session_id}\n")
         f.write(f"{tool_use_id}\n")
@@ -160,7 +176,7 @@ def _compress_response(
     session_id: str,
     tool_call_id: str,
 ) -> str | None:
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
     if not tokenless_bin:
         return None
 
@@ -190,7 +206,7 @@ def _compress_response(
 
 
 def _encode_toon(data: str, session_id: str = "", tool_call_id: str = "") -> tuple[str, int] | None:
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
     if not tokenless_bin:
         return None
 
@@ -227,7 +243,7 @@ def _encode_toon(data: str, session_id: str = "", tool_call_id: str = "") -> tup
 
 def _env_check(tool_name: str) -> str | None:
     """Run tool-ready env-check and return feedback if tool is not ready."""
-    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB)
+    tokenless_bin = _resolve_binary("tokenless", _TOKENLESS_FALLBACK)
     if not tokenless_bin:
         return None
 
@@ -284,7 +300,7 @@ def _try_rewrite(
     executes the command.  On success, returns a block directive suggesting
     the rewritten command so the agent re-executes with the optimized version.
     """
-    rtk_bin = _resolve_binary("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB)
+    rtk_bin = _resolve_binary("rtk", _RTK_FALLBACK)
     if not rtk_bin:
         return None
 
@@ -377,7 +393,7 @@ def on_pre_tool_call(
     command (one extra round-trip; safe — rtk rewrite never executes).
     """
     # Step 1: env-check (all tools, needs tokenless)
-    if _have("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
+    if _have("tokenless", _TOKENLESS_FALLBACK):
         if session_id:
             os.environ["TOKENLESS_SESSION_ID"] = str(session_id)
         feedback = _env_check(tool_name)
@@ -386,7 +402,7 @@ def on_pre_tool_call(
             return {"action": "block", "message": feedback}
 
     # Step 2: RTK rewrite (terminal only, needs rtk)
-    if tool_name in _SHELL_TOOLS and _have("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB):
+    if tool_name in _SHELL_TOOLS and _have("rtk", _RTK_FALLBACK):
         result = _try_rewrite(args, str(session_id), str(tool_call_id))
         if result:
             return result
@@ -409,7 +425,7 @@ def on_transform_tool_result(
     Replaces the tool result string with a compressed/TOON-encoded version.
     Runs after post_tool_call; first valid string return wins.
     """
-    if not _have("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
+    if not _have("tokenless", _TOKENLESS_FALLBACK):
         return None
 
     # Skip content-retrieval tools
@@ -488,11 +504,11 @@ def register(ctx: Any) -> None:
 
     # Log what's active
     features: list[str] = []
-    if _have("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
+    if _have("tokenless", _TOKENLESS_FALLBACK):
         features.append("response-compression")
         features.append("toon-encoding")
         features.append("tool-ready")
-    if _have("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB):
+    if _have("rtk", _RTK_FALLBACK):
         features.append("rtk-rewrite")
 
     logger.info(

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -35,14 +35,17 @@ let tokenlessAvailable: boolean | null = null;
 
 // Resolved absolute paths — set by check*() functions so subprocess calls
 // use the correct path even when the binary is not on PATH (e.g. RPM installs
-// that place rtk/toon in /usr/libexec/anolisa/tokenless/).
+// that place rtk/toon in /usr/libexec/anolisa/tokenless/ or Debian installs
+// that use /usr/lib/anolisa/tokenless/).
 let rtkPath: string = "rtk";
 let tokenlessPath: string = "tokenless";
 
 const LIBEXEC_FALLBACK = "/usr/libexec/anolisa/tokenless";
+const LIB_FALLBACK = "/usr/lib/anolisa/tokenless";
 const TOKENLESS_FALLBACK = "/usr/bin/tokenless";
-const LOCAL_SHARE = `${process.env.HOME || ""}/.local/share/anolisa/tokenless`;
+const LOCAL_BIN = `${process.env.HOME || ""}/.local/bin`;
 const LOCAL_LIB = `${process.env.HOME || ""}/.local/lib/anolisa/tokenless`;
+const LOCAL_FALLBACK = `${process.env.HOME || ""}/.local/share/anolisa/tokenless`;
 
 // Check both existence and execute permission (mirrors shell `-x` test).
 function isExecutable(path: string): boolean {
@@ -53,40 +56,22 @@ function isExecutable(path: string): boolean {
   }
 }
 
+function resolveBinaryPath(name: string, ...fallbacks: string[]): string | null {
+  try {
+    const result = execSync(`sh -c 'command -v ${name}'`, { encoding: "utf-8" }).trim();
+    if (result && result !== "") return result;
+  } catch { /* not on PATH */ }
+  for (const fb of fallbacks) {
+    if (fb && isExecutable(fb)) return fb;
+  }
+  return null;
+}
+
 function checkRtk(): boolean {
   if (rtkAvailable !== null) return rtkAvailable;
-  try {
-    const result = execSync("which rtk 2>/dev/null || echo ''", { encoding: "utf-8" }).trim();
-    if (result && result !== "") {
-      rtkPath = result;
-      rtkAvailable = true;
-    } else if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
-      rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
-      rtkAvailable = true;
-    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/rtk`)) {
-      rtkPath = `${LOCAL_SHARE}/rtk`;
-      rtkAvailable = true;
-    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/rtk`)) {
-      rtkPath = `${LOCAL_LIB}/rtk`;
-      rtkAvailable = true;
-    } else {
-      rtkAvailable = false;
-    }
-  } catch {
-    if (isExecutable(`${LIBEXEC_FALLBACK}/rtk`)) {
-      rtkPath = `${LIBEXEC_FALLBACK}/rtk`;
-      rtkAvailable = true;
-    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/rtk`)) {
-      rtkPath = `${LOCAL_SHARE}/rtk`;
-      rtkAvailable = true;
-    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/rtk`)) {
-      rtkPath = `${LOCAL_LIB}/rtk`;
-      rtkAvailable = true;
-    } else {
-      rtkAvailable = false;
-    }
-    return rtkAvailable;
-  }
+  const resolved = resolveBinaryPath("rtk", `${LIBEXEC_FALLBACK}/rtk`, `${LIB_FALLBACK}/rtk`, `${LOCAL_FALLBACK}/rtk`, `${LOCAL_LIB}/rtk`, `${LOCAL_BIN}/rtk`);
+  if (resolved) { rtkPath = resolved; rtkAvailable = true; }
+  else { rtkAvailable = false; }
   return rtkAvailable;
 }
 
@@ -103,41 +88,11 @@ function isSkillContent(message: any): boolean {
 
 function checkTokenless(): boolean {
   if (tokenlessAvailable !== null) return tokenlessAvailable;
-  try {
-    const result = execSync("which tokenless 2>/dev/null || echo ''", { encoding: "utf-8" }).trim();
-    if (result && result !== "") {
-      tokenlessPath = result;
-      tokenlessAvailable = true;
-    } else if (isExecutable(TOKENLESS_FALLBACK)) {
-      tokenlessPath = TOKENLESS_FALLBACK;
-      tokenlessAvailable = true;
-    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/tokenless`)) {
-      tokenlessPath = `${LOCAL_SHARE}/tokenless`;
-      tokenlessAvailable = true;
-    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/tokenless`)) {
-      tokenlessPath = `${LOCAL_LIB}/tokenless`;
-      tokenlessAvailable = true;
-    } else {
-      tokenlessAvailable = false;
-    }
-  } catch {
-    if (isExecutable(TOKENLESS_FALLBACK)) {
-      tokenlessPath = TOKENLESS_FALLBACK;
-      tokenlessAvailable = true;
-    } else if (LOCAL_SHARE && isExecutable(`${LOCAL_SHARE}/tokenless`)) {
-      tokenlessPath = `${LOCAL_SHARE}/tokenless`;
-      tokenlessAvailable = true;
-    } else if (LOCAL_LIB && isExecutable(`${LOCAL_LIB}/tokenless`)) {
-      tokenlessPath = `${LOCAL_LIB}/tokenless`;
-      tokenlessAvailable = true;
-    } else {
-      tokenlessAvailable = false;
-    }
-    return tokenlessAvailable;
-  }
+  const resolved = resolveBinaryPath("tokenless", TOKENLESS_FALLBACK, `${LOCAL_FALLBACK}/tokenless`, `${LOCAL_LIB}/tokenless`, `${LOCAL_BIN}/tokenless`);
+  if (resolved) { tokenlessPath = resolved; tokenlessAvailable = true; }
+  else { tokenlessAvailable = false; }
   return tokenlessAvailable;
 }
-
 
 // ---- Subprocess helpers -------------------------------------------------------
 

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -26,6 +26,7 @@ fn is_trusted_path(path: &std::path::Path) -> bool {
     // System paths are always trusted
     if path.starts_with("/usr/share")
         || path.starts_with("/usr/libexec")
+        || path.starts_with("/usr/lib/anolisa")
         || path.starts_with("/usr/local/share")
     {
         return true;
@@ -37,6 +38,7 @@ fn is_trusted_path(path: &std::path::Path) -> bool {
                 // System targets are always trusted
                 if resolved.starts_with("/usr/share")
                     || resolved.starts_with("/usr/libexec")
+                    || resolved.starts_with("/usr/lib/anolisa")
                     || resolved.starts_with("/usr/local/share")
                 {
                     return true;
@@ -77,6 +79,8 @@ struct DepEntry {
     binary: String,
     version: Option<String>,
     package: String,
+    apt_package: Option<String>,
+    apk_package: Option<String>,
     manager: String,
     pip_name: Option<String>,
     uv_name: Option<String>,
@@ -155,6 +159,8 @@ fn normalize_dep(value: &Value) -> DepEntry {
                     binary,
                     version,
                     package: s[..idx].to_string(),
+                    apt_package: None,
+                    apk_package: None,
                     manager: "rpm".to_string(),
                     pip_name: None,
                     uv_name: None,
@@ -167,6 +173,8 @@ fn normalize_dep(value: &Value) -> DepEntry {
                     binary: s.clone(),
                     version: None,
                     package: s.clone(),
+                    apt_package: None,
+                    apk_package: None,
                     manager: "rpm".to_string(),
                     pip_name: None,
                     uv_name: None,
@@ -191,6 +199,14 @@ fn normalize_dep(value: &Value) -> DepEntry {
                 .and_then(|v| v.as_str())
                 .unwrap_or(&binary)
                 .to_string();
+            let apt_package = obj
+                .get("apt_package")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let apk_package = obj
+                .get("apk_package")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             let manager = obj
                 .get("manager")
                 .and_then(|v| v.as_str())
@@ -267,6 +283,8 @@ fn normalize_dep(value: &Value) -> DepEntry {
                 binary,
                 version,
                 package,
+                apt_package,
+                apk_package,
                 manager,
                 pip_name,
                 uv_name,
@@ -279,6 +297,8 @@ fn normalize_dep(value: &Value) -> DepEntry {
             binary: "".to_string(),
             version: None,
             package: "".to_string(),
+            apt_package: None,
+            apk_package: None,
             manager: "rpm".to_string(),
             pip_name: None,
             uv_name: None,
@@ -356,6 +376,31 @@ fn resolve_manager(manager: &str) -> String {
     }
 }
 
+/// Resolve the actual package name for the detected system manager.
+/// When manager="rpm" (meaning auto-detect), the detected manager may be apt/apk,
+/// and those systems have different package names. apt_package/apk_package override
+/// the default package field when present.
+fn resolve_package(dep: &DepEntry) -> String {
+    let detected = resolve_manager(&dep.manager);
+    if dep.manager == "rpm" {
+        match detected.as_str() {
+            "apt" => dep
+                .apt_package
+                .as_deref()
+                .unwrap_or(&dep.package)
+                .to_string(),
+            "apk" => dep
+                .apk_package
+                .as_deref()
+                .unwrap_or(&dep.package)
+                .to_string(),
+            _ => dep.package.clone(),
+        }
+    } else {
+        dep.package.clone()
+    }
+}
+
 /// Extract the required version from a constraint string like ">=0.35".
 fn extract_required_version(version: &str) -> &str {
     version
@@ -406,11 +451,45 @@ fn check_dep(dep: &DepEntry) -> DepStatus {
         .args(["-c", "command -v \"$1\"", "--", &dep.binary])
         .output();
 
-    match which_result {
+    let binary_path: Option<String> = match which_result {
         Ok(output) if output.status.success() => {
+            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        }
+        _ => {
+            // PATH lookup failed — try known install paths
+            let home = super::get_home_dir();
+            let candidates = [
+                format!("/usr/libexec/anolisa/tokenless/{}", dep.binary),
+                format!("/usr/lib/anolisa/tokenless/{}", dep.binary),
+                format!("{}/.local/bin/{}", home, dep.binary),
+                format!("{}/.local/lib/anolisa/tokenless/{}", home, dep.binary),
+            ];
+            candidates
+                .iter()
+                .find(|p| {
+                    let path = std::path::Path::new(p);
+                    path.exists()
+                        && std::fs::metadata(path)
+                            .map(|m| {
+                                #[cfg(unix)]
+                                {
+                                    use std::os::unix::fs::PermissionsExt;
+                                    m.permissions().mode() & 0o111 != 0
+                                }
+                                #[cfg(not(unix))]
+                                true
+                            })
+                            .unwrap_or(false)
+                })
+                .cloned()
+        }
+    };
+
+    match binary_path {
+        Some(path) if !path.is_empty() => {
             if let Some(ref version) = dep.version {
                 let required_version = extract_required_version(version);
-                let version_output = Command::new(&dep.binary).arg("--version").output();
+                let version_output = Command::new(&path).arg("--version").output();
                 let installed_version = match version_output {
                     Ok(out) => {
                         let stdout = String::from_utf8_lossy(&out.stdout);
@@ -475,8 +554,8 @@ fn check_permission(perm: &str) -> bool {
             }
             can_write
         }
-        "exec_shell" => Command::new("which")
-            .arg("bash")
+        "exec_shell" => Command::new("sh")
+            .args(["-c", "command -v bash"])
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false),
@@ -781,7 +860,13 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
             if let Some(ref v) = dep.version {
                 obj.insert("version".to_string(), Value::String(v.clone()));
             }
-            obj.insert("package".to_string(), Value::String(dep.package.clone()));
+            obj.insert("package".to_string(), Value::String(resolve_package(dep)));
+            if let Some(ref ap) = dep.apt_package {
+                obj.insert("apt_package".to_string(), Value::String(ap.clone()));
+            }
+            if let Some(ref akp) = dep.apk_package {
+                obj.insert("apk_package".to_string(), Value::String(akp.clone()));
+            }
             obj.insert("manager".to_string(), Value::String(dep.manager.clone()));
             if let Some(ref pn) = dep.pip_name {
                 obj.insert("pip_name".to_string(), Value::String(pn.clone()));
@@ -835,16 +920,34 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
     let json_str = serde_json::to_string(&deps_json)
         .map_err(|e| format!("Failed to serialize deps: {}", e))?;
 
-    let mut child = Command::new("timeout")
-        .arg("120")
-        .arg("bash")
-        .arg(&fix_script)
-        .arg("fix-all")
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("Failed to run env-fix: {}", e))?;
+    // Use timeout if available (coreutils procps), otherwise run without timeout
+    let has_timeout = Command::new("sh")
+        .args(["-c", "command -v timeout"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let mut child = if has_timeout {
+        Command::new("timeout")
+            .arg("120")
+            .arg("bash")
+            .arg(&fix_script)
+            .arg("fix-all")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to run env-fix: {}", e))?
+    } else {
+        Command::new("bash")
+            .arg(&fix_script)
+            .arg("fix-all")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to run env-fix: {}", e))?
+    };
 
     let mut stdin_handle = child
         .stdin
@@ -1420,6 +1523,8 @@ mod tests {
                     binary: "fake".to_string(),
                     version: None,
                     package: "fake".to_string(),
+                    apt_package: None,
+                    apk_package: None,
                     manager: "rpm".to_string(),
                     pip_name: None,
                     uv_name: None,


### PR DESCRIPTION
## Description

- add /usr/lib/anolisa fallback paths for Debian (RPM uses /usr/libexec)
- add apt_package/apk_package overrides for distro-specific package names
- fix hermes symlink import (realpath) and use shared hook_utils constants
- secure .rewrite-context writes (O_NOFOLLOW, 0o600, unlink symlink)
- remove duplicate libc dep and dead checkToon code

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes #563 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
测试结果报告 — commit 178e1fe

  ┌─────────────────────────────────┬──────────────────┬────────────────────────────────────────────────┐
  │             检查项              │       结果       │                      详情                      │
  ├─────────────────────────────────┼──────────────────┼────────────────────────────────────────────────┤
  │ cargo fmt --check     P      P  │ ✅ PASS │        │ —                              │              │
  ├─────────────────────────────────┼──────────────────┼────────────────────────────────────────────────┤
  │ cargo clippy -D warnings     P  │ ✅ PASS │        │ —                              │              │
  ├─────────────────────────────────┼──────────────────┼────────────────────────────────────────────────┤
  │ cargo test (70 tests)        P  │ ✅ PASS         │ cli 29 + schema 23 + integration 19 + stats 18 │
  ├─────────────────────────────────┼──────────────────┼────────────────────────────────────────────────┤
  │ hook 集成测试                P  │ ✅ PASS         │ 90/90                                          │
  ├─────────────────────────────────┼──────────────────┼────────────────────────────────────────────────┤
  │ hermes realpath import       P  │ ✅ PASS         │ 实测 symlink 场景 import 成功                  │
  ├─────────────────────────────────┼──────────────────┼────────────────────────────────────────────────┤
  │ hermes _resolve_binary 路径覆盖 │ ✅ 无 regression │ 新版 5 候选路径覆盖旧版全部 4 路径 + 新增 3    │
  └─────────────────────────────────┴──────────────────┴────────────────────────────────────────────────┘

  全部门禁通过，0 失败，0 regression。
```