### PR TITLE
fix(cosh): keep prompt ids monotonic after /bash

### DIFF
--- a/src/copilot-shell/packages/cli/src/gemini.test.tsx
+++ b/src/copilot-shell/packages/cli/src/gemini.test.tsx
@@ -74,6 +74,14 @@ vi.mock('./utils/events.js', async (importOriginal) => {
   };
 });
 
+vi.mock('./ui/hooks/useKittyKeyboardProtocol.js', () => ({
+  useKittyKeyboardProtocol: vi.fn(() => ({
+    supported: false,
+    enabled: false,
+    checking: false,
+  })),
+}));
+
 vi.mock('./utils/relaunch.js', () => ({
   relaunchAppInChildProcess: vi.fn(),
 }));
@@ -499,6 +507,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       getExperimentalZedIntegration: () => false,
       getScreenReader: () => false,
       getGeminiMdFileCount: () => 0,
+      getResumedSessionData: () => undefined,
     } as unknown as Config);
     vi.mocked(loadSettings).mockReturnValue({
       errors: [],
@@ -600,9 +609,58 @@ describe('validateDnsResolutionOrder', () => {
   });
 });
 
+type ReactElementLike = {
+  type?: unknown;
+  props?: {
+    children?: unknown;
+    initialPromptCount?: number;
+    onPromptCountChange?: (promptCount: number) => void;
+  };
+};
+
+function isReactElementLike(value: unknown): value is ReactElementLike {
+  return typeof value === 'object' && value !== null && 'props' in value;
+}
+
+function renderAppWrapper(element: unknown): unknown {
+  if (!isReactElementLike(element) || typeof element.type !== 'function') {
+    return element;
+  }
+  return element.type(element.props ?? {});
+}
+
+function findSessionStatsProviderProps(
+  element: unknown,
+): ReactElementLike['props'] | undefined {
+  if (Array.isArray(element)) {
+    for (const child of element) {
+      const result = findSessionStatsProviderProps(child);
+      if (result) {
+        return result;
+      }
+    }
+    return undefined;
+  }
+
+  if (!isReactElementLike(element)) {
+    return undefined;
+  }
+
+  if (
+    typeof element.props?.initialPromptCount === 'number' &&
+    typeof element.props?.onPromptCountChange === 'function'
+  ) {
+    return element.props;
+  }
+
+  return findSessionStatsProviderProps(element.props?.children);
+}
+
 describe('startInteractiveUI', () => {
   // Mock dependencies
   const mockConfig = {
+    getSessionId: () => 'session-1',
+    getResumedSessionData: () => undefined,
     getProjectRoot: () => '/root',
     getScreenReader: () => false,
   } as Config;
@@ -672,6 +730,39 @@ describe('startInteractiveUI', () => {
 
     // Verify React element structure is valid (but don't deep dive into JSX internals)
     expect(reactElement).toBeDefined();
+  });
+
+  it('should carry prompt count into remounted UI after shell suspend', async () => {
+    const { render } = await import('ink');
+    const renderSpy = vi.mocked(render);
+
+    const mockInitializationResult = {
+      authError: null,
+      themeError: null,
+      shouldOpenAuthDialog: false,
+      geminiMdFileCount: 0,
+    };
+
+    await startInteractiveUI(
+      mockConfig,
+      mockSettings,
+      mockStartupWarnings,
+      mockWorkspaceRoot,
+      mockInitializationResult,
+    );
+
+    const [reactElement] = renderSpy.mock.calls[0];
+    const firstProviderProps = findSessionStatsProviderProps(
+      renderAppWrapper(reactElement),
+    );
+    expect(firstProviderProps?.initialPromptCount).toBe(0);
+
+    firstProviderProps?.onPromptCountChange?.(2);
+
+    const remountedProviderProps = findSessionStatsProviderProps(
+      renderAppWrapper(reactElement),
+    );
+    expect(remountedProviderProps?.initialPromptCount).toBe(2);
   });
 
   it('should perform all startup tasks in correct order', async () => {

--- a/src/copilot-shell/packages/cli/src/gemini.tsx
+++ b/src/copilot-shell/packages/cli/src/gemini.tsx
@@ -30,7 +30,10 @@ import { runNonInteractiveStreamJson } from './nonInteractive/session.js';
 import { AppContainer } from './ui/AppContainer.js';
 import { setMaxSizedBoxDebugging } from './ui/components/shared/MaxSizedBox.js';
 import { KeypressProvider } from './ui/contexts/KeypressContext.js';
-import { SessionStatsProvider } from './ui/contexts/SessionContext.js';
+import {
+  getPromptCountFromSessionData,
+  SessionStatsProvider,
+} from './ui/contexts/SessionContext.js';
 import { SettingsContext } from './ui/contexts/SettingsContext.js';
 import { VimModeProvider } from './ui/contexts/VimModeContext.js';
 import { useKittyKeyboardProtocol } from './ui/hooks/useKittyKeyboardProtocol.js';
@@ -142,6 +145,9 @@ export async function startInteractiveUI(
 ) {
   const version = await getCliVersion();
   setWindowTitle(basename(workspaceRoot), settings);
+  let interactivePromptCount = getPromptCountFromSessionData(
+    config.getResumedSessionData(),
+  );
 
   // Create wrapper component to use hooks inside render
   const AppWrapper = () => {
@@ -157,7 +163,13 @@ export async function startInteractiveUI(
             process.platform === 'win32' || nodeMajorVersion < 20
           }
         >
-          <SessionStatsProvider sessionId={config.getSessionId()}>
+          <SessionStatsProvider
+            sessionId={config.getSessionId()}
+            initialPromptCount={interactivePromptCount}
+            onPromptCountChange={(promptCount) => {
+              interactivePromptCount = promptCount;
+            }}
+          >
             <VimModeProvider settings={settings}>
               <AppContainer
                 config={config}

--- a/src/copilot-shell/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -9,7 +9,12 @@ import { render } from 'ink-testing-library';
 import { renderHook } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import type { SessionMetrics } from './SessionContext.js';
-import { SessionStatsProvider, useSessionStats } from './SessionContext.js';
+import type { ResumedSessionData } from '@copilot-shell/core';
+import {
+  getPromptCountFromSessionData,
+  SessionStatsProvider,
+  useSessionStats,
+} from './SessionContext.js';
 import { describe, it, expect, vi } from 'vitest';
 import { uiTelemetryService } from '@copilot-shell/core';
 
@@ -44,6 +49,83 @@ describe('SessionStatsContext', () => {
     expect(stats?.sessionStartTime).toBeInstanceOf(Date);
     expect(stats?.metrics).toBeDefined();
     expect(stats?.metrics.models).toEqual({});
+  });
+
+  it('should initialize prompt count from resumed session state', () => {
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    render(
+      <SessionStatsProvider sessionId="session-1" initialPromptCount={3}>
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
+    );
+
+    expect(contextRef.current?.stats.sessionId).toBe('session-1');
+    expect(contextRef.current?.stats.promptCount).toBe(3);
+    expect(contextRef.current?.getPromptCount()).toBe(3);
+  });
+
+  it('should preserve resumed prompt count when starting a session', () => {
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    render(
+      <SessionStatsProvider>
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
+    );
+
+    act(() => {
+      contextRef.current?.startNewSession('resumed-session', 7);
+    });
+
+    expect(contextRef.current?.stats.sessionId).toBe('resumed-session');
+    expect(contextRef.current?.stats.promptCount).toBe(7);
+  });
+
+  it('should notify prompt count changes for remount persistence', () => {
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+    const onPromptCountChange = vi.fn();
+
+    render(
+      <SessionStatsProvider onPromptCountChange={onPromptCountChange}>
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
+    );
+
+    act(() => {
+      contextRef.current?.startNewPrompt();
+    });
+    act(() => {
+      contextRef.current?.startNewSession('resumed-session', 4);
+    });
+
+    expect(onPromptCountChange).toHaveBeenNthCalledWith(1, 1);
+    expect(onPromptCountChange).toHaveBeenNthCalledWith(2, 4);
+  });
+
+  it('should count user messages in resumed session data', () => {
+    const sessionData = {
+      conversation: {
+        messages: [
+          { type: 'user' },
+          { type: 'assistant' },
+          { type: 'tool_result' },
+          { type: 'user' },
+        ],
+      },
+    };
+
+    expect(
+      getPromptCountFromSessionData(
+        sessionData as unknown as ResumedSessionData,
+      ),
+    ).toBe(2);
   });
 
   it('should update metrics when the uiTelemetryService emits an update', () => {

--- a/src/copilot-shell/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react';
 
 import type {
+  ResumedSessionData,
   SessionMetrics,
   ModelMetrics,
   ToolCallStats,
@@ -176,7 +177,7 @@ export interface ComputedSessionStats {
 // and the functions to update it.
 interface SessionStatsContextValue {
   stats: SessionStatsState;
-  startNewSession: (sessionId: string) => void;
+  startNewSession: (sessionId: string, initialPromptCount?: number) => void;
   startNewPrompt: () => void;
   getPromptCount: () => number;
 }
@@ -187,22 +188,37 @@ const SessionStatsContext = createContext<SessionStatsContextValue | undefined>(
   undefined,
 );
 
-const createDefaultStats = (sessionId: string = ''): SessionStatsState => ({
+export function getPromptCountFromSessionData(
+  sessionData: ResumedSessionData | undefined,
+): number {
+  return (
+    sessionData?.conversation.messages.filter(
+      (message) => message.type === 'user',
+    ).length ?? 0
+  );
+}
+
+const createDefaultStats = (
+  sessionId: string = '',
+  promptCount: number = 0,
+): SessionStatsState => ({
   sessionId,
   sessionStartTime: new Date(),
   metrics: uiTelemetryService.getMetrics(),
   lastPromptTokenCount: 0,
-  promptCount: 0,
+  promptCount,
 });
 
 // --- Provider Component ---
 
 export const SessionStatsProvider: React.FC<{
   sessionId?: string;
+  initialPromptCount?: number;
+  onPromptCountChange?: (promptCount: number) => void;
   children: React.ReactNode;
-}> = ({ sessionId, children }) => {
+}> = ({ sessionId, initialPromptCount = 0, onPromptCountChange, children }) => {
   const [stats, setStats] = useState<SessionStatsState>(() =>
-    createDefaultStats(sessionId ?? ''),
+    createDefaultStats(sessionId ?? '', initialPromptCount),
   );
 
   useEffect(() => {
@@ -240,19 +256,27 @@ export const SessionStatsProvider: React.FC<{
     };
   }, []);
 
-  const startNewSession = useCallback((sessionId: string) => {
-    setStats(() => ({
-      ...createDefaultStats(sessionId),
-      lastPromptTokenCount: uiTelemetryService.getLastPromptTokenCount(),
-    }));
-  }, []);
+  const startNewSession = useCallback(
+    (sessionId: string, initialPromptCount: number = 0) => {
+      onPromptCountChange?.(initialPromptCount);
+      setStats(() => ({
+        ...createDefaultStats(sessionId, initialPromptCount),
+        lastPromptTokenCount: uiTelemetryService.getLastPromptTokenCount(),
+      }));
+    },
+    [onPromptCountChange],
+  );
 
   const startNewPrompt = useCallback(() => {
-    setStats((prevState) => ({
-      ...prevState,
-      promptCount: prevState.promptCount + 1,
-    }));
-  }, []);
+    setStats((prevState) => {
+      const promptCount = prevState.promptCount + 1;
+      onPromptCountChange?.(promptCount);
+      return {
+        ...prevState,
+        promptCount,
+      };
+    });
+  }, [onPromptCountChange]);
 
   const getPromptCount = useCallback(
     () => stats.promptCount,

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.test.ts
@@ -10,10 +10,10 @@ import { useResumeCommand } from './useResumeCommand.js';
 
 const resumeMocks = vi.hoisted(() => {
   let resolveLoadSession:
-    | ((value: { conversation: unknown } | undefined) => void)
+    | ((value: { conversation: { messages: unknown[] } } | undefined) => void)
     | undefined;
   let pendingLoadSession:
-    | Promise<{ conversation: unknown } | undefined>
+    | Promise<{ conversation: { messages: unknown[] } } | undefined>
     | undefined;
 
   return {
@@ -23,7 +23,9 @@ const resumeMocks = vi.hoisted(() => {
       });
       return pendingLoadSession;
     },
-    resolvePendingLoadSession(value: { conversation: unknown } | undefined) {
+    resolvePendingLoadSession(
+      value: { conversation: { messages: unknown[] } } | undefined,
+    ) {
       resolveLoadSession?.(value);
     },
     getPendingLoadSession() {
@@ -47,7 +49,11 @@ vi.mock('@copilot-shell/core', () => {
       return (
         resumeMocks.getPendingLoadSession() ??
         Promise.resolve({
-          conversation: [{ role: 'user', parts: [{ text: 'hello' }] }],
+          conversation: {
+            messages: [
+              { type: 'user', message: { parts: [{ text: 'hello' }] } },
+            ],
+          },
         })
       );
     }
@@ -55,6 +61,12 @@ vi.mock('@copilot-shell/core', () => {
 
   return {
     SessionService,
+    uiTelemetryService: {
+      getMetrics: () => ({ models: {}, tools: {}, files: {} }),
+      getLastPromptTokenCount: () => 0,
+      on: () => {},
+      off: () => {},
+    },
   };
 });
 
@@ -170,7 +182,13 @@ describe('useResumeCommand', () => {
 
     // Now finish the async load and let the handler complete.
     resumeMocks.resolvePendingLoadSession({
-      conversation: [{ role: 'user', parts: [{ text: 'hello' }] }],
+      conversation: {
+        messages: [
+          { type: 'user', message: { parts: [{ text: 'hello' }] } },
+          { type: 'assistant', message: { parts: [{ text: 'hi' }] } },
+          { type: 'user', message: { parts: [{ text: 'again' }] } },
+        ],
+      },
     });
     await act(async () => {
       await resumePromise;
@@ -182,7 +200,7 @@ describe('useResumeCommand', () => {
         conversation: expect.anything(),
       }),
     );
-    expect(startNewSession).toHaveBeenCalledWith('session-2');
+    expect(startNewSession).toHaveBeenCalledWith('session-2', 2);
     expect(geminiClient.initialize).toHaveBeenCalledTimes(1);
     expect(historyManager.clearItems).toHaveBeenCalledTimes(1);
     expect(historyManager.loadHistory).toHaveBeenCalledTimes(1);

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.ts
@@ -7,12 +7,13 @@
 import { useState, useCallback } from 'react';
 import { SessionService, type Config } from '@copilot-shell/core';
 import { buildResumedHistoryItems } from '../utils/resumeHistoryUtils.js';
+import { getPromptCountFromSessionData } from '../contexts/SessionContext.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 
 export interface UseResumeCommandOptions {
   config: Config | null;
   historyManager: Pick<UseHistoryManagerReturn, 'clearItems' | 'loadHistory'>;
-  startNewSession: (sessionId: string) => void;
+  startNewSession: (sessionId: string, initialPromptCount?: number) => void;
   remount?: () => void;
 }
 
@@ -55,8 +56,9 @@ export function useResumeCommand(
         return;
       }
 
-      // Start new session in UI context.
-      startNewSession(sessionId);
+      // Start new session in UI context, preserving the resumed prompt count so
+      // run ids keep increasing for the same session.
+      startNewSession(sessionId, getPromptCountFromSessionData(sessionData));
 
       // Reset UI history.
       const uiHistoryItems = buildResumedHistoryItems(sessionData, config);


### PR DESCRIPTION
## Description

Fix prompt id reset after returning from `/bash`.

When `/bash` exits, the TUI is remounted with the same session id. Previously
the UI prompt counter reset to 0, so new run ids could repeat. This change
preserves the prompt count across remounts and seeds it from resumed session
history.

## Related Issue

fixes #625

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
npx vitest run \
  packages/cli/src/gemini.test.tsx \
  packages/cli/src/ui/contexts/SessionContext.test.tsx \
  packages/cli/src/ui/hooks/useResumeCommand.test.ts \
  packages/cli/src/ui/hooks/useGeminiStream.test.tsx
```

Result: 4 files passed, 84 tests passed.

```bash
git diff --check
```

Result: passed.

Note: `npm run typecheck -w @copilot-shell/cli` still fails on existing
repository issues around `ink` type declarations and existing test imports,
not from this change.

## Additional Notes

The fix covers both `/bash` TUI remount and explicit `/resume` session
switching. Prompt ids now continue from the existing user prompt count for the
reused session.
