### PR TITLE
feat(skill): add OpenClaw dependency precheck

### DIFF
--- a/src/os-skills/ai/install-openclaw/SKILL.md
+++ b/src/os-skills/ai/install-openclaw/SKILL.md
@@ -33,7 +33,20 @@ Use `--region singapore` only for pay-as-you-go Singapore. For deeper billing de
 
 ## Execute
 
-Run exactly this script from the installed skill directory:
+If the user asks to install OpenClaw but has not provided an API key, run the
+basic dependency precheck first:
+
+```bash
+python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_openclaw.py \
+  --billing payg \
+  --precheck-only
+```
+
+After precheck passes, tell the user the matching API key source URL printed by
+the script. If the user already provided an API key, run the full install
+directly; the script performs the same dependency precheck before installing.
+
+Run exactly this script from the installed skill directory for full install:
 
 ```bash
 python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_openclaw.py \
@@ -49,7 +62,7 @@ python3 <install-openclaw-skill-dir>/scripts/install_openclaw.py ...
 
 The authoritative implementation is `scripts/install_openclaw.py`.
 The normal parameters are `--billing`, `--api-key`, `--api-key-env`, `--region`,
-`--model-id`, `--npm-registry`, and DingTalk-specific flags.
+`--model-id`, `--npm-registry`, `--precheck-only`, and DingTalk-specific flags.
 
 ## Examples
 
@@ -99,6 +112,7 @@ python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_op
 ## What The Script Does
 
 - Checks Node.js/npm and installs them with `dnf`/`yum` when needed.
+- Runs dependency precheck before installing or writing config.
 - Installs OpenClaw with npm unless `--skip-install-openclaw` is passed.
 - Uses npm registry `https://registry.npmmirror.com` by default; override with `--npm-registry`.
 - Writes only OpenClaw schema-supported config fields.

--- a/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
+++ b/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
@@ -491,6 +491,96 @@ def sudo_command(cmd):
     return ["sudo", *cmd]
 
 
+def has_package_manager():
+    return command_exists("dnf") or command_exists("yum")
+
+
+def dependency_precheck(args):
+    print("\n--- Dependency precheck ---\n")
+
+    issues = []
+    actions = []
+
+    node_ok = command_exists("node") and node_major() >= 22
+    npm_ok = command_exists("npm")
+    openclaw_ok = command_exists("openclaw") and not args.force_install_openclaw
+    can_sudo = os.geteuid() == 0 or command_exists("sudo")
+
+    node_status = (
+        f"{command_output(['node', '--version'])} major={node_major()}"
+        if command_exists("node")
+        else "missing"
+    )
+    npm_status = command_output(["npm", "--version"]) if command_exists("npm") else "missing"
+    openclaw_status = (
+        command_output(["openclaw", "--version"]) if command_exists("openclaw") else "missing"
+    )
+    package_manager = "dnf" if command_exists("dnf") else "yum" if command_exists("yum") else "missing"
+
+    print(f"  python={sys.version.split()[0]}")
+    print(f"  node={node_status}")
+    print(f"  npm={npm_status}")
+    print(f"  openclaw={openclaw_status}")
+    print(f"  package_manager={package_manager}")
+    print(f"  sudo={'available' if can_sudo else 'missing'}")
+    print(f"  npm_registry={args.npm_registry or 'default'}")
+
+    if args.skip_install_openclaw:
+        print("  install_openclaw=skipped")
+    else:
+        if node_ok and npm_ok:
+            print("  node_npm=ok")
+        elif args.no_install_node:
+            issues.append("Node.js v22+ and npm are required, but --no-install-node was passed.")
+        elif not has_package_manager():
+            issues.append("Node.js/npm are missing or too old, and no dnf/yum package manager was found.")
+        elif not can_sudo:
+            issues.append("Node.js/npm installation needs root or sudo.")
+        else:
+            actions.append("Install Node.js/npm with dnf/yum.")
+
+        npm_available_after_actions = npm_ok or any("Node.js/npm" in action for action in actions)
+        if openclaw_ok:
+            print("  openclaw_cli=ok")
+        elif not npm_available_after_actions:
+            issues.append("OpenClaw is missing and npm is not available to install it.")
+        elif not can_sudo:
+            issues.append("OpenClaw global npm installation needs root or sudo.")
+        else:
+            actions.append(f"Install {args.openclaw_package} with npm.")
+
+    if not args.skip_gateway:
+        if command_exists("ps"):
+            print("  ps=ok")
+        else:
+            issues.append("ps is required for gateway port ownership checks.")
+        if command_exists("fuser") or command_exists("lsof"):
+            print("  port_tools=ok")
+        else:
+            print("  port_tools=missing; stale gateway port inspection will be limited")
+
+    if actions:
+        print("\n  Planned automatic fixes:")
+        for action in actions:
+            print(f"  - {action}")
+
+    if issues:
+        print("\n  Missing dependencies that cannot be fixed automatically:")
+        for issue in issues:
+            print(f"  - {issue}")
+        raise SystemExit("Dependency precheck failed. Fix the items above and rerun.")
+
+    print("\nDependency precheck passed.")
+
+
+def print_api_key_guidance(args):
+    billing = normalize_billing(args.billing)
+    plan = BILLING_PLANS[billing]
+    print("\nNext step:")
+    print(f"  Get the {plan['name']} API key from: {plan['api_key_url']}")
+    print("  Then rerun with --api-key or --api-key-env.")
+
+
 def install_node_with_system_package_manager(args):
     if command_exists("dnf"):
         run_command(
@@ -895,6 +985,11 @@ def parse_args():
     )
     parser.add_argument("--doctor-fix", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--precheck-only",
+        action="store_true",
+        help="Only check basic environment dependencies; do not require API keys or install anything.",
+    )
 
     parser.add_argument("--dingtalk-client-id", default="")
     parser.add_argument("--dingtalk-client-secret", default="")
@@ -908,6 +1003,11 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    dependency_precheck(args)
+    if args.precheck_only:
+        print_api_key_guidance(args)
+        return
 
     if not args.skip_install_openclaw:
         install_openclaw(args)


### PR DESCRIPTION

## Description

Add a basic dependency precheck flow for the OpenClaw install skill.

This adds `--precheck-only` to `install_openclaw.py` so an agent can check Python, Node.js, npm, OpenClaw CLI, package manager, sudo, npm registry, and gateway port tools before asking the user for an API key or starting installation. Full installs now run the same dependency precheck before installing or writing config.

## Related Issue

no-issue: follow-up improvement for the OpenClaw install skill

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [x] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [x] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `python3 -m py_compile src/os-skills/ai/install-openclaw/scripts/install_openclaw.py`
- `python3 src/os-skills/ai/install-openclaw/scripts/install_openclaw.py --billing payg --precheck-only`
- `python3 src/os-skills/ai/install-openclaw/scripts/install_openclaw.py --billing payg --api-key sk-test --dry-run --config /tmp/openclaw-precheck-rebased.json --gateway-ready-timeout 1`
- `bash -n src/os-skills/ai/install-openclaw/scripts/install-openclaw.sh`
- `bash src/os-skills/ai/install-openclaw/scripts/install-openclaw.sh --provider aliyun-mode --precheck-only`
- `git diff --check`