### PR TITLE
fix(sight): harden compressed SSE decode

### DIFF
--- a/src/agentsight/src/aggregator/http/aggregator.rs
+++ b/src/agentsight/src/aggregator/http/aggregator.rs
@@ -13,6 +13,14 @@ use crate::probes::sslsniff::SslEvent;
 use lru::LruCache;
 use std::num::NonZeroUsize;
 
+/// Hard cap on a *compressed* SSE buffer awaiting completion. A malicious or
+/// buggy stream that never sends a chunk terminator would otherwise grow this
+/// buffer unboundedly — the decompression output cap in `utils::decompress`
+/// does not help here because decoding only runs once the stream completes.
+/// 8 MiB of compressed SSE is far beyond any real stream; on overflow the
+/// stream is finalized best-effort so memory stays bounded.
+const MAX_COMPRESSED_SSE_BUFFER: usize = 8 * 1024 * 1024;
+
 /// Connection identifier - uniquely identifies an SSL connection
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct ConnectionId {
@@ -167,27 +175,23 @@ impl HttpConnectionAggregator {
     /// Finish a compressed SSE stream: de-frame chunked transfer-encoding,
     /// decompress the buffered body, parse it into SSE events, and build the
     /// aggregated result (mirrors the live `SseComplete` construction).
-    fn finish_compressed_sse(
-        connection_id: ConnectionId,
-        request: Option<ParsedRequest>,
-        response_headers: ParsedResponse,
-        content_encoding: Option<String>,
-        raw_buffer: Vec<u8>,
-    ) -> AggregatedResult {
-        let is_chunked = response_headers
-            .headers
-            .get("transfer-encoding")
-            .map(|v| v.to_lowercase().contains("chunked"))
-            .unwrap_or(false);
+    /// Decode a buffered *compressed* SSE body into parsed events. Shared by the
+    /// live completion path (`finish_compressed_sse`) and the drain path
+    /// (`drain_and_persist_dead_connections`) so both decode identically. `src`
+    /// supplies provenance (pid/tid/uid/comm/timestamps) for the synthetic event
+    /// handed to the parser.
+    pub(crate) fn decode_compressed_sse(
+        raw_buffer: &[u8],
+        content_encoding: Option<&str>,
+        is_chunked: bool,
+        src: &SslEvent,
+    ) -> Vec<ParsedSseEvent> {
         let body = if is_chunked {
-            crate::utils::decompress::dechunk_body(&raw_buffer)
+            crate::utils::decompress::dechunk_body(raw_buffer)
         } else {
-            raw_buffer
+            raw_buffer.to_vec()
         };
-        let decompressed =
-            crate::utils::decompress::decompress_body(&body, content_encoding.as_deref());
-
-        let src = &response_headers.source_event;
+        let decompressed = crate::utils::decompress::decompress_body(&body, content_encoding);
         let synthetic = std::rc::Rc::new(SslEvent {
             source: src.source,
             timestamp_ns: src.timestamp_ns,
@@ -202,7 +206,32 @@ impl HttpConnectionAggregator {
             is_handshake: src.is_handshake,
             ssl_ptr: src.ssl_ptr,
         });
-        let sse_events = SseParser::new().parse(synthetic);
+        SseParser::new().parse(synthetic)
+    }
+
+    /// Whether a response declares chunked transfer-encoding.
+    pub(crate) fn is_chunked_response(response_headers: &ParsedResponse) -> bool {
+        response_headers
+            .headers
+            .get("transfer-encoding")
+            .map(|v| v.to_lowercase().contains("chunked"))
+            .unwrap_or(false)
+    }
+
+    fn finish_compressed_sse(
+        connection_id: ConnectionId,
+        request: Option<ParsedRequest>,
+        response_headers: ParsedResponse,
+        content_encoding: Option<String>,
+        raw_buffer: Vec<u8>,
+    ) -> AggregatedResult {
+        let is_chunked = Self::is_chunked_response(&response_headers);
+        let sse_events = Self::decode_compressed_sse(
+            &raw_buffer,
+            content_encoding.as_deref(),
+            is_chunked,
+            &response_headers.source_event,
+        );
         log::debug!(
             "[HttpAggregator] Decoded compressed SSE | conn={connection_id:?} | encoding={content_encoding:?} | events={}",
             sse_events.len(),
@@ -313,7 +342,7 @@ impl HttpConnectionAggregator {
                         Self::sse_entry_state(&response_headers);
                     response_headers.body_len = 0;
                     if let Some(buf) = &compressed_buffer {
-                        if buf.windows(5).any(|w| w == b"0\r\n\r\n") {
+                        if crate::utils::decompress::chunked_stream_complete(buf) {
                             return Some(Self::finish_compressed_sse(
                                 connection_id,
                                 Some(completed_request),
@@ -352,7 +381,7 @@ impl HttpConnectionAggregator {
                     response_headers.body_len = 0;
                     // Transition to SSE active state, wait for SSE events
                     if let Some(buf) = &compressed_buffer {
-                        if buf.windows(5).any(|w| w == b"0\r\n\r\n") {
+                        if crate::utils::decompress::chunked_stream_complete(buf) {
                             return Some(Self::finish_compressed_sse(
                                 connection_id,
                                 Some(request),
@@ -398,7 +427,7 @@ impl HttpConnectionAggregator {
                         Self::sse_entry_state(&response_headers);
                     response_headers.body_len = 0;
                     if let Some(buf) = &compressed_buffer {
-                        if buf.windows(5).any(|w| w == b"0\r\n\r\n") {
+                        if crate::utils::decompress::chunked_stream_complete(buf) {
                             return Some(Self::finish_compressed_sse(
                                 connection_id,
                                 None,
@@ -514,7 +543,19 @@ impl HttpConnectionAggregator {
                 // terminator, then de-frame + decompress + parse.
                 let data = &ssl_event.buf[..ssl_event.buf_size() as usize];
                 buf.extend_from_slice(data);
-                if buf.windows(5).any(|w| w == b"0\r\n\r\n") {
+                if buf.len() > MAX_COMPRESSED_SSE_BUFFER {
+                    log::warn!(
+                        "[HttpAggregator] compressed SSE buffer exceeded {MAX_COMPRESSED_SSE_BUFFER} bytes, finalizing best-effort | conn={connection_id:?}"
+                    );
+                    return Some(Self::finish_compressed_sse(
+                        connection_id,
+                        request,
+                        response_headers,
+                        content_encoding,
+                        buf,
+                    ));
+                }
+                if crate::utils::decompress::chunked_stream_complete(&buf) {
                     Some(Self::finish_compressed_sse(
                         connection_id,
                         request,
@@ -1418,6 +1459,116 @@ mod tests {
             }
             other => panic!("expected SseComplete, got {other:?}"),
         }
+    }
+
+    /// Put `aggregator` into a compressed (zstd, chunked) `SseActive` state with
+    /// an empty buffer, ready to receive body fragments via
+    /// `process_raw_body_data`.
+    fn enter_compressed_sse_active(
+        aggregator: &mut HttpConnectionAggregator,
+        pid: u32,
+        ssl_ptr: u64,
+    ) {
+        let req_event = create_mock_ssl_event(pid, ssl_ptr);
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            path: "/v1/messages".to_string(),
+            version: 11,
+            headers: HashMap::new(),
+            body_offset: 0,
+            body_len: 0,
+            source_event: req_event,
+            reassembled_body: None,
+        };
+        aggregator.process_request(request);
+
+        let resp_event = create_mock_ssl_event_with_buf(pid, ssl_ptr, Vec::new(), 0);
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "text/event-stream".to_string());
+        headers.insert("content-encoding".to_string(), "zstd".to_string());
+        headers.insert("transfer-encoding".to_string(), "chunked".to_string());
+        let response = ParsedResponse {
+            version: 11,
+            status_code: 200,
+            reason: "OK".to_string(),
+            headers,
+            body_offset: 0,
+            body_len: 0,
+            source_event: resp_event,
+        };
+        aggregator.process_response(response);
+    }
+
+    fn raw_frag(pid: u32, ssl_ptr: u64, buf: Vec<u8>) -> SslEvent {
+        SslEvent {
+            source: 0,
+            timestamp_ns: 2000,
+            delta_ns: 0,
+            pid,
+            tid: 1,
+            uid: 0,
+            len: buf.len() as u32,
+            rw: 0,
+            comm: String::new(),
+            buf,
+            is_handshake: false,
+            ssl_ptr,
+        }
+    }
+
+    #[test]
+    fn compressed_completion_ignores_embedded_terminator() {
+        // fix(#973): completion must walk chunk framing, not scan the raw bytes
+        // for b"0\r\n\r\n" — that pattern can occur *inside* a compressed payload
+        // and finish the stream early, truncating it so the call is silently
+        // dropped. Reverting to `windows(5).any` makes this return Some and fail.
+        let mut aggregator = HttpConnectionAggregator::new();
+        enter_compressed_sse_active(&mut aggregator, 9, 0x900);
+
+        let data = b"AB0\r\n\r\nCD"; // chunk data that itself contains the terminator
+        let mut raw = Vec::new();
+        raw.extend_from_slice(format!("{:x}\r\n", data.len()).as_bytes());
+        raw.extend_from_slice(data);
+        raw.extend_from_slice(b"\r\n"); // chunk-data CRLF, but NO zero-size chunk yet
+        assert!(
+            raw.windows(5).any(|w| w == b"0\r\n\r\n"),
+            "precondition: the old naive scan WOULD falsely finish here"
+        );
+
+        let result = aggregator.process_raw_body_data(&raw_frag(9, 0x900, raw));
+        assert!(
+            result.is_none(),
+            "embedded terminator must not finish the stream prematurely"
+        );
+    }
+
+    #[test]
+    fn compressed_buffer_cap_finalizes_when_exceeded() {
+        // fix(#973): a never-terminating compressed stream must not grow the
+        // buffer unboundedly; past MAX_COMPRESSED_SSE_BUFFER it finalizes
+        // best-effort. Without the cap this keeps buffering (returns None).
+        let mut aggregator = HttpConnectionAggregator::new();
+        enter_compressed_sse_active(&mut aggregator, 10, 0xA00);
+
+        let over = vec![b'x'; MAX_COMPRESSED_SSE_BUFFER + 1024]; // over cap, no terminator
+        let result = aggregator.process_raw_body_data(&raw_frag(10, 0xA00, over));
+        assert!(
+            result.is_some(),
+            "over-cap compressed buffer must finalize early, not keep buffering"
+        );
+    }
+
+    #[test]
+    fn decode_compressed_sse_decodes_chunked_zstd() {
+        // The shared decode reused by both the live finalizer and the drain path.
+        let (_plain, chunked) = make_zstd_chunked_sse();
+        let src = create_mock_ssl_event(11, 0xB00);
+        let events =
+            HttpConnectionAggregator::decode_compressed_sse(&chunked, Some("zstd"), true, &src);
+        assert!(
+            !events.is_empty(),
+            "must decode chunked zstd SSE into parsed events"
+        );
     }
 
     #[test]

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -1276,9 +1276,24 @@ impl AgentSight {
                 ConnectionState::RequestPending { request } => ("RequestPending", request, vec![]),
                 ConnectionState::SseActive {
                     request: Some(req),
+                    response_headers,
                     sse_events,
-                    ..
-                } => ("SseActive", req, sse_events),
+                    compressed_buffer,
+                    content_encoding,
+                } => {
+                    // A *compressed* SSE stream buffers raw bytes and only decodes at
+                    // completion. If the PID died before the stream completed (e.g.
+                    // HTTP/2, no `0\r\n\r\n` terminator), sse_events is empty and the
+                    // body — model/tokens/output — would be lost on drain. Recover it
+                    // via the same decode path as the live finalizer.
+                    let events = drained_sse_events(
+                        sse_events,
+                        compressed_buffer,
+                        content_encoding,
+                        &response_headers,
+                    );
+                    ("SseActive", req, events)
+                }
                 _ => continue,
             };
 
@@ -1722,6 +1737,27 @@ impl Drop for AgentSight {
     }
 }
 
+fn drained_sse_events(
+    sse_events: Vec<crate::parser::sse::ParsedSseEvent>,
+    compressed_buffer: Option<Vec<u8>>,
+    content_encoding: Option<String>,
+    response_headers: &crate::parser::http::ParsedResponse,
+) -> Vec<crate::parser::sse::ParsedSseEvent> {
+    match compressed_buffer {
+        Some(ref buf) if sse_events.is_empty() && !buf.is_empty() => {
+            let is_chunked =
+                crate::aggregator::HttpConnectionAggregator::is_chunked_response(response_headers);
+            crate::aggregator::HttpConnectionAggregator::decode_compressed_sse(
+                buf,
+                content_encoding.as_deref(),
+                is_chunked,
+                &response_headers.source_event,
+            )
+        }
+        _ => sse_events,
+    }
+}
+
 /// Complete deferred GenAI events: promote pending DB rows to 'complete',
 /// then export to non-SQLite exporters (or FFI).
 ///
@@ -1777,6 +1813,12 @@ fn complete_deferred_genai(
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    use crate::parser::http::ParsedResponse;
+    use crate::parser::sse::ParsedSseEvent;
+    use crate::probes::sslsniff::SslEvent;
+    use std::collections::HashMap;
+    use std::rc::Rc;
 
     /// Generate a unique temp directory for each test invocation.
     fn unique_tmp_dir(tag: &str) -> PathBuf {
@@ -2001,5 +2043,87 @@ mod tests {
             vec![Box::new(RecordingExporter::new("test-recorder"))];
 
         complete_deferred_genai(&[event], None, &exporters, None);
+    }
+
+    fn ssl_event() -> Rc<SslEvent> {
+        Rc::new(SslEvent {
+            source: 0,
+            timestamp_ns: 0,
+            delta_ns: 0,
+            pid: 1,
+            tid: 1,
+            uid: 0,
+            len: 0,
+            rw: 0,
+            comm: String::new(),
+            buf: Vec::new(),
+            is_handshake: false,
+            ssl_ptr: 0x1,
+        })
+    }
+
+    /// A zstd-compressed, chunk-framed SSE body (the #973 shape).
+    fn chunked_zstd_sse() -> Vec<u8> {
+        let sse = b"event: message_start\ndata: {\"type\":\"message_start\"}\n\ndata: [DONE]\n\n";
+        let comp = zstd::encode_all(&sse[..], 3).unwrap();
+        let mut chunked = Vec::new();
+        chunked.extend_from_slice(format!("{:x}\r\n", comp.len()).as_bytes());
+        chunked.extend_from_slice(&comp);
+        chunked.extend_from_slice(b"\r\n0\r\n\r\n");
+        chunked
+    }
+
+    fn chunked_zstd_response() -> ParsedResponse {
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "text/event-stream".to_string());
+        headers.insert("content-encoding".to_string(), "zstd".to_string());
+        headers.insert("transfer-encoding".to_string(), "chunked".to_string());
+        ParsedResponse {
+            version: 11,
+            status_code: 200,
+            reason: "OK".to_string(),
+            headers,
+            body_offset: 0,
+            body_len: 0,
+            source_event: ssl_event(),
+        }
+    }
+
+    #[test]
+    fn drained_sse_events_decodes_unfinalized_compressed_stream() {
+        // fix(#973): a compressed stream that died before finalizing (events empty,
+        // buffer non-empty) must be DECODED on drain, not lost. Reverting the drain
+        // decode yields an empty vec here, so this is discriminating.
+        let events = drained_sse_events(
+            vec![],
+            Some(chunked_zstd_sse()),
+            Some("zstd".to_string()),
+            &chunked_zstd_response(),
+        );
+        assert!(
+            !events.is_empty(),
+            "compressed buffer must be decoded into events on drain"
+        );
+    }
+
+    #[test]
+    fn drained_sse_events_passes_through_when_no_buffer() {
+        // Uncompressed stream: no compressed_buffer -> nothing to decode.
+        let out = drained_sse_events(vec![], None, None, &chunked_zstd_response());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn drained_sse_events_does_not_redecode_when_events_present() {
+        // Live parsing already produced events -> pass them through, don't re-decode.
+        let existing = vec![ParsedSseEvent::new(None, None, None, 0, 0, ssl_event())];
+        let n = existing.len();
+        let out = drained_sse_events(
+            existing,
+            Some(chunked_zstd_sse()),
+            Some("zstd".to_string()),
+            &chunked_zstd_response(),
+        );
+        assert_eq!(out.len(), n, "non-empty events must pass through unchanged");
     }
 }

--- a/src/agentsight/src/utils/decompress.rs
+++ b/src/agentsight/src/utils/decompress.rs
@@ -8,6 +8,43 @@
 
 use std::io::Read;
 
+/// Hard cap on a single decompressed body. Decompression operates on traffic
+/// from observed, untrusted processes, where a crafted "compression bomb" (a
+/// few KB expanding to many GB) could OOM the single privileged observer and
+/// take down the whole observation plane. 32 MiB clears even a maximal
+/// extended-thinking response (bounded by output tokens) while keeping peak
+/// memory to a small multiple of the cap (not the GB a bomb would reach),
+/// regardless of ratio. An over-cap body falls back to raw (that call's SSE
+/// enrichment is dropped).
+const MAX_DECOMPRESSED_LEN: usize = 32 * 1024 * 1024;
+
+/// Decompress through `reader` with a hard output cap (bomb defense). Reads at
+/// most `MAX_DECOMPRESSED_LEN + 1` bytes, so an over-cap stream is detected and
+/// peak memory stays a small multiple of the cap (the read buffer grows by
+/// doubling) rather than the unbounded GB a decompressed bomb would reach; on
+/// over-cap or decoder error it falls back to the raw (still-compressed) `raw`
+/// bytes, matching the existing graceful-degradation policy.
+fn read_capped<R: Read>(mut reader: R, raw: &[u8], codec: &str) -> Vec<u8> {
+    let mut decoded = Vec::new();
+    match reader
+        .by_ref()
+        .take(MAX_DECOMPRESSED_LEN as u64 + 1)
+        .read_to_end(&mut decoded)
+    {
+        Ok(_) if decoded.len() > MAX_DECOMPRESSED_LEN => {
+            log::warn!(
+                "{codec} decompressed output exceeds {MAX_DECOMPRESSED_LEN} bytes, using raw body (possible decompression bomb)"
+            );
+            raw.to_vec()
+        }
+        Ok(_) => decoded,
+        Err(e) => {
+            log::warn!("{codec} decompression failed ({e:?}), using raw body");
+            raw.to_vec()
+        }
+    }
+}
+
 /// Decompress an HTTP body based on its `Content-Encoding` header value.
 ///
 /// - `None` or `"identity"` → return body unchanged
@@ -53,47 +90,24 @@ pub fn decompress_body(body: &[u8], content_encoding: Option<&str>) -> Vec<u8> {
 
     match effective_encoding.as_deref() {
         Some("gzip") | Some("x-gzip") => {
-            let mut decoded = Vec::new();
-            match flate2::read::GzDecoder::new(body).read_to_end(&mut decoded) {
-                Ok(_) => decoded,
-                Err(e) => {
-                    log::warn!("gzip decompression failed ({e:?}), using raw body");
-                    body.to_vec()
-                }
-            }
+            read_capped(flate2::read::GzDecoder::new(body), body, "gzip")
         }
-        Some("deflate") => {
-            let mut decoded = Vec::new();
-            match flate2::read::DeflateDecoder::new(body).read_to_end(&mut decoded) {
-                Ok(_) => decoded,
-                Err(e) => {
-                    log::warn!("deflate decompression failed ({e:?}), using raw body");
-                    body.to_vec()
-                }
-            }
-        }
+        Some("deflate") => read_capped(flate2::read::DeflateDecoder::new(body), body, "deflate"),
         Some("zstd") => {
-            // `decode_all` handles a stream of one or more concatenated frames,
-            // which is what a flushed-per-event zstd SSE stream produces.
-            match zstd::decode_all(body) {
-                Ok(decoded) => decoded,
+            // A streaming decoder (capped via `read_capped`) replaces
+            // `zstd::decode_all`, which would allocate the full output up front
+            // and so could not bound a bomb. `read::Decoder` still consumes the
+            // whole reader, i.e. all concatenated frames of a flushed-per-event
+            // zstd SSE stream.
+            match zstd::stream::read::Decoder::new(body) {
+                Ok(decoder) => read_capped(decoder, body, "zstd"),
                 Err(e) => {
                     log::warn!("zstd decompression failed ({e:?}), using raw body");
                     body.to_vec()
                 }
             }
         }
-        Some("br") => {
-            let mut decoded = Vec::new();
-            let mut reader = brotli::Decompressor::new(body, 4096);
-            match reader.read_to_end(&mut decoded) {
-                Ok(_) => decoded,
-                Err(e) => {
-                    log::warn!("brotli decompression failed ({e:?}), using raw body");
-                    body.to_vec()
-                }
-            }
-        }
+        Some("br") => read_capped(brotli::Decompressor::new(body, 4096), body, "brotli"),
         _ => body.to_vec(),
     }
 }
@@ -146,6 +160,48 @@ pub fn dechunk_body(raw: &[u8]) -> Vec<u8> {
         i += 2;
     }
     out
+}
+
+/// Whether a chunk-framed body contains the terminating zero-size chunk, i.e.
+/// the stream is complete. Unlike scanning the raw bytes for `b"0\r\n\r\n"`
+/// (which can match by chance *inside* a compressed payload and finish a stream
+/// prematurely — truncating the body so decompression fails and the call is
+/// silently dropped), this walks the chunk framing and only reports completion
+/// at a real zero-size chunk boundary. Mirrors `dechunk_body`'s parser.
+pub fn chunked_stream_complete(raw: &[u8]) -> bool {
+    let mut i = 0;
+    while i < raw.len() {
+        // Find the CRLF terminating the chunk-size line.
+        let mut j = i;
+        while j + 1 < raw.len() && !(raw[j] == b'\r' && raw[j + 1] == b'\n') {
+            j += 1;
+        }
+        if j + 1 >= raw.len() {
+            return false; // incomplete chunk-size line
+        }
+        let size_line = &raw[i..j];
+        let hex_end = size_line
+            .iter()
+            .position(|&b| b == b';')
+            .unwrap_or(size_line.len());
+        let size = match std::str::from_utf8(&size_line[..hex_end])
+            .ok()
+            .map(|s| s.trim())
+            .and_then(|s| usize::from_str_radix(s, 16).ok())
+        {
+            Some(s) => s,
+            None => return false, // malformed size line
+        };
+        i = j + 2; // skip CRLF after the size line
+        if size == 0 {
+            return true; // terminating zero-size chunk reached
+        }
+        if i + size > raw.len() {
+            return false; // incomplete final chunk
+        }
+        i += size + 2; // skip chunk data + its trailing CRLF
+    }
+    false
 }
 
 /// Convenience: decompress and then convert to String.
@@ -306,5 +362,93 @@ mod tests {
         let dechunked = dechunk_body(&chunked);
         assert_eq!(dechunked, comp);
         assert_eq!(decompress_body(&dechunked, Some("zstd")), sse);
+    }
+
+    #[test]
+    fn zstd_multiframe_still_decodes() {
+        // Regression guard: replacing `zstd::decode_all` with a streaming capped
+        // decoder must NOT drop concatenated frames — a flushed-per-event zstd
+        // SSE stream is multiple frames back-to-back.
+        let f1 = zstd::encode_all(&b"event: a\ndata: {\"x\":1}\n\n"[..], 3).unwrap();
+        let f2 = zstd::encode_all(&b"event: b\ndata: {\"y\":2}\n\n"[..], 3).unwrap();
+        let mut concat = f1;
+        concat.extend_from_slice(&f2);
+        let out = decompress_body(&concat, Some("zstd"));
+        assert_eq!(
+            out, b"event: a\ndata: {\"x\":1}\n\nevent: b\ndata: {\"y\":2}\n\n",
+            "multi-frame zstd must decode all frames, not just the first"
+        );
+    }
+
+    #[test]
+    fn zstd_bomb_falls_back_to_raw() {
+        // A high-ratio zstd stream expanding past the cap must fall back to the
+        // raw (tiny) body, bounding memory — NOT allocate the full expansion.
+        let huge = vec![0u8; MAX_DECOMPRESSED_LEN + 1024 * 1024];
+        let bomb = zstd::encode_all(&huge[..], 3).unwrap();
+        assert!(
+            bomb.len() < 1024 * 1024,
+            "precondition: bomb is tiny compressed"
+        );
+        let out = decompress_body(&bomb, Some("zstd"));
+        assert_eq!(out, bomb, "over-cap zstd must fall back to raw, not expand");
+        assert!(
+            out.len() <= MAX_DECOMPRESSED_LEN,
+            "output must be bounded by the cap"
+        );
+    }
+
+    #[test]
+    fn gzip_bomb_falls_back_to_raw() {
+        let huge = vec![0u8; MAX_DECOMPRESSED_LEN + 1024 * 1024];
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+        enc.write_all(&huge).unwrap();
+        let bomb = enc.finish().unwrap();
+        let out = decompress_body(&bomb, Some("gzip"));
+        assert_eq!(out, bomb, "over-cap gzip must fall back to raw");
+    }
+
+    #[test]
+    fn under_cap_still_decompresses_fully() {
+        // Discriminating: a large-but-under-cap body must still decompress in
+        // full, so the cap does not break legitimate large SSE responses.
+        let big = vec![b'x'; 2 * 1024 * 1024]; // 2 MiB, well under the cap
+        let comp = zstd::encode_all(&big[..], 3).unwrap();
+        assert_eq!(decompress_body(&comp, Some("zstd")), big);
+    }
+
+    #[test]
+    fn chunked_stream_complete_detects_terminator() {
+        assert!(chunked_stream_complete(b"5\r\nhello\r\n0\r\n\r\n"));
+        assert!(chunked_stream_complete(
+            b"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
+        ));
+    }
+
+    #[test]
+    fn chunked_stream_complete_false_until_terminator() {
+        assert!(!chunked_stream_complete(b"5\r\nhello\r\n")); // mid-stream, no zero chunk
+        assert!(!chunked_stream_complete(b"a\r\nabc")); // incomplete final data
+        assert!(!chunked_stream_complete(b"zz\r\ndata\r\n0\r\n\r\n")); // malformed size
+    }
+
+    #[test]
+    fn chunked_stream_complete_ignores_embedded_terminator() {
+        // THE bug this fixes: the 5-byte terminator pattern occurs *inside* a
+        // chunk's data while the stream is NOT complete. Naive `windows(5).any`
+        // would wrongly report complete; framing-aware parsing must not be fooled.
+        let payload = b"AB0\r\n\r\nCD"; // contains b"0\r\n\r\n" inside the data
+        let mut raw = Vec::new();
+        raw.extend_from_slice(format!("{:x}\r\n", payload.len()).as_bytes());
+        raw.extend_from_slice(payload);
+        raw.extend_from_slice(b"\r\n"); // chunk-data CRLF, but no zero chunk yet
+        assert!(
+            raw.windows(5).any(|w| w == b"0\r\n\r\n"),
+            "precondition: the naive scan WOULD falsely match"
+        );
+        assert!(
+            !chunked_stream_complete(&raw),
+            "framing-aware check must not be fooled by an embedded terminator"
+        );
     }
 }


### PR DESCRIPTION
## Description

Harden the compressed-SSE decode path against three issues:

**1. Decompression bomb.** The decoders (gzip/deflate/zstd/brotli) had no output cap, so a crafted bomb from an observed, untrusted process could OOM the single privileged observer and take down the whole observation plane. Add `MAX_DECOMPRESSED_LEN` (32 MiB) via `Read::take` with a raw fallback; zstd moves off `decode_all` to a streaming `Decoder`. Also cap the in-flight compressed buffer (8 MiB) against a never-terminating stream.

**2. Premature completion.** Scanning the compressed buffer for the chunk terminator `0\r\n\r\n` can match by chance inside a compressed payload and finish the stream early — truncating the body so decompression fails and the call is silently dropped. Detect completion via chunk framing (`chunked_stream_complete`) instead.

**3. Drain data loss.** `drain_and_persist_dead_connections` dropped `compressed_buffer`, so a compressed stream that died before completing (e.g. HTTP/2, which has no chunk terminator) lost its whole body. Decode it on drain via the shared `decode_compressed_sse` / `drained_sse_events`.

## Related Issue

no-issue: hardening of the compressed-SSE decode path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/utils/decompress.rs`: output cap + `read_capped` (streaming zstd, raw fallback); framing-aware `chunked_stream_complete()`.
- `src/aggregator/http/aggregator.rs`: completion via `chunked_stream_complete`; 8 MiB compressed-buffer cap with best-effort finalize; extracted `decode_compressed_sse` / `is_chunked_response`.
- `src/unified.rs`: drain decodes the buffered compressed body via `drained_sse_events`.

## Checklist

- [x] `cargo +1.89.0 fmt --all --check` pass
- [x] `cargo +1.89.0 clippy --all-targets -- -D warnings` pass
- [x] arch-boundary check pass
- [x] `cargo llvm-cov` + `diff-cover --fail-under=80` pass (93%)
- [x] I have added tests

## Testing

**已在 ECS 验证（kernel 6.6.102+, rustc 1.89.0）:**

- `cargo build --release`（含 BPF clang 编译）通过；agentsight 启动、加载全部 BPF 探针、per-process attach 正常 —— 改动无构建/运行回归。

**已单测（判别性，撤回对应修复即失败）:**

- 解压 bomb：gzip/zstd 超 cap → 回退 raw（内存不爆 GB）；under-cap 2 MiB 仍完整解；multi-frame zstd 不回归。
- 完成判定：压缩负载内含 `0\r\n\r\n` 但流未真正结束 → 不提前 finish（`chunked_stream_complete` 抗嵌入终止符）。
- 压缩缓冲 cap：超 cap → best-effort finalize，避免无限增长。
- drain 解码决策：压缩流未完成（事件空、buffer 非空）→ 解码出事件；无 buffer → 透传；已有事件 → 不重解。

**未做（已知）:** 完整 live capture→decode E2E（真 BPF 抓一条压缩 SSE → 走解码）。原因：测试主机够不着会压缩 SSE 的端点（可用的端点要么不压缩，要么仅内网可达）。解码逻辑由上述判别单测覆盖。
