### PR TITLE
feat(sight): add client-side hybrid encryption for sensitive message fields

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -1,5 +1,8 @@
 {
   "tcp_targets": [],
+  "encryption": {
+    "public_key": ""
+  },
   "cmdline": {
     "allow": [
       {"rule": ["hermes*"], "agent_name": "Hermes"},

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -197,6 +197,17 @@ struct JsonFullConfig {
     tcp_ports: Option<Vec<u16>>,
     #[serde(default)]
     tcp_targets: Option<Vec<String>>,
+    #[serde(default)]
+    encryption: Option<JsonEncryption>,
+}
+
+/// 加密配置：可选公钥（PEM 字符串）或公钥文件路径
+#[derive(serde::Deserialize)]
+struct JsonEncryption {
+    #[serde(default)]
+    public_key: Option<String>,
+    #[serde(default)]
+    public_key_path: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -377,6 +388,11 @@ pub struct AgentsightConfig {
     // --- Config File Path ---
     /// Path to JSON configuration file
     pub config_path: Option<PathBuf>,
+
+    // --- Encryption Configuration ---
+    /// RSA 公钥（PEM 字符串）。从 agentsight.json `encryption.public_key`
+    /// 或 `encryption.public_key_path` 加载。若为 None，则不加密敏感消息字段。
+    pub encryption_public_key: Option<String>,
 }
 
 impl Default for AgentsightConfig {
@@ -421,6 +437,9 @@ impl Default for AgentsightConfig {
 
             // Config file path default
             config_path: None,
+
+            // Encryption defaults (loaded from config file)
+            encryption_public_key: None,
         }
     }
 }
@@ -523,6 +542,31 @@ impl AgentsightConfig {
                 .into_iter()
                 .map(|p| TcpTarget { ip: None, port: Some(p) })
                 .collect();
+        }
+
+        // 加载加密公钥：优先 public_key（内联 PEM），其次 public_key_path（文件路径）
+        if let Some(enc) = parsed.encryption.take() {
+            if let Some(pem) = enc.public_key {
+                let trimmed = pem.trim();
+                if !trimmed.is_empty() {
+                    self.encryption_public_key = Some(trimmed.to_string());
+                }
+            } else if let Some(path) = enc.public_key_path {
+                let trimmed = path.trim();
+                if !trimmed.is_empty() {
+                    match std::fs::read_to_string(trimmed) {
+                        Ok(content) => {
+                            self.encryption_public_key = Some(content);
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to read encryption public_key_path {:?}: {}, encryption disabled",
+                                trimmed, e
+                            );
+                        }
+                    }
+                }
+            }
         }
 
         let (cmdline_rules, domain_rules) = extract_rules(parsed);

--- a/src/agentsight/src/genai/encrypt.rs
+++ b/src/agentsight/src/genai/encrypt.rs
@@ -1,0 +1,220 @@
+//! 消息混合加密模块
+//!
+//! 使用 RSA-OAEP(SHA-256) + AES-256-GCM 混合加密方案保护敏感消息字段。
+//! 每次加密生成随机 AES-256 密钥和 nonce，用公钥加密 AES 密钥，
+//! 最终输出 base64 编码的二进制密文。
+//!
+//! 公钥管理策略：代码内嵌默认公钥，环境变量 `MESSAGE_ENCRYPT_PUBLIC_KEY` 可覆盖。
+
+use openssl::rsa::{Rsa, Padding};
+use openssl::pkey::Public;
+use openssl::symm::{Cipher, encrypt_aead};
+use openssl::rand::rand_bytes;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+
+/// 环境变量名（设置后覆盖默认公钥）
+pub const ENCRYPT_PUBLIC_KEY_ENV_VAR: &str = "MESSAGE_ENCRYPT_PUBLIC_KEY";
+
+/// 编译时内嵌的默认 RSA 公钥（开箱即用，无需配置环境变量）
+/// 生产环境可通过环境变量 MESSAGE_ENCRYPT_PUBLIC_KEY 覆盖此默认值
+const DEFAULT_PUBLIC_KEY_PEM: &str = r#"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzK4VhG29nW7eydBm3fzh
+HDVJQ5RQpqOkIhairUWIjH/QS5s9OnPmRTM7vipTvku4yRD6AfJycPIjR0jZXVpd
+EVTsz/K4E4qTm6o1w7ciuTvc56Gt9AHR86OURj9VRcZz058NVZRpYEtQqH9sVjJP
+JwjS5YhpKJef6leQztexxKpMHCMVm2cedCJFUCJDd0bF9NUN04sdr49H/D6U/B09
+oz/VhPlHSn6dMp9yMJtN0YE+X51KQxVqIyuVZ/xgr34AWeweiyLNJTyLFnY5zFIL
+pVe9hOgtU1LkSTW9C41bPOiODD89068dUpYGDrXIzumC8ik54ITNhDVScLS9Beua
+hwIDAQAB
+-----END PUBLIC KEY-----"#;
+
+/// AES-256 密钥长度（32 字节）
+const AES_KEY_LEN: usize = 32;
+
+/// AES-GCM nonce 长度（12 字节）
+const NONCE_LEN: usize = 12;
+
+/// AES-GCM 认证标签长度（16 字节）
+const TAG_LEN: usize = 16;
+
+/// 消息加密器，持有解析后的 RSA 公钥
+pub struct MessageEncryptor {
+    rsa: Rsa<Public>,
+}
+
+impl MessageEncryptor {
+    /// 创建加密器
+    ///
+    /// 优先读取环境变量 `MESSAGE_ENCRYPT_PUBLIC_KEY` 中的 PEM 公钥；
+    /// 若未设置，使用代码内嵌的默认公钥。
+    /// 解析失败时记录警告并返回 None（回退到明文模式）。
+    pub fn new() -> Option<Self> {
+        let pem_str = std::env::var(ENCRYPT_PUBLIC_KEY_ENV_VAR)
+            .unwrap_or_else(|_| DEFAULT_PUBLIC_KEY_PEM.to_string());
+
+        match Rsa::public_key_from_pem(pem_str.as_bytes()) {
+            Ok(rsa) => {
+                log::info!("MessageEncryptor initialized (RSA-{} + AES-256-GCM)", rsa.size() * 8);
+                Some(MessageEncryptor { rsa })
+            }
+            Err(e) => {
+                log::warn!("Failed to parse RSA public key, encryption disabled: {}", e);
+                None
+            }
+        }
+    }
+
+    /// 执行混合加密
+    ///
+    /// 输出格式（base64 编码）：
+    /// `[2字节 encrypted_key 长度(big-endian)] [encrypted_key] [12字节 nonce] [ciphertext + 16字节 tag]`
+    pub fn encrypt(&self, plaintext: &str) -> Result<String, String> {
+        // 1. 生成随机 AES-256 密钥
+        let mut aes_key = vec![0u8; AES_KEY_LEN];
+        rand_bytes(&mut aes_key).map_err(|e| format!("rand_bytes for AES key failed: {}", e))?;
+
+        // 2. 生成随机 12 字节 nonce
+        let mut nonce = vec![0u8; NONCE_LEN];
+        rand_bytes(&mut nonce).map_err(|e| format!("rand_bytes for nonce failed: {}", e))?;
+
+        // 3. AES-256-GCM 加密明文
+        let mut tag = vec![0u8; TAG_LEN];
+        let ciphertext = encrypt_aead(
+            Cipher::aes_256_gcm(),
+            &aes_key,
+            Some(&nonce),
+            &[],  // AAD (Additional Authenticated Data) - 不使用
+            plaintext.as_bytes(),
+            &mut tag,
+        ).map_err(|e| format!("AES-256-GCM encryption failed: {}", e))?;
+
+        // 4. RSA-OAEP(SHA-256) 加密 AES 密钥
+        let mut encrypted_key = vec![0u8; self.rsa.size() as usize];
+        let encrypted_key_len = self.rsa.public_encrypt(
+            &aes_key,
+            &mut encrypted_key,
+            Padding::PKCS1_OAEP,
+        ).map_err(|e| format!("RSA-OAEP encryption failed: {}", e))?;
+        encrypted_key.truncate(encrypted_key_len);
+
+        // 5. 组装二进制输出：[2字节长度] [encrypted_key] [nonce] [ciphertext] [tag]
+        let key_len_bytes = (encrypted_key_len as u16).to_be_bytes();
+        let mut output = Vec::with_capacity(
+            2 + encrypted_key_len + NONCE_LEN + ciphertext.len() + TAG_LEN
+        );
+        output.extend_from_slice(&key_len_bytes);
+        output.extend_from_slice(&encrypted_key);
+        output.extend_from_slice(&nonce);
+        output.extend_from_slice(&ciphertext);
+        output.extend_from_slice(&tag);
+
+        // 6. Base64 编码
+        Ok(BASE64.encode(&output))
+    }
+
+    /// 辅助方法：有加密器则加密，加密失败或无加密器时返回原文
+    pub fn maybe_encrypt(encryptor: Option<&Self>, text: &str) -> String {
+        match encryptor {
+            Some(enc) => match enc.encrypt(text) {
+                Ok(encrypted) => encrypted,
+                Err(e) => {
+                    log::warn!("Encryption failed, falling back to plaintext: {}", e);
+                    text.to_string()
+                }
+            },
+            None => text.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openssl::rsa::Rsa;
+    use openssl::symm::{Cipher, decrypt_aead};
+
+    #[test]
+    fn test_new_with_default_key() {
+        // 不设置环境变量，应使用默认公钥成功创建
+        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
+        let enc = MessageEncryptor::new();
+        assert!(enc.is_some(), "Should create encryptor with default key");
+    }
+
+    #[test]
+    fn test_encrypt_produces_different_output() {
+        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
+        let enc = MessageEncryptor::new().unwrap();
+        let plaintext = "hello world, this is a secret message";
+        let encrypted = enc.encrypt(plaintext).unwrap();
+
+        // 加密结果应该是有效的 base64 且与原文不同
+        assert_ne!(encrypted, plaintext);
+        assert!(!encrypted.is_empty());
+        // base64 解码应成功
+        let decoded = BASE64.decode(&encrypted).unwrap();
+        assert!(decoded.len() > 2 + NONCE_LEN + TAG_LEN);
+    }
+
+    // 该测试依赖本地 tests/test_private_key.pem（与默认公钥配对的私钥）。
+    // 出于安全考虑私钥文件不提交到仓库，仅在本地手动生成密钥对后运行：
+    //   cargo test --lib genai::encrypt::tests::test_encrypt_decrypt_roundtrip -- --ignored
+    #[test]
+    #[ignore]
+    fn test_encrypt_decrypt_roundtrip() {
+        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
+        let enc = MessageEncryptor::new().unwrap();
+        let plaintext = "测试消息：gen_ai.input.messages 内容加密验证";
+
+        let encrypted = enc.encrypt(plaintext).unwrap();
+
+        // 用测试私钥解密
+        let private_key_pem = std::fs::read(
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test_private_key.pem")
+        ).expect("test_private_key.pem should exist in tests/");
+        let private_rsa = Rsa::private_key_from_pem(&private_key_pem).unwrap();
+
+        // 解析密文结构
+        let raw = BASE64.decode(&encrypted).unwrap();
+        let key_len = u16::from_be_bytes([raw[0], raw[1]]) as usize;
+        let encrypted_key = &raw[2..2 + key_len];
+        let nonce = &raw[2 + key_len..2 + key_len + NONCE_LEN];
+        let ciphertext_and_tag = &raw[2 + key_len + NONCE_LEN..];
+        let (ciphertext, tag) = ciphertext_and_tag.split_at(ciphertext_and_tag.len() - TAG_LEN);
+
+        // RSA 解密 AES 密钥
+        let mut aes_key = vec![0u8; private_rsa.size() as usize];
+        let aes_key_len = private_rsa.private_decrypt(
+            encrypted_key, &mut aes_key, Padding::PKCS1_OAEP
+        ).unwrap();
+        let aes_key = &aes_key[..aes_key_len];
+
+        // AES-256-GCM 解密
+        let decrypted = decrypt_aead(
+            Cipher::aes_256_gcm(),
+            aes_key,
+            Some(nonce),
+            &[],
+            ciphertext,
+            tag,
+        ).unwrap();
+
+        assert_eq!(String::from_utf8(decrypted).unwrap(), plaintext);
+    }
+
+    #[test]
+    fn test_maybe_encrypt_without_encryptor() {
+        let text = "plain text content";
+        let result = MessageEncryptor::maybe_encrypt(None, text);
+        assert_eq!(result, text);
+    }
+
+    #[test]
+    fn test_maybe_encrypt_with_encryptor() {
+        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
+        let enc = MessageEncryptor::new().unwrap();
+        let text = "secret content";
+        let result = MessageEncryptor::maybe_encrypt(Some(&enc), text);
+        assert_ne!(result, text);
+    }
+}

--- a/src/agentsight/src/genai/encrypt.rs
+++ b/src/agentsight/src/genai/encrypt.rs
@@ -4,7 +4,7 @@
 //! 每次加密生成随机 AES-256 密钥和 nonce，用公钥加密 AES 密钥，
 //! 最终输出 base64 编码的二进制密文。
 //!
-//! 公钥管理策略：代码内嵌默认公钥，环境变量 `MESSAGE_ENCRYPT_PUBLIC_KEY` 可覆盖。
+//! 公钥来源：由调用方从 agentsight.json 的 `encryption.public_key` 读取后传入。
 
 use openssl::rsa::{Rsa, Padding};
 use openssl::pkey::Public;
@@ -12,21 +12,6 @@ use openssl::symm::{Cipher, encrypt_aead};
 use openssl::rand::rand_bytes;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-
-/// 环境变量名（设置后覆盖默认公钥）
-pub const ENCRYPT_PUBLIC_KEY_ENV_VAR: &str = "MESSAGE_ENCRYPT_PUBLIC_KEY";
-
-/// 编译时内嵌的默认 RSA 公钥（开箱即用，无需配置环境变量）
-/// 生产环境可通过环境变量 MESSAGE_ENCRYPT_PUBLIC_KEY 覆盖此默认值
-const DEFAULT_PUBLIC_KEY_PEM: &str = r#"-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzK4VhG29nW7eydBm3fzh
-HDVJQ5RQpqOkIhairUWIjH/QS5s9OnPmRTM7vipTvku4yRD6AfJycPIjR0jZXVpd
-EVTsz/K4E4qTm6o1w7ciuTvc56Gt9AHR86OURj9VRcZz058NVZRpYEtQqH9sVjJP
-JwjS5YhpKJef6leQztexxKpMHCMVm2cedCJFUCJDd0bF9NUN04sdr49H/D6U/B09
-oz/VhPlHSn6dMp9yMJtN0YE+X51KQxVqIyuVZ/xgr34AWeweiyLNJTyLFnY5zFIL
-pVe9hOgtU1LkSTW9C41bPOiODD89068dUpYGDrXIzumC8ik54ITNhDVScLS9Beua
-hwIDAQAB
------END PUBLIC KEY-----"#;
 
 /// AES-256 密钥长度（32 字节）
 const AES_KEY_LEN: usize = 32;
@@ -43,16 +28,12 @@ pub struct MessageEncryptor {
 }
 
 impl MessageEncryptor {
-    /// 创建加密器
+    /// 从指定 PEM 字符串创建加密器
     ///
-    /// 优先读取环境变量 `MESSAGE_ENCRYPT_PUBLIC_KEY` 中的 PEM 公钥；
-    /// 若未设置，使用代码内嵌的默认公钥。
     /// 解析失败时记录警告并返回 None（回退到明文模式）。
-    pub fn new() -> Option<Self> {
-        let pem_str = std::env::var(ENCRYPT_PUBLIC_KEY_ENV_VAR)
-            .unwrap_or_else(|_| DEFAULT_PUBLIC_KEY_PEM.to_string());
-
-        match Rsa::public_key_from_pem(pem_str.as_bytes()) {
+    /// PEM 来源由调用方决定（通常来自 agentsight.json 的 encryption.public_key）。
+    pub fn from_pem(pem: &str) -> Option<Self> {
+        match Rsa::public_key_from_pem(pem.as_bytes()) {
             Ok(rsa) => {
                 log::info!("MessageEncryptor initialized (RSA-{} + AES-256-GCM)", rsa.size() * 8);
                 Some(MessageEncryptor { rsa })
@@ -130,76 +111,12 @@ impl MessageEncryptor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openssl::rsa::Rsa;
-    use openssl::symm::{Cipher, decrypt_aead};
 
     #[test]
-    fn test_new_with_default_key() {
-        // 不设置环境变量，应使用默认公钥成功创建
-        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
-        let enc = MessageEncryptor::new();
-        assert!(enc.is_some(), "Should create encryptor with default key");
-    }
-
-    #[test]
-    fn test_encrypt_produces_different_output() {
-        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
-        let enc = MessageEncryptor::new().unwrap();
-        let plaintext = "hello world, this is a secret message";
-        let encrypted = enc.encrypt(plaintext).unwrap();
-
-        // 加密结果应该是有效的 base64 且与原文不同
-        assert_ne!(encrypted, plaintext);
-        assert!(!encrypted.is_empty());
-        // base64 解码应成功
-        let decoded = BASE64.decode(&encrypted).unwrap();
-        assert!(decoded.len() > 2 + NONCE_LEN + TAG_LEN);
-    }
-
-    // 该测试依赖本地 tests/test_private_key.pem（与默认公钥配对的私钥）。
-    // 出于安全考虑私钥文件不提交到仓库，仅在本地手动生成密钥对后运行：
-    //   cargo test --lib genai::encrypt::tests::test_encrypt_decrypt_roundtrip -- --ignored
-    #[test]
-    #[ignore]
-    fn test_encrypt_decrypt_roundtrip() {
-        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
-        let enc = MessageEncryptor::new().unwrap();
-        let plaintext = "测试消息：gen_ai.input.messages 内容加密验证";
-
-        let encrypted = enc.encrypt(plaintext).unwrap();
-
-        // 用测试私钥解密
-        let private_key_pem = std::fs::read(
-            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test_private_key.pem")
-        ).expect("test_private_key.pem should exist in tests/");
-        let private_rsa = Rsa::private_key_from_pem(&private_key_pem).unwrap();
-
-        // 解析密文结构
-        let raw = BASE64.decode(&encrypted).unwrap();
-        let key_len = u16::from_be_bytes([raw[0], raw[1]]) as usize;
-        let encrypted_key = &raw[2..2 + key_len];
-        let nonce = &raw[2 + key_len..2 + key_len + NONCE_LEN];
-        let ciphertext_and_tag = &raw[2 + key_len + NONCE_LEN..];
-        let (ciphertext, tag) = ciphertext_and_tag.split_at(ciphertext_and_tag.len() - TAG_LEN);
-
-        // RSA 解密 AES 密钥
-        let mut aes_key = vec![0u8; private_rsa.size() as usize];
-        let aes_key_len = private_rsa.private_decrypt(
-            encrypted_key, &mut aes_key, Padding::PKCS1_OAEP
-        ).unwrap();
-        let aes_key = &aes_key[..aes_key_len];
-
-        // AES-256-GCM 解密
-        let decrypted = decrypt_aead(
-            Cipher::aes_256_gcm(),
-            aes_key,
-            Some(nonce),
-            &[],
-            ciphertext,
-            tag,
-        ).unwrap();
-
-        assert_eq!(String::from_utf8(decrypted).unwrap(), plaintext);
+    fn test_from_pem_invalid_returns_none() {
+        // 非法 PEM 应该返回 None（不崩溃）
+        let enc = MessageEncryptor::from_pem("not a valid pem");
+        assert!(enc.is_none());
     }
 
     #[test]
@@ -207,14 +124,5 @@ mod tests {
         let text = "plain text content";
         let result = MessageEncryptor::maybe_encrypt(None, text);
         assert_eq!(result, text);
-    }
-
-    #[test]
-    fn test_maybe_encrypt_with_encryptor() {
-        unsafe { std::env::remove_var(ENCRYPT_PUBLIC_KEY_ENV_VAR); }
-        let enc = MessageEncryptor::new().unwrap();
-        let text = "secret content";
-        let result = MessageEncryptor::maybe_encrypt(Some(&enc), text);
-        assert_ne!(result, text);
     }
 }

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -44,13 +44,20 @@ impl LogtailExporter {
     ///
     /// 从环境变量 `SLS_LOGTAIL_FILE` 读取路径，自动创建父目录。
     /// 如果环境变量未设置，返回 `None`。
-    pub fn new() -> Option<Self> {
+    ///
+    /// `encryption_pem`：可选 RSA 公钥 PEM（通常来自 agentsight.json
+    /// 的 `encryption.public_key`）。有值且解析成功则启用加密；
+    /// 为 None 或解析失败则不加密。
+    pub fn new(encryption_pem: Option<&str>) -> Option<Self> {
         let path_str = logtail_path()?;
         let path = PathBuf::from(path_str);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).ok();
         }
-        let encryptor = MessageEncryptor::new();
+        let encryptor = encryption_pem.and_then(MessageEncryptor::from_pem);
+        if encryptor.is_none() {
+            log::info!("Logtail exporter: encryption disabled (no public key configured)");
+        }
         Some(LogtailExporter { path, encryptor })
     }
 

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -14,6 +14,7 @@ use std::io::{Write, BufWriter};
 use super::semantic::GenAISemanticEvent;
 use super::exporter::GenAIExporter;
 use super::instance_id;
+use super::encrypt::MessageEncryptor;
 
 /// 环境变量名称
 pub const LOGTAIL_ENV_VAR: &str = "SLS_LOGTAIL_FILE";
@@ -32,8 +33,10 @@ pub fn logtail_path() -> Option<String> {
 ///
 /// 将 GenAI 事件以扁平化 JSON 格式（每行一条记录）写入指定路径，
 /// 由 iLogtail 自动采集上传到 SLS。字段命名与 SLS PutLogs 完全一致。
+/// 敏感消息字段使用 RSA+AES 混合加密保护。
 pub struct LogtailExporter {
     path: PathBuf,
+    encryptor: Option<MessageEncryptor>,
 }
 
 impl LogtailExporter {
@@ -47,7 +50,8 @@ impl LogtailExporter {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).ok();
         }
-        Some(LogtailExporter { path })
+        let encryptor = MessageEncryptor::new();
+        Some(LogtailExporter { path, encryptor })
     }
 
     /// 返回导出文件路径
@@ -57,7 +61,7 @@ impl LogtailExporter {
 
     /// 将扁平化记录批量写入文件（append 模式）
     fn write_batch(&self, events: &[GenAISemanticEvent]) {
-        let records = events_to_flat_records(events);
+        let records = events_to_flat_records(events, self.encryptor.as_ref());
         if records.is_empty() {
             return;
         }
@@ -112,7 +116,8 @@ impl GenAIExporter for LogtailExporter {
 /// 包含 iLogtail 保留字段：`__time__`、`__source__`、`__topic__`。
 ///
 /// 此函数被 Logtail 文件导出器使用，由 iLogtail 采集后上传到 SLS。
-pub fn events_to_flat_records(events: &[GenAISemanticEvent]) -> Vec<BTreeMap<String, String>> {
+/// 敏感消息字段（system_instructions/input.messages/output.messages）使用混合加密保护。
+pub fn events_to_flat_records(events: &[GenAISemanticEvent], encryptor: Option<&MessageEncryptor>) -> Vec<BTreeMap<String, String>> {
     let hostname = instance_id::get_instance_id();
     let uid = instance_id::get_owner_account_id();
     let mut records = Vec::with_capacity(events.len());
@@ -195,6 +200,47 @@ pub fn events_to_flat_records(events: &[GenAISemanticEvent]) -> Vec<BTreeMap<Str
                     m.insert("server.address".to_string(), addr.clone());
                 }
                 m.insert("gen_ai.output.type".to_string(), "text".to_string());
+
+                // ── gen_ai.system_instructions (system role messages) ──
+                let system_msgs: Vec<&super::semantic::InputMessage> = call.request.messages.iter()
+                    .filter(|msg| msg.role == "system")
+                    .collect();
+                if !system_msgs.is_empty() {
+                    if let Ok(json) = serde_json::to_string(&system_msgs) {
+                        m.insert("gen_ai.system_instructions".to_string(),
+                            MessageEncryptor::maybe_encrypt(encryptor, &json));
+                    }
+                }
+
+                // ── gen_ai.input.messages (增量：只取最新一轮) ──
+                // 从后往前找最后一条 user message，取它及之后的所有非 system 消息
+                let non_system: Vec<&super::semantic::InputMessage> = call.request.messages.iter()
+                    .filter(|msg| msg.role != "system")
+                    .collect();
+                let latest_msgs: &[&super::semantic::InputMessage] = if let Some(last_user_idx) = non_system.iter().rposition(|m| m.role == "user") {
+                    &non_system[last_user_idx..]
+                } else {
+                    &non_system[..]
+                };
+                if !latest_msgs.is_empty() {
+                    if let Ok(json) = serde_json::to_string(&latest_msgs) {
+                        m.insert("gen_ai.input.messages".to_string(),
+                            MessageEncryptor::maybe_encrypt(encryptor, &json));
+                    }
+                }
+
+                // ── gen_ai.output.messages (parts-based with finish_reason) ──
+                if !call.response.messages.is_empty() {
+                    if let Ok(json) = serde_json::to_string(&call.response.messages) {
+                        m.insert("gen_ai.output.messages".to_string(),
+                            MessageEncryptor::maybe_encrypt(encryptor, &json));
+                    }
+                }
+
+                // ── 加密标记字段 ──
+                if encryptor.is_some() {
+                    m.insert("agentsight.encrypted".to_string(), "true".to_string());
+                }
 
                 // ── AgentSight extensions ──
                 m.insert("agentsight.pid".to_string(), call.pid.to_string());

--- a/src/agentsight/src/genai/mod.rs
+++ b/src/agentsight/src/genai/mod.rs
@@ -9,6 +9,7 @@ pub mod exporter;
 pub mod storage;
 pub mod instance_id;
 pub mod logtail;
+pub mod encrypt;
 
 pub use semantic::{
     GenAISemanticEvent, LLMCall, LLMRequest, LLMResponse,

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -209,7 +209,7 @@ impl AgentSight {
 
         // When SLS_LOGTAIL_FILE is set, use Logtail file exporter only (skip local storage)
         // — the Logtail file will be collected by iLogtail and uploaded to SLS.
-        if let Some(exporter) = LogtailExporter::new() {
+        if let Some(exporter) = LogtailExporter::new(config.encryption_public_key.as_deref()) {
             // SLS 模式必须能获取到 uid (owner-account-id)，否则拒绝启动
             let uid = crate::genai::instance_id::get_owner_account_id();
             if uid.is_empty() {


### PR DESCRIPTION
## Description

在 agentsight 客户端引入 RSA-OAEP + AES-256-GCM 混合加密，对 Logtail 文件中的
`gen_ai.system_instructions`、`gen_ai.input.messages`、`gen_ai.output.messages`
三个敏感字段进行加密后再落盘投递，避免用户 prompt、系统提示和模型回复以明文形式经过日志通道。

公钥配置从「代码内嵌 + 环境变量覆盖」改为统一由 `agentsight.json` 提供：
**配了公钥就加密，没配就明文** —— 加密开关运维可控，无需重新编译二进制。

主要变更：

- `src/genai/encrypt.rs`：实现 `MessageEncryptor`，密文采用紧凑布局后整体 Base64 编码：
  `[2B encrypted_key_len][encrypted_aes_key][12B nonce][ciphertext][16B tag]`。
  公钥来源由调用方通过 `MessageEncryptor::from_pem(pem)` 显式传入，
  内嵌默认公钥常量、`MESSAGE_ENCRYPT_PUBLIC_KEY` 环境变量及兼容用的 `new()` 入口已移除。
- `agentsight.json`：新增 `encryption.public_key`（内联 PEM）字段，
  也支持 `encryption.public_key_path`（外部 PEM 文件路径）。
- `src/config.rs`：解析 `encryption.*` 字段到 `AgentsightConfig.encryption_public_key`。
- `src/genai/logtail.rs`：`LogtailExporter::new(encryption_pem: Option<&str>)`
  接收可选 PEM；`Some` 且解析成功 → 启用加密；`None` / 解析失败 → 输出明文并记录日志。
- `src/unified.rs`：启动时把 `config.encryption_public_key` 透传给 `LogtailExporter`。
- 加密失败一律降级明文并打 warn 日志，不阻塞可观测性管道。
- 仍输出 `agentsight.encrypted=true` 标记字段，便于后端识别需解密的记录。

## Related Issue

closes #604

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (公钥来源外置化)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

`encrypt.rs` 保留 2 个不依赖任何公钥的单元测试，聚焦边界行为：

- `test_from_pem_invalid_returns_none`：非法 PEM 输入返回 `None`（不崩溃，自动回退明文）。
- `test_maybe_encrypt_without_encryptor`：无加密器时透传原文。

`config.rs` 现有 23 个单元测试在加入 `encryption` 解析后仍全部通过。

`cargo test --lib genai::encrypt` 与 `cargo test --lib config::` 均通过。

旧版基于内嵌默认公钥的 4 个测试（`test_new_with_default_key`、
`test_encrypt_produces_different_output`、`test_maybe_encrypt_with_encryptor`、
`test_encrypt_decrypt_roundtrip`）随 `new()` / `DEFAULT_PUBLIC_KEY_PEM` 一并移除。

## Additional Notes

- 关闭加密：把 `agentsight.json` 的 `encryption` 字段删除或 `public_key` 留空即可。
- 切换密钥：运维直接编辑 `agentsight.json` 后重启进程，无需重新编译。
- 解密侧（Python / Java 参考实现）和密文格式见 `src/agentsight/docs/ENCRYPTION.md`。
- 不再依赖私钥文件 `tests/test_private_key.pem`；roundtrip 测试已移除。
