### PR TITLE
chore(tokenless): bump to v0.4.0

### DIFF
--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.0
+
+- correct 5 bugs in stats, naming, SQL, paths and permissions
+- align FHS paths, restructure adapter dir, remove install.sh
+- address code review findings across schema, env-check, hooks, and plugin
+- add hermes agent plugin
+- security hardening & critical algorithm correctness
+- behavioral correctness & logic fixes
+- dedup, dead code removal & cosmetic cleanup
+- support staged installs
+- support Debian/Ubuntu FHS paths and harden binary resolution
+- build OpenClaw plugin to dist/index.js
+
 ## 0.3.2
 
 - replace spoofable home-dir uid derivation with libc::getuid() syscall for trust chain integrity

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "regex",
  "serde_json",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -238,6 +238,18 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Sun May 25 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.4.0-1
+- feat(tokenless): add hermes agent plugin
+- refactor(tokenless): align FHS paths, restructure adapter dir, remove install.sh
+- refactor(tokenless): support staged installs
+- fix(tokenless): correct 5 bugs in stats, naming, SQL, paths and permissions
+- fix(tokenless): address code review findings across schema, env-check, hooks, and plugin
+- fix(tokenless): security hardening & critical algorithm correctness
+- fix(tokenless): behavioral correctness & logic fixes
+- fix(tokenless): dedup, dead code removal & cosmetic cleanup
+- fix(tokenless): support Debian/Ubuntu FHS paths and harden binary resolution
+- fix(tokenless): build OpenClaw plugin to dist/index.js
+
 * Fri May 22 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.3.2-2
 - refactor(tokenless): replace submodules with crates.io deps and inline toon
 - fix(tokenless): use libc::getuid() syscall instead of spoofable home-dir uid


### PR DESCRIPTION
## Description

Bump tokenless from v0.3.2 to v0.4.0 (MINOR — new feature: hermes agent plugin).

Changes since v0.3.2:
- **Added**: hermes agent plugin (response compression, TOON encoding, command rewriting via RTK, and Tool Ready)
- **Changed**: FHS path alignment, adapter dir restructuring, install.sh removal, staged installs support
- **Changed**: replace submodules with crates.io deps and inline toon (already in v0.3.2 but carried forward)
- **Fixed**: 5 bugs in stats, naming, SQL, paths and permissions
- **Fixed**: code review findings across schema, env-check, hooks, and plugin
- **Fixed**: security hardening & critical algorithm correctness
- **Fixed**: behavioral correctness & logic fixes
- **Fixed**: dedup, dead code removal & cosmetic cleanup
- **Fixed**: Debian/Ubuntu FHS paths and hardened binary resolution
- **Fixed**: OpenClaw plugin build to dist/index.js

Files changed:
- `Cargo.toml`: workspace version 0.3.2 → 0.4.0
- `Cargo.lock`: synced workspace crate versions
- `CHANGELOG.md`: git-cliff generated v0.4.0 section
- `tokenless.spec.in`: %changelog entry for 0.4.0-1 RPM release

## Related Issue

no-issue: release bump following SemVer SOP

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional change)
- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo fmt -p tokenless-cli -p tokenless-schema -p tokenless-stats -- --check` ✓
- `cargo clippy -p tokenless-cli -p tokenless-schema -p tokenless-stats -- -D warnings` ✓
- `cargo test -p tokenless-cli -p tokenless-schema -p tokenless-stats` — 89/89 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)