### PR TITLE
fix(cosh): add response language and model identity rules

### DIFF
--- a/src/copilot-shell/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/src/copilot-shell/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`Core System Prompt (prompts.ts) > should append userMemory with separator when provided 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "unknown". If asked about your model or version, answer using this runtime metadata and do not guess.
+
 # Core Mandates
 
 - **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.
@@ -217,6 +222,11 @@ Be extra polite."
 
 exports[`Core System Prompt (prompts.ts) > should include git instructions when in a git repo 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "unknown". If asked about your model or version, answer using this runtime metadata and do not guess.
 
 # Core Mandates
 
@@ -443,6 +453,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 exports[`Core System Prompt (prompts.ts) > should not include git instructions when not in a git repo 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "unknown". If asked about your model or version, answer using this runtime metadata and do not guess.
+
 # Core Mandates
 
 - **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.
@@ -652,6 +667,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 
 exports[`Core System Prompt (prompts.ts) > should return the base prompt when no userMemory is provided 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "unknown". If asked about your model or version, answer using this runtime metadata and do not guess.
 
 # Core Mandates
 
@@ -863,6 +883,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 exports[`Core System Prompt (prompts.ts) > should return the base prompt when userMemory is empty string 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "unknown". If asked about your model or version, answer using this runtime metadata and do not guess.
+
 # Core Mandates
 
 - **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.
@@ -1073,6 +1098,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 exports[`Core System Prompt (prompts.ts) > should return the base prompt when userMemory is whitespace only 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "unknown". If asked about your model or version, answer using this runtime metadata and do not guess.
+
 # Core Mandates
 
 - **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.
@@ -1282,6 +1312,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 
 exports[`Model-specific tool call formats > should preserve model-specific formats with user memory 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "qwen3-coder-14b". If asked about your model or version, answer using this runtime metadata and do not guess.
 
 # Core Mandates
 
@@ -1576,6 +1611,11 @@ User prefers concise responses."
 exports[`Model-specific tool call formats > should use JSON format for qwen-vl model 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "qwen-vl-max". If asked about your model or version, answer using this runtime metadata and do not guess.
+
 # Core Mandates
 
 - **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.
@@ -1808,6 +1848,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 
 exports[`Model-specific tool call formats > should use XML format for qwen3-coder model 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "qwen3-coder-7b". If asked about your model or version, answer using this runtime metadata and do not guess.
 
 # Core Mandates
 
@@ -2098,6 +2143,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 exports[`Model-specific tool call formats > should use bracket format for generic models 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "gpt-4". If asked about your model or version, answer using this runtime metadata and do not guess.
+
 # Core Mandates
 
 - **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.
@@ -2307,6 +2357,11 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 
 exports[`Model-specific tool call formats > should use bracket format when no model is specified 1`] = `
 "You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "unknown". If asked about your model or version, answer using this runtime metadata and do not guess.
 
 # Core Mandates
 

--- a/src/copilot-shell/packages/core/src/core/prompts.ts
+++ b/src/copilot-shell/packages/core/src/core/prompts.ts
@@ -137,6 +137,11 @@ export function getCoreSystemPrompt(
     : `
 You are Copilot Shell, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
+# Runtime Context
+
+- **Response Language:** By default, respond in the same natural language as the user's latest message. If the user explicitly asks for a different language, follow that request. Preserve code, commands, paths, logs, identifiers, and quoted text verbatim unless translation is explicitly requested.
+- **Model Identity:** You are running in Copilot Shell on the QWEN3.6-PLUS base model. The configured model identifier for this session is "${model || 'unknown'}". If asked about your model or version, answer using this runtime metadata and do not guess.
+
 # Core Mandates
 
 - **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.


### PR DESCRIPTION
## Description

Add a "Runtime Context" section to the core system prompt that
addresses two behavioral inconsistencies:

1. **Response language:** Instruct the agent to reply in the same
   natural language as the user's latest message by default, while
   preserving code/paths/identifiers verbatim.
2. **Model identity:** Inject the configured model identifier into
   the prompt so the agent can answer "what model are you?" from
   runtime metadata instead of guessing or hallucinating.

## Related Issue

fixes #919

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- Verified the prompt renders correctly with the model variable interpolated
- Manual test: asked "what model are you?" — agent responds with the configured model identifier
- Manual test: sent messages in Chinese — agent replies in Chinese; switched to English — agent follows

## Additional Notes

Prompt-only change; no runtime logic or dependency changes.