### PR TITLE
fix(anolisa): show install-all failure reasons

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -454,6 +454,11 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
                 failed_names.join(", "),
                 skipped,
             );
+            for item in items.iter().filter(|i| i.status == "failed") {
+                if let Some(reason) = &item.reason {
+                    eprintln!("{} {}: {reason}", color.err("failed:"), item.component);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Fix human-mode diagnostics for `anolisa install --all` when one or more
components fail.

Previously, batch install printed the summary and returned a non-zero exit
code, but the underlying component failure reason was hidden because
`BatchPartial` skips top-level error rendering. This made human output hard
to act on.

This change keeps the existing batch summary and JSON behavior unchanged,
but prints each failed component's reason to stderr in human mode.

## Related Issue

closes #971

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings`