### PR TITLE
feat(anolisa): rpm drift status with repair and forget commands

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -97,6 +97,10 @@ pub enum ComponentCommands {
     Restart(tier1::restart::RestartArgs),
     /// Update a component (`update <component>`), the CLI binary (`self`), or everything (`all`)
     Update(tier1::update::UpdateArgs),
+    /// Reconcile a component's ANOLISA state with rpmdb after manual RPM changes
+    Repair(tier1::repair::RepairArgs),
+    /// Drop a component's ANOLISA state record without any package operation
+    Forget(tier1::forget::ForgetArgs),
     /// Manage component-to-framework adapters
     Adapter(adapter::AdapterArgs),
 }
@@ -196,6 +200,8 @@ pub fn dispatch(cli: Cli, ctx: &CliContext) -> Result<(), CliError> {
             ComponentCommands::Logs(args) => tier1::logs::handle(args, ctx),
             ComponentCommands::Restart(args) => tier1::restart::handle(args, ctx),
             ComponentCommands::Update(args) => tier1::update::handle(args, ctx),
+            ComponentCommands::Repair(args) => tier1::repair::handle(args, ctx),
+            ComponentCommands::Forget(args) => tier1::forget::handle(args, ctx),
             ComponentCommands::Adapter(args) => adapter::handle(args, ctx),
         },
         Commands::Management(cmd) => match cmd {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
@@ -3,9 +3,11 @@
 pub mod bug;
 pub mod doctor;
 pub mod env;
+pub mod forget;
 pub mod install;
 pub mod list;
 pub mod logs;
+pub mod repair;
 pub mod restart;
 pub mod status;
 pub mod uninstall;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -1,0 +1,542 @@
+//! `anolisa forget <component>` — drop a component's ANOLISA state record
+//! without touching the underlying package or files.
+//!
+//! `forget` is the escape hatch for stale state: after a manual `rpm -e` (the
+//! `missing` case from `anolisa status`), or whenever the operator wants ANOLISA
+//! to stop tracking a component, `forget` removes the `installed.toml` object
+//! and records the operation. It performs **no** package operation — no
+//! `dnf remove`, no `rpm -e` — and deletes no files. An observed/managed RPM
+//! stays installed in rpmdb; a raw component's owned files stay on disk (use
+//! `anolisa uninstall` to remove those).
+
+use chrono::{SecondsFormat, Utc};
+use clap::Parser;
+use serde::Serialize;
+
+use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
+use anolisa_core::lock::InstallLock;
+use anolisa_core::state::{ObjectKind, OperationRecord};
+
+use crate::color::Palette;
+use crate::commands::common;
+use crate::context::CliContext;
+use crate::response::{CliError, render_json};
+
+/// Command label for JSON envelopes and error routing.
+const COMMAND: &str = "forget";
+
+/// Arguments for `anolisa forget <component>`.
+#[derive(Debug, Parser)]
+pub struct ForgetArgs {
+    /// Component whose ANOLISA state record should be dropped
+    #[arg(value_name = "COMPONENT")]
+    pub component: String,
+}
+
+/// Wire shape for a `forget <component>` result (`--json`) and its dry-run
+/// preview.
+#[derive(Serialize)]
+struct ForgetPayload {
+    component: String,
+    /// Provenance label of the dropped record, for the audit trail.
+    ownership: &'static str,
+    install_mode: String,
+    /// Whether the state record was actually removed (false on dry-run).
+    forgotten: bool,
+    dry_run: bool,
+    /// `None` on dry-run (nothing recorded).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation_id: Option<String>,
+}
+
+/// Dispatch `forget <component>`: drop the ANOLISA state record, run no package
+/// operation.
+///
+/// # Errors
+///
+/// Returns [`CliError`] when the component is absent, still has enabled adapter
+/// receipts, or the state write fails.
+pub fn handle(args: ForgetArgs, ctx: &CliContext) -> Result<(), CliError> {
+    let target = args.component.as_str();
+    let command = format!("forget {target}");
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+
+    let obj = installed
+        .find_object(ObjectKind::Component, target)
+        .ok_or_else(|| CliError::InvalidArgument {
+            command: command.clone(),
+            reason: format!(
+                "component '{target}' is not installed — nothing to forget (run `anolisa status` to see what is tracked)"
+            ),
+        })?;
+    let ownership_label = obj.effective_ownership().label();
+
+    // Adapter receipts must be released before the component is dropped:
+    // silently orphaning a registered plugin is worse than refusing. This guard
+    // is a fast-fail and the dry-run preview; `persist_forget` re-checks
+    // authoritatively under the lock. Mirrors `uninstall`, pointing at
+    // `adapter disable`.
+    if !ctx.dry_run {
+        let claims = installed.adapter_claims_for_component(target);
+        if !claims.is_empty() {
+            let mut frameworks: Vec<&str> = claims.iter().map(|c| c.framework.as_str()).collect();
+            frameworks.sort_unstable();
+            frameworks.dedup();
+            return Err(CliError::InvalidArgument {
+                command,
+                reason: format!(
+                    "'{target}' has enabled adapters ({}); run `anolisa adapter disable {target}` for each framework before forgetting",
+                    frameworks.join(", ")
+                ),
+            });
+        }
+    }
+
+    if ctx.dry_run {
+        let payload = ForgetPayload {
+            component: target.to_string(),
+            ownership: ownership_label,
+            install_mode: ctx.install_mode.as_str().to_string(),
+            forgotten: false,
+            dry_run: true,
+            operation_id: None,
+        };
+        render_forget(ctx, &payload);
+        return Ok(());
+    }
+
+    let (operation_id, ownership_label) = persist_forget(ctx, target, &command)?;
+    let payload = ForgetPayload {
+        component: target.to_string(),
+        ownership: ownership_label,
+        install_mode: ctx.install_mode.as_str().to_string(),
+        forgotten: true,
+        dry_run: false,
+        operation_id: Some(operation_id),
+    };
+    render_forget(ctx, &payload);
+    Ok(())
+}
+
+/// Remove the component's state object under the install lock and append an
+/// audit record. No package operation, no file deletion. Returns the operation
+/// id.
+fn persist_forget(
+    ctx: &CliContext,
+    component: &str,
+    command: &str,
+) -> Result<(String, &'static str), CliError> {
+    let layout = common::resolve_layout(ctx);
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state = common::load_installed_state(ctx, command)?;
+
+    // Authoritative adapter-claim guard, under the lock. The check in `handle`
+    // is only a fast-fail / dry-run preview: a concurrent `adapter enable`
+    // landing between that read and this removal would otherwise orphan its
+    // receipt once the component object is gone. Re-checking the freshly
+    // reloaded state here closes that window.
+    let claims = state.adapter_claims_for_component(component);
+    if !claims.is_empty() {
+        let mut frameworks: Vec<&str> = claims.iter().map(|c| c.framework.as_str()).collect();
+        frameworks.sort_unstable();
+        frameworks.dedup();
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "'{component}' has enabled adapters ({}); run `anolisa adapter disable {component}` for each framework before forgetting",
+                frameworks.join(", ")
+            ),
+        });
+    }
+
+    // Re-validate object presence under the lock (a concurrent uninstall/forget
+    // may have dropped it), and take ownership of the removed object so the
+    // response reports the provenance the lock actually observed rather than the
+    // pre-lock read.
+    let removed = state
+        .remove_object(ObjectKind::Component, component)
+        .ok_or_else(|| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' disappeared from state during forget; nothing removed"
+            ),
+        })?;
+    let ownership_label = removed.effective_ownership().label();
+
+    let now = now_iso8601();
+    let lock_ts = Utc::now();
+    let operation_id = format!(
+        "op-forget-{}-{}",
+        lock_ts.format("%Y%m%d%H%M%S"),
+        lock_ts.timestamp_subsec_nanos()
+    );
+    state.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: now.clone(),
+        finished_at: Some(now.clone()),
+    });
+
+    let state_path = layout.state_dir.join("installed.toml");
+    state.save(&state_path).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to save state: {err}"),
+    })?;
+
+    // Audit log is best-effort: the state already persisted, so a log failure
+    // downgrades to a warning instead of unwinding.
+    let log = CentralLog::open(layout.central_log.clone());
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.clone()),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message: format!(
+            "forgot ANOLISA state for component {component}; no package operation performed"
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at: now.clone(),
+        finished_at: Some(now),
+        status: Some(LogStatus::Ok),
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: Vec::new(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = log.append(&record) {
+        eprintln!("warning: failed to write central log: {err}");
+    }
+
+    Ok((operation_id, ownership_label))
+}
+
+/// Human/JSON renderer for a forget result.
+fn render_forget(ctx: &CliContext, payload: &ForgetPayload) {
+    if ctx.json {
+        // Errors here are unreachable for a plain Serialize struct; ignore the
+        // Result so an (already-persisted) forget is not reported as failed.
+        let _ = render_json(COMMAND, payload);
+        return;
+    }
+    if ctx.quiet {
+        return;
+    }
+    let color = Palette::new(ctx.no_color);
+    if payload.dry_run {
+        println!(
+            "{} {} {} {}",
+            color.command("forget"),
+            payload.component,
+            color.muted(format!("({})", payload.ownership)),
+            color.muted("(dry-run — ANOLISA state not modified)"),
+        );
+        println!(
+            "  {}",
+            color.muted("no package operation would be performed")
+        );
+        return;
+    }
+    println!(
+        "{} {} {}",
+        color.ok("✓ forgot"),
+        payload.component,
+        color.muted(format!("({})", payload.ownership)),
+    );
+    println!(
+        "    {} ANOLISA stopped tracking this component; no package operation was performed",
+        color.label("note:"),
+    );
+    // Tailor the residue reminder to what forget deliberately left behind.
+    if payload.ownership == "raw-managed" {
+        println!(
+            "    {} ANOLISA-owned files remain on disk; forget dropped their inventory, so 'anolisa uninstall' can no longer remove them — delete them manually (next time, run 'anolisa uninstall' instead of 'forget' when you want ANOLISA to remove files)",
+            color.label("note:"),
+        );
+    } else {
+        println!(
+            "    {} the RPM package remains installed; use dnf/rpm directly if you want to remove it",
+            color.label("note:"),
+        );
+    }
+}
+
+/// RFC3339 UTC timestamp, seconds precision (matches the install/update paths).
+fn now_iso8601() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus, DriverPayload, OpenClawClaim};
+    use anolisa_core::state::{
+        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, Ownership,
+        RpmMetadata,
+    };
+
+    use crate::context::InstallMode;
+
+    fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        CliContext {
+            install_mode,
+            prefix: Some(prefix),
+            json: false,
+            dry_run,
+            verbose: false,
+            quiet: true,
+            no_color: true,
+        }
+    }
+
+    /// An adopted rpm-observed component object.
+    fn rpm_observed_object(component: &str, package: &str, evr: &str) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: evr.to_string(),
+            status: ObjectStatus::Adopted,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmObserved),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: package.to_string(),
+                evr: Some(evr.to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: false,
+            adopted: true,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    fn sample_claim(component: &str, framework: &str) -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: 1,
+            component: component.to_string(),
+            framework: framework.to_string(),
+            plugin_id: None,
+            enabled_at: "2026-06-01T10:00:00Z".to_string(),
+            resource_root: PathBuf::from("/tmp/anolisa-forget-test"),
+            bundle_digest: None,
+            driver_schema: 1,
+            status: ClaimStatus::Enabled,
+            resources: Vec::new(),
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "state".to_string(),
+                plugin_resource: "plugin".to_string(),
+            }),
+        }
+    }
+
+    fn seed(ctx: &CliContext, objs: Vec<InstalledObject>, claims: Vec<AdapterClaim>) {
+        let layout = common::resolve_layout(ctx);
+        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        let mut state = InstalledState {
+            install_mode: match ctx.install_mode {
+                InstallMode::System => StateInstallMode::System,
+                InstallMode::User => StateInstallMode::User,
+            },
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        for obj in objs {
+            state.upsert_object(obj);
+        }
+        for claim in claims {
+            state.upsert_adapter_claim(claim);
+        }
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state");
+    }
+
+    fn load_state(ctx: &CliContext) -> InstalledState {
+        let layout = common::resolve_layout(ctx);
+        InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+    }
+
+    /// forget drops the state object and records the operation; no package
+    /// operation is involved (there is no package query/transaction at all).
+    #[test]
+    fn forget_drops_object_and_records_operation() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![rpm_observed_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+            )],
+            Vec::new(),
+        );
+
+        handle(
+            ForgetArgs {
+                component: "copilot-shell".to_string(),
+            },
+            &c,
+        )
+        .expect("forget ok");
+
+        let after = load_state(&c);
+        assert!(
+            after
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "state object must be dropped",
+        );
+        assert!(
+            after
+                .operations
+                .iter()
+                .any(|o| o.command == "forget copilot-shell"),
+            "an operation record must be appended",
+        );
+    }
+
+    /// Forgetting an absent component routes to INVALID_ARGUMENT (exit 2).
+    #[test]
+    fn forget_unknown_component_routes_to_invalid_argument() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let err = handle(
+            ForgetArgs {
+                component: "ghost".to_string(),
+            },
+            &c,
+        )
+        .expect_err("absent component must error");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.exit_code(), 2);
+        assert!(err.reason().contains("not installed"));
+    }
+
+    /// A component with an adapter receipt is refused until the adapter is
+    /// disabled — forget must not silently orphan a registered plugin.
+    #[test]
+    fn forget_refuses_with_enabled_adapter_claim() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![rpm_observed_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+            )],
+            vec![sample_claim("copilot-shell", "openclaw")],
+        );
+        let err = handle(
+            ForgetArgs {
+                component: "copilot-shell".to_string(),
+            },
+            &c,
+        )
+        .expect_err("enabled adapter must block forget");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("adapter disable"),
+            "reason must point at adapter disable: {}",
+            err.reason()
+        );
+        // The component must still be present — forget refused.
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+        );
+    }
+
+    /// `persist_forget` enforces the adapter-claim guard under the lock, not only
+    /// in `handle`. Calling it directly — bypassing the pre-lock fast-fail, as a
+    /// concurrent `adapter enable` effectively would — on a state that already
+    /// holds a claim must refuse and leave the object intact. This is what closes
+    /// the enable-during-forget race; a regression that drops the locked check
+    /// fails here while the `handle`-level test above would still pass.
+    #[test]
+    fn persist_forget_rechecks_adapter_claim_under_lock() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![rpm_observed_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+            )],
+            vec![sample_claim("copilot-shell", "openclaw")],
+        );
+        let err = persist_forget(&c, "copilot-shell", "forget copilot-shell")
+            .expect_err("locked claim check must refuse");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("adapter disable"),
+            "reason must point at adapter disable: {}",
+            err.reason()
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "object must remain when the locked claim check refuses",
+        );
+    }
+
+    /// Dry-run leaves the state record in place.
+    #[test]
+    fn forget_dry_run_leaves_state_untouched() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        seed(
+            &c,
+            vec![rpm_observed_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+            )],
+            Vec::new(),
+        );
+        handle(
+            ForgetArgs {
+                component: "copilot-shell".to_string(),
+            },
+            &c,
+        )
+        .expect("dry-run ok");
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "dry-run must not remove the state object",
+        );
+    }
+
+    /// CLI surface: `forget <component>` parses to the positional.
+    #[test]
+    fn forget_parses_positional_component() {
+        use clap::Parser as _;
+        let a = ForgetArgs::try_parse_from(["forget", "copilot-shell"]).expect("parse");
+        assert_eq!(a.component, "copilot-shell");
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -1,0 +1,1004 @@
+//! `anolisa repair <component>` — reconcile ANOLISA state with rpmdb reality.
+//!
+//! When a user runs `dnf update`/`downgrade` outside ANOLISA, the recorded EVR
+//! drifts from rpmdb (surfaced as `drifted` by `anolisa status`). `repair`
+//! reads rpmdb, confirms the package identity is still valid, and refreshes the
+//! ANOLISA state record (version, EVR, arch, source repo). It runs **no**
+//! dnf/rpm transaction and never switches backend — only rpmdb reads plus a
+//! state write.
+//!
+//! A package that has been `rpm -e`'d cannot be repaired: there is nothing to
+//! refresh from, so `repair` refuses and points at `anolisa forget`. Raw
+//! components have no rpmdb to reconcile against and are not handled yet.
+
+use chrono::{SecondsFormat, Utc};
+use clap::Parser;
+use serde::Serialize;
+
+use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
+use anolisa_core::lock::InstallLock;
+use anolisa_core::state::{ObjectKind, OperationRecord, Ownership, RpmMetadata};
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
+use anolisa_platform::rpm_query::RpmPackageQuery;
+
+use crate::color::Palette;
+use crate::commands::common;
+use crate::commands::tier1::install::rpm_package_candidates;
+use crate::context::CliContext;
+use crate::repo_config::RepoConfig;
+use crate::response::{CliError, render_json};
+
+/// Command label for JSON envelopes and error routing.
+const COMMAND: &str = "repair";
+
+/// Arguments for `anolisa repair <component>`.
+#[derive(Debug, Parser)]
+pub struct RepairArgs {
+    /// Component whose ANOLISA state should be refreshed from rpmdb
+    #[arg(value_name = "COMPONENT")]
+    pub component: String,
+}
+
+/// Wire shape for a `repair <component>` result (`--json`) and its dry-run
+/// preview.
+#[derive(Serialize)]
+struct RepairPayload {
+    component: String,
+    package: String,
+    /// Always `rpm`: repair never switches backend.
+    backend: &'static str,
+    /// `rpm-observed` or `rpm-managed`; preserved across the repair.
+    ownership: &'static str,
+    install_mode: String,
+    /// EVR ANOLISA had recorded; `None` for a legacy row with no metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from_version: Option<String>,
+    /// EVR read back from rpmdb (the value state is reconciled to).
+    to_version: String,
+    /// Whether state was actually written (false on dry-run).
+    refreshed: bool,
+    /// Whether the rpmdb EVR differed from what ANOLISA had recorded.
+    changed: bool,
+    dry_run: bool,
+    /// `None` on dry-run (nothing recorded).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation_id: Option<String>,
+    warnings: Vec<String>,
+}
+
+/// Dispatch `repair <component>`: build the real rpm-backed query and reconcile.
+///
+/// # Errors
+///
+/// Returns [`CliError`] when the component is absent, raw-backed (unsupported),
+/// the package is gone from rpmdb, the rpmdb read is ambiguous, or the state
+/// write fails.
+pub fn handle(args: RepairArgs, ctx: &CliContext) -> Result<(), CliError> {
+    let query = RpmPackageQuery::system();
+    repair_with_query(&args.component, ctx, &query)
+}
+
+/// Core of [`handle`] with the package query injected so tests drive the
+/// reconcile path without a live rpmdb. Repair runs no dnf transaction, so only
+/// a [`PackageQuery`] is required.
+fn repair_with_query(
+    target: &str,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+) -> Result<(), CliError> {
+    let command = format!("repair {target}");
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+
+    let obj = installed
+        .find_object(ObjectKind::Component, target)
+        .ok_or_else(|| CliError::InvalidArgument {
+            command: command.clone(),
+            reason: format!(
+                "component '{target}' is not installed — nothing to repair (run `anolisa status` to see what is installed)"
+            ),
+        })?;
+
+    let ownership = obj.effective_ownership();
+    // Raw components have no rpmdb to reconcile against. Keep them on the same
+    // not-implemented boundary the update path uses for raw.
+    if !ownership.is_rpm() {
+        return Err(CliError::not_implemented_with_hint(
+            command,
+            "raw component repair is not implemented yet; only RPM-backed components can be repaired today",
+        ));
+    }
+
+    // Resolve the package to reconcile against. A recorded package name is the
+    // identity to confirm; when absent (a legacy row with no rpm_metadata), fall
+    // back to the adopt candidate chain so repair can backfill the metadata the
+    // update path refuses to run without.
+    let package = resolve_repair_package(target, obj.rpm_metadata.as_ref(), ctx, query, &command)?;
+    let recorded_evr = obj.rpm_metadata.as_ref().and_then(|m| m.evr.clone());
+    let ownership_label = ownership.label();
+
+    // rpmdb query — the truth repair reconciles to.
+    let info = match query.query_installed(&package) {
+        Ok(Some(info)) => info,
+        // rpm -e: nothing to refresh from. repair cannot conjure the package
+        // back, so point at forget (or reinstall) rather than fabricating state.
+        Ok(None) => {
+            return Err(CliError::Runtime {
+                command,
+                reason: format!(
+                    "RPM package '{package}' for component '{target}' is recorded in ANOLISA state but is not present in rpmdb — it may have been removed with `rpm -e`; run `anolisa forget {target}` to drop the stale state, or reinstall"
+                ),
+            });
+        }
+        // rpm could not be reduced to a single installed version (duplicates, a
+        // malformed `--qf` row, or none on a zero exit): an ambiguous reconcile
+        // target. Refuse with the backend's own detail rather than asserting one
+        // specific cause.
+        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => {
+            return Err(CliError::Runtime {
+                command,
+                reason: format!(
+                    "rpm returned unexpected output for package '{package}': {detail}; refusing to refresh until it resolves to a single installed version"
+                ),
+            });
+        }
+        Err(PackageQueryError::CommandMissing { .. }) => {
+            return Err(rpm_tooling_missing_error(&command));
+        }
+        Err(err) => return Err(rpm_query_err(err, &command)),
+    };
+
+    let to_evr = info.version.to_string();
+    let changed = recorded_evr.as_deref() != Some(to_evr.as_str());
+
+    // source_repo is supplementary metadata: a failed origin lookup degrades to
+    // `None` with a warning and never fails the repair (mirrors adopt).
+    let mut warnings: Vec<String> = Vec::new();
+    let source_repo = match query.installed_origin(&package) {
+        Ok(origin) => origin,
+        Err(err) => {
+            warnings.push(format!(
+                "could not determine source repo for '{package}': {err}"
+            ));
+            None
+        }
+    };
+
+    if ctx.dry_run {
+        let payload = RepairPayload {
+            component: target.to_string(),
+            package,
+            backend: "rpm",
+            ownership: ownership_label,
+            install_mode: ctx.install_mode.as_str().to_string(),
+            from_version: recorded_evr,
+            to_version: to_evr,
+            refreshed: false,
+            changed,
+            dry_run: true,
+            operation_id: None,
+            warnings,
+        };
+        render_repair(ctx, &payload);
+        return Ok(());
+    }
+
+    let operation_id = persist_repair(
+        ctx,
+        target,
+        &package,
+        ownership,
+        &info,
+        &to_evr,
+        source_repo.as_deref(),
+        &command,
+        &warnings,
+    )?;
+
+    let payload = RepairPayload {
+        component: target.to_string(),
+        package,
+        backend: "rpm",
+        ownership: ownership_label,
+        install_mode: ctx.install_mode.as_str().to_string(),
+        from_version: recorded_evr,
+        to_version: to_evr,
+        refreshed: true,
+        changed,
+        dry_run: false,
+        operation_id: Some(operation_id),
+        warnings,
+    };
+    render_repair(ctx, &payload);
+    Ok(())
+}
+
+/// Resolve the RPM package name `repair` should reconcile against.
+///
+/// A recorded, non-empty package name is the identity to confirm. When it is
+/// absent — a legacy row written before `rpm_metadata` existed — fall back to
+/// the adopt candidate chain ([`rpm_package_candidates`]) so repair can backfill
+/// the metadata that `update` refuses to run without.
+fn resolve_repair_package(
+    component: &str,
+    meta: Option<&RpmMetadata>,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    command: &str,
+) -> Result<String, CliError> {
+    if let Some(name) = meta
+        .map(|m| m.package_name.as_str())
+        .filter(|n| !n.is_empty())
+    {
+        return Ok(name.to_string());
+    }
+
+    // Legacy row with no recorded package name: resolve via the same candidate
+    // chain adopt uses. repo.toml / catalog are best-effort inputs (mirrors
+    // status::observed_record): a load failure just drops that precedence tier.
+    let layout = common::resolve_layout(ctx);
+    let repo_config = RepoConfig::load(&layout).ok();
+    let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
+    let manifest = common::load_bundled_catalog(ctx, COMMAND)
+        .ok()
+        .and_then(|cat| cat.component(component).cloned());
+
+    let candidates =
+        match rpm_package_candidates(None, manifest.as_ref(), rpm_backend, query, component) {
+            Ok(candidates) => candidates,
+            Err(PackageQueryError::CommandMissing { .. }) => {
+                return Err(rpm_tooling_missing_error(command));
+            }
+            Err(err) => return Err(rpm_query_err(err, command)),
+        };
+    if candidates.len() >= 2 {
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "multiple candidate RPMs for component '{component}': {}; cannot repair unambiguously — reinstall to pin one, or fix the manifest/package_map mapping",
+                candidates.join(", ")
+            ),
+        });
+    }
+    // `rpm_package_candidates` always backfills the default name, so this is the
+    // single-candidate case.
+    candidates
+        .into_iter()
+        .next()
+        .ok_or_else(|| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("could not resolve an RPM package name for component '{component}'"),
+        })
+}
+
+/// Persist the reconciled RPM metadata under the install lock, then append an
+/// audit record. Ownership and `install_backend` are left untouched — repair
+/// never switches backend. Returns the operation id.
+#[allow(clippy::too_many_arguments)]
+fn persist_repair(
+    ctx: &CliContext,
+    component: &str,
+    package: &str,
+    ownership: Ownership,
+    info: &PackageInfo,
+    to_evr: &str,
+    source_repo: Option<&str>,
+    command: &str,
+    warnings: &[String],
+) -> Result<String, CliError> {
+    let layout = common::resolve_layout(ctx);
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state = common::load_installed_state(ctx, command)?;
+
+    // Re-validate under the lock: the component must still exist and still be
+    // RPM-owned. A concurrent uninstall/forget or backend change between the
+    // pre-lock read and here must not be clobbered by a stale repair record.
+    let obj = state
+        .find_object_mut(ObjectKind::Component, component)
+        .ok_or_else(|| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' disappeared from state during repair; no changes recorded"
+            ),
+        })?;
+    if !obj.effective_ownership().is_rpm() {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' is no longer an RPM component in state; refusing to record an RPM repair"
+            ),
+        });
+    }
+    // A recorded package name must be unchanged under the lock: `query_installed`
+    // ran against `package` (snapshotted before the lock), so a concurrent
+    // re-point to a different RPM would graft this EVR onto the wrong package.
+    // An empty/absent prior name is a legacy backfill and allowed.
+    if let Some(recorded) = obj
+        .rpm_metadata
+        .as_ref()
+        .map(|m| m.package_name.as_str())
+        .filter(|n| !n.is_empty())
+        && recorded != package
+    {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' RPM package identity changed during repair (expected package '{package}'); refusing to record an EVR against a different package — run `anolisa status {component}`"
+            ),
+        });
+    }
+
+    let now = now_iso8601();
+    let lock_ts = Utc::now();
+    let operation_id = format!(
+        "op-repair-{}-{}",
+        lock_ts.format("%Y%m%d%H%M%S"),
+        lock_ts.timestamp_subsec_nanos()
+    );
+
+    // Reconcile the recorded version to rpmdb truth. ownership / install_backend
+    // / status are deliberately untouched: repair refreshes facts, it does not
+    // re-decide the lifecycle.
+    obj.version = to_evr.to_string();
+    obj.last_operation_id = Some(operation_id.clone());
+    match obj.rpm_metadata.as_mut() {
+        Some(meta) => {
+            // Backfill the name for a legacy row; a no-op when already set.
+            meta.package_name = package.to_string();
+            meta.evr = Some(to_evr.to_string());
+            meta.arch = Some(info.arch.clone());
+            // Only overwrite source_repo when freshly determined — a failed
+            // origin lookup must not erase a previously-good value.
+            if let Some(repo) = source_repo {
+                meta.source_repo = Some(repo.to_string());
+            }
+        }
+        None => {
+            obj.rpm_metadata = Some(RpmMetadata {
+                package_name: package.to_string(),
+                evr: Some(to_evr.to_string()),
+                arch: Some(info.arch.clone()),
+                source_repo: source_repo.map(str::to_string),
+            });
+        }
+    }
+
+    state.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: now.clone(),
+        finished_at: Some(now.clone()),
+    });
+
+    let state_path = layout.state_dir.join("installed.toml");
+    state.save(&state_path).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to save state: {err}"),
+    })?;
+
+    // Audit log is best-effort: the repair already persisted, so a log failure
+    // downgrades to a warning instead of unwinding.
+    let log = CentralLog::open(layout.central_log.clone());
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.clone()),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message: format!(
+            "refreshed ANOLISA state for component {component} to {to_evr} from rpmdb package {package} ({ownership_label})",
+            ownership_label = ownership.label(),
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at: now.clone(),
+        finished_at: Some(now),
+        status: Some(LogStatus::Ok),
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: warnings.to_vec(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = log.append(&record) {
+        eprintln!("warning: failed to write central log: {err}");
+    }
+
+    Ok(operation_id)
+}
+
+/// Human/JSON renderer for a repair result.
+fn render_repair(ctx: &CliContext, payload: &RepairPayload) {
+    if ctx.json {
+        // Errors here are unreachable for a plain Serialize struct; ignore the
+        // Result so an (already-persisted) repair is not reported as failed.
+        let _ = render_json(COMMAND, payload);
+        return;
+    }
+    if ctx.quiet {
+        return;
+    }
+    let color = Palette::new(ctx.no_color);
+    let from = payload.from_version.as_deref().unwrap_or("(none recorded)");
+    if payload.dry_run {
+        println!(
+            "{} {} {} {}",
+            color.command("repair"),
+            payload.component,
+            color.muted(format!("({}, {})", payload.ownership, payload.package)),
+            color.muted("(dry-run — nothing written)"),
+        );
+        if payload.changed {
+            println!(
+                "{} {} → {}",
+                color.label("would refresh:"),
+                from,
+                payload.to_version
+            );
+        } else {
+            println!(
+                "{} state already matches rpmdb ({})",
+                color.label("would refresh:"),
+                payload.to_version,
+            );
+        }
+    } else if payload.changed {
+        println!(
+            "{} {} {} → {}",
+            color.ok("✓ repaired"),
+            payload.component,
+            from,
+            payload.to_version,
+        );
+    } else {
+        println!(
+            "{} {} already matches rpmdb ({})",
+            color.ok("✓"),
+            payload.component,
+            payload.to_version,
+        );
+    }
+    // Remind the operator that an observed row is a pre-existing system RPM.
+    if payload.ownership == "rpm-observed" {
+        println!(
+            "    {} {} is a system RPM observed by ANOLISA; dnf owns the file transaction",
+            color.label("note:"),
+            payload.package,
+        );
+    }
+    render_warnings(&payload.warnings, &color);
+}
+
+/// Map a [`PackageQueryError`] onto a CLI runtime error (the benign
+/// not-installed / multi-version branches are split off by the caller).
+fn rpm_query_err(err: PackageQueryError, command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("rpm query failed: {err}"),
+    }
+}
+
+/// Warn-and-exit error when `rpm`/`dnf` is absent: an RPM component cannot be
+/// reconciled without the package manager.
+fn rpm_tooling_missing_error(command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: "rpm/dnf not found: cannot reconcile an RPM-backed component without the package manager. Install rpm/dnf and retry".to_string(),
+    }
+}
+
+/// Render any accumulated warnings to stderr, one per line.
+fn render_warnings(warnings: &[String], color: &Palette) {
+    for w in warnings {
+        eprintln!("{} {w}", color.warn("warning:"));
+    }
+}
+
+/// RFC3339 UTC timestamp, seconds precision (matches the install/update paths).
+fn now_iso8601() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use anolisa_core::state::{
+        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
+    };
+    use anolisa_platform::pkg_query::PackageVersion;
+
+    use crate::context::InstallMode;
+
+    /// Configurable in-memory [`PackageQuery`] for the repair tests. Repair runs
+    /// no transaction, so a query alone drives every path.
+    struct FakeQuery {
+        package: String,
+        installed: Option<PackageInfo>,
+        origin: Option<String>,
+        multi_version: bool,
+        command_missing: bool,
+    }
+
+    impl FakeQuery {
+        fn new(package: &str, installed: Option<PackageInfo>) -> Self {
+            Self {
+                package: package.to_string(),
+                installed,
+                origin: None,
+                multi_version: false,
+                command_missing: false,
+            }
+        }
+        fn with_origin(mut self, origin: &str) -> Self {
+            self.origin = Some(origin.to_string());
+            self
+        }
+        fn multi_version(mut self) -> Self {
+            self.multi_version = true;
+            self
+        }
+        fn command_missing(mut self) -> Self {
+            self.command_missing = true;
+            self
+        }
+    }
+
+    impl PackageQuery for FakeQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if self.command_missing {
+                return Err(PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                });
+            }
+            if package != self.package {
+                return Ok(None);
+            }
+            if self.multi_version {
+                return Err(PackageQueryError::UnexpectedOutput {
+                    command: "rpm".to_string(),
+                    detail: "2 installed versions".to_string(),
+                });
+            }
+            Ok(self.installed.clone())
+        }
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+        fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+            if package == self.package {
+                Ok(self.origin.clone())
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: version.to_string(),
+                release: release.map(str::to_string),
+            },
+            arch: arch.to_string(),
+            origin: None,
+        }
+    }
+
+    fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        CliContext {
+            install_mode,
+            prefix: Some(prefix),
+            json: false,
+            dry_run,
+            verbose: false,
+            quiet: true,
+            no_color: true,
+        }
+    }
+
+    /// An RPM-backed component object (observed or managed).
+    fn rpm_object(
+        component: &str,
+        package: &str,
+        evr: &str,
+        ownership: Ownership,
+        status: ObjectStatus,
+    ) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: evr.to_string(),
+            status,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(ownership),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: package.to_string(),
+                evr: Some(evr.to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: !matches!(ownership, Ownership::RpmObserved),
+            adopted: matches!(ownership, Ownership::RpmObserved),
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    /// A raw-managed component object (no rpm metadata).
+    fn raw_object(component: &str, version: &str) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: version.to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("https://example.com/x".to_string()),
+            install_backend: Some("raw".to_string()),
+            ownership: Some(Ownership::RawManaged),
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    fn seed(ctx: &CliContext, obj: InstalledObject) {
+        let layout = common::resolve_layout(ctx);
+        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        let mut state = InstalledState {
+            install_mode: match ctx.install_mode {
+                InstallMode::System => StateInstallMode::System,
+                InstallMode::User => StateInstallMode::User,
+            },
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(obj);
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state");
+    }
+
+    fn load_state(ctx: &CliContext) -> InstalledState {
+        let layout = common::resolve_layout(ctx);
+        InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+    }
+
+    /// A drifted rpm-observed component refreshes its EVR/arch/source from rpmdb
+    /// while ownership, backend, and lifecycle status are preserved.
+    #[test]
+    fn repair_refreshes_drifted_evr_and_keeps_ownership() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        // rpmdb has moved on to 2.3.0 via a manual dnf update.
+        let rpm = FakeQuery::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.3.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .with_origin("alinux-updates");
+
+        repair_with_query("copilot-shell", &c, &rpm).expect("repair ok");
+
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("present");
+        assert_eq!(obj.version, "2.3.0-1.al8", "version reconciled to rpmdb");
+        assert_eq!(
+            obj.ownership,
+            Some(Ownership::RpmObserved),
+            "ownership kept"
+        );
+        assert_eq!(obj.install_backend.as_deref(), Some("rpm"), "backend kept");
+        assert_eq!(obj.status, ObjectStatus::Adopted, "status unchanged");
+        let meta = obj.rpm_metadata.expect("metadata");
+        assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
+        assert_eq!(meta.source_repo.as_deref(), Some("alinux-updates"));
+        assert_ne!(obj.last_operation_id.as_deref(), Some("op-prior"));
+    }
+
+    /// A failed origin lookup must not erase a previously-good source_repo.
+    #[test]
+    fn repair_keeps_prior_source_repo_when_origin_unknown() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        // No origin configured on the fake -> installed_origin yields None.
+        let rpm = FakeQuery::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.3.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        );
+        repair_with_query("copilot-shell", &c, &rpm).expect("repair ok");
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("present");
+        assert_eq!(
+            obj.rpm_metadata.expect("meta").source_repo.as_deref(),
+            Some("@System"),
+            "prior source_repo preserved when origin re-lookup is empty",
+        );
+    }
+
+    /// `rpm -e`'d package: repair refuses and points at forget; state untouched.
+    #[test]
+    fn repair_on_missing_package_points_at_forget() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeQuery::new("anolisa-copilot-shell", None);
+        let err =
+            repair_with_query("copilot-shell", &c, &rpm).expect_err("removed package must error");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("forget"),
+            "reason must point at forget: {}",
+            err.reason()
+        );
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .map(|o| o.version.clone())
+                .as_deref(),
+            Some("2.2.0-1.al8"),
+            "state must be untouched",
+        );
+    }
+
+    /// A same-name multi-version rpmdb is an ambiguous reconcile target.
+    #[test]
+    fn repair_multi_version_is_refused() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let rpm = FakeQuery::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.2.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .multi_version();
+        let err =
+            repair_with_query("copilot-shell", &c, &rpm).expect_err("multi-version must error");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(err.reason().contains("unexpected output"));
+        assert!(err.reason().contains("2 installed versions"));
+    }
+
+    /// Missing rpm/dnf tooling surfaces as an actionable runtime error.
+    #[test]
+    fn repair_without_rpm_tooling_errors() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeQuery::new("anolisa-copilot-shell", None).command_missing();
+        let err =
+            repair_with_query("copilot-shell", &c, &rpm).expect_err("missing tooling must error");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(err.reason().contains("rpm/dnf not found"));
+    }
+
+    /// Raw components are not repairable yet -> NOT_IMPLEMENTED.
+    #[test]
+    fn repair_raw_component_is_not_implemented() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::User, false);
+        seed(&c, raw_object("copilot-shell", "9.9.9"));
+        let rpm = FakeQuery::new("anolisa-copilot-shell", None);
+        let err = repair_with_query("copilot-shell", &c, &rpm)
+            .expect_err("raw repair is not implemented");
+        assert_eq!(err.code(), "NOT_IMPLEMENTED");
+    }
+
+    /// An absent component routes to INVALID_ARGUMENT (exit 2).
+    #[test]
+    fn repair_unknown_component_routes_to_invalid_argument() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let rpm = FakeQuery::new("anolisa-copilot-shell", None);
+        let err =
+            repair_with_query("copilot-shell", &c, &rpm).expect_err("absent component must error");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.exit_code(), 2);
+        assert!(err.reason().contains("not installed"));
+    }
+
+    /// Dry-run previews the reconcile without writing state.
+    #[test]
+    fn repair_dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeQuery::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.3.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        );
+        repair_with_query("copilot-shell", &c, &rpm).expect("dry-run ok");
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .map(|o| o.version.clone())
+                .as_deref(),
+            Some("2.2.0-1.al8"),
+            "dry-run must not refresh the recorded version",
+        );
+    }
+
+    /// Repair on an already-matching component is a no-op refresh: it succeeds,
+    /// records an operation, and leaves the version in place.
+    #[test]
+    fn repair_no_op_when_already_matches() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.3.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeQuery::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.3.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        );
+        repair_with_query("copilot-shell", &c, &rpm).expect("repair ok");
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("present");
+        assert_eq!(obj.version, "2.3.0-1.al8");
+        assert_ne!(obj.last_operation_id.as_deref(), Some("op-prior"));
+    }
+
+    /// A legacy RPM row with no recorded metadata is repaired by resolving the
+    /// default package name and backfilling `rpm_metadata` from rpmdb.
+    #[test]
+    fn repair_backfills_metadata_for_legacy_row() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        // RPM-owned (managed) row, but rpm_metadata absent (pre-v3 shape).
+        let mut obj = rpm_object(
+            "legacy-rpm",
+            "",
+            "0.0.0",
+            Ownership::RpmManaged,
+            ObjectStatus::Installed,
+        );
+        obj.rpm_metadata = None;
+        seed(&c, obj);
+        // Candidate chain falls through to the default `anolisa-<component>`.
+        let rpm = FakeQuery::new(
+            "anolisa-legacy-rpm",
+            Some(pkg_info(
+                "anolisa-legacy-rpm",
+                "1.0.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        )
+        .with_origin("@System");
+        repair_with_query("legacy-rpm", &c, &rpm).expect("repair ok");
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "legacy-rpm")
+            .cloned()
+            .expect("present");
+        let meta = obj.rpm_metadata.expect("metadata backfilled");
+        assert_eq!(meta.package_name, "anolisa-legacy-rpm");
+        assert_eq!(meta.evr.as_deref(), Some("1.0.0-1.al8"));
+        assert_eq!(obj.version, "1.0.0-1.al8");
+    }
+
+    /// CLI surface: `repair <component>` parses to the positional.
+    #[test]
+    fn repair_parses_positional_component() {
+        use clap::Parser as _;
+        let a = RepairArgs::try_parse_from(["repair", "copilot-shell"]).expect("parse");
+        assert_eq!(a.component, "copilot-shell");
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -23,7 +23,7 @@ use anolisa_core::adapter::manager::ScanEntry;
 use anolisa_core::path_safety::{PathBoundaryError, validate_owned_path};
 use anolisa_core::{
     Catalog, ComponentManifest, HealthEntry, HealthSpec, InstalledObject, InstalledState,
-    IntegrityStatus, ObjectKind, ServiceState, check_owned_file,
+    IntegrityStatus, ObjectKind, RpmMetadata, ServiceState, check_owned_file,
     service_for_install_mode as service_factory,
 };
 
@@ -48,7 +48,7 @@ const SHELL_METACHARS: &[char] = &[
 ];
 use anolisa_env::EnvService;
 use anolisa_platform::fs_layout::FsLayout;
-use anolisa_platform::pkg_query::PackageQuery;
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::{Palette, pad_right};
@@ -161,6 +161,13 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
         }
     }
 
+    // Drift adjudication (#960): compare in-state RPM components against rpmdb
+    // and override the wire status with `drifted` / `missing` on divergence.
+    // Like the observed report above this stays strictly read-only — it adjusts
+    // only the wire records, never `installed.toml`.
+    let drift_query = RpmPackageQuery::system();
+    apply_rpm_drift(&mut records, &state, &drift_query);
+
     if ctx.json {
         let data = serde_json::json!({ "components": records });
         return render_json(COMMAND, data);
@@ -261,6 +268,124 @@ fn observed_record(
         });
     }
     None
+}
+
+/// Live rpmdb-drift classification for an in-state RPM component (#960).
+///
+/// `None` (from [`probe_rpm_drift`]) means "no drift to report" — the recorded
+/// status stands. The two variants are the manual-mutation cases the proposal
+/// calls out: a `dnf update`/`downgrade` (or a same-name multi-version rpmdb)
+/// surfaces as [`Drifted`](RpmDrift::Drifted); an `rpm -e` surfaces as
+/// [`Missing`](RpmDrift::Missing).
+enum RpmDrift {
+    /// rpmdb holds the package at a different version than ANOLISA recorded, or
+    /// holds several versions at once. `reason` explains which.
+    Drifted { reason: String },
+    /// rpmdb no longer holds the package at all.
+    Missing,
+}
+
+/// Compare an RPM component's recorded EVR against live rpmdb reality.
+///
+/// `status` is read-only and best-effort: an unrunnable or anomalous query
+/// (`rpm`/`dnf` missing, spawn/permission/parse failure) yields `None` rather
+/// than crying drift on a read we cannot trust. A same-name multi-version rpmdb
+/// is a genuine divergence from the single recorded version, so it classifies
+/// as drift. `query` is injected so tests drive this without a live rpmdb.
+fn probe_rpm_drift(meta: &RpmMetadata, query: &dyn PackageQuery) -> Option<RpmDrift> {
+    match query.query_installed(&meta.package_name) {
+        Ok(Some(info)) => {
+            let live = info.version.to_string();
+            match meta.evr.as_deref() {
+                // Recorded EVR diverges from rpmdb: a manual dnf update/downgrade.
+                Some(recorded) if recorded != live => Some(RpmDrift::Drifted {
+                    reason: format!(
+                        "rpmdb reports {live} for package {} but ANOLISA state records {recorded}",
+                        meta.package_name
+                    ),
+                }),
+                // EVR matches, or none recorded to compare against: no drift.
+                _ => None,
+            }
+        }
+        // State records the package but rpmdb no longer has it: an `rpm -e` drift.
+        Ok(None) => Some(RpmDrift::Missing),
+        // rpm returned output we can't reduce to a single installed version
+        // (several versions, a malformed `--qf` row, or none on a zero exit).
+        // The recorded version can no longer be trusted as-is, so surface it as
+        // drift carrying the backend's own detail rather than guessing the cause.
+        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => Some(RpmDrift::Drifted {
+            reason: format!(
+                "rpmdb returned unexpected output for package {}: {detail}",
+                meta.package_name
+            ),
+        }),
+        // rpm/dnf absent, or a spawn/permission/query failure: cannot prove
+        // drift on an unrunnable query, so keep the recorded status untouched.
+        Err(_) => None,
+    }
+}
+
+/// Layer live rpmdb drift onto the projected records (#960).
+///
+/// For every record whose in-state object carries [`RpmMetadata`] *and* whose
+/// live projection is still clean (`installed` / `adopted`), compare against
+/// rpmdb and, on divergence, override the wire status with `drifted` / `missing`
+/// plus a `rpm:drift` health entry. Surfacing a manual `dnf update` / `rpm -e`
+/// is the point.
+///
+/// The clean-status gate is deliberate: integrity / manifest health may already
+/// have escalated an RPM object to `failed` / `degraded`, and a component may be
+/// deliberately `disabled` — those carry a more-severe signal that a drift label
+/// must not mask, so they are left untouched (the divergence still shows up in
+/// `repair`). Objects without RPM metadata (raw installs, legacy rows with no
+/// recorded package name) never reach the rpmdb probe.
+fn apply_rpm_drift(
+    records: &mut [ComponentRecord],
+    state: &InstalledState,
+    query: &dyn PackageQuery,
+) {
+    // Index RPM metadata by component name in a single pass so the per-record
+    // lookup is O(1) instead of re-scanning the object list for every record.
+    let rpm_meta: std::collections::HashMap<&str, &RpmMetadata> = state
+        .objects
+        .iter()
+        .filter(|o| o.kind == ObjectKind::Component)
+        .filter_map(|o| o.rpm_metadata.as_ref().map(|m| (o.name.as_str(), m)))
+        .collect();
+    if rpm_meta.is_empty() {
+        return;
+    }
+    let checked_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    for record in records.iter_mut() {
+        // Only adjudicate drift on a clean live projection; never demote a
+        // failed/degraded/disabled record (see fn doc). This also bounds the
+        // rpm -q probes below to the records that can actually drift.
+        if !matches!(record.status.as_str(), "installed" | "adopted") {
+            continue;
+        }
+        let Some(&meta) = rpm_meta.get(record.name.as_str()) else {
+            continue;
+        };
+        let (status, reason) = match probe_rpm_drift(meta, query) {
+            Some(RpmDrift::Drifted { reason }) => ("drifted", reason),
+            Some(RpmDrift::Missing) => (
+                "missing",
+                format!(
+                    "package {} recorded in ANOLISA state is no longer present in rpmdb",
+                    meta.package_name
+                ),
+            ),
+            None => continue,
+        };
+        record.status = status.to_string();
+        record.health.push(HealthEntry {
+            name: "rpm:drift".to_string(),
+            status: status.to_string(),
+            checked_at: checked_at.clone(),
+            reason: Some(reason),
+        });
+    }
 }
 
 /// Build adapter summary records for `component` from the scan entries.
@@ -847,6 +972,20 @@ fn render_human(records: &[ComponentRecord], verbose: bool, no_color: bool) {
                 "    {} run 'anolisa --install-mode system install {}' to adopt as rpm-observed",
                 color.label("hint:"),
                 record.name,
+            );
+        }
+        // Drift / missing point at the repair / forget remediation (#960).
+        if record.status == "drifted" {
+            println!(
+                "    {} run 'anolisa repair {}' to refresh ANOLISA state from rpmdb",
+                color.label("hint:"),
+                record.name,
+            );
+        } else if record.status == "missing" {
+            println!(
+                "    {} reinstall, or run 'anolisa forget {name}' to drop the stale state (repair cannot refresh a package gone from rpmdb)",
+                color.label("hint:"),
+                name = record.name,
             );
         }
         if verbose {
@@ -2364,5 +2503,243 @@ mod tests {
         let rec = observed_record("copilot-shell", backend, None, &q).expect("observed");
         assert_eq!(rec.rpm_package.as_deref(), Some("site-copilot"));
         assert_eq!(rec.rpm_source_repo, None);
+    }
+
+    // ── rpm drift adjudication (#960) ───────────────────────────────
+
+    /// Query whose `query_installed` always returns a preset anomalous error,
+    /// to exercise the drift classification of the non-`Ok` branches.
+    struct ErrQuery(PackageQueryError);
+
+    impl PackageQuery for ErrQuery {
+        fn query_installed(&self, _: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            Err(match &self.0 {
+                PackageQueryError::UnexpectedOutput { command, detail } => {
+                    PackageQueryError::UnexpectedOutput {
+                        command: command.clone(),
+                        detail: detail.clone(),
+                    }
+                }
+                _ => PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                },
+            })
+        }
+        fn query_available(&self, _: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn rpm_meta(package: &str, evr: &str) -> RpmMetadata {
+        RpmMetadata {
+            package_name: package.to_string(),
+            evr: Some(evr.to_string()),
+            arch: Some("x86_64".to_string()),
+            source_repo: Some("@System".to_string()),
+        }
+    }
+
+    /// rpmdb EVR matching the recorded one is not drift.
+    #[test]
+    fn probe_rpm_drift_none_when_evr_matches() {
+        let meta = rpm_meta("anolisa-copilot-shell", "2.3.0-1.al8");
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+            )],
+            origins: Vec::new(),
+        };
+        assert!(probe_rpm_drift(&meta, &q).is_none());
+    }
+
+    /// A newer rpmdb EVR than recorded (manual `dnf update`) is drift.
+    #[test]
+    fn probe_rpm_drift_detects_evr_mismatch() {
+        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+            )],
+            origins: Vec::new(),
+        };
+        assert!(matches!(
+            probe_rpm_drift(&meta, &q),
+            Some(RpmDrift::Drifted { .. })
+        ));
+    }
+
+    /// The package gone from rpmdb (manual `rpm -e`) is Missing.
+    #[test]
+    fn probe_rpm_drift_detects_missing() {
+        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let q = FakeQuery::default();
+        assert!(matches!(
+            probe_rpm_drift(&meta, &q),
+            Some(RpmDrift::Missing)
+        ));
+    }
+
+    /// A same-name multi-version rpmdb is surfaced as drift, not a silent pass.
+    #[test]
+    fn probe_rpm_drift_multi_version_is_drifted() {
+        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let q = ErrQuery(PackageQueryError::UnexpectedOutput {
+            command: "rpm".to_string(),
+            detail: "2 installed versions".to_string(),
+        });
+        assert!(matches!(
+            probe_rpm_drift(&meta, &q),
+            Some(RpmDrift::Drifted { .. })
+        ));
+    }
+
+    /// Missing rpm/dnf tooling cannot prove drift; the recorded status stands.
+    #[test]
+    fn probe_rpm_drift_tooling_missing_keeps_status() {
+        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let q = ErrQuery(PackageQueryError::CommandMissing {
+            command: "rpm".to_string(),
+        });
+        assert!(probe_rpm_drift(&meta, &q).is_none());
+    }
+
+    /// `apply_rpm_drift` overrides an adopted rpm-observed row to `drifted` and
+    /// records a `rpm:drift` health entry when rpmdb has moved on.
+    #[test]
+    fn apply_rpm_drift_overrides_status_to_drifted() {
+        let mut state = InstalledState::default();
+        state.upsert_object(rpm_observed_object(
+            "copilot-shell",
+            "anolisa-copilot-shell",
+            "2.2.0-1.al8",
+        ));
+        let mut records = select_components(
+            &state,
+            &dummy_layout(),
+            None,
+            "system",
+            Some("copilot-shell"),
+            None,
+        );
+        assert_eq!(records[0].status, "adopted", "baseline before drift");
+
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+            )],
+            origins: Vec::new(),
+        };
+        apply_rpm_drift(&mut records, &state, &q);
+        assert_eq!(records[0].status, "drifted");
+        assert!(
+            records[0]
+                .health
+                .iter()
+                .any(|h| h.name == "rpm:drift" && h.status == "drifted"),
+            "a rpm:drift health entry must be recorded",
+        );
+    }
+
+    /// `apply_rpm_drift` overrides to `missing` when rpmdb no longer has the
+    /// package (the `rpm -e` case must not be silently reinstalled).
+    #[test]
+    fn apply_rpm_drift_overrides_status_to_missing() {
+        let mut state = InstalledState::default();
+        state.upsert_object(rpm_observed_object(
+            "copilot-shell",
+            "anolisa-copilot-shell",
+            "2.2.0-1.al8",
+        ));
+        let mut records = select_components(
+            &state,
+            &dummy_layout(),
+            None,
+            "system",
+            Some("copilot-shell"),
+            None,
+        );
+        let q = FakeQuery::default();
+        apply_rpm_drift(&mut records, &state, &q);
+        assert_eq!(records[0].status, "missing");
+        assert!(
+            records[0]
+                .health
+                .iter()
+                .any(|h| h.name == "rpm:drift" && h.status == "missing"),
+        );
+    }
+
+    /// A raw component (no RPM metadata) is never touched by drift adjudication,
+    /// even when the injected query would report the package absent.
+    #[test]
+    fn apply_rpm_drift_leaves_non_rpm_component_untouched() {
+        let mut state = InstalledState::default();
+        state.upsert_object(component_object(
+            "agentsight",
+            "0.1.0",
+            ObjectStatus::Installed,
+        ));
+        let mut records = select_components(
+            &state,
+            &dummy_layout(),
+            None,
+            "system",
+            Some("agentsight"),
+            None,
+        );
+        let q = FakeQuery::default();
+        apply_rpm_drift(&mut records, &state, &q);
+        assert_eq!(records[0].status, "installed", "raw row must not drift");
+        assert!(
+            !records[0].health.iter().any(|h| h.name == "rpm:drift"),
+            "no drift entry for a non-RPM component",
+        );
+    }
+
+    /// Drift never demotes a record that integrity/manifest health already
+    /// escalated past a clean projection: a `failed` RPM row keeps its
+    /// more-severe status even when rpmdb has moved on, and gains no drift entry.
+    #[test]
+    fn apply_rpm_drift_keeps_escalated_status() {
+        let mut state = InstalledState::default();
+        state.upsert_object(rpm_observed_object(
+            "copilot-shell",
+            "anolisa-copilot-shell",
+            "2.2.0-1.al8",
+        ));
+        // A record whose live projection already escalated past `installed`.
+        let mut records = vec![ComponentRecord {
+            name: "copilot-shell".to_string(),
+            status: "failed".to_string(),
+            version: Some("2.2.0-1.al8".to_string()),
+            installed_at: None,
+            last_operation_id: None,
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+            adapters: Vec::new(),
+            rpm_package: None,
+            rpm_evr: None,
+            rpm_source_repo: None,
+        }];
+        // rpmdb has drifted, but the failed status must survive untouched.
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+            )],
+            origins: Vec::new(),
+        };
+        apply_rpm_drift(&mut records, &state, &q);
+        assert_eq!(
+            records[0].status, "failed",
+            "escalated status must not be demoted to drifted",
+        );
+        assert!(
+            !records[0].health.iter().any(|h| h.name == "rpm:drift"),
+            "no drift entry when the record is already escalated",
+        );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -241,13 +241,13 @@ fn update_rpm_component(
     let current = match query.query_installed(package) {
         Ok(Some(info)) => info,
         // State records the package but rpmdb no longer has it: a Missing drift.
-        // Drift adjudication / repair is #960; here we refuse rather than run
-        // dnf blindly, and point at the repair path.
+        // The package is gone, so `repair` cannot refresh it; point at `forget`
+        // (or reinstall) rather than running dnf blindly.
         Ok(None) => {
             return Err(CliError::Runtime {
                 command: command.to_string(),
                 reason: format!(
-                    "RPM package '{package}' for component '{component}' is recorded in ANOLISA state but is not present in rpmdb — it may have been removed with `rpm -e`; run `anolisa repair {component}` or reinstall before updating"
+                    "RPM package '{package}' for component '{component}' is recorded in ANOLISA state but is not present in rpmdb — it may have been removed with `rpm -e`; run `anolisa forget {component}` to drop the stale state, or reinstall before updating"
                 ),
             });
         }
@@ -273,7 +273,7 @@ fn update_rpm_component(
     //    the dry-run preview.
     let candidates = available_candidates(query, package, &current.arch, &mut warnings);
 
-    let ownership_label = ownership_label(ownership);
+    let ownership_label = ownership.label();
 
     // 3. Dry-run preview — never touches the filesystem, never needs root.
     if ctx.dry_run {
@@ -472,7 +472,7 @@ fn persist_rpm_update(
         severity: Severity::Info,
         message: format!(
             "updated RPM package {package} for component {component} to {to_evr} via dnf ({ownership_label})",
-            ownership_label = ownership_label(ownership),
+            ownership_label = ownership.label(),
         ),
         actor: "cli".to_string(),
         install_mode: Some(ctx.install_mode.as_str().to_string()),
@@ -627,15 +627,6 @@ fn txn_err(err: PackageTransactionError, command: &str) -> CliError {
 fn render_warnings(warnings: &[String], color: &Palette) {
     for w in warnings {
         eprintln!("{} {w}", color.warn("warning:"));
-    }
-}
-
-/// Stable provenance label for an [`Ownership`] value used in wire output.
-fn ownership_label(ownership: Ownership) -> &'static str {
-    match ownership {
-        Ownership::RawManaged => "raw-managed",
-        Ownership::RpmManaged => "rpm-managed",
-        Ownership::RpmObserved => "rpm-observed",
     }
 }
 
@@ -1388,9 +1379,10 @@ mod tests {
     }
 
     /// State records the RPM but rpmdb no longer has it (rpm -e drift): refuse
-    /// with a repair pointer rather than running dnf.
+    /// with a forget pointer rather than running dnf (the gone package cannot be
+    /// refreshed by repair).
     #[test]
-    fn missing_from_rpmdb_refuses_with_repair_hint() {
+    fn missing_from_rpmdb_refuses_with_forget_hint() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         seed(
@@ -1409,8 +1401,8 @@ mod tests {
             .expect_err("drift must error");
         assert_eq!(err.code(), "EXECUTION_FAILED");
         assert!(
-            err.reason().contains("repair"),
-            "reason must point at repair: {}",
+            err.reason().contains("forget"),
+            "reason must point at forget: {}",
             err.reason()
         );
         assert_eq!(rpm.update_calls.get(), 0);

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -138,6 +138,17 @@ impl Ownership {
     pub fn is_rpm(self) -> bool {
         matches!(self, Self::RpmManaged | Self::RpmObserved)
     }
+
+    /// Stable provenance label for wire output (`raw-managed`, `rpm-managed`,
+    /// `rpm-observed`). Centralized so every command renders the same string
+    /// and a future ownership class cannot be given two different labels.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::RawManaged => "raw-managed",
+            Self::RpmManaged => "rpm-managed",
+            Self::RpmObserved => "rpm-observed",
+        }
+    }
 }
 
 /// RPM package metadata recorded when a component is managed or observed


### PR DESCRIPTION
## Description

Adds the final piece of the RPM lifecycle loop: `anolisa status` now adjudicates each in-state RPM component against the live rpmdb, and two new commands let the user reconcile what it reports.

- `status` compares a tracked RPM component's recorded EVR against rpmdb. A manual `dnf update` renders the component as `drifted`; a manual `rpm -e` renders it as `missing`. ANOLISA never silently reinstalls — it reports the divergence and points at a remediation.
- `anolisa repair <component>` refreshes ANOLISA state from rpmdb (version / EVR / arch / source repo) when the package is still installed, and backfills metadata for legacy rows. It runs no `dnf` / `rpm` mutation.
- `anolisa forget <component>` drops the ANOLISA state record with no package operation and no file removal.

## Design Note

`drifted` and `missing` are computed wire-status labels rendered at `status` time — alongside the existing `observed` label and the integrity/manifest health escalations — **not** new `ObjectStatus` variants. Drift is a comparison between persisted EVR and live rpmdb EVR, so persisting it would contradict the invariant that `status` is strictly read-only and never writes `installed.toml`. No schema bump.

Drift adjudication overrides only a clean projection (`installed` / `adopted`); it never demotes a record that integrity/manifest health already escalated to `failed` / `degraded`, nor a deliberately `disabled` one, since those carry a more-severe signal a drift label must not mask.

`repair` reuses the injected-`PackageQuery` pattern (so it can run without dnf), the adopt candidate chain for legacy metadata backfill, and the same lock + reload-and-revalidate persistence as `update`. `forget` mirrors `uninstall`'s adapter-claim guard. `Ownership::label()` was centralized in `anolisa-core` so every command renders the provenance string identically.

## Ship Note

- `repair` supports RPM-backed components only; a raw component returns `NOT_IMPLEMENTED`.
- `repair` on a package that is gone from rpmdb refuses and redirects to `forget` — it cannot conjure a removed package back.
- `forget` performs no package operation: for RPM the package stays installed; for raw the owned files remain on disk (use `uninstall` for file teardown).
- Out of scope, left for later issues: `uninstall --remove-system-package`, migration / downgrade flows.

## Test

- Drift unit tests (injected `PackageQuery` fakes): EVR-match → no drift, EVR-mismatch → `drifted`, `rpm -e` → `missing`, unexpected/multi-version output → drift carrying the backend's own detail, missing tooling → recorded status preserved, an already-escalated (`failed`) record is never demoted, and non-RPM rows are untouched.
- `repair`: drift refresh updates EVR and preserves ownership, keep-prior-source-repo on a failed origin lookup, missing-package → forget pointer, unexpected-output refusal, missing tooling, raw → `NOT_IMPLEMENTED`, absent → `INVALID_ARGUMENT`, dry-run writes nothing, legacy metadata backfill.
- `forget`: drops the object and records the op, unknown component → `INVALID_ARGUMENT`, refuses with an enabled adapter claim, dry-run leaves state untouched.
- Quality gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (anolisa-cli 215 tests), `cargo doc --workspace --no-deps`.
- Also exercised end-to-end against a real host rpmdb: seeded a stale EVR → `status` `drifted` → `repair` refreshed to live EVR → `adopted`; uninstalled the package → `missing` → `repair` refused toward `forget` → `forget` dropped the state.

Closes #960.