### PR TITLE
fix(tokenless): error on TTY stdin instead of hang

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -155,6 +155,10 @@ fn read_input(file: &Option<String>) -> Result<String, String> {
             Ok(content)
         }
         None => {
+            use std::io::IsTerminal as _;
+            if io::stdin().is_terminal() {
+                return Err("No input provided. Use --file <path> or pipe via stdin: echo '{...}' | tokenless <command>".to_string());
+            }
             let mut buf = String::new();
             io::stdin()
                 .lock()
@@ -163,6 +167,9 @@ fn read_input(file: &Option<String>) -> Result<String, String> {
                 .map_err(|e| format!("Failed to read stdin: {}", e))?;
             if buf.len() > MAX_INPUT_BYTES {
                 return Err(too_large());
+            }
+            if buf.trim().is_empty() {
+                return Err("No input received on stdin".to_string());
             }
             Ok(buf)
         }


### PR DESCRIPTION
## Summary

`tokenless compress-schema` (and other stdin-reading commands) hangs indefinitely when run without input in a terminal.

Adds two guards in `read_input()`:
1. TTY stdin → immediate error with usage hint
2. Empty pipe stdin → "No input received on stdin" (instead of cryptic JSON parse error)

## What is NOT changed

- Normal pipe usage (`echo ... | tokenless compress-schema`) works as before
- Hook pipeline (stdin always has JSON data) unaffected
- File input (`--file`) path untouched

## Test plan

- [x] 107 tests passed
- [x] Manual: `tokenless compress-schema` on TTY → error immediately
- [x] Manual: `echo "" | tokenless compress-schema` → "No input received on stdin"
- [x] Manual: `echo {...} | tokenless compress-schema` → works normally
- [x] Workflow adversarial review: 0 findings

Fixes #711

Generated with [Claude Code](https://claude.com/claude-code)