### PR TITLE
feat(sight): support cgroup-level event filtering with v1/v2 compatib…

### DIFF
--- a/src/agentsight/src/bpf/cgroup_helper.h
+++ b/src/agentsight/src/bpf/cgroup_helper.h
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// Cgroup ID helper: provides get_cgroup_id_compat() returning a single u64
+// cgroup inode ID suitable for container association.
+//
+// v1/v2 detection is done by user-space and passed via rodata (cgroup_v2_mode).
+// - v2: uses bpf_get_current_cgroup_id() helper directly (zero CO-RE overhead)
+// - v1: CO-RE reads subsys[MEMORY]->cgroup->kn->id
+
+#ifndef CGROUP_HELPER_H
+#define CGROUP_HELPER_H
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+/* cgroup subsystem index for memory controller (Anolis/RHEL standard) */
+#define CGRP_SUBSYS_MEMORY 4
+
+/*
+ * User-space sets this before BPF load:
+ *   true  = cgroup v2 unified hierarchy (bpf_get_current_cgroup_id() is valid)
+ *   false = cgroup v1 (must CO-RE read memory subsys cgroup)
+ *
+ * Detection: check existence of /sys/fs/cgroup/cgroup.controllers
+ */
+const volatile bool cgroup_v2_mode = false;
+
+/*
+ * Local definition of kernfs_node_id union for CO-RE compatibility.
+ * On kernels >= 5.14, this union no longer exists in BTF (kernfs_node.id is
+ * directly u64). We define it locally so struct kernfs_node___old compiles
+ * on both old and new build environments. The CO-RE resolver matches by
+ * field name (not local type name), so this does not affect runtime behavior.
+ *
+ * Guard with a custom macro to avoid duplicate definition when older vmlinux.h
+ * already provides this union via BTF.
+ */
+#ifndef __KERNFS_NODE_ID_DEFINED
+#define __KERNFS_NODE_ID_DEFINED
+union kernfs_node_id {
+    struct {
+        u32 ino;
+        u32 generation;
+    };
+    u64 id;
+};
+#endif /* __KERNFS_NODE_ID_DEFINED */
+
+/*
+ * CO-RE flavor types for kernfs_node->id field compatibility.
+ *
+ * Three variants covering the full kernel version range:
+ *
+ *   ___419  — vanilla 4.19: kn->id is "union kernfs_node_id"
+ *             (struct { u32 ino; u32 generation; } + u64 id overlay)
+ *
+ *   ___rh8  — RHEL8 / Anolis 8 ANCK 5.10: KABI preservation wrapper
+ *             kn->id is an anonymous union exposing u64 id directly,
+ *             with the old union stashed under rh_kabi_hidden_172.
+ *             bpf_core_field_exists(kn_rh8->id) is TRUE on RHEL8 and
+ *             also on modern kernels where id is already plain u64.
+ *
+ *   ___new  — alinux3 / Anolis 23+ / upstream >= 5.14:
+ *             kn->id is plain u64 with no union wrapper.
+ *             Kept for documentation; in practice ___rh8 also covers
+ *             this case since the anonymous union member matches u64.
+ *
+ * Detection order mirrors mem_latency.bpf.c (sysAK reference):
+ *   1. bpf_core_field_exists(kn_rh8->id)  → RHEL8 + modern  (u64 accessible)
+ *   2. fallback                            → 4.19            (union variant)
+ */
+
+/* 4.19-style: id is union kernfs_node_id */
+struct kernfs_node___419 {
+    const char *name;
+    union kernfs_node_id id;
+};
+
+/* RHEL8 KABI-preserved layout: anonymous union exposes u64 id directly */
+struct kernfs_node___rh8 {
+    const char *name;
+    union {
+        u64 id;
+        struct {
+            union kernfs_node_id id;
+        } rh_kabi_hidden_172;
+        union { };
+    };
+};
+
+/* Modern (>= 5.14 / alinux3): id is plain u64 */
+struct kernfs_node___new {
+    u64 id;
+};
+
+/*
+ * __read_kn_id - Read kernfs_node->id with three-variant CO-RE compatibility
+ *
+ * Priority:
+ *   1. RHEL8 / modern: bpf_core_field_exists(kn_rh8->id) TRUE
+ *      -> read u64 id directly via anonymous union member
+ *   2. 4.19 legacy: id is union kernfs_node_id
+ *      -> read the u64 overlay of the union
+ */
+static __always_inline u64 __read_kn_id(struct kernfs_node *kn)
+{
+    if (!kn)
+        return 0;
+
+    struct kernfs_node___rh8 *kn_rh8 = (void *)kn;
+
+    if (bpf_core_field_exists(kn_rh8->id)) {
+        /*
+         * RHEL8: anonymous union exposes u64 id directly.
+         * Modern kernels (plain u64 id) also match this branch.
+         */
+        u64 id;
+        bpf_core_read(&id, sizeof(u64), &kn_rh8->id);
+        return id;
+    }
+
+    /* 4.19: kn->id is union kernfs_node_id; read as u64 overlay */
+    struct kernfs_node___419 *kn_419 = (void *)kn;
+    u64 id;
+    bpf_core_read(&id, sizeof(u64), &kn_419->id);
+    return id;
+}
+
+/*
+ * get_cgroup_id_compat - Get the effective cgroup inode ID for container association
+ *
+ * Strategy (determined by user-space via cgroup_v2_mode rodata):
+ *   v2 mode: call bpf_get_current_cgroup_id() directly.
+ *            Returns dfl_cgrp->kn->id — the canonical kernel cgroup id.
+ *            Zero CO-RE overhead, available since Linux 4.18.
+ *
+ *   v1 mode: CO-RE read task->cgroups->subsys[MEMORY]->cgroup->kn->id.
+ *            Returns the memory controller cgroup's kernfs inode,
+ *            matching stat(v1_memory_cgroup_path).st_ino.
+ *
+ * Kernel requirements: BTF enabled, Linux 4.18+ (for bpf_get_current_cgroup_id)
+ * Supported environments: Anolis OS 8 ANCK 5.10+, alinux3/Anolis 23+
+ */
+static __always_inline u64 get_cgroup_id_compat(void)
+{
+    if (cgroup_v2_mode) {
+        /*
+         * cgroup v2 unified hierarchy:
+         * bpf_get_current_cgroup_id() returns dfl_cgrp->kn->id directly.
+         * No CO-RE reads, no __ksym dependency.
+         */
+        return bpf_get_current_cgroup_id();
+    }
+
+    /*
+     * cgroup v1 path:
+     * Container isolation is via v1 memory subsystem.
+     * Read subsys[MEMORY]->cgroup->kn->id via CO-RE.
+     */
+    struct task_struct *task = (void *)bpf_get_current_task();
+    if (!task)
+        return 0;
+
+    struct cgroup_subsys_state *css = BPF_CORE_READ(task, cgroups,
+                                                     subsys[CGRP_SUBSYS_MEMORY]);
+    if (!css)
+        return 0;
+
+    struct cgroup *mem_cgrp = BPF_CORE_READ(css, cgroup);
+    if (!mem_cgrp)
+        return 0;
+
+    struct kernfs_node *kn = BPF_CORE_READ(mem_cgrp, kn);
+    return __read_kn_id(kn);
+}
+
+#endif /* CGROUP_HELPER_H */

--- a/src/agentsight/src/bpf/common.h
+++ b/src/agentsight/src/bpf/common.h
@@ -118,5 +118,30 @@ static __always_inline u32 is_pid_traced(u32 host_pid)
 }
 #endif
 
+/* ========== cgroup filter ==========
+ *
+ * Optional cgroup-level filter shared across all probes that include common.h.
+ * When `filter_cgroup_enabled` is false (default), the cgroup filter logic in
+ * each probe short-circuits to true and behavior is identical to before.
+ * When enabled, only cgroups registered in the cgroup_filter map pass.
+ *
+ * Probes that act as full-system audit (e.g. procmon) should define
+ * NO_CGROUP_FILTER before including common.h to opt out entirely.
+ */
+#ifndef NO_CGROUP_FILTER
+#ifndef MAX_CGROUP_FILTER_ENTRIES
+#define MAX_CGROUP_FILTER_ENTRIES 512
+#endif
+
+const volatile bool filter_cgroup_enabled = false;
+
+struct
+{
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_CGROUP_FILTER_ENTRIES);
+    __type(key, u64);    /* cgroup inode id from get_cgroup_id_compat() */
+    __type(value, u8);   /* 1 = tracked */
+} cgroup_filter SEC(".maps");
+#endif
 
 #endif

--- a/src/agentsight/src/bpf/filewatch.bpf.c
+++ b/src/agentsight/src/bpf/filewatch.bpf.c
@@ -1,3 +1,11 @@
+/*
+ * @Descripttion: 
+ * @version: 
+ * @Author: Jietao Xiao
+ * @Date: 2026-06-08 10:48:08
+ * @LastEditors: Jietao Xiao
+ * @LastEditTime: 2026-06-08 11:52:29
+ */
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 // Copyright (c) 2025 AgentSight Project
 //
@@ -9,6 +17,7 @@
 #include <bpf/bpf_tracing.h>
 #include "filewatch.h"
 #include "common.h"
+#include "cgroup_helper.h"
 
 // Tracepoint for openat - captures file open events
 // Filters for .jsonl suffix at BPF layer to minimize user-space overhead
@@ -22,6 +31,12 @@ int trace_openat_enter(struct trace_event_raw_sys_enter *ctx)
     u32 ns_pid = is_pid_traced(pid);
     if (!ns_pid)
         return 0;
+    u64 cg_id = get_cgroup_id_compat();
+#ifndef NO_CGROUP_FILTER
+    if (filter_cgroup_enabled &&
+        !bpf_map_lookup_elem(&cgroup_filter, &cg_id))
+        return 0;
+#endif
 
     // Reserve space in ring buffer
     struct filewatch_event *event = bpf_ringbuf_reserve(&rb, sizeof(*event), 0);
@@ -30,17 +45,24 @@ int trace_openat_enter(struct trace_event_raw_sys_enter *ctx)
 
     // Read filename from user-space
     const char *filename_ptr = (const char *)ctx->args[1];
-    int len = bpf_probe_read_user_str(event->filename, MAX_FILENAME_LEN, filename_ptr);
-
-    // len includes null terminator; need at least 7 chars: x.jsonl\0
-    if (len < 8) {
+    /* Use long like the helper's return type; narrow checks in two steps so the
+     * verifier proves len >= 0 before filename[off + k] pointer arithmetic.
+     */
+    long len = bpf_probe_read_user_str(event->filename, MAX_FILENAME_LEN, filename_ptr);
+    if (len < 0) {
+        bpf_ringbuf_discard(event, 0);
+        return 0;
+    }
+    /* len includes null terminator; need at least 8 chars ('x'.jsonl\0) */
+    if (len < 8 || len > MAX_FILENAME_LEN) {
         bpf_ringbuf_discard(event, 0);
         return 0;
     }
 
-    // Check .jsonl suffix (len includes null terminator, so last char is at len-2)
-    // suffix starts at offset len-7: '.', 'j', 's', 'o', 'n', 'l', '\0'
-    int off = len - 7;
+    /* Check .jsonl suffix (len includes null terminator, so last char is at len-2)
+     * suffix starts at offset len-7: '.', 'j', 's', 'o', 'n', 'l', '\0'
+     */
+    long off = len - 7;
     if (event->filename[off]     != '.' ||
         event->filename[off + 1] != 'j' ||
         event->filename[off + 2] != 's' ||
@@ -59,6 +81,7 @@ int trace_openat_enter(struct trace_event_raw_sys_enter *ctx)
     event->uid = bpf_get_current_uid_gid();
     event->flags = (s32)ctx->args[2];
     bpf_get_current_comm(&event->comm, sizeof(event->comm));
+    event->cgroup_id = cg_id;
 
     bpf_ringbuf_submit(event, 0);
     return 0;

--- a/src/agentsight/src/bpf/filewatch.h
+++ b/src/agentsight/src/bpf/filewatch.h
@@ -28,6 +28,7 @@ struct filewatch_event {
     s32 flags;                       // openat flags (O_RDONLY, O_WRONLY, etc.)
     char comm[TASK_COMM_LEN];
     char filename[MAX_FILENAME_LEN]; // captured file path
+    u64 cgroup_id;                   // unified cgroup inode from get_cgroup_id_compat()
 };
 
 #endif /* __FILEWATCH_H */

--- a/src/agentsight/src/bpf/filewrite.bpf.c
+++ b/src/agentsight/src/bpf/filewrite.bpf.c
@@ -10,6 +10,7 @@
 #include <bpf/bpf_tracing.h>
 #include "filewrite.h"
 #include "common.h"
+#include "cgroup_helper.h"
 
 // UUID format: 8-4-4-4-12 hex digits with hyphens (36 chars total)
 #define UUID_LEN 36
@@ -52,6 +53,13 @@ int BPF_PROG(trace_vfs_write, struct file *file, const char *buf, size_t count, 
     u32 ns_pid = is_pid_traced(pid);
     if (!ns_pid)
         return 0;
+
+    u64 cg_id = get_cgroup_id_compat();
+#ifndef NO_CGROUP_FILTER
+    if (filter_cgroup_enabled &&
+        !bpf_map_lookup_elem(&cgroup_filter, &cg_id))
+        return 0;
+#endif
 
     // Extract filename from file->f_path.dentry->d_name.name (basename)
     // Check early so we can skip non-.jsonl files before reserving ringbuf
@@ -96,6 +104,7 @@ int BPF_PROG(trace_vfs_write, struct file *file, const char *buf, size_t count, 
     event->uid = bpf_get_current_uid_gid();
     event->write_size = (u32)count;
     bpf_get_current_comm(&event->comm, sizeof(event->comm));
+    event->cgroup_id = cg_id;
 
     // Copy filename we already read into the event
     __builtin_memcpy(event->filename, fname, MAX_FILENAME_LEN);

--- a/src/agentsight/src/bpf/filewrite.h
+++ b/src/agentsight/src/bpf/filewrite.h
@@ -30,6 +30,7 @@ struct filewrite_event {
     u32 buf_size;                       // actual bytes copied (min(count, MAX_FILEWRITE_BUF))
     char comm[TASK_COMM_LEN];           // process name (16 bytes)
     char filename[MAX_FILENAME_LEN];    // basename from dentry (256 bytes)
+    u64 cgroup_id;                      // cgroup inode from get_cgroup_id_compat()
     u8  buf[MAX_FILEWRITE_BUF];         // write content (up to 16KB)
 };
 

--- a/src/agentsight/src/bpf/procmon.bpf.c
+++ b/src/agentsight/src/bpf/procmon.bpf.c
@@ -9,6 +9,7 @@
 #include <bpf/bpf_tracing.h>
 #include "procmon.h"
 #define NO_TRACED_PROCESSES_MAP
+#define NO_CGROUP_FILTER
 #include "common.h"
 
 // Tracepoint for execve exit - captures process execution after it completes

--- a/src/agentsight/src/bpf/proctrace.bpf.c
+++ b/src/agentsight/src/bpf/proctrace.bpf.c
@@ -9,6 +9,7 @@
 #include <bpf/bpf_tracing.h>
 #include "proctrace.h"
 #include "common.h"
+#include "cgroup_helper.h"
 
 // Target uid filter (optional, -1 means trace all uids)
 const volatile uid_t targ_uid = -1;
@@ -79,6 +80,13 @@ int trace_execve_enter(struct sys_enter_execve_args *args)
     u8 *ppid_traced = bpf_map_lookup_elem(&traced_processes, &ppid);
 
     if (ppid_traced) {
+        // cgroup-level gate: drop child if parent's cgroup is not in filter
+        u64 cg_id = get_cgroup_id_compat();
+#ifndef NO_CGROUP_FILTER
+        if (filter_cgroup_enabled &&
+            !bpf_map_lookup_elem(&cgroup_filter, &cg_id))
+            return 0;
+#endif
         // Also track in child_pids for stdout capture
         bpf_map_update_elem(&child_pids, &pid, &value, BPF_ANY);
     } else {
@@ -197,6 +205,7 @@ int trace_execve_exit(struct sys_exit_execve_args *args)
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     long ret = args->ret;
+    u64 cg_id = get_cgroup_id_compat();
 
     // Look up pending event
     struct proc_event_t *pending = bpf_map_lookup_elem(&pending_exec_events, &pid);
@@ -235,6 +244,7 @@ int trace_execve_exit(struct sys_exit_execve_args *args)
     event->data_len = sizeof(struct proc_exec_data) + args_size;
     for (int i = 0; i < TASK_COMM_LEN; i++)
         event->comm[i] = pending->comm[i];
+    event->cgroup_id = cg_id;
 
     // Fill exec_data
     struct proc_exec_data *exec_data = (void *)(event + 1);
@@ -285,6 +295,12 @@ int trace_write_enter(struct syscall_trace_enter *ctx)
     u8 *traced = bpf_map_lookup_elem(&child_pids, &pid);
     if (!traced)
         return 0;
+    u64 cg_id = get_cgroup_id_compat();
+#ifndef NO_CGROUP_FILTER
+    if (filter_cgroup_enabled &&
+        !bpf_map_lookup_elem(&cgroup_filter, &cg_id))
+        return 0;
+#endif
     
     // Calculate actual payload size (limit to MAX_STDOUT_PAYLOAD)
     u32 payload_len = count;
@@ -307,7 +323,8 @@ int trace_write_enter(struct syscall_trace_enter *ctx)
     event->event_type = PROCTRACE_EVENT_STDOUT;
     event->data_len = sizeof(struct proc_stdout_data) + payload_len;
     bpf_get_current_comm(&event->comm, sizeof(event->comm));
-    
+    event->cgroup_id = cg_id;
+
     // Fill stdout_data
     struct proc_stdout_data *stdout_data = (void *)(event + 1);
     stdout_data->fd = fd;
@@ -346,6 +363,7 @@ int trace_process_exit(void *ctx)
     u8 *traced = bpf_map_lookup_elem(&child_pids, &pid);
     if (!traced)
         return 0;
+    u64 cg_id = get_cgroup_id_compat();
     
     bpf_map_delete_elem(&child_pids, &pid);
     bpf_map_delete_elem(&traced_processes, &pid);
@@ -368,6 +386,7 @@ int trace_process_exit(void *ctx)
     event->event_type = PROCTRACE_EVENT_EXIT;
     event->data_len = sizeof(struct proc_exit_data);
     bpf_get_current_comm(&event->comm, sizeof(event->comm));
+    event->cgroup_id = cg_id;
     
     // Fill exit_data
     struct proc_exit_data *exit_data = (void *)(event + 1);

--- a/src/agentsight/src/bpf/proctrace.h
+++ b/src/agentsight/src/bpf/proctrace.h
@@ -44,6 +44,7 @@ struct proc_event_header {
     u32 event_type;         // enum proctrace_event_type
     u32 data_len;           // Length of variable data following this header
     char comm[TASK_COMM_LEN];
+    u64 cgroup_id;          // unified cgroup inode from get_cgroup_id_compat()
 };
 
 // Exec event specific data (variable length, follows header)
@@ -85,6 +86,7 @@ struct proc_event_t {
     char filename[ARGSIZE]; // Executable path from execve
     char args_buf[TOTAL_MAX_ARGS * ARGSIZE]; // Argv strings packed end-to-end
     u8  buf[MAX_BUF_SIZE];  // stdout data or other payload
+    u64 cgroup_id;          // unified cgroup inode from get_cgroup_id_compat()
 };
 
 #endif /* __PROCTRACE_H */

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -237,6 +237,10 @@ struct JsonFullConfig {
     runtime: Option<JsonRuntime>,
     #[serde(default)]
     deadloop: Option<JsonDeadloop>,
+    #[serde(default)]
+    cgroup_filter_enabled: Option<bool>,
+    #[serde(default)]
+    cgroup_ids: Option<Vec<u64>>,
 }
 
 /// DeadLoop 检测配置区段
@@ -431,6 +435,16 @@ pub struct AgentsightConfig {
     pub poll_timeout_ms: u64,
     /// Enable file watch probe (monitors .jsonl file opens from traced processes)
     pub enable_filewatch: bool,
+    /// Enable cgroup-level event filtering. When true, proctrace /
+    /// filewatch / filewrite only emit events from cgroup ids
+    /// registered via `Probes::add_traced_cgroup`. procmon is unaffected
+    /// (full audit coverage). Default: false (no cgroup filtering).
+    pub cgroup_filter_enabled: bool,
+    /// Cgroup inode IDs seeded into `cgroup_filter` at startup.
+    /// Only effective when `cgroup_filter_enabled` is true.
+    /// Obtain via `stat -c %i /sys/fs/cgroup/<path>` (v2) or
+    /// `stat -c %i /sys/fs/cgroup/memory/<path>` (v1).
+    pub cgroup_ids: Vec<u64>,
     /// TCP capture targets for plain HTTP capture (empty = disabled).
     /// Each entry specifies destination IP, port, or both.
     pub tcp_targets: Vec<TcpTarget>,
@@ -509,6 +523,8 @@ impl Default for AgentsightConfig {
             target_uid: None,
             poll_timeout_ms: DEFAULT_POLL_TIMEOUT_MS,
             enable_filewatch: false,
+            cgroup_filter_enabled: false,
+            cgroup_ids: Vec::new(),
             tcp_targets: Vec::new(),
 
             // HTTP/Aggregation defaults
@@ -603,6 +619,17 @@ impl AgentsightConfig {
         self
     }
 
+    /// Enable or disable cgroup-level event filtering.
+    ///
+    /// When enabled, only events from cgroup ids registered via
+    /// `Probes::add_traced_cgroup` are emitted by the filtered probes.
+    /// procmon keeps full audit coverage regardless. Must be set before
+    /// probes are created (the value is baked into the BPF rodata at load).
+    pub fn set_cgroup_filter_enabled(mut self, enabled: bool) -> Self {
+        self.cgroup_filter_enabled = enabled;
+        self
+    }
+
     /// Set connection capacity
     pub fn set_connection_capacity(mut self, capacity: usize) -> Self {
         self.connection_capacity = capacity;
@@ -674,6 +701,14 @@ impl AgentsightConfig {
             if let Some(count) = dl.kill_after_count {
                 self.deadloop_kill_after_count = count;
             }
+        }
+
+        // Parse cgroup filter settings
+        if let Some(v) = parsed.cgroup_filter_enabled {
+            self.cgroup_filter_enabled = v;
+        }
+        if let Some(ids) = parsed.cgroup_ids.take() {
+            self.cgroup_ids = ids;
         }
 
         let (cmdline_rules, https_rules, http_targets) = extract_rules(&parsed);
@@ -936,6 +971,7 @@ mod tests {
         assert!(config.log_path.is_none());
         assert!(config.target_uid.is_none());
         assert!(!config.enable_filewatch);
+        assert!(!config.cgroup_filter_enabled);
         assert_eq!(config.retention_days, 30);
         assert_eq!(config.purge_interval, 1000);
     }

--- a/src/agentsight/src/event.rs
+++ b/src/agentsight/src/event.rs
@@ -142,6 +142,7 @@ mod tests {
             write_size: 10,
             comm: "writer".to_string(),
             filename: "test.jsonl".to_string(),
+            cgroup_id: 0,
             buf: b"content".to_vec(),
         }
     }
@@ -155,6 +156,7 @@ mod tests {
             flags: 0,
             comm: "watcher".to_string(),
             filename: "data.jsonl".to_string(),
+            cgroup_id: 0,
         }
     }
 

--- a/src/agentsight/src/probes/filewatch.rs
+++ b/src/agentsight/src/probes/filewatch.rs
@@ -35,6 +35,7 @@ pub struct FileWatchEvent {
     pub flags: i32,
     pub comm: String,
     pub filename: String,
+    pub cgroup_id: u64,
 }
 
 impl FileWatchEvent {
@@ -72,6 +73,7 @@ impl FileWatchEvent {
             flags: raw.flags,
             comm,
             filename,
+            cgroup_id: raw.cgroup_id,
         })
     }
 }
@@ -90,11 +92,28 @@ impl FileWatch {
     /// * `traced_processes` - External MapHandle for process filtering
     /// * `rb` - External ring buffer MapHandle
     pub fn new_with_maps(traced_processes: &MapHandle, rb: &MapHandle) -> Result<Self> {
+        Self::new_with_full_maps(traced_processes, rb, None, false)
+    }
+
+    /// Create a new FileWatch with optional cgroup_filter map sharing.
+    pub fn new_with_full_maps(
+        traced_processes: &MapHandle,
+        rb: &MapHandle,
+        cgroup_filter: Option<&MapHandle>,
+        cgroup_filter_enabled: bool,
+    ) -> Result<Self> {
         let mut builder = FilewatchSkelBuilder::default();
         builder.obj_builder.debug(config::verbose());
 
         let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
         let mut open_skel = builder.open().context("failed to open filewatch BPF object")?;
+
+        // Mirror the cgroup-filter rodata flag.
+        open_skel.rodata_mut().filter_cgroup_enabled = cgroup_filter_enabled;
+
+        // Detect cgroup v2 and pass to BPF via rodata.
+        open_skel.rodata_mut().cgroup_v2_mode =
+            std::path::Path::new("/sys/fs/cgroup/cgroup.controllers").exists();
 
         // Reuse external traced_processes map
         open_skel
@@ -109,6 +128,15 @@ impl FileWatch {
             .rb()
             .reuse_fd(rb.as_fd())
             .context("failed to reuse external rb map for filewatch")?;
+
+        // Reuse external cgroup_filter map (if provided)
+        if let Some(map) = cgroup_filter {
+            open_skel
+                .maps_mut()
+                .cgroup_filter()
+                .reuse_fd(map.as_fd())
+                .context("failed to reuse external cgroup_filter map for filewatch")?;
+        }
 
         let skel = open_skel.load().context("failed to load filewatch BPF object")?;
 

--- a/src/agentsight/src/probes/filewrite.rs
+++ b/src/agentsight/src/probes/filewrite.rs
@@ -35,6 +35,7 @@ pub struct FileWriteEvent {
     pub write_size: u32,
     pub comm: String,
     pub filename: String,
+    pub cgroup_id: u64,
     pub buf: Vec<u8>,
 }
 
@@ -78,6 +79,7 @@ impl FileWriteEvent {
             write_size: raw.write_size,
             comm,
             filename,
+            cgroup_id: raw.cgroup_id,
             buf,
         })
     }
@@ -97,11 +99,28 @@ impl FileWrite {
     /// * `traced_processes` - External MapHandle for process filtering
     /// * `rb` - External ring buffer MapHandle
     pub fn new_with_maps(traced_processes: &MapHandle, rb: &MapHandle) -> Result<Self> {
+        Self::new_with_full_maps(traced_processes, rb, None, false)
+    }
+
+    /// Create a new FileWrite with optional cgroup_filter map sharing.
+    pub fn new_with_full_maps(
+        traced_processes: &MapHandle,
+        rb: &MapHandle,
+        cgroup_filter: Option<&MapHandle>,
+        cgroup_filter_enabled: bool,
+    ) -> Result<Self> {
         let mut builder = FilewriteSkelBuilder::default();
         builder.obj_builder.debug(config::verbose());
 
         let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
         let mut open_skel = builder.open().context("failed to open filewrite BPF object")?;
+
+        // Cgroup filter flag
+        open_skel.rodata_mut().filter_cgroup_enabled = cgroup_filter_enabled;
+
+        // Detect cgroup v2 and pass to BPF via rodata.
+        open_skel.rodata_mut().cgroup_v2_mode =
+            std::path::Path::new("/sys/fs/cgroup/cgroup.controllers").exists();
 
         // Reuse external traced_processes map
         open_skel
@@ -116,6 +135,15 @@ impl FileWrite {
             .rb()
             .reuse_fd(rb.as_fd())
             .context("failed to reuse external rb map for filewrite")?;
+
+        // Reuse external cgroup_filter map (if provided)
+        if let Some(map) = cgroup_filter {
+            open_skel
+                .maps_mut()
+                .cgroup_filter()
+                .reuse_fd(map.as_fd())
+                .context("failed to reuse external cgroup_filter map for filewrite")?;
+        }
 
         let skel = open_skel.load().context("failed to load filewrite BPF object")?;
 

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -66,33 +66,93 @@ pub struct Probes {
 
 impl Probes {
     /// Create a new unified probe manager
-    /// 
+    ///
     /// # Arguments
     /// * `target_pids` - Initial PIDs to trace (empty means trace all matching UID)
     /// * `target_uid` - Optional UID filter
-    pub fn new(target_pids: &[u32], target_uid: Option<u32>, enable_filewatch: bool, enable_udpdns: bool, tcp_targets: &[TcpTarget]) -> Result<Self> {
-        // Create proctrace first - it will own the traced_processes map and ring buffer
-        let proctrace = ProcTrace::new_with_target(target_pids, target_uid)
-            .context("failed to create proctrace")?;
-        
+    /// * `enable_filewatch` - Enable filewatch probe
+    /// * `enable_udpdns` - Enable udpdns probe
+    /// * `tcp_targets` - TCP targets for plain HTTP capture
+    pub fn new(
+        target_pids: &[u32],
+        target_uid: Option<u32>,
+        enable_filewatch: bool,
+        enable_udpdns: bool,
+        tcp_targets: &[TcpTarget],
+    ) -> Result<Self> {
+        Self::new_with_cgroup_filter(
+            target_pids,
+            target_uid,
+            enable_filewatch,
+            enable_udpdns,
+            tcp_targets,
+            false,
+        )
+    }
+
+    /// Create a new unified probe manager with explicit cgroup-level filtering toggle.
+    ///
+    /// When `cgroup_filter_enabled` is true, every probe (except procmon, which
+    /// keeps full audit coverage) gates its events behind the shared
+    /// `cgroup_filter` map. Cgroup ids can then be registered at runtime via
+    /// `add_traced_cgroup`. When false (default), every probe behaves exactly
+    /// like before this feature existed.
+    pub fn new_with_cgroup_filter(
+        target_pids: &[u32],
+        target_uid: Option<u32>,
+        enable_filewatch: bool,
+        enable_udpdns: bool,
+        tcp_targets: &[TcpTarget],
+        cgroup_filter_enabled: bool,
+    ) -> Result<Self> {
+        // Create proctrace first - it owns the traced_processes map, the ring
+        // buffer, and (when enabled) the cgroup_filter map.
+        let proctrace = ProcTrace::new_with_target_and_maps(
+            target_pids,
+            target_uid,
+            None,
+            None,
+            cgroup_filter_enabled,
+        )
+        .context("failed to create proctrace")?;
+
         // Get handles to the shared maps for reuse
         let map_handle = proctrace.traced_processes_handle()
             .context("failed to get traced_processes handle")?;
         let rb_handle = proctrace.rb_handle()
             .context("failed to get rb handle")?;
-        
+
+        // Only fetch a cgroup_filter handle when the feature is on; when off,
+        // we let each probe load its own private (unused) cgroup_filter map
+        // so we never burn an extra fd in the steady state.
+        let cgroup_filter_handle = if cgroup_filter_enabled {
+            Some(
+                proctrace
+                    .cgroup_filter_handle()
+                    .context("failed to get cgroup_filter handle")?,
+            )
+        } else {
+            None
+        };
+        let cgroup_filter_ref = cgroup_filter_handle.as_ref();
+
         // Create sslsniff - it will reuse both the traced_processes map and ring buffer
         let sslsniff = SslSniff::new_with_traced_processes(Some(&map_handle), Some(&rb_handle))
             .context("failed to create sslsniff")?;
 
-        // Create procmon - it reuses the ring buffer
+        // Create procmon - it reuses the ring buffer (no cgroup filter: full audit)
         let procmon = ProcMon::new_with_rb(&rb_handle)
             .context("failed to create procmon")?;
 
         // Optionally create filewatch - it reuses both the traced_processes map and ring buffer
         let filewatch = if enable_filewatch {
-            let fw = FileWatch::new_with_maps(&map_handle, &rb_handle)
-                .context("failed to create filewatch")?;
+            let fw = FileWatch::new_with_full_maps(
+                &map_handle,
+                &rb_handle,
+                cgroup_filter_ref,
+                cgroup_filter_enabled,
+            )
+            .context("failed to create filewatch")?;
             Some(fw)
         } else {
             log::info!("FileWatch probe disabled");
@@ -100,8 +160,13 @@ impl Probes {
         };
 
         // Create filewrite - it reuses both the traced_processes map and ring buffer (always enabled)
-        let filewrite = FileWriteProbe::new_with_maps(&map_handle, &rb_handle)
-            .context("failed to create filewrite")?;
+        let filewrite = FileWriteProbe::new_with_full_maps(
+            &map_handle,
+            &rb_handle,
+            cgroup_filter_ref,
+            cgroup_filter_enabled,
+        )
+        .context("failed to create filewrite")?;
 
         // Optionally create udpdns - it reuses traced_processes map and ring buffer
         // Skips already-traced processes to avoid redundant discovery events
@@ -339,6 +404,24 @@ impl Probes {
     /// Get a handle to the traced_processes map
     pub fn traced_processes_handle(&self) -> Result<MapHandle> {
         self.proctrace.traced_processes_handle()
+    }
+
+    /// Add a cgroup inode id to the shared cgroup_filter map at runtime.
+    ///
+    /// Has no observable effect unless probes were created with
+    /// `cgroup_filter_enabled = true`; in that case, only events from
+    /// processes whose cgroup id is registered here will be emitted by
+    /// proctrace / filewatch / filewrite. sslsniff, udpdns, and procmon are
+    /// unaffected.
+    pub fn add_traced_cgroup(&mut self, cgroup_id: u64) -> Result<()> {
+        self.proctrace.add_traced_cgroup(cgroup_id)
+            .context("failed to add traced cgroup")
+    }
+
+    /// Remove a cgroup inode id from the shared cgroup_filter map at runtime.
+    pub fn remove_traced_cgroup(&mut self, cgroup_id: u64) -> Result<()> {
+        self.proctrace.remove_traced_cgroup(cgroup_id)
+            .context("failed to remove traced cgroup")
     }
 }
 

--- a/src/agentsight/src/probes/proctrace.rs
+++ b/src/agentsight/src/probes/proctrace.rs
@@ -360,6 +360,27 @@ impl ProcTrace {
         traced_processes: Option<&MapHandle>,
         rb: Option<&MapHandle>,
     ) -> Result<Self> {
+        Self::new_with_target_and_maps(
+            target_pids,
+            target_uid,
+            traced_processes,
+            rb,
+            false,
+        )
+    }
+
+    /// Create a new ProcTrace with extra control over the cgroup-level filter.
+    ///
+    /// `cgroup_filter_enabled` flips the rodata flag baked into the BPF object.
+    /// When false (default), the cgroup filter logic short-circuits to true and
+    /// the cgroup_filter map is ignored — behavior identical to pre-feature.
+    pub fn new_with_target_and_maps(
+        target_pids: &[u32],
+        target_uid: Option<u32>,
+        traced_processes: Option<&MapHandle>,
+        rb: Option<&MapHandle>,
+        cgroup_filter_enabled: bool,
+    ) -> Result<Self> {
         // Open + load skeleton
         let mut builder = ProctraceSkelBuilder::default();
         builder.obj_builder.debug(config::verbose());
@@ -371,6 +392,16 @@ impl ProcTrace {
         if let Some(uid) = target_uid {
             open_skel.rodata_mut().targ_uid = uid;
         }
+
+        // Set cgroup-filter rodata flag before load. Defaults to false so
+        // existing behavior is preserved when feature is unused.
+        open_skel.rodata_mut().filter_cgroup_enabled = cgroup_filter_enabled;
+
+        // Detect cgroup v2 unified hierarchy and pass to BPF via rodata.
+        // When true, get_cgroup_id_compat() uses bpf_get_current_cgroup_id() directly.
+        // When false, it CO-RE reads the v1 memory subsys cgroup.
+        open_skel.rodata_mut().cgroup_v2_mode =
+            std::path::Path::new("/sys/fs/cgroup/cgroup.controllers").exists();
 
         // If external traced_processes map is provided, reuse its fd
         if let Some(map) = traced_processes {
@@ -445,6 +476,40 @@ impl ProcTrace {
             .traced_processes()
             .delete(&key)
             .with_context(|| format!("failed to remove pid {} from traced_processes", pid))
+    }
+
+    /// Add a cgroup inode id to the cgroup_filter map at runtime.
+    ///
+    /// When the rodata flag `filter_cgroup_enabled` was set to true at load
+    /// time, only events from cgroups registered here will pass the cgroup
+    /// gate. The id must match what `get_cgroup_id_compat()` returns in BPF,
+    /// which equals `stat(cgroup_path).st_ino` for the corresponding
+    /// hierarchy (v2 unified path or v1 memory subsystem path).
+    pub fn add_traced_cgroup(&mut self, cgroup_id: u64) -> Result<()> {
+        let key = cgroup_id.to_ne_bytes();
+        let val = 1u8.to_ne_bytes();
+        self.skel
+            .maps_mut()
+            .cgroup_filter()
+            .update(&key, &val, libbpf_rs::MapFlags::ANY)
+            .with_context(|| format!("failed to add cgroup_id {} to cgroup_filter", cgroup_id))
+    }
+
+    /// Remove a cgroup inode id from the cgroup_filter map at runtime.
+    pub fn remove_traced_cgroup(&mut self, cgroup_id: u64) -> Result<()> {
+        let key = cgroup_id.to_ne_bytes();
+        self.skel
+            .maps_mut()
+            .cgroup_filter()
+            .delete(&key)
+            .with_context(|| format!("failed to remove cgroup_id {} from cgroup_filter", cgroup_id))
+    }
+
+    /// Create a MapHandle from the cgroup_filter map for cross-probe reuse.
+    pub fn cgroup_filter_handle(&self) -> Result<MapHandle> {
+        let binding = self.skel.maps();
+        let map = binding.cgroup_filter();
+        MapHandle::try_clone(map).context("failed to create MapHandle from cgroup_filter")
     }
 
     /// Create a MapHandle from the traced_processes map for external reuse

--- a/src/agentsight/src/response_map.rs
+++ b/src/agentsight/src/response_map.rs
@@ -229,6 +229,7 @@ mod tests {
             write_size: 0,
             comm: "agent".to_string(),
             filename: "550e8400-e29b-41d4-a716-446655440000.jsonl".to_string(),
+            cgroup_id: 0,
             buf: br#"{"responseId":"chatcmpl-abc123","content":"hello"}
 {"responseId":"chatcmpl-def456","content":"world"}
 "#
@@ -259,6 +260,7 @@ mod tests {
             write_size: 0,
             comm: "node".to_string(),
             filename: "a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl".to_string(),
+            cgroup_id: 0,
             buf: br#"{"type":"system","subtype":"ui_telemetry","systemPayload":{"uiEvent":{"event.name":"api_response","response_id":"chatcmpl-f2748a8e-85d0-9058-b28f-c70e6f5fd590","model":"qwen-plus"}}}
 "#
             .to_vec(),
@@ -301,6 +303,7 @@ mod tests {
             write_size: 0,
             comm: "claude".to_string(),
             filename: "002b93c6-fbc3-4c66-9a8e-4a157715c049.jsonl".to_string(),
+            cgroup_id: 0,
             buf: br#"{"message":{"model":"glm-5.1","id":"msg_72b84528-120a-4857-8c20-a3d1747c062b","role":"assistant","content":[]},"type":"assistant","sessionId":"002b93c6-fbc3-4c66-9a8e-4a157715c049"}
 "#
             .to_vec(),

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -214,10 +214,27 @@ impl AgentSight {
         // Create probes - agent discovery is handled by AgentScanner via ProcMon events
         let enable_udpdns = !config.https_rules.is_empty() || !http_domains.is_empty();
         let mut probes =
-            Probes::new(&[], config.target_uid, config.enable_filewatch, enable_udpdns, &tcp_targets).context("Failed to create probes")?;
+            Probes::new_with_cgroup_filter(
+                &[],
+                config.target_uid,
+                config.enable_filewatch,
+                enable_udpdns,
+                &tcp_targets,
+                config.cgroup_filter_enabled,
+            )
+            .context("Failed to create probes")?;
 
         // Attach procmon for process monitoring
         probes.attach().context("Failed to attach probes")?;
+
+        // Seed cgroup_filter map with pre-configured cgroup inode IDs
+        if config.cgroup_filter_enabled && !config.cgroup_ids.is_empty() {
+            for &cg_id in &config.cgroup_ids {
+                probes.add_traced_cgroup(cg_id)
+                    .context("Failed to register cgroup_id")?;
+                log::info!("Registered cgroup_id {}", cg_id);
+            }
+        }
 
         // Create scanner with all rules (allow/deny/https)
         let mut scanner = AgentScanner::from_rules(&all_cmdline_rules, &config.https_rules);


### PR DESCRIPTION
## Description

Add cgroup-level event filtering support with automatic cgroup v1/v2 detection.

When `cgroup_filter_enabled` is set to `true` in the JSON config, proctrace / filewatch / filewrite probes gate events behind a shared `cgroup_filter` BPF HASH map. Only events originating from registered cgroup inode IDs pass through. procmon remains unfiltered to maintain full audit coverage.

The implementation introduces:
- **BPF layer**: `cgroup_helper.h` providing `get_cgroup_id_compat()` with automatic v1 (CO-RE memory subsys read) / v2 (`bpf_get_current_cgroup_id()`) selection via rodata flag
- **Map sharing**: `cgroup_filter` defined in `common.h`, owned by proctrace skeleton, reused by filewatch/filewrite via `MapHandle`
- **Runtime API**: `add_traced_cgroup()` / `remove_traced_cgroup()` on `Probes` for dynamic cgroup registration
- **Config**: new JSON fields `cgroup_filter_enabled` (bool) and `cgroup_ids` (u64 array) for startup seed

Example config:
```json
{
  "cgroup_filter_enabled": true,
  "cgroup_ids": [12345678, 87654321]
}
```


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide


## Testing

1. **Unit tests**: `cargo test` passes (including `response_map` tests with new `cgroup_id` field)
2. **Feature-off path**: default config (`cgroup_filter_enabled: false`) — all probes behave identically to pre-feature baseline, `cgroup_filter` map is loaded but never queried
3. **Feature-on path**: set `cgroup_filter_enabled: true` + `cgroup_ids: [<inode>]` in JSON config, verify startup log emits `Registered cgroup_id <id>` and only events from matching cgroups appear
4. **v1/v2 auto-detection**: validated via presence check of `/sys/fs/cgroup/cgroup.controllers` at BPF load time

## Additional Notes

- `cgroup_ids` values must be obtained via `stat -c %i /sys/fs/cgroup/<container-path>` (v2) or `stat -c %i /sys/fs/cgroup/memory/<container-path>` (v1)
- When `cgroup_filter_enabled` is false, the feature has zero runtime overhead — the BPF-side gate short-circuits immediately
- procmon intentionally opts out via `#define NO_CGROUP_FILTER` to preserve full-system audit semantics
