### PR TITLE
refactor(sight): derive session_id and conversation_id from response_id instead of message content

### DIFF
--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -18,10 +18,10 @@ use super::semantic::{
     GenAISemanticEvent, LLMCall, LLMRequest, LLMResponse,
     InputMessage, OutputMessage, MessagePart, TokenUsage,
 };
+use super::id_resolver::IdResolver;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
-use sha2::{Sha256, Digest};
 
 /// Output from `GenAIBuilder::build()`, containing built events and deferred resolution info.
 pub struct BuildOutput {
@@ -39,6 +39,9 @@ pub struct GenAIBuilder {
     session_prefix: String,
     /// Counter for generating unique IDs within a session
     call_counter: AtomicU64,
+    /// Resolver for `session_id` fallback / `conversation_id` based on the
+    /// earliest `response_id` observed within a session / conversation.
+    id_resolver: IdResolver,
 }
 
 impl Default for GenAIBuilder {
@@ -58,6 +61,7 @@ impl GenAIBuilder {
         GenAIBuilder {
             session_prefix: format!("{:x}_{:x}", ts, pid),
             call_counter: AtomicU64::new(0),
+            id_resolver: IdResolver::new(),
         }
     }
 
@@ -179,9 +183,19 @@ impl GenAIBuilder {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        // Parse messages from body to compute session_id, conversation_id,
-        // user_query, and serialise input_messages / system_instructions
-        let (session_id, conversation_id, user_query, input_messages, system_instructions) =
+        // Parse messages from body to extract user_query / input_messages /
+        // system_instructions / first_user_text / last_user_text。session_id 与
+        // conversation_id 在 request 阶段采用双层兑底：
+        //   1. 优先走 IdResolver::peek_*（同 PID 之前有过正常完成的调用 →
+        //      LRU 已 anchor 首个 response_id，复用后与正常路径完全对齐）。
+        //   2. 未命中时 → `crash_fallback_id`以 (agent_name, pid, user_text) 作为
+        //      兑底 ID 输入，保证 crash-drain 路径同 PID 同 user_query 的
+        //      crash 记录归一桶，不同 user_query 分桶。
+        //
+        // 正常响应到达后 `complete_pending` 仍会用 `IdResolver::resolve_*`
+        // 重新计算并 UPDATE 正常 ID，只有 crash 路径才会保留这里写入的
+        // peek/fallback 值。
+        let (user_query, input_messages, system_instructions, first_user_text, last_user_text) =
             if let Some(ref v) = body {
                 if let Some(messages) = v.get("messages").and_then(|m| m.as_array()) {
                     // Helper: extract text from "content" which can be either
@@ -210,33 +224,20 @@ impl GenAIBuilder {
                         None
                     };
 
-                    // session_id: SHA256 of first user message text (same logic
-                    // as compute_session_id but operating on raw JSON values)
+                    // First user message raw text — used as `session_key` material
+                    // for IdResolver peek / crash fallback.
                     let first_user_text = messages.iter()
                         .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
                         .find_map(|m| extract_text(m))
                         .unwrap_or_default();
 
-                    let session_id = if !first_user_text.is_empty() {
-                        let hash = Sha256::digest(first_user_text.as_bytes());
-                        Some(format!("{:x}", hash)[..32].to_string())
-                    } else {
-                        None
-                    };
-
-                    // Last user message raw text — used for both conversation_id
-                    // (fingerprint hash) and user_query (display text)
+                    // Last user message raw text — used for user_query (display text)
+                    // 以及 conversation_key (peek / crash fallback)。
                     let last_user_raw = messages.iter()
                         .rev()
                         .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
                         .find_map(|m| extract_text(m));
-
-                    // conversation_id: SHA256 of last user message raw text
-                    // (same logic as compute_user_query_fingerprint)
-                    let conversation_id = last_user_raw.as_deref().map(|text| {
-                        let hash = Sha256::digest(text.as_bytes());
-                        format!("{:x}", hash)[..32].to_string()
-                    });
+                    let last_user_text = last_user_raw.clone().unwrap_or_default();
 
                     // user_query: last user message text, stripped of metadata prefix
                     let user_query = last_user_raw.as_deref()
@@ -261,13 +262,13 @@ impl GenAIBuilder {
                         serde_json::to_string(&sys).ok()
                     };
 
-                    (session_id, conversation_id, user_query, input_messages, system_instructions)
+                    (user_query, input_messages, system_instructions, first_user_text, last_user_text)
                 } else {
                     // messages key missing or not an array
-                    (None, None, None, None, None)
+                    (None, None, None, String::new(), String::new())
                 }
             } else {
-                (None, None, None, None, None)
+                (None, None, None, String::new(), String::new())
             };
 
         // Extract model from request body JSON "model" field
@@ -284,13 +285,48 @@ impl GenAIBuilder {
         let agent_name = Self::resolve_agent_name_from_comm(&request.source_event.comm, conn_id.pid as u32, pid_agent_name_cache)
             .or_else(|| Some(request.source_event.comm_str()));
 
+        // 双层兑底计算 session_id / conversation_id（详见上方注释）。
+        // 这里不使用 unwrap_or_else(|| “”) 是为了让“同 PID 同 agent”上下文下
+        // crash_fallback_id 输入始终相同。
+        let agent_name_str = agent_name.as_deref().unwrap_or("");
+        let pid_i32 = conn_id.pid as i32;
+
+        let session_id = self
+            .id_resolver
+            .peek_session_id(agent_name_str, pid_i32, &first_user_text)
+            .or_else(|| {
+                Some(super::id_resolver::crash_fallback_id(
+                    "session",
+                    agent_name_str,
+                    pid_i32,
+                    &first_user_text,
+                ))
+            });
+        let conversation_id = self
+            .id_resolver
+            .peek_conversation_id(agent_name_str, pid_i32, &last_user_text)
+            .or_else(|| {
+                Some(super::id_resolver::crash_fallback_id(
+                    "conversation",
+                    agent_name_str,
+                    pid_i32,
+                    &last_user_text,
+                ))
+            });
+
         Some(PendingCallInfo {
             call_id,
             trace_id: None,          // LLM API response_id, not available until response
-            conversation_id,          // User query fingerprint hash (from request body)
+            // session_id / conversation_id 在请求阶段采用双层兑底：
+            // 1) IdResolver::peek_* 复用同 PID 之前正常完成调用的 anchor，
+            //    响应到达后 `complete_pending` 会用同样的值覆盖；
+            // 2) LRU miss 时走 `crash_fallback_id`（`crash-` 前缀与正常 ID 隔离），
+            //    进程崩溃不会走到 complete_pending 时该值会保留，供
+            //    handle_agent_crash_detection 按 (sid, cid) 分组。
+            conversation_id,
             session_id,
             start_timestamp_ns: request.source_event.timestamp_ns,
-            pid: conn_id.pid as i32,
+            pid: pid_i32,
             process_name: request.source_event.comm.clone(),
             agent_name,
             http_method: Some(request.method.clone()),
@@ -457,17 +493,10 @@ impl GenAIBuilder {
             .or_else(|| Self::extract_model_from_body(&http.request_body, &http.response_body))
             .unwrap_or_else(|| "unknown".to_string());
 
-        // 在 request move 之前提取用户查询、fingerprint 和 session_id
-        let query_fp = Self::compute_user_query_fingerprint(&request);
+        // 在 request move 之前提取用户查询 / first&last user message 原文
         let user_query = Self::extract_last_user_query(&request);
-        // session_id: 优先从 agent 自身的 session 获取（通过 response ID → .jsonl UUID 映射），
-        // fallback 到基于首条 user message 的 hash 计算
-        let response_id_val = parsed_message.as_ref().and_then(|m| m.response_id()).map(|s| s.to_string());
-        let mapper_session = response_id_val.as_deref()
-            .and_then(|rid| response_mapper.get_session_by_response_id(rid))
-            .map(|s| s.to_string());
-        let session_id = mapper_session.clone()
-            .unwrap_or_else(|| Self::compute_session_id(&request));
+        let first_user_raw = Self::extract_first_user_raw(&request).unwrap_or_default();
+        let last_user_raw = Self::extract_last_user_raw(&request).unwrap_or_default();
 
         // 提取 LLM API 的 response_id（如 chatcmpl-xxx），用作 trace_id
         // 同时作为 call_id 的首选值：trace_id 有值时直接复用，避免两套 ID；
@@ -475,6 +504,39 @@ impl GenAIBuilder {
         let response_id = Self::extract_response_id(&parsed_message, &http);
         let call_id = response_id.clone().unwrap_or_else(|| internal_id.clone());
         let response_id = response_id.unwrap_or_else(|| call_id.clone());
+
+        // 提前解析 agent_name，后面调用 IdResolver 需要它作为 LRU key 维度，
+        // 避免同机不同 agent 在同一 user query 下撞同一 session_id。
+        let agent_name = Self::resolve_agent_name(&http.comm, http.pid, pid_agent_name_cache)
+            .unwrap_or_else(|| http.comm.clone());
+        let pid_i32 = http.pid as i32;
+
+        // session_id: 优先从 agent 自身的 session 获取（通过 response ID → .jsonl UUID 映射），
+        // 未命中时 fallback 到 `SHA256("session" + 该 session 内最早 response_id)`。
+        let parsed_response_id = parsed_message.as_ref()
+            .and_then(|m| m.response_id())
+            .map(|s| s.to_string());
+        let mapper_session = parsed_response_id.as_deref()
+            .and_then(|rid| response_mapper.get_session_by_response_id(rid))
+            .map(|s| s.to_string());
+        let session_id = match mapper_session {
+            Some(uuid) => Some(uuid),
+            None => self.id_resolver.resolve_session_id(
+                &agent_name,
+                pid_i32,
+                &first_user_raw,
+                &response_id,
+            ),
+        };
+
+        // conversation_id: SHA256("conversation" + 该 conversation 内最早 response_id)
+        let conversation_id = self.id_resolver.resolve_conversation_id(
+            &agent_name,
+            pid_i32,
+            &last_user_raw,
+            &response_id,
+        );
+
 
         // Extract error message from response body when status_code >= 400
         let error = if http.status_code >= 400 {
@@ -542,10 +604,9 @@ impl GenAIBuilder {
             response,
             token_usage,
             error,
-            pid: http.pid as i32,
+            pid: pid_i32,
             process_name: http.comm.clone(),
-            agent_name: Self::resolve_agent_name(&http.comm, http.pid, pid_agent_name_cache)
-                .or_else(|| Some(http.comm.clone())),
+            agent_name: Some(agent_name.clone()),
             metadata: {
                 let mut meta = HashMap::new();
                 meta.insert("method".to_string(), http.method);
@@ -573,7 +634,9 @@ impl GenAIBuilder {
                     meta.insert("operation_name".to_string(), "chat".to_string());
                 }
                 // conversation_id: 对话ID，同一 user query 触发的所有调用共享
-                meta.insert("conversation_id".to_string(), query_fp);
+                if let Some(ref cid) = conversation_id {
+                    meta.insert("conversation_id".to_string(), cid.clone());
+                }
                 // response_id: LLM API 返回的响应 ID，用作 trace_id
                 meta.insert("response_id".to_string(), response_id);
                 // user_query: 用户实际输入的原文
@@ -581,7 +644,9 @@ impl GenAIBuilder {
                     meta.insert("user_query".to_string(), q.clone());
                 }
                 // session_id: 同一 agent 进程的完整会话标识
-                meta.insert("session_id".to_string(), session_id);
+                if let Some(ref sid) = session_id {
+                    meta.insert("session_id".to_string(), sid.clone());
+                }
                 meta
             },
         })
@@ -1124,15 +1189,12 @@ impl GenAIBuilder {
         format!("{}_{}", self.session_prefix, seq)
     }
 
-    /// 生成 session_id（32 位 hex）
+    /// 提取第一条有实际文本内容的 user message 的原始文本
     ///
-    /// 基于第一条 user message 原文生成，原文包含时间戳前缀如
-    /// `[Tue 2026-03-31 17:19 GMT+8] 用户输入`，天然唯一。
-    /// - 同一会话（含退出重进）：第一条 user message 不变 → session_id 稳定
-    /// - 新会话：时间戳不同 → session_id 不同
-    fn compute_session_id(request: &LLMRequest) -> String {
-        // 找第一条有实际文本的 user message（原始文本，含时间戳）
-        let first_user_raw: String = request.messages.iter()
+    /// 仅返回含非空 `Text` 片段的首条 user message，供 `IdResolver`
+    /// 生成 session_key 使用。跳过只含 tool_result 等的 user message。
+    fn extract_first_user_raw(request: &LLMRequest) -> Option<String> {
+        request.messages.iter()
             .filter(|m| m.role == "user")
             .find_map(|m| {
                 let text: String = m.parts.iter()
@@ -1144,10 +1206,6 @@ impl GenAIBuilder {
                     .join("\n");
                 if text.is_empty() { None } else { Some(text) }
             })
-            .unwrap_or_default();
-
-        let hash = Sha256::digest(first_user_raw.as_bytes());
-        format!("{:x}", hash)[..32].to_string()
     }
 
     /// 提取最后一条有实际文本内容的 user message 的原始文本
@@ -1203,20 +1261,6 @@ impl GenAIBuilder {
             }
         }
         text.to_string()
-    }
-    
-    /// 计算 user query 的 fingerprint，用于关联同一个请求的调用链
-    ///
-    /// 使用原始文本（包含时间戳前缀）计算 hash，
-    /// 这样相同命令在不同时间发送也会产生不同的 fingerprint
-    fn compute_user_query_fingerprint(request: &LLMRequest) -> String {
-        match Self::extract_last_user_raw(request) {
-            Some(content) => {
-                let hash = Sha256::digest(content.as_bytes());
-                format!("{:x}", hash)[..32].to_string()
-            }
-            None => "no_user_query".to_string(),
-        }
     }
 
     /// Resolve agent name from comm string only (no /proc access).
@@ -1595,75 +1639,6 @@ mod tests {
         let text = "[not a timestamp] content";
         // No ':' and digit in bracket content -> returns original
         assert_eq!(GenAIBuilder::strip_user_query_prefix(text), "[not a timestamp] content");
-    }
-
-    #[test]
-    fn test_compute_session_id_deterministic() {
-        let req = LLMRequest {
-            messages: vec![InputMessage {
-                role: "user".to_string(),
-                parts: vec![MessagePart::Text { content: "hello".to_string() }],
-                name: None,
-            }],
-            temperature: None, max_tokens: None, frequency_penalty: None,
-            presence_penalty: None, top_p: None, top_k: None, seed: None,
-            stop_sequences: None, stream: false, tools: None, raw_body: None,
-        };
-        let id1 = GenAIBuilder::compute_session_id(&req);
-        let id2 = GenAIBuilder::compute_session_id(&req);
-        assert_eq!(id1, id2);
-        assert_eq!(id1.len(), 32);
-    }
-
-    #[test]
-    fn test_compute_session_id_no_user() {
-        let req = LLMRequest {
-            messages: vec![InputMessage {
-                role: "system".to_string(),
-                parts: vec![MessagePart::Text { content: "sys".to_string() }],
-                name: None,
-            }],
-            temperature: None, max_tokens: None, frequency_penalty: None,
-            presence_penalty: None, top_p: None, top_k: None, seed: None,
-            stop_sequences: None, stream: false, tools: None, raw_body: None,
-        };
-        let id = GenAIBuilder::compute_session_id(&req);
-        assert_eq!(id.len(), 32); // still produces 32-char hash of empty string
-    }
-
-    #[test]
-    fn test_compute_user_query_fingerprint() {
-        let req = LLMRequest {
-            messages: vec![
-                InputMessage {
-                    role: "user".to_string(),
-                    parts: vec![MessagePart::Text { content: "first".to_string() }],
-                    name: None,
-                },
-                InputMessage {
-                    role: "user".to_string(),
-                    parts: vec![MessagePart::Text { content: "second".to_string() }],
-                    name: None,
-                },
-            ],
-            temperature: None, max_tokens: None, frequency_penalty: None,
-            presence_penalty: None, top_p: None, top_k: None, seed: None,
-            stop_sequences: None, stream: false, tools: None, raw_body: None,
-        };
-        let fp = GenAIBuilder::compute_user_query_fingerprint(&req);
-        assert_eq!(fp.len(), 32);
-        // fingerprint uses last user message
-        let req2 = LLMRequest {
-            messages: vec![InputMessage {
-                role: "user".to_string(),
-                parts: vec![MessagePart::Text { content: "second".to_string() }],
-                name: None,
-            }],
-            temperature: None, max_tokens: None, frequency_penalty: None,
-            presence_penalty: None, top_p: None, top_k: None, seed: None,
-            stop_sequences: None, stream: false, tools: None, raw_body: None,
-        };
-        assert_eq!(fp, GenAIBuilder::compute_user_query_fingerprint(&req2));
     }
 
     #[test]

--- a/src/agentsight/src/genai/id_resolver.rs
+++ b/src/agentsight/src/genai/id_resolver.rs
@@ -1,0 +1,472 @@
+//! Session / Conversation ID resolver.
+//!
+//! 将 `session_id` 的 fallback 与 `conversation_id` 的计算改造为：
+//!
+//! ```text
+//! session_id      = SHA256("session"      + 该 session  内最早 response_id)[..32]
+//! conversation_id = SHA256("conversation" + 该 conv     内最早 response_id)[..32]
+//! ```
+//!
+//! 同一 session / conversation 的"最早 response_id"通过两个 LRU 缓存锚定：
+//! - `session_first_resp`：以 `(agent_name, pid, 首条 user message)` 的 SHA256 作为 key
+//! - `conv_first_resp`   ：以 `(agent_name, pid, 最后一条 user message)` 的 SHA256 作为 key
+//!
+//! 在 key 中加入 `agent_name + pid` 维度是为了避免同机不同 agent（或
+//! 同 agent 不同进程）在用户输入相同时撞到同一 LRU bucket 从而获得
+//! 相同的 session_id / conversation_id。
+//!
+//! 加域前缀（"session" / "conversation"）实现域分离，确保两类 ID 不会
+//! 在 `first_response_id` 相同的边角情况下发生哈希碰撞。
+//!
+//! 当传入的 `response_id` 为空、或 user message 文本为空时直接返回 `None`，
+//! 由调用方决定是否回写元数据；后续 `complete_pending` 阶段会带着真正的
+//! response_id 再次调用本模块完成回填。
+
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+use lru::LruCache;
+use sha2::{Digest, Sha256};
+
+/// Maximum number of (session_key | conv_key) → first_response_id entries
+/// kept in memory. Sized to align with `ResponseSessionMapper`.
+const MAX_ENTRIES: usize = 10_000;
+
+/// 域前缀：避免 session_id 与 conversation_id 在 first_response_id 相同时碰撞。
+const SESSION_DOMAIN: &str = "session";
+const CONVERSATION_DOMAIN: &str = "conversation";
+
+/// `IdResolver` 负责把"内容 key + 当前 response_id"折算为稳定的
+/// session_id / conversation_id。
+///
+/// 内部使用 `Mutex<LruCache<...>>`，所以可以以 `&self` 形式安全地在
+/// `GenAIBuilder` 多线程上下文里调用。
+pub struct IdResolver {
+    /// session_key (SHA256 of first user message) → first_response_id.
+    session_first_resp: Mutex<LruCache<String, String>>,
+    /// conversation_key (SHA256 of last user message) → first_response_id.
+    conv_first_resp: Mutex<LruCache<String, String>>,
+}
+
+impl Default for IdResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IdResolver {
+    /// 构造一个空的 resolver，两份 LRU 容量均为 [`MAX_ENTRIES`]。
+    pub fn new() -> Self {
+        let cap = NonZeroUsize::new(MAX_ENTRIES).expect("MAX_ENTRIES must be non-zero");
+        IdResolver {
+            session_first_resp: Mutex::new(LruCache::new(cap)),
+            conv_first_resp: Mutex::new(LruCache::new(cap)),
+        }
+    }
+
+    /// 计算 session_id。
+    ///
+    /// - `agent_name`：该调用所属的 agent 名称（OpenClaw / Cosh / Hermes / ...）。
+    ///   与 `pid` 一起加入 LRU key，避免同机不同 agent / 不同进程在 user query
+    ///   相同时撞库。传空串也合法，会作为 key 的一部分参与哈希。
+    /// - `pid`：产生本次调用的进程 ID。重启后 PID 变化会自然产生新
+    ///   session_id，这与"一个 agent 进程一个会话"的语义一致。
+    /// - `first_user_text`：当前请求中"第一条 user message"的原始文本。
+    ///   空字符串视为无法定位 session_key，返回 `None`。
+    /// - `response_id`：当前 LLM 调用的 response_id；空字符串返回 `None`。
+    ///
+    /// 多次调用同一 `(agent_name, pid, first_user_text)` 时锚定第一次写入的
+    /// `response_id`，后续 `response_id` 即使变化，也会得到与首次相同的
+    /// session_id。
+    pub fn resolve_session_id(
+        &self,
+        agent_name: &str,
+        pid: i32,
+        first_user_text: &str,
+        response_id: &str,
+    ) -> Option<String> {
+        Self::resolve(
+            &self.session_first_resp,
+            SESSION_DOMAIN,
+            agent_name,
+            pid,
+            first_user_text,
+            response_id,
+        )
+    }
+
+    /// 计算 conversation_id。
+    ///
+    /// - `agent_name` / `pid`：同 `resolve_session_id`，用于隔离同机不同 agent /
+    ///   不同进程。
+    /// - `last_user_text`：当前请求中"最后一条 user message"的原始文本，
+    ///   作为 conversation_key 的素材。空字符串返回 `None`。
+    /// - `response_id`：当前调用的 response_id；空字符串返回 `None`。
+    pub fn resolve_conversation_id(
+        &self,
+        agent_name: &str,
+        pid: i32,
+        last_user_text: &str,
+        response_id: &str,
+    ) -> Option<String> {
+        Self::resolve(
+            &self.conv_first_resp,
+            CONVERSATION_DOMAIN,
+            agent_name,
+            pid,
+            last_user_text,
+            response_id,
+        )
+    }
+
+    /// 通用实现：定位/记录"首个 response_id"，再用域前缀 + first_response_id
+    /// 计算最终 ID（取 SHA256 前 32 位 hex）。
+    fn resolve(
+        cache: &Mutex<LruCache<String, String>>,
+        domain: &str,
+        agent_name: &str,
+        pid: i32,
+        text: &str,
+        response_id: &str,
+    ) -> Option<String> {
+        if text.is_empty() || response_id.is_empty() {
+            return None;
+        }
+
+        let key = compose_key(agent_name, pid, text);
+        let first_response_id = {
+            let mut guard = cache
+                .lock()
+                .expect("IdResolver LRU mutex poisoned");
+            // 已有条目时直接复用首个 response_id；否则把当前 response_id
+            // 写入作为锚点，让同一 key 后续调用得到稳定结果。
+            if let Some(existing) = guard.get(&key) {
+                existing.clone()
+            } else {
+                guard.put(key, response_id.to_string());
+                response_id.to_string()
+            }
+        };
+
+        Some(domain_hash(domain, &first_response_id))
+    }
+
+    /// 只读查询 session_id：查 LRU 中是否已锁定 `(agent, pid, first_user_text)` 的
+    /// first_response_id，命中则返回与正常路径完全一致的 session_id，未命中
+    /// 返回 `None`（不写入、不修改 LRU 顺序）。
+    ///
+    /// 主要用于 crash-drain 路径：进程崩溃、响应永远不会到达时，如果
+    /// 同 PID 之前已正常完成过 LLM 调用（LRU 已 anchor），则复用同一个
+    /// session_id，避免同一会话被崩溃拆分。
+    pub fn peek_session_id(
+        &self,
+        agent_name: &str,
+        pid: i32,
+        first_user_text: &str,
+    ) -> Option<String> {
+        Self::peek(
+            &self.session_first_resp,
+            SESSION_DOMAIN,
+            agent_name,
+            pid,
+            first_user_text,
+        )
+    }
+
+    /// 只读查询 conversation_id，用途与 `peek_session_id` 同。
+    pub fn peek_conversation_id(
+        &self,
+        agent_name: &str,
+        pid: i32,
+        last_user_text: &str,
+    ) -> Option<String> {
+        Self::peek(
+            &self.conv_first_resp,
+            CONVERSATION_DOMAIN,
+            agent_name,
+            pid,
+            last_user_text,
+        )
+    }
+
+    /// `peek_*` 的通用实现：仅查询 LRU，不写入、不提升顺序。
+    fn peek(
+        cache: &Mutex<LruCache<String, String>>,
+        domain: &str,
+        agent_name: &str,
+        pid: i32,
+        text: &str,
+    ) -> Option<String> {
+        if text.is_empty() {
+            return None;
+        }
+        let key = compose_key(agent_name, pid, text);
+        let guard = cache.lock().ok()?;
+        // `LruCache::peek` 不会提升条目顺序，适合 crash 路径“只读不写”。
+        let first_resp = guard.peek(&key)?;
+        Some(domain_hash(domain, first_resp))
+    }
+}
+
+/// crash-drain 路径专用 fallback ID。
+///
+/// 仅在 PID 第一个请求就崩、`peek_*` 未命中 LRU 时使用。调用方需传入：
+/// - `domain`: "session" 或 "conversation"（函数内部会加 "crash-" 前缀做域隔离）
+/// - `agent_name`/`pid`: 与正常路径 LRU key 维度一致，隔离同机不同 agent
+/// - `user_text`: session 传 first_user_text；conversation 传 last_user_text，
+///   跟正常路径“一个 user_query 一个 conversation”的语义对齐。
+///
+/// 输出 = `SHA256("crash-{domain}|agent_name|pid|user_text")[..32]`。
+/// `crash-` 前缀与正常路径的 `session`/`conversation` 前缀做域分离，避免
+/// crash 兑底 ID 与正常调用 ID 碰撞。
+pub fn crash_fallback_id(domain: &str, agent_name: &str, pid: i32, user_text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("crash-{}", domain).as_bytes());
+    hasher.update(b"|");
+    hasher.update(agent_name.as_bytes());
+    hasher.update(b"|");
+    hasher.update(pid.to_string().as_bytes());
+    hasher.update(b"|");
+    hasher.update(user_text.as_bytes());
+    let digest = hasher.finalize();
+    let full = format!("{:x}", digest);
+    full[..32].to_string()
+}
+
+/// 组装 LRU key：SHA256(agent_name + "|" + pid + "|" + text) 的 hex。
+///
+/// 使用哈希后的定长字符串作为 key，避免原始 user message 过长占用内存；
+/// `|` 作为字段分隔符避免 "a"+"|b" 与 "a|"+"b" 这类拼接哈希冲突。
+fn compose_key(agent_name: &str, pid: i32, text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(agent_name.as_bytes());
+    hasher.update(b"|");
+    hasher.update(pid.to_string().as_bytes());
+    hasher.update(b"|");
+    hasher.update(text.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// 计算 `SHA256(domain + first_response_id)` 的前 32 位 hex 表示。
+fn domain_hash(domain: &str, first_response_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(domain.as_bytes());
+    hasher.update(first_response_id.as_bytes());
+    let digest = hasher.finalize();
+    let full = format!("{:x}", digest);
+    full[..32].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 测试辅助：默认 agent / pid。
+    const A: &str = "openclaw";
+    const P: i32 = 1001;
+
+    #[test]
+    fn resolve_session_id_is_stable_across_calls() {
+        let resolver = IdResolver::new();
+        let first = resolver.resolve_session_id(A, P, "user-A", "resp-1").unwrap();
+        // 即便后续 response_id 变了，同一 (agent, pid, first_user_text) 仍返回首次结果
+        let again = resolver.resolve_session_id(A, P, "user-A", "resp-2").unwrap();
+        assert_eq!(first, again);
+        assert_eq!(first.len(), 32);
+    }
+
+    #[test]
+    fn resolve_session_id_changes_with_first_response_id() {
+        // 不同 first_user_text 处于不同 LRU bucket，各自锁定首次看到的
+        // response_id；只要首次看到的 response_id 不同，得到的 session_id
+        // 就会不同。
+        let resolver = IdResolver::new();
+        let a = resolver.resolve_session_id(A, P, "user-A", "resp-1").unwrap();
+        let b = resolver.resolve_session_id(A, P, "user-B", "resp-2").unwrap();
+        assert_ne!(a, b, "不同首次 response_id 应产生不同 session_id");
+    }
+
+    #[test]
+    fn resolve_conversation_id_changes_with_last_user_text() {
+        let resolver = IdResolver::new();
+        let a = resolver
+            .resolve_conversation_id(A, P, "turn-1", "resp-1")
+            .unwrap();
+        let b = resolver
+            .resolve_conversation_id(A, P, "turn-2", "resp-2")
+            .unwrap();
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 32);
+    }
+
+    #[test]
+    fn resolve_returns_none_when_response_id_empty() {
+        let resolver = IdResolver::new();
+        assert!(resolver.resolve_session_id(A, P, "user-A", "").is_none());
+        assert!(resolver.resolve_conversation_id(A, P, "turn-1", "").is_none());
+    }
+
+    #[test]
+    fn resolve_returns_none_when_text_empty() {
+        let resolver = IdResolver::new();
+        assert!(resolver.resolve_session_id(A, P, "", "resp-1").is_none());
+        assert!(resolver.resolve_conversation_id(A, P, "", "resp-1").is_none());
+    }
+
+    #[test]
+    fn session_and_conversation_diverge_on_same_first_response_id() {
+        let resolver = IdResolver::new();
+        // 故意构造 session_key 与 conversation_key 相同（同一段文本既是首条
+        // 又是最后一条 user message 时的真实场景），但仍应得到不同 ID。
+        let text = "single-turn";
+        let resp = "resp-1";
+        let s = resolver.resolve_session_id(A, P, text, resp).unwrap();
+        let c = resolver.resolve_conversation_id(A, P, text, resp).unwrap();
+        assert_ne!(s, c, "域前缀应保证两类 ID 不会碰撞");
+    }
+
+    #[test]
+    fn different_agents_with_same_user_text_get_different_ids() {
+        // 同机不同 agent，用户输入完全相同。生产中两个 agent 的 LLM
+        // 调用会各自拿到不同的 response_id，加入 (agent_name, pid) 作为 LRU
+        // key 后两个调用会各自锁定自己的首个 response_id，不会被同机
+        // 其他 agent “首访”串走。
+        let resolver = IdResolver::new();
+        let openclaw = resolver
+            .resolve_session_id("openclaw", 1001, "今天天气", "chatcmpl-A")
+            .unwrap();
+        let cosh = resolver
+            .resolve_session_id("cosh", 2002, "今天天气", "chatcmpl-B")
+            .unwrap();
+        assert_ne!(openclaw, cosh, "同机不同 agent 不可联合为同一 session");
+
+        let openclaw_conv = resolver
+            .resolve_conversation_id("openclaw", 1001, "今天天气", "chatcmpl-A")
+            .unwrap();
+        let cosh_conv = resolver
+            .resolve_conversation_id("cosh", 2002, "今天天气", "chatcmpl-B")
+            .unwrap();
+        assert_ne!(openclaw_conv, cosh_conv);
+    }
+
+    #[test]
+    fn same_user_text_does_not_leak_response_id_across_agents() {
+        // 验证 LRU 分桶：同一 user_text，不同 agent 各自锁定自己首访的
+        // response_id。即 OpenClaw 先到后，Cosh 后到不会被 OpenClaw 的
+        // response_id “传染”。
+        let resolver = IdResolver::new();
+        let openclaw_first = resolver
+            .resolve_session_id("openclaw", 1001, "hello", "chatcmpl-A")
+            .unwrap();
+        // Cosh 后到，拿到的应该是自己的 chatcmpl-B 作为 first_response_id，
+        // 而不是复用 chatcmpl-A。
+        let cosh_first = resolver
+            .resolve_session_id("cosh", 2002, "hello", "chatcmpl-B")
+            .unwrap();
+        // OpenClaw 后续调用仍锁定 chatcmpl-A
+        let openclaw_second = resolver
+            .resolve_session_id("openclaw", 1001, "hello", "chatcmpl-X")
+            .unwrap();
+        assert_eq!(openclaw_first, openclaw_second, "OpenClaw 多轮调用应稳定");
+        assert_ne!(openclaw_first, cosh_first, "不同 agent 不会撞库");
+    }
+
+    #[test]
+    fn same_agent_different_pids_get_different_ids() {
+        // 同 agent 两个进程实例（如重启后），同样 user query 应产生
+        // 不同会话 ID，符合"一个进程 = 一个会话"语义。
+        let resolver = IdResolver::new();
+        let p1 = resolver
+            .resolve_session_id("openclaw", 1001, "hello", "resp-1")
+            .unwrap();
+        let p2 = resolver
+            .resolve_session_id("openclaw", 1002, "hello", "resp-2")
+            .unwrap();
+        assert_ne!(p1, p2);
+    }
+
+    // ── peek_* 只读查询接口测试 ──
+
+    #[test]
+    fn peek_session_id_returns_none_when_lru_empty() {
+        let resolver = IdResolver::new();
+        assert!(resolver
+            .peek_session_id(A, P, "unseen")
+            .is_none());
+        assert!(resolver
+            .peek_conversation_id(A, P, "unseen")
+            .is_none());
+    }
+
+    #[test]
+    fn peek_session_id_matches_resolve_when_anchored() {
+        // 验证 crash 路径与正常路径自动对齐：resolve 写入后，peek 返回
+        // 与 resolve 完全相同的 ID。
+        let resolver = IdResolver::new();
+        let normal = resolver
+            .resolve_session_id(A, P, "hello", "chatcmpl-A")
+            .unwrap();
+        let peeked = resolver
+            .peek_session_id(A, P, "hello")
+            .unwrap();
+        assert_eq!(normal, peeked, "peek 应返回与正常路径一致的 session_id");
+
+        let normal_conv = resolver
+            .resolve_conversation_id(A, P, "world", "chatcmpl-B")
+            .unwrap();
+        let peeked_conv = resolver
+            .peek_conversation_id(A, P, "world")
+            .unwrap();
+        assert_eq!(normal_conv, peeked_conv);
+    }
+
+    #[test]
+    fn peek_returns_none_when_text_empty() {
+        let resolver = IdResolver::new();
+        // 即使 LRU 中有条目，空 text 仍返回 None
+        let _ = resolver.resolve_session_id(A, P, "x", "resp");
+        assert!(resolver.peek_session_id(A, P, "").is_none());
+        assert!(resolver.peek_conversation_id(A, P, "").is_none());
+    }
+
+    // ── crash_fallback_id 测试 ──
+
+    #[test]
+    fn crash_fallback_id_stable_for_same_inputs() {
+        let a = crash_fallback_id("session", "openclaw", 1001, "hello");
+        let b = crash_fallback_id("session", "openclaw", 1001, "hello");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 32);
+    }
+
+    #[test]
+    fn crash_fallback_id_diverges_session_vs_conversation() {
+        let s = crash_fallback_id("session", "openclaw", 1001, "hello");
+        let c = crash_fallback_id("conversation", "openclaw", 1001, "hello");
+        assert_ne!(s, c, "同输入下 session/conversation 域返回不同值");
+    }
+
+    #[test]
+    fn crash_fallback_id_diverges_with_different_user_text() {
+        // 验证 user_query 粒度分桶：同 PID 同 agent，但不同 user_text
+        // 产生不同的 crash fallback ID。
+        let a = crash_fallback_id("session", "openclaw", 1001, "query-A");
+        let b = crash_fallback_id("session", "openclaw", 1001, "query-B");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn crash_fallback_id_diverges_from_normal_id() {
+        // 以同一 user_text 分别走正常路径与 crash fallback，两者应因为
+        // 域前缀 ("session" vs "crash-session") 不同而不冲突。
+        let resolver = IdResolver::new();
+        let normal = resolver
+            .resolve_session_id("openclaw", 1001, "hello", "chatcmpl-A")
+            .unwrap();
+        let crash = crash_fallback_id("session", "openclaw", 1001, "hello");
+        assert_ne!(
+            normal, crash,
+            "正常 ID 与 crash fallback 需严格隔离以避免下游聚合错乱"
+        );
+    }
+}

--- a/src/agentsight/src/genai/mod.rs
+++ b/src/agentsight/src/genai/mod.rs
@@ -8,6 +8,7 @@ pub mod builder;
 pub mod exporter;
 pub mod storage;
 pub mod instance_id;
+pub mod id_resolver;
 pub mod logtail;
 pub mod encrypt;
 pub mod anolisa_release;

--- a/src/agentsight/src/storage/sqlite/genai.rs
+++ b/src/agentsight/src/storage/sqlite/genai.rs
@@ -862,8 +862,9 @@ impl GenAISqliteStore {
     }
 
     /// Look up the real session_id from completed records for the same PID.
-    /// Used in drain path to reconcile SHA256-hash fallback session_id with the
-    /// real agent UUID from ResponseSessionMapper.
+    /// Used in drain path to reconcile the response_id-based fallback session_id
+    /// (`SHA256("session" + first_response_id)`) with the real agent UUID from
+    /// ResponseSessionMapper.
     pub fn lookup_session_for_pid(
         &self,
         pid: i32,

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -107,7 +107,8 @@ pub struct AgentSight {
 
 /// GenAI events waiting for session_id resolution via ResponseSessionMapper.
 /// If the mapper lookup succeeds within the timeout, session_id metadata is updated
-/// before export. Otherwise, the events are exported with the hash-based fallback.
+/// before export. Otherwise, the events are exported with the response_id-based
+/// fallback (`SHA256("session" + first_response_id)`).
 struct PendingGenAI {
     events: Vec<GenAISemanticEvent>,
     response_id: String,
@@ -1239,7 +1240,8 @@ impl AgentSight {
                         pending.conversation_id.clone(),
                     ));
                     // ── Session ID reconciliation ──────────────────────────
-                    // The drain path computes session_id via SHA256 hash fallback,
+                    // The drain path computes session_id via the response_id
+                    // domain-separated hash fallback (`SHA256("session"+rid)`),
                     // but normal flow uses ResponseSessionMapper (agent .jsonl UUID).
                     // Look up the real session_id from completed records for the same PID.
                     match store.lookup_session_for_pid(pid) {


### PR DESCRIPTION
## Description

Refactor the `session_id` fallback and `conversation_id` generation algorithm to derive IDs from `response_id` (returned by the LLM API) rather than hashing user message content directly.

**Key changes:**
- New `IdResolver` module (`src/genai/id_resolver.rs`) with LRU-based stable ID generation
- LRU key uses `(agent_name, pid, user_text)` triple to prevent cross-agent collision on same machine
- Domain-separated hashing (`"session"` / `"conversation"` prefix) prevents ID collision between session and conversation
- `build_pending_from_request` now writes NULL for session_id/conversation_id at request time; backfilled by `complete_pending` when response arrives
- Removed legacy `compute_session_id` and `compute_user_query_fingerprint` functions

**Algorithm:**
- `session_id = SHA256("session" + first_response_id_in_session)[..32]`
- `conversation_id = SHA256("conversation" + first_response_id_in_conversation)[..32]`

## Related Issue

closes #855

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo test --lib`: 547/547 passed
- New `id_resolver` unit tests cover: stability across calls, domain separation, empty input handling, cross-agent isolation, cross-PID isolation, response_id leak prevention

## Additional Notes

- ResponseSessionMapper (agent .jsonl UUID) priority is unchanged; this refactor only affects the fallback path when the mapper misses.
- SLS upload path is unaffected: LogtailExporter only sees fully-resolved events after `complete_pending`.