### PR TITLE
style(sight): use inline format args in ffi cgroup logs

### DIFF
--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -742,16 +742,16 @@ fn ffi_background_thread(
             match cmd {
                 ProbeCommand::AddCgroup(id) => {
                     if let Err(e) = sight.add_traced_cgroup(id) {
-                        log::warn!("add_traced_cgroup({}) failed: {}", id, e);
+                        log::warn!("add_traced_cgroup({id}) failed: {e}");
                     } else {
-                        log::info!("Added cgroup_id {} to BPF filter", id);
+                        log::info!("Added cgroup_id {id} to BPF filter");
                     }
                 }
                 ProbeCommand::RemoveCgroup(id) => {
                     if let Err(e) = sight.remove_traced_cgroup(id) {
-                        log::warn!("remove_traced_cgroup({}) failed: {}", id, e);
+                        log::warn!("remove_traced_cgroup({id}) failed: {e}");
                     } else {
-                        log::info!("Removed cgroup_id {} from BPF filter", id);
+                        log::info!("Removed cgroup_id {id} from BPF filter");
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Fix 4 `clippy::uninlined_format_args` warnings in `ffi.rs` (lines 745-754) introduced by 7915172 (cgroup gate PR)
- Unblocks `clippy -D warnings` CI gate for all agentsight PRs on rustc 1.89+

## Test plan

- [x] `cargo clippy -D warnings` — zero errors
- [x] `cargo fmt --check` — pass
- [x] No logic change — string formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)