### PR TITLE
chore(sec-core): set isort line-length

### DIFF
--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -5,7 +5,7 @@
 .PHONY: python-code-pretty
 python-code-pretty: ## Format Python code using black and isort
 	@echo "🎨 Formatting code with black and isort..."
-	@uv run --project agent-sec-cli isort --profile black --skip-glob "*/backend-skill/templates/*" .
+	@uv run --project agent-sec-cli isort --profile black --line-length 80 --skip-glob "*/backend-skill/templates/*" .
 	@uv run --project agent-sec-cli black --force-exclude "backend-skill/templates/" .
 
 .PHONY: python-lint

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -158,7 +158,7 @@ extend-exclude = "/backend-skill/templates/"
 
 [tool.isort]
 profile = "black"
-line_length = 100
+line_length = 80
 known_first_party = ["agent_sec_cli"]
 extend_skip_glob = ["dev-tools/backend-skill/templates/*"]
 


### PR DESCRIPTION
## Description                                                                                                                
                                         
修复 `make python-code-pretty` 在不同平台行为不一致的问题。

**问题**：isort 会读取仓库根目录的 `.editorconfig`（`max_line_length = 80`），且其优先级**高于** pyproject.toml 里的             
`[tool.isort] line_length = 100`。结果是：
                                                                                                                                 
- CI（Linux，找得到 `.editorconfig`）：isort 按 80 切 imports                                                                    
- 部分环境如WSL（找不到 `.editorconfig` 或路径不通）：isort 退回 pyproject 的 100
                                                                                                                                 
同一份代码在不同环境下 `make python-code-pretty` 的产出可能不一样，CI 偶发抓到 diff。                                            
                                                                                                                                 
black 不读 `.editorconfig`（官方设计），所有平台一直按 pyproject 的 100，**不在本次改动范围内**。                                
                                         
## Changes                                                                                                                       
                                       
1. **`agent-sec-cli/pyproject.toml`**：`[tool.isort] line_length` 从 `100` 改为 `80`，与 `.editorconfig` 数值对齐 ——             
两源数值一致后，「.editorconfig 是否被发现」就不再影响结果。
2. **`Makefile`**：`isort` 命令显式追加 `--line-length 80` —— CLI 参数优先级最高，作为 `.editorconfig` 未来万一被改、或 isort 配置发现链异常时的兜底。                                                                                                         

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
