### PR TITLE
fix(sight): preserve initial SSE chunk in event-stream responses

### DIFF
--- a/src/agentsight/src/aggregator/http/aggregator.rs
+++ b/src/agentsight/src/aggregator/http/aggregator.rs
@@ -8,7 +8,7 @@ use lru::LruCache;
 use crate::config::DEFAULT_CONNECTION_CAPACITY;
 use crate::probes::sslsniff::SslEvent;
 use crate::parser::http::{ParsedRequest, ParsedResponse};
-use crate::parser::sse::ParsedSseEvent;
+use crate::parser::sse::{ParsedSseEvent, SseParser};
 use super::response::AggregatedResponse;
 use super::pair::HttpPair;
 use super::super::result::AggregatedResult;
@@ -97,6 +97,36 @@ impl HttpConnectionAggregator {
                 );
             }
         }
+    }
+
+    /// Parse initial SSE body bytes from the first HTTP response packet.
+    ///
+    /// When HTTP response headers and the first SSE `data:` chunk arrive in the
+    /// same SSL_read buffer, the parser only emits `ParsedResponse`. Downstream
+    /// SSE analysis consumes `sse_events`, so we must convert the response body
+    /// into initial `ParsedSseEvent`s before entering `SseActive`.
+    fn initial_sse_events(response: &ParsedResponse) -> Vec<ParsedSseEvent> {
+        let body = response.body();
+        if body.is_empty() {
+            return Vec::new();
+        }
+
+        let synthetic_event = std::rc::Rc::new(SslEvent {
+            source: response.source_event.source,
+            timestamp_ns: response.source_event.timestamp_ns,
+            delta_ns: response.source_event.delta_ns,
+            pid: response.source_event.pid,
+            tid: response.source_event.tid,
+            uid: response.source_event.uid,
+            len: body.len() as u32,
+            rw: response.source_event.rw,
+            comm: response.source_event.comm.clone(),
+            buf: body.to_vec(),
+            is_handshake: response.source_event.is_handshake,
+            ssl_ptr: response.source_event.ssl_ptr,
+        });
+
+        SseParser::new().parse(synthetic_event)
     }
 
     /// Process HTTP Request (from HTTP Parser)
@@ -189,12 +219,15 @@ impl HttpConnectionAggregator {
                 completed_request.reassembled_body = Some(body_buffer);
 
                 if response.is_sse() {
+                    let mut response_headers = response;
+                    let sse_events = Self::initial_sse_events(&response_headers);
+                    response_headers.body_len = 0;
                     self.insert(
                         connection_id,
                         ConnectionState::SseActive {
                             request: Some(completed_request),
-                            response_headers: response,
-                            sse_events: Vec::new(),
+                            response_headers,
+                            sse_events,
                         },
                     );
                     None
@@ -214,13 +247,16 @@ impl HttpConnectionAggregator {
                         connection_id,
                         response.status_code,
                     );
+                    let mut response_headers = response;
+                    let sse_events = Self::initial_sse_events(&response_headers);
+                    response_headers.body_len = 0;
                     // Transition to SSE active state, wait for SSE events
                     self.insert(
                         connection_id,
                         ConnectionState::SseActive {
                             request: Some(request),
-                            response_headers: response,
-                            sse_events: Vec::new(),
+                            response_headers,
+                            sse_events,
                         },
                     );
                     
@@ -248,12 +284,15 @@ impl HttpConnectionAggregator {
                         connection_id,
                         response.status_code
                     );
+                    let mut response_headers = response;
+                    let sse_events = Self::initial_sse_events(&response_headers);
+                    response_headers.body_len = 0;
                     self.insert(
                         connection_id,
                         ConnectionState::SseActive {
                             request: None,
-                            response_headers: response,
-                            sse_events: Vec::new(),
+                            response_headers,
+                            sse_events,
                         },
                     );
                     None
@@ -903,5 +942,72 @@ mod tests {
         assert!(result.is_none());
         let conn_id = ConnectionId { pid: 1234, ssl_ptr: 0x6000 };
         assert!(aggregator.is_sse_active(&conn_id));
+    }
+
+    #[test]
+    fn test_sse_first_chunk_in_initial_response_body_is_preserved() {
+        let mut aggregator = HttpConnectionAggregator::new();
+
+        let req_event = create_mock_ssl_event_with_buf(
+            4321,
+            0x7000,
+            b"POST /stream HTTP/1.1\r\nContent-Length: 2\r\n\r\n{}".to_vec(),
+            1,
+        );
+        let mut req_headers = HashMap::new();
+        req_headers.insert("content-length".to_string(), "2".to_string());
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            path: "/stream".to_string(),
+            version: 1,
+            headers: req_headers,
+            body_offset: 43,
+            body_len: 2,
+            source_event: req_event,
+            reassembled_body: None,
+        };
+        aggregator.process_request(request);
+
+        let resp_buf = b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\ndata: {\"choices\":[{\"delta\":{\"content\":\"3\"}}]}\n\n".to_vec();
+        let resp_event = create_mock_ssl_event_with_buf(4321, 0x7000, resp_buf.clone(), 0);
+        let response = ParsedResponse {
+            version: 1,
+            status_code: 200,
+            reason: "OK".to_string(),
+            headers: {
+                let mut h = HashMap::new();
+                h.insert("content-type".to_string(), "text/event-stream".to_string());
+                h
+            },
+            body_offset: resp_buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4,
+            body_len: resp_buf.len() - (resp_buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4),
+            source_event: resp_event,
+        };
+
+        let result = aggregator.process_response(response);
+        assert!(result.is_none());
+
+        let done_event = create_mock_ssl_event_with_buf(
+            4321,
+            0x7000,
+            b"data: [DONE]\n\n".to_vec(),
+            0,
+        );
+        let done = ParsedSseEvent::new(None, None, None, 6, 6, done_event);
+        let conn_id = ConnectionId { pid: 4321, ssl_ptr: 0x7000 };
+        let result = aggregator.process_sse_event(&conn_id, done);
+        let pair = match result {
+            Some(AggregatedResult::SseComplete(pair)) => pair,
+            other => panic!("expected SseComplete, got {:?}", other),
+        };
+
+        assert_eq!(pair.response.sse_event_count(), 2);
+        let chunks = pair.response.json_body();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(
+            chunks[0]["choices"][0]["delta"]["content"].as_str(),
+            Some("3")
+        );
+        assert!(pair.response.parsed.body_str().is_empty());
     }
 }


### PR DESCRIPTION
## 背景

在 AgentSight 的 SSE 聚合逻辑中，如果 HTTP 响应头与首个 `text/event-stream` 数据片段位于同一个响应包中，当前实现会在进入`SseActive` 时忽略这部分初始 body，导致首个 SSE chunk 丢失。

这会进一步表现为最终 assistant 文本缺少首字符或首个 token，例如：

- `37 × 19 = ...` 被重建成 `7 × 19 = ...`
- `ok compat-...` 被重建成 ` compat-...`
- 单字首 chunk 在极端情况下可能整个丢失

## 根因

`process_response()` 在识别到 SSE 响应时，会直接把连接状态切换到 `SseActive`，但没有把 `ParsedResponse.body()` 中已经存在的那段 SSE body 转换成初始 `ParsedSseEvent`。

后续下游分析只消费 `resp.sse_events`，因此首个 chunk 被跳过。

  ## 修复内容

本 PR 做了两件事：

1. 在 `HttpConnectionAggregator` 中新增首包 SSE body 解析逻辑
   - 当响应为 `text/event-stream` 时，如果 `ParsedResponse.body()` 非空，先将这部分 body 解析为初始 `ParsedSseEvent`

2. 在进入 `SseActive` 前，将这些初始事件注入 `sse_events`
   - 同时将 `response_headers.body_len` 置零，避免后续重复拼接

## 测试

新增回归测试，覆盖：

- 响应头与首个 SSE `data:` chunk 同包
- 后续收到 `[DONE]`
- 最终聚合结果中保留首个 delta 内容

本地验证：

```bash
cargo test -q aggregator::http
```

结果：

- 12 passed
 - 0 failed


## 影响范围

这是一个通用的 SSE 聚合修复，不依赖具体上层产品逻辑。任何采用 HTTP + SSE 流式返回、且首个 chunk 可能与响应头同包的provider / model 都可能受益。