### PR TITLE
feat(anolisa): enforce safe uninstall semantics for rpm-observed components

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -3933,6 +3933,9 @@ scope = "@anolisa"
         fn update(&self, _package: &str) -> Result<(), PackageTransactionError> {
             panic!("adopt-path test reached a dnf update");
         }
+        fn remove(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("adopt-path test reached a dnf remove");
+        }
     }
 
     /// Test seam that drives [`handle_one_with_exec`] with only a query (no
@@ -4040,6 +4043,9 @@ scope = "@anolisa"
         }
         fn update(&self, _package: &str) -> Result<(), PackageTransactionError> {
             panic!("delegated-install test must not run a dnf update");
+        }
+        fn remove(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("delegated-install test must not run a dnf remove");
         }
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1,17 +1,33 @@
-//! `anolisa uninstall <COMPONENT>` (with optional `--purge`).
+//! `anolisa uninstall <COMPONENT>` (with optional `--purge` /
+//! `--remove-system-package`).
 //!
-//! The CLI face of [`anolisa_core::execute_plan`] for component
-//! teardown. Two surfaces:
+//! Teardown is **ownership-driven** (`raw_rpm_lifecycle_proposal.md` §11):
 //!
-//!   * `--dry-run` — render the [`LifecyclePlan`] (human or JSON) and
-//!     return without touching the filesystem.
-//!   * default — execute the plan: only ANOLISA-owned files are
-//!     removed; external residue is preserved and surfaced as
-//!     warnings.
+//!   * `raw-managed` — the CLI face of [`anolisa_core::execute_plan`]:
+//!     only ANOLISA-owned files are removed, external residue is kept.
+//!     Unchanged by the RPM lifecycle work.
+//!   * `rpm-managed` — delegates `dnf remove` then drops ANOLISA state
+//!     (`Ownership::owns_removal()` is `true`).
+//!   * `rpm-observed` — a preinstalled system RPM: the default uninstall
+//!     drops **only** the ANOLISA state record and never runs dnf
+//!     (`owns_removal()` is `false`). Removing the system package
+//!     requires the explicit `--remove-system-package` override.
 //!
-//! `--purge` widens the scope from "uninstall" to "uninstall + drop
+//! The removal decision collapses to
+//! `ownership.owns_removal() || --remove-system-package`. The RPM path
+//! mirrors `update`'s dnf delegation (injected query/transaction, root
+//! gate) and `forget`'s state drop; the raw path is untouched.
+//!
+//! Two surfaces apply to every ownership:
+//!
+//!   * `--dry-run` — render the plan (human or JSON), touching nothing.
+//!     For RPM components it states whether package removal will happen.
+//!   * default — execute.
+//!
+//! `--purge` widens the raw scope from "uninstall" to "uninstall + drop
 //! ANOLISA-owned config/cache/state fragments". External modifications
-//! are always refused regardless of `--purge`.
+//! are always refused regardless of `--purge`. `--purge` keeps its
+//! existing (plan-only) path and is independent of the RPM routing.
 //!
 //! `--force` is parsed today as a wire stub (the spec calls it out)
 //! but the executor does not yet branch on it. We surface a warning so
@@ -36,11 +52,20 @@
 //! `anolisa-core::lifecycle::check_destructive_execute_gate`; see the
 //! docstring there for the lift conditions.
 
+use chrono::{SecondsFormat, Utc};
 use clap::Parser;
 
+use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
+use anolisa_core::lock::InstallLock;
+use anolisa_core::state::{OperationRecord, Ownership};
 use anolisa_core::{
     LifecycleError, LifecycleOperation, LifecycleOutcome, LifecyclePlan, ObjectKind, execute_plan,
 };
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
+use anolisa_platform::privilege;
+use anolisa_platform::rpm_query::RpmPackageQuery;
+use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use crate::color::Palette;
 use crate::commands::common;
@@ -57,12 +82,39 @@ pub struct UninstallArgs {
     /// Also remove ANOLISA-owned config / cache / state fragments
     #[arg(long)]
     pub purge: bool,
+    /// For an `rpm-observed` system RPM, delegate package removal to
+    /// `dnf remove`. Without it, uninstall drops only ANOLISA state and
+    /// leaves the preinstalled RPM in place. No effect on raw components.
+    #[arg(long)]
+    pub remove_system_package: bool,
     /// Reserved for forcing through warnings (spec only, no behavior change yet)
     #[arg(long)]
     pub force: bool,
 }
 
+/// Dispatch `uninstall <component>`: build the real rpm/dnf-backed query and
+/// transaction, then route by recorded ownership.
+///
+/// # Errors
+///
+/// Returns [`CliError`] when the component is absent, has enabled adapter
+/// receipts, or teardown fails. See the module docs for the ownership matrix.
 pub fn handle(args: UninstallArgs, ctx: &CliContext) -> Result<(), CliError> {
+    let query = RpmPackageQuery::system();
+    let txn = RpmTransaction::system();
+    handle_with_deps(args, ctx, &query, &txn, privilege::is_root())
+}
+
+/// Core of [`handle`] with the package query, transaction, and root status
+/// injected so the RPM path is testable without a live rpmdb/dnf or real
+/// privileges. The raw and purge paths ignore the injected dependencies.
+fn handle_with_deps(
+    args: UninstallArgs,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+) -> Result<(), CliError> {
     let operation = if args.purge {
         LifecycleOperation::Purge
     } else {
@@ -117,6 +169,56 @@ pub fn handle(args: UninstallArgs, ctx: &CliContext) -> Result<(), CliError> {
         }
     }
 
+    // `--force` is a wire stub on every path; surface it on real runs so users do
+    // not assume it changes behavior. Hoisted above the ownership routing so the
+    // RPM path (which returns before the raw executor) warns too. Dry-run stays
+    // quiet, matching the previous release.
+    if args.force && !ctx.dry_run {
+        eprintln!("warning: --force is a spec stub today and has no behavioral effect yet");
+    }
+
+    // Ownership routing: an RPM-backed component (managed or observed) takes the
+    // dnf-delegating path, not the raw file-removal executor. Only the plain
+    // `Uninstall` operation reroutes; `--purge` keeps its existing plan-only
+    // path regardless of ownership.
+    if matches!(operation, LifecycleOperation::Uninstall)
+        && let Some(obj) = installed.find_object(ObjectKind::Component, target)
+    {
+        let ownership = obj.effective_ownership();
+        if ownership.is_rpm() {
+            let package = obj
+                .rpm_metadata
+                .as_ref()
+                .map(|m| m.package_name.clone())
+                .filter(|p| !p.is_empty())
+                .ok_or_else(|| CliError::Runtime {
+                    command: command.clone(),
+                    reason: format!(
+                        "component '{target}' is recorded as an RPM component but has no package metadata; run `anolisa repair {target}` to refresh it before uninstalling"
+                    ),
+                })?;
+            return uninstall_rpm_component(
+                target,
+                &package,
+                ownership,
+                args.remove_system_package,
+                ctx,
+                query,
+                txn,
+                is_root,
+                &command,
+            );
+        }
+        // Raw component: `--remove-system-package` only governs observed system
+        // RPMs. Flag it instead of silently ignoring, then fall through to the
+        // unchanged raw teardown path.
+        if args.remove_system_package && !ctx.json {
+            eprintln!(
+                "warning: --remove-system-package has no effect for raw component '{target}' (there is no system RPM to remove)"
+            );
+        }
+    }
+
     let plan = match operation {
         LifecycleOperation::Uninstall => LifecyclePlan::for_component_uninstall(target, &installed),
         LifecycleOperation::Purge => LifecyclePlan::for_component_purge(target, &installed),
@@ -137,12 +239,6 @@ pub fn handle(args: UninstallArgs, ctx: &CliContext) -> Result<(), CliError> {
     let actor = std::env::var("USER")
         .or_else(|_| std::env::var("LOGNAME"))
         .unwrap_or_else(|_| "cli".to_string());
-
-    if args.force {
-        // Wire-only stub; flag it so users do not assume any
-        // behavioral change.
-        eprintln!("warning: --force is a spec stub today and has no behavioral effect yet");
-    }
 
     // `purge` is still gated pending manifest-driven config / cache /
     // state discovery — print the same plan-only warning the previous
@@ -244,6 +340,493 @@ fn lifecycle_err_to_cli(command: &str, err: LifecycleError) -> CliError {
                     .unwrap_or_else(|| "?".to_string()),
             ),
         },
+    }
+}
+
+/// What happens (or, on dry-run, would happen) to the underlying RPM package.
+///
+/// Distinguishes the three outcomes the `package_removal` field must report
+/// accurately, instead of collapsing "kept on purpose" and "already gone" into
+/// one label:
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PackageDisposition {
+    /// `dnf remove` runs (real) or would run (dry-run intent).
+    Removed,
+    /// The package stays installed; only the ANOLISA state record is dropped —
+    /// an `rpm-observed` default with no `--remove-system-package`.
+    Kept,
+    /// Removal was requested but the package is not in rpmdb — already gone via a
+    /// manual `rpm -e` (the §10.2 Missing drift), so there is nothing to remove.
+    AlreadyAbsent,
+}
+
+impl PackageDisposition {
+    /// Wire label for the `package_removal` field.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Removed => "dnf remove",
+            Self::Kept => "state only",
+            Self::AlreadyAbsent => "already absent",
+        }
+    }
+}
+
+/// Decide the disposition from the removal intent and rpmdb presence.
+///
+/// `present` is `Some(true)`/`Some(false)` when an rpmdb probe confirmed the
+/// package is/ isn't installed, and `None` when the probe could not confirm
+/// (e.g. a query error) — in which case we preview the *intent* rather than
+/// claim the package is absent.
+fn disposition_for(remove_package: bool, present: Option<bool>) -> PackageDisposition {
+    match (remove_package, present) {
+        (false, _) => PackageDisposition::Kept,
+        (true, Some(false)) => PackageDisposition::AlreadyAbsent,
+        (true, _) => PackageDisposition::Removed,
+    }
+}
+
+/// Uninstall an RPM-backed component (`rpm-managed` or `rpm-observed`).
+///
+/// `rpm-managed` owns its removal, so it delegates `dnf remove` by default;
+/// `rpm-observed` is a preinstalled system RPM, so removal happens only when the
+/// operator passes `--remove-system-package`. Either way the ANOLISA state
+/// record is dropped (mirroring [`forget`](super::forget)). The dnf transaction
+/// and state mutation run under the install lock so the adapter-claim guard
+/// fires before the irreversible removal.
+#[allow(clippy::too_many_arguments)]
+fn uninstall_rpm_component(
+    component: &str,
+    package: &str,
+    ownership: Ownership,
+    remove_system_package: bool,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    command: &str,
+) -> Result<(), CliError> {
+    // Dry-run: never locks, never needs root, never mutates rpmdb. Decide from the
+    // pre-lock read and probe rpmdb so the preview reports accurately whether
+    // removal would run, be declined (state only), or be skipped (already absent).
+    if ctx.dry_run {
+        let remove_package = ownership.owns_removal() || remove_system_package;
+        let probe = query.query_installed(package);
+        let installed_version = match &probe {
+            Ok(Some(info)) => Some(info.version.to_string()),
+            _ => None,
+        };
+        // Only a confirmed `Ok(None)` means "absent"; a query error is unconfirmed,
+        // so the preview shows the removal *intent* rather than claiming absence.
+        let present = match &probe {
+            Ok(Some(_)) => Some(true),
+            Ok(None) => Some(false),
+            Err(_) => None,
+        };
+        let payload = UninstallRpmPayload {
+            component: component.to_string(),
+            package: package.to_string(),
+            ownership: ownership.label(),
+            install_mode: ctx.install_mode.as_str().to_string(),
+            remove_system_package,
+            package_removal: disposition_for(remove_package, present).label(),
+            installed_version,
+            state_dropped: false,
+            dry_run: true,
+            operation_id: None,
+        };
+        render_uninstall_rpm(ctx, &payload);
+        return Ok(());
+    }
+
+    // Real run, entirely under the install lock. install/update delegate dnf
+    // *outside* the lock, but neither gates a destructive removal on adapter
+    // state. Here the adapter guard must fire before the irreversible
+    // `dnf remove`, so a concurrent `adapter enable` cannot slip past a pre-lock
+    // check and strand a removed package's plugin — hold the lock across the
+    // whole critical section.
+    let layout = common::resolve_layout(ctx);
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state = common::load_installed_state(ctx, command)?;
+
+    // Re-validate under the lock: the component must still exist, still be the
+    // same RPM-owned package. A concurrent uninstall/forget/backend change must
+    // not be clobbered.
+    let obj = state
+        .find_object(ObjectKind::Component, component)
+        .ok_or_else(|| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' disappeared from state during uninstall; nothing removed"
+            ),
+        })?;
+    let locked_ownership = obj.effective_ownership();
+    if !locked_ownership.is_rpm() {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' is no longer an RPM component in state; refusing to run an RPM uninstall"
+            ),
+        });
+    }
+    let package_matches = obj
+        .rpm_metadata
+        .as_ref()
+        .is_some_and(|m| m.package_name == package);
+    if !package_matches {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' RPM package identity changed during uninstall (expected '{package}'); run `anolisa status {component}`"
+            ),
+        });
+    }
+
+    // Recompute the removal decision from the *locked* ownership, never the
+    // pre-lock value. If a concurrent op flipped this component from rpm-managed
+    // to rpm-observed under the same package name, the pre-lock `owns_removal()`
+    // would still say "remove" and a default uninstall would wrongly `dnf remove`
+    // a preinstalled system RPM — exactly the safety guarantee rpm-observed
+    // exists to provide. The locked read is the source of truth.
+    let remove_package = locked_ownership.owns_removal() || remove_system_package;
+    let ownership_label = locked_ownership.label();
+
+    // Authoritative adapter-claim guard under the lock (the check in `handle` is
+    // only a fast-fail / dry-run preview). Refuse before any dnf remove so a
+    // registered plugin is never orphaned.
+    let claims = state.adapter_claims_for_component(component);
+    if !claims.is_empty() {
+        let mut frameworks: Vec<&str> = claims.iter().map(|c| c.framework.as_str()).collect();
+        frameworks.sort_unstable();
+        frameworks.dedup();
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "'{component}' has enabled adapters ({}); run `anolisa adapter disable {component}` for each framework before uninstalling",
+                frameworks.join(", ")
+            ),
+        });
+    }
+
+    let mut warnings: Vec<String> = Vec::new();
+    let disposition = if !remove_package {
+        PackageDisposition::Kept
+    } else {
+        // Confirm the package is in rpmdb before removing. Already gone (a manual
+        // `rpm -e`, the §10.2 Missing drift) is not an error: drop the stale state
+        // record only and report it as already-absent.
+        match query.query_installed(package) {
+            Ok(Some(_)) => {
+                if !is_root {
+                    // Echo the flag in the hint only when it drove the removal:
+                    // rpm-managed removes by default and needs no override.
+                    let flag_suffix = if remove_system_package {
+                        " --remove-system-package"
+                    } else {
+                        ""
+                    };
+                    return Err(CliError::Runtime {
+                        command: command.to_string(),
+                        reason: format!(
+                            "removing system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa --install-mode system uninstall {component}{flag_suffix}`"
+                        ),
+                    });
+                }
+                txn.remove(package).map_err(|err| match err {
+                    // `dnf` missing even though the rpm-query above succeeded (rpm
+                    // present, dnf absent): give the same ownership-aware guidance
+                    // as the query-missing branch rather than a generic failure.
+                    PackageTransactionError::CommandMissing { command: bin } => {
+                        tooling_missing_err(command, &bin, package, component, locked_ownership)
+                    }
+                    other => txn_remove_err(other, command),
+                })?;
+                PackageDisposition::Removed
+            }
+            Ok(None) => {
+                warnings.push(format!(
+                    "RPM package '{package}' is not present in rpmdb (already removed by a manual `rpm -e`); dropping ANOLISA state only"
+                ));
+                PackageDisposition::AlreadyAbsent
+            }
+            Err(PackageQueryError::CommandMissing { command: bin }) => {
+                return Err(tooling_missing_err(
+                    command,
+                    &bin,
+                    package,
+                    component,
+                    locked_ownership,
+                ));
+            }
+            Err(PackageQueryError::UnexpectedOutput { detail, .. }) => {
+                // Covers malformed output as well as the multi-version invariant
+                // violation; surface `detail` instead of guessing the cause.
+                return Err(CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!(
+                        "cannot remove '{package}': unexpected rpmdb query result ({detail}); refusing to remove against an ambiguous package — run `anolisa status {component}`"
+                    ),
+                });
+            }
+            Err(err) => {
+                return Err(CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!("failed to query rpmdb for '{package}': {err}"),
+                });
+            }
+        }
+    };
+
+    // Drop the ANOLISA state record (mirrors `forget::persist_forget`). The
+    // provenance reported to the user comes from `locked_ownership` above — the
+    // value observed under this same lock.
+    state
+        .remove_object(ObjectKind::Component, component)
+        .ok_or_else(|| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' disappeared from state during uninstall; nothing removed"
+            ),
+        })?;
+
+    let now = now_iso8601();
+    let lock_ts = Utc::now();
+    let operation_id = format!(
+        "op-uninstall-{}-{}",
+        lock_ts.format("%Y%m%d%H%M%S"),
+        lock_ts.timestamp_subsec_nanos()
+    );
+    state.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: now.clone(),
+        finished_at: Some(now.clone()),
+    });
+
+    let state_path = layout.state_dir.join("installed.toml");
+    state.save(&state_path).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to save state: {err}"),
+    })?;
+
+    // Audit log is best-effort: the state already persisted, so a log failure
+    // downgrades to a warning instead of unwinding.
+    let log = CentralLog::open(layout.central_log.clone());
+    let message = match disposition {
+        PackageDisposition::Removed => format!(
+            "uninstalled component {component}: removed RPM package {package} via dnf and dropped ANOLISA state"
+        ),
+        PackageDisposition::Kept => format!(
+            "uninstalled component {component}: dropped ANOLISA state; RPM package {package} left installed"
+        ),
+        PackageDisposition::AlreadyAbsent => format!(
+            "uninstalled component {component}: dropped ANOLISA state; RPM package {package} was already absent from rpmdb"
+        ),
+    };
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.clone()),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message,
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at: now.clone(),
+        finished_at: Some(now),
+        status: Some(LogStatus::Ok),
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: warnings.clone(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = log.append(&record) {
+        eprintln!("warning: failed to write central log: {err}");
+    }
+
+    if !ctx.json && !ctx.quiet {
+        let color = Palette::new(ctx.no_color);
+        for w in &warnings {
+            eprintln!("{} {w}", color.warn("warning:"));
+        }
+    }
+
+    let payload = UninstallRpmPayload {
+        component: component.to_string(),
+        package: package.to_string(),
+        ownership: ownership_label,
+        install_mode: ctx.install_mode.as_str().to_string(),
+        remove_system_package,
+        package_removal: disposition.label(),
+        installed_version: None,
+        state_dropped: true,
+        dry_run: false,
+        operation_id: Some(operation_id),
+    };
+    render_uninstall_rpm(ctx, &payload);
+    Ok(())
+}
+
+/// Build the actionable "rpm/dnf tooling missing" error for the RPM uninstall
+/// path, shared by the rpmdb-query and the `dnf remove` missing-binary branches
+/// so both give identical guidance.
+///
+/// The escape hatch depends on the removal *driver*, not the flag: an
+/// owns-removal component (rpm-managed) is removed with or without the flag, so
+/// its actionable fallback is `forget` (drop state, no package op); an
+/// rpm-observed removal is driven solely by `--remove-system-package`, so there
+/// the fallback is to drop the flag.
+fn tooling_missing_err(
+    command: &str,
+    bin: &str,
+    package: &str,
+    component: &str,
+    locked_ownership: Ownership,
+) -> CliError {
+    let alt = if locked_ownership.owns_removal() {
+        format!(
+            "run `anolisa forget {component}` to drop ANOLISA state without a package operation"
+        )
+    } else {
+        "re-run without --remove-system-package to drop ANOLISA state only".to_string()
+    };
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "cannot remove '{package}': {bin} not found on PATH — install rpm/dnf, or {alt}"
+        ),
+    }
+}
+
+/// Map a [`PackageTransactionError`] from `dnf remove` onto a CLI runtime error.
+///
+/// `CommandMissing` is handled at the call site via [`tooling_missing_err`] so
+/// it carries ownership-aware guidance; this mapper covers the other variants.
+fn txn_remove_err(err: PackageTransactionError, command: &str) -> CliError {
+    match err {
+        PackageTransactionError::CommandMissing { command: bin } => CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("{bin} not found on PATH; cannot remove the RPM package"),
+        },
+        PackageTransactionError::PermissionDenied { command: bin } => CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("permission denied running {bin}; re-run the uninstall with sudo"),
+        },
+        PackageTransactionError::TransactionFailed { code, stderr, .. } => CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "dnf remove failed (exit {}): {}",
+                code.map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string()),
+                stderr.trim(),
+            ),
+        },
+    }
+}
+
+/// RFC3339 UTC timestamp, seconds precision (matches the install/update paths).
+fn now_iso8601() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+/// Wire shape for an RPM-component uninstall result (`--json`) and its dry-run
+/// preview.
+#[derive(serde::Serialize)]
+struct UninstallRpmPayload {
+    component: String,
+    package: String,
+    /// Provenance label of the component (`rpm-managed` / `rpm-observed`).
+    ownership: &'static str,
+    install_mode: String,
+    /// Whether the operator passed `--remove-system-package`.
+    remove_system_package: bool,
+    /// [`PackageDisposition::label`]: `"dnf remove"`, `"state only"`, or
+    /// `"already absent"` — what happens (or would happen) to the package.
+    package_removal: &'static str,
+    /// Current rpmdb EVR; populated best-effort on the dry-run preview only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    installed_version: Option<String>,
+    /// Whether the ANOLISA state record was dropped (false on dry-run).
+    state_dropped: bool,
+    dry_run: bool,
+    /// `None` on dry-run (nothing recorded).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation_id: Option<String>,
+}
+
+/// Human/JSON renderer for an RPM-component uninstall result.
+fn render_uninstall_rpm(ctx: &CliContext, payload: &UninstallRpmPayload) {
+    if ctx.json {
+        // Errors here are unreachable for a plain Serialize struct; ignore the
+        // Result so an (already-persisted) uninstall is not reported as failed.
+        let _ = render_json(COMMAND, payload);
+        return;
+    }
+    if ctx.quiet {
+        return;
+    }
+    let color = Palette::new(ctx.no_color);
+    if payload.dry_run {
+        println!(
+            "{} {} {} {}",
+            color.command("uninstall"),
+            payload.component,
+            color.muted(format!("({})", payload.ownership)),
+            color.muted("(dry-run — nothing removed)"),
+        );
+        println!("{} {}", color.label("package:"), payload.package);
+        if let Some(v) = &payload.installed_version {
+            println!("{} {}", color.label("installed:"), v);
+        }
+        println!(
+            "{} {}",
+            color.label("package_removal:"),
+            payload.package_removal,
+        );
+        match payload.package_removal {
+            "state only" => println!(
+                "  {}",
+                color.muted(
+                    "the system RPM stays installed; pass --remove-system-package to delegate removal to dnf"
+                ),
+            ),
+            "already absent" => println!(
+                "  {}",
+                color.muted("the RPM package is not in rpmdb; uninstall will drop ANOLISA state only"),
+            ),
+            _ => {}
+        }
+        return;
+    }
+    println!(
+        "{} {} {}",
+        color.ok("✓ uninstalled"),
+        payload.component,
+        color.muted(format!("({})", payload.ownership)),
+    );
+    match payload.package_removal {
+        "dnf remove" => println!(
+            "    {} removed RPM package {} via dnf",
+            color.label("note:"),
+            payload.package,
+        ),
+        "already absent" => println!(
+            "    {} ANOLISA state dropped; RPM package {} was already absent from rpmdb",
+            color.label("note:"),
+            payload.package,
+        ),
+        _ => println!(
+            "    {} ANOLISA state dropped; RPM package {} left installed",
+            color.label("note:"),
+            payload.package,
+        ),
+    }
+    if let Some(id) = &payload.operation_id {
+        println!("{} {}", color.label("operation_id:"), color.id(id));
     }
 }
 
@@ -397,8 +980,15 @@ mod tests {
     use super::*;
 
     use crate::context::InstallMode;
+    use std::cell::{Cell, RefCell};
     use std::path::PathBuf;
     use tempfile::tempdir;
+
+    use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus, DriverPayload, OpenClawClaim};
+    use anolisa_core::state::{
+        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, RpmMetadata,
+    };
+    use anolisa_platform::pkg_query::{PackageInfo, PackageVersion};
 
     fn ctx_with_prefix(
         json: bool,
@@ -421,6 +1011,7 @@ mod tests {
         UninstallArgs {
             component: component.to_string(),
             purge,
+            remove_system_package: false,
             force: false,
         }
     }
@@ -744,6 +1335,905 @@ mod tests {
         assert_eq!(
             after_bytes, prior_bytes,
             "purge gate must not mutate installed.toml",
+        );
+    }
+
+    // ── RPM ownership-aware uninstall (#962) ────────────────────────────
+
+    /// In-memory rpm world implementing **both** [`PackageQuery`] and
+    /// [`PackageTransaction`] so one fake drives the uninstall flow. A successful
+    /// `remove` clears the package from rpmdb; `install`/`update` panic — the
+    /// uninstall path must never reach them.
+    struct FakeRpm {
+        package: String,
+        installed: RefCell<Option<PackageInfo>>,
+        remove_succeeds: bool,
+        /// When set, `query_installed` reports the rpm/dnf tooling is missing,
+        /// exercising the [`PackageQueryError::CommandMissing`] branch.
+        tooling_missing: bool,
+        /// When set, `query_installed` succeeds but `remove` reports the dnf
+        /// binary missing — the rpm-present / dnf-absent case that must still
+        /// reach the ownership-aware tooling-missing guidance at the call site.
+        remove_tooling_missing: bool,
+        remove_calls: Cell<usize>,
+    }
+
+    impl FakeRpm {
+        fn present(package: &str) -> Self {
+            Self {
+                package: package.to_string(),
+                installed: RefCell::new(Some(pkg_info(package, "2.2.0", Some("1.al8"), "x86_64"))),
+                remove_succeeds: true,
+                tooling_missing: false,
+                remove_tooling_missing: false,
+                remove_calls: Cell::new(0),
+            }
+        }
+        fn absent(package: &str) -> Self {
+            Self {
+                package: package.to_string(),
+                installed: RefCell::new(None),
+                remove_succeeds: true,
+                tooling_missing: false,
+                remove_tooling_missing: false,
+                remove_calls: Cell::new(0),
+            }
+        }
+        fn failing(mut self) -> Self {
+            self.remove_succeeds = false;
+            self
+        }
+        fn tooling_missing(mut self) -> Self {
+            self.tooling_missing = true;
+            self
+        }
+        fn remove_tooling_missing(mut self) -> Self {
+            self.remove_tooling_missing = true;
+            self
+        }
+    }
+
+    impl PackageQuery for FakeRpm {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if package != self.package {
+                return Ok(None);
+            }
+            if self.tooling_missing {
+                return Err(PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                });
+            }
+            Ok(self.installed.borrow().clone())
+        }
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl PackageTransaction for FakeRpm {
+        fn install(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("uninstall path must not delegate a dnf install");
+        }
+        fn update(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("uninstall path must not delegate a dnf update");
+        }
+        fn remove(&self, package: &str) -> Result<(), PackageTransactionError> {
+            self.remove_calls.set(self.remove_calls.get() + 1);
+            assert_eq!(package, self.package, "remove targeted the wrong package");
+            if self.remove_tooling_missing {
+                return Err(PackageTransactionError::CommandMissing {
+                    command: "dnf".to_string(),
+                });
+            }
+            if !self.remove_succeeds {
+                return Err(PackageTransactionError::TransactionFailed {
+                    command: "dnf".to_string(),
+                    operation: "remove".to_string(),
+                    code: Some(1),
+                    stderr: "dnf remove failed".to_string(),
+                });
+            }
+            *self.installed.borrow_mut() = None;
+            Ok(())
+        }
+    }
+
+    fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: version.to_string(),
+                release: release.map(str::to_string),
+            },
+            arch: arch.to_string(),
+            origin: None,
+        }
+    }
+
+    fn rpm_object(component: &str, package: &str, ownership: Ownership) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: "2.2.0-1.al8".to_string(),
+            status: if matches!(ownership, Ownership::RpmObserved) {
+                ObjectStatus::Adopted
+            } else {
+                ObjectStatus::Installed
+            },
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(ownership),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: package.to_string(),
+                evr: Some("2.2.0-1.al8".to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: !matches!(ownership, Ownership::RpmObserved),
+            adopted: matches!(ownership, Ownership::RpmObserved),
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    fn sample_claim(component: &str, framework: &str) -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: 1,
+            component: component.to_string(),
+            framework: framework.to_string(),
+            plugin_id: None,
+            enabled_at: "2026-06-01T10:00:00Z".to_string(),
+            resource_root: PathBuf::from("/tmp/anolisa-uninstall-test"),
+            bundle_digest: None,
+            driver_schema: 1,
+            status: ClaimStatus::Enabled,
+            resources: Vec::new(),
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "state".to_string(),
+                plugin_resource: "plugin".to_string(),
+            }),
+        }
+    }
+
+    fn seed(ctx: &CliContext, objs: Vec<InstalledObject>, claims: Vec<AdapterClaim>) {
+        let layout = common::resolve_layout(ctx);
+        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        for obj in objs {
+            state.upsert_object(obj);
+        }
+        for claim in claims {
+            state.upsert_adapter_claim(claim);
+        }
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state");
+    }
+
+    fn load_state(ctx: &CliContext) -> InstalledState {
+        let layout = common::resolve_layout(ctx);
+        InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+    }
+
+    fn args_rm(component: &str) -> UninstallArgs {
+        UninstallArgs {
+            component: component.to_string(),
+            purge: false,
+            remove_system_package: true,
+            force: false,
+        }
+    }
+
+    fn run(
+        args: UninstallArgs,
+        ctx: &CliContext,
+        rpm: &FakeRpm,
+        is_root: bool,
+    ) -> Result<(), CliError> {
+        handle_with_deps(args, ctx, rpm, rpm, is_root)
+    }
+
+    /// The new `--remove-system-package` flag parses to the positional + flag.
+    #[test]
+    fn uninstall_parses_remove_system_package_flag() {
+        use clap::Parser as _;
+        let a = UninstallArgs::try_parse_from([
+            "uninstall",
+            "copilot-shell",
+            "--remove-system-package",
+        ])
+        .expect("parse");
+        assert_eq!(a.component, "copilot-shell");
+        assert!(a.remove_system_package);
+    }
+
+    /// Acceptance ①: a default uninstall of an `rpm-observed` component drops only
+    /// ANOLISA state — it must NOT run `dnf remove`.
+    #[test]
+    fn uninstall_rpm_observed_default_drops_state_without_dnf_remove() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        run(args("copilot-shell", false), &c, &rpm, true).expect("uninstall ok");
+
+        assert_eq!(
+            rpm.remove_calls.get(),
+            0,
+            "rpm-observed default must not run dnf remove",
+        );
+        let after = load_state(&c);
+        assert!(
+            after
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "ANOLISA state record must be dropped",
+        );
+        assert!(
+            after
+                .operations
+                .iter()
+                .any(|o| o.command == "uninstall copilot-shell"),
+            "an operation record must be appended",
+        );
+    }
+
+    /// Acceptance ②: `--remove-system-package` on an `rpm-observed` component (as
+    /// root) delegates `dnf remove` and then drops state.
+    #[test]
+    fn uninstall_rpm_observed_remove_system_package_runs_dnf_remove() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        run(args_rm("copilot-shell"), &c, &rpm, true).expect("uninstall ok");
+
+        assert_eq!(
+            rpm.remove_calls.get(),
+            1,
+            "dnf remove must run with the flag"
+        );
+        assert!(
+            rpm.installed.borrow().is_none(),
+            "package must be gone from rpmdb after dnf remove",
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "state record must be dropped",
+        );
+    }
+
+    /// `--remove-system-package` on a non-root real run is refused with an
+    /// actionable message; dnf never runs and the state record stays put.
+    #[test]
+    fn uninstall_rpm_observed_remove_system_package_non_root_refused() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let err = run(args_rm("copilot-shell"), &c, &rpm, false).expect_err("must refuse");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("root") && err.reason().contains("sudo"),
+            "must point at sudo: {}",
+            err.reason(),
+        );
+        assert_eq!(rpm.remove_calls.get(), 0, "dnf must not run without root");
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "state must be intact when the root gate refuses",
+        );
+    }
+
+    /// `rpm-managed` owns its removal, so a default uninstall delegates
+    /// `dnf remove` even without `--remove-system-package`.
+    #[test]
+    fn uninstall_rpm_managed_default_runs_dnf_remove() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmManaged,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        run(args("copilot-shell", false), &c, &rpm, true).expect("uninstall ok");
+
+        assert_eq!(
+            rpm.remove_calls.get(),
+            1,
+            "rpm-managed owns removal: dnf remove runs by default",
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "state record must be dropped",
+        );
+    }
+
+    /// Acceptance ③ (decision): `owns_removal() || --remove-system-package` drives
+    /// whether the package is removed, across the matrix.
+    #[test]
+    fn rpm_removal_decision_matrix() {
+        // `flag` is a bound variable so the test exercises the real branch rather
+        // than a constant-folded literal.
+        let decide = |ownership: Ownership, flag: bool| ownership.owns_removal() || flag;
+        assert!(
+            !decide(Ownership::RpmObserved, false),
+            "rpm-observed default keeps the system RPM",
+        );
+        assert!(
+            decide(Ownership::RpmObserved, true),
+            "rpm-observed + flag removes the system RPM",
+        );
+        assert!(
+            decide(Ownership::RpmManaged, false),
+            "rpm-managed removes by default",
+        );
+        // NB: only RPM ownerships reach this formula. RawManaged also reports
+        // owns_removal() == true, but raw components are routed to the file-removal
+        // executor instead, never here — so it is intentionally not asserted.
+    }
+
+    /// Disposition labels are the stable wire strings the `package_removal` field
+    /// and renderers branch on.
+    #[test]
+    fn package_disposition_labels() {
+        assert_eq!(PackageDisposition::Removed.label(), "dnf remove");
+        assert_eq!(PackageDisposition::Kept.label(), "state only");
+        assert_eq!(PackageDisposition::AlreadyAbsent.label(), "already absent");
+    }
+
+    /// `disposition_for` maps (removal intent, rpmdb presence) onto the outcome:
+    /// kept when not removing, already-absent only when absence is *confirmed*,
+    /// and removed otherwise (including the unconfirmed/query-error case).
+    #[test]
+    fn disposition_for_maps_intent_and_presence() {
+        assert_eq!(disposition_for(false, Some(true)).label(), "state only");
+        assert_eq!(disposition_for(false, None).label(), "state only");
+        assert_eq!(disposition_for(true, Some(true)).label(), "dnf remove");
+        assert_eq!(disposition_for(true, Some(false)).label(), "already absent");
+        assert_eq!(
+            disposition_for(true, None).label(),
+            "dnf remove",
+            "unconfirmed presence previews the removal intent, not absence",
+        );
+    }
+
+    /// Acceptance ③ (safety): dry-run, even with the removal flag, touches
+    /// neither rpmdb nor ANOLISA state.
+    #[test]
+    fn uninstall_rpm_observed_dry_run_touches_nothing() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            true,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        run(args_rm("copilot-shell"), &c, &rpm, true).expect("dry-run ok");
+
+        assert_eq!(rpm.remove_calls.get(), 0, "dry-run must not run dnf");
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "dry-run must not drop the state record",
+        );
+    }
+
+    /// `--remove-system-package` but the package is already gone from rpmdb
+    /// (manual `rpm -e`, the §10.2 Missing drift): no dnf remove, state-only drop.
+    #[test]
+    fn uninstall_rpm_observed_remove_system_package_already_absent_drops_state_only() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::absent("anolisa-copilot-shell");
+        run(args_rm("copilot-shell"), &c, &rpm, true).expect("uninstall ok");
+
+        assert_eq!(
+            rpm.remove_calls.get(),
+            0,
+            "already-absent package must not trigger dnf remove",
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "state record must still be dropped",
+        );
+    }
+
+    /// A `dnf remove` failure aborts the uninstall and leaves the state record in
+    /// place so the operator can retry or `forget`.
+    #[test]
+    fn uninstall_rpm_observed_dnf_failure_keeps_state() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell").failing();
+        let err =
+            run(args_rm("copilot-shell"), &c, &rpm, true).expect_err("dnf failure must surface");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("dnf remove failed"),
+            "must report the dnf failure: {}",
+            err.reason(),
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "state must be intact when dnf remove fails",
+        );
+    }
+
+    /// rpm-managed + `--remove-system-package`, but rpm/dnf tooling is missing:
+    /// the CommandMissing hint must steer at `forget` — for an owns-removal
+    /// component, dropping the flag would NOT avoid the package operation, so the
+    /// "re-run without --remove-system-package" advice would be non-actionable.
+    #[test]
+    fn uninstall_rpm_managed_tooling_missing_points_at_forget() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmManaged,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell").tooling_missing();
+        let err = run(args_rm("copilot-shell"), &c, &rpm, true)
+            .expect_err("missing rpm tooling must surface");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("forget"),
+            "rpm-managed path must steer at forget: {}",
+            err.reason(),
+        );
+        assert!(
+            !err.reason().contains("--remove-system-package"),
+            "must not give the non-actionable drop-the-flag hint to an owns-removal component: {}",
+            err.reason(),
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "state must be intact when the rpmdb probe errors",
+        );
+    }
+
+    /// rpm-observed + `--remove-system-package`, tooling missing: here dropping the
+    /// flag *does* fall back to state-only, so the hint points at the flag (the
+    /// counterpart to the rpm-managed branch above).
+    #[test]
+    fn uninstall_rpm_observed_tooling_missing_points_at_dropping_flag() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell").tooling_missing();
+        let err = run(args_rm("copilot-shell"), &c, &rpm, true)
+            .expect_err("missing rpm tooling must surface");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("--remove-system-package"),
+            "rpm-observed path must point at dropping the flag: {}",
+            err.reason(),
+        );
+    }
+
+    /// rpm present but `dnf` absent: the rpmdb query succeeds, so the
+    /// missing-tooling guidance must come from the `txn.remove` `CommandMissing`
+    /// branch at the call site — and it must match the query-missing branch
+    /// (owns-removal → `forget`), not fall back to `txn_remove_err`'s generic
+    /// "cannot remove the RPM package" message.
+    #[test]
+    fn uninstall_rpm_managed_dnf_missing_points_at_forget() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmManaged,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell").remove_tooling_missing();
+        let err = run(args("copilot-shell", false), &c, &rpm, true)
+            .expect_err("missing dnf must surface");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert_eq!(
+            rpm.remove_calls.get(),
+            1,
+            "the rpmdb query succeeded, so dnf remove was attempted before failing",
+        );
+        assert!(
+            err.reason().contains("forget"),
+            "owns-removal must steer at forget even when dnf (not rpm) is missing: {}",
+            err.reason(),
+        );
+        assert!(
+            !err.reason().contains("cannot remove the RPM package"),
+            "must not fall back to the generic txn_remove_err message: {}",
+            err.reason(),
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "state must be intact when the removal could not run",
+        );
+    }
+
+    /// A raw component with `--remove-system-package` ignores the flag (warns) and
+    /// runs the unchanged raw teardown: owned files removed, state dropped.
+    #[test]
+    fn uninstall_raw_with_remove_system_package_flag_warns_but_succeeds() {
+        use anolisa_core::{FileOwner, OwnedFile};
+        use anolisa_platform::fs_layout::FsLayout;
+
+        let tmp = tempdir().expect("tmpdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
+        let owned = layout.bin_dir.join("agentsight");
+        std::fs::write(&owned, b"binary").expect("write owned");
+
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "agentsight".to_string(),
+            version: "0.2.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("file:///fake".to_string()),
+            install_backend: Some("raw".to_string()),
+            ownership: None,
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: vec![OwnedFile {
+                path: owned.clone(),
+                owner: FileOwner::Anolisa,
+                sha256: Some("0".repeat(64)),
+            }],
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state save");
+
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        handle(args_rm("agentsight"), &c).expect("raw uninstall must succeed");
+
+        assert!(
+            !owned.exists(),
+            "raw teardown must still remove the owned file"
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "agentsight")
+                .is_none(),
+            "raw component object must be dropped",
+        );
+    }
+
+    /// An `rpm-observed` component with an enabled adapter receipt is refused
+    /// (fast-fail in `handle`) before any removal — dnf must not run.
+    #[test]
+    fn uninstall_rpm_observed_refuses_with_enabled_adapter() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            vec![sample_claim("copilot-shell", "openclaw")],
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let err = run(args_rm("copilot-shell"), &c, &rpm, true).expect_err("adapter must block");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("adapter disable"),
+            "must point at adapter disable: {}",
+            err.reason(),
+        );
+        assert_eq!(
+            rpm.remove_calls.get(),
+            0,
+            "no dnf remove while adapters enabled"
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "component must remain when refused",
+        );
+    }
+
+    /// `uninstall_rpm_component` re-checks the adapter guard under the lock,
+    /// bypassing the pre-lock fast-fail (as a concurrent `adapter enable` would).
+    /// It must refuse **before** the irreversible `dnf remove`.
+    #[test]
+    fn uninstall_rpm_component_rechecks_adapter_under_lock() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            vec![sample_claim("copilot-shell", "openclaw")],
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let err = uninstall_rpm_component(
+            "copilot-shell",
+            "anolisa-copilot-shell",
+            Ownership::RpmObserved,
+            true,
+            &c,
+            &rpm,
+            &rpm,
+            true,
+            "uninstall copilot-shell",
+        )
+        .expect_err("locked claim check must refuse");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("adapter disable"));
+        assert_eq!(
+            rpm.remove_calls.get(),
+            0,
+            "guard must fire before the irreversible dnf remove",
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "object must remain when the locked claim check refuses",
+        );
+    }
+
+    /// Regression for the locked-recompute Blocker: the caller passes a stale
+    /// pre-lock `rpm-managed` ownership (owns_removal == true), but the on-disk
+    /// state is `rpm-observed`. The locked recompute must win — a default
+    /// uninstall (no flag) must NOT run `dnf remove` on the system RPM.
+    #[test]
+    fn uninstall_rpm_recomputes_removal_decision_under_lock() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object(
+                "copilot-shell",
+                "anolisa-copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        uninstall_rpm_component(
+            "copilot-shell",
+            "anolisa-copilot-shell",
+            Ownership::RpmManaged, // stale pre-lock read; the on-disk state is observed
+            false,                 // no --remove-system-package
+            &c,
+            &rpm,
+            &rpm,
+            true,
+            "uninstall copilot-shell",
+        )
+        .expect("uninstall ok");
+
+        assert_eq!(
+            rpm.remove_calls.get(),
+            0,
+            "locked rpm-observed must not dnf remove despite a stale rpm-managed pre-lock read",
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "state record must still be dropped",
+        );
+    }
+
+    /// An RPM component whose state lost its package metadata is steered at
+    /// `repair` rather than running a removal against an empty package name.
+    #[test]
+    fn uninstall_rpm_missing_package_metadata_points_at_repair() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        let mut obj = rpm_object(
+            "copilot-shell",
+            "anolisa-copilot-shell",
+            Ownership::RpmObserved,
+        );
+        obj.rpm_metadata = None;
+        seed(&c, vec![obj], Vec::new());
+        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let err = run(args("copilot-shell", false), &c, &rpm, true).expect_err("must refuse");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("repair"),
+            "must point at repair: {}",
+            err.reason(),
         );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -1030,6 +1030,11 @@ mod tests {
             }
             Ok(())
         }
+
+        fn remove(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            // The update flow never removes; a call here is a routing bug.
+            panic!("update path must not delegate a dnf remove");
+        }
     }
 
     fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {

--- a/src/anolisa/crates/anolisa-platform/src/pkg_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/pkg_transaction.rs
@@ -3,9 +3,9 @@
 //! [`PackageTransaction`] is the write-side counterpart to
 //! [`PackageQuery`](crate::pkg_query::PackageQuery): where the query contract
 //! only reads rpmdb / repo metadata, this one runs the package-manager
-//! transactions ANOLISA delegates to dnf/rpm. The MVP exposes a single
-//! operation — `update` — used by `anolisa update` for `rpm-observed` and
-//! `rpm-managed` components.
+//! transactions ANOLISA delegates to dnf/rpm — `install`, `update`, and
+//! `remove`, used by `anolisa install` / `update` / `uninstall` for
+//! `rpm-observed` and `rpm-managed` components.
 //!
 //! The trait is object-safe so the CLI can hold a `&dyn PackageTransaction`
 //! and inject a fake in tests instead of shelling out to a live `dnf`.
@@ -85,4 +85,22 @@ pub trait PackageTransaction {
     /// is responsible for the privilege precondition and for refreshing
     /// ANOLISA state from rpmdb after a successful update.
     fn update(&self, package: &str) -> Result<(), PackageTransactionError>;
+
+    /// Remove `package`, delegating the file transaction (scriptlets, rpmdb
+    /// write) to the package manager — ANOLISA never deletes RPM-owned files
+    /// directly. A package that is already absent is reported by the backend as
+    /// a hard failure (no match), so the caller should confirm presence first
+    /// when it wants to treat "already gone" as success.
+    ///
+    /// This method is only the spawn/exit mechanism; **whether** a removal is
+    /// authorized is the caller's decision. For an `rpm-observed` package
+    /// (`Ownership::owns_removal()` is `false`) the caller must require an
+    /// explicit `--remove-system-package` override before invoking this, so a
+    /// preinstalled system RPM is never dropped by a default uninstall.
+    ///
+    /// # Errors
+    /// See [`PackageTransactionError`] for the failure conditions. The caller
+    /// owns the privilege precondition and drops ANOLISA state after a
+    /// successful removal.
+    fn remove(&self, package: &str) -> Result<(), PackageTransactionError>;
 }

--- a/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
@@ -1,9 +1,9 @@
 //! RPM/DNF backend for [`PackageTransaction`].
 //!
-//! Runs `dnf <verb> -y <package>` (`install`/`update`) through the injectable
-//! [`CommandRunner`] so the transaction can be tested with a fake runner
-//! instead of a live `dnf`. Only the spawn/exit classification lives here;
-//! privilege checks and state refresh stay in the CLI consumer.
+//! Runs `dnf <verb> -y <package>` (`install`/`update`/`remove`) through the
+//! injectable [`CommandRunner`] so the transaction can be tested with a fake
+//! runner instead of a live `dnf`. Only the spawn/exit classification lives
+//! here; privilege checks and state refresh stay in the CLI consumer.
 
 use crate::command::{CommandRunner, SystemCommandRunner};
 use crate::pkg_transaction::{PackageTransaction, PackageTransactionError};
@@ -36,8 +36,9 @@ impl<R: CommandRunner> RpmTransaction<R> {
 
     /// Run `dnf <verb> -y <package>` and classify the outcome.
     ///
-    /// Shared by [`install`](PackageTransaction::install) and
-    /// [`update`](PackageTransaction::update) since they differ only in the
+    /// Shared by [`install`](PackageTransaction::install),
+    /// [`update`](PackageTransaction::update), and
+    /// [`remove`](PackageTransaction::remove) since they differ only in the
     /// dnf verb; `verb` is echoed into the [`TransactionFailed`] operation so
     /// the caller can tell which transaction failed.
     fn run_dnf(&self, verb: &str, package: &str) -> Result<(), PackageTransactionError> {
@@ -76,6 +77,10 @@ impl<R: CommandRunner> PackageTransaction for RpmTransaction<R> {
 
     fn update(&self, package: &str) -> Result<(), PackageTransactionError> {
         self.run_dnf("update", package)
+    }
+
+    fn remove(&self, package: &str) -> Result<(), PackageTransactionError> {
+        self.run_dnf("remove", package)
     }
 }
 
@@ -188,6 +193,41 @@ mod tests {
             ok_out(Some(0), "Installed:\n  anolisa-copilot-shell\n", ""),
         );
         t.install("anolisa-copilot-shell").expect("install ok");
+    }
+
+    #[test]
+    fn remove_success_returns_ok() {
+        let t = txn(
+            "remove",
+            "anolisa-copilot-shell",
+            ok_out(Some(0), "Removed:\n  anolisa-copilot-shell\n", ""),
+        );
+        t.remove("anolisa-copilot-shell").expect("remove ok");
+    }
+
+    #[test]
+    fn remove_nonzero_exit_records_remove_operation() {
+        // The failed-operation label must follow the verb so callers can tell a
+        // remove failure apart from an install/update failure.
+        let t = txn(
+            "remove",
+            "anolisa-copilot-shell",
+            ok_out(
+                Some(1),
+                "",
+                "Error: No match for argument: anolisa-copilot-shell",
+            ),
+        );
+        let err = t.remove("anolisa-copilot-shell").unwrap_err();
+        match err {
+            PackageTransactionError::TransactionFailed {
+                operation, stderr, ..
+            } => {
+                assert_eq!(operation, "remove");
+                assert!(stderr.contains("No match for argument"));
+            }
+            other => panic!("expected TransactionFailed, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Makes `anolisa uninstall` ownership-driven so a preinstalled system RPM is never removed by default. Today uninstall is ownership-blind: every component goes through core's `LifecyclePlan`/`execute_plan`, which only removes ANOLISA-owned files and drops state — it never calls `dnf`. That made `rpm-observed` *accidentally* safe (no owned files, so only state was dropped) with no way to explicitly remove the package, and left `rpm-managed` packages in rpmdb even though they should be delegated to `dnf remove`.

New behavior, keyed on `effective_ownership()`:

| ownership | `uninstall` | `uninstall --remove-system-package` |
|---|---|---|
| `raw-managed` | remove ANOLISA-owned files + drop state (**unchanged**) | no-op for raw → warn, proceed as default |
| `rpm-managed` | `dnf remove` + drop state (`owns_removal() == true`) | same as default (flag redundant, harmless) |
| `rpm-observed` | **drop state only, no dnf** (`owns_removal() == false`) | `dnf remove` + drop state |

Acceptance: ① rpm-observed never runs `dnf remove` by default; ② removing an observed system package requires an explicit `--remove-system-package`; ③ dry-run states whether the package will be removed (`package_removal`: `dnf remove` / `state only` / `already absent`).

## Design Note

- **dnf delegation stays at the CLI layer.** Core's `lifecycle.rs` does not shell out to dnf. The RPM path branches inside `uninstall.rs`, mirroring `update.rs`'s `update_rpm_component` pattern (inject `query`/`txn`/`is_root`, dnf delegation + root gating + error mapping). Raw components keep the existing `LifecyclePlan`/`execute_plan` path with zero behavior change; only `Uninstall` on an `is_rpm()` component is rerouted (`--purge` is untouched, still plan-gated).
- **Removal decision recomputed under the lock.** `remove_package = locked_ownership.owns_removal() || --remove-system-package` is evaluated from the *locked* ownership, never the pre-lock read. If a concurrent op flipped the component from rpm-managed to rpm-observed under the same package name, the stale pre-lock value would still say "remove" and a default uninstall would wrongly `dnf remove` a preinstalled RPM — the exact guarantee rpm-observed exists to provide. The locked path also re-checks that `rpm_metadata.package_name` is unchanged (TOCTOU identity guard), consistent with adopt's `refuse_observed_repoint`.
- **Lock held across the dnf remove (unlike install/update, which release before dnf).** The destructive path runs entirely under the install lock: `acquire → reload → in-lock adapter-claim re-check → (optional dnf remove) → remove_object → record op → save → central log`. The adapter guard must take effect *before* the irreversible `dnf remove`, otherwise a concurrent `adapter enable` could slip in, remove the package, then refuse to drop state — orphaning a registered plugin. A comment documents why this differs from install/update.
- **Tooling-missing guidance is ownership-aware on both probes.** Whether rpm/dnf is found absent by the rpmdb query *or* by `dnf remove` itself (rpm present, dnf absent), the error steers an owns-removal component at `anolisa forget` and an rpm-observed removal at dropping `--remove-system-package` — both paths share one `tooling_missing_err` helper so the guidance can't diverge.
- Adds `PackageTransaction::remove` (delegates to `dnf remove`); a `PackageDisposition` three-state enum keeps "already absent" (the package already gone via a manual `rpm -e`) distinct from "intentionally kept" and "removed".

## Ship Note

- **`rpm-managed` default is now `dnf remove`** (previously state-only, leaving the package in rpmdb). Unified through `owns_removal()`. In scope, but flagged as a behavior change; happy to split it out if you'd rather keep this PR to rpm-observed safety only.
- **Missing handled gracefully:** with removal intended, the package is `query_installed`-checked first; if it's already gone, that's not an error — drop the stale state and report `already absent`.
- **Known limitation — the save-after-remove window:** `dnf remove` runs before `state.save()`, so a state-write failure *after* a successful removal leaves the package gone but the ANOLISA record present — a Missing drift the user can resolve with `status` / `forget` / `repair`. This is inherent to a two-phase destructive op (an external rpmdb change cannot be made atomic with a local state write), so it is flagged here rather than papered over.
- **`--remove-system-package` does not stack with `--purge`** (purge path unchanged, still gated); on a raw component the flag warns and proceeds as default.

## Test

- **Unit (uninstall):** rpm-observed default drops state with `remove_calls == 0`; `--remove-system-package` + root runs `dnf remove`; same flag non-root refuses with a sudo hint and no dnf; rpm-managed default delegates `dnf remove`; dry-run touches nothing and reports the right `package_removal`; already-absent drops state only; dnf failure keeps state; rpm-query tooling missing points at `forget` (managed) vs dropping the flag (observed); rpm-present / dnf-absent (the `txn.remove` `CommandMissing` branch) gives the same `forget` guidance instead of the generic message; raw + flag warns but succeeds; enabled-adapter refusal (incl. in-lock re-check); removal decision recomputed under the lock; package-metadata-missing points at `repair`; decision matrix + disposition label/intent mapping; flag parse.
- **Unit (platform):** `RpmTransaction::remove` success → ok; non-zero exit → `TransactionFailed`.
- **Full gate green:** `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- **Real-host rpmdb (dry-run, no root):** a seeded rpm-observed component shows `package removal: state only`; with `--remove-system-package --dry-run` shows `dnf remove`. The real removal path is covered by the `FakeRpm` unit tests.

Closes #962
