### PR TITLE
fix(tokenless): dedup rewrite_hook, import from hook_utils

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -14,45 +14,29 @@ FHS spec: /usr/libexec/anolisa/tokenless/rtk.
 
 import json
 import os
-import re
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from hook_utils import resolve_binary, skip, warn, _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB, _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB
+from hook_utils import (
+    _RTK_FALLBACK,
+    _RTK_LOCAL_LIB,
+    _RTK_LOCAL_SHARE,
+    _TOKENLESS_FALLBACK,
+    _TOKENLESS_LOCAL_LIB,
+    _TOKENLESS_LOCAL_SHARE,
+    parse_version,
+    resolve_binary,
+    skip,
+    warn,
+    write_context,
+)
 
 # -- constants ---------------------------------------------------------------
 
 _MIN_RTK_VERSION = (0, 35, 0)
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
-
-_CONTEXT_DIR = os.path.join(os.path.expanduser("~"), ".tokenless")
-_CONTEXT_FILE = os.path.join(_CONTEXT_DIR, ".rewrite-context")
-
-
-# -- helpers -----------------------------------------------------------------
-
-
-def _parse_version(version_str: str) -> tuple | None:
-    m = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)
-    if m:
-        return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
-    return None
-
-
-def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
-    os.makedirs(_CONTEXT_DIR, mode=0o700, exist_ok=True)
-    if os.path.islink(_CONTEXT_FILE):
-        os.unlink(_CONTEXT_FILE)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-    fd = os.open(_CONTEXT_FILE, flags, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(f"{agent_id}\n")
-        f.write(f"{session_id}\n")
-        f.write(f"{tool_use_id}\n")
 
 
 # -- main --------------------------------------------------------------------
@@ -60,7 +44,9 @@ def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
 
 def main() -> None:
     # 1. Resolve rtk binary
-    rtk_bin = resolve_binary("rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB)
+    rtk_bin = resolve_binary(
+        "rtk", _RTK_FALLBACK, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB
+    )
     if not rtk_bin:
         warn("rtk is not installed or not in PATH. Hook disabled.")
         skip()
@@ -69,9 +55,11 @@ def main() -> None:
     try:
         result = subprocess.run(
             [rtk_bin, "--version"],
-            capture_output=True, text=True, timeout=3,
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
-        ver = _parse_version(result.stdout)
+        ver = parse_version(result.stdout)
         if ver and ver < _MIN_RTK_VERSION:
             warn(f"rtk {result.stdout.strip()} is too old (need >= 0.35.0).")
             skip()
@@ -79,7 +67,12 @@ def main() -> None:
         warn(f"rtk version check failed: {e}")
 
     # 3. Check tokenless binary (for stats)
-    if not resolve_binary("tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
+    if not resolve_binary(
+        "tokenless",
+        _TOKENLESS_FALLBACK,
+        _TOKENLESS_LOCAL_SHARE,
+        _TOKENLESS_LOCAL_LIB,
+    ):
         warn("tokenless is not installed. Hook disabled.")
         skip()
 
@@ -99,18 +92,23 @@ def main() -> None:
     env = os.environ.copy()
     env["TOKENLESS_AGENT_ID"] = _AGENT_ID
     session_id = input_data.get("session_id", "")
-    tool_use_id = input_data.get("tool_use_id") or input_data.get("toolCallId", "")
+    tool_use_id = input_data.get("tool_use_id") or input_data.get(
+        "toolCallId", ""
+    )
     if session_id:
         env["TOKENLESS_SESSION_ID"] = session_id
     if tool_use_id:
         env["TOKENLESS_TOOL_USE_ID"] = tool_use_id
 
-    _write_context(_AGENT_ID, session_id, tool_use_id)
+    write_context(_AGENT_ID, session_id, tool_use_id)
 
     try:
         proc = subprocess.run(
             [rtk_bin, "rewrite", cmd],
-            capture_output=True, text=True, timeout=5, env=env,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
         )
     except Exception as e:
         warn(f"rtk rewrite subprocess failed: {e}")


### PR DESCRIPTION
## Summary

Fixes #760. rewrite_hook.py defined local copies of _parse_version() and _write_context() identical to the canonical versions in hook_utils.py. Replaced with imports. _write_context contains security-sensitive O_NOFOLLOW symlink protection — duplicate copies risk diverging on security patches.

## Changes

- `rewrite_hook.py`: Add `parse_version, write_context` to hook_utils import, delete local copies + constants, update call sites

## Verification

- E2E on ECS (Python 3.11): import resolution verified
- isort --profile black + black formatting verified
- Python AST syntax check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)