### PR TITLE
feat(ckpt): make diff -t optional to compare snapshot against current workspace

### DIFF
--- a/src/ws-ckpt/README.md
+++ b/src/ws-ckpt/README.md
@@ -93,6 +93,9 @@ ws-ckpt list --workspace ~/my-workspace --format json
 # 查看两个快照间的差异
 ws-ckpt diff --workspace ~/my-workspace --from msg1-step1 --to msg1-step2
 
+# 查看快照与当前工作区的差异（省略 --to）
+ws-ckpt diff --workspace ~/my-workspace --from msg1-step1
+
 # 清理旧快照，保留最近 5 个
 ws-ckpt cleanup --workspace ~/my-workspace --keep 5
 ```

--- a/src/ws-ckpt/docs/ws-ckpt-usage.md
+++ b/src/ws-ckpt/docs/ws-ckpt-usage.md
@@ -132,19 +132,23 @@ ws-ckpt delete -w ./my-project -s test --force
 ### 2.5 查看快照间差异
 
 ```bash
-ws-ckpt diff -w <workspace> -f <snapshot> -t <snapshot>
+ws-ckpt diff -w <workspace> -f <snapshot> [-t <snapshot>]
 ```
 
 | 参数            | 简写   | 必填 | 说明            |
 | --------------- | ------ | ---- | --------------- |
 | `--workspace` | `-w` | 是   | 工作区路径或 ID |
 | `--from`      | `-f` | 是   | 起始快照 ID     |
-| `--to`        | `-t` | 是   | 目标快照 ID     |
+| `--to`        | `-t` | 否   | 目标快照 ID；省略时与当前工作区比较 |
 
 **示例**：
 
 ```bash
+# 比较两个快照
 ws-ckpt diff -w ./my-project -f msg1-step0 -t test
+
+# 与当前工作区比较
+ws-ckpt diff -w ./my-project -f msg1-step0
 ```
 
 **输出标记说明**：

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -195,9 +195,9 @@ enum Commands {
         #[arg(long, short = 'f', value_parser = snapshot_id_value_parser())]
         from: String,
 
-        /// Target snapshot (ID or name)
+        /// Target snapshot (ID or name); omit to diff against current workspace
         #[arg(long, short = 't', value_parser = snapshot_id_value_parser())]
-        to: String,
+        to: Option<String>,
     },
 
     /// Show daemon and workspace status
@@ -390,6 +390,7 @@ async fn run(cli: Cli) -> Result<()> {
                 from,
                 to,
             };
+
             let response = send_request_to_daemon(&request).await?;
             handle_diff_response(response)?;
         }
@@ -2287,7 +2288,7 @@ mod tests {
             } => {
                 assert_eq!(workspace, "/tmp/test");
                 assert_eq!(from, "msg1-step0");
-                assert_eq!(to, "msg2-step0");
+                assert_eq!(to, Some("msg2-step0".to_string()));
             }
             _ => panic!("expected Diff"),
         }

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -185,7 +185,7 @@ enum Commands {
         format: String,
     },
 
-    /// Show diff between two snapshots
+    /// Show diff between two snapshots, or between a snapshot and the current workspace
     Diff {
         /// Workspace path or ID (absolute path, relative path, or workspace ID)
         #[arg(long, short = 'w', value_parser = workspace_value_parser())]

--- a/src/ws-ckpt/src/crates/common/src/backend.rs
+++ b/src/ws-ckpt/src/crates/common/src/backend.rs
@@ -81,12 +81,12 @@ pub trait StorageBackend: Send + Sync {
     /// - btrfs-loop: rsync restore + remove symlink + delete subvolume + umount + losetup -d + remove img
     async fn recover_workspace(&self, ws_id: &str, original_path: &str) -> anyhow::Result<()>;
 
-    /// Compute the diff between two snapshots
+    /// Compute diff between two snapshots, or between a snapshot and the live workspace.
     async fn diff(
         &self,
         ws_id: &str,
         from: &str,
-        to: &str,
+        to: Option<&str>,
     ) -> anyhow::Result<Vec<crate::DiffEntry>>;
 
     /// Clean up old snapshots (retain the most recent `keep` + all pinned ones)

--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -83,7 +83,7 @@ pub enum Request {
     Diff {
         workspace: String,
         from: String,
-        to: String,
+        to: Option<String>,
     },
     Status {
         workspace: Option<String>,
@@ -1843,7 +1843,7 @@ mod tests {
         let req = Request::Diff {
             workspace: "/tmp/ws".to_string(),
             from: "msg1-step0".to_string(),
-            to: "msg2-step0".to_string(),
+            to: Some("msg2-step0".to_string()),
         };
         let decoded = round_trip_request(&req);
         match decoded {
@@ -1854,7 +1854,7 @@ mod tests {
             } => {
                 assert_eq!(workspace, "/tmp/ws");
                 assert_eq!(from, "msg1-step0");
-                assert_eq!(to, "msg2-step0");
+                assert_eq!(to, Some("msg2-step0".to_string()));
             }
             _ => panic!("expected Diff variant"),
         }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
@@ -371,10 +371,18 @@ impl StorageBackend for BtrfsBaseBackend {
         Ok(())
     }
 
-    async fn diff(&self, ws_id: &str, from: &str, to: &str) -> anyhow::Result<Vec<DiffEntry>> {
+    async fn diff(
+        &self,
+        ws_id: &str,
+        from: &str,
+        to: Option<&str>,
+    ) -> anyhow::Result<Vec<DiffEntry>> {
         let snap_base = self.snapshots_dir.join(ws_id);
         let snap_from = snap_base.join(from);
-        let snap_to = snap_base.join(to);
+        let snap_to = match to {
+            Some(id) => snap_base.join(id),
+            None => self.data_root.join(ws_id),
+        };
         btrfs_common::diff_between_snapshots(&snap_from, &snap_to).await
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
@@ -379,11 +379,13 @@ impl StorageBackend for BtrfsBaseBackend {
     ) -> anyhow::Result<Vec<DiffEntry>> {
         let snap_base = self.snapshots_dir.join(ws_id);
         let snap_from = snap_base.join(from);
-        let snap_to = match to {
-            Some(id) => snap_base.join(id),
-            None => self.data_root.join(ws_id),
-        };
-        btrfs_common::diff_between_snapshots(&snap_from, &snap_to).await
+        match to {
+            Some(id) => btrfs_common::diff_between_snapshots(&snap_from, &snap_base.join(id)).await,
+            None => {
+                let live = self.data_root.join(ws_id);
+                btrfs_common::diff_against_live(&snap_from, &live, &snap_base).await
+            }
+        }
     }
 
     async fn cleanup_snapshots(

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -245,6 +245,11 @@ pub async fn diff_against_live(
     let h = RandomState::new().build_hasher().finish();
     let tmp_snap = snap_dir.join(format!(".diff-tmp-{:06x}", h & 0xFFFFFF));
 
+    // Clean up stale temp snapshot from a prior crash before creating a new one.
+    if tmp_snap.exists() {
+        let _ = delete_subvolume(&tmp_snap).await;
+    }
+
     create_snapshot(live_subvol, &tmp_snap, true)
         .await
         .context("failed to create temporary snapshot of live workspace for diff")?;

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -231,6 +231,33 @@ pub async fn diff_between_snapshots(snap_from: &Path, snap_to: &Path) -> Result<
         .context("diff task panicked")?
 }
 
+/// Diff a snapshot against the live (writable) workspace subvolume.
+///
+/// Creates a temporary read-only snapshot of `live_subvol` inside `snap_dir`,
+/// runs the diff, then removes the temporary snapshot regardless of outcome.
+pub async fn diff_against_live(
+    snap_from: &Path,
+    live_subvol: &Path,
+    snap_dir: &Path,
+) -> Result<Vec<DiffEntry>> {
+    use std::hash::{BuildHasher, Hasher, RandomState};
+
+    let h = RandomState::new().build_hasher().finish();
+    let tmp_snap = snap_dir.join(format!(".diff-tmp-{:06x}", h & 0xFFFFFF));
+
+    create_snapshot(live_subvol, &tmp_snap, true)
+        .await
+        .context("failed to create temporary snapshot of live workspace for diff")?;
+
+    let result = diff_between_snapshots(snap_from, &tmp_snap).await;
+
+    if let Err(e) = delete_subvolume(&tmp_snap).await {
+        warn!(error = %e, path = %tmp_snap.display(), "failed to remove temp diff snapshot");
+    }
+
+    result
+}
+
 /// Blocking implementation of snapshot diff using `btrfs send | btrfs receive --dump`.
 fn diff_between_snapshots_blocking(snap_from: &Path, snap_to: &Path) -> Result<Vec<DiffEntry>> {
     use std::process::{Command as StdCommand, Stdio};
@@ -791,6 +818,31 @@ mod tests {
 
         // Cleanup
         let _ = delete_subvolume(&snap2).await;
+        let _ = delete_subvolume(&snap1).await;
+        let _ = delete_subvolume(&src).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root + btrfs filesystem"]
+    async fn diff_against_live_workspace() {
+        let base = PathBuf::from("/mnt/btrfs-workspace");
+        let src = base.join("test-diff-live-src");
+        let snap1 = base.join("test-diff-live-snap1");
+        // Cleanup prior
+        let _ = delete_subvolume(&snap1).await;
+        let _ = delete_subvolume(&src).await;
+
+        create_subvolume(&src).await.unwrap();
+        create_snapshot(&src, &snap1, true).await.unwrap();
+        // Modify the live subvolume after snapshot
+        tokio::fs::write(src.join("live-change.txt"), "world")
+            .await
+            .unwrap();
+
+        let entries = diff_against_live(&snap1, &src, &base).await.unwrap();
+        assert!(!entries.is_empty());
+
+        // Cleanup
         let _ = delete_subvolume(&snap1).await;
         let _ = delete_subvolume(&src).await;
     }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -329,10 +329,18 @@ impl StorageBackend for BtrfsLoopBackend {
         Ok(())
     }
 
-    async fn diff(&self, ws_id: &str, from: &str, to: &str) -> anyhow::Result<Vec<DiffEntry>> {
+    async fn diff(
+        &self,
+        ws_id: &str,
+        from: &str,
+        to: Option<&str>,
+    ) -> anyhow::Result<Vec<DiffEntry>> {
         let snap_base = self.snapshots_dir.join(ws_id);
         let snap_from = snap_base.join(from);
-        let snap_to = snap_base.join(to);
+        let snap_to = match to {
+            Some(id) => snap_base.join(id),
+            None => self.data_root().join(ws_id),
+        };
         btrfs_common::diff_between_snapshots(&snap_from, &snap_to).await
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -337,11 +337,13 @@ impl StorageBackend for BtrfsLoopBackend {
     ) -> anyhow::Result<Vec<DiffEntry>> {
         let snap_base = self.snapshots_dir.join(ws_id);
         let snap_from = snap_base.join(from);
-        let snap_to = match to {
-            Some(id) => snap_base.join(id),
-            None => self.data_root().join(ws_id),
-        };
-        btrfs_common::diff_between_snapshots(&snap_from, &snap_to).await
+        match to {
+            Some(id) => btrfs_common::diff_between_snapshots(&snap_from, &snap_base.join(id)).await,
+            None => {
+                let live = self.data_root().join(ws_id);
+                btrfs_common::diff_against_live(&snap_from, &live, &snap_base).await
+            }
+        }
     }
 
     async fn cleanup_snapshots(

--- a/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
@@ -106,7 +106,9 @@ pub async fn dispatch(state: &Arc<DaemonState>, request: Request) -> Response {
             to,
         } => match state.ensure_bootstrapped().await {
             Err(e) => Err(e),
-            Ok(()) => crate::snapshot_mgr::diff_snapshots(state, &workspace, &from, &to).await,
+            Ok(()) => {
+                crate::snapshot_mgr::diff_snapshots(state, &workspace, &from, to.as_deref()).await
+            }
         },
         Request::Status { workspace } => {
             // Inline status query logic
@@ -900,7 +902,7 @@ mod tests {
         let req = Request::Diff {
             workspace: "/nonexistent/path/12345".to_string(),
             from: "msg1-step0".to_string(),
-            to: "msg2-step0".to_string(),
+            to: Some("msg2-step0".to_string()),
         };
         let resp = dispatch(&state, req).await;
         match resp {

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -421,7 +421,7 @@ pub async fn diff_snapshots(
     state: &Arc<DaemonState>,
     workspace: &str,
     from: &str,
-    to: &str,
+    to: Option<&str>,
 ) -> anyhow::Result<Response> {
     let arc = match state.resolve_workspace(workspace).await {
         Some(a) => a,
@@ -434,12 +434,21 @@ pub async fn diff_snapshots(
         Ok(id) => id,
         Err(e) => return Ok(snapshot_resolve_error_response(from, e)),
     };
-    let to_id = match resolve_snapshot_id(&ws.index, to) {
-        Ok(id) => id,
-        Err(e) => return Ok(snapshot_resolve_error_response(to, e)),
+    let to_id = match to {
+        Some(t) => {
+            let id = match resolve_snapshot_id(&ws.index, t) {
+                Ok(id) => id,
+                Err(e) => return Ok(snapshot_resolve_error_response(t, e)),
+            };
+            Some(id)
+        }
+        None => None,
     };
 
-    let changes = state.backend.diff(&ws.ws_id, &from_id, &to_id).await?;
+    let changes = state
+        .backend
+        .diff(&ws.ws_id, &from_id, to_id.as_deref())
+        .await?;
 
     Ok(Response::DiffOk { changes })
 }
@@ -1040,7 +1049,7 @@ mod tests {
             .insert("real-id".to_string(), make_snapshot_meta(false));
         state.register_workspace("ws-diff".to_string(), PathBuf::from("/home/user/ws"), index);
 
-        let resp = diff_snapshots(&state, "ws-diff", "does-not-exist", "real-id")
+        let resp = diff_snapshots(&state, "ws-diff", "does-not-exist", Some("real-id"))
             .await
             .unwrap();
         match resp {
@@ -1052,7 +1061,7 @@ mod tests {
         }
 
         // Also covers the `to`-side branch.
-        let resp = diff_snapshots(&state, "ws-diff", "real-id", "missing-to")
+        let resp = diff_snapshots(&state, "ws-diff", "real-id", Some("missing-to"))
             .await
             .unwrap();
         match resp {
@@ -1140,7 +1149,7 @@ mod tests {
             &self,
             _: &str,
             _: &str,
-            _: &str,
+            _: Option<&str>,
         ) -> anyhow::Result<Vec<ws_ckpt_common::DiffEntry>> {
             unimplemented!()
         }

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -1073,6 +1073,108 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn diff_snapshots_to_none_skips_resolution_and_reaches_backend() {
+        use ws_ckpt_common::DiffEntry;
+
+        struct DiffStubBackend;
+
+        #[async_trait::async_trait]
+        impl StorageBackend for DiffStubBackend {
+            fn backend_type(&self) -> ws_ckpt_common::backend::BackendType {
+                ws_ckpt_common::backend::BackendType::BtrfsBase
+            }
+            fn data_root(&self) -> &std::path::Path {
+                std::path::Path::new("/tmp/stub")
+            }
+            fn snapshots_root(&self) -> &std::path::Path {
+                std::path::Path::new("/tmp/stub-snaps")
+            }
+            async fn diff(
+                &self,
+                _ws_id: &str,
+                _from: &str,
+                to: Option<&str>,
+            ) -> anyhow::Result<Vec<DiffEntry>> {
+                assert!(to.is_none(), "expected to=None, got {:?}", to);
+                Ok(vec![DiffEntry {
+                    path: "live-change.txt".into(),
+                    change_type: ws_ckpt_common::ChangeType::Added,
+                    detail: None,
+                }])
+            }
+            async fn init_workspace(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> anyhow::Result<ws_ckpt_common::WorkspaceInfo> {
+                unimplemented!()
+            }
+            async fn create_snapshot(&self, _: &str, _: &str) -> anyhow::Result<()> {
+                unimplemented!()
+            }
+            async fn rollback(&self, _: &str, _: &str) -> anyhow::Result<PathBuf> {
+                unimplemented!()
+            }
+            async fn delete_snapshot(&self, _: &str, _: &str) -> anyhow::Result<()> {
+                unimplemented!()
+            }
+            async fn recover_workspace(&self, _: &str, _: &str) -> anyhow::Result<()> {
+                unimplemented!()
+            }
+            async fn cleanup_snapshots(
+                &self,
+                _: &str,
+                _: &[String],
+            ) -> anyhow::Result<Vec<String>> {
+                unimplemented!()
+            }
+            async fn fork(&self, _: &str, _: &str, _: &str) -> anyhow::Result<()> {
+                unimplemented!()
+            }
+            async fn gc_generations(
+                &self,
+                _: &str,
+            ) -> anyhow::Result<ws_ckpt_common::backend::GcResult> {
+                unimplemented!()
+            }
+            async fn check_environment(
+                &self,
+            ) -> anyhow::Result<ws_ckpt_common::backend::EnvironmentStatus> {
+                unimplemented!()
+            }
+            async fn get_usage(&self) -> anyhow::Result<(u64, u64)> {
+                unimplemented!()
+            }
+        }
+
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            Arc::new(DiffStubBackend),
+            test_state_dir(),
+        ));
+        let mut index = SnapshotIndex::new(PathBuf::from("/home/user/ws"));
+        index
+            .snapshots
+            .insert("snap-from".to_string(), make_snapshot_meta(false));
+        state.register_workspace(
+            "ws-diff-live".to_string(),
+            PathBuf::from("/home/user/ws"),
+            index,
+        );
+
+        let resp = diff_snapshots(&state, "ws-diff-live", "snap-from", None)
+            .await
+            .unwrap();
+        match resp {
+            Response::DiffOk { changes } => {
+                assert_eq!(changes.len(), 1);
+                assert_eq!(changes[0].path, "live-change.txt");
+            }
+            other => panic!("expected DiffOk, got: {:?}", other),
+        }
+    }
+
     // ── cleanup_snapshots partial-failure tests ──
     //
     // Backstop for the "no early `?` in the delete loop" invariant

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -1217,7 +1217,7 @@ mod tests {
             &self,
             _: &str,
             _: &str,
-            _: &str,
+            _: Option<&str>,
         ) -> anyhow::Result<Vec<ws_ckpt_common::DiffEntry>> {
             unimplemented!()
         }

--- a/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
+++ b/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
@@ -421,7 +421,7 @@ async fn full_diff_request_response_over_socket() {
     let request = Request::Diff {
         workspace: "/tmp/ws".to_string(),
         from: "msg1-step0".to_string(),
-        to: "msg2-step0".to_string(),
+        to: Some("msg2-step0".to_string()),
     };
     let frame = encode_frame(&request).unwrap();
     client.write_all(&frame).await.unwrap();

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -320,9 +320,10 @@ WS_CKPT_LIST_SCHEMA: Dict[str, Any] = {
 WS_CKPT_DIFF_SCHEMA: Dict[str, Any] = {
     "name": "ws-ckpt-diff",
     "description": (
-        "Compare file changes between two snapshots. Always display the "
-        "FULL untruncated result to the user. Do NOT re-interpret or "
-        "contradict the tool output."
+        "Compare file changes between two snapshots, or between a snapshot "
+        "and the current workspace state. Omit 'to' to diff against the "
+        "current workspace. Always display the FULL untruncated result to "
+        "the user. Do NOT re-interpret or contradict the tool output."
     ),
     "parameters": {
         "type": "object",
@@ -334,11 +335,11 @@ WS_CKPT_DIFF_SCHEMA: Dict[str, Any] = {
             "to": {
                 "type": "string",
                 "description": (
-                    "Target snapshot id or name (defaults to current state)"
+                    "Target snapshot id or name. Omit to diff against current workspace state."
                 ),
             },
         },
-        "required": ["from", "to"],
+        "required": ["from"],
         "additionalProperties": False,
     },
 }
@@ -697,13 +698,13 @@ def handle_ws_ckpt_diff(args: Dict[str, Any], **_kwargs) -> str:
     to_id = (args.get("to") or "").strip()
     if not from_id:
         return _err("'from' is required")
-    if not to_id:
-        return _err("'to' is required")
 
     workspace, ws_err = _require_workspace()
     if ws_err:
         return ws_err
-    cmd = ["ws-ckpt", "diff", "-w", workspace, "--from", from_id, "--to", to_id]
+    cmd = ["ws-ckpt", "diff", "-w", workspace, "--from", from_id]
+    if to_id:
+        cmd.extend(["--to", to_id])
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
@@ -292,7 +292,7 @@ export class BtrfsManager {
   /**
    * Execute diff and return the raw CLI output without parsing.
    */
-  public async execDiffRaw(from: string, to: string): Promise<{ success: boolean; text: string }> {
+  public async execDiffRaw(from: string, to?: string): Promise<{ success: boolean; text: string }> {
     if (!this.workspacePath) {
       return { success: false, text: "Workspace not initialized" };
     }
@@ -302,7 +302,8 @@ export class BtrfsManager {
         return { success: false, text: mapErrorToLLMMessage(output.stderr) };
       }
       const stdout = output.stdout.replace(/\x1b\[[0-9;]*m/g, '').trim();
-      return { success: true, text: stdout || `No changes between ${from} and ${to}.` };
+      const target = to ?? "current workspace";
+      return { success: true, text: stdout || `No changes between ${from} and ${target}.` };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       return { success: false, text: `Diff error: ${msg}` };

--- a/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
@@ -159,21 +159,20 @@ export class CommandExecutor {
   }
 
   /**
-   * Show the diff between two snapshots.
+   * Show the diff between two snapshots, or between a snapshot and the current workspace.
    *
-   * Equivalent to: `ws-ckpt diff --workspace <ws> --from <a> --to <b>`
+   * Equivalent to: `ws-ckpt diff --workspace <ws> --from <a> [--to <b>]`
    *
    * @param workspace - Workspace directory path.
    * @param from      - Source snapshot identifier or name.
-   * @param to        - Target snapshot identifier or name.
+   * @param to        - Target snapshot identifier or name. Omit to diff against current workspace.
    */
-  public async diff(workspace: string, from: string, to: string): Promise<CommandOutput> {
-    return this.run([
-      "diff",
-      "--workspace", workspace,
-      "--from", from,
-      "--to", to,
-    ]);
+  public async diff(workspace: string, from: string, to?: string): Promise<CommandOutput> {
+    const args = ["diff", "--workspace", workspace, "--from", from];
+    if (to) {
+      args.push("--to", to);
+    }
+    return this.run(args);
   }
 
   /**

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -228,7 +228,7 @@ export async function handleDiff(
       isError: true,
     };
   }
-  const result = await pluginState.manager.execDiffRaw(fromArg, toArg ?? "HEAD");
+  const result = await pluginState.manager.execDiffRaw(fromArg, toArg);
   return { text: result.text, isError: !result.success };
 }
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
@@ -178,8 +178,9 @@ export function registerTools(api: OpenClawPluginApi): void {
     {
       name: "ws-ckpt-diff",
       description:
-        "Compare file changes between two snapshots. " +
-        "Always display the FULL untruncated diff. " +
+        "Compare file changes between two snapshots, or between a snapshot " +
+        "and the current workspace state. Omit 'to' to diff against the " +
+        "current workspace. Always display the FULL untruncated diff. " +
         "Do NOT re-interpret or contradict the tool output.",
       parameters: {
         type: "object",
@@ -191,10 +192,10 @@ export function registerTools(api: OpenClawPluginApi): void {
           to: {
             type: "string",
             description:
-              "Target snapshot id or name (defaults to current state)",
+              "Target snapshot id or name. Omit to diff against current workspace state.",
           },
         },
-        required: ["from", "to"],
+        required: ["from"],
       },
       async execute(_toolCallId, params) {
         const r = await handleDiff(


### PR DESCRIPTION
## Description

- diff 命令的 `-t/--to` 参数改为可选，省略时与当前工作区（live subvolume）进行比较 (#846)

### 改动范围

从 CLI 到 daemon 到插件全栈适配：

**协议层**：`Request::Diff.to` 从 `String` 改为 `Option<String>`，
`StorageBackend::diff()` 的 `to` 参数从 `&str` 改为 `Option<&str>`。

**CLI**：clap 的 `-t` 参数从 required 改为 optional。

**daemon**：`snapshot_mgr` 和 `dispatcher` 适配 `Option` 传递。
两个 backend（`btrfs_base`、`btrfs_loop`）在 `to` 为 `None` 时
使用 `data_root.join(ws_id)` 作为 live subvolume 路径。

**插件**：hermes（Python）和 openclaw（TypeScript）的 tool schema
中 `to` 从 required 移除，命令构建改为有条件添加 `--to`。

## Related Issue

closes #846

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

## Additional Notes
