### PR TITLE
feat(sight): add auto-format develop-skill

### DIFF
--- a/src/agentsight/develop-skills/README.md
+++ b/src/agentsight/develop-skills/README.md
@@ -31,3 +31,4 @@ AgentSight 为开发者提供的 AI coding skill 集合，帮助 AI agent 遵循
 |-------|------|
 | `agentsight-pr-body` | 分析分支变更，按 anolisa 规范生成/更新 PR 标题和正文 |
 | `agentsight-code-review` | 6 维度代码审查：硬性规则、eBPF 安全、FFI 边界、Footprint Ladder、流水线测试、文档同步 |
+| `agentsight-auto-format` | 编辑代码后自动运行 rustfmt/ruff/prettier，保持代码风格一致 |

--- a/src/agentsight/develop-skills/agentsight-auto-format/SKILL.md
+++ b/src/agentsight/develop-skills/agentsight-auto-format/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: agentsight-auto-format
+description: 编辑代码文件后自动运行对应格式化工具，保持代码风格一致。适用于任何 AI coding agent。
+---
+
+# 代码自动格式化
+
+## 目标
+
+编辑 `.rs`、`.py`、`.ts`、`.tsx` 文件后，自动运行对应的格式化工具，保持代码风格一致。
+
+## 触发时自动执行
+
+每次编辑代码文件后（Edit、Write 等操作），对被修改的文件运行对应的格式化命令。格式化失败时静默跳过，不阻断工作流。
+
+### 格式化规则
+
+| 扩展名 | 命令 | 备注 |
+|--------|------|------|
+| `.rs` | `rustfmt <file>` | 直接调用，不需要 crate 上下文 |
+| `.py` | `ruff format <file>` | 没有 ruff 时用 `black --quiet <file>` |
+| `.ts` `.tsx` | `prettier --write <file>` | 需要本地已安装 prettier |
+
+### 注意事项
+
+- 只格式化本次编辑的文件，不要全量格式化
+- 格式化工具不存在时跳过，不报错
+- 不要用 `cargo fmt`（需要 crate 上下文，对单文件不友好）
+- 不要用 `npx prettier`（会触发网络下载，有供应链风险）
+- 提交前仍需运行 `cargo fmt --check` / `cargo clippy` 做最终检查
+
+## Hook 自动化
+
+本目录下的 `post-edit-format.py` 脚本可挂接到任何支持 PostToolUse hook 的 agent，实现机械式自动格式化。
+
+脚本从 stdin 读取被编辑的文件信息（支持 hook JSON 和纯文本路径），自动分发到对应 formatter。用法：
+
+```bash
+echo "/path/to/file.rs" | python3 develop-skills/agentsight-auto-format/post-edit-format.py
+```
+
+各 agent 的 hook 配置方式不同，请参考对应 agent 文档将脚本挂在 PostToolUse（Edit/Write）事件上。hook 配置属于开发者本地设置，不提交仓库。

--- a/src/agentsight/develop-skills/agentsight-auto-format/post-edit-format.py
+++ b/src/agentsight/develop-skills/agentsight-auto-format/post-edit-format.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Post-edit auto-format for AI agents.
+
+Reads edited file paths from stdin and runs the appropriate formatter.
+Failures are logged to stderr but never block the agent workflow.
+
+Stdin formats (auto-detected):
+  - Hook JSON: {"tool_name":"Edit","tool_input":{"file_path":"..."},...}
+  - Plain text: one file path per line
+
+Supported formatters:
+  .rs          -> rustfmt
+  .py          -> ruff format (fallback: black)
+  .ts/.tsx     -> prettier --write (must be locally installed)
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def format_rust(path):
+    rustfmt = shutil.which("rustfmt")
+    if rustfmt:
+        subprocess.run(
+            [rustfmt, path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+
+
+def format_python(path):
+    ruff = shutil.which("ruff")
+    if ruff:
+        subprocess.run(
+            [ruff, "format", path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        return
+    black = shutil.which("black")
+    if black:
+        subprocess.run(
+            [black, "--quiet", path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+
+
+def format_typescript(path):
+    prettier = shutil.which("prettier")
+    if prettier:
+        subprocess.run(
+            [prettier, "--write", path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+
+
+FORMATTERS = {
+    ".rs": format_rust,
+    ".py": format_python,
+    ".ts": format_typescript,
+    ".tsx": format_typescript,
+}
+
+
+def extract_paths(raw):
+    """Extract file paths from stdin (hook JSON or plain text)."""
+    paths = []
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            # Hook format: {"tool_input": {"file_path": "..."}, ...}
+            tool_input = data.get("tool_input", {})
+            if isinstance(tool_input, dict) and "file_path" in tool_input:
+                paths.append(tool_input["file_path"])
+            # Legacy: {"file_path": "..."}
+            elif "file_path" in data:
+                paths.append(data["file_path"])
+            # Legacy MultiEdit: {"edits": [{"file_path": "..."}, ...]}
+            for edit in data.get("edits", []):
+                if isinstance(edit, dict) and "file_path" in edit:
+                    paths.append(edit["file_path"])
+    except (json.JSONDecodeError, TypeError):
+        paths = [line.strip() for line in raw.splitlines() if line.strip()]
+    return paths
+
+
+def main():
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return
+
+    for path in extract_paths(raw):
+        if not os.path.isfile(path):
+            continue
+        ext = os.path.splitext(path)[1].lower()
+        formatter = FORMATTERS.get(ext)
+        if formatter:
+            try:
+                formatter(path)
+            except Exception as e:
+                print("auto-format: %s: %s" % (path, e), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

#943 被 reviewer 打回：Codex 专属 hook 配置不该进仓库。#942 develop-skills 框架合入后，重新实现为跨 agent skill。

两层设计：
- **SKILL.md**（prompt 层）：通用指令，任何 agent 读了即可跟编辑后格式化
- **post-edit-format.py**（hook 层）：通用脚本，支持 PostToolUse hook 的 agent 可挂接实现机械式自动化

不提交任何 agent 专属 hook 配置文件（`.codex/`、`.claude/` 等）。

## Related Issue

closes #907

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `develop-skills/agentsight-auto-format/SKILL.md`: 通用格式化指令 + hook 自动化说明
- `develop-skills/agentsight-auto-format/post-edit-format.py`: 格式化脚本（rustfmt/ruff/prettier）
- `develop-skills/README.md`: 添加 auto-format skill 索引

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- 空 stdin: 静默退出 ✓
- 不存在文件: 静默跳过 ✓
- .rs 格式化 (纯文本 stdin): rustfmt 正确执行 ✓
- Hook JSON stdin (`tool_input.file_path`): 正确解析 + 格式化 ✓
- Legacy JSON stdin (`file_path`): 兼容旧格式 ✓
- Hook JSON + 不存在文件: 静默跳过 ✓
- Python AST 解析: 3.6+ 兼容 ✓

25-agent workflow review 发现 4 个问题，全部修复：
- hook stdin `file_path` 在 `tool_input` 内层（不在顶层）
- `npx prettier` 自动下载有供应链风险 → 改为直接查本地 `prettier`
- `shutil.which()` 返回值被丢弃 → 捕获后传给 subprocess
- 静默吞异常 → 改为 stderr 输出