### PR TITLE
fix(sight): tiered SSL ring buffer reservations

### DIFF
--- a/src/agentsight/docs/design-docs/ebpf-probes.md
+++ b/src/agentsight/docs/design-docs/ebpf-probes.md
@@ -137,7 +137,7 @@ All probes share one ring buffer, distinguished by `common_event_hdr.source` fie
 | source value | Event type | Parse method |
 |-------------|-----------|-------------|
 | 1 (EVENT_SOURCE_PROC) | proctrace event | `VariableEvent::from_bytes()` |
-| 2 (EVENT_SOURCE_SSL) | sslsniff event | `SslEvent::from_bpf()` |
+| 2 (EVENT_SOURCE_SSL) | sslsniff event | `SslEvent::from_bytes()` |
 | 3 (EVENT_SOURCE_PROCMON) | procmon event | `procmon::Event::from_bytes()` |
 | 4 (EVENT_SOURCE_FILEWATCH) | filewatch event | `FileWatchEvent::from_bytes()` |
 | 5 (EVENT_SOURCE_FILEWRITE) | filewrite event | `FileWriteEvent::from_bytes()` |

--- a/src/agentsight/src/bpf/sslsniff.bpf.c
+++ b/src/agentsight/src/bpf/sslsniff.bpf.c
@@ -78,8 +78,67 @@ int BPF_UPROBE(probe_SSL_rw_enter, void *ssl, void *buf, int num) {
     return 0;
 }
 
+/* Emit ONE SSL record using the per-tier record TYPE (e.g. probe_SSL_data_small)
+ * whose buf[] is exactly TIER bytes. The reservation is sizeof(struct TYPE) — a
+ * true compile-time constant — and the payload is clamped to TIER and copied
+ * WITHIN that type's buf: the only shape the verifier accepts. (Reserving fewer
+ * bytes than sizeof(struct) and then writing into a LARGER typed buf[] is
+ * REJECTED with EACCES at load — confirmed on 6.6.) A small SSL call reserves a
+ * small type, so it no longer pads the shared ring to the 4 MiB worst case
+ * (#759). `truncated` is set only when the payload exceeds the chosen tier
+ * (possible only at the top 4 MiB tier). */
+#define SSL_EMIT_ONE(TYPE, TIER, src_, len_, rw_, ts_, delta_, pid_, tid_, uid_, ssl_, ishs_) \
+    do {                                                                        \
+        struct TYPE *_d = bpf_ringbuf_reserve(&rb, sizeof(struct TYPE), 0);     \
+        if (!_d)                                                                \
+            break;                                                              \
+        _d->source = EVENT_SOURCE_SSL;                                          \
+        _d->timestamp_ns = (ts_);                                              \
+        _d->delta_ns = (delta_);                                               \
+        _d->pid = (pid_);                                                       \
+        _d->tid = (tid_);                                                       \
+        _d->uid = (uid_);                                                       \
+        _d->len = (u32)(len_);                                                  \
+        _d->rw = (rw_);                                                         \
+        _d->is_handshake = (ishs_);                                             \
+        _d->ssl_ptr = (ssl_);                                                   \
+        _d->truncated = ((u32)(len_) > (u32)(TIER)) ? 1 : 0;                    \
+        bpf_get_current_comm(&_d->comm, sizeof(_d->comm));                      \
+        /* Re-clamp the copy length to the tier right before the read. Two      \
+         * verifier traps must be dodged: (1) a length computed earlier is      \
+         * spilled across bpf_get_current_comm() and reloaded as an UNBOUNDED   \
+         * scalar; (2) the outer tier-selection already proved len_ <= TIER, so \
+         * clang folds a plain `if (_n > TIER)` away as dead code -- yet the     \
+         * verifier does NOT carry that bound across the spill, so the clamp     \
+         * still has to execute. The asm barrier makes _n opaque to clang so the \
+         * clamp is emitted, handing bpf_probe_read_user a fresh umax=TIER bound \
+         * (TIER is a compile-time constant). Without it the load is rejected:   \
+         * "R2 min value is negative, either use unsigned or 'var &= const'". */ \
+        u32 _n = (u32)(len_);                                                   \
+        asm volatile("" : "+r"(_n));                                            \
+        if (_n > (u32)(TIER))                                                   \
+            _n = (u32)(TIER);                                                   \
+        int _rc = (src_) ? bpf_probe_read_user(&_d->buf, _n, (const char *)(src_)) : -1; \
+        if (_rc) { _d->buf_filled = 0; _d->buf_size = 0; }                      \
+        else     { _d->buf_filled = 1; _d->buf_size = _n; }                     \
+        bpf_ringbuf_submit(_d, 0);                                              \
+    } while (0)
+
+/* Pick the smallest tier (and its record type) that holds `len_` and emit one. */
+#define SSL_EMIT_TIERED(src_, len_, rw_, ts_, delta_, pid_, tid_, uid_, ssl_, ishs_)       \
+    do {                                                                                   \
+        u32 _l = (u32)(len_);                                                              \
+        if (_l <= SSL_TIER_SMALL)                                                          \
+            SSL_EMIT_ONE(probe_SSL_data_small, SSL_TIER_SMALL, src_, len_, rw_, ts_, delta_, pid_, tid_, uid_, ssl_, ishs_);   \
+        else if (_l <= SSL_TIER_MEDIUM)                                                    \
+            SSL_EMIT_ONE(probe_SSL_data_medium, SSL_TIER_MEDIUM, src_, len_, rw_, ts_, delta_, pid_, tid_, uid_, ssl_, ishs_); \
+        else if (_l <= SSL_TIER_LARGE)                                                     \
+            SSL_EMIT_ONE(probe_SSL_data_large, SSL_TIER_LARGE, src_, len_, rw_, ts_, delta_, pid_, tid_, uid_, ssl_, ishs_);   \
+        else                                                                              \
+            SSL_EMIT_ONE(probe_SSL_data_t, MAX_BUF_SIZE, src_, len_, rw_, ts_, delta_, pid_, tid_, uid_, ssl_, ishs_);         \
+    } while (0)
+
 static int SSL_exit(struct pt_regs *ctx, int rw) {
-    int ret = 0;
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     u32 tid = (u32)pid_tgid;
@@ -91,7 +150,7 @@ static int SSL_exit(struct pt_regs *ctx, int rw) {
         return 0;
     }
 
-    /* store arg info for later lookup */
+    /* fetch the buffer pointer + timing stored at enter */
     u64 *bufp = bpf_map_lookup_elem(&bufs, &tid);
     if (bufp == 0)
         return 0;
@@ -101,52 +160,22 @@ static int SSL_exit(struct pt_regs *ctx, int rw) {
         return 0;
     u64 delta_ns = ts - *tsp;
 
-    /* lookup ssl pointer for connection tracking */
     u64 *ssl_ptrp = bpf_map_lookup_elem(&ssl_ptrs, &tid);
     u64 ssl_ptr = ssl_ptrp ? *ssl_ptrp : 0;
 
     int len = PT_REGS_RC(ctx);
-    if (len <= 0)  // no data
-        return 0;
-
-    /* reserve space in ring buffer */
-    struct probe_SSL_data_t *data = bpf_ringbuf_reserve(&rb, sizeof(*data), 0);
-    if (!data)
-        return 0;
-
-    data->source = EVENT_SOURCE_SSL;
-    data->timestamp_ns = ts;
-    data->delta_ns = delta_ns;
-    data->pid = ns_pid;
-    data->tid = tid;
-    data->uid = uid;
-    data->len = (u32)len;
-    data->buf_filled = 0;
-    data->buf_size = 0;
-    data->rw = rw;
-    data->is_handshake = false;
-    data->ssl_ptr = ssl_ptr;
-    u32 buf_copy_size = min((size_t)MAX_BUF_SIZE, (size_t)len);
-
-    bpf_get_current_comm(&data->comm, sizeof(data->comm));
-
-    if (bufp != 0)
-        ret = bpf_probe_read_user(&data->buf, buf_copy_size, (char *)*bufp);
+    const char *src = (const char *)*bufp;
 
     bpf_map_delete_elem(&bufs, &tid);
     bpf_map_delete_elem(&start_ns, &tid);
     bpf_map_delete_elem(&ssl_ptrs, &tid);
 
-    if (!ret) {
-        data->buf_filled = 1;
-        data->buf_size = buf_copy_size;
-    } else {
-        data->buf_filled = 0;
-        data->buf_size = 0;
-    }
+    if (len <= 0)  // no data
+        return 0;
 
-    /* submit to ring buffer */
-    bpf_ringbuf_submit(data, 0);
+    /* Tiered emit: reserve the smallest tier that fits `len` (#759), capture up
+     * to 4 MiB whole (#763, no regression vs the prior single 4 MiB reserve). */
+    SSL_EMIT_TIERED(src, len, rw, ts, delta_ns, ns_pid, tid, uid, ssl_ptr, 0);
     return 0;
 }
 
@@ -207,7 +236,6 @@ int BPF_UPROBE(probe_SSL_read_ex_enter, void *ssl, void *buf, size_t num, size_t
 }
 
 static int ex_SSL_exit(struct pt_regs *ctx, int rw, int len) {
-    int ret = 0;
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     u32 tid = (u32)pid_tgid;
@@ -233,53 +261,20 @@ static int ex_SSL_exit(struct pt_regs *ctx, int rw, int len) {
     u64 *ssl_ptrp = bpf_map_lookup_elem(&ssl_ptrs, &tid);
     u64 ssl_ptr = ssl_ptrp ? *ssl_ptrp : 0;
 
-    if (len <= 0)  // no data
-        return 0;
-
-    /* reserve space in ring buffer */
-    struct probe_SSL_data_t *data = bpf_ringbuf_reserve(&rb, sizeof(*data), 0);
-    if (!data)
-        return 0;
-
-    data->source = EVENT_SOURCE_SSL;
-    data->timestamp_ns = ts;
-    data->delta_ns = delta_ns;
-    data->pid = ns_pid;
-    data->tid = tid;
-    data->uid = uid;
-    data->len = (u32)len;
-    data->buf_filled = 0;
-    data->buf_size = 0;
-    data->rw = rw;
-    data->is_handshake = false;
-    data->ssl_ptr = ssl_ptr;
-    
-    /* Explicit bounds clamping to satisfy eBPF verifier
-     * Use bitmask first to ensure value range, then clamp to actual max */
-    u32 buf_copy_size = (u32)len & 0xFFFFF;  /* Mask to 20 bits (1MB-1) */
-    if (buf_copy_size > MAX_BUF_SIZE)
-        buf_copy_size = MAX_BUF_SIZE;
-
-    bpf_get_current_comm(&data->comm, sizeof(data->comm));
-
-    if (bufp != 0)
-        ret = bpf_probe_read_user(&data->buf, buf_copy_size, (char *)*bufp);
+    const char *src = (const char *)*bufp;
 
     bpf_map_delete_elem(&bufs, &tid);
     bpf_map_delete_elem(&start_ns, &tid);
     bpf_map_delete_elem(&ssl_ptrs, &tid);
 
-    if (!ret) {
-        data->buf_filled = 1;
-        data->buf_size = buf_copy_size;
-    } else {
-        data->buf_filled = 0;
-        data->buf_size = 0;
-    }
+    if (len <= 0)  // no data
+        return 0;
 
-    /* submit to ring buffer */
-    bpf_ringbuf_submit(data, 0);
-    
+    /* Tiered emit (same as SSL_exit). The old `& 0xFFFFF` mask silently capped
+     * the _ex path at 1 MiB; the tier clamp restores the full 4 MiB cap,
+     * consistent with the non-_ex path. The per-tier branch also narrows the
+     * (user-read-derived) len for the verifier. */
+    SSL_EMIT_TIERED(src, len, rw, ts, delta_ns, ns_pid, tid, uid, ssl_ptr, 0);
     return 0;
 }
 
@@ -364,8 +359,10 @@ int BPF_URETPROBE(probe_SSL_do_handshake_exit) {
     if (ret <= 0)  // handshake failed
         return 0;
 
-    /* reserve space in ring buffer */
-    struct probe_SSL_data_t *data = bpf_ringbuf_reserve(&rb, sizeof(*data), 0);
+    /* Handshake records carry no payload: reserve ONLY the header (no buf), so a
+     * handshake costs ~one header in the ring instead of the prior 4 MiB reserve. */
+    struct probe_SSL_data_t *data =
+        bpf_ringbuf_reserve(&rb, __builtin_offsetof(struct probe_SSL_data_t, buf), 0);
     if (!data)
         return 0;
 
@@ -379,7 +376,9 @@ int BPF_URETPROBE(probe_SSL_do_handshake_exit) {
     data->buf_filled = 0;
     data->buf_size = 0;
     data->rw = 2;
-    data->is_handshake = true;
+    data->is_handshake = 1;
+    data->truncated = 0;
+    data->ssl_ptr = 0;
     bpf_get_current_comm(&data->comm, sizeof(data->comm));
     bpf_map_delete_elem(&start_ns, &tid);
 

--- a/src/agentsight/src/bpf/sslsniff.h
+++ b/src/agentsight/src/bpf/sslsniff.h
@@ -6,7 +6,19 @@
 #ifndef __SSLSNIFF_H
 #define __SSLSNIFF_H
 
-#define MAX_BUF_SIZE (8 * 512 * 1024)  // 512KB eBPF buffer size (kernel limit)
+// SSL/TCP payload capture is tiered: each event reserves the SMALLEST tier that
+// fits its payload, so the shared ring buffer (RING_BUFFER_SIZE in common.h) is
+// not padded to the 4 MiB worst case for every event (that padding is #759: the
+// 32 MiB ring held only ~8 in-flight 4 MiB reservations and dropped events under
+// burst). Each tier is a COMPILE-TIME constant so it can be the size argument to
+// bpf_ringbuf_reserve (which requires a literal-constant size); the per-record
+// reservation is offsetof(struct probe_SSL_data_t, buf) + <tier>.
+// MAX_BUF_SIZE is the TOP tier and equals the pre-existing capture cap, so a
+// single SSL call up to 4 MiB is still captured whole (no #763 regression).
+#define SSL_TIER_SMALL  (16 * 1024)        // 16 KiB
+#define SSL_TIER_MEDIUM (128 * 1024)       // 128 KiB
+#define SSL_TIER_LARGE  (512 * 1024)       // 512 KiB
+#define MAX_BUF_SIZE    (4 * 1024 * 1024)  // 4 MiB top tier (application cap, not a kernel limit)
 #define TASK_COMM_LEN 16
 
 typedef signed char         s8;
@@ -21,21 +33,36 @@ typedef _Bool bool;
 typedef u32 __be32;
 typedef u64 __be64;
 
-struct probe_SSL_data_t {
-    u32 source;           // EVENT_SOURCE_SSL (from common.h)
-    u64 timestamp_ns;
-    u64 delta_ns;
-    u32 pid;
-    u32 tid;
-    u32 uid;
-    u32 len;
-    u32 buf_size;         // Actual bytes copied to buf
-    int buf_filled;
-    int rw;
+// Header fields shared byte-for-byte by EVERY tier record type, so a single
+// header-prefix decode (offsetof(probe_SSL_data_t, buf)) works for all of them.
+#define SSL_DATA_HEADER_FIELDS                                                  \
+    u32 source;       /* EVENT_SOURCE_SSL (from common.h) */                    \
+    u64 timestamp_ns;                                                           \
+    u64 delta_ns;                                                               \
+    u32 pid;                                                                    \
+    u32 tid;                                                                    \
+    u32 uid;                                                                    \
+    u32 len;          /* total bytes of the SSL call (> buf_size if truncated) */\
+    u32 buf_size;     /* actual bytes copied into buf for THIS record */        \
+    int buf_filled;                                                             \
+    int rw;                                                                     \
+    int is_handshake;                                                           \
+    int truncated;    /* 1 if len exceeded the chosen tier's buf capacity */    \
+    u64 ssl_ptr;      /* SSL connection pointer for connection tracking */      \
     char comm[TASK_COMM_LEN];
-    u8 buf[MAX_BUF_SIZE];
-    int is_handshake;
-    u64 ssl_ptr;          // SSL connection pointer for connection tracking
-};
+
+// Per-tier record types. Each one reserves sizeof(its type) — a true
+// compile-time constant — and the payload is copied WITHIN its own buf[]. That
+// is the ONLY shape the (6.6) verifier accepts: reserving fewer bytes than
+// sizeof(struct) and then writing into a LARGER typed buf[] is REJECTED
+// (EACCES at load). buf MUST be the last member of every variant, and the
+// header is identical (via SSL_DATA_HEADER_FIELDS) so offsetof(buf) is the same
+// for all — the userspace decodes the header once and slices buf by buf_size.
+// probe_SSL_data_t is the largest (4 MiB) variant and the canonical type the
+// userspace uses for the shared header offsets.
+struct probe_SSL_data_small  { SSL_DATA_HEADER_FIELDS u8 buf[SSL_TIER_SMALL]; };
+struct probe_SSL_data_medium { SSL_DATA_HEADER_FIELDS u8 buf[SSL_TIER_MEDIUM]; };
+struct probe_SSL_data_large  { SSL_DATA_HEADER_FIELDS u8 buf[SSL_TIER_LARGE]; };
+struct probe_SSL_data_t      { SSL_DATA_HEADER_FIELDS u8 buf[MAX_BUF_SIZE]; };
 
 #endif /* __SSLSNIFF_H */

--- a/src/agentsight/src/bpf/tcpsniff.bpf.c
+++ b/src/agentsight/src/bpf/tcpsniff.bpf.c
@@ -213,6 +213,12 @@ static __always_inline int emit_tcp_event_buf(
     data->len = data_len;
     data->rw = rw;
     data->is_handshake = false;
+    /* Initialize the shared `truncated` header field. tcpsniff masks the payload
+     * to <=1 MiB (below) and never truncates against the 4 MiB cap, so it is 0.
+     * This MUST be set: every EVENT_SOURCE_SSL record shares this header and the
+     * consumer (sslsniff::from_bytes) reads `truncated`; bpf_ringbuf_reserve does
+     * not zero the reservation, so an omitted field reads stale ring bytes. */
+    data->truncated = 0;
     data->ssl_ptr = (u64)sk;  // use sock pointer as connection identifier
 
     // Clamp buffer size for verifier
@@ -306,6 +312,7 @@ int BPF_PROG(trace_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
     data->len = (u32)size;
     data->rw = 1;
     data->is_handshake = false;
+    data->truncated = 0;  /* see emit_tcp_event_buf: shared header field, never truncates against the 4 MiB cap */
     data->ssl_ptr = (u64)sk;
     bpf_get_current_comm(&data->comm, sizeof(data->comm));
 

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -23,7 +23,6 @@ use super::filewrite::{FileWrite as FileWriteProbe, RawFileWriteEvent};
 use super::procmon::{ProcMon, ProcMonEvent};
 use super::proctrace::{ProcEventHeader, ProcTrace, VariableEvent};
 use super::sslsniff::SslSniff;
-use super::sslsniff::bpf::probe_SSL_data_t as RawSslEvent;
 use super::tcpsniff::TcpSniff;
 use super::udpdns::{RawUdpDnsEvent, UdpDns};
 use crate::config::TcpTarget;
@@ -255,7 +254,6 @@ impl Probes {
     /// events as unified Event type to the channel.
     pub fn run(&self) -> Result<ProbesPoller> {
         let proc_min_sz = mem::size_of::<ProcEventHeader>();
-        let ssl_event_size = mem::size_of::<RawSslEvent>();
         let procmon_event_size = mem::size_of::<ProcMonEvent>();
         let filewatch_event_size = mem::size_of::<RawFileWatchEvent>();
         let filewrite_event_size = mem::size_of::<RawFileWriteEvent>();
@@ -284,15 +282,9 @@ impl Probes {
                         }
                     }
                     EVENT_SOURCE_SSL => {
-                        // SSL event - convert raw BPF data to user-space SslEvent
-                        if data.len() >= ssl_event_size {
-                            // SAFETY: BPF guarantees layout and alignment
-                            let raw = unsafe { &*(data.as_ptr() as *const RawSslEvent) };
-                            let ssl_event = crate::probes::sslsniff::SslEvent::from_bpf(raw);
-                            Some(Event::Ssl(ssl_event))
-                        } else {
-                            None
-                        }
+                        // SSL records are variable-length (tiered reservation):
+                        // decode by header prefix + buf_size, not a full-struct cast.
+                        crate::probes::sslsniff::SslEvent::from_bytes(data).map(Event::Ssl)
                     }
                     EVENT_SOURCE_PROCMON => {
                         // Process monitor event

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -93,6 +93,66 @@ impl SslEvent {
         }
     }
 
+    /// Create SslEvent from a raw ring-buffer sample of VARIABLE length.
+    ///
+    /// SSL records are tiered: the BPF side reserves only
+    /// `offsetof(probe_SSL_data_t, buf) + <tier>` bytes, so a sample is the
+    /// header prefix followed by `buf_size` payload bytes — NOT the full
+    /// fixed-size struct. We therefore (1) gate on the header size, (2) read each
+    /// scalar field from the prefix at its real (bindgen) offset — NOT via a
+    /// full-struct cast, which is UB on a short sample and would also put the
+    /// 4 MiB `buf` array on the stack if materialized — and (3) slice the payload
+    /// by the `buf_size` FIELD, never by `data.len()` (which over-counts for any
+    /// still-full-size record such as tcpsniff's 4 MiB reservation).
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        type R = bpf::probe_SSL_data_t;
+        let hdr = mem::offset_of!(R, buf);
+        if data.len() < hdr {
+            return None;
+        }
+        let u32_at = |off: usize| u32::from_ne_bytes(data[off..off + 4].try_into().unwrap());
+        let u64_at = |off: usize| u64::from_ne_bytes(data[off..off + 8].try_into().unwrap());
+        let i32_at = |off: usize| i32::from_ne_bytes(data[off..off + 4].try_into().unwrap());
+
+        let len = u32_at(mem::offset_of!(R, len)) as usize;
+        let buf_size = (u32_at(mem::offset_of!(R, buf_size)) as usize)
+            .min(MAX_BUF_SIZE)
+            .min(data.len() - hdr);
+        // Warn only on a genuine over-cap capture. The `len > MAX_BUF_SIZE` guard is
+        // defense-in-depth: every EVENT_SOURCE_SSL producer shares this header and
+        // bpf_ringbuf_reserve does not zero the reservation, so a producer that omits
+        // `truncated` cannot trip a false warning on stale ring bytes.
+        if i32_at(mem::offset_of!(R, truncated)) != 0 && len > MAX_BUF_SIZE {
+            log::warn!(
+                "SSL payload exceeded {}-byte capture cap; captured {} of {} bytes (pid={})",
+                MAX_BUF_SIZE,
+                buf_size,
+                len,
+                u32_at(mem::offset_of!(R, pid)),
+            );
+        }
+        let buf = data[hdr..hdr + buf_size].to_vec();
+
+        let comm_off = mem::offset_of!(R, comm);
+        let mut comm_arr = [0u8; 16];
+        comm_arr.copy_from_slice(&data[comm_off..comm_off + 16]);
+
+        Some(Self {
+            source: u32_at(mem::offset_of!(R, source)),
+            timestamp_ns: config::ktime_to_unix_ns(u64_at(mem::offset_of!(R, timestamp_ns))),
+            delta_ns: u64_at(mem::offset_of!(R, delta_ns)),
+            pid: u32_at(mem::offset_of!(R, pid)),
+            tid: u32_at(mem::offset_of!(R, tid)),
+            uid: u32_at(mem::offset_of!(R, uid)),
+            len: len as u32,
+            rw: i32_at(mem::offset_of!(R, rw)),
+            comm: Self::parse_comm(&comm_arr),
+            buf,
+            is_handshake: i32_at(mem::offset_of!(R, is_handshake)) != 0,
+            ssl_ptr: u64_at(mem::offset_of!(R, ssl_ptr)),
+        })
+    }
+
     /// Parse comm from the BPF struct field (layout matches C `char comm[16]`; generated
     /// bindings may use `[i8; 16]` or `[u8; 16]` depending on target / libbpf-cargo version).
     fn parse_comm<T>(comm: &[T; 16]) -> String {
@@ -354,7 +414,6 @@ impl SslSniff {
     /// Returns a [`SslPoller`] handle.  Drop it (or call [`SslPoller::stop`])
     /// to signal the poll thread to exit.
     pub fn run(&self) -> Result<SslPoller> {
-        let min_sz = std::mem::size_of::<RawEvent>();
         let tx = self.tx.clone();
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stop_flag_inner = Arc::clone(&stop_flag);
@@ -366,14 +425,11 @@ impl SslSniff {
         let binding = self.skel.maps();
         rb_builder
             .add(binding.rb(), move |data: &[u8]| {
-                if data.len() < min_sz {
-                    return 0;
+                // SSL records are variable-length (tiered reservation): decode by
+                // header prefix + buf_size, not a full-struct cast.
+                if let Some(event) = SslEvent::from_bytes(data) {
+                    let _ = tx.send(event);
                 }
-                // SAFETY: eBPF side guarantees the layout and alignment.
-                // Read raw BPF event and convert to user-space SslEvent (copies only actual data)
-                let raw = unsafe { &*(data.as_ptr() as *const RawEvent) };
-                let event = SslEvent::from_bpf(raw);
-                let _ = tx.send(event);
                 0
             })
             .context("failed to add ring buffer")?;
@@ -447,10 +503,6 @@ impl Drop for SslPoller {
         }
     }
 }
-
-// ─── Raw kernel event layout (matches sslsniff.h) ────────────────────────────
-
-type RawEvent = bpf::probe_SSL_data_t;
 
 // ─── BoringSSL pattern detection ─────────────────────────────────────────────
 
@@ -903,4 +955,157 @@ fn attach_boringssl_by_offset(
         )?);
     }
     Ok(links)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a raw ring-buffer sample: the header prefix (each field written at its
+    /// real bindgen offset) followed by `payload`, with buf_size/len/truncated/
+    /// is_handshake set explicitly. Each scalar header field gets a DISTINCT
+    /// sentinel (pid≠tid≠uid, a marker delta_ns/comm) so any field/offset swap among
+    /// the adjacent u32s or on rw/comm/is_handshake fails a test. `tail_pad` appends
+    /// bytes AFTER the payload to simulate a still-full-size record (e.g. tcpsniff's
+    /// 4 MiB reservation) whose data.len() exceeds buf_size.
+    fn make_record(
+        payload: &[u8],
+        buf_size: u32,
+        len: u32,
+        truncated: i32,
+        tail_pad: usize,
+        is_handshake: i32,
+    ) -> Vec<u8> {
+        type R = bpf::probe_SSL_data_t;
+        let hdr = std::mem::offset_of!(R, buf);
+        let mut v = vec![0u8; hdr + payload.len() + tail_pad];
+        let put_u32 = |v: &mut [u8], off: usize, val: u32| {
+            v[off..off + 4].copy_from_slice(&val.to_ne_bytes())
+        };
+        let put_u64 = |v: &mut [u8], off: usize, val: u64| {
+            v[off..off + 8].copy_from_slice(&val.to_ne_bytes())
+        };
+        let put_i32 = |v: &mut [u8], off: usize, val: i32| {
+            v[off..off + 4].copy_from_slice(&val.to_ne_bytes())
+        };
+        put_u32(&mut v, std::mem::offset_of!(R, source), 2); // EVENT_SOURCE_SSL
+        put_u64(&mut v, std::mem::offset_of!(R, timestamp_ns), 0);
+        put_u64(&mut v, std::mem::offset_of!(R, delta_ns), 0xDEAD_BEEF);
+        put_u32(&mut v, std::mem::offset_of!(R, pid), 1234);
+        put_u32(&mut v, std::mem::offset_of!(R, tid), 5678);
+        put_u32(&mut v, std::mem::offset_of!(R, uid), 4321);
+        put_u32(&mut v, std::mem::offset_of!(R, len), len);
+        put_u32(&mut v, std::mem::offset_of!(R, buf_size), buf_size);
+        put_i32(&mut v, std::mem::offset_of!(R, rw), 1);
+        put_i32(&mut v, std::mem::offset_of!(R, is_handshake), is_handshake);
+        put_i32(&mut v, std::mem::offset_of!(R, truncated), truncated);
+        put_u64(&mut v, std::mem::offset_of!(R, ssl_ptr), 0xABCD);
+        let comm_off = std::mem::offset_of!(R, comm);
+        v[comm_off..comm_off + 4].copy_from_slice(b"node");
+        v[hdr..hdr + payload.len()].copy_from_slice(payload);
+        v
+    }
+
+    #[test]
+    fn from_bytes_decodes_small_record() {
+        // A small (16 KiB-tier) record — the whole point of the fix. Under the old
+        // `data.len() >= size_of::<full struct>()` (~4 MiB) gate this sample was
+        // DROPPED, so reverting to that gate makes this test fail.
+        let payload = b"POST /v1/messages HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello";
+        let rec = make_record(payload, payload.len() as u32, payload.len() as u32, 0, 0, 0);
+        assert!(
+            rec.len() < MAX_BUF_SIZE,
+            "record is far smaller than the full struct"
+        );
+        let ev = SslEvent::from_bytes(&rec).expect("small record must decode");
+        assert_eq!(&ev.buf[..], &payload[..]);
+        assert_eq!(ev.len as usize, payload.len());
+        assert_eq!(ev.ssl_ptr, 0xABCD);
+        // Each header scalar decodes from its OWN offset (distinct sentinels: a
+        // pid/tid offset swap, or an unset uid/delta_ns/rw/comm, fails here).
+        assert_eq!(ev.pid, 1234);
+        assert_eq!(ev.tid, 5678, "tid decodes from its own offset, not pid's");
+        assert_eq!(ev.uid, 4321);
+        assert_eq!(ev.delta_ns, 0xDEAD_BEEF);
+        assert_eq!(ev.rw, 1);
+        assert_eq!(ev.comm, "node");
+        assert!(!ev.is_handshake);
+    }
+
+    #[test]
+    fn from_bytes_decodes_handshake_header_only() {
+        // A handshake record carries NO payload: the BPF reserves header-only, so
+        // data.len() == offset_of!(buf) EXACTLY. The decoder must ACCEPT this
+        // boundary (a `<`→`<=` off-by-one at the header-length check would reject it)
+        // and decode is_handshake. Complements the reject-at-hdr-1 test below, so the
+        // header boundary is pinned on both sides.
+        let rec = make_record(&[], 0, 0, 0, 0, 1);
+        assert_eq!(
+            rec.len(),
+            std::mem::offset_of!(bpf::probe_SSL_data_t, buf),
+            "handshake record is exactly the header prefix"
+        );
+        let ev = SslEvent::from_bytes(&rec).expect("header-only handshake must decode");
+        assert!(ev.is_handshake, "is_handshake decodes true");
+        assert!(ev.buf.is_empty(), "no payload");
+    }
+
+    #[test]
+    fn from_bytes_uses_buf_size_field_not_data_len() {
+        // A still-full-size record (e.g. tcpsniff's 4 MiB reservation): data carries
+        // many bytes after the payload, but buf_size says only `n` are real. The
+        // decoder MUST take buf_size bytes, never data.len()-hdr — otherwise it would
+        // read the padding tail. Reverting to a data.len()-derived length fails this.
+        let payload = b"hi there";
+        let rec = make_record(
+            payload,
+            payload.len() as u32,
+            payload.len() as u32,
+            0,
+            4096,
+            0,
+        );
+        let ev = SslEvent::from_bytes(&rec).expect("full-size record must decode");
+        assert_eq!(
+            &ev.buf[..],
+            &payload[..],
+            "buf is the buf_size bytes, not the padded tail"
+        );
+    }
+
+    #[test]
+    fn from_bytes_rejects_short_header() {
+        // A sample shorter than the header prefix is rejected (no UB, no full cast).
+        let hdr = std::mem::offset_of!(bpf::probe_SSL_data_t, buf);
+        assert!(SslEvent::from_bytes(&vec![0u8; hdr - 1]).is_none());
+    }
+
+    #[test]
+    fn from_bytes_decodes_truncated_record() {
+        // A truncated record (payload clamped to the cap): buf_size < len, truncated=1,
+        // len > MAX_BUF_SIZE. The decoder still returns the captured bytes; len reports
+        // the true size. Also exercises the warn guard's positive case.
+        let captured = vec![b'x'; 64];
+        let rec = make_record(&captured, captured.len() as u32, 9_000_000, 1, 0, 0);
+        let ev = SslEvent::from_bytes(&rec).expect("truncated record must still decode");
+        assert_eq!(ev.buf.len(), 64);
+        assert_eq!(
+            ev.len, 9_000_000,
+            "len reports the true (pre-truncation) size"
+        );
+    }
+
+    #[test]
+    fn from_bytes_clamps_oversized_buf_size_to_available() {
+        // Defense: a buf_size larger than the bytes present must not read past the
+        // sample (clamped to data.len()-hdr).
+        let payload = b"abc";
+        let rec = make_record(payload, 1000, 1000, 0, 0, 0);
+        let ev = SslEvent::from_bytes(&rec).expect("decode");
+        assert_eq!(
+            ev.buf.len(),
+            payload.len(),
+            "buf_size clamped to available bytes"
+        );
+    }
 }

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -65,34 +65,6 @@ pub struct SslEvent {
 }
 
 impl SslEvent {
-    /// Create SslEvent from BPF raw event, copying only the actual data
-    ///
-    /// Note: BPF timestamp_ns is from bpf_ktime_get_ns() which returns
-    /// nanoseconds since system boot. We convert it to Unix timestamp.
-    pub fn from_bpf(raw: &bpf::probe_SSL_data_t) -> Self {
-        let buf_size = raw.buf_size as usize;
-        let buf = raw.buf[..buf_size.min(MAX_BUF_SIZE)].to_vec();
-
-        // Convert ktime (nanoseconds since boot) to Unix timestamp
-        let ktime_ns = raw.timestamp_ns;
-        let unix_ts_ns = config::ktime_to_unix_ns(ktime_ns);
-
-        Self {
-            source: raw.source,
-            timestamp_ns: unix_ts_ns,
-            delta_ns: raw.delta_ns,
-            pid: raw.pid,
-            tid: raw.tid,
-            uid: raw.uid,
-            len: raw.len,
-            rw: raw.rw,
-            comm: Self::parse_comm(&raw.comm),
-            buf,
-            is_handshake: raw.is_handshake != 0,
-            ssl_ptr: raw.ssl_ptr,
-        }
-    }
-
     /// Create SslEvent from a raw ring-buffer sample of VARIABLE length.
     ///
     /// SSL records are tiered: the BPF side reserves only
@@ -110,9 +82,27 @@ impl SslEvent {
         if data.len() < hdr {
             return None;
         }
-        let u32_at = |off: usize| u32::from_ne_bytes(data[off..off + 4].try_into().unwrap());
-        let u64_at = |off: usize| u64::from_ne_bytes(data[off..off + 8].try_into().unwrap());
-        let i32_at = |off: usize| i32::from_ne_bytes(data[off..off + 4].try_into().unwrap());
+        // Build the byte arrays directly (no `.unwrap()`; see AGENTS.md §0). Every `off`
+        // is a header field offset < `hdr`, and the guard above proves `data.len() >= hdr`,
+        // so each index is in-bounds (`buf` is the last struct member).
+        let u32_at = |off: usize| {
+            u32::from_ne_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]])
+        };
+        let u64_at = |off: usize| {
+            u64::from_ne_bytes([
+                data[off],
+                data[off + 1],
+                data[off + 2],
+                data[off + 3],
+                data[off + 4],
+                data[off + 5],
+                data[off + 6],
+                data[off + 7],
+            ])
+        };
+        let i32_at = |off: usize| {
+            i32::from_ne_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]])
+        };
 
         let len = u32_at(mem::offset_of!(R, len)) as usize;
         let buf_size = (u32_at(mem::offset_of!(R, buf_size)) as usize)


### PR DESCRIPTION
## Summary

Replace the fixed **4 MiB-per-record** SSL ring-buffer reservation with **per-tier reservations** sized to the payload, so small SSL calls no longer pad the shared 32 MiB ring to the worst case and get dropped under burst (#759) — while a single SSL call up to 4 MiB is still captured **whole** (no truncation).

**Supersedes #763** (my own PR, which shrank `MAX_BUF_SIZE` to a flat 32 KiB). As raised in review on #763, a flat 32 KiB cap truncates large request/response bodies; tiering keeps the full 4 MiB ceiling without padding every record. I'll close #763 once this lands.

## What changed

- **`sslsniff.h`** — four per-tier record types (`probe_SSL_data_{small,medium,large,t}` = 16 KiB / 128 KiB / 512 KiB / 4 MiB) sharing one byte-for-byte header (`SSL_DATA_HEADER_FIELDS`).
- **`sslsniff.bpf.c`** — `SSL_EMIT_TIERED` reserves `sizeof(smallest tier that fits len)`. The copy length is re-clamped to the tier **immediately before** `bpf_probe_read_user`, behind an `asm` barrier so clang can't drop the clamp as dead code (the outer tier branch already bounds it) while the verifier still gets a fresh in-register bound — otherwise the program is rejected at load with `R2 min value is negative` once the bound is lost across the `bpf_get_current_comm` register spill. Handshake records reserve header-only.
- **`probes/sslsniff.rs`** — `from_bytes()` decodes the shared header by offset and slices the payload by the `buf_size` field (never `data.len()`), so a variable-length / still-full-size record decodes correctly. Both consumers use it.
- **`tcpsniff.bpf.c`** — a second `EVENT_SOURCE_SSL` producer sharing this header; it now initializes the new shared `truncated` field (the ring reservation is not zeroed), and the consumer only warns when `truncated` is set **and** `len` exceeds the cap.

## Verification

**✅ E2E — real 6.6 kernel (6.6.102):**
- BPF object loads (all 4 tier programs + handshake verify; `main` also loads — the `pids[]` CO-RE relocation "invalid insn" is a pre-existing dead-branch artifact present on `main` too).
- Live capture: a single **300 KiB** `SSL_write` captured **whole** in one record (`len=307200`, `buf=307200`, `truncated=0`), decoded and parsed as a complete POST; small records (handshake, response chunks) too; **0** truncation warnings.

**✅ Unit (toolchain 1.89, exact CI command):** 669 tests, incl. 6 discriminating `from_bytes` tests (all tier shapes, truncation, `buf_size` clamp, header-only handshake, per-field sentinels). `clippy --all-targets -- -D warnings` clean; `fmt --all --check` clean.

**◑ tcpsniff field-init:** the BPF object loads + attaches (verifier-safe); the fix is correct by construction (`truncated = 0` + the consumer guard) and the `from_bytes` truncated path is E2E-exercised via sslsniff. Live tcpsniff **capture** was not triggered in a loopback E2E (0 stored HTTP rows — a tcpsniff capture-path matter orthogonal to this field-init), so the no-false-warning behavior was not exercised against live tcpsniff records.

## Notes

- Kernel floor stays 5.8 (no dynptr / `bpf_loop` introduced).
- tcpsniff still reserves the full 4 MiB; giving it per-tier reservations is intentionally a follow-up, not in this PR.
