### PR TITLE
feat(sight): add unit tests for http endpoint and domain rule parsing

### DIFF
--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -937,4 +937,50 @@ mod tests {
         assert_eq!(cfg.cmdline_rules.len(), 1);
         assert_eq!(cfg.https_rules.len(), 1);
     }
+
+    #[test]
+    fn test_load_json_http_endpoint() {
+        let mut cfg = new_cfg();
+        let json = r#"{
+            "http": [
+                {"rule": [":8080", "10.0.0.1:9090"]}
+            ]
+        }"#;
+        assert!(cfg.load_from_json(json).is_ok());
+        assert_eq!(cfg.http_targets.len(), 2);
+        match &cfg.http_targets[0] {
+            crate::config::HttpTarget::Endpoint(t) => {
+                assert_eq!(t.ip, None);
+                assert_eq!(t.port, Some(8080));
+            }
+            _ => panic!("expected Endpoint"),
+        }
+        match &cfg.http_targets[1] {
+            crate::config::HttpTarget::Endpoint(t) => {
+                assert_eq!(t.ip, Some(std::net::Ipv4Addr::new(10, 0, 0, 1)));
+                assert_eq!(t.port, Some(9090));
+            }
+            _ => panic!("expected Endpoint"),
+        }
+    }
+
+    #[test]
+    fn test_load_json_http_domain() {
+        let mut cfg = new_cfg();
+        let json = r#"{
+            "http": [
+                {"rule": ["model-svc.default.svc", "*.internal.com"]}
+            ]
+        }"#;
+        assert!(cfg.load_from_json(json).is_ok());
+        assert_eq!(cfg.http_targets.len(), 2);
+        match &cfg.http_targets[0] {
+            crate::config::HttpTarget::Domain(d) => assert_eq!(d, "model-svc.default.svc"),
+            _ => panic!("expected Domain"),
+        }
+        match &cfg.http_targets[1] {
+            crate::config::HttpTarget::Domain(d) => assert_eq!(d, "*.internal.com"),
+            _ => panic!("expected Domain"),
+        }
+    }
 }


### PR DESCRIPTION
## Description

Add unit tests covering the HTTP target configuration parsing logic:

- `test_load_json_http_endpoint`: validates endpoint parsing for `:port` and `ip:port` formats
- `test_load_json_http_domain`: validates domain rule parsing including exact match and wildcard patterns

## Related Issue

closes #630

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

`cargo test --lib` — all tests pass including the two new test cases.