### PR TITLE
fix(sight): clamp stdout payload to MAX-1 to avoid mask zeroing

### DIFF
--- a/src/agentsight/src/bpf/proctrace.bpf.c
+++ b/src/agentsight/src/bpf/proctrace.bpf.c
@@ -288,8 +288,8 @@ int trace_write_enter(struct syscall_trace_enter *ctx)
     
     // Calculate actual payload size (limit to MAX_STDOUT_PAYLOAD)
     u32 payload_len = count;
-    if (payload_len > MAX_STDOUT_PAYLOAD)
-        payload_len = MAX_STDOUT_PAYLOAD;
+    if (payload_len >= MAX_STDOUT_PAYLOAD)
+        payload_len = MAX_STDOUT_PAYLOAD - 1;
     
     // Use fixed maximum size for ringbuffer reservation (BPF verifier requirement)
     // The actual data length is recorded in data_len field


### PR DESCRIPTION
## Summary

Fixes #757. The BPF verifier mask `payload_len &= (MAX_STDOUT_PAYLOAD - 1)` zeroes payload_len when it equals exactly 1024 (or any value clamped to 1024). This causes all stdout/stderr captures for writes >= 1024 bytes to produce empty payload while the header claims data is present.

## Changes

- `proctrace.bpf.c:291-292`: Change `>` to `>=` and clamp to `MAX_STDOUT_PAYLOAD - 1` (1023) instead of `MAX_STDOUT_PAYLOAD` (1024)

## Verification

- E2E on ECS (kernel 6.6.102+): `bpftool prog dump xlated` confirms fixed bytecode clamps to 1023
- Arithmetic proof: 1023 & 0x3FF = 1023 (no-op), vs old: 1024 & 0x3FF = 0 (bug)
- cargo check + cargo test passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)