### PR TITLE
fix(anolisa-cli): improve missing catalog hint with explanation and examples

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -120,7 +120,10 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
 fn render_missing_catalog(ctx: &CliContext) -> Result<(), CliError> {
     let config_path = common::resolve_layout(ctx).etc_dir.join("repo.toml");
     let warning = format!(
-        "component catalog is not configured; set ANOLISA_CATALOG_URL or configure [backends.raw].base_url in {}",
+        "component catalog is not configured; \
+         the catalog provides the list of available components — without it, \
+         `anolisa ls` cannot display anything. \
+         Set ANOLISA_CATALOG_URL or configure [backends.raw].base_url in {}",
         config_path.display()
     );
 
@@ -146,10 +149,21 @@ fn render_missing_catalog(ctx: &CliContext) -> Result<(), CliError> {
     if !ctx.quiet {
         let color = Palette::new(ctx.no_color);
         println!("{}", color.muted("no component catalog configured"));
-        println!("  {}", color.label("config:"));
+        println!();
+        println!("  The component catalog provides the list of available ANOLISA components.");
+        println!("  Without it, `anolisa ls` cannot display anything.");
+        println!();
+        println!("  {}", color.label("config file:"));
         println!("    {}", config_path.display());
-        println!("  {}", color.label("hint:"));
-        println!("    set ANOLISA_CATALOG_URL or configure [backends.raw].base_url in repo.toml");
+        println!();
+        println!("  {}", color.label("option 1 — environment variable:"));
+        println!(
+            "    export ANOLISA_CATALOG_URL=https://example.com/anolisa-releases/anolisa/v1/catalog.json"
+        );
+        println!();
+        println!("  {}", color.label("option 2 — add to repo.toml:"));
+        println!("    [backends.raw]");
+        println!("    base_url = \"https://example.com/anolisa-releases/anolisa/v1/\"");
     }
     Ok(())
 }


### PR DESCRIPTION
## Description

This pull request improves the user experience when the component catalog is missing in the `anolisa ls` command by clarifying error messages and providing more detailed setup instructions.

Enhanced error and configuration guidance:

* Expanded the warning message in `render_missing_catalog` to explain the importance of the component catalog and why `anolisa ls` cannot display anything without it.
* Updated the CLI output to include a clearer explanation of the catalog's role, specify the config file location, and provide step-by-step instructions for configuring the catalog via either an environment variable or the `repo.toml` file.

## Related Issue

closes #880 

## Type of Change

<!-- Check all that apply. -->

- [-] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [-] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide



## Additional Notes

Address alibaba/anolisa#880:
- Explain what the component catalog is and why it is needed
- Show the correct config file path (repo.toml)
- Provide two concrete setup options (env var / repo.toml section)
- Include example URLs so new users can adapt quickly