### PR TITLE
fix(cosh): render HookSystemMessage as info and fix Content/Thought duplication

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -3317,4 +3317,163 @@ describe('useGeminiStream', () => {
       expect(result.current.userPromptConfirmationRequest).toBeNull();
     });
   });
+
+  // Regression coverage for issue #635: HookSystemMessage must not be
+  // routed through assistant content, and pending content flushes triggered
+  // by Content<->Thought block switches must advance the redaction cursor.
+  describe('HookSystemMessage and Content/Thought interleaving', () => {
+    const geminiTextCalls = () =>
+      mockAddItem.mock.calls
+        .filter(
+          (call) =>
+            call[0].type === 'gemini' || call[0].type === 'gemini_content',
+        )
+        .map((call) => call[0].text as string);
+
+    it('renders HookSystemMessage as an info item and does not duplicate it into later assistant content', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.HookSystemMessage,
+            value: '[test-hook] warning',
+          };
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: { subject: '', description: 'thinking' },
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'answer',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('hook test');
+      });
+
+      await waitFor(() => {
+        // Hook message must surface as a host/info notification.
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: MessageType.INFO,
+            text: '[test-hook] warning',
+          }),
+          expect.any(Number),
+        );
+        // The model answer is still committed as a gemini item.
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'gemini', text: 'answer' }),
+          expect.any(Number),
+        );
+      });
+
+      // No gemini / gemini_content item may carry the hook warning text —
+      // it must never have been treated as assistant content.
+      for (const text of geminiTextCalls()) {
+        expect(text).not.toContain('[test-hook] warning');
+      }
+    });
+
+    it('does not re-emit earlier content when a Thought separates two Content chunks', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'first',
+          };
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: { subject: '', description: 'thinking' },
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'second',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('split test');
+      });
+
+      await waitFor(() => {
+        // The post-thought content must commit as just "second", not
+        // "firstsecond" (which would mean the redaction cursor was not
+        // advanced when the thought flushed the pending gemini item).
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'gemini', text: 'second' }),
+          expect.any(Number),
+        );
+      });
+
+      const texts = geminiTextCalls();
+      // Each text is exactly one chunk, never a concatenation that would
+      // indicate a re-slice of already-committed content.
+      expect(texts).toEqual(expect.arrayContaining(['first', 'second']));
+      for (const text of texts) {
+        expect(text).not.toBe('firstsecond');
+        expect(text).not.toContain('firstfirst');
+      }
+    });
+
+    it('handles repeated Thought -> Content block switches without duplicating prior content', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: { subject: '', description: 't1' },
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'c1',
+          };
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: { subject: '', description: 't2' },
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'c2',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('multi switch');
+      });
+
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'gemini', text: 'c2' }),
+          expect.any(Number),
+        );
+      });
+
+      const texts = geminiTextCalls();
+      expect(texts).toEqual(expect.arrayContaining(['c1', 'c2']));
+      for (const text of texts) {
+        expect(text).not.toBe('c1c2');
+        expect(text).not.toContain('c1c1');
+      }
+    });
+  });
 });

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -486,6 +486,29 @@ export const useGeminiStream = (
 
   // --- Stream Event Handlers ---
 
+  // Flush the pending streaming history item. For gemini / gemini_content
+  // items the redaction cursor must also advance, otherwise a subsequent
+  // Content event will re-slice the already-flushed prefix from the raw
+  // turn buffer and duplicate it in history (see issue #635).
+  const finalizePendingHistoryItem = useCallback(
+    (userMessageTimestamp: number) => {
+      const pendingItem = pendingHistoryItemRef.current;
+      if (!pendingItem) return;
+
+      addItem(pendingItem, userMessageTimestamp);
+
+      if (
+        pendingItem.type === 'gemini' ||
+        pendingItem.type === 'gemini_content'
+      ) {
+        committedRedactedTextRef.current += pendingItem.text;
+      }
+
+      setPendingHistoryItem(null);
+    },
+    [addItem, pendingHistoryItemRef, setPendingHistoryItem],
+  );
+
   const handleContentEvent = useCallback(
     (
       eventValue: ContentEvent['value'],
@@ -610,10 +633,10 @@ export const useGeminiStream = (
 
       // If we're not already showing a thought, start a new one
       if (!isPendingThought) {
-        // If there's a pending non-thought item, finalize it first
-        if (pendingHistoryItemRef.current) {
-          addItem(pendingHistoryItemRef.current, userMessageTimestamp);
-        }
+        // If there's a pending non-thought item, finalize it first. This
+        // also advances the redaction cursor for gemini/gemini_content so
+        // that the next Content event does not re-slice committed text.
+        finalizePendingHistoryItem(userMessageTimestamp);
         setPendingHistoryItem({ type: 'gemini_thought', text: '' });
       }
 
@@ -654,7 +677,13 @@ export const useGeminiStream = (
 
       return newThoughtBuffer;
     },
-    [addItem, pendingHistoryItemRef, setPendingHistoryItem, mergeThought],
+    [
+      addItem,
+      pendingHistoryItemRef,
+      setPendingHistoryItem,
+      mergeThought,
+      finalizePendingHistoryItem,
+    ],
   );
 
   const handleUserCancelledEvent = useCallback(
@@ -712,6 +741,26 @@ export const useGeminiStream = (
       setThought(null); // Reset thought when there's an error
     },
     [addItem, pendingHistoryItemRef, setPendingHistoryItem, config, setThought],
+  );
+
+  const handleHookSystemMessageEvent = useCallback(
+    (message: string, userMessageTimestamp: number) => {
+      if (turnCancelledRef.current) {
+        return;
+      }
+      // Hook/host notifications are not assistant content. Flush any
+      // pending streaming item (advancing the redaction cursor when needed)
+      // and render the hook message as a standalone info item.
+      finalizePendingHistoryItem(userMessageTimestamp);
+      addItem(
+        {
+          type: MessageType.INFO,
+          text: message,
+        },
+        userMessageTimestamp,
+      );
+    },
+    [addItem, finalizePendingHistoryItem],
   );
 
   const handleCitationEvent = useCallback(
@@ -937,13 +986,11 @@ export const useGeminiStream = (
             // Will add the missing logic later
             break;
           case ServerGeminiEventType.HookSystemMessage:
-            // Display system message from hooks (e.g., Ralph Loop iteration info)
-            // This is handled as a content event to show in the UI
-            geminiMessageBuffer = handleContentEvent(
-              event.value + '\n',
-              geminiMessageBuffer,
-              userMessageTimestamp,
-            );
+            // Hook/host notifications are NOT model assistant content. They
+            // must not be routed through handleContentEvent (which would add
+            // them to rawTurnContentRef and risk duplicate rendering when
+            // later Content / Thought events re-slice that buffer).
+            handleHookSystemMessageEvent(event.value, userMessageTimestamp);
             break;
           case ServerGeminiEventType.AfterModelHookStop:
             // AfterModel hook requested stop — agent loop is ended by client.ts.
@@ -983,6 +1030,7 @@ export const useGeminiStream = (
       handleMaxSessionTurnsEvent,
       handleSessionTokenLimitExceededEvent,
       handleCitationEvent,
+      handleHookSystemMessageEvent,
       setThought,
     ],
   );


### PR DESCRIPTION
## Description

Fix two related bugs in the interactive UI stream handler surfaced by
issue #635:

1. `HookSystemMessage` was routed through `handleContentEvent`, so hook
   / host notifications were rendered as assistant `Content` and also
   appended to `rawTurnContentRef`.
2. When the stream interleaved `Content -> Thought -> Content`, the
   pending gemini item was flushed to history on the block switch but
   the redaction cursor (`committedRedactedTextRef`) was not advanced.
   The next `Content` event re-sliced the same raw buffer and the
   previously-committed text was duplicated.

The fix:

- Add a `finalizePendingHistoryItem` helper that flushes the pending
  history item and, when it is a `gemini` / `gemini_content` item,
  advances the redaction cursor by the item's text.
- Use the helper in `handleThoughtEvent` instead of a bare `addItem`.
- Add a dedicated `handleHookSystemMessageEvent` that renders the hook
  message as an `INFO` history item and never touches the assistant
  content buffer; route `HookSystemMessage` to it in the stream switch.

Scope is intentionally minimal: no changes to core event definitions or
client emit logic.

## Related Issue

closes #635

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] \`cosh\` (copilot-shell)
- [ ] \`sec-core\` (agent-sec-core)
- [ ] \`skill\` (os-skills)
- [ ] \`sight\` (agentsight)
- [ ] \`tokenless\` (tokenless)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For \`cosh\`: Lint passes, type check passes, and tests pass
- [ ] For \`sec-core\` (Rust): \`cargo clippy -- -D warnings\` and \`cargo fmt --check\` pass
- [ ] For \`sec-core\` (Python): Ruff format and pytest pass
- [ ] For \`skill\`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For \`sight\`: \`cargo clippy -- -D warnings\` and \`cargo fmt --check\` pass
- [ ] For \`tokenless\`: \`cargo clippy -- -D warnings\` and \`cargo fmt --check\` pass
- [ ] Lock files are up to date (\`package-lock.json\` / \`Cargo.lock\`)

## Testing

- \`npm run test --workspace=packages/cli -- useGeminiStream.test.tsx\` → 56 passed, including 3 new tests:
  - \`HookSystemMessage -> Thought -> Content\`: hook text appears as \`info\`, never in any \`gemini\` / \`gemini_content\` item.
  - \`Content -> Thought -> Content\`: post-thought content commits as just \`second\`, never \`firstsecond\`.
  - \`Thought -> Content -> Thought -> Content\`: multiple block switches do not duplicate prior content.
- \`npm run typecheck --workspace=packages/cli\`: no new errors introduced (the pre-existing \`ink\` / \`@testing-library/react\` errors also appear on \`main\`).

## Additional Notes

Per the issue, this PR deliberately does not touch \`SessionContext.tsx\`,
\`gemini.tsx\`, or \`useResumeCommand.ts\` (those belong to the #625 prompt
id work and are kept out of this PR).