### PR TITLE
docs(sight): add scoped AGENTS.md for ffi, unified, storage

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -214,7 +214,17 @@ React + TypeScript + Webpack + Tailwind CSS，位于 `dashboard/`。开发: `npm
 - [数据流水线设计](docs/design-docs/data-pipeline.md)
 - [GenAI 语义层设计](docs/design-docs/genai-semantic.md)
 
-## 12. Prerequisites
+## 12. Scoped Rules
+
+高风险模块有独立的边界约束文件：
+
+| 模块 | 规则文件 | 关注点 |
+|------|----------|--------|
+| FFI 导出层 | [src/FFI_AGENTS.md](src/FFI_AGENTS.md) | ABI 安全、cbindgen 同步、panic 隔离 |
+| 主编排器 | [src/UNIFIED_AGENTS.md](src/UNIFIED_AGENTS.md) | 禁止业务逻辑、保持委托模式 |
+| 存储层 | [src/storage/AGENTS.md](src/storage/AGENTS.md) | SQL 注入防护、schema 兼容、mutex 处理 |
+
+## 13. Prerequisites
 
 - Linux kernel >= 5.8（BTF 支持）
 - Rust >= 1.80

--- a/src/agentsight/src/FFI_AGENTS.md
+++ b/src/agentsight/src/FFI_AGENTS.md
@@ -1,0 +1,10 @@
+# FFI Layer Rules
+
+> 适用于 `src/ffi.rs` 及所有 `extern "C"` 导出函数。
+
+1. 新增 `extern "C"` 函数必须同时在 `cbindgen.toml` 的 `after_includes` 中添加 C 声明（cbindgen 0.27 不识别 `#[unsafe(no_mangle)]`）
+2. FFI 类型必须标注 `#[repr(C)]`
+3. 禁止 panic 穿越 FFI 边界 — 所有入口函数用 `std::panic::catch_unwind` 包裹
+4. 错误通过 thread-local `LAST_ERROR` 返回，调用方用 `agentsight_last_error()` 读取
+5. 指针参数必须在函数入口做 null check，返回错误码而非 UB
+6. 修改函数签名后必须确认 `build.rs` drift guard 通过（注意：drift guard 只检查函数名，不检查签名）

--- a/src/agentsight/src/UNIFIED_AGENTS.md
+++ b/src/agentsight/src/UNIFIED_AGENTS.md
@@ -1,0 +1,10 @@
+# Orchestrator Rules
+
+> 适用于 `src/unified.rs`（AgentSight 主编排器，当前 2200+ 行）。
+
+1. unified.rs 只做组件装配和事件分发，禁止添加业务逻辑（解析、分析、存储）
+2. 新流水线阶段必须放在独立模块，unified.rs 只调用其公开接口
+3. `AgentSight::new()` 只做组件初始化和装配，不执行 I/O 或阻塞操作
+4. `try_process()` 保持精简，通过委托给具体 analyzer/builder 处理，不内联处理逻辑
+5. 新增字段前先考虑是否应属于子模块（Footprint Ladder 级别 1-2 优先）
+6. 该文件已超过 2000 行，新增代码前必须评估是否可以提取到子模块

--- a/src/agentsight/src/storage/AGENTS.md
+++ b/src/agentsight/src/storage/AGENTS.md
@@ -1,0 +1,9 @@
+# Storage Layer Rules
+
+> 适用于 `src/storage/` 目录下所有文件。
+
+1. SQL 查询必须使用参数化语句（`?` 占位符），禁止字符串拼接
+2. 新 store 类型必须实现统一的 trait 接口，通过 `Storage` 统一访问
+3. 数据库 schema 变更必须向后兼容，不得破坏已有数据
+4. `conn.lock().unwrap()` 是已知技术债 — 新代码应使用 `map_err` 处理 mutex poisoned
+5. 查询接口必须支持时间范围过滤，与 `data_retention_days` 清理策略一致


### PR DESCRIPTION
## Summary
- 为三个高风险模块创建 scoped AGENTS.md 边界约束：
  - `src/FFI_AGENTS.md` — FFI 导出层（ABI 安全、cbindgen 同步、panic 隔离）
  - `src/UNIFIED_AGENTS.md` — 主编排器（禁止业务逻辑、保持委托模式、控制文件膨胀）
  - `src/storage/AGENTS.md` — 存储层（参数化 SQL、schema 兼容、mutex 处理）
- 顶层 AGENTS.md 新增 `## 12. Scoped Rules` 索引表

Closes #903

## Test plan
- [ ] 确认三个 scoped AGENTS.md 文件存在且规则 ≤10 条
- [ ] 确认顶层 AGENTS.md 索引链接路径正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)