### PR TITLE
fix(sight): add agentsight-start to RPM spec

### DIFF
--- a/src/agentsight/agentsight.spec.in
+++ b/src/agentsight/agentsight.spec.in
@@ -36,6 +36,7 @@ install -d -m 0755 %{buildroot}%{_unitdir}
 install -d -m 0755 %{buildroot}%{_docdir}/agentsight
 
 install -p -m 0755 agentsight %{buildroot}/usr/local/bin/
+install -p -m 0755 agentsight-start %{buildroot}/usr/local/bin/
 install -p -m 0644 agentsight.service %{buildroot}%{_unitdir}/
 install -p -m 0644 README.md %{buildroot}%{_docdir}/agentsight/
 install -p -m 0644 README_CN.md %{buildroot}%{_docdir}/agentsight/
@@ -53,6 +54,7 @@ install -p -m 0644 LICENSE %{buildroot}%{_docdir}/agentsight/
 %files
 %defattr(0644,root,root,0755)
 %attr(0755,root,root) /usr/local/bin/agentsight
+%attr(0755,root,root) /usr/local/bin/agentsight-start
 %{_unitdir}/agentsight.service
 %doc %{_docdir}/agentsight/README.md
 %doc %{_docdir}/agentsight/README_CN.md


### PR DESCRIPTION
## Summary

Fixes #758. The agentsight.spec.in omits the agentsight-start wrapper script from %install and %files, causing systemd service to fail with 203/EXEC after RPM install.

## Changes

- `agentsight.spec.in`: Add `install -p -m 0755 agentsight-start` to %install, add `%attr(0755,root,root) /usr/local/bin/agentsight-start` to %files

## Verification

- E2E on ECS: rpmbuild -> rpm install -> `rpm -ql` now shows agentsight-start -> `systemctl start` returns status=0/SUCCESS (was 203/EXEC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)