### PR TITLE
feat(sight): stateful HPACK decoder for HTTP/2 header extraction

### DIFF
--- a/src/agentsight/src/aggregator/http2.rs
+++ b/src/agentsight/src/aggregator/http2.rs
@@ -4,14 +4,78 @@
 //! by their stream_id and correlating request (client->server) with response (server->client)
 //! to form complete HTTP/2 request/response pairs.
 
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use lru::LruCache;
+use hpack::Decoder;
 use crate::config::DEFAULT_CONNECTION_CAPACITY;
-use crate::parser::http2::ParsedHttp2Frame;
+use crate::parser::http2::{ParsedHttp2Frame, Http2FrameType};
 use crate::parser::sse::SSEParser;
 use crate::aggregator::http::ConnectionId;
 use crate::aggregator::result::AggregatedResult;
 use crate::chrome_trace::{ChromeTraceEvent, ToChromeTraceEvent, ns_to_us};
+
+const MAX_CONTINUATION_BUFFER: usize = 65536;
+
+/// Per-connection HPACK decoder state (one decoder per direction)
+struct HpackConnectionState {
+    req_decoder: Decoder<'static>,
+    resp_decoder: Decoder<'static>,
+}
+
+impl HpackConnectionState {
+    fn new() -> Self {
+        HpackConnectionState {
+            req_decoder: Decoder::new(),
+            resp_decoder: Decoder::new(),
+        }
+    }
+}
+
+impl std::fmt::Debug for HpackConnectionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HpackConnectionState").finish_non_exhaustive()
+    }
+}
+
+/// Buffer for reassembling CONTINUATION frames
+#[derive(Debug, Clone)]
+struct ContinuationBuffer {
+    data: Vec<u8>,
+    direction: StreamDirection,
+}
+
+/// Strip PADDED and PRIORITY framing from a HEADERS frame payload,
+/// returning the raw header block fragment.
+fn strip_headers_framing(payload: &[u8], flags: u8) -> &[u8] {
+    let mut offset = 0;
+    let mut end = payload.len();
+
+    // PADDED flag (0x08): first byte is pad_length, last pad_length bytes are padding
+    if flags & 0x08 != 0 {
+        if payload.is_empty() {
+            return &[];
+        }
+        let pad_length = payload[0] as usize;
+        offset += 1;
+        if end > pad_length {
+            end -= pad_length;
+        } else {
+            return &[];
+        }
+    }
+
+    // PRIORITY flag (0x20): 5 bytes (4-byte stream dependency + 1 byte weight)
+    if flags & 0x20 != 0 {
+        offset += 5;
+    }
+
+    if offset >= end {
+        return &[];
+    }
+
+    &payload[offset..end]
+}
 
 /// Stream identifier within an HTTP/2 connection
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
@@ -106,6 +170,10 @@ pub struct Http2Stream {
     pub start_timestamp_ns: u64,
     /// Timestamp of the last frame
     pub end_timestamp_ns: u64,
+    /// Decoded request headers from stateful HPACK (name, value) pairs
+    pub decoded_request_headers: Option<Vec<(String, String)>>,
+    /// Decoded response headers from stateful HPACK (name, value) pairs
+    pub decoded_response_headers: Option<Vec<(String, String)>>,
 }
 
 impl Http2Stream {
@@ -121,6 +189,8 @@ impl Http2Stream {
             response_complete: false,
             start_timestamp_ns: timestamp_ns,
             end_timestamp_ns: timestamp_ns,
+            decoded_request_headers: None,
+            decoded_response_headers: None,
         }
     }
 
@@ -166,31 +236,20 @@ impl Http2Stream {
         self.is_complete()
     }
 
-    /// Concatenate all request data frames into a single buffer
+    /// Concatenate all request DATA frames into a single buffer.
+    /// HEADERS payload is HPACK-encoded metadata, not body data.
     pub fn request_body(&self) -> Vec<u8> {
         let mut result = Vec::new();
-        if let Some(ref headers) = self.request_headers {
-            // Include any data from HEADERS frame (though typically empty for HEADERS)
-            let payload = headers.payload();
-            if !payload.is_empty() {
-                result.extend_from_slice(payload);
-            }
-        }
         for frame in &self.request_data_frames {
             result.extend_from_slice(frame.payload());
         }
         result
     }
 
-    /// Concatenate all response data frames into a single buffer
+    /// Concatenate all response DATA frames into a single buffer.
+    /// HEADERS payload is HPACK-encoded metadata, not body data.
     pub fn response_body(&self) -> Vec<u8> {
         let mut result = Vec::new();
-        if let Some(ref headers) = self.response_headers {
-            let payload = headers.payload();
-            if !payload.is_empty() {
-                result.extend_from_slice(payload);
-            }
-        }
         for frame in &self.response_data_frames {
             result.extend_from_slice(frame.payload());
         }
@@ -305,7 +364,13 @@ impl Http2Stream {
     }
 
     /// Extract HTTP method from request headers (e.g., "GET", "POST")
+    /// Prefers stateful decoded headers, falls back to stateless.
     pub fn method(&self) -> String {
+        if let Some(ref hdrs) = self.decoded_request_headers {
+            if let Some((_, v)) = hdrs.iter().find(|(n, _)| n == ":method") {
+                return v.clone();
+            }
+        }
         self.request_headers.as_ref()
             .map(|h| {
                 let headers = h.decode_headers_stateless();
@@ -318,7 +383,13 @@ impl Http2Stream {
     }
 
     /// Extract path from request headers (e.g., "/v1/chat/completions")
+    /// Prefers stateful decoded headers, falls back to stateless.
     pub fn path(&self) -> String {
+        if let Some(ref hdrs) = self.decoded_request_headers {
+            if let Some((_, v)) = hdrs.iter().find(|(n, _)| n == ":path") {
+                return v.clone();
+            }
+        }
         self.request_headers.as_ref()
             .map(|h| {
                 let headers = h.decode_headers_stateless();
@@ -331,7 +402,13 @@ impl Http2Stream {
     }
 
     /// Extract status code from response headers
+    /// Prefers stateful decoded headers, falls back to stateless.
     pub fn status_code(&self) -> u16 {
+        if let Some(ref hdrs) = self.decoded_response_headers {
+            if let Some((_, v)) = hdrs.iter().find(|(n, _)| n == ":status") {
+                return v.parse().unwrap_or(0);
+            }
+        }
         self.response_headers.as_ref()
             .map(|h| {
                 let headers = h.decode_headers_stateless();
@@ -391,16 +468,30 @@ impl Http2Stream {
     }
 }
 
+/// Decoded headers pair for a stream (request + response)
+#[derive(Debug, Clone, Default)]
+struct DecodedHeadersPair {
+    request: Option<Vec<(String, String)>>,
+    response: Option<Vec<(String, String)>>,
+}
+
 /// HTTP/2 Stream Aggregator
 ///
 /// Aggregates HTTP/2 frames by stream_id within a connection,
 /// correlating request and response frames to form complete streams.
+/// Maintains per-connection HPACK decoder state for stateful header decoding.
 #[derive(Debug)]
 pub struct Http2StreamAggregator {
     /// Active streams being aggregated (key: StreamId)
     streams: LruCache<StreamId, Http2StreamState>,
     /// Completed streams waiting to be retrieved
     completed_streams: Vec<Http2Stream>,
+    /// Per-connection HPACK decoder state
+    hpack_states: LruCache<ConnectionId, HpackConnectionState>,
+    /// Buffers for CONTINUATION frame reassembly (key: StreamId)
+    continuation_buffers: HashMap<StreamId, ContinuationBuffer>,
+    /// Decoded headers waiting to be attached to streams on completion
+    decoded_headers_store: HashMap<StreamId, DecodedHeadersPair>,
 }
 
 impl Default for Http2StreamAggregator {
@@ -415,6 +506,9 @@ impl Http2StreamAggregator {
         Http2StreamAggregator {
             streams: LruCache::new(NonZeroUsize::new(DEFAULT_CONNECTION_CAPACITY * 4).unwrap()),
             completed_streams: Vec::new(),
+            hpack_states: LruCache::new(NonZeroUsize::new(DEFAULT_CONNECTION_CAPACITY).unwrap()),
+            continuation_buffers: HashMap::new(),
+            decoded_headers_store: HashMap::new(),
         }
     }
 
@@ -423,49 +517,233 @@ impl Http2StreamAggregator {
         Http2StreamAggregator {
             streams: LruCache::new(NonZeroUsize::new(capacity).unwrap()),
             completed_streams: Vec::new(),
+            hpack_states: LruCache::new(NonZeroUsize::new(capacity).unwrap()),
+            continuation_buffers: HashMap::new(),
+            decoded_headers_store: HashMap::new(),
         }
     }
 
     /// Process a batch of HTTP/2 frames
     ///
-    /// Returns completed streams that have both request and response with END_STREAM
+    /// Returns completed streams that have both request and response with END_STREAM.
+    /// Handles SETTINGS (dynamic table size), HEADERS (with PADDED/PRIORITY stripping),
+    /// and CONTINUATION reassembly with stateful HPACK decoding.
     pub fn process_frames(&mut self, frames: Vec<ParsedHttp2Frame>) -> Vec<Http2Stream> {
         let mut completed = Vec::new();
 
         for frame in frames {
-            // Skip non-stream frames (SETTINGS, PING, etc.)
+            let connection_id = ConnectionId::from_ssl_event(&frame.source_event);
+            let direction = StreamDirection::from_rw(frame.source_event.rw);
+
+            // Handle connection-level frames (stream_id == 0)
             if frame.stream_id == 0 {
+                if frame.is_settings() {
+                    self.handle_settings_frame(&frame, connection_id, direction);
+                }
                 continue;
             }
 
-            let connection_id = ConnectionId::from_ssl_event(&frame.source_event);
             let stream_id = StreamId::new(connection_id, frame.stream_id);
-            let direction = StreamDirection::from_rw(frame.source_event.rw);
 
-            // Get or create stream state
-            let state = self.streams.pop(&stream_id);
-            let mut state = state.unwrap_or_else(|| {
+            // Handle CONTINUATION frames: buffer until END_HEADERS
+            if frame.frame_type == Http2FrameType::Continuation {
+                self.handle_continuation_frame(&frame, stream_id, connection_id, direction);
+                continue;
+            }
+
+            // Handle HEADERS frames: strip framing, possibly buffer for CONTINUATION
+            if frame.is_headers() {
+                let decoded = if frame.has_end_headers() {
+                    let fragment = strip_headers_framing(frame.payload(), frame.flags);
+                    self.decode_header_block(connection_id, direction, fragment)
+                } else {
+                    // No END_HEADERS — start buffering for CONTINUATION
+                    let fragment = strip_headers_framing(frame.payload(), frame.flags);
+                    if fragment.len() <= MAX_CONTINUATION_BUFFER {
+                        self.continuation_buffers.insert(stream_id, ContinuationBuffer {
+                            data: fragment.to_vec(),
+                            direction,
+                        });
+                    }
+                    None
+                };
+
+                self.store_decoded_headers(stream_id, direction, decoded);
+
+                // Get or create stream state, process frame
+                let state = self.streams.pop(&stream_id).unwrap_or_else(|| {
+                    Http2StreamState::WaitingRequestData {
+                        request_headers: None,
+                        request_data_frames: Vec::new(),
+                    }
+                });
+
+                let state = self.process_frame_in_state(state, frame, direction, &stream_id);
+
+                match state {
+                    Http2StreamState::Complete(stream) => {
+                        completed.push(self.finalize_stream(stream_id, stream));
+                    }
+                    _ => { self.insert_stream_state(stream_id, state); }
+                }
+                continue;
+            }
+
+            // DATA and other frames: normal processing
+            let state = self.streams.pop(&stream_id).unwrap_or_else(|| {
                 Http2StreamState::WaitingRequestData {
                     request_headers: None,
                     request_data_frames: Vec::new(),
                 }
             });
 
-            // Process frame based on current state and direction
-            state = self.process_frame_in_state(state, frame, direction, &stream_id);
+            let state = self.process_frame_in_state(state, frame, direction, &stream_id);
 
-            // Check if stream is now complete
             match state {
                 Http2StreamState::Complete(stream) => {
-                    completed.push(stream);
+                    completed.push(self.finalize_stream(stream_id, stream));
                 }
-                _ => {
-                    self.streams.put(stream_id, state);
-                }
+                _ => { self.insert_stream_state(stream_id, state); }
             }
         }
 
         completed
+    }
+
+    /// Handle SETTINGS frame: update HPACK decoder dynamic table size
+    fn handle_settings_frame(&mut self, frame: &ParsedHttp2Frame, conn_id: ConnectionId, direction: StreamDirection) {
+        // ACK frames have no payload
+        if frame.flags & 0x01 != 0 {
+            return;
+        }
+
+        let payload = frame.payload();
+        // SETTINGS payload is a list of 6-byte entries: (2-byte id, 4-byte value)
+        let mut pos = 0;
+        while pos + 6 <= payload.len() {
+            let id = ((payload[pos] as u16) << 8) | payload[pos + 1] as u16;
+            let value = ((payload[pos + 2] as u32) << 24)
+                | ((payload[pos + 3] as u32) << 16)
+                | ((payload[pos + 4] as u32) << 8)
+                | payload[pos + 5] as u32;
+            pos += 6;
+
+            // SETTINGS_HEADER_TABLE_SIZE (0x01)
+            // Per RFC 7540 §6.5.2: SETTINGS from peer X constrains the OTHER
+            // direction's encoder, so we resize the decoder for the opposite direction.
+            if id == 0x01 {
+                let state = self.hpack_states.get_or_insert_mut(conn_id, HpackConnectionState::new);
+                match direction {
+                    StreamDirection::Request => state.resp_decoder.set_max_table_size(value as usize),
+                    StreamDirection::Response => state.req_decoder.set_max_table_size(value as usize),
+                }
+                log::debug!("HPACK table size update: conn={:?} dir={:?} size={}", conn_id, direction, value);
+            }
+        }
+    }
+
+    /// Handle CONTINUATION frame: append to buffer, decode on END_HEADERS
+    fn handle_continuation_frame(
+        &mut self,
+        frame: &ParsedHttp2Frame,
+        stream_id: StreamId,
+        conn_id: ConnectionId,
+        _direction: StreamDirection,
+    ) {
+        let payload = frame.payload();
+
+        if let Some(buffer) = self.continuation_buffers.get_mut(&stream_id) {
+            if buffer.data.len() + payload.len() <= MAX_CONTINUATION_BUFFER {
+                buffer.data.extend_from_slice(payload);
+            } else {
+                log::warn!("CONTINUATION buffer overflow for stream {:?}, dropping", stream_id);
+                self.continuation_buffers.remove(&stream_id);
+                return;
+            }
+
+            if frame.has_end_headers() {
+                let buffer = self.continuation_buffers.remove(&stream_id).unwrap();
+                let decoded = self.decode_header_block(conn_id, buffer.direction, &buffer.data);
+                self.store_decoded_headers(stream_id, buffer.direction, decoded);
+            }
+        }
+        // If no buffer exists, this CONTINUATION is orphaned — ignore
+    }
+
+    /// Decode a header block fragment using the stateful HPACK decoder.
+    /// On error, resets the decoder for that direction and returns None.
+    fn decode_header_block(
+        &mut self,
+        conn_id: ConnectionId,
+        direction: StreamDirection,
+        fragment: &[u8],
+    ) -> Option<Vec<(String, String)>> {
+        if fragment.is_empty() {
+            return Some(Vec::new());
+        }
+
+        let state = self.hpack_states.get_or_insert_mut(conn_id, HpackConnectionState::new);
+        let decoder = match direction {
+            StreamDirection::Request => &mut state.req_decoder,
+            StreamDirection::Response => &mut state.resp_decoder,
+        };
+
+        match decoder.decode(fragment) {
+            Ok(headers) => {
+                let result: Vec<(String, String)> = headers
+                    .into_iter()
+                    .map(|(name, value)| {
+                        (String::from_utf8_lossy(&name).into_owned(),
+                         String::from_utf8_lossy(&value).into_owned())
+                    })
+                    .collect();
+                Some(result)
+            }
+            Err(e) => {
+                log::warn!("HPACK decode error for conn={:?} dir={:?}: {:?}, resetting decoder",
+                    conn_id, direction, e);
+                // Reset decoder for this direction
+                let state = self.hpack_states.get_or_insert_mut(conn_id, HpackConnectionState::new);
+                match direction {
+                    StreamDirection::Request => state.req_decoder = Decoder::new(),
+                    StreamDirection::Response => state.resp_decoder = Decoder::new(),
+                }
+                None
+            }
+        }
+    }
+
+    /// Insert stream state back into LRU, cleaning up side-maps on eviction.
+    fn insert_stream_state(&mut self, stream_id: StreamId, state: Http2StreamState) {
+        if let Some((evicted_id, _)) = self.streams.push(stream_id, state) {
+            self.continuation_buffers.remove(&evicted_id);
+            self.decoded_headers_store.remove(&evicted_id);
+        }
+    }
+
+    /// Store decoded headers for a stream. They'll be attached when the stream completes.
+    fn store_decoded_headers(
+        &mut self,
+        stream_id: StreamId,
+        direction: StreamDirection,
+        decoded: Option<Vec<(String, String)>>,
+    ) {
+        if let Some(hdrs) = decoded {
+            let pair = self.decoded_headers_store.entry(stream_id).or_default();
+            match direction {
+                StreamDirection::Request => pair.request = Some(hdrs),
+                StreamDirection::Response => pair.response = Some(hdrs),
+            }
+        }
+    }
+
+    /// Finalize a completed stream by attaching any decoded headers from the store.
+    fn finalize_stream(&mut self, stream_id: StreamId, mut stream: Http2Stream) -> Http2Stream {
+        if let Some(pair) = self.decoded_headers_store.remove(&stream_id) {
+            stream.decoded_request_headers = pair.request;
+            stream.decoded_response_headers = pair.response;
+        }
+        stream
     }
 
     /// Process a single frame within the context of a stream state
@@ -638,20 +916,23 @@ impl Http2StreamAggregator {
     pub fn clear(&mut self) {
         self.streams.clear();
         self.completed_streams.clear();
+        self.hpack_states.clear();
+        self.continuation_buffers.clear();
+        self.decoded_headers_store.clear();
     }
 
     /// Drain all pending streams and return them as completed
     /// Useful for shutdown or forced completion
     pub fn drain_pending(&mut self) -> Vec<Http2Stream> {
         let mut result = Vec::new();
-        
+
         // Move all streams from LRU cache
         while let Some((stream_id, state)) = self.streams.pop_lru() {
             if let Some(stream) = self.stream_from_state(state, stream_id) {
-                result.push(stream);
+                result.push(self.finalize_stream(stream_id, stream));
             }
         }
-        
+
         result
     }
 
@@ -744,6 +1025,7 @@ impl ToChromeTraceEvent for Http2Stream {
 mod tests {
     use super::*;
     use std::rc::Rc;
+    use hpack::Encoder;
     use crate::probes::sslsniff::SslEvent;
 
     fn create_test_event(pid: u32, ssl_ptr: u64, rw: i32, timestamp_ns: u64) -> Rc<SslEvent> {
@@ -772,7 +1054,7 @@ mod tests {
     ) -> ParsedHttp2Frame {
         let payload_offset = 9; // Skip frame header
         let payload_len = payload.len();
-        
+
         // Create a new event with the payload in buf
         let mut buf = Vec::with_capacity(9 + payload_len);
         // Frame header
@@ -787,7 +1069,7 @@ mod tests {
         buf.push((stream_id & 0xFF) as u8);
         // Payload
         buf.extend_from_slice(&payload);
-        
+
         let event_with_buf = Rc::new(SslEvent {
             source: event.source,
             timestamp_ns: event.timestamp_ns,
@@ -804,11 +1086,7 @@ mod tests {
         });
 
         ParsedHttp2Frame {
-            frame_type: match frame_type {
-                0 => crate::parser::http2::Http2FrameType::Data,
-                1 => crate::parser::http2::Http2FrameType::Headers,
-                _ => crate::parser::http2::Http2FrameType::Unknown(frame_type),
-            },
+            frame_type: Http2FrameType::from_u8(frame_type),
             flags,
             stream_id,
             payload_offset,
@@ -885,9 +1163,289 @@ mod tests {
 
         let completed = aggregator.process_frames(vec![resp_headers]);
         assert_eq!(completed.len(), 1);
-        
+
         let stream = &completed[0];
         assert_eq!(stream.request_data_frames.len(), 1);
         assert_eq!(stream.response_data_frames.len(), 0);
+    }
+
+    // --- HPACK stateful decode tests ---
+
+    #[test]
+    fn test_strip_headers_framing_bare() {
+        let payload = b"\x82\x86\x84";
+        assert_eq!(strip_headers_framing(payload, 0x00), payload.as_slice());
+    }
+
+    #[test]
+    fn test_strip_headers_framing_padded() {
+        // PADDED flag = 0x08: first byte = pad_length, last N bytes = padding
+        let mut payload = vec![3]; // pad_length = 3
+        payload.extend_from_slice(b"\x82\x86\x84"); // header block fragment
+        payload.extend_from_slice(&[0, 0, 0]); // 3 bytes of padding
+        let result = strip_headers_framing(&payload, 0x08);
+        assert_eq!(result, b"\x82\x86\x84");
+    }
+
+    #[test]
+    fn test_strip_headers_framing_priority() {
+        // PRIORITY flag = 0x20: 5 bytes (4-byte dependency + 1 byte weight)
+        let mut payload = vec![0x80, 0x00, 0x00, 0x01, 0x10]; // priority data
+        payload.extend_from_slice(b"\x82\x86"); // header block fragment
+        let result = strip_headers_framing(&payload, 0x20);
+        assert_eq!(result, b"\x82\x86");
+    }
+
+    #[test]
+    fn test_strip_headers_framing_padded_and_priority() {
+        // Both PADDED (0x08) and PRIORITY (0x20) = 0x28
+        let mut payload = vec![2]; // pad_length = 2
+        payload.extend_from_slice(&[0x80, 0x00, 0x00, 0x01, 0x10]); // priority
+        payload.extend_from_slice(b"\x82"); // header block fragment
+        payload.extend_from_slice(&[0, 0]); // 2 bytes padding
+        let result = strip_headers_framing(&payload, 0x28);
+        assert_eq!(result, b"\x82");
+    }
+
+    #[test]
+    fn test_strip_headers_framing_empty_after_strip() {
+        // Only padding, no actual content
+        let payload = vec![5, 0, 0, 0, 0, 0]; // pad_length=5, then 5 bytes padding
+        let result = strip_headers_framing(&payload, 0x08);
+        assert_eq!(result, &[] as &[u8]);
+    }
+
+    #[test]
+    fn test_stateful_hpack_decode_static_table() {
+        // Use hpack::Encoder to produce valid HPACK blocks
+        let mut encoder = Encoder::new();
+        let headers = vec![
+            (b":method".to_vec(), b"POST".to_vec()),
+            (b":path".to_vec(), b"/v1/chat/completions".to_vec()),
+            (b":scheme".to_vec(), b"https".to_vec()),
+        ];
+        let encoded = encoder.encode(headers.iter().map(|(n, v)| (&n[..], &v[..])));
+
+        let mut aggregator = Http2StreamAggregator::new();
+        let conn_id = ConnectionId { pid: 100, ssl_ptr: 0x2000 };
+        let decoded = aggregator.decode_header_block(conn_id, StreamDirection::Request, &encoded);
+
+        assert!(decoded.is_some());
+        let hdrs = decoded.unwrap();
+        assert_eq!(hdrs.iter().find(|(n, _)| n == ":method").unwrap().1, "POST");
+        assert_eq!(hdrs.iter().find(|(n, _)| n == ":path").unwrap().1, "/v1/chat/completions");
+        assert_eq!(hdrs.iter().find(|(n, _)| n == ":scheme").unwrap().1, "https");
+    }
+
+    #[test]
+    fn test_stateful_hpack_decode_dynamic_table() {
+        // Verify that the second request using dynamic table refs decodes correctly
+        let mut encoder = Encoder::new();
+        let conn_id = ConnectionId { pid: 200, ssl_ptr: 0x3000 };
+        let mut aggregator = Http2StreamAggregator::new();
+
+        // First request: headers get added to dynamic table
+        let headers1 = vec![
+            (b":method".to_vec(), b"POST".to_vec()),
+            (b":path".to_vec(), b"/v1/chat/completions".to_vec()),
+            (b"authorization".to_vec(), b"Bearer sk-test123".to_vec()),
+        ];
+        let encoded1 = encoder.encode(headers1.iter().map(|(n, v)| (&n[..], &v[..])));
+        let decoded1 = aggregator.decode_header_block(conn_id, StreamDirection::Request, &encoded1);
+        assert!(decoded1.is_some());
+
+        // Second request: encoder reuses dynamic table entries (shorter encoding)
+        let headers2 = vec![
+            (b":method".to_vec(), b"POST".to_vec()),
+            (b":path".to_vec(), b"/v1/chat/completions".to_vec()),
+            (b"authorization".to_vec(), b"Bearer sk-test123".to_vec()),
+        ];
+        let encoded2 = encoder.encode(headers2.iter().map(|(n, v)| (&n[..], &v[..])));
+        // Second encoding should be shorter due to dynamic table
+        assert!(encoded2.len() <= encoded1.len());
+
+        let decoded2 = aggregator.decode_header_block(conn_id, StreamDirection::Request, &encoded2);
+        assert!(decoded2.is_some());
+        let hdrs = decoded2.unwrap();
+        assert_eq!(hdrs.iter().find(|(n, _)| n == ":path").unwrap().1, "/v1/chat/completions");
+        assert_eq!(hdrs.iter().find(|(n, _)| n == "authorization").unwrap().1, "Bearer sk-test123");
+    }
+
+    #[test]
+    fn test_stateful_hpack_error_recovery() {
+        let mut aggregator = Http2StreamAggregator::new();
+        let conn_id = ConnectionId { pid: 300, ssl_ptr: 0x4000 };
+
+        // Feed corrupt data — should fail and reset decoder
+        let corrupt = vec![0xFF, 0xFF, 0xFF, 0xFF];
+        let decoded = aggregator.decode_header_block(conn_id, StreamDirection::Request, &corrupt);
+        assert!(decoded.is_none());
+
+        // After reset, valid HPACK should decode fine
+        let mut encoder = Encoder::new();
+        let headers = vec![
+            (b":method".to_vec(), b"GET".to_vec()),
+            (b":path".to_vec(), b"/health".to_vec()),
+        ];
+        let encoded = encoder.encode(headers.iter().map(|(n, v)| (&n[..], &v[..])));
+        let decoded = aggregator.decode_header_block(conn_id, StreamDirection::Request, &encoded);
+        assert!(decoded.is_some());
+        let hdrs = decoded.unwrap();
+        assert_eq!(hdrs.iter().find(|(n, _)| n == ":method").unwrap().1, "GET");
+    }
+
+    #[test]
+    fn test_continuation_reassembly() {
+        let mut aggregator = Http2StreamAggregator::new();
+        let mut encoder = Encoder::new();
+
+        let headers = vec![
+            (b":method".to_vec(), b"POST".to_vec()),
+            (b":path".to_vec(), b"/v1/chat/completions".to_vec()),
+            (b":scheme".to_vec(), b"https".to_vec()),
+            (b"content-type".to_vec(), b"application/json".to_vec()),
+        ];
+        let encoded = encoder.encode(headers.iter().map(|(n, v)| (&n[..], &v[..])));
+
+        // Split encoded block into two parts
+        let mid = encoded.len() / 2;
+        let part1 = &encoded[..mid];
+        let part2 = &encoded[mid..];
+
+        // HEADERS frame without END_HEADERS (flags=0x00), with END_STREAM (0x01)
+        let req_event = create_test_event(400, 0x5000, 1, 1000);
+        let headers_frame = create_test_frame(1, 1, 0x01, part1.to_vec(), req_event.clone());
+
+        // CONTINUATION frame with END_HEADERS (flags=0x04)
+        let cont_frame = create_test_frame(1, 9, 0x04, part2.to_vec(), req_event);
+
+        // Process: HEADERS then CONTINUATION
+        let completed = aggregator.process_frames(vec![headers_frame, cont_frame]);
+        assert!(completed.is_empty()); // Still waiting for response
+
+        // Send response to complete the stream
+        let mut resp_encoder = Encoder::new();
+        let resp_headers = vec![(b":status".to_vec(), b"200".to_vec())];
+        let resp_encoded = resp_encoder.encode(resp_headers.iter().map(|(n, v)| (&n[..], &v[..])));
+        let resp_event = create_test_event(400, 0x5000, 0, 2000);
+        let resp_frame = create_test_frame(1, 1, 0x05, resp_encoded, resp_event);
+
+        let completed = aggregator.process_frames(vec![resp_frame]);
+        assert_eq!(completed.len(), 1);
+
+        let stream = &completed[0];
+        // Decoded request headers should be available
+        assert!(stream.decoded_request_headers.is_some());
+        let req_hdrs = stream.decoded_request_headers.as_ref().unwrap();
+        assert_eq!(req_hdrs.iter().find(|(n, _)| n == ":method").unwrap().1, "POST");
+        assert_eq!(req_hdrs.iter().find(|(n, _)| n == ":path").unwrap().1, "/v1/chat/completions");
+        assert_eq!(req_hdrs.iter().find(|(n, _)| n == "content-type").unwrap().1, "application/json");
+    }
+
+    #[test]
+    fn test_settings_table_size_update() {
+        let mut aggregator = Http2StreamAggregator::new();
+        let conn_id = ConnectionId { pid: 500, ssl_ptr: 0x6000 };
+
+        // SETTINGS frame with HEADER_TABLE_SIZE = 0 (disable dynamic table)
+        // Format: 2-byte id (0x0001) + 4-byte value (0x00000000)
+        let settings_payload = vec![0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
+        let settings_event = create_test_event(500, 0x6000, 0, 1000); // from server
+        let settings_frame = create_test_frame(0, 4, 0x00, settings_payload, settings_event);
+
+        aggregator.process_frames(vec![settings_frame]);
+
+        // The decoder should now have table_size=0
+        // Encode with literal-only (since table_size=0 the encoder won't add to dynamic table)
+        let mut encoder = Encoder::new();
+        let headers = vec![
+            (b":status".to_vec(), b"200".to_vec()),
+        ];
+        let encoded = encoder.encode(headers.iter().map(|(n, v)| (&n[..], &v[..])));
+        let decoded = aggregator.decode_header_block(conn_id, StreamDirection::Response, &encoded);
+        assert!(decoded.is_some());
+        assert_eq!(decoded.unwrap().iter().find(|(n, _)| n == ":status").unwrap().1, "200");
+    }
+
+    #[test]
+    fn test_full_hpack_request_response_with_decoded_headers() {
+        let mut aggregator = Http2StreamAggregator::new();
+        let mut req_encoder = Encoder::new();
+        let mut resp_encoder = Encoder::new();
+
+        // Encode request headers
+        let req_headers = vec![
+            (b":method".to_vec(), b"POST".to_vec()),
+            (b":path".to_vec(), b"/v1/chat/completions".to_vec()),
+            (b":scheme".to_vec(), b"https".to_vec()),
+        ];
+        let req_encoded = req_encoder.encode(req_headers.iter().map(|(n, v)| (&n[..], &v[..])));
+
+        // Request HEADERS with END_HEADERS (0x04), no END_STREAM (body follows)
+        let req_event = create_test_event(600, 0x7000, 1, 1000);
+        let req_hdr_frame = create_test_frame(3, 1, 0x04, req_encoded, req_event.clone());
+
+        // Request DATA with END_STREAM
+        let req_data_frame = create_test_frame(
+            3, 0, 0x01,
+            b"{\"model\":\"qwen\",\"messages\":[]}".to_vec(),
+            req_event,
+        );
+
+        aggregator.process_frames(vec![req_hdr_frame, req_data_frame]);
+
+        // Encode response headers
+        let resp_headers = vec![
+            (b":status".to_vec(), b"200".to_vec()),
+            (b"content-type".to_vec(), b"application/json".to_vec()),
+        ];
+        let resp_encoded = resp_encoder.encode(resp_headers.iter().map(|(n, v)| (&n[..], &v[..])));
+
+        // Response HEADERS with END_HEADERS (0x04), no END_STREAM
+        let resp_event = create_test_event(600, 0x7000, 0, 2000);
+        let resp_hdr_frame = create_test_frame(3, 1, 0x04, resp_encoded, resp_event.clone());
+
+        // Response DATA with END_STREAM
+        let resp_data_frame = create_test_frame(
+            3, 0, 0x01,
+            b"{\"id\":\"chatcmpl-1\",\"choices\":[]}".to_vec(),
+            resp_event,
+        );
+
+        let completed = aggregator.process_frames(vec![resp_hdr_frame, resp_data_frame]);
+        assert_eq!(completed.len(), 1);
+
+        let stream = &completed[0];
+        // Verify decoded headers are attached
+        assert!(stream.decoded_request_headers.is_some());
+        assert!(stream.decoded_response_headers.is_some());
+
+        // path()/method()/status_code() should use decoded headers
+        assert_eq!(stream.path(), "/v1/chat/completions");
+        assert_eq!(stream.method(), "POST");
+        assert_eq!(stream.status_code(), 200);
+    }
+
+    #[test]
+    fn test_independent_req_resp_decoders() {
+        // Request and response decoders are independent per connection
+        let mut aggregator = Http2StreamAggregator::new();
+        let conn_id = ConnectionId { pid: 700, ssl_ptr: 0x8000 };
+
+        let mut req_encoder = Encoder::new();
+        let mut resp_encoder = Encoder::new();
+
+        // Request direction decode
+        let req_h = vec![(b":method".to_vec(), b"GET".to_vec())];
+        let req_enc = req_encoder.encode(req_h.iter().map(|(n, v)| (&n[..], &v[..])));
+        let req_dec = aggregator.decode_header_block(conn_id, StreamDirection::Request, &req_enc);
+        assert!(req_dec.is_some());
+
+        // Response direction decode (independent table)
+        let resp_h = vec![(b":status".to_vec(), b"404".to_vec())];
+        let resp_enc = resp_encoder.encode(resp_h.iter().map(|(n, v)| (&n[..], &v[..])));
+        let resp_dec = aggregator.decode_header_block(conn_id, StreamDirection::Response, &resp_enc);
+        assert!(resp_dec.is_some());
+        assert_eq!(resp_dec.unwrap()[0], (":status".to_string(), "404".to_string()));
     }
 }

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -528,10 +528,19 @@ impl Analyzer {
                 let req_body = request.json_body();
                 self.analyze_message(&request.path, req_body.as_ref(), None)
             }
+            AggregatedResult::Http2StreamComplete(stream) => {
+                let path = stream.path();
+                if path.is_empty() {
+                    return None;
+                }
+                let req_body = stream.request_json_body();
+                let resp_body = stream.response_sse_json_array()
+                    .or_else(|| stream.response_json_body());
+                self.analyze_message(&path, req_body.as_ref(), resp_body.as_ref())
+            }
             AggregatedResult::ResponseOnly { .. }
             | AggregatedResult::ProcessComplete(_)
-            | AggregatedResult::Http2Frames { .. }
-            | AggregatedResult::Http2StreamComplete(_) => None,
+            | AggregatedResult::Http2Frames { .. } => None,
         }
     }
 

--- a/src/agentsight/src/parser/http2/frame.rs
+++ b/src/agentsight/src/parser/http2/frame.rs
@@ -105,6 +105,10 @@ impl ParsedHttp2Frame {
         self.frame_type == Http2FrameType::Settings
     }
 
+    pub fn is_continuation(&self) -> bool {
+        self.frame_type == Http2FrameType::Continuation
+    }
+
     /// Check END_STREAM flag (0x01) on DATA/HEADERS frames
     pub fn has_end_stream(&self) -> bool {
         matches!(self.frame_type, Http2FrameType::Data | Http2FrameType::Headers)

--- a/src/agentsight/src/parser/http2/parser.rs
+++ b/src/agentsight/src/parser/http2/parser.rs
@@ -71,15 +71,18 @@ impl Http2Parser {
                 source_event: Rc::clone(&event),
             };
 
-            // Only keep DATA frames for API payload analysis
-            if frame.is_data() {
-                log::debug!(
-                    "HTTP/2 DATA frame: stream={} flags={} len={}, payload={}",
-                    stream_id,
-                    frame.flags_description(),
-                    length,
-                    frame.body_str()
-                );
+            if frame.is_data() || frame.is_headers() || frame.is_continuation() || frame.is_settings() {
+                if frame.is_data() {
+                    log::debug!(
+                        "HTTP/2 DATA frame: stream={} flags={} len={}",
+                        stream_id, frame.flags_description(), length,
+                    );
+                } else {
+                    log::trace!(
+                        "HTTP/2 {:?} frame: stream={} flags={} len={}",
+                        frame.frame_type, stream_id, frame.flags_description(), length,
+                    );
+                }
                 frames.push(frame);
             }
 
@@ -151,17 +154,36 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_non_data_frames_filtered() {
-        // SETTINGS frame should be filtered out
+    fn test_parse_headers_and_settings_kept() {
+        // SETTINGS frame is now kept (needed for HPACK table size updates)
         let raw = build_frame(4, 0x01, 0, &[]);
+        let event = create_test_event(raw);
+        let parser = Http2Parser::new();
+        let frames = parser.parse(event);
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].is_settings());
+
+        // HEADERS frame is now kept (needed for HPACK decode)
+        let hpack_data = vec![0x82, 0x86, 0x84];
+        let raw = build_frame(1, 0x05, 3, &hpack_data);
+        let event = create_test_event(raw);
+        let parser = Http2Parser::new();
+        let frames = parser.parse(event);
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].is_headers());
+    }
+
+    #[test]
+    fn test_parse_irrelevant_frames_filtered() {
+        // WINDOW_UPDATE (type=8) should still be filtered out
+        let raw = build_frame(8, 0x00, 1, &[0x00, 0x00, 0x00, 0x01]);
         let event = create_test_event(raw);
         let parser = Http2Parser::new();
         let frames = parser.parse(event);
         assert_eq!(frames.len(), 0);
 
-        // HEADERS frame should be filtered out
-        let hpack_data = vec![0x82, 0x86, 0x84];
-        let raw = build_frame(1, 0x05, 3, &hpack_data);
+        // PING (type=6) should still be filtered out
+        let raw = build_frame(6, 0x00, 0, &[0; 8]);
         let event = create_test_event(raw);
         let parser = Http2Parser::new();
         let frames = parser.parse(event);
@@ -169,17 +191,18 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_multiple_frames_only_data_kept() {
+    fn test_parse_multiple_frames_settings_and_data_kept() {
         let mut raw = build_frame(4, 0x00, 0, &[0x00, 0x03, 0x00, 0x00, 0x00, 0x64]); // SETTINGS
         raw.extend(build_frame(0, 0x01, 1, b"{\"ok\":true}")); // DATA END_STREAM
         let event = create_test_event(raw);
         let parser = Http2Parser::new();
         let frames = parser.parse(event);
 
-        // Only DATA frame is kept
-        assert_eq!(frames.len(), 1);
-        assert!(frames[0].is_data());
-        assert_eq!(frames[0].body_str(), "{\"ok\":true}");
+        // Both SETTINGS and DATA frames are kept
+        assert_eq!(frames.len(), 2);
+        assert!(frames[0].is_settings());
+        assert!(frames[1].is_data());
+        assert_eq!(frames[1].body_str(), "{\"ok\":true}");
     }
 
     #[test]
@@ -254,8 +277,7 @@ mod tests {
     #[test]
     fn test_sample_data_from_python_script() {
         // Test vector from scripts/http2_parser.py
-        // Contains a HEADERS frame (len=83) and an incomplete DATA frame (len=16384, truncated)
-        // Since we only keep DATA frames, and the DATA frame is truncated, result should be empty
+        // Contains a HEADERS frame (len=83, stream=171) and an incomplete DATA frame (len=16384, truncated)
         let sample_data: Vec<u8> = vec![
             0, 0, 83, 1, 4, 0, 0, 0, 171, 203, 131, 4, 153, 96, 135, 166,
             177, 164, 209, 208, 85, 169, 60, 133, 99, 184, 88, 36, 227, 75,
@@ -274,7 +296,9 @@ mod tests {
         let parser = Http2Parser::new();
         let frames = parser.parse(event);
 
-        // HEADERS frame is filtered, DATA frame is truncated -> empty result
-        assert_eq!(frames.len(), 0);
+        // HEADERS frame is now kept, DATA frame is truncated -> 1 HEADERS frame
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].is_headers());
+        assert_eq!(frames[0].stream_id, 171);
     }
 }


### PR DESCRIPTION
## Summary

- Resolves the observation blind spot where HTTP/2 traffic (DashScope/OpenAI/Azure) had no path/method/status extraction
- Implements per-connection stateful HPACK decode with aggressive fallback (stateful → stateless → body inference)
- Parser now emits HEADERS/CONTINUATION/SETTINGS frames (was DATA-only)
- Aggregator: HpackConnectionState per connection, CONTINUATION reassembly, PADDED/PRIORITY stripping, SETTINGS table size, error recovery with decoder reset
- Analyzer: Http2StreamComplete now produces ParsedApiMessage (was returning None)
- Fix: request_body()/response_body() no longer include HPACK binary payload
- Fix: SETTINGS direction per RFC 7540 §6.5.2
- Fix: LRU eviction cleans continuation_buffers/decoded_headers_store

## E2E verified

- ECS: httpx HTTP/2 client → dashscope.aliyuncs.com → agentsight correctly extracts path, model, messages from H2 traffic
- Both first request (static table) and second request (dynamic table reuse) decode correctly
- GenAI events stored in sqlite with provider=openai, path=/compatible-mode/v1/chat/completions

## Test plan

- [x] 458 unit tests pass (15 new HPACK-specific tests)
- [x] Workflow adversarial review (3 reviewers + 6 verifiers), 4 confirmed bugs fixed
- [x] ECS E2E with real HTTP/2 DashScope traffic
- [ ] Reviewer sign-off

Fixes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)