### PR TITLE
fix(tokenless): add absolute saved values + schema version to JSON

### DIFF
--- a/src/tokenless/crates/tokenless-stats/src/query.rs
+++ b/src/tokenless/crates/tokenless-stats/src/query.rs
@@ -1,6 +1,6 @@
 //! Query and formatting utilities for tokenless stats.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::record::StatsRecord;
 use crate::recorder::StatsSummary;
@@ -89,7 +89,7 @@ pub fn format_summary(records: &[StatsRecord], title: Option<&str>) -> String {
 pub fn format_summary_json(records: &[StatsRecord]) -> String {
     let total = StatsSummary::from_records(records);
 
-    let mut by_op: HashMap<&str, StatsSummary> = HashMap::new();
+    let mut by_op: BTreeMap<&str, StatsSummary> = BTreeMap::new();
     for r in records {
         let entry = by_op.entry(r.operation.as_str()).or_default();
         entry.total_records += 1;
@@ -108,8 +108,10 @@ pub fn format_summary_json(records: &[StatsRecord]) -> String {
                     "records": s.total_records,
                     "before_chars": s.total_before_chars,
                     "after_chars": s.total_after_chars,
+                    "chars_saved": s.chars_saved(),
                     "before_tokens": s.total_before_tokens,
                     "after_tokens": s.total_after_tokens,
+                    "tokens_saved": s.tokens_saved(),
                     "chars_saved_percent": s.chars_percent(),
                     "tokens_saved_percent": s.tokens_percent(),
                 }),
@@ -119,6 +121,14 @@ pub fn format_summary_json(records: &[StatsRecord]) -> String {
 
     let mut total_json = serde_json::to_value(&total).unwrap_or_default();
     if let Some(obj) = total_json.as_object_mut() {
+        obj.insert(
+            "chars_saved".to_string(),
+            serde_json::json!(total.chars_saved()),
+        );
+        obj.insert(
+            "tokens_saved".to_string(),
+            serde_json::json!(total.tokens_saved()),
+        );
         obj.insert(
             "chars_saved_percent".to_string(),
             serde_json::json!(total.chars_percent()),
@@ -130,6 +140,7 @@ pub fn format_summary_json(records: &[StatsRecord]) -> String {
     }
 
     let output = serde_json::json!({
+        "schema_version": "1.0",
         "total": total_json,
         "by_operation": by_op_json,
     });
@@ -301,6 +312,9 @@ mod tests {
         let output = format_summary_json(&records);
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
 
+        // schema_version
+        assert_eq!(parsed.get("schema_version").unwrap(), "1.0");
+
         let total = parsed.get("total").unwrap();
         // StatsRecord::new(op, agent, before_chars=1000, before_tokens=400,
         //                  after_chars=500, after_tokens=200)
@@ -309,6 +323,9 @@ mod tests {
         assert_eq!(total.get("after_chars").unwrap(), 500);
         assert_eq!(total.get("before_tokens").unwrap(), 400);
         assert_eq!(total.get("after_tokens").unwrap(), 200);
+        // absolute saved values (shiloong review feedback)
+        assert_eq!(total.get("chars_saved").unwrap(), 500);
+        assert_eq!(total.get("tokens_saved").unwrap(), 200);
         assert!(total.get("chars_saved_percent").unwrap().as_f64().unwrap() > 0.0);
         assert!(total.get("tokens_saved_percent").unwrap().as_f64().unwrap() > 0.0);
 
@@ -316,6 +333,8 @@ mod tests {
         assert!(ops.contains_key("compress-schema"));
         let op = ops.get("compress-schema").unwrap();
         assert_eq!(op.get("records").unwrap(), 1);
+        assert_eq!(op.get("chars_saved").unwrap(), 500);
+        assert_eq!(op.get("tokens_saved").unwrap(), 200);
     }
 
     #[test]
@@ -359,6 +378,27 @@ mod tests {
                 val.as_object().unwrap().keys().cloned().collect();
             assert_eq!(total_keys, op_keys, "field names must be identical");
         }
+    }
+
+    #[test]
+    fn test_format_summary_json_ordered_operations() {
+        let mut r1 = test_record();
+        r1.operation = OperationType::CompressResponse;
+
+        let mut r2 = test_record();
+        r2.operation = OperationType::RewriteCommand;
+
+        let mut r3 = test_record();
+        r3.operation = OperationType::CompressSchema;
+
+        let records = vec![r2, r1, r3]; // intentionally unordered
+        let output = format_summary_json(&records);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        let ops = parsed.get("by_operation").unwrap().as_object().unwrap();
+        let keys: Vec<&String> = ops.keys().collect();
+        // BTreeMap sorts lexicographically
+        assert_eq!(keys, vec!["compress-response", "compress-schema", "rewrite-command"]);
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-stats/src/query.rs
+++ b/src/tokenless/crates/tokenless-stats/src/query.rs
@@ -398,7 +398,10 @@ mod tests {
         let ops = parsed.get("by_operation").unwrap().as_object().unwrap();
         let keys: Vec<&String> = ops.keys().collect();
         // BTreeMap sorts lexicographically
-        assert_eq!(keys, vec!["compress-response", "compress-schema", "rewrite-command"]);
+        assert_eq!(
+            keys,
+            vec!["compress-response", "compress-schema", "rewrite-command"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #795 addressing @shiloong's review feedback.

## Changes (1 file, +42/-2)

1. **`chars_saved` / `tokens_saved` absolute values** — added to both `total` and per-operation sections. Previously only percentages were reported, losing the magnitude signal.
2. **`schema_version: "1.0"`** — top-level field for JSON API stability.
3. **`BTreeMap` replaces `HashMap`** — `by_operation` keys are now deterministically sorted by operation name.

## Before → After

```json
{
  "schema_version": "1.0",        ← NEW
  "total": {
    ...
    "chars_saved": 401453,         ← NEW
    "tokens_saved": 100366,        ← NEW
    "chars_saved_percent": 83.0,
    "tokens_saved_percent": 83.0
  },
  "by_operation": {
    "compress-response": { ... },  ← deterministic order (BTreeMap)
    "compress-schema": { ... },
    "rewrite-command": { ... }
  }
}
```

## Testing

- ✅ 29 existing + 1 new test pass (field consistency check validates total/by_operation parity)
- ✅ ECS E2E with real `stats.db` (43 records) confirms correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)