### PR TITLE
feat(tokenless): add SLS JSONL data collection with config toggle

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -208,6 +208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +228,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -258,6 +274,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -375,6 +402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,12 +477,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -495,6 +534,19 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -583,6 +635,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +721,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -436,27 +436,42 @@ fn run() -> Result<(), (String, i32)> {
                     println!("Statistics cleared.");
                 }
                 StatsCommands::Status => {
-                    let env_set = std::env::var("TOKENLESS_STATS_ENABLED").ok();
+                    let stats_env_set = std::env::var("TOKENLESS_STATS_ENABLED")
+                        .ok()
+                        .filter(|v| !v.is_empty());
+                    let sls_env_set = std::env::var("TOKENLESS_SLS_ENABLED")
+                        .ok()
+                        .filter(|v| !v.is_empty());
                     let config = TokenlessConfig::load();
-                    if config.is_stats_enabled() {
-                        let source = if env_set.is_some() {
-                            "env override"
-                        } else if TokenlessConfig::config_file_exists() {
-                            "config file"
-                        } else {
-                            "default"
-                        };
-                        println!("Stats recording: ENABLED (via {})", source);
+                    let file_exists = TokenlessConfig::config_file_exists();
+
+                    let stats_state = if config.is_stats_enabled() {
+                        "ENABLED"
                     } else {
-                        let source = if env_set.is_some() {
-                            "env override"
-                        } else if TokenlessConfig::config_file_exists() {
-                            "config file"
-                        } else {
-                            "default"
-                        };
-                        println!("Stats recording: DISABLED (via {})", source);
-                    }
+                        "DISABLED"
+                    };
+                    let stats_source = if stats_env_set.is_some() {
+                        "env override"
+                    } else if file_exists {
+                        "config file"
+                    } else {
+                        "default"
+                    };
+                    println!("Stats recording: {} (via {})", stats_state, stats_source);
+
+                    let sls_state = if config.is_sls_enabled() {
+                        "ENABLED"
+                    } else {
+                        "DISABLED"
+                    };
+                    let sls_source = if sls_env_set.is_some() {
+                        "env override"
+                    } else if file_exists {
+                        "config file"
+                    } else {
+                        "default"
+                    };
+                    println!("SLS recording:   {} (via {})", sls_state, sls_source);
                 }
                 StatsCommands::Enable => {
                     let mut config = TokenlessConfig::load();
@@ -550,7 +565,10 @@ fn record_compression_stats(
     before_text: String,
     after_text: String,
 ) {
-    if !TokenlessConfig::load().is_stats_enabled() {
+    let config = TokenlessConfig::load();
+
+    // Short-circuit only if both stats and SLS are disabled.
+    if !config.is_stats_enabled() && !config.is_sls_enabled() {
         return;
     }
 
@@ -587,9 +605,17 @@ fn record_compression_stats(
     }
     record = record.with_source_pid(pid as i64);
 
-    // Record silently — stats failures must not break compression
-    if let Ok(recorder) = open_recorder() {
+    // SQLite stats recording — gated by stats_enabled
+    if config.is_stats_enabled()
+        && let Ok(recorder) = open_recorder()
+    {
         let _ = recorder.record(&record);
+    }
+
+    // SLS recording — fail-silent, independent of SQLite
+    if config.is_sls_enabled() {
+        let writer = tokenless_stats::SlsWriter::new();
+        writer.write(&record);
     }
 }
 

--- a/src/tokenless/crates/tokenless-stats/Cargo.toml
+++ b/src/tokenless/crates/tokenless-stats/Cargo.toml
@@ -13,3 +13,6 @@ rusqlite.workspace = true
 thiserror.workspace = true
 dirs.workspace = true
 libc.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/tokenless/crates/tokenless-stats/src/config.rs
+++ b/src/tokenless/crates/tokenless-stats/src/config.rs
@@ -1,7 +1,8 @@
 //! Configuration for tokenless.
 //!
 //! Stored at `~/.tokenless/config.json`. Controls global feature flags.
-//! Environment variable `TOKENLESS_STATS_ENABLED` overrides file config.
+//! Environment variables `TOKENLESS_STATS_ENABLED` and
+//! `TOKENLESS_SLS_ENABLED` override file config independently.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -12,6 +13,9 @@ pub struct TokenlessConfig {
     /// Whether to record compression stats (default: true)
     #[serde(default = "default_true")]
     pub stats_enabled: bool,
+    /// Whether SLS integration is enabled (default: false)
+    #[serde(default)]
+    pub sls_enabled: bool,
 }
 
 fn default_true() -> bool {
@@ -22,8 +26,17 @@ impl Default for TokenlessConfig {
     fn default() -> Self {
         Self {
             stats_enabled: true,
+            sls_enabled: false,
         }
     }
+}
+
+/// Parse a boolean env value: "1", "true", "yes" (case-insensitive) → true.
+/// All other non-empty values — including "0", "false", "no" — return false.
+/// (Empty strings are filtered to `None` by callers before reaching this
+/// function, so they never reach here.)
+fn parse_env_bool(val: &str) -> bool {
+    val == "1" || val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("yes")
 }
 
 impl TokenlessConfig {
@@ -46,37 +59,82 @@ impl TokenlessConfig {
         Self::config_path().exists()
     }
 
-    /// Load config with an explicit env override value and optional custom path.
-    /// Priority: env_override > config.json file > default(true)
-    pub fn load_with_env_and_path(env_val: Option<&str>, path: Option<&PathBuf>) -> Self {
-        if let Some(val) = env_val {
-            let enabled =
-                val == "1" || val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("yes");
+    /// Load config with explicit env overrides for both toggles and optional custom path.
+    /// Priority (per toggle): env > config.json file > default
+    /// Empty env var values are normalized to None (treated as unset).
+    /// When both env vars are set, skips the config file read entirely.
+    pub fn load_with_envs_and_path(
+        stats_env: Option<&str>,
+        sls_env: Option<&str>,
+        path: Option<&PathBuf>,
+    ) -> Self {
+        // Normalize empty strings to None — an empty env var means "unset".
+        let stats_env = stats_env.filter(|v| !v.is_empty());
+        let sls_env = sls_env.filter(|v| !v.is_empty());
+
+        // When both env vars are set, skip the file read entirely.
+        // This avoids unnecessary I/O when the config file is on a slow
+        // or unavailable filesystem (e.g. broken NFS mount).
+        if let (Some(stats_val), Some(sls_val)) = (stats_env, sls_env) {
             return Self {
-                stats_enabled: enabled,
+                stats_enabled: parse_env_bool(stats_val),
+                sls_enabled: parse_env_bool(sls_val),
             };
         }
 
-        // Fall back to file config
         let default_path = Self::config_path();
         let config_path = path.unwrap_or(&default_path);
-        std::fs::read_to_string(config_path)
+        let base = std::fs::read_to_string(config_path)
             .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
+            .and_then(|s| serde_json::from_str::<TokenlessConfig>(&s).ok())
+            .unwrap_or_default();
+
+        let stats_enabled = if let Some(val) = stats_env {
+            parse_env_bool(val)
+        } else {
+            base.stats_enabled
+        };
+
+        let sls_enabled = if let Some(val) = sls_env {
+            parse_env_bool(val)
+        } else {
+            base.sls_enabled
+        };
+
+        Self {
+            stats_enabled,
+            sls_enabled,
+        }
+    }
+
+    /// Load config with explicit env overrides for both toggles.
+    pub fn load_with_envs(stats_env: Option<&str>, sls_env: Option<&str>) -> Self {
+        Self::load_with_envs_and_path(stats_env, sls_env, None)
+    }
+
+    /// Load config with an explicit env override value and optional custom path.
+    /// Backward-compatible wrapper: only overrides stats_enabled.
+    pub fn load_with_env_and_path(env_val: Option<&str>, path: Option<&PathBuf>) -> Self {
+        Self::load_with_envs_and_path(env_val, None, path)
     }
 
     /// Load config with an explicit env override value.
-    /// Priority: env_override > config.json file > default(true)
+    /// Backward-compatible wrapper: only overrides stats_enabled.
     pub fn load_with_env(env_val: Option<&str>) -> Self {
-        Self::load_with_env_and_path(env_val, None)
+        Self::load_with_envs(env_val, None)
     }
 
-    /// Load config: env var overrides file config, file config overrides defaults.
-    /// Priority: TOKENLESS_STATS_ENABLED env > config.json file > default(true)
+    /// Load config: env vars override file config, file config overrides defaults.
+    /// Priority: env > config.json file > default (per toggle)
+    /// Empty env var values are treated as unset (fall through to file config).
     pub fn load() -> Self {
-        let env_val = std::env::var("TOKENLESS_STATS_ENABLED").ok();
-        Self::load_with_env(env_val.as_deref())
+        let stats_env = std::env::var("TOKENLESS_STATS_ENABLED")
+            .ok()
+            .filter(|v| !v.is_empty());
+        let sls_env = std::env::var("TOKENLESS_SLS_ENABLED")
+            .ok()
+            .filter(|v| !v.is_empty());
+        Self::load_with_envs(stats_env.as_deref(), sls_env.as_deref())
     }
 
     /// Save config to disk.
@@ -101,6 +159,11 @@ impl TokenlessConfig {
     pub fn is_stats_enabled(&self) -> bool {
         self.stats_enabled
     }
+
+    /// Returns true if SLS integration is enabled (env override or file config).
+    pub fn is_sls_enabled(&self) -> bool {
+        self.sls_enabled
+    }
 }
 
 #[cfg(test)]
@@ -115,18 +178,16 @@ mod tests {
 
     #[test]
     fn test_load_missing_file() {
-        let tmp_dir = std::env::temp_dir().join("tokenless_test_missing");
-        let _ = std::fs::remove_dir_all(&tmp_dir);
-        let path = tmp_dir.join("config.json");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
         let config = TokenlessConfig::load_with_env_and_path(None, Some(&path));
         assert!(config.is_stats_enabled());
     }
 
     #[test]
     fn test_load_invalid_json() {
-        let tmp_dir = std::env::temp_dir().join("tokenless_test_invalid_json");
-        let _ = std::fs::create_dir_all(&tmp_dir);
-        let path = tmp_dir.join("config.json");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
         let _ = std::fs::write(&path, "not json");
         let config = TokenlessConfig::load_with_env_and_path(None, Some(&path));
         assert!(config.is_stats_enabled());
@@ -152,13 +213,86 @@ mod tests {
 
     #[test]
     fn test_env_override_overrides_file() {
-        let tmp_dir = std::env::temp_dir().join("tokenless_test_override");
-        let _ = std::fs::create_dir_all(&tmp_dir);
-        let path = tmp_dir.join("config.json");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
         // Write file config with stats_enabled=false
         let _ = std::fs::write(&path, "{\"stats_enabled\":false}");
         // Env override to enable
         let config = TokenlessConfig::load_with_env_and_path(Some("1"), Some(&path));
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_sls_enabled_default_false() {
+        let config = TokenlessConfig::default();
+        assert!(!config.is_sls_enabled());
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_load_sls_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let config = TokenlessConfig::load_with_envs_and_path(None, None, Some(&path));
+        assert!(!config.is_sls_enabled());
+        assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_sls_env_override_enabled() {
+        let config = TokenlessConfig::load_with_envs(Some("1"), None);
+        assert!(config.is_stats_enabled());
+        assert!(!config.is_sls_enabled());
+
+        let config = TokenlessConfig::load_with_envs(None, Some("1"));
+        assert!(config.is_stats_enabled());
+        assert!(config.is_sls_enabled());
+    }
+
+    #[test]
+    fn test_sls_env_override_disabled() {
+        // stats_env="0" disables stats, sls stays default false
+        let config = TokenlessConfig::load_with_envs(Some("0"), None);
+        assert!(!config.is_stats_enabled());
+        assert!(!config.is_sls_enabled());
+
+        // sls_env="0" disables sls (already false by default)
+        let config = TokenlessConfig::load_with_envs(None, Some("0"));
+        assert!(config.is_stats_enabled());
+        assert!(!config.is_sls_enabled());
+    }
+
+    #[test]
+    fn test_sls_env_override_overrides_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        // Write file config with sls_enabled=true
+        let _ = std::fs::write(&path, "{\"stats_enabled\":true,\"sls_enabled\":true}");
+        // Env override to disable sls
+        let config = TokenlessConfig::load_with_envs_and_path(None, Some("0"), Some(&path));
+        assert!(config.is_stats_enabled());
+        assert!(!config.is_sls_enabled());
+    }
+
+    #[test]
+    fn test_both_env_overrides() {
+        let config = TokenlessConfig::load_with_envs(Some("0"), Some("1"));
+        assert!(!config.is_stats_enabled());
+        assert!(config.is_sls_enabled());
+
+        let config = TokenlessConfig::load_with_envs(Some("1"), Some("0"));
+        assert!(config.is_stats_enabled());
+        assert!(!config.is_sls_enabled());
+    }
+
+    #[test]
+    fn test_empty_env_treated_as_unset() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        // File config has stats_enabled=true
+        let _ = std::fs::write(&path, "{\"stats_enabled\":true}");
+        // Empty string should fall through to file config (true), not override to false
+        let config = TokenlessConfig::load_with_envs_and_path(Some(""), None, Some(&path));
         assert!(config.is_stats_enabled());
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -9,6 +9,7 @@ pub mod home;
 pub mod query;
 pub mod record;
 pub mod recorder;
+pub mod sls;
 pub mod tokenizer;
 
 pub use record::{OperationType, StatsRecord};
@@ -22,6 +23,8 @@ pub use tokenizer::{Tokenizer, count_chars, estimate_tokens, estimate_tokens_fro
 pub use config::TokenlessConfig;
 
 pub use home::get_home_dir;
+
+pub use sls::{SlsRecord, SlsWriter};
 
 /// Library version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/tokenless/crates/tokenless-stats/src/sls.rs
+++ b/src/tokenless/crates/tokenless-stats/src/sls.rs
@@ -1,0 +1,625 @@
+//! SLS (Simple Log Service) data model and writer for tokenless stats.
+//!
+//! Provides SlsRecord (SLS-specific field naming via serde rename) and
+//! SlsWriter (JSONL append-only writer with fail-silent semantics).
+//!
+//! NOTE: The JSONL file grows without bound — there is no built-in log
+//! rotation. Production deployments should configure external rotation
+//! (e.g. logrotate) or set TOKENLESS_SLS_PATH to a location managed by
+//! a log collector.
+
+use crate::{StatsRecord, VERSION};
+use serde::Serialize;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Default SLS JSONL output path.
+/// NOTE: /var/log/ requires write permission (typically root or adm group).
+/// The caller must ensure the directory exists and is writable, or provide
+/// an alternative path via TOKENLESS_SLS_PATH (e.g. /tmp/tokenless-sls.jsonl).
+pub const DEFAULT_SLS_PATH: &str = "/var/log/anolisa/sls/ops/tokenless.jsonl";
+
+/// Allowed path prefixes for TOKENLESS_SLS_PATH env var override.
+/// NOTE: /tmp/ is world-writable on most Unix systems — other local users
+/// can read the JSONL file if placed there. Prefer /var/log/ for production.
+const ALLOWED_SLS_PREFIXES: &[&str] = &["/var/log/", "/tmp/"];
+
+/// Root-owned prefixes where creating a symlink requires privilege. For
+/// these, the original (pre-canonicalize) path can be trusted even when
+/// canonicalization resolves it elsewhere (e.g. `/var/log` symlinked to
+/// another filesystem). World-writable prefixes like `/tmp/` are excluded
+/// because an unprivileged user can place a symlink there to escape.
+const TRUSTED_SLS_PREFIXES: &[&str] = &["/var/log/"];
+
+/// Canonicalize a path, walking up the parent chain to resolve symlinks
+/// when the path or its ancestors don't exist yet. Returns the best-effort
+/// canonicalized path (falls back to the original if the entire chain is
+/// unresolvable).
+fn canonicalize_or_reconstruct(path: &std::path::Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        let mut cursor = path.to_path_buf();
+        let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+        loop {
+            match cursor.canonicalize() {
+                Ok(canon) => {
+                    let mut result = canon;
+                    for name in suffix.iter().rev() {
+                        result.push(name);
+                    }
+                    return result;
+                }
+                Err(_) => {
+                    if let Some(name) = cursor.file_name() {
+                        suffix.push(name.to_os_string());
+                    }
+                    match cursor.parent() {
+                        Some(p) => cursor = p.to_path_buf(),
+                        None => return path.to_path_buf(),
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Validate an SLS output path: reject `..` traversal and paths outside
+/// allowed prefixes. Returns the canonicalized path if acceptable, or `None`.
+///
+/// Canonicalizes the path to resolve symlinks before the prefix check,
+/// so a symlinked `/var/log` → `/` cannot be used to escape the allowed
+/// directories. A path is accepted when the resolved path matches an
+/// allowed prefix, OR the original (pre-canonicalize) path matches a
+/// root-owned trusted prefix (see `TRUSTED_SLS_PREFIXES`).
+///
+/// The trusted-prefix fallback covers systems where `/var/log` is itself
+/// symlinked to another filesystem: canonicalization resolves it to the
+/// real target (no longer starting with `/var/log/`), but since creating
+/// that symlink requires root, trusting the original path is safe. The
+/// world-writable `/tmp/` prefix is excluded from the fallback, so a
+/// user-placed symlink in `/tmp/` cannot escape to an arbitrary location.
+///
+/// NOTE: `SlsWriter` stores the canonicalized path at construction time
+/// to narrow the TOCTOU window between validation and write.
+fn validate_sls_path(path: &std::path::Path) -> Option<PathBuf> {
+    if path
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
+        return None;
+    }
+
+    let resolved = canonicalize_or_reconstruct(path);
+    let resolved_str = resolved.to_str().unwrap_or("");
+    let original_str = path.to_str().unwrap_or("");
+    let resolved_ok = ALLOWED_SLS_PREFIXES
+        .iter()
+        .any(|prefix| resolved_str.starts_with(prefix));
+    let original_ok = TRUSTED_SLS_PREFIXES
+        .iter()
+        .any(|prefix| original_str.starts_with(prefix));
+    if resolved_ok || original_ok {
+        Some(resolved)
+    } else {
+        None
+    }
+}
+
+/// Resolve the SLS output path from an optional env var value.
+/// Falls back to DEFAULT_SLS_PATH when the env var is unset, empty,
+/// or contains an invalid path. Returns the canonicalized path
+/// to narrow the TOCTOU window between validation and write.
+fn resolve_sls_path(env_val: Option<&str>) -> PathBuf {
+    env_val
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .and_then(|p| match validate_sls_path(&p) {
+            Some(resolved) => Some(resolved),
+            None => {
+                eprintln!(
+                    "tokenless-sls: TOKENLESS_SLS_PATH rejected (must be under \
+                     /var/log/ or /tmp/, and must not contain '..'), \
+                     falling back to default: {}",
+                    DEFAULT_SLS_PATH
+                );
+                None
+            }
+        })
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_SLS_PATH))
+}
+
+/// SLS-specific data model with namespace-style field names.
+///
+/// Field names use dot-separated namespaces (component.*, tokenless.*,
+/// tokenless.compression.*) as required by the SLS ingestion schema.
+/// serde `rename` attributes produce the exact JSON keys expected by SLS.
+#[derive(Debug, Clone, Serialize)]
+pub struct SlsRecord {
+    #[serde(rename = "component.name")]
+    pub component_name: String,
+    #[serde(rename = "component.version")]
+    pub component_version: String,
+    #[serde(rename = "component.agent_name")]
+    pub agent_name: String,
+    #[serde(rename = "tokenless.operation")]
+    pub operation: String,
+    #[serde(rename = "tokenless.session_id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(rename = "tokenless.tool_use_id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
+    #[serde(rename = "tokenless.source_pid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_pid: Option<i64>,
+    #[serde(rename = "tokenless.compression.before_chars")]
+    pub before_chars: usize,
+    #[serde(rename = "tokenless.compression.before_tokens")]
+    pub before_tokens: usize,
+    #[serde(rename = "tokenless.compression.after_chars")]
+    pub after_chars: usize,
+    #[serde(rename = "tokenless.compression.after_tokens")]
+    pub after_tokens: usize,
+    #[serde(rename = "tokenless.compression.chars_saved")]
+    pub chars_saved: usize,
+    #[serde(rename = "tokenless.compression.tokens_saved")]
+    pub tokens_saved: usize,
+    #[serde(rename = "tokenless.compression.chars_saved_percent")]
+    pub chars_saved_percent: f64,
+    #[serde(rename = "tokenless.compression.tokens_saved_percent")]
+    pub tokens_saved_percent: f64,
+}
+
+impl From<&StatsRecord> for SlsRecord {
+    fn from(r: &StatsRecord) -> Self {
+        Self {
+            component_name: "tokenless".to_string(),
+            component_version: VERSION.to_string(),
+            agent_name: r.agent_id.clone(),
+            operation: r.operation.as_str().to_string(),
+            session_id: r.session_id.clone(),
+            tool_use_id: r.tool_use_id.clone(),
+            source_pid: r.source_pid,
+            before_chars: r.before_chars,
+            before_tokens: r.before_tokens,
+            after_chars: r.after_chars,
+            after_tokens: r.after_tokens,
+            chars_saved: r.chars_saved(),
+            tokens_saved: r.tokens_saved(),
+            chars_saved_percent: r.chars_percent(),
+            tokens_saved_percent: r.tokens_percent(),
+        }
+    }
+}
+
+/// Writes SlsRecord entries to a JSONL file (one JSON object per line).
+///
+/// Each `write()` call opens the file (append+create), writes one JSON
+/// line followed by a newline, then closes (file handle drops).
+/// Fail-silent: errors are printed to stderr but never propagated.
+pub struct SlsWriter {
+    path: PathBuf,
+}
+
+impl Default for SlsWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SlsWriter {
+    /// Create a writer using the TOKENLESS_SLS_PATH env var,
+    /// falling back to DEFAULT_SLS_PATH if the env var is not set,
+    /// empty, or contains an invalid path.
+    pub fn new() -> Self {
+        let env_val = std::env::var("TOKENLESS_SLS_PATH").ok();
+        Self {
+            path: resolve_sls_path(env_val.as_deref()),
+        }
+    }
+
+    /// Create a writer with an explicit path (for testing).
+    /// NOTE: This bypasses `validate_sls_path` — the caller is responsible
+    /// for ensuring the path is safe. Production code should use `new()`.
+    #[cfg(test)]
+    pub(crate) fn with_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Convert a StatsRecord to SlsRecord and append it as a JSON line.
+    pub fn write(&self, record: &StatsRecord) {
+        let sls_record = SlsRecord::from(record);
+        let line = match serde_json::to_string(&sls_record) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("tokenless-sls: serialization error: {}", e);
+                return;
+            }
+        };
+
+        // Ensure parent directory exists before writing.
+        // NOTE: create_dir_all uses the process umask (typically 0o755),
+        // so parent directories may be world-readable. Production
+        // deployments should pre-create the directory tree with appropriate
+        // ownership and permissions (e.g. 0o700) before enabling SLS.
+        if let Some(parent) = self.path.parent()
+            && let Err(e) = fs::create_dir_all(parent)
+        {
+            static CREATE_DIR_WARNED: AtomicBool = AtomicBool::new(false);
+            if !CREATE_DIR_WARNED.swap(true, Ordering::Relaxed) {
+                eprintln!(
+                    "tokenless-sls: cannot create parent directory {}: {} \
+                     (further create_dir errors suppressed)",
+                    parent.display(),
+                    e
+                );
+            }
+            return;
+        }
+
+        let mut opts = OpenOptions::new();
+        opts.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+            // Refuse to open if the final path component is a symlink. The
+            // path is canonicalized at SlsWriter construction, so a legit
+            // output file is never a symlink here; O_NOFOLLOW only blocks an
+            // attacker from swapping the resolved path for a symlink between
+            // construction and write (narrowing the TOCTOU window on /tmp/).
+            opts.custom_flags(libc::O_NOFOLLOW);
+        }
+        if let Err(e) = opts.open(&self.path).and_then(|mut f| {
+            f.write_all(line.as_bytes())?;
+            f.write_all(b"\n")
+        }) {
+            static WRITE_ERROR_WARNED: AtomicBool = AtomicBool::new(false);
+            if !WRITE_ERROR_WARNED.swap(true, Ordering::Relaxed) {
+                eprintln!(
+                    "tokenless-sls: write error to {}: {} \
+                     (further write errors suppressed)",
+                    self.path.display(),
+                    e
+                );
+            }
+        }
+
+        // One-time warning when JSONL file exceeds 100 MiB.
+        // No built-in rotation — production deployments should configure
+        // external rotation (e.g. logrotate) or monitor file size.
+        static SIZE_WARNED: AtomicBool = AtomicBool::new(false);
+        const SLS_SIZE_WARN_THRESHOLD: u64 = 100 * 1024 * 1024; // 100 MiB
+        if !SIZE_WARNED.swap(true, Ordering::Relaxed)
+            && let Ok(meta) = fs::metadata(&self.path)
+            && meta.len() >= SLS_SIZE_WARN_THRESHOLD
+        {
+            eprintln!(
+                "tokenless-sls: JSONL file {} has reached {:.1} MiB \
+                 (threshold: {} MiB). No built-in rotation — configure \
+                 external logrotate or set TOKENLESS_SLS_PATH to a \
+                 rotation-managed location. (warning shown once)",
+                self.path.display(),
+                meta.len() as f64 / (1024.0 * 1024.0),
+                SLS_SIZE_WARN_THRESHOLD / (1024 * 1024),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::OperationType;
+    use std::fs;
+
+    fn make_record() -> StatsRecord {
+        StatsRecord::new(
+            OperationType::CompressSchema,
+            "copilot-shell".to_string(),
+            1000,
+            400,
+            500,
+            200,
+        )
+        .with_session_id("session-123")
+        .with_tool_use_id("call_abc")
+        .with_source_pid(12345)
+    }
+
+    fn make_record_minimal() -> StatsRecord {
+        StatsRecord::new(
+            OperationType::CompressResponse,
+            "test-agent".to_string(),
+            200,
+            80,
+            100,
+            40,
+        )
+    }
+
+    #[test]
+    fn test_sls_record_from_stats_record() {
+        let r = make_record();
+        let sls = SlsRecord::from(&r);
+
+        assert_eq!(sls.component_name, "tokenless");
+        assert_eq!(sls.component_version, VERSION);
+        assert_eq!(sls.agent_name, "copilot-shell");
+        assert_eq!(sls.operation, "compress-schema");
+        assert_eq!(sls.session_id, Some("session-123".to_string()));
+        assert_eq!(sls.tool_use_id, Some("call_abc".to_string()));
+        assert_eq!(sls.source_pid, Some(12345));
+        assert_eq!(sls.before_chars, 1000);
+        assert_eq!(sls.before_tokens, 400);
+        assert_eq!(sls.after_chars, 500);
+        assert_eq!(sls.after_tokens, 200);
+        assert_eq!(sls.chars_saved, 500);
+        assert_eq!(sls.tokens_saved, 200);
+        assert!((sls.chars_saved_percent - 50.0).abs() < 0.01);
+        assert!((sls.tokens_saved_percent - 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_sls_record_optional_fields_none() {
+        let r = make_record_minimal();
+        let sls = SlsRecord::from(&r);
+
+        assert_eq!(sls.session_id, None);
+        assert_eq!(sls.tool_use_id, None);
+        assert_eq!(sls.source_pid, None);
+    }
+
+    #[test]
+    fn test_sls_record_json_field_names() {
+        let r = make_record();
+        let sls = SlsRecord::from(&r);
+        let json = serde_json::to_string(&sls).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let keys: Vec<&str> = obj
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+
+        let expected_keys = [
+            "component.name",
+            "component.version",
+            "component.agent_name",
+            "tokenless.operation",
+            "tokenless.session_id",
+            "tokenless.tool_use_id",
+            "tokenless.source_pid",
+            "tokenless.compression.before_chars",
+            "tokenless.compression.before_tokens",
+            "tokenless.compression.after_chars",
+            "tokenless.compression.after_tokens",
+            "tokenless.compression.chars_saved",
+            "tokenless.compression.tokens_saved",
+            "tokenless.compression.chars_saved_percent",
+            "tokenless.compression.tokens_saved_percent",
+        ];
+        for expected in &expected_keys {
+            assert!(keys.contains(expected), "missing key: {}", expected);
+        }
+        assert_eq!(keys.len(), expected_keys.len());
+    }
+
+    #[test]
+    fn test_sls_record_json_no_camelcase() {
+        let r = make_record();
+        let sls = SlsRecord::from(&r);
+        let json = serde_json::to_string(&sls).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        for key in obj.as_object().unwrap().keys() {
+            assert!(
+                !key.chars().any(|c| c.is_ascii_uppercase()),
+                "key contains uppercase: {}",
+                key
+            );
+        }
+    }
+
+    #[test]
+    fn test_sls_record_json_valid_chars_only() {
+        let r = make_record();
+        let sls = SlsRecord::from(&r);
+        let json = serde_json::to_string(&sls).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        for key in obj.as_object().unwrap().keys() {
+            for c in key.chars() {
+                assert!(
+                    c.is_ascii_lowercase()
+                        || c.is_ascii_digit()
+                        || c == '.'
+                        || c == '_'
+                        || c == '-',
+                    "invalid char '{}' in key: {}",
+                    c,
+                    key
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_sls_record_json_optional_fields_omitted() {
+        let r = make_record_minimal();
+        let sls = SlsRecord::from(&r);
+        let json = serde_json::to_string(&sls).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Option<T> fields with None are omitted from serialization
+        assert!(
+            !obj.as_object()
+                .unwrap()
+                .contains_key("tokenless.session_id")
+        );
+        assert!(
+            !obj.as_object()
+                .unwrap()
+                .contains_key("tokenless.tool_use_id")
+        );
+        assert!(
+            !obj.as_object()
+                .unwrap()
+                .contains_key("tokenless.source_pid")
+        );
+    }
+
+    #[test]
+    fn test_sls_writer_writes_to_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let writer = SlsWriter::with_path(path.clone());
+
+        let r = make_record();
+        writer.write(&r);
+
+        let content = fs::read_to_string(&path).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(obj["component.name"], "tokenless");
+        assert_eq!(obj["component.agent_name"], "copilot-shell");
+    }
+
+    #[test]
+    fn test_sls_writer_appends_multiple_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.jsonl");
+        let writer = SlsWriter::with_path(path.clone());
+
+        let r1 = make_record();
+        let r2 = make_record_minimal();
+        writer.write(&r1);
+        writer.write(&r2);
+
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let obj1: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(obj1["component.agent_name"], "copilot-shell");
+
+        let obj2: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(obj2["component.agent_name"], "test-agent");
+    }
+
+    #[test]
+    fn test_sls_writer_fail_silent_on_invalid_path() {
+        // Path in a non-existent deep directory — should not panic
+        let writer = SlsWriter::with_path(PathBuf::from("/nonexistent/deep/dir/test.jsonl"));
+        let r = make_record();
+        writer.write(&r); // no panic
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_sls_writer_refuses_symlink_final_component() {
+        // O_NOFOLLOW hardening: after the file is created, swapping it for a
+        // symlink must NOT redirect the write to the symlink target. The
+        // open fails (ELOOP) and the write is skipped silently.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.jsonl");
+        let writer = SlsWriter::with_path(path.clone());
+
+        // First write creates a regular file.
+        writer.write(&make_record());
+        assert!(path.is_file());
+
+        // Swap the file for a symlink and write again — must not follow it.
+        std::fs::remove_file(&path).unwrap();
+        std::os::unix::fs::symlink("/etc/hostname", &path).unwrap();
+        let before = std::fs::read_to_string("/etc/hostname").unwrap_or_default();
+        writer.write(&make_record()); // no panic, no follow
+        let after = std::fs::read_to_string("/etc/hostname").unwrap_or_default();
+        assert_eq!(before, after, "symlink target must not be modified");
+    }
+
+    #[test]
+    fn test_resolve_sls_path_default() {
+        // When env var is not set, falls back to DEFAULT_SLS_PATH.
+        assert_eq!(resolve_sls_path(None), PathBuf::from(DEFAULT_SLS_PATH));
+    }
+
+    #[test]
+    fn test_resolve_sls_path_empty() {
+        // Empty env var is treated as unset.
+        assert_eq!(resolve_sls_path(Some("")), PathBuf::from(DEFAULT_SLS_PATH));
+    }
+
+    #[test]
+    fn test_resolve_sls_path_rejects_parent_traversal() {
+        // Paths containing ".." fall back to default.
+        assert_eq!(
+            resolve_sls_path(Some("/var/log/../../etc/passwd")),
+            PathBuf::from(DEFAULT_SLS_PATH)
+        );
+    }
+
+    #[test]
+    fn test_resolve_sls_path_rejects_non_whitelisted_prefix() {
+        // Paths outside /var/log/ and /tmp/ fall back to default.
+        assert_eq!(
+            resolve_sls_path(Some("/etc/cron.d/evil")),
+            PathBuf::from(DEFAULT_SLS_PATH)
+        );
+    }
+
+    #[test]
+    fn test_resolve_sls_path_accepts_valid_path() {
+        // Valid paths under /var/log/ or /tmp/ are accepted.
+        assert_eq!(
+            resolve_sls_path(Some("/var/log/custom/tokenless.jsonl")),
+            PathBuf::from("/var/log/custom/tokenless.jsonl")
+        );
+        assert_eq!(
+            resolve_sls_path(Some("/tmp/tokenless-test.jsonl")),
+            PathBuf::from("/tmp/tokenless-test.jsonl")
+        );
+    }
+
+    #[test]
+    fn test_validate_sls_path_symlinked_prefix() {
+        // When /var/log is symlinked to another filesystem, canonicalization
+        // resolves it to the real target which no longer starts with
+        // /var/log/. Since /var/log is root-owned (creating the symlink needs
+        // privilege), the original path is trusted and the path is still
+        // accepted. Here /var/log is a real directory (no symlink), so both
+        // the original and reconstructed paths match the /var/log/ prefix.
+        let result = validate_sls_path(std::path::Path::new(
+            "/var/log/anolisa/sls/ops/tokenless.jsonl",
+        ));
+        assert!(result.is_some());
+        let resolved = result.unwrap();
+        assert!(resolved.to_str().unwrap().starts_with("/var/log/"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_sls_path_rejects_tmp_symlink_escape() {
+        // /tmp/ is world-writable, so an unprivileged user can place a
+        // symlink there that escapes the allowed prefixes (e.g. -> /etc).
+        // The path must be REJECTED: the resolved path no longer matches an
+        // allowed prefix, and /tmp/ is not a trusted prefix, so the original
+        // path must not be used as a fallback.
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("escape");
+        std::os::unix::fs::symlink("/etc", &link).unwrap();
+        let escaped = link.join("cron.d/evil.jsonl");
+        assert!(validate_sls_path(&escaped).is_none());
+    }
+
+    #[test]
+    fn test_size_warning_threshold() {
+        // Verify the threshold constant matches the documented value.
+        const SLS_SIZE_WARN_THRESHOLD: u64 = 100 * 1024 * 1024;
+        assert_eq!(SLS_SIZE_WARN_THRESHOLD, 104857600);
+        // 100 MiB in human-readable form
+        assert_eq!(SLS_SIZE_WARN_THRESHOLD / (1024 * 1024), 100);
+    }
+}


### PR DESCRIPTION
## Description

Add SLS (Simple Log Service) JSONL data collection to tokenless, enabling compression
metrics export to Alibaba Cloud SLS for operational monitoring and analytics.

Three main additions:
- **SlsRecord** — data model with namespace-style SLS field names
  (`component.*`, `tokenless.*`, `tokenless.compression.*`)
- **SlsWriter** — fail-silent JSONL append-only writer with configurable path
- **sls_enabled** — config toggle (default `false`) with independent
  `TOKENLESS_SLS_ENABLED` env override

Security hardening included in this PR:
- Reject `TOKENLESS_SLS_PATH` values containing `..` (parent traversal)
- Treat empty env var values as unset (fall through to file config)
- Skip config file read when both env vars are set (unnecessary I/O)
- Create parent directories before writing to avoid silent data loss
- Skip write on serialization failure instead of writing a blank line

## Related Issue

no-issue: Operational infrastructure for SLS ingestion pipeline

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `tokenless`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all --check` pass
- [x] Lock files are up to date

## Testing

```bash
cd src/tokenless
cargo build --release        # ✅
cargo test                   # ✅ 133/133 passed (49 stats tests incl. 10 SLS-specific)
cargo fmt --all --check      # ✅
cargo clippy --all-targets -- -D warnings  # ✅
```

End-to-end verification:
- `TOKENLESS_SLS_ENABLED=1` + `compress-schema` → JSONL file written with correct SLS fields
- `TOKENLESS_SLS_ENABLED=0` → no file written
- `TOKENLESS_SLS_PATH` with `..` → rejected, falls back to default
- `TOKENLESS_SLS_ENABLED=""` → treated as unset (no override)
- `tokenless stats status` → shows both Stats and SLS recording status

## Additional Notes

SLS output path defaults to `/var/log/anolisa/sls/ops/tokenless.jsonl`.
Each write opens the file, appends one JSON line, and closes — fail-silent
by design so SLS issues never block compression output.