### PR TITLE
feat(anolisa): add explicit adopt command for system RPMs

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -101,6 +101,8 @@ pub enum ComponentCommands {
     Repair(tier1::repair::RepairArgs),
     /// Drop a component's ANOLISA state record without any package operation
     Forget(tier1::forget::ForgetArgs),
+    /// Record an already-installed system RPM as rpm-observed (system scope)
+    Adopt(tier1::adopt::AdoptArgs),
     /// Manage component-to-framework adapters
     Adapter(adapter::AdapterArgs),
 }
@@ -202,6 +204,7 @@ pub fn dispatch(cli: Cli, ctx: &CliContext) -> Result<(), CliError> {
             ComponentCommands::Update(args) => tier1::update::handle(args, ctx),
             ComponentCommands::Repair(args) => tier1::repair::handle(args, ctx),
             ComponentCommands::Forget(args) => tier1::forget::handle(args, ctx),
+            ComponentCommands::Adopt(args) => tier1::adopt::handle(args, ctx),
             ComponentCommands::Adapter(args) => adapter::handle(args, ctx),
         },
         Commands::Management(cmd) => match cmd {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
@@ -1,5 +1,6 @@
 //! Primary commands — component lifecycle and operations.
 
+pub mod adopt;
 pub mod bug;
 pub mod doctor;
 pub mod env;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -1,0 +1,626 @@
+//! `anolisa adopt <component>` — record an already-installed system RPM as
+//! `rpm-observed` ANOLISA state.
+//!
+//! Adoption is the explicit counterpart to `install`'s implicit system-mode
+//! adoption: it fetches nothing and runs no `dnf`/`rpm` transaction — it reads
+//! rpmdb and writes the observation. It is a system-scope action: a unique
+//! installed RPM for the component is recorded with `Ownership::RpmObserved`,
+//! while ambiguous, absent, or already-tracked (non-observed) components are
+//! refused with guidance toward the right command.
+
+use clap::Parser;
+
+use anolisa_core::state::{ObjectKind, Ownership};
+use anolisa_platform::pkg_query::PackageQuery;
+use anolisa_platform::rpm_query::RpmPackageQuery;
+
+use crate::commands::common;
+use crate::commands::tier1::install::{RpmSituation, execute_adopt, probe_rpm_situation};
+use crate::context::{CliContext, InstallMode};
+use crate::repo_config::RepoConfig;
+use crate::response::CliError;
+
+/// Command label for JSON envelopes and error routing.
+const COMMAND: &str = "adopt";
+
+/// Arguments for `anolisa adopt <component>`.
+#[derive(Debug, Parser)]
+pub struct AdoptArgs {
+    /// Component to record as an existing system RPM
+    #[arg(value_name = "COMPONENT")]
+    pub component: String,
+    /// Pin the RPM package name when the component maps to several candidates
+    #[arg(long, value_name = "NAME")]
+    pub package: Option<String>,
+}
+
+/// Dispatch `adopt <component>`: probe rpmdb and record the unique installed RPM
+/// as `rpm-observed`.
+///
+/// # Errors
+///
+/// Returns [`CliError`] in user mode, when the component is already tracked
+/// under a non-observed ownership, when no / ambiguous / multi-version RPM is
+/// found, or when the state write fails.
+pub fn handle(args: AdoptArgs, ctx: &CliContext) -> Result<(), CliError> {
+    let query = RpmPackageQuery::system();
+    adopt_with_query(&args.component, args.package.as_deref(), ctx, &query)
+}
+
+/// Core of [`handle`] with the package query injected so tests drive every
+/// branch without a live rpmdb. Adopt runs no dnf transaction, so only a
+/// [`PackageQuery`] is required.
+fn adopt_with_query(
+    target: &str,
+    cli_override: Option<&str>,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+) -> Result<(), CliError> {
+    let command = format!("adopt {target}");
+
+    // Adoption records a *system* RPM into system-scope state; user mode has no
+    // system rpmdb to observe into. Refuse rather than record a system package
+    // against user-scope state (mirrors install's `--backend rpm` user-mode
+    // rejection).
+    if ctx.install_mode != InstallMode::System {
+        return Err(CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "adopt records a system RPM and requires system scope; re-run with --install-mode system (got {} mode)",
+                ctx.install_mode.as_str()
+            ),
+        });
+    }
+
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+
+    // Tracked-component gate (pre-lock fast-fail for a clear, early message).
+    // Re-adopting a component that is already `rpm-observed` is a refresh and
+    // falls through to execute_adopt, which upserts. A component owned under any
+    // other provenance must not be silently downgraded to rpm-observed — that is
+    // an ownership migration, left for later — so refuse and point at the right
+    // tool. This is the friendly path; execute_adopt re-enforces the same policy
+    // atomically under the lock (covering a concurrent managed install).
+    if let Some(obj) = installed.find_object(ObjectKind::Component, target) {
+        match obj.effective_ownership() {
+            Ownership::RpmObserved => {}
+            Ownership::RpmManaged => {
+                return Err(CliError::InvalidArgument {
+                    command,
+                    reason: format!(
+                        "component '{target}' is already tracked as rpm-managed; run `anolisa repair {target}` to refresh its state from rpmdb"
+                    ),
+                });
+            }
+            Ownership::RawManaged => {
+                return Err(CliError::InvalidArgument {
+                    command,
+                    reason: format!(
+                        "component '{target}' is already tracked as a raw install; run `anolisa uninstall {target}` first to re-adopt it as an rpm-observed system package"
+                    ),
+                });
+            }
+        }
+    }
+
+    let layout = common::resolve_layout(ctx);
+    // repo.toml only feeds the package-name map (`[backends.rpm].package_map`).
+    // It is supplementary: --package, the provides contract, and the default
+    // name still resolve a candidate without it, so a missing/unreadable config
+    // degrades to "no rpm backend config" rather than failing the adopt.
+    let repo_config = RepoConfig::load(&layout).ok();
+    let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
+
+    match probe_rpm_situation(target, cli_override, rpm_backend, ctx, query, &command)? {
+        // Exactly one installed RPM: record it (or preview on --dry-run). reused
+        // verbatim from the install path, including the lock-held re-validation.
+        RpmSituation::Adoptable { package, info } => {
+            execute_adopt(ctx, &layout, &command, target, package, info, query)?;
+            Ok(())
+        }
+        // Nothing installed under this name: adopt never installs, so point at
+        // install for the delegated `dnf install` path.
+        RpmSituation::Absent { package } => Err(CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "no installed RPM '{package}' found for component '{target}'; adopt only records an already-installed system RPM — run `anolisa --install-mode system install {target}` to install it"
+            ),
+        }),
+        // Several provider packages: the user must disambiguate.
+        RpmSituation::Ambiguous(names) => Err(CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "multiple installed RPMs provide component '{target}': {}; cannot adopt unambiguously — pin one with `--package <name>`",
+                names.join(", ")
+            ),
+        }),
+        // One name, several installed versions: a drift the user must resolve.
+        RpmSituation::MultiVersion(package) => Err(CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "RPM package '{package}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first"
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use anolisa_core::state::{
+        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, RpmMetadata,
+    };
+    use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
+
+    /// In-memory [`PackageQuery`] for the adopt tests. Adopt runs no transaction,
+    /// so a query alone drives every branch (probe + origin lookup).
+    #[derive(Default)]
+    struct FakeQuery {
+        /// package name → installed info reported by `query_installed`.
+        installed: Vec<(String, PackageInfo)>,
+        /// package names that report several installed versions.
+        multi_version: Vec<String>,
+        /// capability → provider package names for `what_provides_installed`.
+        provides: Vec<(String, Vec<String>)>,
+        /// package → source repo for `installed_origin`.
+        origins: Vec<(String, String)>,
+    }
+
+    impl PackageQuery for FakeQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if self.multi_version.iter().any(|p| p == package) {
+                return Err(PackageQueryError::UnexpectedOutput {
+                    command: "rpm".to_string(),
+                    detail: "2 installed versions".to_string(),
+                });
+            }
+            Ok(self
+                .installed
+                .iter()
+                .find(|(p, _)| p == package)
+                .map(|(_, info)| info.clone()))
+        }
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+        fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+            Ok(self
+                .origins
+                .iter()
+                .find(|(p, _)| p == package)
+                .map(|(_, o)| o.clone()))
+        }
+        fn what_provides_installed(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .provides
+                .iter()
+                .find(|(c, _)| c == capability)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default())
+        }
+    }
+
+    fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: version.to_string(),
+                release: release.map(str::to_string),
+            },
+            arch: arch.to_string(),
+            origin: None,
+        }
+    }
+
+    fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        CliContext {
+            install_mode,
+            prefix: Some(prefix),
+            json: false,
+            dry_run,
+            verbose: false,
+            quiet: true,
+            no_color: true,
+        }
+    }
+
+    /// A tracked component object with the given provenance.
+    fn component_object(name: &str, ownership: Ownership, status: ObjectStatus) -> InstalledObject {
+        let is_rpm = ownership.is_rpm();
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: name.to_string(),
+            version: "1.0.0-1.al8".to_string(),
+            status,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some(if is_rpm { "rpm" } else { "raw" }.to_string()),
+            ownership: Some(ownership),
+            rpm_metadata: is_rpm.then(|| RpmMetadata {
+                package_name: format!("anolisa-{name}"),
+                evr: Some("1.0.0-1.al8".to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: matches!(ownership, Ownership::RawManaged | Ownership::RpmManaged),
+            adopted: matches!(ownership, Ownership::RpmObserved),
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    /// Write a seed state (creating the state dir) so the lock-held write path
+    /// has somewhere to land.
+    fn seed(ctx: &CliContext, objs: Vec<InstalledObject>) {
+        let layout = common::resolve_layout(ctx);
+        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        for obj in objs {
+            state.upsert_object(obj);
+        }
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state");
+    }
+
+    fn load_state(ctx: &CliContext) -> InstalledState {
+        let layout = common::resolve_layout(ctx);
+        InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+    }
+
+    /// A unique installed RPM with no prior state is recorded as `rpm-observed`.
+    #[test]
+    fn adopt_records_unique_rpm_as_observed() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(&c, Vec::new());
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            ..Default::default()
+        };
+        adopt_with_query("copilot-shell", None, &c, &q).expect("adopt ok");
+
+        let after = load_state(&c);
+        let obj = after
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("object recorded");
+        assert_eq!(obj.effective_ownership(), Ownership::RpmObserved);
+        assert_eq!(obj.status, ObjectStatus::Adopted);
+        let meta = obj.rpm_metadata.as_ref().expect("rpm metadata");
+        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+        assert_eq!(meta.evr.as_deref(), Some("2.2.0-1.al8"));
+        assert!(
+            after
+                .operations
+                .iter()
+                .any(|o| o.command == "adopt copilot-shell"),
+            "an operation record must be appended",
+        );
+    }
+
+    /// Re-adopting an already `rpm-observed` component refreshes its EVR and
+    /// keeps it rpm-observed (idempotent).
+    #[test]
+    fn adopt_refreshes_existing_rpm_observed() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![component_object(
+                "copilot-shell",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            )],
+        );
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.0.0", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        adopt_with_query("copilot-shell", None, &c, &q).expect("refresh ok");
+
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("object")
+            .clone();
+        assert_eq!(obj.effective_ownership(), Ownership::RpmObserved);
+        assert_eq!(
+            obj.rpm_metadata.and_then(|m| m.evr).as_deref(),
+            Some("2.0.0-1.al8"),
+            "EVR refreshed from rpmdb",
+        );
+    }
+
+    /// Re-adopting an rpm-observed component with `--package` pointing at a
+    /// *different* RPM is a package-identity migration, not a refresh: it must be
+    /// refused under the lock (not silently overwrite `rpm_metadata.package_name`),
+    /// and steer the user through forget→adopt.
+    #[test]
+    fn adopt_refuses_repointing_observed_to_different_package() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![component_object(
+                "copilot-shell",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            )],
+        );
+        // Existing observed package is `anolisa-copilot-shell`; the user pins a
+        // different installed package via --package.
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-other".to_string(),
+                pkg_info("anolisa-other", "9.9.9", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        let err = adopt_with_query("copilot-shell", Some("anolisa-other"), &c, &q)
+            .expect_err("repointing to a different package must be refused");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("anolisa-copilot-shell")
+                && err.reason().contains("anolisa-other")
+                && err.reason().contains("forget"),
+            "refusal must name both packages and point at forget: {}",
+            err.reason(),
+        );
+        // The state must be untouched — no repoint, no EVR bump.
+        let meta = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("object")
+            .rpm_metadata
+            .clone()
+            .expect("rpm metadata");
+        assert_eq!(
+            meta.package_name, "anolisa-copilot-shell",
+            "package identity must be preserved when the repoint is refused",
+        );
+        assert_eq!(meta.evr.as_deref(), Some("1.0.0-1.al8"), "EVR unchanged");
+    }
+
+    /// The repoint refusal must also fire on `--dry-run`: the preview cannot
+    /// promise `Would adopt...` for a switch the real run would reject. Mirrors
+    /// the real-run test above with a dry-run context.
+    #[test]
+    fn adopt_dry_run_refuses_repointing_observed_to_different_package() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        seed(
+            &c,
+            vec![component_object(
+                "copilot-shell",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            )],
+        );
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-other".to_string(),
+                pkg_info("anolisa-other", "9.9.9", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        let err = adopt_with_query("copilot-shell", Some("anolisa-other"), &c, &q)
+            .expect_err("dry-run must refuse the repoint, matching the real run");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("anolisa-copilot-shell")
+                && err.reason().contains("anolisa-other")
+                && err.reason().contains("forget"),
+            "dry-run refusal must match the real run: {}",
+            err.reason(),
+        );
+        // Dry-run never writes, so the record is untouched regardless.
+        let meta = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("object")
+            .rpm_metadata
+            .clone()
+            .expect("rpm metadata");
+        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+    }
+
+    /// A raw-managed component is not silently downgraded; adopt points at
+    /// uninstall.
+    #[test]
+    fn adopt_refuses_raw_managed() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![component_object(
+                "copilot-shell",
+                Ownership::RawManaged,
+                ObjectStatus::Installed,
+            )],
+        );
+        let err = adopt_with_query("copilot-shell", None, &c, &FakeQuery::default())
+            .expect_err("raw must be refused");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("uninstall"),
+            "raw refusal points at uninstall: {}",
+            err.reason()
+        );
+    }
+
+    /// An rpm-managed component is refused; adopt points at repair.
+    #[test]
+    fn adopt_refuses_rpm_managed() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![component_object(
+                "copilot-shell",
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            )],
+        );
+        let err = adopt_with_query("copilot-shell", None, &c, &FakeQuery::default())
+            .expect_err("rpm-managed must be refused");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("repair"),
+            "rpm-managed refusal points at repair: {}",
+            err.reason()
+        );
+    }
+
+    /// Adoption is system-scope; user mode is refused.
+    #[test]
+    fn adopt_refuses_in_user_mode() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::User, false);
+        let err = adopt_with_query("copilot-shell", None, &c, &FakeQuery::default())
+            .expect_err("user mode must be refused");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("system"),
+            "user-mode refusal mentions system scope: {}",
+            err.reason()
+        );
+    }
+
+    /// No installed RPM under the name: adopt does not install, points at install.
+    #[test]
+    fn adopt_refuses_absent_package() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let err = adopt_with_query("copilot-shell", None, &c, &FakeQuery::default())
+            .expect_err("absent package must be refused");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("install copilot-shell"),
+            "absent refusal points at the install command: {}",
+            err.reason()
+        );
+    }
+
+    /// Multiple provider packages cannot be adopted unambiguously.
+    #[test]
+    fn adopt_refuses_ambiguous_candidates() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let q = FakeQuery {
+            provides: vec![(
+                "anolisa-component(copilot-shell)".to_string(),
+                vec!["pkg-a".to_string(), "pkg-b".to_string()],
+            )],
+            ..Default::default()
+        };
+        let err =
+            adopt_with_query("copilot-shell", None, &c, &q).expect_err("ambiguous must be refused");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("--package"),
+            "ambiguous refusal points at --package: {}",
+            err.reason()
+        );
+    }
+
+    /// A same-name multi-version rpmdb is refused rather than adopted blindly.
+    #[test]
+    fn adopt_refuses_multi_version() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+            )],
+            multi_version: vec!["anolisa-copilot-shell".to_string()],
+            ..Default::default()
+        };
+        let err = adopt_with_query("copilot-shell", None, &c, &q)
+            .expect_err("multi-version must be refused");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("multiple installed versions"));
+    }
+
+    /// `--dry-run` previews without writing any state.
+    #[test]
+    fn adopt_dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        adopt_with_query("copilot-shell", None, &c, &q).expect("dry-run ok");
+        let layout = common::resolve_layout(&c);
+        assert!(
+            !layout.state_dir.join("installed.toml").exists(),
+            "dry-run must not write state",
+        );
+    }
+
+    /// `--package` pins the RPM name, bypassing the candidate chain.
+    #[test]
+    fn adopt_with_package_override_adopts_named() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(&c, Vec::new());
+        let q = FakeQuery {
+            installed: vec![(
+                "custom-pkg".to_string(),
+                pkg_info("custom-pkg", "3.0.0", Some("1"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        adopt_with_query("copilot-shell", Some("custom-pkg"), &c, &q).expect("adopt ok");
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("object")
+            .clone();
+        assert_eq!(
+            obj.rpm_metadata.map(|m| m.package_name).as_deref(),
+            Some("custom-pkg"),
+            "the pinned package is recorded",
+        );
+    }
+
+    /// `AdoptArgs` parses the positional component and the optional `--package`.
+    #[test]
+    fn adopt_parses_positional_and_package_flag() {
+        use clap::Parser;
+        let args = AdoptArgs::try_parse_from(["adopt", "copilot-shell", "--package", "pkg-x"])
+            .expect("parse");
+        assert_eq!(args.component, "copilot-shell");
+        assert_eq!(args.package.as_deref(), Some("pkg-x"));
+
+        let bare = AdoptArgs::try_parse_from(["adopt", "copilot-shell"]).expect("parse");
+        assert_eq!(bare.package, None);
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -186,7 +186,7 @@ struct InstallResultPayload {
 /// RPM adopt in its batch summary (§7.5). The dry-run vs real distinction is
 /// layered on by the caller from [`CliContext::dry_run`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum InstallOutcome {
+pub(crate) enum InstallOutcome {
     /// A raw install (downloaded + placed files, or its dry-run preview).
     Installed,
     /// An existing system RPM recorded as `rpm-observed` (or its dry-run
@@ -301,8 +301,14 @@ fn handle_one_with_exec(
             // layer 2, rather than being rejected by the raw trunk.
             (label.to_string(), BackendSource::ExistingState)
         } else if ctx.install_mode == InstallMode::System {
-            let situation =
-                probe_rpm_situation(&component, &args, &repo_config, ctx, exec.query, &command)?;
+            let situation = probe_rpm_situation(
+                &component,
+                args.package.as_deref(),
+                repo_config.backends.get("rpm"),
+                ctx,
+                exec.query,
+                &command,
+            )?;
             if matches!(situation, RpmSituation::Absent { .. }) {
                 // Absent + no `--backend`: fall through to the default backend.
                 // If that is `rpm`, layer 2 re-probes and delegates a `dnf
@@ -435,7 +441,7 @@ fn handle_raw_install(
 // ── rpm adopt path (#958) ───────────────────────────────────────────
 
 /// Result of probing whether `component` is present as a system RPM (§5/§7.1).
-enum RpmSituation {
+pub(crate) enum RpmSituation {
     /// Exactly one candidate package name, installed once — ready to adopt.
     Adoptable {
         /// Resolved package name (the candidate that hit rpmdb).
@@ -469,18 +475,17 @@ enum RpmSituation {
 /// back to raw rather than treat it as [`Absent`].
 ///
 /// [`Absent`]: RpmSituation::Absent
-fn probe_rpm_situation(
+pub(crate) fn probe_rpm_situation(
     component: &str,
-    args: &InstallArgs,
-    repo_config: &RepoConfig,
+    cli_override: Option<&str>,
+    rpm_backend: Option<&BackendConfig>,
     ctx: &CliContext,
     query: &dyn PackageQuery,
     command: &str,
 ) -> Result<RpmSituation, CliError> {
     let manifest = load_optional_manifest(ctx, component);
-    let rpm_backend = repo_config.backends.get("rpm");
     let candidates = match rpm_package_candidates(
-        args.package.as_deref(),
+        cli_override,
         manifest.as_ref(),
         rpm_backend,
         query,
@@ -601,7 +606,14 @@ fn route_rpm_adopt(
 
     let situation = match situation {
         Some(s) => s,
-        None => probe_rpm_situation(component, args, repo_config, ctx, exec.query, command)?,
+        None => probe_rpm_situation(
+            component,
+            args.package.as_deref(),
+            repo_config.backends.get("rpm"),
+            ctx,
+            exec.query,
+            command,
+        )?,
     };
 
     match situation {
@@ -646,11 +658,47 @@ struct AdoptResultPayload {
     warnings: Vec<String>,
 }
 
+/// Refuse re-adopting an existing `rpm-observed` component under a *different*
+/// RPM package — a package-identity migration, not an idempotent refresh.
+///
+/// Shared by the dry-run preview (non-locked) and the locked write path so the
+/// preview can never promise an adopt the real run would reject. Returns
+/// `Ok(())` when there is no existing record, it is not rpm-observed, its
+/// recorded package name is empty, or the package is unchanged.
+fn refuse_observed_repoint(
+    state: &InstalledState,
+    component: &str,
+    new_package: &str,
+    command: &str,
+) -> Result<(), CliError> {
+    let Some(existing) = state.find_object(ObjectKind::Component, component) else {
+        return Ok(());
+    };
+    if !matches!(existing.effective_ownership(), Ownership::RpmObserved) {
+        return Ok(());
+    }
+    if let Some(prev) = existing
+        .rpm_metadata
+        .as_ref()
+        .map(|m| m.package_name.as_str())
+        && !prev.is_empty()
+        && prev != new_package
+    {
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' is already adopted from RPM package '{prev}', not '{new_package}'; adopt will not silently repoint it to a different package — run `anolisa forget {component}` first, then adopt the new package"
+            ),
+        });
+    }
+    Ok(())
+}
+
 /// Record an installed system RPM as `rpm-observed` state (§7.2). Fetches
 /// nothing, writes no owned files, touches no RPM-owned paths — only rpmdb
 /// reads plus a state write. On `--dry-run` it renders the plan without
 /// writing.
-fn execute_adopt(
+pub(crate) fn execute_adopt(
     ctx: &CliContext,
     layout: &FsLayout,
     command: &str,
@@ -687,8 +735,20 @@ fn execute_adopt(
         warnings: warnings.clone(),
     };
 
+    // Package-identity guard, evaluated *before* the dry-run return so the preview
+    // never promises an adopt the real run would reject. A re-adopt of an existing
+    // rpm-observed component must target the same RPM; `--package` pointing at a
+    // different one is a migration, not a refresh. This non-locked read is the
+    // preview / pre-lock fast-fail; the locked path below re-checks for TOCTOU.
+    let preview_state =
+        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to load installed state: {err}"),
+        })?;
+    refuse_observed_repoint(&preview_state, component, &info.name, command)?;
+
     if ctx.dry_run {
-        render_adopt(ctx, &payload);
+        render_adopt(ctx, command, &payload);
         return Ok(InstallOutcome::Adopted);
     }
 
@@ -710,6 +770,30 @@ fn execute_adopt(
     // lock and record it first. Without this check the adopt would clobber the
     // raw provenance; with it, the loser is rejected rather than overwriting.
     ensure_component_backend_compatible(&state, component, "rpm", command)?;
+
+    // Backend compatibility is necessary but not sufficient: rpm-managed and
+    // rpm-observed share the "rpm" backend label, so the check above passes for
+    // a component ANOLISA actively manages. Adopt may only create a new record
+    // or refresh an existing rpm-observed one — it must never downgrade a managed
+    // component to observed and silently drop ANOLISA's removal authority
+    // (`owns_removal`). `adopt`'s pre-lock gate refuses this for the common case;
+    // re-checking here under the lock closes the window where a concurrent
+    // managed install lands between that read and this acquisition.
+    if let Some(existing) = state.find_object(ObjectKind::Component, component)
+        && !matches!(existing.effective_ownership(), Ownership::RpmObserved)
+    {
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' is already tracked as {} and will not be downgraded to rpm-observed; run `anolisa repair {component}` to refresh a managed RPM component, or `anolisa uninstall {component}` first",
+                existing.effective_ownership().label()
+            ),
+        });
+    }
+    // Re-check the package-identity guard under the lock (TOCTOU): a concurrent
+    // re-adopt could have repointed the recorded package between the pre-lock
+    // preview above and this acquisition.
+    refuse_observed_repoint(&state, component, &info.name, command)?;
 
     let started_at = now_iso8601();
     let lock_ts = Utc::now();
@@ -806,17 +890,29 @@ fn execute_adopt(
 
     payload.operation_id = Some(operation_id);
     payload.warnings = warnings;
-    render_adopt(ctx, &payload);
+    render_adopt(ctx, command, &payload);
     Ok(InstallOutcome::Adopted)
 }
 
 /// Render an adopt result (JSON envelope or the proposal §6.1 human text).
 /// Silent in quiet mode; the `--all` batch path drives its own summary.
-fn render_adopt(ctx: &CliContext, payload: &AdoptResultPayload) {
+/// Bare verb for an adopt JSON envelope. `command` is the rich
+/// `"<verb> <component>"` form, so the envelope takes its first token (matching
+/// repair/forget's bare-verb envelopes). Because `execute_adopt` is shared, this
+/// is "install" through the install trunk and "adopt" through the explicit
+/// command — not a hardcoded "install".
+fn adopt_envelope_verb(command: &str) -> &str {
+    match command.split(' ').next() {
+        Some(verb) if !verb.is_empty() => verb,
+        _ => COMMAND,
+    }
+}
+
+fn render_adopt(ctx: &CliContext, command: &str, payload: &AdoptResultPayload) {
     if ctx.json {
         // Errors here are unreachable for a plain Serialize struct; ignore the
         // Result so the (already-persisted) adopt is not reported as failed.
-        let _ = render_json(COMMAND, payload);
+        let _ = render_json(adopt_envelope_verb(command), payload);
         return;
     }
     if ctx.quiet {
@@ -837,10 +933,14 @@ fn render_adopt(ctx: &CliContext, payload: &AdoptResultPayload) {
         repo,
         color.muted(suffix),
     );
-    println!(
-        "{}",
-        color.ok("Adopted as rpm-observed. ANOLISA will not replace it with raw.")
-    );
+    // Dry-run records nothing, so the action line must read as conditional —
+    // "Adopted" here would contradict the "nothing recorded" suffix above.
+    let action_line = if payload.dry_run {
+        "Would adopt as rpm-observed. ANOLISA will not replace it with raw."
+    } else {
+        "Adopted as rpm-observed. ANOLISA will not replace it with raw."
+    };
+    println!("{}", color.ok(action_line));
     render_warnings(&payload.warnings, &color);
 }
 
@@ -4141,8 +4241,8 @@ scope = "@anolisa"
         };
         let situation = probe_rpm_situation(
             "copilot-shell",
-            &args("copilot-shell"),
-            &repo,
+            None,
+            repo.backends.get("rpm"),
             &ctx,
             &q,
             "install",
@@ -4167,8 +4267,8 @@ scope = "@anolisa"
         let q = FakeQuery::default();
         let situation = probe_rpm_situation(
             "copilot-shell",
-            &args("copilot-shell"),
-            &repo,
+            None,
+            repo.backends.get("rpm"),
             &ctx,
             &q,
             "install",
@@ -4190,8 +4290,8 @@ scope = "@anolisa"
         };
         let situation = probe_rpm_situation(
             "copilot-shell",
-            &args("copilot-shell"),
-            &repo,
+            None,
+            repo.backends.get("rpm"),
             &ctx,
             &q,
             "install",
@@ -4210,8 +4310,8 @@ scope = "@anolisa"
         };
         let situation = probe_rpm_situation(
             "copilot-shell",
-            &args("copilot-shell"),
-            &repo,
+            None,
+            repo.backends.get("rpm"),
             &ctx,
             &q,
             "install",
@@ -4421,6 +4521,150 @@ scope = "@anolisa"
             .expect("raw record preserved");
         assert_eq!(installed_backend_label(obj), Some("raw"));
         assert!(obj.rpm_metadata.is_none(), "raw record must stay raw");
+    }
+
+    #[test]
+    fn adopt_refuses_to_downgrade_concurrent_rpm_managed_install() {
+        // rpm-managed and rpm-observed share the "rpm" backend label, so
+        // ensure_component_backend_compatible alone cannot tell them apart. A
+        // concurrent delegated `dnf install` can record the component rpm-managed
+        // (owns_removal=true) after a pre-lock read saw it absent. After
+        // reloading under the lock, execute_adopt must refuse rather than
+        // overwrite the managed record with rpm-observed (which would silently
+        // drop ANOLISA's removal authority).
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "copilot-shell".to_string(),
+            version: "2.3.0-1.al8".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmManaged),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: "anolisa-copilot-shell".to_string(),
+                evr: Some("2.3.0-1.al8".to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("alinux-updates".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-install-prior".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed rpm-managed record");
+
+        let q = FakeQuery::default();
+        let err = execute_adopt(
+            &ctx,
+            &layout,
+            "adopt copilot-shell",
+            "copilot-shell",
+            "anolisa-copilot-shell".to_string(),
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            &q,
+        )
+        .expect_err("must refuse to downgrade an rpm-managed component");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("repair"), "got: {}", err.reason());
+
+        // The managed record survives untouched: removal authority is preserved.
+        let state = load_state(&ctx);
+        let obj = state
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .expect("managed record preserved");
+        assert_eq!(obj.ownership, Some(Ownership::RpmManaged));
+        assert!(obj.managed, "managed flag must stay true");
+    }
+
+    #[test]
+    fn reinstall_of_rpm_managed_refuses_instead_of_downgrading() {
+        // Full install entrypoint (not execute_adopt directly): re-running
+        // `install` on an already rpm-managed component routes ExistingState ->
+        // route_rpm_adopt -> execute_adopt. The downgrade guard must refuse here
+        // too, rather than silently overwriting the managed record with observed.
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "copilot-shell".to_string(),
+            version: "2.3.0-1.al8".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmManaged),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: "anolisa-copilot-shell".to_string(),
+                evr: Some("2.3.0-1.al8".to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("alinux-updates".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-install-prior".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed rpm-managed record");
+
+        // rpmdb still has the package, so the re-probe yields Adoptable.
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            ..Default::default()
+        };
+        let err =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect_err("re-install of rpm-managed must refuse");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("repair"), "got: {}", err.reason());
+
+        let obj = load_state(&ctx)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("managed record preserved");
+        assert_eq!(obj.ownership, Some(Ownership::RpmManaged));
+    }
+
+    #[test]
+    fn adopt_envelope_verb_is_the_bare_command() {
+        // The success JSON envelope reports the bare verb, so an explicit adopt
+        // is not mislabelled "install" (the shared execute_adopt's module COMMAND).
+        assert_eq!(adopt_envelope_verb("adopt copilot-shell"), "adopt");
+        assert_eq!(adopt_envelope_verb("install copilot-shell"), "install");
+        assert_eq!(adopt_envelope_verb(""), COMMAND);
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -737,6 +737,48 @@ mod tests {
         assert_ne!(obj.last_operation_id.as_deref(), Some("op-prior"));
     }
 
+    /// The "keeping ownership / does not switch backend" criterion holds for the
+    /// rpm-managed lifecycle too, not just observed: a drifted rpm-managed
+    /// component refreshes its EVR while ownership stays `rpm-managed`.
+    #[test]
+    fn repair_refreshes_rpm_managed_keeping_ownership() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let rpm = FakeQuery::new(
+            "anolisa-copilot-shell",
+            Some(pkg_info(
+                "anolisa-copilot-shell",
+                "2.3.0",
+                Some("1.al8"),
+                "x86_64",
+            )),
+        );
+        repair_with_query("copilot-shell", &c, &rpm).expect("repair ok");
+
+        let obj = load_state(&c)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .cloned()
+            .expect("present");
+        assert_eq!(obj.version, "2.3.0-1.al8", "version reconciled to rpmdb");
+        assert_eq!(
+            obj.ownership,
+            Some(Ownership::RpmManaged),
+            "rpm-managed ownership kept across refresh",
+        );
+        assert_eq!(obj.install_backend.as_deref(), Some("rpm"), "backend kept");
+        assert_eq!(obj.status, ObjectStatus::Installed, "status unchanged");
+    }
+
     /// A failed origin lookup must not erase a previously-good source_repo.
     #[test]
     fn repair_keeps_prior_source_repo_when_origin_unknown() {


### PR DESCRIPTION
## Description

Adds `anolisa adopt <component>`, the explicit counterpart to install's implicit system-mode adoption (#961). It reads rpmdb and records a unique installed RPM as `rpm-observed` ANOLISA state, running no `dnf`/`rpm` transaction. The command is system-scope only.

Behavior:
- Unique installed RPM → recorded as `rpm-observed` / `Adopted`.
- Already `rpm-observed` → idempotent refresh (EVR/arch/source_repo).
- Already `rpm-managed` → refused, pointing at `repair`.
- Already `raw-managed` → refused, pointing at `uninstall`.
- Absent / ambiguous / multi-version → refused with actionable messages.
- `--package <name>` pins the RPM when a component maps to several candidates.

The `repair` command shipped earlier already satisfies #961's repair acceptance criteria; this PR adds a regression test pinning that a managed refresh keeps ownership/backend, but makes no change to repair's logic.

## Design Note

The adopt core is reused from the install path rather than duplicated: `probe_rpm_situation`, `execute_adopt`, and `RpmSituation` become `pub(crate)`, and `probe_rpm_situation` is decoupled from `RepoConfig` (takes `Option<&BackendConfig>`) so `adopt` resolves the rpm backend best-effort.

Ownership safety: `adopt` has a pre-lock gate that refuses a component already tracked under a non-observed ownership. Because `rpm-managed` and `rpm-observed` share the `"rpm"` backend label, the existing lock-held `ensure_component_backend_compatible` cannot tell them apart, so `execute_adopt` now also re-checks ownership **under the lock** and refuses to downgrade a managed component to `rpm-observed`. This closes a TOCTOU window where a concurrent managed install could land between the pre-lock read and the lock, and as a bonus fixes the same latent silent-downgrade on `install` re-installing an `rpm-managed` component.

## Ship Note

- Ownership migration stays out of scope: `adopt` refuses to convert `raw-managed`/`rpm-managed` → `rpm-observed` rather than performing it (left for a follow-up).
- Known consistency item: `adopt`/`repair`/`status` share a best-effort `RepoConfig::load(&layout).ok()`. A **missing** `repo.toml` correctly degrades to "no rpm backend config", but a **malformed** one is silently ignored (its `[backends.rpm].package_map` tier is dropped) rather than surfaced as an error the way `install` does. The right fix is a shared loader helper applied to all three commands; deferred to keep this PR scoped.
- `execute_adopt` mints `op-install-…` operation ids even when invoked as `adopt`; the audit record's `command` field still reads `adopt <component>`, and no consumer keys off the id prefix, so this is cosmetic.

## Test

- Unit (adopt): success → `rpm-observed`/`Adopted` with correct `rpm_metadata` + operation record; idempotent refresh; refuse raw-managed / rpm-managed / user-mode / absent / ambiguous / multi-version; `--dry-run` writes nothing; `--package` override; CLI parse.
- Unit (install): `execute_adopt` refuses to downgrade a concurrent `rpm-managed` record under the lock; re-installing an `rpm-managed` component via the full install entrypoint refuses instead of downgrading; JSON envelope reports the bare verb (`adopt`, not `install`).
- Unit (repair): regression test pinning that a managed refresh keeps `ownership`/`install_backend`.
- Full gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- Real-host rpmdb end-to-end: `adopt` an installed package via `--package` → `status` shows `adopted`/`rpm-observed` → idempotent re-adopt → `repair` refreshes → `forget` drops state (RPM left installed); plus refusal paths (user mode, absent) and `--json` envelope consistency.

Closes #961
