### PR TITLE
fix(scripts): install Node.js for agentsight builds

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1340,7 +1340,7 @@ do_install_deps() {
     if $DRY_RUN; then
         step "Dependency plan"
         echo "DRY-RUN: detect Linux distribution and package manager"
-        if want_component cosh || want_component sec-core; then
+        if want_component cosh || want_component sec-core || want_component sight; then
             echo "DRY-RUN: check/install Node.js and build tools if needed"
         fi
         if want_component sec-core || want_component sight || want_component tokenless || want_component ws-ckpt || want_component memory; then
@@ -1362,7 +1362,7 @@ do_install_deps() {
     step "Detecting system"
     detect_distro
 
-    if want_component cosh || want_component sec-core; then
+    if want_component cosh || want_component sec-core || want_component sight; then
         install_node
         install_build_tools
     fi


### PR DESCRIPTION
## Description

This PR fixes `build-all.sh --component sight` on clean systems.

AgentSight builds its frontend through `src/agentsight/Makefile`:

```bash
cd dashboard && npm install && npm run build:embed
```

However, `build-all.sh` only installed Node.js when `cosh` or `sec-core`
was selected. When users selected only `sight`, the script installed Rust and
eBPF dependencies, then failed during the AgentSight frontend build because
`npm` was missing.

This change adds `sight` to the Node.js dependency setup path and keeps the
dry-run dependency plan consistent with the real execution path.

## Related Issue

no-issue: small build dependency fix found during manual validation

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Local syntax and dry-run checks:

```bash
bash -n scripts/build-all.sh
./scripts/build-all.sh --dry-run --install-mode system --component sight
```

Remote validation on Alibaba Cloud Linux 4 / Agentic_os:

```bash
command -v node || true
command -v npm || true
./scripts/build-all.sh --install-mode system --component sight
```

Observed result:

```text
node_before=
npm_before=

==> Node.js (for copilot-shell)
[info]  Repository provides nodejs 22.22.0 (>= 20.0.0), installing via rpm ...
[ok]    Node.js v22.22.0 installed via package manager

[ok]    agentsight built successfully
[ok]    agentsight installed to /usr/local/bin/agentsight
[ok]    Done
```

The original failure was:

```text
/bin/sh: line 1: npm: command not found
make: *** [Makefile:17: build-frontend] Error 127
```

This no longer reproduces after the fix.

## Additional Notes

The code change is intentionally small: it only adds `sight` to the existing
Node.js/build-tools dependency condition and updates the dry-run output.
