### PR TITLE
feat(anolisa): resolve list catalog from repo config

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -6,8 +6,6 @@
 
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
-
 use anolisa_core::{
     Catalog, CatalogLayers, DistributionIndex, FetchFailure, HttpFetch, InstalledState,
     ObjectStatus, UreqFetch,
@@ -16,6 +14,7 @@ use anolisa_platform::fs_layout::FsLayout;
 
 use crate::context::{CliContext, InstallMode};
 use crate::packaged;
+use crate::repo_config::{HostVars, RepoConfig, raw_relative_root};
 use crate::response::CliError;
 
 /// Subdirectory under `datadir` and `etc_dir` where capability/component
@@ -169,24 +168,14 @@ fn distribution_index_path(layout: &FsLayout) -> Option<PathBuf> {
 
 // ── Component catalog URL resolution ────────────────────────────────
 
-#[derive(Debug, Default, Deserialize)]
-struct ConfigFileForCatalog {
-    catalog: Option<CatalogTableRaw>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct CatalogTableRaw {
-    url: Option<String>,
-}
-
 /// Resolve the component catalog URL.
 ///
 /// Resolution order (first non-empty wins):
 ///   1. `$ANOLISA_CATALOG_URL` env var
-///   2. `[catalog] url` in `etc_dir/config.toml`
+///   2. `[backends.raw].base_url` in `repo.toml`, plus `/catalog.json`
 ///
-/// Returns `Ok(None)` when neither source provides a URL. A present but
-/// malformed config file is still an error so operators can fix it.
+/// `repo.toml` follows its own discovery chain, including the embedded
+/// default, so upgraded hosts do not need a pre-existing local config file.
 pub fn resolve_catalog_url(ctx: &CliContext, command: &str) -> Result<Option<String>, CliError> {
     if let Ok(url) = std::env::var("ANOLISA_CATALOG_URL") {
         let trimmed = url.trim();
@@ -196,31 +185,32 @@ pub fn resolve_catalog_url(ctx: &CliContext, command: &str) -> Result<Option<Str
     }
 
     let layout = resolve_layout(ctx);
-    let config_path = layout.etc_dir.join("config.toml");
-    match std::fs::read_to_string(&config_path) {
-        Ok(content) => {
-            let parsed: ConfigFileForCatalog =
-                toml::from_str(&content).map_err(|e| CliError::InvalidArgument {
-                    command: command.to_string(),
-                    reason: format!("invalid config at {}: {e}", config_path.display()),
-                })?;
-            if let Some(url) = parsed.catalog.and_then(|c| c.url) {
-                let trimmed = url.trim();
-                if !trimmed.is_empty() {
-                    return Ok(Some(trimmed.to_string()));
-                }
-            }
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
-            return Err(CliError::Runtime {
+    let repo_config = RepoConfig::load(&layout).map_err(|err| CliError::InvalidArgument {
+        command: command.to_string(),
+        reason: format!("failed to resolve component catalog from repo.toml: {err}"),
+    })?;
+    let (backend_name, backend) =
+        repo_config
+            .select_backend(Some("raw"))
+            .map_err(|err| CliError::InvalidArgument {
                 command: command.to_string(),
-                reason: format!("failed to read config at {}: {e}", config_path.display()),
-            });
-        }
-    }
-
-    Ok(None)
+                reason: format!("failed to resolve component catalog from repo.toml: {err}"),
+            })?;
+    let env = anolisa_env::EnvService::detect();
+    let host = HostVars {
+        os: env.os,
+        arch: env.arch,
+    };
+    let base_url = repo_config
+        .resolved_base_url(backend_name, backend, &host)
+        .map_err(|err| CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!("failed to resolve component catalog from repo.toml: {err}"),
+        })?;
+    Ok(Some(format!(
+        "{}/catalog.json",
+        raw_relative_root(&base_url)
+    )))
 }
 
 /// Fetch raw bytes from a catalog URL.
@@ -274,6 +264,7 @@ pub(crate) fn status_is_enabled(status_label: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     /// `object_status_str` must cover every variant of `ObjectStatus` and
     /// produce the exact wire vocabulary the spec promises. If a new variant
     /// is added, this test forces us to extend the mapping.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -115,9 +115,9 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
 }
 
 fn render_missing_catalog(ctx: &CliContext) -> Result<(), CliError> {
-    let config_path = common::resolve_layout(ctx).etc_dir.join("config.toml");
+    let config_path = common::resolve_layout(ctx).etc_dir.join("repo.toml");
     let warning = format!(
-        "component catalog is not configured; set ANOLISA_CATALOG_URL or add [catalog].url to {}",
+        "component catalog is not configured; set ANOLISA_CATALOG_URL or configure [backends.raw].base_url in {}",
         config_path.display()
     );
 
@@ -146,7 +146,7 @@ fn render_missing_catalog(ctx: &CliContext) -> Result<(), CliError> {
         println!("  {}", color.label("config:"));
         println!("    {}", config_path.display());
         println!("  {}", color.label("hint:"));
-        println!("    set ANOLISA_CATALOG_URL or add [catalog].url to config.toml");
+        println!("    set ANOLISA_CATALOG_URL or configure [backends.raw].base_url in repo.toml");
     }
     Ok(())
 }


### PR DESCRIPTION
## Description

Make `anolisa list/ls` use the same repository configuration chain as
`anolisa install`.

Before this change, `list` required a separate catalog source from
`ANOLISA_CATALOG_URL` or `[catalog].url` in `config.toml`. Hosts upgraded
from older versions could miss that local config file and get stuck at
"no component catalog configured".

Now `list` keeps `ANOLISA_CATALOG_URL` as an explicit override, otherwise
it loads `repo.toml` through the existing `RepoConfig` discovery chain and
derives the component catalog URL from the configured raw backend:

```text
[backends.raw].base_url -> <raw-root>/catalog.json
```

This means fresh or upgraded hosts can list components using the embedded
default repo configuration, without requiring a separate local
`config.toml`.

## Ship Note

**What was done:**
- `anolisa list/ls` now resolves the remote component catalog from `repo.toml`
- `ANOLISA_CATALOG_URL` remains available as a one-off override
- Missing local `config.toml` is no longer a blocker for `list`
- User-facing missing-catalog hints now point to `repo.toml` / raw backend config
- The mock catalog was published to OSS at:
  `https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/catalog.json`

**Limitations:**
- `list` still does not merge local installed state; rows currently show `not_installed`
- `list` does not yet filter by current platform, so a component may be listed even if no matching `index.toml` entry exists for the host

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p anolisa-cli -- --nocapture`
- `cargo clippy -p anolisa-cli --all-targets -- -D warnings`
