### PR TITLE
fix(tokenless): harden hook exit-code handling + trust model consistency

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -123,8 +123,10 @@ def main() -> None:
     #   3 = Ask/Default verdict (rewrite available but permission model requires
     #       user confirmation; in non-interactive hook context, treat as valid
     #       rewrite since the intent is token optimization, not permission gating)
-    if proc.returncode not in (0, 3):
+    if proc.returncode not in (0, 1, 2, 3):
         warn(f"rtk rewrite exited with unexpected code {proc.returncode}")
+        skip()
+    if proc.returncode in (1, 2):
         skip()
     rewritten = proc.stdout.strip()
     if not rewritten or rewritten == cmd:

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -123,10 +123,11 @@ def main() -> None:
     #   3 = Ask/Default verdict (rewrite available but permission model requires
     #       user confirmation; in non-interactive hook context, treat as valid
     #       rewrite since the intent is token optimization, not permission gating)
-    if proc.returncode in (1, 2):
+    if proc.returncode not in (0, 3):
+        warn(f"rtk rewrite exited with unexpected code {proc.returncode}")
         skip()
     rewritten = proc.stdout.strip()
-    if rewritten == cmd:
+    if not rewritten or rewritten == cmd:
         skip()
 
     # 7. Build response

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -305,6 +305,8 @@ for i in $(seq 0 $((req_count - 1))); do
   esac
 done
 
+REQUIRED_MISSING_COUNT=$(echo "$MISSING_DEP_JSONS" | jq 'length' 2>/dev/null || echo 0)
+
 # Check recommended deps
 rec_count=$(echo "$RECOMMENDED" | jq 'length')
 missing_count_rec=0
@@ -363,7 +365,9 @@ if [ "$missing_count" -gt 0 ] && [ -n "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; t
         binary=$(echo "$MISSING_DEP_JSONS" | jq -r ".[$i].binary")
         if ! resolve_binary "$binary" >/dev/null 2>&1; then
             STILL_MISSING="${STILL_MISSING} ${binary}"
-            HAS_REQUIRED_MISSING=true
+            if [ "$i" -lt "$REQUIRED_MISSING_COUNT" ]; then
+                HAS_REQUIRED_MISSING=true
+            fi
         fi
     done
 

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -75,14 +75,16 @@ fn is_trusted_path(path: &std::path::Path) -> bool {
     };
     // Helper: check a directory for foreign ownership or world-writable bit.
     fn check_parent_dir(parent: &std::path::Path) -> bool {
-        if let Ok(parent_meta) = fs::symlink_metadata(parent) {
-            let parent_uid = parent_meta.uid();
-            if parent_uid != current_uid() && parent_uid != 0 {
-                return false;
-            }
-            if parent_meta.mode() & 0o002 != 0 {
-                return false;
-            }
+        let parent_meta = match fs::symlink_metadata(parent) {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+        let parent_uid = parent_meta.uid();
+        if parent_uid != current_uid() && parent_uid != 0 {
+            return false;
+        }
+        if parent_meta.mode() & 0o002 != 0 {
+            return false;
         }
         true
     }


### PR DESCRIPTION
## Summary

- **rewrite_hook.py**: use blocklist (`not in (0, 3)`) instead of allowlist (`in (1, 2)`) for rtk exit codes; add empty-stdout guard and `warn()` on unexpected codes. Prevents replacing user's command with empty string when rtk crashes.
- **tool_ready_hook.sh**: fix post-fix re-scan conflating recommended deps with required deps. A missing recommended dep no longer incorrectly blocks the tool — it correctly enters PARTIAL (degraded) mode.
- **env_check.rs**: change `check_parent_dir` to fail-closed on stat error, matching the shell `_check_parent` behavior. Both files carry `KEEP IN SYNC` comments.

## Verification

| Fix | Test |
|-----|------|
| rewrite_hook | 9/9 exit-code scenarios pass (0,1,2,3,101,127,137,empty stdout,unchanged cmd) |
| tool_ready_hook | E2E: old code → `decision:block` on recommended-only missing; fixed → `PARTIAL` |
| env_check.rs | Rust binary: stat failure on unreachable dir → old returns `true`, fixed returns `false`; normal path: no regression |
| All | `cargo test` 25/25, `cargo check` OK, `bash -n` OK, `ast.parse` OK |
| All | Adversarial workflow review: 7 agents, all APPROVED, 0 blocking issues |

Closes #749, closes #750, closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)