### PR TITLE
[ignore] fix(ckpt): reject empty/path-traversal snapshot ids at checkpoint

### DIFF
--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -69,7 +69,7 @@ enum Commands {
         workspace: String,
 
         /// Snapshot ID (must be unique within the workspace)
-        #[arg(long, short = 'i')]
+        #[arg(long, short = 'i', value_parser = snapshot_id_value_parser())]
         id: String,
 
         /// Commit message describing the checkpoint
@@ -421,6 +421,23 @@ fn workspace_value_parser() -> impl TypedValueParser<Value = String> {
         } else {
             Ok(s)
         }
+    })
+}
+
+/// Clap value parser for `checkpoint --id`. The snapshot id becomes a path
+/// component (`<snapshots_dir>/<ws_id>/<snapshot_id>`), so empty/whitespace-only
+/// values and path-traversal characters must be rejected — otherwise the
+/// snapshot can be created but never addressed for delete/rollback, leaving an
+/// undeletable record in the index (issue #672).
+fn snapshot_id_value_parser() -> impl TypedValueParser<Value = String> {
+    StringValueParser::new().try_map(|s: String| {
+        if s.trim().is_empty() {
+            return Err("snapshot id must not be empty or whitespace");
+        }
+        if s.contains('/') || s.contains('\\') || s == "." || s == ".." {
+            return Err("snapshot id must not contain path separators or be '.'/'..'");
+        }
+        Ok(s)
     })
 }
 
@@ -1379,6 +1396,48 @@ mod tests {
                 assert_eq!(message.as_deref(), Some("备注"));
             }
             _ => panic!("expected Checkpoint"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_empty_or_whitespace_checkpoint_id() {
+        // Regression for issue #672 — empty/whitespace ids let the user
+        // create snapshots they could never delete.
+        for blank in ["", " ", "   ", "\t"] {
+            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", blank])
+                .err()
+                .unwrap_or_else(|| panic!("expected parse error for id {:?}", blank));
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "id {:?} should fail with ValueValidation, got {:?}",
+                blank,
+                err.kind()
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_checkpoint_id_with_path_separators() {
+        for bad in ["foo/bar", "..", ".", "a\\b", "/abs"] {
+            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", bad])
+                .err()
+                .unwrap_or_else(|| panic!("expected parse error for id {:?}", bad));
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "id {:?} should fail with ValueValidation, got {:?}",
+                bad,
+                err.kind()
+            );
+        }
+    }
+
+    #[test]
+    fn parse_accepts_reasonable_checkpoint_ids() {
+        for good in ["snap-1", "msg1-step2", "before-refactor", "v1.2.3"] {
+            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", good])
+                .unwrap_or_else(|_| panic!("expected acceptance for id {:?}", good));
         }
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -16,6 +16,34 @@ fn workspace_not_found(workspace: &str) -> Response {
     }
 }
 
+/// Validate a snapshot id at creation time. Returns `Some(error_response)` if
+/// the id is unusable; `None` if the id is acceptable.
+///
+/// The id is materialized as a path component
+/// (`<snapshots_dir>/<ws_id>/<snapshot_id>`); empty/whitespace-only values and
+/// path-traversal characters would either fail silently or land outside the
+/// snapshots dir, and afterwards the record could not be addressed for
+/// delete/rollback. CLI parsing rejects the same set, this is defense in depth
+/// for any client that talks to the daemon socket directly (issue #672).
+fn snapshot_id_error(id: &str) -> Option<Response> {
+    if id.trim().is_empty() {
+        return Some(Response::Error {
+            code: ErrorCode::InvalidPath,
+            message: "snapshot id must not be empty or whitespace".to_string(),
+        });
+    }
+    if id.contains('/') || id.contains('\\') || id == "." || id == ".." {
+        return Some(Response::Error {
+            code: ErrorCode::InvalidPath,
+            message: format!(
+                "snapshot id '{}' must not contain path separators or be '.'/'..'",
+                id
+            ),
+        });
+    }
+    None
+}
+
 pub async fn checkpoint(
     state: &Arc<DaemonState>,
     workspace: &str,
@@ -24,6 +52,11 @@ pub async fn checkpoint(
     metadata: Option<String>,
     pin: bool,
 ) -> anyhow::Result<Response> {
+    // 0. Validate snapshot id before touching state or filesystem
+    if let Some(resp) = snapshot_id_error(id) {
+        return Ok(resp);
+    }
+
     // 1. Resolve workspace (by ID, absolute path, or relative path)
     let arc = match state.resolve_workspace(workspace).await {
         Some(a) => a,
@@ -477,6 +510,102 @@ mod tests {
         // Exact match
         let result = index.resolve_by_prefix("abcdef1234567890abcdef1234567890abcdef12");
         assert!(result.is_ok());
+    }
+
+    // ── Snapshot ID validation tests (issue #672) ──
+
+    #[test]
+    fn snapshot_id_error_rejects_empty_and_whitespace() {
+        for bad in ["", " ", "   ", "\t", "\n"] {
+            let resp = snapshot_id_error(bad)
+                .unwrap_or_else(|| panic!("expected rejection for {:?}", bad));
+            match resp {
+                Response::Error { code, .. } => assert_eq!(code, ErrorCode::InvalidPath),
+                _ => panic!("expected Error response"),
+            }
+        }
+    }
+
+    #[test]
+    fn snapshot_id_error_rejects_path_separators_and_dots() {
+        for bad in ["foo/bar", "..", ".", "a\\b", "/abs", "a/b/c"] {
+            let resp = snapshot_id_error(bad)
+                .unwrap_or_else(|| panic!("expected rejection for {:?}", bad));
+            match resp {
+                Response::Error { code, .. } => assert_eq!(code, ErrorCode::InvalidPath),
+                _ => panic!("expected Error response"),
+            }
+        }
+    }
+
+    #[test]
+    fn snapshot_id_error_accepts_reasonable_ids() {
+        for good in [
+            "snap-1",
+            "msg1-step2",
+            "before-refactor",
+            "v1.2.3",
+            "中文-id",
+        ] {
+            assert!(
+                snapshot_id_error(good).is_none(),
+                "expected acceptance for {:?}",
+                good
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn checkpoint_empty_id_is_rejected_before_state_lookup() {
+        // No workspace registered — if the id check runs first, we should get
+        // InvalidPath rather than WorkspaceNotFound.
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        let resp = checkpoint(&state, "any-ws", "", None, None, false)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::InvalidPath);
+                assert!(message.to_lowercase().contains("snapshot id"));
+            }
+            _ => panic!("expected InvalidPath error for empty snapshot id"),
+        }
+    }
+
+    #[tokio::test]
+    async fn checkpoint_whitespace_id_is_rejected() {
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        let resp = checkpoint(&state, "any-ws", "   ", None, None, false)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::InvalidPath),
+            _ => panic!("expected InvalidPath error for whitespace snapshot id"),
+        }
+    }
+
+    #[tokio::test]
+    async fn checkpoint_id_with_path_separator_is_rejected() {
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        let resp = checkpoint(&state, "any-ws", "foo/bar", None, None, false)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::InvalidPath),
+            _ => panic!("expected InvalidPath error for id with path separator"),
+        }
     }
 
     // ── Checkpoint duplicate detection test ──


### PR DESCRIPTION
误建,已关闭,请忽略。改动若需要走正式流程会另开 PR。

原描述见 commit message。