### PR TITLE
chore(sec-core): backport release v0.6.0 commits

### DIFF
--- a/src/agent-sec-core/adapters/adapter-manifest.json
+++ b/src/agent-sec-core/adapters/adapter-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1",
   "component": "sec-core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Security protection, code scanning, prompt scanning, and secure skills for agent runtimes.",
   "targets": {
     "openclaw": {

--- a/src/agent-sec-core/agent-sec-cli/Cargo.lock
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "pyo3",
 ]

--- a/src/agent-sec-core/agent-sec-cli/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-sec-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Agent Security Core CLI - Native Rust extensions"
 license = "Apache-2.0"

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-sec-cli"
-version = "0.6.0"
+version = "0.6.1"
 description = "Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification for AI Agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
@@ -1,3 +1,3 @@
 """Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -31,7 +31,7 @@ try:
 
     __version__ = get_version("agent-sec-cli")
 except Exception:
-    __version__ = "0.6.0"  # pragma: no cover
+    __version__ = "0.6.1"  # pragma: no cover
 
 app = typer.Typer(
     name="agent-sec-cli",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
@@ -148,6 +148,30 @@ def _get_mode(event: SecurityEvent) -> str:
     return ""
 
 
+def _has_hardening_stats(event: SecurityEvent) -> bool:
+    """Return whether a hardening event has parsed rule summary statistics."""
+    result = _get_result(event)
+    return isinstance(result.get("total"), int) and result.get("total", 0) > 0
+
+
+def _has_actionable_hardening_failure(event: SecurityEvent) -> bool:
+    """Return whether a hardening event has a parsed rule failure to fix."""
+    result = _get_result(event)
+    failures = result.get("failures", [])
+    if not isinstance(failures, list):
+        return False
+
+    for failure in failures:
+        if not isinstance(failure, dict):
+            continue
+        if failure.get("status") == "UNKNOWN":
+            continue
+        if not failure.get("rule_id"):
+            continue
+        return True
+    return False
+
+
 def _format_timestamp(ts: str) -> str:
     """Render an ISO-8601 timestamp in local time for inline display."""
     try:
@@ -192,8 +216,9 @@ def _summarize_hardening(events: list[SecurityEvent]) -> str:
             f"(succeeded: {reinf_ok}, failed: {reinf_fail})"
         )
 
-    # Latest scan result details (prefer succeeded, fall back to latest failed)
-    latest_scan = next((e for e in scans if e.result == "succeeded"), None)
+    # Latest scan result details. Loongshield returns non-zero for non-compliant
+    # scans, but the backend may still parse usable passed/total statistics.
+    latest_scan = next((e for e in scans if _has_hardening_stats(e)), None)
     if latest_scan:
         result = _get_result(latest_scan)
         passed = result.get("passed", 0)
@@ -645,12 +670,10 @@ def _compute_suggestions(
     # --- Hardening suggestions ---
     if hardening_events:
         latest = hardening_events[0]  # newest-first after _group_by_category sort
-        if latest.result == "succeeded":
-            result = _get_result(latest)
-            if result.get("failures"):
-                suggestions.append(
-                    "agent-sec-cli harden --reinforce    Fix failed rules"
-                )
+        if _has_actionable_hardening_failure(latest) and (
+            latest.result == "succeeded" or _has_hardening_stats(latest)
+        ):
+            suggestions.append("agent-sec-cli harden --reinforce    Fix failed rules")
 
     # --- Skill-ledger suggestions ---
     if ledger_statuses:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
@@ -228,7 +228,7 @@ def _summarize_hardening(events: list[SecurityEvent]) -> str:
         # Include fixed count from reinforce operations in compliance calculation
         fixed_count = 0
         for e in reinforcements:
-            if e.result == "succeeded":
+            if _has_hardening_stats(e):
                 reinf_result = _get_result(e)
                 fixed_count += reinf_result.get("fixed", 0)
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
@@ -31,11 +31,16 @@ logger = logging.getLogger(__name__)
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _RULE_STATUS_RE = re.compile(
-    r"\[(?P<rule_id>[\w.]+)\]\s+"
-    r"(?P<status>FAIL|FAILED|FAILED-TO-FIX|ERROR|ENFORCE-ERROR|DRY-RUN|MANUAL|SKIP):\s*"
+    r"\[(?P<rule_id>[^\]\s]+)\]\s+"
+    r"(?P<status>FAIL|FAILED|FIXED|FAILED-TO-FIX|ERROR|ENFORCE-ERROR|DRY-RUN|MANUAL|SKIP):\s*"
     r"(?P<message>.+?)\s*$"
 )
-_ENGINE_ERROR_RE = re.compile(r"Engine\s+Error:\s*(?P<message>.+?)\s*$")
+_VERBOSE_RULE_STATUS_RE = re.compile(
+    r"^\s*(?P<status>PASS|FAIL)\s+\[(?P<rule_id>[^\]\s]+)\]\s+" r"(?P<message>.+?)\s*$"
+)
+_ENGINE_ERROR_RE = re.compile(
+    r"(?:\[(?P<rule_id>[^\]\s]+)\]\s+)?Engine\s+Error:\s*" r"(?P<message>.+?)\s*$"
+)
 
 
 def _strip_ansi(text: str) -> str:
@@ -43,17 +48,38 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
+def _parse_rule_status_line(line: str) -> dict[str, str] | None:
+    """Parse supported loongshield per-rule status line formats."""
+    match = _RULE_STATUS_RE.search(line)
+    if match:
+        return {
+            "rule_id": match.group("rule_id"),
+            "status": match.group("status"),
+            "message": match.group("message").strip(),
+        }
+
+    match = _VERBOSE_RULE_STATUS_RE.search(line)
+    if not match or match.group("status") == "PASS":
+        return None
+
+    return {
+        "rule_id": match.group("rule_id"),
+        "status": match.group("status"),
+        "message": match.group("message").strip(),
+    }
+
+
 class HardeningBackend(BaseBackend):
     """Execute `loongshield seharden` and keep structured hardening results."""
 
     _SUMMARY_RE = re.compile(
-        r"SEHarden\s+Finished\.\s*"
+        r"(?:SEHarden\s+Finished\.|Summary:)\s*"
         r"(?P<passed>\d+)\s+passed,\s*"
         r"(?P<fixed>\d+)\s+fixed,\s*"
         r"(?P<failed>\d+)\s+failed,\s*"
         r"(?P<manual>\d+)\s+manual,\s*"
         r"(?P<dry_run_pending>\d+)\s+dry-run-pending\s*/\s*"
-        r"(?P<total>\d+)\s+total\."
+        r"(?P<total>\d+)\s+total\.?"
     )
 
     def execute(
@@ -255,36 +281,39 @@ class HardeningBackend(BaseBackend):
 
         entries: list[dict[str, str]] = []
         for line in clean_output.splitlines():
-            match = _RULE_STATUS_RE.search(line)
+            match = _parse_rule_status_line(line)
             if match:
-                entries.append(
-                    {
-                        "rule_id": match.group("rule_id"),
-                        "status": match.group("status"),
-                        "message": match.group("message").strip(),
-                    }
-                )
+                entries.append(match)
                 continue
 
             engine_match = _ENGINE_ERROR_RE.search(line)
             if engine_match:
                 entries.append(
                     {
-                        "rule_id": "",
+                        "rule_id": engine_match.group("rule_id") or "",
                         "status": "Engine Error",
                         "message": engine_match.group("message").strip(),
                     }
                 )
 
         mode = data.get("mode")
-        fixed_statuses = frozenset({"FAIL", "FAILED"})
+        fixed_statuses = frozenset({"FIXED"})
+        legacy_fixed_statuses = frozenset({"FAIL", "FAILED"})
+        all_fixed_statuses = fixed_statuses | legacy_fixed_statuses
         if mode == "reinforce":
             data["failures"] = [
-                entry for entry in entries if entry["status"] not in fixed_statuses
+                entry for entry in entries if entry["status"] not in all_fixed_statuses
             ]
-            data["fixed_items"] = [
+            fixed_items = [
                 entry for entry in entries if entry["status"] in fixed_statuses
             ]
+            if not fixed_items:
+                fixed_items = [
+                    entry
+                    for entry in entries
+                    if entry["status"] in legacy_fixed_statuses
+                ]
+            data["fixed_items"] = fixed_items
         else:
             data["failures"] = entries
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
@@ -56,6 +56,7 @@ def _parse_rule_status_line(line: str) -> dict[str, str] | None:
             "rule_id": match.group("rule_id"),
             "status": match.group("status"),
             "message": match.group("message").strip(),
+            "_source": "legacy",
         }
 
     match = _VERBOSE_RULE_STATUS_RE.search(line)
@@ -66,6 +67,16 @@ def _parse_rule_status_line(line: str) -> dict[str, str] | None:
         "rule_id": match.group("rule_id"),
         "status": match.group("status"),
         "message": match.group("message").strip(),
+        "_source": "verbose",
+    }
+
+
+def _public_entry(entry: dict[str, str]) -> dict[str, str]:
+    """Return a parsed rule entry without internal parser metadata."""
+    return {
+        "rule_id": entry["rule_id"],
+        "status": entry["status"],
+        "message": entry["message"],
     }
 
 
@@ -293,29 +304,40 @@ class HardeningBackend(BaseBackend):
                         "rule_id": engine_match.group("rule_id") or "",
                         "status": "Engine Error",
                         "message": engine_match.group("message").strip(),
+                        "_source": "engine",
                     }
                 )
 
         mode = data.get("mode")
-        fixed_statuses = frozenset({"FIXED"})
+        fixed_statuses = {"FIXED"}
         legacy_fixed_statuses = frozenset({"FAIL", "FAILED"})
-        all_fixed_statuses = fixed_statuses | legacy_fixed_statuses
         if mode == "reinforce":
-            data["failures"] = [
-                entry for entry in entries if entry["status"] not in all_fixed_statuses
-            ]
-            fixed_items = [
-                entry for entry in entries if entry["status"] in fixed_statuses
-            ]
-            if not fixed_items:
-                fixed_items = [
-                    entry
-                    for entry in entries
-                    if entry["status"] in legacy_fixed_statuses
-                ]
+            fixed_rule_ids = {
+                entry["rule_id"]
+                for entry in entries
+                if entry["status"] in fixed_statuses
+            }
+            failures: list[dict[str, str]] = []
+            fixed_items: list[dict[str, str]] = []
+            for entry in entries:
+                status = entry["status"]
+                source = entry.get("_source")
+                rule_id = entry["rule_id"]
+                if status in fixed_statuses:
+                    fixed_items.append(_public_entry(entry))
+                elif status in legacy_fixed_statuses and source == "legacy":
+                    if rule_id not in fixed_rule_ids:
+                        fixed_items.append(_public_entry(entry))
+                elif status in legacy_fixed_statuses and source == "verbose":
+                    if rule_id not in fixed_rule_ids:
+                        failures.append(_public_entry(entry))
+                else:
+                    failures.append(_public_entry(entry))
+
+            data["failures"] = failures
             data["fixed_items"] = fixed_items
         else:
-            data["failures"] = entries
+            data["failures"] = [_public_entry(entry) for entry in entries]
 
         reported_nonpass = (
             data.get("failed", 0)

--- a/src/agent-sec-core/agent-sec-cli/uv.lock
+++ b/src/agent-sec-core/agent-sec-cli/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "hooks": {
     "PreToolUse": [
       {

--- a/src/agent-sec-core/hermes-plugin/src/plugin.yaml
+++ b/src/agent-sec-core/hermes-plugin/src/plugin.yaml
@@ -1,5 +1,5 @@
 name: agent-sec-core-hermes-plugin
-version: 0.6.0
+version: 0.6.1
 description: "OS-level security guardrails for Hermes Agent — powered by agent-sec-cli"
 provides_hooks:
   - pre_llm_call

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "agent-sec",
   "name": "Agent Security",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Security hooks powered by agent-sec-cli",
   "activation": {
     "onCapabilities": ["hook"]

--- a/src/agent-sec-core/openclaw-plugin/package-lock.json
+++ b/src/agent-sec-core/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-sec-openclaw-plugin",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-sec-core/openclaw-plugin/package.json
+++ b/src/agent-sec-core/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
@@ -31,6 +31,10 @@ def _run_harden_and_expected_event_result() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _expected_event_result(cli_result):
+    return "succeeded" if cli_result.returncode == 0 else "failed"
+
+
 class TestHardenEventLogging:
     """Verify that invoking `harden` produces a queryable event."""
 
@@ -164,7 +168,8 @@ class TestEventQueryFilters:
         """Default output is human-readable table format."""
         since = iso_now()
         time.sleep(0.05)
-        expected_result = _run_harden_and_expected_event_result()
+        harden_result = run_cli("harden")
+        expected_result = _expected_event_result(harden_result)
         time.sleep(0.1)
 
         result = run_cli("events", "--event-type", "harden", "--since", since)
@@ -252,7 +257,8 @@ class TestCLIValidation:
         """Verify that --output json returns a valid JSON array with complete event data."""
         since = iso_now()
         time.sleep(0.05)
-        expected_result = _run_harden_and_expected_event_result()
+        harden_result = run_cli("harden")
+        expected_result = _expected_event_result(harden_result)
         time.sleep(0.1)
 
         result = run_cli(
@@ -300,16 +306,17 @@ class TestCLIValidation:
         assert "details" in event
 
     def test_result_field_in_table_output(self):
-        """Verify that table output shows the ActionResult-derived result."""
+        """Verify that result column shows the harden command outcome."""
         since = iso_now()
         time.sleep(0.05)
-        expected_result = _run_harden_and_expected_event_result()
+        harden_result = run_cli("harden")
+        expected_result = _expected_event_result(harden_result)
         time.sleep(0.1)
 
         result = run_cli("events", "--event-type", "harden", "--since", since)
         assert result.returncode == 0
 
-        # Table output should contain RESULT column with the recorded result.
+        # Table output should contain RESULT column with the command outcome.
         assert "RESULT" in result.stdout
         assert expected_result in result.stdout
 
@@ -410,7 +417,8 @@ class TestEventsDefaultOutput:
         """TC-005: Default output is human-readable table format."""
         since = iso_now()
         time.sleep(0.05)
-        expected_result = _run_harden_and_expected_event_result()
+        harden_result = run_cli("harden")
+        expected_result = _expected_event_result(harden_result)
         time.sleep(0.1)
 
         result = run_cli("events", "--event-type", "harden", "--since", since)

--- a/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
@@ -433,8 +433,8 @@ class TestEventsDefaultOutput:
         - Whether harden ran in scan or reinforce mode
         - The actual output from the harden command
 
-        We verify core fields that ALWAYS exist, and make statistical
-        fields (passed/failed/total) conditional.
+        We verify core fields that ALWAYS exist, and make seharden summary
+        statistics conditional.
         """
         since = iso_now()
         time.sleep(0.05)
@@ -472,9 +472,8 @@ class TestEventsDefaultOutput:
         result_data = event["details"]["result"]
         assert "argv" in result_data or "mode" in result_data
 
-        # Statistical fields (passed/failed/total) only present if loongshield
-        # is installed and harden completed successfully
-        # When loongshield is missing, harden may exit 127 without stats
+        # Statistical fields are present when loongshield emits a parseable
+        # seharden summary. A non-compliant scan may still exit 1 with stats.
         if "passed" in result_data:
             # If one statistical field exists, all should exist
             assert (
@@ -490,7 +489,7 @@ class TestEventsDefaultOutput:
         """TC-006 (extended): When loongshield is installed, verify full stats.
 
         This test validates that when loongshield is available, the harden
-        event contains complete statistical data (passed/failed/total fields).
+        event contains complete parsed seharden summary statistics.
         """
         require_loongshield()
 
@@ -507,18 +506,34 @@ class TestEventsDefaultOutput:
         events = json.loads(result.stdout)
         assert len(events) == 1
 
-        # With loongshield, statistical fields should be present
+        # With loongshield, statistical fields should be present when seharden
+        # emits a parseable summary.
         result_data = events[0]["details"]["result"]
         assert "passed" in result_data, "Expected 'passed' field with loongshield"
         assert "failed" in result_data, "Expected 'failed' field with loongshield"
+        assert "fixed" in result_data, "Expected 'fixed' field with loongshield"
+        assert "manual" in result_data, "Expected 'manual' field with loongshield"
+        assert (
+            "dry_run_pending" in result_data
+        ), "Expected 'dry_run_pending' field with loongshield"
         assert "total" in result_data, "Expected 'total' field with loongshield"
 
         # Validate data types and consistency
         assert isinstance(result_data["passed"], int)
         assert isinstance(result_data["failed"], int)
+        assert isinstance(result_data["fixed"], int)
+        assert isinstance(result_data["manual"], int)
+        assert isinstance(result_data["dry_run_pending"], int)
         assert isinstance(result_data["total"], int)
         assert result_data["total"] > 0, "Total rules should be > 0"
-        assert result_data["passed"] + result_data["failed"] == result_data["total"]
+        assert (
+            result_data["passed"]
+            + result_data["fixed"]
+            + result_data["failed"]
+            + result_data["manual"]
+            + result_data["dry_run_pending"]
+            == result_data["total"]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
@@ -242,6 +242,47 @@ class TestHardeningSummary:
         # Latest harden failed -> needs_attention (not critical)
         assert "Needs attention" in output
 
+    def test_failed_scan_with_stats_still_shows_compliance(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={
+                    "request": {
+                        "args": ["--scan", "--config", "agentos_baseline", "--verbose"]
+                    },
+                    "result": {
+                        "mode": "scan",
+                        "config": "agentos_baseline",
+                        "passed": 20,
+                        "failed": 3,
+                        "total": 23,
+                        "failures": [
+                            {
+                                "rule_id": "SEC-001",
+                                "status": "FAIL",
+                                "message": "issue",
+                            }
+                        ],
+                        "fixed": 0,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            )
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert "Scans performed:  1 (succeeded: 0, failed: 1)" in output
+        assert "Latest scan result:" in output
+        assert "Compliance: 20/23 rules passed (87.0%)" in output
+        assert "Latest scan failed" not in output
+        assert "agent-sec-cli harden --reinforce" in output
+
 
 # ---------------------------------------------------------------------------
 # Test: asset verify summary
@@ -912,6 +953,38 @@ class TestSuggestionsEdgeCases:
             ),
         ]
         output = format_summary(events, "last 24 hours")
+        assert "agent-sec-cli harden --reinforce" not in output
+
+    def test_no_reinforce_suggestion_when_failed_harden_has_parser_failure(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={
+                    "request": {"args": ["--scan"]},
+                    "result": {
+                        "mode": "scan",
+                        "passed": 22,
+                        "failed": 1,
+                        "total": 23,
+                        "failures": [
+                            {
+                                "rule_id": "",
+                                "status": "UNKNOWN",
+                                "message": "Summary reports non-pass rules but details failed.",
+                            }
+                        ],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            )
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert "Compliance: 22/23 rules passed" in output
+        assert "Latest scan failed" not in output
         assert "agent-sec-cli harden --reinforce" not in output
 
     def test_no_suggestion_when_no_hardening_events(self):

--- a/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
@@ -283,6 +283,89 @@ class TestHardeningSummary:
         assert "Latest scan failed" not in output
         assert "agent-sec-cli harden --reinforce" in output
 
+    def test_failed_reinforce_with_stats_contributes_fixed_count(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={
+                    "request": {
+                        "args": ["--scan", "--config", "agentos_baseline", "--verbose"]
+                    },
+                    "result": {
+                        "mode": "scan",
+                        "config": "agentos_baseline",
+                        "passed": 20,
+                        "failed": 3,
+                        "total": 23,
+                        "failures": [
+                            {
+                                "rule_id": "SEC-001",
+                                "status": "FAIL",
+                                "message": "issue",
+                            }
+                        ],
+                        "fixed": 0,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={
+                    "request": {
+                        "args": [
+                            "--reinforce",
+                            "--config",
+                            "agentos_baseline",
+                            "--verbose",
+                        ]
+                    },
+                    "result": {
+                        "mode": "reinforce",
+                        "config": "agentos_baseline",
+                        "passed": 20,
+                        "failed": 1,
+                        "total": 23,
+                        "failures": [
+                            {
+                                "rule_id": "SEC-003",
+                                "status": "FAIL",
+                                "message": "still failing",
+                            }
+                        ],
+                        "fixed": 2,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [
+                            {
+                                "rule_id": "SEC-001",
+                                "status": "FIXED",
+                                "message": "fixed",
+                            },
+                            {
+                                "rule_id": "SEC-002",
+                                "status": "FIXED",
+                                "message": "fixed",
+                            },
+                        ],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert "Reinforcements:   1 (succeeded: 0, failed: 1)" in output
+        assert "Compliance: 22/23 rules passed (20 passed + 2 fixed, 95.7%)" in output
+
 
 # ---------------------------------------------------------------------------
 # Test: asset verify summary

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
@@ -25,11 +25,26 @@ LOONGSHIELD_WITH_FAILURES = """\
 \x1b[32m[INFO  14:30:04]\x1b[0m engine.lua:292: SEHarden Finished. 20 passed, 0 fixed, 2 failed, 1 manual, 0 dry-run-pending / 23 total.
 """
 
+LOONGSHIELD_VERBOSE_SCAN_WITH_FAILURES = """\
+\x1b[1;36mSEHarden scan\x1b[0m: profile='loongshield_e2e', level='strict', 2 rule(s)
+  \x1b[1;32mPASS\x1b[0m [e2e.max_auth_tries] Ensure fixture MaxAuthTries is hardened
+  \x1b[1;31mFAIL\x1b[0m [e2e.strict_banner] Ensure fixture SSH banner is configured
+    \x1b[33mreason:\x1b[0m actual: nil
+\x1b[1;36mSummary:\x1b[0m \x1b[32m1 passed\x1b[0m, \x1b[32m0 fixed\x1b[0m, \x1b[31m1 failed\x1b[0m, \x1b[2m0 manual\x1b[0m, \x1b[2m0 dry-run-pending\x1b[0m / 2 total
+"""
+
 LOONGSHIELD_REINFORCE = """\
 \x1b[33m[WARN  14:30:01]\x1b[0m engine.lua:186: [fs.udf_disabled] FAIL: Ensure mounting of udf is disabled
 \x1b[31m[ERROR 14:30:04]\x1b[0m engine.lua:307: [fs.shadow_perms] FAILED-TO-FIX: Cannot set file permissions on /etc/shadow
 \x1b[31m[ERROR 14:30:04]\x1b[0m engine.lua:295: [kern.sysctl_apply] ENFORCE-ERROR: Failed to apply sysctl setting
 \x1b[32m[INFO  14:30:05]\x1b[0m engine.lua:292: SEHarden Finished. 18 passed, 1 fixed, 1 failed, 0 manual, 0 dry-run-pending / 20 total.
+"""
+
+LOONGSHIELD_REINFORCE_FIXED = """\
+  \x1b[1;31mFAIL\x1b[0m [e2e.max_auth_tries] Ensure fixture MaxAuthTries is hardened
+    \x1b[33mreason:\x1b[0m actual: 6
+\x1b[32m[INFO  14:30:05]\x1b[0m engine.lua:292: [e2e.max_auth_tries] FIXED: Ensure fixture MaxAuthTries is hardened
+\x1b[32m[INFO  14:30:06]\x1b[0m engine.lua:292: SEHarden Finished. 0 passed, 1 fixed, 0 failed, 0 manual, 0 dry-run-pending / 1 total.
 """
 
 LOONGSHIELD_DRYRUN = """\
@@ -219,6 +234,29 @@ class TestHardeningExecute(unittest.TestCase):
 
     @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
     @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_verbose_summary_and_rule_status_are_parsed(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(LOONGSHIELD_VERBOSE_SCAN_WITH_FAILURES, 1)
+
+        result = self.backend.execute(self.ctx, args=["--scan", "--verbose"])
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.data["passed"], 1)
+        self.assertEqual(result.data["failed"], 1)
+        self.assertEqual(result.data["total"], 2)
+        self.assertEqual(
+            result.data["failures"],
+            [
+                {
+                    "rule_id": "e2e.strict_banner",
+                    "status": "FAIL",
+                    "message": "Ensure fixture SSH banner is configured",
+                }
+            ],
+        )
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
     def test_legacy_mode_and_config_are_translated(self, mock_which, mock_run):
         mock_which.return_value = "/usr/bin/loongshield"
         mock_run.return_value = _mock_proc(LOONGSHIELD_REINFORCE, 1)
@@ -263,6 +301,32 @@ class TestHardeningExecute(unittest.TestCase):
         statuses = [item["status"] for item in result.data["failures"]]
         self.assertIn("FAILED-TO-FIX", statuses)
         self.assertIn("ENFORCE-ERROR", statuses)
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_reinforce_fixed_status_is_preferred_over_verbose_fail(
+        self, mock_which, mock_run
+    ):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(LOONGSHIELD_REINFORCE_FIXED, 0)
+
+        result = self.backend.execute(
+            self.ctx, args=["--reinforce", "--verbose", "--config", "agentos_baseline"]
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["fixed"], 1)
+        self.assertEqual(result.data["failures"], [])
+        self.assertEqual(
+            result.data["fixed_items"],
+            [
+                {
+                    "rule_id": "e2e.max_auth_tries",
+                    "status": "FIXED",
+                    "message": "Ensure fixture MaxAuthTries is hardened",
+                }
+            ],
+        )
 
     @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
     @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_hardening_backend.py
@@ -47,6 +47,14 @@ LOONGSHIELD_REINFORCE_FIXED = """\
 \x1b[32m[INFO  14:30:06]\x1b[0m engine.lua:292: SEHarden Finished. 0 passed, 1 fixed, 0 failed, 0 manual, 0 dry-run-pending / 1 total.
 """
 
+LOONGSHIELD_REINFORCE_MIXED_FAIL_AND_FIXED = """\
+  \x1b[1;31mFAIL\x1b[0m [e2e.strict_banner] Ensure fixture SSH banner is configured
+    \x1b[33mreason:\x1b[0m actual: nil
+\x1b[32m[INFO  14:30:05]\x1b[0m engine.lua:292: [e2e.max_auth_tries] FIXED: Ensure fixture MaxAuthTries is hardened
+\x1b[33m[WARN  14:30:06]\x1b[0m engine.lua:186: [fs.udf_disabled] FAIL: Ensure mounting of udf is disabled
+\x1b[32m[INFO  14:30:07]\x1b[0m engine.lua:292: SEHarden Finished. 0 passed, 2 fixed, 1 failed, 0 manual, 0 dry-run-pending / 3 total.
+"""
+
 LOONGSHIELD_DRYRUN = """\
 \x1b[32m[INFO  14:30:01]\x1b[0m engine.lua:298: [fs.cramfs_blacklist] DRY-RUN: would apply cramfs blacklist
 \x1b[32m[INFO  14:30:02]\x1b[0m engine.lua:298: [svc.chronyd_enable] DRY-RUN: would enable chronyd
@@ -325,6 +333,49 @@ class TestHardeningExecute(unittest.TestCase):
                     "status": "FIXED",
                     "message": "Ensure fixture MaxAuthTries is hardened",
                 }
+            ],
+        )
+
+    @patch("agent_sec_cli.security_middleware.backends.hardening.subprocess.run")
+    @patch("agent_sec_cli.security_middleware.backends.hardening.shutil.which")
+    def test_reinforce_distinguishes_verbose_fail_from_legacy_fail(
+        self, mock_which, mock_run
+    ):
+        mock_which.return_value = "/usr/bin/loongshield"
+        mock_run.return_value = _mock_proc(
+            LOONGSHIELD_REINFORCE_MIXED_FAIL_AND_FIXED, 1
+        )
+
+        result = self.backend.execute(
+            self.ctx, args=["--reinforce", "--verbose", "--config", "agentos_baseline"]
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.data["fixed"], 2)
+        self.assertEqual(result.data["failed"], 1)
+        self.assertEqual(
+            result.data["failures"],
+            [
+                {
+                    "rule_id": "e2e.strict_banner",
+                    "status": "FAIL",
+                    "message": "Ensure fixture SSH banner is configured",
+                }
+            ],
+        )
+        self.assertEqual(
+            result.data["fixed_items"],
+            [
+                {
+                    "rule_id": "e2e.max_auth_tries",
+                    "status": "FIXED",
+                    "message": "Ensure fixture MaxAuthTries is hardened",
+                },
+                {
+                    "rule_id": "fs.udf_disabled",
+                    "status": "FAIL",
+                    "message": "Ensure mounting of udf is disabled",
+                },
             ],
         )
 

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -82,6 +82,20 @@ class TestPostAction(unittest.TestCase):
         self.assertEqual(event.category, "code_scan")
         self.assertEqual(event.result, "failed")
         self.assertEqual(event.details["result"], {"ok": False, "verdict": "error"})
+    
+    @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
+    def test_post_action_maps_failed_result_to_event_result(self, mock_log):
+        ctx = RequestContext(action="harden", trace_id="t-123")
+        result = ActionResult(
+            success=False,
+            data={"passed": 20, "failed": 3, "total": 23},
+            exit_code=1,
+        )
+        post_action(ctx, result, {"args": ["--scan"]}, DummyBackend())
+
+        event = mock_log.call_args[0][0]
+        self.assertEqual(event.result, "failed")
+        self.assertEqual(event.details["result"]["passed"], 20)
 
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_post_action_copies_request_tracing_to_security_event(self, mock_log):

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -82,7 +82,7 @@ class TestPostAction(unittest.TestCase):
         self.assertEqual(event.category, "code_scan")
         self.assertEqual(event.result, "failed")
         self.assertEqual(event.details["result"], {"ok": False, "verdict": "error"})
-    
+
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_post_action_maps_failed_result_to_event_result(self, mock_log):
         ctx = RequestContext(action="harden", trace_id="t-123")


### PR DESCRIPTION
## Description

回合sec-core v0.6.0 release分支提交

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
