### PR TITLE
feat(sec-core): write telemetry to sls jsonl file

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/base.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/base.py
@@ -20,10 +20,13 @@ class BaseBackend(ABC):
         self, result: ActionResult, kwargs: dict[str, Any]
     ) -> dict[str, Any]:
         """Build success audit details for the lifecycle event."""
-        return {
+        details = {
             "request": copy.deepcopy(kwargs),
             "result": copy.deepcopy(result.data),
         }
+        if not result.success and result.error:
+            details["error"] = result.error
+        return details
 
     def build_error_details(
         self, exception: Exception, kwargs: dict[str, Any]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
@@ -6,6 +6,7 @@ from agent_sec_cli.security_events import SecurityEvent, log_event
 from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
+from agent_sec_cli.telemetry import record_security_event_telemetry
 
 # ---------------------------------------------------------------------------
 # Action → SecurityEvent category mapping
@@ -26,6 +27,18 @@ _ACTION_CATEGORY: dict[str, str] = {
 def _category_for(action: str) -> str:
     """Return the event category for *action*, defaulting to the action name."""
     return _ACTION_CATEGORY.get(action, action)
+
+
+def _emit_event(event: SecurityEvent) -> None:
+    """Best-effort emit of security event and derived telemetry."""
+    try:
+        log_event(event)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        record_security_event_telemetry(event)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +81,7 @@ def post_action(
             call_id=ctx.call_id,
             tool_call_id=ctx.tool_call_id,
         )
-        log_event(event)
+        _emit_event(event)
     except Exception:  # noqa: BLE001
         pass
 
@@ -97,6 +110,6 @@ def on_error(
             call_id=ctx.call_id,
             tool_call_id=ctx.tool_call_id,
         )
-        log_event(event)
+        _emit_event(event)
     except Exception:  # noqa: BLE001
         pass

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/__init__.py
@@ -1,1 +1,5 @@
 """Telemetry support package."""
+
+from agent_sec_cli.telemetry.writer import record_security_event_telemetry
+
+__all__ = ["record_security_event_telemetry"]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/config.py
@@ -1,9 +1,27 @@
-"""Telemetry component metadata."""
+"""Telemetry path and component metadata."""
+
+import os
+from pathlib import Path
 
 from agent_sec_cli import __version__
 
 COMPONENT_NAME = "agent-sec-core"
 COMPONENT_AGENT_NAME = ""
+DEFAULT_TELEMETRY_LOG_PATH = "/var/log/anolisa/sls/ops/agent-sec-core.jsonl"
+TELEMETRY_LOG_PATH_ENV = "AGENT_SEC_TELEMETRY_LOG_PATH"
+
+
+def get_telemetry_log_path() -> Path:
+    """Return the configured Agentic OS telemetry JSONL path."""
+    override = os.environ.get(TELEMETRY_LOG_PATH_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path(DEFAULT_TELEMETRY_LOG_PATH)
+
+
+def telemetry_log_path_exists() -> bool:
+    """Return whether the configured telemetry JSONL file exists."""
+    return get_telemetry_log_path().is_file()
 
 
 def get_component_fields() -> dict[str, str]:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
@@ -1,0 +1,104 @@
+"""Best-effort telemetry JSONL writer."""
+
+import fcntl
+import json
+import logging
+import os
+import threading
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.telemetry.config import get_telemetry_log_path
+from agent_sec_cli.telemetry.schema import build_telemetry_security_event
+
+_logger = logging.getLogger("agent_sec_cli.telemetry.writer")
+_writer: "TelemetryWriter | None" = None
+
+
+def _log_telemetry_write_failure(exc: Exception) -> None:
+    """Best-effort diagnostic logging for swallowed telemetry write failures."""
+    try:
+        _logger.warning(
+            "telemetry JSONL write failed",
+            extra={
+                "data": {
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                }
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+class TelemetryWriter:
+    """Append telemetry records to an existing JSONL file.
+
+    The Agentic OS component file is pre-created.
+    This writer deliberately does not create directories, files, lock
+    files, rotation backups, or temporary files.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = (
+            Path(path).expanduser() if path is not None else get_telemetry_log_path()
+        )
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        """Return the writer target path."""
+        return self._path
+
+    def exists(self) -> bool:
+        """Return whether the target telemetry file currently exists."""
+        return self._path.is_file()
+
+    def write(self, record: Mapping[str, Any]) -> None:
+        """Best-effort append of a telemetry record as one JSONL line."""
+        with self._lock:
+            try:
+                line = json.dumps(record, ensure_ascii=False) + "\n"
+                self._append_line(line)
+            except FileNotFoundError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                _log_telemetry_write_failure(exc)
+
+    def _append_line(self, line: str) -> None:
+        """Open, lock, append, unlock, then close the target path for this write."""
+        flags = os.O_WRONLY | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
+        fd = os.open(self._path, flags)
+        lock_acquired = False
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            lock_acquired = True
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            if lock_acquired:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            os.close(fd)
+
+
+def get_writer() -> TelemetryWriter:
+    """Return the module-level telemetry writer singleton."""
+    global _writer  # noqa: PLW0603
+    if _writer is None:
+        _writer = TelemetryWriter()
+    return _writer
+
+
+def record_security_event_telemetry(event: SecurityEvent) -> None:
+    """Best-effort write of telemetry mapped from a SecurityEvent."""
+    try:
+        writer = get_writer()
+        if not writer.exists():
+            return
+        writer.write(build_telemetry_security_event(event))
+    except Exception as exc:  # noqa: BLE001
+        _log_telemetry_write_failure(exc)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
@@ -1,5 +1,6 @@
 """Best-effort telemetry JSONL writer."""
 
+import errno
 import fcntl
 import json
 import logging
@@ -15,6 +16,7 @@ from agent_sec_cli.telemetry.schema import build_telemetry_security_event
 
 _logger = logging.getLogger("agent_sec_cli.telemetry.writer")
 _writer: "TelemetryWriter | None" = None
+_writer_lock = threading.Lock()
 
 
 def _log_telemetry_write_failure(exc: Exception) -> None:
@@ -58,24 +60,39 @@ class TelemetryWriter:
 
     def write(self, record: Mapping[str, Any]) -> None:
         """Best-effort append of a telemetry record as one JSONL line."""
-        with self._lock:
-            try:
-                line = json.dumps(record, ensure_ascii=False) + "\n"
-                self._append_line(line)
-            except FileNotFoundError:
-                pass
-            except Exception as exc:  # noqa: BLE001
-                _log_telemetry_write_failure(exc)
+        try:
+            payload = (json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8")
+        except Exception as exc:  # noqa: BLE001
+            _log_telemetry_write_failure(exc)
+            return
 
-    def _append_line(self, line: str) -> None:
+        if not self._lock.acquire(blocking=False):
+            return
+        try:
+            self._append_line(payload)
+        except FileNotFoundError:
+            pass
+        except BlockingIOError:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            _log_telemetry_write_failure(exc)
+        finally:
+            self._lock.release()
+
+    def _append_line(self, payload: bytes) -> None:
         """Open, lock, append, unlock, then close the target path for this write."""
         flags = os.O_WRONLY | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
         fd = os.open(self._path, flags)
         lock_acquired = False
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                if exc.errno in {errno.EACCES, errno.EAGAIN}:
+                    raise BlockingIOError from exc
+                raise
             lock_acquired = True
-            os.write(fd, line.encode("utf-8"))
+            self._write_all(fd, payload)
         finally:
             if lock_acquired:
                 try:
@@ -84,12 +101,23 @@ class TelemetryWriter:
                     pass
             os.close(fd)
 
+    def _write_all(self, fd: int, payload: bytes) -> None:
+        """Write the complete payload, handling short writes."""
+        remaining = payload
+        while remaining:
+            written = os.write(fd, remaining)
+            if written <= 0:
+                raise OSError("os.write returned no bytes")
+            remaining = remaining[written:]
+
 
 def get_writer() -> TelemetryWriter:
     """Return the module-level telemetry writer singleton."""
     global _writer  # noqa: PLW0603
     if _writer is None:
-        _writer = TelemetryWriter()
+        with _writer_lock:
+            if _writer is None:
+                _writer = TelemetryWriter()
     return _writer
 
 

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -549,7 +549,7 @@ class TestSqliteEventWriter:
         conn.commit()
         conn.close()
 
-        writer = SqliteEventWriter(path=db_path)
+        writer = SqliteEventWriter(path=db_path, max_age_days=None)
         writer.write(
             SecurityEvent(
                 event_type="prompt_scan",

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -50,6 +50,13 @@ class TestPreAction(unittest.TestCase):
 
 
 class TestPostAction(unittest.TestCase):
+    def setUp(self):
+        self.telemetry_patch = patch(
+            "agent_sec_cli.security_middleware.lifecycle.record_security_event_telemetry"
+        )
+        self.mock_telemetry = self.telemetry_patch.start()
+        self.addCleanup(self.telemetry_patch.stop)
+
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_post_action_logs_event(self, mock_log):
         ctx = RequestContext(action="harden", trace_id="t-123")
@@ -118,6 +125,38 @@ class TestPostAction(unittest.TestCase):
         self.assertEqual(event.call_id, "call-1")
         self.assertEqual(event.tool_call_id, "tool-1")
 
+    def test_post_action_writes_telemetry_for_security_event(self):
+        ctx = RequestContext(action="code_scan", trace_id="trace-telemetry")
+        result = ActionResult(success=True, data={"verdict": "pass"})
+
+        with patch("agent_sec_cli.security_middleware.lifecycle.log_event") as mock_log:
+            post_action(ctx, result, {"code": "echo ok"}, DummyBackend())
+
+        event = mock_log.call_args[0][0]
+        self.mock_telemetry.assert_called_once_with(event)
+
+    def test_post_action_swallows_telemetry_failure(self):
+        ctx = RequestContext(action="code_scan", trace_id="trace-telemetry-fail")
+        result = ActionResult(success=True, data={"verdict": "pass"})
+
+        self.mock_telemetry.side_effect = RuntimeError("telemetry failed")
+        with patch("agent_sec_cli.security_middleware.lifecycle.log_event") as mock_log:
+            post_action(ctx, result, {"code": "echo ok"}, DummyBackend())
+
+        mock_log.assert_called_once()
+
+    def test_post_action_log_event_failure_does_not_block_telemetry(self):
+        ctx = RequestContext(action="code_scan", trace_id="trace-log-fail")
+        result = ActionResult(success=True, data={"verdict": "pass"})
+
+        with patch(
+            "agent_sec_cli.security_middleware.lifecycle.log_event",
+            side_effect=RuntimeError("log failed"),
+        ):
+            post_action(ctx, result, {"code": "echo ok"}, DummyBackend())
+
+        self.mock_telemetry.assert_called_once()
+
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_pii_scan_event_redacts_request_and_result(self, mock_log):
         ctx = RequestContext(action="pii_scan", trace_id="t-pii")
@@ -168,6 +207,13 @@ class TestPostAction(unittest.TestCase):
 
 
 class TestOnError(unittest.TestCase):
+    def setUp(self):
+        self.telemetry_patch = patch(
+            "agent_sec_cli.security_middleware.lifecycle.record_security_event_telemetry"
+        )
+        self.mock_telemetry = self.telemetry_patch.start()
+        self.addCleanup(self.telemetry_patch.stop)
+
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_on_error_logs_event(self, mock_log):
         ctx = RequestContext(action="verify", trace_id="t-456")
@@ -203,6 +249,38 @@ class TestOnError(unittest.TestCase):
         self.assertEqual(event.run_id, "run-1")
         self.assertEqual(event.call_id, "call-1")
         self.assertEqual(event.tool_call_id, "tool-1")
+
+    def test_on_error_writes_telemetry_for_security_event(self):
+        ctx = RequestContext(action="verify", trace_id="trace-error-telemetry")
+        exc = RuntimeError("boom")
+
+        with patch("agent_sec_cli.security_middleware.lifecycle.log_event") as mock_log:
+            on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
+
+        event = mock_log.call_args[0][0]
+        self.mock_telemetry.assert_called_once_with(event)
+
+    def test_on_error_swallows_telemetry_failure(self):
+        ctx = RequestContext(action="verify", trace_id="trace-error-telemetry-fail")
+        exc = RuntimeError("boom")
+
+        self.mock_telemetry.side_effect = RuntimeError("telemetry failed")
+        with patch("agent_sec_cli.security_middleware.lifecycle.log_event") as mock_log:
+            on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
+
+        mock_log.assert_called_once()
+
+    def test_on_error_log_event_failure_does_not_block_telemetry(self):
+        ctx = RequestContext(action="verify", trace_id="trace-error-log-fail")
+        exc = RuntimeError("boom")
+
+        with patch(
+            "agent_sec_cli.security_middleware.lifecycle.log_event",
+            side_effect=RuntimeError("log failed"),
+        ):
+            on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
+
+        self.mock_telemetry.assert_called_once()
 
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_pii_scan_error_redacts_request(self, mock_log):

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -89,6 +89,8 @@ class TestPostAction(unittest.TestCase):
         self.assertEqual(event.category, "code_scan")
         self.assertEqual(event.result, "failed")
         self.assertEqual(event.details["result"], {"ok": False, "verdict": "error"})
+        self.assertEqual(event.details["error"], "scan error")
+        self.assertNotIn("error_type", event.details)
 
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_post_action_maps_failed_result_to_event_result(self, mock_log):

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_config.py
@@ -1,0 +1,46 @@
+"""Unit tests for telemetry configuration."""
+
+from pathlib import Path
+
+from agent_sec_cli import __version__
+from agent_sec_cli.telemetry.config import (
+    DEFAULT_TELEMETRY_LOG_PATH,
+    TELEMETRY_LOG_PATH_ENV,
+    get_component_fields,
+    get_telemetry_log_path,
+    telemetry_log_path_exists,
+)
+
+
+def test_default_telemetry_log_path_is_agentic_os_component_file(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv(TELEMETRY_LOG_PATH_ENV, raising=False)
+
+    assert get_telemetry_log_path() == Path(DEFAULT_TELEMETRY_LOG_PATH)
+
+
+def test_telemetry_log_path_env_override(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    monkeypatch.setenv(TELEMETRY_LOG_PATH_ENV, str(path))
+
+    assert get_telemetry_log_path() == path
+
+
+def test_telemetry_log_path_exists_only_for_existing_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    monkeypatch.setenv(TELEMETRY_LOG_PATH_ENV, str(path))
+    assert telemetry_log_path_exists() is False
+
+    path.write_text("", encoding="utf-8")
+    assert telemetry_log_path_exists() is True
+
+
+def test_component_fields_are_fixed() -> None:
+    assert get_component_fields() == {
+        "component.name": "agent-sec-core",
+        "component.version": __version__,
+        "component.agent_name": "",
+    }

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_sanitizer.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_sanitizer.py
@@ -1,0 +1,95 @@
+"""Unit tests for telemetry sanitizer helpers."""
+
+import json
+from datetime import datetime
+
+from agent_sec_cli.telemetry.sanitizer import (
+    details_dict,
+    error_type_value,
+    error_value,
+    now_iso,
+    request_value,
+    result_dict,
+    result_value,
+    to_json_safe,
+    value_or_none,
+)
+
+
+class ModelLike:
+    def model_dump(self):
+        return {"items": ("a", "b"), "bad": float("nan")}
+
+
+class NotJsonSerializable:
+    def __str__(self):
+        return "fallback-string"
+
+
+def test_now_iso_returns_parseable_timestamp() -> None:
+    datetime.fromisoformat(now_iso())
+
+
+def test_to_json_safe_normalizes_nested_values() -> None:
+    value = {
+        1: ("x", float("nan")),
+        "set": {"z", "a"},
+        "list": [float("inf"), float("-inf"), 1.25],
+    }
+
+    safe = to_json_safe(value)
+
+    assert safe == {
+        "1": ["x", None],
+        "set": ["a", "z"],
+        "list": [None, None, 1.25],
+    }
+    json.dumps(safe, allow_nan=False)
+
+
+def test_to_json_safe_uses_model_dump_and_string_fallback() -> None:
+    assert to_json_safe(ModelLike()) == {"items": ["a", "b"], "bad": None}
+    assert to_json_safe(NotJsonSerializable()) == "fallback-string"
+
+
+def test_details_dict_returns_dict_or_empty_dict() -> None:
+    details = {"request": {"source": "manual"}}
+
+    assert details_dict(details) is details
+    assert details_dict(("not", "a", "dict")) == {}
+    assert details_dict(None) == {}
+
+
+def test_value_or_none_converts_empty_string_only() -> None:
+    assert value_or_none("") is None
+    assert value_or_none("value") == "value"
+    assert value_or_none(False) is False
+    assert value_or_none(0) == 0
+
+
+def test_result_dict_returns_nested_result_dict_or_empty_dict() -> None:
+    result = {"verdict": "deny"}
+
+    assert result_dict({"result": result}) is result
+    assert result_dict({}) == {}
+    assert result_dict({"result": "not-a-dict"}) == {}
+
+
+def test_request_value_handles_missing_and_json_safe_values() -> None:
+    assert request_value({}) is None
+    assert request_value({"request": {"items": ("a", "b")}}) == {"items": ["a", "b"]}
+
+
+def test_error_values_handle_missing_and_json_safe_values() -> None:
+    assert error_value({}) is None
+    assert error_type_value({}) is None
+    assert error_value({"error": float("nan")}) is None
+    assert error_type_value({"error_type": ("RuntimeError",)}) == ["RuntimeError"]
+
+
+def test_result_value_handles_missing_and_json_safe_values() -> None:
+    result = {"summary": {"values": {"z", "a"}}, "elapsed_ms": float("inf")}
+
+    assert result_value(result, "missing") is None
+    assert result_value(result, "summary") == {"values": ["a", "z"]}
+    assert result_value(result, "elapsed_ms") is None

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
@@ -1,0 +1,209 @@
+"""Unit tests for telemetry writer."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import agent_sec_cli.telemetry as telemetry
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.telemetry import writer as telemetry_writer
+from agent_sec_cli.telemetry.writer import (
+    TelemetryWriter,
+    get_writer,
+    record_security_event_telemetry,
+)
+
+
+def _event() -> SecurityEvent:
+    return SecurityEvent(
+        event_id="event-1",
+        event_type="pii_scan",
+        category="pii_scan",
+        result="succeeded",
+        timestamp="2026-06-15T12:00:00+00:00",
+        trace_id="trace-1",
+        details={
+            "request": {"source": "manual"},
+            "result": {"verdict": "deny", "summary": {"total": 1}, "elapsed_ms": 3},
+        },
+    )
+
+
+def test_telemetry_package_exports_public_api() -> None:
+    assert telemetry.record_security_event_telemetry is record_security_event_telemetry
+    assert telemetry.__all__ == ["record_security_event_telemetry"]
+
+
+def test_telemetry_package_imports_in_clean_interpreter() -> None:
+    probe = """
+import agent_sec_cli.telemetry as telemetry
+
+print(",".join(telemetry.__all__))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "record_security_event_telemetry"
+
+
+def test_writer_skips_missing_target_without_creating_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "missing" / "agent-sec-core.jsonl"
+    writer = TelemetryWriter(path=path)
+    log_failure = MagicMock()
+    monkeypatch.setattr(telemetry_writer, "_log_telemetry_write_failure", log_failure)
+
+    writer.write({"component.name": "agent-sec-core"})
+
+    assert not path.exists()
+    assert not path.parent.exists()
+    log_failure.assert_not_called()
+
+
+def test_writer_appends_existing_file(tmp_path: Path) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    writer = TelemetryWriter(path=path)
+
+    writer.write({"component.name": "agent-sec-core", "seccore.event_id": "event-1"})
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {
+        "component.name": "agent-sec-core",
+        "seccore.event_id": "event-1",
+    }
+    assert not Path(f"{path}.lock").exists()
+    assert list(tmp_path.glob("agent-sec-core.jsonl.*")) == []
+
+
+def test_writer_uses_short_lived_flock_on_target_fd(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    writer = TelemetryWriter(path=path)
+    flock_calls: list[tuple[int, int]] = []
+
+    def record_flock(fd: int, operation: int) -> None:
+        flock_calls.append((fd, operation))
+
+    monkeypatch.setattr(telemetry_writer.fcntl, "flock", record_flock)
+
+    writer.write({"seq": 1})
+
+    assert [operation for _, operation in flock_calls] == [
+        telemetry_writer.fcntl.LOCK_EX,
+        telemetry_writer.fcntl.LOCK_UN,
+    ]
+    assert flock_calls[0][0] == flock_calls[1][0]
+    assert not Path(f"{path}.lock").exists()
+
+
+def test_writer_reopens_target_path_after_rename_rotation(tmp_path: Path) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    rotated_path = tmp_path / "agent-sec-core.jsonl.rotated"
+    path.write_text("", encoding="utf-8")
+    writer = TelemetryWriter(path=path)
+
+    writer.write({"seq": 1})
+    path.rename(rotated_path)
+    path.write_text("", encoding="utf-8")
+    writer.write({"seq": 2})
+
+    assert json.loads(rotated_path.read_text(encoding="utf-8").splitlines()[0]) == {
+        "seq": 1
+    }
+    assert json.loads(path.read_text(encoding="utf-8").splitlines()[0]) == {"seq": 2}
+
+
+def test_writer_swallows_missing_file_race_after_exists_check(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    writer = TelemetryWriter(path=path)
+    open_calls = 0
+
+    def race_open(file_path: Path, flags: int) -> int:
+        nonlocal open_calls
+        open_calls += 1
+        raise FileNotFoundError(file_path)
+
+    monkeypatch.setattr(telemetry_writer.os, "open", race_open)
+
+    writer.write({"seq": 1})
+
+    assert open_calls == 1
+    assert path.read_text(encoding="utf-8") == ""
+
+
+def test_record_security_event_telemetry_uses_mapping_and_writer(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
+    monkeypatch.setattr(telemetry_writer, "_writer", None)
+
+    record_security_event_telemetry(_event())
+
+    record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["component.name"] == "agent-sec-core"
+    assert record["seccore.event_id"] == "event-1"
+    assert record["seccore.verdict"] == "deny"
+
+
+def test_record_security_event_telemetry_skips_mapping_when_target_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "missing.jsonl"
+    monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
+    monkeypatch.setattr(telemetry_writer, "_writer", None)
+    mapper = MagicMock(return_value={"component.name": "agent-sec-core"})
+    monkeypatch.setattr(telemetry_writer, "build_telemetry_security_event", mapper)
+
+    record_security_event_telemetry(_event())
+
+    mapper.assert_not_called()
+    assert not path.exists()
+
+
+def test_record_security_event_telemetry_swallows_mapping_errors(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
+    monkeypatch.setattr(telemetry_writer, "_writer", None)
+
+    def fail_mapping(event: SecurityEvent) -> dict[str, object]:
+        raise RuntimeError("mapping failed")
+
+    monkeypatch.setattr(
+        telemetry_writer, "build_telemetry_security_event", fail_mapping
+    )
+
+    record_security_event_telemetry(_event())
+
+    assert path.read_text(encoding="utf-8") == ""
+
+
+def test_get_writer_returns_singleton(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
+    monkeypatch.setattr(telemetry_writer, "_writer", None)
+
+    first = get_writer()
+    second = get_writer()
+
+    assert first is second
+    assert first.path == path

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
@@ -3,6 +3,8 @@
 import json
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -85,6 +87,32 @@ def test_writer_appends_existing_file(tmp_path: Path) -> None:
     assert list(tmp_path.glob("agent-sec-core.jsonl.*")) == []
 
 
+def test_writer_handles_short_os_writes(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    writer = TelemetryWriter(path=path)
+    original_write = telemetry_writer.os.write
+    write_calls: list[bytes] = []
+
+    def short_write(fd: int, payload: bytes) -> int:
+        write_calls.append(payload)
+        if len(payload) > 1:
+            return original_write(fd, payload[: len(payload) // 2])
+        return original_write(fd, payload)
+
+    monkeypatch.setattr(telemetry_writer.os, "write", short_write)
+
+    writer.write({"component.name": "agent-sec-core", "seccore.event_id": "event-1"})
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(write_calls) > 1
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {
+        "component.name": "agent-sec-core",
+        "seccore.event_id": "event-1",
+    }
+
+
 def test_writer_uses_short_lived_flock_on_target_fd(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -101,11 +129,44 @@ def test_writer_uses_short_lived_flock_on_target_fd(
     writer.write({"seq": 1})
 
     assert [operation for _, operation in flock_calls] == [
-        telemetry_writer.fcntl.LOCK_EX,
+        telemetry_writer.fcntl.LOCK_EX | telemetry_writer.fcntl.LOCK_NB,
         telemetry_writer.fcntl.LOCK_UN,
     ]
     assert flock_calls[0][0] == flock_calls[1][0]
     assert not Path(f"{path}.lock").exists()
+
+
+def test_writer_skips_when_target_flock_is_busy(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    writer = TelemetryWriter(path=path)
+    log_failure = MagicMock()
+    monkeypatch.setattr(telemetry_writer, "_log_telemetry_write_failure", log_failure)
+
+    def busy_flock(fd: int, operation: int) -> None:
+        if operation & telemetry_writer.fcntl.LOCK_EX:
+            raise BlockingIOError
+
+    monkeypatch.setattr(telemetry_writer.fcntl, "flock", busy_flock)
+
+    writer.write({"seq": 1})
+
+    assert path.read_text(encoding="utf-8") == ""
+    log_failure.assert_not_called()
+
+
+def test_writer_skips_when_process_lock_is_busy(tmp_path: Path) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    writer = TelemetryWriter(path=path)
+
+    writer._lock.acquire()
+    try:
+        writer.write({"seq": 1})
+    finally:
+        writer._lock.release()
+
+    assert path.read_text(encoding="utf-8") == ""
 
 
 def test_writer_reopens_target_path_after_rename_rotation(tmp_path: Path) -> None:
@@ -207,3 +268,44 @@ def test_get_writer_returns_singleton(monkeypatch, tmp_path: Path) -> None:
 
     assert first is second
     assert first.path == path
+
+
+def test_get_writer_initializes_singleton_once_under_concurrency(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
+    monkeypatch.setattr(telemetry_writer, "_writer", None)
+    created: list[TelemetryWriter] = []
+
+    class SlowTelemetryWriter(TelemetryWriter):
+        def __init__(self) -> None:
+            time.sleep(0.01)
+            super().__init__()
+            created.append(self)
+
+    monkeypatch.setattr(telemetry_writer, "TelemetryWriter", SlowTelemetryWriter)
+    barrier = threading.Barrier(8)
+    writers: list[TelemetryWriter] = []
+    errors: list[Exception] = []
+
+    def get_concurrent_writer() -> None:
+        try:
+            barrier.wait()
+            writers.append(get_writer())
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=get_concurrent_writer) for _ in range(barrier.parties)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(created) == 1
+    assert len(writers) == barrier.parties
+    assert all(writer is writers[0] for writer in writers)
+    assert writers[0].path == path


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
