### PR TITLE
fix(ci): harden self-hosted runner workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -297,7 +297,7 @@ jobs:
           sudo apt-get install -y clang llvm libssl-dev libseccomp-dev bubblewrap
 
       - name: Install diff-cover
-        run: uv tool install diff-cover
+        run: uv tool install --force diff-cover
 
       - name: Check formatting
         run: |

--- a/.github/workflows/prelint.yml
+++ b/.github/workflows/prelint.yml
@@ -24,7 +24,7 @@ jobs:
   # =========================================================================
   commit-lint:
     name: 📝 Commit Message Lint
-    runs-on: [self-hosted, Linux, ubuntu-any]
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -208,4 +208,3 @@ jobs:
             console.log('All checks completed. Any warnings above are non-blocking suggestions.');
             console.log('The only hard error that blocks merging is a missing commit scope.');
             console.log('See CONTRIBUTING.md or AGENT.md for guidance on commit messages and PR conventions.');
-


### PR DESCRIPTION
## Summary

- Route commitlint to X64 self-hosted Ubuntu runners because `wagoid/commitlint-github-action` uses an amd64 Docker image.
- Make `diff-cover` installation repeatable on persistent self-hosted runners by using `uv tool install --force`.

## Why

Self-hosted runners keep state between jobs. Two issues were found during migration validation:

- `commit-lint` could be scheduled onto the ARM64 runner via `ubuntu-any`, but the commitlint Docker action image is amd64-only, causing `exec format error`.
- `uv tool install diff-cover` failed when `diff-cover` / `diff-quality` already existed from a previous job.

## Validation

- Workflow YAML parses successfully.
- `git diff --check` passes.