### PR TITLE
feat(sight): support runtime SLS logtail path via config hot-reload

### DIFF
--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 1.1.1",
  "socket2 0.5.10",
  "tokio",
  "tracing",
@@ -248,6 +248,7 @@ dependencies = [
  "minijinja",
  "minijinja-contrib",
  "moka",
+ "notify",
  "num_cpus",
  "once_cell",
  "openssl",
@@ -1390,6 +1391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2090,6 +2110,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2226,26 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -2529,6 +2589,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log 0.4.29",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -2621,6 +2693,25 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log 0.4.29",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3290,6 +3381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,7 +3952,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4254,6 +4354,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,6 +4578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,11 +4664,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4558,7 +4686,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4572,19 +4700,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4594,9 +4743,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4612,9 +4773,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4624,9 +4797,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -78,6 +78,7 @@ actix-cors = { version = "0.7", optional = true }
 include_dir = { version = "0.7", optional = true }
 # hf-hub for downloading tokenizer files (patched to use GitHub version below)
 hf-hub = "0.5"
+notify = "6"
 
 # [profile.release]
 # debug = true

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -1,4 +1,7 @@
 {
+  "runtime": {
+    "sls_logtail_path": ""
+  },
   "https": [],
   "http": [],
   "encryption": {

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -2,7 +2,7 @@
   "runtime": {
     "sls_logtail_path": ""
   },
-  "https": [],
+  "https": [{"rule": ["dashscope.aliyuncs.com"]}],
   "http": [],
   "encryption": {
     "public_key": ""

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -233,6 +233,16 @@ struct JsonFullConfig {
     http: Option<Vec<JsonHttpGroup>>,
     #[serde(default)]
     encryption: Option<JsonEncryption>,
+    #[serde(default)]
+    runtime: Option<JsonRuntime>,
+}
+
+/// Runtime 动态配置区段（支持热加载，无需重启）
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct JsonRuntime {
+    /// SLS Logtail 输出文件路径。非空时激活 SLS 上传。
+    #[serde(default)]
+    pub sls_logtail_path: Option<String>,
 }
 
 /// 加密配置：可选公钥（PEM 字符串）或公钥文件路径
@@ -454,6 +464,11 @@ pub struct AgentsightConfig {
     /// RSA 公钥（PEM 字符串）。从 agentsight.json `encryption.public_key`
     /// 或 `encryption.public_key_path` 加载。若为 None，则不加密敏感消息字段。
     pub encryption_public_key: Option<String>,
+
+    // --- Runtime Dynamic Configuration ---
+    /// SLS Logtail 输出文件路径（来自 `runtime.sls_logtail_path`）。
+    /// 非空时激活 SLS 上传。支持运行期热加载。
+    pub sls_logtail_path: Option<String>,
 }
 
 impl Default for AgentsightConfig {
@@ -505,6 +520,9 @@ impl Default for AgentsightConfig {
 
             // Encryption defaults (loaded from config file)
             encryption_public_key: None,
+
+            // Runtime dynamic configuration defaults
+            sls_logtail_path: None,
         }
     }
 }
@@ -615,6 +633,16 @@ impl AgentsightConfig {
             }
         }
 
+        // 解析 runtime 动态配置
+        if let Some(ref rt) = parsed.runtime {
+            if let Some(ref path) = rt.sls_logtail_path {
+                let trimmed = path.trim();
+                if !trimmed.is_empty() {
+                    self.sls_logtail_path = Some(trimmed.to_string());
+                }
+            }
+        }
+
         let (cmdline_rules, https_rules, http_targets) = extract_rules(&parsed);
         self.cmdline_rules.extend(cmdline_rules);
         self.https_rules.extend(https_rules);
@@ -676,6 +704,28 @@ impl AgentsightConfig {
     pub fn resolve_config_path(&self) -> PathBuf {
         assert!(self.config_path.is_some(), "config_path must be set via --config");
         self.config_path.clone().unwrap()
+    }
+}
+
+/// Parse `runtime.sls_logtail_path` from a JSON config string.
+///
+/// Returns `Some(path)` if the runtime section has a non-empty `sls_logtail_path`;
+/// returns `None` otherwise or on parse failure. Used by the config watcher to
+/// detect runtime changes without a full config reload.
+pub fn parse_runtime_sls_path(json: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        #[serde(default)]
+        runtime: Option<JsonRuntime>,
+    }
+    let parsed: Partial = serde_json::from_str(json).ok()?;
+    let rt = parsed.runtime?;
+    let path = rt.sls_logtail_path?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
 }
 
@@ -1031,5 +1081,53 @@ mod tests {
         let (cmdline_rules, _, _) = parse_json_rules(json).unwrap();
         assert_eq!(cmdline_rules.len(), 1);
         assert_eq!(cmdline_rules[0].agent_name, Some("Kept".to_string()));
+    }
+
+    #[test]
+    fn test_parse_runtime_sls_path_present() {
+        let json = r#"{"runtime": {"sls_logtail_path": "/var/log/sls/agentsight.log"}}"#;
+        assert_eq!(
+            parse_runtime_sls_path(json),
+            Some("/var/log/sls/agentsight.log".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_runtime_sls_path_empty() {
+        let json = r#"{"runtime": {"sls_logtail_path": ""}}"#;
+        assert_eq!(parse_runtime_sls_path(json), None);
+    }
+
+    #[test]
+    fn test_parse_runtime_sls_path_whitespace_only() {
+        let json = r#"{"runtime": {"sls_logtail_path": "   "}}"#;
+        assert_eq!(parse_runtime_sls_path(json), None);
+    }
+
+    #[test]
+    fn test_parse_runtime_sls_path_missing_section() {
+        let json = r#"{"cmdline": {"allow": []}}"#;
+        assert_eq!(parse_runtime_sls_path(json), None);
+    }
+
+    #[test]
+    fn test_parse_runtime_sls_path_invalid_json() {
+        assert_eq!(parse_runtime_sls_path("not json"), None);
+    }
+
+    #[test]
+    fn test_load_from_json_runtime_sls_path() {
+        let json = r#"{"runtime": {"sls_logtail_path": "/tmp/sls.log"}}"#;
+        let mut config = AgentsightConfig::new();
+        config.load_from_json(json).unwrap();
+        assert_eq!(config.sls_logtail_path, Some("/tmp/sls.log".to_string()));
+    }
+
+    #[test]
+    fn test_load_from_json_runtime_sls_path_empty_is_none() {
+        let json = r#"{"runtime": {"sls_logtail_path": ""}}"#;
+        let mut config = AgentsightConfig::new();
+        config.load_from_json(json).unwrap();
+        assert_eq!(config.sls_logtail_path, None);
     }
 }

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -1036,7 +1036,8 @@ mod tests {
     fn test_default_agents_json_valid() {
         let (cmdline_rules, https_rules, http_targets) = parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
         assert!(!cmdline_rules.is_empty());
-        assert!(https_rules.is_empty());
+        // https rules: dashscope.aliyuncs.com configured by default
+        assert_eq!(https_rules.len(), 1);
         assert!(http_targets.is_empty());
     }
 

--- a/src/agentsight/src/genai/anolisa_release.rs
+++ b/src/agentsight/src/genai/anolisa_release.rs
@@ -1,0 +1,104 @@
+//! Anolisa OS release detection
+//!
+//! 通过检查 `/etc/anolisa-release` 判断当前主机是否运行 Anolisa OS，
+//! 并解析其中的 `PRODUCT_TYPE=value`，用于 SLS 日志注入额外标签：
+//! - `agentsight.source = "agenticos"`（仅当文件存在时写入）
+//! - `agentsight.product_type = <PRODUCT_TYPE value>`（仅当 key 存在时写入）
+//!
+//! 解析结果通过 `OnceLock` 缓存，文件每个进程生命周期只读一次。
+
+use std::sync::OnceLock;
+
+/// Anolisa release 文件路径
+const ANOLISA_RELEASE_PATH: &str = "/etc/anolisa-release";
+
+/// SLS 注入字段值：`agentsight.source = "agenticos"`
+pub const AGENTSIGHT_SOURCE_AGENTICOS: &str = "agenticos";
+
+/// 解析后的 release 信息
+#[derive(Debug, Clone)]
+pub struct AnolisaRelease {
+    /// `PRODUCT_TYPE` 字段值（key 缺失时为 None）
+    pub product_type: Option<String>,
+}
+
+/// 全局缓存：`Some(_)` 表示 `/etc/anolisa-release` 存在；`None` 表示不存在
+static ANOLISA_RELEASE: OnceLock<Option<AnolisaRelease>> = OnceLock::new();
+
+/// 获取 release 信息（带缓存）。文件不存在时返回 `None`。
+pub fn get() -> Option<&'static AnolisaRelease> {
+    ANOLISA_RELEASE
+        .get_or_init(|| match std::fs::read_to_string(ANOLISA_RELEASE_PATH) {
+            Ok(content) => {
+                let parsed = parse(&content);
+                log::info!(
+                    "Detected Anolisa OS via {}, PRODUCT_TYPE={:?}",
+                    ANOLISA_RELEASE_PATH,
+                    parsed.product_type
+                );
+                Some(parsed)
+            }
+            Err(_) => None,
+        })
+        .as_ref()
+}
+
+/// 当前主机是否运行 Anolisa OS（即 `/etc/anolisa-release` 是否存在）
+pub fn is_anolisa() -> bool {
+    get().is_some()
+}
+
+/// 获取 `PRODUCT_TYPE` 值（带缓存），文件不存在或 key 缺失时返回 `None`
+pub fn product_type() -> Option<&'static str> {
+    get().and_then(|r| r.product_type.as_deref())
+}
+
+/// 解析 shell-style key=value 文件内容（支持引号包裹与 `#` 注释）
+fn parse(content: &str) -> AnolisaRelease {
+    let mut product_type = None;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            let k = k.trim();
+            // 去除值两侧可能的引号
+            let v = v.trim().trim_matches(|c| c == '"' || c == '\'');
+            if k == "PRODUCT_TYPE" {
+                product_type = Some(v.to_string());
+            }
+        }
+    }
+    AnolisaRelease { product_type }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_quoted_product_type() {
+        let r = parse("PRODUCT_TYPE=\"AgenticOS\"\nFOO=bar\n");
+        assert_eq!(r.product_type.as_deref(), Some("AgenticOS"));
+    }
+
+    #[test]
+    fn parse_unquoted_product_type() {
+        let r = parse("PRODUCT_TYPE=anolisa-server\n");
+        assert_eq!(r.product_type.as_deref(), Some("anolisa-server"));
+    }
+
+    #[test]
+    fn parse_skips_comments_and_blank_lines() {
+        let content = "# header comment\n\nPRODUCT_TYPE='edge'\n# trailing\n";
+        let r = parse(content);
+        assert_eq!(r.product_type.as_deref(), Some("edge"));
+    }
+
+    #[test]
+    fn parse_missing_product_type_returns_none() {
+        let r = parse("FOO=bar\nBAZ=qux\n");
+        assert!(r.product_type.is_none());
+    }
+}

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -20,14 +20,43 @@ use crate::interruption::types::InterruptionEvent;
 /// 环境变量名称
 pub const LOGTAIL_ENV_VAR: &str = "SLS_LOGTAIL_FILE";
 
-/// 检查 Logtail 导出是否启用（环境变量 SLS_LOGTAIL_FILE 是否设置）
-pub fn logtail_enabled() -> bool {
-    std::env::var(LOGTAIL_ENV_VAR).is_ok()
+/// 动态 Logtail 路径（由 config watcher 运行时设置）
+static DYNAMIC_LOGTAIL_PATH: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
+
+/// 设置动态 Logtail 输出路径（线程安全）。
+///
+/// 由 config watcher 在检测到 `runtime.sls_logtail_path` 变更时调用。
+/// 设置后，`logtail_path()` 将在 env 未设置时返回此路径。
+pub fn set_dynamic_logtail_path(path: &str) {
+    if let Ok(mut guard) = DYNAMIC_LOGTAIL_PATH.write() {
+        *guard = Some(path.to_string());
+        log::info!("Dynamic logtail path set: {}", path);
+    }
 }
 
-/// 获取 Logtail 输出路径（从环境变量读取）
+/// 检查 Logtail 导出是否启用（环境变量 SLS_LOGTAIL_FILE 是否设置，或动态路径已配置）
+pub fn logtail_enabled() -> bool {
+    std::env::var(LOGTAIL_ENV_VAR).is_ok() || {
+        DYNAMIC_LOGTAIL_PATH
+            .read()
+            .map(|g| g.is_some())
+            .unwrap_or(false)
+    }
+}
+
+/// 获取 Logtail 输出路径
+///
+/// 优先级：环境变量 `SLS_LOGTAIL_FILE` > 动态配置路径
 pub fn logtail_path() -> Option<String> {
-    std::env::var(LOGTAIL_ENV_VAR).ok()
+    // 环境变量优先
+    if let Ok(p) = std::env::var(LOGTAIL_ENV_VAR) {
+        return Some(p);
+    }
+    // 回退到动态配置路径
+    DYNAMIC_LOGTAIL_PATH
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
 }
 
 /// iLogtail 文件导出器
@@ -71,6 +100,24 @@ impl LogtailExporter {
             log::info!("Logtail exporter: traceEnabled=false, conversation content fields (gen_ai.input.messages, gen_ai.output.messages) will NOT be uploaded");
         }
         Some(LogtailExporter { path, encryptor, trace_enabled })
+    }
+
+    /// 从显式路径创建 Logtail 导出器（用于运行时动态激活）
+    ///
+    /// 与 `new()` 不同，不依赖环境变量，直接使用传入的路径。
+    pub fn new_with_path(path_str: &str, encryption_pem: Option<&str>, trace_enabled: bool) -> Self {
+        let path = PathBuf::from(path_str);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let encryptor = encryption_pem.and_then(MessageEncryptor::from_pem);
+        if encryptor.is_none() {
+            log::info!("Logtail exporter (dynamic): encryption disabled (no public key configured)");
+        }
+        if !trace_enabled {
+            log::info!("Logtail exporter (dynamic): traceEnabled=false, conversation content fields will NOT be uploaded");
+        }
+        LogtailExporter { path, encryptor, trace_enabled }
     }
 
     /// 返回导出文件路径

--- a/src/agentsight/src/genai/mod.rs
+++ b/src/agentsight/src/genai/mod.rs
@@ -10,6 +10,7 @@ pub mod storage;
 pub mod instance_id;
 pub mod logtail;
 pub mod encrypt;
+pub mod anolisa_release;
 
 pub use semantic::{
     GenAISemanticEvent, LLMCall, LLMRequest, LLMResponse,

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -20,9 +20,10 @@
 
 use anyhow::{Context, Result};
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 use crate::aggregator::Aggregator;
 use crate::analyzer::Analyzer;
@@ -93,6 +94,11 @@ pub struct AgentSight {
     pid_agent_name_cache: HashMap<u32, String>,
     /// HTTP domain patterns from config, used for runtime DNS-based tcpsniff target addition
     http_domains: Vec<String>,
+    /// Flag indicating SLS Logtail has been activated (irreversible)
+    #[allow(dead_code)]
+    sls_activated: Arc<AtomicBool>,
+    /// Mailbox for watcher thread to deposit a dynamically-created LogtailExporter
+    pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>>,
 }
 
 /// GenAI events waiting for session_id resolution via ResponseSessionMapper.
@@ -253,44 +259,91 @@ impl AgentSight {
         // Build GenAI exporters
         let mut genai_exporters: Vec<Box<dyn GenAIExporter>> = Vec::new();
         let mut genai_sqlite_store: Option<Arc<GenAISqliteStore>> = None;
+        let sls_activated = Arc::new(AtomicBool::new(false));
 
-        // When SLS_LOGTAIL_FILE is set, use Logtail file exporter only (skip local storage)
-        // — the Logtail file will be collected by iLogtail and uploaded to SLS.
-        // `config.trace_enabled` (from `traceEnabled` in agentsight.json) controls whether
-        // conversation content fields (gen_ai.input.messages / gen_ai.output.messages) are
-        // included in the uploaded records. When false, only token metadata is uploaded.
-        if let Some(exporter) = LogtailExporter::new(
-            config.encryption_public_key.as_deref(),
-            config.trace_enabled,
-        ) {
-            // SLS 模式必须能获取到 uid (owner-account-id)，否则拒绝启动
-            let uid = crate::genai::instance_id::get_owner_account_id();
-            if uid.is_empty() {
-                anyhow::bail!(
-                    "SLS Logtail exporter is enabled (SLS_LOGTAIL_FILE set) but failed to \
-                     fetch owner-account-id from ECS metadata service. \
-                     Cannot upload logs without uid. Aborting."
-                );
-            }
-            log::info!(
-                "Logtail file exporter enabled ({}), uid={}",
-                exporter.path().display(),
-                uid
-            );
-            genai_exporters.push(Box::new(exporter));
-        } else {
-            // No Logtail: use local JSONL + SQLite
-            genai_exporters.push(Box::new(GenAIStore::new(&GenAIStore::default_path())));
+        // If config has runtime.sls_logtail_path set, seed the dynamic path
+        if let Some(ref sls_path) = config.sls_logtail_path {
+            crate::genai::logtail::set_dynamic_logtail_path(sls_path);
+        }
 
+        let is_agentic_os = crate::genai::anolisa_release::is_anolisa();
+
+        // Determine if Logtail is currently enabled (env var OR dynamic config)
+        let logtail_currently_enabled = crate::genai::logtail::logtail_enabled();
+
+        if is_agentic_os {
+            // ── Anolisa OS: always register SQLite ──
             match GenAISqliteStore::new() {
                 Ok(store) => {
-                    log::info!("SQLite GenAI exporter enabled");
+                    log::info!("SQLite GenAI exporter enabled (agentic os)");
                     let store = Arc::new(store);
                     genai_sqlite_store = Some(Arc::clone(&store));
                     genai_exporters.push(Box::new(store));
                 }
                 Err(e) => {
                     log::warn!("Failed to initialize SQLite GenAI exporter: {}", e);
+                }
+            }
+            // If Logtail is enabled at startup, also register it (dual-write)
+            if logtail_currently_enabled {
+                if let Some(exporter) = LogtailExporter::new(
+                    config.encryption_public_key.as_deref(),
+                    config.trace_enabled,
+                ) {
+                    let uid = crate::genai::instance_id::get_owner_account_id();
+                    if uid.is_empty() {
+                        anyhow::bail!(
+                            "SLS Logtail exporter is enabled but failed to \
+                             fetch owner-account-id from ECS metadata service. \
+                             Cannot upload logs without uid. Aborting."
+                        );
+                    }
+                    log::info!(
+                        "Logtail file exporter enabled (agentic os, {}), uid={}",
+                        exporter.path().display(),
+                        uid
+                    );
+                    genai_exporters.push(Box::new(exporter));
+                    sls_activated.store(true, Ordering::SeqCst);
+                }
+            }
+        } else {
+            // ── Non-Anolisa OS: keep original mutual exclusion behavior ──
+            if logtail_currently_enabled {
+                if let Some(exporter) = LogtailExporter::new(
+                    config.encryption_public_key.as_deref(),
+                    config.trace_enabled,
+                ) {
+                    let uid = crate::genai::instance_id::get_owner_account_id();
+                    if uid.is_empty() {
+                        anyhow::bail!(
+                            "SLS Logtail exporter is enabled (SLS_LOGTAIL_FILE set) but failed to \
+                             fetch owner-account-id from ECS metadata service. \
+                             Cannot upload logs without uid. Aborting."
+                        );
+                    }
+                    log::info!(
+                        "Logtail file exporter enabled ({}), uid={}",
+                        exporter.path().display(),
+                        uid
+                    );
+                    genai_exporters.push(Box::new(exporter));
+                    sls_activated.store(true, Ordering::SeqCst);
+                }
+            } else {
+                // No Logtail: use local JSONL + SQLite
+                genai_exporters.push(Box::new(GenAIStore::new(&GenAIStore::default_path())));
+
+                match GenAISqliteStore::new() {
+                    Ok(store) => {
+                        log::info!("SQLite GenAI exporter enabled");
+                        let store = Arc::new(store);
+                        genai_sqlite_store = Some(Arc::clone(&store));
+                        genai_exporters.push(Box::new(store));
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to initialize SQLite GenAI exporter: {}", e);
+                    }
                 }
             }
         }
@@ -353,6 +406,21 @@ impl AgentSight {
             genai_exporters.len(),
         );
 
+        // Shared mailbox for dynamic LogtailExporter activation
+        let pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>> =
+            Arc::new(Mutex::new(None));
+
+        // Spawn config file watcher for runtime hot-reload
+        if let Some(ref cfg_path) = config.config_path {
+            Self::start_config_watcher(
+                cfg_path.clone(),
+                Arc::clone(&sls_activated),
+                Arc::clone(&pending_logtail),
+                config.encryption_public_key.clone(),
+                config.trace_enabled,
+            );
+        }
+
         // Spawn background thread that marks stale PENDING calls as 'interrupted'.
         // Fires every 60 seconds; any pending call older than 5 minutes is assumed lost.
         if let Some(ref sqlite_store) = genai_sqlite_store {
@@ -393,6 +461,8 @@ impl AgentSight {
             last_drain_check: std::time::Instant::now(),
             pid_agent_name_cache,
             http_domains,
+            sls_activated,
+            pending_logtail,
         })
     }
 
@@ -718,6 +788,8 @@ impl AgentSight {
                 self.flush_expired_pending_genai();
                 // Drain orphaned connections from dead PIDs and persist as pending
                 self.drain_and_persist_dead_connections();
+                // Check if config watcher deposited a new LogtailExporter
+                self.check_pending_logtail();
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
         }
@@ -734,6 +806,146 @@ impl AgentSight {
         // Flush all pending GenAI events before exit
         self.flush_all_pending_genai();
         // poller will be dropped automatically when AgentSight is dropped
+    }
+
+    /// Check and drain the pending_logtail mailbox.
+    /// If the config watcher deposited a new LogtailExporter, register it.
+    fn check_pending_logtail(&mut self) {
+        if let Ok(mut guard) = self.pending_logtail.try_lock() {
+            if let Some(exporter) = guard.take() {
+                log::info!("Registering dynamically-activated LogtailExporter: '{}'", exporter.name());
+                self.genai_exporters.push(exporter);
+            }
+        }
+    }
+
+    /// Start a background thread that watches the config file for changes.
+    ///
+    /// When `runtime.sls_logtail_path` becomes non-empty and SLS has not yet been
+    /// activated, this thread validates uid, sets the dynamic logtail path, creates
+    /// a LogtailExporter, and deposits it into `pending_logtail` for the main loop
+    /// to pick up.
+    fn start_config_watcher(
+        config_path: PathBuf,
+        sls_activated: Arc<AtomicBool>,
+        pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>>,
+        encryption_pem: Option<String>,
+        trace_enabled: bool,
+    ) {
+        use notify::{RecommendedWatcher, RecursiveMode, Watcher, Event as NotifyEvent, EventKind};
+
+        let watch_path = config_path.clone();
+        std::thread::Builder::new()
+            .name("config-watcher".to_string())
+            .spawn(move || {
+                log::info!("Config watcher started for {:?}", watch_path);
+
+                let (tx, rx) = std::sync::mpsc::channel::<notify::Result<NotifyEvent>>();
+
+                let mut watcher: RecommendedWatcher = match notify::recommended_watcher(tx) {
+                    Ok(w) => w,
+                    Err(e) => {
+                        log::warn!("Failed to create config file watcher: {}", e);
+                        return;
+                    }
+                };
+
+                // Watch the parent directory (inotify requires watching dirs)
+                let watch_dir = watch_path.parent().unwrap_or(Path::new("/"));
+                if let Err(e) = watcher.watch(watch_dir, RecursiveMode::NonRecursive) {
+                    log::warn!("Failed to watch config directory {:?}: {}", watch_dir, e);
+                    return;
+                }
+
+                let target_filename = watch_path.file_name().map(|f| f.to_os_string());
+
+                for event in rx {
+                    let event = match event {
+                        Ok(e) => e,
+                        Err(e) => {
+                            log::warn!("Config watcher error: {}", e);
+                            continue;
+                        }
+                    };
+
+                    // Only process CloseWrite events (file fully written)
+                    match event.kind {
+                        EventKind::Access(notify::event::AccessKind::Close(
+                            notify::event::AccessMode::Write,
+                        )) => {}
+                        _ => continue,
+                    }
+
+                    // Filter by filename
+                    let is_target = event.paths.iter().any(|p| {
+                        p.file_name().map(|f| f.to_os_string()) == target_filename
+                    });
+                    if !is_target {
+                        continue;
+                    }
+
+                    // Already activated? Skip.
+                    if sls_activated.load(Ordering::SeqCst) {
+                        continue;
+                    }
+
+                    // Re-read config file
+                    let content = match std::fs::read_to_string(&watch_path) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            log::warn!("Config watcher: failed to read {:?}: {}", watch_path, e);
+                            continue;
+                        }
+                    };
+
+                    // Parse runtime.sls_logtail_path
+                    let new_path = match crate::config::parse_runtime_sls_path(&content) {
+                        Some(p) => p,
+                        None => continue,
+                    };
+
+                    log::info!(
+                        "Config watcher: detected runtime.sls_logtail_path = {:?}",
+                        new_path
+                    );
+
+                    // Validate uid (strong check: abort process on failure)
+                    let uid = crate::genai::instance_id::get_owner_account_id();
+                    if uid.is_empty() {
+                        log::error!(
+                            "Config watcher: SLS activation requested but uid fetch failed. \
+                             Terminating process."
+                        );
+                        std::process::exit(1);
+                    }
+
+                    // Set dynamic path so logtail_path() returns it
+                    crate::genai::logtail::set_dynamic_logtail_path(&new_path);
+
+                    // Create exporter and deposit into mailbox
+                    let exporter = LogtailExporter::new_with_path(
+                        &new_path,
+                        encryption_pem.as_deref(),
+                        trace_enabled,
+                    );
+                    log::info!(
+                        "Config watcher: LogtailExporter created (path={}, uid={})",
+                        new_path,
+                        uid
+                    );
+
+                    if let Ok(mut guard) = pending_logtail.lock() {
+                        *guard = Some(Box::new(exporter));
+                    }
+
+                    // Mark activated (irreversible)
+                    sls_activated.store(true, Ordering::SeqCst);
+                    log::info!("Config watcher: SLS Logtail activated dynamically");
+                }
+
+                log::info!("Config watcher exiting");
+            })
+            .ok();
     }
 
     /// Install an FFI event sender for C API mode.


### PR DESCRIPTION
## Description

Support dynamic SLS logtail path configuration via `agentsight.json` hot-reload, enabling SLS upload activation without restarting the agentsight process.

Key changes:
- Add `runtime.sls_logtail_path` field to `agentsight.json` for runtime configuration
- Use `notify` crate (inotify `IN_CLOSE_WRITE`) to watch config file changes
- Dynamically create and activate LogtailExporter when path is configured
- Support SQLite + Logtail dual-write mode on Anolisa OS
- Add `anolisa_release` module for Anolisa OS detection (`/etc/anolisa-release`)
- Add default `dashscope.aliyuncs.com` HTTPS domain rule

Design decisions:
- Activation is irreversible (once SLS is activated, clearing config does not stop upload)
- Environment variable `SLS_LOGTAIL_FILE` takes priority over config file
- Uses `CloseWrite` event to avoid reading half-written files
- Strong uid validation: abort process if owner-account-id fetch fails during dynamic activation

## Related Issue

closes #728

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass (472 tests)
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- 7 unit tests added for `parse_runtime_sls_path()` covering empty/null/valid/whitespace cases
- All 472 existing tests pass
- Manual verification on remote machine (47.111.15.172) confirmed config hot-reload works

## Additional Notes

Files changed:
- `Cargo.toml`: add `notify = "6"` dependency
- `agentsight.json`: add `runtime` section and default https rule
- `src/config.rs`: `JsonRuntime` struct, `parse_runtime_sls_path()` helper
- `src/genai/logtail.rs`: dynamic path RwLock, `set_dynamic_logtail_path()`, `new_with_path()`
- `src/genai/anolisa_release.rs`: Anolisa OS detection with OnceLock cache
- `src/genai/mod.rs`: register anolisa_release module
- `src/unified.rs`: config watcher thread, dual-write logic, pending_logtail mailbox