### PR TITLE
fix(cosh): show visible cursor in provider/auth config inputs

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/components/AliyunAuthPrompt.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/AliyunAuthPrompt.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2026 Copilot Shell
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import chalk from 'chalk';
+import { AliyunAuthPrompt } from './AliyunAuthPrompt.js';
+import type { Key } from '../hooks/useKeypress.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+
+vi.mock('../hooks/useKeypress.js', () => ({
+  useKeypress: vi.fn(),
+}));
+
+vi.mock('@copilot-shell/core', async () => {
+  const actual = await vi.importActual<typeof import('@copilot-shell/core')>(
+    '@copilot-shell/core',
+  );
+  return {
+    ...actual,
+    // Force non-ECS path so the component lands in the AK/SK input step.
+    getECSInstanceId: vi.fn(async () => null),
+    getECSRegionId: vi.fn(async () => null),
+    generateConsoleUrl: vi.fn(() => ''),
+    pollForECSRamRoleAuthorization: vi.fn(async () => false),
+    getECSRamRoleCredentials: vi.fn(async () => null),
+  };
+});
+
+function makeKey(overrides: Partial<Key> = {}): Key {
+  return {
+    name: '',
+    ctrl: false,
+    meta: false,
+    shift: false,
+    paste: false,
+    sequence: '',
+    ...overrides,
+  };
+}
+
+function latestHandler(): (key: Key) => void {
+  const mock = vi.mocked(useKeypress);
+  return mock.mock.calls[mock.mock.calls.length - 1]![0];
+}
+
+async function pressKey(key: Partial<Key>): Promise<void> {
+  await act(() => {
+    latestHandler()(makeKey(key));
+  });
+}
+
+/**
+ * Wait until the AK/SK input step is rendered. The detect-environment
+ * useEffect resolves through the mocked `getECSInstanceId(null)` path and
+ * advances state into `aksk_input`, at which point "Access Key ID:" appears.
+ *
+ * Polls microtasks deterministically instead of a fixed-duration sleep.
+ */
+async function waitForAkskInput(
+  lastFrame: () => string | undefined,
+  maxTicks = 50,
+): Promise<void> {
+  for (let i = 0; i < maxTicks; i++) {
+    if (lastFrame()?.includes('Access Key ID:')) return;
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+  throw new Error(
+    `AK/SK input step did not render within ${maxTicks} microtask ticks`,
+  );
+}
+
+describe('AliyunAuthPrompt cursor rendering', () => {
+  // chalk is a process-wide singleton; save/restore so we don't leak ANSI
+  // settings into unrelated tests sharing the same Vitest worker.
+  let originalChalkLevel: typeof chalk.level;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Force chalk to emit ANSI codes so the cursor is distinguishable from padding.
+    originalChalkLevel = chalk.level;
+    chalk.level = 1;
+  });
+
+  afterEach(() => {
+    chalk.level = originalChalkLevel;
+  });
+
+  it('renders cursor on active accessKeyId field when empty', async () => {
+    const { lastFrame } = render(
+      <AliyunAuthPrompt
+        isAuthenticating={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await waitForAkskInput(lastFrame);
+
+    // Default field is accessKeyId, empty → only the inverse cursor
+    expect(lastFrame()).toContain('Access Key ID:');
+    expect(lastFrame()).toContain(chalk.inverse(' '));
+  });
+
+  it('renders cursor at end of accessKeyId after typing', async () => {
+    const { lastFrame } = render(
+      <AliyunAuthPrompt
+        isAuthenticating={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await waitForAkskInput(lastFrame);
+
+    for (const ch of ['L', 'T', 'A', 'I']) {
+      await pressKey({ sequence: ch });
+    }
+
+    expect(lastFrame()).toContain(`LTAI${chalk.inverse(' ')}`);
+  });
+
+  it('moves cursor to model field after navigating past AK/SK', async () => {
+    const { lastFrame } = render(
+      <AliyunAuthPrompt
+        isAuthenticating={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        defaultModel="qwen3-coder-plus"
+      />,
+    );
+    await waitForAkskInput(lastFrame);
+
+    // accessKeyId → accessKeySecret → model via Tab
+    await pressKey({ name: 'tab', sequence: '\t' });
+    await pressKey({ name: 'tab', sequence: '\t' });
+
+    expect(lastFrame()).toContain(`qwen3-coder-plus${chalk.inverse(' ')}`);
+  });
+
+  it('shows cursor only on the active field, not on inactive ones', async () => {
+    const { lastFrame } = render(
+      <AliyunAuthPrompt
+        isAuthenticating={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        defaultModel="qwen3-coder-plus"
+      />,
+    );
+    await waitForAkskInput(lastFrame);
+
+    // Active is accessKeyId; model is shown but inactive → only one inverse space (the cursor)
+    const frame = lastFrame()!;
+    const cursorOccurrences = frame.split(chalk.inverse(' ')).length - 1;
+    expect(cursorOccurrences).toBe(1);
+  });
+});

--- a/src/copilot-shell/packages/cli/src/ui/components/AliyunAuthPrompt.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/AliyunAuthPrompt.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import Link from 'ink-link';
+import chalk from 'chalk';
 import qrcode from 'qrcode-terminal';
 import { Colors } from '../colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -503,7 +504,7 @@ export function AliyunAuthPrompt({
             <Text>
               {currentField === 'accessKeyId' ? '> ' : '  '}
               {currentField === 'accessKeyId'
-                ? accessKeyId || ' '
+                ? `${accessKeyId}${chalk.inverse(' ')}`
                 : maskedAccessKeyId || ' '}
             </Text>
           </Box>
@@ -523,7 +524,9 @@ export function AliyunAuthPrompt({
           <Box flexGrow={1}>
             <Text>
               {currentField === 'accessKeySecret' ? '> ' : '  '}
-              {maskedSecret || ' '}
+              {currentField === 'accessKeySecret'
+                ? `${maskedSecret}${chalk.inverse(' ')}`
+                : maskedSecret || ' '}
             </Text>
           </Box>
         </Box>
@@ -538,7 +541,9 @@ export function AliyunAuthPrompt({
           <Box flexGrow={1}>
             <Text>
               {currentField === 'model' ? '> ' : '  '}
-              {model}
+              {currentField === 'model'
+                ? `${model}${chalk.inverse(' ')}`
+                : model || ' '}
             </Text>
           </Box>
         </Box>

--- a/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
@@ -6,7 +6,8 @@
 
 import { act } from 'react';
 import { render } from 'ink-testing-library';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import chalk from 'chalk';
 import { OpenAIKeyPrompt, credentialSchema } from './OpenAIKeyPrompt.js';
 import type { Key } from '../hooks/useKeypress.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -17,8 +18,20 @@ vi.mock('../hooks/useKeypress.js', () => ({
 }));
 
 describe('OpenAIKeyPrompt', () => {
+  // chalk is a process-wide singleton; save/restore so we don't leak ANSI
+  // settings into unrelated tests sharing the same Vitest worker.
+  let originalChalkLevel: typeof chalk.level;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    // Force chalk to emit ANSI codes so cursor (chalk.inverse) is distinguishable
+    // from regular padding spaces in the rendered frame.
+    originalChalkLevel = chalk.level;
+    chalk.level = 1;
+  });
+
+  afterEach(() => {
+    chalk.level = originalChalkLevel;
   });
 
   // ─── 基础渲染 ───────────────────────────────────────────────────────────────
@@ -405,6 +418,92 @@ describe('OpenAIKeyPrompt', () => {
 
       // Should no longer show original key prefix
       expect(lastFrame()).not.toContain('sk-');
+    });
+
+    it('should render visible cursor on active apiKey field (empty value)', async () => {
+      // DeepSeek (leaf) → defaults straight to provider field; navigate to apiKey.
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          defaultBaseUrl="https://api.deepseek.com"
+        />,
+      );
+
+      await pressKey({ name: 'return', sequence: '\r' });
+
+      expect(lastFrame()).toContain(chalk.inverse(' '));
+    });
+
+    it('should render cursor at end of value when typing into apiKey', async () => {
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          defaultBaseUrl="https://api.deepseek.com"
+        />,
+      );
+
+      await pressKey({ name: 'return', sequence: '\r' });
+      for (const ch of ['a', 'b', 'c', 'd']) {
+        await pressKey({ sequence: ch });
+      }
+
+      // maskApiKey('abcd') → 'abc*'; cursor sits at the end
+      expect(lastFrame()).toContain(`abc*${chalk.inverse(' ')}`);
+    });
+
+    it('should not render cursor on non-active fields', () => {
+      // Provider is the active field on initial render for a leaf provider.
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          defaultBaseUrl="https://api.deepseek.com"
+          defaultApiKey="sk-abcdef"
+        />,
+      );
+
+      // apiKey / baseUrl / model fields are visible but inactive — no inverse cursor present.
+      expect(lastFrame()).not.toContain(chalk.inverse(' '));
+    });
+
+    it('should render cursor on active Model field after navigating from apiKey', async () => {
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          defaultBaseUrl="https://api.deepseek.com"
+          defaultApiKey="sk-abcdef"
+        />,
+      );
+
+      // provider → apiKey → model (DeepSeek is non-custom, so Base URL is skipped)
+      await pressKey({ name: 'return', sequence: '\r' });
+      await pressKey({ name: 'return', sequence: '\r' });
+
+      // default model 'deepseek-chat' with cursor at end
+      expect(lastFrame()).toContain(`deepseek-chat${chalk.inverse(' ')}`);
+    });
+
+    it('should render cursor on active Base URL field for custom provider', async () => {
+      // Use custom provider so Base URL is editable.
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt onSubmit={vi.fn()} onCancel={vi.fn()} />,
+      );
+
+      // Navigate down through the provider list to the custom entry (last one).
+      // OPENAI_PROVIDERS has 8 entries; default index 0 (DashScope) → press ↓ 7 times to reach custom.
+      for (let i = 0; i < 7; i++) {
+        await pressKey({ name: 'down', sequence: '' });
+      }
+      // Enter to leave provider field; for custom (no subProviders) → apiKey directly.
+      await pressKey({ name: 'return', sequence: '\r' });
+      // apiKey → baseUrl (custom)
+      await pressKey({ name: 'return', sequence: '\r' });
+
+      // Empty base URL on custom → only the cursor shows
+      expect(lastFrame()).toContain(chalk.inverse(' '));
     });
 
     it('should delete single char on backspace after user clears and types new key', async () => {

--- a/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { z } from 'zod';
 import { Box, Text } from 'ink';
+import chalk from 'chalk';
 import { Colors } from '../colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { t } from '../../i18n/index.js';
@@ -560,7 +561,9 @@ export function OpenAIKeyPrompt({
             <Box flexGrow={1}>
               <Text>
                 {currentField === 'apiKey' ? '> ' : '  '}
-                {maskApiKey(apiKey) || ' '}
+                {currentField === 'apiKey'
+                  ? `${maskApiKey(apiKey)}${chalk.inverse(' ')}`
+                  : maskApiKey(apiKey) || ' '}
               </Text>
             </Box>
           </Box>
@@ -592,7 +595,9 @@ export function OpenAIKeyPrompt({
             <Box flexGrow={1}>
               <Text>
                 {currentField === 'model' ? '> ' : '  '}
-                {model}
+                {currentField === 'model'
+                  ? `${model}${chalk.inverse(' ')}`
+                  : model || ' '}
               </Text>
             </Box>
           </Box>
@@ -666,7 +671,9 @@ export function OpenAIKeyPrompt({
                 <Box flexGrow={1}>
                   <Text>
                     {currentField === 'apiKey' ? '> ' : '  '}
-                    {maskApiKey(apiKey) || ' '}
+                    {currentField === 'apiKey'
+                      ? `${maskApiKey(apiKey)}${chalk.inverse(' ')}`
+                      : maskApiKey(apiKey) || ' '}
                   </Text>
                 </Box>
               </Box>
@@ -688,7 +695,9 @@ export function OpenAIKeyPrompt({
                   {isCustom ? (
                     <Text>
                       {currentField === 'baseUrl' ? '> ' : '  '}
-                      {baseUrl}
+                      {currentField === 'baseUrl'
+                        ? `${baseUrl}${chalk.inverse(' ')}`
+                        : baseUrl || ' '}
                     </Text>
                   ) : (
                     <Text color={Colors.Gray}>
@@ -713,7 +722,9 @@ export function OpenAIKeyPrompt({
                 <Box flexGrow={1}>
                   <Text>
                     {currentField === 'model' ? '> ' : '  '}
-                    {model}
+                    {currentField === 'model'
+                      ? `${model}${chalk.inverse(' ')}`
+                      : model || ' '}
                   </Text>
                 </Box>
               </Box>


### PR DESCRIPTION
## Description

Provider/auth config inputs in Copilot Shell did not render a visible cursor while editing, making it unclear where keystrokes would land. This PR appends a `chalk.inverse(' ')` cursor to the currently active field in both `OpenAIKeyPrompt` (API Key / Custom Base URL / Model) and `AliyunAuthPrompt` (Access Key ID / Access Key Secret / Model). Empty active fields show just the inverted-space cursor for clear focus; inactive fields are unchanged. Main chat input and global render logic are untouched.

## Related Issue

closes #682

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] \`cosh\` (copilot-shell)
- [ ] \`sec-core\` (agent-sec-core)
- [ ] \`skill\` (os-skills)
- [ ] \`sight\` (agentsight)
- [ ] \`tokenless\` (tokenless)
- [ ] \`memory\` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For \`cosh\`: Lint passes, type check passes, and tests pass
- [ ] For \`sec-core\` (Rust): \`cargo clippy -- -D warnings\` and \`cargo fmt --check\` pass
- [ ] For \`sec-core\` (Python): Ruff format and pytest pass
- [ ] For \`skill\`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For \`sight\`: \`cargo clippy -- -D warnings\` and \`cargo fmt --check\` pass
- [ ] For \`tokenless\`: \`cargo clippy -- -D warnings\` and \`cargo fmt --check\` pass
- [ ] For \`memory\` (Linux only): \`cargo clippy --all-targets -- -D warnings\`, \`cargo fmt --check\`, and \`cargo test\` pass
- [x] Lock files are up to date (\`package-lock.json\` / \`Cargo.lock\`)

## Testing

- \`vitest run src/ui/components/OpenAIKeyPrompt.test.tsx\` — 27/27 pass (5 new cursor-visibility tests)
- \`vitest run src/ui/components/AliyunAuthPrompt.test.tsx\` — 4/4 pass (new file)
- ESLint clean on changed files
- Manual: launch \`cosh\`, open OpenAI/Aliyun config, confirm cursor visible on active field, hidden on others, and main chat input behavior unchanged

## Additional Notes

Tests force \`chalk.level = 1\` (with save/restore in \`afterEach\`) so the inverse-space cursor is distinguishable from padding in the rendered frame.