### PR TITLE
fix(sight): rename token --hours to --last for CLI consistency

### DIFF
--- a/src/agentsight/src/bin/cli/token.rs
+++ b/src/agentsight/src/bin/cli/token.rs
@@ -14,8 +14,8 @@ pub struct TokenCommand {
     pub period: Option<String>,
 
     /// Query last N hours
-    #[structopt(long)]
-    pub hours: Option<u64>,
+    #[structopt(long, alias = "hours")]
+    pub last: Option<u64>,
 
     /// Compare with previous period
     #[structopt(long)]
@@ -49,7 +49,7 @@ impl TokenCommand {
         let query = agentsight::TokenQuery::new(&store);
 
         // Execute query
-        let result = if let Some(hours) = self.hours {
+        let result = if let Some(hours) = self.last {
             if self.compare {
                 query.by_hours_with_compare(hours)
             } else {


### PR DESCRIPTION
## Summary

Rename `token --hours` to `token --last` for consistency with `audit --last`, `interruption list --last`, and `skill-metrics --last`. The old `--hours` flag is preserved as an alias for backward compatibility.

## Test plan

- [x] `agentsight token --last 24` works
- [x] `agentsight token --hours 24` still works (alias)
- [x] 573 unit tests pass
- [x] Verified on ECS

🤖 Generated with [Claude Code](https://claude.com/claude-code)