### PR TITLE
fix(tokenless): drop TOON wrapper prefix and slim diagnostic tags

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -121,13 +121,12 @@ def _classify_env_error(parsed: dict) -> tuple[str | None, str | None]:
 
 
 def _build_additional_context(
-    tool_name: str, savings_pct: int, savings_label: str, content: str,
+    content: str,
     env_attribution: str = "",
 ) -> str:
     parts = []
     if env_attribution:
         parts.append(env_attribution)
-    parts.append(f"[tokenless] {tool_name} → {savings_label} ({savings_pct}% savings)")
     parts.append(content)
     return "\n".join(parts)
 
@@ -192,9 +191,8 @@ def main() -> None:
     attr_category, attr_fix_hint = _classify_env_error(parsed if isinstance(parsed, dict) else {})
     if attr_category:
         env_attribution = (
-            f"[tokenless env-attribution] {tool_name} tool failed: "
-            f"{attr_category} ({attr_fix_hint}). "
-            f"Skip retry — this is an environment issue, not a logic error."
+            f"[tokenless:env] {tool_name} failed: "
+            f"{attr_category} ({attr_fix_hint}). Skip retry."
         )
 
     # 10. Step 1: Response compression (only on JSON objects/arrays)
@@ -222,7 +220,6 @@ def main() -> None:
 
     # 11. Step 2: TOON encoding (via tokenless compress-toon for stats)
     toon_output = ""
-    savings_label = ""
 
     if tokenless_bin:
         toon_parsed = try_parse_json(compressed)
@@ -242,36 +239,15 @@ def main() -> None:
                     candidate = proc.stdout.strip()
                     if len(candidate) < len(compressed):
                         toon_output = candidate
-                        if used_resp_compression:
-                            savings_label = "response compressed + TOON encoded"
-                        else:
-                            savings_label = "TOON encoded"
             except Exception:
                 pass
 
-    # Determine final label
-    if not savings_label:
-        if used_resp_compression:
-            savings_label = "response compressed"
-        else:
-            savings_label = "passed through"
-
-    # Determine final output and metrics
-    if toon_output:
-        final_output = toon_output
-    else:
-        final_output = compressed
-
-    before_chars = len(tool_response)
-    after_chars = len(final_output)
-
-    savings_pct = 0
-    if before_chars > 0:
-        savings_pct = (before_chars - after_chars) * 100 // before_chars
+    # Determine final output
+    final_output = toon_output if toon_output else compressed
 
     # 12. Build response
     context = _build_additional_context(
-        tool_name, savings_pct, savings_label, final_output,
+        final_output,
         env_attribution=env_attribution,
     )
 

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
@@ -120,19 +120,12 @@ def main() -> None:
     if after_chars >= before_chars:
         skip()
 
-    savings_pct = (before_chars - after_chars) * 100 // before_chars if before_chars > 0 else 0
-
     # 12. Build response
-    context = (
-        f"[tokenless] {tool_name} → TOON encoded ({savings_pct}% savings)\n"
-        f"{toon_output}"
-    )
-
     output = {
         "suppressOutput": True,
         "hookSpecificOutput": {
             "hookEventName": "PostToolUse",
-            "additionalContext": context,
+            "additionalContext": toon_output,
         },
     }
     print(json.dumps(output, ensure_ascii=False))

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -115,7 +115,13 @@ def main() -> None:
     except Exception:
         skip()
 
-    # exit 1/2 = no rewrite; exit 0 = same or rewritten
+    # Exit code protocol (from rtk rewrite_cmd.rs):
+    #   0 = rewrite available, Allow verdict (auto-allow by permission rule)
+    #   1 = no RTK equivalent (passthrough)
+    #   2 = deny rule matched (let hook handle)
+    #   3 = Ask/Default verdict (rewrite available but permission model requires
+    #       user confirmation; in non-interactive hook context, treat as valid
+    #       rewrite since the intent is token optimization, not permission gating)
     if proc.returncode in (1, 2):
         skip()
     rewritten = proc.stdout.strip()

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 VERBOSE="${TOKENLESS_VERBOSE:-}"
-log_v() { [ -n "$VERBOSE" ] && echo "[tokenless tool-ready] $1" >&2 || true; }
+log_v() { [ -n "$VERBOSE" ] && echo "[tokenless:ready] $1" >&2 || true; }
 
 # --- Dependency check (fail-open) ---
 if ! command -v jq &>/dev/null; then log_v "jq not found, skipping"; exit 0; fi
@@ -361,7 +361,7 @@ if [ "$missing_count" -gt 0 ] && [ -n "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; t
     # If only recommended still missing but required OK → PARTIAL, don't block
     if ! $HAS_REQUIRED_MISSING && ! $HAS_VERSION_LOW && [ -z "$PERM_MISSING" ]; then
         log_v "Phase 3 FIX: recommended deps partially installed, remaining: ${RECOMMENDED_MISSING_LIST}"
-        DIAG_MSG="[tokenless tool-ready] ${TOOL_NAME}: PARTIAL — recommended deps not installed:${RECOMMENDED_MISSING_LIST}. Core tool is functional."
+        DIAG_MSG="[tokenless:ready] ${TOOL_NAME}: PARTIAL — recommended deps not installed:${RECOMMENDED_MISSING_LIST}. Core tool is functional."
         jq -n --arg context "$DIAG_MSG" --arg msg "$DIAG_MSG" '{
           "systemMessage": $msg,
           "hookSpecificOutput": {
@@ -379,7 +379,7 @@ fi
 
 # PARTIAL (no fix script available): inform Agent but don't block
 if $IS_PARTIAL && ! $HAS_REQUIRED_MISSING && ! $HAS_VERSION_LOW && [ -z "$PERM_MISSING" ]; then
-    DIAG_MSG="[tokenless tool-ready] ${TOOL_NAME}: PARTIAL — recommended deps missing:${RECOMMENDED_MISSING_LIST}. Core tool is functional, extended deps may be unavailable."
+    DIAG_MSG="[tokenless:ready] ${TOOL_NAME}: PARTIAL — recommended deps missing:${RECOMMENDED_MISSING_LIST}. Core tool is functional, extended deps may be unavailable."
     log_v "Phase 4 FEEDBACK: $TOOL_NAME → PARTIAL → injecting additionalContext (non-blocking)"
     jq -n --arg context "$DIAG_MSG" --arg msg "$DIAG_MSG" '{
       "systemMessage": $msg,
@@ -403,8 +403,7 @@ DIAG_PARTS=""
 $HAS_VERSION_LOW       && DIAG_PARTS="${DIAG_PARTS} version too low;"
 [ -n "$PERM_MISSING" ] && DIAG_PARTS="${DIAG_PARTS} permission missing:${PERM_MISSING};"
 
-DIAG_MSG="[tokenless tool-ready] ${TOOL_NAME}: NOT_READY (${DIAG_PARTS})"
-DIAG_MSG="${DIAG_MSG} Skip retry — environment issue, not logic error."
+DIAG_MSG="[tokenless:ready] ${TOOL_NAME}: NOT_READY (${DIAG_PARTS}) Skip retry."
 
 log_v "Phase 4 FEEDBACK: $TOOL_NAME → NOT_READY → blocking with decision:block"
 

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -337,13 +337,15 @@ def _try_rewrite(
     )
 
     # Exit code protocol (from rtk rewrite_cmd.rs):
-    #   0 = rewrite available (stdout = rewritten command)
+    #   0 = rewrite available, Allow verdict (auto-allow by permission rule)
     #   1 = no RTK equivalent (passthrough)
     #   2 = deny rule matched (let Hermes handle)
-    #   3 = ask rule matched (let Hermes handle)
-    if proc.returncode == 1 or proc.returncode == 2 or proc.returncode == 3:
+    #   3 = Ask/Default verdict (rewrite available but permission model requires
+    #       user confirmation; in non-interactive hook context, treat as valid
+    #       rewrite since the intent is token optimization, not permission gating)
+    if proc.returncode == 1 or proc.returncode == 2:
         return None
-    if proc.returncode != 0:
+    if proc.returncode != 0 and proc.returncode != 3:
         return None
 
     rewritten = proc.stdout.strip()

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -226,7 +226,7 @@ def _encode_toon(data: str, session_id: str = "", tool_call_id: str = "") -> tup
 
     toon_text = proc.stdout.strip()
     # Skip if TOON didn't reduce size
-    if toon_text == data or len(toon_text) > len(data):
+    if toon_text == data or len(toon_text) >= len(data):
         return None
 
     savings_pct = 0
@@ -278,10 +278,7 @@ def _env_check(tool_name: str) -> str | None:
 
 
 def _not_ready_msg(tool_name: str) -> str:
-    return (
-        f"[tokenless tool-ready] {tool_name}: NOT_READY — "
-        f"environment issue. Skip retry, this is not a logic error."
-    )
+    return f"[tokenless:ready] {tool_name}: NOT_READY. Skip retry."
 
 
 # ---------------------------------------------------------------------------
@@ -356,12 +353,7 @@ def _try_rewrite(
     logger.info("tokenless: rtk rewrite %s → %s", command, rewritten)
     return {
         "action": "block",
-        "message": (
-            f"[tokenless] Command rewritten for token savings.\n"
-            f"Original: {command}\n"
-            f"Optimized: {rewritten}\n"
-            f"Re-execute with the optimized command to save 60-90% tokens."
-        ),
+        "message": f"[tokenless:rewrite] Re-execute as: {rewritten}",
     }
 
 
@@ -468,14 +460,13 @@ def on_transform_tool_result(
     # Build final output
     if used_toon:
         toon_text, savings_pct = toon_result
+        final = toon_text
         final_len = len(toon_text)
         savings_label = (
             "response compressed + TOON encoded"
             if used_compression
             else "TOON encoded"
         )
-        # Wrap TOON so the model sees the format hint
-        final = f"[TOON format, {savings_pct}% token savings]\n{toon_text}"
     else:
         final = current  # type: ignore[assignment]
         final_len = len(final)

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -104,6 +104,13 @@ function tryRtkRewrite(command: string): string | null {
       stdio: ["ignore", "pipe", "pipe"],
     });
     const rewritten = result.stdout?.trim();
+    // Exit code protocol (from rtk rewrite_cmd.rs):
+    //   0 = rewrite available, Allow verdict (auto-allow by permission rule)
+    //   1 = no RTK equivalent (passthrough)
+    //   2 = deny rule matched (let agent handle)
+    //   3 = Ask/Default verdict (rewrite available but permission model requires
+    //       user confirmation; in non-interactive hook context, treat as valid
+    //       rewrite since the intent is token optimization, not permission gating)
     if ((result.status === 0 || result.status === 3) && rewritten && rewritten !== command) {
       return rewritten;
     }

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -149,7 +149,7 @@ function tryCompressToon(response: any, sessionId?: string, toolCallId?: string)
       input,
     }).trim();
     if (!toonText || toonText === input) return null;
-    if (toonText.length > beforeChars) return null;
+    if (toonText.length >= beforeChars) return null;
 
     const afterChars = toonText.length;
     const savingsPct = beforeChars > 0 ? Math.round(((beforeChars - afterChars) / beforeChars) * 100) : 0;
@@ -184,7 +184,7 @@ function tryEnvCheck(toolName: string): { status: string; diagnostic: string } |
 
     // Phase 4: Fix failed → feedback to Agent
     const diagnostic: string = fixParsed.diagnostic
-      || `[tokenless tool-ready] ${toolName}: NOT_READY — environment issue. Skip retry.`;
+      || `[tokenless:ready] ${toolName}: NOT_READY. Skip retry.`;
     return { status: postStatus, diagnostic };
   } catch {
     return null;
@@ -233,7 +233,7 @@ export default {
         if (!result) return;
 
         if (verbose) {
-          console.log(`[tokenless/tool-ready] ${event.toolName}: ${result.status} — tool not available`);
+          console.log(`[tokenless:ready] ${event.toolName}: ${result.status} — tool not available`);
         }
         return { contextPrefix: result.diagnostic };
       },
@@ -261,7 +261,7 @@ export default {
         if (!rewritten) return;
 
         if (verbose) {
-          console.log(`[tokenless/rtk] rewrite: ${command} -> ${rewritten}`);
+          console.log(`[tokenless:rtk] rewrite: ${command} -> ${rewritten}`);
         }
 
         return { params: { ...event.params, command: rewritten } };
@@ -340,19 +340,17 @@ export default {
           savingsLabel = usedResponseCompression
             ? "response compressed + TOON encoded"
             : "TOON encoded";
-          // Wrap TOON text in the original tool result message structure.
-          // If we return a raw string, OpenClaw's tool_result_persist hook
-          // replaces the entire message body, dropping role/toolCallId/toolName.
-          // That causes session-transcript-repair to inject a synthetic
-          // "missing tool result" error on the next run, breaking the session.
-          const toonWrapped = `[TOON format, ${totalSavingsPct}% token savings]\n${toonText}`;
+          // Preserve original tool result message structure. Returning a raw
+          // string causes OpenClaw's tool_result_persist hook to drop
+          // role/toolCallId/toolName, which makes session-transcript-repair
+          // inject a synthetic "missing tool result" error on the next run.
           if (typeof event.message === "object" && event.message?.role === "toolResult") {
             finalMessage = {
               ...event.message,
-              content: [{ type: "text" as const, text: toonWrapped }],
+              content: [{ type: "text" as const, text: toonText }],
             };
           } else {
-            finalMessage = toonWrapped;
+            finalMessage = toonText;
           }
         } else {
           const before = JSON.stringify(event.message).length;
@@ -366,7 +364,7 @@ export default {
           const before = JSON.stringify(event.message).length;
           const after = usedToon ? toonText.length : JSON.stringify(finalMessage).length;
           console.log(
-            `[tokenless/${savingsLabel}] ${event.toolName}: ${before} -> ${after} chars (${totalSavingsPct}% reduction)`,
+            `[tokenless:${savingsLabel}] ${event.toolName}: ${before} -> ${after} chars (${totalSavingsPct}% reduction)`,
           );
         }
 

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -1040,10 +1040,14 @@ fn build_json_result(
             .iter()
             .map(|m| format!("required dependency missing: {}", m))
             .collect();
-        obj.insert("diagnostic".to_string(), Value::String(
-            format!("[tokenless tool-ready] {}: NOT_READY — {}. Skip retry — environment issue, not logic error.",
-                tool_name, diag_parts.join(", "))
-        ));
+        obj.insert(
+            "diagnostic".to_string(),
+            Value::String(format!(
+                "[tokenless:ready] {}: NOT_READY — {}. Skip retry.",
+                tool_name,
+                diag_parts.join(", ")
+            )),
+        );
     }
     Value::Object(obj)
 }

--- a/src/tokenless/tests/test-toon-full.sh
+++ b/src/tokenless/tests/test-toon-full.sh
@@ -265,7 +265,12 @@ else
     fail "TOON Hook 响应结构异常"
 fi
 context=$(echo "$result" | jq -r '.hookSpecificOutput.additionalContext')
-assert_contains "$context" "token savings" "TOON Hook 包含压缩率信息"
+assert_contains "$context" "users[5]" "TOON Hook additionalContext 为裸 TOON 内容"
+if echo "$context" | grep -qF "TOON format"; then
+    fail "TOON Hook 仍包含已废弃的 [TOON format ...] 前缀"
+else
+    pass "TOON Hook 已去除 [TOON format ...] 前缀"
+fi
 
 scenario "2.2 独立 TOON Hook — 转义 JSON 字符串"
 
@@ -312,7 +317,12 @@ EOF
 result=$(echo "$payload" | python3 "$HOOK_DIR/compress_response_hook.py" 2>/dev/null)
 assert_not_empty "$result" "Response→TOON 流水线输出"
 context=$(echo "$result" | jq -r '.hookSpecificOutput.additionalContext')
-assert_contains "$context" "response compressed + TOON encoded" "流水线标签正确"
+assert_contains "$context" "data[5]" "流水线产出 TOON 表格内容"
+if echo "$context" | grep -qE "\[tokenless\]|TOON format"; then
+    fail "流水线 additionalContext 仍包含已废弃的标签前缀"
+else
+    pass "流水线 additionalContext 已去除标签前缀"
+fi
 # 验证 debug 字段被移除
 if echo "$context" | grep -qvF "debug_trace_id"; then
     pass "Response 压缩移除了 debug 字段"


### PR DESCRIPTION
## Description

The [TOON format, X% token savings]\n wrapper added on every TOON tool result consumed ~10 tokens per call and polluted the agent's view of the actual content. It served no functional purpose and existed only as a "format hint". The size guard also compared raw TOON against raw input without accounting for the wrapper, so boundary-size TOON could end up larger than the original.

Changes
- Drop the [TOON format ...] wrapper in openclaw, hermes, and the two common PostToolUse hooks. additionalContext is now raw TOON / raw compressed JSON.
- Tighten the TOON-vs-input size guard from > to >= in openclaw and hermes (no point switching to TOON when sizes match).
- Unify diagnostic tags: [tokenless tool-ready] -> [tokenless:ready], [tokenless env-attribution] -> [tokenless:env], [tokenless] Command rewritten -> [tokenless:rewrite]. Applied across env_check.rs, tool_ready_hook.sh, openclaw, hermes, and compress_response_hook.
- Drop the redundant "environment issue, not logic error" suffix from the diagnostic message; the [tokenless:env|ready] tag already conveys the source.
- Compress the hermes RTK rewrite block message from a 4-line preamble to a single line: [tokenless:rewrite] Re-execute as: <cmd>.
- Update test-toon-full.sh assertions: drop checks on the removed wrapper text, add regression guards that TOON content is present and no legacy prefix leaks back in.

Verification
- cargo fmt + clippy + test (29 env_check tests pass)
- py_compile for all three Python adapters
- bash -n for tool_ready_hook.sh and test-toon-full.sh
- End-to-end smoke test of compress_toon_hook and compress_response_hook with locally-built tokenless: 4/4 new assertions pass

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

fixes # codereview + benchmarking findings

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
