### PR TITLE
fix(tokenless): add trusted FHS fallback paths for hook_utils import in codex scripts

### DIFF
--- a/src/tokenless/adapters/tokenless/codex/scripts/compress-response
+++ b/src/tokenless/adapters/tokenless/codex/scripts/compress-response
@@ -32,19 +32,125 @@ import subprocess
 import sys
 from typing import Optional
 
-# Resolve shared hook utilities (common/hooks/ relative to adapters root).
+# Resolve shared hook utilities (common/hooks/) with FHS fallback paths.
+# Primary: relative path (works for source-tree and FHS/RPM install).
+# Fallbacks: system and user FHS paths (works when Codex caches only the
+# plugin subdirectory and the relative path resolves outside the cache).
+#
+# Trust model (aligned with bash is_trusted_file / Rust is_trusted_path):
+#   - System FHS paths (/usr/share, /usr/local/share) are unconditional.
+#   - User-relative paths use passwd DB home (NOT $HOME — env-controllable),
+#     with ownership and parent-dir permission checks.
+#   - Relative ../../common/hooks is trusted only if the resolved target
+#     exists and is under a system prefix or a passwd-validated home path.
 _HERE = os.path.dirname(os.path.abspath(__file__))
-_COMMON = os.path.join(_HERE, "..", "..", "common", "hooks")
-if _COMMON not in sys.path:
-    sys.path.insert(0, _COMMON)
-from hook_utils import (  # noqa: E402
-    skip_silent as _skip,
-    try_parse_json as _try_parse_json,
-    warn as _warn,
-    classify_env_error as _classify_env_error,
-    get_thresholds as _get_thresholds,
-    SKIP_TOOLS as _SKIP_TOOLS_SHARED,
-)
+
+
+def _is_trusted_dir(path: str) -> bool:
+    """Check whether a directory is trusted for Python module imports.
+
+    Mirrors the trust criteria in bash tool_ready_hook.sh (is_trusted_file)
+    and Rust env_check.rs (is_trusted_path): system paths unconditional,
+    user paths validated via passwd + ownership + parent permission checks.
+
+    NOTE: Callers should pass realpath-resolved paths (not just abspath)
+    so that symlink targets are validated before the trust check — a
+    symlinked /usr/share/anolisa → /tmp/ would bypass the prefix check
+    if only abspath is used.
+    """
+    # System FHS prefixes are always trusted
+    for prefix in ("/usr/share/", "/usr/local/share/", "/usr/libexec/", "/usr/lib/anolisa/"):
+        if path.startswith(prefix):
+            return True
+    # For paths outside system prefixes (e.g. source-tree cloned to
+    # /opt/anolisa/), trust them if owned by current uid or root AND
+    # parent directory is not world-writable. This covers developer
+    # worktrees without requiring the path to be under passwd home.
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    if st.st_uid != os.getuid() and st.st_uid != 0:
+        # Not owned by us or root — refuse. Home paths must be owned by
+        # us or root; source-tree paths outside system prefixes are
+        # already covered by the ownership check above (current uid/root).
+        return False
+    # Ownership OK — check parent directory is not world-writable
+    parent = os.path.dirname(path)
+    try:
+        pst = os.stat(parent)
+    except OSError:
+        return False
+    if pst.st_uid != os.getuid() and pst.st_uid != 0:
+        return False
+    if pst.st_mode & 0o002:  # world-writable
+        return False
+    return True
+
+
+# Resolve real home from passwd DB for user-install fallback path.
+# Falls back to "" (empty) when unavailable — candidate is then skipped.
+try:
+    import pwd as _pwd
+    _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
+except (ImportError, KeyError):
+    _REAL_HOME = ""
+
+_HOOK_UTILS_CANDIDATES = [
+    os.path.join(_HERE, "..", "..", "common", "hooks"),                   # source-tree / FHS
+    "/usr/share/anolisa/adapters/tokenless/common/hooks",                  # RPM system
+    "/usr/local/share/anolisa/adapters/tokenless/common/hooks",            # manual system
+    os.path.join(_REAL_HOME, ".local", "share",
+                 "anolisa", "adapters", "tokenless", "common", "hooks") if _REAL_HOME else "",
+]
+_HOOK_UTILS_RESOLVED = ""
+for _C in _HOOK_UTILS_CANDIDATES:
+    if _C and _is_trusted_dir(os.path.realpath(_C)) and os.path.isdir(_C):
+        _HOOK_UTILS_RESOLVED = os.path.realpath(_C)
+        sys.path.insert(0, _C)
+        break
+
+if _HOOK_UTILS_RESOLVED:
+    from hook_utils import (  # noqa: E402
+        skip_silent as _skip,
+        try_parse_json as _try_parse_json,
+        warn as _warn,
+        classify_env_error as _classify_env_error,
+        get_thresholds as _get_thresholds,
+        SKIP_TOOLS as _SKIP_TOOLS_SHARED,
+    )
+else:
+    # Fail-open: no trusted hook_utils found → provide inline fallbacks
+    # so the hook script exits 0 (passthrough) rather than ImportError → exit 1.
+    def _skip() -> None:  # type: ignore[assignment,misc]
+        sys.exit(0)
+
+    def _try_parse_json(data: str) -> object | None:  # type: ignore[assignment,misc]
+        try:
+            return json.loads(data)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    def _warn(msg: str) -> None:  # type: ignore[assignment,misc]
+        print(f"[tokenless] WARNING: {msg}", file=sys.stderr)
+
+    def _classify_env_error(tool_response) -> tuple[str | None, str | None]:  # type: ignore[assignment,misc]
+        # Classification unavailable without hook_utils — return no-op.
+        # Caller handles (None, None) by skipping env error injection.
+        return None, None
+
+    def _get_thresholds(tool_name: str) -> tuple[int, int, int]:  # type: ignore[assignment,misc]
+        # Hardcoded defaults mirroring hook_utils.get_thresholds().
+        # Keep in sync with common/hooks/hook_utils.py thresholds.
+        return (65_536, 128, 8) if tool_name in {"Bash", "bash", "Shell", "shell", "exec", "terminal"} else (1_048_576, 65_536, 32)
+
+    _SKIP_TOOLS_SHARED: set[str] = {  # type: ignore[assignment,misc]
+        "Read", "read", "read_file", "read_many_files",
+        "Glob", "glob", "list_directory",
+        "Grep", "grep", "grep_search", "search_files",
+        "Lsp", "lsp",
+        "NotebookRead", "notebook_read", "notebookread",
+    }
 
 # ---------------------------------------------------------------------------
 # constants

--- a/src/tokenless/adapters/tokenless/codex/scripts/rewrite-hook
+++ b/src/tokenless/adapters/tokenless/codex/scripts/rewrite-hook
@@ -27,12 +27,107 @@ import subprocess
 import sys
 from typing import Optional
 
-# Resolve shared hook utilities (common/hooks/ relative to adapters root).
+# Resolve shared hook utilities (common/hooks/) with FHS fallback paths.
+# Primary: relative path (works for source-tree and FHS/RPM install).
+# Fallbacks: system and user FHS paths (works when Codex caches only the
+# plugin subdirectory and the relative path resolves outside the cache).
+#
+# Trust model (aligned with bash is_trusted_file / Rust is_trusted_path):
+#   - System FHS paths (/usr/share, /usr/local/share) are unconditional.
+#   - User-relative paths use passwd DB home (NOT $HOME — env-controllable),
+#     with ownership and parent-dir permission checks.
+#   - Relative ../../common/hooks is trusted only if the resolved target
+#     exists and is under a system prefix or a passwd-validated home path.
 _HERE = os.path.dirname(os.path.abspath(__file__))
-_COMMON = os.path.join(_HERE, "..", "..", "common", "hooks")
-if _COMMON not in sys.path:
-    sys.path.insert(0, _COMMON)
-from hook_utils import parse_version as _parse_version, skip_silent as _skip, write_context as _write_context  # noqa: E402
+
+
+def _is_trusted_dir(path: str) -> bool:
+    """Check whether a directory is trusted for Python module imports.
+
+    Mirrors the trust criteria in bash tool_ready_hook.sh (is_trusted_file)
+    and Rust env_check.rs (is_trusted_path): system paths unconditional,
+    user paths validated via passwd + ownership + parent permission checks.
+
+    NOTE: Callers should pass realpath-resolved paths (not just abspath)
+    so that symlink targets are validated before the trust check — a
+    symlinked /usr/share/anolisa → /tmp/ would bypass the prefix check
+    if only abspath is used.
+    """
+    # System FHS prefixes are always trusted
+    for prefix in ("/usr/share/", "/usr/local/share/", "/usr/libexec/", "/usr/lib/anolisa/"):
+        if path.startswith(prefix):
+            return True
+    # For paths outside system prefixes (e.g. source-tree cloned to
+    # /opt/anolisa/), trust them if owned by current uid or root AND
+    # parent directory is not world-writable. This covers developer
+    # worktrees without requiring the path to be under passwd home.
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    if st.st_uid != os.getuid() and st.st_uid != 0:
+        # Not owned by us or root — refuse. Home paths must be owned by
+        # us or root; source-tree paths outside system prefixes are
+        # already covered by the ownership check above (current uid/root).
+        return False
+    # Ownership OK — check parent directory is not world-writable
+    parent = os.path.dirname(path)
+    try:
+        pst = os.stat(parent)
+    except OSError:
+        return False
+    if pst.st_uid != os.getuid() and pst.st_uid != 0:
+        return False
+    if pst.st_mode & 0o002:  # world-writable
+        return False
+    return True
+
+
+# Resolve real home from passwd DB for user-install fallback path.
+# Falls back to "" (empty) when unavailable — candidate is then skipped.
+try:
+    import pwd as _pwd
+    _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
+except (ImportError, KeyError):
+    _REAL_HOME = ""
+
+_HOOK_UTILS_CANDIDATES = [
+    os.path.join(_HERE, "..", "..", "common", "hooks"),                   # source-tree / FHS
+    "/usr/share/anolisa/adapters/tokenless/common/hooks",                  # RPM system
+    "/usr/local/share/anolisa/adapters/tokenless/common/hooks",            # manual system
+    os.path.join(_REAL_HOME, ".local", "share",
+                 "anolisa", "adapters", "tokenless", "common", "hooks") if _REAL_HOME else "",
+]
+_HOOK_UTILS_RESOLVED = ""
+for _C in _HOOK_UTILS_CANDIDATES:
+    if _C and _is_trusted_dir(os.path.realpath(_C)) and os.path.isdir(_C):
+        _HOOK_UTILS_RESOLVED = os.path.realpath(_C)
+        sys.path.insert(0, _C)
+        break
+
+if _HOOK_UTILS_RESOLVED:
+    from hook_utils import parse_version as _parse_version, skip_silent as _skip, write_context as _write_context  # noqa: E402
+else:
+    # Fail-open: no trusted hook_utils found → provide inline fallbacks
+    # so the hook script exits 0 (passthrough) rather than ImportError → exit 1.
+    import re as _re
+
+    def _skip() -> None:  # type: ignore[assignment,misc]
+        sys.exit(0)
+
+    def _parse_version(version_str: str) -> tuple | None:  # type: ignore[assignment,misc]
+        m = _re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)
+        if m:
+            return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        return None
+
+    _WRITE_CONTEXT_WARNED = False
+
+    def _write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:  # type: ignore[assignment,misc]
+        global _WRITE_CONTEXT_WARNED
+        if not _WRITE_CONTEXT_WARNED:
+            print("[tokenless] WARNING: rtk session tracking unavailable (hook_utils not loaded, rewrite still works)", file=sys.stderr)
+            _WRITE_CONTEXT_WARNED = True
 
 # ---------------------------------------------------------------------------
 # constants

--- a/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
+++ b/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
@@ -33,12 +33,90 @@ import subprocess
 import sys
 from typing import Optional
 
-# Resolve shared hook utilities (common/hooks/ relative to adapters root).
+# Resolve shared hook utilities (common/hooks/) with FHS fallback paths.
+# Primary: relative path (works for source-tree and FHS/RPM install).
+# Fallbacks: system and user FHS paths (works when Codex caches only the
+# plugin subdirectory and the relative path resolves outside the cache).
+#
+# Trust model (aligned with bash is_trusted_file / Rust is_trusted_path):
+#   - System FHS paths (/usr/share, /usr/local/share) are unconditional.
+#   - User-relative paths use passwd DB home (NOT $HOME — env-controllable),
+#     with ownership and parent-dir permission checks.
+#   - Relative ../../common/hooks is trusted only if the resolved target
+#     exists and is under a system prefix or a passwd-validated home path.
 _HERE = os.path.dirname(os.path.abspath(__file__))
-_COMMON = os.path.join(_HERE, "..", "..", "common", "hooks")
-if _COMMON not in sys.path:
-    sys.path.insert(0, _COMMON)
-from hook_utils import skip_silent as _skip  # noqa: E402
+
+
+def _is_trusted_dir(path: str) -> bool:
+    """Check whether a directory is trusted for Python module imports.
+
+    Mirrors the trust criteria in bash tool_ready_hook.sh (is_trusted_file)
+    and Rust env_check.rs (is_trusted_path): system paths unconditional,
+    user paths validated via passwd + ownership + parent permission checks.
+
+    NOTE: Callers should pass realpath-resolved paths (not just abspath)
+    so that symlink targets are validated before the trust check — a
+    symlinked /usr/share/anolisa → /tmp/ would bypass the prefix check
+    if only abspath is used.
+    """
+    # System FHS prefixes are always trusted
+    for prefix in ("/usr/share/", "/usr/local/share/", "/usr/libexec/", "/usr/lib/anolisa/"):
+        if path.startswith(prefix):
+            return True
+    # For paths outside system prefixes (e.g. source-tree cloned to
+    # /opt/anolisa/), trust them if owned by current uid or root AND
+    # parent directory is not world-writable. This covers developer
+    # worktrees without requiring the path to be under passwd home.
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    if st.st_uid != os.getuid() and st.st_uid != 0:
+        # Not owned by us or root — refuse. Home paths must be owned by
+        # us or root; source-tree paths outside system prefixes are
+        # already covered by the ownership check above (current uid/root).
+        return False
+    # Ownership OK — check parent directory is not world-writable
+    parent = os.path.dirname(path)
+    try:
+        pst = os.stat(parent)
+    except OSError:
+        return False
+    if pst.st_uid != os.getuid() and pst.st_uid != 0:
+        return False
+    if pst.st_mode & 0o002:  # world-writable
+        return False
+    return True
+
+# Resolve real home from passwd DB for user-install fallback path.
+# Falls back to "" (empty) when unavailable — candidate is then skipped.
+try:
+    import pwd as _pwd
+    _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
+except (ImportError, KeyError):
+    _REAL_HOME = ""
+
+_HOOK_UTILS_CANDIDATES = [
+    os.path.join(_HERE, "..", "..", "common", "hooks"),                   # source-tree / FHS
+    "/usr/share/anolisa/adapters/tokenless/common/hooks",                  # RPM system
+    "/usr/local/share/anolisa/adapters/tokenless/common/hooks",            # manual system
+    os.path.join(_REAL_HOME, ".local", "share",
+                 "anolisa", "adapters", "tokenless", "common", "hooks") if _REAL_HOME else "",
+]
+_HOOK_UTILS_RESOLVED = ""
+for _C in _HOOK_UTILS_CANDIDATES:
+    if _C and _is_trusted_dir(os.path.realpath(_C)) and os.path.isdir(_C):
+        _HOOK_UTILS_RESOLVED = os.path.realpath(_C)
+        sys.path.insert(0, _C)
+        break
+
+if _HOOK_UTILS_RESOLVED:
+    from hook_utils import skip_silent as _skip  # noqa: E402
+else:
+    # Fail-open: no trusted hook_utils found → provide inline fallbacks
+    # so the hook script exits 0 (passthrough) rather than ImportError → exit 1.
+    def _skip() -> None:  # type: ignore[assignment,misc]
+        sys.exit(0)
 
 # ---------------------------------------------------------------------------
 # constants


### PR DESCRIPTION
## Description

Codex plugin cache only copies the `codex/` subdirectory (`plugin.json` + `hooks/` + `scripts/`), omitting the upstream `common/hooks/` directory. The three Python hook scripts (`tool-ready`, `compress-response`, `rewrite-hook`) import `hook_utils` via relative path `../../common/hooks`, which resolves outside the cache boundary and causes `ImportError` → exit code 1 — contradicting the stated "fail-open" design intent (all error paths should exit 0 passthrough).

This fix adds multi-level FHS fallback paths for `hook_utils` import resolution, aligned with the bash hook `tool_ready_hook.sh` candidate search pattern. It also hardens trust validation to match the security model established in Rust `home.rs` and bash `is_trusted_source_path()`:

1. **FHS fallback paths**: Add `/usr/share`, `/usr/local/share`, and user-install candidates as fallbacks when the relative path fails (Codex cache / marketplace install scenarios).

2. **Passwd DB home resolution**: Replace `os.path.expanduser("~")` (reads `$HOME` env variable) with `pwd.getpwuid(os.getuid()).pw_dir` (reads passwd database). `$HOME` is env-controllable — a parent process can redirect trust evaluation to an attacker-controlled directory. Rust `home.rs` and bash `is_trusted_source_path()` explicitly reject `$HOME` for the same reason.

3. **`_is_trusted_dir()` validation**: Add ownership and permission checks for non-system paths (mirroring bash `is_trusted_file` and Rust `is_trusted_path`):
   - Path owner must be current uid or root (uid 0)
   - Parent directory owner must be current uid or root
   - Parent directory must not be world-writable (TOCTOU protection)

4. **Inline fail-open fallbacks**: When no trusted `hook_utils` is found, provide inline implementations of `skip_silent`, `try_parse_json`, `warn`, etc. so scripts exit 0 passthrough instead of `ImportError` exit 1.

## Related Issue

no-issue: Codex PreToolUse hook (failed) error reported in production — no GitHub issue exists for this specific bug

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] My code follows the project code style
- [x] For tokenless: cargo clippy -- -D warnings and cargo fmt --check pass
- [x] Lock files are up to date

## Testing

**Rust CI** (full regression):

```bash
cd src/tokenless
cargo fmt --all --check   # pass
cargo clippy --workspace -- -D warnings  # pass
cargo test --workspace    # 29 tests pass
```

**Python hook functional validation** (5 scenarios):

| Scenario | tool-ready | compress-response | rewrite-hook |
|---|---|---|---|
| FHS install (/usr/share/...) | exit 0 | exit 0 | exit 0 |
| Source tree (relative path) | exit 0 | exit 0 | exit 0 |
| Codex plugin cache (relative fails, FHS fallback) | exit 0 | exit 0 | exit 0 |
| HOME env attack (HOME=/tmp/evil) | exit 0 (rejects fake home) | exit 0 | -- |
| World-writable parent dir | is_trusted_dir = False | -- | -- |

## Additional Notes

The trust model is now consistent across three implementation layers:
- **Rust**: `is_trusted_path()` in `env_check.rs` + `getpwuid_r` in `home.rs`
- **Bash**: `is_trusted_file()` in `tool_ready_hook.sh` + `getent passwd` in `tokenless-env-fix.sh`
- **Python**: `_is_trusted_dir()` in codex hook scripts + `pwd.getpwuid` for home resolution
