### PR TITLE
feat(tokenless): add --json output to stats summary

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -111,6 +111,9 @@ enum StatsCommands {
     Summary {
         #[arg(long)]
         limit: Option<usize>,
+        /// Output machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
     /// List recent records
     List {
@@ -386,14 +389,18 @@ fn run() -> Result<(), (String, i32)> {
             let recorder = open_recorder()?;
 
             match stats_cmd {
-                StatsCommands::Summary { limit } => {
+                StatsCommands::Summary { limit, json } => {
                     let records = recorder
                         .all_records(limit)
                         .map_err(|e| (format!("Failed to query records: {}", e), 1))?;
-                    println!(
-                        "{}",
-                        format_summary(&records, Some("Tokenless Statistics Summary"))
-                    );
+                    if json {
+                        println!("{}", tokenless_stats::format_summary_json(&records));
+                    } else {
+                        println!(
+                            "{}",
+                            format_summary(&records, Some("Tokenless Statistics Summary"))
+                        );
+                    }
                 }
                 StatsCommands::List { limit } => {
                     let records = recorder

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -15,7 +15,7 @@ pub use record::{OperationType, StatsRecord};
 
 pub use recorder::{StatsError, StatsRecorder, StatsResult, StatsSummary};
 
-pub use query::{format_list, format_show, format_summary};
+pub use query::{format_list, format_show, format_summary, format_summary_json};
 
 pub use tokenizer::{Tokenizer, count_chars, estimate_tokens, estimate_tokens_from_bytes};
 

--- a/src/tokenless/crates/tokenless-stats/src/query.rs
+++ b/src/tokenless/crates/tokenless-stats/src/query.rs
@@ -76,6 +76,67 @@ pub fn format_summary(records: &[StatsRecord], title: Option<&str>) -> String {
     output
 }
 
+/// Format summary as machine-readable JSON.
+///
+/// Output structure:
+/// ```json
+/// {
+///   "total": { "records": N, "before_tokens": N, "after_tokens": N,
+///              "chars_saved_percent": 83.0, "tokens_saved_percent": 83.0, ... },
+///   "by_operation": { "compress-response": { "records": N, ... }, ... }
+/// }
+/// ```
+pub fn format_summary_json(records: &[StatsRecord]) -> String {
+    let total = StatsSummary::from_records(records);
+
+    let mut by_op: HashMap<&str, StatsSummary> = HashMap::new();
+    for r in records {
+        let entry = by_op.entry(r.operation.as_str()).or_default();
+        entry.total_records += 1;
+        entry.total_before_chars += r.before_chars;
+        entry.total_after_chars += r.after_chars;
+        entry.total_before_tokens += r.before_tokens;
+        entry.total_after_tokens += r.after_tokens;
+    }
+
+    let by_op_json: serde_json::Map<String, serde_json::Value> = by_op
+        .iter()
+        .map(|(op, s)| {
+            (
+                op.to_string(),
+                serde_json::json!({
+                    "records": s.total_records,
+                    "before_chars": s.total_before_chars,
+                    "after_chars": s.total_after_chars,
+                    "before_tokens": s.total_before_tokens,
+                    "after_tokens": s.total_after_tokens,
+                    "chars_saved_percent": s.chars_percent(),
+                    "tokens_saved_percent": s.tokens_percent(),
+                }),
+            )
+        })
+        .collect();
+
+    let mut total_json = serde_json::to_value(&total).unwrap_or_default();
+    if let Some(obj) = total_json.as_object_mut() {
+        obj.insert(
+            "chars_saved_percent".to_string(),
+            serde_json::json!(total.chars_percent()),
+        );
+        obj.insert(
+            "tokens_saved_percent".to_string(),
+            serde_json::json!(total.tokens_percent()),
+        );
+    }
+
+    let output = serde_json::json!({
+        "total": total_json,
+        "by_operation": by_op_json,
+    });
+
+    serde_json::to_string_pretty(&output).unwrap_or_default()
+}
+
 /// Format a list of records for display
 pub fn format_list(records: &[StatsRecord], limit: usize) -> String {
     if records.is_empty() {
@@ -232,6 +293,72 @@ mod tests {
 
         let output = format_show(&r);
         assert!(output.contains("no text content stored"));
+    }
+
+    #[test]
+    fn test_format_summary_json_valid() {
+        let records = vec![test_record()];
+        let output = format_summary_json(&records);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        let total = parsed.get("total").unwrap();
+        // StatsRecord::new(op, agent, before_chars=1000, before_tokens=400,
+        //                  after_chars=500, after_tokens=200)
+        assert_eq!(total.get("records").unwrap(), 1);
+        assert_eq!(total.get("before_chars").unwrap(), 1000);
+        assert_eq!(total.get("after_chars").unwrap(), 500);
+        assert_eq!(total.get("before_tokens").unwrap(), 400);
+        assert_eq!(total.get("after_tokens").unwrap(), 200);
+        assert!(total.get("chars_saved_percent").unwrap().as_f64().unwrap() > 0.0);
+        assert!(total.get("tokens_saved_percent").unwrap().as_f64().unwrap() > 0.0);
+
+        let ops = parsed.get("by_operation").unwrap().as_object().unwrap();
+        assert!(ops.contains_key("compress-schema"));
+        let op = ops.get("compress-schema").unwrap();
+        assert_eq!(op.get("records").unwrap(), 1);
+    }
+
+    #[test]
+    fn test_format_summary_json_empty() {
+        let records: Vec<StatsRecord> = vec![];
+        let output = format_summary_json(&records);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        let total = parsed.get("total").unwrap();
+        assert_eq!(total.get("records").unwrap(), 0);
+        assert_eq!(
+            total.get("chars_saved_percent").unwrap().as_f64().unwrap(),
+            0.0
+        );
+        assert_eq!(
+            total.get("tokens_saved_percent").unwrap().as_f64().unwrap(),
+            0.0
+        );
+
+        let ops = parsed.get("by_operation").unwrap().as_object().unwrap();
+        assert!(ops.is_empty());
+    }
+
+    #[test]
+    fn test_format_summary_json_field_consistency() {
+        let records = vec![test_record()];
+        let output = format_summary_json(&records);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        let total_keys: std::collections::BTreeSet<String> = parsed
+            .get("total")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+        let ops = parsed.get("by_operation").unwrap().as_object().unwrap();
+        for (_op, val) in ops {
+            let op_keys: std::collections::BTreeSet<String> =
+                val.as_object().unwrap().keys().cloned().collect();
+            assert_eq!(total_keys, op_keys, "field names must be identical");
+        }
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -275,12 +275,17 @@ impl StatsRecorder {
 }
 
 /// Summary statistics
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct StatsSummary {
+    #[serde(rename = "records")]
     pub total_records: usize,
+    #[serde(rename = "before_chars")]
     pub total_before_chars: usize,
+    #[serde(rename = "after_chars")]
     pub total_after_chars: usize,
+    #[serde(rename = "before_tokens")]
     pub total_before_tokens: usize,
+    #[serde(rename = "after_tokens")]
     pub total_after_tokens: usize,
 }
 


### PR DESCRIPTION
## Summary

Add `tokenless stats summary --json` for machine-readable output, enabling programmatic consumption by `agentsight summary` and other tools.

## Usage

```bash
# Text (unchanged)
tokenless stats summary

# JSON
tokenless stats summary --json
```

## JSON Structure

```json
{
  "total": {
    "records": 43,
    "before_chars": 483727, "after_chars": 82274,
    "before_tokens": 120951, "after_tokens": 20585,
    "chars_saved_percent": 83.0, "tokens_saved_percent": 83.0
  },
  "by_operation": {
    "compress-response": { "records": 26, "before_tokens": 42796, ... },
    "rewrite-command": { ... }
  }
}
```

Field names are consistent between `total` and `by_operation` entries — consumers can use a single schema.

## Changes

| File | Change |
|------|--------|
| `recorder.rs` | `#[derive(Serialize)]` + `#[serde(rename)]` on `StatsSummary` |
| `query.rs` | New `format_summary_json()` function |
| `lib.rs` | Re-export `format_summary_json` |
| `main.rs` | `--json` flag on `Summary` variant |

## What's NOT changed

- Text output (no `--json`) is identical to before
- No new dependencies (serde/serde_json already in Cargo.toml)

## Verification (ECS)

| Test | Result |
|------|--------|
| Text regression | PASS |
| `--json` valid JSON | PASS |
| `--json --limit 0` (empty) | PASS (no div-by-zero) |
| `--json --limit 1` | PASS |
| Field consistency (total vs by_operation) | PASS (identical keys) |
| cargo fmt | Clean |

## Context

This PR enables `agentsight summary` (planned) to call `tokenless stats summary --json` via CLI, following the API-over-direct-DB-access principle raised in PR #703 review.