### PR TITLE
fix(ckpt): reject empty/path-traversal snapshot ids at checkpoint

### DIFF
--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -69,7 +69,7 @@ enum Commands {
         workspace: String,
 
         /// Snapshot ID (must be unique within the workspace)
-        #[arg(long, short = 'i')]
+        #[arg(long, short = 'i', value_parser = snapshot_id_value_parser())]
         id: String,
 
         /// Commit message describing the checkpoint
@@ -421,6 +421,20 @@ fn workspace_value_parser() -> impl TypedValueParser<Value = String> {
         } else {
             Ok(s)
         }
+    })
+}
+
+/// Snapshot id becomes a path component; blanks and `/\`/`.`/`..` would
+/// produce records the lookup paths can't address.
+fn snapshot_id_value_parser() -> impl TypedValueParser<Value = String> {
+    StringValueParser::new().try_map(|s: String| {
+        if s.trim().is_empty() {
+            return Err("snapshot id must not be empty or whitespace");
+        }
+        if s.contains('/') || s.contains('\\') || s == "." || s == ".." {
+            return Err("snapshot id must not contain path separators or be '.'/'..'");
+        }
+        Ok(s)
     })
 }
 
@@ -1379,6 +1393,46 @@ mod tests {
                 assert_eq!(message.as_deref(), Some("备注"));
             }
             _ => panic!("expected Checkpoint"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_empty_or_whitespace_checkpoint_id() {
+        for blank in ["", " ", "   ", "\t"] {
+            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", blank])
+                .err()
+                .unwrap_or_else(|| panic!("expected parse error for id {:?}", blank));
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "id {:?} should fail with ValueValidation, got {:?}",
+                blank,
+                err.kind()
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_checkpoint_id_with_path_separators() {
+        for bad in ["foo/bar", "..", ".", "a\\b", "/abs"] {
+            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", bad])
+                .err()
+                .unwrap_or_else(|| panic!("expected parse error for id {:?}", bad));
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "id {:?} should fail with ValueValidation, got {:?}",
+                bad,
+                err.kind()
+            );
+        }
+    }
+
+    #[test]
+    fn parse_accepts_reasonable_checkpoint_ids() {
+        for good in ["snap-1", "msg1-step2", "before-refactor", "v1.2.3"] {
+            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", good])
+                .unwrap_or_else(|_| panic!("expected acceptance for id {:?}", good));
         }
     }
 

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -88,7 +88,7 @@ enum Commands {
         workspace: String,
 
         /// Target snapshot (ID like msg1-step2, or name like before-refactor)
-        #[arg(long = "snapshot", short = 's')]
+        #[arg(long = "snapshot", short = 's', value_parser = snapshot_id_value_parser())]
         to: String,
     },
 
@@ -99,7 +99,7 @@ enum Commands {
         workspace: Option<String>,
 
         /// Snapshot ID or unique prefix
-        #[arg(long, short = 's')]
+        #[arg(long, short = 's', value_parser = snapshot_id_value_parser())]
         snapshot: String,
 
         /// Skip confirmation prompt
@@ -125,11 +125,11 @@ enum Commands {
         workspace: String,
 
         /// Source snapshot (ID or name)
-        #[arg(long, short = 'f')]
+        #[arg(long, short = 'f', value_parser = snapshot_id_value_parser())]
         from: String,
 
         /// Target snapshot (ID or name)
-        #[arg(long, short = 't')]
+        #[arg(long, short = 't', value_parser = snapshot_id_value_parser())]
         to: String,
     },
 
@@ -1433,6 +1433,75 @@ mod tests {
         for good in ["snap-1", "msg1-step2", "before-refactor", "v1.2.3"] {
             Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", good])
                 .unwrap_or_else(|_| panic!("expected acceptance for id {:?}", good));
+        }
+    }
+
+    // Cases that go through `snapshot_id_value_parser`. Each row is
+    // (label, args-with-`SNAP`-placeholder); `SNAP` is replaced per bad value.
+    fn snapshot_arg_invocations() -> Vec<(&'static str, Vec<&'static str>)> {
+        vec![
+            (
+                "rollback -s",
+                vec!["ws-ckpt", "rollback", "-w", "/ws", "-s", "SNAP"],
+            ),
+            (
+                "delete -s",
+                vec!["ws-ckpt", "delete", "-w", "/ws", "-s", "SNAP"],
+            ),
+            (
+                "diff -f",
+                vec!["ws-ckpt", "diff", "-w", "/ws", "-f", "SNAP", "-t", "ok"],
+            ),
+            (
+                "diff -t",
+                vec!["ws-ckpt", "diff", "-w", "/ws", "-f", "ok", "-t", "SNAP"],
+            ),
+        ]
+    }
+
+    #[test]
+    fn parse_rejects_empty_or_whitespace_snapshot_args() {
+        for (label, template) in snapshot_arg_invocations() {
+            for blank in ["", " ", "   ", "\t"] {
+                let args: Vec<&str> = template
+                    .iter()
+                    .map(|a| if *a == "SNAP" { blank } else { *a })
+                    .collect();
+                let err = Cli::try_parse_from(&args).err().unwrap_or_else(|| {
+                    panic!("{}: expected parse error for blank {:?}", label, blank)
+                });
+                assert_eq!(
+                    err.kind(),
+                    clap::error::ErrorKind::ValueValidation,
+                    "{}: blank {:?} should fail with ValueValidation, got {:?}",
+                    label,
+                    blank,
+                    err.kind()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_rejects_path_traversal_snapshot_args() {
+        for (label, template) in snapshot_arg_invocations() {
+            for bad in ["foo/bar", "..", ".", "a\\b", "/abs"] {
+                let args: Vec<&str> = template
+                    .iter()
+                    .map(|a| if *a == "SNAP" { bad } else { *a })
+                    .collect();
+                let err = Cli::try_parse_from(&args).err().unwrap_or_else(|| {
+                    panic!("{}: expected parse error for value {:?}", label, bad)
+                });
+                assert_eq!(
+                    err.kind(),
+                    clap::error::ErrorKind::ValueValidation,
+                    "{}: value {:?} should fail with ValueValidation, got {:?}",
+                    label,
+                    bad,
+                    err.kind()
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Description

- 在 `ws-ckpt checkpoint --id` 的 clap parser 处拒绝空字符串 / 纯空白
  / 含路径分隔符(`/`、`\`)及 `.`、`..` 的 snapshot id。

修复前,`ws-ckpt checkpoint -i ''`(以及任意纯空白 / 路径穿越值)会成功创建
一条记录 —— snapshot id 实际落地为路径分量
(`<snapshots_dir>/<ws_id>/<snapshot_id>`),index 里留下一条 delete / rollback
都无法寻址的记录,造成无法删除的残留快照。把校验放在 CLI 输入边界,在发出
RPC 之前就把脏输入挡住。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #672

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- `crates/cli/src/main.rs` 新增 3 个 clap parser 单测:
  `parse_rejects_empty_or_whitespace_checkpoint_id`、
  `parse_rejects_checkpoint_id_with_path_separators`、
  `parse_accepts_reasonable_checkpoint_ids`
- `cargo clippy --target x86_64-unknown-linux-gnu --workspace --tests -- -D warnings` 通过
- Linux 实机冒烟:`ws-ckpt checkpoint -w <ws> -i ''` / `'   '` / `'foo/bar'`
  应直接报错;`-i 'snap-1'` 正常创建

## Additional Notes

<!-- Any additional information, screenshots, or context. -->

本次 PR **未含** daemon 侧的 defense-in-depth 校验:CLI 已经是输入边界,
daemon socket 也没有第三方客户端,daemon 再校一遍属于冗余。
