### PR TITLE
chore(ci): migrate all workflow runners to self-hosted

### DIFF
--- a/.github/workflows/_rpm-build.yaml
+++ b/.github/workflows/_rpm-build.yaml
@@ -33,7 +33,7 @@ on:
 jobs:
   build-rpm:
     name: "Build"
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
+    runs-on: [self-hosted, Linux, "${{ inputs.arch == 'arm64' && 'ARM64' || 'X64' }}", "${{ inputs.arch == 'arm64' && 'ubuntu-any' || 'ubuntu' }}"]
     container:
       image: alibaba-cloud-linux-4-registry.cn-hangzhou.cr.aliyuncs.com/alinux4/alinux4:latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
   # =========================================================================
   detect-changes:
     name: Detect Changes
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     outputs:
       copilot_shell: ${{ steps.changes.outputs.copilot_shell }}
       agent_sec_core: ${{ steps.changes.outputs.agent_sec_core }}
@@ -161,7 +161,7 @@ jobs:
     name: Build copilot-shell
     needs: detect-changes
     if: needs.detect-changes.outputs.copilot_shell == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 
@@ -205,7 +205,7 @@ jobs:
     name: Test copilot-shell/cli
     needs: [detect-changes, build-copilot-shell]
     if: needs.detect-changes.outputs.copilot_shell == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 
@@ -235,7 +235,7 @@ jobs:
     name: Test copilot-shell/core
     needs: [detect-changes, build-copilot-shell]
     if: needs.detect-changes.outputs.copilot_shell == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 
@@ -268,7 +268,7 @@ jobs:
     name: Test agent-sec-core
     needs: detect-changes
     if: needs.detect-changes.outputs.agent_sec_core == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -542,7 +542,7 @@ jobs:
     name: Test agentsight
     needs: detect-changes
     if: needs.detect-changes.outputs.agentsight == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 
@@ -573,7 +573,7 @@ jobs:
     name: Test tokenless
     needs: detect-changes
     if: needs.detect-changes.outputs.tokenless == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 
@@ -608,7 +608,7 @@ jobs:
     name: Test ws-ckpt
     needs: detect-changes
     if: needs.detect-changes.outputs.ws_ckpt == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 
@@ -647,7 +647,7 @@ jobs:
     name: Test agent-memory
     needs: detect-changes
     if: needs.detect-changes.outputs.agent_memory == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 
@@ -687,7 +687,7 @@ jobs:
     name: Test anolisa
     needs: detect-changes
     if: needs.detect-changes.outputs.anolisa == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -24,7 +24,7 @@ jobs:
   # ===========================================================================
   versions:
     name: Calculate Versions
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     outputs:
       cosh-version: ${{ steps.cosh.outputs.version }}
       skill-version: ${{ steps.skill.outputs.version }}
@@ -129,7 +129,7 @@ jobs:
   # ===========================================================================
   package-cosh:
     name: "Package: copilot-shell"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     needs: versions
     steps:
       - uses: actions/checkout@v4
@@ -144,7 +144,7 @@ jobs:
 
   package-skill:
     name: "Package: os-skills"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     needs: versions
     steps:
       - uses: actions/checkout@v4
@@ -161,7 +161,7 @@ jobs:
 
   package-tokenless:
     name: "Package: tokenless"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     needs: versions
     steps:
       - uses: actions/checkout@v4
@@ -176,7 +176,7 @@ jobs:
 
   package-ws-ckpt:
     name: "Package: ws-ckpt"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     needs: versions
     steps:
       - uses: actions/checkout@v4
@@ -199,7 +199,7 @@ jobs:
 
   package-agent-memory:
     name: "Package: agent-memory"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     needs: versions
     steps:
       - uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
   # TODO: uncomment when agentsight is integrated
   # package-sight:
   #   name: "Package: agentsight"
-  #   runs-on: ubuntu-22.04
+  #   runs-on: [self-hosted, ubuntu]
   #   needs: versions
   #   steps:
   #     - uses: actions/checkout@v4
@@ -238,7 +238,7 @@ jobs:
 
   package-sec-core:
     name: "Package: agent-sec-core"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     needs: versions
     if: needs.versions.outputs.sec-core-ref != ''
     steps:
@@ -370,7 +370,7 @@ jobs:
   # ===========================================================================
   docker-build-push:
     name: Build & Push Docker Image
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     needs:
       - versions
       - rpm-cosh

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   triage:
     name: 🏷️ Auto Triage
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, ubuntu-any]
     env:
       DINGTALK_WEBHOOK: ${{ secrets.DINGTALK_WEBHOOK }}
       DINGTALK_SECRET: ${{ secrets.DINGTALK_SECRET }}

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -17,7 +17,7 @@ jobs:
   notify:
     name: DingTalk Notification
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, ubuntu-any]
     env:
       DINGTALK_WEBHOOK: ${{ secrets.DINGTALK_WEBHOOK }}
       DINGTALK_SECRET: ${{ secrets.DINGTALK_SECRET }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   label:
     name: Auto Label
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, ubuntu-any]
     steps:
       - name: Apply component and scope labels
         uses: actions/github-script@v7
@@ -104,7 +104,7 @@ jobs:
 
   notify:
     name: DingTalk Notification
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, ubuntu-any]
     env:
       DINGTALK_WEBHOOK: ${{ secrets.DINGTALK_WEBHOOK }}
       DINGTALK_SECRET: ${{ secrets.DINGTALK_SECRET }}

--- a/.github/workflows/prelint.yml
+++ b/.github/workflows/prelint.yml
@@ -24,7 +24,7 @@ jobs:
   # =========================================================================
   commit-lint:
     name: 📝 Commit Message Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ubuntu-any]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +44,7 @@ jobs:
   # =========================================================================
   pr-checks:
     name: 🔍 PR Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ubuntu-any]
     steps:
       # -----------------------------------------------------------------------
       # Step 1: PR Title Validation (warning only)

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -37,7 +37,7 @@ jobs:
   # =========================================================================
   package-preview:
     name: Packaging Preview ${{ inputs.component }}-${{ inputs.version }}
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
   # =========================================================================
   package:
     name: Package ${{ github.ref_name }}
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     outputs:
       component: ${{ steps.parse.outputs.component }}
       version: ${{ steps.parse.outputs.version }}
@@ -94,7 +94,7 @@ jobs:
     name: Publish ${{ needs.package.outputs.tag }}
     needs: package
     environment: release
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build-rpm:
     name: Build agent-sec-core RPM
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu]
     container:
       image: alibaba-cloud-linux-4-registry.cn-hangzhou.cr.aliyuncs.com/alinux4/alinux4:latest
     steps:

--- a/.github/workflows/sec-core-source-code-build.yaml
+++ b/.github/workflows/sec-core-source-code-build.yaml
@@ -24,10 +24,10 @@ jobs:
             runner: ubuntu-22.04
             container: ''
           - name: Alinux4
-            runner: ubuntu-22.04
+            runner: ubuntu
             container: alibaba-cloud-linux-4-registry.cn-hangzhou.cr.aliyuncs.com/alinux4/alinux4:latest
     name: Source Build (${{ matrix.name }})
-    runs-on: ${{ matrix.runner }}
+    runs-on: [self-hosted, Linux, X64, "${{ matrix.runner }}"]
     container: ${{ matrix.container || '' }}
     steps:
       - name: Configure mirrors and install base tools (Alinux4)


### PR DESCRIPTION
## Description

Migrate all GitHub Actions workflow runners from GitHub-hosted
(`ubuntu-22.04` / `ubuntu-latest`) to self-hosted runners
(`[self-hosted, ubuntu]`). This covers CI, prelint, release,
nightly docker build, RPM build, and issue/PR automation workflows.

## Related Issue

no-issue: infrastructure change, no feature issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [x] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Testing

Merge and observe that all workflow runs execute on the
three self-hosted runners successfully.

## Additional Notes

11 workflow files changed, 31 `runs-on` declarations updated.