### PR TITLE
fix(cosh): preserve custom model configuration

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1035,6 +1035,12 @@ export default {
   'Invalid auth method selected.': 'Invalid auth method selected.',
   'Failed to authenticate. Message: {{message}}':
     'Failed to authenticate. Message: {{message}}',
+  'Configuration verification failed. Please check your API Key and model settings.':
+    'Configuration verification failed. Please check your API Key and model settings.',
+  'Verifying and saving configuration...':
+    'Verifying and saving configuration...',
+  '{{authType}} configuration saved successfully, current model: {{model}}':
+    '{{authType}} configuration saved successfully, current model: {{model}}',
   '{{authType}} credentials saved successfully.':
     '{{authType}} credentials saved successfully.',
   // OpenAI API key validation errors

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -981,6 +981,11 @@ export default {
     '未找到 ANTHROPIC_BASE_URL 环境变量。',
   'Invalid auth method selected.': '选择了无效的认证方式。',
   'Failed to authenticate. Message: {{message}}': '认证失败。消息：{{message}}',
+  'Configuration verification failed. Please check your API Key and model settings.':
+    '配置验证失败。请检查您的 API Key 和模型设置。',
+  'Verifying and saving configuration...': '正在验证并保存配置...',
+  '{{authType}} configuration saved successfully, current model: {{model}}':
+    '{{authType}} 配置已保存，当前模型：{{model}}',
   '{{authType}} credentials saved successfully.':
     '{{authType}} 认证方式凭据已保存。',
   // OpenAI API key validation errors

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
@@ -18,6 +18,10 @@ vi.mock('../hooks/useQwenAuth.js', () => ({
   }),
 }));
 
+vi.mock('../../config/modelProvidersScope.js', () => ({
+  getPersistScopeForModelSelection: () => 'user',
+}));
+
 describe('useAuthCommand', () => {
   const createMockSettings = (): LoadedSettings =>
     ({
@@ -25,8 +29,12 @@ describe('useAuthCommand', () => {
         security: {
           auth: {},
         },
+        model: {},
       },
       setValue: vi.fn(),
+      isTrusted: false,
+      user: { settings: {} },
+      workspace: { settings: {} },
     }) as unknown as LoadedSettings;
 
   const createMockConfig = (): Config =>
@@ -84,5 +92,115 @@ describe('useAuthCommand', () => {
 
     expect(result.current.isAuthDialogOpen).toBe(true);
     expect(result.current.showBashOptionInAuthDialog).toBe(false);
+  });
+
+  it('should persist effective model to model.name and security.auth.openaiModel', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    const addItem = vi.fn();
+    vi.mocked(config.refreshAuth).mockResolvedValue(undefined);
+    vi.mocked(config.getContentGeneratorConfig).mockReturnValue({
+      model: 'my-model',
+    } as ReturnType<Config['getContentGeneratorConfig']>);
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, false),
+    );
+
+    // Step 1: set pendingAuthType (simulates user selecting OpenAI in AuthDialog)
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+
+    // Step 2: submit credentials (simulates OpenAIKeyPrompt submission)
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI, {
+        apiKey: 'sk-test',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'my-model',
+      });
+    });
+
+    const calls = vi.mocked(settings.setValue).mock.calls;
+    const modelNameCall = calls.find(([, key]) => key === 'model.name');
+    const openaiModelCall = calls.find(
+      ([, key]) => key === 'security.auth.openaiModel',
+    );
+    expect(modelNameCall).toBeDefined();
+    expect(modelNameCall![2]).toBe('my-model');
+    expect(openaiModelCall).toBeDefined();
+    expect(openaiModelCall![2]).toBe('my-model');
+  });
+
+  it('should persist validated fallback model over submitted model', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    const addItem = vi.fn();
+    vi.mocked(config.refreshAuth).mockResolvedValue(undefined);
+    vi.mocked(config.getContentGeneratorConfig).mockReturnValue({
+      model: 'qwen3-coder-plus',
+    } as ReturnType<Config['getContentGeneratorConfig']>);
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, false),
+    );
+
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI, {
+        apiKey: 'sk-test',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'my-model',
+      });
+    });
+
+    const calls = vi.mocked(settings.setValue).mock.calls;
+    const modelNameCall = calls.find(([, key]) => key === 'model.name');
+    const openaiModelCall = calls.find(
+      ([, key]) => key === 'security.auth.openaiModel',
+    );
+    expect(modelNameCall).toBeDefined();
+    expect(modelNameCall![2]).toBe('qwen3-coder-plus');
+    expect(openaiModelCall).toBeDefined();
+    expect(openaiModelCall![2]).toBe('qwen3-coder-plus');
+  });
+
+  it('should set authError and keep isAuthenticating for OpenAI on failure', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    const addItem = vi.fn();
+    vi.mocked(config.refreshAuth).mockRejectedValue(
+      new Error('Invalid API key'),
+    );
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, false),
+    );
+
+    // Step 1: set pendingAuthType
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+
+    // Step 2: submit credentials that will fail
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI, {
+        apiKey: 'sk-bad',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'test-model',
+      });
+    });
+
+    expect(result.current.authError).toBeTruthy();
+    expect(result.current.isAuthenticating).toBe(true);
+
+    const errorItem = addItem.mock.calls.find(([item]) => {
+      const historyItem = item as Omit<import('../types.js').HistoryItem, 'id'>;
+      return historyItem.type === 'error';
+    });
+    expect(errorItem).toBeDefined();
   });
 });

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -113,11 +113,16 @@ export const useAuthCommand = (
       // For OpenAI auth, keep OpenAIKeyPrompt open to show error
       // by NOT calling onAuthError which would open AuthDialog
       if (pendingAuthType === AuthType.USE_OPENAI) {
-        // Only set authError state, don't open AuthDialog
-        // OpenAIKeyPrompt will read authError from UIStateContext and display it
         setAuthError(errorMessage);
-        // Keep isAuthenticating=true so OpenAIKeyPrompt stays open
-        // User can press Escape to cancel and go back to AuthDialog
+        addItem(
+          {
+            type: MessageType.ERROR,
+            text: t(
+              'Configuration verification failed. Please check your API Key and model settings.',
+            ),
+          },
+          Date.now(),
+        );
       } else {
         // For other auth types, use onAuthError which opens AuthDialog
         setIsAuthenticating(false);
@@ -125,7 +130,7 @@ export const useAuthCommand = (
         onAuthError(errorMessage);
       }
     },
-    [translateAuthError, onAuthError, pendingAuthType, config],
+    [translateAuthError, onAuthError, pendingAuthType, config, addItem],
   );
 
   const handleAuthSuccess = useCallback(
@@ -140,42 +145,30 @@ export const useAuthCommand = (
           authType,
         );
 
-        // Persist model from ContentGenerator config (handles fallback cases)
-        // This ensures that when syncAfterAuthRefresh falls back to default model,
-        // it gets persisted to settings.json
         const contentGeneratorConfig = config.getContentGeneratorConfig();
-        if (contentGeneratorConfig?.model) {
-          settings.setValue(
-            authTypeScope,
-            'model.name',
-            contentGeneratorConfig.model,
-          );
-          // 同时写入按认证方式隔离的模型字段，避免不同认证方式互相覆盖
+        const submittedModel = credentials?.model?.trim();
+        // For OpenAI auth, persist the model from the post-refresh content
+        // generator config. That is the model validateApiKey() actually checked.
+        const resolvedModel =
+          authType === AuthType.USE_OPENAI
+            ? contentGeneratorConfig?.model
+            : contentGeneratorConfig?.model || submittedModel;
+
+        if (resolvedModel) {
+          settings.setValue(authTypeScope, 'model.name', resolvedModel);
           if (authType === AuthType.USE_OPENAI) {
             settings.setValue(
               authTypeScope,
               'security.auth.openaiModel',
-              contentGeneratorConfig.model,
+              resolvedModel,
             );
           } else if (authType === AuthType.USE_ALIYUN) {
             settings.setValue(
               authTypeScope,
               'security.auth.aliyunModel',
-              contentGeneratorConfig.model,
+              resolvedModel,
             );
           }
-        } else if (authType === AuthType.USE_ALIYUN && credentials?.model) {
-          // For Aliyun auth, specifically preserve the user-entered model
-          settings.setValue(
-            authTypeScope,
-            'model.name',
-            credentials.model.trim(),
-          );
-          settings.setValue(
-            authTypeScope,
-            'security.auth.aliyunModel',
-            credentials.model.trim(),
-          );
         }
 
         if (credentials) {
@@ -209,13 +202,21 @@ export const useAuthCommand = (
       const authEvent = new AuthEvent(authType, 'manual', 'success');
       logAuth(config, authEvent);
 
-      // Show success message
+      // Show success message with resolved model name
+      const contentGeneratorConfig = config.getContentGeneratorConfig();
+      const savedModel =
+        authType === AuthType.USE_OPENAI
+          ? contentGeneratorConfig?.model
+          : contentGeneratorConfig?.model || credentials?.model?.trim();
       addItem(
         {
           type: MessageType.INFO,
-          text: t('{{authType}} credentials saved successfully.', {
-            authType,
-          }),
+          text: savedModel
+            ? t(
+                '{{authType}} configuration saved successfully, current model: {{model}}',
+                { authType, model: savedModel },
+              )
+            : t('{{authType}} credentials saved successfully.', { authType }),
         },
         Date.now(),
       );
@@ -313,6 +314,13 @@ export const useAuthCommand = (
         // Only perform authentication when credentials are provided (from OpenAIKeyPrompt)
         // When credentials are undefined, DialogManager will show OpenAIKeyPrompt for user input
         if (credentials && 'apiKey' in credentials) {
+          addItem(
+            {
+              type: MessageType.INFO,
+              text: t('Verifying and saving configuration...'),
+            },
+            Date.now(),
+          );
           // Pass settings.model.generationConfig to updateCredentials so it can be merged
           // after clearing provider-sourced config. This ensures settings.json generationConfig
           // fields (e.g., samplingParams, timeout) are preserved.
@@ -408,6 +416,7 @@ export const useAuthCommand = (
       isProviderManagedModel,
       onAuthError,
       settings,
+      addItem,
     ],
   );
 

--- a/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
@@ -531,4 +531,86 @@ describe('OpenAIKeyPrompt', () => {
       expect(lastFrame()).not.toContain('abc*');
     });
   });
+
+  // ─── Model retention on re-entry ──────────────────────────────────────────
+
+  describe('Model retention on re-entry', () => {
+    const makeKey = (overrides: Partial<Key> = {}): Key => ({
+      name: '',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: '',
+      ...overrides,
+    });
+
+    function getLatestHandler(): (key: Key) => void {
+      const mock = vi.mocked(useKeypress);
+      return mock.mock.calls[mock.mock.calls.length - 1]![0];
+    }
+
+    async function pressKey(key: Partial<Key>): Promise<void> {
+      await act(() => {
+        getLatestHandler()(makeKey(key));
+      });
+    }
+
+    it('should display defaultModel instead of provider default when re-entering config', () => {
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          defaultBaseUrl="https://dashscope.aliyuncs.com/compatible-mode/v1"
+          defaultModel="custom-saved-model"
+          defaultApiKey="sk-existing"
+        />,
+      );
+      const output = lastFrame()!;
+      expect(output).toContain('custom-saved-model');
+      expect(output).not.toContain('qwen3-coder-plus');
+    });
+
+    it('should preserve defaultModel when navigating within initial subProvider', async () => {
+      // DashScope Beijing is the initial subProvider (index [0, 0])
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          defaultBaseUrl="https://dashscope.aliyuncs.com/compatible-mode/v1"
+          defaultModel="custom-saved-model"
+          defaultApiKey="sk-existing"
+        />,
+      );
+
+      // Enter subProvider menu
+      await pressKey({ name: 'return', sequence: '\r' });
+      // Navigate to apiKey
+      await pressKey({ name: 'return', sequence: '\r' });
+      // Navigate to model field
+      await pressKey({ name: 'return', sequence: '\r' });
+
+      expect(lastFrame()).toContain('custom-saved-model');
+    });
+
+    it('should use new provider default model when switching to a different provider', async () => {
+      const { lastFrame } = render(
+        <OpenAIKeyPrompt
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          defaultBaseUrl="https://dashscope.aliyuncs.com/compatible-mode/v1"
+          defaultModel="custom-saved-model"
+          defaultApiKey="sk-existing"
+        />,
+      );
+
+      // Navigate down to DeepSeek (index 3 from DashScope at 0)
+      await pressKey({ name: 'down', sequence: '' }); // DashScope Coding Plan
+      await pressKey({ name: 'down', sequence: '' }); // DashScope Token Plan
+      await pressKey({ name: 'down', sequence: '' }); // DeepSeek
+
+      expect(lastFrame()).toContain('deepseek-chat');
+      expect(lastFrame()).not.toContain('custom-saved-model');
+    });
+  });
 });

--- a/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
@@ -247,7 +247,13 @@ export function OpenAIKeyPrompt({
   const applyProvider = (pIdx: number, sIdx: number) => {
     const p = getEffectiveProvider(pIdx, sIdx);
     setBaseUrl(p.id !== 'custom' ? p.baseUrl : '');
-    setModel(p.id !== 'custom' ? p.defaultModel : '');
+    const [initP, initS] = initialIndices;
+    const isInitialProvider = pIdx === initP && sIdx === initS;
+    if (isInitialProvider && defaultModel) {
+      setModel(defaultModel);
+    } else {
+      setModel(p.id !== 'custom' ? p.defaultModel : '');
+    }
   };
 
   const handleProviderChange = (newIndex: number) => {


### PR DESCRIPTION
## Description

Fixes the custom provider configuration flow in `cosh`.

This change keeps the user-selected OpenAI-compatible model from being silently reset to the provider default, and adds clear status messages when verifying, saving, or failing configuration.

## Related Issue

closes #886

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm exec eslint -- packages/cli/src/ui/auth/useAuth.ts packages/cli/src/ui/components/OpenAIKeyPrompt.tsx packages/cli/src/ui/auth/useAuth.test.ts packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
```

Result: passed with no output.

```bash
cd src/copilot-shell/packages/cli
npm test -- src/ui/components/OpenAIKeyPrompt.test.tsx src/ui/auth/useAuth.test.ts
```

Result: 35 tests passed.

```bash
cd src/copilot-shell
npm run typecheck --workspace=packages/cli
```
