### PR TITLE
feat(tokenless): add Claude Code adapter plugin

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -455,6 +455,7 @@ build_tokenless() {
         --exclude='adapters/tokenless/openclaw/openclaw.plugin.json' \
         --exclude='adapters/tokenless/hermes/plugin.yaml' \
         --exclude='adapters/tokenless/qoder/.qoder-plugin/plugin.json' \
+        --exclude='adapters/tokenless/claude-code/.claude-plugin/plugin.json' \
         . | tar -xf - -C "$pkg_dir"
 
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}"

--- a/src/tokenless/.gitignore
+++ b/src/tokenless/.gitignore
@@ -7,3 +7,4 @@ adapters/tokenless/openclaw/package.json
 adapters/tokenless/openclaw/openclaw.plugin.json
 adapters/tokenless/hermes/plugin.yaml
 adapters/tokenless/qoder/.qoder-plugin/plugin.json
+adapters/tokenless/claude-code/.claude-plugin/plugin.json

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -25,7 +25,8 @@ ADAPTER_TEMPLATES := \
     $(ADAPTER_SRC_DIR)/openclaw/package.json \
     $(ADAPTER_SRC_DIR)/openclaw/openclaw.plugin.json \
     $(ADAPTER_SRC_DIR)/hermes/plugin.yaml \
-    $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json
+    $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json \
+    $(ADAPTER_SRC_DIR)/claude-code/.claude-plugin/plugin.json
 TOON_VER := 0.4.6
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
@@ -38,6 +39,7 @@ VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1
         openclaw-install openclaw-uninstall \
         hermes-install hermes-uninstall \
         qoder-install qoder-uninstall \
+        claude-code-install claude-code-uninstall \
         setup help \
         test-hooks
 
@@ -78,6 +80,11 @@ $(ADAPTER_SRC_DIR)/hermes/plugin.yaml: $(ADAPTER_SRC_DIR)/hermes/plugin.yaml.in 
 
 $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json: $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json.in Cargo.toml
 	@echo "==> Generating qoder/.qoder-plugin/plugin.json (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+$(ADAPTER_SRC_DIR)/claude-code/.claude-plugin/plugin.json: \
+    $(ADAPTER_SRC_DIR)/claude-code/.claude-plugin/plugin.json.in Cargo.toml
+	@echo "==> Generating claude-code/.claude-plugin/plugin.json (version=$(VERSION))..."
 	sed 's/@VERSION@/$(VERSION)/g' $< > $@
 
 # Build the tokenless OpenClaw plugin (TypeScript -> dist/index.js).
@@ -184,9 +191,9 @@ ADAPTER_ENV = ANOLISA_PREFIX=$(HOME)/.local \
               ANOLISA_COMPONENT=tokenless \
               ANOLISA_VERSION=$(VERSION)
 
-adapter-install: cosh-extension-install openclaw-install hermes-install qoder-install
+adapter-install: cosh-extension-install openclaw-install hermes-install qoder-install claude-code-install
 
-adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall qoder-uninstall
+adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall qoder-uninstall claude-code-uninstall
 
 adapter-scan:
 	@echo "=== Tokenless Adapter Manifest ==="
@@ -246,6 +253,23 @@ qoder-uninstall:
 	@echo "==> Uninstalling tokenless Qoder CLI plugin..."
 	@$(ADAPTER_ENV) ANOLISA_TARGET=qoder bash $(QODER_ADAPTER_DIR)/scripts/uninstall.sh
 
+# --- Claude Code ---
+# Plugin is sourced from SHARE_DIR (FHS-installed adapter resources). When
+# claude is not available the scripts gracefully no-op so `make adapter-install`
+# stays usable on machines without Claude Code.
+CLAUDE_CODE_ADAPTER_DIR = $(SHARE_DIR)/claude-code
+
+claude-code-install:
+	@echo "==> Installing Claude Code plugin..."
+	@# detect.sh exits 1 (installable) or 2 (missing prereq); we tolerate both
+	@# and let install.sh make the final call (it gracefully no-ops without claude CLI).
+	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/detect.sh || true
+	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/install.sh
+
+claude-code-uninstall:
+	@echo "==> Uninstalling Claude Code plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/uninstall.sh
+
 # One-step setup: build + install + all adapters
 setup: install adapter-install
 	@echo ""
@@ -261,7 +285,7 @@ setup: install adapter-install
 	@echo "  Adapter (FHS):"
 	@echo "    $(SHARE_DIR)/"
 	@echo "  Registered:"
-	@echo "    cosh, openclaw, hermes, qoder"
+	@echo "    cosh, openclaw, hermes, qoder, claude-code"
 	@echo ""
 	@echo "Verify:"
 	@echo "  tokenless --version"
@@ -285,7 +309,7 @@ help:
 	@echo "  fmt               Format code"
 	@echo "  clean             Clean build artifacts"
 	@echo "  adapter-scan      List registered adapter capabilities"
-	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes+qoder)"
+	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes+qoder+claude-code)"
 	@echo "  adapter-uninstall Unregister all adapters"
 	@echo "  cosh-extension-install  Install cosh extension"
 	@echo "  cosh-extension-uninstall Uninstall cosh extension"
@@ -295,6 +319,8 @@ help:
 	@echo "  hermes-uninstall  Uninstall Hermes Agent plugin"
 	@echo "  qoder-install     Register Qoder CLI plugin"
 	@echo "  qoder-uninstall   Unregister Qoder CLI plugin"
+	@echo "  claude-code-install   Register Claude Code plugin via claude CLI"
+	@echo "  claude-code-uninstall Unregister Claude Code plugin"
 	@echo "  setup             Full setup: build + install + register adapters"
 	@echo "  help              Show this help"
 	@echo ""

--- a/src/tokenless/adapters/tokenless/claude-code/.claude-plugin/marketplace.json
+++ b/src/tokenless/adapters/tokenless/claude-code/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "anolisa",
+  "description": "ANOLISA local marketplace — bundles the Token-Less plugin for Claude Code",
+  "owner": {
+    "name": "ANOLISA"
+  },
+  "plugins": [
+    {
+      "name": "tokenless",
+      "source": "./",
+      "description": "Token-Less context compression for Claude Code — RTK command rewriting, response/TOON compression, and Tool Ready environment pre-check",
+      "category": "productivity"
+    }
+  ]
+}

--- a/src/tokenless/adapters/tokenless/claude-code/.claude-plugin/plugin.json.in
+++ b/src/tokenless/adapters/tokenless/claude-code/.claude-plugin/plugin.json.in
@@ -1,0 +1,9 @@
+{
+  "name": "tokenless",
+  "version": "@VERSION@",
+  "description": "Token-Less context compression for Claude Code — RTK command rewriting, response/TOON compression, and Tool Ready environment pre-check",
+  "author": { "name": "ANOLISA" },
+  "license": "MIT",
+  "homepage": "https://github.com/alibaba/anolisa/tree/main/src/tokenless",
+  "keywords": ["token-optimization", "rtk", "compression", "toon", "tool-ready"]
+}

--- a/src/tokenless/adapters/tokenless/claude-code/hooks/hooks.json
+++ b/src/tokenless/adapters/tokenless/claude-code/hooks/hooks.json
@@ -1,0 +1,38 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TOKENLESS_AGENT_ID=claude-code TOKENLESS_HOST=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" rewrite_hook.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TOKENLESS_AGENT_ID=claude-code TOKENLESS_HOST=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" tool_ready_hook.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(?!(?:Read|Glob|NotebookRead)$).+",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TOKENLESS_AGENT_ID=claude-code TOKENLESS_HOST=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" compress_response_hook.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/tokenless/adapters/tokenless/claude-code/hooks/run-hook.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/hooks/run-hook.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# run-hook.sh — Locate and exec a shared tokenless hook script.
+#
+# Claude Code copies the plugin into a versioned cache directory
+# (~/.claude/plugins/cache/<mkt>/<plugin>/<ver>/), so relative paths into
+# common/ no longer resolve. We instead look up the named hook under the
+# FHS layout installed by the tokenless RPM / Makefile.
+#
+# Usage:    run-hook.sh <hook-script-basename> [args...]
+# Examples: run-hook.sh rewrite_hook.py
+#           run-hook.sh compress_response_hook.py
+#           run-hook.sh tool_ready_hook.sh
+#
+# Fail-open contract: any not-found / missing-interpreter condition emits
+# an empty JSON object on stdout and exits 0, so Claude Code never blocks
+# on us.
+#
+# PreToolUse matcher overlap is by design: hooks.json registers both a
+# Bash-specific entry (rewrite) and a catch-all entry (tool-ready). Bash
+# tool calls therefore fire both — Claude Code evaluates each matching
+# matcher independently, so this is the documented way to attach a
+# tool-specific hook alongside a global one. The timeout values are
+# upper bounds; observed runtimes are well under them.
+set -euo pipefail
+
+SCRIPT="${1:?usage: run-hook.sh <hook-script-basename> [args...]}"
+shift
+
+fail_open() { echo "{}"; exit 0; }
+
+# Reject anything but a bare basename. Practical risk is low — hooks.json is
+# RPM-installed root:root 0644 and unwritable at runtime — but a defense-in-
+# depth check costs one line and stops any future caller from smuggling a
+# traversal segment through this argument.
+case "$SCRIPT" in
+    */*|"") fail_open ;;
+esac
+
+CANDIDATES=(
+    "/usr/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"
+    "${HOME}/.local/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"
+)
+
+for candidate in "${CANDIDATES[@]}"; do
+    [ -f "$candidate" ] || continue
+    case "$candidate" in
+        *.py)
+            command -v python3 >/dev/null 2>&1 || fail_open
+            exec python3 "$candidate" "$@"
+            ;;
+        *.sh)
+            exec bash "$candidate" "$@"
+            ;;
+        *)
+            fail_open
+            ;;
+    esac
+done
+
+fail_open

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# detect.sh — Inspect Claude Code presence and the tokenless plugin state.
+# Read-only. Tri-state exit aligns with openclaw/hermes detect.sh:
+#   0 = installed and ready
+#   1 = not installed but installable (prereqs OK)
+#   2 = missing prerequisites
+set -euo pipefail
+
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+AGENT="${ANOLISA_TARGET:-claude-code}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+PLUGIN_ID="tokenless@anolisa"
+PLUGIN_SRC="$ADAPTER_DIR/claude-code"
+
+CLAUDE_BIN="${CLAUDE_BIN:-}"
+export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+
+line()  { printf '[%s] %s\n' "$COMPONENT" "$*"; }
+field() { printf '[%s]   %-26s %s\n' "$COMPONENT" "$1" "$2"; }
+
+PREREQ_MISSING=()
+INSTALL_MISSING=()
+note_prereq_missing()  { PREREQ_MISSING+=("$1"); }
+note_install_missing() { INSTALL_MISSING+=("$1"); }
+
+if [ -z "$CLAUDE_BIN" ]; then
+    CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
+fi
+
+line "${AGENT} detect"
+if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
+    CLAUDE_VER="$("$CLAUDE_BIN" --version 2>/dev/null | awk '{print $1}' || echo unknown)"
+    field "claude CLI"        "present (${CLAUDE_BIN}, v${CLAUDE_VER})"
+else
+    field "claude CLI"        "missing"
+    note_prereq_missing "claude CLI"
+fi
+
+# Informational only: claude creates ~/.claude on first run; absence is
+# not a prerequisite failure.
+if [ -d "$HOME/.claude" ]; then
+    field "claude config dir" "present ($HOME/.claude)"
+else
+    field "claude config dir" "missing (created on first claude run)"
+fi
+
+if [ -f "$PLUGIN_SRC/.claude-plugin/marketplace.json" ]; then
+    field "marketplace.json"  "present"
+else
+    field "marketplace.json"  "missing"
+    note_prereq_missing "marketplace.json"
+fi
+
+if [ -f "$PLUGIN_SRC/.claude-plugin/plugin.json" ]; then
+    field "plugin.json"       "present"
+else
+    field "plugin.json"       "missing (run: make stamp-adapter-templates)"
+fi
+
+if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
+    if "$CLAUDE_BIN" plugin list 2>&1 | grep -qF "$PLUGIN_ID"; then
+        field "plugin install"    "installed ($PLUGIN_ID)"
+    else
+        field "plugin install"    "not installed"
+        note_install_missing "$PLUGIN_ID"
+    fi
+fi
+
+if [ -f "$PLUGIN_SRC/hooks/run-hook.sh" ]; then
+    field "hook dispatcher"   "present"
+else
+    field "hook dispatcher"   "missing (hooks/run-hook.sh)"
+    note_prereq_missing "hook dispatcher"
+fi
+
+if command -v python3 &>/dev/null; then
+    field "python3"           "present ($(command -v python3))"
+else
+    field "python3"           "missing"
+    note_prereq_missing "python3"
+fi
+
+# jq is required by tool_ready_hook.sh; absence disables that hook only
+# (rewrite + compress-response still work). Treat as informational.
+if command -v jq &>/dev/null; then
+    field "jq"                "present ($(command -v jq))"
+else
+    field "jq"                "missing (tool-ready hook disabled)"
+fi
+
+runtime_bin="$(command -v tokenless 2>/dev/null || true)"
+if [ -n "$runtime_bin" ]; then
+    field "tokenless binary"  "present (${runtime_bin})"
+else
+    field "tokenless binary"  "missing"
+    note_prereq_missing "tokenless binary"
+fi
+
+rtk_bin="$(command -v rtk 2>/dev/null || true)"
+if [ -n "$rtk_bin" ]; then
+    field "rtk binary"        "present (${rtk_bin})"
+else
+    field "rtk binary"        "missing"
+    note_prereq_missing "rtk binary"
+fi
+
+# Shared hook scripts live under FHS; warn when missing so user knows to run
+# `make install` (or install the RPM) before adapter actually fires.
+SHARED_HOOKS_DIR=""
+for d in /usr/share/anolisa/adapters/tokenless/common/hooks \
+         "$HOME/.local/share/anolisa/adapters/tokenless/common/hooks"; do
+    if [ -d "$d" ]; then SHARED_HOOKS_DIR="$d"; break; fi
+done
+if [ -n "$SHARED_HOOKS_DIR" ]; then
+    field "shared hooks dir"  "present ($SHARED_HOOKS_DIR)"
+else
+    field "shared hooks dir"  "missing (run: make -C src/tokenless install)"
+    note_prereq_missing "shared hooks dir"
+fi
+
+if [ ${#PREREQ_MISSING[@]} -gt 0 ]; then
+    line "${AGENT}: missing prerequisites (${PREREQ_MISSING[*]})"
+    exit 2
+fi
+if [ ${#INSTALL_MISSING[@]} -gt 0 ]; then
+    line "${AGENT}: not installed (ready to install)"
+    exit 1
+fi
+line "${AGENT}: ready"
+exit 0

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# install.sh — Register tokenless as a local Claude Code marketplace and
+# install the plugin via the official `claude plugin` CLI.
+#
+# Responsibility boundary (mirrors openclaw/scripts/install.sh):
+#   - This script ONLY deploys an already-stamped plugin manifest.
+#   - Manifest stamping (plugin.json.in -> plugin.json) is the Makefile's job:
+#       make -C src/tokenless stamp-adapter-templates
+#     which `make install` runs automatically before `install-adapter-resources`
+#     copies the result into $SHARE_DIR/claude-code.
+#   - A dev-only fallback stamps the manifest in place when called outside the
+#     RPM/Makefile flow, so adapter-install works on a freshly checked-out tree.
+#
+# Claude Code v2 requires plugins to be sourced from a registered marketplace.
+# We expose the adapter's claude-code/ directory itself as a single-plugin
+# marketplace ("anolisa"), then install tokenless@anolisa from it.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-claude-code}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+PLUGIN_SRC="$ADAPTER_DIR/claude-code"
+MARKETPLACE_NAME="anolisa"
+PLUGIN_ID="tokenless@${MARKETPLACE_NAME}"
+
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+
+echo "[${COMPONENT}] Installing ${AGENT} plugin..."
+
+if ! command -v "$CLAUDE_BIN" &>/dev/null; then
+    echo "[${COMPONENT}] claude CLI not found (CLAUDE_BIN=${CLAUDE_BIN}) — skipping plugin installation."
+    echo "[${COMPONENT}] Install Claude Code first, then run this script again."
+    exit 0
+fi
+
+if [ ! -d "$PLUGIN_SRC" ]; then
+    echo "[${COMPONENT}] Plugin source not found: $PLUGIN_SRC" >&2
+    exit 1
+fi
+
+if [ ! -f "$PLUGIN_SRC/.claude-plugin/marketplace.json" ]; then
+    echo "[${COMPONENT}] ERROR: $PLUGIN_SRC/.claude-plugin/marketplace.json missing." >&2
+    exit 1
+fi
+
+# Dev-only fallback: stamp plugin.json from .in template when Makefile hasn't
+# run yet. Production installs (RPM, `make install`) ship a stamped manifest
+# inside SHARE_DIR, so this branch is a no-op in those flows.
+PLUGIN_MANIFEST="$PLUGIN_SRC/.claude-plugin/plugin.json"
+PLUGIN_TEMPLATE="$PLUGIN_SRC/.claude-plugin/plugin.json.in"
+if [ ! -f "$PLUGIN_MANIFEST" ] && [ -f "$PLUGIN_TEMPLATE" ]; then
+    VERSION="${TOKENLESS_VERSION:-${ANOLISA_VERSION:-0.0.0-dev}}"
+    sed "s/@VERSION@/${VERSION}/g" "$PLUGIN_TEMPLATE" > "$PLUGIN_MANIFEST"
+    echo "[${COMPONENT}] dev-fallback: stamped plugin.json (version=${VERSION}) — production builds should stamp via Makefile"
+fi
+
+if [ ! -f "$PLUGIN_MANIFEST" ] ; then
+    echo "[${COMPONENT}] ERROR: $PLUGIN_MANIFEST missing." >&2
+    echo "[${COMPONENT}]        Stamp the manifest first:" >&2
+    echo "[${COMPONENT}]            make -C src/tokenless stamp-adapter-templates" >&2
+    exit 1
+fi
+
+# Validate the stamped plugin via the official CLI — same gate the install
+# call would hit; surfacing the error here gives a cleaner failure message.
+"$CLAUDE_BIN" plugin validate "$PLUGIN_SRC" >/dev/null \
+    || { echo "[${COMPONENT}] plugin validation failed" >&2; exit 1; }
+
+# Idempotent marketplace add. We probe `marketplace list` first so that a
+# `marketplace add` failure surfaces its real cause (bad path, malformed
+# manifest, settings.json write error) instead of being swallowed as
+# "already registered".
+echo "[${COMPONENT}] registering marketplace '${MARKETPLACE_NAME}' from ${PLUGIN_SRC}..."
+if "$CLAUDE_BIN" plugin marketplace list 2>/dev/null \
+       | grep -qE "(^|[[:space:]])${MARKETPLACE_NAME}([[:space:]]|$)"; then
+    echo "[${COMPONENT}] marketplace '${MARKETPLACE_NAME}' already registered"
+else
+    "$CLAUDE_BIN" plugin marketplace add "$PLUGIN_SRC" \
+        || { echo "[${COMPONENT}] marketplace add failed" >&2; exit 1; }
+fi
+
+# Idempotent plugin install.
+echo "[${COMPONENT}] installing ${PLUGIN_ID}..."
+"$CLAUDE_BIN" plugin install "$PLUGIN_ID" 2>&1 \
+    || { echo "[${COMPONENT}] plugin install failed" >&2; exit 1; }
+
+echo "[${COMPONENT}] ${AGENT} plugin installed via claude CLI."
+echo "[${COMPONENT}] Restart claude (or run /plugin) to activate."

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/uninstall.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/uninstall.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# uninstall.sh — Remove the tokenless plugin and the anolisa marketplace via
+# the official `claude plugin` CLI. Falls back to manual cleanup of the
+# settings.json + plugin cache when claude is unavailable (e.g. RPM %preun
+# running after the user uninstalled claude themselves).
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-claude-code}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+
+MARKETPLACE_NAME="anolisa"
+PLUGIN_ID="tokenless@${MARKETPLACE_NAME}"
+
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+
+echo "[${COMPONENT}] Uninstalling ${AGENT} plugin..."
+
+if command -v "$CLAUDE_BIN" &>/dev/null; then
+    "$CLAUDE_BIN" plugin uninstall "$PLUGIN_ID" 2>&1 || true
+    "$CLAUDE_BIN" plugin marketplace remove "$MARKETPLACE_NAME" 2>&1 || true
+    echo "[${COMPONENT}] ${AGENT} plugin removed via claude CLI."
+    exit 0
+fi
+
+echo "[${COMPONENT}] claude CLI not found — falling back to manual cleanup."
+SETTINGS="$HOME/.claude/settings.json"
+if command -v jq &>/dev/null && [ -f "$SETTINGS" ]; then
+    # del(.[$key]) silently no-ops on non-object values. Verify shape up-front
+    # so a schema change in a future Claude Code release surfaces as a clear
+    # warning instead of a silent "cleaned" message that left residue behind.
+    EP_TYPE=$(jq -r '.enabledPlugins | type' "$SETTINGS" 2>/dev/null || echo "missing")
+    MK_TYPE=$(jq -r '.extraKnownMarketplaces | type' "$SETTINGS" 2>/dev/null || echo "missing")
+    if [ "$EP_TYPE" != "object" ] && [ "$EP_TYPE" != "null" ] && [ "$EP_TYPE" != "missing" ]; then
+        echo "[${COMPONENT}] WARN: .enabledPlugins is ${EP_TYPE}, expected object — skipping jq cleanup." >&2
+        echo "[${COMPONENT}] WARN: remove '${PLUGIN_ID}' from $SETTINGS manually." >&2
+    elif [ "$MK_TYPE" != "object" ] && [ "$MK_TYPE" != "null" ] && [ "$MK_TYPE" != "missing" ]; then
+        echo "[${COMPONENT}] WARN: .extraKnownMarketplaces is ${MK_TYPE}, expected object — skipping jq cleanup." >&2
+        echo "[${COMPONENT}] WARN: remove '${MARKETPLACE_NAME}' from $SETTINGS manually." >&2
+    else
+        tmp="$(mktemp "${SETTINGS}.XXXXXX")"
+        jq --arg id "$PLUGIN_ID" --arg mkt "$MARKETPLACE_NAME" '
+            if .enabledPlugins then .enabledPlugins |= del(.[$id]) else . end
+            | if .extraKnownMarketplaces then .extraKnownMarketplaces |= del(.[$mkt]) else . end
+        ' "$SETTINGS" > "$tmp" && mv "$tmp" "$SETTINGS"
+        echo "[${COMPONENT}] cleaned $SETTINGS"
+    fi
+fi
+rm -rf "$HOME/.claude/plugins/cache/${MARKETPLACE_NAME}" 2>/dev/null || true
+echo "[${COMPONENT}] manual cleanup complete."

--- a/src/tokenless/adapters/tokenless/manifest.json.in
+++ b/src/tokenless/adapters/tokenless/manifest.json.in
@@ -35,7 +35,7 @@
         "hooks": [
           "compress-response",
           "compress-toon",
-          "rtk-rewrite",
+          "rewrite",
           "tool-ready"
         ]
       },
@@ -58,6 +58,25 @@
         "detect":    "qoder/scripts/detect.sh",
         "install":   "qoder/scripts/install.sh",
         "uninstall": "qoder/scripts/uninstall.sh"
+      }
+    },
+    "claude-code": {
+      "compatibleVersions": ">=2.0.0",
+      "method": "plugin",
+      "marketplace": "anolisa",
+      "pluginId": "tokenless@anolisa",
+      "capabilities": {
+        "hooks": [
+          "rewrite",
+          "compress-response",
+          "compress-toon",
+          "tool-ready"
+        ]
+      },
+      "actions": {
+        "detect":    "claude-code/scripts/detect.sh",
+        "install":   "claude-code/scripts/install.sh",
+        "uninstall": "claude-code/scripts/uninstall.sh"
       }
     }
   }

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 2
+%define anolis_release 3
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -53,6 +53,10 @@ Copilot-shell extension is auto-discovered from /usr/share/anolisa/extensions/to
 Hermes Agent plugin (response compression, TOON encoding, command rewriting via RTK,
 and Tool Ready) is available under /usr/share/anolisa/adapters/tokenless/hermes/.
 Run the install script to register with Hermes: hermes/scripts/install.sh
+Claude Code plugin (RTK command rewriting, response/TOON compression, and Tool Ready
+environment pre-check) is available under /usr/share/anolisa/adapters/tokenless/claude-code/.
+Register it with the official `claude plugin marketplace add` / `claude plugin install`
+CLI, or run the install script: claude-code/scripts/install.sh
 
 %prep
 %setup -q -n tokenless
@@ -69,7 +73,14 @@ cargo build --release
 cargo build --release --manifest-path third_party/rtk/Cargo.toml
 
 # Build toon (standalone binary for Python hooks)
-cargo install toon-format --version 0.4.6 --root %{_builddir}/toon-root --locked
+# Note: toon-format's transitive deps (darling, image, time, plist, etc.)
+# have MSRV 1.88+, which exceeds the build environment's Rust 1.86.
+# Fall back to the system-provided toon binary when available.
+if test -x "%{_bindir}/toon"; then
+    echo "toon (system) already available, skipping cargo install"
+else
+    cargo install toon-format --version 0.4.6 --root %{_builddir}/toon-root --locked
+fi
 
 # Compile the OpenClaw TS plugin via the project Makefile.
 # Produces adapters/tokenless/openclaw/dist/index.js, which package.json
@@ -89,12 +100,23 @@ mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/commands
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/.claude-plugin
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/hooks
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/scripts
 mkdir -p %{buildroot}%{_docdir}/tokenless
 
 # Install binaries — tokenless (user-facing) to /usr/bin, helpers to /usr/libexec/anolisa/tokenless
 install -m 0755 target/release/tokenless %{buildroot}%{_bindir}/tokenless
 install -m 0755 third_party/rtk/target/release/rtk %{buildroot}%{_libexecdir}/anolisa/tokenless/rtk
-install -m 0755 %{_builddir}/toon-root/bin/toon %{buildroot}%{_libexecdir}/anolisa/tokenless/toon
+# Install toon — prefer cargo build output, fall back to system binary
+if [ -f %{_builddir}/toon-root/bin/toon ]; then
+    install -m 0755 %{_builddir}/toon-root/bin/toon %{buildroot}%{_libexecdir}/anolisa/tokenless/toon
+elif command -v toon &>/dev/null; then
+    cp "$(command -v toon)" %{buildroot}%{_libexecdir}/anolisa/tokenless/toon
+else
+    echo "ERROR: toon binary not found"
+    exit 1
+fi
 
 # Create symlinks so rtk and toon are discoverable via PATH
 ln -sf %{_libexecdir}/anolisa/tokenless/rtk %{buildroot}%{_bindir}/rtk
@@ -140,6 +162,17 @@ install -m 0755 adapters/tokenless/qoder/scripts/detect.sh %{buildroot}%{_datadi
 install -m 0755 adapters/tokenless/qoder/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts/
 install -m 0755 adapters/tokenless/qoder/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts/
 
+# Install Claude Code plugin (marketplace + plugin manifest + wrapper hook + scripts).
+# plugin.json is stamped from .in by `make stamp-adapter-templates` during %build
+# (transitive dep of build-openclaw-plugin); shipped as a regular file here.
+install -m 0644 adapters/tokenless/claude-code/.claude-plugin/marketplace.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/.claude-plugin/
+install -m 0644 adapters/tokenless/claude-code/.claude-plugin/plugin.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/.claude-plugin/
+install -m 0644 adapters/tokenless/claude-code/hooks/hooks.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/hooks/
+install -m 0755 adapters/tokenless/claude-code/hooks/run-hook.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/hooks/
+install -m 0755 adapters/tokenless/claude-code/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/scripts/
+install -m 0755 adapters/tokenless/claude-code/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/scripts/
+install -m 0755 adapters/tokenless/claude-code/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/scripts/
+
 # Install cosh extension for auto-discovery at /usr/share/anolisa/extensions/tokenless/
 mkdir -p %{buildroot}%{_datadir}/anolisa/extensions/tokenless/hooks
 mkdir -p %{buildroot}%{_datadir}/anolisa/extensions/tokenless/commands
@@ -177,6 +210,10 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %dir %{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin
 %dir %{_datadir}/anolisa/adapters/tokenless/qoder/scripts
 %dir %{_datadir}/anolisa/adapters/tokenless/qoder/commands
+%dir %{_datadir}/anolisa/adapters/tokenless/claude-code
+%dir %{_datadir}/anolisa/adapters/tokenless/claude-code/.claude-plugin
+%dir %{_datadir}/anolisa/adapters/tokenless/claude-code/hooks
+%dir %{_datadir}/anolisa/adapters/tokenless/claude-code/scripts
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/manifest.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/common/tool-ready-spec.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/common/cosh-extension.json
@@ -202,6 +239,14 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/scripts/uninstall.sh
+
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/claude-code/.claude-plugin/marketplace.json
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/claude-code/.claude-plugin/plugin.json
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/claude-code/hooks/hooks.json
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/claude-code/hooks/run-hook.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/claude-code/scripts/detect.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/claude-code/scripts/install.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/claude-code/scripts/uninstall.sh
 # Cosh extension — auto-discovered from /usr/share/anolisa/extensions/
 %dir %{_datadir}/anolisa/extensions
 %dir %{_datadir}/anolisa/extensions/tokenless
@@ -277,9 +322,22 @@ if [ $1 -eq 0 ]; then
     elif [ -d "$HOME/.hermes/plugins/tokenless" ]; then
         rm -rf "$HOME/.hermes/plugins/tokenless" 2>/dev/null || true
     fi
+    # Uninstall claude-code plugin (remove via claude CLI or strip settings.json).
+    # Note: %preun runs as root so this only touches root's ~/.claude — per-user
+    # configs under non-root home dirs are intentionally left alone. Users who
+    # installed claude per-user (npm i -g) must run the cleanup themselves.
+    CLAUDE_CODE_SCRIPT="%{_datadir}/anolisa/adapters/tokenless/claude-code/scripts/uninstall.sh"
+    if [ -f "$CLAUDE_CODE_SCRIPT" ]; then
+        bash "$CLAUDE_CODE_SCRIPT" || true
+        echo "WARN: per-user Claude Code plugin entries are not removed by RPM %preun." >&2
+        echo "WARN: each user running claude should run: claude plugin uninstall tokenless@anolisa" >&2
+    fi
 fi
 
 %changelog
+* Thu Jun 04 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.4.1-3
+- feat(tokenless): add Claude Code adapter plugin support
+
 * Wed Jun 03 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.4.1-2
 - feat(tokenless): add qodercli plugin support
 


### PR DESCRIPTION
## Description

Register tokenless as a local Claude Code marketplace plugin via the official `claude plugin` CLI, mirroring openclaw/hermes coverage:

  - PreToolUse(Bash)  -> rtk command rewriting
  - PreToolUse(*)     -> Tool Ready env pre-check + auto-fix
  - PostToolUse(*)    -> response/TOON compression (excludes read-only tools)

All hooks share a single dispatcher (run-hook.sh) that resolves shared scripts under FHS layout and fails open on missing dependencies.

Also harmonize hermes manifest hook capability from "rtk-rewrite" to "rewrite" for cross-adapter consistency.

Let-chain compatibility fix: replace unstable `if let ... && let` syntax with nested if-let blocks to support rustc 1.86.



<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue # new feature

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
  ┌──────────────────────┬─────────┬───────────────────────────────────────────────────────────────────────────────────────────────────┐
  │         步骤         │  状态   │                                               详情                                                │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ release 号           │ 1 → 3   │ %define anolis_release 3                                                                          │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ changelog            │ 0.4.1-3 │ feat(tokenless): add Claude Code plugin support                                                   │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ let-chain 修复       │ ✅  3 处 │ recorder.rs / main.rs / env_check.rs 已修复合并入 commit                                         │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ make dist            │ ✅       │ 源码包 tokenless-0.4.1.tar.gz                                                                    │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ rpmbuild -bb         │ ✅       │ tokenless-0.4.1-3.alnx4.x86_64.rpm                                                               │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 安装                 │ ✅       │ 新版本安装成功                                                                                   │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 版本验证             │ ✅       │ tokenless 0.4.1 / rtk 0.36.0 / toon 0.4.6                                                        │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Claude Code 插件文件 │ ✅       │ marketplace.json / plugin.json / hooks.json / run-hook.sh / detect.sh / install.sh / uninstall.sh │
  ├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 全量测试             │ ✅       │ 90/90 全部通过                                                                                   │
  └──────────────────────┴─────────┴───────────────────────────────────────────────────────────────────────────────────────────────────┘
```
