### PR TITLE
feat(anolisa): adopt pre-installed system RPMs as rpm-observed

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -83,7 +83,7 @@ pub enum ComponentCommands {
     /// List available components from remote catalog
     #[command(visible_alias = "ls")]
     List(tier1::list::ListArgs),
-    /// Install a component from a configured backend (raw today; yum/npm planned)
+    /// Install a component from a configured backend (raw today; rpm/npm planned)
     Install(tier1::install::InstallArgs),
     /// Uninstall a component
     Uninstall(tier1::uninstall::UninstallArgs),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -8,8 +8,16 @@
 //! from the raw repository root, resolve an artifact, then execute by
 //! downloading it with mandatory sha256 verification, loading the install
 //! contract, installing the declared files, and recording state plus a
-//! central-log audit entry. `yum` / `npm` backends are selectable but their
-//! executors are NOT_IMPLEMENTED.
+//! central-log audit entry.
+//!
+//! The `rpm` backend additionally supports **adopt** (issue #958): in system
+//! mode, when a component is already present as a system RPM, `install`
+//! records it as `rpm-observed` state without downloading or running
+//! `dnf install`. The backend decision is two-layered — pick a backend name
+//! (`--backend` > existing state > system RPM presence > `default_backend`),
+//! then pick an action by `(backend, rpmdb hit, install mode)`. Delegated
+//! `dnf install` for not-yet-installed RPM components is out of scope (#959),
+//! and `npm` remains NOT_IMPLEMENTED.
 //!
 //! Deliberately out of scope for this milestone: execution-policy gating,
 //! pre/post hooks, health checks, and service start/enable. Installed
@@ -31,21 +39,23 @@ use anolisa_core::lock::InstallLock;
 use anolisa_core::path_safety::validate_owned_path;
 use anolisa_core::state::{
     FileOwner, InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind,
-    ObjectStatus, OperationRecord, OwnedFile, Ownership, ServiceRef,
+    ObjectStatus, OperationRecord, OwnedFile, Ownership, RpmMetadata, ServiceRef,
 };
 use anolisa_core::{
     ArtifactType, ComponentManifest, DistributionEntry, DistributionIndex, FileKind, ResolveQuery,
     expand_layout_placeholders,
 };
 use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
+use anolisa_platform::rpm_query::RpmPackageQuery;
 use chrono::{SecondsFormat, Utc};
 
 use crate::color::Palette;
 use crate::commands::common;
-use crate::context::CliContext;
+use crate::context::{CliContext, InstallMode};
 use crate::repo_config::{
-    HostVars, RepoConfig, RepoConfigError, normalize_override_url, raw_artifact_url, raw_index_url,
-    raw_relative_root,
+    BackendConfig, HostVars, RepoConfig, RepoConfigError, normalize_override_url, raw_artifact_url,
+    raw_index_url, raw_relative_root,
 };
 use crate::response::{CliError, render_json, render_json_with_status};
 
@@ -74,7 +84,7 @@ pub struct InstallArgs {
     /// Install a specific version instead of the latest in the channel
     #[arg(long, value_name = "VERSION")]
     pub version: Option<String>,
-    /// Backend override (raw | yum | npm); defaults to repo.toml default_backend
+    /// Backend override (raw | rpm | npm); defaults to repo.toml default_backend
     #[arg(long, value_name = "BACKEND")]
     pub backend: Option<String>,
     /// One-off base_url override for the selected backend
@@ -167,6 +177,33 @@ struct InstallResultPayload {
     warnings: Vec<String>,
 }
 
+/// What `handle_one` did, so `--all` can distinguish a fresh install from an
+/// RPM adopt in its batch summary (§7.5). The dry-run vs real distinction is
+/// layered on by the caller from [`CliContext::dry_run`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallOutcome {
+    /// A raw install (downloaded + placed files, or its dry-run preview).
+    Installed,
+    /// An existing system RPM recorded as `rpm-observed` (or its dry-run
+    /// preview); no bytes fetched, no owned files written.
+    Adopted,
+}
+
+/// Source that decided the backend name in layer 1 (§4). Only used to phrase
+/// conflict errors; the action is chosen by layer 2 from `(backend, rpmdb,
+/// mode)`, independent of how the name was picked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackendSource {
+    /// Explicit `--backend`.
+    Explicit,
+    /// Component already in state; backend follows its recorded provenance.
+    ExistingState,
+    /// State miss; system mode + rpmdb hit selected `rpm`.
+    SystemRpm,
+    /// None of the above; fell back to `default_backend`.
+    Default,
+}
+
 pub fn handle(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
     if args.fail_fast && !args.all {
         return Err(CliError::InvalidArgument {
@@ -183,22 +220,130 @@ pub fn handle(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
         .component
         .clone()
         .expect("clap ArgGroup ensures component is set when --all is absent");
-    handle_one(component, args, ctx)
+    handle_one(component, args, ctx).map(|_| ())
 }
 
-fn handle_one(component: String, args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
+fn handle_one(
+    component: String,
+    args: InstallArgs,
+    ctx: &CliContext,
+) -> Result<InstallOutcome, CliError> {
+    // Production uses the real rpm/dnf-backed query; tests inject a fake via
+    // `handle_one_with_query`. Construction is side-effect-free (it only holds
+    // a command runner), so building it on the raw path costs nothing.
+    let query = RpmPackageQuery::system();
+    handle_one_with_query(component, args, ctx, &query)
+}
+
+/// Core of [`handle_one`] with the package query injected, so tests can drive
+/// the adopt path without a live rpmdb.
+fn handle_one_with_query(
+    component: String,
+    args: InstallArgs,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+) -> Result<InstallOutcome, CliError> {
     let command = format!("install {component}");
 
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
-
-    // — Resolution chain: repo.toml → backend → base_url → package. —
     let repo_config = RepoConfig::load(&layout).map_err(|err| repo_config_err(err, false))?;
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+
+    // ── Layer 1: pick the backend name + its source (§4). ──
+    //
+    // Priority: explicit --backend > existing state > system RPM presence
+    // (system mode only) > default_backend. The system-RPM probe runs only
+    // when nothing earlier decided, so non-RPM hosts and the common raw path
+    // never shell out to rpm/dnf.
+    let mut adopt_situation: Option<RpmSituation> = None;
+    let (backend_name, source): (String, BackendSource) = if let Some(explicit) =
+        args.backend.as_deref()
+    {
+        (explicit.to_string(), BackendSource::Explicit)
+    } else if let Some(label) = installed
+        .find_object(ObjectKind::Component, &component)
+        .and_then(installed_backend_label)
+    {
+        // Provenance is sticky: a re-`install` of an adopted rpm-observed
+        // component lands on `rpm` here and is routed to adopt-refresh by
+        // layer 2, rather than being rejected by the raw trunk.
+        (label.to_string(), BackendSource::ExistingState)
+    } else if ctx.install_mode == InstallMode::System {
+        let situation = probe_rpm_situation(&component, &args, &repo_config, ctx, query, &command)?;
+        if matches!(situation, RpmSituation::Absent) {
+            (repo_config.default_backend.clone(), BackendSource::Default)
+        } else {
+            adopt_situation = Some(situation);
+            ("rpm".to_string(), BackendSource::SystemRpm)
+        }
+    } else {
+        (repo_config.default_backend.clone(), BackendSource::Default)
+    };
+
+    // ── Layer 2: pick the action by (backend, rpmdb, mode) (§7.1). ──
+    if backend_name == "rpm" {
+        return route_rpm_adopt(
+            &component,
+            &args,
+            ctx,
+            &command,
+            &layout,
+            &repo_config,
+            &installed,
+            source,
+            adopt_situation,
+            query,
+        );
+    }
+
+    handle_raw_install(
+        component,
+        args,
+        ctx,
+        &command,
+        &layout,
+        &env,
+        &repo_config,
+        &installed,
+        &backend_name,
+    )
+}
+
+/// Existing raw-backend trunk: repo.toml → base_url → package → resolve →
+/// (dry-run preview | download + execute). Backends other than `raw` that
+/// reach here have no executor yet and return a not-implemented hint.
+#[allow(clippy::too_many_arguments)]
+fn handle_raw_install(
+    component: String,
+    args: InstallArgs,
+    ctx: &CliContext,
+    command: &str,
+    layout: &FsLayout,
+    env: &anolisa_env::EnvFacts,
+    repo_config: &RepoConfig,
+    installed: &InstalledState,
+    backend_name: &str,
+) -> Result<InstallOutcome, CliError> {
+    // Re-resolve through `select_backend` so the configured `[backends.<name>]`
+    // table (base_url, package_map, scope) is in hand. This stays on the raw
+    // path only; the rpm/adopt branch above never calls it (no table required).
     let (backend_name, backend) = repo_config
-        .select_backend(args.backend.as_deref())
-        // Only reachable via --backend (validation guarantees the default
-        // is configured), so this is caller input.
+        .select_backend(Some(backend_name))
         .map_err(|err| repo_config_err(err, true))?;
+
+    ensure_component_backend_compatible(installed, &component, backend_name, command)?;
+
+    // Backend gate: only raw can execute today. The selection above already
+    // validated the name/configuration, so this is purely "executor missing".
+    if backend_name != "raw" {
+        return Err(CliError::not_implemented_with_hint(
+            format!("install --backend {backend_name}"),
+            format!(
+                "the '{backend_name}' backend is configured but its executor is not implemented yet — only 'raw' can install today",
+            ),
+        ));
+    }
 
     let mut warnings: Vec<String> = Vec::new();
     let base_url = match args.repo.as_deref() {
@@ -225,24 +370,10 @@ fn handle_one(component: String, args: InstallArgs, ctx: &CliContext) -> Result<
     };
     let package = repo_config.package_name(backend, &component, args.package.as_deref());
 
-    let installed = common::load_installed_state(ctx, COMMAND)?;
-    ensure_component_backend_compatible(&installed, &component, backend_name, COMMAND)?;
-
-    // Backend gate: only raw can execute today. The selection above already
-    // validated the name/configuration, so this is purely "executor missing".
-    if backend_name != "raw" {
-        return Err(CliError::not_implemented_with_hint(
-            format!("install --backend {backend_name}"),
-            format!(
-                "the '{backend_name}' backend is configured but its executor is not implemented yet — only 'raw' can install today",
-            ),
-        ));
-    }
-
     let resolved = resolve_raw(
         ctx,
-        &layout,
-        &env,
+        layout,
+        env,
         ResolveInputs {
             component,
             package,
@@ -254,12 +385,411 @@ fn handle_one(component: String, args: InstallArgs, ctx: &CliContext) -> Result<
     )?;
 
     if ctx.dry_run {
-        let preview = build_install_preview(ctx, &layout, resolved)?;
-        return render_plan(ctx, &preview);
+        let preview = build_install_preview(ctx, layout, resolved)?;
+        render_plan(ctx, &preview)?;
+        return Ok(InstallOutcome::Installed);
     }
 
-    let prepared = prepare_raw_execution(ctx, &layout, resolved)?;
-    execute_raw(ctx, &layout, &command, prepared)
+    let prepared = prepare_raw_execution(ctx, layout, resolved)?;
+    execute_raw(ctx, layout, command, prepared)?;
+    Ok(InstallOutcome::Installed)
+}
+
+// ── rpm adopt path (#958) ───────────────────────────────────────────
+
+/// Result of probing whether `component` is present as a system RPM (§5/§7.1).
+enum RpmSituation {
+    /// Exactly one candidate package name, installed once — ready to adopt.
+    Adoptable {
+        /// Resolved package name (the candidate that hit rpmdb).
+        package: String,
+        /// rpmdb query result carrying EVR/arch for the state record.
+        info: PackageInfo,
+    },
+    /// Not present as a system RPM: the single candidate is not installed, or
+    /// the host has no rpm tooling at all. Layer 1 falls through to the
+    /// default backend; an explicit `--backend rpm` turns this into the
+    /// "dnf install not implemented" hint (§7.4).
+    Absent,
+    /// `provides` reverse-lookup matched several distinct installed packages
+    /// (§5.5). Reported, never silently adopted.
+    Ambiguous(Vec<String>),
+    /// The candidate resolved but rpmdb holds several installed versions of it
+    /// (`UnexpectedOutput`, §5.5) — a drift state, not a clean adopt target.
+    MultiVersion(String),
+}
+
+/// Resolve the candidate RPM package name(s) for `component` and probe rpmdb.
+///
+/// Errors only when a query hard-fails in a way that is not the host's normal
+/// "absent" signal; a missing `rpm`/`dnf` binary is treated as [`Absent`]
+/// (the host is not RPM-based, so no component can be a system RPM there).
+///
+/// [`Absent`]: RpmSituation::Absent
+fn probe_rpm_situation(
+    component: &str,
+    args: &InstallArgs,
+    repo_config: &RepoConfig,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    command: &str,
+) -> Result<RpmSituation, CliError> {
+    let manifest = load_optional_manifest(ctx, component);
+    let rpm_backend = repo_config.backends.get("rpm");
+    let candidates = rpm_package_candidates(
+        args.package.as_deref(),
+        manifest.as_ref(),
+        rpm_backend,
+        query,
+        component,
+    )
+    .map_err(|err| pkg_query_err(err, command))?;
+
+    if candidates.len() >= 2 {
+        return Ok(RpmSituation::Ambiguous(candidates));
+    }
+    // `rpm_package_candidates` always backfills the default name, so exactly
+    // one candidate remains here.
+    let package = candidates
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| format!("anolisa-{component}"));
+
+    match query.query_installed(&package) {
+        Ok(Some(info)) => Ok(RpmSituation::Adoptable { package, info }),
+        Ok(None) => Ok(RpmSituation::Absent),
+        // Same name, several installed versions: a drift the caller reports.
+        Err(PackageQueryError::UnexpectedOutput { .. }) => Ok(RpmSituation::MultiVersion(package)),
+        // No rpm/dnf on this host → it cannot host system RPMs at all.
+        Err(PackageQueryError::CommandMissing { .. }) => Ok(RpmSituation::Absent),
+        Err(err) => Err(pkg_query_err(err, command)),
+    }
+}
+
+/// Resolve candidate RPM package names for `component`, highest precedence
+/// first (§5): CLI `--package` > manifest `[backends.rpm].package` > repo.toml
+/// `package_map` > RPM `provides` reverse-lookup > default `anolisa-<name>`.
+///
+/// The first four levels short-circuit to a single candidate; only the
+/// `provides` level can yield several (the ambiguous case, §5.5). The default
+/// name backfills whenever `provides` is empty, so the result is never empty.
+///
+/// # Errors
+/// Propagates a hard [`PackageQueryError`] from the `provides` query; an empty
+/// `provides` result is the normal "no contract / no match" branch and falls
+/// through to default naming.
+pub(crate) fn rpm_package_candidates(
+    cli_override: Option<&str>,
+    manifest: Option<&ComponentManifest>,
+    rpm_backend: Option<&BackendConfig>,
+    query: &dyn PackageQuery,
+    component: &str,
+) -> Result<Vec<String>, PackageQueryError> {
+    if let Some(name) = cli_override {
+        return Ok(vec![name.to_string()]);
+    }
+    if let Some(name) = manifest.and_then(ComponentManifest::rpm_package) {
+        return Ok(vec![name.to_string()]);
+    }
+    if let Some(mapped) = rpm_backend.and_then(|b| b.package_map.get(component)) {
+        return Ok(vec![mapped.clone()]);
+    }
+    // Virtual-provides contract (`anolisa-component(<name>)`). It does not yet
+    // exist on the packaging side, so this returns empty today and the chain
+    // falls through to default naming — by design, not an error (§5.3).
+    let provides = query.what_provides_installed(&format!("anolisa-component({component})"))?;
+    if !provides.is_empty() {
+        return Ok(provides);
+    }
+    Ok(vec![format!("anolisa-{component}")])
+}
+
+/// Best-effort lookup of a component's manifest from the bundled catalog, for
+/// the `[backends.rpm].package` mapping level. Adopt does not require a local
+/// manifest (§5.1): any failure or miss yields `None` and the package-name
+/// chain falls through to the lower tiers.
+fn load_optional_manifest(ctx: &CliContext, component: &str) -> Option<ComponentManifest> {
+    let catalog = common::load_bundled_catalog(ctx, COMMAND).ok()?;
+    catalog.component(component).cloned()
+}
+
+/// Layer 2 for the `rpm` backend: reject in user mode, otherwise adopt an
+/// installed package, or surface the ambiguous / drift / not-yet-installed
+/// cases (§7.1). `situation` is reused from layer 1's probe when present
+/// (the `SystemRpm` source), and computed here otherwise (`Explicit` rpm).
+#[allow(clippy::too_many_arguments)]
+fn route_rpm_adopt(
+    component: &str,
+    args: &InstallArgs,
+    ctx: &CliContext,
+    command: &str,
+    layout: &FsLayout,
+    repo_config: &RepoConfig,
+    installed: &InstalledState,
+    source: BackendSource,
+    situation: Option<RpmSituation>,
+    query: &dyn PackageQuery,
+) -> Result<InstallOutcome, CliError> {
+    // Adopt is a system-scope action (§4.1). The only way to reach `rpm` in
+    // user mode is an explicit `--backend rpm`, which we reject rather than
+    // record a system RPM into user-scope state.
+    if ctx.install_mode != InstallMode::System {
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "--backend rpm adopts a system RPM and requires system scope; re-run with --install-mode system (got {} mode)",
+                ctx.install_mode.as_str()
+            ),
+        });
+    }
+
+    // Explicit `--backend rpm` may switch an already-installed component's
+    // provenance; reuse the same guard the raw path uses.
+    if source == BackendSource::Explicit {
+        ensure_component_backend_compatible(installed, component, "rpm", command)?;
+    }
+
+    let situation = match situation {
+        Some(s) => s,
+        None => probe_rpm_situation(component, args, repo_config, ctx, query, command)?,
+    };
+
+    match situation {
+        RpmSituation::Adoptable { package, info } => {
+            execute_adopt(ctx, layout, command, component, package, info, query)
+        }
+        RpmSituation::Absent => Err(CliError::not_implemented_with_hint(
+            format!("install --backend rpm {component}"),
+            "--backend rpm requires the package to be installed for adopt; delegated 'dnf install' is not implemented yet (tracked in #959)"
+                .to_string(),
+        )),
+        RpmSituation::Ambiguous(names) => Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "multiple installed RPMs provide component '{component}': {}; cannot adopt unambiguously — pin one with `--package <name>` or fix the manifest/package_map mapping",
+                names.join(", ")
+            ),
+        }),
+        RpmSituation::MultiVersion(package) => Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "RPM package '{package}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first",
+            ),
+        }),
+    }
+}
+
+/// Wire shape for an adopt result (`--json`) and its dry-run preview.
+#[derive(Serialize)]
+struct AdoptResultPayload {
+    component: String,
+    package: String,
+    backend: &'static str,
+    /// Always `rpm-observed`: adopt only records observation, never ownership.
+    ownership: &'static str,
+    version: String,
+    arch: Option<String>,
+    source_repo: Option<String>,
+    install_mode: String,
+    /// `None` on dry-run (nothing written).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation_id: Option<String>,
+    dry_run: bool,
+    warnings: Vec<String>,
+}
+
+/// Record an installed system RPM as `rpm-observed` state (§7.2). Fetches
+/// nothing, writes no owned files, touches no RPM-owned paths — only rpmdb
+/// reads plus a state write. On `--dry-run` it renders the plan without
+/// writing.
+fn execute_adopt(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    command: &str,
+    component: &str,
+    package: String,
+    info: PackageInfo,
+    query: &dyn PackageQuery,
+) -> Result<InstallOutcome, CliError> {
+    let mut warnings: Vec<String> = Vec::new();
+    // source_repo is supplementary metadata: a failed origin lookup degrades
+    // to `None` with a warning and never fails the adopt (§7.2).
+    let source_repo = match query.installed_origin(&package) {
+        Ok(origin) => origin,
+        Err(err) => {
+            warnings.push(format!(
+                "could not determine source repo for '{package}': {err}"
+            ));
+            None
+        }
+    };
+    let evr = info.version.to_string();
+
+    let mut payload = AdoptResultPayload {
+        component: component.to_string(),
+        package: package.clone(),
+        backend: "rpm",
+        ownership: "rpm-observed",
+        version: evr.clone(),
+        arch: Some(info.arch.clone()),
+        source_repo: source_repo.clone(),
+        install_mode: ctx.install_mode.as_str().to_string(),
+        operation_id: None,
+        dry_run: ctx.dry_run,
+        warnings: warnings.clone(),
+    };
+
+    if ctx.dry_run {
+        render_adopt(ctx, &payload);
+        return Ok(InstallOutcome::Adopted);
+    }
+
+    // Acquire the lock, then load state inside it so a concurrent writer is
+    // not clobbered — mirrors `execute_raw`'s ordering.
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state =
+        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to load installed state: {err}"),
+        })?;
+
+    let started_at = now_iso8601();
+    let lock_ts = Utc::now();
+    let operation_id = format!(
+        "op-install-{}-{}",
+        lock_ts.format("%Y%m%d%H%M%S"),
+        lock_ts.timestamp_subsec_nanos()
+    );
+
+    // Adopt is system-scope by construction (route_rpm_adopt rejects user mode).
+    state.install_mode = StateInstallMode::System;
+    state.prefix = layout.prefix.clone();
+    state.upsert_object(InstalledObject {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        // EVR form, the observed version.
+        version: evr.clone(),
+        // `Adopted` is the lifecycle status (state.rs); `RpmObserved` below is
+        // the orthogonal provenance. Together they model proposal §12 Adopted.
+        status: ObjectStatus::Adopted,
+        manifest_digest: None,
+        // Not an ANOLISA-delivered artifact.
+        distribution_source: None,
+        install_backend: Some("rpm".to_string()),
+        ownership: Some(Ownership::RpmObserved),
+        rpm_metadata: Some(RpmMetadata {
+            package_name: info.name.clone(),
+            evr: Some(evr.clone()),
+            arch: Some(info.arch.clone()),
+            source_repo: source_repo.clone(),
+        }),
+        installed_at: started_at.clone(),
+        last_operation_id: Some(operation_id.clone()),
+        // ANOLISA does not own the file transaction (owns_removal=false).
+        managed: false,
+        // Audit/UI vocabulary: explicit adoption.
+        adopted: true,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        // RPM-owned files stay out of ANOLISA owned-files: status/uninstall
+        // must not treat them as ANOLISA-owned.
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+    });
+    state.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: started_at.clone(),
+        finished_at: Some(now_iso8601()),
+    });
+
+    let state_path = layout.state_dir.join("installed.toml");
+    state.save(&state_path).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to save state: {err}"),
+    })?;
+
+    // Audit log is best-effort: the adopt already persisted, so a log failure
+    // downgrades to a warning instead of unwinding.
+    let log = CentralLog::open(layout.central_log.clone());
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.clone()),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message: format!(
+            "adopted existing RPM package {package} ({evr}) as rpm-observed for component {component}"
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at,
+        finished_at: Some(now_iso8601()),
+        status: Some(LogStatus::Ok),
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: warnings.clone(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = log.append(&record) {
+        eprintln!("warning: failed to write central log: {err}");
+    }
+
+    payload.operation_id = Some(operation_id);
+    render_adopt(ctx, &payload);
+    Ok(InstallOutcome::Adopted)
+}
+
+/// Render an adopt result (JSON envelope or the proposal §6.1 human text).
+/// Silent in quiet mode; the `--all` batch path drives its own summary.
+fn render_adopt(ctx: &CliContext, payload: &AdoptResultPayload) {
+    if ctx.json {
+        // Errors here are unreachable for a plain Serialize struct; ignore the
+        // Result so the (already-persisted) adopt is not reported as failed.
+        let _ = render_json(COMMAND, payload);
+        return;
+    }
+    if ctx.quiet {
+        return;
+    }
+    let color = Palette::new(ctx.no_color);
+    let repo = payload.source_repo.as_deref().unwrap_or("unknown repo");
+    let suffix = if payload.dry_run {
+        " (dry-run — nothing recorded)"
+    } else {
+        ""
+    };
+    println!(
+        "{} {} ({}, {}){}",
+        color.label("Detected existing RPM package:"),
+        payload.package,
+        payload.version,
+        repo,
+        color.muted(suffix),
+    );
+    println!(
+        "{}",
+        color.ok("Adopted as rpm-observed. ANOLISA will not replace it with raw.")
+    );
+    render_warnings(&payload.warnings, &color);
+}
+
+/// Map a [`PackageQueryError`] onto a CLI error. Spawn/permission/query
+/// failures are runtime faults; output-shape problems are runtime faults too
+/// (the caller has already split off the benign "not installed" branches).
+fn pkg_query_err(err: PackageQueryError, command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("rpm query failed: {err}"),
+    }
 }
 
 // ── --all support ───────────────────────────────────────────────────
@@ -283,7 +813,8 @@ struct AllCatalogEntry {
 }
 
 /// Wire shape for a batch entry.  `status` is one of:
-/// `installed` | `planned` (dry-run) | `failed` | `skipped`.
+/// `installed` | `planned` (dry-run) | `adopted` | `adopt-planned` (dry-run) |
+/// `failed` | `skipped`.
 #[derive(Serialize)]
 struct AllSummaryItem {
     component: String,
@@ -296,6 +827,10 @@ struct AllSummaryPayload {
     total: usize,
     installed: usize,
     planned: usize,
+    /// Existing system RPMs recorded as rpm-observed (§7.5).
+    adopted: usize,
+    /// Dry-run adopt previews.
+    adopt_planned: usize,
     failed: usize,
     skipped: usize,
     dry_run: bool,
@@ -319,6 +854,8 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
                     total: 0,
                     installed: 0,
                     planned: 0,
+                    adopted: 0,
+                    adopt_planned: 0,
                     failed: 0,
                     skipped: 0,
                     dry_run: ctx.dry_run,
@@ -338,10 +875,6 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
         quiet: true,
         ..ctx.clone()
     };
-
-    // Dry-run successes are "planned" rather than "installed": no files or
-    // state were written.
-    let ok_status: &'static str = if ctx.dry_run { "planned" } else { "installed" };
 
     let mut items: Vec<AllSummaryItem> = Vec::with_capacity(names.len());
     let mut first_error: Option<CliError> = None;
@@ -363,9 +896,12 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
             package: None,
         };
         match handle_one(name.clone(), per_args, &suppressed_ctx) {
-            Ok(()) => items.push(AllSummaryItem {
+            // Map (outcome, dry-run) to a batch status string so the summary
+            // distinguishes a fresh install from an RPM adopt (§7.5). Dry-run
+            // successes are "planned"/"adopt-planned": nothing was written.
+            Ok(outcome) => items.push(AllSummaryItem {
                 component: name.clone(),
-                status: ok_status,
+                status: batch_status(outcome, ctx.dry_run),
                 reason: None,
             }),
             Err(err) => {
@@ -397,6 +933,8 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     let installed = items.iter().filter(|i| i.status == "installed").count();
     let planned = items.iter().filter(|i| i.status == "planned").count();
+    let adopted = items.iter().filter(|i| i.status == "adopted").count();
+    let adopt_planned = items.iter().filter(|i| i.status == "adopt-planned").count();
     let failed = items.iter().filter(|i| i.status == "failed").count();
     let skipped = items.iter().filter(|i| i.status == "skipped").count();
 
@@ -412,6 +950,8 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
                 total: names.len(),
                 installed,
                 planned,
+                adopted,
+                adopt_planned,
                 failed,
                 skipped,
                 dry_run: ctx.dry_run,
@@ -436,9 +976,22 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
             .collect();
         let ok_word = if ctx.dry_run { "planned" } else { "installed" };
         let ok_count = if ctx.dry_run { planned } else { installed };
+        // Adopts are a distinct outcome from installs; show them as their own
+        // segment (and only when non-zero) so the count isn't lost (§7.5).
+        let adopt_word = if ctx.dry_run {
+            "adopt-planned"
+        } else {
+            "adopted"
+        };
+        let adopt_count = if ctx.dry_run { adopt_planned } else { adopted };
+        let adopt_segment = if adopt_count > 0 {
+            format!("  {adopt_word}={adopt_count}")
+        } else {
+            String::new()
+        };
         if failed_names.is_empty() {
             println!(
-                "{} total={}  {ok_word}={}  skipped={}",
+                "{} total={}  {ok_word}={}{adopt_segment}  skipped={}",
                 color.label("summary:"),
                 names.len(),
                 ok_count,
@@ -446,7 +999,7 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
             );
         } else {
             println!(
-                "{} total={}  {ok_word}={}  failed={} ({})  skipped={}",
+                "{} total={}  {ok_word}={}{adopt_segment}  failed={} ({})  skipped={}",
                 color.label("summary:"),
                 names.len(),
                 ok_count,
@@ -460,6 +1013,18 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
                 }
             }
         }
+        // List adopted components explicitly so `--all` shows which were
+        // taken over rather than freshly installed.
+        for item in items
+            .iter()
+            .filter(|i| i.status == "adopted" || i.status == "adopt-planned")
+        {
+            println!(
+                "{} {}",
+                color.label("adopted rpm-observed:"),
+                item.component
+            );
+        }
     }
 
     // Human mode: preserve non-zero exit code on failure.
@@ -468,6 +1033,18 @@ fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
             command: "install --all".to_string(),
         }),
         None => Ok(()),
+    }
+}
+
+/// Batch status string for a successful `handle_one`, combining the outcome
+/// with dry-run. Kept aligned with the `filter`-by-string counting in
+/// [`handle_all`] (§7.5): a new string here must be matched there too.
+fn batch_status(outcome: InstallOutcome, dry_run: bool) -> &'static str {
+    match (outcome, dry_run) {
+        (InstallOutcome::Installed, false) => "installed",
+        (InstallOutcome::Installed, true) => "planned",
+        (InstallOutcome::Adopted, false) => "adopted",
+        (InstallOutcome::Adopted, true) => "adopt-planned",
     }
 }
 
@@ -2146,8 +2723,10 @@ sha256 = "{sha}"
     }
 
     /// A configured non-raw backend selects fine but has no executor yet.
+    /// `npm` is the stand-in: it is in `KNOWN_BACKENDS` and configurable, but
+    /// has no installer (unlike `rpm`, which routes to the adopt path).
     #[test]
-    fn install_configured_yum_backend_is_not_implemented() {
+    fn install_configured_npm_backend_is_not_implemented() {
         let tmp = tempdir().expect("tmpdir");
         let prefix = tmp.path().to_path_buf();
         let layout = FsLayout::system(Some(prefix.clone()));
@@ -2160,17 +2739,18 @@ default_backend = "raw"
 [backends.raw]
 base_url = "https://example.com/anolisa"
 
-[backends.yum]
-base_url = "https://example.com/yum-repo"
+[backends.npm]
+base_url = "https://registry.npmjs.org"
+scope = "@anolisa"
 "#,
         )
         .expect("write repo.toml");
 
         let mut a = args("agentsight");
-        a.backend = Some("yum".to_string());
+        a.backend = Some("npm".to_string());
         let err = handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
         assert_eq!(err.code(), "NOT_IMPLEMENTED");
-        assert!(err.reason().contains("yum"), "got: {}", err.reason());
+        assert!(err.reason().contains("npm"), "got: {}", err.reason());
     }
 
     /// A malformed `--repo` URL fails the same shape rules as configured
@@ -2420,8 +3000,9 @@ default_backend = "raw"
 [backends.raw]
 base_url = "https://example.com/anolisa"
 
-[backends.yum]
-base_url = "https://example.com/yum-repo"
+[backends.npm]
+base_url = "https://registry.npmjs.org"
+scope = "@anolisa"
 "#,
         )
         .expect("write repo.toml");
@@ -2458,13 +3039,13 @@ base_url = "https://example.com/yum-repo"
             .expect("save state");
 
         let mut a = args("agentsight");
-        a.backend = Some("yum".to_string());
+        a.backend = Some("npm".to_string());
         let err = handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
 
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
             err.reason().contains("already installed via backend 'raw'")
-                && err.reason().contains("backend 'yum'"),
+                && err.reason().contains("backend 'npm'"),
             "reason must explain backend conflict: {}",
             err.reason()
         );
@@ -2676,5 +3257,568 @@ base_url = "https://example.com/yum-repo"
             .filter(|n| !n.trim().is_empty())
             .collect();
         assert_eq!(names, vec!["valid"]);
+    }
+
+    // ── rpm adopt path (#958) ───────────────────────────────────────
+
+    use anolisa_platform::pkg_query::PackageVersion;
+
+    /// Configurable in-memory [`PackageQuery`] so adopt tests run without a
+    /// live rpmdb.
+    #[derive(Default)]
+    struct FakeQuery {
+        installed: Vec<(String, PackageInfo)>,
+        origins: Vec<(String, String)>,
+        provides: Vec<(String, Vec<String>)>,
+        multi_version: Vec<String>,
+        origin_fails: bool,
+    }
+
+    impl PackageQuery for FakeQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if self.multi_version.iter().any(|p| p == package) {
+                return Err(PackageQueryError::UnexpectedOutput {
+                    command: "rpm".to_string(),
+                    detail: "2 installed versions".to_string(),
+                });
+            }
+            Ok(self
+                .installed
+                .iter()
+                .find(|(n, _)| n == package)
+                .map(|(_, info)| info.clone()))
+        }
+
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+
+        fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+            if self.origin_fails {
+                return Err(PackageQueryError::QueryFailed {
+                    command: "dnf".to_string(),
+                    code: Some(1),
+                    stderr: "boom".to_string(),
+                });
+            }
+            Ok(self
+                .origins
+                .iter()
+                .find(|(n, _)| n == package)
+                .map(|(_, repo)| repo.clone()))
+        }
+
+        fn what_provides_installed(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .provides
+                .iter()
+                .find(|(cap, _)| cap == capability)
+                .map(|(_, names)| names.clone())
+                .unwrap_or_default())
+        }
+    }
+
+    fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: version.to_string(),
+                release: release.map(str::to_string),
+            },
+            arch: arch.to_string(),
+            origin: None,
+        }
+    }
+
+    /// System-mode ctx over a tempdir with a raw-only `repo.toml` (the AC1
+    /// shape: no `[backends.rpm]` table). Returns the temp guard so callers
+    /// keep the directory alive.
+    fn system_ctx_with_raw_repo(dry_run: bool) -> (tempfile::TempDir, CliContext) {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix.clone()));
+        std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+        std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+        std::fs::write(
+            layout.etc_dir.join("repo.toml"),
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"https://example.com/anolisa\"\n",
+        )
+        .expect("write repo.toml");
+        let mut ctx = ctx_with_prefix(false, Some(prefix));
+        ctx.dry_run = dry_run;
+        (tmp, ctx)
+    }
+
+    fn load_state(ctx: &CliContext) -> InstalledState {
+        let layout = common::resolve_layout(ctx);
+        InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+    }
+
+    fn repo_with_rpm_map(pairs: &[(&str, &str)]) -> RepoConfig {
+        let mut map = String::new();
+        for (k, v) in pairs {
+            map.push_str(&format!("{k} = \"{v}\"\n"));
+        }
+        RepoConfig::from_toml_str(&format!(
+            "schema_version = 1\ndefault_backend = \"rpm\"\n[backends.rpm]\nbase_url = \"https://e/x\"\n[backends.rpm.package_map]\n{map}"
+        ))
+        .expect("parse repo")
+    }
+
+    // ── §5 package-name mapping ──
+
+    #[test]
+    fn candidates_cli_override_wins() {
+        let q = FakeQuery::default();
+        let got =
+            rpm_package_candidates(Some("explicit-pkg"), None, None, &q, "copilot-shell").unwrap();
+        assert_eq!(got, vec!["explicit-pkg".to_string()]);
+    }
+
+    #[test]
+    fn candidates_manifest_package_wins_over_default() {
+        let manifest = ComponentManifest::from_toml_str(
+            "[component]\nname = \"copilot-shell\"\nversion = \"1.0.0\"\nlayer = \"runtime\"\n\n[backends.rpm]\npackage = \"vendor-copilot\"\n",
+        )
+        .expect("parse manifest");
+        let q = FakeQuery::default();
+        let got = rpm_package_candidates(None, Some(&manifest), None, &q, "copilot-shell").unwrap();
+        assert_eq!(got, vec!["vendor-copilot".to_string()]);
+    }
+
+    #[test]
+    fn candidates_package_map_wins_over_default() {
+        let repo = repo_with_rpm_map(&[("copilot-shell", "site-copilot")]);
+        let backend = repo.backends.get("rpm");
+        let q = FakeQuery::default();
+        let got = rpm_package_candidates(None, None, backend, &q, "copilot-shell").unwrap();
+        assert_eq!(got, vec!["site-copilot".to_string()]);
+    }
+
+    #[test]
+    fn candidates_provides_single_match() {
+        let q = FakeQuery {
+            provides: vec![(
+                "anolisa-component(copilot-shell)".to_string(),
+                vec!["anolisa-copilot-shell".to_string()],
+            )],
+            ..Default::default()
+        };
+        let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
+        assert_eq!(got, vec!["anolisa-copilot-shell".to_string()]);
+    }
+
+    #[test]
+    fn candidates_provides_multiple_is_ambiguous() {
+        let q = FakeQuery {
+            provides: vec![(
+                "anolisa-component(copilot-shell)".to_string(),
+                vec!["pkg-a".to_string(), "pkg-b".to_string()],
+            )],
+            ..Default::default()
+        };
+        let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
+        assert_eq!(got, vec!["pkg-a".to_string(), "pkg-b".to_string()]);
+    }
+
+    #[test]
+    fn candidates_falls_back_to_default_naming() {
+        let q = FakeQuery::default();
+        let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
+        assert_eq!(got, vec!["anolisa-copilot-shell".to_string()]);
+    }
+
+    // ── §5/§7.1 situation probe ──
+
+    #[test]
+    fn probe_reports_adoptable_for_installed_default_name() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        let situation = probe_rpm_situation(
+            "copilot-shell",
+            &args("copilot-shell"),
+            &repo,
+            &ctx,
+            &q,
+            "install",
+        )
+        .expect("probe");
+        match situation {
+            RpmSituation::Adoptable { package, info } => {
+                assert_eq!(package, "anolisa-copilot-shell");
+                assert_eq!(info.version.to_string(), "2.3.0-1.al8");
+            }
+            other => panic!(
+                "expected Adoptable, got {other:?}",
+                other = situation_label(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn probe_reports_absent_when_not_installed() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
+        let q = FakeQuery::default();
+        let situation = probe_rpm_situation(
+            "copilot-shell",
+            &args("copilot-shell"),
+            &repo,
+            &ctx,
+            &q,
+            "install",
+        )
+        .expect("probe");
+        assert!(matches!(situation, RpmSituation::Absent));
+    }
+
+    #[test]
+    fn probe_reports_ambiguous_for_multiple_providers() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
+        let q = FakeQuery {
+            provides: vec![(
+                "anolisa-component(copilot-shell)".to_string(),
+                vec!["pkg-a".to_string(), "pkg-b".to_string()],
+            )],
+            ..Default::default()
+        };
+        let situation = probe_rpm_situation(
+            "copilot-shell",
+            &args("copilot-shell"),
+            &repo,
+            &ctx,
+            &q,
+            "install",
+        )
+        .expect("probe");
+        assert!(matches!(situation, RpmSituation::Ambiguous(_)));
+    }
+
+    #[test]
+    fn probe_reports_multi_version_drift() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
+        let q = FakeQuery {
+            multi_version: vec!["anolisa-copilot-shell".to_string()],
+            ..Default::default()
+        };
+        let situation = probe_rpm_situation(
+            "copilot-shell",
+            &args("copilot-shell"),
+            &repo,
+            &ctx,
+            &q,
+            "install",
+        )
+        .expect("probe");
+        assert!(matches!(situation, RpmSituation::MultiVersion(_)));
+    }
+
+    fn situation_label(s: &RpmSituation) -> &'static str {
+        match s {
+            RpmSituation::Adoptable { .. } => "Adoptable",
+            RpmSituation::Absent => "Absent",
+            RpmSituation::Ambiguous(_) => "Ambiguous",
+            RpmSituation::MultiVersion(_) => "MultiVersion",
+        }
+    }
+
+    // ── §7.2 adopt state write ──
+
+    #[test]
+    fn adopt_writes_rpm_observed_state() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            ..Default::default()
+        };
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("adopt ok");
+        assert_eq!(outcome, InstallOutcome::Adopted);
+
+        let state = load_state(&ctx);
+        let obj = state
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("component recorded");
+        assert_eq!(obj.status, ObjectStatus::Adopted);
+        assert_eq!(obj.ownership, Some(Ownership::RpmObserved));
+        assert_eq!(obj.install_backend.as_deref(), Some("rpm"));
+        assert!(!obj.managed, "rpm-observed must not be ANOLISA-managed");
+        assert!(obj.adopted);
+        assert!(obj.files.is_empty(), "RPM-owned files stay out of state");
+        assert_eq!(obj.version, "2.3.0-1.al8");
+        let meta = obj.rpm_metadata.as_ref().expect("rpm metadata");
+        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+        assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
+        assert_eq!(meta.arch.as_deref(), Some("x86_64"));
+        assert_eq!(meta.source_repo.as_deref(), Some("@System"));
+    }
+
+    #[test]
+    fn adopt_dry_run_does_not_write_state() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(true);
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("adopt plan ok");
+        assert_eq!(outcome, InstallOutcome::Adopted);
+        let state = load_state(&ctx);
+        assert!(
+            state
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "dry-run must not persist adopt state"
+        );
+    }
+
+    #[test]
+    fn adopt_refresh_overwrites_evr() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        // Pre-seed an older rpm-observed record.
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: common::resolve_layout(&ctx).prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "copilot-shell".to_string(),
+            version: "2.2.0-1.al8".to_string(),
+            status: ObjectStatus::Adopted,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmObserved),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: "anolisa-copilot-shell".to_string(),
+                evr: Some("2.2.0-1.al8".to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: false,
+            adopted: true,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(
+                &common::resolve_layout(&ctx)
+                    .state_dir
+                    .join("installed.toml"),
+            )
+            .expect("seed state");
+
+        // rpmdb now reports a newer EVR.
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            ..Default::default()
+        };
+        // No --backend: existing rpm-observed state must route to adopt-refresh,
+        // not be blocked by the raw trunk.
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("refresh ok");
+        assert_eq!(outcome, InstallOutcome::Adopted);
+        let state = load_state(&ctx);
+        let obj = state
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("still recorded");
+        assert_eq!(obj.version, "2.3.0-1.al8");
+        assert_eq!(
+            obj.rpm_metadata.as_ref().and_then(|m| m.evr.as_deref()),
+            Some("2.3.0-1.al8")
+        );
+    }
+
+    #[test]
+    fn adopt_origin_failure_degrades_to_none() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            origin_fails: true,
+            ..Default::default()
+        };
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("adopt still succeeds");
+        assert_eq!(outcome, InstallOutcome::Adopted);
+        let state = load_state(&ctx);
+        let obj = state
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("recorded");
+        assert_eq!(
+            obj.rpm_metadata
+                .as_ref()
+                .and_then(|m| m.source_repo.as_deref()),
+            None,
+            "origin lookup failure must degrade source_repo to None, not fail the adopt"
+        );
+    }
+
+    #[test]
+    fn explicit_rpm_not_installed_is_not_implemented() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let q = FakeQuery::default();
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+        let err = handle_one_with_query("copilot-shell".to_string(), a, &ctx, &q)
+            .expect_err("not installed → not implemented");
+        assert_eq!(err.code(), "NOT_IMPLEMENTED");
+        // The #959 delegation hint rides on the NotImplemented variant; reason()
+        // surfaces the command, which still names the rpm backend.
+        assert!(err.reason().contains("rpm"), "got: {}", err.reason());
+    }
+
+    #[test]
+    fn adopt_ambiguous_is_invalid_argument() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let q = FakeQuery {
+            provides: vec![(
+                "anolisa-component(copilot-shell)".to_string(),
+                vec!["pkg-a".to_string(), "pkg-b".to_string()],
+            )],
+            ..Default::default()
+        };
+        let err =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect_err("ambiguous → refuse");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("pkg-a") && err.reason().contains("pkg-b"));
+    }
+
+    #[test]
+    fn explicit_rpm_in_user_mode_is_rejected() {
+        // route_rpm_adopt rejects user scope before touching rpmdb; call it
+        // directly so the test needs no $HOME isolation.
+        let tmp = tempdir().expect("tmpdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let repo =
+            RepoConfig::from_toml_str("schema_version = 1\ndefault_backend = \"raw\"\n[backends.raw]\nbase_url = \"https://e/x\"\n")
+                .expect("repo");
+        let installed = InstalledState::default();
+        let q = FakeQuery::default();
+        let mut user_ctx = ctx_with_prefix(false, Some(tmp.path().to_path_buf()));
+        user_ctx.install_mode = InstallMode::User;
+
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+        let err = route_rpm_adopt(
+            "copilot-shell",
+            &a,
+            &user_ctx,
+            "install copilot-shell",
+            &layout,
+            &repo,
+            &installed,
+            BackendSource::Explicit,
+            None,
+            &q,
+        )
+        .expect_err("user mode must be rejected");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("system"),
+            "rejection must point at --install-mode system: {}",
+            err.reason()
+        );
+    }
+
+    #[test]
+    fn explicit_rpm_on_raw_installed_component_is_rejected() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        // Component already installed via raw.
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: common::resolve_layout(&ctx).prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "copilot-shell".to_string(),
+            version: "1.0.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("https://example.com/raw".to_string()),
+            install_backend: Some("raw".to_string()),
+            ownership: Some(Ownership::RawManaged),
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(
+                &common::resolve_layout(&ctx)
+                    .state_dir
+                    .join("installed.toml"),
+            )
+            .expect("seed state");
+
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+        let err = handle_one_with_query("copilot-shell".to_string(), a, &ctx, &q)
+            .expect_err("backend switch must be rejected");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("raw") && err.reason().contains("rpm"));
+    }
+
+    #[test]
+    fn batch_status_maps_outcome_and_dry_run() {
+        assert_eq!(batch_status(InstallOutcome::Installed, false), "installed");
+        assert_eq!(batch_status(InstallOutcome::Installed, true), "planned");
+        assert_eq!(batch_status(InstallOutcome::Adopted, false), "adopted");
+        assert_eq!(batch_status(InstallOutcome::Adopted, true), "adopt-planned");
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -406,10 +406,11 @@ enum RpmSituation {
         /// rpmdb query result carrying EVR/arch for the state record.
         info: PackageInfo,
     },
-    /// Not present as a system RPM: the single candidate is not installed, or
-    /// the host has no rpm tooling at all. Layer 1 falls through to the
+    /// Not present as a system RPM: the single candidate is not installed
+    /// (rpm tooling ran and returned nothing). Layer 1 falls through to the
     /// default backend; an explicit `--backend rpm` turns this into the
-    /// "dnf install not implemented" hint (§7.4).
+    /// "dnf install not implemented" hint (§7.4). A *missing* rpm/dnf binary
+    /// is a different case — it is a hard warn-and-exit, not `Absent`.
     Absent,
     /// `provides` reverse-lookup matched several distinct installed packages
     /// (§5.5). Reported, never silently adopted.
@@ -421,9 +422,10 @@ enum RpmSituation {
 
 /// Resolve the candidate RPM package name(s) for `component` and probe rpmdb.
 ///
-/// Errors only when a query hard-fails in a way that is not the host's normal
-/// "absent" signal; a missing `rpm`/`dnf` binary is treated as [`Absent`]
-/// (the host is not RPM-based, so no component can be a system RPM there).
+/// Errors when a query hard-fails. A missing `rpm`/`dnf` binary is a
+/// warn-and-exit ([`rpm_tooling_missing_error`]): the probe cannot prove the
+/// component is *not* an unobserved system RPM, so we refuse to silently fall
+/// back to raw rather than treat it as [`Absent`].
 ///
 /// [`Absent`]: RpmSituation::Absent
 fn probe_rpm_situation(
@@ -436,14 +438,20 @@ fn probe_rpm_situation(
 ) -> Result<RpmSituation, CliError> {
     let manifest = load_optional_manifest(ctx, component);
     let rpm_backend = repo_config.backends.get("rpm");
-    let candidates = rpm_package_candidates(
+    let candidates = match rpm_package_candidates(
         args.package.as_deref(),
         manifest.as_ref(),
         rpm_backend,
         query,
         component,
-    )
-    .map_err(|err| pkg_query_err(err, command))?;
+    ) {
+        Ok(candidates) => candidates,
+        // No rpm/dnf on this host: refuse to silently fall back to raw (§7.1).
+        Err(PackageQueryError::CommandMissing { .. }) => {
+            return Err(rpm_tooling_missing_error(command));
+        }
+        Err(err) => return Err(pkg_query_err(err, command)),
+    };
 
     if candidates.len() >= 2 {
         return Ok(RpmSituation::Ambiguous(candidates));
@@ -460,8 +468,8 @@ fn probe_rpm_situation(
         Ok(None) => Ok(RpmSituation::Absent),
         // Same name, several installed versions: a drift the caller reports.
         Err(PackageQueryError::UnexpectedOutput { .. }) => Ok(RpmSituation::MultiVersion(package)),
-        // No rpm/dnf on this host → it cannot host system RPMs at all.
-        Err(PackageQueryError::CommandMissing { .. }) => Ok(RpmSituation::Absent),
+        // No rpm/dnf on this host: refuse to silently fall back to raw (§7.1).
+        Err(PackageQueryError::CommandMissing { .. }) => Err(rpm_tooling_missing_error(command)),
         Err(err) => Err(pkg_query_err(err, command)),
     }
 }
@@ -789,6 +797,21 @@ fn pkg_query_err(err: PackageQueryError, command: &str) -> CliError {
     CliError::Runtime {
         command: command.to_string(),
         reason: format!("rpm query failed: {err}"),
+    }
+}
+
+/// Warn-and-exit error raised when the system-RPM probe cannot run because
+/// `rpm`/`dnf` is absent (§7.1).
+///
+/// Without rpm tooling the probe cannot tell whether the component is already
+/// installed as a system RPM. We deliberately refuse to silently fall back to
+/// a raw install here: a raw install over an unobserved system RPM could
+/// clobber or duplicate it. The caller may still force a raw install with an
+/// explicit `--backend raw`, which bypasses the probe entirely.
+fn rpm_tooling_missing_error(command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: "rpm/dnf not found: cannot detect whether this component is already installed as a system RPM. Install rpm/dnf, or pass `--backend raw` to install without RPM adoption".to_string(),
     }
 }
 
@@ -2248,6 +2271,22 @@ mod tests {
         }
     }
 
+    /// Single-component [`handle`] seam that injects a fake package query
+    /// reporting an rpm-capable host with no anolisa packages installed.
+    ///
+    /// System-mode installs with no `--backend` run the system-RPM probe, which
+    /// now warn-and-exits when rpm/dnf is absent. Raw-path tests must not depend
+    /// on the CI host actually having rpm tooling, so they drive the probe with
+    /// this benign fake (every candidate resolves to "not installed" → `Absent`
+    /// → the default raw backend proceeds), keeping them hermetic.
+    fn handle_with_fake_rpm(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
+        let component = args
+            .component
+            .clone()
+            .expect("single-component install test sets args.component");
+        handle_one_with_query(component, args, ctx, &FakeQuery::default()).map(|_| ())
+    }
+
     fn toml_string_array(values: &[&str]) -> String {
         let quoted: Vec<String> = values.iter().map(|value| format!("\"{value}\"")).collect();
         format!("[{}]", quoted.join(", "))
@@ -2638,7 +2677,8 @@ sha256 = "{sha}"
         let mut a = args("no-such-component");
         a.repo = Some(write_empty_repo(&tmp.path().join("repo")));
 
-        let err = handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
+        let err =
+            handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(err.reason().contains("no-such-component"));
     }
@@ -2657,7 +2697,8 @@ sha256 = "{sha}"
             &["user"],
         ));
 
-        let err = handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
+        let err =
+            handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
             err.reason().contains("install mode is not supported"),
@@ -2682,7 +2723,8 @@ sha256 = "{sha}"
             &["user"],
         ));
 
-        let err = handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
+        let err =
+            handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
             err.reason()
@@ -2760,7 +2802,7 @@ scope = "@anolisa"
         let tmp = tempdir().expect("tmpdir");
         let mut a = args("agentsight");
         a.repo = Some("ftp://example.com/repo".to_string());
-        let err = handle(a, &ctx_with_prefix(false, Some(tmp.path().to_path_buf())))
+        let err = handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(tmp.path().to_path_buf())))
             .expect_err("must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(err.reason().contains("ftp"), "got: {}", err.reason());
@@ -2778,7 +2820,7 @@ scope = "@anolisa"
         a.repo = Some(repo_url);
         let mut ctx = ctx_with_prefix(false, Some(prefix.clone()));
         ctx.dry_run = true;
-        handle(a, &ctx).expect("dry-run must succeed");
+        handle_with_fake_rpm(a, &ctx).expect("dry-run must succeed");
 
         let layout = FsLayout::system(Some(prefix));
         assert!(
@@ -2886,7 +2928,8 @@ scope = "@anolisa"
             &["system"],
         ));
 
-        handle(a, &ctx_with_prefix(false, Some(prefix.clone()))).expect("install must succeed");
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install must succeed");
 
         let bin = FsLayout::system(Some(prefix)).bin_dir.join("legacy-bin");
         assert!(bin.exists(), "binary artifact must be installed");
@@ -2907,7 +2950,8 @@ scope = "@anolisa"
 
         let mut a = args("agentsight");
         a.repo = Some(repo_url.clone());
-        handle(a, &ctx_with_prefix(false, Some(prefix.clone()))).expect("install must succeed");
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install must succeed");
 
         let layout = FsLayout::system(Some(prefix));
         let bin = layout.bin_dir.join("agentsight");
@@ -2968,7 +3012,8 @@ scope = "@anolisa"
 
         let mut a = args("remote-only");
         a.repo = Some(repo_url);
-        handle(a, &ctx_with_prefix(false, Some(prefix.clone()))).expect("install must succeed");
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install must succeed");
 
         let layout = FsLayout::system(Some(prefix));
         assert!(
@@ -3061,7 +3106,8 @@ scope = "@anolisa"
 
         let mut a = args("agentsight");
         a.repo = Some(repo_url.clone());
-        handle(a, &ctx_with_prefix(false, Some(prefix.clone()))).expect("install must succeed");
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install must succeed");
 
         let layout = FsLayout::system(Some(prefix));
         assert!(layout.bin_dir.join("agentsight").exists());
@@ -3103,7 +3149,8 @@ scope = "@anolisa"
 
         let mut a = args("agentsight");
         a.repo = Some(template_url);
-        handle(a, &ctx_with_prefix(false, Some(prefix.clone()))).expect("install must succeed");
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install must succeed");
 
         let layout = FsLayout::system(Some(prefix));
         assert!(layout.bin_dir.join("agentsight").exists());
@@ -3139,8 +3186,8 @@ scope = "@anolisa"
         let mut a = args("agentsight");
         a.repo = Some(repo_url);
         a.version = Some("9.9.9".to_string());
-        let err =
-            handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must fail to resolve");
+        let err = handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix)))
+            .expect_err("must fail to resolve");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(err.reason().contains("9.9.9"), "got: {}", err.reason());
     }
@@ -3272,10 +3319,19 @@ scope = "@anolisa"
         provides: Vec<(String, Vec<String>)>,
         multi_version: Vec<String>,
         origin_fails: bool,
+        /// Simulate a host with no rpm/dnf: every rpmdb-touching query returns
+        /// [`PackageQueryError::CommandMissing`], exercising the probe's
+        /// warn-and-exit guard.
+        command_missing: bool,
     }
 
     impl PackageQuery for FakeQuery {
         fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if self.command_missing {
+                return Err(PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                });
+            }
             if self.multi_version.iter().any(|p| p == package) {
                 return Err(PackageQueryError::UnexpectedOutput {
                     command: "rpm".to_string(),
@@ -3312,6 +3368,11 @@ scope = "@anolisa"
             &self,
             capability: &str,
         ) -> Result<Vec<String>, PackageQueryError> {
+            if self.command_missing {
+                return Err(PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                });
+            }
             Ok(self
                 .provides
                 .iter()
@@ -3704,6 +3765,56 @@ scope = "@anolisa"
         // The #959 delegation hint rides on the NotImplemented variant; reason()
         // surfaces the command, which still names the rpm backend.
         assert!(err.reason().contains("rpm"), "got: {}", err.reason());
+    }
+
+    #[test]
+    fn system_install_without_rpm_tooling_warns_and_exits() {
+        // Auto-detect path (system mode, no --backend, fresh state): with rpm/dnf
+        // absent the probe cannot prove the component is not an unobserved system
+        // RPM, so install refuses rather than silently falling back to raw (§7.1).
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let q = FakeQuery {
+            command_missing: true,
+            ..Default::default()
+        };
+        let err =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect_err("missing rpm/dnf must abort, not fall back to raw");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("rpm/dnf not found"),
+            "got: {}",
+            err.reason()
+        );
+        // No fallback raw install happened: state stays empty.
+        let state = load_state(&ctx);
+        assert!(
+            state
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "warn-and-exit must not write any state"
+        );
+    }
+
+    #[test]
+    fn explicit_rpm_without_tooling_warns_and_exits() {
+        // Explicit `--backend rpm` cannot adopt without rpmdb either; missing
+        // tooling is a warn-and-exit, not the #959 "dnf install" hint.
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let q = FakeQuery {
+            command_missing: true,
+            ..Default::default()
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+        let err = handle_one_with_query("copilot-shell".to_string(), a, &ctx, &q)
+            .expect_err("missing rpm/dnf must abort");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("rpm/dnf not found"),
+            "got: {}",
+            err.reason()
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -254,8 +254,12 @@ fn handle_one_with_query(
     //
     // Priority: explicit --backend > existing state > system RPM presence
     // (system mode only) > default_backend. The system-RPM probe runs only
-    // when nothing earlier decided, so non-RPM hosts and the common raw path
-    // never shell out to rpm/dnf.
+    // when nothing earlier decided AND we are in system mode, so user mode,
+    // an explicit --backend, and existing-state hits never shell out to
+    // rpm/dnf. The default/auto-detect system path DOES probe rpm; when that
+    // probe cannot run because rpm/dnf is absent it fail-fasts with a
+    // `--backend raw` hint (§7.1) rather than silently installing raw over a
+    // possibly-unobserved system RPM.
     let mut adopt_situation: Option<RpmSituation> = None;
     let (backend_name, source): (String, BackendSource) = if let Some(explicit) =
         args.backend.as_deref()
@@ -663,6 +667,13 @@ fn execute_adopt(
             command: command.to_string(),
             reason: format!("failed to load installed state: {err}"),
         })?;
+
+    // Re-validate against the freshly-reloaded state, mirroring execute_raw's
+    // post-lock guard. Layer 1 may have decided "adopt" from a pre-lock read
+    // where the component was absent, but a concurrent raw install can win the
+    // lock and record it first. Without this check the adopt would clobber the
+    // raw provenance; with it, the loser is rejected rather than overwriting.
+    ensure_component_backend_compatible(&state, component, "rpm", command)?;
 
     let started_at = now_iso8601();
     let lock_ts = Utc::now();
@@ -3723,6 +3734,71 @@ scope = "@anolisa"
             obj.rpm_metadata.as_ref().and_then(|m| m.evr.as_deref()),
             Some("2.3.0-1.al8")
         );
+    }
+
+    #[test]
+    fn adopt_refuses_to_clobber_concurrent_raw_install() {
+        // Post-lock TOCTOU guard: layer 1 may decide "adopt" from a pre-lock
+        // read where the component is absent, but a concurrent raw install can
+        // win the lock and record it first. After reloading state under the
+        // lock, adopt must re-check backend compatibility and refuse rather
+        // than overwrite the raw provenance with rpm-observed. Calling
+        // `execute_adopt` directly reproduces the "state changed under the lock"
+        // window that layer 1's routing would otherwise hide.
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "copilot-shell".to_string(),
+            version: "1.0.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("raw".to_string()),
+            ownership: Some(Ownership::RawManaged),
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-raw".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed raw record");
+
+        let q = FakeQuery::default();
+        let err = execute_adopt(
+            &ctx,
+            &layout,
+            "install copilot-shell",
+            "copilot-shell",
+            "anolisa-copilot-shell".to_string(),
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            &q,
+        )
+        .expect_err("must refuse to clobber a concurrent raw install");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("raw"), "got: {}", err.reason());
+
+        // The raw record survives untouched: nothing was overwritten.
+        let state = load_state(&ctx);
+        let obj = state
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("raw record preserved");
+        assert_eq!(installed_backend_label(obj), Some("raw"));
+        assert!(obj.rpm_metadata.is_none(), "raw record must stay raw");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -22,8 +22,9 @@ use anolisa_core::adapter::claim::ClaimStatus;
 use anolisa_core::adapter::manager::ScanEntry;
 use anolisa_core::path_safety::{PathBoundaryError, validate_owned_path};
 use anolisa_core::{
-    Catalog, HealthEntry, HealthSpec, InstalledObject, InstalledState, IntegrityStatus, ObjectKind,
-    ServiceState, check_owned_file, service_for_install_mode as service_factory,
+    Catalog, ComponentManifest, HealthEntry, HealthSpec, InstalledObject, InstalledState,
+    IntegrityStatus, ObjectKind, ServiceState, check_owned_file,
+    service_for_install_mode as service_factory,
 };
 
 /// Wall-clock ceiling for a single manifest command-kind probe. `status`
@@ -47,10 +48,14 @@ const SHELL_METACHARS: &[char] = &[
 ];
 use anolisa_env::EnvService;
 use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::PackageQuery;
+use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::{Palette, pad_right};
 use crate::commands::common;
-use crate::context::CliContext;
+use crate::commands::tier1::install::rpm_package_candidates;
+use crate::context::{CliContext, InstallMode};
+use crate::repo_config::{BackendConfig, RepoConfig};
 use crate::response::{CliError, render_json};
 
 const COMMAND: &str = "status";
@@ -104,6 +109,17 @@ struct ComponentRecord {
     /// Associated adapter summaries from `AdapterManager::scan()`.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     adapters: Vec<AdapterSummaryRecord>,
+    /// RPM package name, set only for `observed` rows (rpmdb hit, no state)
+    /// and adopted `rpm-observed` rows (§8). Absent for raw components.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rpm_package: Option<String>,
+    /// Full EVR of the RPM, paired with [`rpm_package`](Self::rpm_package).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rpm_evr: Option<String>,
+    /// Source repo/label that supplied the RPM (e.g. `@System`); `None` when
+    /// it could not be determined.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rpm_source_repo: Option<String>,
 }
 
 pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
@@ -118,7 +134,7 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     let adapter_scan = common::build_adapter_manager(ctx).scan().ok();
 
-    let records = select_components(
+    let mut records = select_components(
         &state,
         &layout,
         catalog.as_ref(),
@@ -126,6 +142,24 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
         args.component.as_deref(),
         adapter_scan.as_ref().map(|r| r.entries.as_slice()),
     );
+
+    // Read-only Observed report (§8): when a named component is absent from
+    // ANOLISA state but present in rpmdb (system mode), upgrade the synthetic
+    // `not_installed` row to `observed` with the package/EVR/repo. This never
+    // writes state — adopting is `install`'s job.
+    if let Some(target) = args.component.as_deref()
+        && ctx.install_mode == InstallMode::System
+        && records.len() == 1
+        && records[0].status == "not_installed"
+    {
+        let repo_config = RepoConfig::load(&layout).ok();
+        let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
+        let manifest = catalog.as_ref().and_then(|c| c.component(target).cloned());
+        let query = RpmPackageQuery::system();
+        if let Some(observed) = observed_record(target, rpm_backend, manifest.as_ref(), &query) {
+            records = vec![observed];
+        }
+    }
 
     if ctx.json {
         let data = serde_json::json!({ "components": records });
@@ -180,9 +214,53 @@ fn select_components(
                 enabled_features: Vec::new(),
                 health: Vec::new(),
                 adapters: Vec::new(),
+                rpm_package: None,
+                rpm_evr: None,
+                rpm_source_repo: None,
             }],
         },
     }
+}
+
+/// Probe rpmdb for `component` and, if a matching system RPM is installed,
+/// build an `observed` record (§8). Returns `None` when nothing is installed
+/// or the host has no rpm tooling — the caller keeps the `not_installed` row.
+///
+/// Read-only and best-effort: a single hard query failure on a candidate
+/// stops the probe (returns `None`) rather than failing `status`. `query` is
+/// injected so tests can drive this without a live rpmdb.
+fn observed_record(
+    component: &str,
+    rpm_backend: Option<&BackendConfig>,
+    manifest: Option<&ComponentManifest>,
+    query: &dyn PackageQuery,
+) -> Option<ComponentRecord> {
+    // Same candidate chain as adopt (§5), minus the CLI `--package` override
+    // (status takes no such flag).
+    let candidates = rpm_package_candidates(None, manifest, rpm_backend, query, component).ok()?;
+    for package in candidates {
+        let Ok(Some(info)) = query.query_installed(&package) else {
+            // Not this candidate (absent), or a hard error / multi-version
+            // drift: status does not adjudicate drift, so move on.
+            continue;
+        };
+        let evr = info.version.to_string();
+        let source_repo = query.installed_origin(&package).ok().flatten();
+        return Some(ComponentRecord {
+            name: component.to_string(),
+            status: "observed".to_string(),
+            version: Some(evr.clone()),
+            installed_at: None,
+            last_operation_id: None,
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+            adapters: Vec::new(),
+            rpm_package: Some(info.name),
+            rpm_evr: Some(evr),
+            rpm_source_repo: source_repo,
+        });
+    }
+    None
 }
 
 /// Build adapter summary records for `component` from the scan entries.
@@ -228,13 +306,30 @@ fn record_from_object(
     // can fail an otherwise-clean install). Probes are skipped when no
     // catalog is loaded — fresh checkouts without a packaged catalog still
     // get integrity-only behavior.
-    let manifest_status = if let Some(cat) = catalog {
-        let (manifest_entries, escalated) =
-            manifest_health_probe(layout, cat, install_mode, obj, &integrity_status);
-        health.extend(manifest_entries);
-        escalated
-    } else {
-        integrity_status
+    //
+    // rpm-observed objects are exempt: ANOLISA owns none of their files and
+    // does not lay out the raw artifact tree, so the manifest health checks
+    // (which assume that layout) would spuriously escalate an adopted row to
+    // degraded/failed (§8, review P2). The status stays `adopted`.
+    let manifest_status = match catalog {
+        Some(cat) if !obj.is_rpm_observed() => {
+            let (manifest_entries, escalated) =
+                manifest_health_probe(layout, cat, install_mode, obj, &integrity_status);
+            health.extend(manifest_entries);
+            escalated
+        }
+        _ => integrity_status,
+    };
+
+    // Surface RPM provenance for adopted rpm-observed rows so human/JSON
+    // output shows the package/EVR/repo behind the `adopted` status.
+    let (rpm_package, rpm_evr, rpm_source_repo) = match &obj.rpm_metadata {
+        Some(meta) => (
+            Some(meta.package_name.clone()),
+            meta.evr.clone(),
+            meta.source_repo.clone(),
+        ),
+        None => (None, None, None),
     };
 
     ComponentRecord {
@@ -246,6 +341,9 @@ fn record_from_object(
         enabled_features: obj.enabled_features.clone(),
         health,
         adapters: Vec::new(),
+        rpm_package,
+        rpm_evr,
+        rpm_source_repo,
     }
 }
 
@@ -737,6 +835,20 @@ fn render_human(records: &[ComponentRecord], verbose: bool, no_color: bool) {
             version = version,
             installed_at = color.muted(installed_at),
         );
+        // RPM provenance for observed / adopted rpm-observed rows (§8).
+        if let Some(pkg) = record.rpm_package.as_deref() {
+            let repo = record.rpm_source_repo.as_deref().unwrap_or("unknown repo");
+            let evr = record.rpm_evr.as_deref().unwrap_or("-");
+            println!("    {} {pkg} ({evr}, {repo})", color.label("rpm package:"),);
+        }
+        // Observed = present in rpmdb but not yet tracked; point at adopt.
+        if record.status == "observed" {
+            println!(
+                "    {} run 'anolisa --install-mode system install {}' to adopt as rpm-observed",
+                color.label("hint:"),
+                record.name,
+            );
+        }
         if verbose {
             if let Some(op) = record.last_operation_id.as_deref() {
                 println!("    {} {}", color.label("last_operation_id:"), color.id(op));
@@ -2028,11 +2140,18 @@ mod tests {
             enabled_features: Vec::new(),
             health: Vec::new(),
             adapters: Vec::new(),
+            rpm_package: None,
+            rpm_evr: None,
+            rpm_source_repo: None,
         };
         let json = serde_json::to_value(&record).expect("serialize");
         assert!(
             json.get("adapters").is_none(),
             "empty adapters must be omitted from JSON"
+        );
+        assert!(
+            json.get("rpm_package").is_none(),
+            "empty rpm fields must be omitted from JSON"
         );
     }
 
@@ -2063,5 +2182,187 @@ mod tests {
         let mut not_enabled = base.clone();
         not_enabled.enabled = false;
         assert_eq!(adapter_state_label(&not_enabled), "not enabled");
+    }
+
+    // ── rpm-observed status (#958) ──────────────────────────────────
+
+    use anolisa_core::{Ownership, RpmMetadata};
+    use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
+
+    /// An adopted `rpm-observed` component record.
+    fn rpm_observed_object(name: &str, package: &str, evr: &str) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: name.to_string(),
+            version: evr.to_string(),
+            status: ObjectStatus::Adopted,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmObserved),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: package.to_string(),
+                evr: Some(evr.to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-adopt-001".to_string()),
+            managed: false,
+            adopted: true,
+            subscription_scope: SubscriptionScope::None,
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    /// P2 gate: an rpm-observed row must keep `adopted` even when a manifest
+    /// health check would fail a raw install — ANOLISA owns none of its files
+    /// and never laid out the raw tree, so those checks do not apply (§8).
+    #[test]
+    fn rpm_observed_row_skips_manifest_health_escalation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let layout = test_layout(dir.path());
+        let probe_path = layout.bin_dir.join("ghost-binary");
+        let manifest = format!(
+            r#"
+            [component]
+            name = "copilot-shell"
+            version = "2.3.0-1.al8"
+
+            [[health_checks]]
+            name = "binary"
+            kind = "file"
+            probe = "{}"
+        "#,
+            probe_path.display()
+        );
+        let (catalog, _guard) = catalog_with_component("copilot-shell", &manifest);
+
+        // Control: a raw install with the same failing check escalates.
+        let mut raw_state = InstalledState::default();
+        raw_state.upsert_object(component_object(
+            "copilot-shell",
+            "2.3.0",
+            ObjectStatus::Installed,
+        ));
+        let raw = select_components(
+            &raw_state,
+            &layout,
+            Some(&catalog),
+            "system",
+            Some("copilot-shell"),
+            None,
+        );
+        assert_eq!(raw[0].status, "failed", "raw install must escalate");
+
+        // rpm-observed with the same catalog stays adopted and surfaces the
+        // RPM provenance fields.
+        let mut obs_state = InstalledState::default();
+        obs_state.upsert_object(rpm_observed_object(
+            "copilot-shell",
+            "anolisa-copilot-shell",
+            "2.3.0-1.al8",
+        ));
+        let obs = select_components(
+            &obs_state,
+            &layout,
+            Some(&catalog),
+            "system",
+            Some("copilot-shell"),
+            None,
+        );
+        assert_eq!(obs[0].status, "adopted", "rpm-observed must not escalate");
+        assert_eq!(obs[0].rpm_package.as_deref(), Some("anolisa-copilot-shell"));
+        assert_eq!(obs[0].rpm_evr.as_deref(), Some("2.3.0-1.al8"));
+        assert_eq!(obs[0].rpm_source_repo.as_deref(), Some("@System"));
+    }
+
+    /// Configurable [`PackageQuery`] for the observed-probe tests.
+    #[derive(Default)]
+    struct FakeQuery {
+        installed: Vec<(String, PackageInfo)>,
+        origins: Vec<(String, String)>,
+    }
+
+    impl PackageQuery for FakeQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            Ok(self
+                .installed
+                .iter()
+                .find(|(n, _)| n == package)
+                .map(|(_, i)| i.clone()))
+        }
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+        fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+            Ok(self
+                .origins
+                .iter()
+                .find(|(n, _)| n == package)
+                .map(|(_, r)| r.clone()))
+        }
+    }
+
+    fn pkg_info(name: &str, version: &str, release: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: version.to_string(),
+                release: Some(release.to_string()),
+            },
+            arch: "x86_64".to_string(),
+            origin: None,
+        }
+    }
+
+    #[test]
+    fn observed_record_reports_installed_default_name() {
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+        };
+        let rec = observed_record("copilot-shell", None, None, &q).expect("observed");
+        assert_eq!(rec.status, "observed");
+        assert_eq!(rec.rpm_package.as_deref(), Some("anolisa-copilot-shell"));
+        assert_eq!(rec.rpm_evr.as_deref(), Some("2.3.0-1.al8"));
+        assert_eq!(rec.rpm_source_repo.as_deref(), Some("@System"));
+        assert_eq!(rec.version.as_deref(), Some("2.3.0-1.al8"));
+    }
+
+    #[test]
+    fn observed_record_none_when_not_installed() {
+        let q = FakeQuery::default();
+        assert!(observed_record("copilot-shell", None, None, &q).is_none());
+    }
+
+    #[test]
+    fn observed_record_honors_package_map() {
+        // package_map renames the component's RPM; the probe must query the
+        // mapped name, not the default.
+        let repo = RepoConfig::from_toml_str(
+            "schema_version = 1\ndefault_backend = \"rpm\"\n[backends.rpm]\nbase_url = \"https://e/x\"\n[backends.rpm.package_map]\ncopilot-shell = \"site-copilot\"\n",
+        )
+        .expect("repo");
+        let backend = repo.backends.get("rpm");
+        let q = FakeQuery {
+            installed: vec![(
+                "site-copilot".to_string(),
+                pkg_info("site-copilot", "9.9", "1"),
+            )],
+            origins: Vec::new(),
+        };
+        let rec = observed_record("copilot-shell", backend, None, &q).expect("observed");
+        assert_eq!(rec.rpm_package.as_deref(), Some("site-copilot"));
+        assert_eq!(rec.rpm_source_repo, None);
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -4,14 +4,14 @@
 //! Design (see the install-backend discussion):
 //!
 //! * **One configuration table per backend** (`[backends.raw]`,
-//!   `[backends.yum]`, `[backends.npm]`) — no repo list, no priorities.
+//!   `[backends.rpm]`, `[backends.npm]`) — no repo list, no priorities.
 //!   Selection is explicit: CLI `--backend` > `default_backend`. There is
 //!   no cross-backend fallback, so the origin of an installed component
 //!   is always deterministic.
 //! * **`base_url` is a directory root**, never a file. The per-backend
 //!   convention decides what lives under it: raw treats it as the
-//!   `v1/` distribution root containing `index.toml`; yum hands it to
-//!   dnf; npm treats it as the registry API root.
+//!   `v1/` distribution root containing `index.toml`; the rpm backend
+//!   hands it to dnf; npm treats it as the registry API root.
 //! * **Variables** `$os` / `$arch` / `$basearch` / `$releasever` /
 //!   `$channel` substitute into `base_url` only. Values come from host
 //!   detection and can be overridden in `[vars]`; an unknown or unset
@@ -67,10 +67,14 @@ pub const RAW_ARTIFACT_FILENAME: &str = "{component}-{version}-{os}-{arch}{ext}"
 /// Code-owned artifact directory layout under a raw `base_url`.
 pub const RAW_ARTIFACT_DIR: &str = "{component}/{version}/{os}/{arch}";
 
-/// Backend names this binary knows how to drive (or will: yum/npm are
+/// Backend names this binary knows how to drive (or will: `rpm`/`npm` are
 /// configuration-valid before their executors land so a site can stage
 /// config ahead of the rollout).
-pub const KNOWN_BACKENDS: &[&str] = &["raw", "yum", "npm"];
+///
+/// `rpm` is the RPM-backend name; the pre-release `yum` spelling was retired
+/// (no released CLI, no site-config compatibility burden) so only `rpm` is
+/// accepted here — see the adopt design doc, §3.1.
+pub const KNOWN_BACKENDS: &[&str] = &["raw", "rpm", "npm"];
 
 /// Errors surfaced while loading, parsing, or resolving `repo.toml`.
 #[derive(Debug, thiserror::Error)]
@@ -175,7 +179,7 @@ pub struct RepoVars {
 
 /// One `[backends.<name>]` table. A single struct covers all backend
 /// kinds; fields irrelevant to a kind are simply unused (e.g. `gpgcheck`
-/// outside yum) — the executor for each backend consumes its own subset.
+/// outside rpm) — the executor for each backend consumes its own subset.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BackendConfig {
@@ -184,10 +188,10 @@ pub struct BackendConfig {
     /// Opt-in for plaintext `http://` sources.
     #[serde(default)]
     pub insecure: bool,
-    /// yum: signature verification toggle, handed to dnf.
+    /// rpm: signature verification toggle, handed to dnf.
     ///
     /// This and the two raw cache knobs below are deserialized for the
-    /// executors that will consume them (yum delegation / raw index
+    /// executors that will consume them (rpm delegation / raw index
     /// cache); nothing reads them during resolution, hence the narrow
     /// dead-code allowance until those land.
     #[serde(default)]
@@ -335,8 +339,8 @@ impl RepoConfig {
         let values: BTreeMap<&str, Option<String>> = BTreeMap::from([
             ("os", Some(self.vars.os.clone().unwrap_or(host.os.clone()))),
             ("arch", Some(arch.clone())),
-            // $basearch is a yum-ism alias of $arch; kept so existing
-            // yum baseurls can be pasted verbatim.
+            // $basearch is a dnf/rpm-style alias of $arch; kept so existing
+            // dnf baseurls can be pasted verbatim.
             ("basearch", Some(arch)),
             // No host probe for the distro release yet — referencing
             // $releasever without a [vars] override is an error.
@@ -667,9 +671,11 @@ base_url = "https://pypi.org"
 
     #[test]
     fn default_backend_without_table_is_rejected() {
+        // `rpm` is a known backend but has no `[backends.rpm]` table here, so
+        // the default-backend presence check (not the allow-list) must fire.
         let err = RepoConfig::from_toml_str(
             r#"schema_version = 1
-default_backend = "yum"
+default_backend = "rpm"
 [backends.raw]
 base_url = "file:///srv/repo"
 "#,
@@ -677,7 +683,7 @@ base_url = "file:///srv/repo"
         .expect_err("must reject");
         assert!(matches!(
             err,
-            RepoConfigError::DefaultBackendNotConfigured { name } if name == "yum"
+            RepoConfigError::DefaultBackendNotConfigured { name } if name == "rpm"
         ));
     }
 
@@ -730,14 +736,14 @@ base_url = "file:///srv/repo"
         ));
     }
 
-    fn yum_cfg(vars: &str) -> RepoConfig {
+    fn rpm_cfg(vars: &str) -> RepoConfig {
         RepoConfig::from_toml_str(&format!(
             r#"schema_version = 1
-default_backend = "yum"
+default_backend = "rpm"
 {vars}
-[backends.yum]
+[backends.rpm]
 base_url = "https://mirrors.openanolis.cn/anolis/$releasever/agents/$basearch/"
-[backends.yum.package_map]
+[backends.rpm.package_map]
 agentsight = "anolis-agentsight"
 "#
         ))
@@ -746,8 +752,8 @@ agentsight = "anolis-agentsight"
 
     #[test]
     fn variable_substitution_uses_vars_overrides_and_detection() {
-        let cfg = yum_cfg("[vars]\nreleasever = \"23\"");
-        let (name, backend) = cfg.select_backend(None).expect("yum");
+        let cfg = rpm_cfg("[vars]\nreleasever = \"23\"");
+        let (name, backend) = cfg.select_backend(None).expect("rpm");
         let url = cfg.resolved_base_url(name, backend, &host()).expect("url");
         // $releasever from [vars], $basearch from host detection,
         // trailing slash trimmed.
@@ -756,8 +762,8 @@ agentsight = "anolis-agentsight"
 
     #[test]
     fn unset_releasever_is_a_hard_error() {
-        let cfg = yum_cfg("");
-        let (name, backend) = cfg.select_backend(None).expect("yum");
+        let cfg = rpm_cfg("");
+        let (name, backend) = cfg.select_backend(None).expect("rpm");
         let err = cfg
             .resolved_base_url(name, backend, &host())
             .expect_err("must reject");
@@ -789,9 +795,9 @@ base_url = "https://example.com/$typo_var/repo"
 
     #[test]
     fn select_backend_cli_override_and_unconfigured_error() {
-        let cfg = yum_cfg("[vars]\nreleasever = \"23\"");
-        let (name, _) = cfg.select_backend(Some("yum")).expect("explicit yum");
-        assert_eq!(name, "yum");
+        let cfg = rpm_cfg("[vars]\nreleasever = \"23\"");
+        let (name, _) = cfg.select_backend(Some("rpm")).expect("explicit rpm");
+        assert_eq!(name, "rpm");
         let err = cfg
             .select_backend(Some("npm"))
             .expect_err("npm not configured");
@@ -891,20 +897,20 @@ base_url = "https://example.com/$typo_var/repo"
 
     #[test]
     fn package_name_chain_cli_then_map_then_scope_then_component() {
-        let cfg = yum_cfg("[vars]\nreleasever = \"23\"");
-        let (_, yum) = cfg.select_backend(None).expect("yum");
+        let cfg = rpm_cfg("[vars]\nreleasever = \"23\"");
+        let (_, rpm) = cfg.select_backend(None).expect("rpm");
         // CLI override wins over the map.
         assert_eq!(
-            cfg.package_name(yum, "agentsight", Some("agentsight-0917test")),
+            cfg.package_name(rpm, "agentsight", Some("agentsight-0917test")),
             "agentsight-0917test"
         );
         // package_map applies.
         assert_eq!(
-            cfg.package_name(yum, "agentsight", None),
+            cfg.package_name(rpm, "agentsight", None),
             "anolis-agentsight"
         );
         // Fallback is the component name itself.
-        assert_eq!(cfg.package_name(yum, "tokenless", None), "tokenless");
+        assert_eq!(cfg.package_name(rpm, "tokenless", None), "tokenless");
 
         // npm scope prefixes the default name.
         let npm_cfg = RepoConfig::from_toml_str(

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -45,6 +45,11 @@ pub struct ComponentManifest {
     pub build: BuildSpec,
     /// Files, services, and capabilities installed by this component.
     pub install: InstallSpec,
+    /// `[backends]` — backend-specific packaging metadata. Empty for components
+    /// that only ship raw artifacts; the RPM backend reads
+    /// [`ManifestBackends::rpm`] to resolve the package name during adopt.
+    #[serde(default, skip_serializing_if = "ManifestBackends::is_empty")]
+    pub backends: ManifestBackends,
     /// Component-level host requirements.
     pub env_requirements: EnvRequirements,
     /// Structured dependency lists. `build`, `runtime`, and `components`
@@ -90,6 +95,37 @@ pub struct DistributionSelector {
     /// Artifact-type preference used only after target filtering.
     #[serde(default)]
     pub preferred_artifact_types: Vec<ArtifactType>,
+}
+
+/// `[backends]` — backend-specific packaging metadata.
+///
+/// Orthogonal to [`DistributionSelector::pkg_base`] (which says *which package
+/// format a distribution uses*): this says *what the component is named under a
+/// given backend*. Only populated where a backend needs an explicit name; an
+/// absent table leaves package-name resolution to the lower mapping tiers
+/// (repo.toml `package_map` / RPM provides / default `anolisa-<component>`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ManifestBackends {
+    /// RPM backend packaging info; `None` falls through to the lower tiers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpm: Option<RpmBackendSpec>,
+}
+
+impl ManifestBackends {
+    /// Whether no backend metadata is present (used by `skip_serializing_if` so
+    /// raw-only manifests round-trip without an empty `[backends]` table).
+    pub fn is_empty(&self) -> bool {
+        self.rpm.is_none()
+    }
+}
+
+/// `[backends.rpm]` — RPM-backend packaging info for a component.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpmBackendSpec {
+    /// RPM package name for this component (e.g. `anolisa-copilot-shell`),
+    /// the highest-precedence package-name source after a CLI `--package`
+    /// override.
+    pub package: String,
 }
 
 /// Component identity and placement metadata.
@@ -369,6 +405,11 @@ struct ComponentManifestRaw {
     build: Option<BuildRaw>,
     #[serde(default)]
     install: Option<InstallRaw>,
+    // `[backends]` deserializes directly into the typed shape: the structs are
+    // simple and tolerant (`default` table, optional `rpm` sub-table), so no
+    // separate Raw mirror is warranted.
+    #[serde(default)]
+    backends: ManifestBackends,
     #[serde(default, alias = "env_requirements")]
     environment: EnvRequirementsRaw,
     #[serde(default)]
@@ -790,6 +831,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             distribution_selectors,
             build,
             install,
+            backends: raw.backends,
             env_requirements,
             dependencies,
             features,
@@ -982,6 +1024,15 @@ impl ComponentManifest {
         toml::from_str(s).map_err(|e| ManifestError::Parse("<string>".into(), e.to_string()))
     }
 
+    /// Declared RPM package name from `[backends.rpm].package`, if any.
+    ///
+    /// This is the highest-precedence package-name source after a CLI
+    /// `--package` override during RPM adopt; `None` falls through to the
+    /// repo.toml `package_map` / provides / default-naming tiers.
+    pub fn rpm_package(&self) -> Option<&str> {
+        self.backends.rpm.as_ref().map(|s| s.package.as_str())
+    }
+
     /// Health check to run after install: the declared
     /// `[component.health_check]`, or a synthesized `binary_version` over the
     /// first [`FileKind::Executable`] layout file. Returns `None` when neither
@@ -1105,6 +1156,64 @@ mod tests {
         assert_eq!(m.dependencies.build, vec!["rust>=1.91"]);
         assert_eq!(m.dependencies.runtime, vec!["kernel-headers"]);
         assert!(m.dependencies.components.is_empty());
+        // No `[backends]` table → empty, and the rpm-package accessor is None.
+        assert!(m.backends.is_empty());
+        assert_eq!(m.rpm_package(), None);
+    }
+
+    #[test]
+    fn component_manifest_parses_rpm_backend_package() {
+        let toml_text = r#"
+            [component]
+            name = "copilot-shell"
+            version = "0.1.0"
+            layer = "runtime"
+
+            [backends.rpm]
+            package = "anolisa-copilot-shell"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert!(!m.backends.is_empty());
+        assert_eq!(m.rpm_package(), Some("anolisa-copilot-shell"));
+    }
+
+    #[test]
+    fn component_manifest_rpm_backend_round_trips() {
+        // `[backends]` must survive a serialize→deserialize cycle, and a
+        // manifest without it must serialize *without* an empty table (the
+        // `skip_serializing_if` contract that keeps raw-only manifests clean).
+        let with_rpm = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "copilot-shell"
+            version = "0.1.0"
+            layer = "runtime"
+
+            [backends.rpm]
+            package = "anolisa-copilot-shell"
+        "#,
+        )
+        .expect("parse");
+        let dumped = toml::to_string(&with_rpm).expect("serialize");
+        assert!(
+            dumped.contains("anolisa-copilot-shell"),
+            "rpm package must round-trip: {dumped}"
+        );
+
+        let without = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "agentsight"
+            version = "0.2.0"
+            layer = "runtime"
+        "#,
+        )
+        .expect("parse");
+        let dumped = toml::to_string(&without).expect("serialize");
+        assert!(
+            !dumped.contains("[backends]"),
+            "empty backends must be skipped on serialize: {dumped}"
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-platform/src/pkg_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/pkg_query.rs
@@ -120,4 +120,32 @@ pub trait PackageQuery {
     /// # Errors
     /// See [`PackageQueryError`].
     fn query_available(&self, package: &str) -> Result<Vec<PackageInfo>, PackageQueryError>;
+
+    /// Source repo of an *installed* package (e.g. `@System`, `anolisa-release`);
+    /// `None` when it cannot be determined.
+    ///
+    /// [`query_installed`](Self::query_installed) cannot report this (its
+    /// `rpm -q` path yields no reponame, hence [`PackageInfo::origin`] is always
+    /// `None` there), so adopt/observe callers query the origin separately to
+    /// populate `source_repo`. The default returns `None` so backends without
+    /// origin support still satisfy the trait.
+    ///
+    /// # Errors
+    /// See [`PackageQueryError`]; "no origin" is `Ok(None)`, not an error.
+    fn installed_origin(&self, _package: &str) -> Result<Option<String>, PackageQueryError> {
+        Ok(None)
+    }
+
+    /// Names of *installed* packages that provide `capability` (an RPM virtual
+    /// provide such as `anolisa-component(<name>)`), de-duplicated by name.
+    ///
+    /// No provider yields an empty `Vec` (a normal branch, not an error). The
+    /// default returns empty so backends without provides lookup still satisfy
+    /// the trait. Callers treat ≥2 distinct names as an ambiguous match.
+    ///
+    /// # Errors
+    /// See [`PackageQueryError`]; "nothing provides it" is `Ok(vec![])`.
+    fn what_provides_installed(&self, _capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        Ok(Vec::new())
+    }
 }

--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -23,6 +23,19 @@ const INSTALLED_QF: &str = "%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}\n";
 /// their source repo.
 const AVAILABLE_QF: &str = "%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{REPONAME}\n";
 
+/// Query format for the *installed* source repo (`dnf repoquery --installed`).
+///
+/// `rpm -q` cannot report a reponame, so `source_repo` for observed packages
+/// must come from the dnf side; this yields just the bare reponame per line.
+const REPONAME_QF: &str = "%{reponame}\n";
+
+/// Query format for the provides reverse-lookup (`rpm -q --whatprovides`).
+///
+/// Takes the bare `%{NAME}` rather than the default NEVRA string so the result
+/// is directly usable as a package name (the default `name-version-release.arch`
+/// is not).
+const PROVIDES_NAME_QF: &str = "%{NAME}\n";
+
 const RPM: &str = "rpm";
 const DNF: &str = "dnf";
 
@@ -99,6 +112,70 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
             .filter(|line| !line.is_empty())
             .map(parse_available_line)
             .collect()
+    }
+
+    fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+        let out = self
+            .runner
+            .run(
+                DNF,
+                &["repoquery", "--installed", "--qf", REPONAME_QF, package],
+            )
+            .map_err(|e| map_spawn_error(e, DNF))?;
+
+        if out.code != Some(0) {
+            return Err(PackageQueryError::QueryFailed {
+                command: DNF.to_string(),
+                code: out.code,
+                stderr: out.stderr,
+            });
+        }
+
+        // First non-empty reponame line is the source repo (`@System`,
+        // `anolisa-release`, ...); no line means the origin is unknown, which
+        // is a non-fatal `None` rather than an error (it is supplementary
+        // metadata for the adopt record).
+        Ok(out
+            .stdout
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .map(str::to_string))
+    }
+
+    fn what_provides_installed(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        let out = self
+            .runner
+            .run(
+                RPM,
+                &["-q", "--whatprovides", "--qf", PROVIDES_NAME_QF, capability],
+            )
+            .map_err(|e| map_spawn_error(e, RPM))?;
+
+        if out.code == Some(0) {
+            // De-dup by name: one package can match through several Provides
+            // lines. Insertion order is preserved; provider counts are tiny.
+            let mut names: Vec<String> = Vec::new();
+            for name in out.stdout.lines().map(str::trim).filter(|l| !l.is_empty()) {
+                if !names.iter().any(|n| n == name) {
+                    names.push(name.to_string());
+                }
+            }
+            return Ok(names);
+        }
+
+        // "nothing provides it" is a normal empty result, mirroring the
+        // not-installed branch: rpm writes the notice to stdout, pinned to
+        // English by LC_ALL=C.
+        if out.stdout.contains("no package provides") {
+            return Ok(Vec::new());
+        }
+
+        Err(PackageQueryError::QueryFailed {
+            command: RPM.to_string(),
+            code: out.code,
+            stderr: out.stderr,
+        })
     }
 }
 
@@ -266,6 +343,25 @@ mod tests {
     /// would still pass the output-based assertions.
     fn assert_call_contract(program: &str, args: &[&str], expected_package: &str) {
         match program {
+            // `rpm -q --whatprovides --qf <fmt> <cap>` (what_provides_installed)
+            RPM if args.get(1) == Some(&"--whatprovides") => {
+                assert_eq!(
+                    args.len(),
+                    5,
+                    "rpm whatprovides needs [-q, --whatprovides, --qf, <fmt>, <cap>]: {args:?}"
+                );
+                assert_eq!(args[0], "-q");
+                assert_eq!(args[2], "--qf");
+                assert_eq!(
+                    args[3], PROVIDES_NAME_QF,
+                    "rpm whatprovides --qf drifted from PROVIDES_NAME_QF: {args:?}"
+                );
+                assert_eq!(
+                    args[4], expected_package,
+                    "rpm capability argument must be last: {args:?}"
+                );
+            }
+            // `rpm -q --qf <fmt> <pkg>` (query_installed)
             RPM => {
                 assert_eq!(
                     args.len(),
@@ -283,6 +379,25 @@ mod tests {
                     "rpm package argument must be last: {args:?}"
                 );
             }
+            // `dnf repoquery --installed --qf <fmt> <pkg>` (installed_origin)
+            DNF if args.get(1) == Some(&"--installed") => {
+                assert_eq!(
+                    args.len(),
+                    5,
+                    "dnf installed-origin needs [repoquery, --installed, --qf, <fmt>, <pkg>]: {args:?}"
+                );
+                assert_eq!(args[0], "repoquery");
+                assert_eq!(args[2], "--qf");
+                assert_eq!(
+                    args[3], REPONAME_QF,
+                    "dnf installed --qf drifted from REPONAME_QF: {args:?}"
+                );
+                assert_eq!(
+                    args[4], expected_package,
+                    "dnf package argument must be last: {args:?}"
+                );
+            }
+            // `dnf repoquery --quiet --qf <fmt> <pkg>` (query_available)
             DNF => {
                 assert_eq!(
                     args.len(),
@@ -505,5 +620,117 @@ mod tests {
         let q = query_with_dnf("pkg", ok_out(Some(0), "pkg|2.0.1\n", ""));
         let err = q.query_available("pkg").unwrap_err();
         assert!(matches!(err, PackageQueryError::UnexpectedOutput { .. }));
+    }
+
+    #[test]
+    fn installed_origin_returns_reponame() {
+        let q = query_with_dnf("anolisa-tokenless", ok_out(Some(0), "@System\n", ""));
+        assert_eq!(
+            q.installed_origin("anolisa-tokenless").unwrap().as_deref(),
+            Some("@System")
+        );
+    }
+
+    #[test]
+    fn installed_origin_empty_is_none() {
+        // A package with no reported reponame yields an empty repoquery result;
+        // origin is supplementary, so absence is a non-fatal `None`.
+        let q = query_with_dnf("anolisa-tokenless", ok_out(Some(0), "", ""));
+        assert_eq!(q.installed_origin("anolisa-tokenless").unwrap(), None);
+    }
+
+    #[test]
+    fn installed_origin_failure_maps_to_error() {
+        let q = query_with_dnf("x", ok_out(Some(1), "", "error: rpmdb open failed"));
+        let err = q.installed_origin("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageQueryError::QueryFailed { command, .. } if command == DNF
+        ));
+    }
+
+    #[test]
+    fn installed_origin_command_missing_maps_to_error() {
+        let q = query_with_dnf("x", FakeOutcome::Err(io::ErrorKind::NotFound));
+        let err = q.installed_origin("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageQueryError::CommandMissing { command } if command == DNF
+        ));
+    }
+
+    #[test]
+    fn what_provides_returns_single_name() {
+        let q = query_with_rpm(
+            "anolisa-component(tokenless)",
+            ok_out(Some(0), "anolisa-tokenless\n", ""),
+        );
+        let names = q
+            .what_provides_installed("anolisa-component(tokenless)")
+            .unwrap();
+        assert_eq!(names, vec!["anolisa-tokenless".to_string()]);
+    }
+
+    #[test]
+    fn what_provides_dedups_by_name() {
+        // One package can satisfy a capability through several Provides lines;
+        // the same name must collapse to a single entry.
+        let q = query_with_rpm(
+            "anolisa-component(tokenless)",
+            ok_out(Some(0), "anolisa-tokenless\nanolisa-tokenless\n", ""),
+        );
+        let names = q
+            .what_provides_installed("anolisa-component(tokenless)")
+            .unwrap();
+        assert_eq!(names, vec!["anolisa-tokenless".to_string()]);
+    }
+
+    #[test]
+    fn what_provides_keeps_distinct_names() {
+        // Two different packages providing the same capability is the ambiguous
+        // case callers must detect; both names are preserved in order.
+        let q = query_with_rpm(
+            "anolisa-component(tokenless)",
+            ok_out(Some(0), "anolisa-tokenless\nvendor-tokenless\n", ""),
+        );
+        let names = q
+            .what_provides_installed("anolisa-component(tokenless)")
+            .unwrap();
+        assert_eq!(
+            names,
+            vec![
+                "anolisa-tokenless".to_string(),
+                "vendor-tokenless".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn what_provides_not_provided_is_empty() {
+        // rpm writes "no package provides <cap>" to stdout with a non-zero exit;
+        // that is the normal "nothing matches" branch, not an error.
+        let q = query_with_rpm(
+            "anolisa-component(absent)",
+            ok_out(
+                Some(1),
+                "no package provides anolisa-component(absent)\n",
+                "",
+            ),
+        );
+        let names = q
+            .what_provides_installed("anolisa-component(absent)")
+            .unwrap();
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn what_provides_failure_maps_to_error() {
+        // Non-zero exit without the not-provided marker is a hard failure.
+        let q = query_with_rpm("x", ok_out(Some(1), "", "error: rpmdb open failed"));
+        let err = q.what_provides_installed("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageQueryError::QueryFailed { command, .. } if command == RPM
+        ));
     }
 }

--- a/src/anolisa/templates/repo.toml
+++ b/src/anolisa/templates/repo.toml
@@ -11,7 +11,7 @@
 #
 #   * It is a directory root, not a file. What lives under it is a
 #     per-backend convention: raw → the v1 distribution root containing
-#     `index.toml`; yum → handed to dnf as-is (must contain `repodata/`);
+#     `index.toml`; rpm → handed to dnf as-is (must contain `repodata/`);
 #     npm → the registry API root.
 #   * It may reference `$os`, `$arch`, `$basearch`, `$releasever`,
 #     `$channel`. Values come from host detection, overridable in
@@ -57,13 +57,13 @@ base_url = "https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolis
 cache_ttl_secs = 3600
 offline_fallback = true
 
-# yum — resolution/install delegated to dnf against this repo.
-[backends.yum]
+# rpm — resolution/install delegated to dnf against this repo.
+[backends.rpm]
 base_url = "http://mirrors.cloud.aliyuncs.com/alinux/$releasever/os/$basearch/os/"
 insecure = true
 gpgcheck = true
 
-[backends.yum.package_map]
+[backends.rpm.package_map]
 agentsight = "anolis-agentsight"
 
 # npm — Node-ecosystem components.


### PR DESCRIPTION
## 1. Description

When a component is already installed as a system RPM, `anolisa install`
(system mode) now **adopts** it as `rpm-observed` state instead of replacing it
with a raw install, and `status` reports it. This lets ANOLISA coexist with
image-preinstalled RPM components rather than fighting the package manager.

Concretely:

- `install` records the existing RPM as `rpm-observed` (ownership
  `RpmObserved`, status `Adopted`) — reading `rpmdb` and writing ANOLISA state
  only. It never downloads an artifact, runs `dnf`, or claims ownership of the
  RPM's files (`owns_removal() == false`).
- `status` reports an installed-but-untracked component as `observed`, and an
  adopted one as `adopted`, with `rpm_package` / `rpm_evr` / `rpm_source_repo`
  details. `status` stays strictly read-only.
- The pre-release `yum` backend name is renamed to `rpm` throughout
  (`KNOWN_BACKENDS`, bundled `templates/repo.toml`, fixtures). The CLI is
  unreleased, so no alias is kept.

## 2. Design Note

**Two-layer backend decision.** Layer 1 picks a backend *name*
(`--backend` > existing state > system-RPM presence > `default_backend`); layer 2
picks the *action* from `(backend, rpmdb hit, install mode)`. Decoupling them
means a component already adopted as `rpm-observed` re-routes to an **adopt
refresh** on the next `install`, instead of being blocked by the raw trunk. The
adopt branch bypasses `select_backend` / `resolved_base_url`, so it works with a
raw-only `repo.toml` (no `[backends.rpm]` table required).

**Package-name resolution**, highest precedence first:

1. CLI `--package <name>`
2. manifest `[backends.rpm].package`
3. repo.toml `[backends.rpm].package_map[component]`
4. RPM `provides` reverse-lookup — `rpm -q --whatprovides 'anolisa-component(<component>)'` (deduped)
5. default naming `anolisa-<component>`

The first three short-circuit to one candidate; `provides` may return several or
none. **Ambiguous providers**, **multi-version drift**, and **user-mode
`--backend rpm`** are rejected with a clear error — never silently adopted.

**`status` projection.** Adopted (`rpm-observed`) rows skip the raw-layout
manifest health probe, so they stay `adopted` rather than being spuriously
escalated to `degraded`/`failed` by checks that assume a raw install layout.

## 3. Ship Note

- **Scope:** install-path auto-adopt + read-only `status` Observed reporting
  only. Out of scope and tracked separately: delegated `dnf install` (#959),
  drift/repair of adopted rows (#960), and an explicit `adopt` subcommand (#961).
- **`provides` lookup (mapping level 4) is dormant.** It depends on a virtual
  provide `Provides: anolisa-component(<name>)` that does **not yet exist** on
  the packaging side. The chain tolerates this: an absent/empty result silently
  falls through to default naming, so this change is not blocked on packaging.
  Until that provide ships, adoption relies on levels 1-3 and default naming.
- **Explicit `--backend rpm` against a not-yet-installed package** returns
  `not_implemented` (pointing at #959) rather than installing via `dnf`.
- **`status` aggregate view** (no component name) does not scan rpmdb for
  Observed components yet — only a named-component query does. Full-scan is left
  to #960/#963.
- The orthogonal `yum-repo` artifact-source enum in the distribution index is
  intentionally left untouched by the `yum` -> `rpm` rename.

## 4. Test

Deterministic coverage via injected fakes (`FakeCommandRunner` / `dyn PackageQuery`),
no live rpmdb required:

- **platform (+9):** `installed_origin` and `what_provides_installed` — reponame
  parse, empty -> `None`, provides dedup / multiple-distinct / not-provided ->
  empty, query failure -> error.
- **core (+3):** manifest `[backends.rpm].package` parse, `rpm_package()`
  accessor, serialize round-trip (empty backends omitted).
- **install (+19):** package-name precedence (all 5 levels); situation probe
  (adoptable / absent / ambiguous / multi-version); adopt writes `rpm-observed`
  state with empty owned files; dry-run writes nothing; adopt refresh overwrites
  EVR; origin-lookup failure degrades to `None` without failing adopt; explicit
  rpm not-installed -> `not_implemented`; ambiguous / user-mode / backend-switch
  rejections; `--all` batch status mapping.
- **status (+4):** `observed` projection from rpmdb; `None` when absent;
  `package_map` honored; rpm-observed row skips manifest health escalation.

Full workspace `fmt` / `clippy -D warnings` / `check` / `test` / `doc --no-deps`
all pass.

close #958.