### PR TITLE
fix(sec-core): optimizer self-protection rules in code-scan

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-hermes.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-hermes.yaml
@@ -1,10 +1,10 @@
 rule_id: shell-self-protect-hermes
 cwe_id: CWE-284
 desc_en: >-
-  Command disables or removes the agent-sec security plugin in Hermes,
+  Command disables or removes the agent-sec-core plugin in Hermes,
   which would remove all agent-sec-core security guardrails.
 desc_zh: >-
-  命令禁用或移除了 Hermes 中的 agent-sec 安全插件，将移除 agent-sec-core 所有的安全防护。
+  命令禁用或移除了 Hermes 中的 agent-sec-core 插件，将移除 agent-sec-core 所有的安全防护。
 regex: |-
-  \bhermes\s+plugins\s+(disable|remove)\s+agent-sec-core-hermes-plugin\b
+  \bhermes\s+plugins\s+(disable|remove)\s+agent-sec-core-hermes-plugin(?:\s|$)
 severity: warn

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-hermes.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-hermes.yaml
@@ -6,5 +6,5 @@ desc_en: >-
 desc_zh: >-
   命令禁用或移除了 Hermes 中的 agent-sec-core 插件，将移除 agent-sec-core 所有的安全防护。
 regex: |-
-  \bhermes\s+plugins\s+(disable|remove)\s+agent-sec-core-hermes-plugin(?:\s|$)
+  \bhermes\s+plugins\s+(disable|remove|uninstall|rm)\s+agent-sec-core-hermes-plugin(?:[\s;&|><)]|$)
 severity: warn

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-openclaw.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-openclaw.yaml
@@ -1,11 +1,11 @@
 rule_id: shell-self-protect-openclaw
 cwe_id: CWE-284
 desc_en: >-
-  Command disables or uninstalls the agent-sec security plugin in OpenClaw,
+  Command disables or uninstalls the agent-sec-core plugin in OpenClaw,
   which would remove all agent-sec-core security guardrails.
 desc_zh: >-
-  命令禁用或卸载了 OpenClaw 中的 agent-sec 安全插件，将移除 agent-sec-core 所有的安全防护。
+  命令禁用或卸载了 OpenClaw 中的 agent-sec-core 插件，将移除 agent-sec-core 所有的安全防护。
 regex: |-
   \bopenclaw\s+config\s+set\s+plugins\.entries\.agent-sec\.enabled\s+false\b
-  |\bopenclaw\s+plugins\s+(disable|uninstall|remove)\s+agent-sec\b
+  |\bopenclaw\s+plugins\s+(disable|uninstall|remove)\s+agent-sec(?:\s|$)
 severity: warn

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-openclaw.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/shell-self-protect-openclaw.yaml
@@ -7,5 +7,5 @@ desc_zh: >-
   命令禁用或卸载了 OpenClaw 中的 agent-sec-core 插件，将移除 agent-sec-core 所有的安全防护。
 regex: |-
   \bopenclaw\s+config\s+set\s+plugins\.entries\.agent-sec\.enabled\s+false\b
-  |\bopenclaw\s+plugins\s+(disable|uninstall|remove)\s+agent-sec(?:\s|$)
+  |\bopenclaw\s+plugins\s+(disable|uninstall)\s+agent-sec(?:[\s;&|><)]|$)
 severity: warn

--- a/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
+++ b/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
@@ -1195,6 +1195,25 @@ SHELL_SELF_PROTECT_OPENCLAW_CASES = [
     ("openclaw plugins disable tokenless", "bash", "shell-self-protect-openclaw", 0),
     ("openclaw plugins install agent-sec", "bash", "shell-self-protect-openclaw", 0),
     ("openclaw gateway restart", "bash", "shell-self-protect-openclaw", 0),
+    # --- False positive regression: plugin names prefixed with agent-sec ---
+    (
+        "openclaw plugins disable agent-sec-memory",
+        "bash",
+        "shell-self-protect-openclaw",
+        0,
+    ),
+    (
+        "openclaw plugins uninstall agent-sec-memory --force",
+        "bash",
+        "shell-self-protect-openclaw",
+        0,
+    ),
+    (
+        "openclaw plugins remove agent-sec-core-openclaw-plugin",
+        "bash",
+        "shell-self-protect-openclaw",
+        0,
+    ),
 ]
 
 SHELL_SELF_PROTECT_HERMES_CASES = [
@@ -1233,6 +1252,19 @@ SHELL_SELF_PROTECT_HERMES_CASES = [
     ("hermes plugins disable other-plugin", "bash", "shell-self-protect-hermes", 0),
     ("hermes plugins remove tokenless", "bash", "shell-self-protect-hermes", 0),
     ("hermes plugins list", "bash", "shell-self-protect-hermes", 0),
+    # --- False positive regression: plugin names prefixed with agent-sec-core-hermes-plugin ---
+    (
+        "hermes plugins disable agent-sec-core-hermes-plugin-2",
+        "bash",
+        "shell-self-protect-hermes",
+        0,
+    ),
+    (
+        "hermes plugins remove agent-sec-core-hermes-plugin-extended",
+        "bash",
+        "shell-self-protect-hermes",
+        0,
+    ),
 ]
 
 # =====================================================================

--- a/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
+++ b/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
@@ -1139,10 +1139,9 @@ SHELL_SELF_PROTECT_OPENCLAW_CASES = [
         "shell-self-protect-openclaw",
         1,
     ),
-    # === True Positives: plugins disable/uninstall/remove ===
+    # === True Positives: plugins disable/uninstall ===
     ("openclaw plugins disable agent-sec", "bash", "shell-self-protect-openclaw", 1),
     ("openclaw plugins uninstall agent-sec", "bash", "shell-self-protect-openclaw", 1),
-    ("openclaw plugins remove agent-sec", "bash", "shell-self-protect-openclaw", 1),
     (
         "openclaw plugins uninstall agent-sec --force",
         "bash",
@@ -1163,6 +1162,31 @@ SHELL_SELF_PROTECT_OPENCLAW_CASES = [
     ),
     (
         "openclaw plugins disable agent-sec 2>&1",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    # --- True Positives: shell separators directly after plugin name ---
+    (
+        "openclaw plugins disable agent-sec;echo hacked",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "openclaw plugins uninstall agent-sec&&echo done",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "openclaw plugins uninstall agent-sec|cat",
+        "bash",
+        "shell-self-protect-openclaw",
+        1,
+    ),
+    (
+        "openclaw plugins disable agent-sec>log.txt",
         "bash",
         "shell-self-protect-openclaw",
         1,
@@ -1214,6 +1238,9 @@ SHELL_SELF_PROTECT_OPENCLAW_CASES = [
         "shell-self-protect-openclaw",
         0,
     ),
+    # --- TN: subcommands not supported by OpenClaw ---
+    ("openclaw plugins remove agent-sec", "bash", "shell-self-protect-openclaw", 0),
+    ("openclaw plugins rm agent-sec", "bash", "shell-self-protect-openclaw", 0),
 ]
 
 SHELL_SELF_PROTECT_HERMES_CASES = [
@@ -1238,6 +1265,43 @@ SHELL_SELF_PROTECT_HERMES_CASES = [
     ),
     (
         "HERMES_HOME=/tmp hermes plugins remove agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "hermes plugins uninstall agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "hermes plugins rm agent-sec-core-hermes-plugin",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    # --- True Positives: shell separators directly after plugin name ---
+    (
+        "hermes plugins disable agent-sec-core-hermes-plugin;echo hacked",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "hermes plugins remove agent-sec-core-hermes-plugin&&echo done",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "hermes plugins disable agent-sec-core-hermes-plugin|cat",
+        "bash",
+        "shell-self-protect-hermes",
+        1,
+    ),
+    (
+        "hermes plugins remove agent-sec-core-hermes-plugin>log.txt",
         "bash",
         "shell-self-protect-hermes",
         1,


### PR DESCRIPTION
## Description

修复 self-protect 正则规则的误报问题。\b（word boundary）会在 - 处触发边界匹配，导致以 agent-sec 为前缀的其他插件名（如 openclaw plugins disable agent-sec-memory、hermes plugins disable agent-sec-core-hermes-plugin-2）被错误拦截。          
                                                                                                                        
将尾部的 \b 替换为 (?:\s|$)，仅在插件名后跟空白或行尾时匹配，消除前缀误匹配。    

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
