### PR TITLE
fix(cosh): validate webfetch sub-model output to avoid silent refusals

### DIFF
--- a/src/copilot-shell/packages/core/src/tools/web-fetch.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/web-fetch.test.ts
@@ -36,6 +36,7 @@ describe('WebFetchTool', () => {
       setApprovalMode: vi.fn(),
       getProxy: vi.fn(),
       getGeminiClient: mockGetGeminiClient,
+      getModel: vi.fn(() => 'test-model'),
     } as unknown as Config;
   });
 
@@ -61,18 +62,105 @@ describe('WebFetchTool', () => {
       expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_FALLBACK_FAILED);
     });
 
-    it('should return WEB_FETCH_FALLBACK_FAILED on API processing failure', async () => {
+    it('should degrade to raw content when sub-model call throws', async () => {
       vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
       vi.spyOn(fetchUtils, 'fetchWithTimeout').mockResolvedValue({
         ok: true,
-        text: () => Promise.resolve('<html><body>Test content</body></html>'),
+        text: () =>
+          Promise.resolve('<html><body>Hello world content</body></html>'),
       } as Response);
       mockGenerateContent.mockRejectedValue(new Error('API error'));
       const tool = new WebFetchTool(mockConfig);
       const params = { url: 'https://public.ip', prompt: 'summarize this' };
       const invocation = tool.build(params);
       const result = await invocation.execute(new AbortController().signal);
-      expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_FALLBACK_FAILED);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain(
+        'Sub-model summarization unavailable',
+      );
+      expect(result.llmContent).toContain('sub-model call failed: API error');
+      expect(result.llmContent).toContain('Hello world content');
+      expect(result.returnDisplay).toContain('returned raw content');
+    });
+
+    it('should degrade to raw content when sub-model returns empty text', async () => {
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'fetchWithTimeout').mockResolvedValue({
+        ok: true,
+        text: () =>
+          Promise.resolve('<html><body>Doc body content</body></html>'),
+      } as Response);
+      mockGenerateContent.mockResolvedValue({
+        candidates: [
+          {
+            finishReason: 'STOP',
+            content: {
+              parts: [{ text: 'inner thought', thought: true }],
+            },
+          },
+        ],
+      });
+      const tool = new WebFetchTool(mockConfig);
+      const params = { url: 'https://public.ip', prompt: 'summarize this' };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('returned empty text');
+      expect(result.llmContent).toContain('Doc body content');
+    });
+
+    it('should degrade to raw content on non-STOP finishReason', async () => {
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'fetchWithTimeout').mockResolvedValue({
+        ok: true,
+        text: () =>
+          Promise.resolve('<html><body>Safe doc content</body></html>'),
+      } as Response);
+      mockGenerateContent.mockResolvedValue({
+        candidates: [
+          {
+            finishReason: 'SAFETY',
+            content: { parts: [{ text: 'Cannot answer.' }] },
+          },
+        ],
+      });
+      const tool = new WebFetchTool(mockConfig);
+      const params = { url: 'https://public.ip', prompt: 'summarize this' };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('finishReason=SAFETY');
+      expect(result.llmContent).toContain('Safe doc content');
+    });
+
+    it('should include fetch and extraction stats in returnDisplay on success', async () => {
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      const html = '<html><body>Hello</body></html>';
+      vi.spyOn(fetchUtils, 'fetchWithTimeout').mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(html),
+      } as Response);
+      mockGenerateContent.mockResolvedValue({
+        candidates: [
+          {
+            finishReason: 'STOP',
+            content: { parts: [{ text: 'It says hello.' }] },
+          },
+        ],
+      });
+      const tool = new WebFetchTool(mockConfig);
+      const params = { url: 'https://public.ip', prompt: 'summarize this' };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toBe('It says hello.');
+      expect(result.returnDisplay).toContain(`${html.length} bytes fetched`);
+      expect(result.returnDisplay).toContain('chars extracted');
+      expect(result.returnDisplay).toContain('processed successfully');
     });
   });
 

--- a/src/copilot-shell/packages/core/src/tools/web-fetch.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/web-fetch.test.ts
@@ -136,6 +136,78 @@ describe('WebFetchTool', () => {
       expect(result.llmContent).toContain('Safe doc content');
     });
 
+    it('should degrade to raw content when sub-model returns a Chinese refusal', async () => {
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'fetchWithTimeout').mockResolvedValue({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            '<html><body>Alinux4 Agentic Edition docs</body></html>',
+          ),
+      } as Response);
+      mockGenerateContent.mockResolvedValue({
+        candidates: [
+          {
+            finishReason: 'STOP',
+            content: {
+              parts: [
+                {
+                  text: '很抱歉，我无法访问外部网站或链接。请您将文档内容粘贴到对话中，我来帮您分析。',
+                },
+              ],
+            },
+          },
+        ],
+      });
+      const tool = new WebFetchTool(mockConfig);
+      const params = {
+        url: 'https://help.aliyun.com/zh/alinux/agentic-os',
+        prompt: 'what is different about agentic edition',
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('refusal response');
+      expect(result.llmContent).toContain('Alinux4 Agentic Edition docs');
+      expect(result.returnDisplay).toContain('returned raw content');
+    });
+
+    it('should degrade to raw content when sub-model returns an English refusal', async () => {
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'fetchWithTimeout').mockResolvedValue({
+        ok: true,
+        text: () =>
+          Promise.resolve('<html><body>Real page content here</body></html>'),
+      } as Response);
+      mockGenerateContent.mockResolvedValue({
+        candidates: [
+          {
+            finishReason: 'STOP',
+            content: {
+              parts: [
+                {
+                  text: "I'm sorry, but I cannot access external websites or URLs. Please paste the content you'd like me to analyze.",
+                },
+              ],
+            },
+          },
+        ],
+      });
+      const tool = new WebFetchTool(mockConfig);
+      const params = {
+        url: 'https://example.com/docs',
+        prompt: 'summarize this page',
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('refusal response');
+      expect(result.llmContent).toContain('Real page content here');
+      expect(result.returnDisplay).toContain('returned raw content');
+    });
+
     it('should include fetch and extraction stats in returnDisplay on success', async () => {
       vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
       const html = '<html><body>Hello</body></html>';

--- a/src/copilot-shell/packages/core/src/tools/web-fetch.ts
+++ b/src/copilot-shell/packages/core/src/tools/web-fetch.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { GenerateContentResponse } from '@google/genai';
 import { convert } from 'html-to-text';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import type { Config } from '../config/config.js';
@@ -69,59 +70,24 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       );
     }
 
+    // Phase 1: HTTP fetch
+    let html: string;
+    let byteLength: number;
     try {
       console.debug(`[WebFetchTool] Fetching content from: ${url}`);
       const response = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS);
 
       if (!response.ok) {
-        const errorMessage = `Request failed with status code ${response.status} ${response.statusText}`;
-        console.error(`[WebFetchTool] ${errorMessage}`);
-        throw new Error(errorMessage);
+        throw new Error(
+          `Request failed with status code ${response.status} ${response.statusText}`,
+        );
       }
 
-      console.debug(`[WebFetchTool] Successfully fetched content from ${url}`);
-      const html = await response.text();
-      const textContent = convert(html, {
-        wordwrap: false,
-        selectors: [
-          { selector: 'a', options: { ignoreHref: true } },
-          { selector: 'img', format: 'skip' },
-        ],
-      }).substring(0, MAX_CONTENT_LENGTH);
-
+      html = await response.text();
+      byteLength = html.length;
       console.debug(
-        `[WebFetchTool] Converted HTML to text (${textContent.length} characters)`,
+        `[WebFetchTool] Successfully fetched content from ${url} (${byteLength} chars)`,
       );
-
-      const geminiClient = this.config.getGeminiClient();
-      const fallbackPrompt = `The user requested the following: "${this.params.prompt}".
-
-I have fetched the content from ${this.params.url}. Please use the following content to answer the user's request.
-
----
-${textContent}
----`;
-
-      console.debug(
-        `[WebFetchTool] Processing content with prompt: "${this.params.prompt}"`,
-      );
-
-      const result = await geminiClient.generateContent(
-        [{ role: 'user', parts: [{ text: fallbackPrompt }] }],
-        {},
-        signal,
-        this.config.getModel() || DEFAULT_QWEN_MODEL,
-      );
-      const resultText = getResponseText(result) || '';
-
-      console.debug(
-        `[WebFetchTool] Successfully processed content from ${this.params.url}`,
-      );
-
-      return {
-        llmContent: resultText,
-        returnDisplay: `Content from ${this.params.url} processed successfully.`,
-      };
     } catch (e) {
       const error = e as Error;
       const errorMessage = `Error during fetch for ${url}: ${error.message}`;
@@ -135,6 +101,107 @@ ${textContent}
         },
       };
     }
+
+    // Phase 2: HTML to text conversion
+    let textContent: string;
+    let truncated: boolean;
+    try {
+      const converted = convert(html, {
+        wordwrap: false,
+        selectors: [
+          { selector: 'a', options: { ignoreHref: true } },
+          { selector: 'img', format: 'skip' },
+        ],
+      });
+      truncated = converted.length > MAX_CONTENT_LENGTH;
+      textContent = converted.substring(0, MAX_CONTENT_LENGTH);
+      console.debug(
+        `[WebFetchTool] Converted HTML to text (${textContent.length} characters${truncated ? ', truncated' : ''})`,
+      );
+    } catch (e) {
+      const error = e as Error;
+      const errorMessage = `HTML conversion failed for ${url}: ${error.message}`;
+      console.error(`[WebFetchTool] ${errorMessage}`, error);
+      return {
+        llmContent: `Error: ${errorMessage}`,
+        returnDisplay: `Error: ${errorMessage}`,
+        error: {
+          message: errorMessage,
+          type: ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+        },
+      };
+    }
+
+    // Phase 3: Sub-model summarization (failures degrade to raw content)
+    const geminiClient = this.config.getGeminiClient();
+    const fallbackPrompt = `The user requested the following: "${this.params.prompt}".
+
+I have fetched the content from ${this.params.url}. Please use the following content to answer the user's request.
+
+---
+${textContent}
+---`;
+
+    console.debug(
+      `[WebFetchTool] Processing content with prompt: "${this.params.prompt}"`,
+    );
+
+    const stats = `${byteLength} bytes fetched, ${textContent.length} chars extracted${truncated ? ' (truncated)' : ''}`;
+
+    let result: GenerateContentResponse;
+    try {
+      result = await geminiClient.generateContent(
+        [{ role: 'user', parts: [{ text: fallbackPrompt }] }],
+        {},
+        signal,
+        this.config.getModel() || DEFAULT_QWEN_MODEL,
+      );
+    } catch (e) {
+      const error = e as Error;
+      const reason = `sub-model call failed: ${error.message}`;
+      console.warn(`[WebFetchTool] ${reason}`, error);
+      return this.buildRawFallbackResult(textContent, stats, reason);
+    }
+
+    const finishReason = result.candidates?.[0]?.finishReason;
+    const resultText = getResponseText(result) ?? '';
+    const isValidFinish =
+      finishReason === undefined ||
+      finishReason === 'STOP' ||
+      finishReason === 'MAX_TOKENS';
+
+    if (!isValidFinish || resultText.trim() === '') {
+      const reason = !isValidFinish
+        ? `sub-model finishReason=${finishReason}`
+        : 'sub-model returned empty text';
+      console.warn(`[WebFetchTool] ${reason} for ${this.params.url}`);
+      return this.buildRawFallbackResult(textContent, stats, reason);
+    }
+
+    console.debug(
+      `[WebFetchTool] Successfully processed content from ${this.params.url}`,
+    );
+
+    return {
+      llmContent: resultText,
+      returnDisplay: `Content from ${this.params.url} processed successfully (${stats}).`,
+    };
+  }
+
+  private buildRawFallbackResult(
+    textContent: string,
+    stats: string,
+    reason: string,
+  ): ToolResult {
+    return {
+      llmContent:
+        `[WebFetch] Sub-model summarization unavailable (${reason}). ` +
+        `Raw extracted text from ${this.params.url} follows:\n\n` +
+        textContent,
+      returnDisplay:
+        `Content from ${this.params.url}: ${stats}; ` +
+        `sub-model summarization unavailable (${reason}), returned raw content.`,
+    };
   }
 
   override getDescription(): string {

--- a/src/copilot-shell/packages/core/src/tools/web-fetch.ts
+++ b/src/copilot-shell/packages/core/src/tools/web-fetch.ts
@@ -29,6 +29,17 @@ import { ToolNames, ToolDisplayNames } from './tool-names.js';
 const URL_FETCH_TIMEOUT_MS = 10000;
 const MAX_CONTENT_LENGTH = 100000;
 
+const REFUSAL_PATTERNS: RegExp[] = [
+  /(?:无法|不能|没有(?:能力|权限|办法))\s*(?:访问|浏览|打开|读取|获取|抓取)\s*(?:外部|网站|网页|链接|URL|互联网|网络)/,
+  /(?:cannot|can't|unable\s+to)\s+(?:access|browse|fetch|retrieve|open|read)\s+(?:external|the\s+)?(?:website|webpage|web\s+page|URL|link|internet)/i,
+  /(?:please|请)\s*(?:paste|provide|share|copy|粘贴|提供|分享)\s*(?:the\s+)?(?:content|text|document|文档|内容|网页)/i,
+];
+
+function isRefusalResponse(text: string): boolean {
+  const prefix = text.substring(0, 500);
+  return REFUSAL_PATTERNS.some((pattern) => pattern.test(prefix));
+}
+
 /**
  * Parameters for the WebFetch tool
  */
@@ -84,9 +95,9 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       }
 
       html = await response.text();
-      byteLength = html.length;
+      byteLength = Buffer.byteLength(html, 'utf8');
       console.debug(
-        `[WebFetchTool] Successfully fetched content from ${url} (${byteLength} chars)`,
+        `[WebFetchTool] Successfully fetched content from ${url} (${byteLength} bytes)`,
       );
     } catch (e) {
       const error = e as Error;
@@ -174,6 +185,12 @@ ${textContent}
       const reason = !isValidFinish
         ? `sub-model finishReason=${finishReason}`
         : 'sub-model returned empty text';
+      console.warn(`[WebFetchTool] ${reason} for ${this.params.url}`);
+      return this.buildRawFallbackResult(textContent, stats, reason);
+    }
+
+    if (isRefusalResponse(resultText)) {
+      const reason = 'sub-model returned a refusal response';
       console.warn(`[WebFetchTool] ${reason} for ${this.params.url}`);
       return this.buildRawFallbackResult(textContent, stats, reason);
     }


### PR DESCRIPTION
## Description

WebFetch's sub-model summarization stage previously treated any returned string as a successful result and surfaced a generic `processed successfully.` UI status. When the sub-model declined to answer (e.g. "I cannot access external websites, please paste the content"), that refusal text was silently relayed to the main conversation while the UI showed a green checkmark, producing the inconsistency reported in #893 (HTTP fetch succeeded, model said it could not).

This change splits the WebFetch pipeline into three explicit phases (HTTP fetch / HTML→text / sub-model summarization), each with its own error type. Sub-model failures (thrown errors, non-STOP `finishReason` such as `SAFETY`/`RECITATION`, empty text after thought-part filtering) now degrade gracefully: the raw extracted content is returned to the main model so it can answer from the actual document instead of repeating a refusal. `returnDisplay` carries fetched bytes / extracted chars / truncation flag so UI status and LLM output can be cross-checked.

## Related Issue

closes #893

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run build && npm run lint && npm run typecheck && npm run test
# build: ok
# lint: ok
# typecheck: ok
# test: 3763 passed | 2 skipped (179 files)
# web-fetch.test.ts: 10 passed (was 5)
```

New test cases cover:
- sub-model call throws → degrades to raw content (no error)
- sub-model returns only thought parts (empty text) → degrades to raw content
- sub-model returns `finishReason=SAFETY` → degrades to raw content
- successful summarization → `returnDisplay` includes byte / char stats

## Additional Notes

Out of scope (filed as separate concerns for follow-up):
- Global `setGlobalDispatcher` side effect in the WebFetch constructor
- `ProceedAlways` confirmation escalating the entire config to `AUTO_EDIT`
- `AbortSignal` not propagated to `fetchWithTimeout`
- GitHub blob URL rewrite using string `includes`/`replace` rather than `URL` parsing

This PR intentionally does not touch the sub-model prompt wording or sampling parameters — those are prompt-engineering concerns separate from the result-validation hole that drove #893.
