### PR TITLE
feat(sight): persist http.domain to SLS alongside http.path

### DIFF
--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -229,6 +229,9 @@ impl GenAIBuilder {
                         }
                     }
                 }
+                if let Some(addr) = meta.get("server.address").cloned() {
+                    meta.insert("http.domain".to_string(), addr);
+                }
                 // Derive gen_ai.operation.name from path
                 if http.path.contains("/chat/completions") || http.path.contains("/v1/messages") {
                     meta.insert("operation_name".to_string(), "chat".to_string());
@@ -695,6 +698,7 @@ mod tests {
             "api.openai.com"
         );
         assert_eq!(call.metadata.get("server.port").unwrap(), "443");
+        assert_eq!(call.metadata.get("http.domain").unwrap(), "api.openai.com");
         assert_eq!(call.metadata.get("operation_name").unwrap(), "chat");
         assert!(call.metadata.contains_key("user_query"));
     }
@@ -708,6 +712,7 @@ mod tests {
         let call = build_call(&builder, &[AnalysisResult::Http(http)]).unwrap();
         assert_eq!(call.metadata.get("server.address").unwrap(), "example.com");
         assert!(!call.metadata.contains_key("server.port"));
+        assert_eq!(call.metadata.get("http.domain").unwrap(), "example.com");
     }
 
     #[test]

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -437,6 +437,9 @@ pub fn events_to_flat_records(
                 if let Some(path) = call.metadata.get("path") {
                     m.insert("agentsight.http.path".to_string(), path.clone());
                 }
+                if let Some(domain) = call.metadata.get("http.domain") {
+                    m.insert("agentsight.http.domain".to_string(), domain.clone());
+                }
                 if let Some(status) = call.metadata.get("status_code") {
                     m.insert("agentsight.http.status_code".to_string(), status.clone());
                 }


### PR DESCRIPTION
## Summary

Closes #964

在 SLS 上传的 LLM 调用记录中新增 `http.domain` 字段，值来自 Host header 域名（即已有的 `server.address`）。

## Changes

| File | Change |
|---|---|
| `src/agentsight/src/genai/call_builder.rs` | Host header 解析后写入 `http.domain` metadata (+3 行业务 + 2 行测试 assert) |
| `src/agentsight/src/genai/logtail.rs` | SLS 导出时映射 `agentsight.http.domain` (+3 行) |

**净增 8 行代码。**

## Design

- 复用现有 `server.address` 值，避免重复解析
- metadata HashMap 存储，不修改 LLMCall 结构体
- SLS 字段命名 `agentsight.http.domain` 与现有 `agentsight.http.path`/`agentsight.http.method` 风格一致
- 仅在 Host header 存在时才写入，缺失时不产生空字段

## Testing

- ECS: `cargo test -p agentsight --lib` — 598 passed, 0 failed
- `cargo fmt --check` — 通过
- 覆盖场景：Host 带端口、Host 无端口、无 Host header
