### PR TITLE
fix(sec-core): restore validation error diagnostic in event insert

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -44,7 +44,8 @@ class SecurityEventRepository:
         """Insert an event. Returns False for invalid or skipped writes."""
         try:
             values = self._event_values(event)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as exc:
+            logger.warning("invalid event params: %s", exc)
             return False
         session_factory = self._store.session_factory(raise_on_error=True)
         if session_factory is None:


### PR DESCRIPTION
## Summary

- Restore diagnostic logging in `SecurityEventRepository.insert()` except block
- Commit `8eadfe4` removed `stderr` print without adding replacement — the actual `ValueError`/`TypeError` message was silently discarded
- The caller only saw a generic `RuntimeError("sqlite write was skipped")` with no root cause
- Now logs via `logger.warning("invalid event params: %s", exc)` using lazy formatting

## Verification

- `ast.parse`: syntax OK
- Adversarial workflow review: APPROVED, 0 issues
- Not E2E testable — change is diagnostic-only (adds log output on error path, does not alter control flow)

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)