### PR TITLE
fix(sight): fix traced_processes BPF map leak causing uprobe failure after long run

### DIFF
--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -78,7 +78,7 @@ impl TraceCommand {
         let mut sight = match AgentSight::new(config) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("Failed to create AgentSight: {e:#}");
+                eprintln!("Failed to create AgentSight: {e}");
                 std::process::exit(1);
             }
         };

--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -78,7 +78,7 @@ impl TraceCommand {
         let mut sight = match AgentSight::new(config) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("Failed to create AgentSight: {e}");
+                eprintln!("Failed to create AgentSight: {e:#}");
                 std::process::exit(1);
             }
         };

--- a/src/agentsight/src/bpf/proctrace.bpf.c
+++ b/src/agentsight/src/bpf/proctrace.bpf.c
@@ -346,14 +346,15 @@ int trace_process_exit(void *ctx)
     u32 uid = bpf_get_current_uid_gid();
     u64 ts = bpf_ktime_get_ns();
     
-    // Check if this process should be traced
-    u8 *traced = bpf_map_lookup_elem(&child_pids, &pid);
-    if (!traced)
+    // Gate on traced_processes (covers both BPF-inserted and user-space-inserted PIDs)
+    u32 *in_traced = bpf_map_lookup_elem(&traced_processes, &pid);
+    if (!in_traced)
         return 0;
     u64 cg_id = get_cgroup_id_compat();
-    
-    bpf_map_delete_elem(&child_pids, &pid);
+
+    // Clean up both maps unconditionally (delete on missing key is a no-op)
     bpf_map_delete_elem(&traced_processes, &pid);
+    bpf_map_delete_elem(&child_pids, &pid);
     // Reserve space in ring buffer for exit event (fixed size)
     struct proc_event_header *event = bpf_ringbuf_reserve(
         &rb, 

--- a/src/agentsight/src/probes/proctrace.rs
+++ b/src/agentsight/src/probes/proctrace.rs
@@ -422,8 +422,9 @@ impl ProcTrace {
 
         let mut skel = open_skel.load().context("failed to load BPF object")?;
 
-        // Populate traced_processes map with target PIDs (only if not reusing external map)
-        // If target_pids is empty, all processes will be traced (BPF side skips filter)
+        // Populate traced_processes and child_pids maps with target PIDs
+        // (only if not reusing external map).
+        // Both maps must contain the PID so that trace_process_exit can clean up.
         if traced_processes.is_none() {
             for &pid in target_pids {
                 let key = pid.to_ne_bytes();
@@ -432,6 +433,10 @@ impl ProcTrace {
                     .traced_processes()
                     .update(&key, &val, libbpf_rs::MapFlags::ANY)
                     .with_context(|| format!("failed to add pid {pid} to traced_processes"))?;
+                skel.maps_mut()
+                    .child_pids()
+                    .update(&key, &val, libbpf_rs::MapFlags::ANY)
+                    .with_context(|| format!("failed to add pid {pid} to child_pids"))?;
             }
         }
 
@@ -456,7 +461,10 @@ impl ProcTrace {
         Self::new_with_target(&[], None)
     }
 
-    /// Add a PID to the traced_processes map at runtime
+    /// Add a PID to the traced_processes and child_pids maps at runtime.
+    ///
+    /// Both maps must contain the PID so that `trace_process_exit` in BPF can
+    /// clean up via either lookup path.
     pub fn add_traced_pid(&mut self, pid: u32) -> Result<()> {
         let key = pid.to_ne_bytes();
         let val = 1u32.to_ne_bytes();
@@ -464,12 +472,18 @@ impl ProcTrace {
             .maps_mut()
             .traced_processes()
             .update(&key, &val, libbpf_rs::MapFlags::ANY)
-            .with_context(|| format!("failed to add pid {pid} to traced_processes"))
+            .with_context(|| format!("failed to add pid {pid} to traced_processes"))?;
+        self.skel
+            .maps_mut()
+            .child_pids()
+            .update(&key, &val, libbpf_rs::MapFlags::ANY)
+            .with_context(|| format!("failed to add pid {pid} to child_pids"))
     }
 
-    /// Remove a PID from the traced_processes map at runtime
+    /// Remove a PID from the traced_processes and child_pids maps at runtime
     pub fn remove_traced_pid(&mut self, pid: u32) -> Result<()> {
         let key = pid.to_ne_bytes();
+        let _ = self.skel.maps_mut().child_pids().delete(&key);
         self.skel
             .maps_mut()
             .traced_processes()

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -373,17 +373,16 @@ impl SslSniff {
         Ok(())
     }
 
-    /// Detach SSL probes for a process and clean up traced inodes.
+    /// Clean up per-pid bookkeeping when a traced process exits.
     ///
-    /// When a process exits, its inodes are removed from `traced_files` so that
-    /// a new process using the same binary can be re-attached.
+    /// Inodes are intentionally kept in `traced_files` because uprobes are
+    /// attached globally (`pid=-1`). The existing Links remain valid for all
+    /// processes using the same library, so re-attaching would only create
+    /// duplicate fds.
     pub fn detach_process(&mut self, pid: u32) {
         if let Some(inodes) = self.pid_inodes.remove(&pid) {
-            for inode in &inodes {
-                self.traced_files.remove(inode);
-            }
             log::debug!(
-                "[detach_process] pid={pid}: removed {} inodes from traced_files",
+                "[detach_process] pid={pid}: removed pid_inodes entry ({} inodes, kept in traced_files)",
                 inodes.len()
             );
         }

--- a/src/agentsight/tests/reproduce_link_leak.sh
+++ b/src/agentsight/tests/reproduce_link_leak.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# reproduce_link_leak.sh — Reproduce SslSniff _links Vec<Link> fd leak
+#
+# Root cause: SslSniff._links only grows (extend), never shrinks. When a
+# process exits, detach_process() removes its inodes from traced_files
+# (allowing re-attach), but the old Link objects stay in _links. When a
+# new process loads the same SSL library, the same uprobe is attached
+# again, creating duplicate Link objects and leaking fds.
+#
+# This script proves the leak by:
+#   1. Starting agentsight trace
+#   2. Recording the initial fd count of the agentsight process
+#   3. Spawning an agent process (python3 with ssl) that gets attach
+#   4. Letting it exit (triggers detach_process, removes inodes from traced_files)
+#   5. Spawning another agent process with the same SSL library
+#   6. Checking that fd count increased (= duplicate Links created)
+#
+# Usage: sudo bash tests/reproduce_link_leak.sh
+# Requires: root, python3 with ssl module
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+cleanup() {
+    echo -e "\n${YELLOW}[cleanup]${NC} stopping agentsight..."
+    kill "$AGENTSIGHT_PID" 2>/dev/null || true
+    wait "$AGENTSIGHT_PID" 2>/dev/null || true
+    echo -e "${GREEN}[cleanup]${NC} done"
+}
+
+count_fds() {
+    ls /proc/"$1"/fd 2>/dev/null | wc -l
+}
+
+count_uprobe_fds() {
+    # Count fds that are perf_event (uprobe) links
+    local pid=$1
+    local count=0
+    for fd in /proc/"$pid"/fdinfo/*; do
+        if grep -q "perf_event" "$fd" 2>/dev/null; then
+            count=$((count + 1))
+        fi
+    done
+    echo "$count"
+}
+
+echo "=== SslSniff _links Vec<Link> fd Leak Reproducer ==="
+echo ""
+
+# --- Step 1: Start agentsight trace ---
+echo -e "${YELLOW}[step 1]${NC} starting agentsight trace..."
+agentsight trace &>/dev/null &
+AGENTSIGHT_PID=$!
+trap cleanup EXIT
+sleep 2
+
+if ! kill -0 "$AGENTSIGHT_PID" 2>/dev/null; then
+    echo -e "${RED}[error]${NC} agentsight failed to start"
+    exit 1
+fi
+echo -e "${GREEN}[step 1]${NC} agentsight running (pid=$AGENTSIGHT_PID)"
+
+# --- Step 2: Wait for startup to stabilize, then record baseline ---
+echo ""
+echo -e "${YELLOW}[step 2]${NC} waiting 10s for startup scanning to stabilize..."
+sleep 10
+INITIAL_FDS=$(count_fds "$AGENTSIGHT_PID")
+echo -e "${GREEN}[step 2]${NC} baseline fd count: $INITIAL_FDS"
+
+# --- Step 3-6: Cycle claude processes and watch fd growth ---
+# Config has: {"rule": ["claude*"], "agent_name": "Claude"}
+# We create a script whose argv[0] matches "claude*" by using exec -a
+NUM_CYCLES=5
+
+echo ""
+echo -e "${YELLOW}[step 3]${NC} running $NUM_CYCLES attach/detach cycles..."
+echo "  Each cycle: spawn a process matching agent rule, loads libssl,"
+echo "  agentsight attaches uprobe, process exits, repeat."
+
+FD_COUNTS=("$INITIAL_FDS")
+
+for i in $(seq 1 $NUM_CYCLES); do
+    # Use exec -a to set argv[0] to "claude-fake" (matches "claude*" rule)
+    # Then run python3 which loads libssl.so
+    bash -c 'exec -a claude-fake python3 -c "import ssl; import time; time.sleep(3)"' &
+    AGENT_PID=$!
+    sleep 2  # Give agentsight time to detect via procmon and attach
+
+    wait "$AGENT_PID" 2>/dev/null || true
+    sleep 2  # Give agentsight time to process exit + detach
+
+    FDS=$(count_fds "$AGENTSIGHT_PID")
+    FD_COUNTS+=("$FDS")
+    echo "  cycle $i: fd count = $FDS (delta from baseline: +$((FDS - INITIAL_FDS)))"
+done
+
+# --- Step 7: Analyze ---
+FINAL_FDS=${FD_COUNTS[-1]}
+FD_GROWTH=$((FINAL_FDS - INITIAL_FDS))
+
+echo ""
+echo "=== Results ==="
+echo "  Initial fds:  $INITIAL_FDS"
+echo "  Final fds:    $FINAL_FDS"
+echo "  Growth:       +$FD_GROWTH over $NUM_CYCLES cycles"
+echo "  Fd counts:    ${FD_COUNTS[*]}"
+echo ""
+
+# The first cycle may grow fds (initial attach of libssl uprobe).
+# A leak means cycles 2+ KEEP growing beyond cycle 1's level.
+CYCLE1_FDS=${FD_COUNTS[1]}
+GROWTH_AFTER_FIRST=0
+for i in $(seq 2 $NUM_CYCLES); do
+    delta=$((${FD_COUNTS[$i]} - CYCLE1_FDS))
+    if [ "$delta" -gt "$GROWTH_AFTER_FIRST" ]; then
+        GROWTH_AFTER_FIRST=$delta
+    fi
+done
+
+echo "  Cycle 1 fds:        $CYCLE1_FDS (first attach, +$((CYCLE1_FDS - INITIAL_FDS)) is expected)"
+echo "  Growth after cycle1: +$GROWTH_AFTER_FIRST"
+echo ""
+
+if [ "$GROWTH_AFTER_FIRST" -gt 5 ]; then
+    echo -e "${RED}[BUG CONFIRMED]${NC} fd count grew by $GROWTH_AFTER_FIRST AFTER the first attach!"
+    echo "  _links Vec<Link> is only appended to, never cleaned up."
+    echo "  Each cycle re-attaches the same SSL library, creating duplicate uprobe Links."
+    exit 1
+elif [ "$GROWTH_AFTER_FIRST" -gt 0 ]; then
+    echo -e "${YELLOW}[POSSIBLE LEAK]${NC} fd count grew by $GROWTH_AFTER_FIRST after first cycle"
+    exit 1
+else
+    echo -e "${GREEN}[NO LEAK]${NC} fd count stable after first attach across $NUM_CYCLES cycles"
+    exit 0
+fi

--- a/src/agentsight/tests/reproduce_map_leak.sh
+++ b/src/agentsight/tests/reproduce_map_leak.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# reproduce_map_leak.sh — Reproduce traced_processes BPF Map leak
+#
+# Root cause: trace_process_exit() gates cleanup of traced_processes on a
+# child_pids lookup. User-space add_traced_pid() only writes traced_processes,
+# so those entries are never cleaned up by the BPF exit handler.
+#
+# This script proves the leak by:
+#   1. Starting agentsight trace
+#   2. Directly inserting PIDs into traced_processes (simulating user-space add_traced_pid)
+#      WITHOUT inserting into child_pids
+#   3. Spawning and killing processes with those PIDs
+#   4. Checking that traced_processes entries are NOT cleaned up (= leak confirmed)
+#
+# Usage: sudo bash tests/reproduce_map_leak.sh
+# Requires: root, bpftool, agentsight binary
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+cleanup() {
+    echo -e "\n${YELLOW}[cleanup]${NC} stopping agentsight..."
+    kill "$AGENTSIGHT_PID" 2>/dev/null || true
+    wait "$AGENTSIGHT_PID" 2>/dev/null || true
+    echo -e "${GREEN}[cleanup]${NC} done"
+}
+
+# Get BPF map ID by name (bpftool truncates names to 15 chars)
+get_map_id() {
+    local name="$1"
+    bpftool map list 2>/dev/null | grep -E "hash.*name ${name}" | head -1 | awk -F: '{print $1}'
+}
+
+count_map_entries() {
+    local map_id="$1"
+    local count
+    count=$(bpftool map dump id "$map_id" 2>/dev/null | grep -c '"key"') || count=0
+    echo "$count"
+}
+
+echo "=== traced_processes Map Leak Reproducer ==="
+echo ""
+
+# --- Step 1: Start agentsight trace ---
+echo -e "${YELLOW}[step 1]${NC} starting agentsight trace..."
+agentsight trace &>/dev/null &
+AGENTSIGHT_PID=$!
+trap cleanup EXIT
+sleep 2
+
+if ! kill -0 "$AGENTSIGHT_PID" 2>/dev/null; then
+    echo -e "${RED}[error]${NC} agentsight failed to start"
+    exit 1
+fi
+echo -e "${GREEN}[step 1]${NC} agentsight running (pid=$AGENTSIGHT_PID)"
+
+# Resolve map IDs (bpftool truncates map names to 15 chars)
+TRACED_MAP_ID=$(get_map_id "traced_processe")
+CHILD_MAP_ID=$(get_map_id "child_pids")
+
+if [ -z "$TRACED_MAP_ID" ] || [ -z "$CHILD_MAP_ID" ]; then
+    echo -e "${RED}[error]${NC} could not find BPF maps (traced_processe=$TRACED_MAP_ID child_pids=$CHILD_MAP_ID)"
+    exit 1
+fi
+echo -e "${GREEN}[step 1]${NC} map IDs: traced_processes=$TRACED_MAP_ID, child_pids=$CHILD_MAP_ID"
+
+# --- Step 2: Record initial map state ---
+INITIAL_TRACED=$(count_map_entries "$TRACED_MAP_ID")
+INITIAL_CHILD=$(count_map_entries "$CHILD_MAP_ID")
+echo ""
+echo -e "${YELLOW}[step 2]${NC} initial map state:"
+echo "  traced_processes: $INITIAL_TRACED entries"
+echo "  child_pids:       $INITIAL_CHILD entries"
+
+# --- Step 3: Simulate user-space add_traced_pid (write traced_processes only) ---
+# We spawn N short-lived background processes, grab their PIDs, and insert
+# each PID into traced_processes ONLY (not child_pids) via bpftool.
+# Then we let the processes exit naturally.
+# BPF trace_process_exit should clean up, but it won't because child_pids
+# has no matching entry.
+
+NUM_PROCS=50
+echo ""
+echo -e "${YELLOW}[step 3]${NC} spawning $NUM_PROCS processes and inserting into traced_processes only..."
+
+# Snapshot the set of PIDs currently in the map (baseline, e.g. running agents)
+BASELINE_PIDS=$(bpftool map dump id "$TRACED_MAP_ID" 2>/dev/null \
+    | python3 -c "import json,sys; [print(e['key']) for e in json.load(sys.stdin)]" 2>/dev/null || true)
+
+PIDS=()
+for i in $(seq 1 $NUM_PROCS); do
+    # Spawn a process that sleeps briefly
+    sleep 3 &
+    pid=$!
+    PIDS+=("$pid")
+
+    # Insert into traced_processes ONLY (simulating user-space add_traced_pid)
+    key=$(printf '0x%02x 0x%02x 0x%02x 0x%02x' \
+        $((pid & 0xFF)) $(((pid >> 8) & 0xFF)) $(((pid >> 16) & 0xFF)) $(((pid >> 24) & 0xFF)))
+    bpftool map update id "$TRACED_MAP_ID" key $key value 0x01 0x00 0x00 0x00 any 2>/dev/null || true
+done
+
+MID_TRACED=$(count_map_entries "$TRACED_MAP_ID")
+MID_CHILD=$(count_map_entries "$CHILD_MAP_ID")
+echo -e "${GREEN}[step 3]${NC} after inserting $NUM_PROCS PIDs:"
+echo "  traced_processes: $MID_TRACED entries (added ~$((MID_TRACED - INITIAL_TRACED)))"
+echo "  child_pids:       $MID_CHILD entries"
+
+# --- Step 4: Wait for all spawned processes to exit ---
+echo ""
+echo -e "${YELLOW}[step 4]${NC} waiting for all $NUM_PROCS processes to exit..."
+for pid in "${PIDS[@]}"; do
+    wait "$pid" 2>/dev/null || true
+done
+# Give BPF exit handler time to fire
+sleep 5
+
+# --- Step 5: Check map state after exit ---
+# Count only the PIDs we inserted (exclude baseline agent PIDs)
+LEAKED=0
+for pid in "${PIDS[@]}"; do
+    # Check if this specific PID is still in traced_processes
+    key=$(printf '0x%02x 0x%02x 0x%02x 0x%02x' \
+        $((pid & 0xFF)) $(((pid >> 8) & 0xFF)) $(((pid >> 16) & 0xFF)) $(((pid >> 24) & 0xFF)))
+    if bpftool map lookup id "$TRACED_MAP_ID" key $key 2>/dev/null | grep -q "value"; then
+        LEAKED=$((LEAKED + 1))
+    fi
+done
+
+FINAL_TRACED=$(count_map_entries "$TRACED_MAP_ID")
+FINAL_CHILD=$(count_map_entries "$CHILD_MAP_ID")
+echo -e "${GREEN}[step 4]${NC} all processes exited"
+echo ""
+echo -e "${YELLOW}[step 5]${NC} final map state:"
+echo "  traced_processes: $FINAL_TRACED entries (baseline was $INITIAL_TRACED)"
+echo "  child_pids:       $FINAL_CHILD entries"
+
+# --- Step 6: Analyze ---
+echo ""
+echo "=== Results ==="
+echo "  Inserted: $NUM_PROCS entries into traced_processes (not child_pids)"
+echo "  Leaked:   $LEAKED/$NUM_PROCS test PIDs still in map after exit"
+echo ""
+
+if [ "$LEAKED" -gt $((NUM_PROCS / 2)) ]; then
+    echo -e "${RED}[BUG CONFIRMED]${NC} traced_processes leaked $LEAKED/$NUM_PROCS entries!"
+    echo "  trace_process_exit() failed to clean up because child_pids had no matching entry."
+    echo "  This will exhaust the 1024-entry map over time."
+    exit 1
+elif [ "$LEAKED" -gt 0 ]; then
+    echo -e "${YELLOW}[PARTIAL LEAK]${NC} $LEAKED/$NUM_PROCS entries leaked"
+    exit 1
+else
+    echo -e "${GREEN}[NO LEAK]${NC} all $NUM_PROCS test entries cleaned up on process exit"
+    exit 0
+fi


### PR DESCRIPTION
## Description

AgentSight trace 进程持续运行约 19 小时后，所有新进程的 uprobe attach 均失败，日志持续输出 `bpf call "..." returned NULL`，重启可恢复。

**根因 1（traced_processes Map 泄漏）**：`trace_process_exit()` 中 `traced_processes` Map 的清理逻辑依赖 `child_pids` Map 的查找结果，但用户空间 `add_traced_pid()` 只写入 `traced_processes` 不写入 `child_pids`。因此用户空间注册的 agent PID 在进程退出时不会被 BPF 侧清理，导致 `traced_processes`（上限 1024 条）逐渐被填满，最终 `is_pid_traced()` 对所有新进程返回 0，uprobe 过滤拒绝所有新进程的 SSL 事件。

**根因 2（uprobe Link fd 泄漏）**：`SslSniff.detach_process()` 在进程退出时移除了 `traced_files` 中的 inode，导致新进程加载同一 SSL 库时重新 attach 全局 uprobe（`pid=-1`），产生重复的 Link 对象和 fd。由于 `_links: Vec<Link>` 只增不减，fd 持续增长。

## Related Issue

closes #1016

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/bpf/proctrace.bpf.c`: `trace_process_exit()` 改用 `traced_processes` 做入口判断，无条件清理两个 Map
- `src/probes/proctrace.rs`: `add_traced_pid()` / `remove_traced_pid()` 同时操作 `child_pids` 和 `traced_processes`；初始化时 target_pids 也同步写入 `child_pids`
- `src/probes/sslsniff.rs`: `detach_process()` 不再移除 `traced_files` 中的 inode，保持全局 uprobe 去重
- `src/bin/cli/trace.rs`: 错误输出改用 `{e:#}` 显示完整 anyhow cause chain
- `tests/reproduce_map_leak.sh`: 新增 traced_processes 泄漏复现脚本
- `tests/reproduce_link_leak.sh`: 新增 uprobe Link fd 泄漏复现脚本

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] `cargo fmt --check` pass
- [x] `cargo test` pass (603 tests, 0 failed)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

**Bug 1 (traced_processes 泄漏)**:
1. `tests/reproduce_map_leak.sh` 在修复前确认泄漏（50 个测试 PID 全部残留），修复后确认 0 泄漏
2. 通过 bpftool 手工插入单个 PID 到 `traced_processes`，进程退出后确认条目被 BPF exit handler 清理

**Bug 2 (uprobe Link fd 泄漏)**:
1. `tests/reproduce_link_leak.sh` 修复前确认 fd 跨 cycle 持续增长，修复后确认首次 attach 后 fd 稳定
2. 通过 debug 日志确认 detach 后 inode 保留在 `traced_files`，后续 cycle 输出 `skipping already-traced`