### PR TITLE
ci(sight): add architecture boundary check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -571,6 +571,11 @@ jobs:
           cd src/agentsight
           cargo fmt --all --check
 
+      - name: Check architecture boundaries
+        run: |
+          cd src/agentsight
+          python3 scripts/check-arch-boundaries.py
+
       - name: Lint
         run: |
           cd src/agentsight

--- a/src/agentsight/docs/ARCHITECTURE.md
+++ b/src/agentsight/docs/ARCHITECTURE.md
@@ -83,10 +83,10 @@ graph TB
 | **L1: Capture** | `src/probes/`, `src/event.rs` | 探针加载、事件轮询、统一事件类型 | → L0 |
 | **L2: Parse** | `src/parser/` | HTTP/1.x, HTTP/2, SSE, ProcTrace 协议解析 | → L1 |
 | **L3: Aggregate** | `src/aggregator/` | 请求-响应关联、进程生命周期聚合 | → L2 |
-| **L4: Analyze** | `src/analyzer/`, `src/tokenizer/` | Token 提取、审计记录、消息解析 | → L3 |
-| **L5: Semantic** | `src/genai/`, `src/atif/` | 语义事件构建、轨迹格式导出 | → L4 |
+| **L4: Analyze** | `src/analyzer/`, `src/tokenizer/` | Token 提取、审计记录、消息解析 | → L3, L2 |
+| **L5: Semantic** | `src/genai/`, `src/atif/` | 语义事件构建、轨迹格式导出 | → L4, L3, L2, Cross |
 | **L6: Persist** | `src/storage/` | SQLite 持久化、SLS 远程导出 | → L4, L5 |
-| **L7: Serve** | `src/server/`, `src/health/` | HTTP API、前端、健康检查 | → L6 |
+| **L7: Serve** | `src/server/`, `src/health/` | HTTP API、前端、健康检查 | → L6, L5 |
 | **L8: Entry** | `src/bin/`, `src/unified.rs`, `src/config.rs` | CLI 入口、编排器、配置 | → L1-L7 |
 | **Cross** | `src/discovery/` | Agent 进程发现与匹配 | 被 L1, L8 使用 |
 
@@ -121,14 +121,23 @@ graph LR
 
     probes --> event
     parser --> probes
+    parser --> event
     aggregator --> parser
+    aggregator --> probes
+    aggregator --> event
     analyzer --> aggregator
     analyzer --> tokenizer
+    analyzer --> parser
     genai --> analyzer
     genai --> discovery
+    genai --> aggregator
+    genai --> parser
     storage --> analyzer
+    storage --> genai
     server --> storage
     server --> health
+    server --> atif
+    health --> storage
     atif --> genai
     atif --> storage
 ```

--- a/src/agentsight/docs/DEVELOPMENT.md
+++ b/src/agentsight/docs/DEVELOPMENT.md
@@ -138,9 +138,17 @@ CI (`ci.yaml` 的 `test-agentsight` job) 对每次 PR 执行以下检查：
 | 检查项 | 命令 | 失败条件 |
 |--------|------|----------|
 | 格式化 | `cargo fmt --all --check` | 代码未格式化 |
+| 架构边界 | `python3 scripts/check-arch-boundaries.py` | 存在未声明的跨模块依赖 |
 | Lint | `cargo clippy --all-targets -- -D warnings` | 存在 clippy 警告 |
 | 单元测试 | `cargo test`（通过 `cargo llvm-cov`） | 任何测试失败 |
 | 增量覆盖率 | `diff-cover --fail-under=80` | 新增/修改代码行覆盖率 < 80% |
+
+**架构边界检查**：脚本验证 `use crate::` 跨模块引用是否符合 `ARCHITECTURE.md` 声明的层级依赖。若需要新增跨模块依赖，先确认是否合理，然后更新脚本中的 `ALLOWED_DEPS` 和 `ARCHITECTURE.md` 依赖图。若为暂时无法修复的历史违规，添加到 `KNOWN_VIOLATIONS` 并附 issue 链接。
+
+本地运行：
+```bash
+python3 scripts/check-arch-boundaries.py
+```
 
 覆盖率报告在 CI 运行结果页的 **Step Summary** 中可见，完整的 Cobertura XML 可从 **Artifacts** 下载。
 

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -67,7 +67,7 @@ CROSS_CUTTING = {
 # Known violations: (source_file_relative_to_src, target_module, reason)
 KNOWN_VIOLATIONS = [
     ("genai/builder.rs", "storage",
-     "L5->L6: PendingCallInfo/SseEnrichment types pending migration"),
+     "L5->L6: PendingCallInfo/SseEnrichment types pending migration (#906)"),
 ]
 
 USE_RE = re.compile(r"use\s+crate::(\w+)")

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Architecture boundary checker for AgentSight.
+
+Validates that `use crate::` imports respect the L0-L8 layer constraints
+defined in docs/ARCHITECTURE.md.
+
+Exit codes:
+  0 — no new violations (known violations in allowlist are OK)
+  1 — new violations found
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Layer numbers (informational, used for diagnostic output).
+LAYER_MAP = {
+    "bpf":         0,   # L0: Kernel
+    "probes":      1,   # L1: Capture
+    "event":       1,   # L1: Capture
+    "parser":      2,   # L2: Parse
+    "aggregator":  3,   # L3: Aggregate
+    "analyzer":    4,   # L4: Analyze
+    "tokenizer":   4,   # L4: Analyze
+    "genai":       5,   # L5: Semantic
+    "atif":        5,   # L5: Semantic
+    "storage":     6,   # L6: Persist
+    "server":      7,   # L7: Serve
+    "health":      7,   # L7: Serve
+    "bin":         8,   # L8: Entry
+    "unified":     8,   # L8: Entry
+    "config":      8,   # L8: Entry
+    "ffi":         8,   # L8: Entry
+}
+
+# Allowed dependency edges. A set lists allowed targets; "*" allows any module.
+ALLOWED_DEPS = {
+    "probes":      {"event"},
+    "parser":      {"probes", "event"},
+    "aggregator":  {"parser", "probes", "event"},
+    "analyzer":    {"aggregator", "tokenizer", "parser"},
+    "tokenizer":   set(),
+    "genai":       {"analyzer", "discovery", "aggregator", "parser"},
+    "atif":        {"genai", "storage"},
+    "storage":     {"analyzer", "genai"},
+    "server":      {"storage", "health", "atif"},
+    "health":      {"storage"},
+    "unified":     "*",
+    "config":      set(),
+    "ffi":         "*",
+    "bin":         "*",
+}
+
+# Cross-cutting modules — any module may import these.
+CROSS_CUTTING = {
+    "config",          # global configuration
+    "chrome_trace",    # data format helpers
+    "interruption",    # cross-layer event detection
+    "response_map",    # session mapping helpers
+    "logging",         # logging init
+    "utils",           # utility functions
+    "discovery",       # process discovery (Cross in ARCHITECTURE.md)
+    "skill_metrics",   # metric helpers
+    "token_breakdown", # token analysis helpers
+}
+
+# Known violations: (source_file_relative_to_src, target_module, reason)
+KNOWN_VIOLATIONS = [
+    ("genai/builder.rs", "storage",
+     "L5->L6: PendingCallInfo/SseEnrichment types pending migration"),
+]
+
+USE_RE = re.compile(r"use\s+crate::(\w+)")
+PATH_RE = re.compile(r"crate::(\w+)::")
+CFG_TEST_RE = re.compile(r"#\[cfg\(test\)\]")
+MOD_RE = re.compile(r"\bmod\s+\w+")
+
+
+def source_module_for(rel_path: Path) -> str:
+    """Derive the module name owning a source file.
+
+    Examples:
+        genai/builder.rs        -> genai
+        unified.rs              -> unified
+        bin/cli/token.rs        -> bin
+    """
+    parts = rel_path.parts
+    if len(parts) >= 2:
+        return parts[0]
+    # top-level file like unified.rs / config.rs / lib.rs
+    return rel_path.stem
+
+
+def is_test_file(rel_path: Path) -> bool:
+    s = str(rel_path).replace("\\", "/")
+    if "/tests/" in s:
+        return True
+    if rel_path.name.endswith("_tests.rs"):
+        return True
+    return False
+
+
+def extract_imports(text: str):
+    """Yield (line_no, target_module) tuples for crate-internal imports.
+
+    Skips imports inside `#[cfg(test)] mod ... { ... }` blocks using a simple
+    brace-depth tracker.
+
+    Limitations:
+      - Only recognises `#[cfg(test)]` followed by `mod <name> {` with the
+        opening brace on the same line as the `mod` keyword.
+      - Does not handle `use super::super::` cross-module references; code
+        convention must enforce `use crate::` for cross-module imports.
+    """
+    lines = text.splitlines()
+    in_test_block = False
+    test_block_depth = 0  # brace depth at which the test block was opened
+    depth = 0
+    pending_cfg_test = False
+
+    for idx, line in enumerate(lines, start=1):
+        # Skip comment lines (line comments and doc comments).
+        stripped = line.lstrip()
+        if stripped.startswith("//"):
+            continue
+
+        # Detect cfg(test) attribute on its own line — applies to the next item.
+        if CFG_TEST_RE.search(line):
+            pending_cfg_test = True
+
+        # If we have a pending cfg(test), look for `mod ... {` to enter a block.
+        if pending_cfg_test and not in_test_block and MOD_RE.search(line):
+            if "{" in line:
+                in_test_block = True
+                test_block_depth = depth  # opening brace counted below
+                pending_cfg_test = False
+
+        # Update brace depth from this line's braces.
+        opens = line.count("{")
+        closes = line.count("}")
+        new_depth = depth + opens - closes
+
+        # Process imports if not inside a test block.
+        if not in_test_block:
+            for m in USE_RE.finditer(line):
+                yield idx, m.group(1)
+            for m in PATH_RE.finditer(line):
+                yield idx, m.group(1)
+
+        depth = new_depth
+
+        # Exit test block once depth falls back to its opening level.
+        if in_test_block and depth <= test_block_depth:
+            in_test_block = False
+            test_block_depth = 0
+
+
+def known_violation_match(rel_path: Path, target: str):
+    rel_str = str(rel_path).replace("\\", "/")
+    for src_file, tgt, reason in KNOWN_VIOLATIONS:
+        if src_file == rel_str and tgt == target:
+            return reason
+    return None
+
+
+def classify(source: str, target: str, rel_path: Path):
+    """Return ("pass" | "known" | "violation", detail)."""
+    if target in CROSS_CUTTING:
+        return "pass", None
+    if target == source:
+        return "pass", None
+    allowed = ALLOWED_DEPS.get(source)
+    if allowed == "*":
+        return "pass", None
+    if allowed is None:
+        # Source has no rule defined (e.g., cross-cutting helper module).
+        # Treat as unconstrained — only modules listed in ALLOWED_DEPS are
+        # subject to layer constraints.
+        return "pass", None
+    if target in allowed:
+        return "pass", None
+    reason = known_violation_match(rel_path, target)
+    if reason is not None:
+        return "known", reason
+    return "violation", None
+
+
+def fmt_layer(module: str) -> str:
+    layer = LAYER_MAP.get(module)
+    return f"L{layer}" if layer is not None else "L?"
+
+
+def fmt_allowed(source: str) -> str:
+    allowed = ALLOWED_DEPS.get(source)
+    if allowed == "*":
+        return "any"
+    if allowed is None:
+        return "(unknown module — no rule defined)"
+    if not allowed:
+        return "(none)"
+    return "{" + ", ".join(sorted(allowed)) + "}"
+
+
+def main() -> int:
+    script_dir = Path(__file__).resolve().parent
+    src_dir = (script_dir / ".." / "src").resolve()
+
+    print("=== AgentSight Architecture Boundary Check ===\n")
+
+    if not src_dir.is_dir():
+        print(f"ERROR: src/ not found at {src_dir}", file=sys.stderr)
+        return 1
+
+    rs_files = sorted(p for p in src_dir.rglob("*.rs"))
+    rs_files = [p for p in rs_files if not is_test_file(p.relative_to(src_dir))]
+
+    print(f"Scanning: src/ ({len(rs_files)} files)\n")
+
+    violations = []
+    knowns = []
+
+    for path in rs_files:
+        rel = path.relative_to(src_dir)
+        source = source_module_for(rel)
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"WARN: cannot read {rel}: {exc}", file=sys.stderr)
+            continue
+
+        seen = set()
+        for line_no, target in extract_imports(text):
+            key = (line_no, target)
+            if key in seen:
+                continue
+            seen.add(key)
+            verdict, detail = classify(source, target, rel)
+            if verdict == "pass":
+                continue
+            entry = (rel, line_no, source, target, detail)
+            if verdict == "known":
+                knowns.append(entry)
+            else:
+                violations.append(entry)
+
+    for rel, line_no, source, target, _ in violations:
+        print(f"[VIOLATION] {rel}:{line_no}")
+        print(f"  {source} ({fmt_layer(source)}) -> {target} ({fmt_layer(target)})")
+        print(f"  Allowed imports for {source}: {fmt_allowed(source)}")
+        print()
+
+    for rel, line_no, source, target, detail in knowns:
+        print(f"[KNOWN] {rel}:{line_no}")
+        print(f"  {source} ({fmt_layer(source)}) -> {target} ({fmt_layer(target)})")
+        print(f"  Tracked: {detail}")
+        print()
+
+    print("---")
+    print(
+        f"Summary: {len(violations)} violations, "
+        f"{len(knowns)} known (allowlisted), "
+        f"{len(rs_files)} files checked"
+    )
+    if violations:
+        print("Result: FAILED (new violations found)")
+        return 1
+    print("Result: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -40,7 +40,7 @@ ALLOWED_DEPS = {
     "aggregator":  {"parser", "probes", "event"},
     "analyzer":    {"aggregator", "tokenizer", "parser"},
     "tokenizer":   set(),
-    "genai":       {"analyzer", "discovery", "aggregator", "parser"},
+    "genai":       {"analyzer", "aggregator", "parser"},
     "atif":        {"genai", "storage"},
     "storage":     {"analyzer", "genai"},
     "server":      {"storage", "health", "atif"},

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -35,6 +35,7 @@ LAYER_MAP = {
 
 # Allowed dependency edges. A set lists allowed targets; "*" allows any module.
 ALLOWED_DEPS = {
+    "event":       {"probes"},
     "probes":      {"event"},
     "parser":      {"probes", "event"},
     "aggregator":  {"parser", "probes", "event"},
@@ -127,6 +128,9 @@ def extract_imports(text: str):
         # Detect cfg(test) attribute on its own line — applies to the next item.
         if CFG_TEST_RE.search(line):
             pending_cfg_test = True
+        elif pending_cfg_test and not MOD_RE.search(line) and stripped:
+            # Reset pending if the next non-empty line is not a `mod` declaration.
+            pending_cfg_test = False
 
         # If we have a pending cfg(test), look for `mod ... {` to enter a block.
         if pending_cfg_test and not in_test_block and MOD_RE.search(line):


### PR DESCRIPTION
## Summary

Add a lightweight Python script that statically enforces AgentSight's L0–L8 layer architecture as a CI gate, preventing undeclared cross-layer dependencies from being merged.

## Changes

1. **`src/agentsight/scripts/check-arch-boundaries.py`** — boundary check script
   - Module-level `ALLOWED_DEPS` allowlist derived from `ARCHITECTURE.md`
   - `CROSS_CUTTING` set for modules exempt from layer constraints
   - `KNOWN_VIOLATIONS` for explicitly tracked tech-debt (currently: `genai→storage`)
   - `#[cfg(test)]` block skipping via brace-depth tracking
   - Comment-line filtering to avoid false positives

2. **`.github/workflows/ci.yaml`** — integrate into `test-agentsight` job (between fmt and clippy)

3. **`src/agentsight/docs/ARCHITECTURE.md`** — supplement Mermaid dependency graph and Layer table with edges that existed in code but were undocumented

## Motivation

Closes #906. As the codebase grows, implicit layer violations accumulate silently. This gate catches them at PR time with zero runtime cost and sub-second CI overhead (130 files, pure regex scan).

## Verification

- Script passes on current codebase: `0 violations, 1 known, PASS`
- Injecting a fake violation → correctly fails with exit 1
- Comment lines (`// use crate::server::...`) are properly ignored