### PR TITLE
fix(tokenless): derive adapter plugin versions from Cargo.toml instead of hardcoding

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -443,10 +443,17 @@ build_tokenless() {
 
     # Copy full source tree (including vendored rtk), excluding build artifacts and VCS
     # Note: third_party/rtk must be included — it's built separately via --manifest-path
+    # Adapter config files (manifest.json, package.json, openclaw.plugin.json, plugin.yaml)
+    # are excluded because they are generated from .in templates by
+    # stamp-adapter-templates during rpmbuild %build (make build-openclaw-plugin).
     tar -cf - -C "$TOKEN_DIR" \
         --exclude='target' \
         --exclude='.git' \
         --exclude='node_modules' \
+        --exclude='adapters/tokenless/manifest.json' \
+        --exclude='adapters/tokenless/openclaw/package.json' \
+        --exclude='adapters/tokenless/openclaw/openclaw.plugin.json' \
+        --exclude='adapters/tokenless/hermes/plugin.yaml' \
         . | tar -xf - -C "$pkg_dir"
 
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}"

--- a/src/tokenless/.gitignore
+++ b/src/tokenless/.gitignore
@@ -1,2 +1,8 @@
 # rtk source is downloaded from GitHub via justfile, not tracked in git
 third_party/rtk/
+
+# Adapter config files are generated from .in templates (VERSION from Cargo.toml)
+adapters/tokenless/manifest.json
+adapters/tokenless/openclaw/package.json
+adapters/tokenless/openclaw/openclaw.plugin.json
+adapters/tokenless/hermes/plugin.yaml

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -20,10 +20,16 @@ BIN_DIR ?= $(BINDIR)
 LIB_DIR ?= $(LIBEXECDIR)
 ADAPTER_SRC_DIR := adapters/tokenless
 OPENCLAW_PLUGIN_SRC_DIR := $(ADAPTER_SRC_DIR)/openclaw
+ADAPTER_TEMPLATES := \
+    $(ADAPTER_SRC_DIR)/manifest.json \
+    $(ADAPTER_SRC_DIR)/openclaw/package.json \
+    $(ADAPTER_SRC_DIR)/openclaw/openclaw.plugin.json \
+    $(ADAPTER_SRC_DIR)/hermes/plugin.yaml
 TOON_VER := 0.4.6
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
 .PHONY: build build-tokenless build-toon build-openclaw-plugin \
+        stamp-adapter-templates \
         install uninstall test lint clean \
         install-binaries install-helpers install-adapter-resources install-cosh-extension \
         adapter-install adapter-uninstall adapter-scan \
@@ -49,12 +55,31 @@ build-toon:
 	@echo "==> Installing toon binary (v$(TOON_VER))..."
 	cargo install toon-format --version $(TOON_VER) --locked
 
+# Generate adapter config files from .in templates (VERSION from Cargo.toml).
+stamp-adapter-templates: $(ADAPTER_TEMPLATES)
+
+$(ADAPTER_SRC_DIR)/manifest.json: $(ADAPTER_SRC_DIR)/manifest.json.in Cargo.toml
+	@echo "==> Generating manifest.json (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+$(ADAPTER_SRC_DIR)/openclaw/package.json: $(ADAPTER_SRC_DIR)/openclaw/package.json.in Cargo.toml
+	@echo "==> Generating openclaw/package.json (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+$(ADAPTER_SRC_DIR)/openclaw/openclaw.plugin.json: $(ADAPTER_SRC_DIR)/openclaw/openclaw.plugin.json.in Cargo.toml
+	@echo "==> Generating openclaw/openclaw.plugin.json (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+$(ADAPTER_SRC_DIR)/hermes/plugin.yaml: $(ADAPTER_SRC_DIR)/hermes/plugin.yaml.in Cargo.toml
+	@echo "==> Generating hermes/plugin.yaml (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
 # Build the tokenless OpenClaw plugin (TypeScript -> dist/index.js).
 # Produces $(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js, which install-adapter-resources
 # then copies into $(SHARE_DIR)/openclaw/dist/index.js. This file is referenced by
 # the plugin's package.json ("main" / "openclaw.extensions") and must be present
 # for `openclaw plugins install` to succeed.
-build-openclaw-plugin:
+build-openclaw-plugin: stamp-adapter-templates
 	@echo "==> Building tokenless OpenClaw plugin..."
 	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm install --legacy-peer-deps --no-audit --no-fund --package-lock=false
 	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm run build
@@ -85,6 +110,7 @@ install-adapter-resources: build-openclaw-plugin
 	# Strip build-only artifacts from the installed plugin tree.
 	rm -rf $(DESTDIR)$(SHARE_DIR)/openclaw/node_modules
 	rm -f  $(DESTDIR)$(SHARE_DIR)/openclaw/package-lock.json
+	find $(DESTDIR)$(SHARE_DIR) -name '*.in' -delete
 	find $(DESTDIR)$(SHARE_DIR) -type f \( -name '*.py' -o -name '*.sh' \) -exec chmod 0755 {} +
 	@test -f $(DESTDIR)$(SHARE_DIR)/openclaw/dist/index.js \
 	    || { echo "ERROR: $(DESTDIR)$(SHARE_DIR)/openclaw/dist/index.js missing after install-adapter-resources"; exit 1; }
@@ -133,6 +159,7 @@ clean:
 	cargo clean --release --manifest-path third_party/rtk/Cargo.toml 2>/dev/null || true
 	rm -rf $(OPENCLAW_PLUGIN_SRC_DIR)/dist $(OPENCLAW_PLUGIN_SRC_DIR)/node_modules
 	rm -f  $(OPENCLAW_PLUGIN_SRC_DIR)/package-lock.json
+	rm -f  $(ADAPTER_TEMPLATES)
 
 # Create source tarball (excludes build artifacts)
 dist: clean

--- a/src/tokenless/adapters/tokenless/hermes/plugin.yaml.in
+++ b/src/tokenless/adapters/tokenless/hermes/plugin.yaml.in
@@ -1,5 +1,5 @@
 name: tokenless
-version: "0.4.0"
+version: "@VERSION@"
 description: "Token-Less context compression for Hermes Agent — response compression, TOON encoding, command rewriting, and Tool Ready environment pre-check"
 author: ANOLISA
 requires_env: []

--- a/src/tokenless/adapters/tokenless/manifest.json.in
+++ b/src/tokenless/adapters/tokenless/manifest.json.in
@@ -1,6 +1,6 @@
 {
   "component": "tokenless",
-  "version": "0.4.0",
+  "version": "@VERSION@",
   "targets": {
     "cosh": {
       "compatibleVersions": "*",

--- a/src/tokenless/adapters/tokenless/openclaw/openclaw.plugin.json.in
+++ b/src/tokenless/adapters/tokenless/openclaw/openclaw.plugin.json.in
@@ -1,7 +1,7 @@
 {
   "id": "tokenless-openclaw",
   "name": "Token-Less",
-  "version": "0.4.0",
+  "version": "@VERSION@",
   "description": "Unified RTK command rewriting + response/TOON compression + Tool Ready environment pre-check",
   "activation": {
     "onCapabilities": ["hook"]

--- a/src/tokenless/adapters/tokenless/openclaw/package.json.in
+++ b/src/tokenless/adapters/tokenless/openclaw/package.json.in
@@ -1,6 +1,6 @@
 {
   "name": "@tokenless/openclaw-plugin",
-  "version": "0.4.0",
+  "version": "@VERSION@",
   "description": "Unified OpenClaw plugin — RTK command rewriting + tokenless schema/response compression for 60-90% LLM token savings",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

OpenClaw and Hermes adapter configs (package.json, openclaw.plugin.json, plugin.yaml, manifest.json) had hardcoded "0.4.0" that didn't sync when the Cargo.toml workspace version changed. Convert them to .in templates with @VERSION@ placeholders; Makefile stamp-adapter-templates reads VERSION from Cargo.toml and generates real files via sed substitution.

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes #623 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
