### PR TITLE
fix(ckpt): preserve user data when init_workspace fails

### DIFF
--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
@@ -11,7 +11,7 @@ use ws_ckpt_common::backend::*;
 use ws_ckpt_common::{DaemonConfig, DiffEntry, WorkspaceInfo, SNAPSHOTS_DIR};
 
 use super::btrfs_common;
-use btrfs_common::resolve_symlink_path;
+use btrfs_common::{backup_path_for, resolve_symlink_path};
 
 /// Deployment scenario for BtrfsBase backend.
 #[derive(Debug, Clone, Copy)]
@@ -42,13 +42,14 @@ impl BtrfsBaseBackend {
         }
     }
 
-    /// Internal init implementation; caller wraps with cleanup-on-failure.
+    /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 5.
     async fn do_init_storage(
         &self,
         original_path: &str,
         ws_id: &str,
         subvol_path: &Path,
         snap_dir: &Path,
+        backup_owned: &mut bool,
     ) -> anyhow::Result<()> {
         // 0. Ensure data_root exists
         tokio::fs::create_dir_all(&self.data_root)
@@ -101,17 +102,25 @@ impl BtrfsBaseBackend {
             Command::new("sync").status().await.ok();
         }
 
-        // 4. Record original directory permissions before removal
+        // 4. Record original directory permissions before backup
         let orig_meta = tokio::fs::metadata(original_path)
             .await
             .context("failed to read original directory metadata")?;
         let orig_uid = orig_meta.uid();
         let orig_gid = orig_meta.gid();
 
-        // 5. Remove original directory (data is safely in btrfs subvolume now)
-        tokio::fs::remove_dir_all(original_path)
+        // 5. Move original aside (#673). Refuse to clobber a pre-existing backup.
+        let backup_path = backup_path_for(original_path);
+        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
+            anyhow::bail!(
+                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
+                backup_path
+            );
+        }
+        tokio::fs::rename(original_path, &backup_path)
             .await
-            .context("failed to remove original directory")?;
+            .context("failed to rename original directory to backup")?;
+        *backup_owned = true;
 
         // 6. Create symlink: user path -> btrfs subvolume
         if let Some(parent) = Path::new(original_path).parent() {
@@ -140,6 +149,14 @@ impl BtrfsBaseBackend {
                 "symlink verification failed: expected {:?}, got {:?}",
                 subvol_path,
                 link_target
+            );
+        }
+
+        // 8. Drop backup. A leftover .pre-init-bak blocks the next init.
+        if let Err(e) = tokio::fs::remove_dir_all(&backup_path).await {
+            error!(
+                "init ok but backup remove failed {:?}: {}; next init will fail until removed",
+                backup_path, e
             );
         }
 
@@ -191,20 +208,6 @@ impl BtrfsBaseBackend {
         }
         Ok(())
     }
-
-    /// Cleanup partially-created storage on init failure.
-    async fn cleanup_init_storage(original_path: &str, subvol_path: &Path, snap_dir: &Path) {
-        // Remove symlink if it exists
-        let _ = tokio::fs::remove_file(original_path).await;
-
-        // Remove snapshots dir
-        let _ = tokio::fs::remove_dir_all(snap_dir).await;
-
-        // Delete subvolume (best effort)
-        if let Err(e) = btrfs_common::delete_subvolume(subvol_path).await {
-            error!("cleanup: failed to delete subvolume: {}", e);
-        }
-    }
 }
 
 #[async_trait]
@@ -233,12 +236,25 @@ impl StorageBackend for BtrfsBaseBackend {
         let subvol_path = self.data_root.join(ws_id);
         let snap_dir = self.snapshots_dir.join(ws_id);
 
+        let mut backup_owned = false;
         if let Err(e) = self
-            .do_init_storage(&resolved_str, ws_id, &subvol_path, &snap_dir)
+            .do_init_storage(
+                &resolved_str,
+                ws_id,
+                &subvol_path,
+                &snap_dir,
+                &mut backup_owned,
+            )
             .await
         {
             error!("init_workspace storage failed, cleaning up: {:#}", e);
-            Self::cleanup_init_storage(&resolved_str, &subvol_path, &snap_dir).await;
+            btrfs_common::cleanup_init_storage(
+                &resolved_str,
+                &subvol_path,
+                &snap_dir,
+                backup_owned,
+            )
+            .await;
             return Err(e);
         }
 

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
@@ -16,7 +16,7 @@ use btrfs_common::{backup_path_for, resolve_symlink_path};
 /// Deployment scenario for BtrfsBase backend.
 #[derive(Debug, Clone, Copy)]
 pub enum BtrfsBaseScenario {
-    /// Scenario A: workspace already on btrfs partition, mv is O(1) zero-copy
+    /// Scenario A: workspace already on btrfs partition, cp --reflink COW
     InPlace,
     /// Scenario B: workspace on non-btrfs disk, needs rsync migration to btrfs data disk
     CrossDisk,
@@ -42,7 +42,7 @@ impl BtrfsBaseBackend {
         }
     }
 
-    /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 5.
+    /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 3.
     async fn do_init_storage(
         &self,
         original_path: &str,
@@ -64,17 +64,48 @@ impl BtrfsBaseBackend {
             .await
             .context("failed to create snapshots directory")?;
 
-        // 3. Data migration (scenario-dependent)
+        // 3. Record permissions and move original aside as backup (#673).
+        //    Must happen BEFORE data migration so cleanup always restores full data.
+        let orig_meta = tokio::fs::metadata(original_path)
+            .await
+            .context("failed to read original directory metadata")?;
+        let orig_uid = orig_meta.uid();
+        let orig_gid = orig_meta.gid();
+
+        let backup_path = backup_path_for(original_path);
+        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
+            anyhow::bail!(
+                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
+                backup_path
+            );
+        }
+        tokio::fs::rename(original_path, &backup_path)
+            .await
+            .context("failed to rename original directory to backup")?;
+        *backup_owned = true;
+
+        // 4. Data migration from backup into subvolume (scenario-dependent)
         match self.scenario {
             BtrfsBaseScenario::InPlace => {
-                // Same btrfs partition: move contents via fs::rename (O(1) per entry)
-                self.move_contents(original_path, subvol_path).await?;
+                // Same btrfs: cp --reflink=always is O(1) COW per file and keeps
+                // backup intact for crash recovery (unlike rename which is destructive).
+                let src = format!("{}/.", backup_path); // trailing /. = contents only
+                let status = Command::new("cp")
+                    .args([
+                        "-a",
+                        "--reflink=always",
+                        &src,
+                        &subvol_path.to_string_lossy(),
+                    ])
+                    .status()
+                    .await
+                    .context("failed to run cp --reflink")?;
+                if !status.success() {
+                    anyhow::bail!("cp --reflink failed with exit code: {:?}", status.code());
+                }
             }
             BtrfsBaseScenario::CrossDisk => {
-                // Cross-disk: rsync migration
-                // --copy-unsafe-links: dereference symlinks that point outside the source tree
-                // (e.g. symlinks to other ws-* subvolumes inside mount point)
-                let src = format!("{}/", original_path); // trailing / is important
+                let src = format!("{}/", backup_path);
                 let status = Command::new("rsync")
                     .args([
                         "-a",
@@ -91,7 +122,7 @@ impl BtrfsBaseBackend {
             }
         }
 
-        // 3a. Flush dirty data to disk so subsequent snapshots are instant
+        // 4a. Flush dirty data to disk so subsequent snapshots are instant
         let sync_status = Command::new("btrfs")
             .args(["filesystem", "sync", &subvol_path.to_string_lossy()])
             .status()
@@ -102,27 +133,7 @@ impl BtrfsBaseBackend {
             Command::new("sync").status().await.ok();
         }
 
-        // 4. Record original directory permissions before backup
-        let orig_meta = tokio::fs::metadata(original_path)
-            .await
-            .context("failed to read original directory metadata")?;
-        let orig_uid = orig_meta.uid();
-        let orig_gid = orig_meta.gid();
-
-        // 5. Move original aside (#673). Refuse to clobber a pre-existing backup.
-        let backup_path = backup_path_for(original_path);
-        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
-            anyhow::bail!(
-                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
-                backup_path
-            );
-        }
-        tokio::fs::rename(original_path, &backup_path)
-            .await
-            .context("failed to rename original directory to backup")?;
-        *backup_owned = true;
-
-        // 6. Create symlink: user path -> btrfs subvolume
+        // 5. Create symlink: user path -> btrfs subvolume
         if let Some(parent) = Path::new(original_path).parent() {
             tokio::fs::create_dir_all(parent)
                 .await
@@ -132,7 +143,7 @@ impl BtrfsBaseBackend {
             .await
             .context("failed to create symlink")?;
 
-        // 6a. Restore ownership on the subvolume root to match original directory
+        // 5a. Restore ownership on the subvolume root to match original directory
         chown(
             subvol_path,
             Some(Uid::from_raw(orig_uid)),
@@ -140,7 +151,7 @@ impl BtrfsBaseBackend {
         )
         .context("failed to restore subvolume ownership")?;
 
-        // 7. Verify symlink
+        // 6. Verify symlink
         let link_target = tokio::fs::read_link(original_path)
             .await
             .context("symlink verification failed: cannot read link")?;
@@ -152,7 +163,7 @@ impl BtrfsBaseBackend {
             );
         }
 
-        // 8. Drop backup. A leftover .pre-init-bak blocks the next init.
+        // 7. Drop backup. A leftover .pre-init-bak blocks the next init.
         if let Err(e) = tokio::fs::remove_dir_all(&backup_path).await {
             error!(
                 "init ok but backup remove failed {:?}: {}; next init will fail until removed",
@@ -166,46 +177,6 @@ impl BtrfsBaseBackend {
             subvol_path.display(),
             self.scenario,
         );
-        Ok(())
-    }
-
-    /// Move all contents from original_path into subvol_path using fs::rename.
-    /// On same btrfs partition this is O(1) per entry.
-    /// Falls back to rsync if any rename fails (e.g. unexpected cross-device).
-    async fn move_contents(&self, original_path: &str, subvol_path: &Path) -> anyhow::Result<()> {
-        let mut entries = tokio::fs::read_dir(original_path)
-            .await
-            .context("failed to read original directory")?;
-
-        while let Some(entry) = entries.next_entry().await? {
-            let src = entry.path();
-            let file_name = entry.file_name();
-            let dst = subvol_path.join(&file_name);
-
-            if let Err(e) = tokio::fs::rename(&src, &dst).await {
-                // rename failed (possibly cross-device despite InPlace scenario);
-                // fallback to rsync for the entire directory
-                warn!(
-                    "rename {:?} -> {:?} failed: {}, falling back to rsync",
-                    src, dst, e
-                );
-                let rsync_src = format!("{}/", original_path);
-                let status = Command::new("rsync")
-                    .args([
-                        "-a",
-                        "--copy-unsafe-links",
-                        &rsync_src,
-                        &subvol_path.to_string_lossy(),
-                    ])
-                    .status()
-                    .await
-                    .context("fallback rsync failed")?;
-                if !status.success() {
-                    anyhow::bail!("fallback rsync failed with exit code: {:?}", status.code());
-                }
-                return Ok(());
-            }
-        }
         Ok(())
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -10,6 +10,76 @@ use ws_ckpt_common::{ChangeType, DiffEntry};
 
 use crate::util::unescape_proc_mount;
 
+/// init_workspace backup path (#673).
+pub fn backup_path_for(original_path: &str) -> String {
+    format!("{}.pre-init-bak", original_path.trim_end_matches('/'))
+}
+
+/// Roll back a failed init_workspace; `backup_owned=true` only when this init created the backup (#673).
+pub async fn cleanup_init_storage(
+    original_path: &str,
+    subvol_path: &Path,
+    snap_dir: &Path,
+    backup_owned: bool,
+) {
+    if backup_owned {
+        restore_original_from_backup(original_path).await;
+    } else if let Ok(meta) = tokio::fs::symlink_metadata(original_path).await {
+        if meta.file_type().is_symlink() {
+            let _ = tokio::fs::remove_file(original_path).await;
+        }
+    }
+    let _ = tokio::fs::remove_dir_all(snap_dir).await;
+    if let Err(e) = delete_subvolume(subvol_path).await {
+        error!("cleanup: failed to delete subvolume: {}", e);
+    }
+}
+
+/// Rename our own `.pre-init-bak` back over original_path; foreign data at original is preserved.
+async fn restore_original_from_backup(original_path: &str) {
+    let backup_path = backup_path_for(original_path);
+    match tokio::fs::symlink_metadata(&backup_path).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            warn!(
+                "cleanup: backup {:?} unexpectedly missing; dropping leftover symlink at {}",
+                backup_path, original_path
+            );
+            if let Ok(meta) = tokio::fs::symlink_metadata(original_path).await {
+                if meta.file_type().is_symlink() {
+                    let _ = tokio::fs::remove_file(original_path).await;
+                }
+            }
+            return;
+        }
+        Err(e) => {
+            error!(
+                "cleanup: cannot stat backup {:?}: {}; aborting restore (manual recovery required)",
+                backup_path, e
+            );
+            return;
+        }
+    }
+
+    match tokio::fs::symlink_metadata(original_path).await {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            let _ = tokio::fs::remove_file(original_path).await;
+        }
+        Ok(meta) if meta.is_dir() => {
+            let _ = tokio::fs::remove_dir(original_path).await;
+        }
+        _ => {}
+    }
+
+    match tokio::fs::rename(&backup_path, original_path).await {
+        Ok(()) => info!("cleanup: restored {} from backup", original_path),
+        Err(e) => error!(
+            "cleanup: failed to restore {:?} -> {:?}: {}; backup retained for manual recovery",
+            backup_path, original_path, e
+        ),
+    }
+}
+
 /// Ensure the current kernel can mount btrfs.
 ///
 /// Checks `/proc/filesystems`; if absent, tries `modprobe btrfs` once and rechecks.
@@ -778,6 +848,163 @@ mod tests {
     fn parse_btrfs_diff_output_empty() {
         let entries = parse_btrfs_diff_output("");
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn backup_path_for_appends_suffix() {
+        assert_eq!(backup_path_for("/tmp/ws"), "/tmp/ws.pre-init-bak");
+        assert_eq!(backup_path_for("/tmp/ws/"), "/tmp/ws.pre-init-bak");
+    }
+
+    /// Backup restores user data when symlink already replaced original (#673).
+    #[tokio::test]
+    async fn restore_swaps_symlink_back_to_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let target = tmp.path().join("subvol");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"important")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&target).await.unwrap();
+        tokio::fs::symlink(&target, &orig).await.unwrap();
+
+        restore_original_from_backup(orig.to_str().unwrap()).await;
+
+        assert!(!bak.exists(), "backup should be renamed away");
+        assert!(orig.is_dir(), "original must be a real dir again");
+        let payload = tokio::fs::read_to_string(orig.join("foo.txt"))
+            .await
+            .unwrap();
+        assert_eq!(payload, "important");
+    }
+
+    /// TOCTOU racer: an empty foreign dir appears at original between rename
+    /// and symlink. Backup must still restore (#673).
+    #[tokio::test]
+    async fn restore_clears_empty_racer_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"keep")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&orig).await.unwrap();
+
+        restore_original_from_backup(orig.to_str().unwrap()).await;
+
+        assert!(!bak.exists());
+        assert!(orig.join("foo.txt").exists(), "user data must be back");
+    }
+
+    /// Non-empty foreign dir at original must NOT be deleted; backup stays put.
+    #[tokio::test]
+    async fn restore_preserves_non_empty_foreign_dir_and_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"keep")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&orig).await.unwrap();
+        tokio::fs::write(orig.join("racer.txt"), b"foreign")
+            .await
+            .unwrap();
+
+        restore_original_from_backup(orig.to_str().unwrap()).await;
+
+        assert!(bak.exists(), "backup must be retained for manual recovery");
+        assert!(orig.join("racer.txt").exists());
+        assert!(bak.join("foo.txt").exists());
+    }
+
+    /// No backup -> noop, must not touch anything else.
+    #[tokio::test]
+    async fn restore_is_noop_when_backup_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        tokio::fs::create_dir(&orig).await.unwrap();
+        tokio::fs::write(orig.join("x"), b"y").await.unwrap();
+
+        restore_original_from_backup(orig.to_str().unwrap()).await;
+
+        assert!(orig.join("x").exists());
+    }
+
+    /// Foreign .pre-init-bak must not be restored when backup_owned=false (#673).
+    #[tokio::test]
+    async fn cleanup_does_not_restore_unowned_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let subvol = tmp.path().join("subvol");
+        let snap = tmp.path().join("snap");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("attacker.txt"), b"foreign")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&orig).await.unwrap();
+        tokio::fs::write(orig.join("user.txt"), b"real")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&snap).await.unwrap();
+
+        cleanup_init_storage(orig.to_str().unwrap(), &subvol, &snap, false).await;
+
+        assert!(orig.join("user.txt").exists(), "user data must remain");
+        assert!(
+            bak.join("attacker.txt").exists(),
+            "foreign backup not restored"
+        );
+        assert!(!snap.exists(), "snap dir cleaned");
+    }
+
+    /// cleanup with backup_owned=false drops a leftover symlink we created in step 6.
+    #[tokio::test]
+    async fn cleanup_drops_leftover_symlink_when_unowned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let target = tmp.path().join("subvol");
+        let snap = tmp.path().join("snap");
+
+        tokio::fs::create_dir(&target).await.unwrap();
+        tokio::fs::symlink(&target, &orig).await.unwrap();
+        tokio::fs::create_dir(&snap).await.unwrap();
+
+        cleanup_init_storage(orig.to_str().unwrap(), &target, &snap, false).await;
+
+        assert!(!orig.exists(), "leftover symlink dropped");
+    }
+
+    /// backup_owned=true restores the backup over original (legit happy path).
+    #[tokio::test]
+    async fn cleanup_restores_owned_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let target = tmp.path().join("subvol");
+        let snap = tmp.path().join("snap");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("user.txt"), b"keep")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&target).await.unwrap();
+        tokio::fs::symlink(&target, &orig).await.unwrap();
+        tokio::fs::create_dir(&snap).await.unwrap();
+
+        cleanup_init_storage(orig.to_str().unwrap(), &target, &snap, true).await;
+
+        assert!(orig.is_dir(), "original restored as real dir");
+        assert!(orig.join("user.txt").exists(), "user data back at original");
+        assert!(!bak.exists(), "backup consumed");
     }
 
     #[test]

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -13,7 +13,7 @@ use ws_ckpt_common::{DaemonConfig, DiffEntry, WorkspaceInfo, SNAPSHOTS_DIR};
 
 use super::btrfs_common;
 use crate::util::{is_mounted, run_command, run_command_checked};
-use btrfs_common::resolve_symlink_path;
+use btrfs_common::{backup_path_for, resolve_symlink_path};
 
 pub struct BtrfsLoopBackend {
     pub mount_path: PathBuf,
@@ -31,13 +31,14 @@ impl BtrfsLoopBackend {
         }
     }
 
-    /// Internal init implementation; caller wraps with cleanup-on-failure.
+    /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 5.
     async fn do_init_storage(
         &self,
         original_path: &str,
         ws_id: &str,
         subvol_path: &Path,
         snap_dir: &Path,
+        backup_owned: &mut bool,
     ) -> anyhow::Result<()> {
         // 1. Create subvolume
         btrfs_common::create_subvolume(subvol_path).await?;
@@ -76,17 +77,25 @@ impl BtrfsLoopBackend {
             Command::new("sync").status().await.ok();
         }
 
-        // 4. Record original directory permissions before removal
+        // 4. Record original directory permissions before backup
         let orig_meta = tokio::fs::metadata(original_path)
             .await
             .context("failed to read original directory metadata")?;
         let orig_uid = orig_meta.uid();
         let orig_gid = orig_meta.gid();
 
-        // 5. Remove original directory (data is safely in btrfs subvolume now)
-        tokio::fs::remove_dir_all(original_path)
+        // 5. Move original aside (#673). Refuse to clobber a pre-existing backup.
+        let backup_path = backup_path_for(original_path);
+        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
+            anyhow::bail!(
+                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
+                backup_path
+            );
+        }
+        tokio::fs::rename(original_path, &backup_path)
             .await
-            .context("failed to remove original directory")?;
+            .context("failed to rename original directory to backup")?;
+        *backup_owned = true;
 
         // 6. Create symlink: user path -> btrfs subvolume
         if let Some(parent) = Path::new(original_path).parent() {
@@ -118,26 +127,20 @@ impl BtrfsLoopBackend {
             );
         }
 
+        // 8. Drop backup. A leftover .pre-init-bak blocks the next init.
+        if let Err(e) = tokio::fs::remove_dir_all(&backup_path).await {
+            error!(
+                "init ok but backup remove failed {:?}: {}; next init will fail until removed",
+                backup_path, e
+            );
+        }
+
         info!(
             "BtrfsLoopBackend: storage init complete for ws_id={}, subvol={}",
             ws_id,
             subvol_path.display()
         );
         Ok(())
-    }
-
-    /// Cleanup partially-created storage on init failure.
-    async fn cleanup_init_storage(original_path: &str, subvol_path: &Path, snap_dir: &Path) {
-        // Remove symlink if it exists
-        let _ = tokio::fs::remove_file(original_path).await;
-
-        // Remove snapshots dir
-        let _ = tokio::fs::remove_dir_all(snap_dir).await;
-
-        // Delete subvolume (best effort)
-        if let Err(e) = btrfs_common::delete_subvolume(subvol_path).await {
-            error!("cleanup: failed to delete subvolume: {}", e);
-        }
     }
 }
 
@@ -167,12 +170,25 @@ impl StorageBackend for BtrfsLoopBackend {
         let subvol_path = self.mount_path.join(ws_id);
         let snap_dir = self.snapshots_dir.join(ws_id);
 
+        let mut backup_owned = false;
         if let Err(e) = self
-            .do_init_storage(&resolved_str, ws_id, &subvol_path, &snap_dir)
+            .do_init_storage(
+                &resolved_str,
+                ws_id,
+                &subvol_path,
+                &snap_dir,
+                &mut backup_owned,
+            )
             .await
         {
             error!("init_workspace storage failed, cleaning up: {:#}", e);
-            Self::cleanup_init_storage(&resolved_str, &subvol_path, &snap_dir).await;
+            btrfs_common::cleanup_init_storage(
+                &resolved_str,
+                &subvol_path,
+                &snap_dir,
+                backup_owned,
+            )
+            .await;
             return Err(e);
         }
 

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -31,7 +31,7 @@ impl BtrfsLoopBackend {
         }
     }
 
-    /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 5.
+    /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 3.
     async fn do_init_storage(
         &self,
         original_path: &str,
@@ -48,10 +48,28 @@ impl BtrfsLoopBackend {
             .await
             .context("failed to create snapshots directory")?;
 
-        // 3. rsync migration
-        // --copy-unsafe-links: dereference symlinks that point outside the source tree
-        // (e.g. symlinks to other ws-* subvolumes inside mount point)
-        let src = format!("{}/", original_path); // trailing / is important
+        // 3. Record permissions and move original aside as backup (#673).
+        //    Must happen BEFORE data migration so cleanup always restores full data.
+        let orig_meta = tokio::fs::metadata(original_path)
+            .await
+            .context("failed to read original directory metadata")?;
+        let orig_uid = orig_meta.uid();
+        let orig_gid = orig_meta.gid();
+
+        let backup_path = backup_path_for(original_path);
+        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
+            anyhow::bail!(
+                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
+                backup_path
+            );
+        }
+        tokio::fs::rename(original_path, &backup_path)
+            .await
+            .context("failed to rename original directory to backup")?;
+        *backup_owned = true;
+
+        // 4. rsync migration from backup into subvolume
+        let src = format!("{}/", backup_path);
         let status = Command::new("rsync")
             .args([
                 "-a",
@@ -66,7 +84,7 @@ impl BtrfsLoopBackend {
             anyhow::bail!("rsync failed with exit code: {:?}", status.code());
         }
 
-        // 3a. Flush dirty data to disk so subsequent snapshots are instant
+        // 4a. Flush dirty data to disk so subsequent snapshots are instant
         let sync_status = Command::new("btrfs")
             .args(["filesystem", "sync", &subvol_path.to_string_lossy()])
             .status()
@@ -77,27 +95,7 @@ impl BtrfsLoopBackend {
             Command::new("sync").status().await.ok();
         }
 
-        // 4. Record original directory permissions before backup
-        let orig_meta = tokio::fs::metadata(original_path)
-            .await
-            .context("failed to read original directory metadata")?;
-        let orig_uid = orig_meta.uid();
-        let orig_gid = orig_meta.gid();
-
-        // 5. Move original aside (#673). Refuse to clobber a pre-existing backup.
-        let backup_path = backup_path_for(original_path);
-        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
-            anyhow::bail!(
-                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
-                backup_path
-            );
-        }
-        tokio::fs::rename(original_path, &backup_path)
-            .await
-            .context("failed to rename original directory to backup")?;
-        *backup_owned = true;
-
-        // 6. Create symlink: user path -> btrfs subvolume
+        // 5. Create symlink: user path -> btrfs subvolume
         if let Some(parent) = Path::new(original_path).parent() {
             tokio::fs::create_dir_all(parent)
                 .await
@@ -107,7 +105,7 @@ impl BtrfsLoopBackend {
             .await
             .context("failed to create symlink")?;
 
-        // 6a. Restore ownership on the subvolume root to match original directory
+        // 5a. Restore ownership on the subvolume root to match original directory
         chown(
             subvol_path,
             Some(Uid::from_raw(orig_uid)),
@@ -115,7 +113,7 @@ impl BtrfsLoopBackend {
         )
         .context("failed to restore subvolume ownership")?;
 
-        // 7. Verify symlink
+        // 6. Verify symlink
         let link_target = tokio::fs::read_link(original_path)
             .await
             .context("symlink verification failed: cannot read link")?;
@@ -127,7 +125,7 @@ impl BtrfsLoopBackend {
             );
         }
 
-        // 8. Drop backup. A leftover .pre-init-bak blocks the next init.
+        // 7. Drop backup. A leftover .pre-init-bak blocks the next init.
         if let Err(e) = tokio::fs::remove_dir_all(&backup_path).await {
             error!(
                 "init ok but backup remove failed {:?}: {}; next init will fail until removed",


### PR DESCRIPTION
## Description

- 用 `rename` 替换 `remove_dir_all`,把原 workspace 备份成 `<original>.pre-init-bak`,init 中途 crash 时用户数据仍然在磁盘上可恢复(#673)
- 通过 `backup_owned` 标志贯穿 `do_init_storage` / `cleanup_init_storage`,只有本次 init 创建的备份才会被还原,绝不会用别的进程留下的备份覆盖用户数据
- step 5 发现已有 `<original>.pre-init-bak` 直接 bail,避免覆盖前一次未清理的备份
- `restore_original_from_backup` 区分 ENOENT 和其他 stat 错误;EACCES/EIO 不再被当成"没有备份"
- 备份删除失败从 warn 升级为 error:残留备份会确定性地阻塞下一次 init
- 补充 foreign-backup 安全、残留符号链接清理、owned-backup 还原三类测试

### 为什么这样改

原实现在 init_workspace 的 step 5 直接 `remove_dir_all` 用户原 workspace,如果 step 5~7 之间进程崩溃(OOM/SIGKILL/掉电),用户数据就永久丢失,且无任何回滚痕迹。改成 `rename` 到 `.pre-init-bak` 后,即使 cleanup 没跑,数据仍在原盘上,可手工 `mv` 回去。

`backup_owned` 标志是为了避免一类竞争:A 进程崩溃后留下了 `.pre-init-bak`,B 进程再来 init 同一个 workspace,如果不区分备份所有权,B 的 cleanup 路径可能把 A 的备份当成自己的还原回去,覆盖 B 刚写入的 workspace。所以 step 5 看到既存备份就 bail,且只有本次 rename 出来的备份在 cleanup 时才会被 restore。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #673

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

新加了三个单元测试覆盖关键路径:foreign-backup 不会被错误还原、残留符号链接被正确清理、owned-backup 在 cleanup 路径下被还原。本地 `cargo test -p ws-ckpt-daemon` 通过。

## Additional Notes
