### PR TITLE
chore(template): simplify bug report issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,14 +6,16 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
-        Select the affected component below — the title will be prefixed automatically.
+        Please prefix the title with `[component]`, e.g. `[cosh] bug: login fails`.
+
+        **Tip:** Run `anolisa bug` to auto-generate diagnostic info, then paste the output into the "Diagnostic Output" field below.
   - type: dropdown
     id: component
     attributes:
       label: Component
       description: Which component is affected?
       options:
+        - anolisa
         - cosh
         - sec-core
         - skill
@@ -27,49 +29,26 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Bug Description
-      description: A clear and concise description of what the bug is.
-    validations:
-      required: true
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Steps to Reproduce
-      description: Steps to reproduce the behavior.
+      label: What happened?
+      description: Describe the bug and how to reproduce it.
       placeholder: |
-        1. Go to '...'
-        2. Run command '...'
-        3. See error '...'
+        Bug description:
+
+        Steps to reproduce:
+        1. Run `anolisa ...`
+        2. Observe ...
+
+        Expected behavior:
     validations:
       required: true
   - type: textarea
-    id: expected
+    id: diagnostics
     attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      description: |
-        Please provide the following information:
-        - OS: [e.g. Anolis OS 8, Ubuntu 22.04]
-        - Component version: [e.g. cosh v2.1.0]
-        - Node.js version (if applicable): [e.g. 20.11.0]
-        - Python version (if applicable): [e.g. 3.12.3]
-        - Rust version (if applicable): [e.g. 1.80.0]
-    validations:
-      required: true
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant Log Output
-      description: Please copy and paste any relevant log output.
+      label: Diagnostic Output
+      description: Paste the output of `anolisa bug` (or `anolisa bug --capability <name>`).
       render: shell
   - type: textarea
     id: additional
     attributes:
       label: Additional Context
-      description: Add any other context about the problem here.
+      description: Screenshots, config snippets, or anything else that helps.


### PR DESCRIPTION
## Description

Simplify the bug report issue template to reduce user friction.

The current template has 7 fields (5 required), requiring users to
manually fill environment info, reproduction steps, expected behavior,
and logs separately. This PR consolidates them into 4 fields (2 required),
with machine-collected diagnostics handled by the upcoming `anolisa bug`
command.

Changes:
- Merge Bug Description, Steps to Reproduce, and Expected Behavior into
  a single "What happened?" field with placeholder guidance.
- Replace Environment and Relevant Log Output with a single "Diagnostic
  Output" field that accepts `anolisa bug` output.
- Align component dropdown with project convention: `anolisa`, `cosh`,
  `sec-core`, `skill`, `sight`, `tokenless`, `ckpt`, `memory`, `other`.
- Add title prefix guidance (`[component] bug: ...`) to match existing
  issue naming convention.

## Related Issue

no-issue: template-only improvement, no functional code change

## Type of Change

- [x] Documentation update
- [x] CI/CD or build changes

## Scope

- [x] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have updated the documentation accordingly

## Testing

- Open `https://github.com/alibaba/anolisa/issues/new?template=bug_report.yml`
  and verify the simplified form renders correctly.
- Confirm placeholder text in "What happened?" guides the user.
- Confirm "Diagnostic Output" field renders as a code block.

## Additional Notes

This change is designed to work with the upcoming `anolisa bug` CLI
command, which will auto-generate environment, component status, and
recent logs for users to paste directly.