### PR TITLE
refactor(sight): extract auto-kill seam

### DIFF
--- a/src/agentsight/src/interruption/escalation.rs
+++ b/src/agentsight/src/interruption/escalation.rs
@@ -1,0 +1,181 @@
+//! DeadLoop auto-kill escalation decision.
+//!
+//! Splits the "given a detection count, which signal (if any) to send" decision
+//! out of `unified.rs::detect_and_store_interruptions` so the SIGTERM→SIGKILL
+//! escalation ladder is unit-testable. The decision is pure; the actual signal
+//! is sent by `execute_kill_action` through an injected [`ProcessKiller`].
+
+use crate::utils::process::{ProcessKiller, Signal};
+
+/// What the auto-kill ladder should do for one DeadLoop detection.
+///
+/// `new_count` is the post-insert unresolved DeadLoop count for the conversation
+/// (`existing_count + 1`); `kill_after_count` is the configured threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KillAction {
+    /// Auto-kill disabled: do nothing.
+    Disabled,
+    /// Below threshold: log progress, send nothing.
+    Wait,
+    /// At threshold: send SIGTERM (graceful).
+    Terminate,
+    /// Past threshold: escalate to SIGKILL.
+    Kill,
+}
+
+/// Decide which signal the DeadLoop auto-kill ladder should send.
+///
+/// Pure: mirrors the original inline logic exactly —
+/// `new_count = existing_count + 1`; `new_count > threshold` → SIGKILL;
+/// `new_count == threshold` → SIGTERM; otherwise wait. When disabled, never acts.
+pub(crate) fn decide_kill(
+    enabled: bool,
+    existing_count: usize,
+    kill_after_count: usize,
+) -> KillAction {
+    if !enabled {
+        return KillAction::Disabled;
+    }
+    let new_count = existing_count + 1;
+    if new_count > kill_after_count {
+        KillAction::Kill
+    } else if new_count == kill_after_count {
+        KillAction::Terminate
+    } else {
+        KillAction::Wait
+    }
+}
+
+/// Carry out a [`KillAction`]: send the signal via `killer` (when there is a pid)
+/// and emit the same log lines as the original inline implementation.
+///
+/// `new_count` / `kill_after_count` are only used for the log messages. A `None`
+/// pid silently skips the signal (preserving the original behavior, where the
+/// kill branches were guarded by `if let Some(pid)` with no else).
+pub(crate) fn execute_kill_action(
+    killer: &dyn ProcessKiller,
+    action: KillAction,
+    pid: Option<i32>,
+    cid: &str,
+    new_count: usize,
+    kill_after_count: usize,
+) {
+    match action {
+        KillAction::Disabled => {}
+        KillAction::Kill => {
+            if let Some(pid) = pid {
+                log::error!(
+                    "DeadLoop auto-kill: escalating to SIGKILL for pid {pid} (conversation={cid}, detections={new_count})"
+                );
+                if let Err(err) = killer.kill(pid, Signal::Kill) {
+                    log::error!("DeadLoop auto-kill: SIGKILL failed for pid {pid}: {err}");
+                }
+            }
+        }
+        KillAction::Terminate => {
+            if let Some(pid) = pid {
+                log::error!(
+                    "DeadLoop auto-kill: sending SIGTERM to pid {pid} (conversation={cid}, detections={new_count})"
+                );
+                if let Err(err) = killer.kill(pid, Signal::Term) {
+                    log::error!("DeadLoop auto-kill: SIGTERM failed for pid {pid}: {err}");
+                }
+            }
+        }
+        KillAction::Wait => {
+            log::warn!(
+                "DeadLoop auto-kill: detection {new_count}/{kill_after_count} for conversation {cid}, waiting..."
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::process::tests::RecordingKiller;
+
+    // ── decide_kill truth table (threshold=3) ──────────────────────
+    #[test]
+    fn decide_disabled_regardless_of_count() {
+        assert_eq!(decide_kill(false, 0, 3), KillAction::Disabled);
+        assert_eq!(decide_kill(false, 5, 3), KillAction::Disabled);
+    }
+
+    #[test]
+    fn decide_below_threshold_waits() {
+        // existing 0 -> new 1 -> Wait; existing 1 -> new 2 -> Wait
+        assert_eq!(decide_kill(true, 0, 3), KillAction::Wait);
+        assert_eq!(decide_kill(true, 1, 3), KillAction::Wait);
+    }
+
+    #[test]
+    fn decide_at_threshold_terminates_not_kills() {
+        // existing 2 -> new 3 == threshold -> SIGTERM (discriminating boundary)
+        assert_eq!(decide_kill(true, 2, 3), KillAction::Terminate);
+        assert_ne!(decide_kill(true, 2, 3), KillAction::Kill);
+    }
+
+    #[test]
+    fn decide_past_threshold_kills_not_terminates() {
+        // existing 3 -> new 4 > threshold -> SIGKILL (discriminating boundary)
+        assert_eq!(decide_kill(true, 3, 3), KillAction::Kill);
+        assert_ne!(decide_kill(true, 3, 3), KillAction::Terminate);
+    }
+
+    #[test]
+    fn decide_zero_threshold_kills_immediately() {
+        // threshold 0: existing 0 -> new 1 > 0 -> Kill
+        assert_eq!(decide_kill(true, 0, 0), KillAction::Kill);
+    }
+
+    // ── execute_kill_action via RecordingKiller ────────────────────
+    #[test]
+    fn execute_terminate_sends_sigterm() {
+        let killer = RecordingKiller::new();
+        execute_kill_action(&killer, KillAction::Terminate, Some(42), "cid", 3, 3);
+        assert_eq!(*killer.calls.lock().unwrap(), vec![(42, Signal::Term)]);
+    }
+
+    #[test]
+    fn execute_kill_sends_sigkill() {
+        let killer = RecordingKiller::new();
+        execute_kill_action(&killer, KillAction::Kill, Some(42), "cid", 4, 3);
+        assert_eq!(*killer.calls.lock().unwrap(), vec![(42, Signal::Kill)]);
+    }
+
+    #[test]
+    fn execute_wait_sends_nothing() {
+        let killer = RecordingKiller::new();
+        execute_kill_action(&killer, KillAction::Wait, Some(42), "cid", 2, 3);
+        assert!(killer.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn execute_disabled_sends_nothing() {
+        let killer = RecordingKiller::new();
+        execute_kill_action(&killer, KillAction::Disabled, Some(42), "cid", 1, 3);
+        assert!(killer.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn execute_none_pid_skips_signal() {
+        // Terminate/Kill with no pid must not signal (preserves original guard).
+        let killer = RecordingKiller::new();
+        execute_kill_action(&killer, KillAction::Terminate, None, "cid", 3, 3);
+        execute_kill_action(&killer, KillAction::Kill, None, "cid", 4, 3);
+        assert!(killer.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn execute_swallows_killer_error() {
+        // When the killer returns Err (e.g. process already gone), the error is
+        // logged but not propagated/panicked — exercises the SIGKILL/SIGTERM
+        // failed arms. A regression that unwrapped instead of `if let Err` would
+        // panic here.
+        let killer = crate::utils::process::tests::FailingKiller;
+        execute_kill_action(&killer, KillAction::Kill, Some(42), "cid", 4, 3);
+        execute_kill_action(&killer, KillAction::Terminate, Some(42), "cid", 3, 3);
+        // Reaching here without panic is the assertion.
+    }
+}

--- a/src/agentsight/src/interruption/mod.rs
+++ b/src/agentsight/src/interruption/mod.rs
@@ -1,6 +1,7 @@
 //! Interruption module — public API.
 
 pub mod detector;
+pub(crate) mod escalation;
 pub mod loop_detector;
 pub mod oom_recovery;
 pub mod types;

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -100,6 +100,8 @@ pub struct AgentSight {
     deadloop_kill_enabled: bool,
     /// DeadLoop auto-kill: trigger threshold (kill after N detections)
     deadloop_kill_after_count: usize,
+    /// Process killer for DeadLoop auto-kill (injectable for tests)
+    process_killer: Arc<dyn crate::utils::process::ProcessKiller>,
 }
 
 /// GenAI events waiting for session_id resolution via ResponseSessionMapper.
@@ -496,6 +498,7 @@ impl AgentSight {
             pending_logtail,
             deadloop_kill_enabled: config.deadloop_kill_enabled,
             deadloop_kill_after_count: config.deadloop_kill_after_count,
+            process_killer: Arc::new(crate::utils::process::LibcProcessKiller),
         })
     }
 
@@ -1037,43 +1040,20 @@ impl AgentSight {
                                     );
 
                                     // ── Auto-kill 止血 ──
-                                    if self.deadloop_kill_enabled {
-                                        let new_count = existing_count + 1;
-                                        if new_count > self.deadloop_kill_after_count {
-                                            if let Some(pid) = loop_event.pid {
-                                                log::error!(
-                                                    "DeadLoop auto-kill: escalating to SIGKILL for pid {pid} (conversation={cid}, detections={new_count})"
-                                                );
-                                                let ret = unsafe { libc::kill(pid, libc::SIGKILL) };
-                                                if ret != 0 {
-                                                    let err = std::io::Error::last_os_error();
-                                                    log::error!(
-                                                        "DeadLoop auto-kill: SIGKILL failed for pid {pid}: {err}"
-                                                    );
-                                                }
-                                            }
-                                        } else if new_count == self.deadloop_kill_after_count {
-                                            if let Some(pid) = loop_event.pid {
-                                                log::error!(
-                                                    "DeadLoop auto-kill: sending SIGTERM to pid {pid} (conversation={cid}, detections={new_count})"
-                                                );
-                                                let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
-                                                if ret != 0 {
-                                                    let err = std::io::Error::last_os_error();
-                                                    log::error!(
-                                                        "DeadLoop auto-kill: SIGTERM failed for pid {pid}: {err}"
-                                                    );
-                                                }
-                                            }
-                                        } else {
-                                            log::warn!(
-                                                "DeadLoop auto-kill: detection {}/{} for conversation {}, waiting...",
-                                                new_count,
-                                                self.deadloop_kill_after_count,
-                                                cid
-                                            );
-                                        }
-                                    }
+                                    let new_count = existing_count + 1;
+                                    let action = crate::interruption::escalation::decide_kill(
+                                        self.deadloop_kill_enabled,
+                                        existing_count,
+                                        self.deadloop_kill_after_count,
+                                    );
+                                    crate::interruption::escalation::execute_kill_action(
+                                        self.process_killer.as_ref(),
+                                        action,
+                                        loop_event.pid,
+                                        cid,
+                                        new_count,
+                                        self.deadloop_kill_after_count,
+                                    );
                                 }
                             }
                         }

--- a/src/agentsight/src/utils/mod.rs
+++ b/src/agentsight/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod decompress;
+pub mod process;
 pub mod thread;

--- a/src/agentsight/src/utils/process.rs
+++ b/src/agentsight/src/utils/process.rs
@@ -1,0 +1,121 @@
+//! Process signalling seam.
+//!
+//! Wraps the one place AgentSight sends OS signals (DeadLoop auto-kill) behind a
+//! trait so the escalation logic can be unit-tested with a recording fake instead
+//! of actually killing processes. `LibcProcessKiller` is the only place the
+//! `unsafe libc::kill` call lives.
+
+use std::io;
+
+/// Signals AgentSight may send to a runaway agent process.
+///
+/// Intentionally models only the two signals the auto-kill ladder uses; not a
+/// general POSIX signal set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Signal {
+    /// Graceful termination (SIGTERM).
+    Term,
+    /// Forceful kill (SIGKILL).
+    Kill,
+}
+
+impl Signal {
+    fn as_raw(self) -> i32 {
+        match self {
+            Signal::Term => libc::SIGTERM,
+            Signal::Kill => libc::SIGKILL,
+        }
+    }
+}
+
+/// Sends a signal to a process. Injected so tests can record calls instead of
+/// signalling real processes.
+pub(crate) trait ProcessKiller: Send + Sync {
+    fn kill(&self, pid: i32, signal: Signal) -> io::Result<()>;
+}
+
+/// Production `ProcessKiller` backed by `libc::kill`.
+pub(crate) struct LibcProcessKiller;
+
+impl ProcessKiller for LibcProcessKiller {
+    fn kill(&self, pid: i32, signal: Signal) -> io::Result<()> {
+        // SAFETY: libc::kill is a thin syscall wrapper; pid/signal are plain
+        // ints. The only place an unsafe signal send lives in agentsight.
+        let ret = unsafe { libc::kill(pid, signal.as_raw()) };
+        if ret != 0 {
+            // Capture errno immediately, before any allocation/logging.
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Records (pid, signal) calls instead of signalling; for escalation tests.
+    pub(crate) struct RecordingKiller {
+        pub calls: Mutex<Vec<(i32, Signal)>>,
+    }
+
+    impl RecordingKiller {
+        pub fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ProcessKiller for RecordingKiller {
+        fn kill(&self, pid: i32, signal: Signal) -> io::Result<()> {
+            self.calls.lock().unwrap().push((pid, signal));
+            Ok(())
+        }
+    }
+
+    /// Always fails with ESRCH; used to exercise execute_kill_action's error arms.
+    pub(crate) struct FailingKiller;
+
+    impl ProcessKiller for FailingKiller {
+        fn kill(&self, _pid: i32, _signal: Signal) -> io::Result<()> {
+            Err(io::Error::from_raw_os_error(libc::ESRCH))
+        }
+    }
+
+    #[test]
+    fn signal_as_raw_maps_to_libc() {
+        assert_eq!(Signal::Term.as_raw(), libc::SIGTERM);
+        assert_eq!(Signal::Kill.as_raw(), libc::SIGKILL);
+    }
+
+    #[test]
+    fn libc_killer_signals_real_child() {
+        // Spawn a child that sleeps, SIGTERM it via the production killer, and
+        // confirm it dies — exercises the unsafe path + Ok branch.
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let killer = LibcProcessKiller;
+        killer
+            .kill(child.id() as i32, Signal::Term)
+            .expect("SIGTERM should succeed on a live child");
+        let status = child.wait().expect("wait child");
+        assert!(!status.success(), "child terminated by signal");
+    }
+
+    #[test]
+    fn libc_killer_errors_on_missing_pid() {
+        // Use a pid that can never exist (i32::MAX > /proc/sys/kernel/pid_max),
+        // so there is no PID-reuse race and we can assert the specific errno.
+        // A reaped real pid would be racy: the kernel may recycle it between
+        // wait() and kill(), making the call succeed (or hit an unrelated proc).
+        let killer = LibcProcessKiller;
+        let err = killer
+            .kill(i32::MAX, Signal::Term)
+            .expect_err("signalling a nonexistent pid must error");
+        assert_eq!(err.raw_os_error(), Some(libc::ESRCH));
+    }
+}


### PR DESCRIPTION
## What

The DeadLoop auto-kill SIGTERM→SIGKILL escalation lived inline in the 170-line `detect_and_store_interruptions` with two `unsafe libc::kill` calls and zero test coverage. This extracts it into a testable seam:

- `utils/process.rs`: `ProcessKiller` trait + `Signal{Term,Kill}` + `LibcProcessKiller` — the only place the `unsafe libc::kill` now lives.
- `interruption/escalation.rs`: pure `decide_kill(enabled, existing_count, threshold) -> KillAction` + `execute_kill_action()` performing the signal via an injected killer. Log strings preserved verbatim.
- `unified.rs`: new `process_killer` field; the 37-line inline block becomes a `decide_kill` + `execute_kill_action` call. The gate, count read, and the rest of the method are untouched.

## Footprint

Pure refactor — **no new probe / FFI / product surface**. Behavior preserved bit-for-bit (escalation thresholds, signal choice, log text, pid-None silent-skip, errno capture timing).

## Tests

`decide_kill` truth table with discriminating boundaries (2→Term, 3→Kill, 0→immediate Kill, disabled→Wait), `execute_kill_action` via a recording/failing fake, and `LibcProcessKiller` against a real child + a guaranteed-missing pid (ESRCH). 686 lib/integration tests green.

## Verification

- **已 E2E**: auto-kill 真信号 escalation was verified on a live ECS run on identical pre-rebase code (while stacked on #969). This rebase is conflict-free, so the diff is byte-identical; **the E2E was not re-run in this round**.
- **已单测 + clippy + fmt** (against current `main`, toolchain 1.89.0): all green — `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, 686 tests pass.
- Originally stacked on #969 (now merged); rebased onto `main` with the surgical `--onto` so only this single refactor commit remains.
