### PR TITLE
feat(sight): add local PR pre-flight checks (#974)

### DIFF
--- a/src/agentsight/Makefile
+++ b/src/agentsight/Makefile
@@ -92,6 +92,34 @@ coverage: ## Generate HTML coverage report (opens browser)
 	cd $(CURDIR) && cargo llvm-cov --html --output-dir coverage-html --open \
 		--ignore-filename-regex '(\.skel\.rs|target/debug/build|target/release/build|src/probes/)'
 
+# =============================================================================
+# GIT HOOKS (opt-in, agent-agnostic)
+# =============================================================================
+
+.PHONY: install-hooks
+install-hooks: ## Install opt-in pre-push hook mirroring CI gates (any human/agent)
+	@existing=$$(git config --get core.hooksPath || true); \
+	if [ -n "$$existing" ] && [ "$$existing" != "src/agentsight/scripts/hooks" ]; then \
+		echo "core.hooksPath already set to '$$existing' (e.g. copilot-shell husky)."; \
+		echo "It is single-valued; not overriding. Unset it first to use the agentsight hook:"; \
+		echo "  git config --unset core.hooksPath"; \
+		exit 1; \
+	fi; \
+	chmod +x scripts/hooks/pre-push; \
+	git config core.hooksPath src/agentsight/scripts/hooks; \
+	echo "Installed pre-push hook (core.hooksPath -> src/agentsight/scripts/hooks)."; \
+	echo "Runs CI-mirror checks on pushes touching src/agentsight/. Uninstall: make uninstall-hooks"
+
+.PHONY: uninstall-hooks
+uninstall-hooks: ## Remove the agentsight pre-push hook (unset core.hooksPath)
+	@current=$$(git config --get core.hooksPath || true); \
+	if [ "$$current" = "src/agentsight/scripts/hooks" ]; then \
+		git config --unset core.hooksPath; \
+		echo "Removed pre-push hook (core.hooksPath unset)."; \
+	else \
+		echo "agentsight hook not active (core.hooksPath='$$current'); nothing to do."; \
+	fi
+
 .PHONY: help
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/src/agentsight/develop-skills/agentsight-pr-body/SKILL.md
+++ b/src/agentsight/develop-skills/agentsight-pr-body/SKILL.md
@@ -34,21 +34,53 @@ gh pr list --head $(git branch --show-current) --repo alibaba/anolisa --state op
 
 在生成 PR 描述前，先执行 `agentsight-code-review` skill 对当前变更进行自检。如果存在 findings，先修复再继续。
 
-### 步骤 1.6：Preflight 检查
+### 步骤 1.6：Preflight 检查（与 CI 门禁逐项对齐）
 
-在分析变更前，运行以下检查并记录结果（后续自动填入 Checklist）：
+在分析变更前，运行以下检查并记录结果（后续自动填入 Checklist）。这些检查
+镜像 `test-agentsight` CI job，目的是在 push 前本地拦截会导致 CI 失败的问题
+（一次 push + CI ≈ 4 分钟，本地检查 ≈ 30 秒）。
 
 ```bash
-# 在 agentsight 目录下执行
-cargo fmt --check          # 格式检查
-cargo clippy --all-targets -- -D warnings  # lint 检查
-cargo test                 # 单元测试 + 集成测试
+# 在 agentsight 目录下执行（CI 锁定 toolchain 1.89.0；缺则先
+# `rustup toolchain install 1.89.0 --component rustfmt --component clippy --component llvm-tools-preview`）
+cargo +1.89.0 fmt --all --check                     # 1. 格式
+cargo +1.89.0 clippy --all-targets -- -D warnings   # 2. lint
+python3 scripts/check-arch-boundaries.py            # 3. 架构边界
+
+# 4. 测试 + 覆盖率（CI 用 llvm-cov 跑测试，不是 cargo test；用默认 toolchain 即可——
+#    覆盖率行映射与工具链版本无关，且 +1.89.0 需该工具链装 llvm-tools-preview，
+#    dev 机常装在 stable 上。fmt/clippy 上面 pin +1.89.0 是因为 lint 规则版本敏感）
+cargo llvm-cov --cobertura --output-path coverage.xml \
+  --ignore-filename-regex '(\.skel\.rs|target/debug/build|target/release/build|src/probes/)'
+
+# 5. 增量覆盖率门禁（与 CI 一致：对比 origin/main，阈值 80%）
+git fetch origin main
+diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
 ```
 
-- 三项全部通过才继续后续步骤
-- 如果 `cargo fmt --check` 失败，自动运行 `cargo fmt` 修复后重新检查
-- 如果 `cargo clippy` 失败，列出告警并尝试修复，修复后重新检查
-- 如果 `cargo test` 失败，停止流程，报告失败的测试用例
+- 五项全部通过才继续；任一失败按下面处理后重跑。
+- `cargo fmt --check` 失败 → 跑 `cargo +1.89.0 fmt` 修复后重新检查。
+- `cargo clippy` 失败 → 列出告警、修复、重新检查。
+- 架构边界失败 → 按 `check-arch-boundaries.py` 的提示修正跨层依赖。
+- **覆盖率门禁失败（增量 < 80%）→ 停止**，为新增/修改但未覆盖的行补测试
+  （diff-cover 输出会列出每个文件的 Missing lines）；不要靠降阈值绕过。
+- `diff-cover` / `cargo-llvm-cov` 未安装 → 安装后再验（`pip install diff-cover`；
+  `rustup component add llvm-tools-preview`），**不要跳过本步却标记"已通过"**。
+
+**6. Commit message 规范检查**：对 `git log origin/main..HEAD` 的每个 commit
+逐条核对是否符合 conventional commit（commitlint 是独立的硬门禁，其中 **scope 必填**
+是最容易漏的硬失败；fmt/clippy/覆盖率同样是硬门禁）：
+
+- `type(scope): subject` 格式，**scope 必填**（缺 scope = CI 硬失败）。
+- type ∈ {feat, fix, refactor, perf, docs, chore, test, ci, build, style, revert}。
+- scope 建议用 {cosh, sec-core, skill, sight, tokenless, ckpt, memory, anolisa,
+  deps, ci, docs, chore}（不在列内 CI 仅告警、不阻断）。
+- header（首行）≤ 120 字符；**body/footer 每行 ≤ 100 字符**；subject 不用 Sentence/Start/Pascal/UPPER case。
+- 不符合 → 用 `git rebase` / `git commit --amend` 修正后再继续。
+
+> 可选：把以上检查装成 git **pre-push hook**，对所有人/所有 agent 通用（git 原生
+> 机制，谁 push 都触发）。在 agentsight 目录跑 `make install-hooks` 即启用；
+> 详见下文「步骤 7：pre-push hook（可选）」。
 
 ### 步骤 2：分析变更
 
@@ -117,7 +149,7 @@ closes #<issue-number>
 - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
 - [x/空] `cargo fmt --check` pass（基于 preflight 结果勾选）
 - [x/空] `cargo clippy --all-targets -- -D warnings` pass（基于 preflight 结果勾选）
-- [x/空] `cargo test` pass（基于 preflight 结果勾选）
+- [x/空] `cargo llvm-cov` 测试 + 增量覆盖率 `diff-cover --fail-under=80` pass（基于 preflight 结果勾选）
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have updated the documentation accordingly
 - [x] Lock files are up to date (`Cargo.lock`)
@@ -195,6 +227,31 @@ EOF
 **选择「仅输出，不提交」**：
 
 不执行任何 GitHub 操作，流程结束。
+
+### 步骤 7：pre-push hook（可选，对所有人/所有 agent 通用）
+
+步骤 1.6 的检查也可装成 git **pre-push hook**——git 原生机制，无论人还是任何
+AI agent `git push` 都会触发，比 skill 多一层兜底（防止漏跑 skill 直接 push）。
+
+**启用**（opt-in，不影响他人；卸载用 `make uninstall-hooks`）：
+
+```bash
+cd src/agentsight
+make install-hooks
+```
+
+**行为**：
+
+- 仅当本次 push 的 commit 改动了 `src/agentsight/` 时才检查，否则直接放行
+  （monorepo 好公民，不干扰其他组件）。
+- 默认跑快检查：`cargo +1.89.0 fmt --check`、`cargo +1.89.0 clippy`、架构边界检查、
+  以及 commit message 规范（conventional commit，scope 必填，跳过 Merge/Revert/fixup! 等）。
+- 覆盖率门禁（`llvm-cov` + `diff-cover`）较慢（约 1 分钟），**默认跳过**；需要时用
+  `PREPUSH_COVERAGE=1 git push` 启用。
+
+**注意（monorepo 限制）**：`core.hooksPath` 是单值的。若你也在用 copilot-shell 的
+husky（它把 hooksPath 指向 `.husky/`），两者只能启用其一；`make install-hooks`
+检测到已有 hooksPath 会**警告而不强行覆盖**。统一的多组件 hook 调度不在本 skill 范围。
 
 ## 内容质量规则
 

--- a/src/agentsight/scripts/hooks/pre-push
+++ b/src/agentsight/scripts/hooks/pre-push
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# AgentSight pre-push hook — mirror the `test-agentsight` CI gates locally so a
+# failing push is caught in ~30s instead of after a ~4min push + CI cycle.
+#
+# Agent-agnostic: git fires this for every push, whether by a human or any AI
+# agent — no per-agent config needed.
+# Opt-in: enabled only via `make install-hooks` (sets core.hooksPath); inert on
+# bare clones and for contributors who don't install it.
+# Monorepo citizen: no-op unless the pushed commits touch src/agentsight/.
+# Fast by default: the coverage gate (~1min llvm-cov) runs only when
+# PREPUSH_COVERAGE=1, so ordinary pushes stay quick.
+#
+# Fidelity: this catches CI's common HARD failures; CI stays authoritative (it
+# also lints commit bodies/footers and may differ on edge rules). The Rust gates
+# run against the WORKING TREE (that is how cargo works), which matches the usual
+# commit-then-push flow; if your worktree differs from the pushed tip the result
+# may not match the pushed commit exactly.
+set -uo pipefail
+
+ZERO='0000000000000000000000000000000000000000'
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Resolve origin/main once. touches-detection mirrors CI's change-detection
+# (branch-vs-base), NOT the incremental push range — so a reword/force-push of a
+# branch that still differs from main under src/agentsight/ is not skipped.
+main_sha="$(git rev-parse -q --verify origin/main 2>/dev/null || true)"
+
+# ── Determine: does the branch touch src/agentsight/, and which commits to lint? ──
+touches=0
+lint_shas=""
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$ZERO" ] && continue # ref deletion: nothing to push
+
+  # touches = branch differs from main under src/agentsight/ (matches CI). If
+  # main is unresolvable (shallow/disjoint clone) we cannot tell -> run the gate.
+  if [ -n "$main_sha" ]; then
+    [ -n "$(git diff --name-only "$main_sha...$local_sha" -- src/agentsight/ 2>/dev/null)" ] && touches=1
+  else
+    touches=1
+  fi
+
+  # commits to lint = the NEW commits in THIS push. Prefer the remote range when
+  # the remote tip object is present locally; else main..tip; else just the tip.
+  if [ "$remote_sha" != "$ZERO" ] && git rev-parse -q --verify "$remote_sha^{commit}" >/dev/null 2>&1; then
+    lint_shas="$lint_shas $(git rev-list "$remote_sha..$local_sha" 2>/dev/null)"
+  elif [ -n "$main_sha" ]; then
+    lint_shas="$lint_shas $(git rev-list "$main_sha..$local_sha" 2>/dev/null)"
+  else
+    echo "[pre-push] note: cannot resolve a base (try: git fetch origin main); linting the pushed tip only"
+    lint_shas="$lint_shas $local_sha"
+  fi
+done
+
+[ "$touches" -eq 0 ] && exit 0 # branch has no agentsight changes -> good monorepo citizen
+
+echo "[pre-push] agentsight changes detected — running CI-mirror checks"
+
+# ── 1. Commit-message lint ──
+# Mirrors CI commitlint's HARD rules; scope-empty is the one that has bitten us.
+# defaultIgnores (Merge / Revert / fixup! / squash! / amend!) are skipped, just
+# like the CI action. subject-case is intentionally NOT checked here — a cheap
+# approximation false-positives on acronym-led subjects (CJK/SSE/API/…); CI owns it.
+type_re='(feat|fix|refactor|perf|docs|chore|test|ci|build|style|revert)'
+for sha in $lint_shas; do
+  subject="$(git log -1 --format='%s' "$sha" 2>/dev/null)"
+  [ -z "$subject" ] && continue
+  case "$subject" in
+    "Merge "* | "Revert "* | "fixup!"* | "squash!"* | "amend!"*) continue ;;
+  esac
+  if ! printf '%s' "$subject" | grep -qE "^${type_re}(\([^)]+\))?!?: .+"; then
+    echo "[pre-push] FAIL: not a conventional commit (need 'type(scope): subject'): $subject"
+    exit 1
+  fi
+  if ! printf '%s' "$subject" | grep -qE "^${type_re}\([^)]+\)!?: "; then
+    echo "[pre-push] FAIL: commit message missing required scope: $subject"
+    exit 1
+  fi
+  # char count under a UTF-8 locale (the common case); counts bytes under C/POSIX,
+  # which could over-count a CJK subject — set a UTF-8 locale if that bites you.
+  if [ "${#subject}" -gt 120 ]; then
+    echo "[pre-push] FAIL: commit header exceeds 120 chars: $subject"
+    exit 1
+  fi
+  if printf '%s' "$subject" | grep -qE '\.$'; then
+    echo "[pre-push] FAIL: subject must not end with '.' (commitlint subject-full-stop): $subject"
+    exit 1
+  fi
+  # body/footer lines must be <=100 chars (commitlint body-max-line-length /
+  # footer-max-line-length, level-2 errors from config-conventional). %b is the
+  # body+footer (everything after the subject and its blank line).
+  if [ -n "$(git log -1 --format='%b' "$sha" 2>/dev/null | awk 'length > 100 { print NR; exit }')" ]; then
+    echo "[pre-push] FAIL: commit body/footer has a line over 100 chars: $sha"
+    exit 1
+  fi
+done
+
+# ── 2. Fast gates (every push) ──
+# fmt/clippy pin CI's toolchain because lint rules are version-sensitive (a
+# different default toolchain flags different uninlined_format_args etc.).
+cd "$REPO_ROOT/src/agentsight" || exit 1
+if ! rustup run 1.89.0 true 2>/dev/null; then
+  echo "[pre-push] FAIL: rust toolchain 1.89.0 not installed (CI pins it)"
+  echo "           run: rustup toolchain install 1.89.0 --component rustfmt --component clippy --component llvm-tools-preview"
+  exit 1
+fi
+echo "[pre-push] arch-boundaries"
+python3 scripts/check-arch-boundaries.py || {
+  echo "[pre-push] FAIL: arch boundary violation"
+  exit 1
+}
+echo "[pre-push] cargo +1.89.0 fmt --all --check"
+cargo +1.89.0 fmt --all --check || {
+  echo "[pre-push] FAIL: formatting (run: cargo +1.89.0 fmt --all)"
+  exit 1
+}
+echo "[pre-push] cargo +1.89.0 clippy --all-targets -- -D warnings"
+cargo +1.89.0 clippy --all-targets -- -D warnings || {
+  echo "[pre-push] FAIL: clippy warnings"
+  exit 1
+}
+
+# ── 3. Incremental coverage gate (slow; opt-in via PREPUSH_COVERAGE=1) ──
+# llvm-cov uses the default toolchain on purpose: coverage line-mapping is stable
+# enough across toolchains for the diff gate, and pinning +1.89.0 would demand
+# llvm-tools-preview on that exact toolchain (dev machines often have it on stable).
+if [ "${PREPUSH_COVERAGE:-0}" = "1" ]; then
+  echo "[pre-push] coverage gate: llvm-cov + diff-cover (>=80%)"
+  cargo llvm-cov --cobertura --output-path coverage.xml \
+    --ignore-filename-regex '(\.skel\.rs|target/debug/build|target/release/build|src/probes/)' || {
+    echo "[pre-push] FAIL: llvm-cov"
+    exit 1
+  }
+  git fetch -q origin main
+  diff-cover coverage.xml --compare-branch=origin/main --fail-under=80 || {
+    echo "[pre-push] FAIL: incremental coverage < 80%"
+    exit 1
+  }
+else
+  echo "[pre-push] coverage gate skipped (set PREPUSH_COVERAGE=1 to run it)"
+fi
+
+echo "[pre-push] all checks passed"
+exit 0


### PR DESCRIPTION
## Description

agentsight PRs had no local pre-flight validation, so they repeatedly failed CI on issues that are catchable locally. The motivating case, #973, cycled through 3 CI rounds (coverage → commit-lint → fmt) — each ~4 min — for failures a ~30s local check would have caught. This adds a pre-flight mechanism that mirrors the `test-agentsight` CI gates.

Two complementary pieces (per #974):

**1. Enhance the `agentsight-pr-body` skill preflight (Step 1.6).** Beyond the existing fmt/clippy it now also runs: the incremental-coverage gate (`cargo llvm-cov` + `diff-cover --fail-under=80`, matching CI), the arch-boundary check, and a conventional-commit lint (scope required — the rule that bit #973). Toolchain note + checklist updated.

**2. Opt-in, agent-agnostic git pre-push hook** (`scripts/hooks/pre-push` + `make install-hooks`). It is a git-native hook, so it fires for any pusher — human or any AI agent — and needs no per-agent config (PR #943's committed agent-specific hook was rejected; the accepted pattern is an opt-in script). It:

- no-ops unless the branch differs from `main` under `src/agentsight/` (mirrors CI's change-detection);
- runs the fast gates on every push — `cargo +1.89.0 fmt --all --check`, `cargo +1.89.0 clippy --all-targets -- -D warnings` (fmt/clippy pinned to CI's toolchain because lint rules are version-sensitive), arch-boundary, and commit-lint;
- gates incremental coverage only under `PREPUSH_COVERAGE=1` (the slow ~1 min step; `llvm-cov` uses the default toolchain since coverage line-mapping is toolchain-stable);
- warns rather than clobbering an existing `core.hooksPath` (e.g. copilot-shell's husky) — `core.hooksPath` is single-valued.

## Related Issue

closes #974

## Type of Change

- [x] CI/CD or build changes (tooling only; no product code)

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `develop-skills/agentsight-pr-body/SKILL.md`: Step 1.6 preflight gains the coverage gate + commit-lint + arch-boundary; checklist updated; new 步骤 7 documents the pre-push hook.
- `scripts/hooks/pre-push` (new): opt-in, agent-agnostic pre-push hook mirroring CI's hard gates.
- `Makefile`: `install-hooks` / `uninstall-hooks` (sets/unsets `core.hooksPath`; warns rather than clobbering an existing one).

## Checklist

- [x] No agentsight Rust code changed (skill/hook/Makefile only) — fmt/clippy/coverage trivially clean
- [x] Commit message follows conventional commits (scope required)
- [x] Hook tested (see Testing)

## Testing

**已 E2E（本地，含真实 git 触发）:**

- 真实 `git push --dry-run`（经 `core.hooksPath` 触发已安装 hook）→ arch-boundary / `fmt --all` / clippy / commit-lint 全过 → 放行。
- commit-lint 判别测试：无 scope、结尾句号 → 正确拦截；首字母缩写（`CJK …`）、`Merge` commit、大写 scope → 正确放行（这些是早期版本的假阳性，已修正）。
- 变更检测：分支相对 `main` 无 `src/agentsight/` 改动 → 静默放行；reword / force-push（增量 range 无文件变更但分支仍异于 `main`）→ 仍跑门禁（已修正的假阴性）。
- `make install-hooks` 在已有 `core.hooksPath`（全局 hooks + copilot-shell husky）的环境 → 正确警告并拒绝覆盖。
- `PREPUSH_COVERAGE=1`：`cargo llvm-cov` + `diff-cover` 跑通。

**说明:** hook 的 Rust 门禁运行于工作树（cargo 本身的行为），匹配常规 commit→push 流程；CI 仍为权威，commit body/footer 等边缘规则以 CI 为准。
