### PR TITLE
feat(sec-core): add self-protect rules for openclaw and hermes agent

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-hermes.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-hermes.yaml
@@ -1,0 +1,10 @@
+rule_id: shell-self-protect-hermes
+cwe_id: CWE-284
+desc_en: >-
+  Command disables or removes the agent-sec security plugin in Hermes,
+  which would remove all agent-sec-core security guardrails.
+desc_zh: >-
+  命令禁用或移除了 Hermes 中的 agent-sec 安全插件，将移除 agent-sec-core 所有的安全防护。
+regex: |-
+  \bhermes\s+plugins\s+(disable|remove)\s+agent-sec-core-hermes-plugin\b
+severity: warn

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-openclaw.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-openclaw.yaml
@@ -1,0 +1,11 @@
+rule_id: shell-self-protect-openclaw
+cwe_id: CWE-284
+desc_en: >-
+  Command disables or uninstalls the agent-sec security plugin in OpenClaw,
+  which would remove all agent-sec-core security guardrails.
+desc_zh: >-
+  命令禁用或卸载了 OpenClaw 中的 agent-sec 安全插件，将移除 agent-sec-core 所有的安全防护。
+regex: |-
+  \bopenclaw\s+config\s+set\s+plugins\.entries\.agent-sec\.enabled\s+false\b
+  |\bopenclaw\s+plugins\s+(disable|uninstall|remove)\s+agent-sec\b
+severity: warn

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/code_scan.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/code_scan.py
@@ -70,6 +70,24 @@ class CodeScanCapability(AgentSecCoreCapability):
             )
             return None
 
+        # Self-protect: force block if the command would disable this plugin
+        findings = scan.get("findings", [])
+        self_protect = next(
+            (f for f in findings if f.get("rule_id") == "shell-self-protect-hermes"),
+            None,
+        )
+        if self_protect:
+            msg = (
+                "[agent-sec-core] 自我保护：该命令将禁用 agent-sec 安全插件。"
+                "如果您确实需要禁用，请手动执行以下命令：\n\n"
+                f"  {code}\n\n"
+                "出于安全原因，AI agent 无法执行此操作。"
+            )
+            logger.warning(
+                f"[agent-sec-core] {self.id} SELF-PROTECT block tool={tool_name} code={code[:120]}"
+            )
+            return {"action": "block", "message": msg}
+
         verdict = scan.get("verdict", "pass")
 
         # warn and deny are separate branches (coding convention), same behavior

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/code-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/code-scan.ts
@@ -31,6 +31,16 @@ export const codeScan: SecurityCapability = {
         const verdict = scanResult.verdict;
         const findings = scanResult.findings ?? [];
 
+        // Self-protect: force block if the command would disable this plugin
+        const selfProtectFinding = findings.find(
+          (f: any) => f.rule_id === "shell-self-protect-openclaw",
+        );
+        if (selfProtectFinding) {
+          const msg = `[agent-sec-core] 自我保护：该命令将禁用 agent-sec 安全插件。如果您确实需要禁用，请手动执行以下命令：\n\n  ${command}\n\n出于安全原因，AI agent 无法执行此操作。`;
+          api.logger.warn(`[scan-code] SELF-PROTECT block — ${command}`);
+          return { block: true, blockReason: msg };
+        }
+
         if (verdict === "pass" || findings.length === 0) {
           api.logger.info(`[scan-code] ✅ pass — allowing command`);
           return undefined;

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/code-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/code-scan-test.ts
@@ -360,4 +360,84 @@ describe("scan-code", () => {
       assert.equal(result, undefined);
     });
   });
+
+  // =========================================================================
+  // Dimension 5: Self-Protect Forced Block
+  // =========================================================================
+  describe("self-protect forced block", () => {
+    it("self-protect-openclaw finding forces block regardless of config", async () => {
+      const { handler } = registerAndGetHandler(); // default: codeScanRequireApproval=false
+      mockCli({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          verdict: "warn",
+          findings: [{ rule_id: "shell-self-protect-openclaw", desc_zh: "禁用 agent-sec 插件" }],
+        }),
+        stderr: "",
+      });
+
+      const result = await handler(
+        execEvent("openclaw config set plugins.entries.agent-sec.enabled false"),
+        {},
+      );
+
+      assert.ok(result);
+      assert.equal(result.block, true);
+      assert.ok(result.blockReason.includes("自我保护"));
+      assert.ok(result.blockReason.includes("手动执行"));
+    });
+
+    it("self-protect block includes the original command in message", async () => {
+      const { handler } = registerAndGetHandler();
+      const cmd = "openclaw config set plugins.entries.agent-sec.enabled false && openclaw gateway restart";
+      mockCli({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          verdict: "warn",
+          findings: [{ rule_id: "shell-self-protect-openclaw", desc_zh: "禁用 agent-sec 插件" }],
+        }),
+        stderr: "",
+      });
+
+      const result = await handler(execEvent(cmd), {});
+
+      assert.ok(result);
+      assert.equal(result.block, true);
+      assert.ok(result.blockReason.includes(cmd));
+    });
+
+    it("non-self-protect deny finding does not force block without codeScanRequireApproval", async () => {
+      const { handler } = registerAndGetHandler(); // codeScanRequireApproval=false
+      mockCli({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          verdict: "deny",
+          findings: [{ rule_id: "shell-recursive-delete", desc_zh: "危险删除" }],
+        }),
+        stderr: "",
+      });
+
+      const result = await handler(execEvent("rm -rf /"), {});
+      assert.equal(result, undefined);
+    });
+
+    it("self-protect hermes finding does NOT trigger block in openclaw hook", async () => {
+      const { handler } = registerAndGetHandler();
+      mockCli({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          verdict: "warn",
+          findings: [{ rule_id: "shell-self-protect-hermes", desc_zh: "禁用 hermes 插件" }],
+        }),
+        stderr: "",
+      });
+
+      const result = await handler(
+        execEvent("hermes plugins disable agent-sec-core-hermes-plugin"),
+        {},
+      );
+      // hermes rule should not trigger openclaw self-protect
+      assert.equal(result, undefined);
+    });
+  });
 });

--- a/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
+++ b/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
@@ -1113,6 +1113,128 @@ PY_OBFUSCATION_CASES = [
     ("exec(open('script.py').read())", "python", "py-obfuscation", 0),
 ]
 
+SHELL_SELF_PROTECT_OPENCLAW_CASES = [
+    # === True Positives: config set disabled ===
+    (
+        "openclaw config set plugins.entries.agent-sec.enabled false",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "openclaw  config  set  plugins.entries.agent-sec.enabled  false",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "echo hi && openclaw config set plugins.entries.agent-sec.enabled false",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "openclaw config set plugins.entries.agent-sec.enabled false && openclaw gateway restart",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    # === True Positives: plugins disable/uninstall/remove ===
+    ("openclaw plugins disable agent-sec", "bash", "shell-self-protect-openclaw", 1),
+    ("openclaw plugins uninstall agent-sec", "bash", "shell-self-protect-openclaw", 1),
+    ("openclaw plugins remove agent-sec", "bash", "shell-self-protect-openclaw", 1),
+    (
+        "openclaw plugins uninstall agent-sec --force",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "openclaw  plugins  disable  agent-sec",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "OPENCLAW_STATE_DIR=/tmp openclaw plugins uninstall agent-sec --force",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "openclaw plugins disable agent-sec 2>&1",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    # === True Negatives ===
+    (
+        "openclaw config set plugins.entries.agent-sec.config.codeScanRequireApproval true",
+        "bash",
+        "shell-self-protect-openclaw",
+        0,
+    ),
+    (
+        "openclaw config set plugins.entries.other-plugin.enabled false",
+        "bash",
+        "shell-self-protect-openclaw",
+        0,
+    ),
+    (
+        "openclaw config set plugins.entries.agent-sec.enabled true",
+        "bash",
+        "shell-self-protect-openclaw",
+        0,
+    ),
+    (
+        "openclaw plugins uninstall tokenless --force",
+        "bash",
+        "shell-self-protect-openclaw",
+        0,
+    ),
+    ("openclaw plugins disable tokenless", "bash", "shell-self-protect-openclaw", 0),
+    ("openclaw plugins install agent-sec", "bash", "shell-self-protect-openclaw", 0),
+    ("openclaw gateway restart", "bash", "shell-self-protect-openclaw", 0),
+]
+
+SHELL_SELF_PROTECT_HERMES_CASES = [
+    # === True Positives ===
+    (
+        "hermes plugins disable agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "hermes plugins remove agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "hermes  plugins  disable  agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "HERMES_HOME=/tmp hermes plugins remove agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    # === True Negatives ===
+    (
+        "hermes plugins enable agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        0,
+    ),
+    ("hermes plugins disable other-plugin", "bash", "shell-self-protect-hermes", 0),
+    ("hermes plugins remove tokenless", "bash", "shell-self-protect-hermes", 0),
+    ("hermes plugins list", "bash", "shell-self-protect-hermes", 0),
+]
+
 # =====================================================================
 # Language-level aggregation
 # =====================================================================

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_code_scan.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_code_scan.py
@@ -192,3 +192,85 @@ class TestCodeScanPreToolCall:
         mock_cli.return_value = CliResult(stdout="not json", stderr="", exit_code=0)
         result = capability._on_pre_tool_call("terminal", {"command": "echo hello"})
         assert result is None
+
+
+class TestCodeScanSelfProtect:
+    """Tests for self-protect forced block behavior."""
+
+    @patch("src.capabilities.code_scan.call_agent_sec_cli")
+    def test_self_protect_hermes_disable_blocks(self, mock_cli, capability_observe):
+        """Self-protect rule forces block even when enable_block=False."""
+        mock_cli.return_value = CliResult(
+            stdout=json.dumps(
+                {
+                    "verdict": "warn",
+                    "findings": [
+                        {
+                            "rule_id": "shell-self-protect-hermes",
+                            "desc_en": "disables agent-sec plugin",
+                            "desc_zh": "禁用 agent-sec 插件",
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        )
+        result = capability_observe._on_pre_tool_call(
+            "terminal",
+            {"command": "hermes plugins disable agent-sec-core-hermes-plugin"},
+        )
+        assert result is not None
+        assert result["action"] == "block"
+        assert "自我保护" in result["message"]
+
+    @patch("src.capabilities.code_scan.call_agent_sec_cli")
+    def test_self_protect_hermes_remove_blocks(self, mock_cli, capability_observe):
+        """Self-protect rule forces block for remove command."""
+        mock_cli.return_value = CliResult(
+            stdout=json.dumps(
+                {
+                    "verdict": "warn",
+                    "findings": [
+                        {
+                            "rule_id": "shell-self-protect-hermes",
+                            "desc_en": "removes agent-sec plugin",
+                            "desc_zh": "移除 agent-sec 插件",
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        )
+        result = capability_observe._on_pre_tool_call(
+            "terminal",
+            {"command": "hermes plugins remove agent-sec-core-hermes-plugin"},
+        )
+        assert result is not None
+        assert result["action"] == "block"
+        assert "手动执行" in result["message"]
+
+    @patch("src.capabilities.code_scan.call_agent_sec_cli")
+    def test_self_protect_other_plugin_not_blocked(self, mock_cli, capability_observe):
+        """Non-self-protect findings respect enable_block=False (observe mode)."""
+        mock_cli.return_value = CliResult(
+            stdout=json.dumps(
+                {
+                    "verdict": "deny",
+                    "findings": [
+                        {
+                            "rule_id": "shell-recursive-delete",
+                            "desc_en": "dangerous rm",
+                            "desc_zh": "危险删除",
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        )
+        result = capability_observe._on_pre_tool_call(
+            "terminal", {"command": "rm -rf /"}
+        )
+        assert result is None


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
