### PR TITLE
fix(tokenless): compress-schema on array input

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -327,6 +327,10 @@ fn run() -> Result<(), (String, i32)> {
             let before_tokens = estimate_tokens_from_bytes(input.len());
             let after_tokens = estimate_tokens_from_bytes(after_compact.len());
             let output_text = if after_tokens >= before_tokens {
+                eprintln!(
+                    "tokenless: response compression did not reduce size ({} -> {} est. tokens), outputting original",
+                    before_tokens, after_tokens
+                );
                 input.clone()
             } else {
                 result_json.clone()
@@ -447,6 +451,10 @@ fn run() -> Result<(), (String, i32)> {
             let before_tokens = estimate_tokens_from_bytes(input.len());
             let after_tokens = estimate_tokens_from_bytes(output.len());
             let display = if output.is_empty() || after_tokens >= before_tokens {
+                eprintln!(
+                    "tokenless: TOON encoding did not reduce size ({} -> {} est. tokens), outputting original JSON",
+                    before_tokens, after_tokens
+                );
                 input.clone()
             } else {
                 output

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -265,7 +265,7 @@ fn run() -> Result<(), (String, i32)> {
 
             let compressor = SchemaCompressor::new();
 
-            let (result_json, after_compact) = if batch {
+            let (result_json, after_compact) = if batch || value.is_array() {
                 let arr = value
                     .as_array()
                     .ok_or_else(|| ("Expected a JSON array for --batch mode".to_string(), 1))?;
@@ -287,6 +287,10 @@ fn run() -> Result<(), (String, i32)> {
             let before_tokens = estimate_tokens_from_bytes(input.len());
             let after_tokens = estimate_tokens_from_bytes(after_compact.len());
             let output_text = if after_tokens >= before_tokens {
+                eprintln!(
+                    "tokenless: schema compression did not reduce size ({} -> {} est. tokens), outputting original",
+                    before_tokens, after_tokens
+                );
                 input.clone()
             } else {
                 result_json.clone()

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -30,6 +30,12 @@ assert_contains() {
     else log_fail "$test_name - Expected: $expected"; fi
 }
 
+assert_not_contains() {
+    local input="$1" unexpected="$2" test_name="$3"
+    if echo "$input" | grep -q "$unexpected"; then log_fail "$test_name - Unexpected: $unexpected"
+    else log_pass "$test_name"; fi
+}
+
 test_schema_compression() {
     log_section "Test 1: Schema Compression"
 
@@ -52,6 +58,13 @@ test_schema_compression() {
     log_info "Test 1.4: Edge cases"
     assert_contains "$(echo '{}' | tokenless compress-schema 2>/dev/null)" '{}' "Empty schema"
     assert_contains "$(echo 'null' | tokenless compress-schema 2>/dev/null)" 'null' "Null schema"
+
+    log_info "Test 1.5: Array input (OpenAI tools format, auto-detected)"
+    local array_schema='[{"type":"function","function":{"name":"f","title":"Remove Me","description":"short","parameters":{"type":"object","properties":{"x":{"type":"string","title":"Also Remove","examples":["ex"]}}}}}]'
+    local arr_compressed=$(echo "$array_schema" | tokenless compress-schema 2>/dev/null)
+    assert_not_contains "$arr_compressed" '"title"' "Array input: titles removed"
+    assert_not_contains "$arr_compressed" '"examples"' "Array input: examples removed"
+    assert_contains "$arr_compressed" '"function"' "Array input: function preserved"
 }
 
 test_response_compression() {


### PR DESCRIPTION
## What

Two fixes for the tokenless CLI compression commands:

### 1. `compress-schema` silently did nothing on array input

OpenAI's `tools` field is always a JSON array `[{type: "function", function: {...}}, ...]`, but `compress-schema` only compressed single objects. Passing the array as a whole `Value` skipped all compression because the top-level `Value` has no `"function"` key.

**Fix**: auto-detect array input (`value.is_array()`) and compress each element individually — same path as `--batch`.

**Result**: realistic schema input 747 → 582 bytes (22% saved); old binary returned input unchanged.

### 2. Silent fallback when compression does not reduce size

All three compression subcommands (`compress-schema`, `compress-response`, `compress-toon`) silently output the original input when the compressed result is not smaller. Users had no way to know compression was skipped.

**Fix**: add `eprintln!` diagnostics to stderr so callers know compression was skipped and why.

## Testing

| Verification | Status | What was checked |
|---|---|---|
| **已 E2E** (ECS, old vs new binary) | ✓ | Same realistic schema: old binary returns 747 bytes unchanged; new binary returns 582 bytes (22% saved) with title/examples removed. stderr warns correctly when no-op. |
| **仅单测** (`cargo test`) | ✓ | All 60 existing tests pass. |
| **新 shell test** (discriminating) | ✓ | `run-all-tests.sh` Test 1.5: pipes a JSON array with title+examples, asserts both are removed. Reverting the `is_array()` condition makes this test fail. |
| **未验证** | — | `--batch` flag interaction; 100+ tool arrays; deeply nested schemas; hook integration (compress_schema_hook.py stderr propagation). |

## Notes

- Does NOT conflict with #671 (security hardening) — that PR adds recursion limits and mutex recovery but does not touch array detection or stderr diagnostics.
- The 3 pre-existing `clippy::uninlined_format_args` errors in `tokenless-schema` are a baseline issue on origin/main (1.89 lint tightening); not introduced by this change.
- `--batch` flag is now semantically redundant for array inputs (auto-detected); consider deprecating in a follow-up.

Fixes #697
