### PR TITLE
fix(tokenless): unset OPENCLAW_HOME in openclaw adapter scripts to avoid double nesting

### DIFF
--- a/src/tokenless/adapters/tokenless/openclaw/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/detect.sh
@@ -46,8 +46,9 @@ fi
 plugin_state="missing"
 plugin_detail="$PLUGIN_ID"
 if [ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]; then
-    plugins_json="$(OPENCLAW_HOME="${OPENCLAW_HOME%/}" "$OPENCLAW_BIN" plugins list --json 2>/dev/null || true)"
-    plugins_txt="$(OPENCLAW_HOME="${OPENCLAW_HOME%/}" "$OPENCLAW_BIN" plugins list 2>/dev/null || true)"
+    # Unset OPENCLAW_HOME for the CLI call — same double-nesting bug as install.sh.
+    plugins_json="$(env -u OPENCLAW_HOME "$OPENCLAW_BIN" plugins list --json 2>/dev/null || true)"
+    plugins_txt="$(env -u OPENCLAW_HOME "$OPENCLAW_BIN" plugins list 2>/dev/null || true)"
     if grep -qE "\"id\"[[:space:]]*:[[:space:]]*\"${PLUGIN_ID}\"" <<<"$plugins_json" \
        || grep -qE "(^|[[:space:]])${PLUGIN_ID}([[:space:]]|$)" <<<"$plugins_txt"; then
         plugin_state="listed"

--- a/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
@@ -19,7 +19,6 @@ ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 # Allow the orchestrator (or a packaging script) to inject a specific openclaw
 # binary. Defaults to whatever `openclaw` resolves to on PATH.
 OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
-OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
 
 PLUGIN_SRC="$ADAPTER_DIR/openclaw"
 
@@ -45,7 +44,12 @@ if [ ! -f "$PLUGIN_SRC/dist/index.js" ]; then
     exit 1
 fi
 
-OPENCLAW_HOME="${OPENCLAW_HOME%/}" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" \
+# Unset OPENCLAW_HOME for the CLI call. When OPENCLAW_HOME is explicitly
+# set (even to its natural default $HOME/.openclaw), the CLI nests
+# .openclaw/extensions/ *inside* OPENCLAW_HOME, creating a double
+# .openclaw/.openclaw/ path. Leaving it unset lets the CLI resolve
+# ~/.openclaw/extensions/ correctly on its own.
+env -u OPENCLAW_HOME "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" \
     --force --dangerously-force-unsafe-install || {
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
     exit 1

--- a/src/tokenless/adapters/tokenless/openclaw/scripts/uninstall.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/uninstall.sh
@@ -26,6 +26,7 @@ if [ -z "$OPENCLAW_BIN" ]; then
 fi
 
 # Use openclaw CLI for proper removal (handles file cleanup + config update)
-OPENCLAW_HOME="${OPENCLAW_HOME%/}" "$OPENCLAW_BIN" plugins uninstall tokenless-openclaw --force || true
+# Unset OPENCLAW_HOME for the CLI call — same double-nesting bug as install.sh.
+env -u OPENCLAW_HOME "$OPENCLAW_BIN" plugins uninstall tokenless-openclaw --force || true
 
 echo "[${COMPONENT}] ${AGENT} plugin removed via openclaw CLI."


### PR DESCRIPTION
## Description

When OPENCLAW_HOME is explicitly set (even to its default $HOME/.openclaw), the openclaw CLI nests .openclaw/ inside OPENCLAW_HOME, creating a ~/.openclaw/.openclaw/ double path. This broke plugin discovery — openclaw plugins list could not find tokenless-openclaw after install.

Fix: env -u OPENCLAW_HOME on all CLI invocations (install/detect/ uninstall), letting the CLI resolve ~/.openclaw/extensions/ on its own. OPENCLAW_HOME variable is retained for directory checks and PATH resolution in detect.sh — only unset for the CLI calls.

Introduced by commit 3b7168d (feat(scripts): #549) which replaced env -u OPENCLAW_HOME with OPENCLAW_HOME="${OPENCLAW_HOME%/}" across all three scripts.


<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes # introduced by PR#549

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
