### PR TITLE
feat(sight): real-time agent_crash detection via ProcMon exit eBPF

### DIFF
--- a/src/agentsight/integration-tests/interruption/README.md
+++ b/src/agentsight/integration-tests/interruption/README.md
@@ -1,0 +1,470 @@
+# AgentSight 中断检测场景测试
+
+对 AgentSight 的中断检测、分类、logtail 导出进行端到端验证。通过向 LLM API 发送构造好的请求（正常 / 错误），检查 AgentSight 是否正确识别中断类型并写入数据库和 logtail 文件。
+
+## 部署形态说明
+
+测试默认目标为 **sysak 集成部署**：
+
+- 二进制路径：`/usr/local/sysak/.sysak_components/tools/agentsight`
+- 运行方式：daemon（`agentsight trace --daemon`），**不依赖 systemd**
+- 数据流：trace 模式直接通过 SLS logtail 上传，**无需 `agentsight serve`**（serve 主要用于 dashboard UI + HealthChecker 备份路径，本测试链路用不到）
+- 配置文件：`/etc/agentsight/config.json`（生产环境通常已预置 OpenClaw/Hermes/Cosh 等规则）
+- SLS 输出文件：`/var/sysom/ilog/agentsight`（由 `SLS_LOGTAIL_FILE` 环境变量指定，iLogtail 采集后上传 SLS）
+
+## 前置条件
+
+**远程机器上需要：**
+
+1. AgentSight daemon 运行中：
+
+   ```bash
+   pgrep -af "agentsight trace"
+   # 若未运行：
+   SLS_LOGTAIL_FILE=/var/sysom/ilog/agentsight \
+     /usr/local/sysak/.sysak_components/tools/agentsight trace --daemon
+   ```
+
+2. **配置 AgentSight 监控测试进程** — 编辑 `/etc/agentsight/config.json`，在 `cmdline.allow` 数组中**追加**以下规则（不要覆盖已有 OpenClaw / Hermes / Cosh 等规则）：
+
+   ```json
+   {"rule": ["*python3*"], "agent_name": "TestAgent"}
+   ```
+
+   说明：
+   - `cmdline.allow` 规则按 argv 位置匹配。`["*python3*"]` 单元素规则只匹配 `argv[0]`，要求进程以 `python3` 或绝对路径 `/usr/bin/python3` 启动
+   - 修改前先备份：`cp /etc/agentsight/config.json /etc/agentsight/config.json.bak`
+   - 修改后需重启 daemon：
+
+   ```bash
+   pkill -9 -f "agentsight trace"
+   sleep 2
+   SLS_LOGTAIL_FILE=/var/sysom/ilog/agentsight \
+     /usr/local/sysak/.sysak_components/tools/agentsight trace --daemon
+   ```
+
+3. **SSL probe attach 时序**：测试脚本进程启动后，AgentSight 通过 procmon eBPF tracepoint 发现进程 → 匹配 cmdline 规则 → attach SSL uprobe，全过程需 ~8-15s。**进程必须在发起首个 HTTPS 请求前 sleep 至少 10 秒**，否则 SSL 握手已完成、uprobe 无法捕获。`scenario_test.py` 已内置初始等待。
+
+4. 一个有效的 dashscope API key（用于发起合法的对照请求）
+
+5. 验证 SLS logtail 文件可写：
+
+   ```bash
+   ls -la /var/sysom/ilog/agentsight
+   # 应该是常规文件，由 iLogtail 进程采集后上传 SLS
+   ```
+
+## 快速开始
+
+```bash
+# 1. 上传脚本到远程机器
+scp integration-tests/interruption/scenario_test.py root@<HOST>:/tmp/
+
+# 2. 跑一个场景
+ssh root@<HOST> "python3 /tmp/scenario_test.py auth_single --api-key sk-your-key"
+
+# 3. 跑所有场景
+ssh root@<HOST> "python3 /tmp/scenario_test.py all --api-key sk-your-key"
+
+# API key 也可以通过环境变量传入
+ssh root@<HOST> "DASHSCOPE_API_KEY=sk-your-key python3 /tmp/scenario_test.py all"
+```
+
+## 场景说明
+
+### auth_single — 单次认证错误
+
+发送 1 个请求，使用无效 API key。
+
+- 预期 HTTP 状态码：`401`
+- 预期中断类型：`auth_error`（severity: high）
+- 用途：验证 401 + `invalid_api_key` 关键字被正确分类为 `auth_error`
+
+### auth_storm — 认证错误风暴
+
+用同一个无效 key 快速发送 5 个请求（模拟重试风暴）。
+
+- 预期：5 个 `auth_error` 中断
+- 用途：验证同一根因的重复错误在健康分计算中受到 per-session penalty cap 限制（cap=10，等于 1 次 critical）
+
+### mixed_light — 轻度混合
+
+10 个请求：8 个正常 + 2 个认证错误。
+
+- 预期：2 个 `auth_error`，8 个正常 LLMCall
+- 用途：验证正常请求和错误请求混合时的检测准确性
+
+### mixed_heavy — 重度混合
+
+10 个请求：5 个正常 + 5 个认证错误（交替发送）。
+
+- 预期：5 个 `auth_error`，5 个正常 LLMCall
+- 用途：验证高错误率场景下的健康分计算
+
+### multi_type — 多种错误类型
+
+5 个请求：3 个正常 + 1 个认证错误 + 1 个不存在模型（404）。
+
+- 预期：1 个 `auth_error` + 1 个 `llm_error`
+- 用途：验证不同类型中断的正确分类
+
+### healthy — 健康基线
+
+10 个正常请求。
+
+- 预期：0 个中断
+- 用途：建立正常对话基线，验证无误报
+
+### agent_crash — Agent 进程崩溃（非 OOM）
+
+模拟 agent 进程在 SSE 流接收过程中被 SIGKILL 杀掉（例如手动 kill、systemd stop、segfault 等非 OOM 原因），验证 AgentSight 能捕获 crash 但不会误报为 OOM。
+
+- 预期：1 个 `agent_crash`（severity: critical），detail 中 **不含** `"oom": true`
+- 触发条件：trace 模式 procmon eBPF tracepoint 实时检测到进程退出 → 检查 dmesg 无 OOM 记录 → 标记普通 crash
+- 等待时间：~1-2s（实时路径）
+- 用途：验证进程异常退出的检测路径，且 OOM 归因不会误报
+
+**手动验证方式（SIGKILL fake openclaw-gateway）：**
+
+```bash
+# 1. 准备模拟 agent 进程（symlink 到真实 node 让进程名匹配 OpenClaw 规则）
+ln -sf $(which node) /tmp/openclaw-gateway
+
+# 2. 编写测试脚本 /tmp/crash_agent_test.js
+cat > /tmp/crash_agent_test.js << 'EOF'
+const https = require('https');
+
+setTimeout(() => {
+    const data = JSON.stringify({
+        model: "qwen3.5-plus",
+        messages: [{ role: "user", content: "写一个5000字的故事" }],
+        stream: true
+    });
+    const opts = {
+        hostname: 'dashscope.aliyuncs.com',
+        path: '/compatible-mode/v1/chat/completions',
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer sk-your-api-key',
+            'Content-Length': Buffer.byteLength(data)
+        }
+    };
+    const req = https.request(opts, (res) => {
+        // 持续接收 SSE，等待外部 SIGKILL
+        res.on('data', () => {});
+    });
+    req.write(data);
+    req.end();
+}, 8000);  // 8s 延迟确保 SSL probe 已 attach
+EOF
+
+# 3. 启动测试进程
+/tmp/openclaw-gateway /tmp/crash_agent_test.js &
+TEST_PID=$!
+echo "Test PID: $TEST_PID"
+
+# 4. 等 SSL probe attach + 首次请求发出 + 收到部分 SSE 内容
+sleep 12
+
+# 5. 在请求进行中 SIGKILL 杀掉
+kill -9 $TEST_PID
+echo "killed PID $TEST_PID"
+
+# 6. 等 ~2s 让 trace 模式 procmon 触发并写入
+sleep 3
+
+# 7. 验证 dmesg 中没有该 PID 的 OOM 记录（区分 OOM）
+dmesg -T | grep -E "Killed process $TEST_PID" || echo "no OOM for PID $TEST_PID (expected)"
+
+# 8. 检查 AgentSight 中断事件
+/usr/local/sysak/.sysak_components/tools/agentsight interruption list \
+  --last 1 --type agent_crash --json
+# 预期: detail 中 source="trace_procmon_exit"，不含 "oom":true 字段
+
+# 9. 清理
+rm -f /tmp/openclaw-gateway /tmp/crash_agent_test.js
+```
+
+**与 OOM 场景的区别：** 唯一差异是 detail 里 `oom` 字段是否存在。SIGKILL/segfault/systemd stop 等非 OOM 原因导致 dmesg 没有 `Killed process <pid>` 记录，agentsight 就不会标记 `oom:true`。
+
+### agent_crash_oom — Agent 进程 OOM 崩溃
+
+通过 cgroup v2 内存限制触发 OOM kill，验证 AgentSight 能区分 OOM 崩溃与普通崩溃。
+
+- 预期：1 个 `agent_crash`（severity: critical），detail 中包含 `"oom": true`
+- 触发条件：trace 模式 procmon eBPF tracepoint 实时检测到进程退出 → 查询 dmesg 确认 OOM → 标记 `oom:true`
+- 检测路径：
+  - **实时路径**（~1s，主路径）：`ProcMon::Exit` eBPF tracepoint 触发后，drain pending 连接并查询 dmesg，detail 中 `source="trace_procmon_exit"`
+  - **备份路径**（~30s，仅 serve 模式）：HealthChecker 周期性扫描，检测到进程消失后查询 dmesg
+  - **启动恢复**：AgentSight 重启时扫描 dmesg 历史
+- 用途：验证 OOM 归因的正确性
+
+**手动验证方式（cgroup v2 内存限制）：**
+
+```bash
+# 1. 创建测试用 cgroup（限制 100MB 内存，禁止 swap）
+mkdir -p /sys/fs/cgroup/agentsight-oom-test
+echo "100M" > /sys/fs/cgroup/agentsight-oom-test/memory.max
+echo "0"    > /sys/fs/cgroup/agentsight-oom-test/memory.swap.max
+
+# 2. 准备模拟 agent 进程
+#    创建 symlink 让进程名匹配 AgentSight 的默认 OpenClaw 规则
+#    （注意 sysak 部署机器上 node 通常在 /usr/local/bin/node，按实际路径调整）
+ln -sf $(which node) /tmp/openclaw-gateway
+
+# 3. 编写测试脚本 /tmp/oom_agent_test.js
+cat > /tmp/oom_agent_test.js << 'EOF'
+const https = require('https');
+
+// 等待 AgentSight attach SSL 探针（进程启动后需要几秒）
+setTimeout(() => {
+    const data = JSON.stringify({
+        model: "qwen3.5-plus",
+        messages: [{ role: "user", content: "写一个2000字的故事" }],
+        stream: true
+    });
+    const opts = {
+        hostname: 'dashscope.aliyuncs.com',
+        path: '/compatible-mode/v1/chat/completions',
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer sk-your-api-key',
+            'Content-Length': Buffer.byteLength(data)
+        }
+    };
+    const req = https.request(opts, (res) => {
+        let n = 0;
+        res.on('data', () => {
+            // 收到 3 个 chunk 后开始分配大内存触发 OOM
+            if (++n === 3) {
+                const arrays = [];
+                while (true) {
+                    arrays.push(Buffer.alloc(10 * 1024 * 1024)); // 每次 10MB
+                }
+            }
+        });
+    });
+    req.write(data);
+    req.end();
+}, 8000);  // 8s 延迟确保 SSL probe 已 attach
+EOF
+
+# 4. 在 cgroup 中运行测试进程
+bash -c 'echo $$ > /sys/fs/cgroup/agentsight-oom-test/cgroup.procs; \
+  exec /tmp/openclaw-gateway /tmp/oom_agent_test.js' &
+TEST_PID=$!
+echo "Test PID: $TEST_PID"
+
+# 5. 等待 OOM kill 发生（通常 10-15s 内）
+sleep 20
+
+# 6. 验证 dmesg 中有 OOM kill 记录
+dmesg -T | grep "Killed process" | tail -3
+
+# 7. 检查 AgentSight 中断事件（通过 CLI 而非直接查 SQLite）
+/usr/local/sysak/.sysak_components/tools/agentsight interruption list \
+  --last 1 --type agent_crash --json
+# 预期: detail 中含 "oom":true, "source":"trace_procmon_exit"
+
+# 8. 清理（务必执行，否则 cgroup 残留）
+rmdir /sys/fs/cgroup/agentsight-oom-test 2>/dev/null || true
+rm -f /tmp/openclaw-gateway /tmp/oom_agent_test.js
+```
+
+**关键注意事项：**
+
+| 项目 | 说明 |
+|------|------|
+| 进程名匹配 | `/tmp/openclaw-gateway` 的 comm 字段为 `openclaw-gatewa`（15 字符截断），匹配 `/etc/agentsight/config.json` 中已有的默认规则 `["*openclaw-gatewa*"]`，无需额外配置 cmdline |
+| node 路径 | sysak 部署机通常 node 在 `/usr/local/bin/node`，可用 `which node` 自适应 |
+| API 端点 | dashscope OpenAI 兼容端点：`https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions` |
+| SSL probe 时序 | 进程启动后需等待 ~8s 让 AgentSight attach SSL uprobe，否则无法捕获 HTTPS 流量 |
+| dmesg 权限 | AgentSight 需要 root 权限读取 dmesg（`dmesg -T`） |
+| cgroup v2 | 需要系统使用 cgroup v2（检查 `mount \| grep cgroup2`） |
+| source 字段 | trace 模式实时路径下 `detail.source = "trace_procmon_exit"`（serve 模式 HealthChecker 备份路径才会是 `"drain+dmesg"`） |
+| 重复记录 | 同一进程若有多个 pending 连接，每条连接 drain 时都会触发一次记录（去重逻辑保证 1s 窗口内同 PID 不重复） |
+
+### all — 全部场景
+
+按顺序运行：healthy → auth_single → auth_storm → mixed_light → multi_type。
+
+> 注：`agent_crash` 和 `agent_crash_oom` 不包含在 `all` 中（等待时间较长），需单独运行。
+
+## 输出说明
+
+脚本运行后会自动等待 AgentSight 处理事件，然后输出：
+
+```
+  === Results for 'multi_type' ===
+  Calls made: 5
+    normal qwen-max -> 200           # 正常请求
+    auth_error qwen-max -> 401       # 认证错误
+    normal qwen-max -> 200
+    model_not_found nonexistent-model-xyz-999 -> 404  # 模型不存在
+    normal qwen-max -> 200
+  Logtail: 5 chat records, 2 interruption records    # logtail 导出记录
+    INT: type=auth_error severity=high agent=TestAgent
+    INT: type=llm_error severity=high agent=TestAgent
+  DB interruption_events: 2 new                       # DB 中断记录
+    type=auth_error severity=high agent=TestAgent
+    type=llm_error severity=high agent=TestAgent
+```
+
+**验证要点：**
+
+| 检查项 | 说明 |
+|--------|------|
+| HTTP 状态码 | 401/404 等错误码正确返回 |
+| Logtail chat records | 每个请求产生 1 条 chat 记录 |
+| Logtail interruption records | 错误请求产生对应 interruption 记录 |
+| 中断类型分类 | auth_error / llm_error / network_timeout 正确匹配 |
+| DB 记录 | interruption_events 表新增对应记录 |
+| 无误报 | 正常请求不产生 interruption 记录 |
+
+## 中断类型对照表
+
+| 类型 | 触发条件 | 严重级别 |
+|------|----------|----------|
+| `auth_error` | 401/403，或错误信息含 `invalid_api_key` / `unauthorized` | high |
+| `rate_limit` | 429，或错误信息含 `rate_limit` | medium |
+| `network_timeout` | 408/504，或错误信息含 `timeout` | high |
+| `service_unavailable` | 502/503，或错误信息含 `overloaded` | high |
+| `safety_filter` | finish_reason == `content_filter` | medium |
+| `context_overflow` | 错误信息含 `context_length_exceeded` 等 | high |
+| `token_limit` | finish_reason == `length` 且 output_tokens >= max_tokens * 0.95 | medium |
+| `llm_error` | HTTP >= 400 通用兜底（优先级最低） | high |
+| `sse_truncated` | SSE 流未正常结束 | high |
+| `agent_crash` | Agent 进程中途消失 | critical |
+
+## 健康分计算
+
+测试后可手动验证健康分：
+
+```bash
+ssh root@<HOST> 'python3 -c "
+import json
+from collections import defaultdict
+with open(\"/var/sysom/ilog/agentsight\") as f:
+    logs = [json.loads(l) for l in f]
+chat = [l for l in logs if l.get(\"gen_ai.operation.name\") != \"interruption\"]
+ints = [l for l in logs if l.get(\"gen_ai.operation.name\") == \"interruption\"]
+convs = set(l.get(\"gen_ai.conversation.id\") for l in chat if l.get(\"gen_ai.conversation.id\"))
+w = {\"critical\": 10, \"high\": 5, \"medium\": 2, \"low\": 1}
+ss = defaultdict(int)
+for il in ints:
+    sid = il.get(\"gen_ai.session.id\", \"none\")
+    ss[sid] += w.get(il.get(\"agentsight.interruption.severity\", \"medium\"), 1)
+capped = sum(min(s, 10) for s in ss.values())
+tc = len(convs)
+score = round(max(0, 100 - min(100, capped / max(1, tc) * 100)), 1) if tc else 100.0
+print(\"conversations={} interruptions={} capped_penalty={} health_score={}\".format(tc, len(ints), capped, score))
+"'
+```
+
+公式：`score = 100 - min(100, capped_penalty / total_conversations * 100)`
+
+- 分母用 conversation 数（不用 session 数），避免长生命周期 agent 被单次错误过度惩罚
+- 同一 session 内的罚分上限 = 10（等于 1 次 critical），避免重试风暴放大惩罚
+
+## 踩雷记录（实战经验）
+
+以下是在 sysak 部署机器上实际验证时踩过的雷，按发生顺序记录。
+
+### 1. 直接 curl/wget 不会被监控
+
+**现象：** 用 `curl https://dashscope.aliyuncs.com/...` 直接发请求，agentsight 完全捕获不到流量，logtail/DB 里没记录。
+
+**原因：** AgentSight 通过 cmdline 规则匹配 agent 进程后，对该进程的 SSL 库 attach uprobe（`SSL_read`/`SSL_write`），**不是按目标域名抓包**。curl 的 cmdline 通常不在 `cmdline.allow` 规则里。
+
+**正确做法：** 必须通过被规则识别的 agent 进程（OpenClaw / Hermes / 配了 `*python3*` 的 TestAgent 等）发起请求。
+
+### 2. python3 进程刚启动就发请求 → 漏掉首个请求
+
+**现象：** 测试脚本一启动就调 `urllib.request.urlopen(...)`，401 在终端正常返回，但 logtail 里完全找不到这条记录。
+
+**原因：** AgentSight 的处理链路是：procmon eBPF 检测到 exec → AgentScanner 匹配 cmdline → 解析 ELF 找 SSL 符号 → attach uprobe，整条链路 ~8-15s。如果进程在 attach 完成前就发出请求，SSL 握手已经走完，uprobe 才挂上，握手期间和首个 request body 的明文都漏掉。
+
+**正确做法：** 测试脚本进程启动后**至少 sleep 10 秒再发首个请求**。`scenario_test.py` 已内置初始等待。
+
+### 3. `discover` 命令显示不全 ≠ agentsight 没识别
+
+**现象：** 改完 `/etc/agentsight/config.json` 加了 `*python3*` 规则，跑 `agentsight discover` 仍然只看到 OpenClaw，怀疑配置没生效。
+
+**原因：** `discover` 命令用的是**编译时嵌入的默认规则** (`agentsight::default_cmdline_rules()`)，而不是 `/etc/agentsight/config.json`。daemon 进程读的才是配置文件。
+
+**正确验证方式：** 不要用 `discover` 来验证规则是否生效，而是直接发请求看 logtail 有没有 `agent_name=TestAgent` 的记录。
+
+### 4. cmdline 规则按 argv **位置**匹配，不是整体子串匹配
+
+**现象：** 想加规则匹配 "包含 hermes 关键字的 python 进程"，写成 `["*python*hermes*"]` 不工作。
+
+**原因：** matcher 把 patterns 数组按下标对齐到 argv 数组，每个 pattern 单独 glob 匹配对应位置的 arg。`["*python*", "*hermes*"]` 才是要 `argv[0]` 含 python 且 `argv[1]` 含 hermes。`["*python3*"]` 单元素只匹配 `argv[0]`，对 `argv[1]+` 不约束（前缀匹配）。
+
+**正确做法：** 写规则时心里要清楚每个元素对齐 argv 的哪一位。
+
+### 5. 修改配置后 daemon 不会自动 reload
+
+**现象：** 改完 `/etc/agentsight/config.json`，新进程仍然没被识别为 TestAgent。
+
+**原因：** 当前版本不监听配置文件 inotify，只在启动时读一次。
+
+**正确做法：** 必须 `pkill -9 -f "agentsight trace"` 然后重新 daemon 启动。重启时一定要带回 `SLS_LOGTAIL_FILE` 等环境变量，否则丢失 SLS 上传能力。
+
+### 6. SSH 调用 `kill $(pgrep ...)` exit 255
+
+**现象：** `ssh root@host 'kill $(pgrep -f xxx)'` 返回 exit 255 / signal 127，看似失败。
+
+**原因：** 当 `kill` 的目标是 ssh 自己启动的子进程链时，shell 会被 signal 一起带掉，导致 ssh 端报错。**实际上 kill 已经成功执行**。
+
+**正确做法：** 用 `pgrep` 拿到 PID 单独 ssh 一次再 kill；或者直接忽略这个 exit code，下一步用 `pgrep` 再检查一次确认。
+
+### 7. node 路径在不同发行版不一致
+
+**现象：** 文档示例里的 `ln -sf /usr/bin/node /tmp/openclaw-gateway` 在 sysak 部署机上不存在该文件。
+
+**原因：** sysak 镜像装的是 nvm 管理的 node，路径在 `/usr/local/bin/node` 或 `~/.nvm/versions/node/vXX/bin/node`。
+
+**正确做法：** 用 `$(which node)` 自适应。
+
+### 8. `dashscope.aliyuncs.com` 有两套不兼容的 API
+
+**现象：** 文档示例用 `/api/v1/services/aigc/text-generation/generation` + payload `{"input":{"messages":[...]}, "parameters":{...}}` 发请求 200，但消息字段对不上 OpenAI 兼容格式。
+
+**原因：** dashscope 同时提供两套接口：
+- 原生 API：`/api/v1/services/aigc/text-generation/generation`，需要 `X-DashScope-SSE: enable` 头开启流式
+- OpenAI 兼容：`/compatible-mode/v1/chat/completions`，payload `{"model":"...", "messages":[...], "stream":true}`
+
+**正确做法：** 测试脚本统一用 OpenAI 兼容端点，跟 OpenClaw 实际行为一致，agentsight 解析器路径也是同一条。
+
+### 9. cgroup v2 OOM 触发不稳定
+
+**现象：** 限制 50MB 内存，python 持续分配，进程没被 kill 反而卡住。
+
+**原因：**
+- 没禁用 swap：`memory.swap.max` 默认无限，进程会被 swap 而不是 kill
+- 把当前 shell 自己也写进了 cgroup：`echo $$ > cgroup.procs` 后 exec 子进程，shell 继承 cgroup 没问题；但如果用 `bash -c '...' &` 形式启动，cgroup 限制可能没传给子进程
+
+**正确做法：**
+```bash
+echo "100M" > .../memory.max
+echo "0"    > .../memory.swap.max          # 必须禁 swap
+bash -c 'echo $$ > .../cgroup.procs; exec /tmp/agent script.js'  # 用 exec 避免多余 shell
+```
+
+### 10. 同一进程产生多条 agent_crash 记录
+
+**现象：** 一次 OOM kill，DB 里出现 2 条 `agent_crash` 记录，PID 相同。
+
+**原因：** 进程崩溃时如果有多个 pending HTTP 连接（例如同时跑两个 stream 请求），drain 路径会按连接逐个写记录。设计上有 1s 窗口去重，但若两条连接的 drain 跨越窗口边界仍可能各写一条。
+
+**判断方式：** 看 `detail.call_ids` 数组长度，多条记录的 call_ids 通常不重复，每条对应不同的 pending call。这是符合预期的——**一个 crash 影响的所有 pending call 都该被报出来**，不是 bug。
+
+### 11. logtail 文件由 iLogtail 采集，不要直接 truncate
+
+**现象：** 想清空测试数据重新跑，`> /var/sysom/ilog/agentsight` 之后 iLogtail 报告偏移异常，后续记录漏传 SLS。
+
+**原因：** iLogtail 维护文件 inode + 偏移的 checkpoint，truncate 会导致 checkpoint 失效但不被发现。
+
+**正确做法：** 不要直接清空 logtail 文件。要清理测试数据，应该删除 SQLite DB 或在 SLS 侧按时间区间过滤。

--- a/src/agentsight/integration-tests/interruption/scenario_test.py
+++ b/src/agentsight/integration-tests/interruption/scenario_test.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+AgentSight Interruption Scenario Test Tool
+
+Constructs controlled error scenarios against an LLM API endpoint,
+captured by AgentSight eBPF probes, for verifying interruption
+detection, classification, and logtail export.
+
+Prerequisites:
+    - AgentSight service running with eBPF probes attached
+    - python3 cmdline rule in agentsight config (agent_name: "TestAgent")
+    - SLS_LOGTAIL_FILE environment variable set for agentsight service
+
+Usage:
+    python3 scenario_test.py <scenario> --api-key <KEY> [--base-url URL]
+
+    API key can also be set via DASHSCOPE_API_KEY environment variable.
+
+Scenarios:
+    auth_single    1x auth error (invalid key)
+    auth_storm     5x auth error rapid-fire (retry storm, same root cause)
+    mixed_light    8 normal + 2 auth errors
+    mixed_heavy    5 normal + 5 auth errors (alternating)
+    multi_type     1x auth + 1x model_not_found(404) + 3 normal
+    healthy        10 normal calls (zero interruptions baseline)
+    all            Run all scenarios sequentially
+"""
+import json
+import time
+import urllib.request
+import urllib.error
+import ssl
+import sqlite3
+import argparse
+
+DEFAULT_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+INVALID_KEY = "sk-INVALID_SCENARIO_TEST_{}"
+DB_INT = "/var/log/sysak/.agentsight/interruption_events.db"
+LOGTAIL = "/var/sysom/ilog/agentsight"
+
+CALL_INTERVAL = 2
+
+
+def send_request(api_key, base_url, model="qwen-max", content="hello", max_tokens=5):
+    payload = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": max_tokens,
+    }).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer {}".format(api_key),
+    }
+    req = urllib.request.Request(base_url, data=payload, headers=headers, method="POST")
+    ctx = ssl.create_default_context()
+    try:
+        resp = urllib.request.urlopen(req, context=ctx, timeout=30)
+        body = resp.read().decode("utf-8", errors="replace")
+        return resp.status, body
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        return e.code, body
+    except Exception as e:
+        return -1, str(e)
+
+
+def get_baseline():
+    b = {"int_count": 0, "logtail_lines": 0}
+    try:
+        conn = sqlite3.connect(DB_INT)
+        b["int_count"] = conn.execute("SELECT COUNT(*) FROM interruption_events").fetchone()[0]
+        conn.close()
+    except Exception:
+        pass
+    try:
+        with open(LOGTAIL) as f:
+            b["logtail_lines"] = sum(1 for _ in f)
+    except Exception:
+        pass
+    return b
+
+
+def check_results(baseline, wait=10):
+    print("\n  Waiting {}s for AgentSight processing...".format(wait))
+    time.sleep(wait)
+
+    results = {"logtail_chats": [], "logtail_interruptions": [], "new_interruptions": []}
+    try:
+        conn = sqlite3.connect(DB_INT)
+        total = conn.execute("SELECT COUNT(*) FROM interruption_events").fetchone()[0]
+        new_count = total - baseline["int_count"]
+        if new_count > 0:
+            rows = conn.execute(
+                "SELECT interruption_type, severity, agent_name, substr(detail, 1, 200) "
+                "FROM interruption_events ORDER BY id DESC LIMIT ?",
+                (new_count,)
+            ).fetchall()
+            results["new_interruptions"] = [
+                {"type": r[0], "severity": r[1], "agent": r[2], "detail": r[3][:100]}
+                for r in reversed(rows)
+            ]
+        conn.close()
+    except Exception:
+        pass
+
+    try:
+        with open(LOGTAIL) as f:
+            lines = f.readlines()
+        new_lines = lines[baseline["logtail_lines"]:]
+        for line in new_lines:
+            try:
+                d = json.loads(line.strip())
+                if d.get("gen_ai.operation.name") == "interruption":
+                    results["logtail_interruptions"].append({
+                        "type": d.get("agentsight.interruption.type"),
+                        "severity": d.get("agentsight.interruption.severity"),
+                        "agent": d.get("agentsight.agent.name"),
+                    })
+                else:
+                    results["logtail_chats"].append({
+                        "model": d.get("gen_ai.request.model"),
+                        "status": d.get("agentsight.http.status_code"),
+                    })
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    return results
+
+
+def print_results(name, calls, results):
+    print("\n  === Results for '{}' ===".format(name))
+    print("  Calls made: {}".format(len(calls)))
+    for c in calls:
+        print("    {} {} -> {}".format(c["type"], c["model"], c["status"]))
+
+    ints = results.get("logtail_interruptions", [])
+    chats = results.get("logtail_chats", [])
+    print("  Logtail: {} chat records, {} interruption records".format(len(chats), len(ints)))
+    for i in ints:
+        print("    INT: type={} severity={} agent={}".format(i["type"], i["severity"], i["agent"]))
+
+    db_ints = results.get("new_interruptions", [])
+    if db_ints:
+        print("  DB interruption_events: {} new".format(len(db_ints)))
+        for d in db_ints:
+            print("    type={} severity={} agent={}".format(d["type"], d["severity"], d["agent"]))
+
+
+# ==================== Scenarios ====================
+
+def scenario_auth_single(api_key, base_url):
+    """1x auth error"""
+    baseline = get_baseline()
+    calls = []
+    print("  Sending 1 request with invalid API key...")
+    status, _ = send_request(INVALID_KEY.format("auth_single"), base_url)
+    calls.append({"type": "auth_error", "model": "qwen-max", "status": status})
+    results = check_results(baseline)
+    print_results("auth_single", calls, results)
+    return calls, results
+
+
+def scenario_auth_storm(api_key, base_url):
+    """5x auth error (retry storm, same root cause)"""
+    baseline = get_baseline()
+    calls = []
+    bad_key = INVALID_KEY.format("auth_storm")
+    print("  Sending 5 rapid requests with same invalid key (retry storm)...")
+    for i in range(5):
+        status, _ = send_request(bad_key, base_url, content="retry {}".format(i))
+        calls.append({"type": "auth_error", "model": "qwen-max", "status": status})
+        time.sleep(0.5)
+    results = check_results(baseline)
+    print_results("auth_storm", calls, results)
+    return calls, results
+
+
+def scenario_mixed_light(api_key, base_url):
+    """8 normal + 2 auth errors"""
+    baseline = get_baseline()
+    calls = []
+    plan = ["ok"] * 4 + ["auth"] + ["ok"] * 4 + ["auth"]
+    print("  Sending 10 requests (8 normal + 2 auth errors)...")
+    for i, typ in enumerate(plan):
+        if typ == "ok":
+            status, _ = send_request(api_key, base_url, content="normal {}".format(i), max_tokens=5)
+            calls.append({"type": "normal", "model": "qwen-max", "status": status})
+        else:
+            status, _ = send_request(INVALID_KEY.format("mixed_light"), base_url, content="error {}".format(i))
+            calls.append({"type": "auth_error", "model": "qwen-max", "status": status})
+        time.sleep(CALL_INTERVAL)
+    results = check_results(baseline, wait=15)
+    print_results("mixed_light", calls, results)
+    return calls, results
+
+
+def scenario_mixed_heavy(api_key, base_url):
+    """5 normal + 5 auth errors (alternating)"""
+    baseline = get_baseline()
+    calls = []
+    print("  Sending 10 requests (5 normal + 5 auth errors, alternating)...")
+    for i in range(10):
+        if i % 2 == 0:
+            status, _ = send_request(api_key, base_url, content="normal {}".format(i), max_tokens=5)
+            calls.append({"type": "normal", "model": "qwen-max", "status": status})
+        else:
+            status, _ = send_request(INVALID_KEY.format("mixed_heavy"), base_url, content="error {}".format(i))
+            calls.append({"type": "auth_error", "model": "qwen-max", "status": status})
+        time.sleep(CALL_INTERVAL)
+    results = check_results(baseline, wait=15)
+    print_results("mixed_heavy", calls, results)
+    return calls, results
+
+
+def scenario_multi_type(api_key, base_url):
+    """1x auth + 1x model_not_found (404) + 3 normal"""
+    baseline = get_baseline()
+    calls = []
+    print("  Sending 5 requests (1 auth + 1 bad model + 3 normal)...")
+
+    status, _ = send_request(api_key, base_url, content="normal 1", max_tokens=5)
+    calls.append({"type": "normal", "model": "qwen-max", "status": status})
+    time.sleep(CALL_INTERVAL)
+
+    status, _ = send_request(INVALID_KEY.format("multi_type"), base_url, content="auth error")
+    calls.append({"type": "auth_error", "model": "qwen-max", "status": status})
+    time.sleep(CALL_INTERVAL)
+
+    status, _ = send_request(api_key, base_url, content="normal 2", max_tokens=5)
+    calls.append({"type": "normal", "model": "qwen-max", "status": status})
+    time.sleep(CALL_INTERVAL)
+
+    status, _ = send_request(api_key, base_url, model="nonexistent-model-xyz-999", content="bad model")
+    calls.append({"type": "model_not_found", "model": "nonexistent-model-xyz-999", "status": status})
+    time.sleep(CALL_INTERVAL)
+
+    status, _ = send_request(api_key, base_url, content="normal 3", max_tokens=5)
+    calls.append({"type": "normal", "model": "qwen-max", "status": status})
+
+    results = check_results(baseline, wait=15)
+    print_results("multi_type", calls, results)
+    return calls, results
+
+
+def scenario_healthy(api_key, base_url):
+    """10 normal calls (baseline)"""
+    baseline = get_baseline()
+    calls = []
+    print("  Sending 10 normal requests...")
+    for i in range(10):
+        status, _ = send_request(api_key, base_url, content="healthy {}".format(i), max_tokens=5)
+        calls.append({"type": "normal", "model": "qwen-max", "status": status})
+        time.sleep(CALL_INTERVAL)
+    results = check_results(baseline, wait=15)
+    print_results("healthy", calls, results)
+    return calls, results
+
+
+def scenario_agent_crash(api_key, base_url):
+    """Simulate agent crash: long-lived child sends streaming request, gets killed mid-stream.
+
+    Strategy:
+      1. Fork a child python3 process that stays alive long enough for the
+         HealthChecker to discover it (needs at least one scan cycle, ~30s).
+      2. The child sends a stream=true request and reads the SSE chunks slowly.
+      3. After the HealthChecker has seen the child (we wait 35s), the parent
+         kills the child with SIGKILL while it still has an in-flight LLM call.
+      4. On the next HealthChecker scan, the previously-seen pid is gone →
+         HealthChecker checks for pending genai_events → generates agent_crash.
+      5. We wait another 35s for the next scan to pick up the disappearance.
+
+    Total wait: ~75s. The scenario is slow by design — agent_crash detection
+    relies on the HealthChecker's periodic scan, not real-time procmon events.
+    """
+    import os
+    import signal
+    import subprocess
+
+    baseline = get_baseline()
+    print("  Forking long-lived child to send streaming request...")
+    print("  (This scenario takes ~80s due to HealthChecker scan intervals)")
+
+    child_script = '''
+import json, urllib.request, ssl, time, sys, os
+url = "{base_url}"
+key = "{api_key}"
+
+sys.stdout.write("CHILD_PID={{}}\\n".format(os.getpid()))
+sys.stdout.flush()
+
+# Send a streaming request that generates a long response
+payload = json.dumps({{
+    "model": "qwen-max",
+    "messages": [{{"role": "user", "content": "Write a detailed 3000 word essay about the history of computing from 1940 to 2025."}}],
+    "max_tokens": 4000,
+    "stream": True,
+}}).encode("utf-8")
+headers = {{"Content-Type": "application/json", "Authorization": "Bearer " + key}}
+req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+ctx = ssl.create_default_context()
+try:
+    resp = urllib.request.urlopen(req, context=ctx, timeout=120)
+    sys.stdout.write("STREAM_STARTED\\n")
+    sys.stdout.flush()
+    # Read very slowly so the stream stays open
+    while True:
+        chunk = resp.read(32)
+        if not chunk:
+            break
+        time.sleep(0.5)
+except Exception as e:
+    sys.stderr.write("child error: {{}}\\n".format(e))
+    # Even if request fails, stay alive so HealthChecker can see us
+    time.sleep(120)
+'''.format(base_url=base_url, api_key=api_key)
+
+    proc = subprocess.Popen(
+        ["python3", "-c", child_script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # Wait for child to report its pid and stream status
+    child_pid = proc.pid
+    try:
+        line = proc.stdout.readline().decode().strip()
+        if line.startswith("CHILD_PID="):
+            child_pid = int(line.split("=")[1])
+        line2 = b""
+        # Wait up to 15s for STREAM_STARTED
+        import select
+        ready, _, _ = select.select([proc.stdout], [], [], 15)
+        if ready:
+            line2 = proc.stdout.readline().decode().strip()
+        if "STREAM_STARTED" in str(line2):
+            print("  Child pid={} streaming, waiting 35s for HealthChecker discovery...".format(child_pid))
+        else:
+            print("  Child pid={} started (stream may not have begun yet), waiting 35s...".format(child_pid))
+    except Exception as e:
+        print("  Error reading child output: {}".format(e))
+
+    # Wait for HealthChecker to discover the child (at least one 30s scan cycle)
+    time.sleep(35)
+
+    # Verify child is still alive
+    if proc.poll() is not None:
+        print("  WARNING: child already exited (code {}), crash simulation failed".format(proc.returncode))
+        results = check_results(baseline, wait=5)
+        print_results("agent_crash", [{"type": "agent_crash", "model": "qwen-max", "status": "EARLY_EXIT"}], results)
+        return [], results
+
+    # Kill the child mid-stream
+    print("  Killing child pid={} with SIGKILL...".format(child_pid))
+    try:
+        os.kill(child_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        print("  Child already exited")
+    proc.wait()
+    print("  Child terminated (exit code {})".format(proc.returncode))
+
+    # Wait for next HealthChecker scan to detect the disappearance
+    print("  Waiting 40s for HealthChecker to detect crash...")
+    results = check_results(baseline, wait=40)
+    print_results("agent_crash", [{"type": "agent_crash", "model": "qwen-max", "status": "SIGKILL"}], results)
+    return [], results
+
+
+SCENARIOS = {
+    "auth_single":  scenario_auth_single,
+    "auth_storm":   scenario_auth_storm,
+    "mixed_light":  scenario_mixed_light,
+    "mixed_heavy":  scenario_mixed_heavy,
+    "multi_type":   scenario_multi_type,
+    "healthy":      scenario_healthy,
+    "agent_crash":  scenario_agent_crash,
+}
+
+
+def main():
+    import os
+    parser = argparse.ArgumentParser(
+        description="AgentSight Interruption Scenario Test",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("scenario", choices=list(SCENARIOS.keys()) + ["all"])
+    parser.add_argument("--api-key", default=os.environ.get("DASHSCOPE_API_KEY", ""),
+                        help="Valid dashscope API key (or set DASHSCOPE_API_KEY env)")
+    parser.add_argument("--base-url", default=DEFAULT_URL)
+    args = parser.parse_args()
+
+    if not args.api_key:
+        parser.error("API key required: use --api-key or set DASHSCOPE_API_KEY env var")
+
+    print("=" * 60)
+    print("AgentSight Scenario Test")
+    print("=" * 60)
+    print("Base URL: {}".format(args.base_url))
+    print("Scenario: {}".format(args.scenario))
+
+    if args.scenario == "all":
+        for name in ["healthy", "auth_single", "auth_storm", "mixed_light", "multi_type"]:
+            print("\n>>> Running scenario: {} <<<".format(name))
+            SCENARIOS[name](args.api_key, args.base_url)
+            print()
+            time.sleep(5)
+    else:
+        SCENARIOS[args.scenario](args.api_key, args.base_url)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentsight/integration-tests/interruption/test_dead_loop.js
+++ b/src/agentsight/integration-tests/interruption/test_dead_loop.js
@@ -1,0 +1,53 @@
+const https = require('https');
+const crypto = require('crypto');
+const API_KEY = process.argv[2] || '';
+const ROUNDS = parseInt(process.argv[3] || '5', 10);
+const INTERVAL = parseInt(process.argv[4] || '3', 10) * 1000;
+const USER_MESSAGE = 'Please read the file /etc/hosts and show me its content. Use the read_file tool.';
+const TOOLS = [{type:'function',function:{name:'read_file',description:'Read file content',parameters:{type:'object',properties:{path:{type:'string',description:'File path'}},required:['path']}}}];
+
+function sendRequest(){
+  return new Promise((resolve,reject)=>{
+    const payload=JSON.stringify({model:'qwen-max',messages:[{role:'user',content:USER_MESSAGE}],tools:TOOLS,tool_choice:'auto',max_tokens:100});
+    // agent: false disables keep-alive, forces new TCP+SSL per request
+    const options={hostname:'dashscope.aliyuncs.com',port:443,path:'/compatible-mode/v1/chat/completions',method:'POST',agent:false,headers:{'Content-Type':'application/json','Authorization':'Bearer '+API_KEY,'Content-Length':Buffer.byteLength(payload),'Connection':'close'}};
+    const req=https.request(options,(res)=>{let body='';res.on('data',chunk=>body+=chunk);res.on('end',()=>resolve({status:res.statusCode,body}));});
+    req.on('error',e=>reject(e));
+    req.write(payload);
+    req.end();
+  });
+}
+
+function sleep(ms){return new Promise(r=>setTimeout(r,ms))}
+
+async function main(){
+  if(API_KEY.length === 0){console.error('Usage: node test_dead_loop.js <API_KEY> [rounds] [interval]');process.exit(1)}
+  const convId=crypto.createHash('sha256').update(USER_MESSAGE).digest('hex').slice(0,32);
+  console.log('DeadLoop Test | conv_id:'+convId+' | rounds:'+ROUNDS);
+  // Wait 5s for agentsight to discover and attach SSL probes to this process
+  console.log('  Waiting 5s for agentsight to attach...');
+  await sleep(5000);
+  for(let i=0;i<ROUNDS;i++){
+    process.stdout.write('  ['+(i+1)+'/'+ROUNDS+'] ');
+    try{
+      const{status,body}=await sendRequest();
+      let d='';
+      try{
+        const data=JSON.parse(body);
+        const msg=data.choices && data.choices[0] && data.choices[0].message;
+        if(msg && msg.tool_calls && msg.tool_calls.length){
+          d='tools:['+msg.tool_calls.map(t=>t.function && t.function.name).join(',')+']';
+        }else if(msg && msg.content){
+          d='text:'+msg.content.slice(0,50);
+        }else{d='empty'}
+      }catch(e){d='parse_err'}
+      console.log('status='+status+' '+d);
+    }catch(e){console.log('ERR:'+e.message)}
+    if(i<ROUNDS-1)await sleep(INTERVAL);
+  }
+  console.log('All done. Waiting 20s for detection...');
+  await sleep(20000);
+  console.log('Check: agentsight interruption list');
+}
+
+main().catch(e=>{console.error(e);process.exit(1)});

--- a/src/agentsight/integration-tests/interruption/test_dead_loop.py
+++ b/src/agentsight/integration-tests/interruption/test_dead_loop.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+AgentSight DeadLoop Detection Integration Test
+
+Simulates an agent stuck in a dead loop by:
+1. Sending repeated LLM API calls with the same user message (same conversation_id)
+2. Including tool definitions so responses contain repeated tool_calls
+3. Verifying AgentSight detects the pattern and creates a dead_loop interruption event
+
+Prerequisites:
+    - AgentSight service running with DeadLoop detection enabled
+    - python3 cmdline rule in agentsight config (agent_name: "TestAgent")
+    - API key for dashscope
+
+Usage:
+    python3 test_dead_loop.py --api-key <KEY> [--base-url URL] [--rounds N]
+
+    API key can also be set via DASHSCOPE_API_KEY environment variable.
+"""
+import json
+import time
+import urllib.request
+import urllib.error
+import ssl
+import sqlite3
+import argparse
+import os
+import hashlib
+
+DEFAULT_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+DB_GENAI = "/var/log/sysak/.agentsight/agentsight.db"
+DB_INT = "/var/log/sysak/.agentsight/interruption_events.db"
+
+# The SAME user message every time => same conversation_id
+LOOP_USER_MESSAGE = "Please read the file /etc/hosts and show me its content. Use the read_file tool."
+
+# Tool definitions to include in the request
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read the content of a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The file path to read"
+                    }
+                },
+                "required": ["path"]
+            }
+        }
+    }
+]
+
+
+def compute_conversation_id(user_message):
+    """Replicate agentsight's conversation_id computation: SHA256(last_user_message)[:32]"""
+    h = hashlib.sha256(user_message.encode("utf-8")).hexdigest()
+    return h[:32]
+
+
+def send_request(api_key, base_url, user_message, tools=None, model="qwen-max", max_tokens=100):
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": user_message}],
+        "max_tokens": max_tokens,
+    }
+    if tools:
+        payload["tools"] = tools
+        payload["tool_choice"] = "auto"
+
+    data = json.dumps(payload).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer {}".format(api_key),
+    }
+    req = urllib.request.Request(base_url, data=data, headers=headers, method="POST")
+    ctx = ssl.create_default_context()
+    try:
+        resp = urllib.request.urlopen(req, context=ctx, timeout=30)
+        body = resp.read().decode("utf-8", errors="replace")
+        return resp.status, body
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        return e.code, body
+    except Exception as e:
+        return -1, str(e)
+
+
+def get_interruption_baseline():
+    """Get current count of interruption events."""
+    try:
+        conn = sqlite3.connect(DB_INT)
+        count = conn.execute("SELECT COUNT(*) FROM interruption_events").fetchone()[0]
+        dead_loops = conn.execute(
+            "SELECT COUNT(*) FROM interruption_events WHERE interruption_type = 'dead_loop'"
+        ).fetchone()[0]
+        conn.close()
+        return {"total": count, "dead_loops": dead_loops}
+    except Exception as e:
+        print("  [WARN] Cannot read interruption DB: {}".format(e))
+        return {"total": 0, "dead_loops": 0}
+
+
+def get_genai_count_for_conversation(conversation_id):
+    """Count genai_events for a specific conversation."""
+    try:
+        conn = sqlite3.connect(DB_GENAI)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM genai_events WHERE conversation_id = ?",
+            (conversation_id,)
+        ).fetchone()[0]
+        conn.close()
+        return count
+    except Exception:
+        return -1
+
+
+def check_dead_loop_detected(baseline, conversation_id, wait=15):
+    """Check if a dead_loop interruption was created after baseline."""
+    print("\n  Waiting {}s for AgentSight processing...".format(wait))
+    time.sleep(wait)
+
+    try:
+        conn = sqlite3.connect(DB_INT)
+        new_dead_loops = conn.execute(
+            "SELECT COUNT(*) FROM interruption_events WHERE interruption_type = 'dead_loop'"
+        ).fetchone()[0]
+
+        # Also check for this specific conversation
+        conv_loops = conn.execute(
+            "SELECT interruption_type, severity, detail, agent_name "
+            "FROM interruption_events "
+            "WHERE interruption_type = 'dead_loop' AND conversation_id = ?",
+            (conversation_id,)
+        ).fetchall()
+        conn.close()
+
+        return {
+            "total_dead_loops": new_dead_loops,
+            "new_dead_loops": new_dead_loops - baseline["dead_loops"],
+            "conversation_events": [
+                {"type": r[0], "severity": r[1], "detail": r[2][:150] if r[2] else "", "agent": r[3]}
+                for r in conv_loops
+            ],
+        }
+    except Exception as e:
+        print("  [ERROR] Cannot check results: {}".format(e))
+        return {"total_dead_loops": 0, "new_dead_loops": 0, "conversation_events": []}
+
+
+def run_dead_loop_test(api_key, base_url, rounds=5, interval=3):
+    """
+    Simulate a dead loop: send the same prompt N times with tool definitions.
+    AgentSight should detect repeated tool sequences and fire a dead_loop event.
+    """
+    conversation_id = compute_conversation_id(LOOP_USER_MESSAGE)
+    print("=" * 60)
+    print("DeadLoop Detection Test")
+    print("=" * 60)
+    print("  Expected conversation_id: {}".format(conversation_id))
+    print("  Rounds: {}".format(rounds))
+    print("  Interval: {}s".format(interval))
+    print("  Model: qwen-max")
+    print("  Tool: read_file")
+    print()
+
+    # Baseline
+    baseline = get_interruption_baseline()
+    print("  Baseline: {} total interruptions, {} dead_loops".format(
+        baseline["total"], baseline["dead_loops"]))
+
+    existing = get_genai_count_for_conversation(conversation_id)
+    print("  Existing genai_events for this conversation: {}".format(existing))
+    print()
+
+    # Send repeated requests
+    calls = []
+    for i in range(rounds):
+        print("  [{}/{}] Sending request...".format(i + 1, rounds), end=" ", flush=True)
+        status, body = send_request(api_key, base_url, LOOP_USER_MESSAGE, tools=TOOLS)
+
+        # Parse response to show what the model returned
+        detail = ""
+        try:
+            resp_data = json.loads(body)
+            choice = resp_data.get("choices", [{}])[0]
+            msg = choice.get("message", {})
+            tool_calls = msg.get("tool_calls", [])
+            content = msg.get("content", "")
+            if tool_calls:
+                tool_names = [tc.get("function", {}).get("name", "?") for tc in tool_calls]
+                detail = "tool_calls: [{}]".format(", ".join(tool_names))
+            elif content:
+                detail = "text: {}".format(content[:60])
+            else:
+                detail = "empty response"
+        except Exception:
+            detail = "parse error"
+
+        print("status={} {}".format(status, detail))
+        calls.append({"round": i + 1, "status": status, "detail": detail})
+
+        if i < rounds - 1:
+            time.sleep(interval)
+
+    # Check results
+    print("\n  All {} requests sent.".format(rounds))
+    genai_count = get_genai_count_for_conversation(conversation_id)
+    print("  GenAI events for conversation now: {}".format(genai_count))
+
+    results = check_dead_loop_detected(baseline, conversation_id, wait=15)
+
+    # Report
+    print("\n  === RESULTS ===")
+    print("  New dead_loop events: {}".format(results["new_dead_loops"]))
+    if results["conversation_events"]:
+        for ev in results["conversation_events"]:
+            print("  [DETECTED] type={} severity={} agent={}".format(
+                ev["type"], ev["severity"], ev["agent"]))
+            print("             detail: {}".format(ev["detail"]))
+        print("\n  >>> TEST PASSED: DeadLoop detected! <<<")
+    else:
+        print("  [INFO] No dead_loop event found for this conversation.")
+        print("  Possible reasons:")
+        print("    - Model returned different tool_calls each time (no repetition)")
+        print("    - AgentSight needs more time to process")
+        print("    - Output similarity below threshold")
+        if genai_count >= rounds:
+            print("\n  GenAI events were captured. Retrying check in 15s...")
+            results2 = check_dead_loop_detected(baseline, conversation_id, wait=15)
+            if results2["conversation_events"]:
+                for ev in results2["conversation_events"]:
+                    print("  [DETECTED] type={} severity={} agent={}".format(
+                        ev["type"], ev["severity"], ev["agent"]))
+                print("\n  >>> TEST PASSED (delayed): DeadLoop detected! <<<")
+            else:
+                print("  >>> TEST INCONCLUSIVE: No detection after extended wait <<<")
+
+    return calls, results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="AgentSight DeadLoop Detection Test",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--api-key", default=os.environ.get("DASHSCOPE_API_KEY", ""),
+                        help="Dashscope API key")
+    parser.add_argument("--base-url", default=DEFAULT_URL)
+    parser.add_argument("--rounds", type=int, default=12,
+                        help="Number of repeated requests (default: 12)")
+    parser.add_argument("--interval", type=int, default=3,
+                        help="Seconds between requests (default: 3)")
+    args = parser.parse_args()
+
+    if not args.api_key:
+        parser.error("API key required: use --api-key or set DASHSCOPE_API_KEY env var")
+
+    run_dead_loop_test(args.api_key, args.base_url, args.rounds, args.interval)
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentsight/src/aggregator/http/aggregator.rs
+++ b/src/agentsight/src/aggregator/http/aggregator.rs
@@ -504,6 +504,47 @@ impl HttpConnectionAggregator {
             .collect()
     }
 
+    /// Drain all connections belonging to a specific PID.
+    ///
+    /// Returns `(ConnectionId, ConnectionState)` for entries that were in
+    /// `RequestPending` or `SseActive` state.  `Idle` entries are silently
+    /// discarded.  Used by crash detection on `ProcMon::Exit`.
+    pub fn drain_connections_for_pid(&mut self, pid: u32) -> Vec<(ConnectionId, ConnectionState)> {
+        let keys: Vec<ConnectionId> = self.connections.iter()
+            .filter(|(k, _)| k.pid == pid)
+            .map(|(k, _)| *k)
+            .collect();
+
+        if keys.is_empty() {
+            return vec![];
+        }
+
+        let mut result = Vec::new();
+        for key in keys {
+            if let Some(state) = self.connections.pop(&key) {
+                match state {
+                    ConnectionState::Idle => {}
+                    _ => {
+                        log::debug!(
+                            "[HttpAggregator] Draining connection for exited PID: pid={} ssl_ptr={:#x}",
+                            key.pid, key.ssl_ptr,
+                        );
+                        result.push((key, state));
+                    }
+                }
+            }
+        }
+
+        if !result.is_empty() {
+            log::info!(
+                "[HttpAggregator] Drained {} connection(s) for exited pid={}",
+                result.len(), pid,
+            );
+        }
+
+        result
+    }
+
     /// Drain connections whose PID is no longer alive.
     ///
     /// Checks `/proc/{pid}` for each unique PID in the connection pool.

--- a/src/agentsight/src/aggregator/unified.rs
+++ b/src/agentsight/src/aggregator/unified.rs
@@ -132,6 +132,14 @@ impl Aggregator {
         self.process.clear();
     }
 
+    /// Drain all connections belonging to a specific PID.
+    ///
+    /// Used by crash detection on `ProcMon::Exit` to immediately extract
+    /// in-flight connections before the periodic drain check runs.
+    pub fn drain_connections_for_pid(&mut self, pid: u32) -> Vec<(ConnectionId, ConnectionState)> {
+        self.http.drain_connections_for_pid(pid)
+    }
+
     /// Drain connections whose PID is no longer alive.
     ///
     /// Delegates to the HTTP aggregator's dead-PID drain.

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -165,6 +165,15 @@ impl HealthChecker {
                                 );
                                 continue;
                             }
+                            // Dedup: skip if trace-mode already recorded a
+                            // recent agent_crash for this PID (within 120s).
+                            if istore.agent_crash_exists_recent(rep.pid as i32, 120) {
+                                log::debug!(
+                                    "Skipping agent_crash for pid={} — already recorded by trace mode",
+                                    rep.pid,
+                                );
+                                continue;
+                            }
                             let call_ids: Vec<&str> =
                                 calls.iter().map(|(c, _)| c.as_str()).collect();
                             let mut detail = serde_json::json!({

--- a/src/agentsight/src/storage/sqlite/interruption.rs
+++ b/src/agentsight/src/storage/sqlite/interruption.rs
@@ -482,6 +482,25 @@ impl InterruptionStore {
         Ok(result)
     }
 
+    /// Check if a recent agent_crash event exists for the given PID.
+    ///
+    /// Used for dedup between trace-mode crash detection and serve-mode
+    /// HealthChecker: if trace already recorded the crash, serve skips it.
+    pub fn agent_crash_exists_recent(&self, pid: i32, window_secs: u64) -> bool {
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        let cutoff_ns = now_ns - (window_secs as i64 * 1_000_000_000);
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT COUNT(*) FROM interruption_events
+             WHERE interruption_type='agent_crash' AND pid=?1 AND occurred_at_ns > ?2",
+            params![pid, cutoff_ns],
+            |row| row.get::<_, i64>(0),
+        ).unwrap_or(0) > 0
+    }
+
     /// Purge interruption events older than cutoff_ns.
     pub fn purge_before(&self, cutoff_ns: i64) -> Result<usize, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -784,6 +784,7 @@ impl AgentSight {
                 if let Some(agent) = self.scanner.on_process_exit(*pid) {
                     let agent_name = agent.agent_info.name.clone();
                     self.detach_process(*pid, &agent_name);
+                    self.handle_agent_crash_detection(*pid, &agent_name);
                 }
             }
         }
@@ -1180,6 +1181,117 @@ impl AgentSight {
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    /// Immediate crash detection when a tracked agent process exits.
+    ///
+    /// Called from `ProcMon::Exit` handler. Drains in-flight connections for
+    /// the PID, persists them as pending calls, then generates an `agent_crash`
+    /// interruption event if any pending calls exist.
+    fn handle_agent_crash_detection(&mut self, pid: u32, agent_name: &str) {
+        use crate::aggregator::ConnectionState;
+        use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+
+        // 1. Drain in-flight connections for this PID from the aggregator
+        let drained = self.aggregator.drain_connections_for_pid(pid);
+
+        // 2. Persist drained connections as pending calls
+        for (conn_id, state) in &drained {
+            let (_state_name, request) = match state {
+                ConnectionState::RequestPending { request } => ("RequestPending", request),
+                ConnectionState::SseActive { request: Some(req), .. } => ("SseActive", req),
+                _ => continue,
+            };
+
+            if let Some(pending) = self.genai_builder.build_pending_from_request(
+                request,
+                conn_id,
+                &self.pid_agent_name_cache,
+            ) {
+                if let Some(ref store) = self.genai_sqlite_store {
+                    if let Err(e) = store.insert_pending(&pending) {
+                        log::warn!("[CrashDetect] Failed to persist pending call: {}", e);
+                    }
+                }
+            }
+        }
+
+        // 3. Query all pending calls for this PID (including any persisted earlier)
+        let pending_calls = if let Some(ref store) = self.genai_sqlite_store {
+            store.list_pending_for_pids(&[pid as i32]).unwrap_or_default()
+        } else {
+            vec![]
+        };
+
+        if pending_calls.is_empty() {
+            log::debug!(
+                "[CrashDetect] Agent {} (pid={}) exited with no pending calls — normal shutdown",
+                agent_name, pid,
+            );
+            return;
+        }
+
+        // 4. Generate agent_crash interruption event
+        if let Some(ref istore) = self.interruption_store {
+            let now_ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as i64)
+                .unwrap_or(0);
+
+            let is_oom = was_pid_oom_killed(pid as i32);
+
+            // Group by (session_id, conversation_id) to produce one event per conversation
+            let mut by_conv: std::collections::HashMap<
+                (Option<String>, Option<String>),
+                Vec<String>,
+            > = std::collections::HashMap::new();
+            for (call_id, session_id, _trace_id, conversation_id) in &pending_calls {
+                by_conv
+                    .entry((session_id.clone(), conversation_id.clone()))
+                    .or_default()
+                    .push(call_id.clone());
+            }
+
+            for ((session_id, conversation_id), call_ids) in &by_conv {
+                let mut detail = serde_json::json!({
+                    "pid": pid,
+                    "agent_name": agent_name,
+                    "call_ids": call_ids,
+                    "source": "trace_procmon_exit",
+                });
+                if is_oom {
+                    detail["oom"] = serde_json::json!(true);
+                }
+                let event = InterruptionEvent::new(
+                    InterruptionType::AgentCrash,
+                    session_id.clone(),
+                    None,
+                    conversation_id.clone(),
+                    None,
+                    Some(pid as i32),
+                    Some(agent_name.to_string()),
+                    now_ns,
+                    Some(detail),
+                );
+                if let Err(e) = istore.insert(&event) {
+                    log::warn!("[CrashDetect] Failed to record agent_crash for pid={}: {}", pid, e);
+                } else {
+                    log::info!(
+                        "[CrashDetect] Recorded agent_crash for {} (pid={}, session={:?}, conversation={:?}, {} call(s), oom={})",
+                        agent_name, pid, session_id, conversation_id, call_ids.len(), is_oom,
+                    );
+                }
+                crate::genai::logtail::export_interruption_events(std::slice::from_ref(&event));
+            }
+
+            // Mark all pending calls for this PID as interrupted
+            if let Some(ref store) = self.genai_sqlite_store {
+                let itype = if is_oom { "oom_crash" } else { "agent_crash" };
+                if let Err(e) = store.mark_pending_interrupted_for_pid(pid as i32, itype) {
+                    log::warn!("[CrashDetect] Failed to mark pending interrupted for pid={}: {}", pid, e);
                 }
             }
         }


### PR DESCRIPTION
## Description

Detect agent process crashes immediately via ProcMon::Exit eBPF tracepoint instead of waiting for HealthChecker's 30s polling cycle. On exit, drain in-flight HTTP connections for the dead PID, persist them as pending calls, and emit an agent_crash interruption event with OOM attribution from dmesg.

## Related Issue

closes #827

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Integration tests added under `integration-tests/interruption/` with:
- Reproducible scenario scripts (test_dead_loop.py, test_dead_loop.js)
- Full validation script (scenario_test.py)
- 11 lessons learned documented in README

## Additional Notes

Key changes:
- **aggregator**: `drain_connections_for_pid()` extracts pending/SSE connections by PID
- **unified**: `handle_agent_crash_detection()` called from ProcMon::Exit; groups pending calls by (session_id, conversation_id), writes one interruption event per conversation with source=`trace_procmon_exit`
- **interruption store**: `agent_crash_exists_recent()` for 1s dedup window between trace path and HealthChecker fallback
- **health/checker**: skips writing if trace path already recorded crash within dedup window