### PR TITLE
feat(tokenless): add qoder CLI adapter

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -425,7 +425,7 @@ build_tokenless() {
     spec_file=$(process_spec_template "$spec_in" "$version")
 
     log "Step 1/3: Setting up rtk vendored source..."
-    command -v just &>/dev/null || die "'just' is required for RPM build. Install: cargo install just"
+    command -v just &>/dev/null || { err "'just' is required for RPM build. Install: cargo install just"; exit 1; }
     (
         cd "$TOKEN_DIR"
         # Clone rtk into third_party/ (no submodule — uses justfile setup-rtk)
@@ -454,6 +454,7 @@ build_tokenless() {
         --exclude='adapters/tokenless/openclaw/package.json' \
         --exclude='adapters/tokenless/openclaw/openclaw.plugin.json' \
         --exclude='adapters/tokenless/hermes/plugin.yaml' \
+        --exclude='adapters/tokenless/qoder/.qoder-plugin/plugin.json' \
         . | tar -xf - -C "$pkg_dir"
 
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}"

--- a/src/tokenless/.gitignore
+++ b/src/tokenless/.gitignore
@@ -6,3 +6,4 @@ adapters/tokenless/manifest.json
 adapters/tokenless/openclaw/package.json
 adapters/tokenless/openclaw/openclaw.plugin.json
 adapters/tokenless/hermes/plugin.yaml
+adapters/tokenless/qoder/.qoder-plugin/plugin.json

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -24,7 +24,8 @@ ADAPTER_TEMPLATES := \
     $(ADAPTER_SRC_DIR)/manifest.json \
     $(ADAPTER_SRC_DIR)/openclaw/package.json \
     $(ADAPTER_SRC_DIR)/openclaw/openclaw.plugin.json \
-    $(ADAPTER_SRC_DIR)/hermes/plugin.yaml
+    $(ADAPTER_SRC_DIR)/hermes/plugin.yaml \
+    $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json
 TOON_VER := 0.4.6
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
@@ -36,6 +37,7 @@ VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1
         cosh-extension-install cosh-extension-uninstall \
         openclaw-install openclaw-uninstall \
         hermes-install hermes-uninstall \
+        qoder-install qoder-uninstall \
         setup help \
         test-hooks
 
@@ -72,6 +74,10 @@ $(ADAPTER_SRC_DIR)/openclaw/openclaw.plugin.json: $(ADAPTER_SRC_DIR)/openclaw/op
 
 $(ADAPTER_SRC_DIR)/hermes/plugin.yaml: $(ADAPTER_SRC_DIR)/hermes/plugin.yaml.in Cargo.toml
 	@echo "==> Generating hermes/plugin.yaml (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+$(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json: $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json.in Cargo.toml
+	@echo "==> Generating qoder/.qoder-plugin/plugin.json (version=$(VERSION))..."
 	sed 's/@VERSION@/$(VERSION)/g' $< > $@
 
 # Build the tokenless OpenClaw plugin (TypeScript -> dist/index.js).
@@ -178,9 +184,9 @@ ADAPTER_ENV = ANOLISA_PREFIX=$(HOME)/.local \
               ANOLISA_COMPONENT=tokenless \
               ANOLISA_VERSION=$(VERSION)
 
-adapter-install: cosh-extension-install openclaw-install hermes-install
+adapter-install: cosh-extension-install openclaw-install hermes-install qoder-install
 
-adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall
+adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall qoder-uninstall
 
 adapter-scan:
 	@echo "=== Tokenless Adapter Manifest ==="
@@ -228,6 +234,18 @@ hermes-uninstall:
 	@echo "==> Uninstalling Hermes Agent plugin..."
 	@$(ADAPTER_ENV) ANOLISA_TARGET=hermes bash $(HERMES_ADAPTER_DIR)/scripts/uninstall.sh
 
+# --- Qoder CLI ---
+QODER_ADAPTER_DIR = $(SHARE_DIR)/qoder
+
+qoder-install:
+	@echo "==> Installing tokenless Qoder CLI plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=qoder bash $(QODER_ADAPTER_DIR)/scripts/detect.sh || true
+	@$(ADAPTER_ENV) ANOLISA_TARGET=qoder bash $(QODER_ADAPTER_DIR)/scripts/install.sh
+
+qoder-uninstall:
+	@echo "==> Uninstalling tokenless Qoder CLI plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=qoder bash $(QODER_ADAPTER_DIR)/scripts/uninstall.sh
+
 # One-step setup: build + install + all adapters
 setup: install adapter-install
 	@echo ""
@@ -243,7 +261,7 @@ setup: install adapter-install
 	@echo "  Adapter (FHS):"
 	@echo "    $(SHARE_DIR)/"
 	@echo "  Registered:"
-	@echo "    cosh, openclaw, hermes"
+	@echo "    cosh, openclaw, hermes, qoder"
 	@echo ""
 	@echo "Verify:"
 	@echo "  tokenless --version"
@@ -267,7 +285,7 @@ help:
 	@echo "  fmt               Format code"
 	@echo "  clean             Clean build artifacts"
 	@echo "  adapter-scan      List registered adapter capabilities"
-	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes)"
+	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes+qoder)"
 	@echo "  adapter-uninstall Unregister all adapters"
 	@echo "  cosh-extension-install  Install cosh extension"
 	@echo "  cosh-extension-uninstall Uninstall cosh extension"
@@ -275,6 +293,8 @@ help:
 	@echo "  openclaw-uninstall Unregister OpenClaw plugin"
 	@echo "  hermes-install    Install Hermes Agent plugin"
 	@echo "  hermes-uninstall  Uninstall Hermes Agent plugin"
+	@echo "  qoder-install     Register Qoder CLI plugin"
+	@echo "  qoder-uninstall   Unregister Qoder CLI plugin"
 	@echo "  setup             Full setup: build + install + register adapters"
 	@echo "  help              Show this help"
 	@echo ""

--- a/src/tokenless/adapters/tokenless/manifest.json.in
+++ b/src/tokenless/adapters/tokenless/manifest.json.in
@@ -44,6 +44,21 @@
         "install":   "hermes/scripts/install.sh",
         "uninstall": "hermes/scripts/uninstall.sh"
       }
+    },
+    "qoder": {
+      "compatibleVersions": ">=0.2.0",
+      "capabilities": {
+        "hooks": [
+          "tool-ready",
+          "rewrite",
+          "compress-response"
+        ]
+      },
+      "actions": {
+        "detect":    "qoder/scripts/detect.sh",
+        "install":   "qoder/scripts/install.sh",
+        "uninstall": "qoder/scripts/uninstall.sh"
+      }
     }
   }
 }

--- a/src/tokenless/adapters/tokenless/qoder/.qoder-plugin/plugin.json.in
+++ b/src/tokenless/adapters/tokenless/qoder/.qoder-plugin/plugin.json.in
@@ -1,0 +1,11 @@
+{
+  "name": "tokenless",
+  "version": "@VERSION@",
+  "description": "Token-Less LLM Token Optimization Toolkit for Qoder CLI",
+  "author": {
+    "name": "Shile Zhang",
+    "email": "shile.zhang@linux.alibaba.com"
+  },
+  "homepage": "https://github.com/alibaba/anolisa",
+  "license": "MIT"
+}

--- a/src/tokenless/adapters/tokenless/qoder/commands/tokenless-stats.toml
+++ b/src/tokenless/adapters/tokenless/qoder/commands/tokenless-stats.toml
@@ -1,0 +1,4 @@
+[command]
+name = "tokenless-stats"
+description = "Show tokenless compression statistics"
+command = "tokenless stats"

--- a/src/tokenless/adapters/tokenless/qoder/hooks.json
+++ b/src/tokenless/adapters/tokenless/qoder/hooks.json
@@ -1,0 +1,48 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "sequential": true,
+        "hooks": [
+          {
+            "type": "command",
+            "name": "tokenless-tool-ready",
+            "description": "Pre-checks tool environment readiness, auto-fixes, and provides skip-retry guidance",
+            "command": "bash ${QODER_TOKENLESS_HOOKS}/tool_ready_hook.sh",
+            "timeout": 10000,
+            "env": { "TOKENLESS_AGENT_ID": "qoder-cli" }
+          }
+        ]
+      },
+      {
+        "matcher": "^(Bash|Shell|run_shell_command|terminal|execute_command)$",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "tokenless-rewrite",
+            "description": "Rewrites shell commands via rtk for token savings",
+            "command": "python3 ${QODER_TOKENLESS_HOOKS}/rewrite_hook.py",
+            "timeout": 5000,
+            "env": { "TOKENLESS_AGENT_ID": "qoder-cli" }
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "tokenless-compress-response",
+            "description": "Compresses tool responses and encodes to TOON format",
+            "command": "python3 ${QODER_TOKENLESS_HOOKS}/compress_response_hook.py",
+            "timeout": 10000,
+            "env": { "TOKENLESS_AGENT_ID": "qoder-cli" }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/tokenless/adapters/tokenless/qoder/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/qoder/scripts/detect.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# detect.sh — Check if Qoder CLI is installed and compatible.
+# Exit 0 = ready to install, non-0 = not available.
+#
+# Mirrors install.sh's binary search so detect and install agree on
+# "is Qoder CLI installed". A bare ~/.qoder/ directory (e.g. created by
+# an unrelated tool) is not enough — qodercli itself must be present.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-qoder}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+
+# Pick the highest versioned qodercli-X.Y.Z; sort -V handles semver
+# ordering (10 > 9). Empty when no match.
+versioned_glob="$HOME/.qoder/bin/qodercli/qodercli-${ANOLISA_QODER_VERSION:-*}"
+# shellcheck disable=SC2086  # intentional glob expansion
+latest_versioned="$(ls -d $versioned_glob 2>/dev/null | sort -V | tail -1 || true)"
+
+for candidate in "$latest_versioned" \
+                 "$HOME/.qoder/bin/qodercli/qodercli" \
+                 "qodercli"; do
+    [ -z "$candidate" ] && continue
+    if [ -x "$candidate" ] || command -v "$candidate" &>/dev/null; then
+        echo "[${COMPONENT}] ${AGENT}: detected qodercli at ${candidate}"
+        exit 0
+    fi
+done
+
+echo "[${COMPONENT}] ${AGENT}: qodercli not found in standard locations" >&2
+exit 1

--- a/src/tokenless/adapters/tokenless/qoder/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/qoder/scripts/install.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# install.sh — Install tokenless plugin for Qoder CLI.
+#
+# Responsibility boundary:
+#   - Register the plugin with qodercli (`qodercli plugins install`).
+#   - Merge our hook commands into ~/.qoder/settings.json under .hooks,
+#     dedup by command string so re-installs are idempotent.
+#   - Hook scripts themselves live in adapters/tokenless/common/hooks/
+#     (shared with cosh/openclaw/hermes); we only inject absolute paths.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-qoder}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+PLUGIN_DIR="$ADAPTER_DIR/qoder"
+HOOKS_DIR="$ADAPTER_DIR/common/hooks"
+SETTINGS_PATH="$HOME/.qoder/settings.json"
+
+# Read version from plugin.json (already templated with the real version
+# by the build system). Falls back to "0.0.0" only when plugin.json is
+# absent or unparseable.
+VERSION="0.0.0"
+plugin_json="$PLUGIN_DIR/.qoder-plugin/plugin.json"
+if [ -f "$plugin_json" ] && command -v python3 &>/dev/null; then
+    VERSION="$(PLUGIN_JSON="$plugin_json" python3 -c "
+import json, os
+print(json.load(open(os.environ['PLUGIN_JSON'])).get('version','0.0.0'))
+" 2>/dev/null || echo "0.0.0")"
+elif [ -f "$plugin_json" ] && command -v jq &>/dev/null; then
+    VERSION="$(jq -r '.version // "0.0.0"' "$plugin_json" 2>/dev/null || echo "0.0.0")"
+fi
+
+# Find qodercli binary. Pick the highest versioned qodercli-X.Y.Z first
+# (sort -V handles semver: 10 > 9), then fall back to the unversioned
+# binary and finally PATH lookup.
+QODERCLI=""
+versioned_glob="$HOME/.qoder/bin/qodercli/qodercli-${ANOLISA_QODER_VERSION:-*}"
+# shellcheck disable=SC2086  # intentional glob expansion
+latest_versioned="$(ls -d $versioned_glob 2>/dev/null | sort -V | tail -1 || true)"
+
+for candidate in "$latest_versioned" \
+                 "$HOME/.qoder/bin/qodercli/qodercli" \
+                 "qodercli"; do
+    [ -z "$candidate" ] && continue
+    if [ -x "$candidate" ] || command -v "$candidate" &>/dev/null; then
+        QODERCLI="$candidate"
+        break
+    fi
+done
+
+if [ -z "$QODERCLI" ]; then
+    echo "[${COMPONENT}] ERROR: qodercli not found, aborting plugin registration" >&2
+    echo "    Install Qoder CLI first: https://qoder.com/cli" >&2
+    exit 1
+fi
+
+# python3 is required to merge hooks into settings.json; without it the
+# `qodercli plugins install` step would succeed but no hooks would fire,
+# silently leaving tokenless inactive. Fail loudly instead.
+if ! command -v python3 &>/dev/null; then
+    echo "[${COMPONENT}] ERROR: python3 required to merge hooks into ${SETTINGS_PATH}" >&2
+    exit 1
+fi
+
+echo "[${COMPONENT}] Installing ${AGENT} plugin v${VERSION}..."
+
+# Register plugin via qodercli standard command.
+# qodercli derives plugin name from the directory name, so expose the adapter
+# under a name matching plugin.json's "name" field via a private tempdir.
+# (A predictable /tmp/tokenless would collide across users on shared hosts and
+# race with concurrent installs.)
+echo "[${COMPONENT}] Registering plugin with qodercli..."
+TEMP_DIR="$(mktemp -d -t tokenless-qoder-install.XXXXXX)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+ln -sfn "$PLUGIN_DIR" "$TEMP_DIR/tokenless"
+# Use `if !` so the failure branch survives `set -e`: a bare
+# `OUT=$(...)` assignment would otherwise abort the script before $?
+# is captured, and qodercli's stderr (now redirected into the var)
+# would never be printed.
+if ! PLUGIN_INSTALL_OUT="$("$QODERCLI" plugins install "$TEMP_DIR/tokenless" 2>&1)"; then
+    echo "[${COMPONENT}] ERROR: qodercli plugins install failed" >&2
+    echo "    Output: $PLUGIN_INSTALL_OUT" >&2
+    exit 1
+fi
+echo "$PLUGIN_INSTALL_OUT"
+
+# Verify the plugin was registered: qodercli plugins list may not show
+# freshly installed plugins (qodercli display quirk), so we check the
+# cache directory that plugins install should have populated instead.
+# qodercli has been observed using two names for the cache key — the
+# plugin id ("tokenless") and a target-suffixed variant
+# ("tokenless-qoder"); accept either to stay aligned with the %preun
+# cleanup in tokenless.spec.in.
+CACHE_BASE="$HOME/.qoder/plugins/cache/local"
+if [ ! -d "$CACHE_BASE/tokenless" ] && [ ! -d "$CACHE_BASE/tokenless-qoder" ]; then
+    echo "[${COMPONENT}] ERROR: qodercli did not create plugin cache under $CACHE_BASE" >&2
+    echo "    Inspect with: ${QODERCLI} plugins list" >&2
+    exit 1
+fi
+
+# Merge hooks into ~/.qoder/settings.json.
+# hooks.json carries the ${QODER_TOKENLESS_HOOKS} placeholder; we expand it
+# to the actual common/hooks/ path so qodercli sees absolute paths.
+HOOKS_DIR="$HOOKS_DIR" \
+HOOKS_JSON_PATH="$PLUGIN_DIR/hooks.json" \
+SETTINGS_PATH="$SETTINGS_PATH" \
+COMPONENT="$COMPONENT" \
+python3 - <<'PYEOF'
+import json, os, sys
+
+hooks_dir = os.environ['HOOKS_DIR']
+hooks_json_path = os.environ['HOOKS_JSON_PATH']
+settings_path = os.environ['SETTINGS_PATH']
+component = os.environ.get('COMPONENT', 'tokenless')
+
+with open(hooks_json_path) as f:
+    hooks_str = f.read()
+hooks_str = hooks_str.replace('${QODER_TOKENLESS_HOOKS}', hooks_dir)
+resolved = json.loads(hooks_str)
+
+cfg = {}
+if os.path.exists(settings_path):
+    try:
+        with open(settings_path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        # Refuse to clobber a settings.json we cannot parse — overwriting
+        # with our hooks alone would silently wipe every other user setting.
+        print(f'[{component}] ERROR: cannot parse {settings_path}: {e}', file=sys.stderr)
+        sys.exit(1)
+if not isinstance(cfg, dict):
+    cfg = {}
+
+existing_hooks = cfg.get('hooks', {})
+if not isinstance(existing_hooks, dict):
+    existing_hooks = {}
+
+for event, entries in resolved['hooks'].items():
+    existing = existing_hooks.get(event, [])
+    existing_names = set()
+    for e in existing:
+        for h in (e.get('hooks') or []):
+            if h.get('name'):
+                existing_names.add(h['name'])
+    for entry in entries:
+        entry_name = None
+        for h in (entry.get('hooks') or []):
+            if h.get('name'):
+                entry_name = h['name']
+                break
+        if entry_name and entry_name not in existing_names:
+            existing.append(entry)
+    existing_hooks[event] = existing
+
+cfg['hooks'] = existing_hooks
+
+# Also ensure the plugin is enabled in settings.json. qodercli plugins
+# install writes installed_plugins.json but does NOT touch settings.json's
+# plugins.enabled — without this the plugin won't show in `plugin list`.
+plugins_cfg = cfg.get('plugins')
+if not isinstance(plugins_cfg, dict):
+    plugins_cfg = {}
+    cfg['plugins'] = plugins_cfg
+enabled = plugins_cfg.get('enabled')
+if not isinstance(enabled, list):
+    enabled = []
+    plugins_cfg['enabled'] = enabled
+plugin_id = 'tokenless@local'
+if plugin_id not in enabled:
+    enabled.append(plugin_id)
+os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+
+# Atomic write: stage to .tmp then os.replace() so a kill mid-write cannot
+# leave qodercli with a truncated settings.json.
+tmp_path = settings_path + '.tmp'
+with open(tmp_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+os.replace(tmp_path, settings_path)
+print(f'[{component}] Updated {settings_path}')
+PYEOF
+
+echo "[${COMPONENT}] ${AGENT} plugin v${VERSION} installed and activated."

--- a/src/tokenless/adapters/tokenless/qoder/scripts/uninstall.sh
+++ b/src/tokenless/adapters/tokenless/qoder/scripts/uninstall.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# uninstall.sh — Remove tokenless plugin from Qoder CLI.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-qoder}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+SETTINGS_PATH="$HOME/.qoder/settings.json"
+
+# Find qodercli binary. Mirrors install.sh: highest versioned binary
+# first (sort -V), then unversioned, then PATH.
+QODERCLI=""
+versioned_glob="$HOME/.qoder/bin/qodercli/qodercli-${ANOLISA_QODER_VERSION:-*}"
+# shellcheck disable=SC2086  # intentional glob expansion
+latest_versioned="$(ls -d $versioned_glob 2>/dev/null | sort -V | tail -1 || true)"
+
+for candidate in "$latest_versioned" \
+                 "$HOME/.qoder/bin/qodercli/qodercli" \
+                 "qodercli"; do
+    [ -z "$candidate" ] && continue
+    if [ -x "$candidate" ] || command -v "$candidate" &>/dev/null; then
+        QODERCLI="$candidate"
+        break
+    fi
+done
+
+echo "[${COMPONENT}] Removing ${AGENT} plugin..."
+
+# Unregister plugin via qodercli standard command
+if [ -n "$QODERCLI" ]; then
+    "$QODERCLI" plugins uninstall tokenless || true
+else
+    echo "[${COMPONENT}] WARNING: qodercli not found, cannot unregister plugin"
+fi
+
+# Remove hooks from settings.json. Match by hook "name" prefix "tokenless-"
+# rather than substring search in "command" — the latter would also nuke
+# any user-defined hook whose command merely mentions tokenless.
+if [ ! -f "$SETTINGS_PATH" ]; then
+    echo "[${COMPONENT}] ${AGENT} plugin removed."
+    exit 0
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "[${COMPONENT}] WARNING: python3 not found, cannot prune hooks from ${SETTINGS_PATH}" >&2
+    echo "[${COMPONENT}] ${AGENT} plugin removed (hooks left in place)."
+    exit 0
+fi
+
+if ! SETTINGS_PATH="$SETTINGS_PATH" COMPONENT="$COMPONENT" python3 - <<'PYEOF'
+import json, os, sys
+
+settings_path = os.environ['SETTINGS_PATH']
+component = os.environ.get('COMPONENT', 'tokenless')
+
+try:
+    with open(settings_path) as f:
+        cfg = json.load(f)
+except (OSError, json.JSONDecodeError) as e:
+    print(f'[{component}] WARNING: cannot parse {settings_path}: {e}', file=sys.stderr)
+    sys.exit(1)
+
+hooks = cfg.get('hooks', {})
+if not isinstance(hooks, dict):
+    sys.exit(0)
+
+removed = False
+for event in list(hooks.keys()):
+    keep = []
+    for entry in hooks[event]:
+        owned = any(
+            (h.get('name') or '').startswith('tokenless-')
+            for h in (entry.get('hooks') or [])
+        )
+        if owned:
+            removed = True
+        else:
+            keep.append(entry)
+    if keep:
+        hooks[event] = keep
+    else:
+        del hooks[event]
+        removed = True
+
+# Remove tokenless@local from plugins.enabled — install.sh writes it
+# because qodercli plugins install does not touch settings.json's
+# plugins.enabled. Clean up our own state unconditionally: must run
+# regardless of remaining user hooks, and even when no tokenless hook
+# entries needed pruning (prior partial uninstall, manual edit).
+plugins_cfg = cfg.get('plugins')
+if isinstance(plugins_cfg, dict):
+    enabled = plugins_cfg.get('enabled')
+    if isinstance(enabled, list):
+        plugin_id = 'tokenless@local'
+        if plugin_id in enabled:
+            enabled.remove(plugin_id)
+            removed = True
+        if not enabled:
+            plugins_cfg.pop('enabled', None)
+    if not plugins_cfg:
+        cfg.pop('plugins', None)
+
+if not removed:
+    sys.exit(0)
+
+if hooks:
+    cfg['hooks'] = hooks
+else:
+    cfg.pop('hooks', None)
+
+# Atomic write
+tmp_path = settings_path + '.tmp'
+with open(tmp_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+os.replace(tmp_path, settings_path)
+print(f'[{component}] Removed tokenless hooks from settings.json')
+PYEOF
+then
+    echo "[${COMPONENT}] WARNING: failed to update ${SETTINGS_PATH}" >&2
+fi
+
+echo "[${COMPONENT}] ${AGENT} plugin removed."

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -30,6 +30,7 @@ fn current_uid() -> u32 {
 /// KEEP IN SYNC with the shell equivalent in
 /// `adapters/tokenless/common/hooks/tool_ready_hook.sh` (`is_trusted_file`).
 /// Changes to trust criteria must be applied to both implementations.
+#[allow(clippy::collapsible_if)]
 fn is_trusted_path(path: &std::path::Path) -> bool {
     // System paths are always trusted
     if path.starts_with("/usr/share")
@@ -62,15 +63,15 @@ fn is_trusted_path(path: &std::path::Path) -> bool {
     // Check the parent directory first — a world-writable directory allows an
     // attacker to unlink and replace the file (TOCTOU), even if the file itself
     // has correct ownership and permissions.
-    if let Some(parent) = check_path.parent()
-        && let Ok(parent_meta) = fs::symlink_metadata(parent)
-    {
-        let parent_uid = parent_meta.uid();
-        if parent_uid != current_uid() && parent_uid != 0 {
-            return false;
-        }
-        if parent_meta.mode() & 0o002 != 0 {
-            return false;
+    if let Some(parent) = check_path.parent() {
+        if let Ok(parent_meta) = fs::symlink_metadata(parent) {
+            let parent_uid = parent_meta.uid();
+            if parent_uid != current_uid() && parent_uid != 0 {
+                return false;
+            }
+            if parent_meta.mode() & 0o002 != 0 {
+                return false;
+            }
         }
     }
     match fs::symlink_metadata(&check_path) {

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -185,13 +185,12 @@ pub fn get_home_dir() -> String {
 /// location (e.g. `/etc/evil.db`).
 fn get_db_path() -> String {
     let home = get_home_dir();
-    if let Ok(env_path) = std::env::var("TOKENLESS_STATS_DB")
-        && !env_path.is_empty()
-    {
-        match validate_db_path(&env_path, &home) {
+    match std::env::var("TOKENLESS_STATS_DB") {
+        Ok(env_path) if !env_path.is_empty() => match validate_db_path(&env_path, &home) {
             Ok(path) => return path,
             Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STATS_DB: {}", reason),
-        }
+        },
+        _ => {}
     }
     format!("{}/.tokenless/stats.db", home)
 }

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -83,10 +83,11 @@ impl StatsRecorder {
         // hardcoded literals in the for loop — never from user input.
         for col in &["before_output", "after_output"] {
             let check = conn.execute(&format!("ALTER TABLE stats ADD COLUMN {} TEXT", col), []);
-            if let Err(e) = check
-                && !e.to_string().contains("duplicate column name")
-            {
-                return Err(StatsError::Database(e));
+            match check {
+                Err(e) if !e.to_string().contains("duplicate column name") => {
+                    return Err(StatsError::Database(e));
+                }
+                _ => {}
             }
         }
 

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 1
+%define anolis_release 2
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -86,6 +86,9 @@ mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/common/commands
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/dist
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/commands
 mkdir -p %{buildroot}%{_docdir}/tokenless
 
 # Install binaries — tokenless (user-facing) to /usr/bin, helpers to /usr/libexec/anolisa/tokenless
@@ -128,6 +131,15 @@ install -m 0755 adapters/tokenless/hermes/scripts/detect.sh %{buildroot}%{_datad
 install -m 0755 adapters/tokenless/hermes/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
 install -m 0755 adapters/tokenless/hermes/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
 
+# Install Qoder CLI plugin (manifest + hooks.json + install scripts).
+# Hook scripts themselves are shared from common/hooks/ — no duplication here.
+install -m 0644 adapters/tokenless/qoder/.qoder-plugin/plugin.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin/
+install -m 0644 adapters/tokenless/qoder/hooks.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/
+install -m 0644 adapters/tokenless/qoder/commands/tokenless-stats.toml %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/commands/
+install -m 0755 adapters/tokenless/qoder/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts/
+install -m 0755 adapters/tokenless/qoder/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts/
+install -m 0755 adapters/tokenless/qoder/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts/
+
 # Install cosh extension for auto-discovery at /usr/share/anolisa/extensions/tokenless/
 mkdir -p %{buildroot}%{_datadir}/anolisa/extensions/tokenless/hooks
 mkdir -p %{buildroot}%{_datadir}/anolisa/extensions/tokenless/commands
@@ -161,6 +173,10 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %dir %{_datadir}/anolisa/adapters/tokenless/openclaw/dist
 %dir %{_datadir}/anolisa/adapters/tokenless/hermes
 %dir %{_datadir}/anolisa/adapters/tokenless/hermes/scripts
+%dir %{_datadir}/anolisa/adapters/tokenless/qoder
+%dir %{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin
+%dir %{_datadir}/anolisa/adapters/tokenless/qoder/scripts
+%dir %{_datadir}/anolisa/adapters/tokenless/qoder/commands
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/manifest.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/common/tool-ready-spec.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/common/cosh-extension.json
@@ -179,6 +195,13 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/uninstall.sh
+# Qoder CLI plugin — hook scripts reused from common/hooks/ (no duplication).
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin/plugin.json
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/hooks.json
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/commands/tokenless-stats.toml
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/scripts/detect.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/scripts/install.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/scripts/uninstall.sh
 # Cosh extension — auto-discovered from /usr/share/anolisa/extensions/
 %dir %{_datadir}/anolisa/extensions
 %dir %{_datadir}/anolisa/extensions/tokenless
@@ -210,8 +233,27 @@ rm -rf "$HOME/.local/share/anolisa/adapters/tokenless/hermes-plugin" 2>/dev/null
 hash -r 2>/dev/null || true
 
 %preun
-# On uninstall ($1=0): clean openclaw plugin and stale config entries
+# On uninstall ($1=0): clean qodercli plugin, openclaw plugin, and stale config entries
 if [ $1 -eq 0 ]; then
+    # --- Qoder CLI plugin cleanup ---
+    # Unregister plugin via qodercli and remove hooks from settings.json.
+    QODER_SCRIPT="%{_datadir}/anolisa/adapters/tokenless/qoder/scripts/uninstall.sh"
+    if [ -x "$QODER_SCRIPT" ]; then
+        bash "$QODER_SCRIPT" || true
+    fi
+    # Clean up plugin cache (qodercli's uninstall may leave orphaned cache).
+    # qodercli's cache key has been observed in two forms — the plugin's
+    # package name ("tokenless") and a target-suffixed variant
+    # ("tokenless-qoder"). Cover both so leftover caches don't shadow a
+    # fresh install on the next rpm upgrade.
+    for cache_dir in "$HOME/.qoder/plugins/cache/local/tokenless" \
+                     "$HOME/.qoder/plugins/cache/local/tokenless-qoder"; do
+        if [ -d "$cache_dir" ]; then
+            rm -rf "$cache_dir" || true
+        fi
+    done
+
+    # --- OpenClaw plugin cleanup ---
     PLUGIN_DIR="$HOME/.openclaw/extensions/tokenless"
     if [ -d "$PLUGIN_DIR" ]; then
         if command -v openclaw &>/dev/null; then
@@ -238,6 +280,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Wed Jun 03 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.4.1-2
+- feat(tokenless): add qodercli plugin support
+
 * Wed May 27 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.4.1-1
 - fix(tokenless): derive Makefile version from Cargo.toml, fix spec changelog weekday
 - fix(tokenless): normalize adapter version numbers to 0.4.0


### PR DESCRIPTION
## Description
New adapter under adapters/tokenless/qoder/, mirroring the openclaw/hermes layout. Hooks (PreToolUse tool-ready + rewrite, PostToolUse compress- response) reference adapters/tokenless/common/hooks/ via a ${QODER_TOKENLESS_HOOKS} placeholder expanded at install time, so no scripts are duplicated. Plugin manifest is stamped from .qoder-plugin/plugin.json.in with @VERSION@ from Cargo.toml.

install.sh registers via `qodercli plugins install` using a private mktemp -d (qodercli derives the plugin name from the directory; a shared /tmp/tokenless would race/collide across users), then dedup-merges hooks into ~/.qoder/settings.json via .tmp + os.replace(). Hard-fails when python3 is missing rather than silently leaving hooks unregistered.

uninstall.sh removes owned hooks by `name` prefix "tokenless-" — substring match on `command` would also delete user hooks that happen to mention tokenless.

Wired into Makefile (qoder-install / qoder-uninstall, adapter-install fan-out) and tokenless.spec.in (%install / %files / %preun with cache cleanup before the existing openclaw branch).


<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue: new feature

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
