### PR TITLE
fix(os-skills): update dashscope proxy url to new anthropic endpoint

### DIFF
--- a/src/os-skills/ai/install-claude-code/SKILL.md
+++ b/src/os-skills/ai/install-claude-code/SKILL.md
@@ -138,7 +138,7 @@ Write the following to `~/.claude/settings.json`:
 ```json
 {
   "env": {
-    "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/api/v2/apps/claude-code-proxy",
+    "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "YOUR_API_KEY",
     "ANTHROPIC_MODEL": "qwen3-coder-plus",
     "ANTHROPIC_SMALL_FAST_MODEL": "qwen3-coder-plus"
@@ -153,7 +153,7 @@ Replace `YOUR_API_KEY` with the user's actual API key.
 If the user prefers shell env vars over `settings.json`, append to `~/.bashrc`:
 
 ```bash
-export ANTHROPIC_BASE_URL="https://dashscope.aliyuncs.com/api/v2/apps/claude-code-proxy"
+export ANTHROPIC_BASE_URL="https://dashscope.aliyuncs.com/apps/anthropic"
 export ANTHROPIC_AUTH_TOKEN="YOUR_API_KEY"
 export ANTHROPIC_MODEL="qwen3-coder-plus"
 export ANTHROPIC_SMALL_FAST_MODEL="qwen3-coder-plus"

--- a/src/os-skills/ai/install-claude-code/scripts/install-claude-code.sh
+++ b/src/os-skills/ai/install-claude-code/scripts/install-claude-code.sh
@@ -261,7 +261,7 @@ write_config() {
   cat > "$settings_file" <<JSONEOF
 {
   "env": {
-    "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/api/v2/apps/claude-code-proxy",
+    "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "${api_key}",
     "ANTHROPIC_MODEL": "qwen3-coder-plus",
     "ANTHROPIC_SMALL_FAST_MODEL": "qwen3-coder-plus"


### PR DESCRIPTION
## Description

- 更新 DashScope 代理 URL，从已废弃的 `/api/v2/apps/claude-code-proxy` 切换到新的 `/apps/anthropic` 端点

SKILL.md 文档和 install-claude-code.sh 安装脚本中的 `ANTHROPIC_BASE_URL` 都指向了旧的代理路径，
导致新用户按文档配置后无法正常连接。统一更新为新端点。

## Related Issue

closes #805

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [x] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [ ] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

手动安装 Claude Code 并配置新的 DashScope 代理 URL，测试可以正常使用。

## Additional Notes