### PR TITLE
feat(sight): restructure config to https/http rules and fix BoringSSL + FFI delivery

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -1,5 +1,6 @@
 {
-  "tcp_targets": [],
+  "https": [],
+  "http": [],
   "encryption": {
     "public_key": ""
   },

--- a/src/agentsight/integration-tests/test_dns.md
+++ b/src/agentsight/integration-tests/test_dns.md
@@ -4,10 +4,10 @@
 
 ## 测试目标
 
-1. 配置含 `domain_rules` 时，UDP DNS BPF 探针应被加载并 attach（日志中无 "UDP DNS probe disabled"）
-2. 配置不含 `domain_rules` 时，UDP DNS BPF 探针不应被加载（日志中出现 "UDP DNS probe disabled"）
-3. DNS 查询匹配 `domain_rules` 的域名时，应触发 SSL 探针 attach 到该进程
-4. DNS 查询不匹配 `domain_rules` 的域名时，不应触发 attach
+1. 配置含 `https` 规则时，UDP DNS BPF 探针应被加载并 attach（日志中无 "UDP DNS probe disabled"）
+2. 配置不含 `https` 规则时，UDP DNS BPF 探针不应被加载（日志中出现 "UDP DNS probe disabled"）
+3. DNS 查询匹配 `https` 规则的域名时，应触发 SSL 探针 attach 到该进程
+4. DNS 查询不匹配 `https` 规则的域名时，不应触发 attach
 5. 被 `cmdline deny` 规则匹配的进程，即使域名匹配也不应 attach
 
 ## 运行条件

--- a/src/agentsight/integration-tests/test_hermes_dns.md
+++ b/src/agentsight/integration-tests/test_hermes_dns.md
@@ -6,10 +6,10 @@
 
 验证通过 UDP DNS 方式捕获 Hermes agent（连接 `dashscope.aliyuncs.com`）的完整流程：
 
-1. 配置含 `domain_rules: ["*.dashscope.aliyuncs.com"]` 时，UDP DNS BPF 探针应被加载并 attach（判定依据：启动日志无 "UDP DNS probe disabled"）
+1. 配置含 `https: [{"rule": ["*.dashscope.aliyuncs.com"]}]` 时，UDP DNS BPF 探针应被加载并 attach（判定依据：启动日志无 "UDP DNS probe disabled"）
 2. Hermes 进程发起 DNS 查询 `dashscope.aliyuncs.com` 时，DNS 事件触发 SSL 探针 attach（判定依据：SQLite `genai_events` 表含 hermes pid 的记录；且**不含** cmdline 发现 hermes 的记录，证明 attach 仅由 DNS 触发）
 3. SSL 探针 attach 后，能捕获 hermes 对 `dashscope.aliyuncs.com/compatible-mode/v1` 的 LLM API 调用（判定依据：SQLite `http_records` 表含 path 为 `/compatible-mode/v1` 的记录）
-4. 不匹配 domain_rules 的域名不触发 attach（判定依据：日志中出现 DNS 事件但无 `Attaching via domain rule` 行）
+4. 不匹配 `https` 规则的域名不触发 attach（判定依据：日志中出现 DNS 事件但无 `Attaching via domain rule` 行）
 5. 被 cmdline deny 规则匹配的进程（如 `curl`），即使域名匹配也不 attach（判定依据：DNS 事件被捕获但无 `Attaching via domain rule` 行）
 
 ## 判定方法
@@ -36,7 +36,7 @@
       {"rule": ["*curl*"]}
     ]
   },
-  "domain": [
+  "https": [
     {"rule": ["*.dashscope.aliyuncs.com"]}
   ]
 }
@@ -74,7 +74,7 @@
 
 ### 步骤 4：验证不匹配域名不触发 attach
 
-核心验证：域名不匹配 domain_rules 时，SSL 探针**未 attach**。
+核心验证：域名不匹配 `https` 规则时，SSL 探针**未 attach**。
 
 1. 用任意进程发起 DNS 查询到不匹配域名（如 `nslookup example.com` 或 `curl https://example.com`）
 2. grep 日志确认 DNS 事件被捕获但**未触发 attach**：
@@ -83,7 +83,7 @@
 
 ### 步骤 5：验证 deny 规则阻止 attach
 
-核心验证：curl 的域名匹配 domain_rules，但被 cmdline deny 规则阻止，SSL 探针**未 attach**。
+核心验证：curl 的域名匹配 `https` 规则，但被 cmdline deny 规则阻止，SSL 探针**未 attach**。
 
 1. 运行 `curl https://dashscope.aliyuncs.com/compatible-mode/v1`（域名匹配但进程被 deny）
 2. grep 日志确认 curl 的 DNS 事件被捕获但**未触发 attach**：

--- a/src/agentsight/integration-tests/test_http.md
+++ b/src/agentsight/integration-tests/test_http.md
@@ -6,8 +6,8 @@
 
 ### 探针加载与内核适配
 
-1. 配置含 `tcp_targets` 时，tcpsniff BPF 探针应被加载并 attach（日志含 "TcpSniff: attached 3 BPF programs"）
-2. 配置 `tcp_targets` 为空或不存在时，tcpsniff 探针不应被加载（日志含 "TcpSniff probe disabled"）
+1. 配置含 `http` 规则时，tcpsniff BPF 探针应被加载并 attach（日志含 "TcpSniff: attached 3 BPF programs"）
+2. 配置 `http` 为空或不存在时，tcpsniff 探针不应被加载（日志含 "TcpSniff probe disabled"）
 3. 在 kernel 5.18+ 上，应使用新签名（日志含 "loaded with new tcp_recvmsg signature (5.18+)"）
 4. 在 kernel 5.8–5.17 上，应自动回退到旧签名（日志含 "loaded with old tcp_recvmsg signature (5.8-5.17)"）
 
@@ -15,7 +15,7 @@
 
 5. 向目标 IP/端口发送 HTTP 请求时，应捕获并解析为 Request 事件（日志含 "Aggregating parsed results(1): Request"）
 6. 捕获的 Request 应包含完整 HTTP headers + body（判定：GenAI 事件中 `input_messages` 非空，`raw_body` 不含 `\x00\x00` 前缀乱码）
-7. 非目标的 TCP 流量不应被捕获（配置 `tcp_targets: [":8080"]`，向其他端口发请求不应产生事件）
+7. 非目标的 TCP 流量不应被捕获（配置 `http: [{"rule": [":8080"]}]`，向其他端口发请求不应产生事件）
 
 ### 响应捕获 (tcp_recvmsg)
 
@@ -31,8 +31,8 @@
 
 ### 配置
 
-14. JSON 配置文件中 `"tcp_targets": [":8080", "10.0.0.1:9090"]` 应正确设置目标（支持仅端口、仅 IP、IP+端口三种格式）
-15. `tcp_targets` 支持三级匹配：精确 IP+端口 → 仅 IP → 仅端口
+14. JSON 配置文件中 `"http": [{"rule": [":8080", "10.0.0.1:9090"]}]` 应正确设置目标（支持仅端口、仅 IP、IP+端口、域名四种格式）
+15. `http` 规则支持自动识别：IP/端口格式直接写入 BPF map，域名格式通过 DNS 解析后写入
 
 ## 运行条件
 

--- a/src/agentsight/src/bpf/udpdns.bpf.c
+++ b/src/agentsight/src/bpf/udpdns.bpf.c
@@ -23,6 +23,54 @@
 // Payload buffer bitmask (DNS_PAYLOAD_MAX = 256, power of 2)
 #define PAYLOAD_MASK (DNS_PAYLOAD_MAX - 1)  // 0xFF
 
+// --- CO-RE compatibility for iov_iter fields ---
+// Kernel 6.4+ renamed iov_iter.iov to iov_iter.__iov.
+struct iov_iter___new {
+    const struct iovec *__iov;
+};
+
+// Kernel 6.0+ added ITER_UBUF: read()/write() on sockets use ubuf instead of iov.
+struct iov_iter___ubuf {
+    void *ubuf;
+    u8 iter_type;
+};
+
+#define ITER_UBUF_TYPE 5
+
+struct dns_buf_info {
+    void *buf;
+    __u64 len;
+};
+
+static __always_inline struct dns_buf_info get_dns_buf_info(struct msghdr *msg)
+{
+    struct dns_buf_info info = { .buf = NULL, .len = 0 };
+    struct iov_iter *iter = &msg->msg_iter;
+
+    struct iov_iter___ubuf *ubuf_iter = (void *)iter;
+    if (bpf_core_field_exists(ubuf_iter->ubuf)) {
+        u8 type = BPF_CORE_READ(ubuf_iter, iter_type);
+        if (type == ITER_UBUF_TYPE) {
+            info.buf = BPF_CORE_READ(ubuf_iter, ubuf);
+            info.len = BPF_CORE_READ(iter, count);
+            return info;
+        }
+    }
+
+    struct iov_iter___new *new_iter = (void *)iter;
+    const struct iovec *iov;
+    if (bpf_core_field_exists(new_iter->__iov)) {
+        iov = BPF_CORE_READ(new_iter, __iov);
+    } else {
+        iov = BPF_CORE_READ(iter, iov);
+    }
+    if (!iov)
+        return info;
+    info.buf = BPF_CORE_READ(iov, iov_base);
+    info.len = BPF_CORE_READ(iov, iov_len);
+    return info;
+}
+
 SEC("fentry/udp_sendmsg")
 int BPF_PROG(trace_udp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
 {
@@ -44,14 +92,8 @@ int BPF_PROG(trace_udp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
     if (bpf_map_lookup_elem(&traced_processes, &pid))
         return 0;
 
-    // Read the first iovec from msg_iter to get user-space buffer pointer
-    const struct iovec *iov = BPF_CORE_READ(msg, msg_iter.iov);
-    if (!iov)
-        return 0;
-
-    void *iov_base = BPF_CORE_READ(iov, iov_base);
-    size_t iov_len = BPF_CORE_READ(iov, iov_len);
-    if (!iov_base || iov_len < 17)
+    struct dns_buf_info buf = get_dns_buf_info(msg);
+    if (!buf.buf || buf.len < 17)
         return 0;
 
     // Reserve ring buffer event
@@ -60,12 +102,12 @@ int BPF_PROG(trace_udp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
         return 0;
 
     // Clamp read size to payload buffer capacity
-    __u32 read_len = iov_len;
+    __u32 read_len = buf.len;
     if (read_len > DNS_PAYLOAD_MAX)
         read_len = DNS_PAYLOAD_MAX;
 
     // Read user-space DNS buffer into event payload
-    int ret = bpf_probe_read_user(event->payload, read_len & PAYLOAD_MASK, iov_base);
+    int ret = bpf_probe_read_user(event->payload, read_len & PAYLOAD_MASK, buf.buf);
     if (ret != 0) {
         bpf_ringbuf_discard(event, 0);
         return 0;

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -116,11 +116,20 @@ pub struct CmdlineRule {
     pub allow: bool,
 }
 
-/// Domain rule for DNS-based SSL attachment filtering
+/// HTTPS rule for DNS-based SSL attachment filtering
 #[derive(Debug, Clone)]
-pub struct DomainRule {
+pub struct HttpsRule {
     /// Glob pattern for domain matching
     pub pattern: String,
+}
+
+/// HTTP target entry — can be an IP/port endpoint or a domain name.
+/// Code auto-detects: entries parseable as TcpTarget are treated as endpoints;
+/// everything else is treated as a domain (resolved via DNS at startup + runtime).
+#[derive(Debug, Clone)]
+pub enum HttpTarget {
+    Endpoint(TcpTarget),
+    Domain(String),
 }
 
 // ==================== Agent Discovery Configuration ====================
@@ -192,11 +201,9 @@ struct JsonFullConfig {
     #[serde(default)]
     cmdline: Option<JsonCmdline>,
     #[serde(default)]
-    domain: Option<Vec<JsonDomainGroup>>,
+    https: Option<Vec<JsonDomainGroup>>,
     #[serde(default)]
-    tcp_ports: Option<Vec<u16>>,
-    #[serde(default)]
-    tcp_targets: Option<Vec<String>>,
+    http: Option<Vec<JsonHttpGroup>>,
     #[serde(default)]
     encryption: Option<JsonEncryption>,
 }
@@ -230,28 +237,34 @@ struct JsonDomainGroup {
     rule: Vec<String>,
 }
 
-/// Extract cmdline and domain rules from a parsed JsonFullConfig.
-fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>) {
-    let mut cmdline_rules = Vec::new();
-    let mut domain_rules = Vec::new();
+#[derive(serde::Deserialize)]
+struct JsonHttpGroup {
+    rule: Vec<String>,
+}
 
-    if let Some(cmdline) = parsed.cmdline {
-        if let Some(allow_list) = cmdline.allow {
+/// Extract cmdline, https, and http rules from a parsed JsonFullConfig.
+fn extract_rules(parsed: &JsonFullConfig) -> (Vec<CmdlineRule>, Vec<HttpsRule>, Vec<HttpTarget>) {
+    let mut cmdline_rules = Vec::new();
+    let mut https_rules = Vec::new();
+    let mut http_targets = Vec::new();
+
+    if let Some(ref cmdline) = parsed.cmdline {
+        if let Some(ref allow_list) = cmdline.allow {
             for entry in allow_list {
                 if !entry.rule.is_empty() {
                     cmdline_rules.push(CmdlineRule {
-                        patterns: entry.rule,
-                        agent_name: entry.agent_name,
+                        patterns: entry.rule.clone(),
+                        agent_name: entry.agent_name.clone(),
                         allow: true,
                     });
                 }
             }
         }
-        if let Some(deny_list) = cmdline.deny {
+        if let Some(ref deny_list) = cmdline.deny {
             for entry in deny_list {
                 if !entry.rule.is_empty() {
                     cmdline_rules.push(CmdlineRule {
-                        patterns: entry.rule,
+                        patterns: entry.rule.clone(),
                         agent_name: None,
                         allow: false,
                     });
@@ -260,26 +273,40 @@ fn extract_rules(parsed: JsonFullConfig) -> (Vec<CmdlineRule>, Vec<DomainRule>) 
         }
     }
 
-    if let Some(domain_groups) = parsed.domain {
-        for group in domain_groups {
-            for pat in group.rule {
+    if let Some(ref https_groups) = parsed.https {
+        for group in https_groups {
+            for pat in &group.rule {
                 if !pat.is_empty() {
-                    domain_rules.push(DomainRule { pattern: pat });
+                    https_rules.push(HttpsRule { pattern: pat.clone() });
                 }
             }
         }
     }
 
-    (cmdline_rules, domain_rules)
+    if let Some(ref http_groups) = parsed.http {
+        for group in http_groups {
+            for entry in &group.rule {
+                if entry.is_empty() {
+                    continue;
+                }
+                match entry.parse::<TcpTarget>() {
+                    Ok(t) => http_targets.push(HttpTarget::Endpoint(t)),
+                    Err(_) => http_targets.push(HttpTarget::Domain(entry.clone())),
+                }
+            }
+        }
+    }
+
+    (cmdline_rules, https_rules, http_targets)
 }
 
-/// Parse a JSON config string into cmdline rules and domain rules.
+/// Parse a JSON config string into cmdline rules, https rules, and http targets.
 ///
 /// This is the shared parser for both the config file and FFI's `load_config()`.
-pub fn parse_json_rules(json: &str) -> Result<(Vec<CmdlineRule>, Vec<DomainRule>), String> {
+pub fn parse_json_rules(json: &str) -> Result<(Vec<CmdlineRule>, Vec<HttpsRule>, Vec<HttpTarget>), String> {
     let parsed: JsonFullConfig = serde_json::from_str(json)
         .map_err(|e| format!("JSON parse error: {}", e))?;
-    Ok(extract_rules(parsed))
+    Ok(extract_rules(&parsed))
 }
 
 
@@ -303,7 +330,7 @@ pub fn ensure_default_agents_config(path: &Path) -> anyhow::Result<()> {
 
 /// Load default cmdline rules (embedded), without touching the filesystem.
 pub fn default_cmdline_rules() -> Vec<CmdlineRule> {
-    let (rules, _) = parse_json_rules(DEFAULT_AGENTS_JSON)
+    let (rules, _, _) = parse_json_rules(DEFAULT_AGENTS_JSON)
         .expect("embedded DEFAULT_AGENTS_JSON is valid");
     rules
 }
@@ -382,8 +409,10 @@ pub struct AgentsightConfig {
     // --- FFI Rule Configuration ---
     /// User-defined cmdline rules for process allowlist/denylist
     pub cmdline_rules: Vec<CmdlineRule>,
-    /// User-defined domain rules for DNS-based SSL attachment
-    pub domain_rules: Vec<DomainRule>,
+    /// User-defined HTTPS rules for DNS-based SSL attachment
+    pub https_rules: Vec<HttpsRule>,
+    /// User-defined HTTP targets (IP/port endpoints + domains for tcpsniff)
+    pub http_targets: Vec<HttpTarget>,
 
     // --- Config File Path ---
     /// Path to JSON configuration file
@@ -433,7 +462,8 @@ impl Default for AgentsightConfig {
 
             // FFI Rule defaults
             cmdline_rules: Vec::new(),
-            domain_rules: Vec::new(),
+            https_rules: Vec::new(),
+            http_targets: Vec::new(),
 
             // Config file path default
             config_path: None,
@@ -497,12 +527,6 @@ impl AgentsightConfig {
         self
     }
 
-    /// Set TCP capture targets for plain HTTP traffic capture
-    pub fn set_tcp_targets(mut self, targets: Vec<TcpTarget>) -> Self {
-        self.tcp_targets = targets;
-        self
-    }
-
     /// Set connection capacity
     pub fn set_connection_capacity(mut self, capacity: usize) -> Self {
         self.connection_capacity = capacity;
@@ -516,7 +540,7 @@ impl AgentsightConfig {
 
     /// Load configuration from a JSON string, appending rules to existing ones.
     ///
-    /// Parses `verbose`, `log_path`, `cmdline` and `domain` fields.
+    /// Parses `verbose`, `log_path`, `cmdline`, `https` and `http` fields.
     pub fn load_from_json(&mut self, json: &str) -> Result<(), String> {
         let mut parsed: JsonFullConfig = serde_json::from_str(json)
             .map_err(|e| format!("JSON parse error: {}", e))?;
@@ -526,22 +550,6 @@ impl AgentsightConfig {
         }
         if let Some(p) = parsed.log_path.take() {
             self.log_path = Some(p);
-        }
-        if let Some(targets) = parsed.tcp_targets.take() {
-            let mut result = Vec::new();
-            for s in &targets {
-                match s.parse::<TcpTarget>() {
-                    Ok(t) => result.push(t),
-                    Err(e) => log::warn!("Ignoring invalid tcp_targets entry '{}': {}", s, e),
-                }
-            }
-            self.tcp_targets = result;
-        } else if let Some(ports) = parsed.tcp_ports.take() {
-            // backward compat: "tcp_ports": [8080] → port-only targets
-            self.tcp_targets = ports
-                .into_iter()
-                .map(|p| TcpTarget { ip: None, port: Some(p) })
-                .collect();
         }
 
         // 加载加密公钥：优先 public_key（内联 PEM），其次 public_key_path（文件路径）
@@ -569,9 +577,10 @@ impl AgentsightConfig {
             }
         }
 
-        let (cmdline_rules, domain_rules) = extract_rules(parsed);
+        let (cmdline_rules, https_rules, http_targets) = extract_rules(&parsed);
         self.cmdline_rules.extend(cmdline_rules);
-        self.domain_rules.extend(domain_rules);
+        self.https_rules.extend(https_rules);
+        self.http_targets.extend(http_targets);
         Ok(())
     }
 
@@ -593,9 +602,15 @@ impl AgentsightConfig {
         self
     }
 
-    /// Add a domain rule
-    pub fn add_domain_rule(mut self, rule: DomainRule) -> Self {
-        self.domain_rules.push(rule);
+    /// Add an HTTPS rule (domain glob pattern for SSL attachment)
+    pub fn add_https_rule(mut self, rule: HttpsRule) -> Self {
+        self.https_rules.push(rule);
+        self
+    }
+
+    /// Add an HTTP target (IP/port endpoint or domain for tcpsniff)
+    pub fn add_http_target(mut self, target: HttpTarget) -> Self {
+        self.http_targets.push(target);
         self
     }
 
@@ -825,11 +840,11 @@ mod tests {
     }
 
     #[test]
-    fn test_add_domain_rule() {
-        let rule = DomainRule { pattern: "*.openai.com".to_string() };
-        let config = AgentsightConfig::new().add_domain_rule(rule);
-        assert_eq!(config.domain_rules.len(), 1);
-        assert_eq!(config.domain_rules[0].pattern, "*.openai.com");
+    fn test_add_https_rule() {
+        let rule = HttpsRule { pattern: "*.openai.com".to_string() };
+        let config = AgentsightConfig::new().add_https_rule(rule);
+        assert_eq!(config.https_rules.len(), 1);
+        assert_eq!(config.https_rules[0].pattern, "*.openai.com");
     }
 
     #[test]
@@ -845,10 +860,10 @@ mod tests {
                 agent_name: Some("Agent2".to_string()),
                 allow: true,
             })
-            .add_domain_rule(DomainRule { pattern: "*.openai.com".to_string() })
-            .add_domain_rule(DomainRule { pattern: "*.anthropic.com".to_string() });
+            .add_https_rule(HttpsRule { pattern: "*.openai.com".to_string() })
+            .add_https_rule(HttpsRule { pattern: "*.anthropic.com".to_string() });
         assert_eq!(config.cmdline_rules.len(), 2);
-        assert_eq!(config.domain_rules.len(), 2);
+        assert_eq!(config.https_rules.len(), 2);
     }
 
     #[test]
@@ -868,10 +883,10 @@ mod tests {
 
     #[test]
     fn test_default_agents_json_valid() {
-        // Verify the embedded JSON is valid and parses correctly
-        let (cmdline_rules, domain_rules) = parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
+        let (cmdline_rules, https_rules, http_targets) = parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
         assert!(!cmdline_rules.is_empty());
-        assert!(domain_rules.is_empty()); // no domain rules in default config
+        assert!(https_rules.is_empty());
+        assert!(http_targets.is_empty());
     }
 
     #[test]
@@ -882,21 +897,25 @@ mod tests {
                 "deny": [{"rule": ["node", "*webpack*"]}]
             }
         }"#;
-        let (cmdline_rules, domain_rules) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, https_rules, http_targets) = parse_json_rules(json).unwrap();
         assert_eq!(cmdline_rules.len(), 2);
         assert!(cmdline_rules[0].allow);
         assert_eq!(cmdline_rules[0].agent_name, Some("Claude Code".to_string()));
         assert!(!cmdline_rules[1].allow);
         assert!(cmdline_rules[1].agent_name.is_none());
-        assert!(domain_rules.is_empty());
+        assert!(https_rules.is_empty());
+        assert!(http_targets.is_empty());
     }
 
     #[test]
-    fn test_parse_json_rules_domain() {
-        let json = r#"{"domain": [{"rule": ["*.openai.com", "*.anthropic.com"]}]}"#;
-        let (cmdline_rules, domain_rules) = parse_json_rules(json).unwrap();
+    fn test_parse_json_rules_https() {
+        let json = r#"{"https": [{"rule": ["*.openai.com", "*.anthropic.com"]}]}"#;
+        let (cmdline_rules, https_rules, http_targets) = parse_json_rules(json).unwrap();
         assert!(cmdline_rules.is_empty());
-        assert_eq!(domain_rules.len(), 2);
+        assert_eq!(https_rules.len(), 2);
+        assert_eq!(https_rules[0].pattern, "*.openai.com");
+        assert_eq!(https_rules[1].pattern, "*.anthropic.com");
+        assert!(http_targets.is_empty());
     }
 
     #[test]
@@ -908,7 +927,7 @@ mod tests {
     #[test]
     fn test_parse_json_rules_empty_rule_skipped() {
         let json = r#"{"cmdline":{"allow":[{"rule":[],"agent_name":"Skipped"},{"rule":["node"],"agent_name":"Kept"}]}}"#;
-        let (cmdline_rules, _) = parse_json_rules(json).unwrap();
+        let (cmdline_rules, _, _) = parse_json_rules(json).unwrap();
         assert_eq!(cmdline_rules.len(), 1);
         assert_eq!(cmdline_rules[0].agent_name, Some("Kept".to_string()));
     }

--- a/src/agentsight/src/discovery/connection_scanner.rs
+++ b/src/agentsight/src/discovery/connection_scanner.rs
@@ -5,7 +5,7 @@
 //! This module performs a one-time scan of established TCP connections to find such processes.
 //!
 //! Flow:
-//! 1. Resolve exact domains from `domain_rules` to IP addresses
+//! 1. Resolve exact domains from `https_rules` to IP addresses
 //! 2. Scan `/proc/net/tcp` for ESTABLISHED connections to those IPs
 //! 3. Map socket inodes back to PIDs
 //! 4. Filter through deny rules before attaching SSL probes
@@ -37,7 +37,7 @@ impl<'a> ConnectionScanner<'a> {
         Self { scanner }
     }
 
-    /// Main entry point: scan for processes with established connections to domain_rules IPs
+    /// Main entry point: scan for processes with established connections to https_rules IPs
     ///
     /// Filters out already-traced PIDs, applies deny rules to candidates.
     pub fn scan(&self, already_traced: &HashSet<u32>) -> Vec<ConnectionScanResult> {

--- a/src/agentsight/src/discovery/scanner.rs
+++ b/src/agentsight/src/discovery/scanner.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use super::agent::{AgentInfo, DiscoveredAgent};
 use super::matcher::{CmdlineGlobMatcher, ProcessContext, match_domain_glob};
-use crate::config::{CmdlineRule, DomainRule};
+use crate::config::{CmdlineRule, HttpsRule};
 
 /// Scanner for discovering AI agent processes on the system
 ///
@@ -33,7 +33,7 @@ impl AgentScanner {
     ///
     /// Separates cmdline_rules into allow matchers and deny matchers,
     /// and stores domain patterns for DNS-based matching.
-    pub fn from_rules(cmdline_rules: &[CmdlineRule], domain_rules: &[DomainRule]) -> Self {
+    pub fn from_rules(cmdline_rules: &[CmdlineRule], https_rules: &[HttpsRule]) -> Self {
         let matchers: Vec<CmdlineGlobMatcher> = cmdline_rules
             .iter()
             .filter_map(|rule| CmdlineGlobMatcher::from_config(rule))
@@ -42,7 +42,7 @@ impl AgentScanner {
             .iter()
             .filter_map(|r| CmdlineGlobMatcher::from_deny_rule(r))
             .collect();
-        let domain_patterns: Vec<String> = domain_rules.iter().map(|r| r.pattern.clone()).collect();
+        let domain_patterns: Vec<String> = https_rules.iter().map(|r| r.pattern.clone()).collect();
         Self {
             matchers,
             deny_matchers,
@@ -344,15 +344,15 @@ mod tests {
 
     #[test]
     fn test_matches_domain() {
-        let domain_rules = vec![
-            DomainRule {
+        let https_rules = vec![
+            HttpsRule {
                 pattern: "*.openai.com".to_string(),
             },
-            DomainRule {
+            HttpsRule {
                 pattern: "*.anthropic.com".to_string(),
             },
         ];
-        let scanner = AgentScanner::from_rules(&[], &domain_rules);
+        let scanner = AgentScanner::from_rules(&[], &https_rules);
 
         assert!(scanner.matches_domain("api.openai.com"));
         assert!(scanner.matches_domain("api.anthropic.com"));

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -485,10 +485,10 @@ pub unsafe extern "C" fn agentsight_config_add_cmdline_rule(
     });
 }
 
-/// Add a domain rule (whitelist for DNS-based attachment).
+/// Add an HTTPS rule (domain glob pattern for SSL/TLS probe attachment).
 /// * `rule` — domain glob pattern (e.g. "*.openai.com").
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn agentsight_config_add_domain_rule(
+pub unsafe extern "C" fn agentsight_config_add_https(
     cfg: *mut AgentsightConfigHandle,
     rule: *const c_char,
 ) {
@@ -498,20 +498,21 @@ pub unsafe extern "C" fn agentsight_config_add_domain_rule(
     let c = unsafe { &mut *cfg };
     let s = unsafe { CStr::from_ptr(rule).to_string_lossy().to_string() };
     if !s.is_empty() {
-        c.domain_rules.push(crate::config::DomainRule { pattern: s });
+        c.https_rules.push(crate::config::HttpsRule { pattern: s });
     }
 }
 
-/// Add a TCP capture target for plain HTTP traffic capture (tcpsniff probe).
+/// Add an HTTP capture target for plain HTTP traffic (tcpsniff probe).
 ///
-/// * `target` — string in one of the following formats:
-///   - `":8080"`          → port-only (any IP, port 8080)
-///   - `"10.0.0.1"`       → IP-only   (IP 10.0.0.1, any port)
-///   - `"10.0.0.1:8080"`  → exact     (IP 10.0.0.1, port 8080)
+/// * `target` — string that is auto-detected:
+///   - `":8080"`          → port-only endpoint
+///   - `"10.0.0.1"`       → IP-only endpoint
+///   - `"10.0.0.1:8080"`  → IP+port endpoint
+///   - `"model-svc.default.svc"` → domain (DNS-resolved at runtime)
 ///
-/// Returns 0 on success, <0 on parse error (call `agentsight_last_error()`).
+/// Returns 0 on success, <0 on error (call `agentsight_last_error()`).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn agentsight_config_add_tcp_target(
+pub unsafe extern "C" fn agentsight_config_add_http(
     cfg: *mut AgentsightConfigHandle,
     target: *const c_char,
 ) -> c_int {
@@ -522,19 +523,14 @@ pub unsafe extern "C" fn agentsight_config_add_tcp_target(
     let c = unsafe { &mut *cfg };
     let s = unsafe { CStr::from_ptr(target).to_string_lossy().to_string() };
     if s.is_empty() {
-        set_last_error("Empty TCP target string");
+        set_last_error("Empty HTTP target string");
         return -1;
     }
     match s.parse::<crate::config::TcpTarget>() {
-        Ok(t) => {
-            c.tcp_targets.push(t);
-            0
-        }
-        Err(e) => {
-            set_last_error(&e);
-            -1
-        }
+        Ok(t) => c.http_targets.push(crate::config::HttpTarget::Endpoint(t)),
+        Err(_) => c.http_targets.push(crate::config::HttpTarget::Domain(s)),
     }
+    0
 }
 
 /// Load configuration from a JSON string. Rules are appended to existing ones.
@@ -789,7 +785,7 @@ mod tests {
     fn new_cfg() -> AgentsightConfig {
         let mut cfg = AgentsightConfig::default();
         cfg.cmdline_rules.clear();
-        cfg.domain_rules.clear();
+        cfg.https_rules.clear();
         cfg
     }
 
@@ -824,17 +820,17 @@ mod tests {
     }
 
     #[test]
-    fn test_load_json_domain_rules() {
+    fn test_load_json_https_rules() {
         let mut cfg = new_cfg();
         let json = r#"{
-            "domain": [
+            "https": [
                 {"rule": ["*.openai.com", "*.anthropic.com"]}
             ]
         }"#;
         assert!(cfg.load_from_json(json).is_ok());
-        assert_eq!(cfg.domain_rules.len(), 2);
-        assert_eq!(cfg.domain_rules[0].pattern, "*.openai.com");
-        assert_eq!(cfg.domain_rules[1].pattern, "*.anthropic.com");
+        assert_eq!(cfg.https_rules.len(), 2);
+        assert_eq!(cfg.https_rules[0].pattern, "*.openai.com");
+        assert_eq!(cfg.https_rules[1].pattern, "*.anthropic.com");
     }
 
     #[test]
@@ -934,11 +930,11 @@ mod tests {
             "cmdline": {
                 "allow": [{"rule": ["node", "*claude*"], "agent_name": "Claude Code"}]
             },
-            "domain": [{"rule": ["*.openai.com"]}]
+            "https": [{"rule": ["*.openai.com"]}]
         }"#;
         assert!(cfg.load_from_json(json).is_ok());
         assert_eq!(cfg.verbose, true);
         assert_eq!(cfg.cmdline_rules.len(), 1);
-        assert_eq!(cfg.domain_rules.len(), 1);
+        assert_eq!(cfg.https_rules.len(), 1);
     }
 }

--- a/src/agentsight/src/parser/http/request.rs
+++ b/src/agentsight/src/parser/http/request.rs
@@ -57,6 +57,14 @@ impl ParsedRequest {
     }
 
     /// Decode HTTP chunked transfer encoding and parse as JSON
+    ///
+    /// All slicing uses `str::get(..)` so that arbitrary binary bodies (e.g.
+    /// OpenTelemetry Protobuf streams that we converted via
+    /// `from_utf8_lossy`) can't panic with "byte index N is not a char
+    /// boundary" when the parsed chunk size happens to point into the middle
+    /// of a multi-byte `U+FFFD` replacement char. In those cases we simply
+    /// abandon the chunked-decode attempt and return `None`, which the caller
+    /// treats as "not JSON".
     fn decode_chunked_json(body: &str) -> Option<serde_json::Value> {
         let mut decoded = String::new();
         let mut remaining = body;
@@ -64,7 +72,7 @@ impl ParsedRequest {
         loop {
             // Find the chunk size line
             let newline_pos = remaining.find("\r\n")?;
-            let size_str = &remaining[..newline_pos];
+            let size_str = remaining.get(..newline_pos)?;
             let chunk_size = usize::from_str_radix(size_str.trim(), 16).ok()?;
 
             if chunk_size == 0 {
@@ -72,18 +80,19 @@ impl ParsedRequest {
             }
 
             let data_start = newline_pos + 2;
-            let data_end = data_start + chunk_size;
+            let data_end = data_start.checked_add(chunk_size)?;
             if data_end > remaining.len() {
-                // Partial chunk — decode what we have
-                decoded.push_str(&remaining[data_start..]);
+                // Partial chunk — decode what we have (still guarded against
+                // landing inside a multi-byte char from from_utf8_lossy).
+                decoded.push_str(remaining.get(data_start..)?);
                 break;
             }
-            decoded.push_str(&remaining[data_start..data_end]);
+            decoded.push_str(remaining.get(data_start..data_end)?);
 
             // Skip past chunk data and trailing \r\n
-            remaining = &remaining[data_end..];
+            remaining = remaining.get(data_end..)?;
             if remaining.starts_with("\r\n") {
-                remaining = &remaining[2..];
+                remaining = remaining.get(2..)?;
             }
         }
 
@@ -287,6 +296,19 @@ mod tests {
     #[test]
     fn test_decode_chunked_json_invalid() {
         assert!(ParsedRequest::decode_chunked_json("not chunked").is_none());
+    }
+
+    #[test]
+    fn test_decode_chunked_json_binary_body_does_not_panic() {
+        // A hex digit + \r\n + arbitrary invalid-UTF8 bytes (rendered as
+        // replacement chars by from_utf8_lossy) that intentionally place
+        // chunk_size past a multi-byte boundary.
+        let mut raw: Vec<u8> = b"c27\r\n".to_vec();
+        for _ in 0..4096 {
+            raw.push(0xC2); // invalid stray UTF-8 lead byte
+        }
+        let lossy = String::from_utf8_lossy(&raw);
+        assert!(ParsedRequest::decode_chunked_json(&lossy).is_none());
     }
 
     #[test]

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -327,6 +327,15 @@ impl Probes {
         self.sslsniff.detach_process(pid);
     }
 
+    pub fn add_tcp_target(&mut self, target: &TcpTarget) -> Result<()> {
+        if let Some(ref mut tcp) = self.tcpsniff {
+            tcp.add_target(target)
+        } else {
+            log::warn!("TcpSniff not enabled, cannot add runtime target {:?}", target);
+            Ok(())
+        }
+    }
+
     /// Get a handle to the traced_processes map
     pub fn traced_processes_handle(&self) -> Result<MapHandle> {
         self.proctrace.traced_processes_handle()

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -110,7 +110,7 @@ impl Probes {
                 .context("failed to create udpdns")?;
             Some(dns)
         } else {
-            log::info!("UDP DNS probe disabled (no domain_rules configured)");
+            log::info!("UDP DNS probe disabled (no https/http domain rules configured)");
             None
         };
 

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -279,16 +279,27 @@ impl SslSniff {
                 SslLibKind::GnuTls => attach_gnutls(&mut self.skel, &path, -1),
                 SslLibKind::Nss => attach_nss(&mut self.skel, &path, -1),
                 SslLibKind::Boring => {
-                    // BoringSSL doesn't export named symbols; detect by byte pattern.
-                    match find_boringssl_offsets(&path) {
-                        Some(off) => {
-                            attach_boringssl_by_offset(&mut self.skel, &path, &off, false, -1)
-                        }
-                        None => {
-                            log::warn!(
-                                "[attach_process] pid={pid}: BoringSSL byte-pattern detection failed for {path}, skipping"
+                    match attach_boringssl_by_symbol(&mut self.skel, &path, -1) {
+                        Ok(ls) => Ok(ls),
+                        Err(sym_err) => {
+                            log::debug!(
+                                "[attach_process] pid={pid}: BoringSSL symbol attach failed for {path} ({sym_err:#}), falling back to byte-pattern"
                             );
-                            continue;
+                            match find_boringssl_offsets(&path) {
+                                Some(off) => attach_boringssl_by_offset(
+                                    &mut self.skel,
+                                    &path,
+                                    &off,
+                                    false,
+                                    -1,
+                                ),
+                                None => {
+                                    log::warn!(
+                                        "[attach_process] pid={pid}: BoringSSL detection failed for {path} (no SSL_* in .dynsym and no byte-pattern match), skipping"
+                                    );
+                                    continue;
+                                }
+                            }
                         }
                     }
                 }
@@ -811,6 +822,36 @@ fn attach_nss(skel: &mut SslsniffSkel<'_>, lib: &str, pid: i32) -> Result<Vec<Li
         ur!(skel.progs_mut().probe_SSL_read_exit(), pid, lib, "PR_Read")?,
         up!(skel.progs_mut().probe_SSL_rw_enter(), pid, lib, "PR_Recv")?,
         ur!(skel.progs_mut().probe_SSL_read_exit(), pid, lib, "PR_Recv")?,
+    ])
+}
+
+fn attach_boringssl_by_symbol(
+    skel: &mut SslsniffSkel<'_>,
+    lib: &str,
+    pid: i32,
+) -> Result<Vec<Link>> {
+    Ok(vec![
+        up!(skel.progs_mut().probe_SSL_rw_enter(), pid, lib, "SSL_write")?,
+        ur!(
+            skel.progs_mut().probe_SSL_write_exit(),
+            pid,
+            lib,
+            "SSL_write"
+        )?,
+        up!(skel.progs_mut().probe_SSL_rw_enter(), pid, lib, "SSL_read")?,
+        ur!(skel.progs_mut().probe_SSL_read_exit(), pid, lib, "SSL_read")?,
+        up!(
+            skel.progs_mut().probe_SSL_do_handshake_enter(),
+            pid,
+            lib,
+            "SSL_do_handshake"
+        )?,
+        ur!(
+            skel.progs_mut().probe_SSL_do_handshake_exit(),
+            pid,
+            lib,
+            "SSL_do_handshake"
+        )?,
     ])
 }
 

--- a/src/agentsight/src/probes/tcpsniff.rs
+++ b/src/agentsight/src/probes/tcpsniff.rs
@@ -168,6 +168,30 @@ impl TcpSniff {
         Ok(())
     }
 
+    pub fn add_target(&mut self, target: &TcpTarget) -> Result<()> {
+        let binding = self.skel.maps();
+        let map = binding.tcp_targets();
+        let dummy: u8 = 1;
+
+        let ip_be: u32 = match target.ip {
+            Some(Ipv4Addr::UNSPECIFIED) | None => 0u32,
+            Some(ip) => u32::from(ip).to_be(),
+        };
+        let port_be: u16 = match target.port {
+            None => 0u16,
+            Some(p) => p.to_be(),
+        };
+        let mut key = [0u8; 8];
+        key[0..4].copy_from_slice(&ip_be.to_ne_bytes());
+        key[4..6].copy_from_slice(&port_be.to_ne_bytes());
+
+        map.update(&key, &[dummy], MapFlags::ANY)
+            .with_context(|| format!("failed to add target {:?} to tcp_targets map", target))?;
+
+        log::info!("TcpSniff: added runtime target {:?}", target);
+        Ok(())
+    }
+
     /// Attach fentry/fexit hooks for tcp_sendmsg and tcp_recvmsg.
     /// Attaches whichever tcp_recvmsg variant was loaded.
     pub fn attach(&mut self) -> Result<()> {

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -91,6 +91,8 @@ pub struct AgentSight {
     last_drain_check: std::time::Instant,
     /// Cache of pid → agent_name, persists after process exit for deferred resolution
     pid_agent_name_cache: HashMap<u32, String>,
+    /// HTTP domain patterns from config, used for runtime DNS-based tcpsniff target addition
+    http_domains: Vec<String>,
 }
 
 /// GenAI events waiting for session_id resolution via ResponseSessionMapper.
@@ -156,7 +158,7 @@ impl AgentSight {
         let all_cmdline_rules = config.cmdline_rules.clone();
 
         // Derive tcp_targets from http_targets (endpoint entries only)
-        let tcp_targets: Vec<crate::config::TcpTarget> = config
+        let mut tcp_targets: Vec<crate::config::TcpTarget> = config
             .http_targets
             .iter()
             .filter_map(|t| match t {
@@ -174,6 +176,30 @@ impl AgentSight {
                 crate::config::HttpTarget::Endpoint(_) => None,
             })
             .collect();
+
+        // Startup DNS resolve: exact http domains → IPs → append to tcp_targets
+        for domain in &http_domains {
+            if domain.contains('*') || domain.contains('?') || domain.contains('[') {
+                continue;
+            }
+            use std::net::ToSocketAddrs;
+            match (domain.as_str(), 0u16).to_socket_addrs() {
+                Ok(addrs) => {
+                    for addr in addrs {
+                        if let std::net::IpAddr::V4(ipv4) = addr.ip() {
+                            log::info!("http domain resolve: {} → {}", domain, ipv4);
+                            tcp_targets.push(crate::config::TcpTarget {
+                                ip: Some(ipv4),
+                                port: None,
+                            });
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::warn!("http domain resolve failed for {}: {}", domain, e);
+                }
+            }
+        }
 
         // Create probes - agent discovery is handled by AgentScanner via ProcMon events
         let enable_udpdns = !config.https_rules.is_empty() || !http_domains.is_empty();
@@ -360,6 +386,7 @@ impl AgentSight {
             ffi_sender: None,
             last_drain_check: std::time::Instant::now(),
             pid_agent_name_cache,
+            http_domains,
         })
     }
 
@@ -461,6 +488,7 @@ impl AgentSight {
                 dns_event.domain
             );
 
+            // HTTPS rules: attach SSL probes to the process
             if self.scanner.on_dns_event(dns_event.pid, &dns_event.domain) {
                 log::info!(
                     "[UDP-DNS] Attaching to pid={} via domain rule (domain={})",
@@ -471,6 +499,37 @@ impl AgentSight {
                     log::warn!("[UDP-DNS] Failed to attach to pid={}: {}", dns_event.pid, e);
                 }
             }
+
+            // HTTP domains: resolve DNS domain → IP, add to tcpsniff BPF map
+            if crate::discovery::matcher::match_domain_glob(&dns_event.domain, &self.http_domains) {
+                use std::net::ToSocketAddrs;
+                match (dns_event.domain.as_str(), 0u16).to_socket_addrs() {
+                    Ok(addrs) => {
+                        for addr in addrs {
+                            if let std::net::IpAddr::V4(ipv4) = addr.ip() {
+                                log::info!(
+                                    "[UDP-DNS] Adding http target {} → {}",
+                                    dns_event.domain, ipv4
+                                );
+                                let target = crate::config::TcpTarget {
+                                    ip: Some(ipv4),
+                                    port: None,
+                                };
+                                if let Err(e) = self.probes.add_tcp_target(&target) {
+                                    log::warn!("[UDP-DNS] Failed to add tcp target {}: {}", ipv4, e);
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[UDP-DNS] DNS resolve failed for http domain {}: {}",
+                            dns_event.domain, e
+                        );
+                    }
+                }
+            }
+
             return None;
         }
 

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -514,6 +514,13 @@ impl AgentSight {
                                     );
                                 }
                             }
+                            if let Some(ref sender) = self.ffi_sender {
+                                for event in &output.events {
+                                    if let GenAISemanticEvent::LLMCall(call) = event {
+                                        sender.send(FfiEvent::Llm(call.clone()));
+                                    }
+                                }
+                            }
                         } else {
                             self.export_genai_events(&output.events);
                         }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -135,9 +135,10 @@ impl AgentSight {
             match load_result {
                 Ok(()) => {
                     log::info!(
-                        "Loaded {} cmdline rule(s) and {} domain rule(s) from {:?}",
+                        "Loaded {} cmdline rule(s), {} https rule(s), {} http target(s) from {:?}",
                         config.cmdline_rules.len(),
-                        config.domain_rules.len(),
+                        config.https_rules.len(),
+                        config.http_targets.len(),
                         path
                     );
                 }
@@ -154,16 +155,36 @@ impl AgentSight {
 
         let all_cmdline_rules = config.cmdline_rules.clone();
 
+        // Derive tcp_targets from http_targets (endpoint entries only)
+        let tcp_targets: Vec<crate::config::TcpTarget> = config
+            .http_targets
+            .iter()
+            .filter_map(|t| match t {
+                crate::config::HttpTarget::Endpoint(ep) => Some(ep.clone()),
+                crate::config::HttpTarget::Domain(_) => None,
+            })
+            .collect();
+
+        // Collect http domain patterns for DNS-based resolution
+        let http_domains: Vec<String> = config
+            .http_targets
+            .iter()
+            .filter_map(|t| match t {
+                crate::config::HttpTarget::Domain(d) => Some(d.clone()),
+                crate::config::HttpTarget::Endpoint(_) => None,
+            })
+            .collect();
+
         // Create probes - agent discovery is handled by AgentScanner via ProcMon events
-        let enable_udpdns = !config.domain_rules.is_empty();
+        let enable_udpdns = !config.https_rules.is_empty() || !http_domains.is_empty();
         let mut probes =
-            Probes::new(&[], config.target_uid, config.enable_filewatch, enable_udpdns, &config.tcp_targets).context("Failed to create probes")?;
+            Probes::new(&[], config.target_uid, config.enable_filewatch, enable_udpdns, &tcp_targets).context("Failed to create probes")?;
 
         // Attach procmon for process monitoring
         probes.attach().context("Failed to attach probes")?;
 
-        // Create scanner with all rules (allow/deny/domain)
-        let mut scanner = AgentScanner::from_rules(&all_cmdline_rules, &config.domain_rules);
+        // Create scanner with all rules (allow/deny/https)
+        let mut scanner = AgentScanner::from_rules(&all_cmdline_rules, &config.https_rules);
         let existing_agents = scanner.scan();
 
         // Attach SSL probes to already-running agents
@@ -171,7 +192,7 @@ impl AgentSight {
             Self::attach_process_internal(&mut probes, agent.pid, &agent.agent_info.name);
         }
 
-        // Connection scan: find processes with established connections to domain_rules IPs
+        // Connection scan: find processes with established connections to https_rules IPs
         let already_traced: HashSet<u32> = existing_agents.iter().map(|a| a.pid).collect();
         let conn_results = if scanner.has_domain_rules() {
             let conn_scanner = crate::discovery::ConnectionScanner::new(&scanner);


### PR DESCRIPTION
## Description

Restructure agentsight capture configuration into symmetric `https`/`http` rule families and ship several stability fixes for BoringSSL probing, FFI fan-out, and HTTP chunked parsing.

1. **Config restructure**: rename JSON key `domain` → `https`, `tcp_targets` → `http`, with unified `{"rule": [...]}` format. `http` entries auto-detect IP/port vs domain. Rust types: `DomainRule` → `HttpsRule`, new `HttpTarget` enum. FFI: `agentsight_config_add_domain_rule` → `add_https`, `agentsight_config_add_tcp_target` → `add_http` (now accepts domains).
2. **BoringSSL probe**: try symbol-based attach first (`SSL_read`/`SSL_write` in `.dynsym`), fall back to byte-pattern scan for stripped builds.
3. **FFI fan-out fix**: SQLite direct-write path also pushes `LLMCall` events through the FFI sender so embedded consumers always receive them.
4. **Chunked JSON parser hardening**: use `str::get()` to prevent panics on binary bodies whose `from_utf8_lossy` form has multi-byte replacement chars.

## Related Issue

closes #620

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- Verified config JSON loads with new `https`/`http` keys; integration test fixtures updated.
- Confirmed BoringSSL probe attaches via symbols on standard builds and falls back to byte-pattern scan on stripped binaries.
- Verified FFI consumers receive `LLMCall` events when SQLite direct-write path is active.
- Exercised chunked JSON parser against binary-body fixtures without panic.

## Additional Notes

This is a **breaking change** for the `agentsight.json` config schema and the FFI symbol names. Downstream consumers must update their JSON keys (`domain` → `https`, `tcp_targets` → `http`) and FFI calls (`agentsight_config_add_domain_rule` → `add_https`, `agentsight_config_add_tcp_target` → `add_http`).
