### PR TITLE
fix(sight): add frontend build step to unified rpm-build.sh

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -371,6 +371,16 @@ build_agentsight() {
     fi
     (
         cd "$SIGHT_DIR"
+        # Build frontend (embed into Rust binary via include_dir!)
+        if [ -d "dashboard" ] && command -v npm &>/dev/null; then
+            log "Building frontend..."
+            cd dashboard
+            npm install
+            npm run build:embed
+            cd "$SIGHT_DIR"
+        else
+            warn "Skipping frontend build (dashboard/ not found or npm unavailable)"
+        fi
         cargo build --release
     )
 


### PR DESCRIPTION
## Problem

The unified build script `scripts/rpm-build.sh agentsight` was missing the frontend build step before `cargo build --release`. This causes the Rust binary to be compiled without the embedded dashboard UI, resulting in **'Frontend not embedded'** when accessing the web interface.

## Fix

Add `npm install` + `npm run build:embed` before `cargo build --release` in the `build_agentsight()` function, so the frontend assets are properly embedded into the binary via `include_dir!`.

## Context

Follow-up to #818 (already merged), which fixed the missing service file and internal npm registry issues.