### PR TITLE
fix(tokenless): restore indentation in compress_response_hook.py

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -232,7 +232,7 @@ def main() -> None:
                 capture_output=True, text=True, timeout=3,
             )
             if proc.returncode == 0 and proc.stdout.strip():
-candidate = proc.stdout.strip()
+                candidate = proc.stdout.strip()
                 if len(candidate) < len(tool_response):
                     compressed = candidate
                     used_resp_compression = True


### PR DESCRIPTION
## Summary

- Fix SyntaxError in `compress_response_hook.py` line 235: restore 16 spaces of indentation that were accidentally removed in #735 (commit 9ca7782)
- One-line whitespace-only change, no logic change

Fixes #746

## Root cause

PR #735 added `elif proc.returncode != 0:` error handling but removed the indentation of `candidate = proc.stdout.strip()`, placing it at column 0 instead of inside the `if proc.returncode == 0` block.

## Impact

Response compression has been broken for **all** agent frameworks since 2026-06-05. CI missed it because `Test tokenless` only runs `cargo test` (Rust), not the Python hook integration tests (`run-all-tests.sh`).

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` — PARSE OK
- [x] `py_compile.compile(...)` — no errors
- [x] Adversarial workflow review (4 agents): fix correct, minimal, matches last-good version (6557e62)
- [x] Scanned all 6 Python hooks + all shell hooks — no other syntax issues found
- [ ] E2E: needs `run-all-tests.sh` on RPM-installed environment (not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)