### PR TITLE
fix(tokenless): stats command syntax

### DIFF
--- a/src/tokenless/adapters/tokenless/common/commands/tokenless-stats.toml
+++ b/src/tokenless/adapters/tokenless/common/commands/tokenless-stats.toml
@@ -1,2 +1,2 @@
 description = "Show tokenless compression stats summary"
-run = "tokenless stats --summary {{args}}"
+run = "tokenless stats summary {{args}}"


### PR DESCRIPTION
## Summary
- Fix `/tokenless-stats` slash command: `--summary` is not a valid flag; the correct CLI syntax is the `summary` subcommand.

## Changes
- `adapters/tokenless/common/commands/tokenless-stats.toml`: `tokenless stats --summary` → `tokenless stats summary`

## Test plan
- [x] 已 E2E: ran `/tokenless-stats` via cosh on Agentic ECS — before: `unexpected argument '--summary'`; after: full stats output

🤖 Generated with [Claude Code](https://claude.com/claude-code)