### PR TITLE
feat(skill): auto-install tokenless plugin for agent install skills

### DIFF
--- a/src/os-skills/ai/install-claude-code/SKILL.md
+++ b/src/os-skills/ai/install-claude-code/SKILL.md
@@ -27,6 +27,7 @@ Task Progress:
 - [ ] Step 3: Verify installation
 - [ ] Step 4: Configure API provider
 - [ ] Step 5: Test run
+- [ ] Step 6: Tokenless plugin auto-installed
 ```
 
 ### Step 1: Check System & Install Prerequisites
@@ -112,6 +113,8 @@ Or use the automated script (auto-fallback all 3 methods):
 ```bash
 bash scripts/install-claude-code.sh
 ```
+
+Pass `--skip-tokenless` to skip the tokenless Claude Code plugin auto-installation.
 
 ### Step 3: Verify Installation
 

--- a/src/os-skills/ai/install-claude-code/scripts/install-claude-code.sh
+++ b/src/os-skills/ai/install-claude-code/scripts/install-claude-code.sh
@@ -4,11 +4,12 @@
 # Automated Claude Code installer for Alibaba Cloud Linux 4 (Alinux 4)
 #
 # Usage:
-#   bash install-claude-code.sh [--config]
+#   bash install-claude-code.sh [--config] [--skip-tokenless]
 #
 # Options:
 #   --config    Also write DashScope/Qwen configuration to ~/.claude/settings.json
 #               (will prompt for API key interactively, or use CLAUDE_API_KEY env var)
+#   --skip-tokenless  Skip tokenless plugin auto-installation
 #
 # Installation priority:
 #   1. Native installer (curl from claude.ai)
@@ -34,9 +35,11 @@ err()   { echo -e "${RED}[ERROR]${NC} $*"; }
 
 # --- Flags ---
 WRITE_CONFIG=false
+SKIP_TOKENLESS=false
 for arg in "$@"; do
   case "$arg" in
     --config) WRITE_CONFIG=true ;;
+    --skip-tokenless) SKIP_TOKENLESS=true ;;
     *) warn "Unknown argument: $arg" ;;
   esac
 done
@@ -270,6 +273,61 @@ JSONEOF
 }
 
 # =============================================================================
+# Tokenless Plugin Installation
+# =============================================================================
+find_tokenless_adapter_dir() {
+  local candidates=(
+    "${ANOLISA_TOKENLESS_ADAPTER_DIR:-}"
+    "/usr/share/anolisa/adapters/tokenless"
+    "$HOME/.local/share/anolisa/adapters/tokenless"
+  )
+  # Source tree layout relative to this script
+  local script_dir
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  candidates+=("$script_dir/../../../../tokenless/adapters/tokenless")
+
+  for candidate in "${candidates[@]}"; do
+    [ -n "$candidate" ] || continue
+    [ -d "$candidate" ] && [ -f "$candidate/manifest.json" ] && echo "$candidate" && return 0
+  done
+  return 1
+}
+
+install_tokenless_plugin() {
+  if [[ "$SKIP_TOKENLESS" == true ]]; then
+    info "Skipping tokenless plugin (--skip-tokenless)"
+    return 0
+  fi
+
+  info "Installing tokenless Claude Code plugin..."
+
+  local adapter_dir
+  adapter_dir="$(find_tokenless_adapter_dir)" || {
+    warn "tokenless adapter not found — skipping tokenless plugin installation."
+    info "Install tokenless first, then run: make -C src/tokenless claude-code-install"
+    return 0
+  }
+
+  local install_script="$adapter_dir/claude-code/scripts/install.sh"
+  if [[ ! -f "$install_script" ]]; then
+    warn "tokenless install script not found: $install_script"
+    return 0
+  fi
+
+  info "tokenless adapter: $adapter_dir"
+  if ANOLISA_ADAPTER_DIR="$adapter_dir" \
+     ANOLISA_COMPONENT="tokenless" \
+     ANOLISA_TARGET="claude-code" \
+     bash "$install_script"; then
+    ok "tokenless Claude Code plugin installed"
+  else
+    warn "tokenless plugin installation failed (non-fatal)"
+    info "You can install it later with:"
+    info "  ANOLISA_ADAPTER_DIR=$adapter_dir bash $install_script"
+  fi
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 main() {
@@ -316,6 +374,9 @@ main() {
     info "Writing API configuration..."
     write_config
   fi
+
+  # Step 6: Install tokenless plugin
+  install_tokenless_plugin
 
   echo ""
   ok "Done! Run 'claude' to get started."

--- a/src/os-skills/ai/install-hermes/SKILL.md
+++ b/src/os-skills/ai/install-hermes/SKILL.md
@@ -43,6 +43,7 @@ hermes doctor      # 验证
 > - 脚本默认**跳过**交互式配置向导，安装完后运行 `hermes setup` 再配置
 > - 如需安装时直接配置，加 `--with-setup` 参数
 > - CI/自动化场景直接运行即可，不会出现任何交互阻塞
+> - **安装完成后会自动安装 tokenless 插件**（token 用量追踪和响应压缩），无需额外操作
 
 **安装参数说明**：
 
@@ -51,6 +52,7 @@ hermes doctor      # 验证
 | （无参数） | 最小安装，仅核心包，速度最快（**推荐新手**） |
 | `--full` | 安装所有 extras（daytona、playwright、WhatsApp 等） |
 | `--with-setup` | 安装完后启动配置向导 |
+| `--skip-tokenless` | 跳过 tokenless 插件自动安装 |
 
 ### 首次配置
 

--- a/src/os-skills/ai/install-hermes/scripts/install.sh
+++ b/src/os-skills/ai/install-hermes/scripts/install.sh
@@ -27,6 +27,7 @@ USE_VENV=true
 RUN_SETUP=false
 BRANCH="main"
 INSTALL_MINIMAL=true   # Default: minimal install (no heavy extras like daytona/playwright/whatsapp)
+SKIP_TOKENLESS=false
 
 # Detect non-interactive mode (e.g. curl | bash)
 # When stdin is not a terminal, read -p will fail with EOF,
@@ -68,6 +69,10 @@ while [[ $# -gt 0 ]]; do
             INSTALL_MINIMAL=false
             shift
             ;;
+        --skip-tokenless)
+            SKIP_TOKENLESS=true
+            shift
+            ;;
         -h|--help)
             echo "Hermes Agent Installer"
             echo ""
@@ -79,6 +84,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --skip-setup   Skip interactive setup wizard (default)"
             echo "  --full         Install all extras (daytona, playwright, whatsapp, etc.)"
             echo "                 Default: minimal install for faster setup"
+            echo "  --skip-tokenless  Skip tokenless plugin auto-installation"
             echo "  --branch NAME  Git branch to install (default: main)"
             echo "  --dir PATH     Installation directory (default: ~/.hermes/hermes-agent)"
             echo "  --hermes-home PATH  Data directory (default: ~/.hermes, or \$HERMES_HOME)"
@@ -1442,6 +1448,59 @@ maybe_start_gateway() {
     fi
 }
 
+find_tokenless_adapter_dir() {
+    local candidates=(
+        "${ANOLISA_TOKENLESS_ADAPTER_DIR:-}"
+        "/usr/share/anolisa/adapters/tokenless"
+        "$HOME/.local/share/anolisa/adapters/tokenless"
+    )
+    # Source tree layout relative to this script
+    local script_dir
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    candidates+=("$script_dir/../../../../tokenless/adapters/tokenless")
+
+    for candidate in "${candidates[@]}"; do
+        [ -n "$candidate" ] || continue
+        [ -d "$candidate" ] && [ -f "$candidate/manifest.json" ] && echo "$candidate" && return 0
+    done
+    return 1
+}
+
+install_tokenless_plugin() {
+    if [ "$SKIP_TOKENLESS" = true ]; then
+        log_info "Skipping tokenless plugin (--skip-tokenless)"
+        return 0
+    fi
+
+    log_info "Installing tokenless Hermes plugin..."
+
+    local adapter_dir
+    adapter_dir="$(find_tokenless_adapter_dir)" || {
+        log_warn "tokenless adapter not found — skipping tokenless plugin installation."
+        log_info "Install tokenless first, then run: make -C src/tokenless hermes-install"
+        return 0
+    }
+
+    local install_script="$adapter_dir/hermes/scripts/install.sh"
+    if [ ! -f "$install_script" ]; then
+        log_warn "tokenless install script not found: $install_script"
+        return 0
+    fi
+
+    log_info "tokenless adapter: $adapter_dir"
+    if ANOLISA_ADAPTER_DIR="$adapter_dir" \
+       ANOLISA_COMPONENT="tokenless" \
+       ANOLISA_TARGET="hermes" \
+       HERMES_HOME="$HERMES_HOME" \
+       bash "$install_script"; then
+        log_success "tokenless Hermes plugin installed"
+    else
+        log_warn "tokenless plugin installation failed (non-fatal)"
+        log_info "You can install it later with:"
+        log_info "  ANOLISA_ADAPTER_DIR=$adapter_dir bash $install_script"
+    fi
+}
+
 print_success() {
     echo ""
     echo -e "${GREEN}${BOLD}"
@@ -1542,6 +1601,7 @@ main() {
     copy_config_templates
     run_setup_wizard
     maybe_start_gateway
+    install_tokenless_plugin
 
     print_success
 }

--- a/src/os-skills/ai/install-openclaw/SKILL.md
+++ b/src/os-skills/ai/install-openclaw/SKILL.md
@@ -62,7 +62,7 @@ python3 <install-openclaw-skill-dir>/scripts/install_openclaw.py ...
 
 The authoritative implementation is `scripts/install_openclaw.py`.
 The normal parameters are `--billing`, `--api-key`, `--api-key-env`, `--region`,
-`--model-id`, `--npm-registry`, `--precheck-only`, and DingTalk-specific flags.
+`--model-id`, `--npm-registry`, `--precheck-only`, `--skip-tokenless`, and DingTalk-specific flags.
 
 ## Examples
 
@@ -120,6 +120,7 @@ python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_op
 - Sets `gateway.mode = local`, `gateway.bind = loopback`, and `gateway.auth.mode = none` for local single-machine setup.
 - Starts OpenClaw through `openclaw gateway install` and `openclaw gateway restart` unless `--skip-gateway` is passed.
 - If the gateway port is occupied by OpenClaw, it clears that stale listener. If the port is occupied by another process, it stops and prints the process details for the user to decide.
+- **Auto-installs the tokenless OpenClaw plugin** after OpenClaw is installed, for token usage tracking and response compression. Pass `--skip-tokenless` to opt out.
 
 ## Verify
 

--- a/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
+++ b/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
@@ -860,6 +860,64 @@ def install_openclaw(args):
     ensure_openclaw(args)
 
 
+def find_tokenless_adapter_dir():
+    """Locate the tokenless adapter directory containing agent plugin install scripts."""
+    candidates = [
+        os.environ.get("ANOLISA_TOKENLESS_ADAPTER_DIR", ""),
+        "/usr/share/anolisa/adapters/tokenless",
+        os.path.expanduser("~/.local/share/anolisa/adapters/tokenless"),
+    ]
+    # Also try relative to the script's own location (source tree layout)
+    script_dir = Path(__file__).resolve().parent
+    source_candidate = script_dir / ".." / ".." / ".." / ".." / "tokenless" / "adapters" / "tokenless"
+    candidates.append(str(source_candidate))
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        p = Path(candidate)
+        if p.is_dir() and (p / "manifest.json").is_file():
+            return p
+    return None
+
+
+def install_tokenless_plugin(args):
+    """Install the tokenless OpenClaw plugin via the tokenless adapter install script."""
+    if args.skip_tokenless:
+        print("\n--- Skipping tokenless plugin (--skip-tokenless) ---\n")
+        return
+
+    print("\n--- Installing tokenless OpenClaw plugin ---\n")
+
+    adapter_dir = find_tokenless_adapter_dir()
+    if adapter_dir is None:
+        print("  tokenless adapter not found — skipping tokenless plugin installation.")
+        print("  Install tokenless first, then run:")
+        print("    make -C src/tokenless openclaw-install")
+        return
+
+    install_script = adapter_dir / "openclaw" / "scripts" / "install.sh"
+    if not install_script.is_file():
+        print(f"  tokenless install script not found: {install_script}")
+        return
+
+    print(f"  tokenless adapter: {adapter_dir}")
+    env = os.environ.copy()
+    env["ANOLISA_ADAPTER_DIR"] = str(adapter_dir)
+    env["ANOLISA_COMPONENT"] = "tokenless"
+    env["ANOLISA_TARGET"] = "openclaw"
+    try:
+        run_command(
+            ["bash", str(install_script)],
+            env=env,
+            dry_run=args.dry_run,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"  tokenless plugin installation failed: {exc}")
+        print("  You can install it later with:")
+        print(f"    ANOLISA_ADAPTER_DIR={adapter_dir} bash {install_script}")
+
+
 def install_dingtalk_plugin(args):
     env = os.environ.copy()
     if args.npm_registry:
@@ -990,6 +1048,11 @@ def parse_args():
         action="store_true",
         help="Only check basic environment dependencies; do not require API keys or install anything.",
     )
+    parser.add_argument(
+        "--skip-tokenless",
+        action="store_true",
+        help="Do not install the tokenless OpenClaw plugin after OpenClaw installation.",
+    )
 
     parser.add_argument("--dingtalk-client-id", default="")
     parser.add_argument("--dingtalk-client-secret", default="")
@@ -1011,6 +1074,7 @@ def main():
 
     if not args.skip_install_openclaw:
         install_openclaw(args)
+        install_tokenless_plugin(args)
 
     config, metadata = build_config(args)
     apply_config(config, Path(args.config).expanduser())


### PR DESCRIPTION
## Description

Add automatic tokenless plugin installation steps to the three agent install skills (openclaw, hermes, claude-code). Each skill now invokes the corresponding tokenless adapter install script after the agent is installed, providing token usage tracking and response compression.

The tokenless adapter directory is located via a common search strategy:
1. ANOLISA_TOKENLESS_ADAPTER_DIR env var
2. /usr/share/anolisa/adapters/tokenless (system RPM)
3. ~/.local/share/anolisa/adapters/tokenless (user install)
4. source tree relative path (dev fallback)

Gracefully skips when tokenless is not installed (non-fatal).

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue: enhancement 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (noxn-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [x] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [x] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing
```code
  测试与 CI 检查结果

  ┌─────┬────────────────────────────────────────────────────┬────────┐
  │  #  │                       检查项                       │  结果  │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 1   │ Python 语法 (py_compile)                           │ ✓      │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 2   │ Hermes bash 语法 (bash -n)                         │ ✓      │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 3   │ Claude Code bash 语法 (bash -n)                    │ ✓      │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 4   │ Python 路径解析 → src/tokenless/adapters/tokenless │ ✓ 正确 │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 5   │ Hermes 路径解析 → tokenless adapter                │ ✓ 正确 │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 6   │ Claude Code 路径解析 → tokenless adapter           │ ✓ 正确 │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 7   │ --skip-tokenless-plugin flag 解析                  │ ✓ 正确 │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 8   │ 无 skip flag 自动安装 dry-run                      │ ✓ 正确 │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 9   │ --skip-tokenless help 文本（hermes）               │ ✓ 正确 │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 10  │ --skip-tokenless flag 解析（claude-code）          │ ✓ 正确 │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 11  │ Commit 格式 feat(skill): ...                       │ ✓      │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 12  │ Commit 行长度 67 字符 (max 120)                    │ ✓      │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 13  │ SOB Signed-off-by: Shile Zhang                     │ ✓      │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 14  │ Makefile build 无编译错误                          │ ✓      │
  ├─────┼────────────────────────────────────────────────────┼────────┤
  │ 15  │ Git 工作区干净                                     │ ✓      │
  └─────┴────────────────────────────────────────────────────┴────────┘
```