### PR TITLE
fix(sight): correctly group agent dashboard cards by process ancestry

### DIFF
--- a/src/agentsight/.gitignore
+++ b/src/agentsight/.gitignore
@@ -1,3 +1,7 @@
 # Generated C header — written on every `cargo build` by build.rs via cbindgen.
 # Consumers regenerate locally; do NOT commit.
 /include/
+
+# Dashboard 前端嵌入产物 — 由 `npm run build:embed` 在 dashboard/ 目录下生成。
+# webpack output.clean=true 每次构建都会覆盖。开发者本地按需重建，不提交。
+/frontend-dist/

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -27,6 +27,7 @@
       {"rule": ["*openclaw-gatewa*"], "agent_name": "OpenClaw"},
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
       {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},
+      {"rule": ["openclaw"], "agent_name": "OpenClaw"},
       {"rule": ["claude*"], "agent_name": "Claude"}
     ]
   }

--- a/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
+++ b/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
@@ -54,9 +54,23 @@ const AgentCard: React.FC<{
   onRestart: (pid: number) => void;
   restarting: boolean;
 }> = ({ agent, onDelete, onRestart, restarting }) => {
-  const dotColor = STATUS_COLORS[agent.status] || 'bg-gray-400';
-  const label = STATUS_LABELS[agent.status] || agent.status;
-  const tooltip = STATUS_TOOLTIPS[agent.status] || '';
+  // 区分：真 Gateway = 本身在监听端口的服务进程（如 OpenClaw Gateway）
+  //       升格 Gateway = 被升格为主卡的单进程 agent（如 Hermes Python CLI）—
+  //       这种不该贴“Gateway”标签，他们业务上没有 gateway 概念。
+  const hasPorts = (agent.ports?.length ?? 0) > 0;
+  const isRealGateway = agent.role === 'gateway' && hasPorts;
+  const isPromotedGateway = agent.role === 'gateway' && !hasPorts;
+
+  // 状态显示：升格 Gateway + status=no_port 用“运行中”绿色，避免
+  // 路用原 no_port 的“客户端进程”灰色语义与主卡身份冲突。
+  const useRunningStatus = isPromotedGateway && agent.status === 'no_port';
+  const dotColor = useRunningStatus
+    ? 'bg-green-500'
+    : STATUS_COLORS[agent.status] || 'bg-gray-400';
+  const label = useRunningStatus ? '运行中' : STATUS_LABELS[agent.status] || agent.status;
+  const tooltip = useRunningStatus
+    ? '单进程 agent，本身不提供服务端口，运行正常'
+    : STATUS_TOOLTIPS[agent.status] || '';
   const isOffline = agent.status === 'offline';
   const isHung = agent.status === 'hung';
   const isUnhealthy = agent.status === 'unhealthy';
@@ -97,7 +111,7 @@ const AgentCard: React.FC<{
         <span className={`font-medium text-sm truncate ${nameColor}`}>
           {agent.agent_name}
         </span>
-        {agent.role === 'gateway' && (
+        {isRealGateway && (
           <span className="text-[10px] px-1 py-0.5 rounded bg-green-100 text-green-700 font-medium">
             Gateway
           </span>
@@ -166,6 +180,39 @@ const AgentCard: React.FC<{
   );
 };
 
+/** 主卡下方按 agent_name 展示同名 client/worker 进程的折叠子列表。
+ *  默认折起以免侧栏过长；点击可展开查看。 */
+const RelatedProcesses: React.FC<{
+  agentName: string;
+  related: AgentHealthStatus[];
+}> = ({ agentName: _agentName, related }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="px-3 py-1.5 border-b border-gray-100 bg-gray-50/50">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="text-[11px] text-gray-500 hover:text-gray-700 flex items-center gap-1"
+      >
+        <span className={`transition-transform ${open ? 'rotate-90' : ''}`}>▶</span>
+        关联进程 ({related.length})
+      </button>
+      {open && (
+        <div className="mt-1 ml-2 border-l-2 border-gray-200 pl-2 space-y-1">
+          {related.map(ca => (
+            <div key={ca.pid} className="text-[11px] text-gray-500 flex items-center gap-1.5">
+              <span className="inline-block w-1.5 h-1.5 rounded-full bg-gray-300" />
+              <span className="text-[10px] px-1 py-0.5 rounded bg-gray-100">
+                {ca.role === 'worker' ? 'Worker' : '客户端'}
+              </span>
+              <span className="text-gray-400">PID {ca.pid}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const AgentHealthSidebar: React.FC = () => {
   const [agents, setAgents] = useState<AgentHealthStatus[]>([]);
   const [clientAgents, setClientAgents] = useState<AgentHealthStatus[]>([]);
@@ -189,7 +236,8 @@ export const AgentHealthSidebar: React.FC = () => {
 
   const refresh = useCallback(async () => {
     try {
-      const data = await fetchAgentHealth();
+      // 一次拉全部（包含 client/worker），后续按 agent_name 分组挂到各自主卡下面
+      const data = await fetchAgentHealth({ includeClients: true });
 
       // 检测新增离线和卡顿 agent
       data.agents.forEach(a => {
@@ -213,15 +261,11 @@ export const AgentHealthSidebar: React.FC = () => {
         if (a.status !== 'hung') notifiedOfflineRef.current.delete(-a.pid);
       });
 
-      setAgents(data.agents);
+      // gateway = 主卡列表；others = client/worker，按 agent_name 挂到各主卡下
+      setAgents(data.agents.filter(a => a.role === 'gateway'));
+      setClientAgents(data.agents.filter(a => a.role !== 'gateway'));
       setLastScan(data.last_scan_time);
       setError(null);
-
-      // 如果当前展开了客户端进程，同步刷新
-      if (showClients) {
-        const allData = await fetchAgentHealth({ includeClients: true });
-        setClientAgents(allData.agents.filter(a => a.role !== 'gateway'));
-      }
     } catch (e: any) {
       if (agents.length === 0) {
         setError(e.message || '\u8bf7\u6c42\u5931\u8d25');
@@ -229,7 +273,7 @@ export const AgentHealthSidebar: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [addToast, showClients]);
+  }, [addToast]);
 
   const handleDelete = async (pid: number) => {
     try {
@@ -325,51 +369,60 @@ export const AgentHealthSidebar: React.FC = () => {
           <div className="px-3 py-6 text-center text-xs text-gray-400">暂无已发现的 Agent</div>
         ) : (
           <div>
-            {sorted.map(agent => (
-              <AgentCard
-                key={agent.pid}
-                agent={agent}
-                onDelete={handleDelete}
-                onRestart={handleRestart}
-                restarting={restartingPids.has(agent.pid)}
-              />
-            ))}
-            {/* 关联客户端进程折叠区 */}
-            <div className="px-3 py-2 border-t border-gray-100">
-              <button
-                onClick={async () => {
-                  const next = !showClients;
-                  setShowClients(next);
-                  if (next) {
-                    const allData = await fetchAgentHealth({ includeClients: true });
-                    setClientAgents(allData.agents.filter(a => a.role !== 'gateway'));
-                  } else {
-                    setClientAgents([]);
-                  }
-                }}
-                className="text-xs text-gray-500 hover:text-gray-700 flex items-center gap-1"
-              >
-                <span className={`transition-transform ${showClients ? 'rotate-90' : ''}`}>▶</span>
-                关联进程{clientAgents.length > 0 ? ` (${clientAgents.length})` : ''}
-              </button>
-              {showClients && clientAgents.length > 0 && (
-                <div className="mt-1 ml-2 border-l-2 border-gray-100 pl-2 space-y-1">
-                  {clientAgents.map(ca => (
-                    <div key={ca.pid} className="text-[11px] text-gray-500 flex items-center gap-1.5">
-                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-gray-300" />
-                      <span className="font-medium">{ca.agent_name}</span>
-                      <span className="text-[10px] px-1 py-0.5 rounded bg-gray-100">
-                        {ca.role === 'worker' ? 'Worker' : '客户端'}
-                      </span>
-                      <span className="text-gray-400">PID {ca.pid}</span>
+            {sorted.map(agent => {
+              // 只把 parent_pid 与当前主卡 pid 严格匹配的 Worker 进程挂为关联进程，
+              // 避免同名独立实例（两个独立终端各开一个 hermes）被错误合并。
+              const related = clientAgents.filter(c => c.parent_pid === agent.pid);
+              return (
+                <React.Fragment key={agent.pid}>
+                  <AgentCard
+                    agent={agent}
+                    onDelete={handleDelete}
+                    onRestart={handleRestart}
+                    restarting={restartingPids.has(agent.pid)}
+                  />
+                  {related.length > 0 && (
+                    <RelatedProcesses agentName={agent.agent_name} related={related} />
+                  )}
+                </React.Fragment>
+              );
+            })}
+            {/* 孤儿关联进程：Worker 但父进程不是任何主卡（不应出现，兑底）。
+             *  过滤 status=offline 的进程——它们 5 分钟后会被 TTL 自动清理，
+             *  不需要提前震出来干扰视线。*/}
+            {(() => {
+              const gatewayPids = new Set(sorted.map(a => a.pid));
+              const orphans = clientAgents.filter(c =>
+                c.status !== 'offline' &&
+                (c.parent_pid === undefined || c.parent_pid === null || !gatewayPids.has(c.parent_pid))
+              );
+              if (orphans.length === 0) return null;
+              return (
+                <div className="px-3 py-2 border-t border-gray-100">
+                  <button
+                    onClick={() => setShowClients(s => !s)}
+                    className="text-xs text-gray-500 hover:text-gray-700 flex items-center gap-1"
+                  >
+                    <span className={`transition-transform ${showClients ? 'rotate-90' : ''}`}>▶</span>
+                    孤儿关联进程 ({orphans.length})
+                  </button>
+                  {showClients && (
+                    <div className="mt-1 ml-2 border-l-2 border-gray-100 pl-2 space-y-1">
+                      {orphans.map(ca => (
+                        <div key={ca.pid} className="text-[11px] text-gray-500 flex items-center gap-1.5">
+                          <span className="inline-block w-1.5 h-1.5 rounded-full bg-gray-300" />
+                          <span className="font-medium">{ca.agent_name}</span>
+                          <span className="text-[10px] px-1 py-0.5 rounded bg-gray-100">
+                            {ca.role === 'worker' ? 'Worker' : '客户端'}
+                          </span>
+                          <span className="text-gray-400">PID {ca.pid}</span>
+                        </div>
+                      ))}
                     </div>
-                  ))}
+                  )}
                 </div>
-              )}
-              {showClients && clientAgents.length === 0 && (
-                <div className="mt-1 ml-4 text-[11px] text-gray-400 italic">无关联客户端进程</div>
-              )}
-            </div>
+              );
+            })()}
           </div>
         )}
 

--- a/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
+++ b/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
@@ -97,6 +97,21 @@ const AgentCard: React.FC<{
         <span className={`font-medium text-sm truncate ${nameColor}`}>
           {agent.agent_name}
         </span>
+        {agent.role === 'gateway' && (
+          <span className="text-[10px] px-1 py-0.5 rounded bg-green-100 text-green-700 font-medium">
+            Gateway
+          </span>
+        )}
+        {agent.role === 'client' && (
+          <span className="text-[10px] px-1 py-0.5 rounded bg-gray-100 text-gray-500 font-medium">
+            客户端
+          </span>
+        )}
+        {agent.role === 'worker' && (
+          <span className="text-[10px] px-1 py-0.5 rounded bg-gray-100 text-gray-500 font-medium">
+            Worker
+          </span>
+        )}
         <span className={`ml-auto text-xs flex-shrink-0 ${labelColor}`}>
           {label}
         </span>
@@ -153,6 +168,8 @@ const AgentCard: React.FC<{
 
 export const AgentHealthSidebar: React.FC = () => {
   const [agents, setAgents] = useState<AgentHealthStatus[]>([]);
+  const [clientAgents, setClientAgents] = useState<AgentHealthStatus[]>([]);
+  const [showClients, setShowClients] = useState(false);
   const [lastScan, setLastScan] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -178,11 +195,11 @@ export const AgentHealthSidebar: React.FC = () => {
       data.agents.forEach(a => {
         if (a.status === 'offline' && !notifiedOfflineRef.current.has(a.pid)) {
           notifiedOfflineRef.current.add(a.pid);
-          addToast(`⚠️ Agent "${a.agent_name}" (PID ${a.pid}) 已下线`);
+          addToast(`\u26a0\ufe0f Agent "${a.agent_name}" (PID ${a.pid}) \u5df2\u9000\u51fa`);
         }
         if (a.status === 'hung' && !notifiedOfflineRef.current.has(-a.pid)) {
           notifiedOfflineRef.current.add(-a.pid); // 用负数区分 hung 通知
-          addToast(`⏳ Agent "${a.agent_name}" (PID ${a.pid}) 响应超时，可能卡顿`);
+          addToast(`\u23f3 Agent "${a.agent_name}" (PID ${a.pid}) \u54cd\u5e94\u8d85\u65f6\uff0c\u53ef\u80fd\u5361\u987f`);
         }
       });
       // 清理不再存在的 PID
@@ -199,16 +216,20 @@ export const AgentHealthSidebar: React.FC = () => {
       setAgents(data.agents);
       setLastScan(data.last_scan_time);
       setError(null);
+
+      // 如果当前展开了客户端进程，同步刷新
+      if (showClients) {
+        const allData = await fetchAgentHealth({ includeClients: true });
+        setClientAgents(allData.agents.filter(a => a.role !== 'gateway'));
+      }
     } catch (e: any) {
-      // If we already have agent data, suppress transient poll errors (e.g. 408
-      // timeout during backend restart) to avoid flickering the error banner.
       if (agents.length === 0) {
-        setError(e.message || '请求失败');
+        setError(e.message || '\u8bf7\u6c42\u5931\u8d25');
       }
     } finally {
       setLoading(false);
     }
-  }, [addToast]);
+  }, [addToast, showClients]);
 
   const handleDelete = async (pid: number) => {
     try {
@@ -313,6 +334,42 @@ export const AgentHealthSidebar: React.FC = () => {
                 restarting={restartingPids.has(agent.pid)}
               />
             ))}
+            {/* 关联客户端进程折叠区 */}
+            <div className="px-3 py-2 border-t border-gray-100">
+              <button
+                onClick={async () => {
+                  const next = !showClients;
+                  setShowClients(next);
+                  if (next) {
+                    const allData = await fetchAgentHealth({ includeClients: true });
+                    setClientAgents(allData.agents.filter(a => a.role !== 'gateway'));
+                  } else {
+                    setClientAgents([]);
+                  }
+                }}
+                className="text-xs text-gray-500 hover:text-gray-700 flex items-center gap-1"
+              >
+                <span className={`transition-transform ${showClients ? 'rotate-90' : ''}`}>▶</span>
+                关联进程{clientAgents.length > 0 ? ` (${clientAgents.length})` : ''}
+              </button>
+              {showClients && clientAgents.length > 0 && (
+                <div className="mt-1 ml-2 border-l-2 border-gray-100 pl-2 space-y-1">
+                  {clientAgents.map(ca => (
+                    <div key={ca.pid} className="text-[11px] text-gray-500 flex items-center gap-1.5">
+                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-gray-300" />
+                      <span className="font-medium">{ca.agent_name}</span>
+                      <span className="text-[10px] px-1 py-0.5 rounded bg-gray-100">
+                        {ca.role === 'worker' ? 'Worker' : '客户端'}
+                      </span>
+                      <span className="text-gray-400">PID {ca.pid}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {showClients && clientAgents.length === 0 && (
+                <div className="mt-1 ml-4 text-[11px] text-gray-400 italic">无关联客户端进程</div>
+              )}
+            </div>
           </div>
         )}
 

--- a/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
+++ b/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
@@ -9,17 +9,27 @@ const STATUS_COLORS: Record<string, string> = {
   hung: 'bg-orange-500',
   unknown: 'bg-yellow-400',
   no_port: 'bg-gray-400',
-  offline: 'bg-red-600',
+  offline: 'bg-gray-500',
 };
 
 /** Status display label */
 const STATUS_LABELS: Record<string, string> = {
   healthy: '正常',
-  unhealthy: '异常',
-  hung: '卡顿',
-  unknown: '未知',
-  no_port: '无端口',
-  offline: '已下线',
+  unhealthy: '端口无响应',
+  hung: '响应卡住',
+  unknown: '待检测',
+  no_port: '客户端进程',
+  offline: '已退出',
+};
+
+/** Status tooltip / 描述，帮助用户理解状态含义 */
+const STATUS_TOOLTIPS: Record<string, string> = {
+  healthy: '服务监听端口且 HTTP 探活成功',
+  unhealthy: '端口不接受连接，可能需要重启',
+  hung: '端口可连但 HTTP 探活超时，进程可能卡死',
+  unknown: '首轮健康检查未完成',
+  no_port: 'TUI / 子进程，本身不提供服务端口（正常）',
+  offline: '进程已退出，5 分钟后从列表自动移除',
 };
 
 /** Format relative time in Chinese */
@@ -46,44 +56,85 @@ const AgentCard: React.FC<{
 }> = ({ agent, onDelete, onRestart, restarting }) => {
   const dotColor = STATUS_COLORS[agent.status] || 'bg-gray-400';
   const label = STATUS_LABELS[agent.status] || agent.status;
+  const tooltip = STATUS_TOOLTIPS[agent.status] || '';
   const isOffline = agent.status === 'offline';
   const isHung = agent.status === 'hung';
+  const isUnhealthy = agent.status === 'unhealthy';
   const canRestart = isHung && !!agent.restart_cmd?.length;
 
+  // 计算 offline 项距离自动移除还有多久（5 分钟 TTL）
+  const OFFLINE_TTL_MS = 5 * 60 * 1000;
+  const offlineRemainSec =
+    isOffline && agent.offline_since
+      ? Math.max(0, Math.ceil((OFFLINE_TTL_MS - (Date.now() - agent.offline_since)) / 1000))
+      : null;
+
+  // 背景色：只有 hung/unhealthy 才是需要告警的，offline 不再标红
+  const bgClass = isHung ? 'bg-orange-50' : isUnhealthy ? 'bg-red-50' : '';
+  // 名称色：offline 用灰色（类似“只读历史”），只有真问题才醒目
+  const nameColor = isOffline
+    ? 'text-gray-500'
+    : isHung
+    ? 'text-orange-700'
+    : isUnhealthy
+    ? 'text-red-700'
+    : 'text-gray-900';
+  const labelColor = isOffline
+    ? 'text-gray-400'
+    : isHung
+    ? 'text-orange-500 font-semibold'
+    : isUnhealthy
+    ? 'text-red-500 font-semibold'
+    : 'text-gray-400';
+
   return (
-    <div className={`px-3 py-2.5 border-b border-gray-100 last:border-b-0 ${
-      isOffline ? 'bg-red-50' : isHung ? 'bg-orange-50' : ''
-    }`}>
+    <div
+      className={`group px-3 py-2.5 border-b border-gray-100 last:border-b-0 ${bgClass}`}
+      title={tooltip}
+    >
       <div className="flex items-center gap-2">
         <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${dotColor}`} />
-        <span className={`font-medium text-sm truncate ${
-          isOffline ? 'text-red-700' : isHung ? 'text-orange-700' : 'text-gray-900'
-        }`}>
+        <span className={`font-medium text-sm truncate ${nameColor}`}>
           {agent.agent_name}
         </span>
-        <span className={`ml-auto text-xs flex-shrink-0 ${
-          isOffline ? 'text-red-500 font-semibold' : isHung ? 'text-orange-500 font-semibold' : 'text-gray-400'
-        }`}>
+        <span className={`ml-auto text-xs flex-shrink-0 ${labelColor}`}>
           {label}
         </span>
       </div>
+      {/* 鼠标悬停整张卡时展开状态说明（重点问题卡 hung/unhealthy 始终显示） */}
+      {tooltip && (
+        <div
+          className={`mt-1 ml-4 text-[11px] leading-snug text-gray-500 italic ${
+            isHung || isUnhealthy ? 'block' : 'hidden group-hover:block'
+          }`}
+        >
+          ℹ️ {tooltip}
+        </div>
+      )}
       <div className="mt-1 ml-4 text-xs text-gray-500 space-y-0.5">
         <div>PID {agent.pid}</div>
         {agent.latency_ms !== null && agent.status === 'healthy' && (
           <span className="text-green-600">{agent.latency_ms}ms</span>
         )}
-        {agent.error_message && (
+        {agent.error_message && !isOffline && (
           <div className={`truncate ${isHung ? 'text-orange-500' : 'text-red-500'}`} title={agent.error_message}>
             {agent.error_message}
           </div>
         )}
         <div className="text-gray-400">{relativeTime(agent.last_check_time)}</div>
+        {isOffline && offlineRemainSec !== null && (
+          <div className="text-gray-400 italic">
+            {offlineRemainSec > 0
+              ? `${offlineRemainSec >= 60 ? Math.ceil(offlineRemainSec / 60) + ' 分钟' : offlineRemainSec + ' 秒'}后自动移除`
+              : '即将移除'}
+          </div>
+        )}
         {isOffline && (
           <button
             onClick={() => onDelete(agent.pid)}
-            className="mt-1 text-xs text-red-400 hover:text-red-600 underline"
+            className="mt-1 text-xs text-gray-400 hover:text-gray-600 underline"
           >
-            确认下线并删除
+            立即移除
           </button>
         )}
         {canRestart && (
@@ -197,9 +248,9 @@ export const AgentHealthSidebar: React.FC = () => {
     };
   }, [refresh]);
 
-  // 排序: offline 首位（告警），其次 hung，然后 unhealthy，再 healthy，最后 no_port/unknown
+  // 排序：hung/unhealthy 首位（真有问题），正常中间，offline 最后（不抢眼）
   const sorted = [...agents].sort((a, b) => {
-    const order: Record<string, number> = { offline: 0, hung: 1, unhealthy: 2, healthy: 3, unknown: 4, no_port: 5 };
+    const order: Record<string, number> = { hung: 0, unhealthy: 1, healthy: 2, no_port: 3, unknown: 4, offline: 5 };
     return (order[a.status] ?? 6) - (order[b.status] ?? 6);
   });
 

--- a/src/agentsight/dashboard/src/types/index.ts
+++ b/src/agentsight/dashboard/src/types/index.ts
@@ -180,6 +180,10 @@ export interface AgentHealthStatus {
   restart_cmd?: string[];
   /** 进入 Offline 状态的时刻（Unix ms）。仅 offline 项有值。 */
   offline_since?: number;
+  /** 进程角色 */
+  role: 'gateway' | 'client' | 'worker';
+  /** 父进程 PID */
+  parent_pid?: number;
 }
 
 export interface AgentHealthResponse {

--- a/src/agentsight/dashboard/src/types/index.ts
+++ b/src/agentsight/dashboard/src/types/index.ts
@@ -178,6 +178,8 @@ export interface AgentHealthStatus {
   error_message: string | null;
   /** 用于重启的完整命令行，undefined 表示不支持重启 */
   restart_cmd?: string[];
+  /** 进入 Offline 状态的时刻（Unix ms）。仅 offline 项有值。 */
+  offline_since?: number;
 }
 
 export interface AgentHealthResponse {

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -475,8 +475,9 @@ export async function fetchInterruptionConversationCounts(
 /**
  * Fetch the current health status of all discovered agent processes.
  */
-export async function fetchAgentHealth(): Promise<AgentHealthResponse> {
-  return apiFetch<AgentHealthResponse>(`${API_BASE}/api/agent-health`);
+export async function fetchAgentHealth(opts?: { includeClients?: boolean }): Promise<AgentHealthResponse> {
+  const qs = opts?.includeClients ? '?include_clients=true' : '';
+  return apiFetch<AgentHealthResponse>(`${API_BASE}/api/agent-health${qs}`);
 }
 
 /**

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -85,7 +85,14 @@ impl HealthChecker {
         // Mark gone processes as Offline (instead of deleting immediately)
         let newly_offline = if let Ok(mut store) = self.store.write() {
             store.last_scan_time = now_ms();
-            store.mark_stale_offline(&active_pids)
+            let offline = store.mark_stale_offline(&active_pids);
+            // 自动清理超过 5 分钟的 Offline 条目，避免历史 PID 在 Sidebar 长期残留
+            const OFFLINE_TTL_MS: u64 = 5 * 60 * 1000;
+            let removed = store.cleanup_stale_offline(OFFLINE_TTL_MS);
+            if removed > 0 {
+                log::info!("HealthStore: cleaned {} stale offline entries (TTL={}s)", removed, OFFLINE_TTL_MS / 1000);
+            }
+            offline
         } else {
             vec![]
         };
@@ -253,6 +260,7 @@ impl HealthChecker {
                     latency_ms: None,
                     error_message: None,
                     restart_cmd,
+                    offline_since: None,
                 }
             } else {
                 self.probe_agent(agent, &ports, restart_cmd)
@@ -306,6 +314,7 @@ impl HealthChecker {
                         latency_ms: Some(latency),
                         error_message: None,
                         restart_cmd,
+                        offline_since: None,
                     };
                 }
                 Err(ureq::Error::Status(_code, _resp)) => {
@@ -321,6 +330,7 @@ impl HealthChecker {
                         latency_ms: Some(latency),
                         error_message: None,
                         restart_cmd,
+                        offline_since: None,
                     };
                 }
                 Err(ureq::Error::Transport(e)) => {
@@ -361,6 +371,7 @@ impl HealthChecker {
             latency_ms: None,
             error_message: Some(last_error),
             restart_cmd,
+            offline_since: None,
         }
     }
 

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -245,8 +245,14 @@ impl HealthChecker {
             .map(|a| (a.pid, a.agent_info.name.clone()))
             .collect();
 
+        // Pre-scan listening ports per pid (also avoids scanning /proc twice).
+        let ports_by_pid: HashMap<u32, Vec<u16>> = agents
+            .iter()
+            .map(|a| (a.pid, detect_listening_ports(a.pid)))
+            .collect();
+
         for agent in &agents {
-            let ports = detect_listening_ports(agent.pid);
+            let ports = ports_by_pid.get(&agent.pid).cloned().unwrap_or_default();
             // Cosh has no daemon process and does not support keepalive/restart.
             // Build restart_cmd only for agents that support it.
             let restart_cmd = if agent.agent_info.name == "Cosh" {
@@ -258,17 +264,29 @@ impl HealthChecker {
             // Read parent PID from /proc/<pid>/stat for role inference
             let ppid = read_ppid(agent.pid);
 
-            // Infer role: Gateway (has ports) > Worker (parent is same agent) > Client
+            // Infer role:
+            //   1. ports != empty            → Gateway (real service with TCP port)
+            //   2. parent is same agent_name → Worker (genuine fork, fold under parent)
+            //   3. otherwise                 → Gateway (independent process, own card)
+            //
+            // Two separately-launched hermes/openclaw client instances are
+            // independent (no parent-child link, different terminals), so they
+            // each deserve their own primary card; only true forks go into the
+            // associated-processes drawer of their parent.
             let role = if !ports.is_empty() {
                 AgentRole::Gateway
             } else if let Some(pp) = ppid {
-                if agent_name_by_pid.get(&pp).map(|n| n == &agent.agent_info.name).unwrap_or(false) {
+                if agent_name_by_pid
+                    .get(&pp)
+                    .map(|n| n == &agent.agent_info.name)
+                    .unwrap_or(false)
+                {
                     AgentRole::Worker
                 } else {
-                    AgentRole::Client
+                    AgentRole::Gateway
                 }
             } else {
-                AgentRole::Client
+                AgentRole::Gateway
             };
 
             let status = if ports.is_empty() {

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -9,7 +9,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use super::port_detector::detect_listening_ports;
-use super::store::{AgentHealthState, AgentHealthStatus, HealthStore, now_ms};
+use super::store::{AgentHealthState, AgentHealthStatus, AgentRole, HealthStore, now_ms};
 use crate::discovery::AgentScanner;
 use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
 use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore};
@@ -239,6 +239,12 @@ impl HealthChecker {
 
         log::debug!("Health check: found {} agent(s)", agents.len());
 
+        // Collect agent names by PID for role inference (detect parent-child within same agent)
+        let agent_name_by_pid: HashMap<u32, String> = agents
+            .iter()
+            .map(|a| (a.pid, a.agent_info.name.clone()))
+            .collect();
+
         for agent in &agents {
             let ports = detect_listening_ports(agent.pid);
             // Cosh has no daemon process and does not support keepalive/restart.
@@ -248,6 +254,23 @@ impl HealthChecker {
             } else {
                 Some(build_restart_cmd(&agent.exe_path, &agent.cmdline_args))
             };
+
+            // Read parent PID from /proc/<pid>/stat for role inference
+            let ppid = read_ppid(agent.pid);
+
+            // Infer role: Gateway (has ports) > Worker (parent is same agent) > Client
+            let role = if !ports.is_empty() {
+                AgentRole::Gateway
+            } else if let Some(pp) = ppid {
+                if agent_name_by_pid.get(&pp).map(|n| n == &agent.agent_info.name).unwrap_or(false) {
+                    AgentRole::Worker
+                } else {
+                    AgentRole::Client
+                }
+            } else {
+                AgentRole::Client
+            };
+
             let status = if ports.is_empty() {
                 AgentHealthStatus {
                     pid: agent.pid,
@@ -261,9 +284,11 @@ impl HealthChecker {
                     error_message: None,
                     restart_cmd,
                     offline_since: None,
+                    role,
+                    parent_pid: ppid,
                 }
             } else {
-                self.probe_agent(agent, &ports, restart_cmd)
+                self.probe_agent(agent, &ports, restart_cmd, role, ppid)
             };
 
             if let Ok(mut store) = self.store.write() {
@@ -283,6 +308,8 @@ impl HealthChecker {
         agent: &crate::discovery::DiscoveredAgent,
         ports: &[u16],
         restart_cmd: Option<Vec<String>>,
+        role: AgentRole,
+        parent_pid: Option<u32>,
     ) -> AgentHealthStatus {
         let mut last_error = String::new();
         // 标记是否遇到了超时错误（区分 hung vs unreachable）
@@ -315,6 +342,8 @@ impl HealthChecker {
                         error_message: None,
                         restart_cmd,
                         offline_since: None,
+                        role: role.clone(),
+                        parent_pid,
                     };
                 }
                 Err(ureq::Error::Status(_code, _resp)) => {
@@ -331,6 +360,8 @@ impl HealthChecker {
                         error_message: None,
                         restart_cmd,
                         offline_since: None,
+                        role: role.clone(),
+                        parent_pid,
                     };
                 }
                 Err(ureq::Error::Transport(e)) => {
@@ -372,6 +403,8 @@ impl HealthChecker {
             error_message: Some(last_error),
             restart_cmd,
             offline_since: None,
+            role,
+            parent_pid,
         }
     }
 
@@ -423,4 +456,18 @@ fn build_restart_cmd(exe_path: &str, cmdline_args: &[String]) -> Vec<String> {
         .collect();
     cmd.extend(args);
     cmd
+}
+
+/// Read the parent PID (ppid) from /proc/<pid>/stat.
+/// Returns None if the file cannot be read or parsed.
+fn read_ppid(pid: u32) -> Option<u32> {
+    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    // Format: "pid (comm) state ppid ..."
+    // Find the closing ')' first (comm may contain spaces/parens)
+    let after_comm = stat.rsplit_once(')')?.1;
+    // after_comm = " state ppid ..."
+    let mut fields = after_comm.split_whitespace();
+    let _state = fields.next()?;
+    let ppid_str = fields.next()?;
+    ppid_str.parse::<u32>().ok()
 }

--- a/src/agentsight/src/health/store.rs
+++ b/src/agentsight/src/health/store.rs
@@ -27,6 +27,18 @@ pub enum AgentHealthState {
     Offline,
 }
 
+/// Role of an agent process in the process group
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRole {
+    /// Service process with listening TCP ports (e.g. OpenClaw Gateway on 18789)
+    Gateway,
+    /// Client process without ports (e.g. TUI main process)
+    Client,
+    /// Worker sub-process forked from a Client (parent_pid is also same agent)
+    Worker,
+}
+
 /// Health status of a single agent process
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentHealthStatus {
@@ -49,6 +61,11 @@ pub struct AgentHealthStatus {
     /// 进入 Offline 状态的时刻（Unix ms）。仅 Offline 项有值，用于 TTL 自动清理。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offline_since: Option<u64>,
+    /// 进程角色：Gateway（有端口）/ Client（无端口）/ Worker（子进程）
+    pub role: AgentRole,
+    /// 父进程 PID（用于折叠展示）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_pid: Option<u32>,
 }
 
 /// Stores the latest health check results for all tracked agents

--- a/src/agentsight/src/health/store.rs
+++ b/src/agentsight/src/health/store.rs
@@ -46,6 +46,9 @@ pub struct AgentHealthStatus {
     /// 用于重启的完整命令行（exe + args），None 表示不支持重启
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restart_cmd: Option<Vec<String>>,
+    /// 进入 Offline 状态的时刻（Unix ms）。仅 Offline 项有值，用于 TTL 自动清理。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offline_since: Option<u64>,
 }
 
 /// Stores the latest health check results for all tracked agents
@@ -78,10 +81,29 @@ impl HealthStore {
                 entry.last_check_time = now_ms();
                 entry.latency_ms = None;
                 entry.error_message = Some("进程已退出".to_string());
+                entry.offline_since = Some(now_ms());
                 newly_offline.push(entry.clone());
             }
         }
         newly_offline
+    }
+
+    /// 自动清理超过 TTL 的 Offline 条目（避免历史进程长期残留 UI）。
+    /// `ttl_ms`: Offline 状态保留时长，超过则从 store 移除。
+    /// 返回被移除的 PID 数量。
+    pub fn cleanup_stale_offline(&mut self, ttl_ms: u64) -> usize {
+        let now = now_ms();
+        let before = self.agents.len();
+        self.agents.retain(|_, entry| {
+            if entry.status != AgentHealthState::Offline {
+                return true;
+            }
+            match entry.offline_since {
+                Some(since) => now.saturating_sub(since) < ttl_ms,
+                None => true, // 兼容老数据：没有时间戳的暂不清理
+            }
+        });
+        before - self.agents.len()
     }
 
     /// Remove a specific PID (user-acknowledged deletion)

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -340,12 +340,21 @@ pub struct AgentHealthResponse {
 /// so there is nothing meaningful to display in the UI. Agent-crash interruption
 /// detection for Cosh still works via the health checker background scan.
 #[get("/api/agent-health")]
-pub async fn get_agent_health(data: web::Data<AppState>) -> impl Responder {
+pub async fn get_agent_health(
+    data: web::Data<AppState>,
+    req: actix_web::HttpRequest,
+) -> impl Responder {
+    let include_clients = req.query_string().contains("include_clients=true");
     let store = data.health_store.read().unwrap();
     let agents = store
         .all_agents()
         .into_iter()
         .filter(|a| a.agent_name != "Cosh")
+        .filter(|a| {
+            include_clients
+                || a.role == crate::health::store::AgentRole::Gateway
+                || a.status == crate::health::store::AgentHealthState::Offline
+        })
         .collect();
     HttpResponse::Ok().json(AgentHealthResponse {
         agents,


### PR DESCRIPTION
## Description

Improve the agentsight Dashboard `Agent 状态` sidebar to render multi-agent coexistence correctly. Three incremental commits land on this branch:

1. **feat(sight): improve agent health status UX with TTL cleanup and tooltip** — auto-cleanup of offline agent cards after 5 min TTL, hover tooltips for status semantics.
2. **feat(sight): filter client processes from health API and add role badges (P1/P2)** — split Gateway / Client / Worker roles, add role badges, expose `includeClients` API parameter.
3. **fix(sight): group dashboard agents by process ancestry, not just agent_name** (this PR's headline fix) — covers the issues described in #913:
   - Backend: `checker.rs` now treats independent processes (no port, no same-name parent) as their own Gateway primary cards. Only true forks (parent process is the same `agent_name`) become Worker.
   - Frontend: `AgentHealthSidebar.tsx` matches associated processes by `parent_pid === card.pid` strictly, so two independent hermes/openclaw instances no longer share each others' workers. Introduces a per-card `RelatedProcesses` foldable subsection.
   - Frontend: only port-owning Gateways display the green `Gateway` badge; promoted single-process agents (e.g. Hermes Python CLI) render as plain green "运行中" cards without the misleading badge.
   - Frontend: hide `status=offline` orphan workers — the 5-min TTL handles cleanup, no need to show transient stale entries.

Net result: each independent agent process gets its own primary card; only true forks fold under their direct parent's drawer.

## Related Issue

closes #913

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo test` pass (573 passed, 0 failed locally)
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- Local `cargo test --release` in `src/agentsight`: **573 passed, 0 failed, 28 ignored**
- Local `cargo build --release` succeeds with embedded dashboard frontend (`make build-frontend && cargo build --release`)
- Manual end-to-end verification against `/api/agent-health` and the embedded Dashboard UI:
  - Two independent `hermes` Python CLI instances each appear as their own primary card (no false aggregation).
  - One `openclaw gateway` plus two independent `openclaw` TUI clients each appear as their own primary card; each TUI's worker fork (`parent_pid` chain) folds only under its actual parent.
  - Only the real Gateway (with `:18789` listening) displays the green `Gateway` badge; promoted port-less primary cards render as `运行中` with no badge.
  - Killing the parent OpenClaw TUI no longer leaves orphan workers visible — they are filtered out and cleaned up by the existing 5-min TTL.

## Additional Notes

- No backend API contract change (the `AgentRole` JSON values still serialize as `gateway` / `worker` / `client`).
- The `Client` role is now effectively unreachable from the new role inference path; we intentionally keep the enum variant to avoid breaking existing serialized state files / API consumers.