### PR TITLE
fix(sight): replace hand-rolled new_id with uuid v4

### DIFF
--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "typed-arena",
  "uname",
  "ureq 2.12.1",
+ "uuid",
 ]
 
 [[package]]

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -68,6 +68,7 @@ symbolic-demangle = { version = "12.10.0", default-features = false, features = 
 thiserror = "1.0.63"
 typed-arena = "2.0.2"
 uname = "0.1.1"
+uuid = { version = "1", features = ["v4"] }
 # Static link OpenSSL to avoid runtime dependency on libssl.so.1.1
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"

--- a/src/agentsight/src/interruption/types.rs
+++ b/src/agentsight/src/interruption/types.rs
@@ -173,17 +173,8 @@ impl InterruptionEvent {
     }
 }
 
-/// Generate a 32-char hex ID (uses current timestamp + random bytes)
 fn new_id() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let ns = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    // Mix with a pseudo-random value derived from address of a stack var
-    let stack_var: u64 = 0;
-    let addr = &stack_var as *const u64 as u64;
-    format!("{:016x}{:016x}", ns as u64 ^ addr, ns as u64)
+    uuid::Uuid::new_v4().simple().to_string()
 }
 
 #[cfg(test)]
@@ -392,11 +383,10 @@ mod tests {
     fn test_new_id_uniqueness() {
         let id1 = new_id();
         let id2 = new_id();
-        // IDs should be 32 chars hex
         assert_eq!(id1.len(), 32);
         assert_eq!(id2.len(), 32);
-        // All hex chars
         assert!(id1.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(id1, id2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace `new_id()` (timestamp XOR stack address, zero entropy) with `uuid::Uuid::new_v4()` (122-bit CSPRNG)
- Add `assert_ne!(id1, id2)` to `test_new_id_uniqueness` (previously only checked format, never asserted uniqueness)
- Fix `rustfmt` on `interruption/types.rs`

## Details

The previous `new_id()` generated 32-char hex IDs using nanosecond timestamp XOR'd with a stack variable address. This provided zero actual entropy — the stack address is deterministic within the same thread/call depth, and the second half was the raw timestamp. The doc comment on `InterruptionEvent.interruption_id` already claimed "UUID v4 hex, 32 chars" but the implementation was not UUID v4.

`uuid` is already a transitive dependency (via moka, debugid, llm-tokenizer) so this adds zero compile cost — only activates the `v4` feature for CSPRNG-based ID generation.

## Test plan
- [x] Local 541/541 tests pass
- [x] ECS 541/541 tests pass
- [x] `test_new_id_uniqueness` now asserts `id1 != id2`
- [x] Output format unchanged (32 lowercase hex chars)
- [x] `rustfmt` clean on `interruption/types.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)