### PR TITLE
feat(anolisa): RPM-backed update and delegated dnf install

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -95,7 +95,7 @@ pub enum ComponentCommands {
     Logs(tier1::logs::LogsArgs),
     /// Restart a component's service
     Restart(tier1::restart::RestartArgs),
-    /// Update anolisa itself (no args) or a specific component
+    /// Update a component (`update <component>`), the CLI binary (`self`), or everything (`all`)
     Update(tier1::update::UpdateArgs),
     /// Manage component-to-framework adapters
     Adapter(adapter::AdapterArgs),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -10,14 +10,16 @@
 //! contract, installing the declared files, and recording state plus a
 //! central-log audit entry.
 //!
-//! The `rpm` backend additionally supports **adopt** (issue #958): in system
+//! The `rpm` backend supports two actions. **Adopt** (issue #958): in system
 //! mode, when a component is already present as a system RPM, `install`
 //! records it as `rpm-observed` state without downloading or running
-//! `dnf install`. The backend decision is two-layered — pick a backend name
+//! `dnf install`. **Delegated install** (issue #959): in system mode, when the
+//! component is *not* yet present, `install` delegates the file transaction to
+//! `dnf install` and records it as `rpm-managed` state (ANOLISA owns the
+//! removal). The backend decision is two-layered — pick a backend name
 //! (`--backend` > existing state > system RPM presence > `default_backend`),
-//! then pick an action by `(backend, rpmdb hit, install mode)`. Delegated
-//! `dnf install` for not-yet-installed RPM components is out of scope (#959),
-//! and `npm` remains NOT_IMPLEMENTED.
+//! then pick an action by `(backend, rpmdb hit, install mode)`. `npm` remains
+//! NOT_IMPLEMENTED.
 //!
 //! Deliberately out of scope for this milestone: execution-policy gating,
 //! pre/post hooks, health checks, and service start/enable. Installed
@@ -47,7 +49,10 @@ use anolisa_core::{
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
+use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
+use anolisa_platform::privilege;
 use anolisa_platform::rpm_query::RpmPackageQuery;
+use anolisa_platform::rpm_transaction::RpmTransaction;
 use chrono::{SecondsFormat, Utc};
 
 use crate::color::Palette;
@@ -223,25 +228,48 @@ pub fn handle(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
     handle_one(component, args, ctx).map(|_| ())
 }
 
+/// RPM-path execution dependencies, bundled so the raw trunk can carry them
+/// untouched while the rpm branch injects fakes in tests.
+///
+/// - [`query`](Self::query) reads rpmdb/repo metadata (probe + post-install
+///   refresh).
+/// - [`txn`](Self::txn) runs the delegated `dnf install` for not-yet-present
+///   components (#959).
+/// - [`is_root`](Self::is_root) gates the privileged dnf transaction so the
+///   user gets an actionable message instead of dnf's mid-transaction refusal.
+struct RpmExec<'a> {
+    query: &'a dyn PackageQuery,
+    txn: &'a dyn PackageTransaction,
+    is_root: bool,
+}
+
 fn handle_one(
     component: String,
     args: InstallArgs,
     ctx: &CliContext,
 ) -> Result<InstallOutcome, CliError> {
-    // Production uses the real rpm/dnf-backed query; tests inject a fake via
-    // `handle_one_with_query`. Construction is side-effect-free (it only holds
-    // a command runner), so building it on the raw path costs nothing.
+    // Production uses the real rpm/dnf-backed query and transaction; tests
+    // inject fakes via `handle_one_with_exec`. Both constructors are
+    // side-effect-free (they only hold a command runner), so building them on
+    // the raw path costs nothing.
     let query = RpmPackageQuery::system();
-    handle_one_with_query(component, args, ctx, &query)
+    let txn = RpmTransaction::system();
+    let exec = RpmExec {
+        query: &query,
+        txn: &txn,
+        is_root: privilege::is_root(),
+    };
+    handle_one_with_exec(component, args, ctx, &exec)
 }
 
-/// Core of [`handle_one`] with the package query injected, so tests can drive
-/// the adopt path without a live rpmdb.
-fn handle_one_with_query(
+/// Core of [`handle_one`] with the RPM execution dependencies injected, so
+/// tests can drive the adopt and delegated-install paths without a live
+/// rpmdb/dnf or real privileges.
+fn handle_one_with_exec(
     component: String,
     args: InstallArgs,
     ctx: &CliContext,
-    query: &dyn PackageQuery,
+    exec: &RpmExec,
 ) -> Result<InstallOutcome, CliError> {
     let command = format!("install {component}");
 
@@ -261,29 +289,34 @@ fn handle_one_with_query(
     // `--backend raw` hint (§7.1) rather than silently installing raw over a
     // possibly-unobserved system RPM.
     let mut adopt_situation: Option<RpmSituation> = None;
-    let (backend_name, source): (String, BackendSource) = if let Some(explicit) =
-        args.backend.as_deref()
-    {
-        (explicit.to_string(), BackendSource::Explicit)
-    } else if let Some(label) = installed
-        .find_object(ObjectKind::Component, &component)
-        .and_then(installed_backend_label)
-    {
-        // Provenance is sticky: a re-`install` of an adopted rpm-observed
-        // component lands on `rpm` here and is routed to adopt-refresh by
-        // layer 2, rather than being rejected by the raw trunk.
-        (label.to_string(), BackendSource::ExistingState)
-    } else if ctx.install_mode == InstallMode::System {
-        let situation = probe_rpm_situation(&component, &args, &repo_config, ctx, query, &command)?;
-        if matches!(situation, RpmSituation::Absent) {
-            (repo_config.default_backend.clone(), BackendSource::Default)
+    let (backend_name, source): (String, BackendSource) =
+        if let Some(explicit) = args.backend.as_deref() {
+            (explicit.to_string(), BackendSource::Explicit)
+        } else if let Some(label) = installed
+            .find_object(ObjectKind::Component, &component)
+            .and_then(installed_backend_label)
+        {
+            // Provenance is sticky: a re-`install` of an adopted rpm-observed
+            // component lands on `rpm` here and is routed to adopt-refresh by
+            // layer 2, rather than being rejected by the raw trunk.
+            (label.to_string(), BackendSource::ExistingState)
+        } else if ctx.install_mode == InstallMode::System {
+            let situation =
+                probe_rpm_situation(&component, &args, &repo_config, ctx, exec.query, &command)?;
+            if matches!(situation, RpmSituation::Absent { .. }) {
+                // Absent + no `--backend`: fall through to the default backend.
+                // If that is `rpm`, layer 2 re-probes and delegates a `dnf
+                // install`; if it is `raw`, the raw trunk installs. Either way
+                // the probe's `adopt_situation` is dropped — the package is not
+                // present to adopt.
+                (repo_config.default_backend.clone(), BackendSource::Default)
+            } else {
+                adopt_situation = Some(situation);
+                ("rpm".to_string(), BackendSource::SystemRpm)
+            }
         } else {
-            adopt_situation = Some(situation);
-            ("rpm".to_string(), BackendSource::SystemRpm)
-        }
-    } else {
-        (repo_config.default_backend.clone(), BackendSource::Default)
-    };
+            (repo_config.default_backend.clone(), BackendSource::Default)
+        };
 
     // ── Layer 2: pick the action by (backend, rpmdb, mode) (§7.1). ──
     if backend_name == "rpm" {
@@ -297,7 +330,7 @@ fn handle_one_with_query(
             &installed,
             source,
             adopt_situation,
-            query,
+            exec,
         );
     }
 
@@ -411,11 +444,15 @@ enum RpmSituation {
         info: PackageInfo,
     },
     /// Not present as a system RPM: the single candidate is not installed
-    /// (rpm tooling ran and returned nothing). Layer 1 falls through to the
-    /// default backend; an explicit `--backend rpm` turns this into the
-    /// "dnf install not implemented" hint (§7.4). A *missing* rpm/dnf binary
-    /// is a different case — it is a hard warn-and-exit, not `Absent`.
-    Absent,
+    /// (rpm tooling ran and returned nothing). Auto-detect falls through to the
+    /// default backend; an explicit `--backend rpm` (or `default_backend =
+    /// "rpm"`) delegates a `dnf install` of this package and records it as
+    /// `rpm-managed`. A *missing* rpm/dnf binary is a different case —
+    /// it is a hard warn-and-exit, not `Absent`.
+    Absent {
+        /// Resolved package name to hand to `dnf install`.
+        package: String,
+    },
     /// `provides` reverse-lookup matched several distinct installed packages
     /// (§5.5). Reported, never silently adopted.
     Ambiguous(Vec<String>),
@@ -469,7 +506,7 @@ fn probe_rpm_situation(
 
     match query.query_installed(&package) {
         Ok(Some(info)) => Ok(RpmSituation::Adoptable { package, info }),
-        Ok(None) => Ok(RpmSituation::Absent),
+        Ok(None) => Ok(RpmSituation::Absent { package }),
         // Same name, several installed versions: a drift the caller reports.
         Err(PackageQueryError::UnexpectedOutput { .. }) => Ok(RpmSituation::MultiVersion(package)),
         // No rpm/dnf on this host: refuse to silently fall back to raw (§7.1).
@@ -526,9 +563,10 @@ fn load_optional_manifest(ctx: &CliContext, component: &str) -> Option<Component
 }
 
 /// Layer 2 for the `rpm` backend: reject in user mode, otherwise adopt an
-/// installed package, or surface the ambiguous / drift / not-yet-installed
-/// cases (§7.1). `situation` is reused from layer 1's probe when present
-/// (the `SystemRpm` source), and computed here otherwise (`Explicit` rpm).
+/// installed package, delegate a `dnf install` for an absent one, or surface
+/// the ambiguous / drift cases. `situation` is reused from layer 1's probe when
+/// present (the `SystemRpm` source), and computed here otherwise
+/// (`Explicit` rpm).
 #[allow(clippy::too_many_arguments)]
 fn route_rpm_adopt(
     component: &str,
@@ -540,7 +578,7 @@ fn route_rpm_adopt(
     installed: &InstalledState,
     source: BackendSource,
     situation: Option<RpmSituation>,
-    query: &dyn PackageQuery,
+    exec: &RpmExec,
 ) -> Result<InstallOutcome, CliError> {
     // Adopt is a system-scope action (§4.1). The only way to reach `rpm` in
     // user mode is an explicit `--backend rpm`, which we reject rather than
@@ -563,18 +601,16 @@ fn route_rpm_adopt(
 
     let situation = match situation {
         Some(s) => s,
-        None => probe_rpm_situation(component, args, repo_config, ctx, query, command)?,
+        None => probe_rpm_situation(component, args, repo_config, ctx, exec.query, command)?,
     };
 
     match situation {
         RpmSituation::Adoptable { package, info } => {
-            execute_adopt(ctx, layout, command, component, package, info, query)
+            execute_adopt(ctx, layout, command, component, package, info, exec.query)
         }
-        RpmSituation::Absent => Err(CliError::not_implemented_with_hint(
-            format!("install --backend rpm {component}"),
-            "--backend rpm requires the package to be installed for adopt; delegated 'dnf install' is not implemented yet (tracked in #959)"
-                .to_string(),
-        )),
+        RpmSituation::Absent { package } => {
+            execute_delegated_install(exec, ctx, layout, command, component, &package)
+        }
         RpmSituation::Ambiguous(names) => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
@@ -799,6 +835,367 @@ fn render_adopt(ctx: &CliContext, payload: &AdoptResultPayload) {
         color.ok("Adopted as rpm-observed. ANOLISA will not replace it with raw.")
     );
     render_warnings(&payload.warnings, &color);
+}
+
+// ── rpm delegated install path (#959) ───────────────────────────────
+
+/// Wire shape for a delegated `dnf install` result (`--json`) and its dry-run
+/// preview.
+#[derive(Serialize)]
+struct DelegatedInstallPayload {
+    component: String,
+    package: String,
+    /// Always `rpm`: delegated install routes through the rpm backend.
+    backend: &'static str,
+    /// Always `rpm-managed`: ANOLISA drove the install and owns the removal.
+    ownership: &'static str,
+    install_mode: String,
+    /// EVR recorded after install (rpmdb truth); `None` on dry-run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_repo: Option<String>,
+    /// Repo candidate EVRs surfaced in the dry-run preview (best-effort).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    available_candidates: Vec<String>,
+    /// `None` on dry-run (nothing recorded).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation_id: Option<String>,
+    dry_run: bool,
+    warnings: Vec<String>,
+}
+
+/// Install a not-yet-present RPM component by delegating to `dnf install`, then
+/// record it as ANOLISA-managed `rpm-managed` state.
+///
+/// This is the write-side mirror of [`execute_adopt`]: where adopt only
+/// observes an already-installed package, delegated install drives the package
+/// manager to place it and records ANOLISA ownership of the removal
+/// (`owns_removal=true`). ANOLISA never fetches bytes itself — dnf owns the
+/// file transaction. Gated on root for the real run; `--dry-run` previews the
+/// `dnf install` without touching the host.
+fn execute_delegated_install(
+    exec: &RpmExec,
+    ctx: &CliContext,
+    layout: &FsLayout,
+    command: &str,
+    component: &str,
+    package: &str,
+) -> Result<InstallOutcome, CliError> {
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Dry-run: preview the dnf transaction with best-effort repo candidates.
+    // Never needs root, never writes state.
+    if ctx.dry_run {
+        let candidates = match exec.query.query_available(package) {
+            Ok(infos) => {
+                let mut evrs: Vec<String> =
+                    infos.into_iter().map(|i| i.version.to_string()).collect();
+                // Display list, not a version ranking — rpmvercmp is dnf's job.
+                evrs.sort();
+                evrs.dedup();
+                evrs
+            }
+            Err(err) => {
+                warnings.push(format!(
+                    "could not query available versions for '{package}': {err}; dnf will still resolve candidates at install time"
+                ));
+                Vec::new()
+            }
+        };
+        let payload = DelegatedInstallPayload {
+            component: component.to_string(),
+            package: package.to_string(),
+            backend: "rpm",
+            ownership: "rpm-managed",
+            install_mode: ctx.install_mode.as_str().to_string(),
+            version: None,
+            arch: None,
+            source_repo: None,
+            available_candidates: candidates,
+            operation_id: None,
+            dry_run: true,
+            warnings,
+        };
+        render_delegated_install(ctx, &payload);
+        return Ok(InstallOutcome::Installed);
+    }
+
+    // Privilege gate: dnf transactions need root. Check up front so the user
+    // gets an actionable message instead of dnf's raw mid-transaction refusal.
+    if !exec.is_root {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "installing system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa --install-mode system install --backend rpm {component}`"
+            ),
+        });
+    }
+
+    // dnf install — delegate the file transaction.
+    exec.txn
+        .install(package)
+        .map_err(|err| txn_install_err(err, command))?;
+
+    // Refresh from rpmdb: the authoritative installed EVR/arch.
+    let info = match exec.query.query_installed(package) {
+        Ok(Some(info)) => info,
+        // dnf reported success, so the package should be present; a miss here is
+        // anomalous (a no-op transaction?). Refuse rather than record a phantom.
+        Ok(None) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "dnf install of '{package}' reported success but rpmdb has no such package; the transaction may have been a no-op — run `anolisa status {component}`"
+                ),
+            });
+        }
+        Err(PackageQueryError::UnexpectedOutput { .. }) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "RPM package '{package}' has multiple installed versions after install; refusing to record an ambiguous version"
+                ),
+            });
+        }
+        Err(err) => return Err(pkg_query_err(err, command)),
+    };
+
+    // source_repo is supplementary metadata: a failed origin lookup degrades to
+    // `None` with a warning and never fails the install (mirrors adopt).
+    let source_repo = match exec.query.installed_origin(package) {
+        Ok(origin) => origin,
+        Err(err) => {
+            warnings.push(format!(
+                "could not determine source repo for '{package}': {err}"
+            ));
+            None
+        }
+    };
+
+    let operation_id = persist_delegated_install(
+        ctx,
+        layout,
+        command,
+        component,
+        package,
+        &info,
+        source_repo.as_deref(),
+        &warnings,
+    )?;
+
+    let payload = DelegatedInstallPayload {
+        component: component.to_string(),
+        package: package.to_string(),
+        backend: "rpm",
+        ownership: "rpm-managed",
+        install_mode: ctx.install_mode.as_str().to_string(),
+        version: Some(info.version.to_string()),
+        arch: Some(info.arch.clone()),
+        source_repo,
+        available_candidates: Vec::new(),
+        operation_id: Some(operation_id),
+        dry_run: false,
+        warnings,
+    };
+    render_delegated_install(ctx, &payload);
+    Ok(InstallOutcome::Installed)
+}
+
+/// Persist a delegated install as `rpm-managed` state under the install lock,
+/// then append an audit record. Returns the operation id.
+///
+/// Mirrors [`execute_adopt`]'s state write but records ANOLISA ownership
+/// (`managed=true`, `adopted=false`, [`Ownership::RpmManaged`]) — the file
+/// transaction was ANOLISA-driven, so a later uninstall delegates back to dnf.
+#[allow(clippy::too_many_arguments)]
+fn persist_delegated_install(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    command: &str,
+    component: &str,
+    package: &str,
+    info: &PackageInfo,
+    source_repo: Option<&str>,
+    warnings: &[String],
+) -> Result<String, CliError> {
+    let evr = info.version.to_string();
+    let started_at = now_iso8601();
+
+    // Acquire the lock, then load state inside it so a concurrent writer is not
+    // clobbered — mirrors `execute_adopt`/`execute_raw` ordering.
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state =
+        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to load installed state: {err}"),
+        })?;
+
+    // Re-validate against the freshly-reloaded state: a concurrent raw install
+    // may have won the lock and recorded the component first. Refuse rather than
+    // overwrite its provenance with rpm-managed.
+    ensure_component_backend_compatible(&state, component, "rpm", command)?;
+
+    let lock_ts = Utc::now();
+    let operation_id = format!(
+        "op-install-{}-{}",
+        lock_ts.format("%Y%m%d%H%M%S"),
+        lock_ts.timestamp_subsec_nanos()
+    );
+
+    // Delegated install is system-scope by construction (route_rpm_adopt
+    // rejects user mode before reaching the Absent branch).
+    state.install_mode = StateInstallMode::System;
+    state.prefix = layout.prefix.clone();
+    state.upsert_object(InstalledObject {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        version: evr.clone(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        // Not an ANOLISA-delivered raw artifact; dnf resolved the source.
+        distribution_source: None,
+        install_backend: Some("rpm".to_string()),
+        ownership: Some(Ownership::RpmManaged),
+        rpm_metadata: Some(RpmMetadata {
+            package_name: info.name.clone(),
+            evr: Some(evr.clone()),
+            arch: Some(info.arch.clone()),
+            source_repo: source_repo.map(str::to_string),
+        }),
+        installed_at: started_at.clone(),
+        last_operation_id: Some(operation_id.clone()),
+        // ANOLISA delegated the install and owns the removal (owns_removal=true).
+        managed: true,
+        // Not an adoption: ANOLISA drove the install.
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        // dnf owns the file transaction; RPM-owned files stay out of state.
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+    });
+    state.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: started_at.clone(),
+        finished_at: Some(now_iso8601()),
+    });
+
+    let state_path = layout.state_dir.join("installed.toml");
+    state.save(&state_path).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to save state: {err}"),
+    })?;
+
+    // Audit log is best-effort: the install already persisted, so a log failure
+    // downgrades to a warning instead of unwinding.
+    let log = CentralLog::open(layout.central_log.clone());
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.clone()),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message: format!(
+            "installed RPM package {package} ({evr}) as rpm-managed for component {component} via dnf"
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at,
+        finished_at: Some(now_iso8601()),
+        status: Some(LogStatus::Ok),
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: warnings.to_vec(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = log.append(&record) {
+        eprintln!("warning: failed to write central log: {err}");
+    }
+
+    Ok(operation_id)
+}
+
+/// Render a delegated-install result (JSON envelope or human text). Silent in
+/// quiet mode; the `--all` batch path drives its own summary.
+fn render_delegated_install(ctx: &CliContext, payload: &DelegatedInstallPayload) {
+    if ctx.json {
+        // Errors here are unreachable for a plain Serialize struct; ignore the
+        // Result so the (already-persisted) install is not reported as failed.
+        let _ = render_json(COMMAND, payload);
+        return;
+    }
+    if ctx.quiet {
+        return;
+    }
+    let color = Palette::new(ctx.no_color);
+    if payload.dry_run {
+        println!(
+            "{} {} {} {}",
+            color.command("install"),
+            payload.component,
+            color.muted(format!("(rpm-managed, {})", payload.package)),
+            color.muted("(dry-run — nothing installed)"),
+        );
+        if payload.available_candidates.is_empty() {
+            println!(
+                "{} {}",
+                color.label("available:"),
+                color.muted("no repo candidates reported"),
+            );
+        } else {
+            println!(
+                "{} {}",
+                color.label("available:"),
+                payload.available_candidates.join(", "),
+            );
+        }
+        println!("  would run: dnf install -y {}", payload.package);
+    } else {
+        println!(
+            "{} {} {} {}",
+            color.command("install"),
+            payload.component,
+            color.muted(format!("(rpm-managed, {})", payload.package)),
+            color.ok("installed via dnf"),
+        );
+        if let Some(v) = &payload.version {
+            println!("{} {}", color.label("version:"), v);
+        }
+    }
+    render_warnings(&payload.warnings, &color);
+}
+
+/// Map a [`PackageTransactionError`] from `dnf install` onto a CLI runtime
+/// error with an actionable hint.
+fn txn_install_err(err: PackageTransactionError, command: &str) -> CliError {
+    match err {
+        PackageTransactionError::CommandMissing { .. } => rpm_tooling_missing_error(command),
+        PackageTransactionError::PermissionDenied { command: bin } => CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("permission denied running {bin}; re-run the install with sudo"),
+        },
+        PackageTransactionError::TransactionFailed { code, stderr, .. } => CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "dnf install failed (exit {}): {}",
+                code.map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string()),
+                stderr.trim(),
+            ),
+        },
+    }
 }
 
 /// Map a [`PackageQueryError`] onto a CLI error. Spawn/permission/query
@@ -3321,6 +3718,129 @@ scope = "@anolisa"
 
     use anolisa_platform::pkg_query::PackageVersion;
 
+    use std::cell::{Cell, RefCell};
+
+    /// No-op transaction for adopt-path tests, which never delegate to dnf.
+    /// A call here means a routing bug sent an adopt down the install path.
+    struct NoTxn;
+
+    impl PackageTransaction for NoTxn {
+        fn install(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("adopt-path test reached a delegated dnf install");
+        }
+        fn update(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("adopt-path test reached a dnf update");
+        }
+    }
+
+    /// Test seam that drives [`handle_one_with_exec`] with only a query (no
+    /// delegated install, non-root). Adopt-path and raw-path tests use this; the
+    /// delegated-install tests build a full [`RpmExec`] instead.
+    fn handle_one_with_query(
+        component: String,
+        args: InstallArgs,
+        ctx: &CliContext,
+        query: &dyn PackageQuery,
+    ) -> Result<InstallOutcome, CliError> {
+        let txn = NoTxn;
+        let exec = RpmExec {
+            query,
+            txn: &txn,
+            is_root: false,
+        };
+        handle_one_with_exec(component, args, ctx, &exec)
+    }
+
+    /// Combined fake [`PackageQuery`] + [`PackageTransaction`] for
+    /// delegated-install tests: the package is absent until `install()` runs,
+    /// after which `query_installed` reports [`installs_to`](Self::installs_to),
+    /// modelling rpmdb gaining the package once dnf places it.
+    struct FakeInstaller {
+        package: String,
+        /// PackageInfo rpmdb reports after a successful install.
+        installs_to: PackageInfo,
+        origin: Option<String>,
+        available: Vec<PackageInfo>,
+        /// `false` makes the dnf install transaction fail.
+        install_succeeds: bool,
+        installed: RefCell<Option<PackageInfo>>,
+        install_calls: Cell<usize>,
+    }
+
+    impl FakeInstaller {
+        fn new(package: &str, installs_to: PackageInfo) -> Self {
+            Self {
+                package: package.to_string(),
+                installs_to,
+                origin: None,
+                available: Vec::new(),
+                install_succeeds: true,
+                installed: RefCell::new(None),
+                install_calls: Cell::new(0),
+            }
+        }
+        fn with_origin(mut self, repo: &str) -> Self {
+            self.origin = Some(repo.to_string());
+            self
+        }
+        fn failing_install(mut self) -> Self {
+            self.install_succeeds = false;
+            self
+        }
+    }
+
+    impl PackageQuery for FakeInstaller {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if package != self.package {
+                return Ok(None);
+            }
+            Ok(self.installed.borrow().clone())
+        }
+
+        fn query_available(&self, package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            if package != self.package {
+                return Ok(Vec::new());
+            }
+            Ok(self.available.clone())
+        }
+
+        fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+            if package != self.package {
+                return Ok(None);
+            }
+            Ok(self.origin.clone())
+        }
+
+        fn what_provides_installed(
+            &self,
+            _capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            // Default-naming path: the probe falls through to `anolisa-<name>`.
+            Ok(Vec::new())
+        }
+    }
+
+    impl PackageTransaction for FakeInstaller {
+        fn install(&self, package: &str) -> Result<(), PackageTransactionError> {
+            self.install_calls.set(self.install_calls.get() + 1);
+            assert_eq!(package, self.package, "install targeted the wrong package");
+            if !self.install_succeeds {
+                return Err(PackageTransactionError::TransactionFailed {
+                    command: "dnf".to_string(),
+                    operation: "install".to_string(),
+                    code: Some(1),
+                    stderr: "No match for argument".to_string(),
+                });
+            }
+            // rpmdb now holds the package, modelling dnf placing it.
+            *self.installed.borrow_mut() = Some(self.installs_to.clone());
+            Ok(())
+        }
+        fn update(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("delegated-install test must not run a dnf update");
+        }
+    }
+
     /// Configurable in-memory [`PackageQuery`] so adopt tests run without a
     /// live rpmdb.
     #[derive(Default)]
@@ -3552,7 +4072,7 @@ scope = "@anolisa"
             "install",
         )
         .expect("probe");
-        assert!(matches!(situation, RpmSituation::Absent));
+        assert!(matches!(situation, RpmSituation::Absent { .. }));
     }
 
     #[test]
@@ -3601,7 +4121,7 @@ scope = "@anolisa"
     fn situation_label(s: &RpmSituation) -> &'static str {
         match s {
             RpmSituation::Adoptable { .. } => "Adoptable",
-            RpmSituation::Absent => "Absent",
+            RpmSituation::Absent { .. } => "Absent",
             RpmSituation::Ambiguous(_) => "Ambiguous",
             RpmSituation::MultiVersion(_) => "MultiVersion",
         }
@@ -3829,18 +4349,146 @@ scope = "@anolisa"
         );
     }
 
+    // ── delegated install (#959) ──
+
+    /// `--backend rpm` on a not-yet-installed component delegates a `dnf
+    /// install` and records `rpm-managed` state: ANOLISA owns the removal,
+    /// the EVR is read back from rpmdb, and ownership/backend are rpm.
     #[test]
-    fn explicit_rpm_not_installed_is_not_implemented() {
+    fn delegated_install_writes_rpm_managed_state() {
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
-        let q = FakeQuery::default();
+        let fake = FakeInstaller::new(
+            "anolisa-copilot-shell",
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        )
+        .with_origin("anolisa");
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
         let mut a = args("copilot-shell");
         a.backend = Some("rpm".to_string());
-        let err = handle_one_with_query("copilot-shell".to_string(), a, &ctx, &q)
-            .expect_err("not installed → not implemented");
-        assert_eq!(err.code(), "NOT_IMPLEMENTED");
-        // The #959 delegation hint rides on the NotImplemented variant; reason()
-        // surfaces the command, which still names the rpm backend.
-        assert!(err.reason().contains("rpm"), "got: {}", err.reason());
+
+        let outcome = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+            .expect("delegated install ok");
+        assert_eq!(outcome, InstallOutcome::Installed);
+        assert_eq!(fake.install_calls.get(), 1, "dnf install must run once");
+
+        let state = load_state(&ctx);
+        let obj = state
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("component recorded");
+        assert_eq!(obj.status, ObjectStatus::Installed);
+        assert_eq!(obj.ownership, Some(Ownership::RpmManaged));
+        assert_eq!(obj.install_backend.as_deref(), Some("rpm"));
+        assert!(obj.managed, "rpm-managed must be ANOLISA-managed");
+        assert!(!obj.adopted, "delegated install is not an adoption");
+        assert!(obj.files.is_empty(), "dnf-owned files stay out of state");
+        assert_eq!(obj.version, "2.3.0-1.al8");
+        let meta = obj.rpm_metadata.as_ref().expect("rpm metadata");
+        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+        assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
+        assert_eq!(meta.arch.as_deref(), Some("x86_64"));
+        assert_eq!(meta.source_repo.as_deref(), Some("anolisa"));
+        assert!(state.operations[0].id.starts_with("op-install-"));
+    }
+
+    /// A non-root real run is refused with an actionable message; dnf never
+    /// runs and no state is written.
+    #[test]
+    fn delegated_install_non_root_is_refused() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let fake = FakeInstaller::new(
+            "anolisa-copilot-shell",
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: false,
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+
+        let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+            .expect_err("must refuse without root");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("root") && err.reason().contains("sudo"),
+            "reason must point at sudo: {}",
+            err.reason()
+        );
+        assert_eq!(fake.install_calls.get(), 0, "dnf must not run without root");
+        assert!(
+            load_state(&ctx)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "refused install must not write state"
+        );
+    }
+
+    /// Dry-run previews the `dnf install` without running it, needing root, or
+    /// writing state — even for a non-root caller.
+    #[test]
+    fn delegated_install_dry_run_previews_without_txn_or_state() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(true);
+        let fake = FakeInstaller::new(
+            "anolisa-copilot-shell",
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: false,
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+
+        let outcome =
+            handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec).expect("dry-run ok");
+        assert_eq!(outcome, InstallOutcome::Installed);
+        assert_eq!(fake.install_calls.get(), 0, "dry-run must not run dnf");
+        assert!(
+            load_state(&ctx)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "dry-run must not persist state"
+        );
+    }
+
+    /// A `dnf install` failure surfaces as EXECUTION_FAILED and writes no state.
+    #[test]
+    fn delegated_install_dnf_failure_surfaces() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let fake = FakeInstaller::new(
+            "anolisa-copilot-shell",
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        )
+        .failing_install();
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+
+        let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+            .expect_err("dnf failure must propagate");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("dnf install failed"),
+            "got: {}",
+            err.reason()
+        );
+        assert_eq!(fake.install_calls.get(), 1);
+        assert!(
+            load_state(&ctx)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "failed install must not write state"
+        );
     }
 
     #[test]
@@ -3926,6 +4574,12 @@ scope = "@anolisa"
 
         let mut a = args("copilot-shell");
         a.backend = Some("rpm".to_string());
+        let txn = NoTxn;
+        let exec = RpmExec {
+            query: &q,
+            txn: &txn,
+            is_root: false,
+        };
         let err = route_rpm_adopt(
             "copilot-shell",
             &a,
@@ -3936,7 +4590,7 @@ scope = "@anolisa"
             &installed,
             BackendSource::Explicit,
             None,
-            &q,
+            &exec,
         )
         .expect_err("user mode must be rejected");
         assert_eq!(err.code(), "INVALID_ARGUMENT");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -1,31 +1,53 @@
-//! `anolisa update` — unified update surface (launch spec §7.3).
+//! `anolisa update` — unified update surface.
 //!
-//! Three subcommands:
+//! Three forms:
+//! - `update <component>` - update one ANOLISA-managed component.
 //! - `update self` - update the `anolisa` CLI binary only.
-//! - `update runtime <COMP|all>` - update one or all ANOLISA-managed
-//!   runtime components.
 //! - `update all` - update every ANOLISA-managed runtime, osbase, and
 //!   adapter object.
 //!
-//! Explicit invariant (spec §7.3, decision §11.2): `update all` does
-//! **not** include CLI self-update. The binary swap never shares a
-//! transaction with component updates. Self-update is reachable via
-//! both `anolisa update self` and `anolisa self update`.
+//! The component is a positional argument; `self` / `all` are subcommands
+//! (kept mutually exclusive with the positional via
+//! `args_conflicts_with_subcommands`). A component literally named `self` or
+//! `all` would be shadowed by the subcommand — those are reserved.
+//!
+//! Explicit invariant: `update all` does **not** include CLI self-update. The
+//! binary swap never shares a transaction with component updates.
+//!
+//! `update <component>` implements the **RPM** update path (issue #959): for
+//! `rpm-observed` and `rpm-managed` components it runs the flow
+//! `rpmdb query -> dnf repo query -> dnf update -> refresh ANOLISA state`,
+//! gated on root for the real run. It never switches backend —
+//! ownership/`install_backend` are preserved. Raw components stay on the
+//! not-yet-implemented planner boundary, and `update all` remains
+//! `NOT_IMPLEMENTED` pending the raw distribution resolver.
 
 use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
 
+use chrono::{SecondsFormat, Utc};
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 
+use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
+use anolisa_core::lock::InstallLock;
 use anolisa_core::self_update::{self, ProgressFn, SelfUpdateOutcome};
+use anolisa_core::state::{ObjectKind, OperationRecord, Ownership};
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
+use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
+use anolisa_platform::privilege;
+use anolisa_platform::rpm_query::RpmPackageQuery;
+use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use crate::color::Palette;
 use crate::commands::common;
 use crate::context::CliContext;
 use crate::repo_config::RepoConfig;
 use crate::response::{self, CliError};
+
+/// Command label for JSON envelopes and error routing.
+const COMMAND: &str = "update";
 
 const CLI_CHANGELOG_URL: &str = "https://agentic-os.sh/#anolisa-cli-changelog";
 
@@ -44,25 +66,30 @@ const DEFAULT_REPO_CONFIG_URL: &str =
 const MAX_REPO_CONFIG_BYTES: u64 = 256 * 1024;
 
 /// Arguments for the unified update command surface.
-#[derive(Parser)]
+///
+/// `anolisa update <component>` updates a single component directly; the
+/// `self` and `all` subcommands cover the CLI binary and the (future) batch
+/// update. `args_conflicts_with_subcommands` keeps the positional and the
+/// subcommands mutually exclusive so `update foo self` is a parse error.
+#[derive(Debug, Parser)]
+#[command(args_conflicts_with_subcommands = true)]
 pub struct UpdateArgs {
-    /// Selected update operation.
+    /// Component to update (omit when using a `self` / `all` subcommand)
+    #[arg(value_name = "COMPONENT")]
+    pub component: Option<String>,
+    /// Update the CLI binary (`self`) or every component (`all`) instead of a
+    /// single component.
     #[command(subcommand)]
-    pub command: UpdateCommands,
+    pub command: Option<UpdateCommands>,
 }
 
-/// Update operations that intentionally keep CLI self-update separate from
-/// component updates.
-#[derive(Subcommand)]
+/// Update operations that intentionally keep CLI self-update and batch update
+/// separate from a single-component update.
+#[derive(Debug, Subcommand)]
 pub enum UpdateCommands {
     /// Update the anolisa CLI binary only
     #[command(name = "self")]
     SelfBin,
-    /// Update one or all ANOLISA-managed runtime components
-    Runtime {
-        /// Component name, or `all`
-        target: String,
-    },
     /// Update every ANOLISA-managed runtime, osbase, and adapter object.
     ///
     /// Does NOT include the CLI binary itself — use `anolisa update self`
@@ -70,25 +97,551 @@ pub enum UpdateCommands {
     All,
 }
 
-/// Dispatches the selected `anolisa update` subcommand.
+/// Dispatches the selected `anolisa update` form.
 ///
 /// # Errors
 ///
-/// Returns [`CliError`] when the selected update operation fails or is not
-/// implemented yet.
+/// Returns [`CliError`] when the selected update operation fails, no target is
+/// given, or the operation is not implemented yet.
 pub fn handle(args: UpdateArgs, ctx: &CliContext) -> Result<(), CliError> {
-    bootstrap_repo_config(ctx);
-    match args.command {
-        UpdateCommands::SelfBin => handle_self_update(ctx),
-        UpdateCommands::Runtime { target } => Err(CliError::not_implemented_with_hint(
-            format!("update runtime {target}"),
-            "update planner / distribution resolver not implemented yet",
-        )),
-        UpdateCommands::All => Err(CliError::not_implemented_with_hint(
+    // `args_conflicts_with_subcommands` guarantees `command` and `component`
+    // are never both set, so a present subcommand always wins.
+    //
+    // Bootstrap the repo config only inside the branches that actually run an
+    // update: with `component` now optional, a bare `anolisa update` (or a
+    // not-yet-implemented `update all`) must fail validation without first
+    // reaching out to the network or writing config.
+    match (args.command, args.component) {
+        (Some(UpdateCommands::SelfBin), _) => {
+            bootstrap_repo_config(ctx);
+            handle_self_update(ctx)
+        }
+        (Some(UpdateCommands::All), _) => Err(CliError::not_implemented_with_hint(
             "update all",
             "update planner / distribution resolver not implemented yet",
         )),
+        (None, Some(component)) => {
+            bootstrap_repo_config(ctx);
+            handle_component_update(&component, ctx)
+        }
+        (None, None) => Err(CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: "specify a component to update (e.g. `anolisa update <component>`), or use `anolisa update self` / `anolisa update all`".to_string(),
+        }),
     }
+}
+
+// ── component update (#959): RPM-backed update for rpm-observed / rpm-managed ──
+
+/// Wire shape for an `update <component>` result (`--json`) and its dry-run
+/// preview.
+#[derive(Serialize)]
+struct ComponentUpdatePayload {
+    component: String,
+    package: String,
+    /// Always `rpm`: update never switches backend. The raw path is a
+    /// separate, not-yet-implemented branch.
+    backend: &'static str,
+    /// `rpm-observed` or `rpm-managed`; preserved across the update.
+    ownership: &'static str,
+    install_mode: String,
+    /// EVR recorded before the update (rpmdb truth).
+    from_version: String,
+    /// EVR after the update; `None` on dry-run (nothing applied).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    to_version: Option<String>,
+    /// Whether the EVR actually changed (false on a no-op "already latest").
+    updated: bool,
+    dry_run: bool,
+    /// Repo candidate EVRs surfaced in the dry-run preview (best-effort).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    available_candidates: Vec<String>,
+    /// `None` on dry-run (nothing recorded).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation_id: Option<String>,
+    warnings: Vec<String>,
+}
+
+/// Dispatch `update <component>`: build the real rpm/dnf-backed query and
+/// transaction, then route by recorded ownership.
+fn handle_component_update(component: &str, ctx: &CliContext) -> Result<(), CliError> {
+    let query = RpmPackageQuery::system();
+    let txn = RpmTransaction::system();
+    update_component_with_deps(component, ctx, &query, &txn, privilege::is_root())
+}
+
+/// Core of [`handle_component_update`] with the package query, transaction, and
+/// root status injected so tests drive the RPM path without a live rpmdb/dnf or
+/// real privileges.
+fn update_component_with_deps(
+    target: &str,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+) -> Result<(), CliError> {
+    let command = format!("update {target}");
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+
+    let obj = installed
+        .find_object(ObjectKind::Component, target)
+        .ok_or_else(|| CliError::InvalidArgument {
+            command: command.clone(),
+            reason: format!(
+                "component '{target}' is not installed — nothing to update (run `anolisa status` to see what is installed, or `anolisa install {target}` to install it)"
+            ),
+        })?;
+
+    match obj.effective_ownership() {
+        // Raw update still needs the distribution-resolver planner; #959 only
+        // wires the RPM path. Keep raw on the same not-implemented boundary as
+        // before so behavior is unchanged for raw components.
+        Ownership::RawManaged => Err(CliError::not_implemented_with_hint(
+            command,
+            "raw component update is not implemented yet (update planner / distribution resolver pending); only RPM-backed components update today",
+        )),
+        ownership @ (Ownership::RpmManaged | Ownership::RpmObserved) => {
+            // Snapshot the package identity, then drop the immutable borrow so
+            // the write path can re-acquire the lock and reload state.
+            let package = match obj.rpm_metadata.as_ref().map(|m| m.package_name.clone()) {
+                Some(p) if !p.is_empty() => p,
+                _ => {
+                    return Err(CliError::Runtime {
+                        command,
+                        reason: format!(
+                            "component '{target}' is recorded as an RPM component but has no package metadata; run `anolisa repair {target}` to refresh it before updating"
+                        ),
+                    });
+                }
+            };
+            update_rpm_component(
+                target, &package, ownership, ctx, query, txn, is_root, &command,
+            )
+        }
+    }
+}
+
+/// Execute the RPM update flow for one component:
+/// `rpmdb query -> dnf repo query -> dnf update -> refresh ANOLISA state`.
+/// Never switches backend; the dnf transaction is gated on root for real runs.
+#[allow(clippy::too_many_arguments)]
+fn update_rpm_component(
+    component: &str,
+    package: &str,
+    ownership: Ownership,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    command: &str,
+) -> Result<(), CliError> {
+    let mut warnings: Vec<String> = Vec::new();
+
+    // 1. rpmdb query — the EVR we update from, and the truth source.
+    let current = match query.query_installed(package) {
+        Ok(Some(info)) => info,
+        // State records the package but rpmdb no longer has it: a Missing drift.
+        // Drift adjudication / repair is #960; here we refuse rather than run
+        // dnf blindly, and point at the repair path.
+        Ok(None) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "RPM package '{package}' for component '{component}' is recorded in ANOLISA state but is not present in rpmdb — it may have been removed with `rpm -e`; run `anolisa repair {component}` or reinstall before updating"
+                ),
+            });
+        }
+        Err(PackageQueryError::CommandMissing { .. }) => {
+            return Err(rpm_tooling_missing_error(command));
+        }
+        // Same name, several installed versions — a drift, not a clean update
+        // target.
+        Err(PackageQueryError::UnexpectedOutput { .. }) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "RPM package '{package}' has multiple installed versions; refusing to update an ambiguous package — resolve the duplicate first"
+                ),
+            });
+        }
+        Err(err) => return Err(rpm_query_err(err, command)),
+    };
+    let from_evr = current.version.to_string();
+
+    // 2. dnf repo query — best-effort candidate enrichment. A repo-query failure
+    //    must not block the update (dnf runs its own resolution); it only feeds
+    //    the dry-run preview.
+    let candidates = available_candidates(query, package, &current.arch, &mut warnings);
+
+    let ownership_label = ownership_label(ownership);
+
+    // 3. Dry-run preview — never touches the filesystem, never needs root.
+    if ctx.dry_run {
+        let payload = ComponentUpdatePayload {
+            component: component.to_string(),
+            package: package.to_string(),
+            backend: "rpm",
+            ownership: ownership_label,
+            install_mode: ctx.install_mode.as_str().to_string(),
+            from_version: from_evr,
+            to_version: None,
+            updated: false,
+            dry_run: true,
+            available_candidates: candidates,
+            operation_id: None,
+            warnings,
+        };
+        render_component_update(ctx, &payload);
+        return Ok(());
+    }
+
+    // 4. Privilege gate — dnf transactions need root. Check up front so the user
+    //    gets an actionable message instead of dnf's raw mid-transaction refusal.
+    if !is_root {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "updating system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa --install-mode system update {component}`"
+            ),
+        });
+    }
+
+    // 5. dnf update — delegate the file transaction.
+    txn.update(package).map_err(|err| txn_err(err, command))?;
+
+    // 6. Refresh ANOLISA state from rpmdb (authoritative post-update EVR).
+    //
+    // The dnf transaction already mutated rpmdb and cannot be rolled back, so a
+    // failed re-read leaves the package updated but its new EVR unconfirmed. We
+    // must not paper over that by recording the *old* EVR as a successful no-op
+    // ("already up to date") — that hides a real change. Surface it as a failure
+    // with a repair pointer instead; `persist_rpm_update` is never reached.
+    let refreshed = match query.query_installed(package) {
+        Ok(Some(info)) => info,
+        Ok(None) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "dnf update of '{package}' succeeded but the package is no longer in rpmdb under that name (it may have been obsoleted or renamed); ANOLISA state for component '{component}' is now stale — run `anolisa repair {component}`"
+                ),
+            });
+        }
+        // Several installed versions after the update — a drift we cannot record
+        // as a single EVR.
+        Err(PackageQueryError::UnexpectedOutput { .. }) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "dnf update of '{package}' succeeded but rpmdb now reports multiple installed versions; ANOLISA state for component '{component}' is now stale — run `anolisa repair {component}`"
+                ),
+            });
+        }
+        Err(err) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "dnf update of '{package}' succeeded but reading the new version from rpmdb failed ({err}); ANOLISA state for component '{component}' is now stale — run `anolisa repair {component}`"
+                ),
+            });
+        }
+    };
+    let to_evr = refreshed.version.to_string();
+    let updated = to_evr != from_evr;
+
+    let operation_id = persist_rpm_update(
+        ctx, component, package, ownership, &refreshed, &to_evr, command, &warnings,
+    )?;
+
+    let payload = ComponentUpdatePayload {
+        component: component.to_string(),
+        package: package.to_string(),
+        backend: "rpm",
+        ownership: ownership_label,
+        install_mode: ctx.install_mode.as_str().to_string(),
+        from_version: from_evr,
+        to_version: Some(to_evr),
+        updated,
+        dry_run: false,
+        available_candidates: Vec::new(),
+        operation_id: Some(operation_id),
+        warnings,
+    };
+    render_component_update(ctx, &payload);
+    Ok(())
+}
+
+/// Persist the refreshed RPM version under the install lock and append an audit
+/// record. Ownership and `install_backend` are left untouched — update never
+/// switches backend. Returns the operation id.
+#[allow(clippy::too_many_arguments)]
+fn persist_rpm_update(
+    ctx: &CliContext,
+    component: &str,
+    package: &str,
+    ownership: Ownership,
+    refreshed: &PackageInfo,
+    to_evr: &str,
+    command: &str,
+    warnings: &[String],
+) -> Result<String, CliError> {
+    let layout = common::resolve_layout(ctx);
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state = common::load_installed_state(ctx, command)?;
+
+    // Re-validate under the lock: the component must still exist and still be
+    // RPM-owned. A concurrent uninstall or backend change between the pre-lock
+    // read and here must not be clobbered by a stale update record.
+    let obj = state
+        .find_object_mut(ObjectKind::Component, component)
+        .ok_or_else(|| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' disappeared from state during update; no changes recorded"
+            ),
+        })?;
+    if !obj.effective_ownership().is_rpm() {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' is no longer an RPM component in state; refusing to record an RPM update"
+            ),
+        });
+    }
+
+    // The package identity must also be unchanged under the lock. `dnf update`
+    // ran against `package` (snapshotted before the lock); if a concurrent
+    // operation re-pointed this component at a different RPM in the meantime,
+    // writing the new EVR in place would graft package A's version onto package
+    // B's metadata. Refuse rather than corrupt the record.
+    let package_matches = obj
+        .rpm_metadata
+        .as_ref()
+        .is_some_and(|m| m.package_name == package);
+    if !package_matches {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' RPM package identity changed during update (expected package '{package}'); refusing to record an EVR against a different package — run `anolisa status {component}`"
+            ),
+        });
+    }
+
+    let now = now_iso8601();
+    let lock_ts = Utc::now();
+    let operation_id = format!(
+        "op-update-{}-{}",
+        lock_ts.format("%Y%m%d%H%M%S"),
+        lock_ts.timestamp_subsec_nanos()
+    );
+
+    // Refresh the observed/managed version in place. ownership / install_backend
+    // are deliberately untouched.
+    obj.version = to_evr.to_string();
+    obj.last_operation_id = Some(operation_id.clone());
+    if let Some(meta) = obj.rpm_metadata.as_mut() {
+        meta.evr = Some(to_evr.to_string());
+        meta.arch = Some(refreshed.arch.clone());
+    }
+
+    state.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: now.clone(),
+        finished_at: Some(now.clone()),
+    });
+
+    let state_path = layout.state_dir.join("installed.toml");
+    state.save(&state_path).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to save state: {err}"),
+    })?;
+
+    // Audit log is best-effort: the update already persisted, so a log failure
+    // downgrades to a warning instead of unwinding.
+    let log = CentralLog::open(layout.central_log.clone());
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.clone()),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message: format!(
+            "updated RPM package {package} for component {component} to {to_evr} via dnf ({ownership_label})",
+            ownership_label = ownership_label(ownership),
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at: now.clone(),
+        finished_at: Some(now),
+        status: Some(LogStatus::Ok),
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: warnings.to_vec(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = log.append(&record) {
+        eprintln!("warning: failed to write central log: {err}");
+    }
+
+    Ok(operation_id)
+}
+
+/// Best-effort repo candidate EVRs for `package`, filtered to the installed
+/// arch (plus `noarch`). A query failure degrades to a warning and an empty
+/// list — dnf still resolves candidates at update time.
+fn available_candidates(
+    query: &dyn PackageQuery,
+    package: &str,
+    arch: &str,
+    warnings: &mut Vec<String>,
+) -> Vec<String> {
+    match query.query_available(package) {
+        Ok(infos) => {
+            let mut evrs: Vec<String> = infos
+                .into_iter()
+                .filter(|i| i.arch == arch || i.arch == "noarch")
+                .map(|i| i.version.to_string())
+                .collect();
+            // Sort + dedup for deterministic output; this is a display list, not
+            // a version-ordered ranking (rpmvercmp is dnf's job at update time).
+            evrs.sort();
+            evrs.dedup();
+            evrs
+        }
+        Err(err) => {
+            warnings.push(format!(
+                "could not query available versions for '{package}': {err}; dnf will still resolve candidates at update time"
+            ));
+            Vec::new()
+        }
+    }
+}
+
+/// Human/JSON renderer for a component update result.
+fn render_component_update(ctx: &CliContext, payload: &ComponentUpdatePayload) {
+    if ctx.json {
+        // Errors here are unreachable for a plain Serialize struct; ignore the
+        // Result so an (already-persisted) update is not reported as failed.
+        let _ = response::render_json(COMMAND, payload);
+        return;
+    }
+    if ctx.quiet {
+        return;
+    }
+    let color = Palette::new(ctx.no_color);
+    if payload.dry_run {
+        println!(
+            "{} {} {} {}",
+            color.command("update"),
+            payload.component,
+            color.muted(format!("({}, {})", payload.ownership, payload.package)),
+            color.muted("(dry-run — nothing updated)"),
+        );
+        println!("{} {}", color.label("current:"), payload.from_version);
+        if payload.available_candidates.is_empty() {
+            println!(
+                "{} {}",
+                color.label("available:"),
+                color.muted("no repo candidates reported"),
+            );
+        } else {
+            println!(
+                "{} {}",
+                color.label("available:"),
+                payload.available_candidates.join(", "),
+            );
+        }
+        println!("  would run: dnf update -y {}", payload.package);
+    } else if payload.updated {
+        println!(
+            "{} {} {} → {}",
+            color.ok("✓ updated"),
+            payload.component,
+            payload.from_version,
+            payload.to_version.as_deref().unwrap_or("-"),
+        );
+    } else {
+        println!(
+            "{} {} is already up to date ({})",
+            color.ok("✓"),
+            payload.component,
+            payload.from_version,
+        );
+    }
+    // Remind the operator that an observed row is a pre-existing system RPM.
+    if payload.ownership == "rpm-observed" {
+        println!(
+            "    {} {} is a system RPM observed by ANOLISA; dnf owns the file transaction",
+            color.label("note:"),
+            payload.package,
+        );
+    }
+    render_warnings(&payload.warnings, &color);
+}
+
+/// Map a [`PackageQueryError`] onto a CLI runtime error (the benign
+/// not-installed / multi-version branches are split off by the caller).
+fn rpm_query_err(err: PackageQueryError, command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("rpm query failed: {err}"),
+    }
+}
+
+/// Warn-and-exit error when `rpm`/`dnf` is absent: an RPM component cannot be
+/// updated without the package manager.
+fn rpm_tooling_missing_error(command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: "rpm/dnf not found: cannot update an RPM-backed component without the package manager. Install rpm/dnf and retry".to_string(),
+    }
+}
+
+/// Map a [`PackageTransactionError`] onto a CLI runtime error with an actionable
+/// hint.
+fn txn_err(err: PackageTransactionError, command: &str) -> CliError {
+    match err {
+        PackageTransactionError::CommandMissing { .. } => rpm_tooling_missing_error(command),
+        PackageTransactionError::PermissionDenied { command: bin } => CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("permission denied running {bin}; re-run the update with sudo"),
+        },
+        PackageTransactionError::TransactionFailed { code, stderr, .. } => CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "dnf update failed (exit {}): {}",
+                code.map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string()),
+                stderr.trim(),
+            ),
+        },
+    }
+}
+
+/// Render any accumulated warnings to stderr, one per line.
+fn render_warnings(warnings: &[String], color: &Palette) {
+    for w in warnings {
+        eprintln!("{} {w}", color.warn("warning:"));
+    }
+}
+
+/// Stable provenance label for an [`Ownership`] value used in wire output.
+fn ownership_label(ownership: Ownership) -> &'static str {
+    match ownership {
+        Ownership::RawManaged => "raw-managed",
+        Ownership::RpmManaged => "rpm-managed",
+        Ownership::RpmObserved => "rpm-observed",
+    }
+}
+
+/// RFC3339 UTC timestamp, seconds precision (matches the install path).
+fn now_iso8601() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
 }
 
 /// TEMPORARY: make sure the user-editable repo config exists before any
@@ -365,5 +918,787 @@ mod tests {
         let data = build_json_data(&outcome, false);
         assert!(!data.update_available);
         assert!(!data.updated);
+    }
+
+    // ── component update (#959): RPM path ───────────────────────────────
+
+    use std::cell::{Cell, RefCell};
+    use std::path::PathBuf;
+
+    use anolisa_core::state::{
+        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, RpmMetadata,
+    };
+    use anolisa_platform::pkg_query::PackageVersion;
+
+    use crate::context::InstallMode;
+
+    /// In-memory rpm world implementing **both** [`PackageQuery`] and
+    /// [`PackageTransaction`], so one fake drives the whole update flow.
+    ///
+    /// `installed` mutates: a successful [`update`](PackageTransaction::update)
+    /// applies `upgrade_to`, modelling rpmdb advancing after dnf runs — so the
+    /// pre-update query and the post-update refresh return different EVRs.
+    struct FakeRpm {
+        package: String,
+        installed: RefCell<Option<PackageInfo>>,
+        available: Vec<PackageInfo>,
+        /// PackageInfo the rpmdb holds after a successful update; `None` keeps
+        /// the same version (a no-op "already latest").
+        upgrade_to: Option<PackageInfo>,
+        /// `false` makes the dnf transaction fail.
+        update_succeeds: bool,
+        /// `true` makes `query_installed` report a same-name multi-version drift.
+        multi_version: bool,
+        /// `true` makes the *post-update* `query_installed` report the package
+        /// gone, modelling a failed rpmdb re-read after a successful dnf update.
+        post_update_missing: bool,
+        update_calls: Cell<usize>,
+    }
+
+    impl FakeRpm {
+        fn new(package: &str, installed: Option<PackageInfo>) -> Self {
+            Self {
+                package: package.to_string(),
+                installed: RefCell::new(installed),
+                available: Vec::new(),
+                upgrade_to: None,
+                update_succeeds: true,
+                multi_version: false,
+                post_update_missing: false,
+                update_calls: Cell::new(0),
+            }
+        }
+        fn with_available(mut self, infos: Vec<PackageInfo>) -> Self {
+            self.available = infos;
+            self
+        }
+        fn upgrading_to(mut self, info: PackageInfo) -> Self {
+            self.upgrade_to = Some(info);
+            self
+        }
+        fn failing_update(mut self) -> Self {
+            self.update_succeeds = false;
+            self
+        }
+        fn multi_version(mut self) -> Self {
+            self.multi_version = true;
+            self
+        }
+        fn post_update_missing(mut self) -> Self {
+            self.post_update_missing = true;
+            self
+        }
+    }
+
+    impl PackageQuery for FakeRpm {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if package != self.package {
+                return Ok(None);
+            }
+            // Simulate a failed post-update re-read: the package "vanishes" only
+            // after dnf update has run, so the pre-update query still succeeds.
+            if self.post_update_missing && self.update_calls.get() > 0 {
+                return Ok(None);
+            }
+            if self.multi_version {
+                return Err(PackageQueryError::UnexpectedOutput {
+                    command: "rpm".to_string(),
+                    detail: "2 installed versions".to_string(),
+                });
+            }
+            Ok(self.installed.borrow().clone())
+        }
+
+        fn query_available(&self, package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            if package != self.package {
+                return Ok(Vec::new());
+            }
+            Ok(self.available.clone())
+        }
+    }
+
+    impl PackageTransaction for FakeRpm {
+        fn install(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            // The update flow never installs; a call here is a routing bug.
+            panic!("update path must not delegate a dnf install");
+        }
+
+        fn update(&self, package: &str) -> Result<(), PackageTransactionError> {
+            self.update_calls.set(self.update_calls.get() + 1);
+            assert_eq!(package, self.package, "update targeted the wrong package");
+            if !self.update_succeeds {
+                return Err(PackageTransactionError::TransactionFailed {
+                    command: "dnf".to_string(),
+                    operation: "update".to_string(),
+                    code: Some(1),
+                    stderr: "repo unreachable".to_string(),
+                });
+            }
+            if let Some(next) = &self.upgrade_to {
+                *self.installed.borrow_mut() = Some(next.clone());
+            }
+            Ok(())
+        }
+    }
+
+    fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: version.to_string(),
+                release: release.map(str::to_string),
+            },
+            arch: arch.to_string(),
+            origin: None,
+        }
+    }
+
+    fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        CliContext {
+            install_mode,
+            prefix: Some(prefix),
+            json: false,
+            dry_run,
+            verbose: false,
+            quiet: true,
+            no_color: true,
+        }
+    }
+
+    /// Build an RPM-backed component object (observed or managed).
+    fn rpm_object(
+        component: &str,
+        package: &str,
+        evr: &str,
+        ownership: Ownership,
+        status: ObjectStatus,
+    ) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: evr.to_string(),
+            status,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(ownership),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: package.to_string(),
+                evr: Some(evr.to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: !matches!(ownership, Ownership::RpmObserved),
+            adopted: matches!(ownership, Ownership::RpmObserved),
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    /// A raw-managed component object (no rpm metadata).
+    fn raw_object(component: &str, version: &str) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: version.to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("https://example.com/x".to_string()),
+            install_backend: Some("raw".to_string()),
+            ownership: Some(Ownership::RawManaged),
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    /// Seed `installed.toml` for `ctx`'s scope with one object.
+    fn seed(ctx: &CliContext, obj: InstalledObject) {
+        let layout = common::resolve_layout(ctx);
+        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        let mut state = InstalledState {
+            install_mode: match ctx.install_mode {
+                InstallMode::System => StateInstallMode::System,
+                InstallMode::User => StateInstallMode::User,
+            },
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(obj);
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state");
+    }
+
+    fn load_state(ctx: &CliContext) -> InstalledState {
+        let layout = common::resolve_layout(ctx);
+        InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+    }
+
+    /// rpm-observed component, root, real run: dnf update runs, the EVR is
+    /// refreshed from rpmdb, and ownership/backend are preserved.
+    #[test]
+    fn rpm_observed_update_refreshes_evr_and_keeps_ownership() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .upgrading_to(pkg_info(
+            "anolisa-copilot-shell",
+            "2.3.0",
+            Some("1.al8"),
+            "x86_64",
+        ));
+
+        update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true).expect("update ok");
+        assert_eq!(rpm.update_calls.get(), 1, "dnf update must run once");
+
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("component present");
+        assert_eq!(obj.version, "2.3.0-1.al8", "version refreshed from rpmdb");
+        assert_eq!(
+            obj.ownership,
+            Some(Ownership::RpmObserved),
+            "ownership preserved"
+        );
+        assert_eq!(
+            obj.install_backend.as_deref(),
+            Some("rpm"),
+            "backend not switched"
+        );
+        assert_eq!(obj.status, ObjectStatus::Adopted, "status unchanged");
+        let meta = obj.rpm_metadata.expect("metadata");
+        assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
+        assert_ne!(obj.last_operation_id.as_deref(), Some("op-prior"));
+    }
+
+    /// rpm-managed component updates the same way (different ownership/status).
+    #[test]
+    fn rpm_managed_update_refreshes_evr() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "1.0.0-1.al8",
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "1.0.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .upgrading_to(pkg_info(
+            "anolisa-copilot-shell",
+            "1.1.0",
+            Some("1.al8"),
+            "x86_64",
+        ));
+
+        update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true).expect("update ok");
+
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("component present");
+        assert_eq!(obj.version, "1.1.0-1.al8");
+        assert_eq!(obj.ownership, Some(Ownership::RpmManaged));
+        assert_eq!(obj.status, ObjectStatus::Installed);
+    }
+
+    /// Non-root real run is refused with an actionable message; dnf never runs
+    /// and state is untouched.
+    #[test]
+    fn non_root_update_is_refused_without_running_dnf() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        );
+
+        let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, false)
+            .expect_err("must refuse without root");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("root") && err.reason().contains("sudo"),
+            "reason must point at sudo: {}",
+            err.reason()
+        );
+        assert_eq!(rpm.update_calls.get(), 0, "dnf must not run without root");
+        // State unchanged.
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .and_then(|o| o.last_operation_id.clone())
+                .as_deref(),
+            Some("op-prior"),
+        );
+    }
+
+    /// Dry-run previews the plan without running dnf, needing root, or writing
+    /// state — even for a non-root caller.
+    #[test]
+    fn dry_run_previews_without_dnf_or_state_write() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .with_available(vec![pkg_info(
+            "anolisa-copilot-shell",
+            "2.3.0",
+            Some("1.al8"),
+            "x86_64",
+        )]);
+
+        update_component_with_deps("copilot-shell", &c, &rpm, &rpm, false).expect("dry-run ok");
+        assert_eq!(rpm.update_calls.get(), 0, "dry-run must not run dnf");
+        // Version stays at the seeded value.
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .map(|o| o.version.clone())
+                .as_deref(),
+            Some("2.2.0-1.al8"),
+        );
+    }
+
+    /// A component absent from state routes to INVALID_ARGUMENT (exit 2), not a
+    /// runtime failure, and never runs dnf.
+    #[test]
+    fn unknown_component_routes_to_invalid_argument() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let rpm = FakeRpm::new("anolisa-copilot-shell", None);
+        let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
+            .expect_err("absent component must error");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.exit_code(), 2);
+        assert!(err.reason().contains("not installed"));
+        assert_eq!(rpm.update_calls.get(), 0);
+    }
+
+    /// Regression: a bare `anolisa update` (no component, no subcommand) fails
+    /// validation as INVALID_ARGUMENT. The positional surface lets `(None,
+    /// None)` reach `handle()`, where the old top-of-function bootstrap would
+    /// otherwise hit the network / write config before this error — so the
+    /// bootstrap now lives inside the real-update branches and this path must
+    /// short-circuit here. The fixed routing reaches no bootstrap, so the test
+    /// makes no network call.
+    #[test]
+    fn bare_update_errors_before_any_bootstrap() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        // Non-dry-run system ctx: an unconditional bootstrap would try to fetch
+        // and write etc_dir/repo.toml here.
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let repo_toml = common::resolve_layout(&c).etc_dir.join("repo.toml");
+
+        let err = handle(
+            UpdateArgs {
+                component: None,
+                command: None,
+            },
+            &c,
+        )
+        .expect_err("bare `update` must fail validation");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.exit_code(), 2);
+        assert!(
+            !repo_toml.exists(),
+            "no repo config must be written for an invalid invocation: {} exists",
+            repo_toml.display()
+        );
+    }
+
+    /// State records the RPM but rpmdb no longer has it (rpm -e drift): refuse
+    /// with a repair pointer rather than running dnf.
+    #[test]
+    fn missing_from_rpmdb_refuses_with_repair_hint() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        // rpmdb reports nothing installed for the package.
+        let rpm = FakeRpm::new("anolisa-copilot-shell", None);
+        let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
+            .expect_err("drift must error");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("repair"),
+            "reason must point at repair: {}",
+            err.reason()
+        );
+        assert_eq!(rpm.update_calls.get(), 0);
+    }
+
+    /// AC4: a user-mode raw override updates only the user raw component and
+    /// never touches the shadowed system RPM. The raw path is not implemented,
+    /// so it surfaces NOT_IMPLEMENTED — crucially without running dnf.
+    #[test]
+    fn user_raw_override_does_not_touch_system_rpm() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::User, false);
+        seed(&c, raw_object("copilot-shell", "9.9.9"));
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        );
+        let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
+            .expect_err("raw update is not implemented");
+        assert_eq!(err.code(), "NOT_IMPLEMENTED");
+        assert_eq!(
+            rpm.update_calls.get(),
+            0,
+            "user raw update must never run dnf on the system RPM"
+        );
+    }
+
+    /// `dnf update` failure surfaces as EXECUTION_FAILED and does not refresh
+    /// state (the version stays at its pre-update value).
+    #[test]
+    fn dnf_failure_surfaces_and_leaves_state_untouched() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .failing_update();
+
+        let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
+            .expect_err("dnf failure must propagate");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(err.reason().contains("dnf update failed"));
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .map(|o| o.version.clone())
+                .as_deref(),
+            Some("2.2.0-1.al8"),
+            "failed update must not refresh the recorded version"
+        );
+    }
+
+    /// A same-name multi-version rpmdb is a drift, not an update target.
+    #[test]
+    fn multi_version_drift_is_refused() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .multi_version();
+        let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
+            .expect_err("multi-version must error");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(err.reason().contains("multiple installed versions"));
+        assert_eq!(rpm.update_calls.get(), 0);
+    }
+
+    /// No-op update (already latest): dnf runs, EVR is unchanged, the result is
+    /// reported as not-updated, and state still records the operation.
+    #[test]
+    fn already_latest_reports_no_change() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.3.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        // upgrade_to is None => update() is a no-op; EVR stays the same.
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.3.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        );
+        update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true).expect("update ok");
+        assert_eq!(rpm.update_calls.get(), 1);
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("present");
+        assert_eq!(obj.version, "2.3.0-1.al8");
+        // Operation still recorded (last_operation_id advanced from the seed).
+        assert_ne!(obj.last_operation_id.as_deref(), Some("op-prior"));
+    }
+
+    /// dnf update applied, but the post-update rpmdb re-read cannot confirm the
+    /// new EVR: surface a repair-pointing failure rather than recording the stale
+    /// EVR as a no-op "already up to date", and leave the recorded version as-is.
+    #[test]
+    fn refresh_failure_after_successful_update_errors_and_leaves_state() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeRpm::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .post_update_missing();
+
+        let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
+            .expect_err("a failed post-update refresh must surface");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("repair"),
+            "reason must point at repair: {}",
+            err.reason()
+        );
+        assert_eq!(rpm.update_calls.get(), 1, "dnf update did run");
+        // The recorded version is untouched: no stale EVR was written as success.
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .map(|o| o.version.clone())
+                .as_deref(),
+            Some("2.2.0-1.al8"),
+        );
+    }
+
+    /// Post-lock guard: if the component's recorded RPM package_name drifted
+    /// while dnf ran, persist refuses rather than grafting the updated package's
+    /// EVR onto a different package's metadata.
+    #[test]
+    fn persist_refuses_when_package_identity_changed_under_lock() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        // State records the component under package B...
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-pkg-b",
+                "1.0.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        // ...but `dnf update` ran against package A (snapshotted before a
+        // concurrent identity change). persist must refuse.
+        let refreshed = pkg_info("anolisa-pkg-a", "2.0.0", Some("1.al8"), "x86_64");
+        let err = persist_rpm_update(
+            &c,
+            "copilot-shell",
+            "anolisa-pkg-a",
+            Ownership::RpmObserved,
+            &refreshed,
+            "2.0.0-1.al8",
+            "update copilot-shell",
+            &[],
+        )
+        .expect_err("package identity drift must be refused");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("package identity changed"),
+            "got: {}",
+            err.reason()
+        );
+        // State untouched: still package B at its old EVR.
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("present");
+        assert_eq!(obj.version, "1.0.0-1.al8");
+        assert_eq!(
+            obj.rpm_metadata.expect("meta").package_name,
+            "anolisa-pkg-b"
+        );
+    }
+
+    // ── CLI surface: `update <component>` is the direct form ────────────
+
+    use clap::Parser;
+
+    /// `update <component>` parses to the positional, with no subcommand.
+    #[test]
+    fn update_component_parses_as_positional() {
+        let a = UpdateArgs::try_parse_from(["update", "copilot-shell"]).expect("parse");
+        assert_eq!(a.component.as_deref(), Some("copilot-shell"));
+        assert!(a.command.is_none());
+    }
+
+    /// `update self` parses to the self subcommand, not a component named
+    /// "self" (subcommands take precedence over the positional).
+    #[test]
+    fn update_self_parses_as_subcommand() {
+        let a = UpdateArgs::try_parse_from(["update", "self"]).expect("parse");
+        assert!(matches!(a.command, Some(UpdateCommands::SelfBin)));
+        assert!(a.component.is_none());
+    }
+
+    /// `update all` parses to the all subcommand.
+    #[test]
+    fn update_all_parses_as_subcommand() {
+        let a = UpdateArgs::try_parse_from(["update", "all"]).expect("parse");
+        assert!(matches!(a.command, Some(UpdateCommands::All)));
+        assert!(a.component.is_none());
+    }
+
+    /// A positional and a subcommand are mutually exclusive.
+    #[test]
+    fn update_component_with_subcommand_is_a_parse_error() {
+        UpdateArgs::try_parse_from(["update", "copilot-shell", "self"])
+            .expect_err("positional + subcommand must conflict");
+    }
+
+    /// `update` with no target is an INVALID_ARGUMENT, not a panic or a silent
+    /// no-op — the dispatcher needs a target. `dry_run` keeps the repo-config
+    /// bootstrap from reaching the network in this unit test.
+    #[test]
+    fn update_with_no_target_is_invalid_argument() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        let args = UpdateArgs {
+            component: None,
+            command: None,
+        };
+        let err = handle(args, &c).expect_err("must require a target");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("specify a component"));
     }
 }

--- a/src/anolisa/crates/anolisa-platform/src/lib.rs
+++ b/src/anolisa/crates/anolisa-platform/src/lib.rs
@@ -8,6 +8,8 @@ pub mod command;
 pub mod fs_layout;
 pub mod package_manager;
 pub mod pkg_query;
+pub mod pkg_transaction;
 pub mod privilege;
 pub mod rpm_query;
+pub mod rpm_transaction;
 pub mod systemd;

--- a/src/anolisa/crates/anolisa-platform/src/pkg_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/pkg_transaction.rs
@@ -1,0 +1,88 @@
+//! Backend-neutral package *mutation* contract.
+//!
+//! [`PackageTransaction`] is the write-side counterpart to
+//! [`PackageQuery`](crate::pkg_query::PackageQuery): where the query contract
+//! only reads rpmdb / repo metadata, this one runs the package-manager
+//! transactions ANOLISA delegates to dnf/rpm. The MVP exposes a single
+//! operation — `update` — used by `anolisa update` for `rpm-observed` and
+//! `rpm-managed` components.
+//!
+//! The trait is object-safe so the CLI can hold a `&dyn PackageTransaction`
+//! and inject a fake in tests instead of shelling out to a live `dnf`.
+//! Privilege checks and post-transaction state refresh are the caller's
+//! responsibility; this layer only spawns the transaction and classifies its
+//! outcome.
+
+use thiserror::Error;
+
+/// Errors raised by [`PackageTransaction`] backends.
+///
+/// Mirrors [`PackageQueryError`](crate::pkg_query::PackageQueryError)'s
+/// spawn-vs-exit split: a missing or non-executable binary is a spawn-phase
+/// fault, while a backend that ran and exited non-zero surfaces as
+/// [`TransactionFailed`](PackageTransactionError::TransactionFailed).
+#[derive(Debug, Error)]
+pub enum PackageTransactionError {
+    /// The backend binary could not be found (spawn `NotFound`).
+    #[error("command not found: {command}")]
+    CommandMissing {
+        /// Backend binary that could not be found.
+        command: String,
+    },
+    /// The backend binary existed but could not be executed
+    /// (`PermissionDenied`). For a privileged transaction this typically
+    /// means the process is not running as root.
+    #[error("permission denied running {command}")]
+    PermissionDenied {
+        /// Backend binary that could not be executed.
+        command: String,
+    },
+    /// The transaction ran but the backend reported a hard failure
+    /// (non-zero exit). `stderr` carries the captured diagnostics so the
+    /// caller can surface why dnf refused.
+    #[error("{command} {operation} failed (code {code:?}): {stderr}")]
+    TransactionFailed {
+        /// Backend binary that exited with a failure.
+        command: String,
+        /// Transaction verb that failed (e.g. `update`).
+        operation: String,
+        /// Exit code; `None` if the process was killed by a signal.
+        code: Option<i32>,
+        /// Captured diagnostics from the failed transaction.
+        stderr: String,
+    },
+}
+
+/// Backend-neutral package mutation contract.
+///
+/// All methods take `&self` and return concrete types, so the trait is
+/// object-safe and any backend can be held as `Box<dyn PackageTransaction>`.
+pub trait PackageTransaction {
+    /// Install `package` from the configured repos.
+    ///
+    /// Delegates the whole file transaction (dependency solving, download,
+    /// scriptlets, rpmdb write) to the package manager. ANOLISA records the
+    /// result as an ANOLISA-delegated *managed* install — the package manager
+    /// owns the files and a later uninstall delegates back to it. A package
+    /// that is already installed is a success
+    /// (the backend performs a no-op), not an error.
+    ///
+    /// # Errors
+    /// See [`PackageTransactionError`]. The caller owns the privilege
+    /// precondition and records ANOLISA state from rpmdb afterwards.
+    fn install(&self, package: &str) -> Result<(), PackageTransactionError>;
+
+    /// Update `package` to the latest candidate the configured repos offer.
+    ///
+    /// Delegates the whole file transaction (download, scriptlets, rpmdb
+    /// write) to the package manager — ANOLISA never touches RPM-owned files
+    /// directly. The update does **not** switch backends: it upgrades the
+    /// package in place. A package that is already at the latest version is a
+    /// success (the backend performs a no-op), not an error.
+    ///
+    /// # Errors
+    /// See [`PackageTransactionError`] for the failure conditions. The caller
+    /// is responsible for the privilege precondition and for refreshing
+    /// ANOLISA state from rpmdb after a successful update.
+    fn update(&self, package: &str) -> Result<(), PackageTransactionError>;
+}

--- a/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
@@ -1,0 +1,283 @@
+//! RPM/DNF backend for [`PackageTransaction`].
+//!
+//! Runs `dnf <verb> -y <package>` (`install`/`update`) through the injectable
+//! [`CommandRunner`] so the transaction can be tested with a fake runner
+//! instead of a live `dnf`. Only the spawn/exit classification lives here;
+//! privilege checks and state refresh stay in the CLI consumer.
+
+use crate::command::{CommandRunner, SystemCommandRunner};
+use crate::pkg_transaction::{PackageTransaction, PackageTransactionError};
+
+const DNF: &str = "dnf";
+
+/// RPM/DNF implementation of [`PackageTransaction`].
+///
+/// Generic over the [`CommandRunner`] so tests can inject a fake; production
+/// code uses [`RpmTransaction::system`]. The default type parameter keeps
+/// production call sites parameter-free while staying zero-cost.
+pub struct RpmTransaction<R: CommandRunner = SystemCommandRunner> {
+    runner: R,
+}
+
+impl RpmTransaction<SystemCommandRunner> {
+    /// Build a transaction that runs real `dnf` on the host.
+    pub fn system() -> Self {
+        Self {
+            runner: SystemCommandRunner,
+        }
+    }
+}
+
+impl<R: CommandRunner> RpmTransaction<R> {
+    /// Build a transaction backed by a custom runner (primarily for tests).
+    pub fn with_runner(runner: R) -> Self {
+        Self { runner }
+    }
+
+    /// Run `dnf <verb> -y <package>` and classify the outcome.
+    ///
+    /// Shared by [`install`](PackageTransaction::install) and
+    /// [`update`](PackageTransaction::update) since they differ only in the
+    /// dnf verb; `verb` is echoed into the [`TransactionFailed`] operation so
+    /// the caller can tell which transaction failed.
+    fn run_dnf(&self, verb: &str, package: &str) -> Result<(), PackageTransactionError> {
+        // `-y` is required: ANOLISA orchestrates the lifecycle non-interactively,
+        // so there is no TTY to answer dnf's confirmation prompt.
+        let out = self
+            .runner
+            .run(DNF, &[verb, "-y", package])
+            .map_err(|e| map_spawn_error(e, DNF, verb))?;
+
+        if out.code == Some(0) {
+            return Ok(());
+        }
+
+        // Prefer stderr for diagnostics; dnf occasionally writes the actionable
+        // line to stdout (e.g. "Error: This command has to be run with
+        // superuser privileges"), so fall back to stdout when stderr is empty.
+        let detail = if out.stderr.trim().is_empty() {
+            out.stdout
+        } else {
+            out.stderr
+        };
+        Err(PackageTransactionError::TransactionFailed {
+            command: DNF.to_string(),
+            operation: verb.to_string(),
+            code: out.code,
+            stderr: detail,
+        })
+    }
+}
+
+impl<R: CommandRunner> PackageTransaction for RpmTransaction<R> {
+    fn install(&self, package: &str) -> Result<(), PackageTransactionError> {
+        self.run_dnf("install", package)
+    }
+
+    fn update(&self, package: &str) -> Result<(), PackageTransactionError> {
+        self.run_dnf("update", package)
+    }
+}
+
+/// Map a spawn-phase [`std::io::Error`] to a transaction error by
+/// [`std::io::ErrorKind`], mirroring the query backend's classification.
+///
+/// `verb` records which dnf transaction was being spawned so a non-spawn
+/// error kind still names the operation that failed.
+fn map_spawn_error(e: std::io::Error, command: &str, verb: &str) -> PackageTransactionError {
+    match e.kind() {
+        std::io::ErrorKind::NotFound => PackageTransactionError::CommandMissing {
+            command: command.to_string(),
+        },
+        std::io::ErrorKind::PermissionDenied => PackageTransactionError::PermissionDenied {
+            command: command.to_string(),
+        },
+        _ => PackageTransactionError::TransactionFailed {
+            command: command.to_string(),
+            operation: verb.to_string(),
+            code: None,
+            stderr: e.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::CommandOutput;
+    use std::io;
+
+    /// Preset result for the fake runner: either a captured output or a
+    /// spawn-phase error kind to replay.
+    enum FakeOutcome {
+        Ok(CommandOutput),
+        Err(io::ErrorKind),
+    }
+
+    /// Fake runner that asserts the dnf call contract and replays a canned
+    /// outcome. A program with no preset yields `NotFound`.
+    struct FakeCommandRunner {
+        dnf: Option<FakeOutcome>,
+        expected_verb: String,
+        expected_package: String,
+    }
+
+    impl CommandRunner for FakeCommandRunner {
+        fn run(&self, program: &str, args: &[&str]) -> io::Result<CommandOutput> {
+            // Pin the invocation shape: a regression that drops `-y`, swaps the
+            // verb, or misplaces the package argument must fail loudly rather
+            // than pass on the canned output alone.
+            assert_eq!(program, DNF, "transaction must shell out to dnf: {program}");
+            assert_eq!(
+                args,
+                [
+                    self.expected_verb.as_str(),
+                    "-y",
+                    self.expected_package.as_str()
+                ],
+                "dnf args drifted: {args:?}"
+            );
+            match &self.dnf {
+                Some(FakeOutcome::Ok(o)) => Ok(o.clone()),
+                Some(FakeOutcome::Err(kind)) => {
+                    Err(io::Error::new(*kind, format!("fake {program} failure")))
+                }
+                None => Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("no fake preset for {program}"),
+                )),
+            }
+        }
+    }
+
+    fn txn(
+        expected_verb: &str,
+        expected_package: &str,
+        outcome: FakeOutcome,
+    ) -> RpmTransaction<FakeCommandRunner> {
+        RpmTransaction::with_runner(FakeCommandRunner {
+            dnf: Some(outcome),
+            expected_verb: expected_verb.to_string(),
+            expected_package: expected_package.to_string(),
+        })
+    }
+
+    fn ok_out(code: Option<i32>, stdout: &str, stderr: &str) -> FakeOutcome {
+        FakeOutcome::Ok(CommandOutput {
+            code,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        })
+    }
+
+    #[test]
+    fn update_success_returns_ok() {
+        let t = txn(
+            "update",
+            "anolisa-copilot-shell",
+            ok_out(Some(0), "Upgraded:\n  anolisa-copilot-shell\n", ""),
+        );
+        t.update("anolisa-copilot-shell").expect("update ok");
+    }
+
+    #[test]
+    fn install_success_returns_ok() {
+        let t = txn(
+            "install",
+            "anolisa-copilot-shell",
+            ok_out(Some(0), "Installed:\n  anolisa-copilot-shell\n", ""),
+        );
+        t.install("anolisa-copilot-shell").expect("install ok");
+    }
+
+    #[test]
+    fn update_nonzero_exit_maps_to_transaction_failed() {
+        let t = txn(
+            "update",
+            "anolisa-copilot-shell",
+            ok_out(Some(1), "", "Error: nothing to do, repo unreachable"),
+        );
+        let err = t.update("anolisa-copilot-shell").unwrap_err();
+        match err {
+            PackageTransactionError::TransactionFailed {
+                command,
+                operation,
+                code,
+                stderr,
+            } => {
+                assert_eq!(command, DNF);
+                assert_eq!(operation, "update");
+                assert_eq!(code, Some(1));
+                assert!(stderr.contains("repo unreachable"));
+            }
+            other => panic!("expected TransactionFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn install_nonzero_exit_records_install_operation() {
+        // The failed-operation label must follow the verb so callers can tell
+        // an install failure apart from an update failure.
+        let t = txn(
+            "install",
+            "anolisa-copilot-shell",
+            ok_out(Some(1), "", "Error: No match for argument"),
+        );
+        let err = t.install("anolisa-copilot-shell").unwrap_err();
+        match err {
+            PackageTransactionError::TransactionFailed {
+                operation, stderr, ..
+            } => {
+                assert_eq!(operation, "install");
+                assert!(stderr.contains("No match for argument"));
+            }
+            other => panic!("expected TransactionFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_failure_falls_back_to_stdout_when_stderr_empty() {
+        // dnf's privilege refusal is written to stdout; surface it rather than
+        // an empty diagnostic.
+        let t = txn(
+            "update",
+            "anolisa-copilot-shell",
+            ok_out(
+                Some(1),
+                "Error: This command has to be run with superuser privileges",
+                "",
+            ),
+        );
+        let err = t.update("anolisa-copilot-shell").unwrap_err();
+        match err {
+            PackageTransactionError::TransactionFailed { stderr, .. } => {
+                assert!(stderr.contains("superuser privileges"), "got: {stderr}");
+            }
+            other => panic!("expected TransactionFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_missing_maps_to_error() {
+        let t = txn("update", "x", FakeOutcome::Err(io::ErrorKind::NotFound));
+        let err = t.update("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageTransactionError::CommandMissing { command } if command == DNF
+        ));
+    }
+
+    #[test]
+    fn permission_denied_maps_to_error() {
+        let t = txn(
+            "update",
+            "x",
+            FakeOutcome::Err(io::ErrorKind::PermissionDenied),
+        );
+        let err = t.update("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageTransactionError::PermissionDenied { command } if command == DNF
+        ));
+    }
+}


### PR DESCRIPTION
## Description

Adds the `anolisa update <component>` surface and wires two RPM/dnf-backed
lifecycle paths:

- **RPM update** for `rpm-observed` / `rpm-managed` components — upgrades the
  package in place via `dnf`, then refreshes ANOLISA state from rpmdb.
- **Delegated install** for not-yet-present RPM components — delegates the file
  transaction to `dnf install` and records `rpm-managed` ownership (the first
  code path to produce `Ownership::RpmManaged`).

The CLI surface changes from `update runtime <component>` to a direct positional
`update <component>`; `self` / `all` remain subcommands, kept mutually exclusive
with the positional via `args_conflicts_with_subcommands`.

## Design Note

- **Platform-layer split.** A new `PackageTransaction` trait (`install` +
  `update`) is the write-side mirror of the existing read-only `PackageQuery`.
  `RpmTransaction<R: CommandRunner>` implements it by running `dnf <verb> -y
  <pkg>` through the injectable `CommandRunner`, sharing one `run_dnf` helper and
  classifying spawn-vs-exit faults the same way as `PackageQuery`. The trait is
  object-safe, so the CLI holds `&dyn PackageTransaction` and injects a fake in
  tests instead of shelling out to a live `dnf`.
- **Privilege and state refresh stay in the CLI.** The platform layer only
  spawns the transaction and classifies the outcome; root-gating, the two-layer
  backend decision, and the post-transaction rpmdb refresh live in the CLI
  consumer.
- **Update never switches backend.** The flow is `rpmdb query -> dnf repo query
  -> dnf update -> refresh state`; ownership and `install_backend` are preserved
  across the upgrade.
- **Delegated-install routing.** In system mode an absent RPM component
  (explicit `--backend rpm`, or `default_backend = rpm`) routes through
  `RpmSituation::Absent { package }` to `dnf install`, injected via
  `RpmExec { query, txn, is_root }`. `dnf` owns the file transaction, so
  RPM-owned paths stay out of ANOLISA owned-files (`managed=true`,
  `adopted=false`).
- **Lock-time guards.** Before persisting an update the package identity is
  re-checked under the install lock; a refresh failure after a successful `dnf
  update` errors out (pointing at `anolisa repair`) rather than recording a
  stale EVR.

## Ship Note

- **Raw-backend update is not implemented.** Raw-trunk components keep the
  existing not-yet-implemented planner boundary; only the RPM path is wired here.
- **Real runs require system mode + root.** RPM update and delegated install
  execute only under `--install-mode system` as root; `--dry-run` previews
  without touching the host. `sudo anolisa update <component>` alone does **not**
  auto-switch `install_mode` to system — it is resolved from the flag (default
  `user`), not from euid. This is a known cross-cutting limitation shared with
  the merged #958 adopt path, to be fixed in a separate issue.
- **RPM only.** Other backends (npm, etc.) are out of scope for this change.

## Test

- Platform-layer unit tests for `RpmTransaction` install/update: success,
  already-satisfied no-op, non-zero exit → `TransactionFailed`, and spawn faults
  (missing binary / permission denied).
- CLI tests for the update flow and delegated install, driven by an injected
  fake (`FakeRpm` / `FakeInstaller`) so no live `dnf` is required — covering a
  successful RPM update, refresh-failure-after-successful-update errors while
  leaving state intact, persist refusing when the package identity changed under
  the lock, and delegated install recording `rpm-managed`.
- Full gate green: `cargo fmt --all -- --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace` (613 passing), `cargo doc --workspace --no-deps`.

Closes #959.