### PR TITLE
refactor(ckpt): simplify cronSchedules from per-workspace map to flat list

### DIFF
--- a/src/ws-ckpt/src/plugins/hermes/__init__.py
+++ b/src/ws-ckpt/src/plugins/hermes/__init__.py
@@ -43,7 +43,7 @@ def _on_session_start(session_id: str = "", model: str = "", **_: Any) -> None:
     # Sync cron schedules — independent of autoCheckpoint
     ws = manager.config.workspace
     if ws:
-        schedules = manager.config.cron_schedules.get(ws, [])
+        schedules = manager.config.cron_schedules
         if schedules:
             try:
                 if CrontabManager.sync_with_retry(ws, schedules):

--- a/src/ws-ckpt/src/plugins/hermes/config.py
+++ b/src/ws-ckpt/src/plugins/hermes/config.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import List
 
 # Message truncation length, hardcoded at 80 characters.
 MSG_TRUNCATE_LEN = 80
@@ -12,7 +12,7 @@ MSG_TRUNCATE_LEN = 80
 class HermesPluginConfig:
     workspace: str  # Workspace directory path
     auto_checkpoint: bool  # Whether to auto-checkpoint on each turn
-    cron_schedules: Dict[str, List[str]] = field(default_factory=dict)  # {workspace: [cron_expr]}
+    cron_schedules: List[str] = field(default_factory=list)
 
 
 def _read_yaml_config() -> dict:
@@ -57,22 +57,16 @@ def load_config() -> HermesPluginConfig:
     else:
         auto_checkpoint = bool(yaml_cfg.get("autoCheckpoint", False))
 
-    # cronSchedules: yaml only (no env override — structure too complex for a flat var)
+    # cronSchedules: yaml only (no env override)
     from .cron import validate_cron_expr
     raw_cron = yaml_cfg.get("cronSchedules")
-    cron_schedules: Dict[str, List[str]] = {}
-    if isinstance(raw_cron, dict):
-        for ws_key, exprs in raw_cron.items():
-            if isinstance(exprs, list):
-                valid = [str(e) for e in exprs if e and validate_cron_expr(str(e))]
-                skipped = [str(e) for e in exprs if e and not validate_cron_expr(str(e))]
-                if skipped:
-                    print(
-                        f"[ws-ckpt] Ignoring invalid cron expression(s) for {ws_key}: {skipped}",
-                        flush=True,
-                    )
-                if valid:
-                    cron_schedules[str(ws_key)] = valid
+    cron_schedules: List[str] = []
+    if isinstance(raw_cron, list):
+        valid = [str(e) for e in raw_cron if e and validate_cron_expr(str(e))]
+        skipped = [str(e) for e in raw_cron if e and not validate_cron_expr(str(e))]
+        if skipped:
+            print(f"[ws-ckpt] Ignoring invalid cron expression(s): {skipped}", flush=True)
+        cron_schedules = valid
 
     return HermesPluginConfig(
         workspace=workspace,

--- a/src/ws-ckpt/src/plugins/hermes/cron.py
+++ b/src/ws-ckpt/src/plugins/hermes/cron.py
@@ -167,14 +167,9 @@ class CrontabManager:
         return CrontabManager.sync_with_retry(workspace, [], retries)
 
     @staticmethod
-    def migrate(old_workspace: str, new_workspace: str, schedules_map: dict) -> List[str]:
-        """Migrate cron schedules to new workspace. Returns warnings.
-        Re-keys schedules_map in-place and syncs crontab.
-        """
+    def migrate(old_workspace: str, new_workspace: str, schedules: List[str]) -> List[str]:
+        """Remove old crontab entries and install under new workspace. Returns warnings."""
         warnings: List[str] = []
-        schedules = schedules_map.pop(old_workspace, [])
-        if schedules:
-            schedules_map[new_workspace] = schedules
         if old_workspace and old_workspace != new_workspace:
             if not CrontabManager.remove_with_retry(old_workspace):
                 warnings.append(

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -408,20 +408,10 @@ def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
             f"  autoCheckpoint: {cfg.auto_checkpoint}",
             f"  workspace:      {cfg.workspace}",
         ]
-        # Show cron schedules grouped by workspace
         if cfg.cron_schedules:
-            active = cfg.cron_schedules.get(ws, [])
-            if active:
-                lines.append("")
-                lines.append(f"  cronSchedules (active — {ws}):")
-                for expr in active:
-                    lines.append(f"    - {expr}")
-            for cron_ws, exprs in cfg.cron_schedules.items():
-                if cron_ws != ws and exprs:
-                    lines.append("")
-                    lines.append(f"  cronSchedules (inactive — {cron_ws}):")
-                    for expr in exprs:
-                        lines.append(f"    - {expr}")
+            lines.append("  cronSchedules:")
+            for expr in cfg.cron_schedules:
+                lines.append(f"    - {expr}")
         else:
             lines.append("  cronSchedules:  (disabled)")
         lines.append("")
@@ -554,14 +544,12 @@ def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
         ws = mgr.config.workspace
         if not ws:
             return _err(_NO_WORKSPACE_MSG)
-        current = list(mgr.config.cron_schedules.get(ws, []))
+        current = list(mgr.config.cron_schedules)
         new_schedules, err_msg = parse_schedules_update(str(value), current)
         if err_msg:
             return _err(err_msg)
-        mgr.config.cron_schedules[ws] = new_schedules
-        if not new_schedules:
-            mgr.config.cron_schedules.pop(ws, None)
-        err = _persist_plugin_yaml(cronSchedules=mgr.config.cron_schedules)
+        mgr.config.cron_schedules = new_schedules
+        err = _persist_plugin_yaml(cronSchedules=new_schedules)
         if err:
             return _err(f"Failed to persist config: {err}")
         cron_note = ""
@@ -571,7 +559,7 @@ def handle_ws_ckpt_config(args: Dict[str, Any], **_kwargs) -> str:
                 "Config saved but cron snapshots will not run until next session start or manual retry."
             )
         return _ok(
-            f"cronSchedules updated for {ws}: {new_schedules or '(disabled)'}"
+            f"cronSchedules updated: {new_schedules or '(disabled)'}"
             + cron_note
         )
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/config.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/config.ts
@@ -98,7 +98,7 @@ export function parseWorkspaceCleanupJson(stdout: string): WorkspaceCleanupParse
 export const DEFAULT_CONFIG: PluginConfig = {
   workspace: `${process.env.HOME ?? "/root"}/.openclaw/workspace`,
   autoCheckpoint: false,
-  cronSchedules: {},
+  cronSchedules: [],
 };
 
 // Intentionally no module-level workspaceCleanup cache.
@@ -128,19 +128,13 @@ export class PluginConfigManager {
    */
   constructor(persistedConfig: Partial<PluginConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...persistedConfig };
-    // Validate cronSchedules loaded from config file
-    if (this.config.cronSchedules && typeof this.config.cronSchedules === "object") {
-      const cleaned: Record<string, string[]> = {};
-      for (const [ws, exprs] of Object.entries(this.config.cronSchedules)) {
-        if (!Array.isArray(exprs)) continue;
-        const valid = exprs.filter((e) => typeof e === "string" && validateCronExpr(e));
-        const skipped = exprs.filter((e) => typeof e === "string" && !validateCronExpr(e));
-        if (skipped.length > 0) {
-          console.warn(`[ws-ckpt] Ignoring invalid cron expression(s) for ${ws}: ${JSON.stringify(skipped)}`);
-        }
-        if (valid.length > 0) cleaned[ws] = valid;
+    if (Array.isArray(this.config.cronSchedules)) {
+      const valid = this.config.cronSchedules.filter((e) => typeof e === "string" && validateCronExpr(e));
+      const skipped = this.config.cronSchedules.filter((e) => typeof e === "string" && !validateCronExpr(e));
+      if (skipped.length > 0) {
+        console.warn(`[ws-ckpt] Ignoring invalid cron expression(s): ${JSON.stringify(skipped)}`);
       }
-      this.config.cronSchedules = cleaned;
+      this.config.cronSchedules = valid;
     }
   }
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/cron.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/cron.ts
@@ -151,14 +151,9 @@ export class CrontabManager {
   static async migrate(
     oldWorkspace: string,
     newWorkspace: string,
-    schedulesMap: Record<string, string[]>,
+    schedules: string[],
   ): Promise<string[]> {
     const warnings: string[] = [];
-    const schedules = schedulesMap[oldWorkspace] ?? [];
-    if (schedules.length > 0 && oldWorkspace !== newWorkspace) {
-      delete schedulesMap[oldWorkspace];
-      schedulesMap[newWorkspace] = schedules;
-    }
     if (oldWorkspace && oldWorkspace !== newWorkspace) {
       if (!(await CrontabManager.removeWithRetry(oldWorkspace))) {
         warnings.push(

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -281,23 +281,10 @@ export async function handleConfig(
         break;
     }
     lines.push(`  workspace: ${cfg.workspace}`);
-    // Show cron schedules grouped by workspace
-    const cronAll = cfg.cronSchedules ?? {};
-    const hasAny = Object.values(cronAll).some((v) => v.length > 0);
-    if (hasAny) {
-      const active = cronAll[cfg.workspace] ?? [];
-      if (active.length > 0) {
-        lines.push("");
-        lines.push(`  cronSchedules (active — ${cfg.workspace}):`);
-        for (const expr of active) lines.push(`    - ${expr}`);
-      }
-      for (const [cronWs, exprs] of Object.entries(cronAll)) {
-        if (cronWs !== cfg.workspace && exprs.length > 0) {
-          lines.push("");
-          lines.push(`  cronSchedules (inactive — ${cronWs}):`);
-          for (const expr of exprs) lines.push(`    - ${expr}`);
-        }
-      }
+    const schedules = cfg.cronSchedules ?? [];
+    if (schedules.length > 0) {
+      lines.push("  cronSchedules:");
+      for (const expr of schedules) lines.push(`    - ${expr}`);
     } else {
       lines.push("  cronSchedules:  (disabled)");
     }
@@ -417,10 +404,9 @@ export async function handleConfig(
       }
       const oldWs = pluginState.resolvedConfig.workspace;
       pluginState.resolvedConfig.workspace = value;
-      const cronMap = pluginState.resolvedConfig.cronSchedules ?? {};
-      const warnings = await CrontabManager.migrate(oldWs, value, cronMap);
-      pluginState.resolvedConfig.cronSchedules = cronMap;
-      const persistErr = persistConfig({ workspace: value, cronSchedules: cronMap });
+      const schedules = pluginState.resolvedConfig.cronSchedules ?? [];
+      const warnings = await CrontabManager.migrate(oldWs, value, schedules);
+      const persistErr = persistConfig({ workspace: value });
       let msg = `Config updated: workspace = ${value}`;
       if (persistErr) msg += `\n\nWARNING: Failed to persist config: ${persistErr}. Change is in-memory only.`;
       if (warnings.length > 0) msg += "\n\n" + warnings.join("\n");
@@ -438,21 +424,13 @@ export async function handleConfig(
       if (!ws) {
         return { text: "No workspace configured", isError: true };
       }
-      if (!pluginState.resolvedConfig.cronSchedules) {
-        pluginState.resolvedConfig.cronSchedules = {};
-      }
-      const cronMap = pluginState.resolvedConfig.cronSchedules;
-      const current = [...(cronMap[ws] ?? [])];
+      const current = [...(pluginState.resolvedConfig.cronSchedules ?? [])];
       const parsed = parseSchedulesUpdate(value, current);
       if ("error" in parsed) {
         return { text: parsed.error, isError: true };
       }
-      if (parsed.schedules.length > 0) {
-        cronMap[ws] = parsed.schedules;
-      } else {
-        delete cronMap[ws];
-      }
-      const persistErr = persistConfig({ cronSchedules: pluginState.resolvedConfig.cronSchedules ?? {} });
+      pluginState.resolvedConfig.cronSchedules = parsed.schedules;
+      const persistErr = persistConfig({ cronSchedules: parsed.schedules });
       let warnings = "";
       if (persistErr) {
         warnings += `\n\nWARNING: Failed to persist config: ${persistErr}. Change is in-memory only.`;
@@ -462,7 +440,7 @@ export async function handleConfig(
           "Config saved but cron snapshots will not run until next session start or manual retry.";
       }
       return {
-        text: `cronSchedules updated for ${ws}: ${parsed.schedules.length > 0 ? JSON.stringify(parsed.schedules) : "(disabled)"}` + warnings,
+        text: `cronSchedules updated: ${parsed.schedules.length > 0 ? JSON.stringify(parsed.schedules) : "(disabled)"}` + warnings,
         isError: false,
       };
     }

--- a/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
@@ -88,7 +88,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PluginConfig): voi
     // Sync cron schedules — independent of autoCheckpoint
     const cronWs = pluginState.resolvedConfig?.workspace;
     if (cronWs) {
-      const schedules = (config.cronSchedules ?? {})[cronWs] ?? [];
+      const schedules = config.cronSchedules ?? [];
       if (schedules.length > 0) {
         try {
           if (await CrontabManager.syncWithRetry(cronWs, schedules)) {

--- a/src/ws-ckpt/src/plugins/openclaw/src/persist.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/persist.ts
@@ -22,8 +22,8 @@ export function loadPersistedConfig(): Partial<PluginConfig> {
     const result: Partial<PluginConfig> = {};
     if (typeof parsed.autoCheckpoint === "boolean") result.autoCheckpoint = parsed.autoCheckpoint;
     if (typeof parsed.workspace === "string") result.workspace = parsed.workspace;
-    if (parsed.cronSchedules && typeof parsed.cronSchedules === "object" && !Array.isArray(parsed.cronSchedules)) {
-      result.cronSchedules = parsed.cronSchedules;
+    if (Array.isArray(parsed.cronSchedules)) {
+      result.cronSchedules = parsed.cronSchedules.filter((e: unknown) => typeof e === "string");
     }
     return result;
   } catch {

--- a/src/ws-ckpt/src/plugins/openclaw/src/types.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/types.ts
@@ -99,8 +99,8 @@ export interface PluginConfig {
   workspace: string;
   /** Whether to automatically create a checkpoint at end of each turn. */
   autoCheckpoint: boolean;
-  /** Scheduled cron snapshots per workspace. Key = workspace path, value = cron expressions. */
-  cronSchedules?: Record<string, string[]>;
+  /** Cron expressions for scheduled snapshots. */
+  cronSchedules?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

- 将 `cronSchedules` 类型从 `Record<string, string[]>` / `Dict[str, List[str]]` 简化为 `string[]` / `List[str]`
- 去掉 workspace key 维度，定时快照只针对当前 workspace 生效

定时快照的 schedule 始终跟随当前 workspace，切换 workspace 时 migrate() 直接把同一组 schedule 从旧 workspace 迁移到新 workspace，不需要维护多工作区的 schedule map。

### 具体改动

**两端对称修改（Hermes + OpenClaw）：**
- config 加载：从解析嵌套 dict/Record 改为解析 flat list/array
- view handler：去掉 active/inactive 分组展示，直接列出 schedule 列表
- update handler：直接操作 `cron_schedules` 列表，不再按 `[ws]` key 存取
- migrate()：签名从 `schedules_map: dict` 改为 `schedules: List[str]`，去掉 re-key 逻辑
- session_start hook：直接读 `cron_schedules`，不再 `.get(ws, [])`
- persist/config 验证：适配新的 flat list 类型

## Related Issue

follow-up to #819

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

## Additional Notes
