### PR TITLE
fix(sight): reduce MAX_BUF_SIZE from 4MB to 32KB

### DIFF
--- a/src/agentsight/src/analyzer/token/parser.rs
+++ b/src/agentsight/src/analyzer/token/parser.rs
@@ -112,7 +112,7 @@ mod tests {
 
     /// Create a mock ParsedSseEvent for testing
     ///
-    /// Note: SslEvent is large (~512KB), so we allocate it on the heap
+    /// Note: SslEvent is large (~32KB), so we allocate it on the heap
     fn create_test_event(data: &str) -> ParsedSseEvent {
         use crate::probes::sslsniff::SslEvent;
         use std::rc::Rc;

--- a/src/agentsight/src/bpf/sslsniff.h
+++ b/src/agentsight/src/bpf/sslsniff.h
@@ -6,7 +6,7 @@
 #ifndef __SSLSNIFF_H
 #define __SSLSNIFF_H
 
-#define MAX_BUF_SIZE (8 * 512 * 1024)  // 512KB eBPF buffer size (kernel limit)
+#define MAX_BUF_SIZE (32 * 1024)  // 32KB max capture per SSL/TCP event
 #define TASK_COMM_LEN 16
 
 typedef signed char         s8;

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -45,7 +45,7 @@ const POLL_TIMEOUT_MS: u64 = 100;
 
 /// User-space SslEvent - lightweight version of BPF probe_SSL_data_t
 ///
-/// Unlike the BPF version which has a 512KB fixed-size buffer, this struct
+/// Unlike the BPF version which has a 32KB fixed-size buffer, this struct
 /// only stores the actual data received, significantly reducing memory usage.
 #[derive(Debug, Clone)]
 pub struct SslEvent {
@@ -58,7 +58,7 @@ pub struct SslEvent {
     pub len: u32,
     pub rw: i32,
     pub comm: String,
-    /// Actual data buffer (only contains received data, not full 512KB)
+    /// Actual data buffer (only contains received data, not full 32KB)
     pub buf: Vec<u8>,
     pub is_handshake: bool,
     pub ssl_ptr: u64,


### PR DESCRIPTION
## Summary

Fixes #759. MAX_BUF_SIZE was 8*512*1024 = 4MB (comment said 512KB). Each SSL/TCP event reserved ~4MB from a 32MB ring buffer, allowing only ~7 concurrent events. Reduced to 32KB (covers max TLS record of 16KB with margin), increasing capacity to ~1000 concurrent events.

## Changes

- `sslsniff.h`: `(8 * 512 * 1024)` -> `(32 * 1024)` with corrected comment
- `sslsniff.rs`: Update 2 misleading '512KB' comments to '32KB'
- `parser.rs`: Update 1 misleading '512KB' comment

## Verification

- E2E on ECS: `bpftool prog dump xlated` confirmed reserve size changed from 4,194,384 to ~32KB
- cargo check + cargo test passed
- BPF verifier masks in sslsniff.bpf.c and tcpsniff.bpf.c verified correct with 32KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)