### PR TITLE
fix(sight): CJK deadloop detection + kill() error check + SIGKILL escalation

### DIFF
--- a/src/agentsight/src/interruption/loop_detector.rs
+++ b/src/agentsight/src/interruption/loop_detector.rs
@@ -279,12 +279,34 @@ impl LoopDetector {
 
 // ─── Utility functions ───────────────────────────────────────────────────────
 
-/// Compute Jaccard similarity between two text strings based on whitespace-split tokens.
+fn is_cjk(c: char) -> bool {
+    matches!(c, '\u{4E00}'..='\u{9FFF}' | '\u{3400}'..='\u{4DBF}' | '\u{F900}'..='\u{FAFF}')
+}
+
+fn tokenize(text: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    for word in text.split_whitespace() {
+        let cjk_chars: Vec<char> = word.chars().filter(|c| is_cjk(*c)).collect();
+        if cjk_chars.len() >= 2 {
+            for pair in cjk_chars.windows(2) {
+                tokens.insert(format!("{}{}", pair[0], pair[1]));
+            }
+        } else if cjk_chars.len() == 1 {
+            tokens.insert(cjk_chars[0].to_string());
+        } else {
+            tokens.insert(word.to_string());
+        }
+    }
+    tokens
+}
+
+/// Compute Jaccard similarity between two text strings.
 ///
-/// Returns a value in [0.0, 1.0] where 1.0 means identical token sets.
+/// Uses whitespace-split tokens for ASCII/Latin text and character bigrams
+/// for CJK text, so deadloop detection works for both English and Chinese.
 fn jaccard_similarity(a: &str, b: &str) -> f64 {
-    let set_a: HashSet<&str> = a.split_whitespace().collect();
-    let set_b: HashSet<&str> = b.split_whitespace().collect();
+    let set_a = tokenize(a);
+    let set_b = tokenize(b);
 
     if set_a.is_empty() && set_b.is_empty() {
         return 1.0;
@@ -526,5 +548,30 @@ mod tests {
     #[test]
     fn test_jaccard_similarity_empty() {
         assert_eq!(jaccard_similarity("", ""), 1.0);
+    }
+
+    #[test]
+    fn test_jaccard_cjk_near_identical() {
+        let a = "根据分析，该数据集包含1000条记录，其中异常值占比约3.2%，建议进一步清洗后重新统计。";
+        let b = "根据分析，该数据集包含1000条记录，其中异常值占比约3.5%，建议进一步清洗后重新统计。";
+        let sim = jaccard_similarity(a, b);
+        assert!(sim > 0.8, "CJK near-identical text should score >0.8, got {sim:.4}");
+    }
+
+    #[test]
+    fn test_jaccard_cjk_different() {
+        let a = "今天天气非常好适合出门散步";
+        let b = "量子计算机可以解决复杂问题";
+        let sim = jaccard_similarity(a, b);
+        assert!(sim < 0.2, "Different CJK text should score <0.2, got {sim:.4}");
+    }
+
+    #[test]
+    fn test_jaccard_english_still_works() {
+        let sim = jaccard_similarity(
+            "analyze the key statistics of this dataset",
+            "analyze the main statistics of this dataset",
+        );
+        assert!(sim > 0.7, "English similarity should still work, got {sim:.4}");
     }
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -1086,7 +1086,7 @@ impl AgentSight {
                             &crate::interruption::InterruptionType::DeadLoop,
                         );
                         let should_detect = if self.deadloop_kill_enabled {
-                            existing_count < self.deadloop_kill_after_count
+                            existing_count <= self.deadloop_kill_after_count
                         } else {
                             existing_count == 0
                         };
@@ -1114,18 +1114,30 @@ impl AgentSight {
                                     );
 
                                     // ── Auto-kill 止血 ──
-                                    // Kill when detection count reaches threshold.
-                                    // count_for_conversation now includes the event we just inserted.
                                     if self.deadloop_kill_enabled {
                                         let new_count = existing_count + 1;
-                                        if new_count >= self.deadloop_kill_after_count {
+                                        if new_count > self.deadloop_kill_after_count {
+                                            if let Some(pid) = loop_event.pid {
+                                                log::error!(
+                                                    "DeadLoop auto-kill: escalating to SIGKILL for pid {} (conversation={}, detections={})",
+                                                    pid, cid, new_count
+                                                );
+                                                let ret = unsafe { libc::kill(pid, libc::SIGKILL) };
+                                                if ret != 0 {
+                                                    let err = std::io::Error::last_os_error();
+                                                    log::error!("DeadLoop auto-kill: SIGKILL failed for pid {}: {}", pid, err);
+                                                }
+                                            }
+                                        } else if new_count == self.deadloop_kill_after_count {
                                             if let Some(pid) = loop_event.pid {
                                                 log::error!(
                                                     "DeadLoop auto-kill: sending SIGTERM to pid {} (conversation={}, detections={})",
                                                     pid, cid, new_count
                                                 );
-                                                unsafe {
-                                                    libc::kill(pid, libc::SIGTERM);
+                                                let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
+                                                if ret != 0 {
+                                                    let err = std::io::Error::last_os_error();
+                                                    log::error!("DeadLoop auto-kill: SIGTERM failed for pid {}: {}", pid, err);
                                                 }
                                             }
                                         } else {


### PR DESCRIPTION
## Summary

Fixes #770. Three hardening improvements to the deadloop detection feature (#740).

## Changes

### 1. CJK Jaccard similarity fix (loop_detector.rs)

`jaccard_similarity()` used `split_whitespace()` which produces a single token for CJK text (Chinese has no spaces). Near-identical Chinese outputs scored 0.0 instead of ~0.95, making Rules 2 and 3 blind to CJK deadloops.

Fix: hybrid tokenizer using character bigrams for CJK, whitespace-split for ASCII.

### 2. kill() return value check (unified.rs)

`libc::kill()` return value was discarded. EPERM (container namespace) or ESRCH (race) failures were silent.

Fix: check return, log error on failure.

### 3. SIGKILL escalation (unified.rs)

After SIGTERM, `should_detect` became false, preventing any follow-up. If the agent ignored SIGTERM, the deadloop continued forever.

Fix: allow one more detection cycle (`<=` instead of `<`). At threshold → SIGTERM; above threshold → SIGKILL.

## Verification

- **CJK**: 7 Rust unit tests (3 new CJK + 4 existing) — all pass. CJK near-identical: sim > 0.8 (was 0.0)
- **kill()**: ECS E2E — EPERM (ret=-1, errno=1) and ESRCH (ret=-1, errno=3) confirmed
- **BPF**: 13 probes load correctly with fixed binary on ECS
- **Full test**: 535 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)