### PR TITLE
ci(anolisa): integrate anolisa into CI and GitHub automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /src/osbase/                            @casparant                  # auto-label: component:osbase
 /src/tokenless/                         @Forrest-ly @shiloong       # auto-label: component:tokenless
 /src/agent-memory/                      @shiloong                   # auto-label: component:memory
+/src/anolisa/                           @kongche-jbw @ikunkun-sys   # auto-label: component:anolisa
 
 # ---------------------------------------------------------------------------
 # Scope paths

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,6 +21,7 @@ body:
         - tokenless
         - ckpt
         - memory
+        - anolisa
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,6 +22,7 @@ body:
         - tokenless
         - ckpt
         - memory
+        - anolisa
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -21,6 +21,7 @@ body:
         - tokenless
         - ckpt
         - memory
+        - anolisa
         - other
   - type: textarea
     id: question

--- a/.github/commitlint.config.json
+++ b/.github/commitlint.config.json
@@ -14,6 +14,7 @@
         "tokenless",
         "ckpt",
         "memory",
+        "anolisa",
         "deps",
         "ci",
         "docs",

--- a/.github/maintainers.json
+++ b/.github/maintainers.json
@@ -82,6 +82,17 @@
                     "github": "shiloong"
                 }
             ]
+        },
+        {
+            "label": "component:anolisa",
+            "maintainers": [
+                {
+                    "github": "kongche-jbw"
+                },
+                {
+                    "github": "ikunkun-sys"
+                }
+            ]
         }
     ],
     "default": {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,6 +41,7 @@ closes #
 - [ ] `tokenless` (tokenless)
 - [ ] `ckpt` (ws-ckpt)
 - [ ] `memory` (agent-memory)
+- [ ] `anolisa` (anolisa-cli)
 - [ ] Multiple / Project-wide
 
 ## Checklist
@@ -58,6 +59,7 @@ closes #
 - [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
 - [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
 - [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
+- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
 - [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)
 
 ## Testing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_anolisa:
+        description: 'Force run anolisa tests (ignore change detection)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -55,6 +60,7 @@ jobs:
       tokenless: ${{ steps.changes.outputs.tokenless }}
       ws_ckpt: ${{ steps.changes.outputs.ws_ckpt }}
       agent_memory: ${{ steps.changes.outputs.agent_memory }}
+      anolisa: ${{ steps.changes.outputs.anolisa }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,6 +87,7 @@ jobs:
           TOKENLESS=false
           WS_CKPT=false
           AGENT_MEMORY=false
+          ANOLISA=false
 
           # Path-based detection
           if echo "$CHANGED" | grep -q "^src/copilot-shell/"; then
@@ -100,6 +107,9 @@ jobs:
           fi
           if echo "$CHANGED" | grep -q "^src/agent-memory/"; then
             AGENT_MEMORY=true
+          fi
+          if echo "$CHANGED" | grep -q "^src/anolisa/"; then
+            ANOLISA=true
           fi
 
           # Manual override via workflow_dispatch
@@ -121,6 +131,9 @@ jobs:
           if [[ "${{ inputs.run_agent_memory }}" == "true" ]]; then
             AGENT_MEMORY=true
           fi
+          if [[ "${{ inputs.run_anolisa }}" == "true" ]]; then
+            ANOLISA=true
+          fi
 
           echo "copilot_shell=$COPILOT_SHELL" >> $GITHUB_OUTPUT
           echo "agent_sec_core=$AGENT_SEC" >> $GITHUB_OUTPUT
@@ -128,6 +141,7 @@ jobs:
           echo "tokenless=$TOKENLESS" >> $GITHUB_OUTPUT
           echo "ws_ckpt=$WS_CKPT" >> $GITHUB_OUTPUT
           echo "agent_memory=$AGENT_MEMORY" >> $GITHUB_OUTPUT
+          echo "anolisa=$ANOLISA" >> $GITHUB_OUTPUT
 
           echo "### Change Detection Results" >> $GITHUB_STEP_SUMMARY
           echo "| Component | Changed |" >> $GITHUB_STEP_SUMMARY
@@ -138,6 +152,7 @@ jobs:
           echo "| tokenless | $TOKENLESS |" >> $GITHUB_STEP_SUMMARY
           echo "| ws-ckpt | $WS_CKPT |" >> $GITHUB_STEP_SUMMARY
           echo "| agent-memory | $AGENT_MEMORY |" >> $GITHUB_STEP_SUMMARY
+          echo "| anolisa | $ANOLISA |" >> $GITHUB_STEP_SUMMARY
 
   # =========================================================================
   # Step 2: Build & Lint copilot-shell
@@ -663,4 +678,39 @@ jobs:
       - name: Run tests
         run: |
           cd src/agent-memory
+          cargo test --locked
+
+  # =========================================================================
+  # Step 9: Test anolisa (Rust workspace)
+  # =========================================================================
+  test-anolisa:
+    name: Test anolisa
+    needs: detect-changes
+    if: needs.detect-changes.outputs.anolisa == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.88.0'
+          components: 'rustfmt, clippy'
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/anolisa
+
+      - name: Check formatting
+        run: |
+          cd src/anolisa
+          cargo fmt --all --check
+
+      - name: Lint
+        run: |
+          cd src/anolisa
+          cargo clippy --all-targets --locked -- -D warnings
+
+      - name: Run tests
+        run: |
+          cd src/anolisa
           cargo test --locked

--- a/.github/workflows/prelint.yml
+++ b/.github/workflows/prelint.yml
@@ -79,7 +79,7 @@ jobs:
             if (scopeMatch) {
               const scope = scopeMatch[1].slice(1, -1);
               const validScopes = [
-                'cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt', 'memory',
+                'cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt', 'memory', 'anolisa',
                 'agent-sec-core', 'agentsight', 'os-skills', 'ws-ckpt', 'agent-memory', // legacy aliases
                 'deps', 'ci', 'docs', 'chore'
               ];
@@ -125,7 +125,7 @@ jobs:
             }
 
             // Valid scopes — short names preferred; legacy long names accepted for forward compatibility
-            const validScopes = ['cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt', 'memory', 'agent-sec-core', 'agentsight', 'os-skills', 'ws-ckpt', 'agent-memory', 'ci', 'docs', 'deps'];
+            const validScopes = ['cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt', 'memory', 'anolisa', 'agent-sec-core', 'agentsight', 'os-skills', 'ws-ckpt', 'agent-memory', 'ci', 'docs', 'deps'];
             const scopePattern = validScopes.join('|');
 
             // Valid branch patterns per development spec

--- a/AGENT.md
+++ b/AGENT.md
@@ -14,6 +14,7 @@ This file provides context for AI coding assistants (Qoder, Claude, etc.) workin
 | **tokenless** | `src/tokenless/` | Rust | Linux only |
 | **agent-memory** (`memory`) | `src/agent-memory/` | Rust | Linux only |
 | **os-skills** | `src/os-skills/` | Python / Shell | All |
+| **anolisa** | `src/anolisa/` | Rust | Linux + macOS (arm64) |
 
 > `agent-sec-core`, `agentsight`, `tokenless`, and `agent-memory` require Linux. Do **not** attempt to build them on macOS or Windows.
 
@@ -62,6 +63,12 @@ cd src/agent-memory
 make build       # cargo build --release --locked
 make test        # cargo test --locked
 make smoke       # end-to-end MCP stdio smoke test
+
+# anolisa (per-component)
+cd src/anolisa
+cargo fmt --all --check
+cargo clippy --all-targets --locked -- -D warnings
+cargo test --locked
 ```
 
 ## Commit Message Rules
@@ -83,6 +90,7 @@ Format: `type(scope): description`
 | `src/agentsight/` | `sight` |
 | `src/tokenless/` | `tokenless` |
 | `src/agent-memory/` | `memory` |
+| `src/anolisa/` | `anolisa` |
 | `.github/workflows/` | `ci` |
 | `docs/` | `docs` |
 | `**/package*.json`, `Cargo.lock`, `*.toml` (dep bumps) | `deps` |
@@ -151,6 +159,7 @@ When generating a PR description, use `.github/pull_request_template.md` as the 
 - `sight` → any file under `src/agentsight/`
 - `tokenless` → any file under `src/tokenless/`
 - `memory` → any file under `src/agent-memory/`
+- `anolisa` → any file under `src/anolisa/`
 - `Multiple / Project-wide` → cross-component or root-level changes
 
 **Checklist** — mark items that actually apply to this PR; skip items for unaffected components.


### PR DESCRIPTION
## Description

Integrate the new anolisa component into all GitHub automation
pipelines. This adds review routing via CODEOWNERS, auto-labeling
via maintainers.json, commit/PR lint scope recognition, a
dedicated CI test job (Rust 1.88, fmt/clippy/test), and updates
all issue/PR templates and contributor docs (AGENT.md).

## Related Issue

no-issue: new component onboarding, no tracking issue

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)
- [x] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have updated the documentation accordingly
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Verified all 10 changed files for consistency:
- CODEOWNERS owner usernames match maintainers.json entries
- commitlint scope-enum, prelint validScopes (×2) all include `anolisa`
- ci.yaml detect-changes outputs, workflow_dispatch input, and test-anolisa job reference correct toolchain (1.88.0) and paths
- Issue/PR templates include anolisa in dropdowns and checklists
- AGENT.md platform marked as `Linux + macOS (arm64)` per rust-toolchain.toml targets

## Additional Notes

Owner list: @kongche-jbw @ikunkun-sys (both in CODEOWNERS and maintainers.json).