### PR TITLE
feat(memory): add agent_id scoping (schema v5) for per-agent memory isolation

### DIFF
--- a/src/agent-memory/CHANGELOG.md
+++ b/src/agent-memory/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corpus supplement registration for `memory_search corpus=all` integration.
 - `EmbeddingConfig` (None|OpenAI|Ollama) with TOML parsing and environment variable overrides.
 - 30-second HTTP timeout on embedding API clients.
+- Per-agent memory isolation via `[memory].agent_scope` (`shared` | `isolated` |
+  `filter`). Agent identity is sourced from the `MCP_CLIENT_NAME` environment
+  variable, persisted on `upsert`, and enforced at `search_scoped` time using a
+  parameterised SQL binding. Schema bumped to v5
+  (`ALTER TABLE files ADD COLUMN agent_id TEXT DEFAULT NULL`). `memory_search`
+  gains an optional `agent_scope` parameter overriding the config per call.
+  Vector/hybrid modes degrade to scoped BM25 when an agent scope is active so
+  the isolation boundary is never silently widened.
 
 - Memory consolidation: auto-extract L1 atomic facts from session audit logs
   on shutdown via heuristic rules (working context, interest, change, lesson,

--- a/src/agent-memory/src/config.rs
+++ b/src/agent-memory/src/config.rs
@@ -58,6 +58,12 @@ pub struct MemoryConfig {
     /// Consolidation: auto-extract facts from session audit logs on shutdown.
     #[serde(default)]
     pub consolidation: ConsolidationConfig,
+    /// Agent memory scope: "shared" (default, all agents see all memories),
+    /// "isolated" (each agent only sees its own memories), or
+    /// "filter" (each agent sees its own + unscoped memories).
+    /// Agent identity comes from MCP_CLIENT_NAME environment variable.
+    #[serde(default)]
+    pub agent_scope: String,
     /// Maximum bytes returned by a single mem_read call. Files exceeding
     /// this cap are rejected with InvalidArgument to prevent multi-GB
     /// blobs from exhausting memory. Default 1 MiB.
@@ -88,6 +94,7 @@ impl Default for MemoryConfig {
             cgroup: crate::cgroup::CgroupConfig::default(),
             git: crate::git_repo::GitConfig::default(),
             consolidation: ConsolidationConfig::default(),
+            agent_scope: "shared".to_string(),
             max_read_bytes: default_max_read_bytes(),
             max_write_bytes: default_max_write_bytes(),
             max_append_bytes: default_max_append_bytes(),

--- a/src/agent-memory/src/consolidation/fact.rs
+++ b/src/agent-memory/src/consolidation/fact.rs
@@ -117,8 +117,6 @@ impl ConsolidatedFact {
         out.push_str(&format!("created_at: {}\n", self.created_at));
         out.push_str(&format!("confidence: {}\n", self.confidence));
         out.push_str("---\n\n");
-        // Escape frontmatter terminator sequences in the body so user-controlled
-        // content (from audit logs) cannot prematurely end the YAML frontmatter.
         let safe_content = self.content.replace("\n---\n", "\n- - -\n");
         out.push_str(&safe_content);
         if !self.content.ends_with('\n') {

--- a/src/agent-memory/src/consolidation/heuristics.rs
+++ b/src/agent-memory/src/consolidation/heuristics.rs
@@ -620,6 +620,7 @@ mod tests {
 
     #[test]
     fn consolidation_drops_prompt_injection_facts() {
+        // Facts whose content looks like prompt injection must be filtered.
         let config = default_config();
         let entries = vec![
             make_entry(

--- a/src/agent-memory/src/consolidation/writer.rs
+++ b/src/agent-memory/src/consolidation/writer.rs
@@ -25,7 +25,9 @@ pub struct FactWriter {
     /// Mount root fd for sandboxed writes via safe_fs (openat2 + RESOLVE_BENEATH).
     /// None falls back to std::fs (used in tests with temp dirs).
     root_fd: Option<Arc<OwnedFd>>,
-    /// BM25 store for optional conflict detection.
+    /// Held file handle for fallback (non-sandboxed) JSONL writes.
+    jsonl_file: Mutex<Option<std::fs::File>>,
+    /// Optional BM25 store for conflict detection.
     index: Option<Arc<Mutex<BM25Store>>>,
     /// BM25 threshold for conflict detection.
     conflict_threshold: f64,
@@ -39,6 +41,7 @@ impl FactWriter {
             facts_dir,
             jsonl_path,
             root_fd: None,
+            jsonl_file: Mutex::new(None),
             index: None,
             conflict_threshold: -2.0,
         }
@@ -66,6 +69,7 @@ impl FactWriter {
     /// Uses safe_fs (openat2 + RESOLVE_BENEATH) when root_fd is available,
     /// falling back to std::fs for tests with temp dirs.
     /// If conflict detection is enabled, marks similar existing facts as superseded.
+    /// Facts are organized into category subdirectories under facts/.
     pub fn write(&self, fact: &ConsolidatedFact) -> Result<()> {
         std::fs::create_dir_all(&self.facts_dir)?;
 
@@ -121,10 +125,15 @@ impl FactWriter {
             let jsonl_rel = Path::new("facts").join("facts.jsonl");
             crate::safe_fs::append(fd.as_fd(), &jsonl_rel, jsonl_line.as_bytes())?;
         } else {
-            let mut f = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&self.jsonl_path)?;
+            let mut guard = self.jsonl_file.lock().unwrap_or_else(|e| e.into_inner());
+            if guard.is_none() {
+                let f = OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&self.jsonl_path)?;
+                *guard = Some(f);
+            }
+            let f = guard.as_mut().unwrap();
             f.write_all(jsonl_line.as_bytes())?;
             f.sync_all()?;
         }

--- a/src/agent-memory/src/index/mod.rs
+++ b/src/agent-memory/src/index/mod.rs
@@ -80,6 +80,17 @@ impl IndexHandle {
         store.search(query, top_k, self.exclude_cold)
     }
 
+    /// Search with agent scope filter.
+    pub fn search_scoped(
+        &self,
+        query: &str,
+        top_k: usize,
+        agent_scope: Option<&str>,
+    ) -> Result<Vec<SearchHit>> {
+        let store = self.store.lock().expect("index store poisoned");
+        store.search_scoped(query, top_k, self.exclude_cold, agent_scope)
+    }
+
     /// Deep search: include cold files too.
     pub fn search_deep(&self, query: &str, top_k: usize) -> Result<Vec<SearchHit>> {
         let store = self.store.lock().expect("index store poisoned");

--- a/src/agent-memory/src/index/store.rs
+++ b/src/agent-memory/src/index/store.rs
@@ -30,7 +30,7 @@ pub struct BM25Store {
 /// On open, an older DB is upgraded step-by-step until it reaches this
 /// version; a newer DB causes the open to fail so a downgraded binary
 /// doesn't silently corrupt rows it doesn't understand.
-pub(crate) const SCHEMA_VERSION: i64 = 4;
+pub(crate) const SCHEMA_VERSION: i64 = 5;
 
 impl BM25Store {
     pub fn open(
@@ -128,6 +128,7 @@ impl BM25Store {
                 1 => Self::migrate_1_to_2(&tx)?,
                 2 => Self::migrate_2_to_3(&tx)?,
                 3 => Self::migrate_3_to_4(&tx)?,
+                4 => Self::migrate_4_to_5(&tx)?,
                 // Future steps insert here, each bumping `at`.
                 n => {
                     return Err(MemoryError::Other(format!(
@@ -198,10 +199,26 @@ impl BM25Store {
         Ok(())
     }
 
+    /// Schema v5: add agent_id column for per-agent memory scoping.
+    fn migrate_4_to_5(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+        tx.execute(
+            "ALTER TABLE files ADD COLUMN agent_id TEXT DEFAULT NULL",
+            [],
+        )?;
+        Ok(())
+    }
+
     /// Insert or replace a file's index entry. `body` is the extracted
     /// text. All writes happen inside one transaction so a crash mid-
     /// upsert can't leave `files` and `files_fts` out of sync.
-    pub fn upsert(&mut self, rel_path: &str, mtime_ms: i64, size: u64, body: &str) -> Result<()> {
+    pub fn upsert(
+        &mut self,
+        rel_path: &str,
+        mtime_ms: i64,
+        size: u64,
+        body: &str,
+        agent_id: Option<&str>,
+    ) -> Result<()> {
         let now = Utc::now().to_rfc3339();
         let tx = self.conn.transaction()?;
         let existing_rowid: Option<i64> = tx
@@ -215,8 +232,8 @@ impl BM25Store {
         match existing_rowid {
             Some(rowid) => {
                 tx.execute(
-                    "UPDATE files SET mtime_ms=?1, size=?2, indexed_at=?3 WHERE rowid=?4",
-                    params![mtime_ms, size as i64, now, rowid],
+                    "UPDATE files SET mtime_ms=?1, size=?2, indexed_at=?3, agent_id=COALESCE(agent_id, ?4) WHERE rowid=?5",
+                    params![mtime_ms, size as i64, now, agent_id, rowid],
                 )?;
                 tx.execute("DELETE FROM files_fts WHERE rowid = ?1", params![rowid])?;
                 tx.execute(
@@ -226,9 +243,9 @@ impl BM25Store {
             }
             None => {
                 tx.execute(
-                    "INSERT INTO files (path, mtime_ms, size, indexed_at) \
-                     VALUES (?1, ?2, ?3, ?4)",
-                    params![rel_path, mtime_ms, size as i64, now],
+                    "INSERT INTO files (path, mtime_ms, size, indexed_at, agent_id) \
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![rel_path, mtime_ms, size as i64, now, agent_id],
                 )?;
                 let rowid = tx.last_insert_rowid();
                 tx.execute(
@@ -276,6 +293,29 @@ impl BM25Store {
     }
 
     pub fn search(&self, query: &str, top_k: usize, exclude_cold: bool) -> Result<Vec<SearchHit>> {
+        self.search_scoped(query, top_k, exclude_cold, None)
+    }
+
+    /// Search with optional agent scope filter.
+    /// `agent_scope` can be:
+    /// - None: return all results (shared mode, default)
+    /// - Some("isolated:<agent_id>"): only results tagged with this agent_id
+    /// - Some("filter:<agent_id>"): results tagged with this agent_id plus
+    ///   any unscoped (agent_id IS NULL) memories
+    ///
+    /// Returns `InvalidArgument` when the scope prefix is recognised but the
+    /// agent_id contains characters that would let it escape the parameterised
+    /// binding path (`'`, `"`, `;`, `\`, `/`, control bytes). Callers must
+    /// surface the error rather than silently falling back to shared mode,
+    /// otherwise a misconfigured `MCP_CLIENT_NAME` would silently widen the
+    /// visibility domain.
+    pub fn search_scoped(
+        &self,
+        query: &str,
+        top_k: usize,
+        exclude_cold: bool,
+        agent_scope: Option<&str>,
+    ) -> Result<Vec<SearchHit>> {
         if query.trim().is_empty() {
             return Err(MemoryError::InvalidArgument("empty search query".into()));
         }
@@ -291,6 +331,41 @@ impl BM25Store {
         };
         let superseded_filter = "AND f.is_superseded = 0";
 
+        // Agent scope filter: when set, only return results from the specified agent.
+        // Use parameterised binding (`?3`) rather than `format!()` so an
+        // attacker-controlled `MCP_CLIENT_NAME` cannot escape the literal.
+        // `/` and `\` are rejected so a client name like `org/team/agent`
+        // cannot be confused with a path component elsewhere in the query.
+        let (agent_filter, agent_param) = match agent_scope {
+            Some(scope) if scope.starts_with("isolated:") || scope.starts_with("filter:") => {
+                let agent_id = scope.split_once(':').map(|x| x.1).unwrap_or("");
+                if agent_id.contains(|c: char| {
+                    c == '\''
+                        || c == '"'
+                        || c == ';'
+                        || c == '\\'
+                        || c == '/'
+                        || c == '\0'
+                        || c == '\n'
+                        || c == '\r'
+                }) {
+                    return Err(MemoryError::InvalidArgument(format!(
+                        "agent_scope contains invalid characters: {agent_id:?}"
+                    )));
+                }
+                // isolated: only the agent's own memories.
+                // filter: agent's own plus unscoped (NULL) memories.
+                let sql_filter = if scope.starts_with("isolated:") {
+                    "AND f.agent_id = ?3"
+                } else {
+                    "AND (f.agent_id = ?3 OR f.agent_id IS NULL)"
+                };
+                (sql_filter.to_string(), Some(agent_id.to_string()))
+            }
+            // Unknown prefix or shared -> no filter (parameter list stays at 2).
+            _ => (String::new(), None),
+        };
+
         // Join with files to get mtime for time decay.
         let sql = format!(
             r#"
@@ -301,47 +376,62 @@ impl BM25Store {
                    f.mtime_ms
             FROM files_fts
             JOIN files f ON f.rowid = files_fts.rowid
-            WHERE files_fts MATCH ?1 {cold_filter} {superseded_filter}
+            WHERE files_fts MATCH ?1 {cold_filter} {superseded_filter} {agent_filter}
             ORDER BY rank
             LIMIT ?2
         "#
         );
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(params![fts_q, top_k as i64], |row| {
-            let body: String = row.get(3)?;
-            let mtime_ms: i64 = row.get(4)?;
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, f64>(2)?,
-                body,
-                mtime_ms,
-            ))
-        })?;
+        let rows: Vec<(String, String, f64, String, i64)> = if let Some(ref agent_id) = agent_param
+        {
+            stmt.query_map(params![fts_q, top_k as i64, agent_id], |row| {
+                let body: String = row.get(3)?;
+                let mtime_ms: i64 = row.get(4)?;
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, f64>(2)?,
+                    body,
+                    mtime_ms,
+                ))
+            })?
+            .flatten()
+            .collect()
+        } else {
+            stmt.query_map(params![fts_q, top_k as i64], |row| {
+                let body: String = row.get(3)?;
+                let mtime_ms: i64 = row.get(4)?;
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, f64>(2)?,
+                    body,
+                    mtime_ms,
+                ))
+            })?
+            .flatten()
+            .collect()
+        };
 
         let mut out: Vec<SearchHit> = rows
-            .flatten()
+            .into_iter()
             .map(|(path, snippet, bm25_score, _body, mtime_ms)| {
                 let decay = time_decay(mtime_ms, self.time_decay_lambda);
                 // BM25 scores are negative (more negative = worse).
                 // Normalize: higher bm25_score (less negative) is better.
                 // Apply time decay as an additive boost.
                 let adjusted_score = bm25_score + self.time_decay_alpha * decay;
-                // Check the cleaned snippet (what's shown to the model), not
-                // the full body. A benign snippet shouldn't be flagged just
-                // because the surrounding body contains injection-like text.
-                let clean = strip_snippet_markers(&snippet);
+                let suspicious =
+                    crate::safety::looks_like_prompt_injection(&strip_snippet_markers(&snippet));
                 SearchHit {
                     path,
                     snippet,
                     score: adjusted_score,
-                    suspicious: crate::safety::looks_like_prompt_injection(&clean),
+                    suspicious,
                 }
             })
             .collect();
 
-        // Re-sort by adjusted score (bm25 scores are negative, so most negative first).
-        // With the decay boost, recent files with slightly worse bm25 can rank higher.
         out.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         Ok(out)
@@ -478,14 +568,22 @@ impl BM25Store {
     pub fn search_vec(&self, query_vec: &[f32], top_k: usize) -> Result<Vec<(String, f64)>> {
         let q_norm = l2_normalise(query_vec);
 
-        let mut stmt = self.conn.prepare("SELECT path, embedding FROM files_vec")?;
+        // JOIN with files to get mtime in a single query (avoids N+1).
+        let mut stmt = self.conn.prepare(
+            "SELECT v.path, v.embedding, f.mtime_ms \
+             FROM files_vec v LEFT JOIN files f ON f.path = v.path",
+        )?;
         let rows = stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+            ))
         })?;
 
         let mut scores: Vec<(String, f64)> = Vec::new();
         for row in rows {
-            let (path, blob) = match row {
+            let (path, blob, mtime_opt) = match row {
                 Ok(r) => r,
                 Err(_) => continue,
             };
@@ -499,9 +597,7 @@ impl BM25Store {
                 tracing::debug!("skipping non-finite similarity for {path}: {similarity}");
                 continue;
             }
-            // Look up mtime for time decay.
-            let mtime_ms = self.mtime_for(&path).unwrap_or(0);
-            let decay = time_decay(mtime_ms, self.time_decay_lambda);
+            let decay = time_decay(mtime_opt.unwrap_or(0), self.time_decay_lambda);
             let adjusted = similarity * (1.0 + self.time_decay_alpha * decay);
             scores.push((path, adjusted));
         }
@@ -777,9 +873,10 @@ mod tests {
     #[test]
     fn upsert_search_remove_roundtrip() {
         let mut s = BM25Store::open_in_memory().unwrap();
-        s.upsert("notes/a.md", 100, 10, "rust loves ownership")
+        s.upsert("notes/a.md", 100, 10, "rust loves ownership", None)
             .unwrap();
-        s.upsert("notes/b.md", 100, 10, "python uses gc").unwrap();
+        s.upsert("notes/b.md", 100, 10, "python uses gc", None)
+            .unwrap();
 
         let hits = s.search("rust", 5, true).unwrap();
         assert_eq!(hits.len(), 1);
@@ -793,7 +890,7 @@ mod tests {
     #[test]
     fn search_handles_chinese() {
         let mut s = BM25Store::open_in_memory().unwrap();
-        s.upsert("a.md", 0, 0, "你好世界 hello").unwrap();
+        s.upsert("a.md", 0, 0, "你好世界 hello", None).unwrap();
         let hits = s.search("hello", 5, true).unwrap();
         assert_eq!(hits.len(), 1);
     }
@@ -814,9 +911,9 @@ mod tests {
         // behind as stale FTS hits. With the cascade, removing the dir
         // prefix nukes every descendant in one transaction.
         let mut s = BM25Store::open_in_memory().unwrap();
-        s.upsert("notes/a.md", 0, 0, "alpha").unwrap();
-        s.upsert("notes/sub/b.md", 0, 0, "beta").unwrap();
-        s.upsert("other/c.md", 0, 0, "gamma").unwrap();
+        s.upsert("notes/a.md", 0, 0, "alpha", None).unwrap();
+        s.upsert("notes/sub/b.md", 0, 0, "beta", None).unwrap();
+        s.upsert("other/c.md", 0, 0, "gamma", None).unwrap();
 
         let existed = s.remove("notes").unwrap();
         assert!(existed, "removing a populated prefix must report true");
@@ -837,7 +934,7 @@ mod tests {
         let path = tmp.path();
         {
             let mut s = BM25Store::open_for_test(path).unwrap();
-            s.upsert("a.md", 1, 1, "x").unwrap();
+            s.upsert("a.md", 1, 1, "x", None).unwrap();
         }
         // Second open must succeed and preserve data.
         let s = BM25Store::open_for_test(path).unwrap();
@@ -875,9 +972,9 @@ mod tests {
         // wrap, a successful upsert always has both, and a successful
         // remove always has neither.
         let mut s = BM25Store::open_in_memory().unwrap();
-        s.upsert("doc.md", 1, 5, "alpha").unwrap();
+        s.upsert("doc.md", 1, 5, "alpha", None).unwrap();
         // Re-upsert with new body; FTS row should match the new body.
-        s.upsert("doc.md", 2, 5, "omega").unwrap();
+        s.upsert("doc.md", 2, 5, "omega", None).unwrap();
         let hits = s.search("omega", 5, true).unwrap();
         assert_eq!(hits.len(), 1);
         let hits = s.search("alpha", 5, true).unwrap();
@@ -928,10 +1025,11 @@ mod tests {
             now_ms - 100 * 86_400_000,
             20,
             "rust ownership rules",
+            None,
         )
         .unwrap();
         // New file: mtime just now
-        s.upsert("new.md", now_ms, 20, "rust ownership rules")
+        s.upsert("new.md", now_ms, 20, "rust ownership rules", None)
             .unwrap();
 
         let hits = s.search("rust", 5, true).unwrap();
@@ -955,9 +1053,10 @@ mod tests {
             now_ms - 365 * 86_400_000,
             20,
             "ancient rust facts",
+            None,
         )
         .unwrap();
-        s.upsert("new.md", now_ms, 20, "modern python tricks")
+        s.upsert("new.md", now_ms, 20, "modern python tricks", None)
             .unwrap();
 
         // Both searches should still work; the scores just don't discriminate by time.
@@ -978,11 +1077,23 @@ mod tests {
 
         let mut s = BM25Store::open_in_memory_with(0.01, 0.3, true).unwrap();
         // Fresh file (5 days old, access_count=0)
-        s.upsert("fresh.md", now_ms - 5 * 86_400_000, 20, "recent knowledge")
-            .unwrap();
+        s.upsert(
+            "fresh.md",
+            now_ms - 5 * 86_400_000,
+            20,
+            "recent knowledge",
+            None,
+        )
+        .unwrap();
         // Old file (60 days old, access_count=0)
-        s.upsert("old.md", now_ms - 60 * 86_400_000, 20, "ancient wisdom")
-            .unwrap();
+        s.upsert(
+            "old.md",
+            now_ms - 60 * 86_400_000,
+            20,
+            "ancient wisdom",
+            None,
+        )
+        .unwrap();
 
         // Compact with 30-day threshold.
         let compacted = s.compact(30).unwrap();
@@ -1014,10 +1125,11 @@ mod tests {
             .as_millis() as i64;
 
         let mut s = BM25Store::open_in_memory_with(0.01, 0.3, true).unwrap();
-        s.upsert("warm.md", now_ms, 20, "warm content").unwrap();
-        s.upsert("old1.md", now_ms - 50 * 86_400_000, 20, "old1")
+        s.upsert("warm.md", now_ms, 20, "warm content", None)
             .unwrap();
-        s.upsert("old2.md", now_ms - 100 * 86_400_000, 20, "old2")
+        s.upsert("old1.md", now_ms - 50 * 86_400_000, 20, "old1", None)
+            .unwrap();
+        s.upsert("old2.md", now_ms - 100 * 86_400_000, 20, "old2", None)
             .unwrap();
 
         let (warm, cold) = s.warm_cold_counts().unwrap();
@@ -1043,6 +1155,7 @@ mod tests {
             now_ms - 50 * 86_400_000,
             20,
             "very old unique keyword",
+            None,
         )
         .unwrap();
 
@@ -1066,7 +1179,7 @@ mod tests {
     #[test]
     fn detect_conflicts_finds_similar_files() {
         let mut s = BM25Store::open_in_memory_with(0.01, 0.3, true).unwrap();
-        s.upsert("user-pref.md", 100, 50, "用户偏好 rust 系统编程")
+        s.upsert("user-pref.md", 100, 50, "用户偏好 rust 系统编程", None)
             .unwrap();
 
         // Search for similar content (shares key terms).
@@ -1078,7 +1191,8 @@ mod tests {
     #[test]
     fn detect_conflicts_no_match() {
         let mut s = BM25Store::open_in_memory_with(0.01, 0.3, true).unwrap();
-        s.upsert("cooking.md", 100, 50, "如何制作意大利面").unwrap();
+        s.upsert("cooking.md", 100, 50, "如何制作意大利面", None)
+            .unwrap();
 
         // Unrelated query should not match.
         let conflicts = s.detect_conflicts("rust ownership rules", -2.0).unwrap();
@@ -1088,9 +1202,9 @@ mod tests {
     #[test]
     fn superseded_files_excluded_from_search() {
         let mut s = BM25Store::open_in_memory_with(0.01, 0.3, true).unwrap();
-        s.upsert("old.md", 100, 50, "unique old content here")
+        s.upsert("old.md", 100, 50, "unique old content here", None)
             .unwrap();
-        s.upsert("new.md", 200, 50, "unique new content here")
+        s.upsert("new.md", 200, 50, "unique new content here", None)
             .unwrap();
 
         // Both visible before superseding.
@@ -1104,5 +1218,69 @@ mod tests {
         let hits = s.search("unique", 10, true).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].path, "new.md");
+    }
+
+    #[test]
+    fn agent_scope_isolated_only_returns_own_memories() {
+        let mut s = BM25Store::open_in_memory().unwrap();
+        s.upsert(
+            "a/own.md",
+            100,
+            10,
+            "agent alpha owns this note",
+            Some("alpha"),
+        )
+        .unwrap();
+        s.upsert(
+            "a/shared.md",
+            100,
+            10,
+            "agent alpha note tagged alpha",
+            Some("alpha"),
+        )
+        .unwrap();
+        s.upsert(
+            "b/other.md",
+            100,
+            10,
+            "agent beta owns this note",
+            Some("beta"),
+        )
+        .unwrap();
+        s.upsert("u/legacy.md", 100, 10, "agent alpha legacy note", None)
+            .unwrap();
+
+        // isolated:alpha sees ONLY alpha's own — not beta, not legacy.
+        let hits = s
+            .search_scoped("agent alpha", 10, true, Some("isolated:alpha"))
+            .unwrap();
+        let paths: Vec<&str> = hits.iter().map(|h| h.path.as_str()).collect();
+        assert_eq!(paths.len(), 2, "isolated:alpha should see 2 own memories");
+        assert!(paths.iter().all(|p| p.starts_with("a/")));
+
+        // filter:alpha sees alpha's own + unscoped (NULL) — legacy included,
+        // but never beta's.
+        let hits = s
+            .search_scoped("agent alpha", 10, true, Some("filter:alpha"))
+            .unwrap();
+        let paths: Vec<&str> = hits.iter().map(|h| h.path.as_str()).collect();
+        assert!(paths.contains(&"u/legacy.md"));
+        assert!(!paths.iter().any(|p| p.starts_with("b/")));
+    }
+
+    #[test]
+    fn agent_scope_rejects_invalid_agent_id() {
+        let s = BM25Store::open_in_memory().unwrap();
+        // SQL-meta chars and path separators must be refused, not silently
+        // widened to shared mode.
+        for bad in ["isolated:foo'bar", "filter:a;b", "isolated:with/slash"] {
+            let err = s
+                .search_scoped("agent alpha", 10, true, Some(bad))
+                .unwrap_err();
+            assert!(
+                matches!(err, MemoryError::InvalidArgument(_)),
+                "expected InvalidArgument for {bad:?}, got {err:?}"
+            );
+        }
     }
 }

--- a/src/agent-memory/src/index/worker.rs
+++ b/src/agent-memory/src/index/worker.rs
@@ -309,13 +309,14 @@ fn flush(
     // small batch of upserts/removes per debounce window instead of the
     // entire walk+extract pass.
     let mut store = store.lock().expect("index store poisoned");
+    let agent_id = std::env::var("MCP_CLIENT_NAME").ok();
     for rel in to_remove {
         if let Err(e) = store.remove(&rel) {
             tracing::warn!("index remove failed for {rel}: {e}");
         }
     }
     for (rel, mtime, size, body) in to_upsert {
-        if let Err(e) = store.upsert(&rel, mtime, size, &body) {
+        if let Err(e) = store.upsert(&rel, mtime, size, &body, agent_id.as_deref()) {
             tracing::warn!("index upsert failed for {rel}: {e}");
         }
     }
@@ -333,6 +334,7 @@ fn full_scan(mount: &MountPointLite, store: &Arc<Mutex<BM25Store>>) -> Result<()
 
     let mut store = store.lock().expect("index store poisoned");
     let mut seen: HashSet<String> = HashSet::new();
+    let agent_id = std::env::var("MCP_CLIENT_NAME").ok();
 
     for entry in WalkDir::new(&mount.root)
         .follow_links(false)
@@ -374,7 +376,7 @@ fn full_scan(mount: &MountPointLite, store: &Arc<Mutex<BM25Store>>) -> Result<()
                 continue;
             }
         }
-        if let Err(e) = store.upsert(&rel, mtime, meta.len(), &body) {
+        if let Err(e) = store.upsert(&rel, mtime, meta.len(), &body, agent_id.as_deref()) {
             tracing::warn!("index full-scan upsert failed for {rel}: {e}");
         }
         seen.insert(rel);

--- a/src/agent-memory/src/mcp_server/tools.rs
+++ b/src/agent-memory/src/mcp_server/tools.rs
@@ -205,7 +205,7 @@ impl MemoryMcpServer {
     // ---- Tier B: structured search/write API for weak models or batch use ----
 
     #[tool(
-        description = "Tier B: search the indexed memory store. Default BM25 keyword search. Set mode=vector for semantic (embedding) search, or mode=hybrid for combined ranking. Requires [memory.embedding] config for vector/hybrid. Optional category filters results to a fact category (e.g. 'lesson', 'interest', 'working-context')."
+        description = "Tier B: search the indexed memory store. Default BM25 keyword search. Set mode=vector for semantic (embedding) search, or mode=hybrid for combined ranking. Requires [memory.embedding] config for vector/hybrid. Optional category filters results to a fact category (e.g. 'lesson', 'interest', 'working-context'). Optional agent_scope overrides [memory].agent_scope for this call; accepted values: 'shared' (no filtering), 'isolated:<id>' (only memories tagged with <id>), or 'filter:<id>' (<id>'s own memories plus unscoped ones). When agent_scope is set to isolated/filter, vector/hybrid degrade to scoped BM25 so the isolation boundary is preserved."
     )]
     async fn memory_search(
         &self,
@@ -213,6 +213,7 @@ impl MemoryMcpServer {
         #[tool(param)] top_k: Option<u32>,
         #[tool(param)] mode: Option<String>,
         #[tool(param)] category: Option<String>,
+        #[tool(param)] agent_scope: Option<String>,
     ) -> ToolResult {
         // Reject excessively long queries to prevent FTS5 resource exhaustion.
         const MAX_QUERY_LEN: usize = 1024;
@@ -230,6 +231,7 @@ impl MemoryMcpServer {
                 k,
                 mode.as_deref(),
                 category.as_deref().filter(|s| !s.is_empty()),
+                agent_scope.as_deref().filter(|s| !s.is_empty()),
             )
             .map_err(|e| fmt_err("search failed", e))?;
         serde_json::to_string_pretty(&hits).map_err(|e| fmt_err("search serialize failed", e))

--- a/src/agent-memory/src/service/mod.rs
+++ b/src/agent-memory/src/service/mod.rs
@@ -175,8 +175,9 @@ impl MemoryService {
         top_k: usize,
         mode: Option<&str>,
         category: Option<&str>,
+        agent_scope: Option<&str>,
     ) -> Result<Vec<SearchHit>> {
-        crate::tools::memory_search(self, query, top_k, mode, category)
+        crate::tools::memory_search(self, query, top_k, mode, category, agent_scope)
     }
 
     pub fn memory_observe(&self, content: &str, hint: Option<&str>) -> Result<String> {

--- a/src/agent-memory/src/tools/memory_search.rs
+++ b/src/agent-memory/src/tools/memory_search.rs
@@ -24,6 +24,7 @@ pub fn memory_search(
     top_k: usize,
     mode: Option<&str>,
     category: Option<&str>,
+    agent_scope: Option<&str>,
 ) -> Result<Vec<SearchHit>> {
     let mode = mode.unwrap_or("bm25");
     let index = match svc.index.as_ref() {
@@ -37,9 +38,42 @@ pub fn memory_search(
         }
     };
 
+    // Determine effective agent scope from parameter or config.
+    // We never silently widen the visibility domain: an explicitly configured
+    // `isolated`/`filter` scope with no `MCP_CLIENT_NAME` is a misconfiguration,
+    // so we warn and run the search *unscoped* (shared semantics) rather than
+    // erroring on every request — the operator-facing warn surfaces the
+    // misconfiguration, while still letting the agent read its shared memory.
+    let config_scope_owned;
+    let scope_ref = if let Some(s) = agent_scope {
+        Some(s)
+    } else {
+        let config_scope = &svc.config.memory.agent_scope;
+        if config_scope.is_empty() || config_scope == "shared" {
+            None
+        } else if !matches!(config_scope.as_str(), "isolated" | "filter") {
+            tracing::warn!(
+                "memory.agent_scope={config_scope:?} is not a recognised value \
+                 (expected \"shared\", \"isolated\", or \"filter\"); \
+                 falling back to shared (unscoped) search."
+            );
+            None
+        } else if let Ok(agent_id) = std::env::var("MCP_CLIENT_NAME") {
+            config_scope_owned = format!("{config_scope}:{agent_id}");
+            Some(config_scope_owned.as_str())
+        } else {
+            tracing::warn!(
+                "memory.agent_scope={config_scope:?} requires MCP_CLIENT_NAME but it is unset; \
+                 falling back to shared (unscoped) search. Set MCP_CLIENT_NAME or switch \
+                 agent_scope to \"shared\" to silence this warning."
+            );
+            None
+        }
+    };
+
     match mode {
         "bm25" => {
-            let hits = index.search(query, top_k.max(1))?;
+            let hits = index.search_scoped(query, top_k.max(1), scope_ref)?;
             let hits = filter_by_category(hits, category);
             let tokens = hits
                 .iter()
@@ -54,17 +88,35 @@ pub fn memory_search(
             Ok(hits)
         }
         "vector" | "hybrid" => {
-            let emb = match svc.embedding.as_ref() {
+            // Vector and hybrid paths do not yet apply agent_scope: `files_vec`
+            // has no `agent_id` column and `search_vec` is a full-table scan.
+            // Rather than silently returning unscoped results (which would
+            // break the isolation contract), we degrade to a *scoped* BM25
+            // search so the agent never sees another agent's memories. This
+            // mirrors the "no embedding provider" fallback below.
+            let emb = if scope_ref.is_some() {
+                tracing::warn!(
+                    "{mode} search requested with agent_scope; vector/hybrid paths do not \
+                     yet enforce agent scoping — falling back to scoped BM25 to preserve \
+                     the isolation boundary."
+                );
+                None
+            } else {
+                svc.embedding.as_ref()
+            };
+            let emb = match emb {
                 Some(e) => e,
                 None => {
                     // Graceful fallback: when no embedding provider is
-                    // configured, vector/hybrid silently degrades to BM25
-                    // so that callers (auto-recall, corpus supplement) can
-                    // safely request hybrid without checking config first.
+                    // configured (or scope requires BM25), vector/hybrid
+                    // silently degrades to BM25 so that callers (auto-recall,
+                    // corpus supplement) can safely request hybrid without
+                    // checking config first. Uses search_scoped for consistent
+                    // agent scope filtering.
                     tracing::debug!(
                         "{mode} requested but no embedding provider — falling back to bm25"
                     );
-                    let hits = index.search(query, top_k.max(1))?;
+                    let hits = index.search_scoped(query, top_k.max(1), scope_ref)?;
                     svc.audit_log(
                         AuditEntry::new(TOOL)
                             .path(format!("bm25(fallback from {mode}):{:.120}", query))

--- a/src/agent-memory/tests/tier_b_test.rs
+++ b/src/agent-memory/tests/tier_b_test.rs
@@ -61,7 +61,7 @@ fn full_scan_indexes_existing_files() {
         );
     }
 
-    let hits = svc.memory_search("rust", 5, None, None).unwrap();
+    let hits = svc.memory_search("rust", 5, None, None, None).unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].path, "notes/a.md");
     assert!(hits[0].snippet.contains("rust") || hits[0].snippet.contains("Rust"));
@@ -75,7 +75,7 @@ fn inotify_picks_up_new_file() {
     svc.write("late.md", "elephants are large", false).unwrap();
     assert!(wait_for_index(&svc, baseline + 1));
 
-    let hits = svc.memory_search("elephants", 5, None, None).unwrap();
+    let hits = svc.memory_search("elephants", 5, None, None, None).unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].path, "late.md");
 }
@@ -86,16 +86,16 @@ fn inotify_unindex_on_delete() {
     svc.write("temp.md", "delete me soon", false).unwrap();
     assert!(wait_for_index(&svc, 2));
 
-    let hits = svc.memory_search("delete", 5, None, None).unwrap();
+    let hits = svc.memory_search("delete", 5, None, None, None).unwrap();
     assert_eq!(hits.len(), 1);
 
     svc.remove("temp.md", false).unwrap();
     // Wait for unindex
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
-    let mut last_hits: Vec<_> = svc.memory_search("delete", 5, None, None).unwrap();
+    let mut last_hits: Vec<_> = svc.memory_search("delete", 5, None, None, None).unwrap();
     while !last_hits.is_empty() && std::time::Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(50));
-        last_hits = svc.memory_search("delete", 5, None, None).unwrap();
+        last_hits = svc.memory_search("delete", 5, None, None, None).unwrap();
     }
     assert!(
         last_hits.is_empty(),
@@ -121,7 +121,7 @@ fn ignores_meta_dir() {
     assert_eq!(after, baseline);
 
     let hits = svc
-        .memory_search("should-not-index", 5, None, None)
+        .memory_search("should-not-index", 5, None, None, None)
         .unwrap();
     assert!(hits.is_empty());
 }
@@ -134,7 +134,9 @@ fn skips_binary_extensions() {
     svc.write("img/pic.png", "fake-png-bytes", false).unwrap();
     std::thread::sleep(Duration::from_millis(400));
 
-    let hits = svc.memory_search("fake-png-bytes", 5, None, None).unwrap();
+    let hits = svc
+        .memory_search("fake-png-bytes", 5, None, None, None)
+        .unwrap();
     assert!(hits.is_empty(), "binary file got indexed: {hits:?}");
 }
 
@@ -144,7 +146,7 @@ fn search_returns_chinese_hits() {
     svc.write("zh.md", "你好世界 foo bar", false).unwrap();
     assert!(wait_for_index(&svc, 2));
 
-    let hits = svc.memory_search("foo", 5, None, None).unwrap();
+    let hits = svc.memory_search("foo", 5, None, None, None).unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].path, "zh.md");
 }
@@ -193,7 +195,7 @@ fn observe_then_search_finds_it() {
         );
     }
 
-    let hits = svc.memory_search("peanuts", 5, None, None).unwrap();
+    let hits = svc.memory_search("peanuts", 5, None, None, None).unwrap();
     assert_eq!(hits.len(), 1);
     assert!(hits[0].path.starts_with("notes/observed/"));
 }
@@ -256,7 +258,7 @@ fn get_context_skips_meta_dir() {
 #[test]
 fn search_empty_query_errors() {
     let (_tmp, svc) = setup();
-    let err = svc.memory_search("   ", 5, None, None).unwrap_err();
+    let err = svc.memory_search("   ", 5, None, None, None).unwrap_err();
     assert!(matches!(err, MemoryError::InvalidArgument(_)));
 }
 
@@ -266,7 +268,7 @@ fn search_returns_empty_when_no_matches() {
     svc.write("a.md", "hello", false).unwrap();
     assert!(wait_for_index(&svc, 2));
     let hits = svc
-        .memory_search("zzzzz_no_such_term", 5, None, None)
+        .memory_search("zzzzz_no_such_term", 5, None, None, None)
         .unwrap();
     assert!(hits.is_empty());
 }
@@ -280,11 +282,13 @@ fn search_mode_bm25_is_default() {
         .unwrap();
     assert!(wait_for_index(&svc, 2));
     // Explicit bm25.
-    let hits = svc.memory_search("rust", 5, Some("bm25"), None).unwrap();
+    let hits = svc
+        .memory_search("rust", 5, Some("bm25"), None, None)
+        .unwrap();
     assert!(!hits.is_empty());
     assert_eq!(hits[0].path, "a.md");
     // Omitting mode should behave the same.
-    let hits = svc.memory_search("rust", 5, None, None).unwrap();
+    let hits = svc.memory_search("rust", 5, None, None, None).unwrap();
     assert!(!hits.is_empty());
 }
 
@@ -292,7 +296,7 @@ fn search_mode_bm25_is_default() {
 fn search_mode_rejects_unknown() {
     let (_tmp, svc) = setup();
     let err = svc
-        .memory_search("x", 5, Some("quantum"), None)
+        .memory_search("x", 5, Some("quantum"), None, None)
         .unwrap_err();
     assert!(matches!(err, MemoryError::InvalidArgument(_)));
 }
@@ -303,7 +307,9 @@ fn search_mode_vector_falls_back_to_bm25_without_provider() {
     svc.write("a.md", "hello world", false).unwrap();
     assert!(wait_for_index(&svc, 2));
     // vector without embedding → falls back to BM25 gracefully.
-    let hits = svc.memory_search("hello", 5, Some("vector"), None).unwrap();
+    let hits = svc
+        .memory_search("hello", 5, Some("vector"), None, None)
+        .unwrap();
     assert!(!hits.is_empty());
 }
 
@@ -312,7 +318,9 @@ fn search_mode_hybrid_falls_back_to_bm25_without_provider() {
     let (_tmp, svc) = setup();
     svc.write("a.md", "hello world", false).unwrap();
     assert!(wait_for_index(&svc, 2));
-    let hits = svc.memory_search("hello", 5, Some("hybrid"), None).unwrap();
+    let hits = svc
+        .memory_search("hello", 5, Some("hybrid"), None, None)
+        .unwrap();
     assert!(!hits.is_empty());
 }
 
@@ -328,7 +336,9 @@ fn search_annotates_suspicious_content() {
         .unwrap();
     assert!(wait_for_index(&svc, 2));
 
-    let hits = svc.memory_search("SYSTEM override", 5, None, None).unwrap();
+    let hits = svc
+        .memory_search("SYSTEM override", 5, None, None, None)
+        .unwrap();
     assert!(!hits.is_empty(), "expected hits but got none");
     let any_suspicious = hits.iter().any(|h| h.suspicious);
     assert!(
@@ -348,7 +358,9 @@ fn search_does_not_flag_normal_content() {
     .unwrap();
     assert!(wait_for_index(&svc, 2));
 
-    let hits = svc.memory_search("Rust backend", 5, None, None).unwrap();
+    let hits = svc
+        .memory_search("Rust backend", 5, None, None, None)
+        .unwrap();
     for h in &hits {
         assert!(
             !h.suspicious,
@@ -380,19 +392,19 @@ fn search_category_filter_works() {
 
     // category=interest should find the interest fact.
     let hits = svc
-        .memory_search("rust", 10, None, Some("interest"))
+        .memory_search("rust", 10, None, Some("interest"), None)
         .unwrap();
     assert!(!hits.is_empty(), "expected hits for category=interest");
 
     // category=lesson should find the lesson fact.
     let hits = svc
-        .memory_search("error", 10, None, Some("lesson"))
+        .memory_search("error", 10, None, Some("lesson"), None)
         .unwrap();
     assert!(!hits.is_empty(), "expected hits for category=lesson");
 
     // Non-existent category returns empty.
     let hits = svc
-        .memory_search("rust", 10, None, Some("nonexistent"))
+        .memory_search("rust", 10, None, Some("nonexistent"), None)
         .unwrap();
     assert!(hits.is_empty(), "expected no hits for unknown category");
 }


### PR DESCRIPTION
## Description

Add per-agent memory isolation with configurable scoping:

### Schema v5 Migration
- Add `agent_id TEXT` column to `files` table
- `migrate_4_to_5`: `ALTER TABLE files ADD COLUMN agent_id TEXT`
- `SCHEMA_VERSION` bumped from 4 to 5

### Agent Scope Configuration
```toml
[memory]
agent_scope = "shared"  # shared | isolated | filter
```

- **shared** (default): All agents see all memories (current behavior)
- **isolated**: Each agent only sees its own memories (filtered by `agent_id`)
- **filter**: Each agent sees its own memories + memories with no `agent_id` (unscoped)

### Search Scoping
- `BM25Store::search_scoped()`: Accepts optional `agent_scope` parameter
- SQL filter: `WHERE agent_id = '<agent_id>' OR agent_id IS NULL`
- `memory_search` MCP tool gains `agent_scope` parameter

### Agent Identity
- Sourced from `MCP_CLIENT_NAME` environment variable
- Written to `agent_id` column on `upsert`
- Backward compatible: existing memories have `agent_id = NULL`

## Related Issue

Depends on #946 (safety-hybrid) — this branch includes its commits.

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `memory` (agent-memory)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `memory`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date

## Testing

### CI Checks (all pass)
- `cargo fmt --all --check`: clean
- `cargo clippy --all-targets --locked -- -D warnings`: clean (0 warnings)
- `cargo test --locked`: 0 failures

## Additional Notes

**Draft PR**: Depends on #946 being merged first. Will rebase after dependency is merged.