### PR TITLE
fix(sight): downgrade detach pid-map error to debug

### DIFF
--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -573,7 +573,7 @@ impl AgentSight {
     pub fn detach_process(&mut self, pid: u32, agent_name: &str) {
         log::debug!("Detaching from pid {}, agent name: {}", pid, agent_name);
         let _ = self.probes.remove_traced_pid(pid).inspect_err(|e| {
-            log::error!("failed to delete {pid} from traced pid map: {e}");
+            log::debug!("traced pid {pid} already removed from BPF map (expected race with sched_process_exit): {e}");
         });
         self.probes.detach_ssl_probes(pid);
     }


### PR DESCRIPTION
## Summary

Downgrade the `remove_traced_pid` failure log from ERROR to DEBUG.

## Root cause

When a traced agent process exits, two cleanup paths race:

1. **BPF (kernel, synchronous):** `sched_process_exit` handler calls `bpf_map_delete_elem(&traced_processes, &pid)` — removes PID from the BPF map immediately
2. **Userspace (async):** ProcMon exit event arrives via ring buffer → `detach_process` → `remove_traced_pid` — tries to delete the same key, gets ENOENT

This is an expected race, not an error. The BPF-side cleanup is the fast path; the userspace removal is a best-effort fallback that naturally fails when the BPF side wins.

## How we found it

Dog-fooding agentsight 0.6.0 on ECS with `cosh -p qwen-plus`. The journal showed:

```
INFO  Attached to agent: Cosh (pid=1585392)
ERROR failed to delete 1585392 from traced pid map: failed to remove traced pid
```

The ERROR log is misleading — data capture was working correctly, but the log made it look like something was broken.

## Test plan

- [x] 573 unit tests pass (local + ECS)
- [x] No logic change — only log level (error → debug) and message clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)