### PR TITLE
fix(ckpt): prevent cwd invalidation on init/rollback

### DIFF
--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -695,6 +695,27 @@ async fn handle_response(response: Response, original_request: &Request) -> Resu
             eprintln!("  Use 'ws-ckpt init' to initialize, or 'ws-ckpt list' to view workspaces.");
             process::exit(1);
         }
+        Response::Error {
+            code: ErrorCode::CwdOccupied,
+            message,
+        } => {
+            eprintln!("\x1b[31m✗ {}\x1b[0m", message);
+            eprintln!(
+                "  Tip: inspect each PID above with `ps -fp <PID>`, then cd them out or kill."
+            );
+            eprintln!(
+                "  (cwd may be a bind-mount alias of the workspace, not the workspace path.)"
+            );
+            process::exit(1);
+        }
+        Response::Error {
+            code: ErrorCode::CwdScanFailed,
+            message,
+        } => {
+            eprintln!("\x1b[31m✗ {}\x1b[0m", message);
+            eprintln!("  This is typically transient — retry the command.");
+            process::exit(1);
+        }
         Response::Error { code, message } => {
             eprintln!("\x1b[31mError [{:?}]: {}\x1b[0m", code, message);
             process::exit(1);
@@ -1113,7 +1134,10 @@ async fn handle_recover(workspace: Option<String>, all: bool, force: bool) -> Re
                 println!("  {} ({} snapshots)", ws.path, ws.snapshot_count);
             }
             println!(
-                "This will delete all snapshots and restore all workspaces to normal directories."
+                "This will delete all snapshots and restore all workspaces to normal directories.\n\
+                 WARNING: ws-ckpt does NOT check for processes with cwd inside any workspace before recover.\n\
+                 Any such process will have its working directory silently invalidated — verify yourself\n\
+                 (e.g. lsof +D <ws>, or ls -l /proc/*/cwd) before confirming."
             );
             eprint!("Proceed? [y/N] ");
             io::stderr().flush()?;
@@ -1172,7 +1196,10 @@ async fn handle_recover(workspace: Option<String>, all: bool, force: bool) -> Re
         if !force {
             println!("Workspace: {} ({} snapshots)", ws_arg, snapshot_count);
             println!(
-                "This will delete all snapshots and restore the workspace to a normal directory."
+                "This will delete all snapshots and restore the workspace to a normal directory.\n\
+                 WARNING: ws-ckpt does NOT check for processes with cwd inside the workspace before recover.\n\
+                 Any such process will have its working directory silently invalidated — verify yourself\n\
+                 (e.g. lsof +D <ws>, or ls -l /proc/*/cwd) before confirming."
             );
             eprint!("Proceed? [y/N] ");
             io::stderr().flush()?;

--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -162,6 +162,8 @@ pub enum ErrorCode {
     SnapshotAlreadyExists,
     WriteLockConflict,
     DiskSpaceInsufficient,
+    CwdOccupied,
+    CwdScanFailed,
 }
 
 // ── Snapshot types ──
@@ -943,6 +945,8 @@ mod tests {
             ErrorCode::SnapshotAlreadyExists,
             ErrorCode::WriteLockConflict,
             ErrorCode::DiskSpaceInsufficient,
+            ErrorCode::CwdOccupied,
+            ErrorCode::CwdScanFailed,
         ];
         for code in codes {
             let resp = Response::Error {

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -121,10 +121,20 @@ pub async fn rollback(
         None => return Ok(workspace_not_found(workspace)),
     };
 
-    // 2. Write lock: validate snapshot → cwd guard → execute rollback
+    // 2. Read lock: grab workspace path for /proc scan
+    let ws_path_str = {
+        let ws = arc.read().await;
+        ws.index.workspace_path.to_string_lossy().to_string()
+    };
+
+    // 3. cwd guard outside lock — /proc scan may be slow
+    if let Some(resp) = crate::util::guard_cwd_occupants(&ws_path_str).await {
+        return Ok(resp);
+    }
+
+    // 4. Write lock: validate snapshot + execute rollback
     let ws = arc.write().await;
 
-    // 3. Resolve target snapshot by prefix
     let resolved_id = match ws.index.resolve_by_prefix(to) {
         Ok((id, _)) => id.clone(),
         Err(ResolveError::NotFound) => {
@@ -141,7 +151,6 @@ pub async fn rollback(
         }
     };
 
-    // Reject missing snapshots — user must manually delete with --force
     if ws
         .index
         .snapshots
@@ -154,17 +163,9 @@ pub async fn rollback(
         });
     }
 
-    // 4. Refuse if any process holds a cwd inside the workspace — rollback
-    //    swaps the subvolume and would invalidate their working directory.
-    let ws_path_str = ws.index.workspace_path.to_string_lossy().to_string();
-    if let Some(resp) = crate::util::guard_cwd_occupants(&ws_path_str).await {
-        return Ok(resp);
-    }
-
     // 5. Rollback via backend (includes warmup, snapshot, cleanup)
     state.backend.rollback(&ws.ws_id, &resolved_id).await?;
 
-    // 6. Return success
     Ok(Response::RollbackOk {
         from: ws.ws_id.clone(),
         to: resolved_id,

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -115,13 +115,13 @@ pub async fn rollback(
     workspace: &str,
     to: &str,
 ) -> anyhow::Result<Response> {
-    // 1. Resolve workspace (by ID, absolute path, or relative path)
+    // 1. Resolve workspace
     let arc = match state.resolve_workspace(workspace).await {
         Some(a) => a,
         None => return Ok(workspace_not_found(workspace)),
     };
 
-    // 2. Acquire write lock
+    // 2. Write lock: validate snapshot → cwd guard → execute rollback
     let ws = arc.write().await;
 
     // 3. Resolve target snapshot by prefix
@@ -141,7 +141,7 @@ pub async fn rollback(
         }
     };
 
-    // 3a. Reject missing snapshots — user must manually delete with --force
+    // Reject missing snapshots — user must manually delete with --force
     if ws
         .index
         .snapshots
@@ -154,8 +154,12 @@ pub async fn rollback(
         });
     }
 
-    // 4. Construct paths
-    let _abs_path_str = ws.path.to_string_lossy().to_string();
+    // 4. Refuse if any process holds a cwd inside the workspace — rollback
+    //    swaps the subvolume and would invalidate their working directory.
+    let ws_path_str = ws.index.workspace_path.to_string_lossy().to_string();
+    if let Some(resp) = crate::util::guard_cwd_occupants(&ws_path_str).await {
+        return Ok(resp);
+    }
 
     // 5. Rollback via backend (includes warmup, snapshot, cleanup)
     state.backend.rollback(&ws.ws_id, &resolved_id).await?;

--- a/src/ws-ckpt/src/crates/daemon/src/util.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/util.rs
@@ -153,6 +153,257 @@ async fn rebuild_symlink(ws_path: &str, expected_subvol_path: &Path) {
     }
 }
 
+// cwd occupant guard.
+//
+// Scans /proc for processes whose cwd resolves into the workspace (including
+// bind-mount aliases derived from /proc/self/mountinfo). Cannot detect
+// cross-namespace occupants: /proc/<pid>/cwd reports paths in the target's
+// own mount namespace, which are not comparable to the daemon's view.
+
+#[derive(Debug)]
+pub(crate) enum CwdScanError {
+    Canonicalize(std::io::Error),
+    ProcRead(std::io::Error),
+    MountinfoRead(std::io::Error),
+}
+
+impl std::fmt::Display for CwdScanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CwdScanError::Canonicalize(e) => {
+                write!(f, "canonicalize workspace failed: {}", e)
+            }
+            CwdScanError::ProcRead(e) => write!(f, "read /proc failed: {}", e),
+            CwdScanError::MountinfoRead(e) => {
+                write!(f, "read /proc/self/mountinfo failed: {}", e)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MountEntry {
+    dev: String,
+    fs_root: String,
+    mountpoint: String,
+}
+
+/// Parse /proc/self/mountinfo: `mount_id parent_id major:minor root mountpoint ...`
+fn parse_mountinfo(content: &str) -> Vec<MountEntry> {
+    let mut out = Vec::new();
+    for line in content.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 5 {
+            continue;
+        }
+        let dev = parts[2].to_string();
+        let fs_root = unescape_proc_mount(parts[3]);
+        let mountpoint = unescape_proc_mount(parts[4]);
+        if !dev.contains(':') || !fs_root.starts_with('/') || !mountpoint.starts_with('/') {
+            continue;
+        }
+        out.push(MountEntry {
+            dev,
+            fs_root,
+            mountpoint,
+        });
+    }
+    out
+}
+
+/// All absolute paths through which `ws_abs` is reachable in the current
+/// mount namespace (bind-mount aliases included). Always contains `ws_abs`.
+fn derive_workspace_aliases(ws_abs: &str, mounts: &[MountEntry]) -> Vec<String> {
+    let mut aliases = vec![ws_abs.to_string()];
+
+    let host = mounts
+        .iter()
+        .filter(|m| {
+            m.mountpoint == ws_abs
+                || ws_abs.starts_with(&format!("{}/", m.mountpoint.trim_end_matches('/')))
+        })
+        .max_by_key(|m| m.mountpoint.len());
+    let Some(host) = host else { return aliases };
+
+    let suffix = if ws_abs == host.mountpoint {
+        String::new()
+    } else {
+        ws_abs[host.mountpoint.len()..]
+            .trim_start_matches('/')
+            .to_string()
+    };
+    let ws_inside_fs = if host.fs_root == "/" {
+        format!("/{}", suffix)
+    } else if suffix.is_empty() {
+        host.fs_root.clone()
+    } else {
+        format!("{}/{}", host.fs_root.trim_end_matches('/'), suffix)
+    };
+    let ws_inside_fs = ws_inside_fs.trim_end_matches('/').to_string();
+    let ws_inside_fs = if ws_inside_fs.is_empty() {
+        "/".to_string()
+    } else {
+        ws_inside_fs
+    };
+
+    for m in mounts {
+        if m.dev != host.dev {
+            continue;
+        }
+        let covers = m.fs_root == ws_inside_fs
+            || ws_inside_fs.starts_with(&format!("{}/", m.fs_root.trim_end_matches('/')));
+        if !covers {
+            continue;
+        }
+        let inner = if m.fs_root == ws_inside_fs {
+            String::new()
+        } else if m.fs_root == "/" {
+            ws_inside_fs.trim_start_matches('/').to_string()
+        } else {
+            ws_inside_fs[m.fs_root.trim_end_matches('/').len()..]
+                .trim_start_matches('/')
+                .to_string()
+        };
+        let alias = if inner.is_empty() {
+            m.mountpoint.clone()
+        } else if m.mountpoint == "/" {
+            format!("/{}", inner)
+        } else {
+            format!("{}/{}", m.mountpoint.trim_end_matches('/'), inner)
+        };
+        if !aliases.contains(&alias) {
+            aliases.push(alias);
+        }
+    }
+
+    aliases
+}
+
+async fn read_mountinfo() -> Result<Vec<MountEntry>, CwdScanError> {
+    let content = tokio::fs::read_to_string("/proc/self/mountinfo")
+        .await
+        .map_err(CwdScanError::MountinfoRead)?;
+    Ok(parse_mountinfo(&content))
+}
+
+fn cwd_matches_any_alias(cwd: &str, aliases: &[String]) -> bool {
+    for alias in aliases {
+        if cwd == alias {
+            return true;
+        }
+        let prefix = if alias.ends_with('/') {
+            alias.clone()
+        } else {
+            format!("{}/", alias)
+        };
+        if cwd.starts_with(&prefix) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Per-entry errors are skipped (PID exit / EPERM are normal on /proc churn);
+/// scan-level failures return `CwdScanError` and the caller must treat the
+/// scan as inconclusive.
+pub(crate) async fn find_cwd_occupants(
+    workspace: &str,
+) -> Result<Vec<(u32, String)>, CwdScanError> {
+    let ws = tokio::fs::canonicalize(workspace)
+        .await
+        .map_err(CwdScanError::Canonicalize)?;
+    let ws_str = ws.to_string_lossy().to_string();
+
+    let mounts = read_mountinfo().await?;
+    let aliases = derive_workspace_aliases(&ws_str, &mounts);
+
+    let mut occupants = Vec::new();
+    let mut entries = tokio::fs::read_dir("/proc")
+        .await
+        .map_err(CwdScanError::ProcRead)?;
+
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(e)) => e,
+            Ok(None) => break,
+            Err(_) => continue,
+        };
+
+        let name = entry.file_name();
+        let Ok(pid) = name.to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+
+        let Ok(target) = tokio::fs::read_link(format!("/proc/{}/cwd", pid)).await else {
+            continue;
+        };
+        let target_str = target.to_string_lossy().to_string();
+        // Orphan cwd from a previously crashed swap: kernel marks the dentry
+        // " (deleted)". The process is already broken; a new swap can't make
+        // it worse, so guard stays purely preventive and skips it. Must skip
+        // before the matcher — "/ws/src (deleted)" would otherwise prefix-
+        // match alias "/ws".
+        if target_str.ends_with(" (deleted)") {
+            continue;
+        }
+        if cwd_matches_any_alias(&target_str, &aliases) {
+            occupants.push((pid, target_str));
+        }
+    }
+
+    Ok(occupants)
+}
+
+/// Returns None (proceed) or an error response.
+/// Confirmed occupants → `CwdOccupied`; scan failures → `CwdScanFailed`.
+pub(crate) async fn guard_cwd_occupants(workspace: &str) -> Option<ws_ckpt_common::Response> {
+    let occupants = match find_cwd_occupants(workspace).await {
+        Ok(list) => list,
+        Err(err) => {
+            warn!(
+                "cwd scan failed for {}: {} — refusing (fail-closed)",
+                workspace, err
+            );
+            return Some(ws_ckpt_common::Response::Error {
+                code: ws_ckpt_common::ErrorCode::CwdScanFailed,
+                message: format!(
+                    "Refused: cwd scan failed ({}). \
+                     The /proc scan could not complete, so occupant status is unknown; \
+                     this is typically transient and the operation may succeed on retry.",
+                    err
+                ),
+            });
+        }
+    };
+
+    if occupants.is_empty() {
+        return None;
+    }
+
+    let detail: Vec<String> = occupants
+        .iter()
+        .map(|(pid, cwd)| format!("PID {} (cwd={})", pid, cwd))
+        .collect();
+
+    warn!(
+        "cwd occupant guard: {} process(es) with cwd inside {}: [{}]",
+        occupants.len(),
+        workspace,
+        detail.join(", ")
+    );
+
+    Some(ws_ckpt_common::Response::Error {
+        code: ws_ckpt_common::ErrorCode::CwdOccupied,
+        message: format!(
+            "Refused: {} process(es) have cwd inside workspace: {}. \
+             Symlink swap would invalidate their cwd. \
+             Move affected processes out of the workspace before retrying.",
+            occupants.len(),
+            detail.join("; "),
+        ),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,5 +434,127 @@ mod tests {
     fn unescape_non_octal_digit_left_literal() {
         // `\089` — '8' is not octal, sequence left untouched.
         assert_eq!(unescape_proc_mount("/x\\089"), "/x\\089");
+    }
+
+    #[test]
+    fn parse_mountinfo_basic_line() {
+        let line = "36 35 8:1 /home/admin /elsewhere rw,relatime shared:5 - ext4 /dev/sda1 rw";
+        let entries = parse_mountinfo(line);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].dev, "8:1");
+        assert_eq!(entries[0].fs_root, "/home/admin");
+        assert_eq!(entries[0].mountpoint, "/elsewhere");
+    }
+
+    #[test]
+    fn parse_mountinfo_skips_malformed_lines() {
+        let input = "\
+36 35 8:1 / /mnt rw - ext4 /dev/sda1 rw
+not enough fields
+123 broken dev field /a /b
+37 35 8:1 / /other rw - ext4 /dev/sda1 rw
+";
+        let entries = parse_mountinfo(input);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].mountpoint, "/mnt");
+        assert_eq!(entries[1].mountpoint, "/other");
+    }
+
+    #[test]
+    fn parse_mountinfo_decodes_octal_escapes() {
+        let line = "36 35 8:1 /home/with\\040space /mnt/dir\\040name rw - ext4 /dev/sda1 rw";
+        let entries = parse_mountinfo(line);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].fs_root, "/home/with space");
+        assert_eq!(entries[0].mountpoint, "/mnt/dir name");
+    }
+
+    fn mount(dev: &str, fs_root: &str, mountpoint: &str) -> MountEntry {
+        MountEntry {
+            dev: dev.to_string(),
+            fs_root: fs_root.to_string(),
+            mountpoint: mountpoint.to_string(),
+        }
+    }
+
+    #[test]
+    fn aliases_canonical_path_when_no_binds() {
+        let mounts = vec![mount("8:1", "/", "/")];
+        let aliases = derive_workspace_aliases("/home/admin", &mounts);
+        assert_eq!(aliases, vec!["/home/admin".to_string()]);
+    }
+
+    #[test]
+    fn aliases_detects_simple_bind_mount() {
+        let mounts = vec![
+            mount("8:1", "/", "/"),
+            mount("8:1", "/home/admin", "/elsewhere"),
+        ];
+        let aliases = derive_workspace_aliases("/home/admin", &mounts);
+        assert!(aliases.contains(&"/home/admin".to_string()));
+        assert!(aliases.contains(&"/elsewhere".to_string()));
+    }
+
+    #[test]
+    fn aliases_detects_ancestor_bind_mount() {
+        // mount --bind /home /mnt/home → workspace /home/admin becomes /mnt/home/admin
+        let mounts = vec![mount("8:1", "/", "/"), mount("8:1", "/home", "/mnt/home")];
+        let aliases = derive_workspace_aliases("/home/admin", &mounts);
+        assert!(aliases.contains(&"/mnt/home/admin".to_string()));
+    }
+
+    #[test]
+    fn aliases_separate_filesystem_mounted_workspace() {
+        // Workspace on separate fs; bind-exposed at /backup.
+        let mounts = vec![
+            mount("8:1", "/", "/"),
+            mount("8:32", "/", "/data"),
+            mount("8:32", "/", "/backup"),
+        ];
+        let aliases = derive_workspace_aliases("/data/ws", &mounts);
+        assert!(aliases.contains(&"/backup/ws".to_string()));
+    }
+
+    #[test]
+    fn aliases_ignores_different_device() {
+        let mounts = vec![
+            mount("8:1", "/", "/"),
+            mount("8:99", "/home/admin", "/decoy"),
+        ];
+        let aliases = derive_workspace_aliases("/home/admin", &mounts);
+        assert!(!aliases.contains(&"/decoy".to_string()));
+    }
+
+    #[test]
+    fn cwd_matches_alias_exact_and_subdir() {
+        let aliases = vec!["/home/admin".to_string(), "/elsewhere".to_string()];
+        assert!(cwd_matches_any_alias("/home/admin", &aliases));
+        assert!(cwd_matches_any_alias("/home/admin/src", &aliases));
+        assert!(cwd_matches_any_alias("/elsewhere", &aliases));
+        assert!(cwd_matches_any_alias("/elsewhere/deep/path", &aliases));
+    }
+
+    #[test]
+    fn cwd_does_not_match_sibling_prefix() {
+        // Regression: /home/administrator must not match alias /home/admin.
+        let aliases = vec!["/home/admin".to_string()];
+        assert!(!cwd_matches_any_alias("/home/administrator", &aliases));
+        assert!(!cwd_matches_any_alias("/home/administrator/foo", &aliases));
+    }
+
+    #[test]
+    fn cwd_does_not_match_unrelated_path() {
+        let aliases = vec!["/home/admin".to_string()];
+        assert!(!cwd_matches_any_alias("/tmp", &aliases));
+        assert!(!cwd_matches_any_alias("/", &aliases));
+    }
+
+    #[test]
+    fn orphan_cwd_requires_external_skip() {
+        // Bare matcher would match subdirectory orphans — caller must skip
+        // " (deleted)" before invoking the matcher.
+        let aliases = vec!["/home/admin".to_string()];
+        assert!(cwd_matches_any_alias("/home/admin/src (deleted)", &aliases));
+        assert!("/home/admin/src (deleted)".ends_with(" (deleted)"));
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -242,6 +242,12 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
         ));
     }
 
+    let abs_path_str = abs_path.to_string_lossy().to_string();
+
+    if let Some(resp) = crate::util::guard_cwd_occupants(&abs_path_str).await {
+        return Ok(resp);
+    }
+
     // Check rsync available
     let rsync_check = Command::new("which")
         .arg("rsync")
@@ -264,8 +270,6 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
         ws_id = format!("{}-{}", base_id, suffix);
         suffix += 1;
     }
-
-    let abs_path_str = abs_path.to_string_lossy().to_string();
 
     // Steps 4-11 via backend, with cleanup handled internally
     if let Err(e) = state.backend.init_workspace(&abs_path_str, &ws_id).await {
@@ -447,6 +451,9 @@ pub async fn recover_workspace(
         let ws = ws_lock.read().await;
         (ws.ws_id.clone(), ws.path.to_string_lossy().to_string())
     };
+
+    // Intentionally no cwd guard: recover is a terminal "tear out" operation
+    // gated by CLI ConfirmationRequired. The CLI prompt is the contract.
 
     // 3. call backend recover
     state

--- a/src/ws-ckpt/src/plugins/hermes/__init__.py
+++ b/src/ws-ckpt/src/plugins/hermes/__init__.py
@@ -52,26 +52,26 @@ def _get_manager() -> CheckpointManager:
 # subvolume symlink, then later snapshot/rollback recreates it), so any process
 # holding cwd inside the workspace will get ENOENT on the next getcwd(). Refuse
 # instead of silently producing broken state.
-CWD_INSIDE_WORKSPACE_REASON = (
-    "The hosting process's cwd is inside the workspace. "
-    "ws-ckpt replaces the workspace inode during init/checkpoint/rollback, "
-    "which would invalidate the process cwd. "
-    "The user must launch the session from outside the workspace directory."
-)
+def _cwd_inside_workspace_reason(cwd: str, workspace: str) -> str:
+    return (
+        f"Refused: cwd={cwd} is inside workspace={workspace}. "
+        "ws-ckpt replaces the workspace inode during init/checkpoint/rollback, "
+        "which would invalidate the process cwd. "
+        "The user must launch the session from outside the workspace directory."
+    )
 
 
-def _cwd_inside_workspace(workspace: str) -> bool:
-    """Return True when the current cwd is the workspace itself or a descendant."""
+def _cwd_inside_workspace(workspace: str) -> tuple[bool, str]:
+    """Return (inside, cwd) — whether the current cwd is the workspace or a descendant."""
     try:
         cwd = Path(os.getcwd()).resolve()
     except (FileNotFoundError, OSError):
-        # cwd already invalid — caller decides what to do; we can't prove containment.
-        return False
+        return False, ""
     try:
         ws_path = Path(workspace).resolve()
     except (FileNotFoundError, OSError):
-        return False
-    return cwd == ws_path or ws_path in cwd.parents
+        return False, str(cwd)
+    return cwd == ws_path or ws_path in cwd.parents, str(cwd)
 
 
 # ---------------------------------------------------------------------------
@@ -94,11 +94,11 @@ def _on_session_start(session_id: str = "", model: str = "", **_: Any) -> None:
         )
         return
 
-    if _cwd_inside_workspace(manager.config.workspace):
-        # Disable for this session so on_session_end stops trying too.
+    inside, cwd = _cwd_inside_workspace(manager.config.workspace)
+    if inside:
         manager.set_auto_checkpoint(False)
         print(
-            f"[ws-ckpt] Refusing auto-checkpoint: {CWD_INSIDE_WORKSPACE_REASON}",
+            f"[ws-ckpt] Refusing auto-checkpoint: {_cwd_inside_workspace_reason(cwd, manager.config.workspace)}",
             flush=True,
         )
         return

--- a/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
+++ b/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
@@ -50,20 +50,18 @@ def map_error_to_message(stderr: str, context: Optional[Dict[str, Any]] = None) 
 
     lowered = stderr.lower()
 
-    if "not initialized" in lowered:
-        return f"Workspace not initialized for ws-ckpt.{ctx_str}"
     # CLI environment issues take priority over generic "not found" (snapshot)
     if "binary not found" in lowered or "not found on path" in lowered:
         return f"ws-ckpt CLI not found on PATH.{ctx_str}"
-    if "not found" in lowered or "no such" in lowered:
-        return f"Snapshot not found.{ctx_str}"
-    if "daemon" in lowered or "connection" in lowered:
-        return f"ws-ckpt daemon is not responding. Is it running?{ctx_str}"
-    if "permission" in lowered:
-        return f"Permission denied.{ctx_str}"
     if "timeout" in lowered:
         return f"Command timed out.{ctx_str}"
-    # Order matters: scan-failed (retryable) before occupants-present (hard).
+    if "already exists" in lowered:
+        return f"Snapshot already exists in this workspace. Use a different ID.{ctx_str}"
+    if "active write" in lowered or "write operations" in lowered:
+        return f"Workspace has active write operations. Wait a moment and retry.{ctx_str}"
+    if "insufficient" in lowered:
+        return f"Insufficient disk space for snapshot. Delete old snapshots to free space.{ctx_str}"
+    # daemon flattens anyhow chains via `format!("{:#}", e)`, so inner io errors leak generic substrings.
     if "cwd scan failed" in lowered:
         return (
             "ws-ckpt could not scan /proc to verify workspace occupants "
@@ -78,6 +76,12 @@ def map_error_to_message(stderr: str, context: Optional[Dict[str, Any]] = None) 
             "This is NOT retryable. The user must move affected processes out of the workspace."
             f"{ctx_str}"
         )
+    if "daemon is not running" in lowered or "daemon is starting up" in lowered:
+        return f"ws-ckpt daemon is not responding. Is it running?{ctx_str}"
+    if "not found" in lowered and "snapshot" in lowered:
+        return f"Snapshot not found.{ctx_str}"
+    if "not found" in lowered and "workspace" in lowered:
+        return f"Workspace not found.{ctx_str}"
 
     return f"ws-ckpt error: {stderr.strip()}{ctx_str}"
 

--- a/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
+++ b/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
@@ -63,6 +63,21 @@ def map_error_to_message(stderr: str, context: Optional[Dict[str, Any]] = None) 
         return f"Permission denied.{ctx_str}"
     if "timeout" in lowered:
         return f"Command timed out.{ctx_str}"
+    # Order matters: scan-failed (retryable) before occupants-present (hard).
+    if "cwd scan failed" in lowered:
+        return (
+            "ws-ckpt could not scan /proc to verify workspace occupants "
+            "(typically a transient /proc or canonicalize race). "
+            "This is retryable — wait a moment and try again."
+            f"{ctx_str}"
+        )
+    if "have cwd inside workspace" in lowered:
+        return (
+            "Other processes have their working directory inside the workspace. "
+            "ws-ckpt cannot proceed because the symlink swap would break those processes. "
+            "This is NOT retryable. The user must move affected processes out of the workspace."
+            f"{ctx_str}"
+        )
 
     return f"ws-ckpt error: {stderr.strip()}{ctx_str}"
 

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -56,12 +56,13 @@ def _require_workspace() -> Tuple[str, Optional[str]]:
 
 def _reject_if_cwd_inside_workspace(workspace: str) -> Optional[str]:
     """Return a serialized error response when cwd is inside workspace, else None."""
-    from . import CWD_INSIDE_WORKSPACE_REASON, _cwd_inside_workspace  # lazy
+    from . import _cwd_inside_workspace, _cwd_inside_workspace_reason  # lazy
 
-    if _cwd_inside_workspace(workspace):
+    inside, cwd = _cwd_inside_workspace(workspace)
+    if inside:
         return _json({
             "success": False,
-            "error": CWD_INSIDE_WORKSPACE_REASON,
+            "error": _cwd_inside_workspace_reason(cwd, workspace),
             "retryable": False,
         })
     return None

--- a/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
@@ -31,13 +31,7 @@ export function mapErrorToLLMMessage(stderr: string, context?: { id?: string }):
   if (stderr.includes('Insufficient disk space') || stderr.includes('insufficient')) {
     return 'Insufficient disk space for snapshot. Delete old snapshots to free space.';
   }
-  if (stderr.includes('not found') && stderr.toLowerCase().includes('snapshot')) {
-    return `Snapshot '${context?.id ?? 'unknown'}' not found. Use ws-ckpt-list to view available snapshots.`;
-  }
-  if (stderr.includes('not found') && stderr.toLowerCase().includes('workspace')) {
-    return 'Workspace not found. Use ws-ckpt-init to initialize first.';
-  }
-  // Order matters: scan-failed (retryable) before occupants-present (hard).
+  // daemon flattens anyhow chains via `format!("{:#}", e)`, so inner io errors leak generic substrings.
   if (stderr.includes('cwd scan failed')) {
     return 'ws-ckpt could not scan /proc to verify workspace occupants ' +
       '(typically a transient /proc/canonicalize race). ' +
@@ -47,6 +41,15 @@ export function mapErrorToLLMMessage(stderr: string, context?: { id?: string }):
     return 'Other processes have their working directory inside the workspace. ' +
       'ws-ckpt cannot proceed because the symlink swap would break those processes. ' +
       'This is NOT retryable. The user must move affected processes out of the workspace.';
+  }
+  if (stderr.includes('daemon is not running') || stderr.includes('daemon is starting up')) {
+    return 'ws-ckpt daemon is not responding. Is it running?';
+  }
+  if (stderr.includes('not found') && stderr.toLowerCase().includes('snapshot')) {
+    return `Snapshot '${context?.id ?? 'unknown'}' not found. Use ws-ckpt-list to view available snapshots.`;
+  }
+  if (stderr.includes('not found') && stderr.toLowerCase().includes('workspace')) {
+    return 'Workspace not found. Use ws-ckpt-init to initialize first.';
   }
   // Default: return original stderr cleaned of ANSI codes
   return stderr.replace(/\x1b\[[0-9;]*m/g, '').trim();

--- a/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
@@ -37,6 +37,17 @@ export function mapErrorToLLMMessage(stderr: string, context?: { id?: string }):
   if (stderr.includes('not found') && stderr.toLowerCase().includes('workspace')) {
     return 'Workspace not found. Use ws-ckpt-init to initialize first.';
   }
+  // Order matters: scan-failed (retryable) before occupants-present (hard).
+  if (stderr.includes('cwd scan failed')) {
+    return 'ws-ckpt could not scan /proc to verify workspace occupants ' +
+      '(typically a transient /proc/canonicalize race). ' +
+      'This is retryable — wait a moment and try again.';
+  }
+  if (stderr.includes('have cwd inside workspace')) {
+    return 'Other processes have their working directory inside the workspace. ' +
+      'ws-ckpt cannot proceed because the symlink swap would break those processes. ' +
+      'This is NOT retryable. The user must move affected processes out of the workspace.';
+  }
   // Default: return original stderr cleaned of ANSI codes
   return stderr.replace(/\x1b\[[0-9;]*m/g, '').trim();
 }

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -8,7 +8,7 @@
 import { CommandExecutor } from "./commands.js";
 import { mapErrorToLLMMessage } from "./btrfs-manager.js";
 import type { AgentToolResult } from "../types-shim.js";
-import { pluginState, UNAVAILABLE_MSG, cwdInsideWorkspace, CWD_INSIDE_WORKSPACE_REASON } from "./state.js";
+import { pluginState, UNAVAILABLE_MSG, cwdInsideWorkspace, cwdInsideWorkspaceReason } from "./state.js";
 import { daemonAutoCleanup } from "./config.js";
 
 // ---------------------------------------------------------------------------
@@ -47,8 +47,9 @@ export async function handleCheckpoint(
   // Explicit workspace bypasses the manager (and its workspace-bound cache),
   // mirroring the handleDelete pattern.
   if (explicitWs) {
-    if (cwdInsideWorkspace(explicitWs)) {
-      return { text: CWD_INSIDE_WORKSPACE_REASON, isError: true };
+    const cwdCheck = cwdInsideWorkspace(explicitWs);
+    if (cwdCheck.inside) {
+      return { text: cwdInsideWorkspaceReason(cwdCheck.cwd, explicitWs), isError: true };
     }
     try {
       const executor = new CommandExecutor();
@@ -67,8 +68,11 @@ export async function handleCheckpoint(
   }
 
   const ws = pluginState.resolvedConfig?.workspace;
-  if (ws && cwdInsideWorkspace(ws)) {
-    return { text: CWD_INSIDE_WORKSPACE_REASON, isError: true };
+  if (ws) {
+    const cwdCheck = cwdInsideWorkspace(ws);
+    if (cwdCheck.inside) {
+      return { text: cwdInsideWorkspaceReason(cwdCheck.cwd, ws), isError: true };
+    }
   }
 
   const result = await pluginState.manager.createCheckpoint({
@@ -98,8 +102,9 @@ export async function handleRollback(
 
   const explicitWs = workspace?.trim();
   if (explicitWs) {
-    if (cwdInsideWorkspace(explicitWs)) {
-      return { text: CWD_INSIDE_WORKSPACE_REASON, isError: true };
+    const cwdCheck = cwdInsideWorkspace(explicitWs);
+    if (cwdCheck.inside) {
+      return { text: cwdInsideWorkspaceReason(cwdCheck.cwd, explicitWs), isError: true };
     }
     try {
       const executor = new CommandExecutor();
@@ -115,8 +120,11 @@ export async function handleRollback(
   }
 
   const ws = pluginState.resolvedConfig?.workspace;
-  if (ws && cwdInsideWorkspace(ws)) {
-    return { text: CWD_INSIDE_WORKSPACE_REASON, isError: true };
+  if (ws) {
+    const cwdCheck = cwdInsideWorkspace(ws);
+    if (cwdCheck.inside) {
+      return { text: cwdInsideWorkspaceReason(cwdCheck.cwd, ws), isError: true };
+    }
   }
 
   const result = await pluginState.manager.rollback(trimmed);
@@ -323,8 +331,11 @@ export async function handleConfig(
       const coerced = value === "true";
       if (coerced) {
         const ws = pluginState.resolvedConfig.workspace;
-        if (ws && cwdInsideWorkspace(ws)) {
-          return { text: CWD_INSIDE_WORKSPACE_REASON, isError: true };
+        if (ws) {
+          const cwdCheck = cwdInsideWorkspace(ws);
+          if (cwdCheck.inside) {
+            return { text: cwdInsideWorkspaceReason(cwdCheck.cwd, ws), isError: true };
+          }
         }
       }
       pluginState.resolvedConfig.autoCheckpoint = coerced;

--- a/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
@@ -9,7 +9,7 @@
 import crypto from "node:crypto";
 import type { OpenClawPluginApi, PluginHookMessageReceivedEvent } from "../types-shim.js";
 import type { PluginConfig } from "./types.js";
-import { pluginState, cwdInsideWorkspace, CWD_INSIDE_WORKSPACE_REASON } from "./state.js";
+import { pluginState, cwdInsideWorkspace, cwdInsideWorkspaceReason } from "./state.js";
 import { mapErrorToLLMMessage } from "./btrfs-manager.js";
 
 // ---------------------------------------------------------------------------
@@ -55,9 +55,10 @@ export function registerHooks(api: OpenClawPluginApi, config: PluginConfig): voi
     if (!pluginState.manager || !pluginState.environmentReady) return;
 
     const workspace = pluginState.resolvedConfig?.workspace;
-    if (workspace && cwdInsideWorkspace(workspace)) {
+    const cwdCheckEnd = workspace ? cwdInsideWorkspace(workspace) : undefined;
+    if (cwdCheckEnd?.inside) {
       config.autoCheckpoint = false;
-      console.warn(`[ws-ckpt] Disabling auto-checkpoint: ${CWD_INSIDE_WORKSPACE_REASON}`);
+      console.warn(`[ws-ckpt] Disabling auto-checkpoint: ${cwdInsideWorkspaceReason(cwdCheckEnd.cwd, workspace!)}`);
     } else {
       const snapshotId = crypto.randomUUID().slice(0, 8);
       const message = tracker.getLastUserMessage() ?? "turn end";
@@ -87,9 +88,10 @@ export function registerHooks(api: OpenClawPluginApi, config: PluginConfig): voi
     const workspace = pluginState.resolvedConfig?.workspace;
     if (!pluginState.manager || !pluginState.environmentReady || !workspace) return;
 
-    if (cwdInsideWorkspace(workspace)) {
+    const cwdCheckStart = cwdInsideWorkspace(workspace);
+    if (cwdCheckStart.inside) {
       config.autoCheckpoint = false;
-      console.warn(`[ws-ckpt] Disabling auto-checkpoint: ${CWD_INSIDE_WORKSPACE_REASON}`);
+      console.warn(`[ws-ckpt] Disabling auto-checkpoint: ${cwdInsideWorkspaceReason(cwdCheckStart.cwd, workspace)}`);
     } else {
       try {
         await pluginState.manager.initialize(workspace);

--- a/src/ws-ckpt/src/plugins/openclaw/src/index.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/index.ts
@@ -19,7 +19,7 @@ import {
   definePluginEntry,
   type OpenClawPluginApi,
 } from "../types-shim.js";
-import { pluginState, cwdInsideWorkspace, CWD_INSIDE_WORKSPACE_REASON } from "./state.js";
+import { pluginState, cwdInsideWorkspace, cwdInsideWorkspaceReason } from "./state.js";
 import { registerTools } from "./tool-registry.js";
 import { registerHooks } from "./hooks.js";
 import { ensureToolsAlsoAllow } from "./whitelist.js";
@@ -83,9 +83,10 @@ function register(api: OpenClawPluginApi): void {
       return;
     }
 
-    if (cwdInsideWorkspace(config.workspace)) {
+    const cwdCheck = cwdInsideWorkspace(config.workspace);
+    if (cwdCheck.inside) {
       pluginState.environmentReady = false;
-      console.warn(`[ws-ckpt] Refusing: ${CWD_INSIDE_WORKSPACE_REASON}`);
+      console.warn(`[ws-ckpt] Refusing: ${cwdInsideWorkspaceReason(cwdCheck.cwd, config.workspace)}`);
     } else {
       try {
         const ok = await pluginState.manager!.ensureWorkspace(config.workspace);

--- a/src/ws-ckpt/src/plugins/openclaw/src/state.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/state.ts
@@ -36,20 +36,23 @@ export const pluginState = {
 export const UNAVAILABLE_MSG =
   "ws-ckpt plugin is not available. Run environment check for details.";
 
-export const CWD_INSIDE_WORKSPACE_REASON =
-  "The hosting process's cwd is inside the workspace. " +
-  "ws-ckpt replaces the workspace inode during init/checkpoint/rollback, " +
-  "which would invalidate the process cwd. " +
-  "This is NOT retryable — do NOT call any ws-ckpt tool again in this session. " +
-  "The user must launch the session from outside the workspace directory.";
+export function cwdInsideWorkspaceReason(cwd: string, workspace: string): string {
+  return (
+    `Refused: cwd=${cwd} is inside workspace=${workspace}. ` +
+    "ws-ckpt replaces the workspace inode during init/checkpoint/rollback, " +
+    "which would invalidate the process cwd. " +
+    "This is NOT retryable — do NOT call any ws-ckpt tool again in this session. " +
+    "The user must launch the session from outside the workspace directory."
+  );
+}
 
-export function cwdInsideWorkspace(workspace: string): boolean {
+export function cwdInsideWorkspace(workspace: string): { inside: boolean; cwd: string } {
   let cwd: string;
   try {
     cwd = path.resolve(process.cwd());
   } catch {
-    return false;
+    return { inside: false, cwd: "" };
   }
   const ws = path.resolve(workspace);
-  return cwd === ws || cwd.startsWith(ws + path.sep);
+  return { inside: cwd === ws || cwd.startsWith(ws + path.sep), cwd };
 }

--- a/src/ws-ckpt/src/skills/ws-ckpt/SKILL.md
+++ b/src/ws-ckpt/src/skills/ws-ckpt/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: ws-ckpt
 description: >
-  工作区快照管理。用户说"保存一下"、"存个快照"时创建 checkpoint;
+  工作区快照管理。用户说"保存一下"、"存个快照"时创建 checkpoint，仅限 Linux;
   说"回滚"、"撤销"、"恢复到之前"时 rollback;说"删掉快照"时 delete;
   说"看看快照"、"有哪些快照"时 list;说"查看快照状态"、"查看快照剩余空间"时 status。
 ---
-
 # ws-ckpt 工作区快照管理
 
 基于 btrfs COW 快照,为任意工作区提供微秒级 checkpoint/rollback。
@@ -13,18 +12,17 @@ description: >
 ## 工作区路径（关键 — 必须遵守）
 
 ⚠️ **绝对禁止猜测或推断工作区路径。**
-⚠️ **绝对禁止工作区路径是 cwd 或 cwd 的父路径**
-如果工作区路径是 cwd 或 cwd 的父路径，拒绝执行
 
 ws-ckpt 的所有命令都需要 `-w <workspace>` 指定工作区路径。执行任何命令前，必须按以下顺序确定 `-w` 参数：
 
 1. 用户在**当前消息中明确给出**了路径 → 直接使用
 2. 否则 → **必须向用户询问**："请提供工作区路径（传给 `-w` 的目录）"，拿到回复后再执行
-3. 工作区路径**不可以**是 hosting process 的 cwd 或 cwd 的父路径
 
 不得从环境变量、默认路径、或任何隐含上下文中猜测。
 
 确定后，本次会话内复用同一个 workspace 路径，不要重复询问。
+
+cwd 占用的拦截由 daemon 层统一处理,skill 不再做前置守卫。
 
 ## 触发规则
 
@@ -40,9 +38,6 @@ ws-ckpt 的所有命令都需要 `-w <workspace>` 指定工作区路径。执行
 
 ### checkpoint — 创建快照
 
-⚠️ **绝对禁止工作区路径是 cwd 或 cwd 的父路径**
-如果工作区路径是 cwd 或 cwd 的父路径，拒绝执行
-
 ```bash
 ws-ckpt checkpoint -w <workspace> -i <id> [-m <message>]
 ```
@@ -56,9 +51,6 @@ ws-ckpt checkpoint -w <path-to-workspace> -i before-refactor -m "重构前备份
 ```
 
 ### rollback — 回滚到快照
-
-⚠️ **绝对禁止工作区路径是 cwd 或 cwd 的父路径**
-如果工作区路径是 cwd 或 cwd 的父路径，拒绝执行
 
 ```bash
 ws-ckpt rollback -w <workspace> -s <snapshot>

--- a/src/ws-ckpt/ws-ckpt.spec.in
+++ b/src/ws-ckpt/ws-ckpt.spec.in
@@ -79,6 +79,7 @@ install -p -m 0755 scripts/uninstall-hermes.sh %{buildroot}%{_datadir}/anolisa/a
 %doc README.md
 %attr(0755,root,root) %{_localbindir}/ws-ckpt
 %{_unitdir}/ws-ckpt.service
+%dir /etc/ws-ckpt
 /etc/ws-ckpt/config.toml.sample
 %dir %{_datadir}/anolisa/runtime
 %dir %{_datadir}/anolisa/runtime/skills
@@ -89,7 +90,10 @@ install -p -m 0755 scripts/uninstall-hermes.sh %{buildroot}%{_datadir}/anolisa/a
 %post
 if [ $1 -ge 2 ]; then
     # Upgrade: try remove legacy binary from old FHS path
-    rm -f %{_bindir}/ws-ckpt 2>/dev/null || true
+    if [ -e %{_bindir}/ws-ckpt ] && \
+       rpm -qf %{_bindir}/ws-ckpt 2>/dev/null | grep -q '^ws-ckpt-[0-9]'; then
+        rm -f %{_bindir}/ws-ckpt
+    fi
 fi
 systemctl daemon-reload
 systemctl enable ws-ckpt.service
@@ -111,20 +115,17 @@ fi
 
 %postun
 if [ $1 -eq 0 ]; then
-    # BtrfsLoop backend: umount, release loop, remove img.
+    # BtrfsLoop backend: umount, detach loop, then wipe state dirs.
     # The daemon may have been serving on either the canonical FHS path or
     # the pre-FHS legacy path (when migration was deferred); clean up both.
     umount /mnt/btrfs-workspace 2>/dev/null || true
     for img in /var/lib/ws-ckpt/btrfs-data.img /data/ws-ckpt/btrfs-data.img; do
         losetup -j "$img" 2>/dev/null | \
             cut -d: -f1 | xargs -r losetup -d 2>/dev/null || true
-        rm -f "$img" 2>/dev/null || true
     done
     rmdir /mnt/btrfs-workspace 2>/dev/null || true
-    rmdir /data/ws-ckpt 2>/dev/null || true
     # Remove daemon runtime state to avoid stale state on reinstall
-    rm -f /var/lib/ws-ckpt/state.json /var/lib/ws-ckpt/daemon.lock 2>/dev/null || true
-    rmdir /var/lib/ws-ckpt 2>/dev/null || true
+    rm -rf /var/lib/ws-ckpt /data/ws-ckpt 2>/dev/null || true
     systemctl daemon-reload
 fi
 


### PR DESCRIPTION
## Description

### 总述
- daemon 层新增 /proc cwd 占用守卫:init/rollback 检测到工作区(含 bind-mount 别名)内有进程的 cwd 时拒绝执行,防止 symlink swap 静默作废活进程的 cwd
- skill 同步删除 prompt 层的 cwd 拦截(daemon 已统一接管),并标注 skill 仅限 Linux
- RPM 打包清理:让 RPM 拥有 /etc/ws-ckpt 目录;%post 仅在 /usr/bin/ws-ckpt 确实归属旧 ws-ckpt 包时才删;%postun 用 rm -rf 一次性清理 /var/lib/ws-ckpt 和 /data/ws-ckpt 的残留(btrfs-data.img / state.json / daemon.lock)
- 优化「拒绝把 cwd 或父路径作为工作区」的拒绝文案

### cwd 守卫实现设计
#### 问题

`init` / `rollback` 通过 `symlink + rename` 原子替换 workspace 的底层 inode。若其他进程的 cwd 在 workspace 下,swap 后其 cwd 指向已失效的旧 inode,后续相对路径操作要么 `ENOENT` 要么落在错误目录树上,进程自身无任何信号能感知。

现有防护仅覆盖**自身进程**(TS 层 `cwdInsideWorkspace`)或**仅查 fd**(`fuser -m`,且只在 image shrink 路径用)。init / rollback 的 swap 没有针对"其他进程 cwd"的检查。

#### 方案

daemon 侧在 swap 之前全量扫描 `/proc/*/cwd`,命中则拒绝。

- **为何 daemon 侧**:swap 的最终执行点,一次实现覆盖所有调用方(CLI / OpenClaw / Hermes)
- **为何全量 /proc**:`readlink(/proc/<pid>/cwd)` 是纯内核内存读取,500 进程 <1ms;只查 caller PID 树会漏掉用户终端和其他 ssh session;`fuser` 查 fd 不查 cwd,语义不匹配

#### 关键设计决策

##### 必须覆盖 bind-mount 别名

`mount --bind /home /mnt/home` 后,`/home/admin` 和 `/mnt/home/admin` 是同一 inode。进程若 `cd /mnt/home/admin/src`,其 `/proc/<pid>/cwd` 读出 `/mnt/home/admin/src`,跟 `canonicalize(/home/admin)` 比较不命中,但 swap 仍会让它失效。

解决:解析 `/proc/self/mountinfo`,按"同 dev + fs_root 覆盖 workspace 在该 fs 内的路径"反推所有等价 mountpoint 路径加入 alias 集。匹配用 `cwd == alias || cwd.starts_with(alias + "/")`,末尾 `/` 不可省 — 否则 `/home/administrator` 会误匹配 `/home/admin`(单测 `cwd_does_not_match_sibling_prefix` 守护)。

##### Fail-closed + 两个错误码

scan 失败(canonicalize / mountinfo / readdir 任一步)时占用状态未知。**不放行**,返回 `CwdScanFailed`;真有占用返回 `CwdOccupied`。两码分离让上层正确决策:

| 错误码            | 含义           | 上层动作                         |
| ----------------- | -------------- | -------------------------------- |
| `CwdOccupied`   | 确认有占用进程 | **不可重试**,移走进程      |
| `CwdScanFailed` | 扫描本身失败   | **可重试**,通常 /proc 瞬态 |

合并成单个错误码会让 LLM 无差别行为:要么对真占用无限重试,要么对瞬态失败放弃过早。CLI / OpenClaw / Hermes 三处的 error mapping 都为两码各加一条,**`cwd scan failed` 必须排在 `have cwd inside workspace` 之前**(前者的兜底消息可能也含 workspace 字眼)。

##### 必须先跳过 `" (deleted)"` 再做 alias 匹配

孤儿 cwd(进程被前一次崩溃的 swap 弄坏后内核标记的 `/ws/src (deleted)`)不是本次能预防的目标 — 进程已经坏了。但若不在 alias 匹配前跳过,`/ws/src (deleted)` 会前缀命中 alias `/ws`,产生假阳性。

##### 接入点

| 操作           | 接入位置                                                   | 入参                                                                                      |
| -------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| `init`       | `abs_path` 计算后、`which rsync` 等副作用前            | `abs_path`                                                                              |
| `rollback`   | snapshot 解析与 missing 检查后、`backend.rollback()` 前  | `ws.index.workspace_path`(逻辑路径,**不是** `ws.path` 这个当前 subvol 物理路径) |
| `recover`    | **刻意不接入**,见下                                  |                                                                                           |
| `checkpoint` | 不需要,底层 `btrfs subvolume snapshot -r` 不替换 symlink |                                                                                           |

##### recover 刻意不接入

recover 语义是"ws-ckpt 退出管理、还原为普通目录",是用户主动发起的终态破坏性操作,执行完不再有后续 swap,cwd 失效是一次性可预期代价。契约由 CLI 二次确认承担,提示文案明确说 ws-ckpt **不**做 occupant 检查,要求用户自行 `lsof +D <ws>` 核对。

#### 已知不覆盖

- **跨 mount namespace**(容器内进程):`/proc/<pid>/cwd` 在另一 namespace 不可比较,需 `setns` 进入每个 ns 重解析。在Agent场景下 工作区运行常驻docker的情景很不常见，防守代价远超收益
- **guard → swap 之间 chdir 进来的进程**:TOCTOU 窗口典型 <10ms,中间只有 btrfs 元数据操作。即使发生,受影响进程症状(cwd stale)与无 guard 时完全一致。`fuser`/`umount` 的 busy 检查本质都是 TOCTOU,内核未提供原子 check-and-swap

## Related Issue

closes #669

## Type of Change

<!-- Check all that apply. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

**L1 — 单元/编译(任意机器)**
- `cargo test -p ws-ckpt-daemon --lib util::tests`:12 个新单元覆盖 mountinfo 解析 / alias 推导 / cwd 匹配 / orphan skip
- `cargo test -p ws-ckpt-common response_error_all_codes_round_trip`:含 `CwdOccupied` / `CwdScanFailed`
- openclaw 插件 `npx tsc --noEmit`;hermes 插件 Python AST 检查

**L2 — daemon 集成(Linux + root + btrfs;`./build-rpm.sh && sudo rpm -Uvh --replacepkgs rpmbuild/RPMS/*/ws-ckpt-*.rpm`)**

挑三条典型场景的复现脚本。前置:`WS=/tmp/ws-test`,`mkdir -p $WS && touch $WS/file && sudo ws-ckpt init -w $WS && sudo ws-ckpt checkpoint -w $WS -i snap1`。

① cwd 在 workspace 根 → rollback 拒绝并显示 PID + cwd:
```bash
( cd $WS && sleep 60 ) & SUB_PID=$!; sleep 0.3
sudo ws-ckpt rollback -w $WS -s snap1   # 期望:Refused: 1 process(es) ... PID <SUB_PID> cwd=$WS,退出码非零
kill $SUB_PID
```

② bind-mount 别名也能拦截(核心新功能):
```bash
mkdir -p /tmp/ws-alias && sudo mount --bind $WS /tmp/ws-alias
( cd /tmp/ws-alias && sleep 60 ) & SUB_PID=$!; sleep 0.3
sudo ws-ckpt rollback -w $WS -s snap1   # 期望:拒绝,cwd=/tmp/ws-alias(别名路径)
kill $SUB_PID; sudo umount /tmp/ws-alias
```

③ recover 故意不守(by design,终端态):
```bash
( cd $WS && sleep 60 ) & SUB_PID=$!; sleep 0.3
sudo ws-ckpt recover -w $WS --force     # 期望:成功(退出码 0),Workspace recovered: ...
kill $SUB_PID
```

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
