### PR TITLE
fix(ckpt): recover bail + lock-free registry + arch-aware seccomp

### DIFF
--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
@@ -330,8 +330,9 @@ impl StorageBackend for BtrfsBaseBackend {
             .await
             .context("failed to run rsync")?;
         if !rsync_status.success() {
-            error!(
-                "rsync failed restoring {} -> {}, exit: {:?}",
+            bail!(
+                "rsync failed restoring {} -> {}, exit: {:?}; \
+                 workspace and snapshots preserved for retry",
                 src,
                 original_path,
                 rsync_status.code()

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -264,8 +264,9 @@ impl StorageBackend for BtrfsLoopBackend {
             .await
             .context("failed to run rsync")?;
         if !rsync_status.success() {
-            error!(
-                "rsync failed restoring {} -> {}, exit: {:?}",
+            bail!(
+                "rsync failed restoring {} -> {}, exit: {:?}; \
+                 workspace and snapshots preserved for retry",
                 src,
                 original_path,
                 rsync_status.code()

--- a/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
@@ -185,7 +185,7 @@ async fn handle_status(
         }]
     } else {
         // Global mode: return all workspaces
-        state.get_all_workspace_info()
+        state.get_all_workspace_info().await
     };
 
     // Try to get filesystem usage; fallback to zeros on error (e.g., macOS)
@@ -305,6 +305,7 @@ fn handle_reload_config(state: &Arc<DaemonState>) -> Response {
 async fn handle_health_advisory(state: &Arc<DaemonState>) -> Response {
     let over_limit_workspace_count: u32 = state
         .get_all_workspace_info()
+        .await
         .iter()
         .filter(|w| w.snapshot_count > ADVISORY_SNAPSHOT_LIMIT)
         .count() as u32;

--- a/src/ws-ckpt/src/crates/daemon/src/seccomp.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/seccomp.rs
@@ -14,7 +14,33 @@ use seccompiler::{
     SeccompFilter, SeccompRule, TargetArch,
 };
 
+/// Match the build target_arch to seccompiler's TargetArch so the BPF
+/// audit_arch check passes at runtime. Returns Err on unsupported arches
+/// (e.g. loongarch64) so the daemon refuses to install a no-op filter.
+fn target_arch() -> anyhow::Result<TargetArch> {
+    #[cfg(target_arch = "x86_64")]
+    return Ok(TargetArch::x86_64);
+    #[cfg(target_arch = "aarch64")]
+    return Ok(TargetArch::aarch64);
+    #[cfg(target_arch = "riscv64")]
+    return Ok(TargetArch::riscv64);
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    )))]
+    anyhow::bail!(
+        "seccomp filter not supported on target arch '{}'; refusing to install no-op filter",
+        std::env::consts::ARCH
+    );
+}
+
 /// Blocked syscalls — operations the daemon should never perform.
+///
+/// Excluded on purpose: new mount API (fsopen/fsmount/fsconfig/move_mount/
+/// open_tree/mount_setattr), io_uring, and landlock. mount(8) and various
+/// libraries probe these and only fall back on ENOSYS; returning EPERM would
+/// break the daemon's own mount path or future tokio io_uring opt-in.
 ///
 /// Categories:
 /// - Kernel/module manipulation
@@ -23,8 +49,8 @@ use seccompiler::{
 /// - Swap management
 /// - Accounting / profiling
 /// - Key management
-/// - Network-related (the daemon only uses Unix domain sockets)
-/// - Virtualization
+/// - Virtualization / namespaces
+/// - pidfd / cross-process memory (daemon never inspects other processes)
 fn blocked_syscalls() -> Vec<i64> {
     vec![
         // ── Kernel module loading ──
@@ -60,10 +86,14 @@ fn blocked_syscalls() -> Vec<i64> {
         libc::SYS_unshare,
         libc::SYS_setns,
         // ── Misc dangerous ──
-        libc::SYS_lookup_dcookie,
         libc::SYS_bpf, // prevent loading arbitrary BPF programs
         libc::SYS_userfaultfd,
         libc::SYS_move_pages,
+        // ── pidfd / cross-process memory (5.x) ──
+        libc::SYS_pidfd_open,
+        libc::SYS_pidfd_send_signal,
+        libc::SYS_pidfd_getfd,
+        libc::SYS_process_madvise,
     ]
 }
 
@@ -92,7 +122,7 @@ pub fn apply_seccomp_filter() -> anyhow::Result<()> {
         rules,
         SeccompAction::Allow,                     // default: allow everything
         SeccompAction::Errno(libc::EPERM as u32), // blocked: return EPERM
-        TargetArch::x86_64,
+        target_arch()?,
     )?;
 
     let bpf: BpfProgram = filter.try_into()?;
@@ -124,7 +154,8 @@ mod tests {
     }
 
     #[test]
-    fn filter_builds_successfully() {
+    fn filter_builds_for_target_arch() {
+        let arch = target_arch().expect("test host arch should be supported");
         let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
         for syscall in blocked_syscalls() {
             rules.insert(syscall, vec![unconditional_rule().unwrap()]);
@@ -133,7 +164,7 @@ mod tests {
             rules,
             SeccompAction::Allow,
             SeccompAction::Errno(libc::EPERM as u32),
-            TargetArch::x86_64,
+            arch,
         );
         assert!(filter.is_ok(), "seccomp filter should build without errors");
     }

--- a/src/ws-ckpt/src/crates/daemon/src/state.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/state.rs
@@ -216,16 +216,19 @@ impl DaemonState {
         Ok(())
     }
 
-    /// Collect current all registered workspace entries
-    /// (for serialization to state.json)
+    /// Collect registered workspace entries for state.json. No RwLock taken so
+    /// a write-locked ws is not silently dropped.
     fn collect_workspace_entries(&self) -> Vec<WorkspaceEntry> {
-        self.workspaces
+        self.path_to_wsid
             .iter()
             .filter_map(|entry| {
-                let ws = entry.value().try_read().ok()?;
+                let ws_id = entry.value().clone();
+                if !self.workspaces.contains_key(&ws_id) {
+                    return None;
+                }
                 Some(WorkspaceEntry {
-                    ws_id: ws.ws_id.clone(),
-                    workspace_path: ws.path.clone(),
+                    ws_id,
+                    workspace_path: entry.key().clone(),
                     registered_at: Utc::now(),
                     origin_backend: self.backend.backend_type(),
                 })
@@ -302,21 +305,15 @@ impl DaemonState {
         self.workspaces.insert(ws_id, state);
     }
 
-    pub fn unregister_workspace(&self, ws_id: &str) {
+    pub fn unregister_workspace(&self, ws_id: &str, path: &Path) {
         // Stop watcher if present
         if let Ok(mut watchers) = self.watchers.lock() {
             if let Some(w) = watchers.remove(ws_id) {
                 w.stop();
             }
         }
-        if let Some((_, ws_state)) = self.workspaces.remove(ws_id) {
-            // We need the path to remove from path_to_wsid.
-            // Since we can't async here, use try_read or blocking_read.
-            // The RwLock should be uncontested at this point.
-            if let Ok(state) = ws_state.try_read() {
-                self.path_to_wsid.remove(&state.path);
-            }
-        }
+        self.workspaces.remove(ws_id);
+        self.path_to_wsid.remove(path);
     }
 
     /// Register a file watcher for a workspace.
@@ -492,28 +489,20 @@ impl DaemonState {
         }
     }
 
-    /// Collect summary information about all registered workspaces.
-    pub fn get_all_workspace_info(&self) -> Vec<WorkspaceInfo> {
-        self.workspaces
-            .iter()
-            .map(|entry| {
-                let ws = entry.value();
-                // Use try_read to avoid blocking; the lock should be uncontested.
-                if let Ok(state) = ws.try_read() {
-                    WorkspaceInfo {
-                        ws_id: state.ws_id.clone(),
-                        path: state.path.to_string_lossy().to_string(),
-                        snapshot_count: state.index.snapshots.len() as u32,
-                    }
-                } else {
-                    WorkspaceInfo {
-                        ws_id: entry.key().clone(),
-                        path: "<locked>".to_string(),
-                        snapshot_count: 0,
-                    }
-                }
-            })
-            .collect()
+    /// Collect summary information about all registered workspaces. Awaits the
+    /// read lock so the result reflects real path/snapshot_count even when a
+    /// ws is held under a write lock.
+    pub async fn get_all_workspace_info(&self) -> Vec<WorkspaceInfo> {
+        let mut out = Vec::new();
+        for arc in self.all_workspaces() {
+            let state = arc.read().await;
+            out.push(WorkspaceInfo {
+                ws_id: state.ws_id.clone(),
+                path: state.path.to_string_lossy().to_string(),
+                snapshot_count: state.index.snapshots.len() as u32,
+            });
+        }
+        out
     }
 }
 
@@ -675,7 +664,7 @@ mod tests {
         assert!(state.get_by_path(&path).is_some());
 
         // Unregister
-        state.unregister_workspace("ws-rm");
+        state.unregister_workspace("ws-rm", &path);
 
         // Verify both mappings removed
         assert!(state.get_by_wsid("ws-rm").is_none());
@@ -805,5 +794,44 @@ mod tests {
         // but we can verify the OnceCell is properly initialized.
         let state = DaemonState::new(test_config(), test_backend(), test_state_dir());
         assert!(state.bootstrapped.get().is_none());
+    }
+
+    #[tokio::test]
+    async fn collect_workspace_entries_does_not_drop_write_locked_ws() {
+        use tokio::sync::oneshot;
+
+        let state = DaemonState::new(test_config(), test_backend(), test_state_dir());
+        let path_a = PathBuf::from("/ws-locked");
+        let path_b = PathBuf::from("/ws-free");
+        state.register_workspace(
+            "ws-a".to_string(),
+            path_a.clone(),
+            SnapshotIndex::new(path_a),
+        );
+        state.register_workspace(
+            "ws-b".to_string(),
+            path_b.clone(),
+            SnapshotIndex::new(path_b),
+        );
+
+        let ws_a = state.get_by_wsid("ws-a").unwrap();
+        let (acquired_tx, acquired_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+        let holder = tokio::spawn(async move {
+            let _guard = ws_a.write().await;
+            let _ = acquired_tx.send(());
+            let _ = release_rx.await;
+        });
+        acquired_rx.await.unwrap();
+
+        let entries = state.collect_workspace_entries();
+        let ids: std::collections::HashSet<&str> =
+            entries.iter().map(|e| e.ws_id.as_str()).collect();
+        assert_eq!(entries.len(), 2);
+        assert!(ids.contains("ws-a"));
+        assert!(ids.contains("ws-b"));
+
+        let _ = release_tx.send(());
+        holder.await.unwrap();
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -143,6 +143,13 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
             ));
         }
     };
+    // Reject non-UTF-8: lossy survives in manifest and breaks fs ops after daemon restart.
+    if abs_path.to_str().is_none() {
+        return Ok(error_resp(
+            ErrorCode::InvalidPath,
+            format!("resolved path is not valid UTF-8: {}", abs_path.display()),
+        ));
+    }
     if abs_path.to_string_lossy() != workspace {
         info!(
             "workspace path resolved: {} -> {}",
@@ -688,6 +695,37 @@ mod tests {
         match resp {
             Response::InitOk { ws_id } => assert_eq!(ws_id, "ws-exist"),
             _ => panic!("expected InitOk for already-initialized workspace"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn init_rejects_non_utf8_canonicalized_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmpdir = tempfile::tempdir().unwrap();
+        // Real directory with a non-UTF-8 byte (\xFF) in its name.
+        let raw_name = OsStr::from_bytes(b"non-utf8-\xFFdir");
+        let raw_dir = tmpdir.path().join(raw_name);
+        tokio::fs::create_dir(&raw_dir).await.unwrap();
+        // ASCII symlink so the user-facing path is valid UTF-8 but resolves to
+        // the non-UTF-8 directory after canonicalize.
+        let link = tmpdir.path().join("ascii-link");
+        tokio::fs::symlink(&raw_dir, &link).await.unwrap();
+
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        let resp = init(&state, &link.to_string_lossy()).await.unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::InvalidPath);
+                assert!(message.contains("not valid UTF-8"), "message: {}", message);
+            }
+            _ => panic!("expected InvalidPath error for non-UTF-8 canonicalized path"),
         }
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -410,8 +410,7 @@ pub async fn delete_snapshot(
         .with_context(|| format!("Failed to create index dir: {:?}", snap_dir))?;
     index_store::save(&snap_dir, &ws.index).await?;
 
-    // 5a. Release write lock before save_manifest (try_read inside
-    //     collect_workspace_entries would fail while write lock is held)
+    // 5a. Release write lock before save_manifest
     drop(ws);
 
     // 5b. Save manifest
@@ -455,7 +454,7 @@ pub async fn recover_workspace(
         .await?;
 
     // 4. unregister workspace from state
-    state.unregister_workspace(&ws_id);
+    state.unregister_workspace(&ws_id, std::path::Path::new(&original_path));
 
     // 4a. Save manifest
     if let Err(e) = state.save_manifest().await {


### PR DESCRIPTION
## Description

三条独立 bug,无相互依赖,可独立 review。

### #674 — `recover_workspace` rsync 失败后仍删快照与 subvol

`recover_workspace` 在 rsync 子卷回 original_path 失败时仅 `error!` 不 `bail!`,后续
照常删快照、删 workspace subvol、删 snap_base。一次 ENOSPC / ro mount / immutable
parent 即抹掉工作区 + 全部历史。

修复:把 `error!` 改成 `bail!`(BtrfsBase / BtrfsLoop 两 backend 同步),错误立即 `?`
向上传播,后续清理永不执行,subvol 与快照保留供用户排查(腾空间 / 改 mount / 修权限)后
重试 `recover`。

### #685 — `try_read` 静默丢失持 write lock 的 workspace

`DaemonState` 三处用 `try_read` 试图在 sync 上下文读 ws 状态,任何持有 write lock 的 ws
会被静默跳过。最致命的 `collect_workspace_entries` 让这些 ws 缺席 state.json,daemon
重启走 `resolve_from_persisted` 分支(不调 `rebuild_from_disk`),这些 ws 在 daemon
视角中永久蒸发,但磁盘 subvol/snapshots 仍真实存在。

修复(根除 `try_read`):
- `collect_workspace_entries`:数据源从 `workspaces` 改为反向索引 `path_to_wsid`
  (`DashMap<PathBuf, String>`),完全不取锁;用 `workspaces.contains_key` 过滤掉
  unregister 后残留的 entry。
- `unregister_workspace`:签名加 `path: &Path` 参数(调用方手里早就有),O(1) 双删
  两个 DashMap,不再依赖 RwLock 状态。
- `get_all_workspace_info`:变 `async`,先 `all_workspaces()` 收集所有 Arc 跳出 DashMap
  iter guard,再循环 `read().await`(避免 shard 锁跨 `.await` 边界);status / health
  响应不再返回 `<locked>` / `snapshot_count=0` 假数据。
- 加并发回归测试 `collect_workspace_entries_does_not_drop_write_locked_ws`:spawn task
  持 ws-a write lock,主任务调 collect,断言两个 ws 都在结果里。

`delete_snapshot` 中 `drop(ws)` 保留作为锁早释优化,原"try_read workaround"注释更新为
中性描述。

### #686 — seccomp 在 aarch64 上整体失效

`SeccompFilter::new(..., TargetArch::x86_64)` 硬编码,生成的 BPF 首条 audit_arch 校验在
aarch64 主机上永远不匹配 → 所有 syscall 走默认 `Allow` → deny-list 等同空集,但日志仍
打印 `"Seccomp filter applied: 38 dangerous syscalls blocked"` — silent security
failure。CI 测试同样硬编码 `TargetArch::x86_64`,100% 通过这个 bug。

修复:
- 新增 `target_arch()` helper:`#[cfg(target_arch = "...")]` 编译时分支映射到 seccompiler
  的 `TargetArch::{x86_64, aarch64, riscv64}`;不支持的 arch(loongarch64 等)走
  `anyhow::bail!`,daemon 拒绝安装 no-op filter 而非静默失效。
- `apply_seccomp_filter` 与单测都用 `target_arch()?` 替换硬编码;单测从此跟 host arch
  走,catch 跨 arch regression。
- deny-list 调整:**+4** pidfd 系列(`pidfd_open / pidfd_send_signal / pidfd_getfd /
  process_madvise`),**-1** `lookup_dcookie`(内核 6.6 已删,死代码)。最终 33 项。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #674
closes #685
closes #686

## Type of Change

<!-- Check all that apply. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

`#685` 加并发单测 `collect_workspace_entries_does_not_drop_write_locked_ws`;三次 commit
的 pre-commit `cargo fmt` / `cargo clippy` 全 Passed。

## Additional Notes

<!-- Any additional information, screenshots, or context. -->

`#686` 的 loongarch64 分支会让 `apply_seccomp_filter` 返回 Err,但 daemon 启动代码
`lib.rs:72` 仍是 warn-and-continue。从修前的 silent 升级到 explicit warn,但 loongarch64
上仍无 seccomp 保护;如需 fail-to-start 可后续单独 PR 改 lib.rs。
