### PR TITLE
feat(sec-core): extend pii scanning coverage

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/cli.py
@@ -16,7 +16,15 @@ scanner_app = typer.Typer(
 )
 
 _OUTPUT_FORMATS = {"json", "text"}
-_SOURCES = {"user_input", "tool_output", "manual", "unknown"}
+_SOURCES = {
+    "user_input",
+    "tool_input",
+    "tool_output",
+    "model_output",
+    "observability",
+    "manual",
+    "unknown",
+}
 _TEXT_OPTION = typer.Option(None, "--text", help="Text to scan.")
 _STDIN_OPTION = typer.Option(
     False,
@@ -60,8 +68,9 @@ _SOURCE_OPTION = typer.Option(
     "unknown",
     "--source",
     help=(
-        "Audit and policy context label: user_input, tool_output, manual, or "
-        "unknown. This does not modify input content."
+        "Audit and policy context label: user_input, tool_input, tool_output, "
+        "model_output, observability, manual, or unknown. This does not modify "
+        "input content."
     ),
 )
 _MAX_BYTES_OPTION = typer.Option(
@@ -180,7 +189,8 @@ def scan_pii(
         raise typer.Exit(code=1)
     if source not in _SOURCES:
         typer.echo(
-            "Error: --source must be one of: user_input, tool_output, manual, unknown.",
+            "Error: --source must be one of: user_input, tool_input, tool_output, "
+            "model_output, observability, manual, unknown.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/scanner.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/scanner.py
@@ -16,7 +16,15 @@ from agent_sec_cli.pii_checker.redactor import redact_text, redact_value
 
 DEFAULT_MAX_BYTES = 1_048_576
 LOW_CONFIDENCE_THRESHOLD = 0.5
-ALLOWED_SOURCES = {"user_input", "tool_output", "manual", "unknown"}
+ALLOWED_SOURCES = {
+    "user_input",
+    "tool_input",
+    "tool_output",
+    "model_output",
+    "observability",
+    "manual",
+    "unknown",
+}
 _MULTI_TYPE_OVERLAPS = {frozenset({"bearer_token", "jwt"})}
 
 

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -39,6 +39,17 @@
         "hooks": [
           {
             "type": "command",
+            "name": "pii-checker",
+            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "description": "Scans tool inputs for PII and credentials.",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "name": "observability-hook",
             "command": "python3 ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
@@ -96,6 +107,17 @@
         "hooks": [
           {
             "type": "command",
+            "name": "pii-checker",
+            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "description": "Scans model responses for PII and credentials.",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "name": "observability-hook",
             "command": "python3 ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
@@ -109,6 +131,17 @@
         "hooks": [
           {
             "type": "command",
+            "name": "pii-checker",
+            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "description": "Scans tool outputs for PII and credentials.",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "name": "observability-hook",
             "command": "python3 ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
@@ -118,6 +151,17 @@
       }
     ],
     "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "pii-checker",
+            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "description": "Scans tool errors for PII and credentials.",
+            "timeout": 10000
+          }
+        ]
+      },
       {
         "hooks": [
           {

--- a/src/agent-sec-core/cosh-extension/hooks/observability_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/observability_hook.py
@@ -24,6 +24,28 @@ _OBSERVABILITY_COMMAND = [
     "json",
     "--stdin",
 ]
+_PII_REDACT_COMMAND = [
+    "agent-sec-cli",
+    "scan-pii",
+    "--stdin",
+    "--format",
+    "json",
+    "--redact-output",
+    "--source",
+    "observability",
+]
+_SENSITIVE_METRIC_KEYS = {
+    "prompt",
+    "user_input",
+    "system_prompt",
+    "messages",
+    "response",
+    "parameters",
+    "result",
+    "error",
+    "tool_calls",
+}
+_DROP = object()
 
 
 def _noop() -> str:
@@ -39,6 +61,10 @@ def _json_dumps(value: Any) -> str:
         sort_keys=True,
         default=str,
     )
+
+
+def _json_loads(value: str) -> Any:
+    return json.loads(value)
 
 
 def _json_size_bytes(value: Any) -> int:
@@ -175,6 +201,77 @@ def _process_output_details(*values: Any) -> str:
     return "no stderr or stdout was captured"
 
 
+def _redact_text(text: str) -> str | None:
+    try:
+        result = subprocess.run(
+            _PII_REDACT_COMMAND,
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    try:
+        data = _json_loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    redacted = data.get("redacted_text")
+    return redacted if isinstance(redacted, str) else None
+
+
+def _redact_sensitive_value(value: Any) -> Any:
+    """Redact a sensitive metric value, or return _DROP on scan failure."""
+    if isinstance(value, str):
+        redacted = _redact_text(value)
+        return _DROP if redacted is None else redacted
+
+    serialized = _json_dumps(value)
+    redacted = _redact_text(serialized)
+    if redacted is None:
+        return _DROP
+    try:
+        return _json_loads(redacted)
+    except (json.JSONDecodeError, ValueError):
+        return redacted
+
+
+def _redact_metrics(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in _SENSITIVE_METRIC_KEYS:
+                safe_item = _redact_sensitive_value(item)
+            else:
+                safe_item = _redact_metrics(item)
+            if safe_item is not _DROP:
+                redacted[key] = safe_item
+        return redacted
+    if isinstance(value, list):
+        return [
+            item
+            for item in (_redact_metrics(item) for item in value)
+            if item is not _DROP
+        ]
+    return value
+
+
+def _redact_observability_record(record: dict[str, Any]) -> dict[str, Any]:
+    safe_record = dict(record)
+    metrics = safe_record.get("metrics")
+    if isinstance(metrics, dict):
+        safe_record["metrics"] = _redact_metrics(metrics)
+    return safe_record
+
+
 def _build_user_prompt_submit(input_data: dict[str, Any]) -> dict[str, Any] | None:
     metrics: dict[str, Any] = {}
     if "prompt" in input_data:
@@ -307,6 +404,7 @@ def _build_record(input_data: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _record_observability(record: dict[str, Any]) -> None:
+    record = _redact_observability_record(record)
     try:
         result = subprocess.run(
             _OBSERVABILITY_COMMAND,

--- a/src/agent-sec-core/cosh-extension/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/pii_checker_hook.py
@@ -17,7 +17,10 @@ from typing import Any
 
 from trace_context import with_trace_context
 
-_DEFAULT_SOURCE = "user_input"
+_USER_INPUT_SOURCE = "user_input"
+_TOOL_INPUT_SOURCE = "tool_input"
+_TOOL_OUTPUT_SOURCE = "tool_output"
+_MODEL_OUTPUT_SOURCE = "model_output"
 _MAX_EVIDENCE_ITEMS = 3
 _MAX_EVIDENCE_CHARS = 80
 
@@ -33,6 +36,16 @@ def _as_list(value: Any) -> list[Any]:
 
 def _safe_text(value: Any) -> str:
     return value if isinstance(value, str) else ""
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
 
 
 def _shorten(value: str, limit: int = _MAX_EVIDENCE_CHARS) -> str:
@@ -81,6 +94,116 @@ def _format_pii_warning(verdict: str, findings: list[Any]) -> str:
     return "；".join(parts)
 
 
+def _scan_text(
+    input_data: dict[str, Any], text: str, source: str
+) -> dict[str, Any] | None:
+    """Run scan-pii with a source label and parse JSON output."""
+    try:
+        cmd = with_trace_context(
+            [
+                "agent-sec-cli",
+                "scan-pii",
+                "--stdin",
+                "--format",
+                "json",
+                "--redact-output",
+                "--source",
+                source,
+            ],
+            input_data,
+        )
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+            input=text,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+
+    if proc.returncode != 0:
+        return None
+
+    try:
+        scan_result = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return scan_result if isinstance(scan_result, dict) else None
+
+
+def _extract_response_text(llm_response: Any) -> str:
+    """Extract text from common Cosh AfterModel response shapes."""
+    if isinstance(llm_response, str):
+        return llm_response
+    if not isinstance(llm_response, dict):
+        return ""
+
+    text = llm_response.get("text")
+    if isinstance(text, str):
+        return text
+
+    candidates = llm_response.get("candidates")
+    if not isinstance(candidates, list):
+        return ""
+
+    parts: list[str] = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        content = candidate.get("content")
+        if not isinstance(content, dict):
+            continue
+        candidate_parts = content.get("parts")
+        if isinstance(candidate_parts, str):
+            parts.append(candidate_parts)
+        elif isinstance(candidate_parts, list):
+            for part in candidate_parts:
+                if isinstance(part, str):
+                    parts.append(part)
+                elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                    parts.append(part["text"])
+    return "".join(parts)
+
+
+def _extract_scan_target(input_data: dict[str, Any]) -> tuple[str, str]:
+    """Return text and source for supported Cosh hook events."""
+    event_name = _safe_text(input_data.get("hook_event_name"))
+    if not event_name:
+        event_name = _safe_text(input_data.get("hookEventName"))
+
+    if event_name in {"", "UserPromptSubmit"}:
+        return _safe_text(input_data.get("prompt")), _USER_INPUT_SOURCE
+
+    if event_name == "PreToolUse":
+        if "tool_input" not in input_data:
+            return "", _TOOL_INPUT_SOURCE
+        value = input_data.get("tool_input")
+        return (
+            value if isinstance(value, str) else _json_dumps(value)
+        ), _TOOL_INPUT_SOURCE
+
+    if event_name == "PostToolUse":
+        if "tool_response" not in input_data:
+            return "", _TOOL_OUTPUT_SOURCE
+        value = input_data.get("tool_response")
+        return (
+            value if isinstance(value, str) else _json_dumps(value)
+        ), _TOOL_OUTPUT_SOURCE
+
+    if event_name == "PostToolUseFailure":
+        return _safe_text(input_data.get("error")), _TOOL_OUTPUT_SOURCE
+
+    if event_name == "AfterModel":
+        return (
+            _extract_response_text(input_data.get("llm_response")),
+            _MODEL_OUTPUT_SOURCE,
+        )
+
+    return "", "unknown"
+
+
 def _format_cosh(scan_result: dict[str, Any]) -> str:
     """Convert a scan-pii result dict into a cosh HookOutput JSON string.
 
@@ -112,46 +235,19 @@ def main() -> None:
         print(_allow())
         return
 
-    prompt_text = input_data.get("prompt", "")
-    if not isinstance(prompt_text, str) or not prompt_text.strip():
+    if not isinstance(input_data, dict):
         print(_allow())
         return
 
-    try:
-        cmd = with_trace_context(
-            [
-                "agent-sec-cli",
-                "scan-pii",
-                "--stdin",
-                "--format",
-                "json",
-                "--source",
-                _DEFAULT_SOURCE,
-            ],
-            input_data,
-        )
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            check=False,
-            input=prompt_text,
-            text=True,
-            timeout=10,
-        )
-    except Exception:
+    scan_text, source = _extract_scan_target(input_data)
+    if not isinstance(scan_text, str) or not scan_text.strip():
         print(_allow())
         return
 
-    if proc.returncode != 0:
+    scan_result = _scan_text(input_data, scan_text, source)
+    if scan_result is None:
         print(_allow())
         return
-
-    try:
-        scan_result = json.loads(proc.stdout)
-    except (json.JSONDecodeError, ValueError):
-        print(_allow())
-        return
-
     print(_format_cosh(scan_result))
 
 

--- a/src/agent-sec-core/hermes-plugin/README.md
+++ b/src/agent-sec-core/hermes-plugin/README.md
@@ -186,17 +186,17 @@ CLI 调用方式和 `openclaw-plugin` 保持一致：helper 将一条 JSON paylo
 
 ### pii-scan-user-input
 
-`pii-scan-user-input` 对齐 Cosh/OpenClaw PII checker v1 语义：
+`pii-scan-user-input` 对齐 Cosh/OpenClaw 多点位 PII checker 语义：
 
-- 挂在 `pre_llm_call`、`transform_llm_output`、`on_session_end`
-- 只扫描本轮用户输入，不扫描 history、tool output 或 terminal 原始输出
-- 调用 `agent-sec-cli scan-pii --stdin --format json --source user_input`，敏感原文仅通过 stdin 传入子进程
-- `warn` / `deny` 不阻断请求，只缓存脱敏 warning
-- `transform_llm_output` 在最终回复前 prepend warning，成功交付后清理缓存
+- 挂在 `pre_llm_call`、`pre_tool_call`、`post_tool_call`、`transform_llm_output`、`on_session_end`
+- 扫描本轮用户输入、tool 参数、tool 返回结果和最终模型回复；不扫描 history、memory 或 RAG context
+- 调用 `agent-sec-cli scan-pii --stdin --format json --redact-output --source <source>`，敏感原文仅通过 stdin 传入子进程
+- tool 参数/结果的 `warn` / `deny` 不阻断请求，只缓存脱敏 warning
+- `transform_llm_output` 会扫描最终模型回复；命中时使用 `redacted_text` 替换用户可见回复，并 prepend 已缓存 warning
 - 当前实现依赖 Hermes 对完整最终回复调用一次 `transform_llm_output`；若未来改成流式分片 transform，需要重新审视 warning pop 语义
 - `on_session_end` 清理残留缓存
 - 所有异常、超时、非 JSON 输出、未知 verdict 都 fail-open
-- warning 只使用 `evidence_redacted`，不展示 raw evidence 或原始用户输入
+- warning 只使用 `evidence_redacted`，不展示 raw evidence 或原始文本
 
 ### prompt-scan-user-input
 

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/pii_scan.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/pii_scan.py
@@ -176,9 +176,14 @@ class PiiScanCapability(AgentSecCoreCapability):
                     redacted_text = self._safe_string(scan.get("redacted_text"))
                     if redacted_text:
                         output_text = redacted_text
-                    logger.warning(
-                        f"[agent-sec-core] {self.id} {verdict.upper()} model output redacted"
-                    )
+                        logger.warning(
+                            f"[agent-sec-core] {self.id} {verdict.upper()} model output redacted"
+                        )
+                    else:
+                        output_text = ""
+                        logger.warning(
+                            f"[agent-sec-core] {self.id} {verdict.upper()} model output redaction missing redacted_text; dropping raw output"
+                        )
                 elif verdict not in {"pass", "warn", "deny"}:
                     logger.warning(
                         f"[agent-sec-core] {self.id} UNKNOWN model output verdict={verdict}, fail-open"

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/pii_scan.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/pii_scan.py
@@ -17,6 +17,11 @@ _DEFAULT_WARNING_TTL_SECONDS = 300.0
 _MAX_EVIDENCE_ITEMS = 3
 _MAX_EVIDENCE_CHARS = 80
 _USER_INPUT_SOURCE = "user_input"
+_TOOL_INPUT_SOURCE = "tool_input"
+_TOOL_OUTPUT_SOURCE = "tool_output"
+_MODEL_OUTPUT_SOURCE = "model_output"
+_CONTEXT_KEY_FIELDS = ("session_id", "task_id", "run_id")
+_HERMES_SESSION_ENV = "HERMES_SESSION_ID"
 
 
 @dataclass
@@ -53,6 +58,8 @@ class PiiScanCapability(AgentSecCoreCapability):
     def get_hooks_define(self) -> dict:
         return {
             "pre_llm_call": self._on_pre_llm_call,
+            "pre_tool_call": self._on_pre_tool_call,
+            "post_tool_call": self._on_post_tool_call,
             "transform_llm_output": self._on_transform_llm_output,
             "on_session_end": self._on_session_end,
         }
@@ -73,27 +80,66 @@ class PiiScanCapability(AgentSecCoreCapability):
             return None
 
         self._warnings_by_key.pop(cache_key, None)
-        scan = self._scan_text(user_text, trace_context(kwargs))
-        if scan is None:
+        self._scan_and_cache(
+            user_text,
+            source=_USER_INPUT_SOURCE,
+            cache_key=cache_key,
+            security_trace_context=trace_context(kwargs),
+        )
+        return None
+
+    def _on_pre_tool_call(
+        self,
+        *,
+        tool_name: Any,
+        args: Any,
+        **kwargs: Any,
+    ):
+        """Scan tool arguments before execution."""
+        self._cleanup_expired()
+        text = self._value_to_text(args)
+        if not text.strip():
             return None
-
-        verdict = self._safe_string(scan.get("verdict")) or "pass"
-        findings = self._as_list(scan.get("findings"))
-
-        if verdict == "pass" or not findings:
-            logger.info(f"[agent-sec-core] {self.id} PASS")
-            return None
-
-        if verdict not in {"warn", "deny"}:
+        cache_key = self._cache_key(kwargs)
+        if cache_key is None:
             logger.warning(
-                f"[agent-sec-core] {self.id} UNKNOWN verdict={verdict}, fail-open"
+                f"[agent-sec-core] {self.id} missing session/task key for tool input, fail-open"
             )
             return None
+        data = {"tool_name": tool_name, "args": args, **kwargs}
+        self._scan_and_cache(
+            text,
+            source=_TOOL_INPUT_SOURCE,
+            cache_key=cache_key,
+            security_trace_context=trace_context(data),
+        )
+        return None
 
-        warning = self._format_pii_warning(verdict, findings)
-        self._push_warning(cache_key, warning)
-        logger.warning(
-            f"[agent-sec-core] {self.id} {verdict.upper()} warning cached key={cache_key}"
+    def _on_post_tool_call(
+        self,
+        *,
+        tool_name: Any,
+        args: Any,
+        result: Any,
+        **kwargs: Any,
+    ):
+        """Scan tool output after execution."""
+        self._cleanup_expired()
+        text = self._value_to_text(result)
+        if not text.strip():
+            return None
+        cache_key = self._cache_key(kwargs)
+        if cache_key is None:
+            logger.warning(
+                f"[agent-sec-core] {self.id} missing session/task key for tool output, fail-open"
+            )
+            return None
+        data = {"tool_name": tool_name, "args": args, "result": result, **kwargs}
+        self._scan_and_cache(
+            text,
+            source=_TOOL_OUTPUT_SOURCE,
+            cache_key=cache_key,
+            security_trace_context=trace_context(data),
         )
         return None
 
@@ -105,21 +151,49 @@ class PiiScanCapability(AgentSecCoreCapability):
     ):
         """Prepend cached PII warnings to the final user-visible response."""
         self._cleanup_expired()
-        if not isinstance(response_text, str) or not response_text:
+        if not isinstance(response_text, str):
             return None
 
         cache_key = self._cache_key({"session_id": session_id, **kwargs})
         if cache_key is None:
             return None
 
-        warnings = self._pop_warnings(cache_key)
-        if not warnings:
+        warnings = self._pop_warnings(cache_key) if cache_key is not None else []
+        output_text = response_text
+        if response_text.strip():
+            scan = self._scan_text(
+                response_text,
+                source=_MODEL_OUTPUT_SOURCE,
+                security_trace_context=trace_context(
+                    {"session_id": session_id, **kwargs}
+                ),
+            )
+            if scan is not None:
+                verdict = self._safe_string(scan.get("verdict")) or "pass"
+                findings = self._as_list(scan.get("findings"))
+                if verdict in {"warn", "deny"} and findings:
+                    warnings.append(self._format_pii_warning(verdict, findings))
+                    redacted_text = self._safe_string(scan.get("redacted_text"))
+                    if redacted_text:
+                        output_text = redacted_text
+                    logger.warning(
+                        f"[agent-sec-core] {self.id} {verdict.upper()} model output redacted"
+                    )
+                elif verdict not in {"pass", "warn", "deny"}:
+                    logger.warning(
+                        f"[agent-sec-core] {self.id} UNKNOWN model output verdict={verdict}, fail-open"
+                    )
+
+        if not warnings and output_text == response_text:
             return None
 
-        # Hermes currently calls transform_llm_output once with the complete
-        # final response. If it later switches to chunk-level streaming
-        # transforms, this pop-once delivery policy should be revisited.
-        return "\n".join(warnings) + "\n\n" + response_text
+        if warnings:
+            warning_text = "\n".join(warnings)
+            if output_text:
+                return f"{warning_text}\n\n{output_text}"
+            return warning_text
+
+        return output_text
 
     def _on_session_end(self, session_id: str = "", **kwargs):
         """Clean cached warnings when Hermes ends a session."""
@@ -132,6 +206,8 @@ class PiiScanCapability(AgentSecCoreCapability):
     def _scan_text(
         self,
         text: str,
+        *,
+        source: str,
         security_trace_context: dict[str, str] | None,
     ) -> dict[str, Any] | None:
         """Run agent-sec-cli scan-pii and parse its JSON output."""
@@ -140,8 +216,9 @@ class PiiScanCapability(AgentSecCoreCapability):
             "--stdin",
             "--format",
             "json",
+            "--redact-output",
             "--source",
-            _USER_INPUT_SOURCE,
+            source,
         ]
         if self._include_low_confidence:
             args.append("--include-low-confidence")
@@ -172,6 +249,42 @@ class PiiScanCapability(AgentSecCoreCapability):
             )
             return None
         return scan
+
+    def _scan_and_cache(
+        self,
+        text: str,
+        *,
+        source: str,
+        cache_key: str,
+        security_trace_context: dict[str, str] | None,
+    ) -> None:
+        """Scan text and cache a minimal warning for warn/deny results."""
+        scan = self._scan_text(
+            text,
+            source=source,
+            security_trace_context=security_trace_context,
+        )
+        if scan is None:
+            return
+
+        verdict = self._safe_string(scan.get("verdict")) or "pass"
+        findings = self._as_list(scan.get("findings"))
+
+        if verdict == "pass" or not findings:
+            logger.info(f"[agent-sec-core] {self.id} PASS source={source}")
+            return
+
+        if verdict not in {"warn", "deny"}:
+            logger.warning(
+                f"[agent-sec-core] {self.id} UNKNOWN verdict={verdict}, fail-open"
+            )
+            return
+
+        warning = self._format_pii_warning(verdict, findings)
+        self._push_warning(cache_key, warning)
+        logger.warning(
+            f"[agent-sec-core] {self.id} {verdict.upper()} warning cached key={cache_key} source={source}"
+        )
 
     def _extract_user_text(self, messages, kwargs: dict[str, Any]) -> str:
         """Extract only the current user input from Hermes hook payloads."""
@@ -206,12 +319,48 @@ class PiiScanCapability(AgentSecCoreCapability):
             return "\n".join(parts)
         return ""
 
+    def _value_to_text(self, value: Any) -> str:
+        """Convert arbitrary hook values into scan text."""
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        try:
+            return json.dumps(
+                value,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+                default=str,
+            )
+        except (TypeError, ValueError):
+            return str(value)
+
     def _cache_key(self, values: dict[str, Any]) -> str | None:
         """Return the best available Hermes turn/session correlation key."""
-        for key in ("session_id", "task_id", "run_id"):
+        runtime_session_id = self._runtime_session_id()
+        if runtime_session_id is not None:
+            return f"session_id:{runtime_session_id}"
+
+        for key in _CONTEXT_KEY_FIELDS:
             value = values.get(key)
             if isinstance(value, str) and value.strip():
-                return value.strip()
+                return f"{key}:{value.strip()}"
+        return None
+
+    @staticmethod
+    def _runtime_session_id() -> str | None:
+        try:
+            from gateway.session_context import get_session_env
+        except Exception:
+            return None
+
+        try:
+            value = get_session_env(_HERMES_SESSION_ENV, "")
+        except Exception:
+            return None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
         return None
 
     def _push_warning(self, cache_key: str, warning: str) -> None:

--- a/src/agent-sec-core/hermes-plugin/src/cli_runner.py
+++ b/src/agent-sec-core/hermes-plugin/src/cli_runner.py
@@ -7,6 +7,19 @@ import subprocess
 from dataclasses import dataclass
 from typing import Any
 
+_OBSERVABILITY_SENSITIVE_KEYS = {
+    "prompt",
+    "user_input",
+    "system_prompt",
+    "messages",
+    "response",
+    "parameters",
+    "result",
+    "error",
+    "tool_calls",
+}
+_DROP = object()
+
 
 @dataclass
 class CliResult:
@@ -71,6 +84,87 @@ def trace_context(data: dict[str, Any]) -> dict[str, str] | None:
     return context or None
 
 
+def _json_dumps(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
+
+
+def _redact_text_for_observability(text: str, timeout: float) -> str | None:
+    result = call_agent_sec_cli(
+        [
+            "scan-pii",
+            "--stdin",
+            "--format",
+            "json",
+            "--redact-output",
+            "--source",
+            "observability",
+        ],
+        timeout=timeout,
+        stdin=text,
+    )
+    if result.exit_code != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    redacted_text = data.get("redacted_text")
+    return redacted_text if isinstance(redacted_text, str) else None
+
+
+def _redact_sensitive_value(value: Any, timeout: float) -> Any:
+    if isinstance(value, str):
+        redacted = _redact_text_for_observability(value, timeout)
+        return _DROP if redacted is None else redacted
+
+    redacted = _redact_text_for_observability(_json_dumps(value), timeout)
+    if redacted is None:
+        return _DROP
+    try:
+        return json.loads(redacted)
+    except (json.JSONDecodeError, ValueError):
+        return redacted
+
+
+def _redact_observability_value(value: Any, timeout: float) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in _OBSERVABILITY_SENSITIVE_KEYS:
+                safe_item = _redact_sensitive_value(item, timeout)
+            else:
+                safe_item = _redact_observability_value(item, timeout)
+            if safe_item is not _DROP:
+                redacted[key] = safe_item
+        return redacted
+    if isinstance(value, list):
+        return [
+            item
+            for item in (_redact_observability_value(item, timeout) for item in value)
+            if item is not _DROP
+        ]
+    return value
+
+
+def _redact_observability_record(
+    record: dict[str, Any],
+    timeout: float,
+) -> dict[str, Any]:
+    safe_record = dict(record)
+    metrics = safe_record.get("metrics")
+    if isinstance(metrics, dict):
+        safe_record["metrics"] = _redact_observability_value(metrics, timeout)
+    return safe_record
+
+
 def _with_trace_context(
     args: list[str],
     context: dict[str, str] | None,
@@ -89,8 +183,9 @@ def record_hermes_observability(
     timeout: float = 10.0,
 ) -> CliResult:
     """Emit one Hermes observability record via agent-sec-cli stdin."""
+    safe_record = _redact_observability_record(record, timeout)
     return call_agent_sec_cli(
         ["observability", "record", "--format", "json", "--stdin"],
         timeout=timeout,
-        stdin=json.dumps(record, ensure_ascii=False, separators=(",", ":")),
+        stdin=json.dumps(safe_record, ensure_ascii=False, separators=(",", ":")),
     )

--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -30,7 +30,7 @@ openclaw-plugin/
 │   │   ├── skill-ledger.ts     #   before_tool_call hook
 │   │   ├── code-scan.ts        #   before_tool_call hook
 │   │   ├── prompt-scan.ts      #   before_dispatch hook
-│   │   ├── pii-scan.ts         #   before_dispatch hook
+│   │   ├── pii-scan.ts         #   PII hooks
 │   │   └── observability.ts    #   observability hook registration
 │   └── helpers/                # Capability support code
 │       └── observability/      #   OpenClaw → agent-sec observability adapter
@@ -232,7 +232,7 @@ AGENT_SEC_LIVE=1 npm run smoke
 
 | Capability         | Hook                  | Priority | Behavior                                             |
 |--------------------|-----------------------|----------|------------------------------------------------------|
-| `pii-scan-user-input` | `before_dispatch` | 200 | Scans inbound user text for PII/credentials before prompt-scan and optionally blocks on `deny` |
+| `pii-scan-user-input` | `before_dispatch`, `before_tool_call`, `after_tool_call`, `llm_output` | 200 before dispatch/tool call | Scans user text, tool parameters, tool output, and model output for PII/credentials; optionally blocks pre-execution `deny` verdicts |
 | `prompt-scan`      | `before_dispatch`     | 190      | Scans inbound messages for prompt injection attacks   |
 | `scan-code`        | `before_tool_call`    | 0 (default) | Scans tool commands for security issues              |
 | `skill-ledger`     | `before_tool_call`    | 80       | Checks skill integrity when SKILL.md is read and optionally asks on risky states |
@@ -250,9 +250,9 @@ openclaw config set plugins.entries.agent-sec.config.codeScanRequireApproval tru
 
 ### Configuring `pii-scan-user-input`
 
-The `pii-scan-user-input` capability scans the current inbound user text in `before_dispatch`, preferring `event.content` and falling back to `event.body`. It intentionally does not scan assembled prompt history, tool results, memory, or RAG context, so older PII does not trigger repeated warnings on later turns.
+The `pii-scan-user-input` capability scans the current inbound user text in `before_dispatch`, tool parameters in `before_tool_call`, tool results/errors in `after_tool_call`, and assistant text in `llm_output`. It intentionally does not scan assembled prompt history, memory, or RAG context, so older PII does not trigger repeated warnings on later turns.
 
-By default, `capabilities["pii-scan-user-input"].enableBlock` is `false`, so `warn` and `deny` verdicts are logged and the turn continues. Set `enableBlock: true` to block `deny` verdicts before prompt-scan runs by returning `{ handled: true, text }`. `warn` verdicts are always logged only. The block text uses redacted evidence and never includes raw PII values.
+By default, `capabilities["pii-scan-user-input"].enableBlock` is `false`, so `warn` and `deny` verdicts are logged and execution continues. Set `enableBlock: true` to block pre-execution `deny` verdicts: user input returns `{ handled: true, text }`, and tool parameters return `{ block: true, blockReason }`. Tool output and model output findings are warning-only. Warning and block text use redacted evidence and never include raw PII values.
 
 ### Configuring `observability`
 

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
@@ -159,10 +159,20 @@ async function scanPiiText(
     return undefined;
   }
 
-  const scanResult = JSON.parse(result.stdout) as {
-    verdict?: unknown;
-    findings?: unknown;
-  };
+  let scanResult: { verdict?: unknown; findings?: unknown };
+  try {
+    scanResult = JSON.parse(result.stdout) as {
+      verdict?: unknown;
+      findings?: unknown;
+    };
+  } catch (error) {
+    api.logger.warn(
+      `[pii-checker] CLI returned invalid JSON, failed open: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return undefined;
+  }
   return {
     verdict: safeString(scanResult.verdict) || "pass",
     findings: Array.isArray(scanResult.findings) ? scanResult.findings : [],

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
@@ -1,5 +1,5 @@
 import type { SecurityCapability } from "../types.js";
-import { callAgentSecCli } from "../utils.js";
+import { buildTraceContext, callAgentSecCli } from "../utils.js";
 
 const CLI_TIMEOUT_MS = 10_000;
 const MAX_EVIDENCE_ITEMS = 3;
@@ -78,14 +78,15 @@ function formatPiiWarning(
   return parts.join("；");
 }
 
-function buildScanArgs(includeLowConfidence: boolean): string[] {
+function buildScanArgs(source: string, includeLowConfidence: boolean): string[] {
   const args = [
     "scan-pii",
     "--stdin",
     "--format",
     "json",
+    "--redact-output",
     "--source",
-    "user_input",
+    source,
   ];
   if (includeLowConfidence) {
     args.push("--include-low-confidence");
@@ -101,6 +102,87 @@ function getInboundText(event: any): string {
   return typeof event?.body === "string" ? event.body : "";
 }
 
+function valueToText(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getModelOutputText(event: any): string {
+  const response = safeString(event?.response);
+  if (response.trim()) {
+    return response;
+  }
+  const lastAssistant = safeString(event?.lastAssistant ?? event?.last_assistant);
+  if (lastAssistant.trim()) {
+    return lastAssistant;
+  }
+  const assistantTexts = Array.isArray(event?.assistantTexts)
+    ? event.assistantTexts
+    : Array.isArray(event?.assistant_texts)
+      ? event.assistant_texts
+      : [];
+  return assistantTexts.filter((item: unknown) => typeof item === "string").join("\n");
+}
+
+function getToolOutputText(event: any): string {
+  const result = valueToText(event?.result);
+  if (result.trim()) {
+    return result;
+  }
+  return safeString(event?.error);
+}
+
+async function scanPiiText(
+  api: any,
+  cfg: PiiScanConfig,
+  event: any,
+  ctx: any,
+  text: string,
+  source: string,
+): Promise<{ verdict: string; findings: unknown[] } | undefined> {
+  const result = await callAgentSecCli(buildScanArgs(source, cfg.includeLowConfidence), {
+    timeout: CLI_TIMEOUT_MS,
+    stdin: text,
+    traceContext: buildTraceContext(event, ctx),
+  });
+  if (result.exitCode !== 0) {
+    api.logger.warn(`[pii-checker] CLI failed: ${result.stderr || result.exitCode}`);
+    return undefined;
+  }
+
+  const scanResult = JSON.parse(result.stdout) as {
+    verdict?: unknown;
+    findings?: unknown;
+  };
+  return {
+    verdict: safeString(scanResult.verdict) || "pass",
+    findings: Array.isArray(scanResult.findings) ? scanResult.findings : [],
+  };
+}
+
+function logPiiWarning(
+  api: any,
+  verdict: string,
+  findings: unknown[],
+  cfg: PiiScanConfig,
+  finalMessage?: string,
+): string {
+  const warning = formatPiiWarning(verdict, findings, finalMessage);
+  api.logger.warn(
+    `[pii-checker] ${verdict.toUpperCase()} (enableBlock=${cfg.enableBlock}) — ${warning}`,
+  );
+  return warning;
+}
+
 /**
  * 用户输入 PII / 凭据检测。
  *
@@ -110,7 +192,7 @@ function getInboundText(event: any): string {
 export const piiScan: SecurityCapability = {
   id: "pii-scan-user-input",
   name: "PII Checker",
-  hooks: ["before_dispatch"],
+  hooks: ["before_dispatch", "before_tool_call", "after_tool_call", "llm_output"],
   register(api) {
     const cfg = readConfig((api.pluginConfig as Record<string, any>) ?? {});
     if (!cfg.scanUserInput) {
@@ -120,30 +202,16 @@ export const piiScan: SecurityCapability = {
 
     api.on(
       "before_dispatch",
-      async (event: any) => {
+      async (event: any, ctx: any) => {
         try {
           const text = getInboundText(event);
           if (!text.trim()) {
             return undefined;
           }
 
-          const result = await callAgentSecCli(buildScanArgs(cfg.includeLowConfidence), {
-            timeout: CLI_TIMEOUT_MS,
-            stdin: text,
-          });
-          if (result.exitCode !== 0) {
-            api.logger.warn(`[pii-checker] CLI failed: ${result.stderr || result.exitCode}`);
-            return undefined;
-          }
-
-          const scanResult = JSON.parse(result.stdout) as {
-            verdict?: unknown;
-            findings?: unknown;
-          };
-          const verdict = safeString(scanResult.verdict) || "pass";
-          const findings = Array.isArray(scanResult.findings)
-            ? scanResult.findings
-            : [];
+          const scanResult = await scanPiiText(api, cfg, event, ctx, text, "user_input");
+          if (scanResult === undefined) return undefined;
+          const { verdict, findings } = scanResult;
 
           if (verdict === "pass" || findings.length === 0) {
             api.logger.info("[pii-checker] pass");
@@ -154,13 +222,12 @@ export const piiScan: SecurityCapability = {
             return undefined;
           }
 
-          const warning = formatPiiWarning(
+          const warning = logPiiWarning(
+            api,
             verdict,
             findings,
+            cfg,
             verdict === "deny" && cfg.enableBlock ? "本轮请求已被阻断。" : undefined,
-          );
-          api.logger.warn(
-            `[pii-checker] ${verdict.toUpperCase()} (enableBlock=${cfg.enableBlock}) — ${warning}`,
           );
           if (verdict === "deny" && cfg.enableBlock) {
             return {
@@ -178,5 +245,75 @@ export const piiScan: SecurityCapability = {
       },
       { priority: BEFORE_DISPATCH_PRIORITY },
     );
+
+    api.on(
+      "before_tool_call",
+      async (event: any, ctx: any) => {
+        try {
+          const text = valueToText(event?.params ?? event?.parameters ?? event?.args);
+          if (!text.trim()) return undefined;
+          const scanResult = await scanPiiText(api, cfg, event, ctx, text, "tool_input");
+          if (scanResult === undefined) return undefined;
+          const { verdict, findings } = scanResult;
+          if (verdict === "pass" || findings.length === 0) return undefined;
+          if (verdict !== "warn" && verdict !== "deny") return undefined;
+          const warning = logPiiWarning(
+            api,
+            verdict,
+            findings,
+            cfg,
+            verdict === "deny" && cfg.enableBlock ? "本次工具调用已被阻断。" : undefined,
+          );
+          if (verdict === "deny" && cfg.enableBlock) {
+            return { block: true, blockReason: warning };
+          }
+          return undefined;
+        } catch (error) {
+          api.logger.warn(
+            `[pii-checker] failed open: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return undefined;
+        }
+      },
+      { priority: BEFORE_DISPATCH_PRIORITY },
+    );
+
+    api.on("after_tool_call", async (event: any, ctx: any) => {
+      try {
+        const text = getToolOutputText(event);
+        if (!text.trim()) return undefined;
+        const scanResult = await scanPiiText(api, cfg, event, ctx, text, "tool_output");
+        if (scanResult === undefined) return undefined;
+        const { verdict, findings } = scanResult;
+        if (verdict === "pass" || findings.length === 0) return undefined;
+        if (verdict !== "warn" && verdict !== "deny") return undefined;
+        logPiiWarning(api, verdict, findings, cfg);
+        return undefined;
+      } catch (error) {
+        api.logger.warn(
+          `[pii-checker] failed open: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return undefined;
+      }
+    });
+
+    api.on("llm_output", async (event: any, ctx: any) => {
+      try {
+        const text = getModelOutputText(event);
+        if (!text.trim()) return undefined;
+        const scanResult = await scanPiiText(api, cfg, event, ctx, text, "model_output");
+        if (scanResult === undefined) return undefined;
+        const { verdict, findings } = scanResult;
+        if (verdict === "pass" || findings.length === 0) return undefined;
+        if (verdict !== "warn" && verdict !== "deny") return undefined;
+        logPiiWarning(api, verdict, findings, cfg);
+        return undefined;
+      } catch (error) {
+        api.logger.warn(
+          `[pii-checker] failed open: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return undefined;
+      }
+    });
   },
 };

--- a/src/agent-sec-core/openclaw-plugin/src/utils.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/utils.ts
@@ -161,6 +161,108 @@ export async function callAgentSecCli(
 
 export type OpenClawObservabilityRecord = Record<string, unknown>;
 
+const OBSERVABILITY_SENSITIVE_KEYS = new Set([
+  "prompt",
+  "user_input",
+  "system_prompt",
+  "messages",
+  "response",
+  "parameters",
+  "result",
+  "error",
+  "tool_calls",
+]);
+const DROP = Symbol("drop-sensitive-observability-field");
+
+async function redactTextForObservability(text: string): Promise<string | undefined> {
+  const result = await callAgentSecCli(
+    [
+      "scan-pii",
+      "--stdin",
+      "--format",
+      "json",
+      "--redact-output",
+      "--source",
+      "observability",
+    ],
+    { stdin: text },
+  );
+  if (result.exitCode !== 0) {
+    return undefined;
+  }
+  try {
+    const data = JSON.parse(result.stdout) as { redacted_text?: unknown };
+    return typeof data.redacted_text === "string" ? data.redacted_text : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function redactSensitiveValue(value: unknown): Promise<unknown | typeof DROP> {
+  if (typeof value === "string") {
+    const redacted = await redactTextForObservability(value);
+    return redacted === undefined ? DROP : redacted;
+  }
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    serialized = String(value);
+  }
+  const redacted = await redactTextForObservability(serialized);
+  if (redacted === undefined) {
+    return DROP;
+  }
+  try {
+    return JSON.parse(redacted);
+  } catch {
+    return redacted;
+  }
+}
+
+async function redactObservabilityValue(value: unknown): Promise<unknown | typeof DROP> {
+  if (Array.isArray(value)) {
+    const redactedItems = await Promise.all(value.map((item) => redactObservabilityValue(item)));
+    return redactedItems.filter((item) => item !== DROP);
+  }
+  if (value && typeof value === "object") {
+    const entries = await Promise.all(
+      Object.entries(value as Record<string, unknown>).map(async ([key, item]) => {
+        const safeItem = OBSERVABILITY_SENSITIVE_KEYS.has(key)
+          ? await redactSensitiveValue(item)
+          : await redactObservabilityValue(item);
+        return [key, safeItem] as const;
+      }),
+    );
+    const redacted: Record<string, unknown> = {};
+    for (const [key, item] of entries) {
+      if (item !== DROP) {
+        redacted[key] = item;
+      }
+    }
+    return redacted;
+  }
+  return value;
+}
+
+async function redactObservabilityRecord(
+  event: OpenClawObservabilityRecord,
+): Promise<OpenClawObservabilityRecord> {
+  const metrics = event.metrics;
+  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) {
+    return event;
+  }
+  const safeMetrics = await redactObservabilityValue(metrics);
+  return {
+    ...event,
+    metrics:
+      safeMetrics && typeof safeMetrics === "object" && !Array.isArray(safeMetrics)
+        ? (safeMetrics as Record<string, unknown>)
+        : {},
+  };
+}
+
 /**
  * Emit one OpenClaw observability record to agent-sec-cli via stdin.
  * Logging is best-effort: callers must not use failures to alter OpenClaw behavior.
@@ -168,10 +270,11 @@ export type OpenClawObservabilityRecord = Record<string, unknown>;
 export async function recordOpenClawObservability(
   event: OpenClawObservabilityRecord,
 ): Promise<CliResult> {
+  const safeEvent = await redactObservabilityRecord(event);
   return callAgentSecCli(
     ["observability", "record", "--format", "json", "--stdin"],
     {
-      stdin: JSON.stringify(event),
+      stdin: JSON.stringify(safeEvent),
     },
   );
 }

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/observability-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/observability-test.ts
@@ -118,11 +118,28 @@ function beforeToolCallEvent() {
 
 let capturedArgs: string[] | undefined;
 let capturedStdin: string | undefined;
+let capturedRecords: { args: string[]; stdin: string | undefined }[] = [];
 
-function mockCli(result: CliResult = { exitCode: 0, stdout: "", stderr: "" }) {
+function mockCli(
+  result: CliResult = { exitCode: 0, stdout: "", stderr: "" },
+  redact: (text: string) => string | undefined = (text) => text,
+) {
   _setCliMock(async (args, opts) => {
+    const offset = args[0] === "--trace-context" ? 2 : 0;
+    if (args[offset] === "scan-pii") {
+      const redactedText = redact(opts.stdin ?? "");
+      if (redactedText === undefined) {
+        return { exitCode: 2, stdout: "", stderr: "redaction failed" };
+      }
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ verdict: "pass", findings: [], redacted_text: redactedText }),
+        stderr: "",
+      };
+    }
     capturedArgs = args;
     capturedStdin = opts.stdin;
+    capturedRecords.push({ args, stdin: opts.stdin });
     return result;
   });
 }
@@ -144,6 +161,7 @@ describe("observability", () => {
   beforeEach(() => {
     capturedArgs = undefined;
     capturedStdin = undefined;
+    capturedRecords = [];
   });
 
   afterEach(() => {
@@ -161,7 +179,7 @@ describe("observability", () => {
     assert.equal(hooks.find((hook) => hook.hookName === "llm_input")?.priority, 1000);
   });
 
-  it("emits the expected CLI payload for before_tool_call", () => {
+  it("emits the expected CLI payload for before_tool_call", async () => {
     mockCli();
     const { api, hooks } = createMockApi();
     observability.register(api);
@@ -175,6 +193,7 @@ describe("observability", () => {
     });
 
     assert.equal(result, undefined);
+    await flushObservabilityWork();
     assert.deepEqual(capturedArgs, ["observability", "record", "--format", "json", "--stdin"]);
     assert.ok(capturedStdin);
     const payload = JSON.parse(capturedStdin);
@@ -189,6 +208,50 @@ describe("observability", () => {
       tool_name: "exec",
       parameters: beforeToolCallEvent().params,
     });
+  });
+
+  it("redacts sensitive observability payload before record", async () => {
+    mockCli(
+      { exitCode: 0, stdout: "", stderr: "" },
+      (text) => text.replace("sk-testsecret1234567890", "sk-t...[REDACTED]...7890"),
+    );
+    const { api, hooks } = createMockApi();
+    observability.register(api);
+    const hook = hooks.find((item) => item.hookName === "before_tool_call");
+    assert.ok(hook);
+
+    hook.handler(beforeToolCallEvent(), {
+      sessionId: "session-001",
+      sessionKey: "session-key-001",
+      runId: "run-ctx",
+    });
+    await flushObservabilityWork();
+
+    assert.ok(capturedStdin);
+    const payloadText = capturedStdin;
+    const payload = JSON.parse(payloadText);
+    assert.equal(payload.metrics.parameters.command.includes("sk-testsecret1234567890"), false);
+    assert.equal(payloadText.includes("sk-testsecret1234567890"), false);
+    assert.match(payload.metrics.parameters.command, /sk-t\.\.\.\[REDACTED\]\.\.\.7890/);
+  });
+
+  it("drops sensitive observability fields when redaction fails", async () => {
+    mockCli({ exitCode: 0, stdout: "", stderr: "" }, () => undefined);
+    const { api, hooks } = createMockApi();
+    observability.register(api);
+    const hook = hooks.find((item) => item.hookName === "before_tool_call");
+    assert.ok(hook);
+
+    hook.handler(beforeToolCallEvent(), {
+      sessionId: "session-001",
+      sessionKey: "session-key-001",
+      runId: "run-ctx",
+    });
+    await flushObservabilityWork();
+
+    assert.ok(capturedStdin);
+    const payload = JSON.parse(capturedStdin);
+    assert.deepEqual(payload.metrics, { tool_name: "exec" });
   });
 
   it("keeps correlation metadata out of metrics", () => {
@@ -235,7 +298,7 @@ describe("observability", () => {
     assertMetricsAllowedByAgentSecSchema(payload);
   });
 
-  it("emits llm_input as before_agent_run and model_call_started as before_llm_call", () => {
+  it("emits llm_input as before_agent_run and model_call_started as before_llm_call", async () => {
     mockCli();
     const { api, hooks } = createMockApi();
     observability.register(api);
@@ -252,6 +315,7 @@ describe("observability", () => {
       },
       { sessionId: "session-model", runId: "run-model" },
     );
+    await flushObservabilityWork();
     assert.ok(capturedStdin);
     const inputPayload = JSON.parse(capturedStdin);
     assert.equal(inputPayload.hook, "before_agent_run");
@@ -283,6 +347,7 @@ describe("observability", () => {
       {},
     );
 
+    await flushObservabilityWork();
     assert.ok(capturedStdin);
     const startedPayload = JSON.parse(capturedStdin);
     assert.ok(startedPayload);
@@ -535,7 +600,7 @@ describe("observability", () => {
     assertMetricsAllowedByAgentSecSchema(payload);
   });
 
-  it("uses run-level aggregate metrics provided by agent_end", () => {
+  it("uses run-level aggregate metrics provided by agent_end", async () => {
     mockCli();
     const { api, hooks } = createMockApi();
     observability.register(api);
@@ -574,8 +639,8 @@ describe("observability", () => {
       {},
     );
 
-    assert.ok(capturedStdin);
-    const payload = JSON.parse(capturedStdin);
+    await flushObservabilityWork();
+    const payload = findCapturedPayload("after_agent_run");
     assert.equal(payload.hook, "after_agent_run");
     assert.equal(payload.metrics.total_api_calls, 3);
     assert.equal(payload.metrics.total_tool_calls, 2);
@@ -584,7 +649,7 @@ describe("observability", () => {
     assertMetricsAllowedByAgentSecSchema(payload);
   });
 
-  it("does not derive after_agent_run aggregate metrics from volatile process state", () => {
+  it("does not derive after_agent_run aggregate metrics from volatile process state", async () => {
     mockCli();
     const { api, hooks } = createMockApi();
     observability.register(api);
@@ -619,8 +684,8 @@ describe("observability", () => {
       {},
     );
 
-    assert.ok(capturedStdin);
-    const payload = JSON.parse(capturedStdin);
+    await flushObservabilityWork();
+    const payload = findCapturedPayload("after_agent_run");
     assert.equal(payload.hook, "after_agent_run");
     assert.deepEqual(payload.metrics, { success: true });
     assertMetricsAllowedByAgentSecSchema(payload);
@@ -686,3 +751,13 @@ describe("observability", () => {
   });
 
 });
+
+function findCapturedPayload(hook: string): { hook: string; metrics: Record<string, unknown> } {
+  const payloads = capturedRecords
+    .map((record) => (record.stdin ? JSON.parse(record.stdin) : undefined))
+    .filter((payload): payload is { hook: string; metrics: Record<string, unknown> } =>
+      payload !== undefined && payload.hook === hook,
+    );
+  assert.ok(payloads.length > 0, `expected captured payload for hook ${hook}`);
+  return payloads[payloads.length - 1];
+}

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
@@ -292,11 +292,12 @@ describe("pii-scan-user-input", () => {
   });
 
   it("invalid CLI JSON fails open", async () => {
-    const { beforeDispatch } = registerHandlers(enableBlockConfig(true));
+    const { beforeDispatch, logs } = registerHandlers(enableBlockConfig(true));
     mockCli({ exitCode: 0, stdout: "not-json", stderr: "" });
 
     const result = await beforeDispatch.handler({ content: "email alice@example.com" });
 
     assert.equal(result, undefined);
+    assert.ok(logs.some((log) => log.includes("CLI returned invalid JSON")));
   });
 });

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { piiScan } from "../../src/capabilities/pii-scan.js";
 import { _setCliMock, _resetCliMock } from "../../src/utils.js";
-import type { CliResult } from "../../src/utils.js";
+import type { CliCallOptions, CliResult } from "../../src/utils.js";
 
 type RegisteredHook = {
   hookName: string;
@@ -45,7 +45,7 @@ function enableBlockConfig(enableBlock: boolean): Record<string, any> {
 }
 
 let lastCliArgs: string[] | undefined;
-let lastCliOpts: { timeout?: number; stdin?: string } | undefined;
+let lastCliOpts: CliCallOptions | undefined;
 
 function mockCli(result: CliResult) {
   _setCliMock(async (args, opts) => {
@@ -93,14 +93,19 @@ describe("pii-scan-user-input", () => {
     _resetCliMock();
   });
 
-  it("registers only before_dispatch before prompt-scan priority", () => {
+  it("registers all PII scan hooks before prompt-scan priority", () => {
     const { hooks } = registerHandlers();
 
     assert.deepEqual(
       hooks.map((hook) => hook.hookName),
-      ["before_dispatch"],
+      ["before_dispatch", "before_tool_call", "after_tool_call", "llm_output"],
     );
-    assert.deepEqual(piiScan.hooks, ["before_dispatch"]);
+    assert.deepEqual(piiScan.hooks, [
+      "before_dispatch",
+      "before_tool_call",
+      "after_tool_call",
+      "llm_output",
+    ]);
     assert.equal(hooks[0].priority, 200);
   });
 
@@ -124,6 +129,7 @@ describe("pii-scan-user-input", () => {
       "--stdin",
       "--format",
       "json",
+      "--redact-output",
       "--source",
       "user_input",
     ]);
@@ -197,6 +203,83 @@ describe("pii-scan-user-input", () => {
     assert.match(result?.text, /本轮请求已被阻断/);
     assert.doesNotMatch(result?.text, /password=secret/);
     assert.doesNotMatch(result?.text, /raw_evidence/);
+  });
+
+  it("blocks before_tool_call deny when enableBlock=true", async () => {
+    const { hooks } = registerHandlers(enableBlockConfig(true));
+    const beforeToolCall = hooks.find((hook) => hook.hookName === "before_tool_call");
+    assert.ok(beforeToolCall);
+    mockCli(scanResult("deny", [denyFinding]));
+
+    const result = await beforeToolCall.handler(
+      {
+        toolName: "exec",
+        params: { command: "password=secret" },
+        sessionId: "session-1",
+        toolCallId: "tool-1",
+      },
+      {},
+    );
+
+    assert.equal(result?.block, true);
+    assert.match(result?.blockReason, /\[pii-checker\]/);
+    assert.match(result?.blockReason, /本次工具调用已被阻断/);
+    assert.doesNotMatch(result?.blockReason, /password=secret/);
+    assert.deepEqual(lastCliArgs, [
+      "--trace-context",
+      '{"session_id":"session-1","tool_call_id":"tool-1"}',
+      "scan-pii",
+      "--stdin",
+      "--format",
+      "json",
+      "--redact-output",
+      "--source",
+      "tool_input",
+    ]);
+    assert.equal(lastCliOpts?.stdin, '{"command":"password=secret"}');
+  });
+
+  it("after_tool_call logs warning without raw evidence", async () => {
+    const { hooks, logs } = registerHandlers();
+    const afterToolCall = hooks.find((hook) => hook.hookName === "after_tool_call");
+    assert.ok(afterToolCall);
+    mockCli(scanResult("warn", [warnFinding]));
+
+    const result = await afterToolCall.handler(
+      {
+        result: { content: "email alice@example.com" },
+        sessionId: "session-1",
+        toolCallId: "tool-1",
+      },
+      {},
+    );
+
+    assert.equal(result, undefined);
+    assert.ok(logs.some((log) => log.includes("[pii-checker] WARN")));
+    assert.ok(logs.some((log) => log.includes("a***@example.com")));
+    assert.ok(!logs.some((log) => log.includes("alice@example.com")));
+    assert.equal(lastCliArgs?.at(-1), "tool_output");
+  });
+
+  it("llm_output logs warning without raw evidence", async () => {
+    const { hooks, logs } = registerHandlers();
+    const llmOutput = hooks.find((hook) => hook.hookName === "llm_output");
+    assert.ok(llmOutput);
+    mockCli(scanResult("warn", [warnFinding]));
+
+    const result = await llmOutput.handler(
+      {
+        assistantTexts: ["email alice@example.com"],
+        sessionId: "session-1",
+      },
+      {},
+    );
+
+    assert.equal(result, undefined);
+    assert.ok(logs.some((log) => log.includes("[pii-checker] WARN")));
+    assert.ok(logs.some((log) => log.includes("a***@example.com")));
+    assert.ok(!logs.some((log) => log.includes("alice@example.com")));
+    assert.equal(lastCliArgs?.at(-1), "model_output");
   });
 
   it("CLI nonzero fails open", async () => {

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_observability_hook.py
@@ -282,6 +282,12 @@ def test_main_invokes_observability_cli_with_record(monkeypatch, capsys):
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
+        if "scan-pii" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"redacted_text": kwargs["input"]}),
+                stderr="",
+            )
         return SimpleNamespace(returncode=0)
 
     monkeypatch.setattr(observability_hook.subprocess, "run", fake_run)
@@ -294,8 +300,8 @@ def test_main_invokes_observability_cli_with_record(monkeypatch, capsys):
     observability_hook.main()
 
     assert json.loads(capsys.readouterr().out) == {}
-    assert len(calls) == 1
-    cmd, kwargs = calls[0]
+    assert len(calls) == 3
+    cmd, kwargs = calls[-1]
     assert cmd == [
         "agent-sec-cli",
         "observability",
@@ -306,6 +312,43 @@ def test_main_invokes_observability_cli_with_record(monkeypatch, capsys):
     ]
     assert kwargs["text"] is True
     assert json.loads(kwargs["input"])["hook"] == "before_agent_run"
+
+
+def test_main_redacts_observability_payload_before_record(monkeypatch, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if "scan-pii" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "redacted_text": kwargs["input"].replace(
+                            "alice@example.com", "a***@example.com"
+                        )
+                    }
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(_base("UserPromptSubmit", prompt="email alice@example.com"))
+        ),
+    )
+
+    observability_hook.main()
+
+    assert json.loads(capsys.readouterr().out) == {}
+    payload = json.loads(calls[-1][1]["input"])
+    payload_text = json.dumps(payload, ensure_ascii=False)
+    assert "alice@example.com" not in payload_text
+    assert "a***@example.com" in payload_text
 
 
 def test_main_invalid_json_returns_noop_without_cli(monkeypatch, capsys):

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
@@ -151,6 +151,7 @@ class TestCoshHookMain:
             "--stdin",
             "--format",
             "json",
+            "--redact-output",
             "--source",
             "user_input",
         ]
@@ -208,10 +209,94 @@ class TestCoshHookMain:
             "--stdin",
             "--format",
             "json",
+            "--redact-output",
             "--source",
             "user_input",
         ]
         assert captured["kwargs"]["check"] is False
+
+    @pytest.mark.parametrize(
+        ("payload", "expected_stdin", "expected_source"),
+        [
+            (
+                {"hook_event_name": "PreToolUse", "tool_input": {"command": "echo ok"}},
+                '{"command":"echo ok"}',
+                "tool_input",
+            ),
+            (
+                {
+                    "hook_event_name": "PostToolUse",
+                    "tool_response": {"stdout": "alice@example.com"},
+                },
+                '{"stdout":"alice@example.com"}',
+                "tool_output",
+            ),
+            (
+                {
+                    "hook_event_name": "PostToolUseFailure",
+                    "error": "token=secret123456",
+                },
+                "token=secret123456",
+                "tool_output",
+            ),
+            (
+                {
+                    "hook_event_name": "AfterModel",
+                    "llm_response": {"text": "Contact alice@example.com"},
+                },
+                "Contact alice@example.com",
+                "model_output",
+            ),
+        ],
+    )
+    def test_scans_additional_hook_events(
+        self,
+        monkeypatch,
+        capsys,
+        payload,
+        expected_stdin,
+        expected_source,
+    ):
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "verdict": "warn",
+                        "findings": [
+                            {
+                                "type": "email",
+                                "severity": "warn",
+                                "evidence_redacted": "a***@example.com",
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fake_run)
+
+        output = self._run_main(monkeypatch, capsys, json.dumps(payload))
+
+        assert captured["args"] == [
+            "agent-sec-cli",
+            "scan-pii",
+            "--stdin",
+            "--format",
+            "json",
+            "--redact-output",
+            "--source",
+            expected_source,
+        ]
+        assert captured["kwargs"]["input"] == expected_stdin
+        assert output["decision"] == "allow"
+        assert "a***@example.com" in output["reason"]
 
     def test_cli_nonzero_allows(self, monkeypatch, capsys):
         def fake_run(args, **kwargs):
@@ -258,4 +343,10 @@ def test_manifest_registers_only_user_prompt_submit_for_pii():
                 if hook.get("name") == "pii-checker":
                     pii_locations.append(hook_name)
 
-    assert pii_locations == ["UserPromptSubmit"]
+    assert pii_locations == [
+        "PreToolUse",
+        "UserPromptSubmit",
+        "AfterModel",
+        "PostToolUse",
+        "PostToolUseFailure",
+    ]

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_observability_cli_runner.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_observability_cli_runner.py
@@ -33,18 +33,57 @@ def _record() -> dict:
 
 @patch("src.cli_runner.call_agent_sec_cli")
 def test_record_hermes_observability_uses_openclaw_cli_shape(mock_cli):
-    mock_cli.return_value = CliResult(stdout="", stderr="", exit_code=0)
+    mock_cli.side_effect = [
+        CliResult(
+            stdout=json.dumps({"redacted_text": "hello"}),
+            stderr="",
+            exit_code=0,
+        ),
+        CliResult(stdout="", stderr="", exit_code=0),
+    ]
 
     result = record_hermes_observability(_record(), timeout=5.0)
 
     assert result.exit_code == 0
-    mock_cli.assert_called_once()
-    args, kwargs = mock_cli.call_args
+    assert mock_cli.call_count == 2
+    scan_args, scan_kwargs = mock_cli.call_args_list[0]
+    assert scan_args[0] == [
+        "scan-pii",
+        "--stdin",
+        "--format",
+        "json",
+        "--redact-output",
+        "--source",
+        "observability",
+    ]
+    assert scan_kwargs["stdin"] == "hello"
+    args, kwargs = mock_cli.call_args_list[1]
     assert args[0] == ["observability", "record", "--format", "json", "--stdin"]
     assert kwargs["timeout"] == 5.0
     payload = json.loads(kwargs["stdin"])
     assert payload["hook"] == "before_agent_run"
     assert payload["metadata"]["sessionId"] == "session-1"
+
+
+@patch("src.cli_runner.call_agent_sec_cli")
+def test_record_hermes_observability_redacts_sensitive_payload(mock_cli):
+    mock_cli.side_effect = [
+        CliResult(
+            stdout=json.dumps({"redacted_text": "a***@example.com"}),
+            stderr="",
+            exit_code=0,
+        ),
+        CliResult(stdout="", stderr="", exit_code=0),
+    ]
+    record = _record()
+    record["metrics"]["user_input"] = "alice@example.com"
+
+    record_hermes_observability(record, timeout=5.0)
+
+    payload = json.loads(mock_cli.call_args_list[1].kwargs["stdin"])
+    payload_text = json.dumps(payload, ensure_ascii=False)
+    assert "alice@example.com" not in payload_text
+    assert "a***@example.com" in payload_text
 
 
 @patch("src.cli_runner.subprocess.run")

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
@@ -6,7 +6,7 @@ import json
 import sys
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -449,6 +449,40 @@ class TestPiiScanCapability:
             "--source",
             "model_output",
         ]
+
+    @patch("src.capabilities.pii_scan.call_agent_sec_cli")
+    def test_model_output_drops_raw_text_when_redaction_missing(
+        self, mock_cli: MagicMock, capability: PiiScanCapability
+    ) -> None:
+        """Model output findings without redacted_text must not expose raw text."""
+        mock_cli.return_value = CliResult(
+            stdout=json.dumps(
+                {
+                    "verdict": "warn",
+                    "findings": [
+                        {
+                            "type": "email",
+                            "severity": "warn",
+                            "evidence_redacted": "a***@example.com",
+                        }
+                    ],
+                    "redacted_text": "",
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        )
+
+        result = capability._on_transform_llm_output(
+            "Contact alice@example.com",
+            session_id="session-1",
+        )
+
+        assert result is not None
+        assert "[pii-checker]" in result
+        assert "a***@example.com" in result
+        assert "alice@example.com" not in result
+        assert "Contact " not in result
 
     @patch("src.capabilities.pii_scan.call_agent_sec_cli")
     def test_tool_input_warning_is_delivered_on_transform(self, mock_cli, capability):

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
@@ -39,6 +40,20 @@ def _scan_result(verdict: str, findings: list[dict] | None = None) -> CliResult:
     )
 
 
+def _install_gateway_session_context(monkeypatch, session_id: str) -> None:
+    gateway_module = ModuleType("gateway")
+    session_context_module = ModuleType("gateway.session_context")
+
+    def get_session_env(name: str, default: str = "") -> str:
+        assert name == "HERMES_SESSION_ID"
+        return session_id or default
+
+    session_context_module.get_session_env = get_session_env
+    gateway_module.session_context = session_context_module
+    monkeypatch.setitem(sys.modules, "gateway", gateway_module)
+    monkeypatch.setitem(sys.modules, "gateway.session_context", session_context_module)
+
+
 @pytest.fixture
 def capability():
     """Create a default PII scan capability."""
@@ -54,6 +69,8 @@ class TestPiiScanCapability:
 
         assert list(hooks) == [
             "pre_llm_call",
+            "pre_tool_call",
+            "post_tool_call",
             "transform_llm_output",
             "on_session_end",
         ]
@@ -73,10 +90,7 @@ class TestPiiScanCapability:
     def test_missing_user_fields_passthrough(self, mock_cli, capability):
         """Missing user text fields should fail open without invoking scan-pii."""
         result = capability._on_pre_llm_call(session_id="session-1")
-        transformed = capability._on_transform_llm_output(
-            "assistant reply",
-            session_id="session-1",
-        )
+        transformed = capability._on_transform_llm_output("", session_id="session-1")
 
         assert result is None
         assert transformed is None
@@ -116,17 +130,21 @@ class TestPiiScanCapability:
     @patch("src.capabilities.pii_scan.call_agent_sec_cli")
     def test_warn_verdict_prepends_warning_once(self, mock_cli, capability):
         """Warn verdict should prepend one redacted warning to final output."""
-        mock_cli.return_value = _scan_result(
-            "warn",
-            [
-                {
-                    "type": "email",
-                    "severity": "warn",
-                    "evidence_redacted": "a***@example.com",
-                    "raw_evidence": "alice@example.com",
-                }
-            ],
-        )
+        mock_cli.side_effect = [
+            _scan_result(
+                "warn",
+                [
+                    {
+                        "type": "email",
+                        "severity": "warn",
+                        "evidence_redacted": "a***@example.com",
+                        "raw_evidence": "alice@example.com",
+                    }
+                ],
+            ),
+            _scan_result("pass"),
+            _scan_result("pass"),
+        ]
 
         capability._on_pre_llm_call(
             user_message="email alice@example.com",
@@ -154,16 +172,19 @@ class TestPiiScanCapability:
     @patch("src.capabilities.pii_scan.call_agent_sec_cli")
     def test_deny_verdict_uses_high_risk_warning(self, mock_cli, capability):
         """Deny verdict should still be warning-only but marked high risk."""
-        mock_cli.return_value = _scan_result(
-            "deny",
-            [
-                {
-                    "type": "generic_secret_field",
-                    "severity": "deny",
-                    "evidence_redacted": "password=[REDACTED]",
-                }
-            ],
-        )
+        mock_cli.side_effect = [
+            _scan_result(
+                "deny",
+                [
+                    {
+                        "type": "generic_secret_field",
+                        "severity": "deny",
+                        "evidence_redacted": "password=[REDACTED]",
+                    }
+                ],
+            ),
+            _scan_result("pass"),
+        ]
 
         capability._on_pre_llm_call(
             user_message="password=super-secret",
@@ -193,6 +214,7 @@ class TestPiiScanCapability:
             "--stdin",
             "--format",
             "json",
+            "--redact-output",
             "--source",
             "user_input",
             "--include-low-confidence",
@@ -219,6 +241,7 @@ class TestPiiScanCapability:
             "--stdin",
             "--format",
             "json",
+            "--redact-output",
             "--source",
             "user_input",
         ]
@@ -233,10 +256,7 @@ class TestPiiScanCapability:
         )
 
         result = capability._on_pre_llm_call(user_message="alice@example.com")
-        transformed = capability._on_transform_llm_output(
-            "assistant reply",
-            session_id="session-1",
-        )
+        transformed = capability._on_transform_llm_output("", session_id="session-1")
 
         assert result is None
         assert transformed is None
@@ -307,7 +327,7 @@ class TestPiiScanCapability:
             session_id="session-1",
         )
         result = cap._on_transform_llm_output(
-            "assistant reply",
+            "",
             session_id="session-1",
         )
 
@@ -327,7 +347,7 @@ class TestPiiScanCapability:
         )
         capability._on_session_end(session_id="session-1")
         result = capability._on_transform_llm_output(
-            "assistant reply",
+            "",
             session_id="session-1",
         )
 
@@ -341,6 +361,7 @@ class TestPiiScanCapability:
                 "warn",
                 [{"type": "email", "severity": "warn", "evidence_redacted": "a***"}],
             ),
+            _scan_result("pass"),
             _scan_result("pass"),
         ]
 
@@ -362,10 +383,17 @@ class TestPiiScanCapability:
     @patch("src.capabilities.pii_scan.call_agent_sec_cli")
     def test_duplicate_warning_is_delivered_once(self, mock_cli, capability):
         """Repeated identical findings in one turn should not duplicate text."""
-        mock_cli.return_value = _scan_result(
-            "warn",
-            [{"type": "email", "severity": "warn", "evidence_redacted": "a***"}],
-        )
+        mock_cli.side_effect = [
+            _scan_result(
+                "warn",
+                [{"type": "email", "severity": "warn", "evidence_redacted": "a***"}],
+            ),
+            _scan_result(
+                "warn",
+                [{"type": "email", "severity": "warn", "evidence_redacted": "a***"}],
+            ),
+            _scan_result("pass"),
+        ]
 
         capability._on_pre_llm_call(
             user_message="alice@example.com",
@@ -382,3 +410,196 @@ class TestPiiScanCapability:
 
         assert result is not None
         assert result.count("[pii-checker]") == 1
+
+    @patch("src.capabilities.pii_scan.call_agent_sec_cli")
+    def test_model_output_is_redacted(self, mock_cli, capability):
+        """transform_llm_output should redact PII from final model text."""
+        mock_cli.return_value = CliResult(
+            stdout=json.dumps(
+                {
+                    "verdict": "warn",
+                    "findings": [
+                        {
+                            "type": "email",
+                            "severity": "warn",
+                            "evidence_redacted": "a***@example.com",
+                        }
+                    ],
+                    "redacted_text": "Contact a***@example.com",
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        )
+
+        result = capability._on_transform_llm_output(
+            "Contact alice@example.com",
+            session_id="session-1",
+        )
+
+        assert result is not None
+        assert "Contact a***@example.com" in result
+        assert "alice@example.com" not in result
+        assert mock_cli.call_args.args[0] == [
+            "scan-pii",
+            "--stdin",
+            "--format",
+            "json",
+            "--redact-output",
+            "--source",
+            "model_output",
+        ]
+
+    @patch("src.capabilities.pii_scan.call_agent_sec_cli")
+    def test_tool_input_warning_is_delivered_on_transform(self, mock_cli, capability):
+        """pre_tool_call findings should be cached for final output."""
+        mock_cli.side_effect = [
+            _scan_result(
+                "deny",
+                [
+                    {
+                        "type": "api_key",
+                        "severity": "deny",
+                        "evidence_redacted": "sk-a...[REDACTED]...1234",
+                    }
+                ],
+            ),
+            _scan_result("pass"),
+        ]
+
+        capability._on_pre_tool_call(
+            tool_name="terminal",
+            args={"command": "API_KEY=sk-abcdefghijklmnop1234"},
+            session_id="session-1",
+            tool_call_id="tool-1",
+        )
+        result = capability._on_transform_llm_output(
+            "assistant reply",
+            session_id="session-1",
+        )
+
+        assert result is not None
+        assert "高风险敏感信息" in result
+        assert "sk-a...[REDACTED]...1234" in result
+        assert result.endswith("\n\nassistant reply")
+        assert mock_cli.call_args_list[0].args[0] == [
+            "scan-pii",
+            "--stdin",
+            "--format",
+            "json",
+            "--redact-output",
+            "--source",
+            "tool_input",
+        ]
+
+    @patch("src.capabilities.pii_scan.call_agent_sec_cli")
+    def test_runtime_hermes_session_context_bridges_missing_tool_session_id(
+        self, mock_cli, capability, monkeypatch
+    ):
+        """Runtime session context should bridge tool hook keys to final output."""
+        mock_cli.side_effect = [
+            _scan_result(
+                "warn",
+                [
+                    {
+                        "type": "email",
+                        "severity": "warn",
+                        "evidence_redacted": "a***@example.com",
+                    }
+                ],
+            ),
+            _scan_result("pass"),
+            _scan_result("pass"),
+        ]
+        _install_gateway_session_context(monkeypatch, "hermes-session-1")
+
+        capability._on_pre_tool_call(
+            tool_name="terminal",
+            args={"command": "echo alice@example.com"},
+            session_id="",
+            task_id="task-1",
+            tool_call_id="tool-1",
+        )
+
+        assert list(capability._warnings_by_key) == ["session_id:hermes-session-1"]
+        output = capability._on_transform_llm_output(
+            response_text="assistant response",
+            session_id="hermes-session-1",
+        )
+        second = capability._on_transform_llm_output(
+            response_text="assistant response",
+            session_id="hermes-session-1",
+        )
+
+        assert output is not None
+        assert "a***@example.com" in output
+        assert output.endswith("\n\nassistant response")
+        assert second is None
+
+    @patch("src.capabilities.pii_scan.call_agent_sec_cli")
+    def test_cached_tool_warning_is_delivered_when_final_output_is_empty(
+        self, mock_cli, capability
+    ):
+        """Empty final model text should still deliver and clear cached warnings."""
+        mock_cli.return_value = _scan_result(
+            "warn",
+            [{"type": "email", "severity": "warn", "evidence_redacted": "a***"}],
+        )
+
+        capability._on_pre_tool_call(
+            tool_name="terminal",
+            args={"command": "echo alice@example.com"},
+            session_id="session-1",
+            tool_call_id="tool-1",
+        )
+        output = capability._on_transform_llm_output("", session_id="session-1")
+        second = capability._on_transform_llm_output("", session_id="session-1")
+
+        assert output is not None
+        assert output.startswith("[pii-checker]")
+        assert "a***" in output
+        assert "\n\n" not in output
+        assert second is None
+        assert mock_cli.call_count == 1
+
+    @patch("src.capabilities.pii_scan.call_agent_sec_cli")
+    def test_tool_output_warning_is_delivered_on_transform(self, mock_cli, capability):
+        """post_tool_call findings should be cached for final output."""
+        mock_cli.side_effect = [
+            _scan_result(
+                "warn",
+                [
+                    {
+                        "type": "phone_cn",
+                        "severity": "warn",
+                        "evidence_redacted": "138****8000",
+                    }
+                ],
+            ),
+            _scan_result("pass"),
+        ]
+
+        capability._on_post_tool_call(
+            tool_name="terminal",
+            args={"command": "cat log"},
+            result={"stdout": "phone 13800138000"},
+            session_id="session-1",
+            tool_call_id="tool-1",
+        )
+        result = capability._on_transform_llm_output(
+            "assistant reply",
+            session_id="session-1",
+        )
+
+        assert result is not None
+        assert "phone_cn" in result
+        assert "138****8000" in result
+        assert mock_cli.call_args_list[0].args[0] == [
+            "scan-pii",
+            "--stdin",
+            "--format",
+            "json",
+            "--redact-output",
+            "--source",
+            "tool_output",
+        ]

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -549,7 +549,7 @@ class TestSqliteEventWriter:
         conn.commit()
         conn.close()
 
-        writer = SqliteEventWriter(path=db_path)
+        writer = SqliteEventWriter(path=db_path, max_age_days=None)
         writer.write(
             SecurityEvent(
                 event_type="prompt_scan",

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -633,6 +633,26 @@ class TestScanPiiCli(unittest.TestCase):
         self.assertIn("--source must be one of", result.output)
 
     @patch("agent_sec_cli.pii_checker.cli.invoke")
+    def test_scan_pii_accepts_runtime_sources(self, mock_invoke):
+        mock_invoke.return_value = ActionResult(
+            success=True,
+            exit_code=0,
+            stdout='{"ok": true, "verdict": "pass"}',
+            data={"ok": True, "verdict": "pass", "summary": {"total": 0}},
+        )
+
+        for source in ["tool_input", "tool_output", "model_output", "observability"]:
+            with self.subTest(source=source):
+                result = self.runner.invoke(
+                    app,
+                    ["scan-pii", "--text", "hello", "--source", source],
+                )
+
+                self.assertEqual(result.exit_code, 0)
+                _, kwargs = mock_invoke.call_args
+                self.assertEqual(kwargs["source"], source)
+
+    @patch("agent_sec_cli.pii_checker.cli.invoke")
     def test_scan_pii_input_default_reads_full_file(self, mock_invoke):
         mock_invoke.return_value = ActionResult(
             success=True,


### PR DESCRIPTION
## Description

Extend the sec-core PII checker from user-input-only coverage to multiple runtime and observability points:

- Add `tool_input`, `model_output`, and `observability` source labels for `scan-pii`.
- Add Cosh PII scans for tool inputs, tool outputs/errors, and model responses while keeping runtime behavior fail-open.
- Add Hermes scans for tool call arguments/results, redact model output via existing `redacted_text`, and surface cached tool warnings in final responses.
- Add OpenClaw PII hooks for tool parameters, tool results/errors, and model output, with optional pre-tool-call blocking on `deny`.
- Redact observability text fields before `agent-sec-cli observability record`; drop high-risk text fields if redaction fails.
- Update tests and docs for the expanded coverage.
- Stabilize the SQLite v1 migration preservation test by disabling retention pruning in that migration-only assertion.

## Related Issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make python-code-pretty` from `src/agent-sec-core`
- `uv run --project src/agent-sec-core/agent-sec-cli pytest src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py src/agent-sec-core/tests/unit-test/test_cli.py src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py src/agent-sec-core/tests/unit-test/cosh_hooks/test_observability_hook.py src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py src/agent-sec-core/tests/unit-test/hermes-plugin/test_observability_cli_runner.py` (137 passed)
- `env npm_config_offline=true npm test` from `src/agent-sec-core/openclaw-plugin` (91 passed)
- `git diff --check`

## Additional Notes

Runtime PII checks remain fail-open. Observability redaction fails safe by dropping sensitive text fields rather than recording raw prompt, response, parameter, result, error, or tool-call content.
