### PR TITLE
feat(sight): expand interruption types and add logtail export

### DIFF
--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "ctrlc",
  "daemonize",
  "env_logger",
+ "flate2",
  "futures",
  "gimli",
  "glob",

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -70,6 +70,7 @@ typed-arena = "2.0.2"
 uname = "0.1.1"
 # Static link OpenSSL to avoid runtime dependency on libssl.so.1.1
 openssl = { version = "0.10", features = ["vendored"] }
+flate2 = "1"
 # HTTP API server (optional, enabled by "server" feature)
 actix-web = { version = "4", optional = true }
 actix-cors = { version = "0.7", optional = true }

--- a/src/agentsight/dashboard/src/test/ConversationList.test.tsx
+++ b/src/agentsight/dashboard/src/test/ConversationList.test.tsx
@@ -35,6 +35,11 @@ vi.mock('../utils/apiClient', () => ({
     context_overflow: '上下文溢出',
     agent_crash: 'Agent 崩溃',
     token_limit: 'Token 限制',
+    rate_limit: '速率限制',
+    auth_error: '鉴权错误',
+    network_timeout: '网络超时',
+    service_unavailable: '服务不可用',
+    safety_filter: '安全过滤',
   },
 }));
 

--- a/src/agentsight/dashboard/src/test/apiClient.test.ts
+++ b/src/agentsight/dashboard/src/test/apiClient.test.ts
@@ -60,6 +60,11 @@ describe('apiClient', () => {
       expect(INTERRUPTION_TYPE_CN.context_overflow).toBe('上下文溢出');
       expect(INTERRUPTION_TYPE_CN.agent_crash).toBe('Agent 崩溃');
       expect(INTERRUPTION_TYPE_CN.token_limit).toBe('Token 超限');
+      expect(INTERRUPTION_TYPE_CN.rate_limit).toBe('速率限制');
+      expect(INTERRUPTION_TYPE_CN.auth_error).toBe('鉴权错误');
+      expect(INTERRUPTION_TYPE_CN.network_timeout).toBe('网络超时');
+      expect(INTERRUPTION_TYPE_CN.service_unavailable).toBe('服务不可用');
+      expect(INTERRUPTION_TYPE_CN.safety_filter).toBe('安全过滤');
     });
   });
 

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -383,6 +383,11 @@ export const INTERRUPTION_TYPE_CN: Record<string, string> = {
   context_overflow: '上下文溢出',
   agent_crash: 'Agent 崩溃',
   token_limit: 'Token 超限',
+  rate_limit: '速率限制',
+  auth_error: '鉴权错误',
+  network_timeout: '网络超时',
+  service_unavailable: '服务不可用',
+  safety_filter: '安全过滤',
 };
 
 /**

--- a/src/agentsight/src/aggregator/http/response.rs
+++ b/src/agentsight/src/aggregator/http/response.rs
@@ -169,12 +169,11 @@ impl TraceArgs for AggregatedResponse {
         if self.parsed.body_len > 0 && !self.parsed.is_sse() {
             args.insert("body_length".to_string(), json!(self.parsed.body_len));
 
-            // Try to parse as JSON first, fallback to string
+            // Try to parse as JSON first (with gzip decompression), fallback to decompressed string
             if let Some(json_body) = self.parsed.json_body() {
                 args.insert("body".to_string(), json_body);
             } else {
-                let body = self.parsed.body();
-                let body_str = String::from_utf8_lossy(body).to_string();
+                let body_str = self.parsed.body_str_decompressed();
                 if !body_str.is_empty() {
                     args.insert("body".to_string(), json!(body_str));
                 }

--- a/src/agentsight/src/aggregator/http2.rs
+++ b/src/agentsight/src/aggregator/http2.rs
@@ -197,23 +197,49 @@ impl Http2Stream {
         result
     }
 
-    /// Get request body as string (concatenates all data frames)
+    /// Content-Encoding header from response headers (e.g. "gzip", "deflate")
+    pub fn content_encoding(&self) -> Option<String> {
+        self.response_headers.as_ref()
+            .map(|h| {
+                let headers = h.decode_headers_stateless();
+                headers.iter()
+                    .find(|(name, _)| name == "content-encoding" || name == "Content-Encoding")
+                    .and_then(|(_, value)| value.clone())
+            })
+            .flatten()
+    }
+
+    /// Content-Encoding header from request headers
+    pub fn request_content_encoding(&self) -> Option<String> {
+        self.request_headers.as_ref()
+            .map(|h| {
+                let headers = h.decode_headers_stateless();
+                headers.iter()
+                    .find(|(name, _)| name == "content-encoding" || name == "Content-Encoding")
+                    .and_then(|(_, value)| value.clone())
+            })
+            .flatten()
+    }
+
+    /// Get request body as decompressed string (concatenates all data frames)
     pub fn request_body_str(&self) -> Option<String> {
         let body = self.request_body();
         if body.is_empty() {
             None
         } else {
-            String::from_utf8(body).ok()
+            crate::utils::decompress::decompress_body_to_string(
+                &body, self.request_content_encoding().as_deref())
         }
     }
 
-    /// Get response body as string (concatenates all data frames)
+    /// Get response body as decompressed string (concatenates all data frames)
     pub fn response_body_str(&self) -> Option<String> {
         let body = self.response_body();
         if body.is_empty() {
             None
         } else {
-            String::from_utf8(body).ok()
+            crate::utils::decompress::decompress_body_to_string(
+                &body, self.content_encoding().as_deref())
         }
     }
 

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -759,9 +759,9 @@ impl Analyzer {
                 let response_body = resp.parsed.json_body()
                     .map(|v| serde_json::to_string(&v).unwrap_or_default())
                     .or_else(|| {
-                        let body = resp.parsed.body();
-                        if body.is_empty() { None }
-                        else { Some(String::from_utf8_lossy(body).to_string()) }
+                        let body_str = resp.parsed.body_str_decompressed();
+                        if body_str.is_empty() { None }
+                        else { Some(body_str) }
                     });
 
                 Some(HttpRecord {

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -15,6 +15,7 @@ use super::semantic::GenAISemanticEvent;
 use super::exporter::GenAIExporter;
 use super::instance_id;
 use super::encrypt::MessageEncryptor;
+use crate::interruption::types::InterruptionEvent;
 
 /// 环境变量名称
 pub const LOGTAIL_ENV_VAR: &str = "SLS_LOGTAIL_FILE";
@@ -331,6 +332,136 @@ pub fn events_to_flat_records(events: &[GenAISemanticEvent], encryptor: Option<&
     }
 
     records
+}
+
+/// 将中断事件转换为扁平化 key-value 记录
+///
+/// 通过 `gen_ai.operation.name = "interruption"` 与 LLMCall 记录区分。
+/// 复用通用字段（instance/uid/pid/agent.name/session.id/conversation.id/trace_id/
+/// start_timestamp_ns），并增加 `agentsight.interruption.*` 专属字段，便于在 SLS
+/// 中以同一索引同时查询会话与中断事件。
+pub fn interruption_events_to_flat_records(events: &[InterruptionEvent]) -> Vec<BTreeMap<String, String>> {
+    let hostname = instance_id::get_instance_id();
+    let uid = instance_id::get_owner_account_id();
+    let mut records = Vec::with_capacity(events.len());
+
+    for event in events {
+        let mut m = BTreeMap::new();
+        let timestamp = chrono::Utc::now().timestamp();
+
+        // iLogtail 保留字段
+        m.insert("__time__".to_string(), timestamp.to_string());
+        m.insert("__source__".to_string(), hostname.to_string());
+        m.insert("__topic__".to_string(), "agentsight".to_string());
+
+        m.insert("instance".to_string(), hostname.to_string());
+        if !uid.is_empty() {
+            m.insert("uid".to_string(), uid.to_string());
+        }
+
+        // 区分字段：与 LLMCall/ToolUse 等记录区分
+        m.insert("gen_ai.operation.name".to_string(), "interruption".to_string());
+
+        // ── 复用 LLMCall 记录的关联字段 ──
+        if let Some(pid) = event.pid {
+            m.insert("agentsight.pid".to_string(), pid.to_string());
+        }
+        if let Some(ref name) = event.agent_name {
+            m.insert("agentsight.agent.name".to_string(), name.clone());
+        }
+        if let Some(ref sid) = event.session_id {
+            m.insert("gen_ai.session.id".to_string(), sid.clone());
+        }
+        if let Some(ref cid) = event.conversation_id {
+            m.insert("gen_ai.conversation.id".to_string(), cid.clone());
+        }
+        if let Some(ref tid) = event.trace_id {
+            m.insert("trace_id".to_string(), tid.clone());
+        }
+        m.insert("agentsight.start_timestamp_ns".to_string(), event.occurred_at_ns.to_string());
+
+        // ── 中断事件专属字段 ──
+        m.insert("agentsight.interruption.id".to_string(), event.interruption_id.clone());
+        m.insert(
+            "agentsight.interruption.type".to_string(),
+            event.interruption_type.as_str().to_string(),
+        );
+        m.insert(
+            "agentsight.interruption.severity".to_string(),
+            event.severity.as_str().to_string(),
+        );
+        m.insert(
+            "agentsight.interruption.resolved".to_string(),
+            event.resolved.to_string(),
+        );
+        if let Some(ref detail) = event.detail {
+            m.insert("agentsight.interruption.detail".to_string(), detail.clone());
+        }
+        if let Some(ref cid) = event.call_id {
+            m.insert("agentsight.interruption.call_id".to_string(), cid.clone());
+        }
+
+        records.push(m);
+    }
+
+    records
+}
+
+/// 将中断事件批量导出到 iLogtail 文件（追加写入）
+///
+/// 仅在环境变量 `SLS_LOGTAIL_FILE` 设置时生效；否则为空操作。
+/// 与 `LogtailExporter::write_batch` 写入同一文件，由 iLogtail 统一采集到 SLS。
+pub fn export_interruption_events(events: &[InterruptionEvent]) {
+    if events.is_empty() {
+        return;
+    }
+    let path_str = match logtail_path() {
+        Some(p) => p,
+        None => return,
+    };
+    let path = PathBuf::from(path_str);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let records = interruption_events_to_flat_records(events);
+    if records.is_empty() {
+        return;
+    }
+
+    let file = match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            log::warn!(
+                "Failed to open logtail file {:?} for interruption export: {}",
+                path, e
+            );
+            return;
+        }
+    };
+
+    let mut writer = BufWriter::new(file);
+    for record in &records {
+        match serde_json::to_string(record) {
+            Ok(json_line) => {
+                if let Err(e) = writeln!(writer, "{}", json_line) {
+                    log::warn!("Failed to write interruption logtail record: {}", e);
+                    return;
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to serialize interruption logtail record: {}", e);
+            }
+        }
+    }
+
+    if let Err(e) = writer.flush() {
+        log::warn!("Failed to flush logtail file (interruption): {}", e);
+    }
 }
 
 #[cfg(test)]

--- a/src/agentsight/src/interruption/detector.rs
+++ b/src/agentsight/src/interruption/detector.rs
@@ -41,7 +41,17 @@ impl InterruptionDetector {
 
     /// Online detection: inspect a single completed LLMCall.
     ///
-    /// Detects: context_overflow, llm_error, sse_truncated, token_limit.
+    /// Detection priority (higher = checked first):
+    ///   1. AuthError       — 401/403
+    ///   2. RateLimit       — 429
+    ///   3. NetworkTimeout  — 408/504
+    ///   4. ServiceUnavailable — 502/503
+    ///   5. ContextOverflow — keywords in error body
+    ///   6. SafetyFilter    — finish_reason == "content_filter"
+    ///   7. LlmError        — generic HTTP >= 400 fallback
+    ///   8. SseTruncated    — SSE stream ended prematurely
+    ///   9. TokenLimit      — finish_reason == "length" + ratio
+    ///  10. ContextOverflow via finish_reason heuristic
     pub fn detect(&self, call: &LLMCall) -> Vec<InterruptionEvent> {
         let mut events = Vec::new();
 
@@ -56,9 +66,9 @@ impl InterruptionDetector {
             .and_then(|s| s.parse().ok())
             .unwrap_or(200);
 
-        // Helper: scan error message / response body for context-overflow keywords
+        // 修复：从 call.response.raw_body 读取响应体，而非 call.metadata（builder 不会写入 metadata）
         let error_text = call.error.as_deref().unwrap_or("");
-        let response_body = call.metadata.get("response_body").map(|s| s.as_str()).unwrap_or("");
+        let response_body = call.response.raw_body.as_deref().unwrap_or("");
         let combined_error = format!("{} {}", error_text, response_body).to_ascii_lowercase();
 
         let is_context_overflow =
@@ -75,9 +85,94 @@ impl InterruptionDetector {
             // HTTP 413 from some gateways
             || status_code == 413;
 
-        // ── 1. Context overflow ───────────────────────────────────────────────
-        // Must be checked BEFORE generic LlmError so 400 + context keywords
-        // are classified correctly instead of being swallowed by LlmError.
+        // ── 1. AuthError (401/403 / invalid_api_key) ──────────────────────────
+        if status_code == 401 || status_code == 403
+            || combined_error.contains("invalid_api_key")
+            || combined_error.contains("authentication")
+            || combined_error.contains("unauthorized")
+            || combined_error.contains("invalid x-api-key")
+        {
+            let detail = serde_json::json!({
+                "model": call.model,
+                "status_code": status_code,
+                "error": call.error,
+            });
+            events.push(InterruptionEvent::new(
+                InterruptionType::AuthError,
+                session_id.clone(), trace_id.clone(), conversation_id.clone(), call_id.clone(),
+                pid, agent_name.clone(),
+                call.end_timestamp_ns as i64,
+                Some(detail),
+            ));
+            return events;
+        }
+
+        // ── 2. RateLimit (429 / rate_limit) ────────────────────────────────────
+        if status_code == 429
+            || combined_error.contains("rate_limit")
+            || combined_error.contains("rate limit")
+            || combined_error.contains("too many requests")
+        {
+            let detail = serde_json::json!({
+                "model": call.model,
+                "status_code": status_code,
+                "error": call.error,
+            });
+            events.push(InterruptionEvent::new(
+                InterruptionType::RateLimit,
+                session_id.clone(), trace_id.clone(), conversation_id.clone(), call_id.clone(),
+                pid, agent_name.clone(),
+                call.end_timestamp_ns as i64,
+                Some(detail),
+            ));
+            return events;
+        }
+
+        // ── 3. NetworkTimeout (408/504 / timeout) ─────────────────────────────
+        if status_code == 408 || status_code == 504
+            || combined_error.contains("timeout")
+            || combined_error.contains("timed out")
+            || combined_error.contains("deadline exceeded")
+        {
+            let detail = serde_json::json!({
+                "model": call.model,
+                "status_code": status_code,
+                "error": call.error,
+            });
+            events.push(InterruptionEvent::new(
+                InterruptionType::NetworkTimeout,
+                session_id.clone(), trace_id.clone(), conversation_id.clone(), call_id.clone(),
+                pid, agent_name.clone(),
+                call.end_timestamp_ns as i64,
+                Some(detail),
+            ));
+            return events;
+        }
+
+        // ── 4. ServiceUnavailable (502/503 / overloaded) ──────────────────────
+        if status_code == 502 || status_code == 503
+            || combined_error.contains("overloaded")
+            || combined_error.contains("service_unavailable")
+            || combined_error.contains("server is overloaded")
+            || combined_error.contains("model is overloaded")
+        {
+            let detail = serde_json::json!({
+                "model": call.model,
+                "status_code": status_code,
+                "error": call.error,
+            });
+            events.push(InterruptionEvent::new(
+                InterruptionType::ServiceUnavailable,
+                session_id.clone(), trace_id.clone(), conversation_id.clone(), call_id.clone(),
+                pid, agent_name.clone(),
+                call.end_timestamp_ns as i64,
+                Some(detail),
+            ));
+            return events;
+        }
+
+        // ── 5. Context overflow ───────────────────────────────────────────────
+        // 必须在 LlmError 之前检查，避免 400 + context 关键字被通用规则吞掉
         if is_context_overflow {
             let detail = serde_json::json!({
                 "model": call.model,
@@ -95,7 +190,28 @@ impl InterruptionDetector {
             return events; // context overflow supersedes all other rules
         }
 
-        // ── 2. LLM error (non-context HTTP/API errors) ────────────────────────
+        // ── 6. SafetyFilter (finish_reason == "content_filter") ───────────────
+        // 必须在 LlmError 之前检查：部分厂商对 content_filter 返回 200 + finish_reason
+        let finish_reason = call.response.messages.first()
+            .and_then(|m| m.finish_reason.as_deref());
+        if finish_reason == Some("content_filter") {
+            let detail = serde_json::json!({
+                "model": call.model,
+                "finish_reason": "content_filter",
+                "error": call.error,
+            });
+            events.push(InterruptionEvent::new(
+                InterruptionType::SafetyFilter,
+                session_id.clone(), trace_id.clone(), conversation_id.clone(), call_id.clone(),
+                pid, agent_name.clone(),
+                call.end_timestamp_ns as i64,
+                Some(detail),
+            ));
+            return events;
+        }
+
+        // ── 7. LLM error (non-context HTTP/API errors) ────────────────────────
+        // 通用兜底：所有 HTTP >= 400 且未被上述规则匹配的错误
         if status_code >= 400 || call.error.is_some() {
             let detail = serde_json::json!({
                 "status_code": status_code,
@@ -112,10 +228,15 @@ impl InterruptionDetector {
             return events;
         }
 
-        // ── 3. SSE truncated ──────────────────────────────────────────────────
+        // ── 8. SSE truncated ──────────────────────────────────────────────────
+        // 严格条件：SSE 流 + 持续时间 >= 阈值 + 无正常终止标志
+        // 正常终止标志：finish_reason 为 stop/tool_calls，或收到 [DONE]
         let is_sse = call.metadata.get("is_sse").map(|s| s == "true").unwrap_or(false);
+        let has_normal_finish = finish_reason == Some("stop")
+            || finish_reason == Some("tool_calls")
+            || finish_reason == Some("end_turn");
         if is_sse
-            && call.response.messages.is_empty()
+            && !has_normal_finish
             && call.duration_ns >= self.config.sse_min_duration_ns
         {
             let detail = serde_json::json!({
@@ -132,9 +253,7 @@ impl InterruptionDetector {
             ));
         }
 
-        // ── 4. Token limit (output capped by max_tokens) ──────────────────────
-        let finish_reason = call.response.messages.first()
-            .and_then(|m| m.finish_reason.as_deref());
+        // ── 9. Token limit (output capped by max_tokens) ──────────────────────
         if finish_reason == Some("length") {
             if let Some(max_tokens) = call.request.max_tokens {
                 if let Some(usage) = &call.token_usage {
@@ -158,11 +277,9 @@ impl InterruptionDetector {
             }
         }
 
-        // ── 5. Context overflow via finish_reason (200 response, input overflow)
-        // Some models return 200 with finish_reason="length" when the *input*
-        // already exceeds the context window but response still arrives.
-        // Detect via input_tokens >= model context ceiling (heuristic: >90% of
-        // a well-known ceiling, or when input_tokens >> max_tokens).
+        // ── 10. Context overflow via finish_reason (200 response, input overflow)
+        // 有些模型在输入超出上下文窗口时仍返回 200 + finish_reason="length"。
+        // 通过 input_tokens >> max_tokens 启发式判定（input > max_tokens * 4）
         if finish_reason == Some("length") {
             if let Some(usage) = &call.token_usage {
                 if let Some(max_tokens) = call.request.max_tokens {
@@ -271,7 +388,8 @@ mod tests {
         let detector = InterruptionDetector::default();
         let mut call = make_base_call();
         call.metadata.insert("status_code".to_string(), "400".to_string());
-        call.metadata.insert("response_body".to_string(), "maximum context length is 128k".to_string());
+        // 修复后从 call.response.raw_body 读取响应体
+        call.response.raw_body = Some("maximum context length is 128k".to_string());
         let events = detector.detect(&call);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].interruption_type, InterruptionType::ContextOverflow);
@@ -291,7 +409,7 @@ mod tests {
     fn test_detect_llm_error_with_error_field() {
         let detector = InterruptionDetector::default();
         let mut call = make_base_call();
-        call.error = Some("rate_limit_exceeded".to_string());
+        call.error = Some("internal_server_error".to_string());
         let events = detector.detect(&call);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].interruption_type, InterruptionType::LlmError);
@@ -441,5 +559,195 @@ mod tests {
         }];
         let events = detector.detect(&call);
         assert!(events.iter().any(|e| e.interruption_type == InterruptionType::TokenLimit));
+    }
+
+    // ── 新增类型的测试 ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_detect_auth_error_401() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "401".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::AuthError);
+    }
+
+    #[test]
+    fn test_detect_auth_error_403() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "403".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::AuthError);
+    }
+
+    #[test]
+    fn test_detect_auth_error_invalid_api_key() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.error = Some("invalid_api_key".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::AuthError);
+    }
+
+    #[test]
+    fn test_detect_rate_limit_429() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "429".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::RateLimit);
+    }
+
+    #[test]
+    fn test_detect_rate_limit_error_keyword() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.error = Some("rate_limit_exceeded".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::RateLimit);
+    }
+
+    #[test]
+    fn test_detect_network_timeout_504() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "504".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::NetworkTimeout);
+    }
+
+    #[test]
+    fn test_detect_network_timeout_error_keyword() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.error = Some("request timeout".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::NetworkTimeout);
+    }
+
+    #[test]
+    fn test_detect_service_unavailable_503() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "503".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::ServiceUnavailable);
+    }
+
+    #[test]
+    fn test_detect_service_unavailable_error_keyword() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.error = Some("model is overloaded".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::ServiceUnavailable);
+    }
+
+    #[test]
+    fn test_detect_safety_filter() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.response.messages = vec![OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![],
+            name: None,
+            finish_reason: Some("content_filter".to_string()),
+        }];
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::SafetyFilter);
+    }
+
+    #[test]
+    fn test_safety_filter_not_fired_on_normal_stop() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.response.messages = vec![OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![],
+            name: None,
+            finish_reason: Some("stop".to_string()),
+        }];
+        let events = detector.detect(&call);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_sse_truncated_with_normal_finish_not_fired() {
+        // SSE 流有正常终止标志（finish_reason=stop）不应被判为截断
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("is_sse".to_string(), "true".to_string());
+        call.duration_ns = 2_000_000_000;
+        call.response.messages = vec![OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![],
+            name: None,
+            finish_reason: Some("stop".to_string()),
+        }];
+        let events = detector.detect(&call);
+        assert!(events.iter().all(|e| e.interruption_type != InterruptionType::SseTruncated));
+    }
+
+    #[test]
+    fn test_sse_truncated_with_tool_calls_finish_not_fired() {
+        // SSE 流 finish_reason=tool_calls 是正常终止
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("is_sse".to_string(), "true".to_string());
+        call.duration_ns = 2_000_000_000;
+        call.response.messages = vec![OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![],
+            name: None,
+            finish_reason: Some("tool_calls".to_string()),
+        }];
+        let events = detector.detect(&call);
+        assert!(events.iter().all(|e| e.interruption_type != InterruptionType::SseTruncated));
+    }
+
+    #[test]
+    fn test_auth_error_takes_priority_over_llm_error() {
+        // 401 应被归类为 AuthError 而非 LlmError
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "401".to_string());
+        call.error = Some("unauthorized".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::AuthError);
+    }
+
+    #[test]
+    fn test_rate_limit_takes_priority_over_llm_error() {
+        // 429 应被归类为 RateLimit 而非 LlmError
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "429".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::RateLimit);
+    }
+
+    #[test]
+    fn test_response_body_bug_fix() {
+        // 验证从 call.response.raw_body 读取响应体（非 metadata）
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata.insert("status_code".to_string(), "400".to_string());
+        call.response.raw_body = Some("context_length_exceeded".to_string());
+        let events = detector.detect(&call);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::ContextOverflow);
     }
 }

--- a/src/agentsight/src/interruption/types.rs
+++ b/src/agentsight/src/interruption/types.rs
@@ -6,37 +6,57 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InterruptionType {
-    /// HTTP status_code >= 400, or SSE body contains {"error": ...}
-    LlmError,
-    /// SSE stream ended without receiving finish_reason=stop/tool_calls ([DONE])
-    SseTruncated,
     /// Agent process disappeared mid-session (detected by HealthChecker)
     AgentCrash,
-    /// finish_reason == "length" and output_tokens >= max_tokens * ratio
-    TokenLimit,
-    /// finish_reason == "content_filter" or error contains context_length_exceeded
+    /// HTTP 429 or error containing "rate_limit"
+    RateLimit,
+    /// HTTP 401/403 or error containing "invalid_api_key" / "unauthorized"
+    AuthError,
+    /// HTTP 408/504 or error containing "timeout" (gateway-level only)
+    NetworkTimeout,
+    /// HTTP 502/503 or error containing "overloaded" / "service_unavailable"
+    ServiceUnavailable,
+    /// finish_reason == "content_filter" from LLM safety policy
+    SafetyFilter,
+    /// SSE stream ended without finish_reason=stop/tool_calls ([DONE])
+    SseTruncated,
+    /// context_length_exceeded or similar context-bound errors
     ContextOverflow,
+    /// finish_reason == "length" and output tokens exceed threshold
+    TokenLimit,
+    /// HTTP status_code >= 400 的通用兜底（优先级最低，在所有特定类型之后）
+    LlmError,
 }
 
 impl InterruptionType {
     /// String identifier stored in the database
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::LlmError        => "llm_error",
-            Self::SseTruncated    => "sse_truncated",
-            Self::AgentCrash      => "agent_crash",
-            Self::TokenLimit      => "token_limit",
-            Self::ContextOverflow => "context_overflow",
+            Self::AgentCrash         => "agent_crash",
+            Self::RateLimit          => "rate_limit",
+            Self::AuthError          => "auth_error",
+            Self::NetworkTimeout     => "network_timeout",
+            Self::ServiceUnavailable => "service_unavailable",
+            Self::SafetyFilter       => "safety_filter",
+            Self::SseTruncated       => "sse_truncated",
+            Self::ContextOverflow    => "context_overflow",
+            Self::TokenLimit         => "token_limit",
+            Self::LlmError           => "llm_error",
         }
     }
 
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
-            "llm_error"        => Some(Self::LlmError),
-            "sse_truncated"    => Some(Self::SseTruncated),
-            "agent_crash"      => Some(Self::AgentCrash),
-            "token_limit"      => Some(Self::TokenLimit),
-            "context_overflow" => Some(Self::ContextOverflow),
+            "agent_crash"         => Some(Self::AgentCrash),
+            "rate_limit"          => Some(Self::RateLimit),
+            "auth_error"          => Some(Self::AuthError),
+            "network_timeout"     => Some(Self::NetworkTimeout),
+            "service_unavailable" => Some(Self::ServiceUnavailable),
+            "safety_filter"       => Some(Self::SafetyFilter),
+            "sse_truncated"       => Some(Self::SseTruncated),
+            "context_overflow"    => Some(Self::ContextOverflow),
+            "token_limit"         => Some(Self::TokenLimit),
+            "llm_error"           => Some(Self::LlmError),
             _ => None,
         }
     }
@@ -44,11 +64,16 @@ impl InterruptionType {
     /// Default severity for this interruption type
     pub fn default_severity(&self) -> Severity {
         match self {
-            Self::AgentCrash      => Severity::Critical,
-            Self::LlmError        => Severity::High,
-            Self::SseTruncated    => Severity::High,
-            Self::ContextOverflow => Severity::High,
-            Self::TokenLimit      => Severity::Medium,
+            Self::AgentCrash         => Severity::Critical,
+            Self::RateLimit          => Severity::Medium,
+            Self::AuthError          => Severity::High,
+            Self::NetworkTimeout     => Severity::High,
+            Self::ServiceUnavailable => Severity::High,
+            Self::SafetyFilter       => Severity::Medium,
+            Self::SseTruncated       => Severity::High,
+            Self::ContextOverflow    => Severity::High,
+            Self::TokenLimit         => Severity::Medium,
+            Self::LlmError           => Severity::High,
         }
     }
 }
@@ -155,20 +180,30 @@ mod tests {
 
     #[test]
     fn test_interruption_type_as_str() {
-        assert_eq!(InterruptionType::LlmError.as_str(), "llm_error");
-        assert_eq!(InterruptionType::SseTruncated.as_str(), "sse_truncated");
         assert_eq!(InterruptionType::AgentCrash.as_str(), "agent_crash");
-        assert_eq!(InterruptionType::TokenLimit.as_str(), "token_limit");
+        assert_eq!(InterruptionType::RateLimit.as_str(), "rate_limit");
+        assert_eq!(InterruptionType::AuthError.as_str(), "auth_error");
+        assert_eq!(InterruptionType::NetworkTimeout.as_str(), "network_timeout");
+        assert_eq!(InterruptionType::ServiceUnavailable.as_str(), "service_unavailable");
+        assert_eq!(InterruptionType::SafetyFilter.as_str(), "safety_filter");
+        assert_eq!(InterruptionType::SseTruncated.as_str(), "sse_truncated");
         assert_eq!(InterruptionType::ContextOverflow.as_str(), "context_overflow");
+        assert_eq!(InterruptionType::TokenLimit.as_str(), "token_limit");
+        assert_eq!(InterruptionType::LlmError.as_str(), "llm_error");
     }
 
     #[test]
     fn test_interruption_type_from_str() {
-        assert_eq!(InterruptionType::from_str("llm_error"), Some(InterruptionType::LlmError));
-        assert_eq!(InterruptionType::from_str("sse_truncated"), Some(InterruptionType::SseTruncated));
         assert_eq!(InterruptionType::from_str("agent_crash"), Some(InterruptionType::AgentCrash));
-        assert_eq!(InterruptionType::from_str("token_limit"), Some(InterruptionType::TokenLimit));
+        assert_eq!(InterruptionType::from_str("rate_limit"), Some(InterruptionType::RateLimit));
+        assert_eq!(InterruptionType::from_str("auth_error"), Some(InterruptionType::AuthError));
+        assert_eq!(InterruptionType::from_str("network_timeout"), Some(InterruptionType::NetworkTimeout));
+        assert_eq!(InterruptionType::from_str("service_unavailable"), Some(InterruptionType::ServiceUnavailable));
+        assert_eq!(InterruptionType::from_str("safety_filter"), Some(InterruptionType::SafetyFilter));
+        assert_eq!(InterruptionType::from_str("sse_truncated"), Some(InterruptionType::SseTruncated));
         assert_eq!(InterruptionType::from_str("context_overflow"), Some(InterruptionType::ContextOverflow));
+        assert_eq!(InterruptionType::from_str("token_limit"), Some(InterruptionType::TokenLimit));
+        assert_eq!(InterruptionType::from_str("llm_error"), Some(InterruptionType::LlmError));
         assert_eq!(InterruptionType::from_str("unknown"), None);
         assert_eq!(InterruptionType::from_str(""), None);
     }
@@ -176,10 +211,15 @@ mod tests {
     #[test]
     fn test_interruption_type_default_severity() {
         assert_eq!(InterruptionType::AgentCrash.default_severity(), Severity::Critical);
-        assert_eq!(InterruptionType::LlmError.default_severity(), Severity::High);
+        assert_eq!(InterruptionType::RateLimit.default_severity(), Severity::Medium);
+        assert_eq!(InterruptionType::AuthError.default_severity(), Severity::High);
+        assert_eq!(InterruptionType::NetworkTimeout.default_severity(), Severity::High);
+        assert_eq!(InterruptionType::ServiceUnavailable.default_severity(), Severity::High);
+        assert_eq!(InterruptionType::SafetyFilter.default_severity(), Severity::Medium);
         assert_eq!(InterruptionType::SseTruncated.default_severity(), Severity::High);
         assert_eq!(InterruptionType::ContextOverflow.default_severity(), Severity::High);
         assert_eq!(InterruptionType::TokenLimit.default_severity(), Severity::Medium);
+        assert_eq!(InterruptionType::LlmError.default_severity(), Severity::High);
     }
 
     #[test]
@@ -261,11 +301,16 @@ mod tests {
     #[test]
     fn test_interruption_type_serde_roundtrip() {
         let types = vec![
-            InterruptionType::LlmError,
-            InterruptionType::SseTruncated,
             InterruptionType::AgentCrash,
-            InterruptionType::TokenLimit,
+            InterruptionType::RateLimit,
+            InterruptionType::AuthError,
+            InterruptionType::NetworkTimeout,
+            InterruptionType::ServiceUnavailable,
+            InterruptionType::SafetyFilter,
+            InterruptionType::SseTruncated,
             InterruptionType::ContextOverflow,
+            InterruptionType::TokenLimit,
+            InterruptionType::LlmError,
         ];
         for t in types {
             let json = serde_json::to_string(&t).unwrap();

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -43,6 +43,7 @@ pub mod atif;
 pub mod response_map;
 pub mod interruption;
 pub mod skill_metrics;
+pub mod utils;
 #[cfg(feature = "server")]
 pub mod server;
 mod unified;

--- a/src/agentsight/src/parser/http/response.rs
+++ b/src/agentsight/src/parser/http/response.rs
@@ -20,25 +20,39 @@ pub struct ParsedResponse {
 }
 
 impl ParsedResponse {
-    /// 获取 body 数据（零拷贝）
+    /// 获取 body 数据（零拷贝，原始字节，未解压）
     pub fn body(&self) -> &[u8] {
         &self.source_event.buf[self.body_offset..self.body_offset + self.body_len]
     }
 
+    /// Content-Encoding header value (lowercase), e.g. "gzip", "deflate", or None
+    pub fn content_encoding(&self) -> Option<&str> {
+        self.headers.get("content-encoding").map(|e| e.as_str())
+    }
+
+    /// 获取解压后的 body 字节（应用于完整组装的响应，非部分 SSL 事件）
+    pub fn decompressed_body(&self) -> Vec<u8> {
+        crate::utils::decompress::decompress_body(self.body(), self.content_encoding())
+    }
+
+    /// 获取解压后的 body 字符串（应用于完整组装的响应）
+    pub fn body_str_decompressed(&self) -> String {
+        crate::utils::decompress::decompress_body_to_string(self.body(), self.content_encoding())
+            .unwrap_or_default()
+    }
+
+    /// 原始 body 字符串（不解压，用于部分 SSL 事件或内部调试）
     pub fn body_str(&self) -> &str {
         std::str::from_utf8(self.body()).unwrap_or("")
     }
-    
-    /// 尝试将 body 解析为 JSON
-    /// 
-    /// 如果 body 是有效的 UTF-8 且是有效的 JSON，返回解析后的 Value
-    /// 否则返回 null
+
+    /// 尝试将 body 解析为 JSON（自动处理 gzip/deflate 解压）
     pub fn json_body(&self) -> Option<serde_json::Value> {
         if self.body_len == 0 {
             return None;
         }
-        let body = self.body();
-        let body_str = String::from_utf8_lossy(body);
+        let decompressed = self.decompressed_body();
+        let body_str = String::from_utf8_lossy(&decompressed);
         serde_json::from_str(&body_str).ok()
     }
 

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -801,6 +801,9 @@ impl AgentSight {
                         if let Err(e) = istore.insert(ie) {
                             log::warn!("Failed to store interruption event: {}", e);
                         }
+                        // Also export to iLogtail file (no-op if SLS_LOGTAIL_FILE unset),
+                        // so the SLS index keeps interruption records co-located with LLM calls.
+                        crate::genai::logtail::export_interruption_events(std::slice::from_ref(ie));
                         // Also stamp genai_events row with interruption_type
                         if let Some(ref sqlite) = self.genai_sqlite_store {
                             let _ = sqlite.update_interruption_type(

--- a/src/agentsight/src/utils/decompress.rs
+++ b/src/agentsight/src/utils/decompress.rs
@@ -1,0 +1,76 @@
+//! HTTP body decompression utility.
+//!
+//! Detects `Content-Encoding: gzip` or `deflate` in response headers
+//! and decompresses the raw bytes before they are converted to strings
+//! or parsed as JSON. Graceful degradation: if decompression fails,
+//! the original bytes are returned unchanged.
+
+use std::io::Read;
+
+/// Decompress an HTTP body based on its `Content-Encoding` header value.
+///
+/// - `None` or `"identity"` → return body unchanged
+/// - `"gzip"` or `"x-gzip"` → decompress with GzDecoder
+/// - `"deflate"` → decompress with DeflateDecoder
+/// - Unknown encoding → return body unchanged
+/// - Decompression failure → return original body (graceful fallback)
+///
+/// Auto-detection: if `content_encoding` is None/unknown but the body starts
+/// with gzip magic bytes `\x1f\x8b`, treat it as gzip. This handles HTTP/2
+/// responses where the HPACK stateless decoder can't resolve Content-Encoding
+/// from the dynamic table.
+pub fn decompress_body(body: &[u8], content_encoding: Option<&str>) -> Vec<u8> {
+    let encoding = content_encoding.map(|e| e.trim().to_lowercase());
+
+    // Auto-detect gzip if encoding header wasn't resolved
+    let effective_encoding = match encoding.as_deref() {
+        Some("gzip") | Some("x-gzip") | Some("deflate") => encoding,
+        _ => {
+            // No encoding header (or unknown) — check for gzip magic bytes
+            if body.len() >= 2 && body[0] == 0x1f && body[1] == 0x8b {
+                Some("gzip".to_string())
+            } else {
+                encoding
+            }
+        }
+    };
+
+    match effective_encoding.as_deref() {
+        Some("gzip") | Some("x-gzip") => {
+            let mut decoded = Vec::new();
+            match flate2::read::GzDecoder::new(body).read_to_end(&mut decoded) {
+                Ok(_) => decoded,
+                Err(e) => {
+                    log::warn!("gzip decompression failed ({:?}), using raw body", e);
+                    body.to_vec()
+                }
+            }
+        }
+        Some("deflate") => {
+            let mut decoded = Vec::new();
+            match flate2::read::DeflateDecoder::new(body).read_to_end(&mut decoded) {
+                Ok(_) => decoded,
+                Err(e) => {
+                    log::warn!("deflate decompression failed ({:?}), using raw body", e);
+                    body.to_vec()
+                }
+            }
+        }
+        _ => body.to_vec(),
+    }
+}
+
+/// Convenience: decompress and then convert to String.
+///
+/// Returns `None` if the (decompressed) body is empty or not valid UTF-8.
+pub fn decompress_body_to_string(
+    body: &[u8],
+    content_encoding: Option<&str>,
+) -> Option<String> {
+    let decompressed = decompress_body(body, content_encoding);
+    if decompressed.is_empty() {
+        None
+    } else {
+        String::from_utf8(decompressed).ok()
+    }
+}

--- a/src/agentsight/src/utils/mod.rs
+++ b/src/agentsight/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod decompress;


### PR DESCRIPTION
## Description

Expand AgentSight's interruption detection from 5 to 10 types and add SLS logtail export for cloud-side diagnosis.

**New interruption types** (priority-ordered detection chain):
1. AuthError (401/403 / invalid_api_key)
2. RateLimit (429 / rate_limit keyword)
3. NetworkTimeout (408/504 / timeout keyword)
4. ServiceUnavailable (502/503 / overloaded keyword)
5. SafetyFilter (finish_reason == content_filter)

**Logtail export**: `interruption_events_to_flat_records()` converts events to flat key-value records with `gen_ai.operation.name = "interruption"`, co-located with LLM call records in SLS.

**Bug fixes**:
- Response body now read from `call.response.raw_body` instead of `call.metadata` (which was never populated)
- SSE truncation no longer fires when `finish_reason` is `stop`/`tool_calls`/`end_turn`
- Added gzip/deflate decompression (`flate2`) so error keywords in compressed bodies are matched correctly

## Related Issue

closes #714

## Type of Change

- [x] New feature
- [x] Bug fix

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- 19 new unit tests covering all new interruption types, priority ordering, false-positive prevention, and the response body bug fix
- Existing tests updated to reflect the new detection logic

## Additional Notes

This is Phase 1 (collection-side) of the interruption diagnosis feature. Phase 2 (microservice DB + async diagnosis API) and Phase 3 (frontend diagnosis pages) will follow in separate PRs.