### PR TITLE
 feat(sight):Add FFI input_message_delta field and unify the per-round increment algorithm

### DIFF
--- a/src/agentsight/docs/design-docs/c-ffi-api.md
+++ b/src/agentsight/docs/design-docs/c-ffi-api.md
@@ -70,6 +70,11 @@ typedef struct {
     /* 工具定义（JSON 数组字符串） */
     const char* tools;                /* LLMRequest.tools 序列化 JSON 数组; 无工具时为 "[]" */
     uint32_t    tools_len;
+
+    /* 增量输入消息（JSON 数组字符串）：与 SQLite genai_events.input_messages 同一套算法，
+       去掉 system 消息后，保留从最后一个 user 消息开始（含）到末尾的部分 */
+    const char* input_message_delta;
+    uint32_t    input_message_delta_len;
 } AgentsightLLMData;
 ```
 

--- a/src/agentsight/examples/agentsight_example.c
+++ b/src/agentsight/examples/agentsight_example.c
@@ -85,6 +85,10 @@ static void on_llm_event(const AgentsightLLMData *data, void *user_data) {
     if (data->tools && data->tools_len > 0) {
         printf("  tools (%u bytes): %.256s\n", data->tools_len, data->tools);
     }
+    if (data->input_message_delta && data->input_message_delta_len > 0) {
+        printf("  input_message_delta (%u bytes): %.256s\n",
+               data->input_message_delta_len, data->input_message_delta);
+    }
 }
 
 int main(void) {

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -146,6 +146,12 @@ pub struct AgentsightLLMData {
     pub response_messages_len: u32,
     pub tools: *const c_char,
     pub tools_len: u32,
+    /// Incremental (latest-round) request messages: the same per-round
+    /// increment stored in SQLite (`genai_events.input_messages`). System
+    /// messages are dropped and everything from the last `user` message onward
+    /// is kept (inclusive). JSON array of InputMessage.
+    pub input_message_delta: *const c_char,
+    pub input_message_delta_len: u32,
 }
 
 // ===========================================================================
@@ -207,6 +213,7 @@ struct LlmDataHolder {
     _req_messages: CString,
     _resp_messages: CString,
     _tools: CString,
+    _input_message_delta: CString,
 }
 
 fn build_https_data(record: &HttpRecord) -> HttpsDataHolder {
@@ -304,6 +311,15 @@ fn build_llm_data(call: &LLMCall) -> LlmDataHolder {
     let req_messages = safe_cstring(&req_messages_json);
     let resp_messages = safe_cstring(&resp_messages_json);
 
+    // Incremental (latest-round) input messages: the same per-round increment
+    // stored in SQLite (`genai_events.input_messages`). Drops system messages
+    // and keeps everything from the last `user` message onward.
+    let input_delta =
+        crate::genai::semantic::latest_round_input_messages(&call.request.messages);
+    let input_message_delta_json =
+        serde_json::to_string(&input_delta).unwrap_or_default();
+    let input_message_delta = safe_cstring(&input_message_delta_json);
+
     let tools_json = call
         .request
         .tools
@@ -339,6 +355,8 @@ fn build_llm_data(call: &LLMCall) -> LlmDataHolder {
         response_messages_len: resp_messages_json.len() as u32,
         tools: tools.as_ptr(),
         tools_len: tools_json.len() as u32,
+        input_message_delta: input_message_delta.as_ptr(),
+        input_message_delta_len: input_message_delta_json.len() as u32,
     };
 
     LlmDataHolder {
@@ -354,6 +372,7 @@ fn build_llm_data(call: &LLMCall) -> LlmDataHolder {
         _req_messages: req_messages,
         _resp_messages: resp_messages,
         _tools: tools,
+        _input_message_delta: input_message_delta,
     }
 }
 

--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -94,11 +94,9 @@ impl GenAIBuilder {
             let (input_messages_json, system_instructions_json) = {
                 let sys: Vec<_> = llm_call.request.messages.iter()
                     .filter(|m| m.role == "system").collect();
-                let non_sys: Vec<_> = llm_call.request.messages.iter()
-                    .filter(|m| m.role != "system").collect();
-                let latest = if let Some(idx) = non_sys.iter().rposition(|m| m.role == "user") {
-                    &non_sys[idx..]
-                } else { &non_sys[..] };
+                let latest = crate::genai::semantic::latest_round_input_messages(
+                    &llm_call.request.messages,
+                );
                 (
                     if latest.is_empty() { None } else { serde_json::to_string(&latest).ok() },
                     if sys.is_empty() { None } else { serde_json::to_string(&sys).ok() },

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -238,14 +238,8 @@ pub fn events_to_flat_records(events: &[GenAISemanticEvent], encryptor: Option<&
                 // 仅保留 token 数量等元数据，不上传用户输入。
                 // 从后往前找最后一条 user message，取它及之后的所有非 system 消息
                 if trace_enabled {
-                    let non_system: Vec<&super::semantic::InputMessage> = call.request.messages.iter()
-                        .filter(|msg| msg.role != "system")
-                        .collect();
-                    let latest_msgs: &[&super::semantic::InputMessage] = if let Some(last_user_idx) = non_system.iter().rposition(|m| m.role == "user") {
-                        &non_system[last_user_idx..]
-                    } else {
-                        &non_system[..]
-                    };
+                    let latest_msgs =
+                        super::semantic::latest_round_input_messages(&call.request.messages);
                     if !latest_msgs.is_empty() {
                         if let Ok(json) = serde_json::to_string(&latest_msgs) {
                             m.insert("gen_ai.input.messages".to_string(),

--- a/src/agentsight/src/genai/semantic.rs
+++ b/src/agentsight/src/genai/semantic.rs
@@ -132,6 +132,48 @@ pub struct InputMessage {
     pub name: Option<String>,
 }
 
+/// Compute the incremental ("latest round") input messages from a full request
+/// history: drop all `system` messages, then keep everything from the last
+/// *real* user turn onward (inclusive). Falls back to all non-system messages
+/// when there is no real user message.
+///
+/// A "real user turn" is a `user` message that carries actual text. This is
+/// important for Anthropic-style traffic, which encodes tool results as
+/// `role = "user"` messages whose only content is a `tool_result` (no text).
+/// Anchoring on the last *any* user message would land on such a tool-result
+/// message and drop the user's actual question (the first segment of the
+/// round). Mirrors the skipping logic in `GenAIBuilder::extract_last_user_raw`.
+///
+/// This is the single source of truth for the per-round increment that is
+/// stored in SQLite (`genai_events.input_messages`) and exposed over FFI
+/// (`AgentsightLLMData.input_message_delta`).
+pub fn latest_round_input_messages(messages: &[InputMessage]) -> Vec<&InputMessage> {
+    // A user message that carries actual text (not just a tool_result).
+    fn is_text_user(m: &InputMessage) -> bool {
+        m.role == "user"
+            && m.parts.iter().any(|p| {
+                matches!(p, MessagePart::Text { content } if !content.is_empty())
+            })
+    }
+
+    let non_system: Vec<&InputMessage> =
+        messages.iter().filter(|m| m.role != "system").collect();
+
+    let last = non_system.iter().rposition(|m| is_text_user(m));
+    let Some(mut idx) = last else {
+        return non_system;
+    };
+    // Walk back across a contiguous run of text-bearing user messages so we
+    // anchor on the FIRST message of the user's turn. Agents such as OpenClaw
+    // emit the real question followed by a separate "runtime context" user
+    // message; both are text-bearing, so anchoring on the last one would drop
+    // the actual question.
+    while idx > 0 && is_text_user(non_system[idx - 1]) {
+        idx -= 1;
+    }
+    non_system[idx..].to_vec()
+}
+
 /// Output message (OTel OutputMessage)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutputMessage {

--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -493,17 +493,9 @@ impl GenAISqliteStore {
                     }
                 };
                 let input_messages: Option<String> = {
-                    let non_sys: Vec<_> = call
-                        .request
-                        .messages
-                        .iter()
-                        .filter(|m| m.role != "system")
-                        .collect();
-                    let latest = if let Some(idx) = non_sys.iter().rposition(|m| m.role == "user") {
-                        &non_sys[idx..]
-                    } else {
-                        &non_sys[..]
-                    };
+                    let latest = crate::genai::semantic::latest_round_input_messages(
+                        &call.request.messages,
+                    );
                     if latest.is_empty() {
                         None
                     } else {
@@ -1702,18 +1694,9 @@ impl GenAISqliteStore {
 
                 // Extract input messages (incremental: latest round only)
                 let input_messages: Option<String> = {
-                    let non_system: Vec<_> = call
-                        .request
-                        .messages
-                        .iter()
-                        .filter(|m| m.role != "system")
-                        .collect();
-                    let latest =
-                        if let Some(idx) = non_system.iter().rposition(|m| m.role == "user") {
-                            &non_system[idx..]
-                        } else {
-                            &non_system[..]
-                        };
+                    let latest = crate::genai::semantic::latest_round_input_messages(
+                        &call.request.messages,
+                    );
                     if latest.is_empty() {
                         None
                     } else {


### PR DESCRIPTION

## Background

`agentsight_read` previously exposed only the full request messages over FFI, so consumers could not get the
per-round delta; meanwhile each "latest round" computation was implemented separately and inconsistently, and
dropped the user's actual question under Anthropic and OpenClaw traffic.

## Scope of Changes

1. **FFI delta field**: Adds `input_message_delta` to `AgentsightLLMData`, populated by `build_llm_data` and
   delivered via the `agentsight_read` callback; the existing full `request_messages` is left unchanged.
2. **Single source for the increment**: Adds `genai::semantic::latest_round_input_messages`; SQLite
   (`try_insert_event` and `complete_pending`), FFI, SLS (`logtail.rs`), and the pending record (`builder.rs`)
   all switch to it.
3. **Fix dropped user question**: Anchors on the first message of the trailing run of text-bearing user messages,
   correctly handling Anthropic tool results encoded as `role=user` and OpenClaw's runtime-context user message
   appended after the question.
4. **Docs and example synced**: Updates `docs/design-docs/c-ffi-api.md` and `examples/agentsight_example.c`.

## Known Issues / Caveats

- `AgentsightLLMData` gains fields appended at the end; `agentsight.h` is generated by cbindgen at build time, so
  downstream must rebuild, and consumers compiled against the old layout face ABI incompatibility.
- `extract_last_user_raw` / `user_query` / fingerprint still use the old "last text user" logic, so under
  OpenClaw's dual-user pattern `user_query` may still be the runtime-context metadata; not fixed in this PR.