### PR TITLE
fix(sight): clamp before mask in filewrite/udpdns BPF probes

### DIFF
--- a/src/agentsight/src/bpf/filewrite.bpf.c
+++ b/src/agentsight/src/bpf/filewrite.bpf.c
@@ -109,12 +109,13 @@ int BPF_PROG(trace_vfs_write, struct file *file, const char *buf, size_t count, 
     // Copy filename we already read into the event
     __builtin_memcpy(event->filename, fname, MAX_FILENAME_LEN);
 
-    // Copy write content (up to 16KB)
-    // Explicit bounds clamping to satisfy eBPF verifier:
-    // bitmask first to ensure value range, then clamp to actual max
-    u32 copy_size = (u32)count & 0x3FFF;  // Mask to 14 bits (16383)
-    if (copy_size > MAX_FILEWRITE_BUF)
-        copy_size = MAX_FILEWRITE_BUF;
+    // Copy write content (up to MAX_FILEWRITE_BUF - 1 bytes)
+    // Pre-clamp before masking to avoid zeroing at power-of-two boundaries:
+    // e.g. 16384 & 0x3FFF = 0, which would silently lose all content.
+    u32 copy_size = (u32)count;
+    if (copy_size >= MAX_FILEWRITE_BUF)
+        copy_size = MAX_FILEWRITE_BUF - 1;
+    copy_size &= (MAX_FILEWRITE_BUF - 1);
 
     ret = bpf_probe_read_user(event->buf, copy_size, buf);
     if (ret != 0) {

--- a/src/agentsight/src/bpf/filewrite.h
+++ b/src/agentsight/src/bpf/filewrite.h
@@ -27,7 +27,7 @@ struct filewrite_event {
     u32 tid;
     u32 uid;
     u32 write_size;                     // original count passed to vfs_write
-    u32 buf_size;                       // actual bytes copied (min(count, MAX_FILEWRITE_BUF))
+    u32 buf_size;                       // actual bytes copied (up to MAX_FILEWRITE_BUF - 1)
     char comm[TASK_COMM_LEN];           // process name (16 bytes)
     char filename[MAX_FILENAME_LEN];    // basename from dentry (256 bytes)
     u64 cgroup_id;                      // cgroup inode from get_cgroup_id_compat()

--- a/src/agentsight/src/bpf/udpdns.bpf.c
+++ b/src/agentsight/src/bpf/udpdns.bpf.c
@@ -102,9 +102,11 @@ int BPF_PROG(trace_udp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
         return 0;
 
     // Clamp read size to payload buffer capacity
+    // Use >= (not >) so read_len never equals DNS_PAYLOAD_MAX (256),
+    // because the subsequent mask (read_len & 0xFF) would zero it.
     __u32 read_len = buf.len;
-    if (read_len > DNS_PAYLOAD_MAX)
-        read_len = DNS_PAYLOAD_MAX;
+    if (read_len >= DNS_PAYLOAD_MAX)
+        read_len = DNS_PAYLOAD_MAX - 1;
 
     // Read user-space DNS buffer into event payload
     int ret = bpf_probe_read_user(event->payload, read_len & PAYLOAD_MASK, buf.buf);


### PR DESCRIPTION
## Summary

- **filewrite.bpf.c**: pre-clamp `copy_size` to `MAX_FILEWRITE_BUF - 1` before applying `& 0x3FFF` mask. Prevents zeroing when `count` is a multiple of 16384.
- **udpdns.bpf.c**: change clamp from `>` to `>=` and clamp to `DNS_PAYLOAD_MAX - 1` (255). Prevents zeroing when `read_len` is ≥ 256.
- **filewrite.h**: update `buf_size` comment to reflect new max.

Same bug class as #757 (proctrace stdout mask zeroing, PR #761).

Fixes #775, fixes #776.

## Bug Mechanism

Both probes used a bitmask to satisfy the BPF verifier, but applied it **before** clamping. When the input value equals the power-of-two buffer size, the mask produces zero:

| Probe | Old code | Trigger | Result |
|-------|----------|---------|--------|
| filewrite | `count & 0x3FFF` | count = 16384 | `0x4000 & 0x3FFF = 0` |
| udpdns | `read_len & 0xFF` | read_len = 256 | `0x100 & 0xFF = 0` |

Fix: clamp to `MAX - 1` first, then mask (mask becomes a no-op, serves only as BPF verifier hint).

## What's NOT changed

- proctrace.bpf.c — covered by PR #761 (same pattern, separate scope)
- sslsniff/tcpsniff — different mask width (0xFFFFF), trigger at 1MB boundary (unrealistic for SSL/TCP), tracked separately
- No Rust code changes
- No buffer size changes

## Verification

| Layer | filewrite | udpdns |
|-------|-----------|--------|
| Arithmetic proof | ✅ 16384→16383 | ✅ 256→255 |
| Code review (2 independent) | ✅ APPROVED | ✅ APPROVED |
| BPF clang compilation (ECS) | ✅ | ✅ |
| BPF verifier load (ECS 6.6.102+) | ✅ | ✅ |
| Bytecode inspection | ✅ clamp-before-mask | ✅ clamp-before-mask |
| cargo build --release (ECS) | ✅ | ✅ |
| **E2E functional test (ECS)** | ✅ 16384-byte write captured (was size=0) | ✅ BPF verifier pass (probe filter prevented functional test) |

### E2E discriminating signal (filewrite)

```
Before fix: write 16384 bytes → copy_size=0, content lost
After fix:  write 16384 bytes → copy_size=16379, content captured ✅
            write 16383 bytes → OK (unchanged)
            write 100 bytes   → OK (no regression)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)