### PR TITLE
fix(sight): add stop signal to background threads

### DIFF
--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -94,9 +94,6 @@ pub struct AgentSight {
     pid_agent_name_cache: HashMap<u32, String>,
     /// HTTP domain patterns from config, used for runtime DNS-based tcpsniff target addition
     http_domains: Vec<String>,
-    /// Flag indicating SLS Logtail has been activated (irreversible)
-    #[allow(dead_code)]
-    sls_activated: Arc<AtomicBool>,
     /// Mailbox for watcher thread to deposit a dynamically-created LogtailExporter
     pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>>,
     /// DeadLoop auto-kill: enabled flag
@@ -452,6 +449,9 @@ impl AgentSight {
         let pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>> =
             Arc::new(Mutex::new(None));
 
+        // Create `running` flag early so background threads can observe shutdown.
+        let running = Arc::new(AtomicBool::new(true));
+
         // Spawn config file watcher for runtime hot-reload
         if let Some(ref cfg_path) = config.config_path {
             Self::start_config_watcher(
@@ -460,23 +460,31 @@ impl AgentSight {
                 Arc::clone(&pending_logtail),
                 config.encryption_public_key.clone(),
                 config.trace_enabled,
+                Arc::clone(&running),
             );
             // Spawn token-collector watcher to bridge ilogtail SLS_LOG_PATH into
             // runtime.sls_logtail_path. Triggered by /etc/anolisa/enable_token_collector
             // file presence; cleared when the file is removed.
-            Self::start_token_collector_watcher(cfg_path.clone());
+            Self::start_token_collector_watcher(cfg_path.clone(), Arc::clone(&running));
         }
 
         // Spawn background thread that marks stale PENDING calls as 'interrupted'.
         // Fires every 60 seconds; any pending call older than 5 minutes is assumed lost.
         if let Some(ref sqlite_store) = genai_sqlite_store {
             let store_ref = Arc::clone(sqlite_store);
+            let stop = Arc::clone(&running);
             std::thread::Builder::new()
                 .name("genai-stale-scanner".to_string())
                 .spawn(move || {
                     log::info!("GenAI stale-pending scanner started (interval=60s, timeout=300s)");
                     loop {
-                        std::thread::sleep(std::time::Duration::from_secs(60));
+                        for _ in 0..60 {
+                            std::thread::sleep(std::time::Duration::from_secs(1));
+                            if !stop.load(Ordering::SeqCst) {
+                                log::info!("GenAI stale-pending scanner stopped");
+                                return;
+                            }
+                        }
                         if let Err(e) = store_ref.mark_interrupted_stale(300) {
                             log::warn!("Stale-pending scan failed: {e}");
                         }
@@ -498,7 +506,7 @@ impl AgentSight {
             storage,
             scanner,
             _poller,
-            running: Arc::new(AtomicBool::new(true)),
+            running,
             event_count: 0,
             filewatch_callback: None,
             response_mapper: ResponseSessionMapper::new(),
@@ -507,7 +515,6 @@ impl AgentSight {
             last_drain_check: std::time::Instant::now(),
             pid_agent_name_cache,
             http_domains,
-            sls_activated,
             pending_logtail,
             deadloop_kill_enabled: config.deadloop_kill_enabled,
             deadloop_kill_after_count: config.deadloop_kill_after_count,
@@ -909,6 +916,7 @@ impl AgentSight {
         pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>>,
         encryption_pem: Option<String>,
         trace_enabled: bool,
+        stop: Arc<AtomicBool>,
     ) {
         use notify::{Event as NotifyEvent, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
@@ -937,7 +945,12 @@ impl AgentSight {
 
                 let target_filename = watch_path.file_name().map(|f| f.to_os_string());
 
-                for event in rx {
+                while stop.load(Ordering::SeqCst) {
+                    let event = match rx.recv_timeout(std::time::Duration::from_secs(1)) {
+                        Ok(event) => event,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    };
                     let event = match event {
                         Ok(e) => e,
                         Err(e) => {
@@ -1045,7 +1058,7 @@ impl AgentSight {
     ///
     /// The actual SLS activation is then handled by `start_config_watcher`, which
     /// reacts to the resulting config file change.
-    fn start_token_collector_watcher(config_path: PathBuf) {
+    fn start_token_collector_watcher(config_path: PathBuf, stop: Arc<AtomicBool>) {
         const ENABLE_FILE: &str = "/etc/anolisa/enable_token_collector";
         const LOGTAIL_CFG: &str = "/etc/anolisa/ilogtail.cfg";
         const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
@@ -1063,7 +1076,7 @@ impl AgentSight {
                 //   Some(None)       — last wrote disabled
                 let mut last_state: Option<Option<String>> = None;
 
-                loop {
+                while stop.load(Ordering::SeqCst) {
                     std::thread::sleep(POLL_INTERVAL);
 
                     let enabled = Path::new(ENABLE_FILE).exists();
@@ -1110,6 +1123,7 @@ impl AgentSight {
                         }
                     }
                 }
+                log::info!("Token-collector watcher stopped");
             })
             .ok();
     }


### PR DESCRIPTION
## Summary

- Three background threads (`genai-stale-scanner`, `config-watcher`, `token-collector-watcher`) ran infinite loops without checking the `running` flag. After `shutdown()`/`Drop`, they survived indefinitely — the stale-scanner held `Arc<GenAISqliteStore>` preventing the DB handle from being freed, undermining the WAL checkpoint contract (added in 559c918).
- Create `running` Arc<AtomicBool> before thread spawns, pass clones to all three
- stale-scanner: split `sleep(60)` into `60×sleep(1)` with stop check each second
- config-watcher: replace blocking `for event in rx` with `recv_timeout(1s)` guarded by stop flag
- token-collector-watcher: change `loop` to `while stop.load()`
- Remove dead `sls_activated` struct field (`#[allow(dead_code)]`, never read via `self` — truth lives in thread-owned clones)

## What changed / what didn't

**Changed (1 file, +24/-10):**
- `unified.rs`: thread lifecycle + dead field removal

**Not changed:**
- Thread business logic inside loops — only loop conditions changed
- shutdown() logic (already sets running=false, no new join/await)
- `sls_activated` constructor local + Arc::clone to threads — only the **struct field** removed

**Known tradeoff:** No JoinHandle storage / explicit join — threads exit on their own within ≤1s of `running=false`. Storing JoinHandles would require changing 3 static methods to return handles + 3 new struct fields — deferred to a follow-up if needed.

## Test plan

- [x] 573 unit tests pass (local + ECS, rustc 1.89)
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -D warnings` pass (unified.rs zero errors)
- [x] ECS E2E: `agentsight trace` → cosh agent → SIGTERM → process **exits cleanly** (previously would hang due to detached threads)
- [x] Adversarial workflow review (5 dimensions, 5 agents): shutdown race / scanner timing / recv_timeout correctness / dead field safety / running flag ordering — all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)