### PR TITLE
feat(sec-core): enhance daemon logging including requests and jobs

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli_logging.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli_logging.py
@@ -1,235 +1,84 @@
 """Diagnostic JSONL logging for the agent-sec-cli process."""
 
 import logging
-import os
-import traceback as traceback_module
-from collections.abc import Mapping
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
-from agent_sec_cli.correlation_context import (
-    get_current_trace_context,
-    get_invocation_id,
-    truncate_correlation_id,
+from agent_sec_cli.correlation_context import get_invocation_id
+from agent_sec_cli.diagnostic_logging import (
+    DiagnosticLoggingConfig,
+    DiagnosticLogRecordHandler,
+    PythonLogRecordDiagnosticLogging,
 )
-from agent_sec_cli.security_events.config import get_stream_log_path
-from agent_sec_cli.security_events.writer import JsonlEventWriter
 
 _LOGGER_NAME = "agent_sec_cli"
 _ENV_LOG_LEVEL = "AGENT_SEC_CLI_LOG_LEVEL"
-_ENV_LOG_DISABLED = "AGENT_SEC_CLI_LOG_DISABLED"
-_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
-_LEVELS = {
-    "debug": logging.DEBUG,
-    "info": logging.INFO,
-    "warning": logging.WARNING,
-    "error": logging.ERROR,
-    "critical": logging.CRITICAL,
-}
-_CORRELATION_FIELDS = (
-    "trace_id",
-    "session_id",
-    "run_id",
-    "call_id",
-    "tool_call_id",
-)
-
 # Diagnostic stream is sized smaller than the business streams: default
 # WARNING volume is low, and DEBUG bursts roll over quickly.
 CLI_LOG_MAX_BYTES = 10 * 1024 * 1024
 CLI_LOG_BACKUP_COUNT = 5
 
-_SETUP_DONE = False
+CliLoggingConfig = DiagnosticLoggingConfig
 
 
-@dataclass(frozen=True)
-class CliLoggingConfig:
-    """Resolved CLI diagnostic logging configuration."""
+class CliDiagnosticLogging(PythonLogRecordDiagnosticLogging):
+    """CLI-specific mapping from Python logging records to diagnostic JSONL."""
 
-    enabled: bool
-    level: int
-    log_file: Path | None
+    component = "cli"
+    stream = "cli"
+    level_env = _ENV_LOG_LEVEL
+    default_level = logging.WARNING
+    max_bytes = CLI_LOG_MAX_BYTES
+    backup_count = CLI_LOG_BACKUP_COUNT
+    python_logger_name = _LOGGER_NAME
+    event = "cli_log"
+    propagate_on_enable = False
+    propagate_on_reset = True
 
+    def create_record_handler(self, path: str | Path) -> "JsonlCliLogHandler":
+        """Create the CLI compatibility handler used by setup and tests."""
+        return JsonlCliLogHandler(path, diagnostic_logging=self)
 
-def _utc_now_iso() -> str:
-    return (
-        datetime.now(timezone.utc)
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z")
-    )
+    def invocation_id_for_record(self, _record: logging.LogRecord) -> str | None:
+        """Return the process-level CLI invocation ID."""
+        return get_invocation_id()
 
-
-def _is_truthy(value: str | None) -> bool:
-    return value is not None and value.strip().lower() in _TRUE_VALUES
-
-
-def _resolve_level(value: str | None) -> tuple[bool, int]:
-    if value is None:
-        return True, logging.WARNING
-
-    normalized = value.strip().lower()
-    if normalized == "off":
-        return False, logging.WARNING
-    return True, _LEVELS.get(normalized, logging.WARNING)
+    def should_remove_handler(self, handler: logging.Handler) -> bool:
+        """Remove every CLI diagnostic handler when tests reset logging."""
+        return isinstance(handler, JsonlCliLogHandler)
 
 
-def _resolve_log_path() -> Path | None:
-    """Resolve `cli.jsonl` through the shared data-dir helper.
+class JsonlCliLogHandler(DiagnosticLogRecordHandler):
+    """Compatibility handler for CLI diagnostic JSONL records."""
 
-    `get_stream_log_path("cli")` already routes through `_resolve_data_dir()`,
-    which `mkdir`s the parent at mode 0o700 and `chmod`s it on every call.
-    All three streams (security-events, observability, cli) share this path
-    resolution and the same access-control guarantees.
-    """
-    try:
-        return Path(get_stream_log_path("cli")).expanduser()
-    except Exception:  # noqa: BLE001 - diagnostic logging is best-effort
-        return None
-
-
-def _clean_correlation_value(field_name: str, value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    stripped = value.strip()
-    if not stripped:
-        return None
-    return truncate_correlation_id(field_name, stripped)
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        diagnostic_logging: CliDiagnosticLogging | None = None,
+    ) -> None:
+        self._path = Path(path).expanduser()
+        if diagnostic_logging is None:
+            diagnostic_logging = _CLI_LOGGING
+        diagnostic_logger = diagnostic_logging.create_jsonl_logger(
+            path=self._path,
+            level=logging.NOTSET,
+        )
+        super().__init__(diagnostic_logging, diagnostic_logger)
 
 
-def _json_safe(value: Any) -> Any:
-    """Return a JSON-serializable representation for diagnostic payloads."""
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, Mapping):
-        return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_safe(item) for item in value]
-    return str(value)
-
-
-def _has_exception(exc_info: object) -> bool:
-    if not isinstance(exc_info, tuple) or len(exc_info) != 3:
-        return False
-    exc_type, exception, _traceback = exc_info
-    return exc_type is not None and exception is not None
+_CLI_LOGGING = CliDiagnosticLogging()
 
 
 def resolve_cli_logging_config() -> CliLoggingConfig:
-    """Resolve CLI diagnostic logging settings from environment variables."""
-    level_enabled, level = _resolve_level(os.environ.get(_ENV_LOG_LEVEL))
-    if _is_truthy(os.environ.get(_ENV_LOG_DISABLED)) or not level_enabled:
-        return CliLoggingConfig(enabled=False, level=level, log_file=None)
-
-    log_file = _resolve_log_path()
-    if log_file is None:
-        return CliLoggingConfig(enabled=False, level=level, log_file=None)
-    return CliLoggingConfig(enabled=True, level=level, log_file=log_file)
-
-
-class JsonlCliLogHandler(logging.Handler):
-    """Convert Python log records into CLI diagnostic JSONL records."""
-
-    def __init__(self, path: str | Path) -> None:
-        super().__init__()
-        self._path = Path(path).expanduser()
-        self._writer = JsonlEventWriter(
-            self._path,
-            max_bytes=CLI_LOG_MAX_BYTES,
-            backup_count=CLI_LOG_BACKUP_COUNT,
-        )
-
-    def emit(self, record: logging.LogRecord) -> None:
-        """Write one logging record. All handler failures are swallowed."""
-        try:
-            self._writer.write(self._record_to_payload(record))
-        except Exception:  # noqa: BLE001
-            pass
-
-    def _record_to_payload(self, record: logging.LogRecord) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "timestamp": _utc_now_iso(),
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.getMessage(),
-            "function": record.funcName,
-            "invocation_id": get_invocation_id(),
-        }
-
-        # Correlation slots: process trace context first, then per-record
-        # overrides via extra={"trace_id": ...}. Only stamp when the value is
-        # a non-empty string — TraceContext fields are always typed as such,
-        # but ``record.<field>`` comes from caller-supplied ``extra={...}``
-        # and a misuse like ``extra={"trace_id": trace_ctx}`` (passing the
-        # whole object) must NOT silently overwrite a real id with a repr.
-        trace_ctx = get_current_trace_context()
-        if trace_ctx is not None:
-            for field_name in _CORRELATION_FIELDS:
-                value = _clean_correlation_value(
-                    field_name,
-                    getattr(trace_ctx, field_name, None),
-                )
-                if value is not None:
-                    payload[field_name] = value
-        for field_name in _CORRELATION_FIELDS:
-            value = _clean_correlation_value(
-                field_name,
-                getattr(record, field_name, None),
-            )
-            if value is not None:
-                payload[field_name] = value
-
-        # Free-form payload slot. Caller owns shape (string or dict); no
-        # whitelist, no schema validation. Call-site discipline is the only
-        # guard against leaking large or sensitive content here.
-        data = getattr(record, "data", None)
-        if data is not None:
-            payload["data"] = _json_safe(data)
-
-        if _has_exception(record.exc_info):
-            exception = record.exc_info[1]
-            payload["error_type"] = type(exception).__name__
-            payload["exception"] = str(exception)
-            if record.levelno >= logging.ERROR:
-                payload["traceback"] = "".join(
-                    traceback_module.format_exception(*record.exc_info)
-                )
-        return _json_safe(payload)
+    """Resolve CLI diagnostic logging settings from the shared base logic."""
+    return _CLI_LOGGING.resolve_config()
 
 
 def setup_cli_logging() -> None:
-    """Idempotently configure diagnostic logging for the agent_sec_cli tree.
-
-    Failures (config resolution or handler construction) leave the logger
-    unattached but still mark setup as done — diagnostic logging never retries
-    mid-process. The first call is the only call that has any effect.
-    """
-    global _SETUP_DONE  # noqa: PLW0603
-    if _SETUP_DONE:
-        return
-    logger = logging.getLogger(_LOGGER_NAME)
-    try:
-        config = resolve_cli_logging_config()
-        if config.enabled and config.log_file is not None:
-            handler = JsonlCliLogHandler(config.log_file)
-            handler.setLevel(config.level)
-            logger.addHandler(handler)
-            logger.setLevel(config.level)
-            logger.propagate = False
-    except Exception:  # noqa: BLE001 - diagnostic logging setup is best-effort
-        pass
-    finally:
-        _SETUP_DONE = True
+    """Idempotently configure diagnostic logging for the agent_sec_cli tree."""
+    _CLI_LOGGING.setup()
 
 
 def _reset_cli_logging_for_tests() -> None:
     """Reset module logging state for in-process unit tests."""
-    global _SETUP_DONE  # noqa: PLW0603
-    logger = logging.getLogger(_LOGGER_NAME)
-    for handler in list(logger.handlers):
-        if isinstance(handler, JsonlCliLogHandler):
-            logger.removeHandler(handler)
-            handler.close()
-    logger.propagate = True
-    _SETUP_DONE = False
+    _CLI_LOGGING.reset_for_tests()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/correlation_context.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/correlation_context.py
@@ -19,6 +19,7 @@ _FIELD_ALIASES: dict[str, tuple[str, str]] = {
     "call_id": ("call_id", "callId"),
     "tool_call_id": ("tool_call_id", "toolCallId"),
 }
+CORRELATION_FIELD_NAMES: tuple[str, ...] = tuple(_FIELD_ALIASES)
 
 
 def truncate_correlation_id(_field_name: str, value: str) -> str:
@@ -49,11 +50,10 @@ class TraceContext:
 # would default to empty in newly-spawned threads and break the invariant
 # that all records in one CLI process share the same trace context.
 #
-# `_trace_context_override` is intentionally unused in the short-lived CLI;
-# it is reserved for a future daemon mode where one process handles multiple
-# concurrent requests, each needing its own per-request context. Do not
-# delete — removing it forces a redesign of every consumer when daemon mode
-# lands.
+# The normal CLI entry point initializes `_PROCESS_TRACE_CONTEXT` and does not
+# set `_trace_context_override`. Daemon and library-mode paths set the override
+# when they need request-local context in a long-lived process, where concurrent
+# requests must not overwrite each other's trace fields.
 # ---------------------------------------------------------------------------
 _PROCESS_TRACE_CONTEXT: TraceContext | None = None
 
@@ -77,10 +77,6 @@ _trace_context_override: ContextVar[_TraceContextOverride] = ContextVar(
 
 _PROCESS_INVOCATION_ID: str = ""
 _INVOCATION_INIT_LOCK = threading.Lock()
-_invocation_id_override: ContextVar[str] = ContextVar(
-    "invocation_id_override",
-    default="",
-)
 
 
 def _clean_string(field_name: str, value: Any) -> str | None:
@@ -90,6 +86,11 @@ def _clean_string(field_name: str, value: Any) -> str | None:
     if not stripped:
         return None
     return truncate_correlation_id(field_name, stripped)
+
+
+def clean_correlation_value(field_name: str, value: Any) -> str | None:
+    """Return a normalized correlation value, or ``None`` when invalid/empty."""
+    return _clean_string(field_name, value)
 
 
 def _normalized_fields(payload: Mapping[str, Any]) -> dict[str, str]:
@@ -127,6 +128,19 @@ def parse_trace_context_payload(
     if payload is None:
         return None
     return TraceContext(**_normalized_fields(payload))
+
+
+def trace_context_to_payload(ctx: TraceContext | None) -> dict[str, str]:
+    """Serialize a trace context into sanitized top-level log fields."""
+    if ctx is None:
+        return {}
+
+    payload: dict[str, str] = {}
+    for field_name in CORRELATION_FIELD_NAMES:
+        value = clean_correlation_value(field_name, getattr(ctx, field_name, None))
+        if value is not None:
+            payload[field_name] = value
+    return payload
 
 
 def init_process_trace_context(ctx: TraceContext | None) -> None:
@@ -201,29 +215,10 @@ def clear_invocation_context_for_tests() -> None:
     """Clear invocation context state for in-process tests."""
     global _PROCESS_INVOCATION_ID  # noqa: PLW0603
     _PROCESS_INVOCATION_ID = ""
-    _invocation_id_override.set("")
-
-
-def set_current_invocation_id(invocation_id: str) -> Token[str]:
-    """Set a request-local invocation ID override.
-
-    Input is normalized the same way as the env value: stripped and truncated
-    to ``MAX_CORRELATION_ID_LENGTH``. Whitespace-only input clears the override.
-    """
-    cleaned = _clean_string("invocation_id", invocation_id)
-    return _invocation_id_override.set(cleaned or "")
-
-
-def reset_current_invocation_id(token: Token[str]) -> None:
-    """Reset a request-local invocation ID override."""
-    _invocation_id_override.reset(token)
 
 
 def get_invocation_id() -> str:
-    """Return request-local invocation ID, falling back to the process value."""
-    override = _invocation_id_override.get()
-    if override:
-        return override
+    """Return the process-level CLI invocation ID."""
     if not _PROCESS_INVOCATION_ID:
         init_invocation_context()
     return _PROCESS_INVOCATION_ID

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/client.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/client.py
@@ -4,6 +4,10 @@ import socket
 from pathlib import Path
 from typing import Any
 
+from agent_sec_cli.correlation_context import (
+    clean_correlation_value,
+    get_invocation_id,
+)
 from agent_sec_cli.daemon.errors import (
     DaemonClientTimeoutError,
     DaemonProtocolError,
@@ -14,7 +18,6 @@ from agent_sec_cli.daemon.protocol import (
     DEFAULT_TIMEOUT_MS,
     DaemonRequest,
     DaemonResponse,
-    generate_request_id,
     parse_response_line,
     serialize_request,
 )
@@ -40,15 +43,15 @@ class DaemonClient:
         params: dict[str, Any] | None = None,
         trace_context: dict[str, Any] | None = None,
         timeout_ms: int | None = None,
-        request_id: str | None = None,
+        caller: str | None = None,
     ) -> DaemonResponse:
         """Send one request and return the daemon response."""
         effective_timeout_ms = timeout_ms or self.timeout_ms
         request = DaemonRequest(
-            id=request_id or generate_request_id(),
             method=method,
             params={} if params is None else params,
-            trace_context={} if trace_context is None else trace_context,
+            trace_context=_trace_context_with_fallback_trace_id(trace_context),
+            caller=caller,
             timeout_ms=effective_timeout_ms,
         )
         return self._send_request(request, effective_timeout_ms)
@@ -105,3 +108,15 @@ def daemon_health_reachable(socket_path: Path, timeout_ms: int = 250) -> bool:
     except (DaemonProtocolError, DaemonTransportError):
         return False
     return response.ok
+
+
+def _trace_context_with_fallback_trace_id(
+    trace_context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    payload = {} if trace_context is None else dict(trace_context)
+    trace_id = clean_correlation_value("trace_id", payload.get("trace_id"))
+    if trace_id is None:
+        trace_id = clean_correlation_value("trace_id", payload.get("traceId"))
+    if trace_id is None:
+        payload["trace_id"] = get_invocation_id()
+    return payload

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/gateway.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/gateway.py
@@ -1,0 +1,166 @@
+"""Daemon request gateway.
+
+The gateway is transport-agnostic: Unix sockets, in-process callers, or future
+ingress paths should all produce a ``DaemonRequest`` and then execute it here.
+"""
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from agent_sec_cli.correlation_context import TraceContext
+from agent_sec_cli.daemon.errors import UnknownMethodError
+from agent_sec_cli.daemon.logging import log_daemon_event
+from agent_sec_cli.daemon.protocol import DaemonRequest, DaemonResponse
+from agent_sec_cli.daemon.registry import MethodRegistry, dispatch_request
+from agent_sec_cli.daemon.request_context import (
+    daemon_request_context,
+    normalize_request_trace_context,
+)
+from agent_sec_cli.daemon.runtime import DaemonRuntime
+from agent_sec_cli.daemon.validation import (
+    DaemonRequestValidator,
+    NoopDaemonRequestValidator,
+)
+
+
+@dataclass(frozen=True)
+class PreparedDaemonRequest:
+    """Daemon request normalized for gateway execution."""
+
+    request: DaemonRequest
+    trace_context: TraceContext
+    access_log: bool
+
+
+class DaemonGateway:
+    """Normalize, validate, log, and dispatch daemon requests."""
+
+    def __init__(
+        self,
+        registry: MethodRegistry,
+        runtime: DaemonRuntime,
+        validator: DaemonRequestValidator | None = None,
+    ) -> None:
+        self.registry = registry
+        self.runtime = runtime
+        self.validator = (
+            validator if validator is not None else NoopDaemonRequestValidator()
+        )
+
+    def prepare(self, request: DaemonRequest) -> PreparedDaemonRequest:
+        """Normalize request context before execution or completion logging."""
+        normalized_request, trace_context = normalize_request_trace_context(request)
+        return PreparedDaemonRequest(
+            request=normalized_request,
+            trace_context=trace_context,
+            access_log=_access_log_enabled(self.registry, normalized_request.method),
+        )
+
+    async def execute(self, prepared: PreparedDaemonRequest) -> DaemonResponse:
+        """Run a prepared daemon request through validation and method dispatch."""
+        began_request = False
+        with daemon_request_context(
+            prepared.trace_context, prepared.request.request_id
+        ):
+            if prepared.access_log:
+                _log_request_started(
+                    request_id=prepared.request.request_id,
+                    method=prepared.request.method,
+                    caller=prepared.request.caller,
+                    trace_context=prepared.trace_context,
+                )
+
+            self.validator.validate(prepared.request)
+            self.runtime.begin_request()
+            began_request = True
+            try:
+                return await dispatch_request(
+                    prepared.request,
+                    self.registry,
+                    self.runtime,
+                )
+            finally:
+                if began_request:
+                    self.runtime.end_request()
+
+    def complete(
+        self,
+        prepared: PreparedDaemonRequest,
+        response: DaemonResponse,
+        started: float,
+        bytes_in: int,
+        bytes_out: int,
+    ) -> None:
+        """Emit gateway completion logging after the transport writes a response."""
+        if prepared.access_log or not response.ok:
+            _log_request_completion(
+                request_id=prepared.request.request_id,
+                method=prepared.request.method,
+                caller=prepared.request.caller,
+                response=response,
+                started=started,
+                bytes_in=bytes_in,
+                bytes_out=bytes_out,
+                trace_context=prepared.trace_context,
+            )
+
+
+def _access_log_enabled(registry: MethodRegistry, method: str) -> bool:
+    try:
+        return registry.get(method).access_log
+    except UnknownMethodError:
+        return True
+
+
+def _log_request_completion(
+    request_id: str,
+    method: str | None,
+    response: DaemonResponse,
+    started: float,
+    bytes_in: int,
+    bytes_out: int,
+    caller: str | None = None,
+    trace_context: TraceContext | None = None,
+) -> None:
+    latency_ms = int((time.monotonic() - started) * 1000)
+    error_code = None if response.error is None else response.error.get("code")
+    data: dict[str, Any] = {
+        "request_id": request_id,
+        "method": method,
+        "caller": caller,
+        "ok": response.ok,
+        "exit_code": response.exit_code,
+        "error_code": error_code,
+        "latency_ms": latency_ms,
+        "queue_ms": 0,
+        "bytes_in": bytes_in,
+        "bytes_out": bytes_out,
+    }
+    log_daemon_event(
+        event="daemon_request_completed",
+        message="daemon request completed",
+        data=data,
+        request_id=request_id,
+        trace_context=trace_context,
+    )
+
+
+def _log_request_started(
+    request_id: str,
+    method: str | None,
+    caller: str | None = None,
+    trace_context: TraceContext | None = None,
+) -> None:
+    data: dict[str, Any] = {
+        "request_id": request_id,
+        "method": method,
+        "caller": caller,
+    }
+    log_daemon_event(
+        event="daemon_request_started",
+        message="daemon request started",
+        data=data,
+        request_id=request_id,
+        trace_context=trace_context,
+    )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/prompt_scan.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/prompt_scan.py
@@ -38,7 +38,6 @@ async def prompt_scan_handler(
     params = request.params
     result = await asyncio.to_thread(
         _invoke_prompt_scan,
-        trace_context=request.trace_context,
         text=_string_param(params, "text"),
         mode=_string_param(params, "mode", default="standard"),
         source=_string_param(params, "source"),
@@ -48,19 +47,17 @@ async def prompt_scan_handler(
 
 def _invoke_prompt_scan(
     *,
-    trace_context: dict[str, Any],
     text: str,
     mode: str,
     source: str,
 ) -> Any:
     from agent_sec_cli.security_middleware import (  # noqa: PLC0415 - lazy import: daemon handler execution only
-        invoke_with_context,
+        invoke,
     )
 
-    return invoke_with_context(
+    return invoke(
         "prompt_scan",
         caller="daemon",
-        trace_context=trace_context,
         text=text,
         mode=mode,
         source=source,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/prompt_scan_protocol.md
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/prompt_scan_protocol.md
@@ -46,7 +46,7 @@ Expected shape:
 
 ```json
 {
-  "id": "req-1",
+  "request_id": "4f56f7b6-0c77-4a71-a6b0-708f6a4f7ec7",
   "ok": false,
   "data": {},
   "stdout": "",
@@ -91,7 +91,7 @@ Expected successful scan shape:
 
 ```json
 {
-  "id": "req-1",
+  "request_id": "4f56f7b6-0c77-4a71-a6b0-708f6a4f7ec7",
   "ok": true,
   "data": {
     "ok": true,
@@ -107,7 +107,7 @@ Expected scanner error result shape:
 
 ```json
 {
-  "id": "req-1",
+  "request_id": "4f56f7b6-0c77-4a71-a6b0-708f6a4f7ec7",
   "ok": true,
   "data": {
     "ok": false,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/__init__.py
@@ -4,6 +4,7 @@ from agent_sec_cli.daemon.jobs.base import (
     BackgroundJob,
     JobManager,
     JobStatus,
+    OneShotBackgroundJob,
     PeriodicBackgroundJob,
 )
 
@@ -11,5 +12,6 @@ __all__ = [
     "BackgroundJob",
     "JobManager",
     "JobStatus",
+    "OneShotBackgroundJob",
     "PeriodicBackgroundJob",
 ]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/base.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/base.py
@@ -2,11 +2,21 @@
 
 import asyncio
 import contextlib
+import logging
 import math
+import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
+
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    reset_current_trace_context,
+    set_current_trace_context,
+)
+from agent_sec_cli.daemon.logging import log_daemon_event
 
 
 @dataclass(frozen=True)
@@ -57,6 +67,187 @@ class BackgroundJob(ABC):
     def status(self) -> JobStatus:
         """Return current job status."""
         pass
+
+
+@contextlib.contextmanager
+def job_trace_context(job_name: str) -> Iterator[TraceContext]:
+    """Set a daemon-owned trace context for one background job run."""
+    trace_context = TraceContext(trace_id=str(uuid.uuid4()))
+    token = set_current_trace_context(trace_context)
+    try:
+        yield trace_context
+    finally:
+        reset_current_trace_context(token)
+
+
+def _log_job_event(
+    *,
+    event: str,
+    message: str,
+    job_name: str,
+    job_kind: str,
+    state: str,
+    trace_context: TraceContext,
+    level: int = logging.INFO,
+    latency_ms: int | None = None,
+    error: Exception | None = None,
+    interval_seconds: float | None = None,
+) -> None:
+    fields: dict[str, Any] = {
+        "job_name": job_name,
+        "job_kind": job_kind,
+        "state": state,
+    }
+    if latency_ms is not None:
+        fields["latency_ms"] = latency_ms
+    if interval_seconds is not None:
+        fields["interval_seconds"] = interval_seconds
+    if error is not None:
+        fields["error_type"] = type(error).__name__
+        fields["error_message"] = str(error)
+
+    log_daemon_event(
+        level=level,
+        event=event,
+        message=message,
+        data=fields,
+        trace_context=trace_context,
+    )
+
+
+def _elapsed_ms(started_monotonic: float) -> int:
+    return int((time_monotonic() - started_monotonic) * 1000)
+
+
+class OneShotBackgroundJob(BackgroundJob, ABC):
+    """Background job that runs once after startup."""
+
+    def __init__(self) -> None:
+        self._task: asyncio.Task[None] | None = None
+        self._state = "stopped"
+        self._last_error: str | None = None
+        self._last_tick_at: str | None = None
+        self._last_started_at: str | None = None
+
+    async def start(self) -> None:
+        """Start the one-shot job without blocking daemon startup."""
+        if self._task is not None and not self._task.done():
+            return
+
+        self._state = "running"
+        self._task = asyncio.create_task(self._run_once_with_lifecycle())
+
+    async def stop(self) -> None:
+        """Cancel the job task if it has not completed."""
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
+        if self._state == "running":
+            self._state = "stopped"
+        self._task = None
+
+    def status(self) -> JobStatus:
+        """Return current one-shot job status."""
+        return JobStatus(
+            name=self.name,
+            state=self._state,
+            last_error=self._last_error,
+            last_tick_at=self._last_tick_at,
+            last_started_at=self._last_started_at,
+        )
+
+    @abstractmethod
+    async def run_once(self) -> None:
+        """Run the one-shot job body."""
+        pass
+
+    def on_run_started(self, started_at: str) -> None:
+        """Handle one-shot job start."""
+        pass
+
+    def on_run_cancelled(self, finished_at: str) -> None:
+        """Handle one-shot job cancellation."""
+        pass
+
+    def on_run_failed(self, exc: Exception, finished_at: str) -> None:
+        """Handle one-shot job failure."""
+        pass
+
+    def on_run_completed(self, finished_at: str) -> None:
+        """Handle one-shot job completion."""
+        pass
+
+    async def _run_once_with_lifecycle(self) -> None:
+        with job_trace_context(self.name) as trace_context:
+            started_monotonic = time_monotonic()
+            started_at = utc_now()
+            self._state = "running"
+            self._last_started_at = started_at
+            self._last_tick_at = started_at
+            _log_job_event(
+                event="daemon_job_started",
+                message="daemon background job started",
+                job_name=self.name,
+                job_kind="one_shot",
+                state=self._state,
+                trace_context=trace_context,
+            )
+
+            try:
+                self.on_run_started(started_at)
+                await self.run_once()
+            except asyncio.CancelledError:
+                finished_at = utc_now()
+                self._last_error = None
+                self._state = "stopped"
+                try:
+                    self.on_run_cancelled(finished_at)
+                finally:
+                    _log_job_event(
+                        event="daemon_job_cancelled",
+                        message="daemon background job cancelled",
+                        job_name=self.name,
+                        job_kind="one_shot",
+                        state=self._state,
+                        trace_context=trace_context,
+                        latency_ms=_elapsed_ms(started_monotonic),
+                    )
+                raise
+            except Exception as exc:
+                finished_at = utc_now()
+                self._last_error = str(exc)
+                self._state = "error"
+                try:
+                    self.on_run_failed(exc, finished_at)
+                finally:
+                    _log_job_event(
+                        level=logging.ERROR,
+                        event="daemon_job_failed",
+                        message="daemon background job failed",
+                        job_name=self.name,
+                        job_kind="one_shot",
+                        state=self._state,
+                        trace_context=trace_context,
+                        latency_ms=_elapsed_ms(started_monotonic),
+                        error=exc,
+                    )
+                return
+
+            finished_at = utc_now()
+            self._last_error = None
+            self._state = "completed"
+            self.on_run_completed(finished_at)
+            _log_job_event(
+                event="daemon_job_completed",
+                message="daemon background job completed",
+                job_name=self.name,
+                job_kind="one_shot",
+                state=self._state,
+                trace_context=trace_context,
+                latency_ms=_elapsed_ms(started_monotonic),
+            )
 
 
 class PeriodicBackgroundJob(BackgroundJob, ABC):
@@ -131,18 +322,62 @@ class PeriodicBackgroundJob(BackgroundJob, ABC):
 
             started_monotonic = time_monotonic()
             started_at = utc_now()
+            self._state = "running"
             self._last_started_at = started_at
             self._last_tick_at = started_at
 
-            try:
-                await self.run_once()
-                self._last_error = None
-                self._state = "running"
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                self._last_error = str(exc)
-                self._state = "error"
+            with job_trace_context(self.name) as trace_context:
+                _log_job_event(
+                    event="daemon_job_started",
+                    message="daemon background job started",
+                    job_name=self.name,
+                    job_kind="periodic",
+                    state=self._state,
+                    trace_context=trace_context,
+                    interval_seconds=self.interval_seconds,
+                )
+                try:
+                    await self.run_once()
+                    self._last_error = None
+                    self._state = "running"
+                except asyncio.CancelledError:
+                    _log_job_event(
+                        event="daemon_job_cancelled",
+                        message="daemon background job cancelled",
+                        job_name=self.name,
+                        job_kind="periodic",
+                        state="stopped",
+                        trace_context=trace_context,
+                        latency_ms=_elapsed_ms(started_monotonic),
+                        interval_seconds=self.interval_seconds,
+                    )
+                    raise
+                except Exception as exc:
+                    self._last_error = str(exc)
+                    self._state = "error"
+                    _log_job_event(
+                        level=logging.ERROR,
+                        event="daemon_job_failed",
+                        message="daemon background job failed",
+                        job_name=self.name,
+                        job_kind="periodic",
+                        state=self._state,
+                        trace_context=trace_context,
+                        latency_ms=_elapsed_ms(started_monotonic),
+                        error=exc,
+                        interval_seconds=self.interval_seconds,
+                    )
+                else:
+                    _log_job_event(
+                        event="daemon_job_completed",
+                        message="daemon background job completed",
+                        job_name=self.name,
+                        job_kind="periodic",
+                        state=self._state,
+                        trace_context=trace_context,
+                        latency_ms=_elapsed_ms(started_monotonic),
+                        interval_seconds=self.interval_seconds,
+                    )
 
             finished_monotonic = time_monotonic()
             next_run_monotonic = next_cycle_start(
@@ -160,8 +395,10 @@ class PeriodicBackgroundJob(BackgroundJob, ABC):
         if self._stop_event is None:
             return
 
-        with contextlib.suppress(asyncio.TimeoutError):
+        try:
             await asyncio.wait_for(self._stop_event.wait(), timeout=wait_seconds)
+        except asyncio.TimeoutError:
+            pass
 
 
 class JobManager:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/prompt_preload.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/prompt_preload.py
@@ -6,7 +6,7 @@ import os
 import sys
 from typing import Any
 
-from agent_sec_cli.daemon.jobs.base import BackgroundJob, JobStatus, utc_now
+from agent_sec_cli.daemon.jobs.base import OneShotBackgroundJob
 
 PROMPT_PRELOAD_ENV = "AGENT_SEC_DAEMON_PROMPT_PRELOAD"
 PROMPT_PRELOAD_DOWNLOAD_TIMEOUT_ENV = (
@@ -18,7 +18,7 @@ PROMPT_PRELOAD_CHILD_TERMINATE_TIMEOUT_SECONDS = 5.0
 _PROMPT_PRELOAD_CHILD_MODULE = "agent_sec_cli.daemon.jobs.prompt_preload"
 
 
-class PromptModelPreloadJob(BackgroundJob):
+class PromptModelPreloadJob(OneShotBackgroundJob):
     """One-shot startup job that downloads, loads, and probes the prompt model."""
 
     name = PROMPT_PRELOAD_JOB_NAME
@@ -29,48 +29,13 @@ class PromptModelPreloadJob(BackgroundJob):
         mode: str = "strict",
         probe_text: str = "hello",
     ) -> None:
+        super().__init__()
         self._prompt_state = prompt_state
         self._mode = mode
         self._probe_text = probe_text
-        self._task: asyncio.Task[None] | None = None
-        self._state = "stopped"
-        self._last_error: str | None = None
-        self._last_tick_at: str | None = None
-        self._last_started_at: str | None = None
 
-    async def start(self) -> None:
-        """Start prompt model preload without blocking daemon startup."""
-        if self._task is not None and not self._task.done():
-            return
-
-        self._state = "running"
-        self._task = asyncio.create_task(self._run_once())
-
-    async def stop(self) -> None:
-        """Cancel the preload task if it has not completed."""
-        if self._task is not None and not self._task.done():
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._task
-
-        if self._state == "running":
-            self._state = "stopped"
-        self._task = None
-
-    def status(self) -> JobStatus:
-        """Return current prompt preload job status."""
-        return JobStatus(
-            name=self.name,
-            state=self._state,
-            last_error=self._last_error,
-            last_tick_at=self._last_tick_at,
-            last_started_at=self._last_started_at,
-        )
-
-    async def _run_once(self) -> None:
-        started_at = utc_now()
-        self._last_started_at = started_at
-        self._last_tick_at = started_at
+    def on_run_started(self, started_at: str) -> None:
+        """Mark prompt model preload as downloading."""
         _update_prompt_state(
             self._prompt_state,
             status="downloading",
@@ -80,43 +45,39 @@ class PromptModelPreloadJob(BackgroundJob):
             last_finished_at=None,
         )
 
-        try:
-            await _run_preload_child_process(self._mode)
-            _update_prompt_state(self._prompt_state, status="loading")
-            await asyncio.to_thread(
-                _preload_prompt_model_sync,
-                self._prompt_state,
-                self._mode,
-                self._probe_text,
-            )
-        except asyncio.CancelledError:
-            finished_at = utc_now()
-            self._last_error = None
-            self._state = "stopped"
-            _update_prompt_state(
-                self._prompt_state,
-                status="stopped",
-                loaded=False,
-                last_error=None,
-                last_finished_at=finished_at,
-            )
-            raise
-        except Exception as exc:
-            finished_at = utc_now()
-            self._last_error = str(exc)
-            self._state = "error"
-            _update_prompt_state(
-                self._prompt_state,
-                status="degraded",
-                loaded=False,
-                last_error=self._last_error,
-                last_finished_at=finished_at,
-            )
-            return
+    async def run_once(self) -> None:
+        """Download, load, and probe the prompt model."""
+        await _run_preload_child_process(self._mode)
+        _update_prompt_state(self._prompt_state, status="loading")
+        await asyncio.to_thread(
+            _preload_prompt_model_sync,
+            self._prompt_state,
+            self._mode,
+            self._probe_text,
+        )
 
-        finished_at = utc_now()
-        self._last_error = None
-        self._state = "completed"
+    def on_run_cancelled(self, finished_at: str) -> None:
+        """Mark prompt model preload as stopped after cancellation."""
+        _update_prompt_state(
+            self._prompt_state,
+            status="stopped",
+            loaded=False,
+            last_error=None,
+            last_finished_at=finished_at,
+        )
+
+    def on_run_failed(self, exc: Exception, finished_at: str) -> None:
+        """Mark prompt model preload as degraded after failure."""
+        _update_prompt_state(
+            self._prompt_state,
+            status="degraded",
+            loaded=False,
+            last_error=str(exc),
+            last_finished_at=finished_at,
+        )
+
+    def on_run_completed(self, finished_at: str) -> None:
+        """Mark prompt model preload as ready after successful preload."""
         _update_prompt_state(
             self._prompt_state,
             status="ready",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/logging.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/logging.py
@@ -1,0 +1,105 @@
+"""Diagnostic JSONL logging for the agent-sec daemon process."""
+
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    trace_context_to_payload,
+)
+from agent_sec_cli.daemon.request_context import get_current_daemon_request_id
+from agent_sec_cli.diagnostic_logging import (
+    DiagnosticLogRecordHandler,
+    PythonLogRecordDiagnosticLogging,
+)
+
+_LOGGER_NAME = "agent-sec-core.daemon"
+_ROOT_LOGGER_NAME = ""
+_ENV_LOG_LEVEL = "AGENT_SEC_DAEMON_LOG_LEVEL"
+DAEMON_LOG_MAX_BYTES = 10 * 1024 * 1024
+DAEMON_LOG_BACKUP_COUNT = 5
+_DAEMON_LOGGER = logging.getLogger(_LOGGER_NAME)
+
+
+class DaemonDiagnosticLogging(PythonLogRecordDiagnosticLogging):
+    """Daemon-specific mapping from Python logging records to diagnostic JSONL."""
+
+    component = "daemon"
+    stream = "daemon"
+    level_env = _ENV_LOG_LEVEL
+    default_level = logging.INFO
+    max_bytes = DAEMON_LOG_MAX_BYTES
+    backup_count = DAEMON_LOG_BACKUP_COUNT
+    python_logger_name = _ROOT_LOGGER_NAME
+    event = "daemon_log"
+
+    def create_record_handler(self, path: str | Path) -> "JsonlDaemonLogHandler":
+        """Create the daemon diagnostic handler used by setup and tests."""
+        return JsonlDaemonLogHandler(path, diagnostic_logging=self)
+
+    def should_remove_handler(self, handler: logging.Handler) -> bool:
+        """Remove every daemon diagnostic handler when tests reset logging."""
+        return isinstance(handler, JsonlDaemonLogHandler)
+
+    def request_id_for_record(
+        self,
+        record: logging.LogRecord,
+    ) -> str | None:
+        """Return the daemon request id for one LogRecord, when available."""
+        return super().request_id_for_record(record) or get_current_daemon_request_id()
+
+
+class JsonlDaemonLogHandler(DiagnosticLogRecordHandler):
+    """Compatibility handler for daemon diagnostic JSONL records."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        diagnostic_logging: DaemonDiagnosticLogging | None = None,
+    ) -> None:
+        self._path = Path(path).expanduser()
+        if diagnostic_logging is None:
+            diagnostic_logging = _DAEMON_LOGGING
+        diagnostic_logger = diagnostic_logging.create_jsonl_logger(
+            path=self._path,
+            level=logging.NOTSET,
+        )
+        super().__init__(diagnostic_logging, diagnostic_logger)
+
+
+_DAEMON_LOGGING = DaemonDiagnosticLogging()
+
+
+def setup_daemon_logging(path: str | Path | None = None) -> None:
+    """Idempotently configure daemon JSONL diagnostic logging."""
+    _DAEMON_LOGGING.setup(path=path)
+
+
+def log_daemon_event(
+    *,
+    level: int = logging.INFO,
+    event: str,
+    message: str,
+    data: Mapping[str, Any] | None = None,
+    request_id: str | None = None,
+    trace_context: TraceContext | None = None,
+) -> None:
+    """Emit one structured daemon event through Python logging."""
+    extra: dict[str, Any] = {"diagnostic_event": event}
+    if data is not None:
+        extra["data"] = data
+    if request_id is not None:
+        extra["diagnostic_request_id"] = request_id
+    if trace_context is not None:
+        extra["trace_context"] = trace_context
+        extra.update(trace_context_to_payload(trace_context))
+
+    _DAEMON_LOGGER.log(level, message, extra=extra)
+
+
+def reset_daemon_diagnostic_logging_for_tests() -> None:
+    """Reset daemon diagnostic logging state for in-process tests."""
+    _DAEMON_LOGGING.reset_for_tests()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/protocol.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/protocol.py
@@ -17,14 +17,20 @@ DEFAULT_TIMEOUT_MS = 5000
 MAX_TIMEOUT_MS = 5 * 60 * 1000
 
 
+def generate_request_id() -> str:
+    """Create a daemon-owned request id for one request."""
+    return str(uuid.uuid4())
+
+
 @dataclass(frozen=True)
 class DaemonRequest:
     """Validated daemon request."""
 
-    id: str
     method: str
+    request_id: str = field(default_factory=generate_request_id)
     params: dict[str, Any] = field(default_factory=dict)
     trace_context: dict[str, Any] = field(default_factory=dict)
+    caller: str | None = None
     timeout_ms: int | None = None
 
 
@@ -32,7 +38,7 @@ class DaemonRequest:
 class DaemonResponse:
     """Validated daemon response."""
 
-    id: str
+    request_id: str
     ok: bool
     data: Any = field(default_factory=dict)
     stdout: str = ""
@@ -77,11 +83,6 @@ class NDJSONFrameParser:
         frame = bytes(self._buffer)
         self._buffer.clear()
         return [frame]
-
-
-def generate_request_id() -> str:
-    """Create a daemon-owned request id for requests that do not provide one."""
-    return f"daemon-{uuid.uuid4().hex}"
 
 
 def _decode_json_object(line: bytes) -> dict[str, Any]:
@@ -133,21 +134,19 @@ def parse_request_line(
         raise PayloadTooLargeError(max_request_bytes)
 
     payload = _decode_json_object(line)
-    request_id = payload.get("id")
-    if request_id is None:
-        request_id = generate_request_id()
-    elif not isinstance(request_id, str) or not request_id.strip():
-        raise BadRequestError("id must be a non-empty string when provided")
-
     method = payload.get("method")
     if not isinstance(method, str) or not method.strip():
         raise BadRequestError("method is required")
 
+    caller = payload.get("caller")
+    caller = caller.strip() if isinstance(caller, str) and caller.strip() else None
+
     return DaemonRequest(
-        id=request_id,
         method=method,
+        request_id=generate_request_id(),
         params=_validate_object_field(payload, "params"),
         trace_context=_validate_object_field(payload, "trace_context"),
+        caller=caller,
         timeout_ms=_validate_timeout_ms(payload),
     )
 
@@ -155,11 +154,12 @@ def parse_request_line(
 def request_to_payload(request: DaemonRequest) -> dict[str, Any]:
     """Convert a daemon request to a JSON-serializable payload."""
     payload: dict[str, Any] = {
-        "id": request.id,
         "method": request.method,
         "params": request.params,
         "trace_context": request.trace_context,
     }
+    if request.caller is not None:
+        payload["caller"] = request.caller
     if request.timeout_ms is not None:
         payload["timeout_ms"] = request.timeout_ms
     return payload
@@ -180,7 +180,7 @@ def success_response(
     """Build a successful daemon response."""
     response_data = {} if data is None else data
     return DaemonResponse(
-        id=request_id,
+        request_id=request_id,
         ok=True,
         data=response_data,
         stdout=stdout,
@@ -192,7 +192,7 @@ def success_response(
 def error_response(request_id: str, error: DaemonError) -> DaemonResponse:
     """Build a structured daemon error response."""
     return DaemonResponse(
-        id=request_id,
+        request_id=request_id,
         ok=False,
         data={},
         stdout="",
@@ -205,7 +205,7 @@ def error_response(request_id: str, error: DaemonError) -> DaemonResponse:
 def response_to_payload(response: DaemonResponse) -> dict[str, Any]:
     """Convert a daemon response to a JSON-serializable payload."""
     payload: dict[str, Any] = {
-        "id": response.id,
+        "request_id": response.request_id,
         "ok": response.ok,
         "data": response.data,
         "stdout": response.stdout,
@@ -226,9 +226,9 @@ def parse_response_line(line: bytes) -> DaemonResponse:
     """Parse and validate one daemon response frame."""
     payload = _decode_json_object(line)
 
-    request_id = payload.get("id")
+    request_id = payload.get("request_id")
     if not isinstance(request_id, str) or not request_id.strip():
-        raise BadRequestError("response id must be a non-empty string")
+        raise BadRequestError("response request_id must be a non-empty string")
 
     ok = payload.get("ok")
     if not isinstance(ok, bool):
@@ -255,7 +255,7 @@ def parse_response_line(line: bytes) -> DaemonResponse:
         error = {"code": code, "message": message}
 
     return DaemonResponse(
-        id=request_id,
+        request_id=request_id,
         ok=ok,
         data=payload.get("data", {}),
         stdout=stdout,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/registry.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/registry.py
@@ -89,18 +89,18 @@ async def dispatch_request(
             timeout=timeout_ms / 1000,
         )
         return success_response(
-            request.id,
+            request.request_id,
             data=result.data,
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.exit_code,
         )
     except asyncio.TimeoutError:
-        return error_response(request.id, DaemonTimeoutError(timeout_ms))
+        return error_response(request.request_id, DaemonTimeoutError(timeout_ms))
     except DaemonError as exc:
-        return error_response(request.id, exc)
+        return error_response(request.request_id, exc)
     except Exception:
-        return error_response(request.id, InternalDaemonError())
+        return error_response(request.request_id, InternalDaemonError())
 
 
 async def _invoke_handler(

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/request_context.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/request_context.py
@@ -1,0 +1,63 @@
+"""Daemon request context normalization and request-local scope."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    parse_trace_context_payload,
+    reset_current_trace_context,
+    set_current_trace_context,
+    trace_context_to_payload,
+)
+from agent_sec_cli.daemon.protocol import DaemonRequest
+
+_CURRENT_DAEMON_REQUEST_ID: ContextVar[str | None] = ContextVar(
+    "daemon_request_id",
+    default=None,
+)
+
+
+def normalize_request_trace_context(
+    request: DaemonRequest,
+) -> tuple[DaemonRequest, TraceContext]:
+    """Return *request* with normalized caller-provided trace context.
+
+    Daemon ingress paths should call this before dispatch so access logs and
+    downstream middleware share the same caller-provided correlation fields.
+    """
+    trace_context = parse_trace_context_payload(request.trace_context) or TraceContext()
+    payload = trace_context_to_payload(trace_context)
+    normalized_trace_context = parse_trace_context_payload(payload) or TraceContext()
+    return (
+        DaemonRequest(
+            method=request.method,
+            request_id=request.request_id,
+            params=request.params,
+            trace_context=payload,
+            caller=request.caller,
+            timeout_ms=request.timeout_ms,
+        ),
+        normalized_trace_context,
+    )
+
+
+@contextmanager
+def daemon_request_context(
+    trace_context: TraceContext,
+    request_id: str | None = None,
+) -> Iterator[None]:
+    """Set request-local tracing context for one daemon request."""
+    trace_token = set_current_trace_context(trace_context)
+    request_token = _CURRENT_DAEMON_REQUEST_ID.set(request_id)
+    try:
+        yield
+    finally:
+        _CURRENT_DAEMON_REQUEST_ID.reset(request_token)
+        reset_current_trace_context(trace_token)
+
+
+def get_current_daemon_request_id() -> str | None:
+    """Return the current daemon request id, when running inside a request."""
+    return _CURRENT_DAEMON_REQUEST_ID.get()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
@@ -4,14 +4,13 @@ import argparse
 import asyncio
 import contextlib
 import fcntl
-import json
 import logging
 import os
 import signal
 import stat
 import time
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 
 from agent_sec_cli.daemon.client import daemon_health_reachable
 from agent_sec_cli.daemon.errors import (
@@ -24,11 +23,17 @@ from agent_sec_cli.daemon.errors import (
     ResponseTooLargeError,
     ShutdownError,
 )
+from agent_sec_cli.daemon.gateway import (
+    DaemonGateway,
+    PreparedDaemonRequest,
+    _log_request_completion,
+)
 from agent_sec_cli.daemon.handlers.prompt_scan import (
     register_prompt_scan_methods,
 )
 from agent_sec_cli.daemon.health import register_health_methods
 from agent_sec_cli.daemon.jobs.registry import register_default_jobs
+from agent_sec_cli.daemon.logging import log_daemon_event, setup_daemon_logging
 from agent_sec_cli.daemon.protocol import (
     DEFAULT_MAX_REQUEST_BYTES,
     DEFAULT_MAX_RESPONSE_BYTES,
@@ -39,7 +44,7 @@ from agent_sec_cli.daemon.protocol import (
     parse_request_line,
     serialize_response,
 )
-from agent_sec_cli.daemon.registry import MethodRegistry, dispatch_request
+from agent_sec_cli.daemon.registry import MethodRegistry
 from agent_sec_cli.daemon.runtime import (
     DaemonRuntime,
     ensure_runtime_directory,
@@ -124,6 +129,7 @@ class DaemonServer:
         self.request_read_timeout_ms = request_read_timeout_ms
         self.runtime = DaemonRuntime(socket_path=resolved_socket_path)
         register_default_jobs(self.runtime.jobs, self.runtime.prompt_scan_state)
+        self.gateway = DaemonGateway(self.registry, self.runtime)
         self._server: asyncio.Server | None = None
         self._lock: SingleInstanceLock | None = None
         self._active_connections = 0
@@ -230,14 +236,12 @@ class DaemonServer:
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
-        request_id = generate_request_id()
-        method: str | None = None
+        fallback_request_id = generate_request_id()
         bytes_in = 0
         bytes_out = 0
         started = time.monotonic()
         response: DaemonResponse | None = None
-        began_request = False
-        access_log = True
+        prepared_request: PreparedDaemonRequest | None = None
 
         try:
             line = await asyncio.wait_for(
@@ -246,23 +250,24 @@ class DaemonServer:
             )
             bytes_in = len(line)
             request = parse_request_line(line, max_request_bytes=self.max_request_bytes)
-            request_id = request.id
-            method = request.method
-            access_log = _access_log_enabled(self.registry, method)
-            self.runtime.begin_request()
-            began_request = True
-            response = await dispatch_request(request, self.registry, self.runtime)
+            prepared_request = self.gateway.prepare(request)
+            response = await self.gateway.execute(prepared_request)
         except asyncio.TimeoutError:
             response = error_response(
-                request_id, DaemonTimeoutError(self.request_read_timeout_ms)
+                fallback_request_id,
+                DaemonTimeoutError(self.request_read_timeout_ms),
             )
         except DaemonError as exc:
-            response = error_response(request_id, exc)
+            response = error_response(
+                _request_id_for_response(prepared_request, fallback_request_id),
+                exc,
+            )
         finally:
-            if began_request:
-                self.runtime.end_request()
             if response is None:
-                response = error_response(request_id, ShutdownError())
+                response = error_response(
+                    _request_id_for_response(prepared_request, fallback_request_id),
+                    ShutdownError(),
+                )
             with contextlib.suppress(
                 ConnectionError,
                 BrokenPipeError,
@@ -270,10 +275,18 @@ class DaemonServer:
                 asyncio.CancelledError,
             ):
                 bytes_out, response = await self._write_response(writer, response)
-            if access_log or not response.ok:
+            if prepared_request is not None:
+                self.gateway.complete(
+                    prepared=prepared_request,
+                    response=response,
+                    started=started,
+                    bytes_in=bytes_in,
+                    bytes_out=bytes_out,
+                )
+            elif not response.ok:
                 _log_request_completion(
-                    request_id=request_id,
-                    method=method,
+                    request_id=fallback_request_id,
+                    method=None,
                     response=response,
                     started=started,
                     bytes_in=bytes_in,
@@ -288,7 +301,7 @@ class DaemonServer:
         raw_response = serialize_response(response)
         if len(raw_response) > self.max_response_bytes:
             response = error_response(
-                response.id, ResponseTooLargeError(self.max_response_bytes)
+                response.request_id, ResponseTooLargeError(self.max_response_bytes)
             )
             raw_response = serialize_response(response)
             if len(raw_response) > self.max_response_bytes:
@@ -328,6 +341,7 @@ class DaemonServer:
             started=started,
             bytes_in=0,
             bytes_out=bytes_out,
+            trace_context=None,
         )
 
     async def _drain_client_tasks(self) -> None:
@@ -401,8 +415,22 @@ def prepare_socket_path(socket_path: Path) -> SingleInstanceLock:
 
 def configure_logging() -> None:
     """Initialize daemon diagnostic logging."""
-    # TODO: Consider rate-limited async logging for slow or blocking stdout/stderr sinks.
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    # The daemon owns process-level logging. Keep root permissive so records
+    # from agent-sec and third-party libraries can reach the JSONL handler;
+    # AGENT_SEC_DAEMON_LOG_LEVEL is enforced by that handler, not by root.
+    logging.getLogger().setLevel(logging.DEBUG)
+    LOGGER.setLevel(logging.NOTSET)
+    LOGGER.propagate = True
+    setup_daemon_logging()
+
+
+def _request_id_for_response(
+    prepared_request: PreparedDaemonRequest | None,
+    fallback_request_id: str,
+) -> str:
+    if prepared_request is None:
+        return fallback_request_id
+    return prepared_request.request.request_id
 
 
 async def run_daemon(
@@ -424,10 +452,20 @@ async def run_daemon(
     stop_event = asyncio.Event()
     _install_signal_handlers(stop_event)
     await daemon.start()
+    log_daemon_event(
+        event="daemon_started",
+        message="daemon started",
+        data=_daemon_lifecycle_data(daemon),
+    )
     try:
         await stop_event.wait()
     finally:
         await daemon.stop()
+        log_daemon_event(
+            event="daemon_stopped",
+            message="daemon stopped",
+            data=_daemon_lifecycle_data(daemon),
+        )
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -492,45 +530,21 @@ def _install_signal_handlers(stop_event: asyncio.Event) -> None:
             loop.add_signal_handler(signal.SIGHUP, _log_sighup_noop)
 
 
-def _access_log_enabled(registry: MethodRegistry, method: str) -> bool:
-    try:
-        return registry.get(method).access_log
-    except DaemonError:
-        return True
-
-
-def _log_request_completion(
-    request_id: str,
-    method: str | None,
-    response: DaemonResponse,
-    started: float,
-    bytes_in: int,
-    bytes_out: int,
-) -> None:
-    latency_ms = int((time.monotonic() - started) * 1000)
-    error_code = None if response.error is None else response.error.get("code")
-    LOGGER.info(
-        json.dumps(
-            {
-                "event": "daemon_request_completed",
-                "request_id": request_id,
-                "method": method,
-                "caller": None,
-                "ok": response.ok,
-                "exit_code": response.exit_code,
-                "error_code": error_code,
-                "latency_ms": latency_ms,
-                "queue_ms": 0,
-                "bytes_in": bytes_in,
-                "bytes_out": bytes_out,
-            },
-            separators=(",", ":"),
-        )
-    )
+def _daemon_lifecycle_data(daemon: DaemonServer) -> dict[str, Any]:
+    return {
+        "socket_path": str(daemon.socket_path),
+        "max_request_bytes": daemon.max_request_bytes,
+        "max_response_bytes": daemon.max_response_bytes,
+        "max_connections": daemon.max_connections,
+        "request_read_timeout_ms": daemon.request_read_timeout_ms,
+    }
 
 
 def _log_sighup_noop() -> None:
-    LOGGER.info(json.dumps({"event": "daemon_sighup_noop"}, separators=(",", ":")))
+    log_daemon_event(
+        event="daemon_sighup_noop",
+        message="daemon SIGHUP ignored",
+    )
 
 
 def _path_exists(path: Path) -> bool:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
@@ -20,6 +20,7 @@ from agent_sec_cli.daemon.errors import (
     DaemonError,
     DaemonRuntimePathError,
     DaemonTimeoutError,
+    InternalDaemonError,
     ResponseTooLargeError,
     ShutdownError,
 )
@@ -262,6 +263,24 @@ class DaemonServer:
                 _request_id_for_response(prepared_request, fallback_request_id),
                 exc,
             )
+        except Exception:
+            request_id = _request_id_for_response(prepared_request, fallback_request_id)
+            LOGGER.exception(
+                "unexpected daemon request failure",
+                extra={
+                    "diagnostic_event": "daemon_request_internal_error",
+                    "diagnostic_request_id": request_id,
+                    "data": {
+                        "request_id": request_id,
+                        "method": (
+                            None
+                            if prepared_request is None
+                            else prepared_request.request.method
+                        ),
+                    },
+                },
+            )
+            response = error_response(request_id, InternalDaemonError())
         finally:
             if response is None:
                 response = error_response(
@@ -298,7 +317,19 @@ class DaemonServer:
         writer: asyncio.StreamWriter,
         response: DaemonResponse,
     ) -> tuple[int, DaemonResponse]:
-        raw_response = serialize_response(response)
+        try:
+            raw_response = serialize_response(response)
+        except Exception:
+            LOGGER.exception(
+                "failed to serialize daemon response",
+                extra={
+                    "diagnostic_event": "daemon_response_serialize_failed",
+                    "diagnostic_request_id": response.request_id,
+                    "data": {"request_id": response.request_id},
+                },
+            )
+            response = error_response(response.request_id, InternalDaemonError())
+            raw_response = serialize_response(response)
         if len(raw_response) > self.max_response_bytes:
             response = error_response(
                 response.request_id, ResponseTooLargeError(self.max_response_bytes)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/validation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/validation.py
@@ -1,0 +1,27 @@
+"""Daemon request validation extension points.
+
+The gateway owns the validation hook because every ingress path should apply
+the same request policy after it has produced a ``DaemonRequest``.  Concrete
+validators are intentionally not implemented yet; future validators should
+raise ``DaemonError`` subclasses so callers receive stable daemon responses.
+"""
+
+from typing import Protocol
+
+from agent_sec_cli.daemon.protocol import DaemonRequest
+
+
+class DaemonRequestValidator(Protocol):
+    """Validate a normalized daemon request before it reaches a method handler."""
+
+    def validate(self, request: DaemonRequest) -> None:
+        """Validate *request* or raise a daemon error."""
+        pass
+
+
+class NoopDaemonRequestValidator:
+    """Placeholder validator until daemon request policy is defined."""
+
+    def validate(self, request: DaemonRequest) -> None:
+        """Accept every request without additional validation."""
+        pass

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/diagnostic_logging.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/diagnostic_logging.py
@@ -1,0 +1,519 @@
+"""Shared JSONL diagnostic logging primitives."""
+
+import logging
+import os
+import traceback as traceback_module
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.correlation_context import (
+    CORRELATION_FIELD_NAMES,
+    TraceContext,
+    clean_correlation_value,
+    get_current_trace_context,
+    trace_context_to_payload,
+)
+from agent_sec_cli.security_events.config import get_stream_log_path
+from agent_sec_cli.security_events.writer import (
+    DEFAULT_BACKUP_COUNT,
+    DEFAULT_MAX_BYTES,
+    JsonlEventWriter,
+)
+
+LOG_LEVELS: dict[str, int] = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+
+@dataclass(frozen=True)
+class DiagnosticLoggingConfig:
+    """Resolved diagnostic logging configuration for one component."""
+
+    enabled: bool
+    level: int
+    log_file: Path | None
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time in the diagnostic JSONL timestamp format."""
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def json_safe(value: Any) -> Any:
+    """Return a JSON-serializable representation for diagnostic payloads."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe(item) for item in value]
+    return str(value)
+
+
+def resolve_log_level(
+    value: str | None, default: int = logging.WARNING
+) -> tuple[bool, int]:
+    """Resolve a user-facing log level string.
+
+    Returns ``(enabled, level)`` so component-specific config can share level
+    parsing while keeping its own env var names and default policy.
+    """
+    if value is None:
+        return True, default
+
+    normalized = value.strip().lower()
+    if normalized == "off":
+        return False, default
+    return True, LOG_LEVELS.get(normalized, default)
+
+
+def _has_exception(exc_info: object) -> bool:
+    if not isinstance(exc_info, tuple) or len(exc_info) != 3:
+        return False
+    exc_type, exception, _traceback = exc_info
+    return exc_type is not None and exception is not None
+
+
+def record_correlation_overrides(record: logging.LogRecord) -> dict[str, Any]:
+    """Return caller-supplied correlation fields from a logging record."""
+    overrides: dict[str, Any] = {}
+    for field_name in CORRELATION_FIELD_NAMES:
+        value = getattr(record, field_name, None)
+        if value is not None:
+            overrides[field_name] = value
+    return overrides
+
+
+class JsonlDiagnosticLogger:
+    """Write structured diagnostic JSONL records through ``JsonlEventWriter``."""
+
+    def __init__(
+        self,
+        path: str | Path | None = None,
+        *,
+        level: int = logging.WARNING,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        backup_count: int = DEFAULT_BACKUP_COUNT,
+        writer: JsonlEventWriter | None = None,
+    ) -> None:
+        if path is None and writer is None:
+            raise ValueError("path or writer is required")
+
+        self.level = level
+        self._path = None if path is None else Path(path).expanduser()
+        self._writer = (
+            writer
+            if writer is not None
+            else JsonlEventWriter(
+                self._path,
+                max_bytes=max_bytes,
+                backup_count=backup_count,
+            )
+        )
+
+    def write(
+        self,
+        *,
+        level: int,
+        component: str,
+        event: str,
+        message: str = "",
+        logger_name: str | None = None,
+        function: str | None = None,
+        invocation_id: str | None = None,
+        request_id: str | None = None,
+        trace_context: TraceContext | None = None,
+        correlation_overrides: Mapping[str, Any] | None = None,
+        data: Any = None,
+        exc_info: object = None,
+    ) -> None:
+        """Build and write one diagnostic record. Failures are swallowed."""
+        if level < self.level:
+            return
+
+        try:
+            self._writer.write(
+                self.build_payload(
+                    level=level,
+                    component=component,
+                    event=event,
+                    message=message,
+                    logger_name=logger_name,
+                    function=function,
+                    invocation_id=invocation_id,
+                    request_id=request_id,
+                    trace_context=trace_context,
+                    correlation_overrides=correlation_overrides,
+                    data=data,
+                    exc_info=exc_info,
+                )
+            )
+        except Exception:  # noqa: BLE001 - diagnostic logging is best-effort
+            pass
+
+    def build_payload(
+        self,
+        *,
+        level: int,
+        component: str,
+        event: str,
+        message: str = "",
+        logger_name: str | None = None,
+        function: str | None = None,
+        invocation_id: str | None = None,
+        request_id: str | None = None,
+        trace_context: TraceContext | None = None,
+        correlation_overrides: Mapping[str, Any] | None = None,
+        data: Any = None,
+        exc_info: object = None,
+    ) -> dict[str, Any]:
+        """Return the normalized diagnostic log envelope."""
+        payload: dict[str, Any] = {
+            "timestamp": utc_now_iso(),
+            "level": logging.getLevelName(level),
+            "component": component,
+            "event": event,
+            "message": message,
+            "pid": os.getpid(),
+        }
+        if logger_name is not None:
+            payload["logger"] = logger_name
+        if function is not None:
+            payload["function"] = function
+        if invocation_id is not None:
+            payload["invocation_id"] = invocation_id
+        if request_id is not None:
+            payload["request_id"] = request_id
+
+        payload.update(trace_context_to_payload(trace_context))
+        if correlation_overrides is not None:
+            for field_name in CORRELATION_FIELD_NAMES:
+                value = clean_correlation_value(
+                    field_name,
+                    correlation_overrides.get(field_name),
+                )
+                if value is not None:
+                    payload[field_name] = value
+
+        if data is not None:
+            payload["data"] = json_safe(data)
+
+        if _has_exception(exc_info):
+            exception = exc_info[1]
+            payload["error_type"] = type(exception).__name__
+            payload["exception"] = str(exception)
+            if level >= logging.ERROR:
+                payload["traceback"] = "".join(
+                    traceback_module.format_exception(*exc_info)
+                )
+        return json_safe(payload)
+
+
+class BaseDiagnosticLogging:
+    """Common setup and event-writing behavior for component diagnostic logs."""
+
+    component = ""
+    stream = ""
+    level_env: str | None = None
+    default_level = logging.WARNING
+    max_bytes = DEFAULT_MAX_BYTES
+    backup_count = DEFAULT_BACKUP_COUNT
+
+    def __init__(self) -> None:
+        self._diagnostic_logger: JsonlDiagnosticLogger | None = None
+        self._setup_done = False
+
+    def resolve_config(
+        self,
+        path: str | Path | None = None,
+    ) -> DiagnosticLoggingConfig:
+        """Resolve path, enabled state, and level for this component."""
+        enabled = True
+        resolved_level = self.default_level
+        if self.level_env is not None:
+            enabled, resolved_level = resolve_log_level(
+                os.environ.get(self.level_env),
+                default=self.default_level,
+            )
+
+        if not enabled:
+            return DiagnosticLoggingConfig(
+                enabled=False,
+                level=resolved_level,
+                log_file=None,
+            )
+
+        try:
+            log_file = (
+                Path(path).expanduser() if path is not None else self.resolve_log_path()
+            )
+        except Exception:  # noqa: BLE001 - diagnostic logging is best-effort
+            log_file = None
+
+        if log_file is None:
+            return DiagnosticLoggingConfig(
+                enabled=False,
+                level=resolved_level,
+                log_file=None,
+            )
+        return DiagnosticLoggingConfig(
+            enabled=True,
+            level=resolved_level,
+            log_file=log_file,
+        )
+
+    def resolve_log_path(self) -> Path | None:
+        """Resolve this component's diagnostic stream path."""
+        if not self.stream:
+            return None
+        try:
+            return Path(get_stream_log_path(self.stream)).expanduser()
+        except Exception:  # noqa: BLE001 - diagnostic logging is best-effort
+            return None
+
+    def setup(
+        self,
+        path: str | Path | None = None,
+    ) -> None:
+        """Idempotently configure this component's diagnostic logger."""
+        if self._setup_done:
+            return
+
+        try:
+            config = self.resolve_config(path=path)
+            if config.enabled and config.log_file is not None:
+                self._setup_enabled(config)
+        except Exception:  # noqa: BLE001 - diagnostic logging is best-effort
+            self._diagnostic_logger = None
+        finally:
+            self._setup_done = True
+
+    def _setup_enabled(self, config: DiagnosticLoggingConfig) -> None:
+        self._diagnostic_logger = self.create_jsonl_logger(
+            path=config.log_file,
+            level=config.level,
+        )
+
+    def create_jsonl_logger(
+        self,
+        path: str | Path,
+        *,
+        level: int,
+    ) -> JsonlDiagnosticLogger:
+        """Create the low-level JSONL logger for this component."""
+        return JsonlDiagnosticLogger(
+            path=path,
+            level=level,
+            max_bytes=self.max_bytes,
+            backup_count=self.backup_count,
+        )
+
+    def write_event(
+        self,
+        *,
+        level: int,
+        event: str,
+        message: str = "",
+        logger_name: str | None = None,
+        function: str | None = None,
+        invocation_id: str | None = None,
+        request_id: str | None = None,
+        trace_context: TraceContext | None = None,
+        correlation_overrides: Mapping[str, Any] | None = None,
+        data: Any = None,
+        exc_info: object = None,
+    ) -> None:
+        """Write one diagnostic event through the configured JSONL logger."""
+        if self._diagnostic_logger is None:
+            return
+
+        self._diagnostic_logger.write(
+            level=level,
+            component=self.component,
+            event=event,
+            message=message,
+            logger_name=logger_name,
+            function=function,
+            invocation_id=invocation_id,
+            request_id=request_id,
+            trace_context=trace_context,
+            correlation_overrides=correlation_overrides,
+            data=data,
+            exc_info=exc_info,
+        )
+
+    def reset_for_tests(self) -> None:
+        """Reset in-process setup state for tests."""
+        self._diagnostic_logger = None
+        self._setup_done = False
+
+
+class PythonLogRecordDiagnosticLogging(BaseDiagnosticLogging):
+    """Base class for components that route Python logging into JSONL."""
+
+    python_logger_name = ""
+    event = "python_log"
+    propagate_on_enable: bool | None = None
+    propagate_on_reset: bool | None = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._handler: logging.Handler | None = None
+
+    def _setup_enabled(self, config: DiagnosticLoggingConfig) -> None:
+        python_logger = self.get_python_logger()
+        handler = self.create_record_handler(config.log_file)
+        handler.setLevel(config.level)
+        # Keep the component logger's level under application control. Changing
+        # it here would affect every other handler attached to the same logger
+        # tree, not just this diagnostic JSONL handler.
+        python_logger.addHandler(handler)
+        if self.propagate_on_enable is not None:
+            python_logger.propagate = self.propagate_on_enable
+        self._handler = handler
+
+    def get_python_logger(self) -> logging.Logger:
+        """Return the Python logger tree this diagnostic logger owns."""
+        return logging.getLogger(self.python_logger_name)
+
+    def create_record_handler(self, path: str | Path) -> "DiagnosticLogRecordHandler":
+        """Create the handler that converts LogRecord objects into JSONL."""
+        diagnostic_logger = self.create_jsonl_logger(
+            path=path,
+            level=logging.NOTSET,
+        )
+        return DiagnosticLogRecordHandler(self, diagnostic_logger)
+
+    def write_log_record(
+        self,
+        record: logging.LogRecord,
+        diagnostic_logger: JsonlDiagnosticLogger,
+    ) -> None:
+        """Write one LogRecord through the provided diagnostic logger."""
+        diagnostic_logger.write(
+            level=record.levelno,
+            component=self.component,
+            event=self.event_for_record(record),
+            message=self.message_for_record(record),
+            logger_name=record.name,
+            function=record.funcName,
+            invocation_id=self.invocation_id_for_record(record),
+            request_id=self.request_id_for_record(record),
+            trace_context=self.trace_context_for_record(record),
+            correlation_overrides=self.correlation_overrides_for_record(record),
+            data=self.data_for_record(record),
+            exc_info=record.exc_info,
+        )
+
+    def build_log_record_payload(
+        self,
+        record: logging.LogRecord,
+        diagnostic_logger: JsonlDiagnosticLogger,
+    ) -> dict[str, Any]:
+        """Build the normalized payload for one LogRecord."""
+        return diagnostic_logger.build_payload(
+            level=record.levelno,
+            component=self.component,
+            event=self.event_for_record(record),
+            message=self.message_for_record(record),
+            logger_name=record.name,
+            function=record.funcName,
+            invocation_id=self.invocation_id_for_record(record),
+            request_id=self.request_id_for_record(record),
+            trace_context=self.trace_context_for_record(record),
+            correlation_overrides=self.correlation_overrides_for_record(record),
+            data=self.data_for_record(record),
+            exc_info=record.exc_info,
+        )
+
+    def invocation_id_for_record(self, record: logging.LogRecord) -> str | None:
+        """Return the invocation ID for one LogRecord, if this component has one."""
+        value = getattr(record, "invocation_id", None)
+        return value if isinstance(value, str) and value else None
+
+    def request_id_for_record(self, record: logging.LogRecord) -> str | None:
+        """Return the request ID for one LogRecord, if this component has one."""
+        value = getattr(record, "diagnostic_request_id", None)
+        return value if isinstance(value, str) and value else None
+
+    def event_for_record(self, record: logging.LogRecord) -> str:
+        """Return the diagnostic event name for one LogRecord."""
+        value = getattr(record, "diagnostic_event", None)
+        return value if isinstance(value, str) and value else self.event
+
+    def message_for_record(self, record: logging.LogRecord) -> str:
+        """Return the diagnostic message for one LogRecord."""
+        value = getattr(record, "diagnostic_message", None)
+        return value if isinstance(value, str) and value else record.getMessage()
+
+    def trace_context_for_record(
+        self,
+        record: logging.LogRecord,
+    ) -> TraceContext | None:
+        """Return explicit record context, falling back to current request/process context."""
+        value = getattr(record, "trace_context", None)
+        record_context = value if isinstance(value, TraceContext) else None
+        return record_context or get_current_trace_context()
+
+    def correlation_overrides_for_record(
+        self,
+        record: logging.LogRecord,
+    ) -> Mapping[str, Any] | None:
+        """Return record-level correlation field overrides."""
+        return record_correlation_overrides(record)
+
+    def data_for_record(self, record: logging.LogRecord) -> Any:
+        """Return the structured payload attached to a LogRecord."""
+        return getattr(record, "data", None)
+
+    def should_remove_handler(self, handler: logging.Handler) -> bool:
+        """Return whether reset should remove a handler from the Python logger."""
+        return handler is self._handler
+
+    def reset_for_tests(self) -> None:
+        """Reset attached Python logging handler state for tests."""
+        python_logger = self.get_python_logger()
+        for handler in list(python_logger.handlers):
+            if self.should_remove_handler(handler):
+                python_logger.removeHandler(handler)
+                handler.close()
+        if self.propagate_on_reset is not None:
+            python_logger.propagate = self.propagate_on_reset
+        self._handler = None
+        super().reset_for_tests()
+
+
+class DiagnosticLogRecordHandler(logging.Handler):
+    """Convert Python LogRecord objects into component diagnostic JSONL records."""
+
+    def __init__(
+        self,
+        diagnostic_logging: PythonLogRecordDiagnosticLogging,
+        diagnostic_logger: JsonlDiagnosticLogger,
+    ) -> None:
+        super().__init__()
+        self._diagnostic_logging = diagnostic_logging
+        self._diagnostic_logger = diagnostic_logger
+
+    @property
+    def diagnostic_logging(self) -> PythonLogRecordDiagnosticLogging:
+        """Return the component mapper used by this handler."""
+        return self._diagnostic_logging
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Write one logging record. All handler failures are swallowed."""
+        try:
+            self._diagnostic_logging.write_log_record(record, self._diagnostic_logger)
+        except Exception:  # noqa: BLE001
+            pass

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/diagnostic_logging.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/diagnostic_logging.py
@@ -221,17 +221,14 @@ class JsonlDiagnosticLogger:
 
 
 class BaseDiagnosticLogging:
-    """Common setup and event-writing behavior for component diagnostic logs."""
+    """Common setup behavior for component diagnostic logs."""
 
     component = ""
     stream = ""
     level_env: str | None = None
     default_level = logging.WARNING
-    max_bytes = DEFAULT_MAX_BYTES
-    backup_count = DEFAULT_BACKUP_COUNT
 
     def __init__(self) -> None:
-        self._diagnostic_logger: JsonlDiagnosticLogger | None = None
         self._setup_done = False
 
     def resolve_config(
@@ -295,67 +292,15 @@ class BaseDiagnosticLogging:
             if config.enabled and config.log_file is not None:
                 self._setup_enabled(config)
         except Exception:  # noqa: BLE001 - diagnostic logging is best-effort
-            self._diagnostic_logger = None
+            pass
         finally:
             self._setup_done = True
 
     def _setup_enabled(self, config: DiagnosticLoggingConfig) -> None:
-        self._diagnostic_logger = self.create_jsonl_logger(
-            path=config.log_file,
-            level=config.level,
-        )
-
-    def create_jsonl_logger(
-        self,
-        path: str | Path,
-        *,
-        level: int,
-    ) -> JsonlDiagnosticLogger:
-        """Create the low-level JSONL logger for this component."""
-        return JsonlDiagnosticLogger(
-            path=path,
-            level=level,
-            max_bytes=self.max_bytes,
-            backup_count=self.backup_count,
-        )
-
-    def write_event(
-        self,
-        *,
-        level: int,
-        event: str,
-        message: str = "",
-        logger_name: str | None = None,
-        function: str | None = None,
-        invocation_id: str | None = None,
-        request_id: str | None = None,
-        trace_context: TraceContext | None = None,
-        correlation_overrides: Mapping[str, Any] | None = None,
-        data: Any = None,
-        exc_info: object = None,
-    ) -> None:
-        """Write one diagnostic event through the configured JSONL logger."""
-        if self._diagnostic_logger is None:
-            return
-
-        self._diagnostic_logger.write(
-            level=level,
-            component=self.component,
-            event=event,
-            message=message,
-            logger_name=logger_name,
-            function=function,
-            invocation_id=invocation_id,
-            request_id=request_id,
-            trace_context=trace_context,
-            correlation_overrides=correlation_overrides,
-            data=data,
-            exc_info=exc_info,
-        )
+        pass
 
     def reset_for_tests(self) -> None:
         """Reset in-process setup state for tests."""
-        self._diagnostic_logger = None
         self._setup_done = False
 
 
@@ -366,6 +311,8 @@ class PythonLogRecordDiagnosticLogging(BaseDiagnosticLogging):
     event = "python_log"
     propagate_on_enable: bool | None = None
     propagate_on_reset: bool | None = None
+    max_bytes = DEFAULT_MAX_BYTES
+    backup_count = DEFAULT_BACKUP_COUNT
 
     def __init__(self) -> None:
         super().__init__()
@@ -394,6 +341,20 @@ class PythonLogRecordDiagnosticLogging(BaseDiagnosticLogging):
             level=logging.NOTSET,
         )
         return DiagnosticLogRecordHandler(self, diagnostic_logger)
+
+    def create_jsonl_logger(
+        self,
+        path: str | Path,
+        *,
+        level: int,
+    ) -> JsonlDiagnosticLogger:
+        """Create the low-level JSONL logger for this component."""
+        return JsonlDiagnosticLogger(
+            path=path,
+            level=level,
+            max_bytes=self.max_bytes,
+            backup_count=self.backup_count,
+        )
 
     def write_log_record(
         self,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from typing import Any
 
 import typer
-from agent_sec_cli.correlation_context import get_current_trace_context
+from agent_sec_cli.correlation_context import (
+    get_current_trace_context,
+    trace_context_to_payload,
+)
 from agent_sec_cli.daemon.client import DaemonClient
 from agent_sec_cli.daemon.env import daemon_disabled
 from agent_sec_cli.daemon.protocol import DaemonResponse
@@ -233,7 +236,8 @@ def _call_scan_prompt_daemon(
     return DaemonClient(timeout_ms=DAEMON_REQUEST_TIMEOUT_MS).call(
         "scan-prompt",
         params={"text": text, "mode": mode, "source": source},
-        trace_context=_current_trace_context_payload(),
+        trace_context=trace_context_to_payload(get_current_trace_context()),
+        caller="cli",
         timeout_ms=DAEMON_REQUEST_TIMEOUT_MS,
     )
 
@@ -243,23 +247,10 @@ def _should_use_daemon() -> bool:
     return not daemon_disabled()
 
 
-def _current_trace_context_payload() -> dict[str, str]:
-    ctx = get_current_trace_context()
-    if ctx is None:
-        return {}
-
-    payload: dict[str, str] = {}
-    for field_name in (
-        "trace_id",
-        "session_id",
-        "run_id",
-        "call_id",
-        "tool_call_id",
-    ):
-        value = getattr(ctx, field_name)
-        if value is not None:
-            payload[field_name] = value
-    return payload
+def _daemon_unavailable_message(detail: str) -> str:
+    return (
+        "Error: agent-sec daemon is unavailable for scan-prompt. " f"Detail: {detail}"
+    )
 
 
 def _daemon_error_message(response: DaemonResponse) -> str:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
@@ -2,8 +2,7 @@
 
 Public API
 ----------
-- ``invoke(action, **kwargs)`` — CLI/local entry point with caller auto-detection
-- ``invoke_with_context(...)`` — explicit context entry point for daemon/plugin paths
+- ``invoke(action, caller=None, **kwargs)`` — entry point with caller attribution
 - ``ActionResult``             — structured return type
 - ``RequestContext``           — per-call context (usually internal)
 """
@@ -11,16 +10,9 @@ Public API
 import logging
 import sys
 import time
-from collections.abc import Mapping
 from pathlib import PurePath
 from typing import Any
 
-from agent_sec_cli.correlation_context import (
-    TraceContext,
-    parse_trace_context_payload,
-    reset_current_trace_context,
-    set_current_trace_context,
-)
 from agent_sec_cli.security_middleware import lifecycle, router
 from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
@@ -63,7 +55,7 @@ def _detect_caller() -> str:
 # ---------------------------------------------------------------------------
 
 
-def invoke(action: str, **kwargs: Any) -> ActionResult:
+def invoke(action: str, *, caller: str | None = None, **kwargs: Any) -> ActionResult:
     """Sole public entry point for all security capabilities.
 
     1. Builds a :class:`RequestContext` (auto ``trace_id``, ``timestamp``).
@@ -78,44 +70,8 @@ def invoke(action: str, **kwargs: Any) -> ActionResult:
 
     Raises whatever exception the backend raises (after logging it).
     """
-    ctx = RequestContext(action=action, caller=_detect_caller())
+    ctx = RequestContext(action=action, caller=caller or _detect_caller())
     return _invoke_with_request_context(ctx, kwargs)
-
-
-def invoke_with_context(
-    action: str,
-    *,
-    caller: str,
-    trace_context: Mapping[str, Any] | TraceContext | None = None,
-    **kwargs: Any,
-) -> ActionResult:
-    """Invoke a security action with explicit daemon/plugin request context.
-
-    This entry point is intended for long-running processes, such as the daemon,
-    where caller identity and trace metadata must come from the request instead
-    of being inferred from the Python call stack or process-level CLI state.
-    """
-    token = set_current_trace_context(_coerce_trace_context(trace_context))
-    try:
-        ctx = RequestContext(action=action, caller=_normalize_caller(caller))
-        return _invoke_with_request_context(ctx, kwargs)
-    finally:
-        reset_current_trace_context(token)
-
-
-def _coerce_trace_context(
-    trace_context: Mapping[str, Any] | TraceContext | None,
-) -> TraceContext | None:
-    if trace_context is None:
-        return None
-    if isinstance(trace_context, TraceContext):
-        return trace_context
-    return parse_trace_context_payload(trace_context)
-
-
-def _normalize_caller(caller: str) -> str:
-    stripped = caller.strip()
-    return stripped if stripped else "unknown"
 
 
 def _invoke_with_request_context(
@@ -134,19 +90,7 @@ def _invoke_with_request_context(
     try:
         backend = router.get_backend(ctx.action)
     except Exception:
-        duration_ms = (time.perf_counter() - started_at) * 1000
-        logger.error(
-            "action routing failed",
-            exc_info=True,
-            extra={
-                "trace_id": ctx.trace_id,
-                "data": {
-                    "action": ctx.action,
-                    "caller": ctx.caller,
-                    "duration_ms": duration_ms,
-                },
-            },
-        )
+        _log_action_error(ctx, started_at, "action routing failed")
         raise
 
     return _execute_action(ctx, kwargs, backend, started_at)
@@ -164,23 +108,10 @@ def _execute_action(
         result = backend.execute(ctx, **kwargs)
     except Exception as exc:
         lifecycle.on_error(ctx, exc, kwargs, backend)
-        duration_ms = (time.perf_counter() - started_at) * 1000
-        logger.error(
-            "backend raised an exception",
-            exc_info=True,
-            extra={
-                "trace_id": ctx.trace_id,
-                "data": {
-                    "action": ctx.action,
-                    "caller": ctx.caller,
-                    "duration_ms": duration_ms,
-                },
-            },
-        )
+        _log_action_error(ctx, started_at, "backend raised an exception")
         raise
 
     lifecycle.post_action(ctx, result, kwargs, backend)
-    duration_ms = (time.perf_counter() - started_at) * 1000
     log_level = logging.INFO if result.exit_code == 0 else logging.WARNING
     logger.log(
         log_level,
@@ -191,7 +122,7 @@ def _execute_action(
             "data": {
                 "action": ctx.action,
                 "caller": ctx.caller,
-                "duration_ms": duration_ms,
+                "duration_ms": _duration_ms(started_at),
                 "exit_code": result.exit_code,
             },
         },
@@ -199,9 +130,31 @@ def _execute_action(
     return result
 
 
+def _log_action_error(
+    ctx: RequestContext,
+    started_at: float,
+    message: str,
+) -> None:
+    logger.error(
+        message,
+        exc_info=True,
+        extra={
+            "trace_id": ctx.trace_id,
+            "data": {
+                "action": ctx.action,
+                "caller": ctx.caller,
+                "duration_ms": _duration_ms(started_at),
+            },
+        },
+    )
+
+
+def _duration_ms(started_at: float) -> float:
+    return (time.perf_counter() - started_at) * 1000
+
+
 __all__: list[str] = [
     "invoke",
-    "invoke_with_context",
     "ActionResult",
     "RequestContext",
 ]

--- a/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
+++ b/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
@@ -259,7 +259,6 @@ def test_daemon_skillfs_notify_refreshes_skill_ledger_activation(
         response = _call_daemon(
             socket_path,
             {
-                "id": "e2e-skillfs-notify",
                 "method": "skill_ledger.skillfs_notify_change",
                 "params": {
                     "schemaVersion": 1,
@@ -282,7 +281,9 @@ def test_daemon_skillfs_notify_refreshes_skill_ledger_activation(
     }
     assert output.returncode == 0
     assert _has_request_log(
-        output, "e2e-skillfs-notify", "skill_ledger.skillfs_notify_change"
+        tmp_path,
+        response["request_id"],
+        "skill_ledger.skillfs_notify_change",
     )
 
 

--- a/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
+++ b/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
@@ -9,6 +9,7 @@ import stat
 import subprocess
 import sys
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -56,7 +57,8 @@ def test_daemon_health_over_unix_socket(
             {"id": "e2e-health", "method": "daemon.health"},
         )
 
-        assert response["id"] == "e2e-health"
+        assert response["request_id"] != "e2e-health"
+        _assert_uuid(response["request_id"])
         assert response["ok"] is True
         assert response["exit_code"] == 0
         assert response.get("error") is None
@@ -75,7 +77,7 @@ def test_daemon_health_over_unix_socket(
 
     assert not socket_path.exists()
     assert output.returncode == 0
-    assert not _has_request_log(output, "e2e-health", "daemon.health")
+    assert not _has_request_log(tmp_path, response["request_id"], "daemon.health")
 
 
 def test_daemon_uses_xdg_runtime_dir_by_default(
@@ -119,7 +121,8 @@ def test_daemon_unknown_method_returns_structured_error(
     finally:
         output = _stop_daemon(process)
 
-    assert response["id"] == "e2e-unknown"
+    assert response["request_id"] != "e2e-unknown"
+    _assert_uuid(response["request_id"])
     assert response["ok"] is False
     assert response["exit_code"] == 1
     assert response["stderr"] == "unknown daemon method: unknown.method"
@@ -128,7 +131,13 @@ def test_daemon_unknown_method_returns_structured_error(
         "message": "unknown daemon method: unknown.method",
     }
     assert output.returncode == 0
-    assert _has_request_log(output, "e2e-unknown", "unknown.method")
+    assert _has_request_event(
+        tmp_path,
+        "daemon_request_started",
+        response["request_id"],
+        "unknown.method",
+    )
+    assert _has_request_log(tmp_path, response["request_id"], "unknown.method")
 
 
 def test_daemon_scan_prompt_returns_unavailable_until_model_ready(
@@ -153,14 +162,15 @@ def test_daemon_scan_prompt_returns_unavailable_until_model_ready(
     finally:
         output = _stop_daemon(process)
 
-    assert response["id"] == "e2e-scan-prompt-not-ready"
+    assert response["request_id"] != "e2e-scan-prompt-not-ready"
+    _assert_uuid(response["request_id"])
     assert response["ok"] is False
     assert response["exit_code"] == 1
     assert response["error"]["code"] == "unavailable"
     assert "prompt scanner is not ready" in response["stderr"]
     assert "status=pending" in response["stderr"]
     assert output.returncode == 0
-    assert _has_request_log(output, "e2e-scan-prompt-not-ready", "scan-prompt")
+    assert _has_request_log(tmp_path, response["request_id"], "scan-prompt")
 
 
 def test_daemon_returns_busy_when_connection_limit_is_exhausted(
@@ -185,6 +195,7 @@ def test_daemon_returns_busy_when_connection_limit_is_exhausted(
         output = _stop_daemon(process)
 
     assert response["ok"] is False
+    _assert_uuid(response["request_id"])
     assert response["exit_code"] == 1
     assert response["error"] == {"code": "busy", "message": "daemon is busy"}
     assert output.returncode == 0
@@ -216,8 +227,10 @@ def test_daemon_idle_client_times_out_and_releases_connection(
         output = _stop_daemon(process)
 
     assert timeout_response["ok"] is False
+    _assert_uuid(timeout_response["request_id"])
     assert timeout_response["error"]["code"] == "timeout"
     assert health_response["ok"] is True
+    _assert_uuid(health_response["request_id"])
     assert output.returncode == 0
 
 
@@ -231,6 +244,8 @@ def test_daemon_sigterm_graceful_shutdown(
 
     assert output.returncode == 0
     assert not socket_path.exists()
+    assert _has_daemon_event(tmp_path, "daemon_started")
+    assert _has_daemon_event(tmp_path, "daemon_stopped")
 
 
 def test_daemon_skillfs_notify_refreshes_skill_ledger_activation(
@@ -428,6 +443,10 @@ def _call_daemon(socket_path: Path, request: dict[str, Any]) -> dict[str, Any]:
     return response
 
 
+def _assert_uuid(value: str) -> None:
+    uuid.UUID(value)
+
+
 def _read_response(client_socket: socket.socket) -> bytes:
     chunks: list[bytes] = []
     total_bytes = 0
@@ -450,19 +469,17 @@ def _read_response(client_socket: socket.socket) -> bytes:
     return raw_response
 
 
-def _has_request_log(output: DaemonOutput, request_id: str, method: str | None) -> bool:
-    for line in f"{output.stdout}\n{output.stderr}".splitlines():
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+def _has_request_log(tmp_path: Path, request_id: str, method: str | None) -> bool:
+    for payload in _read_daemon_log_payloads(tmp_path):
+        data = payload.get("data", {})
         if (
             payload.get("event") == "daemon_request_completed"
             and payload.get("request_id") == request_id
-            and payload.get("method") == method
-            and "latency_ms" in payload
-            and "bytes_in" in payload
-            and "bytes_out" in payload
+            and isinstance(data, dict)
+            and data.get("method") == method
+            and "latency_ms" in data
+            and "bytes_in" in data
+            and "bytes_out" in data
         ):
             return True
     return False
@@ -477,7 +494,8 @@ def _has_request_event(
     return any(
         payload.get("event") == event
         and payload.get("request_id") == request_id
-        and payload.get("method") == method
+        and isinstance(payload.get("data"), dict)
+        and payload["data"].get("method") == method
         for payload in _read_daemon_log_payloads(tmp_path)
     )
 

--- a/src/agent-sec-core/tests/e2e/prompt-scanner/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/prompt-scanner/e2e_test.py
@@ -23,8 +23,10 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import List, Tuple
 
 import pytest
@@ -44,15 +46,28 @@ def _run_scan(
     mode: str = "fast",
     fmt: str = "json",
     extra_args: List[str] | None = None,
+    top_level_args: List[str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run ``agent-sec-cli scan-prompt`` and return CompletedProcess."""
+    top_level = [] if top_level_args is None else top_level_args
     if _CLI_BIN:
-        cmd = [_CLI_BIN, "scan-prompt", "--text", text, "--mode", mode, "--format", fmt]
+        cmd = [
+            _CLI_BIN,
+            *top_level,
+            "scan-prompt",
+            "--text",
+            text,
+            "--mode",
+            mode,
+            "--format",
+            fmt,
+        ]
     else:
         cmd = [
             sys.executable,
             "-m",
             "agent_sec_cli.cli",
+            *top_level,
             "scan-prompt",
             "--text",
             text,
@@ -76,6 +91,30 @@ def _run_scan(
     if proc.stderr:
         print(f"[stderr] {proc.stderr[:200]}")
     return proc
+
+
+def _run_events(trace_id: str) -> subprocess.CompletedProcess:
+    """Run ``agent-sec-cli events`` for a trace id and return CompletedProcess."""
+    if _CLI_BIN:
+        cmd = [_CLI_BIN, "events", "--trace-id", trace_id, "--output", "json"]
+    else:
+        cmd = [
+            sys.executable,
+            "-m",
+            "agent_sec_cli.cli",
+            "events",
+            "--trace-id",
+            trace_id,
+            "--output",
+            "json",
+        ]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=os.environ.copy(),
+    )
 
 
 def _parse_result(proc: subprocess.CompletedProcess) -> dict:
@@ -138,6 +177,64 @@ def _stable_success_contract(result: dict) -> dict:
     }
 
 
+def _read_daemon_log_payloads() -> list[dict]:
+    """Read daemon diagnostic JSONL payloads from the active e2e data dir."""
+    log_path = Path(os.environ["AGENT_SEC_DATA_DIR"]) / "daemon.jsonl"
+    if not log_path.exists():
+        return []
+
+    payloads = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads
+
+
+def _wait_for_daemon_trace_log(trace_context: dict[str, str]) -> dict:
+    """Return the daemon completion log for *trace_context*."""
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        for payload in _read_daemon_log_payloads():
+            data = payload.get("data", {})
+            if (
+                payload.get("event") == "daemon_request_completed"
+                and isinstance(data, dict)
+                and data.get("method") == "scan-prompt"
+                and all(
+                    payload.get(key) == value for key, value in trace_context.items()
+                )
+            ):
+                return payload
+        time.sleep(0.1)
+    raise AssertionError(
+        "daemon completion log did not include trace context " f"{trace_context!r}"
+    )
+
+
+def _wait_for_security_event(trace_context: dict[str, str]) -> dict:
+    """Return a security event matching *trace_context*."""
+    deadline = time.monotonic() + 5
+    trace_id = trace_context["trace_id"]
+    last_output = ""
+    while time.monotonic() < deadline:
+        proc = _run_events(trace_id)
+        last_output = proc.stdout or proc.stderr
+        if proc.returncode == 0:
+            events = json.loads(proc.stdout)
+            for event in events:
+                if all(event.get(key) == value for key, value in trace_context.items()):
+                    return event
+        time.sleep(0.1)
+    raise AssertionError(
+        "security events query did not include trace context "
+        f"{trace_context!r}; last_output={last_output!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # A. Basic functionality
 # ---------------------------------------------------------------------------
@@ -190,7 +287,43 @@ class TestBasicScan:
 
 
 # ---------------------------------------------------------------------------
-# B. Rule coverage — key rules exercised via CLI
+# B. Trace context propagation
+# ---------------------------------------------------------------------------
+
+
+class TestTraceContextPropagation:
+    """Verify CLI trace context reaches daemon logs and security events."""
+
+    def test_trace_context_reaches_daemon_logs_and_security_events(self) -> None:
+        trace_context = {
+            "trace_id": "e2e-scan-prompt-trace",
+            "session_id": "e2e-scan-prompt-session",
+            "run_id": "e2e-scan-prompt-run",
+            "call_id": "e2e-scan-prompt-call",
+            "tool_call_id": "e2e-scan-prompt-tool",
+        }
+
+        proc = _run_scan(
+            "Hello trace context propagation",
+            mode="fast",
+            fmt="json",
+            top_level_args=["--trace-context", json.dumps(trace_context)],
+            extra_args=["--source", "e2e_trace_context"],
+        )
+        result = _parse_result(proc)
+        assert result["verdict"] == "pass"
+
+        daemon_log = _wait_for_daemon_trace_log(trace_context)
+        assert daemon_log["ok"] is True
+        assert daemon_log["exit_code"] == 0
+
+        event = _wait_for_security_event(trace_context)
+        assert event["event_type"] == "prompt_scan"
+        assert event["category"] == "prompt_scan"
+
+
+# ---------------------------------------------------------------------------
+# C. Rule coverage — key rules exercised via CLI
 # ---------------------------------------------------------------------------
 
 # Each entry: (prompt_text, expected_verdict_set, description)
@@ -366,7 +499,7 @@ def test_rule_coverage_via_cli(
 
 
 # ---------------------------------------------------------------------------
-# C. Mode variants
+# D. Mode variants
 # ---------------------------------------------------------------------------
 
 
@@ -402,7 +535,7 @@ class TestModeVariants:
 
 
 # ---------------------------------------------------------------------------
-# D. JSON output format validation
+# E. JSON output format validation
 # ---------------------------------------------------------------------------
 
 
@@ -503,7 +636,7 @@ class TestJsonOutputFormat:
 
 
 # ---------------------------------------------------------------------------
-# E. Error handling
+# F. Error handling
 # ---------------------------------------------------------------------------
 
 

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -404,7 +404,6 @@ def test_daemon_pass_warn_only_policy_hides_deny_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
-                request_id="notify-warn-v1",
             )
             activation_v1 = await wait_for(
                 lambda: (
@@ -421,7 +420,6 @@ def test_daemon_pass_warn_only_policy_hides_deny_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["run.sh"]),
-                request_id="notify-deny-v2",
             )
             activation_after_deny = await wait_for(
                 lambda: (

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -110,7 +110,6 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
-                request_id="notify-weather",
             )
             activation = await wait_for(
                 lambda: (
@@ -122,7 +121,6 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
             health = await asyncio.to_thread(
                 client.call,
                 "daemon.health",
-                request_id="health-after-notify",
             )
             config = read_skill_ledger_config(tmp_path)
         finally:
@@ -161,7 +159,6 @@ def test_daemon_metadata_only_notify_does_not_change_activation(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
-                request_id="notify-weather",
             )
             activation = await wait_for(
                 lambda: (
@@ -174,7 +171,6 @@ def test_daemon_metadata_only_notify_does_not_change_activation(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, [".skill-meta/latest.json"]),
-                request_id="notify-metadata",
             )
             after_ignored = read_activation(skill_dir)
         finally:
@@ -209,7 +205,6 @@ def test_daemon_notify_updates_activation_after_safe_drift(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
-                request_id="notify-v1",
             )
             activation_v1 = await wait_for(
                 lambda: (
@@ -224,7 +219,6 @@ def test_daemon_notify_updates_activation_after_safe_drift(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["run.sh"]),
-                request_id="notify-v2",
             )
             activation_v2 = await wait_for(
                 lambda: (
@@ -263,7 +257,6 @@ def test_daemon_default_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
-                request_id="notify-v1",
             )
             activation_v1 = await wait_for(
                 lambda: (
@@ -286,7 +279,6 @@ def test_daemon_default_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["SKILL.md"]),
-                request_id="notify-risky-v2",
             )
             activation_after_risk = await wait_for(
                 lambda: (
@@ -329,7 +321,6 @@ def test_daemon_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
-                request_id="notify-v1",
             )
             await wait_for(
                 lambda: (
@@ -352,7 +343,6 @@ def test_daemon_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["SKILL.md"]),
-                request_id="notify-risky-v2",
             )
             activation_after_risk = await wait_for(
                 lambda: (
@@ -471,7 +461,6 @@ def test_daemon_invalid_activation_policy_sets_job_error(monkeypatch, tmp_path: 
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
-                request_id="notify-invalid-policy",
             )
             deadline = asyncio.get_running_loop().time() + 5.0
             health = None
@@ -479,7 +468,6 @@ def test_daemon_invalid_activation_policy_sets_job_error(monkeypatch, tmp_path: 
                 candidate = await asyncio.to_thread(
                     client.call,
                     "daemon.health",
-                    request_id="health-invalid-policy",
                 )
                 jobs = {job["name"]: job for job in candidate.data["jobs"]}
                 last_error = jobs["skill-ledger-activation"].get("last_error") or ""

--- a/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
@@ -9,14 +9,25 @@ import socket
 import stat
 import sys
 import time
+import uuid
 from pathlib import Path
 
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    clear_invocation_context_for_tests,
+    get_current_trace_context,
+    init_invocation_context,
+)
 from agent_sec_cli.daemon.client import DaemonClient
 from agent_sec_cli.daemon.errors import (
     DaemonProtocolError,
     DaemonRuntimePathError,
 )
 from agent_sec_cli.daemon.health import build_health_snapshot
+from agent_sec_cli.daemon.logging import (
+    reset_daemon_diagnostic_logging_for_tests,
+    setup_daemon_logging,
+)
 from agent_sec_cli.daemon.protocol import (
     DaemonRequest,
     DaemonResponse,
@@ -29,10 +40,12 @@ from agent_sec_cli.daemon.registry import (
     MethodRegistry,
     MethodSpec,
 )
+from agent_sec_cli.daemon.request_context import daemon_request_context
 from agent_sec_cli.daemon.runtime import DaemonRuntime
 from agent_sec_cli.daemon.server import (
     DaemonServer,
     _log_request_completion,
+    configure_logging,
     create_default_registry,
     prepare_socket_path,
 )
@@ -40,6 +53,11 @@ from agent_sec_cli.daemon.server import (
 
 def _matching_modules(prefixes: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(sorted(name for name in sys.modules if name.startswith(prefixes)))
+
+
+def _assert_uuid(value: str | None) -> None:
+    assert value is not None
+    uuid.UUID(value)
 
 
 def test_client_uses_env_socket_override(monkeypatch, tmp_path: Path):
@@ -51,6 +69,39 @@ def test_client_uses_env_socket_override(monkeypatch, tmp_path: Path):
     assert client.socket_path == socket_path
 
 
+def test_configure_logging_does_not_install_console_handler(monkeypatch):
+    setup_calls = []
+    root_logger = logging.getLogger()
+    logger = logging.getLogger("agent-sec-core.daemon")
+    original_root_level = root_logger.level
+    original_level = logger.level
+    original_propagate = logger.propagate
+
+    def fake_setup_daemon_logging():
+        setup_calls.append(True)
+
+    def fail_basic_config(*_args, **_kwargs):
+        raise AssertionError("daemon logging must not configure stdout/stderr")
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.server.setup_daemon_logging",
+        fake_setup_daemon_logging,
+    )
+    monkeypatch.setattr(logging, "basicConfig", fail_basic_config)
+
+    try:
+        configure_logging()
+
+        assert setup_calls == [True]
+        assert root_logger.level == logging.DEBUG
+        assert logger.level == logging.NOTSET
+        assert logger.propagate is True
+    finally:
+        root_logger.setLevel(original_root_level)
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+
+
 def test_daemon_client_rejects_oversized_response(tmp_path: Path):
     server_socket, client_socket = socket.socketpair()
     try:
@@ -58,7 +109,7 @@ def test_daemon_client_rejects_oversized_response(tmp_path: Path):
             socket_path=tmp_path / "unused.sock", max_response_bytes=8
         )
         server_socket.sendall(
-            b'{"id":"req-1","ok":true,"data":{},"stdout":"","stderr":"","exit_code":0}\n'
+            b'{"request_id":"req-1","ok":true,"data":{},"stdout":"","stderr":"","exit_code":0}\n'
         )
 
         try:
@@ -70,6 +121,91 @@ def test_daemon_client_rejects_oversized_response(tmp_path: Path):
     finally:
         server_socket.close()
         client_socket.close()
+
+
+def test_daemon_client_fills_missing_trace_id_from_invocation_id(
+    monkeypatch,
+    tmp_path: Path,
+):
+    clear_invocation_context_for_tests()
+    monkeypatch.setenv("AGENT_SEC_INVOCATION_ID", "invocation-1")
+    init_invocation_context()
+    client = DaemonClient(socket_path=tmp_path / "unused.sock")
+    captured = {}
+
+    def fake_send_request(request: DaemonRequest, _timeout_ms: int) -> DaemonResponse:
+        captured["request"] = request
+        return DaemonResponse(request_id=request.request_id, ok=True)
+
+    monkeypatch.setattr(client, "_send_request", fake_send_request)
+
+    try:
+        client.call(
+            "scan-prompt",
+            trace_context={"session_id": "session-1"},
+        )
+    finally:
+        clear_invocation_context_for_tests()
+
+    request = captured["request"]
+    assert request.caller is None
+    assert request.trace_context == {
+        "trace_id": "invocation-1",
+        "session_id": "session-1",
+    }
+
+
+def test_daemon_client_preserves_explicit_trace_id(
+    monkeypatch,
+    tmp_path: Path,
+):
+    clear_invocation_context_for_tests()
+    monkeypatch.setenv("AGENT_SEC_INVOCATION_ID", "invocation-1")
+    init_invocation_context()
+    client = DaemonClient(socket_path=tmp_path / "unused.sock")
+    trace_context = {"trace_id": "trace-1", "session_id": "session-1"}
+    captured = {}
+
+    def fake_send_request(request: DaemonRequest, _timeout_ms: int) -> DaemonResponse:
+        captured["request"] = request
+        return DaemonResponse(request_id=request.request_id, ok=True)
+
+    monkeypatch.setattr(client, "_send_request", fake_send_request)
+
+    try:
+        client.call(
+            "scan-prompt",
+            trace_context=trace_context,
+        )
+    finally:
+        clear_invocation_context_for_tests()
+
+    request = captured["request"]
+    assert request.caller is None
+    assert request.trace_context == {
+        "trace_id": "trace-1",
+        "session_id": "session-1",
+    }
+    assert trace_context == {"trace_id": "trace-1", "session_id": "session-1"}
+
+
+def test_daemon_client_allows_caller_override(
+    monkeypatch,
+    tmp_path: Path,
+):
+    client = DaemonClient(socket_path=tmp_path / "unused.sock")
+    captured = {}
+
+    def fake_send_request(request: DaemonRequest, _timeout_ms: int) -> DaemonResponse:
+        captured["request"] = request
+        return DaemonResponse(request_id=request.request_id, ok=True)
+
+    monkeypatch.setattr(client, "_send_request", fake_send_request)
+
+    client.call("daemon.health", caller="health-check")
+
+    request = captured["request"]
+    assert request.caller == "health-check"
 
 
 def test_daemon_write_response_closes_writer_when_drain_is_cancelled(
@@ -144,7 +280,6 @@ def test_daemon_client_calls_health_over_temp_socket(tmp_path: Path):
             response = await asyncio.to_thread(
                 client.call,
                 "daemon.health",
-                request_id="req-health",
             )
             runtime_dir_mode = stat.S_IMODE(socket_path.parent.stat().st_mode)
             socket_mode = stat.S_IMODE(socket_path.stat().st_mode)
@@ -155,7 +290,7 @@ def test_daemon_client_calls_health_over_temp_socket(tmp_path: Path):
 
     response, runtime_dir_mode, socket_mode = asyncio.run(scenario())
 
-    assert response.id == "req-health"
+    _assert_uuid(response.request_id)
     assert response.ok is True
     assert response.exit_code == 0
     assert response.data["status"] == "ok"
@@ -232,14 +367,15 @@ def test_daemon_server_returns_busy_when_connection_limit_is_reached(tmp_path: P
         try:
             first_response_task = asyncio.create_task(
                 _send_daemon_request(
-                    socket_path, DaemonRequest(id="req-slow", method="slow")
+                    socket_path,
+                    DaemonRequest(method="slow"),
                 )
             )
             await asyncio.wait_for(handler_started.wait(), timeout=0.5)
 
             busy_response = await _send_daemon_request(
                 socket_path,
-                DaemonRequest(id="req-busy", method="daemon.health"),
+                DaemonRequest(method="daemon.health"),
             )
 
             handler_release.set()
@@ -252,10 +388,11 @@ def test_daemon_server_returns_busy_when_connection_limit_is_reached(tmp_path: P
     busy_response, first_response = asyncio.run(scenario())
 
     assert busy_response.ok is False
+    _assert_uuid(busy_response.request_id)
     assert busy_response.error is not None
     assert busy_response.error["code"] == "busy"
     assert first_response.ok is True
-    assert first_response.id == "req-slow"
+    _assert_uuid(first_response.request_id)
 
 
 def test_daemon_server_rejects_oversized_handler_response(tmp_path: Path, caplog):
@@ -276,12 +413,13 @@ def test_daemon_server_rejects_oversized_handler_response(tmp_path: Path, caplog
         server = DaemonServer(
             socket_path=socket_path,
             registry=registry,
-            max_response_bytes=220,
+            max_response_bytes=320,
         )
         await server.start()
         try:
             response = await _send_daemon_request(
-                socket_path, DaemonRequest(id="req-large", method="large")
+                socket_path,
+                DaemonRequest(method="large"),
             )
         finally:
             await server.stop()
@@ -290,22 +428,22 @@ def test_daemon_server_rejects_oversized_handler_response(tmp_path: Path, caplog
 
     response = asyncio.run(scenario())
 
-    assert response.id == "req-large"
+    _assert_uuid(response.request_id)
     assert response.ok is False
     assert response.error is not None
     assert response.error["code"] == "payload_too_large"
-    assert response.stderr == "response payload exceeds 220 bytes"
+    assert response.stderr == "response payload exceeds 320 bytes"
 
     matching_logs = [
-        json.loads(record.message)
+        record
         for record in caplog.records
         if record.name == "agent-sec-core.daemon"
-        and _is_json(record.message)
-        and json.loads(record.message).get("request_id") == "req-large"
+        and getattr(record, "diagnostic_event", None) == "daemon_request_completed"
+        and getattr(record, "data", {}).get("request_id") == response.request_id
     ]
     assert matching_logs
-    assert matching_logs[-1]["ok"] is False
-    assert matching_logs[-1]["error_code"] == "payload_too_large"
+    assert matching_logs[-1].data["ok"] is False
+    assert matching_logs[-1].data["error_code"] == "payload_too_large"
 
 
 def test_daemon_server_suppresses_method_access_log(tmp_path: Path, caplog):
@@ -326,7 +464,8 @@ def test_daemon_server_suppresses_method_access_log(tmp_path: Path, caplog):
         await server.start()
         try:
             response = await _send_daemon_request(
-                socket_path, DaemonRequest(id="req-quiet", method="quiet")
+                socket_path,
+                DaemonRequest(method="quiet"),
             )
         finally:
             await server.stop()
@@ -336,10 +475,12 @@ def test_daemon_server_suppresses_method_access_log(tmp_path: Path, caplog):
     response = asyncio.run(scenario())
 
     assert response.ok is True
+    _assert_uuid(response.request_id)
     matching_logs = [
         record
         for record in caplog.records
-        if record.name == "agent-sec-core.daemon" and "req-quiet" in record.message
+        if record.name == "agent-sec-core.daemon"
+        and getattr(record, "data", {}).get("request_id") == response.request_id
     ]
     assert matching_logs == []
 
@@ -361,7 +502,7 @@ def test_idle_request_read_times_out_and_releases_connection(tmp_path: Path):
 
             health_response = await _send_daemon_request(
                 socket_path,
-                DaemonRequest(id="req-after-idle-timeout", method="daemon.health"),
+                DaemonRequest(method="daemon.health"),
             )
         finally:
             await server.stop()
@@ -374,8 +515,9 @@ def test_idle_request_read_times_out_and_releases_connection(tmp_path: Path):
     assert timeout_response.error is not None
     assert timeout_response.error["code"] == "timeout"
     assert timeout_response.stderr == "daemon request timed out after 25 ms"
+    _assert_uuid(timeout_response.request_id)
     assert health_response.ok is True
-    assert health_response.id == "req-after-idle-timeout"
+    _assert_uuid(health_response.request_id)
 
 
 def test_partial_request_read_times_out_and_releases_connection(tmp_path: Path):
@@ -397,7 +539,7 @@ def test_partial_request_read_times_out_and_releases_connection(tmp_path: Path):
 
             health_response = await _send_daemon_request(
                 socket_path,
-                DaemonRequest(id="req-after-partial-timeout", method="daemon.health"),
+                DaemonRequest(method="daemon.health"),
             )
         finally:
             await server.stop()
@@ -409,8 +551,9 @@ def test_partial_request_read_times_out_and_releases_connection(tmp_path: Path):
     assert timeout_response.ok is False
     assert timeout_response.error is not None
     assert timeout_response.error["code"] == "timeout"
+    _assert_uuid(timeout_response.request_id)
     assert health_response.ok is True
-    assert health_response.id == "req-after-partial-timeout"
+    _assert_uuid(health_response.request_id)
 
 
 def test_bad_request_does_not_steal_concurrent_inflight_counter(tmp_path: Path):
@@ -439,7 +582,8 @@ def test_bad_request_does_not_steal_concurrent_inflight_counter(tmp_path: Path):
         try:
             slow_task = asyncio.create_task(
                 _send_daemon_request(
-                    socket_path, DaemonRequest(id="req-slow", method="slow")
+                    socket_path,
+                    DaemonRequest(method="slow"),
                 )
             )
             await asyncio.wait_for(handler_started.wait(), timeout=0.5)
@@ -465,8 +609,9 @@ def test_bad_request_does_not_steal_concurrent_inflight_counter(tmp_path: Path):
     assert bad_response.ok is False
     assert bad_response.error is not None
     assert bad_response.error["code"] == "bad_request"
+    _assert_uuid(bad_response.request_id)
     assert slow_response.ok is True
-    assert slow_response.id == "req-slow"
+    _assert_uuid(slow_response.request_id)
     assert observed_inflight == [1]
 
 
@@ -492,7 +637,8 @@ def test_daemon_server_stop_drains_inflight_request(tmp_path: Path):
 
         response_task = asyncio.create_task(
             _send_daemon_request(
-                socket_path, DaemonRequest(id="req-drain", method="slow")
+                socket_path,
+                DaemonRequest(method="slow"),
             )
         )
         await asyncio.wait_for(handler_started.wait(), timeout=0.5)
@@ -510,7 +656,7 @@ def test_daemon_server_stop_drains_inflight_request(tmp_path: Path):
 
     assert stop_is_waiting_for_drain is True
     assert response.ok is True
-    assert response.id == "req-drain"
+    _assert_uuid(response.request_id)
     assert socket_exists is False
 
 
@@ -642,7 +788,7 @@ def test_completion_log_is_emitted_when_inflight_request_is_cancelled(
         client_task = asyncio.create_task(
             _send_daemon_request(
                 socket_path,
-                DaemonRequest(id="req-cancelled", method="hang", timeout_ms=60_000),
+                DaemonRequest(method="hang", timeout_ms=60_000),
             )
         )
         await asyncio.wait_for(handler_started.wait(), timeout=0.5)
@@ -655,26 +801,19 @@ def test_completion_log_is_emitted_when_inflight_request_is_cancelled(
     asyncio.run(scenario())
 
     matching_logs = [
-        json.loads(record.message)
+        record
         for record in caplog.records
         if record.name == "agent-sec-core.daemon"
-        and _is_json(record.message)
-        and json.loads(record.message).get("request_id") == "req-cancelled"
+        and getattr(record, "diagnostic_event", None) == "daemon_request_completed"
+        and getattr(record, "data", {}).get("method") == "hang"
     ]
 
     assert matching_logs, "expected completion log for cancelled in-flight request"
-    payload = matching_logs[-1]
-    assert payload["event"] == "daemon_request_completed"
-    assert payload["method"] == "hang"
-    assert payload["ok"] is False
-
-
-def _is_json(text: str) -> bool:
-    try:
-        json.loads(text)
-    except (json.JSONDecodeError, TypeError):
-        return False
-    return True
+    record = matching_logs[-1]
+    assert record.diagnostic_event == "daemon_request_completed"
+    _assert_uuid(record.data["request_id"])
+    assert record.data["method"] == "hang"
+    assert record.data["ok"] is False
 
 
 def test_completion_log_outputs_structured_fields(caplog):
@@ -689,8 +828,10 @@ def test_completion_log_outputs_structured_fields(caplog):
         bytes_out=34,
     )
 
-    payload = json.loads(caplog.records[-1].message)
-    assert payload["event"] == "daemon_request_completed"
+    record = caplog.records[-1]
+    payload = record.data
+    assert record.message == "daemon request completed"
+    assert record.diagnostic_event == "daemon_request_completed"
     assert payload["request_id"] == "req-log"
     assert payload["method"] == "daemon.health"
     assert payload["ok"] is True
@@ -699,6 +840,386 @@ def test_completion_log_outputs_structured_fields(caplog):
     assert payload["bytes_in"] == 12
     assert payload["bytes_out"] == 34
     assert "latency_ms" in payload
+
+
+def test_request_started_log_outputs_structured_fields(tmp_path: Path, caplog):
+    caplog.set_level(logging.INFO, logger="agent-sec-core.daemon")
+
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        registry = MethodRegistry()
+        registry.register(
+            MethodSpec(
+                method="started",
+                handler=lambda _request, _runtime: HandlerResult(data={"ok": True}),
+                lifecycle="test",
+            )
+        )
+        server = DaemonServer(socket_path=socket_path, registry=registry)
+        await server.start()
+        try:
+            return await _send_daemon_request(
+                socket_path,
+                DaemonRequest(
+                    method="started",
+                    caller="cli",
+                    trace_context={
+                        "trace_id": "trace-started",
+                        "session_id": "session-started",
+                    },
+                ),
+            )
+        finally:
+            await server.stop()
+
+    response = asyncio.run(scenario())
+
+    assert response.ok is True
+    _assert_uuid(response.request_id)
+    matching_logs = [
+        record
+        for record in caplog.records
+        if record.name == "agent-sec-core.daemon"
+        and getattr(record, "diagnostic_event", None) == "daemon_request_started"
+        and getattr(record, "data", {}).get("request_id") == response.request_id
+    ]
+    assert matching_logs
+    record = matching_logs[-1]
+    assert record.message == "daemon request started"
+    assert record.trace_id == "trace-started"
+    assert record.session_id == "session-started"
+    assert record.data == {
+        "request_id": response.request_id,
+        "method": "started",
+        "caller": "cli",
+    }
+
+
+def test_gateway_preserves_missing_trace_id(tmp_path: Path, caplog):
+    caplog.set_level(logging.INFO, logger="agent-sec-core.daemon")
+    observed_contexts = []
+
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+
+        def capture_handler(
+            request: DaemonRequest, _runtime: DaemonRuntime
+        ) -> HandlerResult:
+            observed_contexts.append(
+                (request.trace_context, get_current_trace_context())
+            )
+            return HandlerResult(data={"trace_context": request.trace_context})
+
+        registry = MethodRegistry()
+        registry.register(
+            MethodSpec(
+                method="capture",
+                handler=capture_handler,
+                lifecycle="test",
+            )
+        )
+        server = DaemonServer(socket_path=socket_path, registry=registry)
+        await server.start()
+        try:
+            return await _send_daemon_request(
+                socket_path,
+                DaemonRequest(
+                    method="capture",
+                    trace_context={"session_id": "session-default"},
+                ),
+            )
+        finally:
+            await server.stop()
+
+    response = asyncio.run(scenario())
+
+    assert response.ok is True
+    assert response.data["trace_context"] == {
+        "session_id": "session-default",
+    }
+    assert observed_contexts == [
+        (
+            {
+                "session_id": "session-default",
+            },
+            TraceContext(
+                session_id="session-default",
+            ),
+        )
+    ]
+
+    matching_logs = [
+        record
+        for record in caplog.records
+        if record.name == "agent-sec-core.daemon"
+        and getattr(record, "diagnostic_event", None)
+        in {"daemon_request_started", "daemon_request_completed"}
+        and getattr(record, "data", {}).get("request_id") == response.request_id
+    ]
+    assert len(matching_logs) == 2
+    assert all(not hasattr(record, "trace_id") for record in matching_logs)
+    assert all(record.session_id == "session-default" for record in matching_logs)
+
+
+def test_completion_log_writes_daemon_jsonl_with_trace_context(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AGENT_SEC_DAEMON_LOG_LEVEL", "info")
+    log_path = tmp_path / "daemon.jsonl"
+    logger = logging.getLogger("agent-sec-core.daemon")
+    original_level = logger.level
+    reset_daemon_diagnostic_logging_for_tests()
+
+    try:
+        logger.setLevel(logging.INFO)
+        setup_daemon_logging(path=log_path)
+        _log_request_completion(
+            request_id="req-daemon-jsonl",
+            method="scan-prompt",
+            caller="cli",
+            response=success_response("req-daemon-jsonl"),
+            started=time.monotonic() - 0.01,
+            bytes_in=56,
+            bytes_out=78,
+            trace_context=TraceContext(
+                trace_id="trace-1",
+                session_id="session-1",
+                run_id="run-1",
+                call_id="call-1",
+                tool_call_id="tool-1",
+            ),
+        )
+    finally:
+        reset_daemon_diagnostic_logging_for_tests()
+        logger.setLevel(original_level)
+
+    payload = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["component"] == "daemon"
+    assert payload["event"] == "daemon_request_completed"
+    assert payload["message"] == "daemon request completed"
+    assert payload["pid"] == os.getpid()
+    assert payload["trace_id"] == "trace-1"
+    assert payload["session_id"] == "session-1"
+    assert payload["run_id"] == "run-1"
+    assert payload["call_id"] == "call-1"
+    assert payload["tool_call_id"] == "tool-1"
+    assert "invocation_id" not in payload
+    assert payload["request_id"] == "req-daemon-jsonl"
+    assert payload["data"]["request_id"] == "req-daemon-jsonl"
+    assert payload["data"]["method"] == "scan-prompt"
+    assert payload["data"]["caller"] == "cli"
+    assert payload["data"]["ok"] is True
+    assert payload["data"]["exit_code"] == 0
+    assert payload["data"]["error_code"] is None
+    assert "latency_ms" in payload["data"]
+    assert payload["data"]["queue_ms"] == 0
+    assert payload["data"]["bytes_in"] == 56
+    assert payload["data"]["bytes_out"] == 78
+
+
+def test_daemon_log_level_off_disables_daemon_jsonl(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AGENT_SEC_DAEMON_LOG_LEVEL", "off")
+    log_path = tmp_path / "daemon.jsonl"
+    logger = logging.getLogger("agent-sec-core.daemon")
+    original_level = logger.level
+    reset_daemon_diagnostic_logging_for_tests()
+
+    try:
+        logger.setLevel(logging.INFO)
+        setup_daemon_logging(path=log_path)
+        _log_request_completion(
+            request_id="req-daemon-off",
+            method="scan-prompt",
+            response=success_response("req-daemon-off"),
+            started=time.monotonic() - 0.01,
+            bytes_in=12,
+            bytes_out=34,
+        )
+    finally:
+        reset_daemon_diagnostic_logging_for_tests()
+        logger.setLevel(original_level)
+
+    assert not log_path.exists()
+
+
+def test_daemon_logging_captures_third_party_logs(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AGENT_SEC_DAEMON_LOG_LEVEL", "info")
+    log_path = tmp_path / "daemon.jsonl"
+    root_logger = logging.getLogger()
+    third_party_logger = logging.getLogger("third_party.daemon_dependency")
+    original_root_level = root_logger.level
+    original_third_party_level = third_party_logger.level
+    original_third_party_propagate = third_party_logger.propagate
+    reset_daemon_diagnostic_logging_for_tests()
+
+    try:
+        root_logger.setLevel(logging.DEBUG)
+        third_party_logger.setLevel(logging.NOTSET)
+        third_party_logger.propagate = True
+        setup_daemon_logging(path=log_path)
+
+        with daemon_request_context(
+            TraceContext(
+                trace_id="trace-third-party",
+                session_id="session-third-party",
+                run_id="run-third-party",
+            ),
+            request_id="req-third-party",
+        ):
+            third_party_logger.info("dependency ready")
+        third_party_logger.info("outside request")
+    finally:
+        reset_daemon_diagnostic_logging_for_tests()
+        root_logger.setLevel(original_root_level)
+        third_party_logger.setLevel(original_third_party_level)
+        third_party_logger.propagate = original_third_party_propagate
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    payload = json.loads(lines[0])
+    assert payload["component"] == "daemon"
+    assert payload["event"] == "daemon_log"
+    assert payload["logger"] == "third_party.daemon_dependency"
+    assert payload["message"] == "dependency ready"
+    assert payload["request_id"] == "req-third-party"
+    assert payload["trace_id"] == "trace-third-party"
+    assert payload["session_id"] == "session-third-party"
+    assert payload["run_id"] == "run-third-party"
+    outside_payload = json.loads(lines[1])
+    assert outside_payload["message"] == "outside request"
+    assert "request_id" not in outside_payload
+
+
+def test_gateway_request_context_adds_request_id_to_ordinary_daemon_logs(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AGENT_SEC_DAEMON_LOG_LEVEL", "info")
+    log_path = tmp_path / "daemon.jsonl"
+    root_logger = logging.getLogger()
+    handler_logger = logging.getLogger("third_party.gateway_dependency")
+    original_root_level = root_logger.level
+    original_handler_level = handler_logger.level
+    original_handler_propagate = handler_logger.propagate
+    reset_daemon_diagnostic_logging_for_tests()
+
+    async def scenario() -> DaemonResponse:
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+
+        def logging_handler(
+            _request: DaemonRequest,
+            _runtime: DaemonRuntime,
+        ) -> HandlerResult:
+            handler_logger.info("inside gateway request")
+            return HandlerResult(data={"ok": True})
+
+        registry = MethodRegistry()
+        registry.register(
+            MethodSpec(method="log-inside", handler=logging_handler, lifecycle="test")
+        )
+        server = DaemonServer(socket_path=socket_path, registry=registry)
+        await server.start()
+        try:
+            return await _send_daemon_request(
+                socket_path,
+                DaemonRequest(method="log-inside"),
+            )
+        finally:
+            await server.stop()
+
+    try:
+        root_logger.setLevel(logging.DEBUG)
+        handler_logger.setLevel(logging.NOTSET)
+        handler_logger.propagate = True
+        setup_daemon_logging(path=log_path)
+
+        response = asyncio.run(scenario())
+    finally:
+        reset_daemon_diagnostic_logging_for_tests()
+        root_logger.setLevel(original_root_level)
+        handler_logger.setLevel(original_handler_level)
+        handler_logger.propagate = original_handler_propagate
+
+    assert response.ok is True
+    _assert_uuid(response.request_id)
+    payloads = [
+        json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    matching_payloads = [
+        payload
+        for payload in payloads
+        if payload.get("message") == "inside gateway request"
+    ]
+    assert matching_payloads
+    assert matching_payloads[-1]["request_id"] == response.request_id
+
+
+def test_setup_daemon_logging_does_not_mutate_daemon_logger_level(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AGENT_SEC_DAEMON_LOG_LEVEL", "debug")
+    logger = logging.getLogger("agent-sec-core.daemon")
+    original_level = logger.level
+    logger.setLevel(logging.ERROR)
+    reset_daemon_diagnostic_logging_for_tests()
+
+    try:
+        setup_daemon_logging(path=tmp_path / "daemon.jsonl")
+        assert logger.level == logging.ERROR
+    finally:
+        reset_daemon_diagnostic_logging_for_tests()
+        logger.setLevel(original_level)
+
+
+def test_unknown_method_completion_log_preserves_trace_context(
+    tmp_path: Path,
+    caplog,
+):
+    caplog.set_level(logging.INFO, logger="agent-sec-core.daemon")
+
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        server = DaemonServer(socket_path=socket_path, registry=MethodRegistry())
+        await server.start()
+        try:
+            return await _send_daemon_request(
+                socket_path,
+                DaemonRequest(
+                    method="unknown.method",
+                    trace_context={
+                        "trace_id": "trace-unknown",
+                        "session_id": "session-unknown",
+                    },
+                ),
+            )
+        finally:
+            await server.stop()
+
+    response = asyncio.run(scenario())
+
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error["code"] == "unknown_method"
+
+    matching_logs = [
+        record
+        for record in caplog.records
+        if record.name == "agent-sec-core.daemon"
+        and getattr(record, "diagnostic_event", None) == "daemon_request_completed"
+        and getattr(record, "data", {}).get("request_id") == response.request_id
+    ]
+    assert matching_logs
+    record = matching_logs[-1]
+    assert record.trace_id == "trace-unknown"
+    assert record.session_id == "session-unknown"
+    assert record.data["method"] == "unknown.method"
 
 
 async def _send_daemon_request(

--- a/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
@@ -446,6 +446,98 @@ def test_daemon_server_rejects_oversized_handler_response(tmp_path: Path, caplog
     assert matching_logs[-1].data["error_code"] == "payload_too_large"
 
 
+def test_daemon_server_returns_internal_error_for_unserializable_response(
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+
+        async def unserializable_handler(
+            _request: DaemonRequest, _runtime: DaemonRuntime
+        ) -> HandlerResult:
+            return HandlerResult(data={"value": object()})
+
+        registry = MethodRegistry()
+        registry.register(
+            MethodSpec(
+                method="unserializable",
+                handler=unserializable_handler,
+                lifecycle="test",
+            )
+        )
+        registry.register(
+            MethodSpec(
+                method="daemon.health",
+                handler=lambda _request, _runtime: HandlerResult(data={}),
+                lifecycle="admin",
+            )
+        )
+        server = DaemonServer(socket_path=socket_path, registry=registry)
+        await server.start()
+        try:
+            error_response = await _send_daemon_request(
+                socket_path,
+                DaemonRequest(method="unserializable"),
+            )
+            health_response = await _send_daemon_request(
+                socket_path,
+                DaemonRequest(method="daemon.health"),
+            )
+        finally:
+            await server.stop()
+
+        return error_response, health_response
+
+    error_response, health_response = asyncio.run(scenario())
+
+    assert error_response.ok is False
+    _assert_uuid(error_response.request_id)
+    assert error_response.error is not None
+    assert error_response.error["code"] == "internal_error"
+    assert error_response.stderr == "daemon internal error"
+    assert health_response.ok is True
+
+
+def test_daemon_server_returns_internal_error_for_unexpected_prepare_failure(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        server = DaemonServer(socket_path=socket_path)
+        original_prepare = server.gateway.prepare
+
+        def fail_prepare_for_request(request: DaemonRequest):
+            if request.method == "explode.prepare":
+                raise RuntimeError("prepare exploded")
+            return original_prepare(request)
+
+        monkeypatch.setattr(server.gateway, "prepare", fail_prepare_for_request)
+        await server.start()
+        try:
+            error_response = await _send_daemon_request(
+                socket_path,
+                DaemonRequest(method="explode.prepare"),
+            )
+            health_response = await _send_daemon_request(
+                socket_path,
+                DaemonRequest(method="daemon.health"),
+            )
+        finally:
+            await server.stop()
+
+        return error_response, health_response
+
+    error_response, health_response = asyncio.run(scenario())
+
+    assert error_response.ok is False
+    _assert_uuid(error_response.request_id)
+    assert error_response.error is not None
+    assert error_response.error["code"] == "internal_error"
+    assert error_response.stderr == "daemon internal error"
+    assert health_response.ok is True
+
+
 def test_daemon_server_suppresses_method_access_log(tmp_path: Path, caplog):
     caplog.set_level(logging.INFO, logger="agent-sec-core.daemon")
 

--- a/src/agent-sec-core/tests/unit-test/daemon/test_jobs.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_jobs.py
@@ -2,13 +2,22 @@
 
 import asyncio
 import contextlib
+import logging
 import sys
 import threading
+import uuid
+from typing import Any
 
 import pytest
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    clear_process_trace_context,
+    get_current_trace_context,
+)
 from agent_sec_cli.daemon.jobs import (
     JobManager,
     JobStatus,
+    OneShotBackgroundJob,
     PeriodicBackgroundJob,
 )
 from agent_sec_cli.daemon.jobs.base import next_cycle_start
@@ -32,11 +41,62 @@ class RecordingPeriodicJob(PeriodicBackgroundJob):
         super().__init__(interval_seconds=interval_seconds)
         self.run_count = 0
         self.started = asyncio.Event()
+        self.trace_contexts: list[TraceContext | None] = []
 
     async def run_once(self) -> None:
         """Record one scheduled run."""
         self.run_count += 1
+        self.trace_contexts.append(get_current_trace_context())
         self.started.set()
+
+
+class RecordingOneShotJob(OneShotBackgroundJob):
+    """One-shot job used by trace-context lifecycle tests."""
+
+    name = "recording-one-shot-job"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.trace_contexts: list[tuple[str, TraceContext | None]] = []
+
+    def on_run_started(self, started_at: str) -> None:
+        self.trace_contexts.append(("started", get_current_trace_context()))
+
+    async def run_once(self) -> None:
+        """Record the active job trace context."""
+        self.trace_contexts.append(("run", get_current_trace_context()))
+
+    def on_run_completed(self, finished_at: str) -> None:
+        self.trace_contexts.append(("completed", get_current_trace_context()))
+
+
+class FailingOneShotJob(OneShotBackgroundJob):
+    """One-shot job that fails for lifecycle logging tests."""
+
+    name = "failing-one-shot-job"
+
+    async def run_once(self) -> None:
+        """Raise a deterministic failure."""
+        raise RuntimeError("forced one-shot failure")
+
+
+def _capture_job_events(monkeypatch) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+
+    def fake_log_daemon_event(**kwargs) -> None:
+        if kwargs["event"].startswith("daemon_job_"):
+            events.append(kwargs)
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.jobs.base.log_daemon_event",
+        fake_log_daemon_event,
+    )
+    return events
+
+
+def _assert_uuid(value: str | None) -> None:
+    assert value is not None
+    assert str(uuid.UUID(value)) == value
 
 
 def test_next_cycle_start_uses_start_time_interval_boundaries():
@@ -85,6 +145,159 @@ def test_periodic_background_job_runs_and_reports_interval():
     assert status["interval_seconds"] == 3600.0
     assert "last_started_at" in status
     assert "next_run_at" in status
+
+
+def test_one_shot_background_job_run_has_trace_context_and_resets() -> None:
+    async def scenario():
+        clear_process_trace_context()
+        try:
+            job = RecordingOneShotJob()
+            await job._run_once_with_lifecycle()
+            return (
+                job.status().to_dict(),
+                list(job.trace_contexts),
+                get_current_trace_context(),
+            )
+        finally:
+            clear_process_trace_context()
+
+    status, trace_contexts, after_context = asyncio.run(scenario())
+
+    labels = [label for label, _ctx in trace_contexts]
+    contexts = [ctx for _label, ctx in trace_contexts]
+    trace_ids = {ctx.trace_id for ctx in contexts if ctx is not None}
+
+    assert labels == ["started", "run", "completed"]
+    assert status["state"] == "completed"
+    assert len(trace_ids) == 1
+    trace_id = trace_ids.pop()
+    _assert_uuid(trace_id)
+    assert all(ctx is not None for ctx in contexts)
+    assert all(ctx.session_id is None for ctx in contexts if ctx is not None)
+    assert all(ctx.run_id is None for ctx in contexts if ctx is not None)
+    assert all(ctx.call_id is None for ctx in contexts if ctx is not None)
+    assert all(ctx.tool_call_id is None for ctx in contexts if ctx is not None)
+    assert after_context is None
+
+
+def test_one_shot_background_job_logs_started_and_completed(monkeypatch) -> None:
+    events = _capture_job_events(monkeypatch)
+
+    async def scenario():
+        clear_process_trace_context()
+        try:
+            job = RecordingOneShotJob()
+            await job._run_once_with_lifecycle()
+            return job.status().to_dict(), get_current_trace_context()
+        finally:
+            clear_process_trace_context()
+
+    status, after_context = asyncio.run(scenario())
+
+    assert status["state"] == "completed"
+    assert after_context is None
+    assert [event["event"] for event in events] == [
+        "daemon_job_started",
+        "daemon_job_completed",
+    ]
+    assert events[0]["data"]["job_name"] == "recording-one-shot-job"
+    assert events[0]["data"]["job_kind"] == "one_shot"
+    assert events[0]["data"]["state"] == "running"
+    assert events[1]["data"]["state"] == "completed"
+    assert isinstance(events[1]["data"]["latency_ms"], int)
+    assert events[0]["trace_context"].trace_id == events[1]["trace_context"].trace_id
+    _assert_uuid(events[0]["trace_context"].trace_id)
+
+
+def test_one_shot_background_job_logs_failure(monkeypatch) -> None:
+    events = _capture_job_events(monkeypatch)
+
+    async def scenario():
+        clear_process_trace_context()
+        try:
+            job = FailingOneShotJob()
+            await job._run_once_with_lifecycle()
+            return job.status().to_dict(), get_current_trace_context()
+        finally:
+            clear_process_trace_context()
+
+    status, after_context = asyncio.run(scenario())
+
+    assert status["state"] == "error"
+    assert status["last_error"] == "forced one-shot failure"
+    assert after_context is None
+    assert [event["event"] for event in events] == [
+        "daemon_job_started",
+        "daemon_job_failed",
+    ]
+    failed = events[1]
+    assert failed["level"] == logging.ERROR
+    assert failed["data"]["job_name"] == "failing-one-shot-job"
+    assert failed["data"]["job_kind"] == "one_shot"
+    assert failed["data"]["state"] == "error"
+    assert failed["data"]["error_type"] == "RuntimeError"
+    assert failed["data"]["error_message"] == "forced one-shot failure"
+    assert isinstance(failed["data"]["latency_ms"], int)
+    assert events[0]["trace_context"].trace_id == failed["trace_context"].trace_id
+
+
+def test_periodic_background_job_run_gets_new_trace_context_each_tick() -> None:
+    async def scenario():
+        clear_process_trace_context()
+        job = RecordingPeriodicJob(interval_seconds=0.01)
+        try:
+            await job.start()
+            for _attempt in range(50):
+                if len(job.trace_contexts) >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            return list(job.trace_contexts[:2]), get_current_trace_context()
+        finally:
+            await job.stop()
+            clear_process_trace_context()
+
+    contexts, after_context = asyncio.run(scenario())
+
+    assert len(contexts) == 2
+    assert all(ctx is not None for ctx in contexts)
+    trace_ids = [ctx.trace_id for ctx in contexts if ctx is not None]
+    for trace_id in trace_ids:
+        _assert_uuid(trace_id)
+    assert len(set(trace_ids)) == 2
+    assert after_context is None
+
+
+def test_periodic_background_job_logs_started_and_completed(monkeypatch) -> None:
+    events = _capture_job_events(monkeypatch)
+
+    async def scenario():
+        clear_process_trace_context()
+        job = RecordingPeriodicJob(interval_seconds=3600.0)
+        try:
+            await job.start()
+            await asyncio.wait_for(job.started.wait(), timeout=0.5)
+            return job.status().to_dict(), get_current_trace_context()
+        finally:
+            await job.stop()
+            clear_process_trace_context()
+
+    status, after_context = asyncio.run(scenario())
+
+    assert status["state"] == "running"
+    assert after_context is None
+    assert [event["event"] for event in events] == [
+        "daemon_job_started",
+        "daemon_job_completed",
+    ]
+    assert events[0]["data"]["job_name"] == "recording-periodic-job"
+    assert events[0]["data"]["job_kind"] == "periodic"
+    assert events[0]["data"]["state"] == "running"
+    assert events[0]["data"]["interval_seconds"] == 3600.0
+    assert events[1]["data"]["state"] == "running"
+    assert events[1]["data"]["interval_seconds"] == 3600.0
+    assert isinstance(events[1]["data"]["latency_ms"], int)
+    assert events[0]["trace_context"].trace_id == events[1]["trace_context"].trace_id
+    _assert_uuid(events[0]["trace_context"].trace_id)
 
 
 def test_register_default_jobs_respects_prompt_preload_env(monkeypatch):
@@ -150,6 +363,58 @@ def test_prompt_model_preload_job_updates_runtime_state(monkeypatch):
     assert prompt_state.last_error is None
     assert prompt_state.last_started_at is not None
     assert prompt_state.last_finished_at is not None
+
+
+def test_prompt_model_preload_job_propagates_trace_context_to_preload_thread(
+    monkeypatch,
+) -> None:
+    prompt_state = PromptScanRuntimeState()
+    trace_contexts: list[tuple[str, TraceContext | None]] = []
+
+    async def fake_child_preload(_mode: str) -> None:
+        trace_contexts.append(("child", get_current_trace_context()))
+
+    def fake_preload(state, _mode: str, _probe_text: str) -> None:
+        trace_contexts.append(("preload", get_current_trace_context()))
+        state.model = "fake-model"
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.jobs.prompt_preload._run_preload_child_process",
+        fake_child_preload,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.jobs.prompt_preload._preload_prompt_model_sync",
+        fake_preload,
+    )
+
+    async def scenario():
+        clear_process_trace_context()
+        try:
+            job = PromptModelPreloadJob(prompt_state, probe_text="probe")
+            await job.start()
+            status = await _wait_for_job_state(job, {"completed", "error"})
+            await job.stop()
+            return status, list(trace_contexts), get_current_trace_context()
+        finally:
+            clear_process_trace_context()
+
+    status, observed_contexts, after_context = asyncio.run(scenario())
+
+    labels = [label for label, _ctx in observed_contexts]
+    contexts = [ctx for _label, ctx in observed_contexts]
+    trace_ids = {ctx.trace_id for ctx in contexts if ctx is not None}
+
+    assert status["state"] == "completed"
+    assert labels == ["child", "preload"]
+    assert all(ctx is not None for ctx in contexts)
+    assert len(trace_ids) == 1
+    trace_id = trace_ids.pop()
+    _assert_uuid(trace_id)
+    assert all(ctx.session_id is None for ctx in contexts if ctx is not None)
+    assert all(ctx.run_id is None for ctx in contexts if ctx is not None)
+    assert all(ctx.call_id is None for ctx in contexts if ctx is not None)
+    assert all(ctx.tool_call_id is None for ctx in contexts if ctx is not None)
+    assert after_context is None
 
 
 def test_prompt_model_preload_job_marks_prompt_degraded_on_failure(monkeypatch):

--- a/src/agent-sec-core/tests/unit-test/daemon/test_prompt_scan_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_prompt_scan_handler.py
@@ -4,9 +4,11 @@ import asyncio
 from pathlib import Path
 
 import pytest
+from agent_sec_cli.correlation_context import TraceContext
 from agent_sec_cli.daemon.errors import UnavailableError
 from agent_sec_cli.daemon.handlers.prompt_scan import prompt_scan_handler
 from agent_sec_cli.daemon.protocol import DaemonRequest
+from agent_sec_cli.daemon.request_context import daemon_request_context
 from agent_sec_cli.daemon.runtime import DaemonRuntime
 from agent_sec_cli.security_middleware.result import ActionResult
 
@@ -14,8 +16,8 @@ from agent_sec_cli.security_middleware.result import ActionResult
 def test_prompt_scan_handler_rejects_when_prompt_runtime_not_ready(tmp_path: Path):
     runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
     request = DaemonRequest(
-        id="req-prompt",
         method="scan-prompt",
+        request_id="req-prompt",
         params={"text": "hello", "mode": "standard"},
     )
 
@@ -79,8 +81,8 @@ def test_prompt_scan_handler_unavailable_message_describes_preload_state(
     runtime.prompt_scan_state.model = model
     runtime.prompt_scan_state.last_error = last_error
     request = DaemonRequest(
-        id="req-prompt",
         method="scan-prompt",
+        request_id="req-prompt",
         params={"text": "hello", "mode": "standard"},
     )
 
@@ -92,7 +94,7 @@ def test_prompt_scan_handler_unavailable_message_describes_preload_state(
         assert expected_part in message
 
 
-def test_prompt_scan_handler_invokes_middleware_with_request_context(
+def test_prompt_scan_handler_invokes_middleware_with_prompt_params(
     monkeypatch,
     tmp_path: Path,
 ):
@@ -115,8 +117,8 @@ def test_prompt_scan_handler_invokes_middleware_with_request_context(
         fake_invoke_prompt_scan,
     )
     request = DaemonRequest(
-        id="req-prompt",
         method="scan-prompt",
+        request_id="req-prompt",
         params={"text": "hello", "mode": "standard", "source": "user_input"},
         trace_context={"trace_id": "trace-1"},
     )
@@ -124,7 +126,6 @@ def test_prompt_scan_handler_invokes_middleware_with_request_context(
     result = asyncio.run(prompt_scan_handler(request, runtime))
 
     assert captured == {
-        "trace_context": {"trace_id": "trace-1"},
         "text": "hello",
         "mode": "standard",
         "source": "user_input",
@@ -133,6 +134,47 @@ def test_prompt_scan_handler_invokes_middleware_with_request_context(
     assert result.stdout == '{"ok": true, "verdict": "pass"}'
     assert result.stderr == ""
     assert result.exit_code == 0
+
+
+def test_prompt_scan_handler_uses_gateway_trace_context(
+    monkeypatch,
+    tmp_path: Path,
+):
+    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
+    runtime.prompt_scan_state.status = "ready"
+    runtime.prompt_scan_state.loaded = True
+    captured = {}
+
+    class FakeBackend:
+        def execute(self, ctx, **_kwargs):
+            captured["ctx"] = ctx
+            return ActionResult(success=True, data={"ok": True})
+
+    monkeypatch.setattr(
+        "agent_sec_cli.security_middleware.router.get_backend",
+        lambda _action: FakeBackend(),
+    )
+    request = DaemonRequest(
+        method="scan-prompt",
+        request_id="req-prompt",
+        params={"text": "hello", "mode": "standard"},
+    )
+
+    with daemon_request_context(
+        TraceContext(
+            trace_id="trace-1",
+            session_id="session-1",
+            run_id="run-1",
+        )
+    ):
+        result = asyncio.run(prompt_scan_handler(request, runtime))
+
+    ctx = captured["ctx"]
+    assert ctx.trace_id == "trace-1"
+    assert ctx.caller == "daemon"
+    assert ctx.session_id == "session-1"
+    assert ctx.run_id == "run-1"
+    assert result.data == {"ok": True}
 
 
 def test_prompt_scan_handler_preserves_action_result_error(
@@ -154,7 +196,7 @@ def test_prompt_scan_handler_preserves_action_result_error(
         "agent_sec_cli.daemon.handlers.prompt_scan._invoke_prompt_scan",
         fake_invoke_prompt_scan,
     )
-    request = DaemonRequest(id="req-prompt", method="scan-prompt")
+    request = DaemonRequest(method="scan-prompt", request_id="req-prompt")
 
     result = asyncio.run(prompt_scan_handler(request, runtime))
 

--- a/src/agent-sec-core/tests/unit-test/daemon/test_protocol.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_protocol.py
@@ -1,6 +1,7 @@
 """Tests for daemon protocol parsing and dispatch."""
 
 import asyncio
+import uuid
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ from agent_sec_cli.daemon.protocol import (
     DaemonRequest,
     NDJSONFrameParser,
     parse_request_line,
+    request_to_payload,
 )
 from agent_sec_cli.daemon.registry import (
     HandlerResult,
@@ -33,12 +35,17 @@ def test_parse_request_rejects_non_object_request():
 def test_frame_parser_handles_partial_and_coalesced_lines():
     parser = NDJSONFrameParser(max_frame_bytes=1024)
 
-    assert parser.feed(b'{"id":"req-1"') == []
-    frames = parser.feed(
-        b',"method":"daemon.health"}\n{"id":"req-2","method":"daemon.health"}\n'
-    )
+    assert parser.feed(b'{"method":"daemon.health"') == []
+    frames = parser.feed(b'}\n{"method":"daemon.health"}\n')
+    requests = [parse_request_line(frame) for frame in frames]
 
-    assert [parse_request_line(frame).id for frame in frames] == ["req-1", "req-2"]
+    assert [request.method for request in requests] == [
+        "daemon.health",
+        "daemon.health",
+    ]
+    assert requests[0].request_id != requests[1].request_id
+    uuid.UUID(requests[0].request_id)
+    uuid.UUID(requests[1].request_id)
 
 
 def test_frame_parser_rejects_oversized_payload():
@@ -51,10 +58,54 @@ def test_frame_parser_rejects_oversized_payload():
 def test_parse_request_generates_missing_request_id():
     request = parse_request_line(b'{"method":"daemon.health"}\n')
 
-    assert request.id.startswith("daemon-")
+    uuid.UUID(request.request_id)
     assert request.method == "daemon.health"
     assert request.params == {}
     assert request.trace_context == {}
+    assert request.caller is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b'{"id":"req-1","method":"daemon.health"}\n',
+        b'{"request_id":"req-1","method":"daemon.health"}\n',
+    ],
+)
+def test_parse_request_ignores_caller_provided_request_id(payload: bytes):
+    request = parse_request_line(payload)
+
+    assert request.request_id != "req-1"
+    uuid.UUID(request.request_id)
+
+
+def test_parse_request_accepts_caller():
+    request = parse_request_line(b'{"method":"scan-prompt","caller":" cli "}\n')
+
+    assert request.caller == "cli"
+
+
+@pytest.mark.parametrize("caller", ['"   "', "42", "false"])
+def test_parse_request_ignores_invalid_optional_caller(caller: str):
+    request = parse_request_line(
+        f'{{"method":"scan-prompt","caller":{caller}}}\n'.encode()
+    )
+
+    assert request.caller is None
+
+
+def test_request_to_payload_includes_caller_when_present():
+    payload = request_to_payload(
+        DaemonRequest(
+            method="scan-prompt",
+            request_id="req-1",
+            caller="cli",
+        )
+    )
+
+    assert "id" not in payload
+    assert "request_id" not in payload
+    assert payload["caller"] == "cli"
 
 
 def test_parse_request_accepts_timeout_ms_at_max():
@@ -75,7 +126,10 @@ def test_parse_request_rejects_timeout_ms_above_max():
 
 def test_dispatch_rejects_unknown_method(tmp_path: Path):
     async def scenario():
-        request = DaemonRequest(id="req-unknown", method="unknown.method")
+        request = DaemonRequest(
+            method="unknown.method",
+            request_id="req-unknown",
+        )
         response = await dispatch_request(
             request,
             MethodRegistry(),
@@ -85,7 +139,7 @@ def test_dispatch_rejects_unknown_method(tmp_path: Path):
 
     response = asyncio.run(scenario())
 
-    assert response.id == "req-unknown"
+    assert response.request_id == "req-unknown"
     assert response.ok is False
     assert response.error == {
         "code": "unknown_method",
@@ -110,7 +164,11 @@ def test_dispatch_applies_request_timeout(tmp_path: Path):
                 timeout_ms=1000,
             )
         )
-        request = DaemonRequest(id="req-timeout", method="slow", timeout_ms=1)
+        request = DaemonRequest(
+            method="slow",
+            request_id="req-timeout",
+            timeout_ms=1,
+        )
         response = await dispatch_request(
             request,
             registry,
@@ -120,7 +178,7 @@ def test_dispatch_applies_request_timeout(tmp_path: Path):
 
     response = asyncio.run(scenario())
 
-    assert response.id == "req-timeout"
+    assert response.request_id == "req-timeout"
     assert response.ok is False
     assert response.error == {
         "code": "timeout",

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -40,7 +40,6 @@ def request_for(skill_dir: Path, **overrides: Any) -> DaemonRequest:
     }
     params.update(overrides)
     return DaemonRequest(
-        id="req-skillfs",
         method=METHOD_SKILLFS_NOTIFY_CHANGE,
         params=params,
     )

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
@@ -69,7 +69,7 @@ def _mock_daemon_call(result: ScanResult):
     """Context manager: patch daemon scan-prompt call to return *result*."""
     d = result.to_dict()
     daemon_response = DaemonResponse(
-        id="req-prompt",
+        request_id="req-prompt",
         ok=True,
         data=d,
         stdout=json.dumps(d, indent=2, ensure_ascii=False),
@@ -464,7 +464,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
         self,
     ) -> None:
         daemon_response = DaemonResponse(
-            id="req-prompt",
+            request_id="req-prompt",
             ok=False,
             stderr="prompt scanner is not ready: status=loading",
             exit_code=1,
@@ -544,7 +544,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
     def test_daemon_action_nonzero_exit_outputs_json_before_exit(self) -> None:
         data = _build_error_output("Scanner error: model exploded")
         daemon_response = DaemonResponse(
-            id="req-prompt",
+            request_id="req-prompt",
             ok=True,
             data=data,
             stdout=json.dumps(data, indent=2, ensure_ascii=False),
@@ -569,7 +569,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
     def test_daemon_action_nonzero_exit_outputs_text_before_exit(self) -> None:
         data = _build_error_output("Scanner error: model exploded")
         daemon_response = DaemonResponse(
-            id="req-prompt",
+            request_id="req-prompt",
             ok=True,
             data=data,
             stdout="{}",
@@ -592,7 +592,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
 
     def test_daemon_action_nonzero_exit_without_output_returns_error_json(self) -> None:
         daemon_response = DaemonResponse(
-            id="req-prompt",
+            request_id="req-prompt",
             ok=True,
             data={},
             stdout="",
@@ -627,7 +627,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
         )
         mock_client = mock_client_cls.return_value
         mock_client.call.return_value = DaemonResponse(
-            id="req-prompt",
+            request_id="req-prompt",
             ok=True,
             data={},
             stdout="{}",
@@ -645,7 +645,37 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
                 "call_id": "call-1",
                 "tool_call_id": "tool-1",
             },
+            caller="cli",
             timeout_ms=30_000,
+        )
+
+    @patch("agent_sec_cli.prompt_scanner.cli.DaemonClient")
+    def test_daemon_call_uses_canonical_trace_context_payload(
+        self, mock_client_cls
+    ) -> None:
+        init_process_trace_context(
+            TraceContext(
+                trace_id=" trace-1 ",
+                session_id="   ",
+                run_id="run-1",
+            )
+        )
+        mock_client = mock_client_cls.return_value
+        mock_client.call.return_value = DaemonResponse(
+            request_id="req-prompt",
+            ok=True,
+            data={},
+            stdout="{}",
+        )
+
+        _call_scan_prompt_daemon("hello", "standard", "user_input")
+
+        self.assertEqual(
+            mock_client.call.call_args.kwargs["trace_context"],
+            {
+                "trace_id": "trace-1",
+                "run_id": "run-1",
+            },
         )
 
 

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
@@ -514,7 +514,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
 
     def test_daemon_protocol_error_response_does_not_fallback(self) -> None:
         daemon_response = DaemonResponse(
-            id="req-prompt",
+            request_id="00000000-0000-4000-8000-000000000000",
             ok=False,
             stderr="request must be valid",
             exit_code=1,

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_invoke.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_invoke.py
@@ -6,13 +6,11 @@ from unittest.mock import MagicMock, patch
 from agent_sec_cli.correlation_context import (
     TraceContext,
     clear_process_trace_context,
-    get_current_trace_context,
     init_process_trace_context,
 )
 from agent_sec_cli.security_middleware import (
     _detect_caller,
     invoke,
-    invoke_with_context,
 )
 from agent_sec_cli.security_middleware.result import ActionResult
 
@@ -67,6 +65,42 @@ class TestInvoke(unittest.TestCase):
         _, call_kwargs = mock_backend.execute.call_args
         self.assertEqual(call_kwargs["command"], "ls")
         self.assertEqual(call_kwargs["cwd"], "/tmp")
+
+    @patch("agent_sec_cli.security_middleware.router.get_backend")
+    def test_invoke_uses_explicit_caller(self, mock_get_backend):
+        mock_backend = MagicMock()
+        mock_backend.execute.return_value = ActionResult(success=True)
+        mock_get_backend.return_value = mock_backend
+
+        invoke("prompt_scan", caller="daemon", text="hello")
+
+        ctx = mock_backend.execute.call_args.args[0]
+        _, call_kwargs = mock_backend.execute.call_args
+        self.assertEqual(ctx.caller, "daemon")
+        self.assertNotIn("caller", call_kwargs)
+
+    @patch("agent_sec_cli.security_middleware.router.get_backend")
+    @patch("agent_sec_cli.security_middleware.lifecycle.post_action")
+    @patch("agent_sec_cli.security_middleware.lifecycle.pre_action")
+    def test_invoke_logs_action_started_at_debug(
+        self,
+        mock_pre,
+        mock_post,
+        mock_get_backend,
+    ):
+        mock_backend = MagicMock()
+        mock_backend.execute.return_value = ActionResult(success=True)
+        mock_get_backend.return_value = mock_backend
+
+        with self.assertLogs("agent_sec_cli.security_middleware", level="DEBUG") as cm:
+            invoke("code_scan", code="safe")
+
+        record = cm.records[0]
+        self.assertEqual(record.levelname, "DEBUG")
+        self.assertEqual(record.message, "action started")
+        self.assertEqual(record.data, {"action": "code_scan", "caller": "unknown"})
+        self.assertIsInstance(record.trace_id, str)
+        self.assertTrue(record.trace_id)
 
     def test_invoke_unknown_action_raises(self):
         with self.assertLogs("agent_sec_cli.security_middleware", level="ERROR") as cm:
@@ -193,61 +227,32 @@ class TestInvoke(unittest.TestCase):
         self.assertEqual(cm.records[0].data["duration_ms"], 2500)
 
     @patch("agent_sec_cli.security_middleware.router.get_backend")
-    @patch("agent_sec_cli.security_middleware.lifecycle.post_action")
-    @patch("agent_sec_cli.security_middleware.lifecycle.pre_action")
-    def test_invoke_with_context_uses_explicit_caller_and_trace_context(
+    def test_invoke_uses_current_trace_context(
         self,
-        mock_pre,
-        mock_post,
         mock_get_backend,
     ):
+        init_process_trace_context(
+            TraceContext(
+                trace_id="trace-1",
+                session_id="session-1",
+                run_id="run-1",
+                call_id="call-1",
+                tool_call_id="tool-1",
+            )
+        )
         mock_backend = MagicMock()
         mock_backend.execute.return_value = ActionResult(success=True)
         mock_get_backend.return_value = mock_backend
 
-        result = invoke_with_context(
-            "prompt_scan",
-            caller="daemon",
-            trace_context={
-                "traceId": "trace-1",
-                "session_id": "session-1",
-                "runId": "run-1",
-                "call_id": "call-1",
-                "toolCallId": "tool-1",
-            },
-            text="hello",
-        )
+        invoke("prompt_scan", text="hello")
 
-        self.assertTrue(result.success)
         ctx = mock_backend.execute.call_args.args[0]
         self.assertEqual(ctx.action, "prompt_scan")
-        self.assertEqual(ctx.caller, "daemon")
         self.assertEqual(ctx.trace_id, "trace-1")
         self.assertEqual(ctx.session_id, "session-1")
         self.assertEqual(ctx.run_id, "run-1")
         self.assertEqual(ctx.call_id, "call-1")
         self.assertEqual(ctx.tool_call_id, "tool-1")
-        mock_pre.assert_called_once()
-        mock_post.assert_called_once()
-
-    @patch("agent_sec_cli.security_middleware.router.get_backend")
-    def test_invoke_with_context_suppresses_process_trace_context(
-        self,
-        mock_get_backend,
-    ):
-        init_process_trace_context(TraceContext(session_id="process-session"))
-        mock_backend = MagicMock()
-        mock_backend.execute.return_value = ActionResult(success=True)
-        mock_get_backend.return_value = mock_backend
-
-        invoke_with_context("prompt_scan", caller="daemon", text="hello")
-
-        ctx = mock_backend.execute.call_args.args[0]
-        self.assertIsNone(ctx.session_id)
-        self.assertEqual(
-            get_current_trace_context(),
-            TraceContext(session_id="process-session"),
-        )
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/tests/unit-test/test_cli_logging.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli_logging.py
@@ -2,12 +2,14 @@
 
 import json
 import logging
+import os
 import stat
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from agent_sec_cli import diagnostic_logging
 from agent_sec_cli.cli_logging import (
     CLI_LOG_BACKUP_COUNT,
     CLI_LOG_MAX_BYTES,
@@ -38,7 +40,6 @@ def reset_logging_state() -> None:
 
 def _clear_cli_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AGENT_SEC_CLI_LOG_LEVEL", raising=False)
-    monkeypatch.delenv("AGENT_SEC_CLI_LOG_DISABLED", raising=False)
     monkeypatch.delenv("AGENT_SEC_INVOCATION_ID", raising=False)
 
 
@@ -95,13 +96,12 @@ def test_log_level_env_accepts_supported_levels(
     assert config.level == level
 
 
-def test_disabled_env_wins_over_log_level(
+def test_log_level_off_disables_cli_logging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _clear_cli_env(monkeypatch)
     monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
-    monkeypatch.setenv("AGENT_SEC_CLI_LOG_LEVEL", "debug")
-    monkeypatch.setenv("AGENT_SEC_CLI_LOG_DISABLED", "true")
+    monkeypatch.setenv("AGENT_SEC_CLI_LOG_LEVEL", "off")
 
     config = resolve_cli_logging_config()
 
@@ -152,13 +152,32 @@ def test_default_path_resolution_failure_disables_cli_logging(
     assert config.log_file is None
 
 
-def test_handler_uses_configured_retention_constants(tmp_path: Path) -> None:
-    handler = JsonlCliLogHandler(tmp_path / "cli.jsonl")
+def test_handler_uses_configured_retention_constants(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_writers: list[tuple[Path, int, int]] = []
 
-    # JsonlEventWriter stores the configured size/count on private attributes.
-    # We assert on them because there is no public API to inspect them.
-    assert handler._writer._max_bytes == CLI_LOG_MAX_BYTES
-    assert handler._writer._backup_count == CLI_LOG_BACKUP_COUNT
+    class CapturingWriter:
+        def __init__(
+            self,
+            path: str | Path,
+            *,
+            max_bytes: int,
+            backup_count: int,
+        ) -> None:
+            created_writers.append((Path(path), max_bytes, backup_count))
+
+        def write(self, _record: dict[str, object]) -> None:
+            pass
+
+    monkeypatch.setattr(diagnostic_logging, "JsonlEventWriter", CapturingWriter)
+
+    JsonlCliLogHandler(tmp_path / "cli.jsonl")
+
+    assert created_writers == [
+        (tmp_path / "cli.jsonl", CLI_LOG_MAX_BYTES, CLI_LOG_BACKUP_COUNT)
+    ]
 
 
 def test_handler_writes_jsonl_with_invocation_and_trace_context(
@@ -191,6 +210,9 @@ def test_handler_writes_jsonl_with_invocation_and_trace_context(
 
     payload = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
     assert payload["level"] == "WARNING"
+    assert payload["component"] == "cli"
+    assert payload["event"] == "cli_log"
+    assert payload["pid"] == os.getpid()
     assert payload["logger"] == "agent_sec_cli.tests"
     assert payload["message"] == "action completed"
     assert payload["function"] == "test_function"
@@ -393,22 +415,31 @@ def test_setup_cli_logging_disables_root_propagation(
     assert logger.propagate is False
 
 
-@pytest.mark.parametrize(
-    ("env_name", "env_value"),
-    [
-        ("AGENT_SEC_CLI_LOG_DISABLED", "true"),
-        ("AGENT_SEC_CLI_LOG_LEVEL", "off"),
-    ],
-)
-def test_setup_cli_logging_preserves_root_propagation_when_logging_is_disabled(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    env_name: str,
-    env_value: str,
+def test_setup_cli_logging_does_not_mutate_cli_logger_level(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _clear_cli_env(monkeypatch)
     monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
-    monkeypatch.setenv(env_name, env_value)
+    monkeypatch.setenv("AGENT_SEC_CLI_LOG_LEVEL", "debug")
+    logger = logging.getLogger("agent_sec_cli")
+    original_level = logger.level
+
+    try:
+        logger.setLevel(logging.ERROR)
+        setup_cli_logging()
+
+        assert logger.level == logging.ERROR
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_setup_cli_logging_preserves_root_propagation_when_logging_is_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_cli_env(monkeypatch)
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("AGENT_SEC_CLI_LOG_LEVEL", "off")
     logger = logging.getLogger("agent_sec_cli")
     logger.propagate = True
 

--- a/src/agent-sec-core/tests/unit-test/test_diagnostic_logging.py
+++ b/src/agent-sec-core/tests/unit-test/test_diagnostic_logging.py
@@ -1,0 +1,257 @@
+"""Unit tests for shared diagnostic JSONL logging."""
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    reset_current_trace_context,
+    set_current_trace_context,
+)
+from agent_sec_cli.diagnostic_logging import (
+    BaseDiagnosticLogging,
+    JsonlDiagnosticLogger,
+    PythonLogRecordDiagnosticLogging,
+    record_correlation_overrides,
+    resolve_log_level,
+)
+
+
+def test_resolve_log_level_accepts_supported_values() -> None:
+    assert resolve_log_level("debug") == (True, logging.DEBUG)
+    assert resolve_log_level("INFO") == (True, logging.INFO)
+    assert resolve_log_level("off") == (False, logging.WARNING)
+    assert resolve_log_level("unknown") == (True, logging.WARNING)
+    assert resolve_log_level(None, default=logging.INFO) == (True, logging.INFO)
+
+
+def test_diagnostic_logger_writes_unified_jsonl_envelope(tmp_path: Path) -> None:
+    path = tmp_path / "diagnostic.jsonl"
+    logger = JsonlDiagnosticLogger(path=path, level=logging.INFO)
+
+    logger.write(
+        level=logging.INFO,
+        component="cli",
+        event="unit_event",
+        message="action completed",
+        logger_name="agent_sec_cli.tests",
+        function="test_function",
+        invocation_id="invocation-1",
+        request_id="request-1",
+        trace_context=TraceContext(
+            trace_id="trace-1",
+            session_id="session-1",
+            run_id="run-1",
+        ),
+        correlation_overrides={
+            "trace_id": "trace-override",
+            "session_id": 12345,
+            "call_id": "call-1",
+        },
+        data={"path": path, "items": [Path("relative")]},
+    )
+
+    payload = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["level"] == "INFO"
+    assert payload["component"] == "cli"
+    assert payload["event"] == "unit_event"
+    assert payload["message"] == "action completed"
+    assert payload["logger"] == "agent_sec_cli.tests"
+    assert payload["function"] == "test_function"
+    assert payload["pid"] == os.getpid()
+    assert payload["invocation_id"] == "invocation-1"
+    assert payload["request_id"] == "request-1"
+    assert payload["trace_id"] == "trace-override"
+    assert payload["session_id"] == "session-1"
+    assert payload["run_id"] == "run-1"
+    assert payload["call_id"] == "call-1"
+    assert payload["data"] == {"path": str(path), "items": ["relative"]}
+
+
+def test_diagnostic_logger_filters_below_configured_level(tmp_path: Path) -> None:
+    path = tmp_path / "diagnostic.jsonl"
+    logger = JsonlDiagnosticLogger(path=path, level=logging.WARNING)
+
+    logger.write(
+        level=logging.INFO,
+        component="cli",
+        event="unit_event",
+        message="below level",
+    )
+
+    assert not path.exists()
+
+
+def test_diagnostic_logger_records_error_traceback(tmp_path: Path) -> None:
+    path = tmp_path / "diagnostic.jsonl"
+    logger = JsonlDiagnosticLogger(path=path, level=logging.INFO)
+
+    try:
+        raise ValueError("bad value")
+    except ValueError:
+        logger.write(
+            level=logging.ERROR,
+            component="cli",
+            event="unit_error",
+            message="backend failed",
+            exc_info=sys.exc_info(),
+        )
+
+    payload = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["error_type"] == "ValueError"
+    assert payload["exception"] == "bad value"
+    assert "ValueError: bad value" in payload["traceback"]
+
+
+def test_diagnostic_logger_swallows_writer_failures() -> None:
+    class RaisingWriter:
+        def write(self, _record):
+            raise RuntimeError("writer failed")
+
+    logger = JsonlDiagnosticLogger(writer=RaisingWriter(), level=logging.INFO)
+
+    logger.write(
+        level=logging.INFO,
+        component="cli",
+        event="unit_event",
+        message="should not raise",
+    )
+
+
+def test_record_correlation_overrides_filters_none_fields() -> None:
+    record = logging.LogRecord(
+        name="agent_sec_cli.tests",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="record event",
+        args=(),
+        exc_info=None,
+    )
+    record.trace_id = "trace-1"
+    record.session_id = None
+    record.run_id = "run-1"
+
+    assert record_correlation_overrides(record) == {
+        "trace_id": "trace-1",
+        "run_id": "run-1",
+    }
+
+
+def test_base_diagnostic_logging_resolves_env_and_stream_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    class UnitDiagnosticLogging(BaseDiagnosticLogging):
+        component = "unit"
+        stream = "unit"
+        level_env = "UNIT_LOG_LEVEL"
+        default_level = logging.INFO
+
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIT_LOG_LEVEL", "debug")
+
+    config = UnitDiagnosticLogging().resolve_config()
+
+    assert config.enabled is True
+    assert config.level == logging.DEBUG
+    assert config.log_file == tmp_path / "unit.jsonl"
+
+    monkeypatch.setenv("UNIT_LOG_LEVEL", "off")
+    disabled = UnitDiagnosticLogging().resolve_config()
+
+    assert disabled.enabled is False
+    assert disabled.log_file is None
+
+
+def test_python_log_record_diagnostic_logging_writes_shared_schema(
+    tmp_path: Path,
+) -> None:
+    class UnitPythonLogging(PythonLogRecordDiagnosticLogging):
+        component = "unit"
+        stream = "unit"
+        python_logger_name = "agent_sec_cli.tests.diagnostic_logging"
+        event = "unit_log"
+        default_level = logging.INFO
+        propagate_on_enable = False
+        propagate_on_reset = True
+
+    path = tmp_path / "unit.jsonl"
+    diagnostic_logging = UnitPythonLogging()
+    diagnostic_logging.reset_for_tests()
+    logger = logging.getLogger("agent_sec_cli.tests.diagnostic_logging")
+    original_level = logger.level
+
+    try:
+        logger.setLevel(logging.INFO)
+        diagnostic_logging.setup(path=path)
+        logger.info(
+            "record event",
+            extra={
+                "data": {"kind": "unit"},
+                "trace_id": "trace-from-record",
+            },
+        )
+    finally:
+        diagnostic_logging.reset_for_tests()
+        logger.setLevel(original_level)
+
+    payload = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["component"] == "unit"
+    assert payload["event"] == "unit_log"
+    assert payload["message"] == "record event"
+    assert payload["logger"] == "agent_sec_cli.tests.diagnostic_logging"
+    assert payload["trace_id"] == "trace-from-record"
+    assert payload["data"] == {"kind": "unit"}
+
+
+def test_python_log_record_diagnostic_logging_prefers_explicit_trace_context(
+    tmp_path: Path,
+) -> None:
+    class UnitPythonLogging(PythonLogRecordDiagnosticLogging):
+        component = "unit"
+        stream = "unit"
+        python_logger_name = "agent_sec_cli.tests.diagnostic_logging.priority"
+        event = "unit_log"
+        default_level = logging.INFO
+        propagate_on_enable = False
+        propagate_on_reset = True
+
+    path = tmp_path / "unit.jsonl"
+    diagnostic_logging = UnitPythonLogging()
+    diagnostic_logging.reset_for_tests()
+    logger = logging.getLogger("agent_sec_cli.tests.diagnostic_logging.priority")
+    original_level = logger.level
+    token = set_current_trace_context(
+        TraceContext(
+            trace_id="ambient-trace",
+            session_id="ambient-session",
+            run_id="ambient-run",
+        )
+    )
+
+    try:
+        logger.setLevel(logging.INFO)
+        diagnostic_logging.setup(path=path)
+        logger.info(
+            "record event",
+            extra={
+                "trace_context": TraceContext(
+                    trace_id="explicit-trace",
+                    call_id="explicit-call",
+                ),
+            },
+        )
+    finally:
+        diagnostic_logging.reset_for_tests()
+        logger.setLevel(original_level)
+        reset_current_trace_context(token)
+
+    payload = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["trace_id"] == "explicit-trace"
+    assert payload["call_id"] == "explicit-call"
+    assert "session_id" not in payload
+    assert "run_id" not in payload


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Trace / Invocation Context

  - 删除 request-local invocation_id override。
  - invocation_id 只保留进程级 CLI invocation id。
  - trace context 仍保留 request-local override，用于 daemon request 和 background
    job。

  CLI → Daemon Trace / Caller Propagation

  - prompt-scanner CLI 调 daemon 时复用 canonical trace_context_to_payload()，避免
    手写 trace schema。

  - CLI 调 daemon 时显式标记 caller="cli"。
  - daemon request 协议支持可选 caller 字段，gateway 日志能把 caller 透传到
    request started/completed log。

  Daemon Prompt Scan Attribution

  - daemon scan-prompt handler 调 security middleware 时显式传 caller="daemon"。
  - security middleware invoke() 支持显式 caller。
  - 修复 daemon 执行 prompt scan 时 middleware diagnostic log 里 caller="unknown"
    的问题。

  Daemon Background Jobs

  - 新增 daemon-owned job trace context，每次 job run 自动生成标准 UUID trace id。
  - 新增 OneShotBackgroundJob，把 one-shot job 的 task/state/error/status
    lifecycle 收到 base class。

  - periodic job 每个 tick 自动获得独立 trace id。
  - job lifecycle 统一写 daemon diagnostic events：
      - daemon_job_started
      - daemon_job_completed
      - daemon_job_failed
      - daemon_job_cancelled

  - PromptModelPreloadJob 迁移到 base lifecycle，只保留 preload 业务逻辑和 prompt
    runtime state 更新。

  Diagnostic Logging Semantics

  - daemon background job logs、model load logs、job lifecycle logs 能共享同一个
    job trace id。

  - daemon request logs、middleware logs、security events 能共享 request trace
    id。

  - job trace 和 request trace 分离，不混用 CLI invocation id。
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
