### PR TITLE
test(sec-core): add conftest.py with short-path tmp_path fixture for macOS

### DIFF
--- a/src/agent-sec-core/tests/conftest.py
+++ b/src/agent-sec-core/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Global test fixtures for agent-sec-core."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Use a short basetemp on macOS to avoid AF_UNIX socket path length limit.
+
+    macOS limits AF_UNIX socket paths to 104 bytes. pytest's default basetemp
+    on macOS is under /private/var/folders/... which can exceed this limit.
+
+    Placed at tests/ root so all subdirectories (unit-test, e2e, integration-test)
+    benefit — tmp_path_factory in unit-test/conftest.py also produces short paths.
+
+    /tmp/agd-pytest-<uid> is used instead of tempfile.gettempdir() because the
+    latter returns /private/var/folders/... on macOS, which is exactly the long
+    path we want to avoid. Residual directories are managed by pytest's built-in
+    basetemp cleanup logic (keeps last 3 runs, removes older ones).
+    """
+    if sys.platform == "darwin" and not config.option.basetemp:
+        basetemp = Path(f"/tmp/agd-pytest-{os.getuid()}")  # noqa: S108
+        basetemp.mkdir(parents=True, exist_ok=True)
+        basetemp.chmod(0o700)
+        config.option.basetemp = basetemp


### PR DESCRIPTION
Override pytest's default tmp_path on macOS to use /tmp prefix, avoiding AF_UNIX socket path length limit (104 bytes on macOS).

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
