### PR TITLE
feat(sight): add FFI interface for tcp_targets config

### DIFF
--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -502,6 +502,41 @@ pub unsafe extern "C" fn agentsight_config_add_domain_rule(
     }
 }
 
+/// Add a TCP capture target for plain HTTP traffic capture (tcpsniff probe).
+///
+/// * `target` — string in one of the following formats:
+///   - `":8080"`          → port-only (any IP, port 8080)
+///   - `"10.0.0.1"`       → IP-only   (IP 10.0.0.1, any port)
+///   - `"10.0.0.1:8080"`  → exact     (IP 10.0.0.1, port 8080)
+///
+/// Returns 0 on success, <0 on parse error (call `agentsight_last_error()`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_config_add_tcp_target(
+    cfg: *mut AgentsightConfigHandle,
+    target: *const c_char,
+) -> c_int {
+    if cfg.is_null() || target.is_null() {
+        set_last_error("NULL config or target");
+        return -1;
+    }
+    let c = unsafe { &mut *cfg };
+    let s = unsafe { CStr::from_ptr(target).to_string_lossy().to_string() };
+    if s.is_empty() {
+        set_last_error("Empty TCP target string");
+        return -1;
+    }
+    match s.parse::<crate::config::TcpTarget>() {
+        Ok(t) => {
+            c.tcp_targets.push(t);
+            0
+        }
+        Err(e) => {
+            set_last_error(&e);
+            -1
+        }
+    }
+}
+
 /// Load configuration from a JSON string. Rules are appended to existing ones.
 /// Returns 0 on success, <0 on parse error.
 #[unsafe(no_mangle)]


### PR DESCRIPTION
## Description

Add an FFI (Foreign Function Interface) entry to expose tcp_targets configuration to non-Rust callers. This enables external integrators (C/C++ wrappers, language bindings) to dynamically configure which TCP endpoints the tcpsniff probe captures via a stable C ABI.

## Related Issue

closes #606

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Verified the FFI symbol is exported correctly and callable from C bindings.

## Additional Notes

This complements the tcpsniff probe (merged in v0.5.0 via #587) by allowing external configuration of TCP target endpoints without requiring Rust-native APIs.
