### PR TITLE
feat(ckpt): add per-workspace auto-cleanup policy override

### DIFF
--- a/src/ws-ckpt/README.md
+++ b/src/ws-ckpt/README.md
@@ -99,23 +99,33 @@ ws-ckpt cleanup --workspace ~/my-workspace --keep 5
 
 ### 状态与配置
 
-配置以 `/etc/ws-ckpt/config.toml` 为唯一持久化入口（参考模板：`/etc/ws-ckpt/config.toml.sample`）。`ws-ckpt config --<flag>` 会写入该文件并通知 daemon reload，两种方式等价。
+配置分两层：**全局**（`/etc/ws-ckpt/config.toml`，daemon-wide 默认值）和**局部**（`/var/lib/ws-ckpt/indexes/<ws_id>/policy.toml`，per-workspace 覆盖）。`ws-ckpt config` 子命令的作用域由 scope 决定：
+
+- 不带 scope：打印只读 overview（全局配置 + workspace 覆盖统计），修改类 flag 会被拒绝
+- `-g` / `--global` 查看或修改全局配置文件
+- `-w <workspace>` / `--workspace <workspace>` 查看或修改单个工作区的 `policy.toml`
 
 ```bash
 # 查看系统状态
 ws-ckpt status --workspace ~/my-workspace
 
-# 查看当前配置
-ws-ckpt config
+# 查看全局配置
+ws-ckpt config -g
 
-# 启用周期性 auto-cleanup
-ws-ckpt config --enable-auto-cleanup
+# 启用周期性 auto-cleanup（全局）
+ws-ckpt config -g --enable-auto-cleanup
 
-# 按数量或时间维度设置保留策略
-ws-ckpt config --auto-cleanup-keep 10
-ws-ckpt config --auto-cleanup-keep 30d
+# 全局保留策略（按数量或时间维度）
+ws-ckpt config -g --auto-cleanup-keep 10
+ws-ckpt config -g --auto-cleanup-keep 30d
 
-# 手工修改 config.toml 后热生效
+# 单个工作区的覆盖（仅 auto_cleanup / auto_cleanup_keep 可 per-ws 覆盖）
+ws-ckpt config -w ~/my-workspace                       # 三栏视图: effective / local / global
+ws-ckpt config -w ~/my-workspace --auto-cleanup-keep 5 # 仅这个 ws 保留 5 份
+ws-ckpt config -w ~/my-workspace --disable-auto-cleanup
+ws-ckpt config -w ~/my-workspace --reset               # 删除局部 policy.toml,沿用全局
+
+# 手工修改 config.toml / policy.toml 后热生效
 ws-ckpt reload
 ```
 

--- a/src/ws-ckpt/docs/ws-ckpt-usage.md
+++ b/src/ws-ckpt/docs/ws-ckpt-usage.md
@@ -176,26 +176,49 @@ ws-ckpt status -w ./my-project
 
 ### 2.8 查看或修改配置
 
-配置以 `/etc/ws-ckpt/config.toml` 为持久化入口，`ws-ckpt config --<flag>` 写入该文件并通知 daemon reload。
+配置分两层:**全局**(`/etc/ws-ckpt/config.toml`,daemon-wide 默认值)和**局部**(`/var/lib/ws-ckpt/indexes/<ws_id>/policy.toml`,per-workspace 覆盖)。`ws-ckpt config` 通过 scope 决定作用范围:
+
+- 不带 scope:打印只读 overview(全局配置 + workspace 覆盖统计),修改类 flag 会被拒绝
+- `-g` / `--global` 查看或修改全局
+- `-w <workspace>` / `--workspace <workspace>` 查看或修改单个 workspace 的 `policy.toml`
+
+`-w` 只能覆盖 `auto_cleanup` 与 `auto_cleanup_keep`,其他字段(interval / image / health check)是 daemon-wide,只能 `-g` 设置。
 
 ```bash
-# 查看当前配置
-ws-ckpt config
+# === 全局 ===
+# 查看
+ws-ckpt config -g
 
 # 开/关后台 auto-cleanup
-ws-ckpt config --enable-auto-cleanup
-ws-ckpt config --disable-auto-cleanup
+ws-ckpt config -g --enable-auto-cleanup
+ws-ckpt config -g --disable-auto-cleanup
 
-# 保留策略：整数=按数量，时长=按时间（单位 s/m/h/d/w）
-ws-ckpt config --auto-cleanup-keep 10
-ws-ckpt config --auto-cleanup-keep 30d
+# 保留策略:整数=按数量,时长=按时间(单位 s/m/h/d/w)
+ws-ckpt config -g --auto-cleanup-keep 10
+ws-ckpt config -g --auto-cleanup-keep 30d
 
-# 调度 / 健康检查间隔（秒，0 禁用）
-ws-ckpt config --auto-cleanup-interval 3600
-ws-ckpt config --health-check-interval 300
+# 调度 / 健康检查间隔(秒,0 禁用)
+ws-ckpt config -g --auto-cleanup-interval 3600
+ws-ckpt config -g --health-check-interval 300
 
-# BtrfsLoop 镜像容量（指定后需要重启 daemon 生效）
-ws-ckpt config --img-size 30 --img-max-percent 40
+# BtrfsLoop 镜像容量(指定后需要重启 daemon 生效)
+ws-ckpt config -g --img-size 30 --img-max-percent 40
+
+# === 局部(per-workspace 覆盖) ===
+# 三栏视图: effective / local / global
+ws-ckpt config -w ~/proj
+
+# 这个 workspace 单独保留 5 份
+ws-ckpt config -w ~/proj --auto-cleanup-keep 5
+
+# 这个 workspace 关掉 auto-cleanup,即便全局是开的
+ws-ckpt config -w ~/proj --disable-auto-cleanup
+
+# 这个 workspace 反之: 全局关闭时单独打开
+ws-ckpt config -w ~/proj --enable-auto-cleanup
+
+# 删除该 workspace 的 policy.toml,回到沿用全局
+ws-ckpt config -w ~/proj --reset
 ```
 
 ### 2.9 重新加载配置

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -4,17 +4,17 @@ use std::process;
 
 use anyhow::{Context, Result};
 use clap::builder::{StringValueParser, TypedValueParser};
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Args, Parser, Subcommand};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
 use ws_ckpt_common::{
     decode_payload, default_auto_cleanup_keep, encode_frame, load_config_file, save_config_file,
-    ChangeType, CleanupRetention, DaemonConfig, ErrorCode, Request, Response,
-    ADVISORY_SNAPSHOT_LIMIT, CONFIG_FILE_PATH, DEFAULT_AUTO_CLEANUP,
-    DEFAULT_AUTO_CLEANUP_INTERVAL_SECS, DEFAULT_HEALTH_CHECK_INTERVAL_SECS,
+    ChangeType, CleanupRetention, DaemonConfig, ErrorCode, GlobalConfigJson, PolicyFieldOp,
+    Request, Response, WorkspacePolicyJson, ADVISORY_SNAPSHOT_LIMIT, CONFIG_FILE_PATH,
+    DEFAULT_AUTO_CLEANUP, DEFAULT_AUTO_CLEANUP_INTERVAL_SECS, DEFAULT_HEALTH_CHECK_INTERVAL_SECS,
     DEFAULT_IMG_MAX_PERCENT, DEFAULT_IMG_SIZE_GB, DEFAULT_MOUNT_PATH, DEFAULT_SOCKET_PATH,
-    MAX_FRAME_SIZE,
+    GLOBAL_CONFIG_JSON_SCHEMA, MAX_FRAME_SIZE, OVERVIEW_JSON_SCHEMA,
 };
 
 /// Backend-usage advisory threshold (percent); CLI-side since daemon returns raw bytes.
@@ -36,6 +36,69 @@ fn parse_cleanup_retention(s: &str) -> Result<CleanupRetention, String> {
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+
+/// Arguments for `ws-ckpt config`. Scope (-g vs -w) is exclusive but optional;
+/// when omitted, the command renders an overview (global + ws roll-up) — view-only.
+///
+/// `--reset` is per-workspace only (deletes that ws's `policy.toml`). The
+/// interval/image flags are global-only; using them with `-w` is rejected
+/// at runtime with a clear error.
+#[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("scope").args(["global", "workspace"]).required(false).multiple(false),
+))]
+struct ConfigArgs {
+    /// Operate on /etc/ws-ckpt/config.toml (daemon-wide).
+    #[arg(short = 'g', long = "global")]
+    global: bool,
+
+    /// Operate on this workspace's policy.toml override.
+    #[arg(short = 'w', long = "workspace", value_parser = workspace_value_parser())]
+    workspace: Option<String>,
+
+    /// Per-workspace only: delete `policy.toml`, restoring inherit-global.
+    #[arg(long, conflicts_with_all = ["enable_auto_cleanup", "disable_auto_cleanup", "auto_cleanup_keep", "auto_cleanup_interval", "health_check_interval", "img_size", "img_max_percent"])]
+    reset: bool,
+
+    /// Set health check interval in seconds (0 disables the scheduler loop).
+    /// Global-only.
+    #[arg(long)]
+    health_check_interval: Option<u64>,
+
+    /// Set target image size in GB (image will be grown/shrunk at next daemon restart).
+    /// Global-only.
+    #[arg(long)]
+    img_size: Option<u64>,
+
+    /// Set initial-creation cap as percentage of host partition (0-100);
+    /// only used on first bootstrap. Global-only.
+    #[arg(long)]
+    img_max_percent: Option<f64>,
+
+    /// Enable periodic auto-cleanup.
+    #[arg(long, conflicts_with = "disable_auto_cleanup")]
+    enable_auto_cleanup: bool,
+
+    /// Disable periodic auto-cleanup.
+    #[arg(long, conflicts_with = "enable_auto_cleanup")]
+    disable_auto_cleanup: bool,
+
+    /// Set cleanup retention: integer (count mode, 0 = disabled) or duration
+    /// like "30d" (age mode, units s/m/h/d/w).
+    #[arg(long, value_parser = parse_cleanup_retention)]
+    auto_cleanup_keep: Option<CleanupRetention>,
+
+    /// Set auto-cleanup interval in seconds (0 disables the scheduler loop).
+    /// Global-only — `-w` callers passing this are rejected.
+    #[arg(long)]
+    auto_cleanup_interval: Option<u64>,
+
+    /// Output format: `text` (human-readable, default) or `json`. Programmatic
+    /// consumers should use `json` — text is not a contract; the JSON shape is
+    /// versioned by its `schema` field.
+    #[arg(long, default_value = "text")]
+    format: String,
 }
 
 #[derive(Subcommand)]
@@ -155,36 +218,14 @@ enum Commands {
         keep: u32,
     },
 
-    /// View or update daemon configuration
-    Config {
-        /// Set health check interval in seconds (0 disables the scheduler loop)
-        #[arg(long)]
-        health_check_interval: Option<u64>,
-
-        /// Set target image size in GB (image will be grown/shrunk at next daemon restart)
-        #[arg(long)]
-        img_size: Option<u64>,
-
-        /// Set initial-creation cap as percentage of host partition (0-100); only used on first bootstrap
-        #[arg(long)]
-        img_max_percent: Option<f64>,
-
-        /// Enable periodic auto-cleanup
-        #[arg(long, conflicts_with = "disable_auto_cleanup")]
-        enable_auto_cleanup: bool,
-
-        /// Disable periodic auto-cleanup
-        #[arg(long, conflicts_with = "enable_auto_cleanup")]
-        disable_auto_cleanup: bool,
-
-        /// Set cleanup retention: integer (count mode, 0 = disabled) or duration like "30d" (age mode, units s/m/h/d/w)
-        #[arg(long, value_parser = parse_cleanup_retention)]
-        auto_cleanup_keep: Option<CleanupRetention>,
-
-        /// Set auto-cleanup interval in seconds (0 disables the scheduler loop)
-        #[arg(long)]
-        auto_cleanup_interval: Option<u64>,
-    },
+    /// View or update daemon / per-workspace configuration.
+    ///
+    /// **Scope is required for any modification**: pass exactly one of
+    /// `-g/--global` or `-w/--workspace` when setting flags or `--reset`.
+    /// No scope = read-only overview (global cfg + per-ws override count);
+    /// no scope + flags = hard error, so it's always obvious which layer
+    /// a write lands on.
+    Config(ConfigArgs),
 
     /// Trigger daemon to reload /etc/ws-ckpt/config.toml
     Reload,
@@ -355,41 +396,8 @@ async fn run(cli: Cli) -> Result<()> {
             let response = send_request_to_daemon(&request).await?;
             handle_cleanup_response(response)?;
         }
-        Commands::Config {
-            health_check_interval,
-            img_size,
-            img_max_percent,
-            enable_auto_cleanup,
-            disable_auto_cleanup,
-            auto_cleanup_keep,
-            auto_cleanup_interval,
-        } => {
-            let auto_cleanup = match (enable_auto_cleanup, disable_auto_cleanup) {
-                (true, _) => Some(true),
-                (_, true) => Some(false),
-                _ => None,
-            };
-            if health_check_interval.is_none()
-                && img_size.is_none()
-                && img_max_percent.is_none()
-                && auto_cleanup.is_none()
-                && auto_cleanup_keep.is_none()
-                && auto_cleanup_interval.is_none()
-            {
-                // View mode: read config file and show
-                handle_config_view()?;
-            } else {
-                // Update mode: modify config file + notify daemon
-                handle_config_update(
-                    health_check_interval,
-                    img_size,
-                    img_max_percent,
-                    auto_cleanup,
-                    auto_cleanup_keep,
-                    auto_cleanup_interval,
-                )
-                .await?;
-            }
+        Commands::Config(args) => {
+            handle_config_command(args).await?;
         }
         Commands::Reload => {
             handle_reload().await?;
@@ -521,9 +529,31 @@ async fn send_request_to_daemon(request: &Request) -> Result<Response> {
     Ok(response)
 }
 
-/// Silent IPC used by best-effort callers (e.g. post-command health advisory).
-/// Never prints to stderr and never calls `process::exit`; all errors bubble up
-/// so the caller can decide to ignore them.
+/// Best-effort pre-view reload. `None` = global only; `Some(ws)` = global + that ws.
+async fn try_reload_daemon_for_view(workspace: Option<&str>) {
+    silent_reload(&Request::ReloadGlobalConfig).await;
+    if let Some(ws) = workspace {
+        silent_reload(&Request::ReloadWorkspacePolicy {
+            workspace: resolve_workspace_arg(ws),
+        })
+        .await;
+    }
+}
+
+async fn silent_reload(req: &Request) {
+    match try_send_request_to_daemon_silent(req).await {
+        Ok(Response::ReloadConfigOk { .. }) | Err(_) => {}
+        Ok(Response::Error { message, .. }) => {
+            eprintln!(
+                "\x1b[33m\u{26a0} View may be stale: daemon reload failed: {}\x1b[0m",
+                message
+            );
+        }
+        Ok(_) => {}
+    }
+}
+
+/// Silent IPC: errors bubble up so the caller can ignore them; never `process::exit`.
 async fn try_send_request_to_daemon_silent(request: &Request) -> Result<Response> {
     let socket_path = get_socket_path();
 
@@ -614,11 +644,11 @@ async fn print_health_advisory_if_needed() {
     eprintln!();
     eprintln!("\x1b[33m  Manual cleanup:   ws-ckpt cleanup -w <workspace> --keep <N>\x1b[0m");
     eprintln!("\x1b[33m  Or enable auto-cleanup for all workspaces:\x1b[0m");
-    eprintln!("\x1b[33m      ws-ckpt config --enable-auto-cleanup \\\x1b[0m");
-    eprintln!("\x1b[33m                     --auto-cleanup-keep <NUM|DURATION> \\\x1b[0m");
-    eprintln!("\x1b[33m                     --auto-cleanup-interval <SECONDS>\x1b[0m");
+    eprintln!("\x1b[33m      ws-ckpt config -g --enable-auto-cleanup \\\x1b[0m");
+    eprintln!("\x1b[33m                        --auto-cleanup-keep <NUM|DURATION> \\\x1b[0m");
+    eprintln!("\x1b[33m                        --auto-cleanup-interval <SECONDS>\x1b[0m");
     eprintln!("\x1b[33m  Suggested values:\x1b[0m");
-    eprintln!("\x1b[33m      ws-ckpt config --enable-auto-cleanup --auto-cleanup-keep 1000 --auto-cleanup-interval 86400\x1b[0m");
+    eprintln!("\x1b[33m      ws-ckpt config -g --enable-auto-cleanup --auto-cleanup-keep 1000 --auto-cleanup-interval 86400\x1b[0m");
 }
 
 /// Handle the response, printing formatted output.
@@ -930,8 +960,283 @@ fn handle_cleanup_response(response: Response) -> Result<()> {
     Ok(())
 }
 
-/// View current configuration from config file (no daemon required).
-fn handle_config_view() -> Result<()> {
+/// Top-level dispatcher for `ws-ckpt config`. Decides global vs per-ws based
+/// on the (clap-enforced) ArgGroup, then routes to the appropriate handler.
+async fn handle_config_command(args: ConfigArgs) -> Result<()> {
+    let format = parse_output_format(&args.format)?;
+    let auto_cleanup = match (args.enable_auto_cleanup, args.disable_auto_cleanup) {
+        (true, _) => Some(true),
+        (_, true) => Some(false),
+        _ => None,
+    };
+    let any_update = auto_cleanup.is_some()
+        || args.auto_cleanup_keep.is_some()
+        || args.auto_cleanup_interval.is_some()
+        || args.health_check_interval.is_some()
+        || args.img_size.is_some()
+        || args.img_max_percent.is_some();
+
+    if args.global {
+        if args.reset {
+            anyhow::bail!("--reset is only valid with -w/--workspace");
+        }
+        if any_update {
+            handle_global_config_update(
+                args.health_check_interval,
+                args.img_size,
+                args.img_max_percent,
+                auto_cleanup,
+                args.auto_cleanup_keep,
+                args.auto_cleanup_interval,
+                format,
+            )
+            .await?;
+        } else {
+            handle_global_config_view(format).await?;
+        }
+        return Ok(());
+    }
+
+    // No scope: overview (view-only). Updates need an explicit scope.
+    if args.workspace.is_none() {
+        if args.reset || any_update {
+            anyhow::bail!("specify -g (global) or -w <ws> (per-workspace) to make changes");
+        }
+        handle_config_overview_view(format).await?;
+        return Ok(());
+    }
+
+    let ws = args
+        .workspace
+        .clone()
+        .expect("workspace is Some in this branch");
+
+    if args.reset {
+        handle_workspace_config_reset(&ws, format).await?;
+        return Ok(());
+    }
+
+    // Per-ws: reject global-only fields up front so the user gets a clear
+    // error instead of a silently dropped flag.
+    if args.auto_cleanup_interval.is_some() {
+        anyhow::bail!("--auto-cleanup-interval is global-only; use `-g` (interval is daemon-wide)");
+    }
+    if args.health_check_interval.is_some() {
+        anyhow::bail!("--health-check-interval is global-only; use `-g`");
+    }
+    if args.img_size.is_some() {
+        anyhow::bail!("--img-size is global-only; use `-g`");
+    }
+    if args.img_max_percent.is_some() {
+        anyhow::bail!("--img-max-percent is global-only; use `-g`");
+    }
+
+    if !any_update {
+        handle_workspace_config_view(&ws, format).await?;
+    } else {
+        handle_workspace_config_update(&ws, auto_cleanup, args.auto_cleanup_keep, format).await?;
+    }
+    Ok(())
+}
+
+/// Per-ws view: queries the daemon for `effective / local / global` and
+/// renders all three columns (or JSON).
+async fn handle_workspace_config_view(workspace: &str, format: OutputFormat) -> Result<()> {
+    // Align daemon snapshot with on-disk config.toml + this ws's policy.toml.
+    try_reload_daemon_for_view(Some(workspace)).await;
+    let req = Request::GetWorkspacePolicy {
+        workspace: resolve_workspace_arg(workspace),
+    };
+    let resp = send_request_to_daemon(&req).await?;
+    print_workspace_policy_response_formatted(resp, format)
+}
+
+/// Per-ws update: send each user-mentioned field as `PolicyFieldOp::Set`,
+/// leave the rest `Unchanged`. The daemon does the read-modify-write
+/// atomically under the per-ws lock (no CLI-side GET), so concurrent
+/// `--enable-auto-cleanup` and `--auto-cleanup-keep N` can't lose updates.
+async fn handle_workspace_config_update(
+    workspace: &str,
+    auto_cleanup: Option<bool>,
+    auto_cleanup_keep: Option<CleanupRetention>,
+    format: OutputFormat,
+) -> Result<()> {
+    let asked_enable = auto_cleanup == Some(true);
+    let supplied_keep = auto_cleanup_keep.is_some();
+    let req = Request::PatchWorkspacePolicy {
+        workspace: resolve_workspace_arg(workspace),
+        auto_cleanup: match auto_cleanup {
+            Some(v) => PolicyFieldOp::Set(v),
+            None => PolicyFieldOp::Unchanged,
+        },
+        auto_cleanup_keep: match auto_cleanup_keep {
+            Some(v) => PolicyFieldOp::Set(v),
+            None => PolicyFieldOp::Unchanged,
+        },
+    };
+    let resp = send_request_to_daemon(&req).await?;
+
+    if let Response::WorkspacePolicyOk {
+        ref effective,
+        ref local,
+        ..
+    } = resp
+    {
+        if let Some(msg) = disabled_warning_for(asked_enable, supplied_keep, effective, local) {
+            eprintln!("\x1b[33m\u{26a0} Warning: {}\x1b[0m", msg);
+        }
+    }
+    print_workspace_policy_response_formatted(resp, format)
+}
+
+/// Warn when the user touched any policy field but the result is still
+/// effective-disabled. Names whichever layer(s) cause it (cleanup off,
+/// keep=0, or both), so the fix hint points at the right knob.
+fn disabled_warning_for(
+    asked_enable: bool,
+    supplied_keep: bool,
+    effective: &ws_ckpt_common::EffectivePolicy,
+    local: &ws_ckpt_common::WorkspacePolicy,
+) -> Option<String> {
+    if !(asked_enable || supplied_keep) || !effective.is_disabled() {
+        return None;
+    }
+    let mut reasons: Vec<String> = Vec::new();
+    if !effective.auto_cleanup {
+        let local_off = local.auto_cleanup == Some(false);
+        reasons.push(if local_off {
+            "local auto_cleanup is false (override with `--enable-auto-cleanup` on this command)".to_string()
+        } else {
+            "global auto_cleanup is false (pass `--enable-auto-cleanup` here for a per-ws override, or `ws-ckpt config -g --enable-auto-cleanup` to flip it globally)".to_string()
+        });
+    }
+    if effective.auto_cleanup_keep.is_disabled() {
+        let local_keep_off = local
+            .auto_cleanup_keep
+            .as_ref()
+            .map(|k| k.is_disabled())
+            .unwrap_or(false);
+        reasons.push(if local_keep_off {
+            format!(
+                "local auto_cleanup_keep is {} (override with `--auto-cleanup-keep <N>`, N >= 1)",
+                format_retention(local.auto_cleanup_keep.as_ref().unwrap())
+            )
+        } else {
+            format!(
+                "global auto_cleanup_keep is {} (pass `--auto-cleanup-keep <N>` here, or `ws-ckpt config -g --auto-cleanup-keep N`)",
+                format_retention(&effective.auto_cleanup_keep)
+            )
+        });
+    }
+    Some(format!(
+        "auto-cleanup is still effectively disabled — {}.",
+        reasons.join("; ")
+    ))
+}
+
+/// Per-ws reset: delete `policy.toml` for this workspace.
+async fn handle_workspace_config_reset(workspace: &str, format: OutputFormat) -> Result<()> {
+    let req = Request::ResetWorkspacePolicy {
+        workspace: resolve_workspace_arg(workspace),
+    };
+    let resp = send_request_to_daemon(&req).await?;
+    print_workspace_policy_response_formatted(resp, format)
+}
+
+fn print_policy_field(name: &str, effective: &str, local: Option<String>, global: &str) {
+    let local_str = match local {
+        Some(s) => s,
+        None => "(inherit)".to_string(),
+    };
+    println!(
+        "  {:<22} effective={:<14} local={:<14} global={}",
+        name, effective, local_str, global
+    );
+}
+
+fn format_retention(r: &CleanupRetention) -> String {
+    match r {
+        CleanupRetention::Count(n) => n.to_string(),
+        CleanupRetention::Age { raw, .. } => format!("\"{}\"", raw),
+    }
+}
+
+// ── Output format flag ──────────────────────────────────────────────────
+//
+// The JSON output struct types themselves live in `ws_ckpt_common`
+// (mirrors how `SnapshotEntry` / `ConfigReport` etc. live there and are
+// dumped by `list --format json` / `status --format json`). Keeping the
+// schemas there means:
+//   - cli stays free of a direct `serde` dep (derive happens in common)
+//   - future Rust tools / tests can share the same versioned schema
+//     definitions without round-tripping JSON
+
+/// Output-format flag value. A typo like `--format jso` is rejected at the
+/// CLI boundary rather than silently falling back to text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputFormat {
+    Text,
+    Json,
+}
+
+fn parse_output_format(s: &str) -> Result<OutputFormat> {
+    match s {
+        "text" => Ok(OutputFormat::Text),
+        "json" => Ok(OutputFormat::Json),
+        other => anyhow::bail!(
+            "unknown --format value: {:?} (expected `text` or `json`)",
+            other
+        ),
+    }
+}
+
+/// Print a `Response::WorkspacePolicyOk` (or surface a daemon error)
+/// according to the requested output format.
+fn print_workspace_policy_response_formatted(resp: Response, format: OutputFormat) -> Result<()> {
+    match resp {
+        Response::WorkspacePolicyOk {
+            ws_id,
+            effective,
+            local,
+            global,
+        } => match format {
+            OutputFormat::Text => {
+                println!("\x1b[1mWorkspace policy: {}\x1b[0m", ws_id);
+                print_policy_field(
+                    "auto_cleanup",
+                    &effective.auto_cleanup.to_string(),
+                    local.auto_cleanup.map(|b| b.to_string()),
+                    &global.auto_cleanup.to_string(),
+                );
+                print_policy_field(
+                    "auto_cleanup_keep",
+                    &format_retention(&effective.auto_cleanup_keep),
+                    local.auto_cleanup_keep.as_ref().map(format_retention),
+                    &format_retention(&global.auto_cleanup_keep),
+                );
+                println!(
+                    "  auto_cleanup_interval: (global-only) — see `ws-ckpt config -g` to view"
+                );
+                Ok(())
+            }
+            OutputFormat::Json => {
+                let json = WorkspacePolicyJson::from_views(ws_id, &effective, &local, &global);
+                println!("{}", serde_json::to_string_pretty(&json)?);
+                Ok(())
+            }
+        },
+        Response::Error { code, message } => {
+            anyhow::bail!("[{:?}] {}", code, message);
+        }
+        other => anyhow::bail!("Unexpected response from daemon: {:?}", other),
+    }
+}
+
+/// View current global configuration. Triggers a best-effort daemon reload
+/// first so what we read from disk also matches what daemon is using; if the
+/// daemon is offline we still render from file (no daemon required).
+async fn handle_global_config_view(format: OutputFormat) -> Result<()> {
+    try_reload_daemon_for_view(None).await;
     let path = std::path::Path::new(CONFIG_FILE_PATH);
     let fc = load_config_file(path).map_err(|e| anyhow::anyhow!("Failed to read config: {}", e))?;
 
@@ -940,10 +1245,6 @@ fn handle_config_view() -> Result<()> {
         .auto_cleanup_keep
         .clone()
         .unwrap_or_else(default_auto_cleanup_keep);
-    let keep_display = match &keep {
-        CleanupRetention::Count(n) => format!("{} (count mode)", n),
-        CleanupRetention::Age { raw, .. } => format!("\"{}\" (age mode)", raw),
-    };
     let interval = fc
         .auto_cleanup_interval_secs
         .unwrap_or(DEFAULT_AUTO_CLEANUP_INTERVAL_SECS);
@@ -957,6 +1258,29 @@ fn handle_config_view() -> Result<()> {
     let img_max = btrfs_loop
         .and_then(|b| b.img_max_percent)
         .unwrap_or(DEFAULT_IMG_MAX_PERCENT * 100.0);
+
+    if format == OutputFormat::Json {
+        let json = GlobalConfigJson {
+            schema: GLOBAL_CONFIG_JSON_SCHEMA,
+            config_file: CONFIG_FILE_PATH.to_string(),
+            mount_path: DEFAULT_MOUNT_PATH.to_string(),
+            socket_path: DEFAULT_SOCKET_PATH.to_string(),
+            auto_cleanup,
+            auto_cleanup_keep: (&keep).into(),
+            auto_cleanup_is_disabled: !auto_cleanup || keep.is_disabled(),
+            auto_cleanup_interval_secs: interval,
+            health_check_interval_secs: health,
+            img_size_gb: img_size,
+            img_max_percent: img_max,
+        };
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+
+    let keep_display = match &keep {
+        CleanupRetention::Count(n) => format!("{} (count mode)", n),
+        CleanupRetention::Age { raw, .. } => format!("\"{}\" (age mode)", raw),
+    };
 
     println!("\x1b[1mDaemon Configuration\x1b[0m");
     println!("  Config file:             {}", CONFIG_FILE_PATH);
@@ -1027,14 +1351,84 @@ fn handle_config_view() -> Result<()> {
     Ok(())
 }
 
-/// Update configuration: write to config file + notify daemon to reload.
-async fn handle_config_update(
+/// `ws-ckpt config` (no scope): global cfg + ws roll-up. View-only.
+async fn handle_config_overview_view(format: OutputFormat) -> Result<()> {
+    try_reload_daemon_for_view(None).await;
+    let resp = send_request_to_daemon(&Request::ConfigOverview).await?;
+    let (config, ws_total, ws_with_override) = match resp {
+        Response::ConfigOverviewOk {
+            config,
+            ws_total,
+            ws_with_override,
+        } => (config, ws_total, ws_with_override),
+        Response::Error { code, message } => anyhow::bail!("[{:?}] {}", code, message),
+        other => anyhow::bail!("Unexpected response from daemon: {:?}", other),
+    };
+    let inherit = ws_total.saturating_sub(ws_with_override);
+
+    if format == OutputFormat::Json {
+        let json = serde_json::json!({
+            "schema": OVERVIEW_JSON_SCHEMA,
+            "config_file": CONFIG_FILE_PATH,
+            "global": config,
+            "workspaces": {
+                "total": ws_total,
+                "with_override": ws_with_override,
+                "inherit_global": inherit,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+
+    println!("\x1b[1mDaemon Configuration\x1b[0m");
+    println!("  Config file:             {}", CONFIG_FILE_PATH);
+    println!("  Mount path:              {}", config.mount_path);
+    println!("  Socket path:             {}", config.socket_path);
+    println!(
+        "  Auto-cleanup:            {}",
+        if config.auto_cleanup {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!(
+        "  Auto-cleanup keep:       {}",
+        format_retention(&config.auto_cleanup_keep)
+    );
+    println!(
+        "  Auto-cleanup interval:   {}s ({}m)",
+        config.auto_cleanup_interval_secs,
+        config.auto_cleanup_interval_secs / 60
+    );
+    println!(
+        "  Health-check interval:   {}s ({}m)",
+        config.health_check_interval_secs,
+        config.health_check_interval_secs / 60
+    );
+    println!("  Image size:              {} GB", config.img_size);
+    println!("  Image max percent:       {}%", config.img_max_percent);
+    println!();
+    println!("\x1b[1mWorkspaces\x1b[0m");
+    println!("  Total:                   {}", ws_total);
+    println!("  With local override:     {}", ws_with_override);
+    println!("  Inherit global:          {}", inherit);
+    if ws_with_override > 0 {
+        println!("\nUse `ws-ckpt config -w <ws>` to inspect a specific workspace.");
+    }
+    Ok(())
+}
+
+/// Update global configuration: write to config file + notify daemon to reload.
+async fn handle_global_config_update(
     health_check_interval: Option<u64>,
     img_size: Option<u64>,
     img_max_percent: Option<f64>,
     auto_cleanup: Option<bool>,
     auto_cleanup_keep: Option<CleanupRetention>,
     auto_cleanup_interval_secs: Option<u64>,
+    format: OutputFormat,
 ) -> Result<()> {
     let path = std::path::Path::new(CONFIG_FILE_PATH);
 
@@ -1074,28 +1468,80 @@ async fn handle_config_update(
     // Save
     save_config_file(path, &fc).map_err(|e| anyhow::anyhow!("Failed to save config: {}", e))?;
 
-    println!(
+    // JSON mode: keep stdout a single parseable payload (the post-update
+    // config) by routing status/advisory lines to stderr.
+    let status_sink: fn(std::fmt::Arguments<'_>) = if format == OutputFormat::Json {
+        |args| eprintln!("{}", args)
+    } else {
+        |args| println!("{}", args)
+    };
+    status_sink(format_args!(
         "\x1b[32m\u{2713} Configuration saved to {}\x1b[0m",
         CONFIG_FILE_PATH
-    );
+    ));
 
-    // Try to notify running daemon
-    match send_request_to_daemon(&Request::ReloadConfig).await {
-        Ok(Response::ReloadConfigOk) => {
-            println!("\x1b[32m\u{2713} Daemon reloaded configuration\x1b[0m");
+    // Try to notify running daemon. Only the global cfg changed — no need
+    // to walk every per-ws policy.toml. The reply carries the post-reload
+    // ConfigReport so JSON mode can emit the landed state on stdout
+    // without a follow-up `Config` round-trip.
+    let mut reloaded_config: Option<ws_ckpt_common::ConfigReport> = None;
+    match send_request_to_daemon(&Request::ReloadGlobalConfig).await {
+        Ok(Response::ReloadConfigOk { config }) => {
+            status_sink(format_args!(
+                "\x1b[32m\u{2713} Daemon reloaded configuration\x1b[0m"
+            ));
             if has_img_settings {
-                println!("\x1b[33m\u{26a0} Note: btrfs-loop image settings (img-size, img-max-percent) require daemon restart to take effect.\x1b[0m");
+                status_sink(format_args!(
+                    "\x1b[33m\u{26a0} Note: btrfs-loop image settings (img-size, img-max-percent) require daemon restart to take effect.\x1b[0m"
+                ));
             }
+            reloaded_config = Some(config);
         }
         Ok(Response::Error { message, .. }) => {
             eprintln!("\x1b[33m\u{26a0} Daemon reload failed: {}\x1b[0m", message);
         }
         Err(_) => {
-            println!("\x1b[33m\u{26a0} Daemon not running, changes will take effect on next start\x1b[0m");
+            status_sink(format_args!(
+                "\x1b[33m\u{26a0} Daemon not running, changes will take effect on next start\x1b[0m"
+            ));
         }
         _ => {}
     }
+
+    // JSON mode emits the post-update state on stdout so callers don't need
+    // a follow-up read. Prefer the daemon's freshly-reloaded ConfigReport
+    // (single source of truth); fall back to a local view only if the
+    // daemon wasn't reachable.
+    if format == OutputFormat::Json {
+        match reloaded_config {
+            Some(cr) => {
+                let json = config_report_to_global_json(&cr);
+                println!("{}", serde_json::to_string_pretty(&json)?);
+            }
+            None => handle_global_config_view(format).await?,
+        }
+    }
+
     Ok(())
+}
+
+/// Render a daemon-returned [`ConfigReport`] as the same [`GlobalConfigJson`]
+/// schema that `config -g --format json` emits. Used by `-g update` to emit
+/// the post-reload state on stdout without a follow-up `Config` IPC.
+fn config_report_to_global_json(cr: &ws_ckpt_common::ConfigReport) -> GlobalConfigJson {
+    GlobalConfigJson {
+        schema: GLOBAL_CONFIG_JSON_SCHEMA,
+        config_file: CONFIG_FILE_PATH.to_string(),
+        mount_path: cr.mount_path.clone(),
+        socket_path: cr.socket_path.clone(),
+        auto_cleanup: cr.auto_cleanup,
+        auto_cleanup_keep: (&cr.auto_cleanup_keep).into(),
+        auto_cleanup_is_disabled: !cr.auto_cleanup || cr.auto_cleanup_keep.is_disabled(),
+        auto_cleanup_interval_secs: cr.auto_cleanup_interval_secs,
+        health_check_interval_secs: cr.health_check_interval_secs,
+        img_size_gb: cr.img_size,
+        img_max_percent: cr.img_max_percent,
+    }
 }
 
 /// Handle `ws-ckpt reload` (also used by systemd `ExecReload=`): send
@@ -1103,7 +1549,7 @@ async fn handle_config_update(
 /// `send_request_to_daemon` exits 1 with a red message.
 async fn handle_reload() -> Result<()> {
     match send_request_to_daemon(&Request::ReloadConfig).await? {
-        Response::ReloadConfigOk => {
+        Response::ReloadConfigOk { .. } => {
             println!("\x1b[32m\u{2713} Daemon reloaded configuration\x1b[0m");
             Ok(())
         }
@@ -1894,50 +2340,58 @@ mod tests {
         assert!(result.is_err(), "cleanup without --workspace should fail");
     }
 
-    #[test]
-    fn parse_config_no_args() {
-        let cli = Cli::try_parse_from(["ws-ckpt", "config"]).unwrap();
+    fn parse_config_args(argv: &[&str]) -> ConfigArgs {
+        let cli = Cli::try_parse_from(argv).expect("config args should parse");
         match cli.command {
-            Commands::Config {
-                health_check_interval,
-                img_size,
-                img_max_percent,
-                ..
-            } => {
-                assert!(health_check_interval.is_none());
-                assert!(img_size.is_none());
-                assert!(img_max_percent.is_none());
-            }
+            Commands::Config(a) => a,
             _ => panic!("expected Config"),
         }
     }
 
     #[test]
-    fn parse_config_with_all_flags() {
-        let cli = Cli::try_parse_from([
+    fn parse_config_no_scope_is_overview() {
+        // `ws-ckpt config` (no -g/-w, no flags) parses successfully — it's the
+        // view-only overview. Update flags without scope are rejected at
+        // runtime, not by clap.
+        let args = parse_config_args(&["ws-ckpt", "config"]);
+        assert!(!args.global);
+        assert!(args.workspace.is_none());
+    }
+
+    #[test]
+    fn parse_config_global_and_workspace_conflict() {
+        let result = Cli::try_parse_from(["ws-ckpt", "config", "-g", "-w", "/tmp/ws"]);
+        assert!(
+            result.is_err(),
+            "-g and -w should be mutually exclusive (ArgGroup)"
+        );
+    }
+
+    #[test]
+    fn parse_config_global_view() {
+        let args = parse_config_args(&["ws-ckpt", "config", "-g"]);
+        assert!(args.global);
+        assert!(args.workspace.is_none());
+        assert!(args.health_check_interval.is_none());
+    }
+
+    #[test]
+    fn parse_config_global_with_all_flags() {
+        let args = parse_config_args(&[
             "ws-ckpt",
             "config",
+            "-g",
             "--health-check-interval",
             "120",
             "--img-size",
             "30",
             "--img-max-percent",
             "40",
-        ])
-        .unwrap();
-        match cli.command {
-            Commands::Config {
-                health_check_interval,
-                img_size,
-                img_max_percent,
-                ..
-            } => {
-                assert_eq!(health_check_interval, Some(120));
-                assert_eq!(img_size, Some(30));
-                assert_eq!(img_max_percent, Some(40.0));
-            }
-            _ => panic!("expected Config"),
-        }
+        ]);
+        assert!(args.global);
+        assert_eq!(args.health_check_interval, Some(120));
+        assert_eq!(args.img_size, Some(30));
+        assert_eq!(args.img_max_percent, Some(40.0));
     }
 
     #[test]
@@ -1953,35 +2407,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_config_enable_auto_cleanup() {
-        let cli = Cli::try_parse_from(["ws-ckpt", "config", "--enable-auto-cleanup"]).unwrap();
-        match cli.command {
-            Commands::Config {
-                enable_auto_cleanup,
-                disable_auto_cleanup,
-                ..
-            } => {
-                assert!(enable_auto_cleanup);
-                assert!(!disable_auto_cleanup);
-            }
-            _ => panic!("expected Config"),
-        }
+    fn parse_config_global_enable_auto_cleanup() {
+        let args = parse_config_args(&["ws-ckpt", "config", "-g", "--enable-auto-cleanup"]);
+        assert!(args.enable_auto_cleanup);
+        assert!(!args.disable_auto_cleanup);
     }
 
     #[test]
-    fn parse_config_disable_auto_cleanup() {
-        let cli = Cli::try_parse_from(["ws-ckpt", "config", "--disable-auto-cleanup"]).unwrap();
-        match cli.command {
-            Commands::Config {
-                enable_auto_cleanup,
-                disable_auto_cleanup,
-                ..
-            } => {
-                assert!(!enable_auto_cleanup);
-                assert!(disable_auto_cleanup);
-            }
-            _ => panic!("expected Config"),
-        }
+    fn parse_config_global_disable_auto_cleanup() {
+        let args = parse_config_args(&["ws-ckpt", "config", "-g", "--disable-auto-cleanup"]);
+        assert!(!args.enable_auto_cleanup);
+        assert!(args.disable_auto_cleanup);
     }
 
     #[test]
@@ -1989,6 +2425,7 @@ mod tests {
         let result = Cli::try_parse_from([
             "ws-ckpt",
             "config",
+            "-g",
             "--enable-auto-cleanup",
             "--disable-auto-cleanup",
         ]);
@@ -2000,52 +2437,33 @@ mod tests {
 
     #[test]
     fn parse_config_auto_cleanup_keep_count() {
-        let cli = Cli::try_parse_from(["ws-ckpt", "config", "--auto-cleanup-keep", "20"]).unwrap();
-        match cli.command {
-            Commands::Config {
-                auto_cleanup_keep, ..
-            } => {
-                assert_eq!(auto_cleanup_keep, Some(CleanupRetention::Count(20)));
-            }
-            _ => panic!("expected Config"),
-        }
+        let args = parse_config_args(&["ws-ckpt", "config", "-g", "--auto-cleanup-keep", "20"]);
+        assert_eq!(args.auto_cleanup_keep, Some(CleanupRetention::Count(20)));
     }
 
     #[test]
     fn parse_config_auto_cleanup_keep_zero_disables() {
-        let cli = Cli::try_parse_from(["ws-ckpt", "config", "--auto-cleanup-keep", "0"]).unwrap();
-        match cli.command {
-            Commands::Config {
-                auto_cleanup_keep, ..
-            } => {
-                let keep = auto_cleanup_keep.expect("keep should be set");
-                assert!(keep.is_disabled());
-                assert_eq!(keep, CleanupRetention::Count(0));
-            }
-            _ => panic!("expected Config"),
-        }
+        let args = parse_config_args(&["ws-ckpt", "config", "-g", "--auto-cleanup-keep", "0"]);
+        let keep = args.auto_cleanup_keep.expect("keep should be set");
+        assert!(keep.is_disabled());
+        assert_eq!(keep, CleanupRetention::Count(0));
     }
 
     #[test]
     fn parse_config_auto_cleanup_keep_age() {
-        let cli = Cli::try_parse_from(["ws-ckpt", "config", "--auto-cleanup-keep", "30d"]).unwrap();
-        match cli.command {
-            Commands::Config {
-                auto_cleanup_keep, ..
-            } => match auto_cleanup_keep {
-                Some(CleanupRetention::Age { raw, secs }) => {
-                    assert_eq!(raw, "30d");
-                    assert_eq!(secs, 30 * 24 * 3600);
-                }
-                other => panic!("expected Age variant, got {:?}", other),
-            },
-            _ => panic!("expected Config"),
+        let args = parse_config_args(&["ws-ckpt", "config", "-g", "--auto-cleanup-keep", "30d"]);
+        match args.auto_cleanup_keep {
+            Some(CleanupRetention::Age { raw, secs }) => {
+                assert_eq!(raw, "30d");
+                assert_eq!(secs, 30 * 24 * 3600);
+            }
+            other => panic!("expected Age variant, got {:?}", other),
         }
     }
 
     #[test]
     fn parse_config_auto_cleanup_keep_invalid() {
-        let result = Cli::try_parse_from(["ws-ckpt", "config", "--auto-cleanup-keep", "abc"]);
+        let result = Cli::try_parse_from(["ws-ckpt", "config", "-g", "--auto-cleanup-keep", "abc"]);
         assert!(
             result.is_err(),
             "non-numeric value without duration unit should be rejected"
@@ -2054,17 +2472,157 @@ mod tests {
 
     #[test]
     fn parse_config_auto_cleanup_interval() {
-        let cli =
-            Cli::try_parse_from(["ws-ckpt", "config", "--auto-cleanup-interval", "3600"]).unwrap();
-        match cli.command {
-            Commands::Config {
-                auto_cleanup_interval,
-                ..
-            } => {
-                assert_eq!(auto_cleanup_interval, Some(3600));
-            }
-            _ => panic!("expected Config"),
-        }
+        let args =
+            parse_config_args(&["ws-ckpt", "config", "-g", "--auto-cleanup-interval", "3600"]);
+        assert_eq!(args.auto_cleanup_interval, Some(3600));
+    }
+
+    #[test]
+    fn parse_config_workspace_view() {
+        let args = parse_config_args(&["ws-ckpt", "config", "-w", "/tmp/proj"]);
+        assert!(!args.global);
+        assert_eq!(args.workspace.as_deref(), Some("/tmp/proj"));
+        assert!(!args.reset);
+    }
+
+    #[test]
+    fn parse_config_workspace_reset() {
+        let args = parse_config_args(&["ws-ckpt", "config", "-w", "/tmp/proj", "--reset"]);
+        assert!(args.reset);
+        assert_eq!(args.workspace.as_deref(), Some("/tmp/proj"));
+    }
+
+    #[test]
+    fn parse_config_workspace_set_keep() {
+        let args = parse_config_args(&[
+            "ws-ckpt",
+            "config",
+            "-w",
+            "/tmp/proj",
+            "--auto-cleanup-keep",
+            "5",
+        ]);
+        assert_eq!(args.auto_cleanup_keep, Some(CleanupRetention::Count(5)));
+    }
+
+    #[test]
+    fn parse_config_reset_conflicts_with_other_updates() {
+        let result = Cli::try_parse_from([
+            "ws-ckpt",
+            "config",
+            "-w",
+            "/tmp/proj",
+            "--reset",
+            "--auto-cleanup-keep",
+            "5",
+        ]);
+        assert!(
+            result.is_err(),
+            "--reset must conflict with other update flags"
+        );
+    }
+
+    #[test]
+    fn parse_config_format_defaults_to_text() {
+        let args = parse_config_args(&["ws-ckpt", "config", "-g"]);
+        assert_eq!(args.format, "text");
+        assert_eq!(
+            parse_output_format(&args.format).unwrap(),
+            OutputFormat::Text
+        );
+    }
+
+    #[test]
+    fn parse_config_format_json_accepted() {
+        let args = parse_config_args(&["ws-ckpt", "config", "-g", "--format", "json"]);
+        assert_eq!(args.format, "json");
+        assert_eq!(
+            parse_output_format(&args.format).unwrap(),
+            OutputFormat::Json
+        );
+    }
+
+    #[test]
+    fn parse_output_format_rejects_typo() {
+        // Anything other than text/json must fail loudly — a silent
+        // fallback to text would break plugin scripts that asked for JSON.
+        assert!(parse_output_format("jso").is_err());
+        assert!(parse_output_format("YAML").is_err());
+        assert!(parse_output_format("").is_err());
+    }
+
+    #[test]
+    fn workspace_policy_json_schema_is_versioned() {
+        // The `schema` field lets consumers reject an unknown version. This
+        // pins v1: a deliberate shape change must also bump this assert, so
+        // an accidental field rename is caught here.
+        use ws_ckpt_common::{EffectivePolicy, GlobalPolicySnapshot, WorkspacePolicy};
+        let effective = EffectivePolicy {
+            auto_cleanup: true,
+            auto_cleanup_keep: CleanupRetention::Count(5),
+        };
+        let local = WorkspacePolicy::default();
+        let global = GlobalPolicySnapshot {
+            auto_cleanup: true,
+            auto_cleanup_keep: CleanupRetention::Count(20),
+        };
+        let json =
+            WorkspacePolicyJson::from_views("ws-test".to_string(), &effective, &local, &global);
+        let s = serde_json::to_string(&json).unwrap();
+        assert!(s.contains(r#""schema":"ws-ckpt-policy/v1""#));
+        // Tagged retention (consumer can match on `mode`, no number-vs-
+        // string discrimination needed).
+        assert!(s.contains(r#""mode":"count""#));
+        assert!(s.contains(r#""count":5"#));
+        // is_disabled pre-computed on the wire.
+        assert!(s.contains(r#""is_disabled":false"#));
+    }
+
+    #[test]
+    fn workspace_policy_json_age_retention_emits_tagged_form() {
+        use ws_ckpt_common::{EffectivePolicy, GlobalPolicySnapshot, WorkspacePolicy};
+        let effective = EffectivePolicy {
+            auto_cleanup: true,
+            auto_cleanup_keep: CleanupRetention::age("30d").unwrap(),
+        };
+        let local = WorkspacePolicy::default();
+        let global = GlobalPolicySnapshot {
+            auto_cleanup: true,
+            auto_cleanup_keep: CleanupRetention::Count(20),
+        };
+        let json =
+            WorkspacePolicyJson::from_views("ws-test".to_string(), &effective, &local, &global);
+        let s = serde_json::to_string(&json).unwrap();
+        assert!(s.contains(r#""mode":"age""#));
+        assert!(s.contains(r#""raw":"30d""#));
+        assert!(s.contains(r#""secs":2592000"#));
+    }
+
+    #[test]
+    fn workspace_policy_json_count_zero_is_disabled() {
+        // Regression: openclaw rendered `Count(0)` as "0" with no disabled
+        // marker, though the scheduler skips it. Pre-computing is_disabled
+        // via from_views(... &effective ...) walks the production path,
+        // so a future regression that breaks `is_disabled()` would fail
+        // here too — not just the wire format.
+        use ws_ckpt_common::{EffectivePolicy, GlobalPolicySnapshot, WorkspacePolicy};
+        let effective = EffectivePolicy {
+            auto_cleanup: true,
+            auto_cleanup_keep: CleanupRetention::Count(0),
+        };
+        let local = WorkspacePolicy::default();
+        let global = GlobalPolicySnapshot {
+            auto_cleanup: true,
+            auto_cleanup_keep: CleanupRetention::Count(0),
+        };
+        let json =
+            WorkspacePolicyJson::from_views("ws-test".to_string(), &effective, &local, &global);
+        let s = serde_json::to_string(&json).unwrap();
+        assert!(s.contains(r#""mode":"count""#));
+        assert!(s.contains(r#""count":0"#));
+        // Critical: is_disabled MUST be true even though auto_cleanup=true,
+        // because keep is Count(0). That's the whole bug this prevents.
+        assert!(s.contains(r#""is_disabled":true"#));
     }
 
     // ── Recover CLI parsing tests ──
@@ -2171,5 +2729,69 @@ mod tests {
             }
             _ => panic!("expected Recover"),
         }
+    }
+
+    // ── disabled_warning_for: warn whenever the user touched a policy field but effective stays disabled ──
+
+    fn eff(cleanup: bool, keep: CleanupRetention) -> ws_ckpt_common::EffectivePolicy {
+        ws_ckpt_common::EffectivePolicy {
+            auto_cleanup: cleanup,
+            auto_cleanup_keep: keep,
+        }
+    }
+
+    #[test]
+    fn warn_enable_only_when_global_keep_is_zero() {
+        // Old gate: --enable-auto-cleanup, no --keep, global keep is 0.
+        let e = eff(true, CleanupRetention::Count(0));
+        let l = ws_ckpt_common::WorkspacePolicy::default();
+        let msg = disabled_warning_for(true, false, &e, &l).expect("warning expected");
+        assert!(
+            msg.contains("global auto_cleanup_keep is 0"),
+            "got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn warn_enable_with_keep_zero_supplied() {
+        // #5: --enable-auto-cleanup --auto-cleanup-keep 0 must still warn.
+        let e = eff(true, CleanupRetention::Count(0));
+        let l = ws_ckpt_common::WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::Count(0)),
+        };
+        let msg = disabled_warning_for(true, true, &e, &l).expect("warning expected");
+        assert!(msg.contains("local auto_cleanup_keep is 0"), "got: {}", msg);
+    }
+
+    #[test]
+    fn warn_keep_only_when_global_cleanup_is_off() {
+        // #6: --auto-cleanup-keep 5 alone, global cleanup is false.
+        let e = eff(false, CleanupRetention::Count(5));
+        let l = ws_ckpt_common::WorkspacePolicy {
+            auto_cleanup: None,
+            auto_cleanup_keep: Some(CleanupRetention::Count(5)),
+        };
+        let msg = disabled_warning_for(false, true, &e, &l).expect("warning expected");
+        assert!(msg.contains("global auto_cleanup is false"), "got: {}", msg);
+    }
+
+    #[test]
+    fn no_warn_when_effective_active() {
+        let e = eff(true, CleanupRetention::Count(20));
+        let l = ws_ckpt_common::WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::Count(20)),
+        };
+        assert!(disabled_warning_for(true, true, &e, &l).is_none());
+    }
+
+    #[test]
+    fn no_warn_when_user_supplied_nothing() {
+        // Daemon view alone (no PATCH fields) must not produce a warning.
+        let e = eff(false, CleanupRetention::Count(0));
+        let l = ws_ckpt_common::WorkspacePolicy::default();
+        assert!(disabled_warning_for(false, false, &e, &l).is_none());
     }
 }

--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -28,6 +28,7 @@ pub const DEFAULT_STATE_DIR: &str = "/var/lib/ws-ckpt"; // systemd StateDirector
 pub const STATE_FILE: &str = "state.json"; // daemon state file
 pub const INDEXES_DIR: &str = "indexes"; // snapshots indexes directory
 pub const LOCKFILE_NAME: &str = "daemon.lock"; // daemon write lockfile
+pub const POLICY_FILE: &str = "policy.toml";
 
 /// Snapshot advisory threshold; strict-greater filter shared by daemon and CLI.
 pub const ADVISORY_SNAPSHOT_LIMIT: u32 = 1000;
@@ -91,12 +92,61 @@ pub enum Request {
     Config,
     /// Reload configuration from file
     ReloadConfig,
+    /// Reload only global config from file; skip the per-ws policy walk so a
+    /// `config -g` view doesn't pay for a 500-ws policy.toml rescan.
+    ReloadGlobalConfig,
+    /// Reload a single workspace's `policy.toml`. Used by `config -w <ws>`
+    /// view alignment so we don't rescan all 500 ws's just to view one.
+    ReloadWorkspacePolicy {
+        workspace: String,
+    },
+    /// `ws-ckpt config` (no scope): global cfg snapshot + ws override counts.
+    ConfigOverview,
     /// Recover workspace to a normal directory (undo init)
     Recover {
         workspace: String,
     },
     /// Aggregated health metrics for post-command CLI advisories.
     HealthAdvisory,
+    /// Read the per-workspace policy (absent ⇒ inherit-global).
+    GetWorkspacePolicy {
+        workspace: String,
+    },
+    /// Delete the per-workspace `policy.toml`, restoring inherit-global.
+    /// The *only* whole-file operation; partial edits go through
+    /// [`Request::PatchWorkspacePolicy`].
+    ResetWorkspacePolicy {
+        workspace: String,
+    },
+    /// Atomic field-level patch; daemon does read-modify-write under the
+    /// per-ws write lock to avoid lost updates.
+    PatchWorkspacePolicy {
+        workspace: String,
+        auto_cleanup: PolicyFieldOp<bool>,
+        auto_cleanup_keep: PolicyFieldOp<CleanupRetention>,
+    },
+}
+
+/// Field-level patch op: `Unchanged` (default) / `Set(v)`.
+///
+/// No `Clear` variant — removing a per-ws override is whole-file, exposed
+/// via [`Request::ResetWorkspacePolicy`]. Adding `Clear` later is a
+/// non-breaking enum extension if a per-field clear UI ever lands.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub enum PolicyFieldOp<T> {
+    #[default]
+    Unchanged,
+    Set(T),
+}
+
+impl<T> PolicyFieldOp<T> {
+    /// Apply this op to a field's existing value. Returns the new value.
+    pub fn apply(self, current: Option<T>) -> Option<T> {
+        match self {
+            Self::Unchanged => current,
+            Self::Set(v) => Some(v),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -133,7 +183,12 @@ pub enum Response {
     ConfigOk {
         config: ConfigReport,
     },
-    ReloadConfigOk,
+    /// Reply to any of the three reload IPCs. Includes the post-reload
+    /// global config snapshot so callers that just wrote settings can
+    /// confirm the landed state without a follow-up `Config` round-trip.
+    ReloadConfigOk {
+        config: ConfigReport,
+    },
     CheckpointSkipped {
         reason: String,
     },
@@ -146,6 +201,20 @@ pub enum Response {
         /// Backend usage bytes; `fs_total_bytes == 0` sentinel means unavailable.
         fs_total_bytes: u64,
         fs_used_bytes: u64,
+    },
+    /// Reply to policy get/set/patch: effective (applied) + local (on-disk
+    /// override) + global (daemon defaults snapshot).
+    WorkspacePolicyOk {
+        ws_id: String,
+        effective: EffectivePolicy,
+        local: WorkspacePolicy,
+        global: GlobalPolicySnapshot,
+    },
+    /// Reply to `ConfigOverview`: full global cfg + ws roll-up.
+    ConfigOverviewOk {
+        config: ConfigReport,
+        ws_total: usize,
+        ws_with_override: usize,
     },
 }
 
@@ -669,6 +738,307 @@ pub fn encode_frame<T: Serialize>(msg: &T) -> Result<Vec<u8>, WsCkptError> {
 /// and then reading exactly N bytes before calling this function)
 pub fn decode_payload<T: DeserializeOwned>(data: &[u8]) -> Result<T, WsCkptError> {
     Ok(bincode::deserialize(data)?)
+}
+
+// ── Per-workspace policy ──
+
+/// On-disk per-workspace policy override (`indexes/<ws_id>/policy.toml`).
+/// `Some(_)` overrides the global field; `None`/missing file ⇒ inherit global.
+/// Daemon-wide fields (intervals, health, image sizing) are excluded and
+/// rejected at the CLI/IPC boundary.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct WorkspacePolicy {
+    pub auto_cleanup: Option<bool>,
+    pub auto_cleanup_keep: Option<CleanupRetention>,
+}
+
+impl WorkspacePolicy {
+    /// True when no field is set — the workspace inherits everything from global.
+    pub fn is_empty(&self) -> bool {
+        self.auto_cleanup.is_none() && self.auto_cleanup_keep.is_none()
+    }
+
+    /// Overlay this local policy on global config, per-field `local.or(global)`.
+    pub fn effective_for(&self, global: &DaemonConfig) -> EffectivePolicy {
+        EffectivePolicy {
+            auto_cleanup: self.auto_cleanup.unwrap_or(global.auto_cleanup),
+            auto_cleanup_keep: self
+                .auto_cleanup_keep
+                .clone()
+                .unwrap_or_else(|| global.auto_cleanup_keep.clone()),
+        }
+    }
+}
+
+/// Merged (local+global) auto-cleanup behavior applied to one workspace.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct EffectivePolicy {
+    pub auto_cleanup: bool,
+    pub auto_cleanup_keep: CleanupRetention,
+}
+
+impl EffectivePolicy {
+    /// Whether scheduler should skip this workspace this tick.
+    pub fn is_disabled(&self) -> bool {
+        !self.auto_cleanup || self.auto_cleanup_keep.is_disabled()
+    }
+}
+
+/// Snapshot of global policy fields at query time, for the CLI 3-column view.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GlobalPolicySnapshot {
+    pub auto_cleanup: bool,
+    pub auto_cleanup_keep: CleanupRetention,
+}
+
+impl GlobalPolicySnapshot {
+    pub fn from_config(cfg: &DaemonConfig) -> Self {
+        Self {
+            auto_cleanup: cfg.auto_cleanup,
+            auto_cleanup_keep: cfg.auto_cleanup_keep.clone(),
+        }
+    }
+}
+
+// ── CLI `--format json` output shapes ──────────────────────────────────
+//
+// Stable, versioned JSON schemas for consumers (openclaw, hermes, CI).
+// Kept in `common` (next to their source types, like `SnapshotEntry`) so
+// the cli crate needs no own serde dep and Rust callers can reuse them.
+//
+// `is_disabled` is pre-computed on the wire so consumers don't re-derive
+// daemon semantics — the only way `Count(0)` / `Count(N)` stay
+// distinguishable to a plugin (the original openclaw bug).
+//
+// `RetentionJson` is a tagged enum (`{mode: "count"|"age", ...}`) rather
+// than `CleanupRetention`'s bare-number/string serde, decoupling the
+// plugin contract and sparing consumers a `typeof` check.
+
+/// JSON shape for `ws-ckpt config -w ... --format json` and the
+/// Patch/Reset responses under `--format json`. Versioned via `schema`.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct WorkspacePolicyJson {
+    pub schema: &'static str,
+    pub ws_id: String,
+    pub effective: EffectivePolicyJson,
+    pub local: LocalPolicyJson,
+    pub global: GlobalPolicyValuesJson,
+}
+
+/// Versioned schema tag for [`WorkspacePolicyJson`]. Bump on any breaking
+/// change so consumers can refuse unknown majors instead of silently
+/// misreading.
+pub const WORKSPACE_POLICY_JSON_SCHEMA: &str = "ws-ckpt-policy/v1";
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct EffectivePolicyJson {
+    pub auto_cleanup: bool,
+    pub auto_cleanup_keep: RetentionJson,
+    /// Pre-computed `!auto_cleanup || keep.is_disabled()`. Plugins MUST
+    /// read this instead of re-deriving it consumer-side.
+    pub is_disabled: bool,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct LocalPolicyJson {
+    pub auto_cleanup: Option<bool>,
+    pub auto_cleanup_keep: Option<RetentionJson>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct GlobalPolicyValuesJson {
+    pub auto_cleanup: bool,
+    pub auto_cleanup_keep: RetentionJson,
+}
+
+/// Tagged retention so consumers can match on a literal `mode` field
+/// instead of discriminating number-vs-string. Mirrors
+/// `CleanupRetention`'s two semantic modes 1:1.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(tag = "mode", rename_all = "lowercase")]
+pub enum RetentionJson {
+    Count { count: u32 },
+    Age { raw: String, secs: u64 },
+}
+
+impl From<&CleanupRetention> for RetentionJson {
+    fn from(r: &CleanupRetention) -> Self {
+        match r {
+            CleanupRetention::Count(n) => Self::Count { count: *n },
+            CleanupRetention::Age { raw, secs } => Self::Age {
+                raw: raw.clone(),
+                secs: *secs,
+            },
+        }
+    }
+}
+
+impl WorkspacePolicyJson {
+    /// Convenience: build the JSON view from the three values returned in
+    /// `Response::WorkspacePolicyOk`, pre-computing `is_disabled` for the
+    /// effective layer so consumers don't have to.
+    pub fn from_views(
+        ws_id: String,
+        effective: &EffectivePolicy,
+        local: &WorkspacePolicy,
+        global: &GlobalPolicySnapshot,
+    ) -> Self {
+        Self {
+            schema: WORKSPACE_POLICY_JSON_SCHEMA,
+            ws_id,
+            effective: EffectivePolicyJson {
+                auto_cleanup: effective.auto_cleanup,
+                auto_cleanup_keep: (&effective.auto_cleanup_keep).into(),
+                is_disabled: effective.is_disabled(),
+            },
+            local: LocalPolicyJson {
+                auto_cleanup: local.auto_cleanup,
+                auto_cleanup_keep: local.auto_cleanup_keep.as_ref().map(Into::into),
+            },
+            global: GlobalPolicyValuesJson {
+                auto_cleanup: global.auto_cleanup,
+                auto_cleanup_keep: (&global.auto_cleanup_keep).into(),
+            },
+        }
+    }
+}
+
+/// JSON shape for `ws-ckpt config -g --format json`.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct GlobalConfigJson {
+    pub schema: &'static str,
+    pub config_file: String,
+    pub mount_path: String,
+    pub socket_path: String,
+    pub auto_cleanup: bool,
+    pub auto_cleanup_keep: RetentionJson,
+    /// Pre-computed: `!auto_cleanup || auto_cleanup_keep.is_disabled()`.
+    /// Same rationale as the per-ws effective view.
+    pub auto_cleanup_is_disabled: bool,
+    pub auto_cleanup_interval_secs: u64,
+    pub health_check_interval_secs: u64,
+    pub img_size_gb: u64,
+    pub img_max_percent: f64,
+}
+
+/// Versioned schema tag for [`GlobalConfigJson`].
+pub const GLOBAL_CONFIG_JSON_SCHEMA: &str = "ws-ckpt-config/v1";
+
+/// Versioned schema tag for the `ws-ckpt config` (no-scope) overview JSON
+/// emitted by the CLI: global config snapshot + workspace override counts.
+/// Same naming convention as the policy/config tags (all `-` separated, /vN).
+pub const OVERVIEW_JSON_SCHEMA: &str = "ws-ckpt-overview/v1";
+
+/// Result of [`load_workspace_policy`]: distinguishes "no file" from "I/O
+/// error" so a reload racing a half-done writer won't nuke the in-memory policy.
+#[derive(Debug)]
+pub enum LoadPolicyOutcome {
+    /// No `policy.toml` — treat as inherit-global.
+    Missing,
+    /// Loaded successfully (may be `WorkspacePolicy::default()` if empty).
+    Loaded(WorkspacePolicy),
+}
+
+/// Load `<index_dir>/policy.toml`: `Missing` if absent, `Loaded(p)` on
+/// success, `Err` otherwise (parse/IO). See [`load_workspace_policy_or_default`]
+/// to collapse `Missing`.
+pub fn load_workspace_policy(index_dir: &Path) -> Result<LoadPolicyOutcome, WsCkptError> {
+    let path = index_dir.join(POLICY_FILE);
+    match std::fs::read_to_string(&path) {
+        Ok(content) => {
+            let p: WorkspacePolicy = toml::from_str(&content)
+                .map_err(|e| WsCkptError::Config(format!("parse {}: {}", path.display(), e)))?;
+            Ok(LoadPolicyOutcome::Loaded(p))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(LoadPolicyOutcome::Missing),
+        Err(e) => Err(WsCkptError::Io(e)),
+    }
+}
+
+/// Like [`load_workspace_policy`] but collapses `Missing` → default. Use only
+/// when there's no in-memory state to preserve on transient errors (e.g. startup).
+pub fn load_workspace_policy_or_default(index_dir: &Path) -> Result<WorkspacePolicy, WsCkptError> {
+    match load_workspace_policy(index_dir)? {
+        LoadPolicyOutcome::Missing => Ok(WorkspacePolicy::default()),
+        LoadPolicyOutcome::Loaded(p) => Ok(p),
+    }
+}
+
+/// Register-time policy loader with `auto_cleanup = false` fail-safe.
+///
+/// Used by every workspace register path (init / adopt_existing_subvol /
+/// rebuild_from_persisted / rebuild_workspace_into_state). Three outcomes:
+/// - `Missing` → `(default(), false)`; user never set a policy, inherit-global is correct
+/// - `Loaded(p)` → `(p, false)`; on-disk truth
+/// - `Err(e)` → `({auto_cleanup: Some(false), ..}, true)`; refuse to inherit-global
+///   because the next scheduler tick under a globally-enabled cfg would delete
+///   protected snapshots. The `true` marker propagates to `policy_failsafe`,
+///   which PATCH refuses until reload/reset.
+///
+/// `entry_label` ("init" / "adopt" / "rebuild") is the only differing piece
+/// across the 4 sites; it goes into the warn! message to keep the per-site
+/// diagnostic.
+pub fn load_workspace_policy_with_failsafe(
+    index_dir: &Path,
+    ws_id: &str,
+    entry_label: &str,
+) -> (WorkspacePolicy, bool) {
+    match load_workspace_policy(index_dir) {
+        Ok(LoadPolicyOutcome::Missing) => (WorkspacePolicy::default(), false),
+        Ok(LoadPolicyOutcome::Loaded(p)) => (p, false),
+        Err(e) => {
+            tracing::warn!(
+                "{} of {}: policy.toml at {:?} unreadable: {} — registering with in-memory \
+                 `auto_cleanup = false` until next reload succeeds. Inherit-global would risk \
+                 deleting protected snapshots, so we explicitly disable cleanup for this ws \
+                 as a fail-safe.",
+                entry_label,
+                ws_id,
+                index_dir,
+                e
+            );
+            (
+                WorkspacePolicy {
+                    auto_cleanup: Some(false),
+                    auto_cleanup_keep: None,
+                },
+                true,
+            )
+        }
+    }
+}
+
+/// Atomically persist a per-workspace policy via [`persist::atomic_write`]
+/// (0600, root-only daemon-internal data).
+pub fn save_workspace_policy(
+    index_dir: &Path,
+    policy: &WorkspacePolicy,
+) -> Result<(), WsCkptError> {
+    let content = toml::to_string_pretty(policy)
+        .map_err(|e| WsCkptError::Config(format!("serialize policy: {}", e)))?;
+    persist::atomic_write(index_dir, POLICY_FILE, content.as_bytes(), Some(0o600))
+        .map_err(|e| WsCkptError::Config(format!("save_workspace_policy: {:#}", e)))
+}
+
+/// Remove `<index_dir>/policy.toml` (missing-file is OK; `--reset` is
+/// idempotent), then fsync the parent dir. A post-unlink fsync failure is
+/// logged, not propagated — the file is already gone.
+pub fn delete_workspace_policy(index_dir: &Path) -> Result<(), WsCkptError> {
+    let target = index_dir.join(POLICY_FILE);
+    match std::fs::remove_file(&target) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(WsCkptError::Io(e)),
+    }
+    if let Err(e) = persist::fsync_dir(index_dir) {
+        tracing::warn!(
+            "delete_workspace_policy: unlink of {:?} succeeded but parent dir fsync failed: {:#} \
+             (file is gone; durability across a crash is best-effort on this fs)",
+            target,
+            e
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1457,9 +1827,27 @@ mod tests {
 
     #[test]
     fn response_reload_config_ok_round_trip() {
-        let resp = Response::ReloadConfigOk;
-        let decoded = round_trip_response(&resp);
-        assert!(matches!(decoded, Response::ReloadConfigOk));
+        let resp = Response::ReloadConfigOk {
+            config: ConfigReport {
+                mount_path: "/mnt/btrfs-workspace".to_string(),
+                socket_path: "/run/ws-ckpt/ws-ckpt.sock".to_string(),
+                log_level: "info".to_string(),
+                auto_cleanup: true,
+                auto_cleanup_keep: CleanupRetention::Count(5),
+                auto_cleanup_interval_secs: 3_600,
+                health_check_interval_secs: 60,
+                img_size: 30,
+                img_max_percent: 40.0,
+            },
+        };
+        match round_trip_response(&resp) {
+            Response::ReloadConfigOk { config } => {
+                assert!(config.auto_cleanup);
+                assert_eq!(config.auto_cleanup_keep, CleanupRetention::Count(5));
+                assert_eq!(config.auto_cleanup_interval_secs, 3_600);
+            }
+            _ => panic!("expected ReloadConfigOk variant"),
+        }
     }
 
     // ── FileConfig tests ──
@@ -1702,6 +2090,283 @@ mod tests {
                 assert_eq!(fs_used_bytes, 94 * 1024 * 1024 * 1024);
             }
             _ => panic!("expected HealthAdvisoryOk variant"),
+        }
+    }
+
+    // ── WorkspacePolicy tests ──
+
+    fn global_count(n: u32) -> DaemonConfig {
+        DaemonConfig {
+            auto_cleanup: true,
+            auto_cleanup_keep: CleanupRetention::Count(n),
+            ..DaemonConfig::default()
+        }
+    }
+
+    #[test]
+    fn workspace_policy_empty_toml_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        save_workspace_policy(dir.path(), &WorkspacePolicy::default()).unwrap();
+        match load_workspace_policy(dir.path()).unwrap() {
+            LoadPolicyOutcome::Loaded(p) => {
+                assert!(p.is_empty());
+                assert_eq!(p, WorkspacePolicy::default());
+            }
+            LoadPolicyOutcome::Missing => panic!("file was just written, must be Loaded"),
+        }
+    }
+
+    #[test]
+    fn workspace_policy_partial_toml_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: None,
+        };
+        save_workspace_policy(dir.path(), &p).unwrap();
+        let loaded = load_workspace_policy_or_default(dir.path()).unwrap();
+        assert_eq!(loaded, p);
+        assert!(!loaded.is_empty());
+    }
+
+    #[test]
+    fn workspace_policy_age_mode_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::age("30d").unwrap()),
+        };
+        save_workspace_policy(dir.path(), &p).unwrap();
+        let loaded = load_workspace_policy_or_default(dir.path()).unwrap();
+        assert_eq!(loaded, p);
+    }
+
+    #[test]
+    fn workspace_policy_count_mode_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = WorkspacePolicy {
+            auto_cleanup: Some(false),
+            auto_cleanup_keep: Some(CleanupRetention::Count(5)),
+        };
+        save_workspace_policy(dir.path(), &p).unwrap();
+        let loaded = load_workspace_policy_or_default(dir.path()).unwrap();
+        assert_eq!(loaded, p);
+    }
+
+    #[test]
+    fn load_workspace_policy_missing_file_returns_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        match load_workspace_policy(dir.path()).unwrap() {
+            LoadPolicyOutcome::Missing => {} // expected — fresh dir, no file
+            LoadPolicyOutcome::Loaded(_) => panic!("empty dir must report Missing"),
+        }
+        // Convenience wrapper collapses Missing → default for fresh-startup
+        // call sites that have no in-memory state to preserve.
+        assert!(load_workspace_policy_or_default(dir.path())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn delete_workspace_policy_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        // No file yet — delete must succeed silently.
+        delete_workspace_policy(dir.path()).unwrap();
+        // Write, then delete.
+        save_workspace_policy(
+            dir.path(),
+            &WorkspacePolicy {
+                auto_cleanup: Some(true),
+                auto_cleanup_keep: None,
+            },
+        )
+        .unwrap();
+        delete_workspace_policy(dir.path()).unwrap();
+        // After delete the load must report Missing (not "Loaded(empty)") —
+        // that distinction is what lets reload preserve in-memory state on
+        // a transient EBUSY.
+        assert!(matches!(
+            load_workspace_policy(dir.path()).unwrap(),
+            LoadPolicyOutcome::Missing
+        ));
+    }
+
+    #[test]
+    fn effective_for_local_some_overrides_global() {
+        let global = global_count(20);
+        let local = WorkspacePolicy {
+            auto_cleanup: Some(false),
+            auto_cleanup_keep: Some(CleanupRetention::Count(5)),
+        };
+        let eff = local.effective_for(&global);
+        assert!(!eff.auto_cleanup);
+        assert_eq!(eff.auto_cleanup_keep, CleanupRetention::Count(5));
+    }
+
+    #[test]
+    fn effective_for_local_none_inherits_global() {
+        let global = global_count(20);
+        let local = WorkspacePolicy::default();
+        let eff = local.effective_for(&global);
+        assert_eq!(eff.auto_cleanup, global.auto_cleanup);
+        assert_eq!(eff.auto_cleanup_keep, global.auto_cleanup_keep);
+    }
+
+    #[test]
+    fn effective_for_local_partial_only_overrides_set_fields() {
+        let global = global_count(20);
+        let local = WorkspacePolicy {
+            auto_cleanup: None,
+            auto_cleanup_keep: Some(CleanupRetention::Count(7)),
+        };
+        let eff = local.effective_for(&global);
+        // auto_cleanup is None ⇒ inherit
+        assert_eq!(eff.auto_cleanup, global.auto_cleanup);
+        // auto_cleanup_keep is Some ⇒ override
+        assert_eq!(eff.auto_cleanup_keep, CleanupRetention::Count(7));
+    }
+
+    #[test]
+    fn effective_policy_is_disabled_propagates() {
+        let global = global_count(20);
+        // Local sets auto_cleanup=false ⇒ disabled regardless of keep.
+        let local = WorkspacePolicy {
+            auto_cleanup: Some(false),
+            auto_cleanup_keep: Some(CleanupRetention::Count(10)),
+        };
+        assert!(local.effective_for(&global).is_disabled());
+        // Local sets keep=Count(0) ⇒ disabled even if auto_cleanup=true.
+        let local = WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::Count(0)),
+        };
+        assert!(local.effective_for(&global).is_disabled());
+        // Local enables on top of disabled global.
+        let mut g_off = global.clone();
+        g_off.auto_cleanup = false;
+        let local = WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: None,
+        };
+        assert!(!local.effective_for(&g_off).is_disabled());
+    }
+
+    #[test]
+    fn workspace_policy_reset_request_round_trip() {
+        let req = Request::ResetWorkspacePolicy {
+            workspace: "/ws".to_string(),
+        };
+        match round_trip_request(&req) {
+            Request::ResetWorkspacePolicy { workspace } => assert_eq!(workspace, "/ws"),
+            _ => panic!("expected ResetWorkspacePolicy"),
+        }
+    }
+
+    #[test]
+    fn workspace_policy_get_request_round_trip() {
+        let req = Request::GetWorkspacePolicy {
+            workspace: "/ws".to_string(),
+        };
+        match round_trip_request(&req) {
+            Request::GetWorkspacePolicy { workspace } => assert_eq!(workspace, "/ws"),
+            _ => panic!("expected GetWorkspacePolicy"),
+        }
+    }
+
+    #[test]
+    fn policy_field_op_apply_semantics() {
+        assert_eq!(
+            PolicyFieldOp::<bool>::Unchanged.apply(Some(true)),
+            Some(true)
+        );
+        assert_eq!(PolicyFieldOp::<bool>::Unchanged.apply(None), None);
+        assert_eq!(
+            PolicyFieldOp::<bool>::Set(false).apply(Some(true)),
+            Some(false)
+        );
+        assert_eq!(PolicyFieldOp::<bool>::Set(true).apply(None), Some(true));
+    }
+
+    #[test]
+    fn workspace_policy_patch_request_round_trip() {
+        let req = Request::PatchWorkspacePolicy {
+            workspace: "/ws".to_string(),
+            auto_cleanup: PolicyFieldOp::Set(true),
+            auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::age("7d").unwrap()),
+        };
+        let decoded = round_trip_request(&req);
+        match decoded {
+            Request::PatchWorkspacePolicy {
+                workspace,
+                auto_cleanup,
+                auto_cleanup_keep,
+            } => {
+                assert_eq!(workspace, "/ws");
+                assert_eq!(auto_cleanup, PolicyFieldOp::Set(true));
+                assert!(matches!(
+                    auto_cleanup_keep,
+                    PolicyFieldOp::Set(CleanupRetention::Age { .. })
+                ));
+            }
+            _ => panic!("expected PatchWorkspacePolicy"),
+        }
+    }
+
+    #[test]
+    fn workspace_policy_patch_request_mixed_round_trip() {
+        // One field Set, one Unchanged — covers both variants on the wire.
+        let req = Request::PatchWorkspacePolicy {
+            workspace: "/ws".to_string(),
+            auto_cleanup: PolicyFieldOp::Unchanged,
+            auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(3)),
+        };
+        match round_trip_request(&req) {
+            Request::PatchWorkspacePolicy {
+                auto_cleanup,
+                auto_cleanup_keep,
+                ..
+            } => {
+                assert_eq!(auto_cleanup, PolicyFieldOp::<bool>::Unchanged);
+                assert_eq!(
+                    auto_cleanup_keep,
+                    PolicyFieldOp::Set(CleanupRetention::Count(3))
+                );
+            }
+            _ => panic!("expected PatchWorkspacePolicy"),
+        }
+    }
+
+    #[test]
+    fn workspace_policy_response_round_trip() {
+        let resp = Response::WorkspacePolicyOk {
+            ws_id: "ws-abc".to_string(),
+            effective: EffectivePolicy {
+                auto_cleanup: true,
+                auto_cleanup_keep: CleanupRetention::Count(5),
+            },
+            local: WorkspacePolicy {
+                auto_cleanup: None,
+                auto_cleanup_keep: Some(CleanupRetention::Count(5)),
+            },
+            global: GlobalPolicySnapshot {
+                auto_cleanup: true,
+                auto_cleanup_keep: CleanupRetention::Count(20),
+            },
+        };
+        match round_trip_response(&resp) {
+            Response::WorkspacePolicyOk {
+                ws_id,
+                effective,
+                local,
+                global,
+            } => {
+                assert_eq!(ws_id, "ws-abc");
+                assert!(effective.auto_cleanup);
+                assert_eq!(effective.auto_cleanup_keep, CleanupRetention::Count(5));
+                assert_eq!(local.auto_cleanup_keep, Some(CleanupRetention::Count(5)));
+                assert_eq!(global.auto_cleanup_keep, CleanupRetention::Count(20));
+            }
+            _ => panic!("expected WorkspacePolicyOk"),
         }
     }
 

--- a/src/ws-ckpt/src/crates/common/src/persist.rs
+++ b/src/ws-ckpt/src/crates/common/src/persist.rs
@@ -136,32 +136,57 @@ pub fn load_state(state_dir: &Path) -> Result<Option<DaemonStateFile>> {
     }
 }
 
-/// Atomically write to state.json (write-tmp + fsync + rename).
+/// Atomically write `bytes` to `<dir>/<name>` via tmp+fsync+rename+parent-
+/// fsync. Optionally create the temp file with `mode` (Unix only).
 ///
-/// Write flow:
-/// 1. Serialize to JSON (pretty print)
-/// 2. Write to temporary file state.json.tmp
-/// 3. fsync to ensure data is written to disk
-/// 4. rename atomically
-pub fn save_state(state_dir: &Path, state: &DaemonStateFile) -> Result<()> {
-    fs::create_dir_all(state_dir)
-        .with_context(|| format!("Failed to create state directory: {}", state_dir.display()))?;
+/// Crash semantics: after Ok the target holds the new content — never a
+/// half-written file. The parent-dir fsync is best-effort: it runs *after*
+/// the rename already succeeded, so propagating its error would
+/// leave the file durably on disk while memory rejects the update, causing
+/// memory-vs-disk drift. We log it at `warn!` instead.
+///
+/// `mode` is applied both via `OpenOptions::mode()` at create time AND via
+/// an explicit `fchmod` on the open handle. The fchmod is required because
+/// `create(true).truncate(true)` reuses the inode of a stale `<name>.tmp`
+/// left by a crashed prior write, inheriting its old (possibly 0o644)
+/// permissions — `OpenOptions::mode()` only fires on a fresh create.
+/// Ignored on non-Unix.
+pub fn atomic_write(
+    dir: &Path,
+    name: &str,
+    bytes: &[u8],
+    #[cfg_attr(not(unix), allow(unused_variables))] mode: Option<u32>,
+) -> Result<()> {
+    fs::create_dir_all(dir)
+        .with_context(|| format!("Failed to create directory: {}", dir.display()))?;
 
-    let target = state_dir.join(STATE_FILE);
-    let tmp = state_dir.join(format!("{}.tmp", STATE_FILE));
+    let target = dir.join(name);
+    let tmp = dir.join(format!("{}.tmp", name));
 
-    let content =
-        serde_json::to_string_pretty(state).context("Failed to serialize DaemonStateFile")?;
+    {
+        let mut opts = fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        if let Some(m) = mode {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(m);
+        }
+        let mut file = opts
+            .open(&tmp)
+            .with_context(|| format!("Failed to create temp file: {}", tmp.display()))?;
+        // fchmod even if file pre-existed: OpenOptions::mode() only applies on create.
+        #[cfg(unix)]
+        if let Some(m) = mode {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(fs::Permissions::from_mode(m))
+                .with_context(|| format!("Failed to chmod temp file: {}", tmp.display()))?;
+        }
+        file.write_all(bytes)
+            .with_context(|| format!("Failed to write temp file: {}", tmp.display()))?;
+        file.sync_all()
+            .with_context(|| format!("Failed to fsync temp file: {}", tmp.display()))?;
+    }
 
-    // Write to temporary file
-    let mut file = fs::File::create(&tmp)
-        .with_context(|| format!("Failed to create temp file: {}", tmp.display()))?;
-    file.write_all(content.as_bytes())
-        .with_context(|| format!("Failed to write temp file: {}", tmp.display()))?;
-    file.sync_all()
-        .with_context(|| format!("Failed to fsync temp file: {}", tmp.display()))?;
-
-    // Atomic rename
     fs::rename(&tmp, &target).with_context(|| {
         format!(
             "Failed to atomically rename: {} -> {}",
@@ -170,7 +195,35 @@ pub fn save_state(state_dir: &Path, state: &DaemonStateFile) -> Result<()> {
         )
     })?;
 
+    // Best-effort: a fsync_dir failure doesn't roll back the rename, and
+    // propagating it as Err would cause the memory-vs-disk drift described
+    // in the docstring above.
+    if let Err(e) = fsync_dir(dir) {
+        tracing::warn!(
+            "atomic_write: rename of {} succeeded but parent dir fsync failed: {:#} \
+             (data is in the right place; durability across a crash is best-effort on this fs)",
+            target.display(),
+            e
+        );
+    }
     Ok(())
+}
+
+/// fsync a directory so a `rename` / `unlink` inside it is durable across a
+/// crash. Surfaces the error so the caller can decide (best-effort).
+pub fn fsync_dir(dir: &Path) -> Result<()> {
+    let f = fs::File::open(dir)
+        .with_context(|| format!("Failed to open directory {} for fsync", dir.display()))?;
+    f.sync_all()
+        .with_context(|| format!("Failed to sync_all on directory {}", dir.display()))?;
+    Ok(())
+}
+
+/// Atomically write to state.json (write-tmp + fsync + rename + parent fsync).
+pub fn save_state(state_dir: &Path, state: &DaemonStateFile) -> Result<()> {
+    let content =
+        serde_json::to_string_pretty(state).context("Failed to serialize DaemonStateFile")?;
+    atomic_write(state_dir, STATE_FILE, content.as_bytes(), None)
 }
 
 #[cfg(test)]
@@ -272,5 +325,29 @@ mod tests {
         // Should not exist .tmp file after successful write
         let tmp_path = dir.path().join(format!("{}.tmp", STATE_FILE));
         assert!(!tmp_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_chmods_over_stale_tmp() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let name = "policy.toml";
+        // Simulate a prior crashed write: stale .tmp on disk with 0o644.
+        let stale_tmp = dir.path().join(format!("{}.tmp", name));
+        fs::write(&stale_tmp, b"old garbage").unwrap();
+        fs::set_permissions(&stale_tmp, fs::Permissions::from_mode(0o644)).unwrap();
+
+        atomic_write(dir.path(), name, b"new content", Some(0o600)).unwrap();
+
+        let final_mode = fs::metadata(dir.path().join(name))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            final_mode, 0o600,
+            "stale-tmp inode reuse must not leak 0o644"
+        );
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
@@ -1,8 +1,10 @@
 use crate::state::DaemonState;
 use std::sync::Arc;
 use ws_ckpt_common::{
-    default_auto_cleanup_keep, load_config_file, ConfigReport, ErrorCode, Request, Response,
-    StatusReport, WorkspaceInfo, ADVISORY_SNAPSHOT_LIMIT, CONFIG_FILE_PATH, DEFAULT_AUTO_CLEANUP,
+    default_auto_cleanup_keep, delete_workspace_policy, load_config_file, save_workspace_policy,
+    ConfigReport, DaemonConfig, EffectivePolicy, ErrorCode, FileConfig, GlobalPolicySnapshot,
+    PolicyFieldOp, Request, Response, StatusReport, WorkspaceInfo, WorkspacePolicy,
+    ADVISORY_SNAPSHOT_LIMIT, CONFIG_FILE_PATH, DEFAULT_AUTO_CLEANUP,
     DEFAULT_AUTO_CLEANUP_INTERVAL_SECS, DEFAULT_HEALTH_CHECK_INTERVAL_SECS,
     DEFAULT_IMG_MAX_PERCENT, DEFAULT_IMG_SIZE_GB,
 };
@@ -109,7 +111,25 @@ pub async fn dispatch(state: &Arc<DaemonState>, request: Request) -> Response {
             Ok(()) => crate::snapshot_mgr::cleanup_snapshots(state, &workspace, keep).await,
         },
         Request::Config => Ok(handle_config(state)),
-        Request::ReloadConfig => Ok(handle_reload_config(state)),
+        Request::ReloadConfig => Ok(handle_reload_config(state).await),
+        Request::ReloadGlobalConfig => Ok(handle_reload_global_config(state)),
+        Request::ReloadWorkspacePolicy { workspace } => {
+            Ok(handle_reload_workspace_policy(state, &workspace).await)
+        }
+        Request::ConfigOverview => Ok(handle_config_overview(state).await),
+        Request::GetWorkspacePolicy { workspace } => {
+            Ok(handle_get_workspace_policy(state, &workspace).await)
+        }
+        Request::ResetWorkspacePolicy { workspace } => {
+            Ok(handle_reset_workspace_policy(state, &workspace).await)
+        }
+        Request::PatchWorkspacePolicy {
+            workspace,
+            auto_cleanup,
+            auto_cleanup_keep,
+        } => Ok(
+            handle_patch_workspace_policy(state, &workspace, auto_cleanup, auto_cleanup_keep).await,
+        ),
         Request::Recover { workspace } => match state.ensure_bootstrapped().await {
             Err(e) => Err(e),
             Ok(()) => crate::workspace_mgr::recover_workspace(state, &workspace).await,
@@ -206,19 +226,43 @@ async fn handle_status(
 
 /// Handle the Config request: return the current daemon configuration.
 fn handle_config(state: &Arc<DaemonState>) -> Response {
-    let cfg = state.config.read().unwrap();
     Response::ConfigOk {
-        config: ConfigReport {
-            mount_path: state.mount_path.to_string_lossy().to_string(),
-            socket_path: state.socket_path.to_string_lossy().to_string(),
-            log_level: cfg.log_level.clone(),
-            auto_cleanup: cfg.auto_cleanup,
-            auto_cleanup_keep: cfg.auto_cleanup_keep.clone(),
-            auto_cleanup_interval_secs: cfg.auto_cleanup_interval_secs,
-            health_check_interval_secs: cfg.health_check_interval_secs,
-            img_size: cfg.img_size,
-            img_max_percent: cfg.img_max_percent,
-        },
+        config: build_config_report(state),
+    }
+}
+
+fn build_config_report(state: &Arc<DaemonState>) -> ConfigReport {
+    let cfg = state.config_snapshot();
+    ConfigReport {
+        mount_path: state.mount_path.to_string_lossy().to_string(),
+        socket_path: state.socket_path.to_string_lossy().to_string(),
+        log_level: cfg.log_level,
+        auto_cleanup: cfg.auto_cleanup,
+        auto_cleanup_keep: cfg.auto_cleanup_keep,
+        auto_cleanup_interval_secs: cfg.auto_cleanup_interval_secs,
+        health_check_interval_secs: cfg.health_check_interval_secs,
+        img_size: cfg.img_size,
+        img_max_percent: cfg.img_max_percent,
+    }
+}
+
+/// Handle ConfigOverview: global cfg + ws override roll-up. Walks every ws
+/// under read locks (cheap; no disk I/O — caller should reload first if alignment matters).
+async fn handle_config_overview(state: &Arc<DaemonState>) -> Response {
+    let config = build_config_report(state);
+    let arcs = state.all_workspaces();
+    let ws_total = arcs.len();
+    let mut ws_with_override = 0;
+    for arc in arcs {
+        let ws = arc.read().await;
+        if !ws.policy.is_empty() {
+            ws_with_override += 1;
+        }
+    }
+    Response::ConfigOverviewOk {
+        config,
+        ws_total,
+        ws_with_override,
     }
 }
 
@@ -228,75 +272,337 @@ fn handle_config(state: &Arc<DaemonState>) -> Response {
 /// only during daemon bootstrap. If they differ from the currently loaded values, a
 /// warning is emitted to tell the operator that a daemon restart is required for the
 /// new values to be applied (via img resize at bootstrap).
-fn handle_reload_config(state: &Arc<DaemonState>) -> Response {
+///
+/// Also rescans every workspace's `policy.toml` so out-of-band edits take
+/// effect on reload. Per-ws policies are reloaded **before** the global cfg:
+/// the resulting window is `(old cfg, new per-ws)`, which can only over-keep
+/// (recoverable), never over-delete.
+async fn handle_reload_config(state: &Arc<DaemonState>) -> Response {
     match load_config_file(std::path::Path::new(CONFIG_FILE_PATH)) {
         Ok(file_config) => {
-            let mut cfg = state.config.write().unwrap();
-            cfg.auto_cleanup = file_config.auto_cleanup.unwrap_or(DEFAULT_AUTO_CLEANUP);
-            cfg.auto_cleanup_keep = file_config
-                .auto_cleanup_keep
-                .clone()
-                .unwrap_or_else(default_auto_cleanup_keep);
-            cfg.auto_cleanup_interval_secs = file_config
-                .auto_cleanup_interval_secs
-                .unwrap_or(DEFAULT_AUTO_CLEANUP_INTERVAL_SECS);
-            cfg.health_check_interval_secs = file_config
-                .health_check_interval_secs
-                .unwrap_or(DEFAULT_HEALTH_CHECK_INTERVAL_SECS);
-            cfg.backend_type = file_config.backend.r#type.clone();
-
-            // img_* fields are bootstrap-only; compare against the new file values and
-            // warn if they changed. We do NOT mutate cfg.img_size / cfg.img_max_percent
-            // here because bootstrap has already consumed them; the loop image size is
-            // fixed until the next restart (at which point bootstrap will reconcile it).
-            //
-            // Both fields participate in the target formula:
-            //   target = min(img_size * GiB, total * img_max_percent / 100)
-            // so a change to either one will affect the reconciled image size after
-            // `systemctl restart ws-ckpt`.
-            let btrfs_loop = file_config.backend.btrfs_loop.as_ref();
-            let new_img_size = btrfs_loop
-                .and_then(|b| b.img_size)
-                .unwrap_or(DEFAULT_IMG_SIZE_GB);
-            let new_img_max_percent = btrfs_loop
-                .and_then(|b| b.img_max_percent)
-                .unwrap_or(DEFAULT_IMG_MAX_PERCENT * 100.0);
-            if new_img_size != cfg.img_size
-                || (new_img_max_percent - cfg.img_max_percent).abs() > f64::EPSILON
-            {
-                tracing::warn!(
-                    "BtrfsLoop image sizing changed in config file (img_size: {} -> {} GB, \
-                     img_max_percent: {} -> {}). These are bootstrap-only settings; \
-                     restart ws-ckpt daemon to apply the new target \
-                     min(img_size GB, total * img_max_percent%).",
-                    cfg.img_size,
-                    new_img_size,
-                    cfg.img_max_percent,
-                    new_img_max_percent,
-                );
-            }
-
-            tracing::info!(
-                "Config reloaded: auto_cleanup={}, keep={}, cleanup_interval={}s, health_interval={}s \
-                 (img fields are bootstrap-only; restart required to apply)",
-                cfg.auto_cleanup,
-                cfg.auto_cleanup_keep,
-                cfg.auto_cleanup_interval_secs,
-                cfg.health_check_interval_secs,
-            );
-            // Drop the write lock before notifying so woken loops can read the
-            // fresh config without contending on the lock.
-            drop(cfg);
+            // Phase 1: refresh per-ws policies (global cfg still OLD — safe,
+            // per-ws layers on any global).
+            state.reload_all_workspace_policies().await;
+            // Phase 2: apply new global cfg.
+            apply_global_config(state, &file_config);
             // Push notification to scheduler loops: break their current sleep
             // (or wake them from a disabled state) so the new config takes
             // effect immediately instead of on the next polling boundary.
             state.config_notify.notify_waiters();
-            Response::ReloadConfigOk
+            Response::ReloadConfigOk {
+                config: build_config_report(state),
+            }
         }
         Err(e) => Response::Error {
             code: ErrorCode::InternalError,
             message: format!("Failed to reload config: {}", e),
         },
+    }
+}
+
+/// Reload one workspace's `policy.toml` — `config -w <ws>` view alignment.
+async fn handle_reload_workspace_policy(state: &Arc<DaemonState>, workspace: &str) -> Response {
+    let ctx = match resolve_ws_for_policy(state, workspace).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    state.reload_workspace_policy(&ctx.ws_id).await;
+    state.config_notify.notify_waiters();
+    Response::ReloadConfigOk {
+        config: build_config_report(state),
+    }
+}
+
+/// Reload only the global config — `config -g` view alignment, no per-ws walk.
+fn handle_reload_global_config(state: &Arc<DaemonState>) -> Response {
+    match load_config_file(std::path::Path::new(CONFIG_FILE_PATH)) {
+        Ok(file_config) => {
+            apply_global_config(state, &file_config);
+            state.config_notify.notify_waiters();
+            Response::ReloadConfigOk {
+                config: build_config_report(state),
+            }
+        }
+        Err(e) => Response::Error {
+            code: ErrorCode::InternalError,
+            message: format!("Failed to reload config: {}", e),
+        },
+    }
+}
+
+/// Apply a freshly-loaded `file_config` to the daemon's in-memory state.
+/// Caller is responsible for `config_notify.notify_waiters()` afterwards.
+fn apply_global_config(state: &Arc<DaemonState>, file_config: &FileConfig) {
+    let mut cfg = match state.config.write() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            tracing::warn!("config RwLock poisoned; reload taking write guard anyway");
+            poisoned.into_inner()
+        }
+    };
+    cfg.auto_cleanup = file_config.auto_cleanup.unwrap_or(DEFAULT_AUTO_CLEANUP);
+    cfg.auto_cleanup_keep = file_config
+        .auto_cleanup_keep
+        .clone()
+        .unwrap_or_else(default_auto_cleanup_keep);
+    cfg.auto_cleanup_interval_secs = file_config
+        .auto_cleanup_interval_secs
+        .unwrap_or(DEFAULT_AUTO_CLEANUP_INTERVAL_SECS);
+    cfg.health_check_interval_secs = file_config
+        .health_check_interval_secs
+        .unwrap_or(DEFAULT_HEALTH_CHECK_INTERVAL_SECS);
+    cfg.backend_type = file_config.backend.r#type.clone();
+
+    // img_* are bootstrap-only: warn if changed but don't mutate cfg
+    // (loop image size is fixed until the next restart, where
+    // bootstrap reconciles target = min(img_size GiB, total * pct/100)).
+    let btrfs_loop = file_config.backend.btrfs_loop.as_ref();
+    let new_img_size = btrfs_loop
+        .and_then(|b| b.img_size)
+        .unwrap_or(DEFAULT_IMG_SIZE_GB);
+    let new_img_max_percent = btrfs_loop
+        .and_then(|b| b.img_max_percent)
+        .unwrap_or(DEFAULT_IMG_MAX_PERCENT * 100.0);
+    if new_img_size != cfg.img_size
+        || (new_img_max_percent - cfg.img_max_percent).abs() > f64::EPSILON
+    {
+        tracing::warn!(
+            "BtrfsLoop image sizing changed in config file (img_size: {} -> {} GB, \
+             img_max_percent: {} -> {}). These are bootstrap-only settings; \
+             restart ws-ckpt daemon to apply the new target \
+             min(img_size GB, total * img_max_percent%).",
+            cfg.img_size,
+            new_img_size,
+            cfg.img_max_percent,
+            new_img_max_percent,
+        );
+    }
+
+    tracing::info!(
+        "Config reloaded: auto_cleanup={}, keep={}, cleanup_interval={}s, health_interval={}s \
+         (img fields are bootstrap-only; restart required to apply)",
+        cfg.auto_cleanup,
+        cfg.auto_cleanup_keep,
+        cfg.auto_cleanup_interval_secs,
+        cfg.health_check_interval_secs,
+    );
+}
+
+/// Snapshot global config once and derive both `global` and `effective` from
+/// it, so a concurrent `ReloadConfig` can't break `effective = local.or(global)`.
+fn render_views(
+    state: &Arc<DaemonState>,
+    local: &WorkspacePolicy,
+) -> (EffectivePolicy, GlobalPolicySnapshot) {
+    let cfg_snapshot: DaemonConfig = state.config_snapshot();
+    let effective = local.effective_for(&cfg_snapshot);
+    let global = GlobalPolicySnapshot::from_config(&cfg_snapshot);
+    (effective, global)
+}
+
+/// Bundle of values every policy handler needs: the ws Arc (for tiny
+/// read/write locks downstream), its stable identifiers, and the per-ws
+/// `policy_io_mu` Arc that PATCH/RESET serialize fsync on.
+struct PolicyCtx {
+    arc: Arc<tokio::sync::RwLock<crate::state::WorkspaceState>>,
+    ws_id: String,
+    index_dir: std::path::PathBuf,
+    policy_io_mu: Arc<tokio::sync::Mutex<()>>,
+}
+
+/// Resolve `workspace` → [`PolicyCtx`], or return a ready-to-send
+/// `WorkspaceNotFound` Response. One tiny read lock snapshots ws_id +
+/// `policy_io_mu` Arc, so all 4 policy handlers (Get / Reset / Patch /
+/// ReloadWorkspacePolicy) share the same boilerplate.
+async fn resolve_ws_for_policy(
+    state: &Arc<DaemonState>,
+    workspace: &str,
+) -> Result<PolicyCtx, Response> {
+    let arc = match state.resolve_workspace(workspace).await {
+        Some(a) => a,
+        None => {
+            return Err(Response::Error {
+                code: ErrorCode::WorkspaceNotFound,
+                message: format!("workspace not found: {}", workspace),
+            });
+        }
+    };
+    let (ws_id, policy_io_mu) = {
+        let ws = arc.read().await;
+        (ws.ws_id.clone(), ws.policy_io_mu.clone())
+    };
+    let index_dir = state.index_dir(&ws_id);
+    Ok(PolicyCtx {
+        arc,
+        ws_id,
+        index_dir,
+        policy_io_mu,
+    })
+}
+
+/// Handle `GetWorkspacePolicy`: return effective + local + global views
+/// (one cfg snapshot keeps `effective` and `global` consistent).
+async fn handle_get_workspace_policy(state: &Arc<DaemonState>, workspace: &str) -> Response {
+    let ctx = match resolve_ws_for_policy(state, workspace).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let local = ctx.arc.read().await.policy.clone();
+    let (effective, global) = render_views(state, &local);
+    Response::WorkspacePolicyOk {
+        ws_id: ctx.ws_id,
+        effective,
+        local,
+        global,
+    }
+}
+
+/// Save the per-ws `policy.toml` on a blocking worker so a slow fsync doesn't
+/// pin a tokio thread; the write lock spans the spawn_blocking so
+/// concurrent patchers serialize.
+async fn save_policy_blocking(
+    index_dir: std::path::PathBuf,
+    new_policy: WorkspacePolicy,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        save_workspace_policy(&index_dir, &new_policy)
+            .map_err(|e| format!("save policy.toml: {}", e))
+    })
+    .await
+    .map_err(|e| format!("blocking-task join error: {}", e))?
+}
+
+/// Delete the per-ws `policy.toml`; same spawn_blocking discipline as [`save_policy_blocking`].
+async fn delete_policy_blocking(index_dir: std::path::PathBuf) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        delete_workspace_policy(&index_dir).map_err(|e| format!("delete policy.toml: {}", e))
+    })
+    .await
+    .map_err(|e| format!("blocking-task join error: {}", e))?
+}
+
+/// Handle `ResetWorkspacePolicy`: always unlink `policy.toml` (idempotent) and
+/// clear the in-memory override — memory and disk can drift, never short-circuit on memory alone.
+///
+/// Lock discipline (see [[ws-lock-no-fs-loops]]): the ws RwLock is held ONLY
+/// for in-memory commit; the unlink + parent fsync runs unlocked. PATCH/RESET
+/// serialization uses a per-ws narrow `policy_io_mu` so concurrent
+/// checkpoint/list/status are not blocked by a slow disk.
+async fn handle_reset_workspace_policy(state: &Arc<DaemonState>, workspace: &str) -> Response {
+    let ctx = match resolve_ws_for_policy(state, workspace).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    // (1) Serialize PATCH/RESET on this ws via the narrow mutex; does NOT
+    //     block readers/checkpoint on the ws RwLock.
+    let _io_guard = ctx.policy_io_mu.lock().await;
+
+    // (2) Slow fs op runs WITHOUT the ws lock.
+    if let Err(e) = delete_policy_blocking(ctx.index_dir).await {
+        return Response::Error {
+            code: ErrorCode::InternalError,
+            message: format!("Failed to delete policy.toml: {}", e),
+        };
+    }
+
+    // (3) Tiny write lock to commit the in-memory result. Disk is the source
+    //     of truth — this just brings memory in sync with the post-unlink state.
+    let local = WorkspacePolicy::default();
+    {
+        let mut ws = ctx.arc.write().await;
+        ws.policy = local.clone();
+        // Reset puts ws into a known-clean inherit-global state — drop any prior fail-safe marker.
+        ws.policy_failsafe = false;
+    }
+
+    let (effective, global) = render_views(state, &local);
+    state.config_notify.notify_waiters();
+    Response::WorkspacePolicyOk {
+        ws_id: ctx.ws_id,
+        effective,
+        local,
+        global,
+    }
+}
+
+/// Handle `PatchWorkspacePolicy`: server-side read-modify-write per field
+/// killing the lost-update race of the CLI's old GET→modify→SET.
+///
+/// Lock discipline (see [[ws-lock-no-fs-loops]]): the ws RwLock is held only
+/// for the few-microsecond memory ops (read snapshot, then write commit).
+/// The fsync+rename+parent-fsync runs WITHOUT the ws lock, under a per-ws
+/// narrow `policy_io_mu` that serializes PATCH/RESET against each other but
+/// does not block checkpoint/list/status. Order is fs-first, memory-second:
+/// if `save_policy_blocking` errors we return without touching memory, so
+/// memory never leads disk (no rollback needed).
+async fn handle_patch_workspace_policy(
+    state: &Arc<DaemonState>,
+    workspace: &str,
+    auto_cleanup: PolicyFieldOp<bool>,
+    auto_cleanup_keep: PolicyFieldOp<ws_ckpt_common::CleanupRetention>,
+) -> Response {
+    let ctx = match resolve_ws_for_policy(state, workspace).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    // (1) Serialize PATCH/RESET on this ws via the narrow mutex; concurrent
+    //     readers/checkpoint on the ws RwLock are NOT blocked by this.
+    let _io_guard = ctx.policy_io_mu.lock().await;
+
+    // (2) Tiny read lock: failsafe gate + snapshot for read-modify-write.
+    //     Held under io_guard, so two PATCHes can't both observe stale state
+    //     and race to write.
+    let (mut new_policy, failsafe) = {
+        let ws = ctx.arc.read().await;
+        (ws.policy.clone(), ws.policy_failsafe)
+    };
+
+    // Refuse: in-memory policy is a fail-safe synthetic, not the user's truth.
+    // Patching from it would persist the synthetic as truth (e.g. silently
+    // turning auto_cleanup=true on disk into false). Force reload/reset first.
+    if failsafe {
+        return Response::Error {
+            code: ErrorCode::InternalError,
+            message: format!(
+                "workspace {} has a fail-safe policy in memory (real policy.toml \
+                 was unreadable at startup). Patching now would overwrite the \
+                 on-disk policy with the fail-safe value. Run `ws-ckpt reload` \
+                 to re-read the file, or `ws-ckpt config -w {} --reset` to \
+                 discard the on-disk override and restart from inherit-global.",
+                ctx.ws_id, ctx.ws_id
+            ),
+        };
+    }
+
+    new_policy.auto_cleanup = auto_cleanup.apply(new_policy.auto_cleanup);
+    new_policy.auto_cleanup_keep = auto_cleanup_keep.apply(new_policy.auto_cleanup_keep);
+
+    // (3) Slow fs save WITHOUT the ws lock. Always save + notify even if mem-equal:
+    //     corrects on-disk drift and re-arms parked schedulers. Patch edits only;
+    //     all-None still writes empty TOML so loads see Loaded(default), not Missing.
+    if let Err(e) = save_policy_blocking(ctx.index_dir, new_policy.clone()).await {
+        // fs-first ordering: memory was not touched, so no rollback needed.
+        return Response::Error {
+            code: ErrorCode::InternalError,
+            message: format!("Failed to persist policy.toml: {}", e),
+        };
+    }
+
+    // (4) Tiny write lock to commit the in-memory result.
+    {
+        let mut ws = ctx.arc.write().await;
+        ws.policy = new_policy.clone();
+    }
+
+    let (effective, global) = render_views(state, &new_policy);
+    state.config_notify.notify_waiters();
+    Response::WorkspacePolicyOk {
+        ws_id: ctx.ws_id,
+        effective,
+        local: new_policy,
+        global,
     }
 }
 
@@ -694,7 +1000,7 @@ mod tests {
         ));
         let req = Request::ReloadConfig;
         let resp = dispatch(&state, req).await;
-        assert!(matches!(resp, Response::ReloadConfigOk));
+        assert!(matches!(resp, Response::ReloadConfigOk { .. }));
     }
 
     #[tokio::test]
@@ -711,6 +1017,507 @@ mod tests {
         match resp {
             Response::Error { code, .. } => assert_eq!(code, ErrorCode::WorkspaceNotFound),
             _ => panic!("expected WorkspaceNotFound error from Recover"),
+        }
+    }
+
+    // ── Per-workspace policy dispatch tests ──
+
+    #[tokio::test]
+    async fn dispatch_get_workspace_policy_unregistered_returns_workspace_not_found() {
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            PathBuf::from("/tmp/test-state"),
+        ));
+        let req = Request::GetWorkspacePolicy {
+            workspace: "/nonexistent/ws".to_string(),
+        };
+        match dispatch(&state, req).await {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::WorkspaceNotFound),
+            other => panic!("expected WorkspaceNotFound, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_workspace_policy_returns_global_default_for_clean_ws() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/clean");
+        state.register_workspace(
+            "ws-clean".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+        );
+        let req = Request::GetWorkspacePolicy {
+            workspace: "ws-clean".to_string(),
+        };
+        match dispatch(&state, req).await {
+            Response::WorkspacePolicyOk {
+                ws_id,
+                effective,
+                local,
+                global,
+            } => {
+                assert_eq!(ws_id, "ws-clean");
+                assert!(local.is_empty(), "fresh ws should have no local override");
+                // effective inherits from global (here: auto_cleanup=false, Count(20))
+                assert_eq!(effective.auto_cleanup, global.auto_cleanup);
+                assert_eq!(effective.auto_cleanup_keep, global.auto_cleanup_keep);
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_patch_then_get_workspace_policy_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/patchget");
+        state.register_workspace(
+            "ws-patchget".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+        );
+
+        // Patch sets both fields (Patch is the only write path, Reset the only delete path).
+        let patch_req = Request::PatchWorkspacePolicy {
+            workspace: "ws-patchget".to_string(),
+            auto_cleanup: PolicyFieldOp::Set(true),
+            auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(3)),
+        };
+        match dispatch(&state, patch_req).await {
+            Response::WorkspacePolicyOk {
+                effective, local, ..
+            } => {
+                assert!(effective.auto_cleanup);
+                assert_eq!(effective.auto_cleanup_keep, CleanupRetention::Count(3));
+                assert_eq!(local.auto_cleanup_keep, Some(CleanupRetention::Count(3)));
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+
+        // Verify policy.toml was actually written to disk under index_dir.
+        let index_dir = state.index_dir("ws-patchget");
+        let on_disk = ws_ckpt_common::load_workspace_policy_or_default(&index_dir).unwrap();
+        assert_eq!(on_disk.auto_cleanup, Some(true));
+        assert_eq!(on_disk.auto_cleanup_keep, Some(CleanupRetention::Count(3)));
+
+        // GetWorkspacePolicy should reflect the same state.
+        let get_req = Request::GetWorkspacePolicy {
+            workspace: "ws-patchget".to_string(),
+        };
+        match dispatch(&state, get_req).await {
+            Response::WorkspacePolicyOk { local, .. } => {
+                assert_eq!(local.auto_cleanup, Some(true));
+                assert_eq!(local.auto_cleanup_keep, Some(CleanupRetention::Count(3)));
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_reset_workspace_policy_deletes_file_and_inherits_global() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/reset");
+        state.register_workspace(
+            "ws-reset".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+        );
+
+        // First Patch a real policy so there's a file to delete.
+        let _ = dispatch(
+            &state,
+            Request::PatchWorkspacePolicy {
+                workspace: "ws-reset".to_string(),
+                auto_cleanup: PolicyFieldOp::Set(true),
+                auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(9)),
+            },
+        )
+        .await;
+        assert!(state.index_dir("ws-reset").join("policy.toml").exists());
+
+        // Reset → file should be gone, in-memory policy is empty.
+        let reset_req = Request::ResetWorkspacePolicy {
+            workspace: "ws-reset".to_string(),
+        };
+        match dispatch(&state, reset_req).await {
+            Response::WorkspacePolicyOk { local, .. } => {
+                assert!(local.is_empty());
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+        assert!(
+            !state.index_dir("ws-reset").join("policy.toml").exists(),
+            "reset must remove policy.toml"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_reset_workspace_policy_is_idempotent_on_empty_policy() {
+        // Calling Reset on a ws with no override must still succeed and converge
+        // (file absent, memory default) — disk is always touched, ENOENT short-circuits.
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/reset-noop");
+        state.register_workspace(
+            "ws-reset-noop".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+        );
+        // No prior Patch — policy is default, file does not exist.
+        assert!(!state
+            .index_dir("ws-reset-noop")
+            .join("policy.toml")
+            .exists());
+
+        let reset_req = Request::ResetWorkspacePolicy {
+            workspace: "ws-reset-noop".to_string(),
+        };
+        match dispatch(&state, reset_req).await {
+            Response::WorkspacePolicyOk { local, .. } => {
+                assert!(local.is_empty());
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+        // Still no file. Idempotency is the whole guarantee.
+        assert!(!state
+            .index_dir("ws-reset-noop")
+            .join("policy.toml")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn dispatch_patch_workspace_policy_refuses_when_failsafe() {
+        // Boot-time fail-safe must not be mistaken for user intent: PATCH that
+        // doesn't explicitly set auto_cleanup would silently persist Some(false).
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/failsafe");
+        state.register_workspace_with_policy(
+            "ws-failsafe".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+            WorkspacePolicy {
+                auto_cleanup: Some(false),
+                auto_cleanup_keep: None,
+            },
+            true,
+        );
+
+        let patch_req = Request::PatchWorkspacePolicy {
+            workspace: "ws-failsafe".to_string(),
+            auto_cleanup: PolicyFieldOp::Unchanged,
+            auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(50)),
+        };
+        match dispatch(&state, patch_req).await {
+            Response::Error {
+                code: ErrorCode::InternalError,
+                message,
+            } => {
+                assert!(
+                    message.contains("fail-safe") && message.contains("--reset"),
+                    "error message should explain the fail-safe state and remediation, got: {}",
+                    message
+                );
+            }
+            other => panic!("expected InternalError refusing patch, got {:?}", other),
+        }
+
+        // Reset clears the fail-safe marker, and a follow-up PATCH then succeeds.
+        let reset_req = Request::ResetWorkspacePolicy {
+            workspace: "ws-failsafe".to_string(),
+        };
+        assert!(matches!(
+            dispatch(&state, reset_req).await,
+            Response::WorkspacePolicyOk { .. }
+        ));
+        let patch_after_reset = Request::PatchWorkspacePolicy {
+            workspace: "ws-failsafe".to_string(),
+            auto_cleanup: PolicyFieldOp::Unchanged,
+            auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(50)),
+        };
+        assert!(matches!(
+            dispatch(&state, patch_after_reset).await,
+            Response::WorkspacePolicyOk { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispatch_patch_workspace_policy_sequential_accumulates() {
+        // Smoke test for Patch semantics under sequential application.
+        // The concurrent guarantee is exercised separately below.
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/patch-seq");
+        state.register_workspace(
+            "ws-patch-seq".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+        );
+
+        let r1 = dispatch(
+            &state,
+            Request::PatchWorkspacePolicy {
+                workspace: "ws-patch-seq".to_string(),
+                auto_cleanup: PolicyFieldOp::Set(true),
+                auto_cleanup_keep: PolicyFieldOp::Unchanged,
+            },
+        )
+        .await;
+        match r1 {
+            Response::WorkspacePolicyOk { local, .. } => {
+                assert_eq!(local.auto_cleanup, Some(true));
+                assert_eq!(local.auto_cleanup_keep, None);
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+
+        let r2 = dispatch(
+            &state,
+            Request::PatchWorkspacePolicy {
+                workspace: "ws-patch-seq".to_string(),
+                auto_cleanup: PolicyFieldOp::Unchanged,
+                auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(11)),
+            },
+        )
+        .await;
+        match r2 {
+            Response::WorkspacePolicyOk { local, .. } => {
+                assert_eq!(local.auto_cleanup, Some(true));
+                assert_eq!(local.auto_cleanup_keep, Some(CleanupRetention::Count(11)));
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+
+        // Patch 3: flip auto_cleanup off via Set(false), leave keep alone
+        // (per-field "clear" has no IPC; whole-policy removal is Reset).
+        let r3 = dispatch(
+            &state,
+            Request::PatchWorkspacePolicy {
+                workspace: "ws-patch-seq".to_string(),
+                auto_cleanup: PolicyFieldOp::Set(false),
+                auto_cleanup_keep: PolicyFieldOp::Unchanged,
+            },
+        )
+        .await;
+        match r3 {
+            Response::WorkspacePolicyOk { local, .. } => {
+                assert_eq!(local.auto_cleanup, Some(false));
+                assert_eq!(local.auto_cleanup_keep, Some(CleanupRetention::Count(11)));
+            }
+            other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn dispatch_patch_workspace_policy_concurrent_no_lost_updates() {
+        // Issue #14: spawn two real concurrent Patches on disjoint fields and
+        // assert both edits survive (a sequential test would pass even without
+        // the lock). Multi-thread runtime so they actually race on the RwLock.
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/patch-conc");
+        state.register_workspace(
+            "ws-patch-conc".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+        );
+
+        // Several iterations to reduce schedule-luck flakiness: without the
+        // lock, at least one is likely to expose the race.
+        for i in 0..16 {
+            // Reset the policy so each iteration starts from a clean slate.
+            let _ = dispatch(
+                &state,
+                Request::ResetWorkspacePolicy {
+                    workspace: "ws-patch-conc".to_string(),
+                },
+            )
+            .await;
+
+            let s1 = state.clone();
+            let s2 = state.clone();
+            let h1 = tokio::spawn(async move {
+                dispatch(
+                    &s1,
+                    Request::PatchWorkspacePolicy {
+                        workspace: "ws-patch-conc".to_string(),
+                        auto_cleanup: PolicyFieldOp::Set(true),
+                        auto_cleanup_keep: PolicyFieldOp::Unchanged,
+                    },
+                )
+                .await
+            });
+            let h2 = tokio::spawn(async move {
+                dispatch(
+                    &s2,
+                    Request::PatchWorkspacePolicy {
+                        workspace: "ws-patch-conc".to_string(),
+                        auto_cleanup: PolicyFieldOp::Unchanged,
+                        auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(11)),
+                    },
+                )
+                .await
+            });
+            let (_r1, _r2) = tokio::join!(h1, h2);
+
+            // Final state must show BOTH edits — the point of the per-ws rmw
+            // lock; the legacy GET→modify→SET would lose one on interleave.
+            let get = dispatch(
+                &state,
+                Request::GetWorkspacePolicy {
+                    workspace: "ws-patch-conc".to_string(),
+                },
+            )
+            .await;
+            match get {
+                Response::WorkspacePolicyOk { local, .. } => {
+                    assert_eq!(
+                        local.auto_cleanup,
+                        Some(true),
+                        "iter {}: concurrent enable+keep lost auto_cleanup",
+                        i
+                    );
+                    assert_eq!(
+                        local.auto_cleanup_keep,
+                        Some(CleanupRetention::Count(11)),
+                        "iter {}: concurrent enable+keep lost keep",
+                        i
+                    );
+                }
+                other => panic!("expected WorkspacePolicyOk, got {:?}", other),
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn dispatch_patch_and_reset_concurrent_serialize_via_policy_io_mu() {
+        // `policy_io_mu` exists to serialize PATCH ↔ RESET on the same ws so
+        // each cycle ends in a deterministic state. We race one PATCH and one
+        // RESET; whichever wins the mutex first commits its memory before the
+        // other proceeds. The final result is whatever the *second* op writes
+        // — never a torn state, never a deadlock.
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            tmp.path().to_path_buf(),
+        ));
+        let path = PathBuf::from("/ws/patch-vs-reset");
+        state.register_workspace(
+            "ws-patch-vs-reset".to_string(),
+            path.clone(),
+            ws_ckpt_common::SnapshotIndex::new(path),
+        );
+
+        // 16 iters: enough for both interleavings (patch-then-reset and
+        // reset-then-patch) to actually occur under different schedules.
+        let timeout = std::time::Duration::from_secs(5);
+        for i in 0..16 {
+            // Seed each iter from a known non-empty state so PATCH and RESET
+            // produce visibly different memory.
+            let _ = dispatch(
+                &state,
+                Request::PatchWorkspacePolicy {
+                    workspace: "ws-patch-vs-reset".to_string(),
+                    auto_cleanup: PolicyFieldOp::Set(true),
+                    auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(7)),
+                },
+            )
+            .await;
+
+            let s1 = state.clone();
+            let s2 = state.clone();
+            let patch = tokio::spawn(async move {
+                dispatch(
+                    &s1,
+                    Request::PatchWorkspacePolicy {
+                        workspace: "ws-patch-vs-reset".to_string(),
+                        auto_cleanup: PolicyFieldOp::Set(false),
+                        auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(3)),
+                    },
+                )
+                .await
+            });
+            let reset = tokio::spawn(async move {
+                dispatch(
+                    &s2,
+                    Request::ResetWorkspacePolicy {
+                        workspace: "ws-patch-vs-reset".to_string(),
+                    },
+                )
+                .await
+            });
+            // No deadlock: both must complete within the timeout.
+            let joined = tokio::time::timeout(timeout, async { tokio::join!(patch, reset) })
+                .await
+                .expect("iter {i}: PATCH+RESET timed out — possible deadlock under policy_io_mu");
+            // Both must succeed (failsafe is off; backend stub is OK).
+            for r in [&joined.0, &joined.1] {
+                let resp = r.as_ref().expect("spawn joined cleanly");
+                assert!(
+                    matches!(resp, Response::WorkspacePolicyOk { .. }),
+                    "iter {}: expected WorkspacePolicyOk, got {:?}",
+                    i,
+                    resp
+                );
+            }
+
+            // Final disk + memory must reflect EXACTLY one of the two ops
+            // (the second one to commit under io_guard). Whether that's
+            // PATCH(false,Count(3)) or RESET(empty) depends on schedule —
+            // but the two states are disjoint, so we can probe.
+            let get = dispatch(
+                &state,
+                Request::GetWorkspacePolicy {
+                    workspace: "ws-patch-vs-reset".to_string(),
+                },
+            )
+            .await;
+            match get {
+                Response::WorkspacePolicyOk { local, .. } => {
+                    let is_patch_winner = local.auto_cleanup == Some(false)
+                        && local.auto_cleanup_keep == Some(CleanupRetention::Count(3));
+                    let is_reset_winner = local.is_empty();
+                    assert!(
+                        is_patch_winner || is_reset_winner,
+                        "iter {}: state is neither patch-winner nor reset-winner: {:?}",
+                        i,
+                        local
+                    );
+                }
+                other => panic!("iter {}: expected WorkspacePolicyOk, got {:?}", i, other),
+            }
         }
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
@@ -7,8 +7,9 @@ use tokio::time::Duration;
 use tracing::{debug, error, info, warn};
 
 use crate::backends::btrfs_common;
+use crate::snapshot_mgr::{delete_snapshots_locked, ensure_index_dir, persist_index_after_cleanup};
 use crate::state::DaemonState;
-use ws_ckpt_common::CleanupRetention;
+use ws_ckpt_common::{CleanupRetention, EffectivePolicy};
 
 /// Start background scheduler tasks: orphan cleanup on boot, periodic auto-cleanup,
 /// and periodic health checks.
@@ -59,16 +60,12 @@ async fn auto_cleanup_loop(state: Arc<DaemonState>) {
         tokio::pin!(notified);
         notified.as_mut().enable();
 
-        let (enabled, interval, keep_disabled) = {
-            let cfg = state.config.read().unwrap();
-            (
-                cfg.auto_cleanup,
-                cfg.auto_cleanup_interval_secs,
-                cfg.auto_cleanup_keep.is_disabled(),
-            )
-        };
-        if !enabled || interval == 0 || keep_disabled {
-            // Disabled: block until a reload arrives, then re-check.
+        let interval = state.config_snapshot().auto_cleanup_interval_secs;
+        // Park unless some ws has an effective (merged local-or-global) policy
+        // that would do work this tick; avoids waking every interval just to
+        // skip all workspaces.
+        let park = interval == 0 || !state.any_ws_has_effective_cleanup().await;
+        if park {
             notified.await;
             continue;
         }
@@ -92,7 +89,7 @@ async fn health_check_loop(state: Arc<DaemonState>) {
         tokio::pin!(notified);
         notified.as_mut().enable();
 
-        let interval = state.config.read().unwrap().health_check_interval_secs;
+        let interval = state.config_snapshot().health_check_interval_secs;
         if interval == 0 {
             notified.await;
             continue;
@@ -164,102 +161,98 @@ pub async fn cleanup_orphans(mount_path: &Path) -> Result<Vec<String>, anyhow::E
 /// - `Count(n)`: keep n newest per workspace.
 /// - `Age { secs, .. }`: delete if older than `secs` (strict, no count floor).
 ///
-/// Caller ([`auto_cleanup_loop`]) filters disabled retention; this function
-/// asserts that invariant in debug builds.
+/// Locking: P1 read-lock probe; P2a read-lock plan (P2b rechecks per-snap);
+/// P2b unlocked deletes with short per-snap write to drop index entry.
 async fn auto_cleanup(state: &DaemonState) {
-    let retention = {
-        let cfg = state.config.read().unwrap();
-        cfg.auto_cleanup_keep.clone()
-    };
-    debug_assert!(
-        !retention.is_disabled(),
-        "caller must filter disabled retention"
-    );
-
-    info!("Running auto-cleanup (retention={})...", retention);
+    info!("Running auto-cleanup pass (per-ws effective retention)...");
     let all_ws = state.all_workspaces();
     let now = chrono::Utc::now();
 
     for ws_arc in &all_ws {
-        let mut ws = ws_arc.write().await;
-        let ws_id = ws.ws_id.clone();
-
-        // index storage directory (for saving index.json)
-        let index_dir = state.index_dir(&ws_id);
-        if let Err(e) = tokio::fs::create_dir_all(&index_dir).await {
-            warn!(
-                "auto-cleanup: failed to create index directory {:?}: {}",
-                index_dir, e
-            );
-            continue;
-        }
-
-        // btrfs snapshot subvolume root directory (for actually deleting subvolumes)
-        let snapshots_ws_dir = state.backend.snapshots_root().join(&ws_id);
-
-        // Collect non-pinned snapshots sorted by created_at ascending
-        let mut unpinned: Vec<(String, chrono::DateTime<chrono::Utc>)> = ws
-            .index
-            .snapshots
-            .iter()
-            .filter(|(_, meta)| !meta.pinned)
-            .map(|(id, meta)| (id.clone(), meta.created_at))
-            .collect();
-        unpinned.sort_by_key(|(_, ts)| *ts);
-
-        // Pick victims according to the active mode
-        let to_remove: Vec<String> = match &retention {
-            CleanupRetention::Count(n) => {
-                let keep = *n as usize;
-                if unpinned.len() <= keep {
-                    continue;
-                }
-                unpinned[..unpinned.len() - keep]
-                    .iter()
-                    .map(|(id, _)| id.clone())
-                    .collect()
-            }
-            CleanupRetention::Age { secs, .. } => {
-                let cutoff = now - chrono::Duration::seconds(*secs as i64);
-                unpinned
-                    .iter()
-                    .filter(|(_, ts)| *ts < cutoff)
-                    .map(|(id, _)| id.clone())
-                    .collect()
+        // Phase 1: cheap read-only probe — exact list is recomputed in Phase 2.
+        let has_potential_work = {
+            let ws = ws_arc.read().await;
+            let cfg = state.config_snapshot();
+            let eff: EffectivePolicy = ws.policy.effective_for(&cfg);
+            if eff.is_disabled() {
+                false
+            } else {
+                // Any unpinned snapshot exists; Phase 2 decides the final set.
+                // `any` short-circuits on large indexes.
+                ws.index.snapshots.values().any(|m| !m.pinned)
             }
         };
-
-        if to_remove.is_empty() {
+        if !has_potential_work {
             continue;
         }
 
-        let mut removed_count = 0;
-        for snap_id in &to_remove {
-            let snap_path = snapshots_ws_dir.join(snap_id);
-            match btrfs_common::delete_subvolume(&snap_path).await {
-                Ok(()) => {
-                    ws.index.snapshots.remove(snap_id);
-                    removed_count += 1;
-                }
-                Err(e) => {
-                    warn!("auto-cleanup: failed to delete {}: {:#}", snap_id, e);
-                }
+        // P2a: plan under read lock (pure compute; P2b rechecks pin per snap).
+        let (ws_id, to_remove, index_dir) = {
+            let ws = ws_arc.read().await;
+            let ws_id = ws.ws_id.clone();
+
+            let cfg = state.config_snapshot();
+            let eff: EffectivePolicy = ws.policy.effective_for(&cfg);
+            if eff.is_disabled() {
+                // Policy flipped to disabled while awaiting the read lock — skip.
+                continue;
             }
+            let retention = eff.auto_cleanup_keep.clone();
+
+            let mut unpinned: Vec<(String, chrono::DateTime<chrono::Utc>)> = ws
+                .index
+                .snapshots
+                .iter()
+                .filter(|(_, meta)| !meta.pinned)
+                .map(|(id, meta)| (id.clone(), meta.created_at))
+                .collect();
+            unpinned.sort_by_key(|(_, ts)| *ts);
+
+            let to_remove: Vec<String> = match &retention {
+                CleanupRetention::Count(n) => {
+                    let keep = *n as usize;
+                    if unpinned.len() <= keep {
+                        Vec::new()
+                    } else {
+                        unpinned[..unpinned.len() - keep]
+                            .iter()
+                            .map(|(id, _)| id.clone())
+                            .collect()
+                    }
+                }
+                CleanupRetention::Age { secs, .. } => {
+                    let cutoff = now - chrono::Duration::seconds(*secs as i64);
+                    unpinned
+                        .iter()
+                        .filter(|(_, ts)| *ts < cutoff)
+                        .map(|(id, _)| id.clone())
+                        .collect()
+                }
+            };
+
+            if to_remove.is_empty() {
+                continue;
+            }
+
+            let index_dir = state.index_dir(&ws_id);
+            (ws_id, to_remove, index_dir)
+        };
+
+        if !ensure_index_dir(&index_dir, "auto-cleanup").await {
+            continue;
         }
 
-        if removed_count > 0 {
-            if let Err(e) = crate::index_store::save(&index_dir, &ws.index).await {
-                warn!("auto-cleanup: failed to save index for {}: {:#}", ws_id, e);
-            }
-            // Release write lock before save_manifest() so that
-            // collect_workspace_entries() can acquire a read lock on this workspace.
-            drop(ws);
-            if let Err(e) = state.save_manifest().await {
-                warn!("save_manifest failed after auto-cleanup: {:#}", e);
-            }
+        // P2b: shared detach-then-delete + persist. Background loop swallows
+        // partial failures (already warn!'d inside the helper) — we never
+        // bail the whole loop on a single snap, the next tick retries.
+        let outcome =
+            delete_snapshots_locked(state, ws_arc, &ws_id, &to_remove, "auto-cleanup").await;
+        if !outcome.removed.is_empty() {
+            persist_index_after_cleanup(state, ws_arc, &index_dir, "auto-cleanup").await;
             info!(
                 "auto-cleanup: removed {} snapshots from {}",
-                removed_count, ws_id
+                outcome.removed.len(),
+                ws_id
             );
         }
     }
@@ -344,5 +337,52 @@ mod tests {
 
         let cleaned = cleanup_orphans(dir.path()).await.unwrap();
         assert!(cleaned.is_empty());
+    }
+
+    // ── Per-workspace effective policy invariants ──
+    // Backend-free: only assert the routing rules `auto_cleanup_loop` relies on.
+    use ws_ckpt_common::{CleanupRetention, DaemonConfig, WorkspacePolicy};
+
+    fn cfg(global_on: bool, keep: CleanupRetention) -> DaemonConfig {
+        DaemonConfig {
+            auto_cleanup: global_on,
+            auto_cleanup_keep: keep,
+            ..DaemonConfig::default()
+        }
+    }
+
+    #[test]
+    fn per_ws_off_overrides_global_on() {
+        let g = cfg(true, CleanupRetention::Count(20));
+        let local = WorkspacePolicy {
+            auto_cleanup: Some(false),
+            auto_cleanup_keep: None,
+        };
+        // Per-ws says off → effective is_disabled, so scheduler will skip.
+        assert!(local.effective_for(&g).is_disabled());
+    }
+
+    #[test]
+    fn per_ws_on_overrides_global_off() {
+        let g = cfg(false, CleanupRetention::Count(20));
+        let local = WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: None,
+        };
+        // Per-ws says on, even though global is off → effective should run.
+        assert!(!local.effective_for(&g).is_disabled());
+    }
+
+    #[test]
+    fn per_ws_keep_count_overrides_global_keep() {
+        let g = cfg(true, CleanupRetention::Count(20));
+        let local = WorkspacePolicy {
+            auto_cleanup: None,
+            auto_cleanup_keep: Some(CleanupRetention::Count(5)),
+        };
+        let eff = local.effective_for(&g);
+        // auto_cleanup is inherited from global (true), keep is overridden.
+        assert!(eff.auto_cleanup);
+        assert_eq!(eff.auto_cleanup_keep, CleanupRetention::Count(5));
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -1,13 +1,125 @@
 use std::sync::Arc;
 
 use anyhow::Context;
+use tokio::sync::RwLock;
 use tracing::info;
 use ws_ckpt_common::{ErrorCode, ResolveError, Response, SnapshotEntry, SnapshotMeta};
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::index_store;
-use crate::state::DaemonState;
+use crate::state::{DaemonState, WorkspaceState};
+
+/// Result of [`delete_snapshots_locked`]: per-snap outcome, no early bail
+/// (caller decides whether failures escalate to an error or just warn).
+pub struct CleanupOutcome {
+    pub removed: Vec<String>,
+    pub failed: Vec<(String, String)>,
+}
+
+/// Shared per-snap detach-then-delete loop, used by both
+/// [`cleanup_snapshots`] (user-triggered Count cleanup) and the scheduler's
+/// background pass. Invariants:
+///
+/// 1. **detach under write lock, delete unlocked** — a concurrent pin RPC
+///    either wins (we skip) or loses (it sees SnapshotNotFound). No
+///    read→fs window where pin sneaks in between recheck and delete.
+/// 2. **per-snap try/recover** — on backend Err the meta is re-inserted so
+///    the index stays in sync with on-disk subvolumes.
+/// 3. **no short-circuit** — earlier successes must persist even if a later
+///    snap fails; the caller persists `index` + manifest from
+///    `outcome.removed`. An early `?` would lose the prior in-memory removes.
+///
+/// `label` ("cleanup" / "auto-cleanup") prefixes log lines.
+pub async fn delete_snapshots_locked(
+    state: &DaemonState,
+    arc: &Arc<RwLock<WorkspaceState>>,
+    ws_id: &str,
+    to_remove: &[String],
+    label: &str,
+) -> CleanupOutcome {
+    let mut removed = Vec::new();
+    let mut failed: Vec<(String, String)> = Vec::new();
+    for snap_id in to_remove {
+        let detached = {
+            let mut ws = arc.write().await;
+            match ws.index.snapshots.get(snap_id) {
+                Some(m) if !m.pinned => ws.index.snapshots.remove(snap_id),
+                _ => None,
+            }
+        };
+        let Some(meta) = detached else { continue };
+
+        match state
+            .backend
+            .cleanup_snapshots(ws_id, std::slice::from_ref(snap_id))
+            .await
+        {
+            Ok(deleted) if deleted.is_empty() => {
+                // Backend reported no-op (already gone); roll back the detach
+                // so the index doesn't drift.
+                arc.write()
+                    .await
+                    .index
+                    .snapshots
+                    .insert(snap_id.clone(), meta);
+            }
+            Ok(_) => {
+                info!("{}: removed snapshot {}", label, snap_id);
+                removed.push(snap_id.clone());
+            }
+            Err(e) => {
+                arc.write()
+                    .await
+                    .index
+                    .snapshots
+                    .insert(snap_id.clone(), meta);
+                tracing::warn!("{}: backend delete failed for {}: {:#}", label, snap_id, e);
+                failed.push((snap_id.clone(), format!("{:#}", e)));
+            }
+        }
+    }
+    CleanupOutcome { removed, failed }
+}
+
+/// After [`delete_snapshots_locked`] succeeded for ≥1 snap, snapshot the
+/// in-memory index outside the lock and persist to `index.json` + manifest.
+/// Both writes are best-effort and warn-only — by the time we get here the
+/// subvolumes are already gone, so an index-save failure just means restart
+/// will rebuild from fs (cheap), and a manifest failure leaves stale entries
+/// but the ws is still usable.
+pub async fn persist_index_after_cleanup(
+    state: &DaemonState,
+    arc: &Arc<RwLock<WorkspaceState>>,
+    snap_dir: &Path,
+    label: &str,
+) {
+    let index_to_persist = {
+        let ws = arc.read().await;
+        ws.index.clone()
+    };
+    if let Err(e) = index_store::save(snap_dir, &index_to_persist).await {
+        tracing::warn!("{}: failed to save index: {:#}", label, e);
+    }
+    if let Err(e) = state.save_manifest().await {
+        tracing::warn!("{}: save_manifest failed: {:#}", label, e);
+    }
+}
+
+/// Ensure `dir` exists; warn-only because every caller is in a per-ws loop
+/// that should continue to the next ws on a single-dir mkdir failure.
+pub async fn ensure_index_dir(dir: &PathBuf, label: &str) -> bool {
+    if let Err(e) = tokio::fs::create_dir_all(dir).await {
+        tracing::warn!(
+            "{}: failed to create index directory {:?}: {}",
+            label,
+            dir,
+            e
+        );
+        return false;
+    }
+    true
+}
 
 fn workspace_not_found(workspace: &str) -> Response {
     Response::Error {
@@ -302,58 +414,55 @@ pub async fn cleanup_snapshots(
         None => return Ok(workspace_not_found(workspace)),
     };
 
-    let mut ws = arc.write().await;
-    let snap_dir = state.index_dir(&ws.ws_id);
-    // Ensure index directory exists
+    // P1: plan under write lock — pure in-memory work, no fs I/O.
+    let (ws_id, to_remove_ids, snap_dir) = {
+        let ws = arc.write().await;
+        let ws_id = ws.ws_id.clone();
+        let snap_dir = state.index_dir(&ws_id);
+
+        let mut unpinned: Vec<(String, chrono::DateTime<chrono::Utc>)> = ws
+            .index
+            .snapshots
+            .iter()
+            .filter(|(_, meta)| !meta.pinned)
+            .map(|(id, meta)| (id.clone(), meta.created_at))
+            .collect();
+        unpinned.sort_by_key(|(_, ts)| *ts);
+
+        let to_remove_ids: Vec<String> = if unpinned.len() > keep {
+            unpinned[..unpinned.len() - keep]
+                .iter()
+                .map(|(id, _)| id.clone())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        (ws_id, to_remove_ids, snap_dir)
+    };
+
+    // P1.5: create index dir unlocked (slow fs must not block the ws write lock).
     tokio::fs::create_dir_all(&snap_dir)
         .await
         .with_context(|| format!("Failed to create index dir: {:?}", snap_dir))?;
 
-    // Collect non-pinned snapshots, sorted by created_at ascending (oldest first)
-    let mut unpinned: Vec<(String, chrono::DateTime<chrono::Utc>)> = ws
-        .index
-        .snapshots
-        .iter()
-        .filter(|(_, meta)| !meta.pinned)
-        .map(|(id, meta)| (id.clone(), meta.created_at))
-        .collect();
-    unpinned.sort_by_key(|(_, ts)| *ts);
-
-    // Determine which to remove (oldest beyond keep count)
-    let to_remove = if unpinned.len() > keep {
-        unpinned[..unpinned.len() - keep].to_vec()
-    } else {
-        vec![]
-    };
-
-    let to_remove_ids: Vec<String> = to_remove.iter().map(|(id, _)| id.clone()).collect();
-    let removed = state
-        .backend
-        .cleanup_snapshots(&ws.ws_id, &to_remove_ids)
-        .await?;
-
-    // Update index for actually removed snapshots
-    for snap_id in &removed {
-        ws.index.snapshots.remove(snap_id);
-        info!("cleanup: removed snapshot {}", snap_id);
+    // P2: detach-then-delete (shared helper); persist (shared helper).
+    let outcome = delete_snapshots_locked(state, &arc, &ws_id, &to_remove_ids, "cleanup").await;
+    if !outcome.removed.is_empty() {
+        persist_index_after_cleanup(state, &arc, &snap_dir, "cleanup").await;
     }
-
-    // Save index if any were removed
-    if !removed.is_empty() {
-        index_store::save(&snap_dir, &ws.index).await?;
+    if !outcome.failed.is_empty() {
+        // User-triggered → surface partial failure as Err so the CLI exits non-zero.
+        anyhow::bail!(
+            "cleanup_snapshots: deleted {}/{}, failed: {:?}",
+            outcome.removed.len(),
+            to_remove_ids.len(),
+            outcome.failed
+        );
     }
-
-    // Release write lock before save_manifest (try_read inside
-    // collect_workspace_entries would fail while write lock is held)
-    drop(ws);
-
-    if !removed.is_empty() {
-        if let Err(e) = state.save_manifest().await {
-            tracing::warn!("save_manifest failed after cleanup_snapshots: {:#}", e);
-        }
-    }
-
-    Ok(Response::CleanupOk { removed })
+    Ok(Response::CleanupOk {
+        removed: outcome.removed,
+    })
 }
 
 #[cfg(test)]
@@ -874,5 +983,163 @@ mod tests {
             }
             other => panic!("expected SnapshotNotFound, got: {:?}", other),
         }
+    }
+
+    // ── cleanup_snapshots partial-failure tests ──
+    //
+    // Backstop for the "no early `?` in the delete loop" invariant
+    // (delete_snapshots_locked): if backend.cleanup_snapshots succeeds for
+    // snaps A,B,C then fails for D, the index must still have A/B/C removed
+    // (and persisted) and D rolled back to its previous meta. The caller
+    // (cleanup_snapshots) then bails with a count summary so the CLI exits
+    // non-zero. Without the shared helper or with an early `?`, prior
+    // in-memory removes would be lost.
+
+    struct PartialFailBackend {
+        data_root: PathBuf,
+        snapshots_root: PathBuf,
+        fail_ids: std::collections::HashSet<String>,
+    }
+
+    impl PartialFailBackend {
+        fn new(fail_ids: impl IntoIterator<Item = String>) -> Self {
+            Self {
+                data_root: PathBuf::from("/tmp/pfb-data"),
+                snapshots_root: PathBuf::from("/tmp/pfb-snaps"),
+                fail_ids: fail_ids.into_iter().collect(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl StorageBackend for PartialFailBackend {
+        fn backend_type(&self) -> ws_ckpt_common::backend::BackendType {
+            ws_ckpt_common::backend::BackendType::BtrfsBase
+        }
+        fn data_root(&self) -> &std::path::Path {
+            &self.data_root
+        }
+        fn snapshots_root(&self) -> &std::path::Path {
+            &self.snapshots_root
+        }
+        async fn cleanup_snapshots(
+            &self,
+            _ws_id: &str,
+            snapshot_ids: &[String],
+        ) -> anyhow::Result<Vec<String>> {
+            // Single-snap calls only (matches snapshot_mgr's per-snap loop).
+            let id = snapshot_ids
+                .first()
+                .expect("PartialFailBackend expects per-snap calls");
+            if self.fail_ids.contains(id) {
+                anyhow::bail!("simulated backend failure for {}", id);
+            }
+            Ok(vec![id.clone()])
+        }
+        // Everything else: panic if hit — keeps the test honest about which
+        // backend methods cleanup actually exercises.
+        async fn init_workspace(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> anyhow::Result<ws_ckpt_common::WorkspaceInfo> {
+            unimplemented!()
+        }
+        async fn create_snapshot(&self, _: &str, _: &str) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn rollback(&self, _: &str, _: &str) -> anyhow::Result<PathBuf> {
+            unimplemented!()
+        }
+        async fn delete_snapshot(&self, _: &str, _: &str) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn recover_workspace(&self, _: &str, _: &str) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn diff(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> anyhow::Result<Vec<ws_ckpt_common::DiffEntry>> {
+            unimplemented!()
+        }
+        async fn fork(&self, _: &str, _: &str, _: &str) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn gc_generations(
+            &self,
+            _: &str,
+        ) -> anyhow::Result<ws_ckpt_common::backend::GcResult> {
+            unimplemented!()
+        }
+        async fn check_environment(
+            &self,
+        ) -> anyhow::Result<ws_ckpt_common::backend::EnvironmentStatus> {
+            unimplemented!()
+        }
+        async fn get_usage(&self) -> anyhow::Result<(u64, u64)> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn cleanup_snapshots_persists_partial_success_and_bails() {
+        // 5 unpinned snapshots, the 3rd fails. Expectation:
+        //   - bail with "deleted 4/5, failed: [snap-3]"
+        //   - in-memory index keeps only snap-3 (others removed)
+        //   - failed snap meta is re-inserted (no detach drift)
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = Arc::new(PartialFailBackend::new(["snap-3".to_string()]));
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            backend as Arc<dyn StorageBackend>,
+            tmp.path().to_path_buf(),
+        ));
+
+        let ws_path = PathBuf::from("/ws/partial-fail");
+        let mut idx = SnapshotIndex::new(ws_path.clone());
+        let now = Utc::now();
+        for (i, off) in [0i64, 1, 2, 3, 4].iter().enumerate() {
+            idx.snapshots.insert(
+                format!("snap-{}", i + 1),
+                make_snapshot_meta_at(false, now - Duration::seconds(*off)),
+            );
+        }
+        state.register_workspace("ws-partial".to_string(), ws_path.clone(), idx);
+
+        // keep=0 → all 5 are removal candidates. cleanup_snapshots returns
+        // Ok(Response) for routing errors (e.g. WorkspaceNotFound) but Err
+        // for partial backend failure — so the user-facing CLI exits non-zero.
+        let result = cleanup_snapshots(&state, "ws-partial", Some(0)).await;
+        let err = result.expect_err("partial failure must bubble up as Err");
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("4/5"),
+            "error should report deleted/total, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("snap-3"),
+            "error should name the failed id, got: {}",
+            msg
+        );
+
+        // In-memory index: snap-3 stays (re-inserted), others gone.
+        let arc = state
+            .get_by_wsid("ws-partial")
+            .expect("ws still registered");
+        let ws = arc.read().await;
+        assert_eq!(ws.index.snapshots.len(), 1, "only the failed snap remains");
+        assert!(ws.index.snapshots.contains_key("snap-3"));
+
+        // Persisted index reflects the same — earlier successes were saved
+        // even though the caller bailed.
+        let on_disk = crate::index_store::load(&state.index_dir("ws-partial"))
+            .await
+            .expect("index.json saved");
+        assert_eq!(on_disk.snapshots.len(), 1);
+        assert!(on_disk.snapshots.contains_key("snap-3"));
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -414,9 +414,9 @@ pub async fn cleanup_snapshots(
         None => return Ok(workspace_not_found(workspace)),
     };
 
-    // P1: plan under write lock — pure in-memory work, no fs I/O.
+    // P1: plan under read lock — pure in-memory work, no fs I/O.
     let (ws_id, to_remove_ids, snap_dir) = {
-        let ws = arc.write().await;
+        let ws = arc.read().await;
         let ws_id = ws.ws_id.clone();
         let snap_dir = state.index_dir(&ws_id);
 

--- a/src/ws-ckpt/src/crates/daemon/src/state.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use dashmap::DashMap;
-use tokio::sync::{Notify, OnceCell, RwLock};
+use tokio::sync::{Mutex, Notify, OnceCell, RwLock, Semaphore};
 use tracing::{error, info, warn};
 
 use ws_ckpt_common::backend::BackendType;
@@ -13,7 +13,8 @@ use ws_ckpt_common::persist::{
     self, BackendIdentity, BackendPaths, DaemonStateFile, WorkspaceEntry, DAEMON_STATE_VERSION,
 };
 use ws_ckpt_common::{
-    DaemonConfig, ResolveError, SnapshotIndex, WorkspaceInfo, INDEXES_DIR, INDEX_FILE,
+    load_workspace_policy, load_workspace_policy_with_failsafe, DaemonConfig, LoadPolicyOutcome,
+    ResolveError, SnapshotIndex, WorkspaceInfo, WorkspacePolicy, INDEXES_DIR, INDEX_FILE,
 };
 
 use crate::fs_watcher::WorkspaceWatcher;
@@ -49,12 +50,30 @@ pub struct DaemonState {
     pub state_dir: PathBuf,
     /// Backend selection method: "auto-detect" | "config" | "persisted"
     selection_method: String,
+    /// Per-ws-id mutex serializing lifecycle ops (init / adopt / recover) that
+    /// race on the same `index_dir(ws_id)` and `workspaces` slot. Distinct
+    /// from `WorkspaceState::policy_io_mu` (which lives inside an Arc that
+    /// recover would unregister). Held across `await`.
+    wsid_locks: DashMap<String, Arc<Mutex<()>>>,
 }
 
 pub struct WorkspaceState {
     pub ws_id: String,
     pub path: PathBuf,
     pub index: SnapshotIndex,
+    /// Per-workspace policy override; `WorkspacePolicy::default()` when no
+    /// `policy.toml` exists (i.e. inherit everything from global).
+    pub policy: WorkspacePolicy,
+    /// True iff `policy` is a synthetic fail-safe value injected at register
+    /// time because `policy.toml` was unreadable. Blocks PATCH (which would
+    /// silently persist the synthetic value as truth) until reload or reset.
+    pub policy_failsafe: bool,
+    /// Narrow per-ws serializer for PATCH/RESET on `policy.toml`. Decoupled
+    /// from the ws RwLock so checkpoint/list/status are NOT blocked by a slow
+    /// fsync; only competing PATCH/RESET wait. Held across spawn_blocking,
+    /// hence `tokio::sync::Mutex`. The ws write lock itself is taken only to
+    /// commit the in-memory result, never across the disk op.
+    pub policy_io_mu: Arc<Mutex<()>>,
 }
 
 impl DaemonState {
@@ -75,12 +94,47 @@ impl DaemonState {
             watchers: std::sync::Mutex::new(HashMap::new()),
             state_dir,
             selection_method,
+            wsid_locks: DashMap::new(),
         }
+    }
+
+    /// Acquire (or get-or-create) the per-ws-id lifecycle lock. Held by
+    /// init / adopt_existing_subvol / recover_workspace to serialize the
+    /// register/unregister + index-dir-mutation window. Entries are not
+    /// removed: each is ~few hundred bytes, and removal would race with
+    /// another waiter that just cloned the Arc.
+    pub async fn lock_wsid(&self, ws_id: &str) -> tokio::sync::OwnedMutexGuard<()> {
+        let mtx = self
+            .wsid_locks
+            .entry(ws_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        mtx.lock_owned().await
     }
 
     /// get the index storage directory for a workspace
     pub fn index_dir(&self, ws_id: &str) -> PathBuf {
         self.state_dir.join(INDEXES_DIR).join(ws_id)
+    }
+
+    /// Poison-safe snapshot of the current daemon config.
+    ///
+    /// A panic under the write lock poisons it, making `.read().unwrap()`
+    /// re-panic and take down every config reader (policy IPCs, scheduler).
+    /// We consume the poison and return the last-written value, which is
+    /// what read-only consumers want. Prefer this over `.read().unwrap()`.
+    pub fn config_snapshot(&self) -> DaemonConfig {
+        let guard = match self.config.read() {
+            Ok(g) => g,
+            Err(poisoned) => {
+                tracing::warn!(
+                    "config RwLock was poisoned by a panicking writer; reading anyway \
+                     to keep policy IPCs and the scheduler alive"
+                );
+                poisoned.into_inner()
+            }
+        };
+        guard.clone()
     }
 
     /// Rebuild runtime state from persisted file
@@ -130,7 +184,17 @@ impl DaemonState {
                     );
                 }
             }
-            state.register_workspace(ws_id.clone(), entry.workspace_path.clone(), index);
+            // Shared helper: Missing → inherit-global; Err → fail-safe
+            // (auto_cleanup=false + policy_failsafe=true). See [[ws-failsafe]].
+            let (policy, failsafe) =
+                load_workspace_policy_with_failsafe(&index_dir, ws_id, "rebuild");
+            state.register_workspace_with_policy(
+                ws_id.clone(),
+                entry.workspace_path.clone(),
+                index,
+                policy,
+                failsafe,
+            );
         }
 
         // Reconcile: mark phantom snapshots whose subvolumes no longer exist
@@ -240,7 +304,7 @@ impl DaemonState {
     pub async fn ensure_bootstrapped(&self) -> anyhow::Result<()> {
         self.bootstrapped
             .get_or_try_init(|| async {
-                let config = self.config.read().unwrap().clone();
+                let config = self.config_snapshot();
                 self.backend.bootstrap(&config).await
             })
             .await?;
@@ -296,24 +360,168 @@ impl DaemonState {
     }
 
     pub fn register_workspace(&self, ws_id: String, path: PathBuf, index: SnapshotIndex) {
+        self.register_workspace_with_policy(ws_id, path, index, WorkspacePolicy::default(), false);
+    }
+
+    pub fn register_workspace_with_policy(
+        &self,
+        ws_id: String,
+        path: PathBuf,
+        index: SnapshotIndex,
+        policy: WorkspacePolicy,
+        failsafe: bool,
+    ) {
         let state = Arc::new(RwLock::new(WorkspaceState {
             ws_id: ws_id.clone(),
             path: path.clone(),
             index,
+            policy,
+            policy_failsafe: failsafe,
+            policy_io_mu: Arc::new(Mutex::new(())),
         }));
-        self.path_to_wsid.insert(path, ws_id.clone());
-        self.workspaces.insert(ws_id, state);
+        self.workspaces.insert(ws_id.clone(), state);
+        self.path_to_wsid.insert(path, ws_id);
+        self.config_notify.notify_waiters();
     }
 
-    pub fn unregister_workspace(&self, ws_id: &str, path: &Path) {
+    /// Reload every `policy.toml` from disk into the in-memory state.
+    /// Called by `handle_reload_config` so out-of-band edits are picked up
+    /// by `ws-ckpt reload` / `systemctl reload`.
+    ///
+    /// Three invariants, each fixing a real bug:
+    /// 1. **fs-serialize via `policy_io_mu`, not the ws RwLock**: a per-ws
+    ///    narrow mutex (the same one PATCH/RESET take around save+commit) is
+    ///    held across the disk read; the ws RwLock is taken only for the
+    ///    few-microsecond memory commit. This still excludes any concurrent
+    ///    SET stomp, but lets checkpoint/list/status keep running while the
+    ///    blocking pool is busy. See [[ws-lock-no-fs-loops]].
+    /// 2. **Blocking I/O on a worker**: `load_workspace_policy` is sync
+    ///    `std::fs`; run it on a blocking thread so N reads don't starve
+    ///    concurrent CLI requests.
+    /// 3. **Strict error handling**: only `Missing` collapses to default;
+    ///    a transient I/O / parse error must NOT erase live policy — we
+    ///    keep it and `warn!`.
+    ///
+    /// Per-ws tasks run concurrently (capped by semaphore) so a 500-ws fleet
+    /// doesn't serialize into a multi-second reload; invariant #1 still holds
+    /// per task because `policy_io_mu` is per-ws, not shared.
+    pub async fn reload_all_workspace_policies(&self) {
+        // Cap to avoid flooding the blocking pool during reload.
+        const RELOAD_CONCURRENCY: usize = 32;
+        let sem = Arc::new(Semaphore::new(RELOAD_CONCURRENCY));
+
+        let ws_ids: Vec<String> = self.workspaces.iter().map(|e| e.key().clone()).collect();
+        let mut set = tokio::task::JoinSet::new();
+        for ws_id in ws_ids {
+            let arc = match self.get_by_wsid(&ws_id) {
+                Some(a) => a,
+                None => continue, // unregistered between snapshot and now
+            };
+            let dir = self.index_dir(&ws_id);
+            let sem = Arc::clone(&sem);
+            set.spawn(async move {
+                let _permit = sem.acquire_owned().await.expect("semaphore not closed");
+                Self::reload_one_workspace_policy_inner(&ws_id, dir, &arc).await;
+            });
+        }
+        // Drain so a panicking task can't abort the reload.
+        while let Some(res) = set.join_next().await {
+            if let Err(e) = res {
+                warn!("reload: per-ws task panicked or was cancelled: {}", e);
+            }
+        }
+    }
+
+    /// Reload a single workspace's `policy.toml`. Returns `false` if the ws is
+    /// no longer registered. Same write-lock-first invariant as the bulk path.
+    pub async fn reload_workspace_policy(&self, ws_id: &str) -> bool {
+        let Some(arc) = self.get_by_wsid(ws_id) else {
+            return false;
+        };
+        let dir = self.index_dir(ws_id);
+        Self::reload_one_workspace_policy_inner(ws_id, dir, &arc).await;
+        true
+    }
+
+    async fn reload_one_workspace_policy_inner(
+        ws_id: &str,
+        dir: PathBuf,
+        arc: &Arc<RwLock<WorkspaceState>>,
+    ) {
+        // (1) Tiny read lock: grab the per-ws fs serializer.
+        let policy_io_mu = {
+            let ws = arc.read().await;
+            ws.policy_io_mu.clone()
+        };
+
+        // (2) Serialize against concurrent PATCH/RESET via the narrow per-ws
+        //     mutex (same one PATCH/RESET hold around save+commit). This gives
+        //     us the original "no SET stomp" guarantee without blocking
+        //     checkpoint/list/status on a slow disk via the ws RwLock.
+        let _io_guard = policy_io_mu.lock().await;
+
+        // (3) Disk read on a blocking worker, with NO ws RwLock held.
+        let outcome = tokio::task::spawn_blocking(move || load_workspace_policy(&dir)).await;
+
+        // (4) Tiny write lock to commit the in-memory result. Disk is the
+        //     source of truth; this just brings memory in sync. PATCH/RESET
+        //     can't have raced here because they're behind `policy_io_mu`.
+        match outcome {
+            // Successful read: real on-disk truth, drop any fail-safe marker.
+            Ok(Ok(LoadPolicyOutcome::Missing)) => {
+                let mut ws = arc.write().await;
+                ws.policy = WorkspacePolicy::default();
+                ws.policy_failsafe = false;
+            }
+            Ok(Ok(LoadPolicyOutcome::Loaded(p))) => {
+                let mut ws = arc.write().await;
+                ws.policy = p;
+                ws.policy_failsafe = false;
+            }
+            Ok(Err(e)) => warn!(
+                "reload: failed to load policy for {}: {}; preserving live in-memory policy",
+                ws_id, e
+            ),
+            Err(join_err) => warn!(
+                "reload: spawn_blocking joined with error for {}: {}; preserving live policy",
+                ws_id, join_err
+            ),
+        }
+    }
+
+    /// True iff at least one workspace's effective policy (local-or-global)
+    /// would do work this tick. Lets `auto_cleanup_loop` decide whether to
+    /// park. Subsumes the legacy global-only short-circuits by checking the
+    /// merged policy of every ws, so a per-ws override that re-enables
+    /// cleanup wins over a globally-off default.
+    pub async fn any_ws_has_effective_cleanup(&self) -> bool {
+        let cfg_snapshot = self.config_snapshot();
+        for arc in self.all_workspaces() {
+            let ws = arc.read().await;
+            if !ws.policy.effective_for(&cfg_snapshot).is_disabled() {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub async fn unregister_workspace(&self, ws_id: &str) {
         // Stop watcher if present
         if let Ok(mut watchers) = self.watchers.lock() {
             if let Some(w) = watchers.remove(ws_id) {
                 w.stop();
             }
         }
-        self.workspaces.remove(ws_id);
-        self.path_to_wsid.remove(path);
+        if let Some((_, ws_state)) = self.workspaces.remove(ws_id) {
+            // Await any in-flight writer (e.g. a concurrent checkpoint) so
+            // path_to_wsid is never leaked. After workspaces.remove no new
+            // holders can appear; existing ones drop quickly.
+            let state = ws_state.read().await;
+            self.path_to_wsid.remove(&state.path);
+        }
+        // Symmetric with register: re-park/re-evaluate the
+        // scheduler when a ws goes away. No-op when no one is parked.
+        self.config_notify.notify_waiters();
     }
 
     /// Register a file watcher for a workspace.
@@ -450,7 +658,12 @@ impl DaemonState {
                 warn!("Failed to start watcher for {}: {}", ws_id, e);
             }
         }
-        state.register_workspace(ws_id, workspace_path, index);
+        // Shared fail-safe helper; same `(policy, failsafe)` semantics as
+        // every other register entry. See [[ws-failsafe]].
+        let policy_dir = state.index_dir(&ws_id);
+        let (policy, failsafe) =
+            load_workspace_policy_with_failsafe(&policy_dir, &ws_id, "rebuild");
+        state.register_workspace_with_policy(ws_id, workspace_path, index, policy, failsafe);
 
         Ok(())
     }
@@ -509,7 +722,9 @@ impl DaemonState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ws_ckpt_common::{CleanupRetention, DaemonConfig, SnapshotIndex, SnapshotMeta};
+    use ws_ckpt_common::{
+        save_workspace_policy, CleanupRetention, DaemonConfig, SnapshotIndex, SnapshotMeta,
+    };
 
     fn test_backend() -> Arc<dyn StorageBackend> {
         Arc::new(crate::backends::btrfs_loop::BtrfsLoopBackend::new(
@@ -652,8 +867,8 @@ mod tests {
         assert_eq!(ws.path, path2);
     }
 
-    #[test]
-    fn unregister_workspace_removes_both_mappings() {
+    #[tokio::test]
+    async fn unregister_workspace_removes_both_mappings() {
         let state = DaemonState::new(test_config(), test_backend(), test_state_dir());
         let path = PathBuf::from("/home/user/removable");
         let index = SnapshotIndex::new(path.clone());
@@ -664,7 +879,7 @@ mod tests {
         assert!(state.get_by_path(&path).is_some());
 
         // Unregister
-        state.unregister_workspace("ws-rm", &path);
+        state.unregister_workspace("ws-rm").await;
 
         // Verify both mappings removed
         assert!(state.get_by_wsid("ws-rm").is_none());
@@ -833,5 +1048,220 @@ mod tests {
 
         let _ = release_tx.send(());
         holder.await.unwrap();
+    }
+
+    // ── Per-workspace policy plumbing tests ──
+
+    #[tokio::test]
+    async fn register_workspace_default_policy_is_inherit_global() {
+        let state = DaemonState::new(test_config(), test_backend(), test_state_dir());
+        let path = PathBuf::from("/ws/inherit");
+        state.register_workspace("ws-i".to_string(), path.clone(), SnapshotIndex::new(path));
+        let arc = state.get_by_wsid("ws-i").unwrap();
+        let ws = arc.read().await;
+        assert!(ws.policy.is_empty(), "default register sets empty policy");
+    }
+
+    #[tokio::test]
+    async fn any_ws_has_effective_cleanup_covers_global_and_local_paths() {
+        // test_config() has auto_cleanup=false, so a fresh state with no
+        // ws (or only inherit-default ws) should report no effective work.
+        let state = DaemonState::new(test_config(), test_backend(), test_state_dir());
+        assert!(!state.any_ws_has_effective_cleanup().await);
+
+        // Inherit-only ws under a globally-off config → still false.
+        let path_a = PathBuf::from("/ws/a");
+        state.register_workspace_with_policy(
+            "ws-a".to_string(),
+            path_a.clone(),
+            SnapshotIndex::new(path_a),
+            WorkspacePolicy::default(),
+            false,
+        );
+        assert!(!state.any_ws_has_effective_cleanup().await);
+
+        // Per-ws override re-enables on top of globally-off → true.
+        let path_b = PathBuf::from("/ws/b");
+        state.register_workspace_with_policy(
+            "ws-b".to_string(),
+            path_b.clone(),
+            SnapshotIndex::new(path_b),
+            WorkspacePolicy {
+                auto_cleanup: Some(true),
+                auto_cleanup_keep: None,
+            },
+            false,
+        );
+        assert!(state.any_ws_has_effective_cleanup().await);
+
+        // Per-ws auto_cleanup=Some(false) on top of globally-off → still
+        // false (the ws-b override above is what keeps the aggregate true).
+        let path_c = PathBuf::from("/ws/c");
+        state.register_workspace_with_policy(
+            "ws-c".to_string(),
+            path_c.clone(),
+            SnapshotIndex::new(path_c),
+            WorkspacePolicy {
+                auto_cleanup: Some(false),
+                auto_cleanup_keep: None,
+            },
+            false,
+        );
+        assert!(state.any_ws_has_effective_cleanup().await);
+    }
+
+    #[tokio::test]
+    async fn any_ws_has_effective_cleanup_global_keep_disabled_per_ws_overrides() {
+        // Globally on but global keep is disabled (Count(0)). A ws with no
+        // override inherits → effective is_disabled. Aggregate must be false.
+        let mut cfg = test_config();
+        cfg.auto_cleanup = true;
+        cfg.auto_cleanup_keep = ws_ckpt_common::CleanupRetention::Count(0);
+        let state = DaemonState::new(cfg, test_backend(), test_state_dir());
+
+        let path_a = PathBuf::from("/ws/a");
+        state.register_workspace_with_policy(
+            "ws-a".to_string(),
+            path_a.clone(),
+            SnapshotIndex::new(path_a),
+            WorkspacePolicy::default(),
+            false,
+        );
+        assert!(!state.any_ws_has_effective_cleanup().await);
+
+        // ws-b overrides keep with a real number → effective re-enabled.
+        let path_b = PathBuf::from("/ws/b");
+        state.register_workspace_with_policy(
+            "ws-b".to_string(),
+            path_b.clone(),
+            SnapshotIndex::new(path_b),
+            WorkspacePolicy {
+                auto_cleanup: None,
+                auto_cleanup_keep: Some(ws_ckpt_common::CleanupRetention::Count(5)),
+            },
+            false,
+        );
+        assert!(state.any_ws_has_effective_cleanup().await);
+    }
+
+    #[tokio::test]
+    async fn reload_all_workspace_policies_picks_up_disk_changes() {
+        // Use a real state_dir so index_dir() points at writable paths.
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().to_path_buf();
+        let state = DaemonState::new(test_config(), test_backend(), state_dir.clone());
+
+        let ws_id = "ws-reload";
+        let path = PathBuf::from("/ws/reload");
+        state.register_workspace_with_policy(
+            ws_id.to_string(),
+            path.clone(),
+            SnapshotIndex::new(path),
+            WorkspacePolicy::default(),
+            false,
+        );
+
+        // Operator hand-edits the policy file out-of-band (no IPC).
+        let ws_index_dir = state.index_dir(ws_id);
+        let new_policy = WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::Count(7)),
+        };
+        save_workspace_policy(&ws_index_dir, &new_policy).unwrap();
+
+        // Before reload, in-memory state still says "inherit".
+        {
+            let ws = state.get_by_wsid(ws_id).unwrap();
+            let g = ws.read().await;
+            assert!(g.policy.is_empty());
+        }
+
+        state.reload_all_workspace_policies().await;
+
+        let ws = state.get_by_wsid(ws_id).unwrap();
+        let g = ws.read().await;
+        assert_eq!(g.policy, new_policy);
+    }
+
+    #[tokio::test]
+    async fn reload_clears_failsafe_when_disk_read_succeeds() {
+        // A ws registered as fail-safe must drop the marker once reload reads
+        // the real policy.toml, so subsequent PATCH is no longer refused.
+        let tmp = tempfile::tempdir().unwrap();
+        let state = DaemonState::new(test_config(), test_backend(), tmp.path().to_path_buf());
+
+        let ws_id = "ws-failsafe-reload";
+        let path = PathBuf::from("/ws/failsafe-reload");
+        state.register_workspace_with_policy(
+            ws_id.to_string(),
+            path.clone(),
+            SnapshotIndex::new(path),
+            WorkspacePolicy {
+                auto_cleanup: Some(false),
+                auto_cleanup_keep: None,
+            },
+            true,
+        );
+
+        let real_policy = WorkspacePolicy {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::Count(100)),
+        };
+        save_workspace_policy(&state.index_dir(ws_id), &real_policy).unwrap();
+
+        state.reload_all_workspace_policies().await;
+
+        let ws = state.get_by_wsid(ws_id).unwrap();
+        let g = ws.read().await;
+        assert_eq!(g.policy, real_policy);
+        assert!(
+            !g.policy_failsafe,
+            "successful reload must drop the fail-safe marker"
+        );
+    }
+
+    // ── lock_wsid: serializes init/adopt/recover on a shared ws_id ──
+
+    #[tokio::test]
+    async fn lock_wsid_serializes_same_id() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        let g1 = state.lock_wsid("ws-abc").await;
+
+        let acquired = Arc::new(AtomicBool::new(false));
+        let acquired_c = acquired.clone();
+        let state_c = state.clone();
+        let h = tokio::spawn(async move {
+            let _g = state_c.lock_wsid("ws-abc").await;
+            acquired_c.store(true, Ordering::SeqCst);
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !acquired.load(Ordering::SeqCst),
+            "second lock on same ws_id must block while first guard is held"
+        );
+
+        drop(g1);
+        h.await.unwrap();
+        assert!(acquired.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn lock_wsid_independent_for_different_ids() {
+        use std::time::Duration;
+
+        let state = DaemonState::new(test_config(), test_backend(), test_state_dir());
+        let _g1 = state.lock_wsid("ws-a").await;
+        // Different ws_id must not block.
+        let _g2 = tokio::time::timeout(Duration::from_millis(100), state.lock_wsid("ws-b"))
+            .await
+            .expect("different ws_id must not block on each other");
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -5,7 +5,9 @@ use sha2::{Digest, Sha256};
 use tokio::process::Command;
 use tracing::{error, info, warn};
 
-use ws_ckpt_common::{ErrorCode, ResolveError, Response, SnapshotIndex};
+use ws_ckpt_common::{
+    load_workspace_policy_with_failsafe, ErrorCode, ResolveError, Response, SnapshotIndex,
+};
 
 use crate::index_store;
 use crate::state::DaemonState;
@@ -47,6 +49,10 @@ async fn adopt_existing_subvol(
     ws_id: &str,
     registered_path: std::path::PathBuf,
 ) -> Response {
+    // Same-ws_id lifecycle lock as init/recover. ws_id here came from the
+    // existing on-disk subvol name, not SHA256(path), but it shares the
+    // index_dir(ws_id) namespace either way.
+    let _wsid_guard = state.lock_wsid(ws_id).await;
     let snap_dir = state.index_dir(ws_id);
     let btrfs_snap_dir = state.backend.snapshots_root().join(ws_id);
     let mut index = if let Ok(idx) = index_store::load(&snap_dir).await {
@@ -69,7 +75,18 @@ async fn adopt_existing_subvol(
             }
         }
     }
-    state.register_workspace(ws_id.to_string(), registered_path, index);
+    // Re-adoption must honor any pre-existing per-ws policy.toml; shared
+    // fail-safe helper means missing→inherit, on read error→auto_cleanup=false
+    // + policy_failsafe=true (won't delete protected snapshots before next
+    // reload, PATCH refused until reload/reset). See [[ws-failsafe]].
+    let (policy, failsafe) = load_workspace_policy_with_failsafe(&snap_dir, ws_id, "re-adoption");
+    state.register_workspace_with_policy(
+        ws_id.to_string(),
+        registered_path,
+        index,
+        policy,
+        failsafe,
+    );
     if let Err(e) = state.save_manifest().await {
         warn!("save_manifest failed after subvol re-adoption: {:#}", e);
     }
@@ -278,6 +295,13 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
         suffix += 1;
     }
 
+    // Serialize against a concurrent `recover` of the same path: ws_id is
+    // SHA256(path), so a recover already in flight would race with our
+    // index_store::save / register / save_manifest below.
+    let _wsid_guard = state.lock_wsid(&ws_id).await;
+
+    let abs_path_str = abs_path.to_string_lossy().to_string();
+
     // Steps 4-11 via backend, with cleanup handled internally
     if let Err(e) = state.backend.init_workspace(&abs_path_str, &ws_id).await {
         error!("init failed: {:#}", e);
@@ -311,13 +335,24 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
     };
     index_store::save(&snap_dir, &index).await?;
 
+    // 12a. Pick up any pre-existing per-ws policy.toml before registering.
+    // If `state.json` was lost but `policy.toml` survived, ws_id stays stable
+    // (SHA256(path)), so default = "inherit global" here would silently
+    // revert and let scheduler delete protected snapshots. Shared helper
+    // handles missing→inherit / Err→fail-safe. See [[ws-failsafe]].
+    let (policy, failsafe) = load_workspace_policy_with_failsafe(&snap_dir, &ws_id, "init");
+
     // 13. Register to state
-    state.register_workspace(ws_id.clone(), abs_path.clone(), index);
+    state.register_workspace_with_policy(ws_id.clone(), abs_path.clone(), index, policy, failsafe);
 
     // 13a. Save manifest
     if let Err(e) = state.save_manifest().await {
         warn!("save_manifest failed after init: {:#}", e);
     }
+
+    // Lifecycle window done (state + index_dir written). Watcher / warmup
+    // below only read paths, so let a queued recover proceed.
+    drop(_wsid_guard);
 
     // 13b. Start file watcher for write-lock detection
     match crate::fs_watcher::WorkspaceWatcher::start(&abs_path) {
@@ -437,6 +472,26 @@ pub async fn delete_snapshot(
 
 // ── recover ──
 
+/// Remove the entire per-ws index dir (`index.json` + `policy.toml` + any
+/// future siblings) recursively. NotFound is fine, other errors warn-only.
+///
+/// Called by `recover_workspace` after `unregister`: ws_id is SHA256(path),
+/// so a future init at the same path would collide on the same dir and
+/// inherit stale `index.json` *and* `policy.toml` — both would mislead
+/// scheduler/PATCH about a workspace the user just tore down.
+async fn wipe_index_dir(state: &Arc<DaemonState>, ws_id: &str) {
+    let dir = state.index_dir(ws_id);
+    match tokio::fs::remove_dir_all(&dir).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => warn!(
+            "wipe index dir {:?} for ws {}: {:#} \
+             (next init at this path may inherit stale metadata)",
+            dir, ws_id, e
+        ),
+    }
+}
+
 pub async fn recover_workspace(
     state: &Arc<DaemonState>,
     workspace: &str,
@@ -461,6 +516,11 @@ pub async fn recover_workspace(
     // Intentionally no cwd guard: recover is a terminal "tear out" operation
     // gated by CLI ConfirmationRequired. The CLI prompt is the contract.
 
+    // Block a concurrent init on the same path (ws_id is SHA256(path), so it
+    // would target the same workspaces slot and index_dir we're about to
+    // unregister + wipe). Held until save_manifest finishes.
+    let _wsid_guard = state.lock_wsid(&ws_id).await;
+
     // 3. call backend recover
     state
         .backend
@@ -468,9 +528,14 @@ pub async fn recover_workspace(
         .await?;
 
     // 4. unregister workspace from state
-    state.unregister_workspace(&ws_id, std::path::Path::new(&original_path));
+    state.unregister_workspace(&ws_id).await;
 
-    // 4a. Save manifest
+    // 4a. Wipe the entire per-ws index dir (policy.toml + index.json) so a
+    // future init at the same path doesn't inherit stale metadata
+    // (ws_id is SHA256(path), so it would collide).
+    wipe_index_dir(state, &ws_id).await;
+
+    // 4b. Save manifest
     if let Err(e) = state.save_manifest().await {
         warn!("save_manifest failed after recover: {:#}", e);
     }
@@ -887,34 +952,233 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recover_registered_workspace_returns_recover_ok_or_backend_error() {
+    async fn wipe_index_dir_removes_policy_and_is_idempotent() {
+        // Recover must clear per-ws metadata so a future init at the same path
+        // doesn't inherit a corrupted policy.toml (which would trigger fail-safe
+        // and lock out PATCH).
+        let state_tmp = tempfile::tempdir().unwrap();
         let state = Arc::new(DaemonState::new(
             test_config(),
             test_backend(),
-            test_state_dir(),
+            state_tmp.path().to_path_buf(),
         ));
-        let tmpdir = tempfile::tempdir().unwrap();
-        let path = tmpdir.path().to_path_buf();
-        let canon = tokio::fs::canonicalize(&path).await.unwrap();
+        let ws_id = "ws-wipe-me";
+        let dir = state.index_dir(ws_id);
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("policy.toml"), b"auto_cleanup = true\n")
+            .await
+            .unwrap();
+        tokio::fs::write(dir.join("index.json"), b"{}")
+            .await
+            .unwrap();
+        assert!(dir.exists());
+
+        wipe_index_dir(&state, ws_id).await;
+        assert!(!dir.exists(), "wipe must remove the index dir");
+
+        // Second call on already-absent dir must not error or panic.
+        wipe_index_dir(&state, ws_id).await;
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn recover_orchestration_calls_backend_then_unregisters_and_wipes_index() {
+        // Happy-path orchestration: backend called, ws unregistered, index dir wiped.
+        let state_tmp = tempfile::tempdir().unwrap();
+        let backend = Arc::new(RecorderStubBackend::new());
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            backend.clone() as Arc<dyn StorageBackend>,
+            state_tmp.path().to_path_buf(),
+        ));
+        let ws_tmp = tempfile::tempdir().unwrap();
+        let canon = tokio::fs::canonicalize(ws_tmp.path()).await.unwrap();
+        let ws_id = "ws-recov-orch";
         state.register_workspace(
-            "ws-test".to_string(),
+            ws_id.to_string(),
             canon.clone(),
             SnapshotIndex::new(canon.clone()),
         );
-        // Backend will fail in test env (no btrfs), so we expect an error propagation
-        // but the workspace should have been resolved (not WorkspaceNotFound)
-        let resp = recover_workspace(&state, &canon.to_string_lossy()).await;
+        // Simulate prior PATCH: write a real policy.toml inside index_dir.
+        let dir = state.index_dir(ws_id);
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("policy.toml"), b"auto_cleanup = true\n")
+            .await
+            .unwrap();
+
+        let resp = recover_workspace(&state, &canon.to_string_lossy())
+            .await
+            .unwrap();
+        assert!(matches!(resp, Response::RecoverOk { .. }));
+        assert_eq!(
+            backend.recover_call_count(),
+            1,
+            "backend.recover_workspace must run once"
+        );
+        assert!(
+            state.get_by_wsid(ws_id).is_none(),
+            "ws must be unregistered"
+        );
+        assert!(!dir.exists(), "recover must wipe stale per-ws index dir");
+    }
+
+    #[tokio::test]
+    async fn recover_blocks_on_lock_wsid_held_by_concurrent_lifecycle_op() {
+        // White-box proof that `recover_workspace` takes `state.lock_wsid(ws_id)`
+        // on the same key that init/adopt take — without it, a concurrent
+        // init on the same path could race recover's unregister+wipe.
+        // We hold the lock externally, spawn recover, and assert it has
+        // NOT reached the backend until we drop our guard.
+        use std::time::Duration;
+
+        let state_tmp = tempfile::tempdir().unwrap();
+        let backend = Arc::new(RecorderStubBackend::new());
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            backend.clone() as Arc<dyn StorageBackend>,
+            state_tmp.path().to_path_buf(),
+        ));
+        let ws_tmp = tempfile::tempdir().unwrap();
+        let canon = tokio::fs::canonicalize(ws_tmp.path()).await.unwrap();
+
+        // ws_id is what `init` would have computed: SHA256(canonicalize(path))[:6].
+        let mut hasher = Sha256::new();
+        hasher.update(canon.to_string_lossy().as_bytes());
+        let ws_id = format!("ws-{}", &format!("{:x}", hasher.finalize())[..6]);
+        state.register_workspace(
+            ws_id.clone(),
+            canon.clone(),
+            SnapshotIndex::new(canon.clone()),
+        );
+
+        // Outside the recover, hold the per-ws_id lifecycle lock — simulates
+        // a concurrent init / adopt that's mid-flight on the same ws_id.
+        let held_guard = state.lock_wsid(&ws_id).await;
+
+        let state_for_task = state.clone();
+        let canon_str = canon.to_string_lossy().to_string();
+        let handle = tokio::spawn(async move {
+            recover_workspace(&state_for_task, &canon_str)
+                .await
+                .unwrap()
+        });
+
+        // Give the task time to reach `lock_wsid` and park on it.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            backend.recover_call_count(),
+            0,
+            "recover must NOT have reached backend while lock_wsid is held",
+        );
+
+        // Release the lock — recover must now proceed.
+        drop(held_guard);
+        let resp = tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("recover did not progress after lock_wsid was released")
+            .unwrap();
+        assert!(matches!(resp, Response::RecoverOk { .. }));
+        assert_eq!(backend.recover_call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn recover_unresolvable_path_returns_not_found_no_backend_call() {
+        // Unresolvable path short-circuits before reaching the backend.
+        let backend = Arc::new(RecorderStubBackend::new());
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            backend.clone() as Arc<dyn StorageBackend>,
+            tempfile::tempdir().unwrap().path().to_path_buf(),
+        ));
+        let resp = recover_workspace(&state, "/nonexistent/path/xyz")
+            .await
+            .unwrap();
         match resp {
-            Ok(Response::RecoverOk { .. }) => {} // success path
-            Err(_) => {}                         // backend error is expected in test env
-            Ok(Response::Error { code, .. }) => {
-                assert_ne!(
-                    code,
-                    ErrorCode::WorkspaceNotFound,
-                    "should not be WsNotFound"
-                );
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::WorkspaceNotFound),
+            other => panic!("expected WorkspaceNotFound, got {:?}", other),
+        }
+        assert_eq!(backend.recover_call_count(), 0);
+    }
+
+    // ── Stub backend: records recover_workspace calls; other methods panic ──
+    struct RecorderStubBackend {
+        data_root_path: PathBuf,
+        snapshots_root_path: PathBuf,
+        recover_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl RecorderStubBackend {
+        fn new() -> Self {
+            Self {
+                data_root_path: PathBuf::from("/tmp/stub-data"),
+                snapshots_root_path: PathBuf::from("/tmp/stub-snapshots"),
+                recover_calls: std::sync::atomic::AtomicUsize::new(0),
             }
-            _ => panic!("unexpected response variant"),
+        }
+        fn recover_call_count(&self) -> usize {
+            self.recover_calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl StorageBackend for RecorderStubBackend {
+        fn backend_type(&self) -> ws_ckpt_common::backend::BackendType {
+            ws_ckpt_common::backend::BackendType::BtrfsBase
+        }
+        fn data_root(&self) -> &std::path::Path {
+            &self.data_root_path
+        }
+        fn snapshots_root(&self) -> &std::path::Path {
+            &self.snapshots_root_path
+        }
+        async fn recover_workspace(&self, _: &str, _: &str) -> anyhow::Result<()> {
+            self.recover_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+        async fn init_workspace(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> anyhow::Result<ws_ckpt_common::WorkspaceInfo> {
+            unimplemented!("stub: init_workspace not used")
+        }
+        async fn create_snapshot(&self, _: &str, _: &str) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn rollback(&self, _: &str, _: &str) -> anyhow::Result<PathBuf> {
+            unimplemented!()
+        }
+        async fn delete_snapshot(&self, _: &str, _: &str) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn diff(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> anyhow::Result<Vec<ws_ckpt_common::DiffEntry>> {
+            unimplemented!()
+        }
+        async fn cleanup_snapshots(&self, _: &str, _: &[String]) -> anyhow::Result<Vec<String>> {
+            unimplemented!()
+        }
+        async fn fork(&self, _: &str, _: &str, _: &str) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn gc_generations(
+            &self,
+            _: &str,
+        ) -> anyhow::Result<ws_ckpt_common::backend::GcResult> {
+            unimplemented!()
+        }
+        async fn check_environment(
+            &self,
+        ) -> anyhow::Result<ws_ckpt_common::backend::EnvironmentStatus> {
+            unimplemented!()
+        }
+        async fn get_usage(&self) -> anyhow::Result<(u64, u64)> {
+            unimplemented!()
         }
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
+++ b/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
@@ -9,8 +9,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 
 use ws_ckpt_common::{
-    decode_payload, encode_frame, ChangeType, CleanupRetention, ConfigReport, DiffEntry, Request,
-    Response, SnapshotEntry, SnapshotMeta, StatusReport, WorkspaceInfo,
+    decode_payload, encode_frame, ChangeType, CleanupRetention, ConfigReport, DiffEntry,
+    EffectivePolicy, GlobalPolicySnapshot, PolicyFieldOp, Request, Response, SnapshotEntry,
+    SnapshotMeta, StatusReport, WorkspaceInfo, WorkspacePolicy,
 };
 
 /// Helper: create a temporary socket path using tempfile
@@ -98,13 +99,105 @@ async fn mock_server_handle(mut stream: tokio::net::UnixStream) {
                 img_max_percent: 40.0,
             },
         },
-        Request::ReloadConfig => Response::ReloadConfigOk,
+        Request::ReloadConfig
+        | Request::ReloadGlobalConfig
+        | Request::ReloadWorkspacePolicy { .. } => Response::ReloadConfigOk {
+            config: ConfigReport {
+                mount_path: "/mnt/btrfs-workspace".to_string(),
+                socket_path: "/run/ws-ckpt/ws-ckpt.sock".to_string(),
+                log_level: "info".to_string(),
+                auto_cleanup: false,
+                auto_cleanup_keep: CleanupRetention::Count(20),
+                auto_cleanup_interval_secs: 86_400,
+                health_check_interval_secs: 300,
+                img_size: 30,
+                img_max_percent: 40.0,
+            },
+        },
+        Request::ConfigOverview => Response::ConfigOverviewOk {
+            config: ConfigReport {
+                mount_path: "/mnt/btrfs-workspace".to_string(),
+                socket_path: "/run/ws-ckpt/ws-ckpt.sock".to_string(),
+                log_level: "info".to_string(),
+                auto_cleanup: false,
+                auto_cleanup_keep: CleanupRetention::Count(20),
+                auto_cleanup_interval_secs: 86_400,
+                health_check_interval_secs: 300,
+                img_size: 30,
+                img_max_percent: 40.0,
+            },
+            ws_total: 3,
+            ws_with_override: 1,
+        },
         Request::Recover { workspace } => Response::RecoverOk { workspace },
         Request::HealthAdvisory => Response::HealthAdvisoryOk {
             over_limit_workspace_count: 0,
             fs_total_bytes: 1_000_000_000,
             fs_used_bytes: 500_000_000,
         },
+        // Each policy-shaped variant returns a *distinct* response so the
+        // matching #[tokio::test] cases below actually catch wire-format
+        // regressions: a different shape per request rules out
+        // "the test only ever decoded one shape, schema drift went unnoticed".
+        Request::GetWorkspacePolicy { workspace } => Response::WorkspacePolicyOk {
+            ws_id: format!("get:{}", workspace),
+            effective: EffectivePolicy {
+                auto_cleanup: true,
+                auto_cleanup_keep: CleanupRetention::Count(5),
+            },
+            local: WorkspacePolicy::default(),
+            global: GlobalPolicySnapshot {
+                auto_cleanup: true,
+                auto_cleanup_keep: CleanupRetention::Count(20),
+            },
+        },
+        Request::ResetWorkspacePolicy { workspace } => {
+            // Mirror the real daemon's Reset semantics: the file is gone,
+            // local is empty, effective == global. The ws_id prefix tells
+            // the test that the right variant arrived (vs Patch).
+            let global = GlobalPolicySnapshot {
+                auto_cleanup: false,
+                auto_cleanup_keep: CleanupRetention::Count(20),
+            };
+            let effective = EffectivePolicy {
+                auto_cleanup: global.auto_cleanup,
+                auto_cleanup_keep: global.auto_cleanup_keep.clone(),
+            };
+            Response::WorkspacePolicyOk {
+                ws_id: format!("reset:{}", workspace),
+                effective,
+                local: WorkspacePolicy::default(),
+                global,
+            }
+        }
+        Request::PatchWorkspacePolicy {
+            workspace,
+            auto_cleanup,
+            auto_cleanup_keep,
+        } => {
+            // Apply the patch on top of an empty baseline so the test can
+            // verify the wire-format actually round-trips PolicyFieldOp.
+            let local = WorkspacePolicy {
+                auto_cleanup: auto_cleanup.apply(None),
+                auto_cleanup_keep: auto_cleanup_keep.apply(None),
+            };
+            let effective = EffectivePolicy {
+                auto_cleanup: local.auto_cleanup.unwrap_or(false),
+                auto_cleanup_keep: local
+                    .auto_cleanup_keep
+                    .clone()
+                    .unwrap_or(CleanupRetention::Count(20)),
+            };
+            Response::WorkspacePolicyOk {
+                ws_id: format!("patch:{}", workspace),
+                effective,
+                local,
+                global: GlobalPolicySnapshot {
+                    auto_cleanup: false,
+                    auto_cleanup_keep: CleanupRetention::Count(20),
+                },
+            }
+        }
     };
 
     // 5. Encode and send response frame
@@ -449,7 +542,13 @@ async fn full_reload_config_request_response_over_socket() {
     client.read_exact(&mut payload).await.unwrap();
 
     let response: Response = decode_payload(&payload).unwrap();
-    assert!(matches!(response, Response::ReloadConfigOk));
+    match response {
+        Response::ReloadConfigOk { config } => {
+            assert_eq!(config.mount_path, "/mnt/btrfs-workspace");
+            assert_eq!(config.auto_cleanup_keep, CleanupRetention::Count(20));
+        }
+        other => panic!("expected ReloadConfigOk, got {:?}", other),
+    }
 
     server.await.unwrap();
 }
@@ -488,4 +587,195 @@ async fn full_config_request_response_over_socket() {
     }
 
     server.await.unwrap();
+}
+
+// ── Per-workspace policy: real end-to-end IPC tests ──
+//
+// Each variant goes through encode → socket → decode on both ends, so a
+// future bincode-tag shuffle, serde rename, or `EffectivePolicy` /
+// `GlobalPolicySnapshot` field reorder will fail loudly here instead of
+// silently breaking the wire format.
+
+/// Shared helper: spawn mock server, encode `req`, return decoded `Response`.
+/// Renamed from `run_policy_request` — also used by the reload-IPC e2e tests
+/// below that aren't policy-shaped.
+async fn run_policy_request(req: Request) -> Response {
+    let socket_path = temp_socket_path();
+    let listener = UnixListener::bind(&socket_path).expect("bind");
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        mock_server_handle(stream).await;
+    });
+    tokio::task::yield_now().await;
+
+    let mut client = UnixStream::connect(&socket_path).await.unwrap();
+    let frame = encode_frame(&req).unwrap();
+    client.write_all(&frame).await.unwrap();
+
+    let mut len_buf = [0u8; 4];
+    client.read_exact(&mut len_buf).await.unwrap();
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut payload = vec![0u8; len];
+    client.read_exact(&mut payload).await.unwrap();
+
+    let resp: Response = decode_payload(&payload).unwrap();
+    server.await.unwrap();
+    resp
+}
+
+#[tokio::test]
+async fn full_get_workspace_policy_over_socket() {
+    let resp = run_policy_request(Request::GetWorkspacePolicy {
+        workspace: "/tmp/ws".to_string(),
+    })
+    .await;
+    match resp {
+        Response::WorkspacePolicyOk {
+            ws_id,
+            effective,
+            local,
+            global,
+        } => {
+            // The mock server prefixes "get:" so we know the request reached
+            // it as the right variant (and not, say, as Set after a tag drift).
+            assert_eq!(ws_id, "get:/tmp/ws");
+            assert_eq!(effective.auto_cleanup_keep, CleanupRetention::Count(5));
+            assert!(effective.auto_cleanup);
+            assert!(local.is_empty());
+            assert_eq!(global.auto_cleanup_keep, CleanupRetention::Count(20));
+        }
+        _ => panic!("expected WorkspacePolicyOk, got {:?}", resp),
+    }
+}
+
+// (full_set_workspace_policy_over_socket removed: there is no longer a
+// "write whole policy" IPC — Patch handles edits, Reset handles removal.)
+
+#[tokio::test]
+async fn full_reset_workspace_policy_over_socket() {
+    // ResetWorkspacePolicy is the only whole-file IPC. Mock+daemon must
+    // both behave the same way: file gone, local empty, effective ==
+    // global. Distinct `reset:` ws_id prefix from the mock so a future
+    // tag-shuffle that delivered the wrong variant fails here.
+    let resp = run_policy_request(Request::ResetWorkspacePolicy {
+        workspace: "ws-reset".to_string(),
+    })
+    .await;
+    match resp {
+        Response::WorkspacePolicyOk {
+            ws_id,
+            local,
+            effective,
+            global,
+        } => {
+            assert_eq!(ws_id, "reset:ws-reset");
+            assert!(local.is_empty(), "reset must produce an empty local");
+            assert_eq!(
+                effective.auto_cleanup, global.auto_cleanup,
+                "with local empty, effective.auto_cleanup must match global"
+            );
+            assert_eq!(
+                effective.auto_cleanup_keep, global.auto_cleanup_keep,
+                "with local empty, effective.auto_cleanup_keep must match global"
+            );
+        }
+        _ => panic!("expected WorkspacePolicyOk, got {:?}", resp),
+    }
+}
+
+#[tokio::test]
+async fn full_patch_workspace_policy_over_socket() {
+    // Cover both PolicyFieldOp variants (Set + Unchanged) on a single
+    // request so each one touches the wire.
+    let resp = run_policy_request(Request::PatchWorkspacePolicy {
+        workspace: "ws-patch".to_string(),
+        auto_cleanup: PolicyFieldOp::Set(true),
+        auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(7)),
+    })
+    .await;
+    match resp {
+        Response::WorkspacePolicyOk {
+            ws_id,
+            local,
+            effective,
+            ..
+        } => {
+            assert_eq!(ws_id, "patch:ws-patch");
+            assert_eq!(local.auto_cleanup, Some(true));
+            assert_eq!(local.auto_cleanup_keep, Some(CleanupRetention::Count(7)));
+            assert!(effective.auto_cleanup);
+            assert_eq!(effective.auto_cleanup_keep, CleanupRetention::Count(7));
+        }
+        _ => panic!("expected WorkspacePolicyOk, got {:?}", resp),
+    }
+}
+
+#[tokio::test]
+async fn full_patch_workspace_policy_unchanged_only_over_socket() {
+    // All-Unchanged Patch: nothing should be applied. Used here mainly to
+    // exercise the `Unchanged` discriminant on the wire (the Set test
+    // above only ever encodes `Set` for both fields).
+    let resp = run_policy_request(Request::PatchWorkspacePolicy {
+        workspace: "ws-patch-noop".to_string(),
+        auto_cleanup: PolicyFieldOp::Unchanged,
+        auto_cleanup_keep: PolicyFieldOp::Unchanged,
+    })
+    .await;
+    match resp {
+        Response::WorkspacePolicyOk { local, .. } => {
+            // Unchanged applied to None stays None — both fields remain unset.
+            assert_eq!(local.auto_cleanup, None);
+            assert_eq!(local.auto_cleanup_keep, None);
+        }
+        _ => panic!("expected WorkspacePolicyOk, got {:?}", resp),
+    }
+}
+
+// ── Reload IPCs: exercise every variant on the wire ──
+//
+// All three reload variants share the `ReloadConfigOk { config }` reply
+// shape. Mock server returns the same body for all three (combined match
+// arm), so these tests verify the *request* tags round-trip distinctly
+// — a bincode tag shuffle that swapped `ReloadConfig` and
+// `ReloadGlobalConfig` would still go through the same arm, but a
+// reorder against any other Request variant (Init/Recover/etc.) would
+// blow up at decode.
+
+#[tokio::test]
+async fn full_reload_config_over_socket() {
+    let resp = run_policy_request(Request::ReloadConfig).await;
+    match resp {
+        Response::ReloadConfigOk { config } => {
+            assert_eq!(config.mount_path, "/mnt/btrfs-workspace");
+            assert_eq!(config.auto_cleanup_keep, CleanupRetention::Count(20));
+        }
+        other => panic!("expected ReloadConfigOk, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn full_reload_global_config_over_socket() {
+    let resp = run_policy_request(Request::ReloadGlobalConfig).await;
+    match resp {
+        Response::ReloadConfigOk { config } => {
+            assert_eq!(config.mount_path, "/mnt/btrfs-workspace");
+        }
+        other => panic!("expected ReloadConfigOk, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn full_reload_workspace_policy_over_socket() {
+    let resp = run_policy_request(Request::ReloadWorkspacePolicy {
+        workspace: "/tmp/ws".to_string(),
+    })
+    .await;
+    match resp {
+        Response::ReloadConfigOk { config } => {
+            // Mock reuses the same global config payload for the per-ws
+            // reload reply; the point of the test is the request side.
+            assert_eq!(config.mount_path, "/mnt/btrfs-workspace");
+        }
+        other => panic!("expected ReloadConfigOk, got {:?}", other),
+    }
 }

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -81,6 +81,91 @@ def _run_ws_ckpt_cmd(cmd: list) -> Tuple[bool, str]:
         return False, str(e)
 
 
+# Schema version the plugin understands. ws-ckpt --format json carries this
+# tag; mismatch means a daemon bump and the plugin should NOT re-interpret.
+_POLICY_JSON_SCHEMA = "ws-ckpt-policy/v1"
+
+
+def _parse_workspace_policy_json(stdout: str) -> Dict[str, Any]:
+    """Parse `ws-ckpt config -w <ws> --format json` stdout.
+
+    Returns one of:
+        {"kind": "parse-error", "reason": str}
+        {"kind": "disabled"}              ← daemon pre-computed is_disabled=true
+        {"kind": "count",    "num": int}
+        {"kind": "age",      "duration": str}
+
+    Mirrors the openclaw discriminated union (config.ts WorkspaceCleanupParsed)
+    so display logic can tell a real "disabled" from a parse failure —
+    treating a parse miss as "disabled" was openclaw's original bug.
+    """
+    try:
+        doc = json.loads(stdout)
+    except json.JSONDecodeError as e:
+        return {"kind": "parse-error", "reason": f"not valid JSON: {e}"}
+    if not isinstance(doc, dict):
+        return {"kind": "parse-error", "reason": "JSON root is not an object"}
+    if doc.get("schema") != _POLICY_JSON_SCHEMA:
+        return {
+            "kind": "parse-error",
+            "reason": f"unknown schema: {doc.get('schema')!r} (expected {_POLICY_JSON_SCHEMA!r})",
+        }
+    eff = doc.get("effective")
+    if not isinstance(eff, dict):
+        return {"kind": "parse-error", "reason": "missing `effective`"}
+    # Trust daemon's pre-computed is_disabled (covers auto_cleanup=false AND
+    # Count(0) / Age{secs:0}); re-deriving consumer-side is what bit openclaw.
+    if eff.get("is_disabled") is True:
+        return {"kind": "disabled"}
+    keep = eff.get("auto_cleanup_keep")
+    if not isinstance(keep, dict):
+        return {"kind": "parse-error", "reason": "missing `effective.auto_cleanup_keep`"}
+    mode = keep.get("mode")
+    if mode == "count":
+        n = keep.get("count")
+        # bool is a subclass of int in Python — exclude explicitly so {"count": true} doesn't slip through.
+        if isinstance(n, bool) or not isinstance(n, int) or n < 0:
+            return {"kind": "parse-error", "reason": f"`count` must be a non-negative int, got {n!r}"}
+        return {"kind": "count", "num": n}
+    if mode == "age":
+        raw = keep.get("raw")
+        if not isinstance(raw, str):
+            return {"kind": "parse-error", "reason": "`raw` is not a string"}
+        return {"kind": "age", "duration": raw}
+    return {"kind": "parse-error", "reason": f"unknown auto_cleanup_keep.mode: {mode!r}"}
+
+
+def _render_workspace_policy(stdout: str, ws: str) -> list:
+    """Render a parsed JSON policy as human-readable lines for `view`.
+
+    A parse failure is reported explicitly, never silently rendered as
+    "auto-cleanup disabled" (openclaw's original bug).
+    """
+    parsed = _parse_workspace_policy_json(stdout)
+    kind = parsed["kind"]
+    if kind == "parse-error":
+        return [
+            f"  (daemon response did not match expected schema: {parsed['reason']}; "
+            f"raw stdout follows)",
+            stdout,
+        ]
+    if kind == "disabled":
+        return [
+            "  maxSnapshotsNum:      not set - auto-cleanup disabled",
+            "  maxSnapshotsDuration: not set - auto-cleanup disabled",
+        ]
+    if kind == "count":
+        return [
+            f"  maxSnapshotsNum:      {parsed['num']}",
+            "  maxSnapshotsDuration: not set",
+        ]
+    # kind == "age"
+    return [
+        "  maxSnapshotsNum:      not set",
+        f"  maxSnapshotsDuration: {parsed['duration']}",
+    ]
+
+
 def _json(obj: Any) -> str:
     return json.dumps(obj, ensure_ascii=False)
 
@@ -148,8 +233,8 @@ WS_CKPT_CONFIG_SCHEMA: Dict[str, Any] = {
                     "New value as a string. Formats: "
                     "autoCheckpoint = \"true\"/\"false\"; "
                     "workspace = absolute path; "
-                    "maxSnapshotsNum = positive integer or \"unset\"; "
-                    "maxSnapshotsDuration = e.g. \"7d\"/\"24h\" or \"unset\"."
+                    "maxSnapshotsNum = positive integer (or \"unset\" to restore inherit-global); "
+                    "maxSnapshotsDuration = e.g. \"7d\"/\"24h\" (or \"unset\" to restore inherit-global)."
                 ),
             },
         },
@@ -305,27 +390,43 @@ WS_CKPT_STATUS_SCHEMA: Dict[str, Any] = {
 def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
     """Handle ws-ckpt-config tool call.
 
-    view  → print plugin config + transparently dump `ws-ckpt config` stdout.
+    view  → print plugin config + transparently dump
+        `ws-ckpt config -w <workspace>` stdout (3-column effective/local/global view).
     update autoCheckpoint / workspace  → mutate the in-process manager
         config; persistence requires editing ~/.hermes/config.yaml.
     update maxSnapshotsNum / maxSnapshotsDuration → shell out to
-        `ws-ckpt config --enable-auto-cleanup --auto-cleanup-keep <v>`.
+        `ws-ckpt config -w <workspace> --enable-auto-cleanup --auto-cleanup-keep <v>`.
+
+    Scope is **per-workspace** (the workspace this plugin manages): a hermes
+    user changing snapshot retention shouldn't accidentally rewrite the
+    daemon-wide default that other workspaces / users share. ws-ckpt v0.3.3
+    introduced explicit scope flags (`-g` global / `-w` per-ws); this plugin
+    always uses `-w`.
     """
     action = (args.get("action") or "view").strip().lower()
 
     if action == "view":
+        ws, ws_err = _require_workspace()
+        if ws_err:
+            return ws_err
         cfg = load_config()
         lines = [
             "Current ws-ckpt plugin configuration:",
             f"  autoCheckpoint: {cfg.auto_checkpoint}",
             f"  workspace:      {cfg.workspace}",
             "",
-            "Daemon configuration (from `ws-ckpt config`):",
+            f"Workspace policy (from `ws-ckpt config -w {ws} --format json`):",
         ]
-        success, output = _run_ws_ckpt_cmd(["ws-ckpt", "config"])
-        lines.append(output if output else "(daemon returned no output)")
+        # Use `--format json`, not raw daemon text: text isn't a contract,
+        # while the JSON schema is versioned and lets us tell parse-error
+        # from a real "disabled" (the openclaw bug we avoid here).
+        success, output = _run_ws_ckpt_cmd(
+            ["ws-ckpt", "config", "-w", ws, "--format", "json"]
+        )
         if not success:
-            lines.append("(failed to query daemon — output above is stderr)")
+            lines.append(f"(failed to query daemon: {output or 'no output'})")
+            return _ok("\n".join(lines))
+        lines.extend(_render_workspace_policy(output, ws))
         return _ok("\n".join(lines))
 
     if action not in ("update", "set"):
@@ -340,21 +441,29 @@ def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
             "maxSnapshotsNum, maxSnapshotsDuration."
         )
 
-    # Daemon-level keys: persist via `ws-ckpt config`
+    # Persist via `ws-ckpt config -w <workspace>` so the change scopes to a
+    # per-ws policy.toml override, not the shared daemon-wide default.
     if key in ("maxSnapshotsNum", "maxSnapshotsDuration"):
+        ws, ws_err = _require_workspace()
+        if ws_err:
+            return ws_err
+
         if value is None:
             return _err(
-                f"{key} requires a value (or \"unset\" to disable auto-cleanup)"
+                f"{key} requires a value (or \"unset\" to restore inherit-global)"
             )
         value = str(value).strip()
 
         if value == "unset":
+            # unset = restore default (delete policy.toml) so admin's later global toggle wins.
             success, output = _run_ws_ckpt_cmd(
-                ["ws-ckpt", "config", "--disable-auto-cleanup"]
+                ["ws-ckpt", "config", "-w", ws, "--reset"]
             )
             if not success:
-                return _err(f"Failed to disable auto-cleanup: {output}")
-            return _ok(f"Cleared: {key} unset — auto-cleanup disabled.")
+                return _err(f"Failed to reset workspace policy for {ws}: {output}")
+            return _ok(
+                f"Cleared: {key} unset — workspace {ws} now inherits global auto-cleanup."
+            )
 
         if key == "maxSnapshotsNum":
             try:
@@ -368,13 +477,13 @@ def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
             keep = value  # daemon parses duration strings like "7d", "24h"
 
         success, output = _run_ws_ckpt_cmd(
-            ["ws-ckpt", "config", "--enable-auto-cleanup",
+            ["ws-ckpt", "config", "-w", ws, "--enable-auto-cleanup",
              "--auto-cleanup-keep", keep]
         )
         if not success:
-            return _err(f"Failed to configure daemon: {output}")
+            return _err(f"Failed to configure workspace {ws}: {output}")
         return _ok(
-            f"Updated daemon config: {key} = {keep} "
+            f"Updated workspace policy for {ws}: {key} = {keep} "
             f"(auto-cleanup enabled, keep {keep})"
         )
 
@@ -383,8 +492,17 @@ def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
     # session without re-reading yaml on every hook fire.
     if key == "autoCheckpoint":
         if value is None:
-            return _err("autoCheckpoint requires a value (true/false)")
-        coerced = str(value).strip().lower() in ("true", "1", "yes", "on")
+            return _err('autoCheckpoint requires a value: "true" or "false"')
+        normalized = str(value).strip().lower()
+        # LLM tool callers and shell users emit a wide vocabulary; accept the
+        # common bool aliases instead of failing silently for anyone who didn't
+        # read stderr. Canonical form remains "true"/"false" in tool descriptions.
+        if normalized in ("true", "1", "yes", "on", "enabled"):
+            coerced = True
+        elif normalized in ("false", "0", "no", "off", "disabled"):
+            coerced = False
+        else:
+            return _err(f'autoCheckpoint must be "true" or "false" (got "{value}")')
         if coerced:
             workspace, ws_err = _require_workspace()
             if ws_err:

--- a/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
@@ -9,6 +9,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import type { CommandOutput } from "./types.js";
+import { pluginState } from "./state.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -190,19 +191,48 @@ export class CommandExecutor {
   }
 
   /**
-   * View or update daemon config.
-   * Maps to `ws-ckpt config [flags]`.
+   * View or update **per-workspace** auto-cleanup config.
+   * Maps to `ws-ckpt config -w <workspace> --format json [flags]`.
+   *
+   * Always uses `--format json`: text output isn't a contract and grepping
+   * it conflated regex-miss / real-disabled / Count(0). The JSON shape is
+   * versioned, so parse failures stay distinct from a real "disabled" state.
+   *
+   * Workspace resolution (mirrors `checkpoint` etc.): explicit `workspace`
+   * arg → `pluginState.resolvedConfig.workspace` → else error (no silent
+   * `-g` fallback; plugin ops are per-workspace by design). The result's
+   * `usedWorkspace` names the ws actually changed.
    */
-  public async config(options?: {
-    enableAutoCleanup?: boolean;
-    disableAutoCleanup?: boolean;
-    autoCleanupKeep?: string;
-  }): Promise<CommandOutput> {
-    const args = ["config"];
-    if (options?.enableAutoCleanup) args.push("--enable-auto-cleanup");
-    if (options?.disableAutoCleanup) args.push("--disable-auto-cleanup");
-    if (options?.autoCleanupKeep !== undefined) args.push("--auto-cleanup-keep", options.autoCleanupKeep);
-    return this.run(args);
+  public async config(
+    workspace?: string,
+    options?: {
+      enableAutoCleanup?: boolean;
+      disableAutoCleanup?: boolean;
+      autoCleanupKeep?: string;
+      reset?: boolean;
+    },
+  ): Promise<CommandOutput & { usedWorkspace?: string }> {
+    const ws = workspace ?? pluginState.resolvedConfig?.workspace;
+    if (!ws) {
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr:
+          "No workspace specified: pass workspace explicitly or set plugins.entries.ws-ckpt.config.workspace.",
+      };
+    }
+    const args = ["config", "-w", ws, "--format", "json"];
+    if (options?.reset) {
+      args.push("--reset");
+    } else {
+      if (options?.enableAutoCleanup) args.push("--enable-auto-cleanup");
+      if (options?.disableAutoCleanup) args.push("--disable-auto-cleanup");
+      if (options?.autoCleanupKeep !== undefined) {
+        args.push("--auto-cleanup-keep", options.autoCleanupKeep);
+      }
+    }
+    const out = await this.run(args);
+    return { ...out, usedWorkspace: ws };
   }
 
   // -----------------------------------------------------------------------

--- a/src/ws-ckpt/src/plugins/openclaw/src/config.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/config.ts
@@ -8,28 +8,89 @@
 import type { PluginConfig } from "./types.js";
 
 /**
- * Parse `ws-ckpt config` stdout to extract daemon auto-cleanup state.
- * Auto-cleanup keep: 3 (count mode) → cleanupNum; 7d → cleanupDuration.
+ * Outcome of extracting per-ws effective auto-cleanup state from a
+ * `ws-ckpt config --format json` payload. Keeps the three "no value" cases
+ * distinct so handlers can react differently:
+ *
+ *   - `parse-error`     → stdout didn't match the expected schema. MUST NOT
+ *                         be treated as "disabled" — that was the orig bug.
+ *   - `disabled`        → effective policy is genuinely off (the CLI
+ *                         pre-computes `is_disabled` on the wire).
+ *   - `count` | `age`   → real cleanup with the carried value.
  */
-export function parseDaemonAutoCleanupConfig(stdout: string): {
-  cleanupNum?: number;
-  cleanupDuration?: string;
-} {
-  // Auto-cleanup disabled
-  if (/Auto-cleanup:\s+disabled/i.test(stdout)) {
-    return {};
-  }
+export type WorkspaceCleanupParsed =
+  | { kind: "parse-error"; reason: string }
+  | { kind: "disabled" }
+  | { kind: "count"; num: number }
+  | { kind: "age"; duration: string };
 
-  // Parse keep value — grab first token after "Auto-cleanup keep:"
-  const keepMatch = stdout.match(/Auto-cleanup keep:\s+(\S+)/);
-  if (!keepMatch) return {};
-
-  const keepVal = keepMatch[1];
-  const num = parseInt(keepVal, 10);
-  if (!isNaN(num) && String(num) === keepVal) {
-    return { cleanupNum: num };
+/**
+ * Parse a `ws-ckpt config -w <ws> --format json` stdout payload.
+ *
+ * The JSON shape is versioned (`schema: "ws-ckpt-policy/v1"`); a mismatch
+ * is reported as `parse-error` so a future daemon bump doesn't silently
+ * get reinterpreted as "auto-cleanup disabled" by an old plugin.
+ */
+export function parseWorkspaceCleanupJson(stdout: string): WorkspaceCleanupParsed {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(stdout);
+  } catch (e) {
+    return {
+      kind: "parse-error",
+      reason: `not valid JSON: ${e instanceof Error ? e.message : String(e)}`,
+    };
   }
-  return { cleanupDuration: keepVal };
+  if (!doc || typeof doc !== "object") {
+    return { kind: "parse-error", reason: "JSON root is not an object" };
+  }
+  const root = doc as Record<string, unknown>;
+  if (root.schema !== "ws-ckpt-policy/v1") {
+    return {
+      kind: "parse-error",
+      reason: `unknown schema: ${JSON.stringify(root.schema)} (expected "ws-ckpt-policy/v1")`,
+    };
+  }
+  const eff = root.effective as Record<string, unknown> | undefined;
+  if (!eff || typeof eff !== "object") {
+    return { kind: "parse-error", reason: "missing or invalid `effective`" };
+  }
+  // Trust the daemon's pre-computed is_disabled (covers auto_cleanup=false
+  // AND Count(0)/Age{secs:0}); re-deriving it was the old parser's bug.
+  if (eff.is_disabled === true) return { kind: "disabled" };
+  const keep = eff.auto_cleanup_keep as Record<string, unknown> | undefined;
+  if (!keep || typeof keep !== "object") {
+    return {
+      kind: "parse-error",
+      reason: "missing or invalid `effective.auto_cleanup_keep`",
+    };
+  }
+  if (keep.mode === "count") {
+    // `typeof === "number"` alone admits NaN, Infinity, and floats. Match
+    // hermes's int() and the daemon's u32 contract: require a finite,
+    // non-negative integer.
+    if (
+      typeof keep.count !== "number" ||
+      !Number.isInteger(keep.count) ||
+      keep.count < 0
+    ) {
+      return {
+        kind: "parse-error",
+        reason: "`count` field must be a non-negative integer",
+      };
+    }
+    return { kind: "count", num: keep.count };
+  }
+  if (keep.mode === "age") {
+    if (typeof keep.raw !== "string") {
+      return { kind: "parse-error", reason: "`raw` field is not a string" };
+    }
+    return { kind: "age", duration: keep.raw };
+  }
+  return {
+    kind: "parse-error",
+    reason: `unknown auto_cleanup_keep.mode: ${JSON.stringify(keep.mode)}`,
+  };
 }
 
 /** Default configuration values. */
@@ -38,11 +99,14 @@ export const DEFAULT_CONFIG: PluginConfig = {
   autoCheckpoint: false,
 };
 
-/** Runtime tracking of daemon auto-cleanup state (global ws-ckpt settings). */
-export const daemonAutoCleanup = {
-  cleanupNum: undefined as number | undefined,
-  cleanupDuration: undefined as string | undefined,
-};
+// Intentionally no module-level workspaceCleanup cache.
+//
+// view path queries daemon every call, so a register-time prefetch would
+// be wasted work; falling back to a stale cache when daemon is unreachable
+// would hand the user/LLM potentially-hours-old values without any "as of
+// when" annotation — worse than a loud "daemon unreachable" error.
+// Matches the hermes plugin (no cache either) and eliminates by
+// construction the cross-call RMW race that the cache used to risk.
 
 /**
  * Configuration manager for the ws-ckpt plugin.

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -9,7 +9,7 @@ import { CommandExecutor } from "./commands.js";
 import { mapErrorToLLMMessage } from "./btrfs-manager.js";
 import type { AgentToolResult } from "../types-shim.js";
 import { pluginState, UNAVAILABLE_MSG, cwdInsideWorkspace, cwdInsideWorkspaceReason } from "./state.js";
-import { daemonAutoCleanup } from "./config.js";
+import { parseWorkspaceCleanupJson } from "./config.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -241,23 +241,48 @@ export async function handleConfig(
     const cfg = pluginState.resolvedConfig;
     const lines: string[] = ["Current ws-ckpt configuration:\n"];
     lines.push(`  autoCheckpoint: ${cfg.autoCheckpoint}`);
-    const autoCleanupDisabled = daemonAutoCleanup.cleanupNum === undefined && daemonAutoCleanup.cleanupDuration === undefined;
-    lines.push(
-      `  maxSnapshotsNum: ${
-        daemonAutoCleanup.cleanupNum !== undefined
-          ? daemonAutoCleanup.cleanupNum
-          : autoCleanupDisabled ? "not set - auto-cleanup disabled" : "not set"
-      }`,
-    );
-    lines.push(
-      `  maxSnapshotsDuration: ${
-        daemonAutoCleanup.cleanupDuration !== undefined
-          ? daemonAutoCleanup.cleanupDuration
-          : autoCleanupDisabled ? "not set - auto-cleanup disabled" : "not set"
-      }`,
-    );
+
+    // Always query daemon via `--format json` (stable versioned wire shape;
+    // text format isn't a contract). No module-level cache — render
+    // directly from this call's parsed result. Aligns with hermes plugin
+    // and removes by construction the cross-call RMW race the old cache
+    // had. Daemon unreachable / parse-error are reported explicitly; we
+    // NEVER fall back to a potentially-stale "last-known" value without
+    // saying so, and NEVER silently degrade either to "disabled" (that
+    // conflation was the original openclaw bug).
+    const cmd = new CommandExecutor();
+    const cfgResult = await cmd.config();
+    if (cfgResult.exitCode !== 0) {
+      lines.push(`  maxSnapshotsNum: (daemon unreachable)`);
+      lines.push(`  maxSnapshotsDuration: (daemon unreachable)`);
+      lines.push(`  workspace: ${cfg.workspace}`);
+      lines.push(`\n(could not query daemon: ${cfgResult.stderr.trim() || "no output"})`);
+      return { text: lines.join("\n"), isError: false };
+    }
+    const parsed = parseWorkspaceCleanupJson(cfgResult.stdout);
+    switch (parsed.kind) {
+      case "parse-error":
+        lines.push(`  maxSnapshotsNum: (unknown — daemon response unparseable)`);
+        lines.push(`  maxSnapshotsDuration: (unknown — daemon response unparseable)`);
+        break;
+      case "disabled":
+        lines.push(`  maxSnapshotsNum: not set - auto-cleanup disabled`);
+        lines.push(`  maxSnapshotsDuration: not set - auto-cleanup disabled`);
+        break;
+      case "count":
+        lines.push(`  maxSnapshotsNum: ${parsed.num}`);
+        lines.push(`  maxSnapshotsDuration: not set`);
+        break;
+      case "age":
+        lines.push(`  maxSnapshotsNum: not set`);
+        lines.push(`  maxSnapshotsDuration: ${parsed.duration}`);
+        break;
+    }
     lines.push(`  workspace: ${cfg.workspace}`);
-    lines.push("\nNote: maxSnapshotsNum / maxSnapshotsDuration are ws-ckpt global daemon settings.");
+    lines.push("\nNote: maxSnapshotsNum / maxSnapshotsDuration are this workspace's effective auto-cleanup policy (per-ws override on top of the daemon default).");
+    if (parsed.kind === "parse-error") {
+      lines.push(`\n(daemon response did not match expected schema: ${parsed.reason})`);
+    }
     return { text: lines.join("\n"), isError: false };
   }
 
@@ -269,66 +294,81 @@ export async function handleConfig(
       };
     }
 
+    // Workspace resolution + per-ws scoping live in `cmd.config()`: it falls
+    // back to `pluginState.resolvedConfig.workspace`, refuses (exit 2) if
+    // neither is set, and reports the chosen ws via `usedWorkspace`.
+
     if (key === "maxSnapshotsNum") {
       if (value === undefined) {
-        return { text: "maxSnapshotsNum requires a value (positive integer, or \"unset\" to disable auto-cleanup)", isError: true };
+        return { text: "maxSnapshotsNum requires a value (positive integer, or \"unset\" to restore inherit-global)", isError: true };
       }
 
-      // --- unset path ---
+      // unset = restore default (delete policy.toml) so admin's later global toggle wins.
       if (value === "unset") {
-        daemonAutoCleanup.cleanupNum = undefined;
         const cmd = new CommandExecutor();
-        const result = await cmd.config({ disableAutoCleanup: true });
+        const result = await cmd.config(undefined, { reset: true });
         if (result.exitCode !== 0) {
-          return { text: `Failed to disable auto-cleanup on daemon: ${result.stderr}`, isError: true };
+          return { text: `Failed to reset workspace policy: ${result.stderr}`, isError: true };
         }
-        return { text: "Cleared: maxSnapshotsNum unset — auto-cleanup disabled on ws-ckpt daemon.", isError: false };
+        return { text: `Cleared: maxSnapshotsNum unset — workspace ${result.usedWorkspace} now inherits global auto-cleanup.`, isError: false };
       }
 
       // --- set path ---
-      const num = parseInt(value, 10);
-      if (isNaN(num) || num < 1) {
+      // parseInt("20abc") returns 20 (silent truncation); reject anything that
+      // isn't a clean positive-integer literal so we match hermes's int(value).
+      const trimmed = value.trim();
+      if (!/^[1-9]\d*$/.test(trimmed)) {
         return { text: "maxSnapshotsNum must be a positive integer", isError: true };
       }
+      const num = Number(trimmed);
       const cmd = new CommandExecutor();
-      const result = await cmd.config({ enableAutoCleanup: true, autoCleanupKeep: String(num) });
+      const result = await cmd.config(undefined, { enableAutoCleanup: true, autoCleanupKeep: String(num) });
       if (result.exitCode !== 0) {
-        return { text: `Failed to configure daemon: ${result.stderr}`, isError: true };
+        return { text: `Failed to configure workspace: ${result.stderr}`, isError: true };
       }
-      daemonAutoCleanup.cleanupNum = num;
-      daemonAutoCleanup.cleanupDuration = undefined; // mutually exclusive
-      return { text: `Updated ws-ckpt global daemon config: maxSnapshotsNum = ${num} (auto-cleanup enabled, keep ${num})`, isError: false };
+      return { text: `Updated workspace policy for ${result.usedWorkspace}: maxSnapshotsNum = ${num} (auto-cleanup enabled, keep ${num})`, isError: false };
     }
 
     if (key === "maxSnapshotsDuration") {
       if (value === undefined) {
-        return { text: "maxSnapshotsDuration requires a value (e.g. \"7d\", \"24h\", or \"unset\" to disable auto-cleanup)", isError: true };
+        return { text: "maxSnapshotsDuration requires a value (e.g. \"7d\", \"24h\", or \"unset\" to restore inherit-global)", isError: true };
       }
 
-      // --- unset path ---
+      // unset = restore default (delete policy.toml) so admin's later global toggle wins.
       if (value === "unset") {
-        daemonAutoCleanup.cleanupDuration = undefined;
         const cmd = new CommandExecutor();
-        const result = await cmd.config({ disableAutoCleanup: true });
+        const result = await cmd.config(undefined, { reset: true });
         if (result.exitCode !== 0) {
-          return { text: `Failed to disable auto-cleanup on daemon: ${result.stderr}`, isError: true };
+          return { text: `Failed to reset workspace policy: ${result.stderr}`, isError: true };
         }
-        return { text: "Cleared: maxSnapshotsDuration unset — auto-cleanup disabled on ws-ckpt daemon.", isError: false };
+        return { text: `Cleared: maxSnapshotsDuration unset — workspace ${result.usedWorkspace} now inherits global auto-cleanup.`, isError: false };
       }
 
       // --- set path ---
       const cmd = new CommandExecutor();
-      const result = await cmd.config({ enableAutoCleanup: true, autoCleanupKeep: value });
+      const result = await cmd.config(undefined, { enableAutoCleanup: true, autoCleanupKeep: value });
       if (result.exitCode !== 0) {
-        return { text: `Failed to configure daemon: ${result.stderr}`, isError: true };
+        return { text: `Failed to configure workspace: ${result.stderr}`, isError: true };
       }
-      daemonAutoCleanup.cleanupDuration = value;
-      daemonAutoCleanup.cleanupNum = undefined; // mutually exclusive
-      return { text: `Updated ws-ckpt global daemon config: maxSnapshotsDuration = ${value} (auto-cleanup enabled, keep ${value})`, isError: false };
+      return { text: `Updated workspace policy for ${result.usedWorkspace}: maxSnapshotsDuration = ${value} (auto-cleanup enabled, keep ${value})`, isError: false };
     }
 
     if (key === "autoCheckpoint") {
-      const coerced = value === "true";
+      if (value === undefined) {
+        return { text: 'autoCheckpoint requires a value: "true" or "false"', isError: true };
+      }
+      const normalized = value.trim().toLowerCase();
+      // LLM tool callers and shell users emit a wide vocabulary; accept the
+      // common bool aliases instead of failing silently for anyone who didn't
+      // read stderr. Canonical form remains "true"/"false" in tool descriptions.
+      let coerced: boolean;
+      if (["true", "1", "yes", "on", "enabled"].includes(normalized)) {
+        coerced = true;
+      } else if (["false", "0", "no", "off", "disabled"].includes(normalized)) {
+        coerced = false;
+      } else {
+        return { text: `autoCheckpoint must be "true" or "false" (got "${value}")`, isError: true };
+      }
       if (coerced) {
         const ws = pluginState.resolvedConfig.workspace;
         if (ws) {

--- a/src/ws-ckpt/src/plugins/openclaw/src/index.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/index.ts
@@ -10,10 +10,9 @@
  * - 3 hooks: message_received, agent_end, session_start
  */
 
-import { PluginConfigManager, parseDaemonAutoCleanupConfig, daemonAutoCleanup } from "./config.js";
+import { PluginConfigManager } from "./config.js";
 import { EnvironmentChecker } from "./environment-check.js";
 import { BtrfsManager } from "./btrfs-manager.js";
-import { CommandExecutor } from "./commands.js";
 import type { PluginConfig } from "./types.js";
 import {
   definePluginEntry,
@@ -105,14 +104,10 @@ function register(api: OpenClawPluginApi): void {
       }
     }
 
-    // Query daemon auto-cleanup config to align in-memory state.
-    const cmd = new CommandExecutor();
-    const cfgResult = await cmd.config();
-    if (cfgResult.exitCode === 0) {
-      const { cleanupNum, cleanupDuration } = parseDaemonAutoCleanupConfig(cfgResult.stdout);
-      daemonAutoCleanup.cleanupNum = cleanupNum;
-      daemonAutoCleanup.cleanupDuration = cleanupDuration;
-    }
+    // No register-time policy prefetch: the view tool queries daemon
+    // every call anyway, and a stale prefetch from register time would
+    // mislead the user/LLM if the policy changed since then. Aligns with
+    // the hermes plugin (no cache).
   })();
 
   // ------------------------------------------------------------------

--- a/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
@@ -56,8 +56,8 @@ export function registerTools(api: OpenClawPluginApi): void {
               "New value as a string. Formats: " +
               "autoCheckpoint = \"true\"/\"false\"; " +
               "workspace = absolute path; " +
-              "maxSnapshotsNum = positive integer or \"unset\"; " +
-              "maxSnapshotsDuration = e.g. \"7d\"/\"24h\" or \"unset\".",
+              "maxSnapshotsNum = positive integer (or \"unset\" to restore inherit-global); " +
+              "maxSnapshotsDuration = e.g. \"7d\"/\"24h\" (or \"unset\" to restore inherit-global).",
           },
         },
       },

--- a/src/ws-ckpt/src/skills/ws-ckpt/SKILL.md
+++ b/src/ws-ckpt/src/skills/ws-ckpt/SKILL.md
@@ -105,6 +105,25 @@ ws-ckpt status
 ws-ckpt status -w <path-to-workspace
 ```
 
+### config — 查看或修改自动清理策略
+
+`ws-ckpt config` 的作用域由 scope 决定:不带 scope = 只读 overview(全局配置 + workspace 覆盖统计,带任何修改 flag 会报错);`-g` 全局;`-w <workspace>` 局部。
+
+```bash
+# 全局(daemon-wide)
+ws-ckpt config -g                                 # 查看
+ws-ckpt config -g --enable-auto-cleanup
+ws-ckpt config -g --auto-cleanup-keep 30d         # 或整数 20
+
+# 局部(只覆盖本 workspace 的 auto_cleanup / auto_cleanup_keep)
+ws-ckpt config -w <path-to-workspace>             # 三栏视图: effective / local / global
+ws-ckpt config -w <path-to-workspace> --auto-cleanup-keep 5
+ws-ckpt config -w <path-to-workspace> --disable-auto-cleanup
+ws-ckpt config -w <path-to-workspace> --reset     # 删除 policy.toml,沿用全局
+```
+
+`-w` 仅可覆盖 `auto_cleanup` 和 `auto_cleanup_keep`,interval/image/health-check 等是 daemon-wide,带 `-w` 设置会被 CLI 拒绝。
+
 ## 注意事项
 
 - checkpoint 用 `-i` 指定快照 ID;rollback 和 delete 用 `-s` 指定快照 ID,不要混淆


### PR DESCRIPTION
## Description

- 引入两层配置:全局 `/etc/ws-ckpt/config.toml`(daemon-wide 默认值)+ 局部
  `/var/lib/ws-ckpt/indexes/<ws_id>/policy.toml`(per-workspace 覆盖),
  `auto_cleanup` 与 `auto_cleanup_keep` 可逐 ws 覆盖
- `ws-ckpt config` 引入 `-g` / `-w` / `--reset` / `--format json` 作用域开关;
  不带 scope 给只读 overview
- daemon 新增 6 个 IPC(Get/Patch/Reset 三件套 + ReloadGlobal/ReloadWs/
  ConfigOverview)与版本化 JSON schema,reload 链 per-ws 先于 global 保证窗口
  只过保留不误删
- daemon 加固:`config_snapshot` 消费 RwLock poison、`wsid_locks` 串行化同
  ws_id 的 init/adopt/recover、recover 清理整个 per-ws index 目录避免同路径
  re-init 继承陈旧 policy.toml
- snapshot_mgr 抽出共享 cleanup helper,释放 ws RwLock 期间不卡慢 fs
- `atomic_write` 加 fchmod over stale `.tmp` 保护 0o600 policy.toml
- hermes / openclaw plugin 改走 `ws-ckpt config -w <ws> --format json`,删模块
  缓存,按 schema 严格区分 parse-error/disabled/count/age,堵掉 openclaw
  之前把 regex miss 当 disabled 的 bug

### 为什么要做

ws-ckpt 之前只有全局保留策略。多 workspace 场景下:hermes/openclaw plugin
用户改保留数会动 daemon-wide 默认影响别人;不同工作流(短期实验 vs 长期归档)
无法分别配置;LLM tool 调用偶发误操作会被放大到全局。per-ws policy.toml +
scope 化 CLI 把"用户调一个 ws"和"管理员调全局"解耦;daemon 层的硬化
(poison-safe / lifecycle lock / 共享 helper)是 per-ws IPC 高并发下不踩坑的
前置工作。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue: pre-emptive feature for multi-workspace cleanup isolation; no pre-filed issue

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
