### PR TITLE
fix(ckpt): bug fix for issue #616 #622 #629 #632 #633

### DIFF
--- a/src/ws-ckpt/scripts/install-hermes.sh
+++ b/src/ws-ckpt/scripts/install-hermes.sh
@@ -12,7 +12,8 @@ SKILL_DST="${HOME}/.hermes/skills/ws-ckpt"
 if PLUGIN_SRC=$(find_plugin_src hermes); then
     mkdir -p "$(dirname "$PLUGIN_DST")"
     ln -sfn "$PLUGIN_SRC" "$PLUGIN_DST"
-    echo "hermes ws-ckpt plugin linked: $PLUGIN_DST -> $PLUGIN_SRC"
+    hermes plugins enable ws-ckpt
+    echo "hermes ws-ckpt plugin linked and enabled: $PLUGIN_DST -> $PLUGIN_SRC"
     exit 0
 fi
 

--- a/src/ws-ckpt/scripts/uninstall-hermes.sh
+++ b/src/ws-ckpt/scripts/uninstall-hermes.sh
@@ -11,7 +11,60 @@ if [ -L "$PLUGIN_DST" ] || [ -d "$PLUGIN_DST" ]; then
     echo "plugin removed: $PLUGIN_DST"
 fi
 
-# 2. Remove skill if exists
+# 2. Remove ws-ckpt config from ~/.hermes/config.yaml
+HERMES_CONFIG="${HOME}/.hermes/config.yaml"
+if [ -f "$HERMES_CONFIG" ]; then
+    python3 -c "
+import sys, re
+
+path = sys.argv[1]
+with open(path) as f:
+    lines = f.readlines()
+
+out = []
+in_plugins = False
+plugins_indent = -1
+skip_indent = -1
+
+for line in lines:
+    stripped = line.strip()
+    indent = len(line) - len(line.lstrip()) if stripped else 0
+
+    # Track whether we're inside the plugins: block
+    if re.match(r'^plugins:\s*$', line):
+        in_plugins = True
+        plugins_indent = indent
+        out.append(line)
+        continue
+    if in_plugins and stripped and indent <= plugins_indent:
+        in_plugins = False
+
+    # Still skipping children of ws-ckpt: block
+    if skip_indent >= 0:
+        if not stripped:
+            out.append(line)
+            continue
+        if indent > skip_indent:
+            continue
+        skip_indent = -1
+
+    # Only act inside plugins: block
+    if in_plugins:
+        if re.match(r'^\s*- ws-ckpt\s*$', line):
+            continue
+        m = re.match(r'^(\s*)ws-ckpt:\s*$', line)
+        if m:
+            skip_indent = len(m.group(1))
+            continue
+
+    out.append(line)
+
+with open(path, 'w') as f:
+    f.writelines(out)
+" "$HERMES_CONFIG" && echo "ws-ckpt config removed from $HERMES_CONFIG"
+fi
+
+# 3. Remove skill if exists
 if [ -d "$SKILL_DST" ]; then
     rm -rf "$SKILL_DST"
     echo "skill removed: $SKILL_DST"

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -634,12 +634,12 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    // NOTE: All btrfs_ops tests require:
+    // NOTE: All btrfs_common tests require:
     //   1. Root privileges (CAP_SYS_ADMIN)
     //   2. A mounted btrfs filesystem
     //   3. btrfs-progs installed
     // They are marked #[ignore] and must be run manually:
-    //   cargo test -p ws-ckpt-daemon btrfs_ops -- --ignored
+    //   cargo test -p ws-ckpt-daemon btrfs_common -- --ignored
 
     #[tokio::test]
     #[ignore = "requires root + btrfs filesystem"]

--- a/src/ws-ckpt/src/crates/daemon/src/btrfs_ops.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/btrfs_ops.rs
@@ -1,4 +1,0 @@
-// Transitional re-export layer — all btrfs CLI operations have moved to
-// `backends::btrfs_common`.  This module preserves the old import paths during
-// the migration period and will be removed in a future PR.
-pub use crate::backends::btrfs_common::*;

--- a/src/ws-ckpt/src/crates/daemon/src/fs_watcher.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/fs_watcher.rs
@@ -2,15 +2,12 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use notify::event::{AccessKind, AccessMode};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tracing::warn;
 
-/// Watches a workspace directory tree for write activity.
-///
-/// Uses the `notify` crate in recursive mode so that writes happening in any
-/// subdirectory (not just the top level) flip the write flag. On Linux the
-/// recommended backend is inotify with recursive registration handled by the
-/// crate itself, including newly created subdirectories.
+/// Recursive workspace write watcher. CLOSE_WRITE clears the flag so
+/// checkpoint can skip the quiescence wait when all writers have closed.
 pub struct WorkspaceWatcher {
     is_writing: Arc<AtomicBool>,
     /// Hold the watcher so its background thread stays alive; dropping the
@@ -47,11 +44,15 @@ impl WorkspaceWatcher {
         tokio::spawn(async move {
             while let Some(res) = rx.recv().await {
                 match res {
-                    Ok(event) => {
-                        if is_write_event(&event.kind) {
+                    Ok(event) => match &event.kind {
+                        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
                             writing.store(true, Ordering::Release);
                         }
-                    }
+                        EventKind::Access(AccessKind::Close(AccessMode::Write)) => {
+                            writing.store(false, Ordering::Release);
+                        }
+                        _ => {}
+                    },
                     Err(e) => {
                         warn!("notify error for {:?}: {}", log_path, e);
                     }
@@ -97,16 +98,4 @@ impl WorkspaceWatcher {
     pub fn is_writing_flag(&self) -> Arc<AtomicBool> {
         self.is_writing.clone()
     }
-}
-
-/// Return true for event kinds that represent actual write activity.
-///
-/// We intentionally treat Create / Modify / Remove / (file) Rename as writes.
-/// Access-only events (e.g. metadata-only access timestamps) are ignored to
-/// avoid false positives.
-fn is_write_event(kind: &EventKind) -> bool {
-    matches!(
-        kind,
-        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
-    )
 }

--- a/src/ws-ckpt/src/crates/daemon/src/lib.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod backend_detect;
 pub mod backends;
-pub mod btrfs_ops;
 pub mod dispatcher;
 pub mod fs_watcher;
 pub mod index_store;

--- a/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::time::Duration;
 use tracing::{debug, error, info, warn};
 
-use crate::btrfs_ops;
+use crate::backends::btrfs_common;
 use crate::state::DaemonState;
 use ws_ckpt_common::CleanupRetention;
 
@@ -135,7 +135,7 @@ pub async fn cleanup_orphans(mount_path: &Path) -> Result<Vec<String>, anyhow::E
             info!("Cleaning up orphan directory: {:?}", path);
 
             // Try btrfs subvolume delete first, fall back to remove_dir_all
-            match btrfs_ops::delete_subvolume(&path).await {
+            match btrfs_common::delete_subvolume(&path).await {
                 Ok(()) => {
                     info!("Deleted orphan subvolume: {:?}", path);
                 }
@@ -236,7 +236,7 @@ async fn auto_cleanup(state: &DaemonState) {
         let mut removed_count = 0;
         for snap_id in &to_remove {
             let snap_path = snapshots_ws_dir.join(snap_id);
-            match btrfs_ops::delete_subvolume(&snap_path).await {
+            match btrfs_common::delete_subvolume(&snap_path).await {
                 Ok(()) => {
                     ws.index.snapshots.remove(snap_id);
                     removed_count += 1;

--- a/src/ws-ckpt/src/plugins/hermes/__init__.py
+++ b/src/ws-ckpt/src/plugins/hermes/__init__.py
@@ -48,25 +48,28 @@ def _get_manager() -> CheckpointManager:
     return _manager
 
 
-def _cwd_invalidation_warning(workspace: str) -> Optional[str]:
-    # btrfs init replaces the workspace directory's inode (remove_dir_all → symlink),
-    # so any shell holding cwd inside it will get ENOENT on getcwd() after exiting hermes.
-    # Re-init is safe because the path is already a symlink — only the very first init
-    # triggers the inode swap.
-    if Path(workspace).is_symlink():
-        return None
+# init/checkpoint/rollback all swap the workspace inode (remove_dir_all → btrfs
+# subvolume symlink, then later snapshot/rollback recreates it), so any process
+# holding cwd inside the workspace will get ENOENT on the next getcwd(). Refuse
+# instead of silently producing broken state.
+CWD_INSIDE_WORKSPACE_REASON = (
+    "`cd` outside the workspace first — ws-ckpt replaces its inode, "
+    "which would invalidate the current cwd."
+)
+
+
+def _cwd_inside_workspace(workspace: str) -> bool:
+    """Return True when the current cwd is the workspace itself or a descendant."""
     try:
         cwd = Path(os.getcwd()).resolve()
     except (FileNotFoundError, OSError):
-        return None
-    ws_path = Path(workspace).resolve()
-    if cwd != ws_path and ws_path not in cwd.parents:
-        return None
-    return (
-        f"first-time init of {workspace} will replace it with a btrfs subvolume symlink. "
-        f"Your shell's cwd is inside this directory — after exiting hermes you'll need to "
-        f"`cd` out and back in (e.g. `cd ~ && cd -`) before the shell can run commands again."
-    )
+        # cwd already invalid — caller decides what to do; we can't prove containment.
+        return False
+    try:
+        ws_path = Path(workspace).resolve()
+    except (FileNotFoundError, OSError):
+        return False
+    return cwd == ws_path or ws_path in cwd.parents
 
 
 # ---------------------------------------------------------------------------
@@ -81,9 +84,22 @@ def _on_session_start(session_id: str = "", model: str = "", **_: Any) -> None:
     if not manager.config.auto_checkpoint:
         return
 
-    warning = _cwd_invalidation_warning(manager.config.workspace)
-    if warning is not None:
-        print(f"[ws-ckpt] Heads-up: {warning}", flush=True)
+    if not manager.config.workspace:
+        manager.set_auto_checkpoint(False)
+        print(
+            "[ws-ckpt] No workspace configured — auto-checkpoint disabled",
+            flush=True,
+        )
+        return
+
+    if _cwd_inside_workspace(manager.config.workspace):
+        # Disable for this session so on_session_end stops trying too.
+        manager.set_auto_checkpoint(False)
+        print(
+            f"[ws-ckpt] Refusing auto-checkpoint: {CWD_INSIDE_WORKSPACE_REASON}",
+            flush=True,
+        )
+        return
 
     # Idempotent: ws-ckpt init is a no-op if the workspace is already registered,
     # so eager-init here avoids the implicit init-on-first-checkpoint cost.

--- a/src/ws-ckpt/src/plugins/hermes/config.py
+++ b/src/ws-ckpt/src/plugins/hermes/config.py
@@ -43,11 +43,10 @@ def load_config() -> HermesPluginConfig:
     """
     yaml_cfg = _read_yaml_config()
 
-    # workspace: env > yaml > TERMINAL_CWD > cwd
+    # workspace: env > yaml > empty (no fallback — caller must handle absence)
     env_ws = os.environ.get("WS_CKPT_WORKSPACE", "").strip()
     yaml_ws = str(yaml_cfg.get("workspace", "")).strip() if yaml_cfg.get("workspace") else ""
-    terminal_cwd = os.environ.get("TERMINAL_CWD", "").strip()
-    workspace = env_ws or yaml_ws or terminal_cwd or os.getcwd()
+    workspace = env_ws or yaml_ws
 
     # autoCheckpoint: env > yaml > False
     env_auto = os.environ.get("WS_CKPT_AUTO_CHECKPOINT", "").strip().lower()

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -113,8 +113,15 @@ def check_ws_ckpt_available() -> bool:
 WS_CKPT_CONFIG_SCHEMA: Dict[str, Any] = {
     "name": "ws-ckpt-config",
     "description": (
-        "View or update ws-ckpt plugin/daemon configuration. "
-        "Only update the specific key explicitly requested by the user."
+        "View or update ws-ckpt configuration. "
+        "Configurable keys: "
+        "autoCheckpoint (whether to auto-snapshot at the end of each conversation turn), "
+        "workspace (default workspace absolute path; used by every command without -w. "
+        "If the path is a symlink, use the link itself — do NOT replace it with the "
+        "resolved real path; the daemon registers and matches by the exact string you pass), "
+        "maxSnapshotsNum (number of snapshots to keep when auto-cleanup is by count), "
+        "maxSnapshotsDuration (duration to keep when auto-cleanup is by time, e.g. \"7d\"/\"24h\"). "
+        "Only update the specific key requested by the user."
     ),
     "parameters": {
         "type": "object",
@@ -133,9 +140,11 @@ WS_CKPT_CONFIG_SCHEMA: Dict[str, Any] = {
             "value": {
                 "type": "string",
                 "description": (
-                    'New value for the config key. For maxSnapshotsNum / '
-                    'maxSnapshotsDuration, pass "unset" to disable '
-                    "auto-cleanup."
+                    "New value as a string. Formats: "
+                    "autoCheckpoint = \"true\"/\"false\"; "
+                    "workspace = absolute path; "
+                    "maxSnapshotsNum = positive integer or \"unset\"; "
+                    "maxSnapshotsDuration = e.g. \"7d\"/\"24h\" or \"unset\"."
                 ),
             },
         },
@@ -146,9 +155,9 @@ WS_CKPT_CONFIG_SCHEMA: Dict[str, Any] = {
 WS_CKPT_CHECKPOINT_SCHEMA: Dict[str, Any] = {
     "name": "ws-ckpt-checkpoint",
     "description": (
-        "Create a checkpoint of the current workspace. Use this to save the "
-        "current state before making significant changes, so you can roll "
-        "back if needed."
+        "Create a checkpoint of the default or specified workspace. Use this "
+        "to save the current state before making significant changes, so you "
+        "can rollback if needed."
     ),
     "parameters": {
         "type": "object",
@@ -160,6 +169,14 @@ WS_CKPT_CHECKPOINT_SCHEMA: Dict[str, Any] = {
             "message": {
                 "type": "string",
                 "description": "Optional message describing the checkpoint",
+            },
+            "workspace": {
+                "type": "string",
+                "description": (
+                    "Optional: workspace absolute path. Defaults to the "
+                    "configured workspace. If the path is a symlink, use the "
+                    "link itself — do NOT replace it with the resolved real path."
+                ),
             },
         },
         "required": ["id"],
@@ -178,7 +195,15 @@ WS_CKPT_ROLLBACK_SCHEMA: Dict[str, Any] = {
         "properties": {
             "target": {
                 "type": "string",
-                "description": "Snapshot hash id to roll back to",
+                "description": "Snapshot id to roll back to.",
+            },
+            "workspace": {
+                "type": "string",
+                "description": (
+                    "Optional: workspace absolute path. Defaults to the "
+                    "configured workspace. If the path is a symlink, use the "
+                    "link itself — do NOT replace it with the resolved real path."
+                ),
             },
         },
         "required": ["target"],
@@ -189,7 +214,7 @@ WS_CKPT_ROLLBACK_SCHEMA: Dict[str, Any] = {
 WS_CKPT_LIST_SCHEMA: Dict[str, Any] = {
     "name": "ws-ckpt-list",
     "description": (
-        "List all checkpoints managed by ws-ckpt. Always display the FULL "
+        "List all snapshots managed by ws-ckpt. Always display the FULL "
         "untruncated result to the user."
     ),
     "parameters": {
@@ -202,7 +227,7 @@ WS_CKPT_LIST_SCHEMA: Dict[str, Any] = {
 WS_CKPT_DIFF_SCHEMA: Dict[str, Any] = {
     "name": "ws-ckpt-diff",
     "description": (
-        "Compare file changes between two checkpoints. Always display the "
+        "Compare file changes between two snapshots. Always display the "
         "FULL untruncated result to the user. Do NOT re-interpret or "
         "contradict the tool output."
     ),
@@ -211,7 +236,7 @@ WS_CKPT_DIFF_SCHEMA: Dict[str, Any] = {
         "properties": {
             "from": {
                 "type": "string",
-                "description": "Source snapshot id or name",
+                "description": "Source snapshot id",
             },
             "to": {
                 "type": "string",
@@ -240,7 +265,11 @@ WS_CKPT_DELETE_SCHEMA: Dict[str, Any] = {
             },
             "workspace": {
                 "type": "string",
-                "description": "Workspace path (defaults to current workspace)",
+                "description": (
+                    "Optional: workspace absolute path. Defaults to the "
+                    "configured workspace. If the path is a symlink, use the "
+                    "link itself — do NOT replace it with the resolved real path."
+                ),
             },
         },
         "required": ["snapshot"],
@@ -421,13 +450,21 @@ def _persist_plugin_yaml(**fields: Any) -> str:
     return ""
 
 
+def _resolve_workspace(args: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+    """Resolve workspace from args (explicit override) or config (fallback)."""
+    explicit = (args.get("workspace") or "").strip()
+    if explicit:
+        return explicit, None
+    return _require_workspace()
+
+
 def handle_ws_ckpt_checkpoint(args: Dict[str, Any], **_kwargs) -> str:
     """Handle ws-ckpt-checkpoint tool call."""
     snapshot_id = (args.get("id") or "").strip()
     if not snapshot_id:
         return _err("'id' is required")
 
-    workspace, ws_err = _require_workspace()
+    workspace, ws_err = _resolve_workspace(args)
     if ws_err:
         return ws_err
     rejection = _reject_if_cwd_inside_workspace(workspace)
@@ -448,7 +485,7 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
     if not target:
         return _err("'target' is required")
 
-    workspace, ws_err = _require_workspace()
+    workspace, ws_err = _resolve_workspace(args)
     if ws_err:
         return ws_err
     rejection = _reject_if_cwd_inside_workspace(workspace)
@@ -493,13 +530,9 @@ def handle_ws_ckpt_delete(args: Dict[str, Any], **_kwargs) -> str:
     if not snapshot:
         return _err("'snapshot' is required")
 
-    explicit_ws = (args.get("workspace") or "").strip()
-    if explicit_ws:
-        workspace = explicit_ws
-    else:
-        workspace, ws_err = _require_workspace()
-        if ws_err:
-            return ws_err
+    workspace, ws_err = _resolve_workspace(args)
+    if ws_err:
+        return ws_err
     cmd = ["ws-ckpt", "delete", "-s", snapshot, "-w", workspace, "--force"]
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -43,6 +43,26 @@ def _get_default_workspace() -> str:
     return _get_manager().config.workspace
 
 
+_NO_WORKSPACE_MSG = "No workspace configured. Tell me the workspace path and I'll set it up."
+
+
+def _require_workspace() -> Tuple[str, Optional[str]]:
+    """Resolve and validate workspace. Returns (workspace, None) or ("", error_json)."""
+    ws = _get_default_workspace()
+    if not ws:
+        return "", _err(_NO_WORKSPACE_MSG)
+    return ws, None
+
+
+def _reject_if_cwd_inside_workspace(workspace: str) -> Optional[str]:
+    """Return a serialized error response when cwd is inside workspace, else None."""
+    from . import CWD_INSIDE_WORKSPACE_REASON, _cwd_inside_workspace  # lazy
+
+    if _cwd_inside_workspace(workspace):
+        return _err(f"Refusing: {CWD_INSIDE_WORKSPACE_REASON}")
+    return None
+
+
 def _run_ws_ckpt_cmd(cmd: list) -> Tuple[bool, str]:
     """Execute a ws-ckpt CLI command and return (success, output)."""
     try:
@@ -331,6 +351,13 @@ def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
         if value is None:
             return _err("autoCheckpoint requires a value (true/false)")
         coerced = str(value).strip().lower() in ("true", "1", "yes", "on")
+        if coerced:
+            workspace, ws_err = _require_workspace()
+            if ws_err:
+                return ws_err
+            rejection = _reject_if_cwd_inside_workspace(workspace)
+            if rejection:
+                return rejection
         err = _persist_plugin_yaml(autoCheckpoint=coerced)
         if err:
             return _err(f"Failed to persist config: {err}")
@@ -400,7 +427,13 @@ def handle_ws_ckpt_checkpoint(args: Dict[str, Any], **_kwargs) -> str:
     if not snapshot_id:
         return _err("'id' is required")
 
-    workspace = _get_default_workspace()
+    workspace, ws_err = _require_workspace()
+    if ws_err:
+        return ws_err
+    rejection = _reject_if_cwd_inside_workspace(workspace)
+    if rejection:
+        return rejection
+
     message = (args.get("message") or "").strip() or "manual checkpoint"
 
     cmd = ["ws-ckpt", "checkpoint", "-w", workspace, "-i", snapshot_id,
@@ -415,7 +448,13 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
     if not target:
         return _err("'target' is required")
 
-    workspace = _get_default_workspace()
+    workspace, ws_err = _require_workspace()
+    if ws_err:
+        return ws_err
+    rejection = _reject_if_cwd_inside_workspace(workspace)
+    if rejection:
+        return rejection
+
     cmd = ["ws-ckpt", "rollback", "-w", workspace, "-s", target]
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)
@@ -423,7 +462,9 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
 
 def handle_ws_ckpt_list(args: Dict[str, Any], **_kwargs) -> str:
     """Handle ws-ckpt-list tool call."""
-    workspace = _get_default_workspace()
+    workspace, ws_err = _require_workspace()
+    if ws_err:
+        return ws_err
     cmd = ["ws-ckpt", "list", "-w", workspace, "--format", "table"]
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)
@@ -438,7 +479,9 @@ def handle_ws_ckpt_diff(args: Dict[str, Any], **_kwargs) -> str:
     if not to_id:
         return _err("'to' is required")
 
-    workspace = _get_default_workspace()
+    workspace, ws_err = _require_workspace()
+    if ws_err:
+        return ws_err
     cmd = ["ws-ckpt", "diff", "-w", workspace, "--from", from_id, "--to", to_id]
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)
@@ -450,7 +493,13 @@ def handle_ws_ckpt_delete(args: Dict[str, Any], **_kwargs) -> str:
     if not snapshot:
         return _err("'snapshot' is required")
 
-    workspace = (args.get("workspace") or "").strip() or _get_default_workspace()
+    explicit_ws = (args.get("workspace") or "").strip()
+    if explicit_ws:
+        workspace = explicit_ws
+    else:
+        workspace, ws_err = _require_workspace()
+        if ws_err:
+            return ws_err
     cmd = ["ws-ckpt", "delete", "-s", snapshot, "-w", workspace, "--force"]
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)
@@ -458,7 +507,9 @@ def handle_ws_ckpt_delete(args: Dict[str, Any], **_kwargs) -> str:
 
 def handle_ws_ckpt_status(args: Dict[str, Any], **_kwargs) -> str:
     """Handle ws-ckpt-status tool call."""
-    workspace = _get_default_workspace()
+    workspace, ws_err = _require_workspace()
+    if ws_err:
+        return ws_err
     cmd = ["ws-ckpt", "status", "-w", workspace, "--format", "table"]
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)

--- a/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json
+++ b/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "ws-ckpt",
   "kind": "tool",
+  "activation": { 
+    "onStartup": true 
+  },
   "install": {
     "npmSpec": "@openclaw/ws-ckpt"
   },

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -42,6 +42,27 @@ export async function handleCheckpoint(
     return { text: "Missing required parameter: id", isError: true };
   }
   const message = args.message?.trim() || "manual checkpoint";
+  const explicitWs = (args.workspace as string | undefined)?.trim();
+
+  // Explicit workspace bypasses the manager (and its workspace-bound cache),
+  // mirroring the handleDelete pattern.
+  if (explicitWs) {
+    try {
+      const executor = new CommandExecutor();
+      const output = await executor.checkpoint(explicitWs, id, { message });
+      if (output.exitCode !== 0) {
+        return { text: mapErrorToLLMMessage(output.stderr, { id }), isError: true };
+      }
+      if (output.stdout && (output.stdout.includes('Skipped') || output.stdout.includes('Empty workspace'))) {
+        return { text: 'Empty workspace, no snapshot created.', isError: false };
+      }
+      return { text: `Checkpoint created: ${id}`, isError: false };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { text: `Checkpoint error: ${msg}`, isError: true };
+    }
+  }
+
   const result = await pluginState.manager.createCheckpoint({
     id,
     message,
@@ -54,6 +75,7 @@ export async function handleCheckpoint(
 
 export async function handleRollback(
   target?: string,
+  workspace?: string,
 ): Promise<{ text: string; isError: boolean }> {
   if (!pluginState.manager || !pluginState.environmentReady) {
     return { text: UNAVAILABLE_MSG, isError: true };
@@ -65,6 +87,22 @@ export async function handleRollback(
       isError: true,
     };
   }
+
+  const explicitWs = workspace?.trim();
+  if (explicitWs) {
+    try {
+      const executor = new CommandExecutor();
+      const output = await executor.rollback(explicitWs, trimmed);
+      if (output.exitCode !== 0) {
+        return { text: mapErrorToLLMMessage(output.stderr, { id: trimmed }), isError: true };
+      }
+      return { text: `Rolled back to ${trimmed}`, isError: false };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { text: `Rollback error: ${msg}`, isError: true };
+    }
+  }
+
   const result = await pluginState.manager.rollback(trimmed);
   return { text: result.message, isError: !result.success };
 }

--- a/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
@@ -28,23 +28,36 @@ export function registerTools(api: OpenClawPluginApi): void {
   api.registerTool(
     {
       name: "ws-ckpt-config",
-      description: "View or update ws-ckpt plugin configuration. Only update the specific key explicitly requested by the user.",
+      description:
+        "View or update ws-ckpt configuration. " +
+        "Configurable keys: " +
+        "autoCheckpoint (whether to auto-snapshot at the end of each conversation turn), " +
+        "workspace (default workspace absolute path; used by every command without -w. " +
+        "If the path is a symlink, use the link itself — do NOT replace it with the " +
+        "resolved real path; the daemon registers and matches by the exact string you pass), " +
+        "maxSnapshotsNum (number of snapshots to keep when auto-cleanup is by count), " +
+        "maxSnapshotsDuration (duration to keep when auto-cleanup is by time, e.g. \"7d\"/\"24h\"). " +
+        "Only update the specific key requested by the user.",
       parameters: {
         type: "object",
         properties: {
           action: {
             type: "string",
-            description:
-              'Action to perform: "view" (default) or "update"',
+            description: 'Action to perform: "view" (default) or "update"',
           },
           key: {
             type: "string",
             description:
-              "Config key to update (autoCheckpoint, maxSnapshotsNum, maxSnapshotsDuration)",
+              "Config key to update: autoCheckpoint, workspace, maxSnapshotsNum, maxSnapshotsDuration",
           },
           value: {
             type: "string",
-            description: "New value for the config key. For maxSnapshotsNum/maxSnapshotsDuration, pass \"unset\" to clear the value and disable auto-cleanup when both are unset.",
+            description:
+              "New value as a string. Formats: " +
+              "autoCheckpoint = \"true\"/\"false\"; " +
+              "workspace = absolute path; " +
+              "maxSnapshotsNum = positive integer or \"unset\"; " +
+              "maxSnapshotsDuration = e.g. \"7d\"/\"24h\" or \"unset\".",
           },
         },
       },
@@ -64,7 +77,7 @@ export function registerTools(api: OpenClawPluginApi): void {
   api.registerTool(
     {
       name: "ws-ckpt-checkpoint",
-      description: "Create a checkpoint of the current workspace. Communicates directly with ws-ckpt daemon — no additional CLI verification needed.",
+      description: "Create a checkpoint of the default or specified workspace. Communicates directly with ws-ckpt daemon — no additional CLI verification needed.",
       parameters: {
         type: "object",
         properties: {
@@ -75,6 +88,13 @@ export function registerTools(api: OpenClawPluginApi): void {
           message: {
             type: "string",
             description: "Optional message describing the checkpoint",
+          },
+          workspace: {
+            type: "string",
+            description:
+              "Optional: workspace absolute path. Defaults to the " +
+              "configured workspace. If the path is a symlink, use the " +
+              "link itself — do NOT replace it with the resolved real path.",
           },
         },
         required: ["id"],
@@ -91,20 +111,32 @@ export function registerTools(api: OpenClawPluginApi): void {
   api.registerTool(
     {
       name: "ws-ckpt-rollback",
-      description: "Roll back the workspace to a specific checkpoint. Communicates directly with ws-ckpt daemon — no additional CLI verification needed.",
+      description:
+        "Roll back the workspace to a previous snapshot. Always call " +
+        "ws-ckpt-list first to confirm the target snapshot id exists; " +
+        "never roll back to an id you haven't verified.",
       parameters: {
         type: "object",
         properties: {
           target: {
             type: "string",
+            description: "Snapshot id to roll back to.",
+          },
+          workspace: {
+            type: "string",
             description:
-              "Snapshot hash id to roll back to",
+              "Optional: workspace absolute path. Defaults to the " +
+              "configured workspace. If the path is a symlink, use the " +
+              "link itself — do NOT replace it with the resolved real path.",
           },
         },
         required: ["target"],
       },
       async execute(_toolCallId, params) {
-        const r = await handleRollback(params.target as string | undefined);
+        const r = await handleRollback(
+          params.target as string | undefined,
+          params.workspace as string | undefined,
+        );
         return textToolResult(r.text, r.isError);
       },
     },
@@ -115,7 +147,9 @@ export function registerTools(api: OpenClawPluginApi): void {
   api.registerTool(
     {
       name: "ws-ckpt-list",
-      description: "List all checkpoints managed by ws-ckpt. Always display the FULL untruncated result to the user.",
+      description:
+        "List all snapshots managed by ws-ckpt. " +
+        "Always display the FULL untruncated table to the user.",
       parameters: { type: "object", properties: {} },
       async execute() {
         const r = await handleListCheckpoints();
@@ -129,13 +163,16 @@ export function registerTools(api: OpenClawPluginApi): void {
   api.registerTool(
     {
       name: "ws-ckpt-diff",
-      description: "Compare file changes between two checkpoints. Always display the FULL untruncated result to the user. Do NOT re-interpret or contradict the tool output.",
+      description:
+        "Compare file changes between two snapshots. " +
+        "Always display the FULL untruncated diff. " +
+        "Do NOT re-interpret or contradict the tool output.",
       parameters: {
         type: "object",
         properties: {
           from: {
             type: "string",
-            description: "Source snapshot id or name",
+            description: "Source snapshot id",
           },
           to: {
             type: "string",
@@ -160,17 +197,23 @@ export function registerTools(api: OpenClawPluginApi): void {
   api.registerTool(
     {
       name: "ws-ckpt-delete",
-      description: "Delete a specific snapshot. Communicates directly with ws-ckpt daemon — no additional CLI verification needed.",
+      description:
+        "Delete a snapshot. Confirm the id with ws-ckpt-list first; " +
+        "never delete without an explicit user request — " +
+        "deletion is permanent and not reversible.",
       parameters: {
         type: "object",
         properties: {
           snapshot: {
             type: "string",
-            description: "Required: snapshot ID to delete",
+            description: "Required: snapshot id to delete.",
           },
           workspace: {
             type: "string",
-            description: "Workspace path (defaults to current workspace)",
+            description:
+              "Optional: workspace absolute path. Defaults to the " +
+              "configured workspace. If the path is a symlink, use the " +
+              "link itself — do NOT replace it with the resolved real path.",
           },
         },
         required: ["snapshot"],
@@ -190,7 +233,10 @@ export function registerTools(api: OpenClawPluginApi): void {
   api.registerTool(
     {
       name: "ws-ckpt-status",
-      description: "Show ws-ckpt service status and workspace information. Returns the complete status from ws-ckpt daemon — no additional CLI or exec verification needed.",
+      description:
+        "Show ws-ckpt daemon and workspace status — snapshot count, disk " +
+        "usage, auto-cleanup policy. Returns complete status from the " +
+        "daemon; no extra CLI verification needed.",
       parameters: { type: "object", properties: {} },
       async execute() {
         const r = await handleStatus();

--- a/src/ws-ckpt/src/skills/ws-ckpt/SKILL.md
+++ b/src/ws-ckpt/src/skills/ws-ckpt/SKILL.md
@@ -66,11 +66,11 @@ ws-ckpt rollback -w <path-to-workspacee -s before-refactor
 ### delete — 删除快照
 
 ```bash
-ws-ckpt delete -s <snapshot> [--force] [-w <workspace>]
+ws-ckpt delete -s <snapshot> --force [-w <workspace>]
 ```
 
 - `-s`:要删除的快照 ID(必填)
-- `--force`:跳过确认
+- `--force`:跳过确认，agent执行必须要求跳过确认
 - `-w`:快照 ID 跨工作区重复时必须指定
 
 ```bash


### PR DESCRIPTION
## Description

bug fix for issue #616 #622 #629 #632 #633

1. fswatch 原本仅关心文件打开就禁止快照，现增加文件关闭就取消禁止快照
2. 安装脚本自动enable
3. openclaw 插件修改配置为随gateway启动
4. 优化工具参数和提示词，支持各工具手动指定workspace而不是默认使用配置中的workspace，优先级指定值大于配置值大于默认值（hermes无默认值）
5. 由于文件系统快照回滚会更改目录inode，导致#633，此为框架固有问题，增加hermes插件对于“hermes的cwd在工作区目录内”的情况进行拦截，显示拒绝并提示用户到父目录再启动hermes。 此外 #638 也是这个inode变更导致的。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #616 
closes #622 
closes #629 
closes #632 
closes #633
closes #638 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [x] `ckpt` (ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
