### PR TITLE
fix(sight): improve c_char / BPF comm portability (i8 vs u8)

### DIFF
--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -74,7 +74,7 @@ fn safe_cstring(s: &str) -> CString {
 
 /// Copy a Rust string into a fixed-size `[c_char; 16]` buffer (NUL-terminated).
 fn copy_process_name(name: &str) -> [c_char; 16] {
-    let mut buf = [0i8; 16];
+    let mut buf = [0 as c_char; 16];
     let bytes = name.as_bytes();
     let len = bytes.len().min(15);
     for i in 0..len {

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -16,8 +16,9 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     io::Write,
-    mem::MaybeUninit,
+    mem::{self, MaybeUninit},
     path::Path,
+    slice,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -87,11 +88,14 @@ impl SslEvent {
         }
     }
 
-    /// Parse comm from raw C char array
-    fn parse_comm(comm: &[i8; 16]) -> String {
-        let bytes: Vec<u8> = comm
+    /// Parse comm from the BPF struct field (layout matches C `char comm[16]`; generated
+    /// bindings may use `[i8; 16]` or `[u8; 16]` depending on target / libbpf-cargo version).
+    fn parse_comm<T>(comm: &[T; 16]) -> String {
+        debug_assert_eq!(mem::size_of::<T>(), 1);
+        let bytes = unsafe { slice::from_raw_parts(comm.as_ptr() as *const u8, 16) };
+        let bytes: Vec<u8> = bytes
             .iter()
-            .map(|&c| c as u8)
+            .copied()
             .take_while(|&b| b != 0)
             .collect();
         String::from_utf8_lossy(&bytes).into_owned()
@@ -680,11 +684,11 @@ fn ssl_libs_from_maps(pid: i32) -> Result<Vec<(String, u64, SslLibKind)>> {
     Ok(results)
 }
 
-/// Convert a null-terminated `i8` array (from C `char comm[TASK_COMM_LEN]`) to a `String`.
-fn comm_to_string(comm: &[i8]) -> String {
+/// Convert a null-terminated byte array (from C `char comm[TASK_COMM_LEN]`) to a `String`.
+fn comm_to_string(comm: &[u8]) -> String {
     let bytes: Vec<u8> = comm
         .iter()
-        .map(|&c| c as u8)
+        .copied()
         .take_while(|&b| b != 0)
         .collect();
     String::from_utf8_lossy(&bytes).into_owned()


### PR DESCRIPTION
## Description

Sync the upstream portability fix from `aliyun/coolbpf` commit [`714a6b8`](https://github.com/aliyun/coolbpf/commit/714a6b8ec8971930de2def2a8a4d9f6f71ef5d10) into `alibaba/anolisa`'s agentsight tree.

`std::os::raw::c_char` is `i8` on x86_64 glibc but `u8` on AArch64 / some musl toolchains, and `libbpf-cargo`-generated bindings can expose `char comm[16]` as either `[i8; 16]` or `[u8; 16]` depending on the version. The previous code hard-coded `i8` and broke compilation on those platforms.

### Changes

- `src/ffi.rs` — `copy_process_name()` now seeds the buffer with `[0 as c_char; 16]` instead of `[0i8; 16]`, so it works regardless of `c_char` signedness.
- `src/probes/sslsniff.rs`
  - Add `mem`, `slice` imports.
  - Generalize `parse_comm()` to `<T>` with a `size_of::<T>() == 1` debug assertion and reinterpret the array bytes via `slice::from_raw_parts`, accommodating bindings that emit either `[i8; 16]` or `[u8; 16]`.
  - Switch `comm_to_string()` to `&[u8]` and use `.copied()` instead of casting.

No behavioural change — the byte layout is identical; only the Rust-side typing is loosened to be portable.

## Related Issue

closes #626

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo check --lib` passes on x86_64 glibc (the original build target).
- `cargo test --lib` — 432 passed, 0 failed.
- Logic is unchanged; only the type signatures are broadened. Cross-platform behaviour follows the upstream `coolbpf` reference fix.

## Additional Notes

This is a straight port of the upstream `aliyun/coolbpf@714a6b8` fix. Keeping the agentsight tree in sync prevents the same build break from re-appearing on AArch64 / musl / newer `libbpf-cargo` users.
