### PR TITLE
test(anolisa): add MVP coverage for image-preinstalled RPM lifecycle

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
@@ -13,3 +13,7 @@ pub mod restart;
 pub mod status;
 pub mod uninstall;
 pub mod update;
+
+// Cross-command end-to-end MVP lifecycle coverage (#963); test-only.
+#[cfg(test)]
+mod mvp_lifecycle;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -50,7 +50,8 @@ pub fn handle(args: AdoptArgs, ctx: &CliContext) -> Result<(), CliError> {
 /// Core of [`handle`] with the package query injected so tests drive every
 /// branch without a live rpmdb. Adopt runs no dnf transaction, so only a
 /// [`PackageQuery`] is required.
-fn adopt_with_query(
+// pub(crate): driven by the cross-command MVP lifecycle test (#963).
+pub(crate) fn adopt_with_query(
     target: &str,
     cli_override: Option<&str>,
     ctx: &CliContext,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -237,10 +237,29 @@ pub fn handle(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
 ///   components (#959).
 /// - [`is_root`](Self::is_root) gates the privileged dnf transaction so the
 ///   user gets an actionable message instead of dnf's mid-transaction refusal.
-struct RpmExec<'a> {
+// pub(crate) with private fields + `new`: the cross-command MVP lifecycle test
+// (#963) builds this to inject its fake rpmdb world, but the internal
+// representation stays encapsulated — construction goes through `new`.
+pub(crate) struct RpmExec<'a> {
     query: &'a dyn PackageQuery,
     txn: &'a dyn PackageTransaction,
     is_root: bool,
+}
+
+impl<'a> RpmExec<'a> {
+    /// Bundle the rpm-path dependencies. The real entry point passes the
+    /// system rpm/dnf backends; tests pass fakes.
+    pub(crate) fn new(
+        query: &'a dyn PackageQuery,
+        txn: &'a dyn PackageTransaction,
+        is_root: bool,
+    ) -> Self {
+        Self {
+            query,
+            txn,
+            is_root,
+        }
+    }
 }
 
 fn handle_one(
@@ -254,18 +273,15 @@ fn handle_one(
     // the raw path costs nothing.
     let query = RpmPackageQuery::system();
     let txn = RpmTransaction::system();
-    let exec = RpmExec {
-        query: &query,
-        txn: &txn,
-        is_root: privilege::is_root(),
-    };
+    let exec = RpmExec::new(&query, &txn, privilege::is_root());
     handle_one_with_exec(component, args, ctx, &exec)
 }
 
 /// Core of [`handle_one`] with the RPM execution dependencies injected, so
 /// tests can drive the adopt and delegated-install paths without a live
 /// rpmdb/dnf or real privileges.
-fn handle_one_with_exec(
+// pub(crate): driven by the cross-command MVP lifecycle test (#963).
+pub(crate) fn handle_one_with_exec(
     component: String,
     args: InstallArgs,
     ctx: &CliContext,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/mvp_lifecycle.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/mvp_lifecycle.rs
@@ -1,0 +1,286 @@
+//! End-to-end MVP lifecycle coverage (#963).
+//!
+//! Drives a single image-preinstalled system RPM through the whole flow —
+//! adopt → update → drift status → uninstall — on **one** state file and
+//! **one** evolving fake rpmdb world. Where the per-command unit tests
+//! each seed their own hand-written start state, these feed *each command's real
+//! output* into the next, so they catch the cross-command regressions those
+//! tests assume away: a state-contract drift between what `adopt` writes and
+//! what `update`/`status`/`uninstall` read, and rpmdb-evolution effects that a
+//! static per-command fake cannot model.
+//!
+//! Scope (#963) → coverage:
+//! - ① adopt under `default_backend = raw` — [`lifecycle_adopt_update_drift_then_uninstall`] (install step)
+//! - ② update delegates to RPM + refreshes state — same test (update step)
+//! - ④ rpm-observed uninstall — same test (uninstall step); `forget` is covered
+//!   by `super::forget::tests::forget_drops_object_and_records_operation`
+//! - ⑤ drift status — same test (drift step); the `Missing` counterpart is
+//!   covered by `super::status::tests::probe_rpm_drift_detects_missing`
+//! - ③ user-mode raw shadows system RPM — covered by
+//!   `super::update::tests::user_raw_override_does_not_touch_system_rpm`; not
+//!   re-done here because `common::resolve_layout` binds user mode to the real
+//!   `$HOME`, so a command-layer user-mode test cannot be isolated without
+//!   polluting the home dir or mutating process-global `XDG_*` (which would race
+//!   other tests).
+
+use std::cell::{Cell, RefCell};
+
+use anolisa_core::state::{InstalledState, ObjectKind, Ownership};
+use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError, PackageVersion};
+use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
+
+use crate::commands::common;
+use crate::context::{CliContext, InstallMode};
+
+use super::install::{InstallArgs, InstallOutcome, RpmExec, handle_one_with_exec};
+use super::status::{RpmDrift, probe_rpm_drift};
+use super::uninstall::{UninstallArgs, handle_with_deps};
+use super::update::update_component_with_deps;
+
+/// An in-memory rpmdb + dnf that **mutates as commands act on it**, so one fake
+/// backs the whole flow: it answers [`PackageQuery`] (adopt probe, status drift)
+/// and runs [`PackageTransaction`] (update/remove).
+///
+/// `installed` is the live rpmdb view. A successful [`update`](PackageTransaction::update)
+/// advances it to `upgrade_to` (dnf moving the version forward); the
+/// `simulate_*` helpers model out-of-band `dnf`/`rpm` changes that ANOLISA state
+/// does not know about, which is exactly what the drift/missing probes must
+/// catch.
+struct RpmWorld {
+    package: String,
+    installed: RefCell<Option<PackageInfo>>,
+    origin: String,
+    /// rpmdb view after a successful in-band `update` (models dnf advancing).
+    upgrade_to: Option<PackageInfo>,
+    update_calls: Cell<usize>,
+    remove_calls: Cell<usize>,
+}
+
+impl RpmWorld {
+    /// A world where `package` is preinstalled at `info`, attributed to `origin`.
+    fn preinstalled(package: &str, info: PackageInfo, origin: &str) -> Self {
+        Self {
+            package: package.to_string(),
+            installed: RefCell::new(Some(info)),
+            origin: origin.to_string(),
+            upgrade_to: None,
+            update_calls: Cell::new(0),
+            remove_calls: Cell::new(0),
+        }
+    }
+
+    /// rpmdb view a subsequent in-band `update` advances to.
+    fn upgrading_to(mut self, info: PackageInfo) -> Self {
+        self.upgrade_to = Some(info);
+        self
+    }
+
+    /// Model an out-of-band `dnf update`/`downgrade`: rpmdb moves, ANOLISA state
+    /// is untouched, so a later status probe must report drift.
+    fn simulate_dnf_upgrade(&self, info: PackageInfo) {
+        *self.installed.borrow_mut() = Some(info);
+    }
+
+    /// Current rpmdb view for `package` (`None` for any other name).
+    fn current(&self, package: &str) -> Option<PackageInfo> {
+        (package == self.package)
+            .then(|| self.installed.borrow().clone())
+            .flatten()
+    }
+}
+
+impl PackageQuery for RpmWorld {
+    fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+        Ok(self.current(package))
+    }
+    fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+        Ok(Vec::new())
+    }
+    fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+        Ok((package == self.package).then(|| self.origin.clone()))
+    }
+    fn what_provides_installed(&self, _capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        Ok(Vec::new())
+    }
+}
+
+impl PackageTransaction for RpmWorld {
+    fn install(&self, _package: &str) -> Result<(), PackageTransactionError> {
+        // The MVP flow adopts a preinstalled RPM; reaching dnf install is a bug.
+        panic!("MVP lifecycle adopts a preinstalled RPM; dnf install must not run");
+    }
+    fn update(&self, package: &str) -> Result<(), PackageTransactionError> {
+        self.update_calls.set(self.update_calls.get() + 1);
+        assert_eq!(package, self.package, "update targeted the wrong package");
+        if let Some(next) = &self.upgrade_to {
+            *self.installed.borrow_mut() = Some(next.clone());
+        }
+        Ok(())
+    }
+    fn remove(&self, package: &str) -> Result<(), PackageTransactionError> {
+        self.remove_calls.set(self.remove_calls.get() + 1);
+        assert_eq!(package, self.package, "remove targeted the wrong package");
+        *self.installed.borrow_mut() = None;
+        Ok(())
+    }
+}
+
+fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
+    PackageInfo {
+        name: name.to_string(),
+        version: PackageVersion {
+            epoch: None,
+            version: version.to_string(),
+            release: release.map(str::to_string),
+        },
+        arch: arch.to_string(),
+        origin: None,
+    }
+}
+
+/// A system-mode ctx whose tempdir holds a `repo.toml` with
+/// `default_backend = raw` — so the install entry point exercises scope ①: raw
+/// is the default backend, yet a preinstalled RPM is still adopted.
+fn system_ctx_with_raw_repo() -> (tempfile::TempDir, CliContext) {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let prefix = tmp.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+    std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+    std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    std::fs::write(
+        layout.etc_dir.join("repo.toml"),
+        "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"https://example.com/anolisa\"\n",
+    )
+    .expect("write repo.toml");
+    let ctx = CliContext {
+        install_mode: InstallMode::System,
+        prefix: Some(prefix),
+        json: false,
+        dry_run: false,
+        verbose: false,
+        quiet: true,
+        no_color: true,
+    };
+    (tmp, ctx)
+}
+
+fn load_state(ctx: &CliContext) -> InstalledState {
+    let layout = common::resolve_layout(ctx);
+    InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+}
+
+fn install_args(component: &str, package: Option<&str>) -> InstallArgs {
+    InstallArgs {
+        component: Some(component.to_string()),
+        all: false,
+        fail_fast: false,
+        version: None,
+        backend: None,
+        repo: None,
+        package: package.map(str::to_string),
+    }
+}
+
+fn uninstall_args(component: &str) -> UninstallArgs {
+    UninstallArgs {
+        component: component.to_string(),
+        purge: false,
+        remove_system_package: false,
+        force: false,
+    }
+}
+
+/// Adopt a preinstalled RPM whose package name (`copilot-shell`) deliberately
+/// differs from the component name (`cosh`) — they share no `anolisa-` prefix,
+/// so the package identity can only flow through the `rpm_metadata.package_name`
+/// adopt writes. The evolving [`RpmWorld`] answers *only* for `copilot-shell`,
+/// so update/status/uninstall pass solely by consuming that recorded name
+/// rather than re-deriving `anolisa-{component}`. Drives adopt → update (rpmdb
+/// advances, state refreshes) → drift after an out-of-band dnf upgrade →
+/// uninstall (state dropped, system RPM left); each step consumes the previous
+/// step's *real* persisted state and the same world.
+#[test]
+fn lifecycle_adopt_update_drift_then_uninstall() {
+    let (_tmp, ctx) = system_ctx_with_raw_repo();
+    let pkg = "copilot-shell";
+    let component = "cosh";
+    let world = RpmWorld::preinstalled(
+        pkg,
+        pkg_info(pkg, "2.3.0", Some("1.al8"), "x86_64"),
+        "@System",
+    )
+    .upgrading_to(pkg_info(pkg, "2.4.0", Some("1.al8"), "x86_64"));
+
+    // ① The install entry point under default_backend=raw, pinned with
+    //    `--package`, adopts the preinstalled RPM rather than fetching raw.
+    let exec = RpmExec::new(&world, &world, true);
+    let outcome = handle_one_with_exec(
+        component.to_string(),
+        install_args(component, Some(pkg)),
+        &ctx,
+        &exec,
+    )
+    .expect("adopt via install entry point");
+    assert_eq!(outcome, InstallOutcome::Adopted);
+    let obj = load_state(&ctx)
+        .find_object(ObjectKind::Component, component)
+        .cloned()
+        .expect("component recorded after adopt");
+    assert_eq!(obj.ownership, Some(Ownership::RpmObserved));
+    assert_eq!(obj.install_backend.as_deref(), Some("rpm"));
+    assert!(!obj.managed, "rpm-observed is not ANOLISA-managed");
+    assert!(obj.adopted);
+    assert!(obj.files.is_empty(), "adopt writes no owned files");
+    let meta = obj.rpm_metadata.clone().expect("rpm metadata");
+    assert_eq!(
+        meta.package_name, pkg,
+        "adopt records the real RPM package name, not anolisa-{component}",
+    );
+    assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
+
+    // ② update delegates dnf and refreshes the recorded EVR from rpmdb, keeping
+    //    rpm-observed ownership. The world answers only for `copilot-shell`, so
+    //    this passes only if update targets the adopted package name.
+    update_component_with_deps(component, &ctx, &world, &world, true).expect("update ok");
+    assert_eq!(world.update_calls.get(), 1, "dnf update ran once");
+    let obj = load_state(&ctx)
+        .find_object(ObjectKind::Component, component)
+        .cloned()
+        .expect("component present after update");
+    assert_eq!(
+        obj.ownership,
+        Some(Ownership::RpmObserved),
+        "update keeps observed ownership",
+    );
+    let meta = obj.rpm_metadata.clone().expect("rpm metadata");
+    assert_eq!(
+        meta.evr.as_deref(),
+        Some("2.4.0-1.al8"),
+        "state EVR refreshed from rpmdb after update",
+    );
+
+    // ⑤ an out-of-band dnf upgrade diverges rpmdb from the recorded EVR → drift.
+    //    The probe resolves the package via the recorded `package_name`.
+    world.simulate_dnf_upgrade(pkg_info(pkg, "2.5.0", Some("1.al8"), "x86_64"));
+    match probe_rpm_drift(&meta, &world) {
+        Some(RpmDrift::Drifted { .. }) => {}
+        _ => panic!("expected drift after an out-of-band dnf upgrade"),
+    }
+
+    // ④ rpm-observed uninstall without --remove-system-package drops only ANOLISA
+    //    state and leaves the system RPM in place.
+    handle_with_deps(uninstall_args(component), &ctx, &world, &world, true).expect("uninstall ok");
+    assert_eq!(
+        world.remove_calls.get(),
+        0,
+        "rpm-observed default must not dnf remove",
+    );
+    assert!(world.current(pkg).is_some(), "system RPM left installed");
+    assert!(
+        load_state(&ctx)
+            .find_object(ObjectKind::Component, component)
+            .is_none(),
+        "ANOLISA state dropped",
+    );
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -277,7 +277,8 @@ fn observed_record(
 /// calls out: a `dnf update`/`downgrade` (or a same-name multi-version rpmdb)
 /// surfaces as [`Drifted`](RpmDrift::Drifted); an `rpm -e` surfaces as
 /// [`Missing`](RpmDrift::Missing).
-enum RpmDrift {
+// pub(crate): the cross-command MVP lifecycle test (#963) asserts on these variants.
+pub(crate) enum RpmDrift {
     /// rpmdb holds the package at a different version than ANOLISA recorded, or
     /// holds several versions at once. `reason` explains which.
     Drifted { reason: String },
@@ -292,7 +293,8 @@ enum RpmDrift {
 /// than crying drift on a read we cannot trust. A same-name multi-version rpmdb
 /// is a genuine divergence from the single recorded version, so it classifies
 /// as drift. `query` is injected so tests drive this without a live rpmdb.
-fn probe_rpm_drift(meta: &RpmMetadata, query: &dyn PackageQuery) -> Option<RpmDrift> {
+// pub(crate): driven by the cross-command MVP lifecycle test (#963).
+pub(crate) fn probe_rpm_drift(meta: &RpmMetadata, query: &dyn PackageQuery) -> Option<RpmDrift> {
     match query.query_installed(&meta.package_name) {
         Ok(Some(info)) => {
             let live = info.version.to_string();

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -108,7 +108,8 @@ pub fn handle(args: UninstallArgs, ctx: &CliContext) -> Result<(), CliError> {
 /// Core of [`handle`] with the package query, transaction, and root status
 /// injected so the RPM path is testable without a live rpmdb/dnf or real
 /// privileges. The raw and purge paths ignore the injected dependencies.
-fn handle_with_deps(
+// pub(crate): driven by the cross-command MVP lifecycle test (#963).
+pub(crate) fn handle_with_deps(
     args: UninstallArgs,
     ctx: &CliContext,
     query: &dyn PackageQuery,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -173,7 +173,8 @@ fn handle_component_update(component: &str, ctx: &CliContext) -> Result<(), CliE
 /// Core of [`handle_component_update`] with the package query, transaction, and
 /// root status injected so tests drive the RPM path without a live rpmdb/dnf or
 /// real privileges.
-fn update_component_with_deps(
+// pub(crate): driven by the cross-command MVP lifecycle test (#963).
+pub(crate) fn update_component_with_deps(
     target: &str,
     ctx: &CliContext,
     query: &dyn PackageQuery,


### PR DESCRIPTION
## Description

Closes out the raw_rpm_lifecycle series (#956–#963) with MVP-flow coverage for the image-preinstalled RPM lifecycle: an image ships an RPM, ANOLISA adopts it and manages its lifecycle. The per-command behaviors already have unit tests from #956–#962; this PR adds one cross-command end-to-end test that feeds each command's *real* persisted output into the next on a single evolving fake rpmdb world, catching the state-contract and rpmdb-evolution regressions the per-command tests assume away by seeding their own start state.

Scope coverage:
- ① adopt under `default_backend = raw` — adopts the preinstalled RPM as `rpm-observed` instead of fetching a raw artifact.
- ② update delegates to the RPM backend and refreshes the recorded EVR, keeping `rpm-observed` ownership.
- ④ rpm-observed uninstall (no `--remove-system-package`) drops only ANOLISA state and leaves the system RPM; `forget` drops state with no package operation.
- ⑤ drift / missing status after a simulated out-of-band `dnf`/`rpm` change.
- ③ user-mode raw shadowing a system RPM — covered by the existing `update::tests::user_raw_override_does_not_touch_system_rpm` unit test (see Design Note).

This is a test-only PR; no production behavior changes.

## Design Note

The end-to-end test is an inline `#[cfg(test)]` module (`commands/tier1/mvp_lifecycle.rs`), because `anolisa-cli` is a bin-only crate (no `lib.rs`) whose private/`pub(crate)` items and test fakes are unreachable from an external `tests/` integration test.

To drive each command from one module, a few per-command injection seams are relaxed to `pub(crate)` (`adopt_with_query`, `update_component_with_deps`, `handle_with_deps`, `probe_rpm_drift`/`RpmDrift`, `handle_one_with_exec`/`RpmExec`); these are pure visibility widenings with no behavior change. A single `RpmWorld` implements both `PackageQuery` and `PackageTransaction` and mutates as commands act on it, so `update` advances the rpmdb view and `simulate_dnf_upgrade` models an out-of-band change the drift probe must catch.

The value is the cross-command state contract: the test feeds adopt's real written state into update, update's into the drift probe, and that into uninstall, so it guards the fields adopt writes against what update/status/uninstall read — something per-command tests cannot do, since each seeds its own start state.

## Ship Note

- Functional coverage of ①–⑤ already exists per-command (#956–#962); this PR's incremental value is the cross-command regression guard, not new functional coverage. The end-to-end module was deliberately scoped to the single highest-value chain; the `missing` and `forget` single-hop cases stay mapped to their existing unit tests (`status::probe_rpm_drift_detects_missing`, `forget::forget_drops_object_and_records_operation`).
- ③ is not re-done end-to-end: `common::resolve_layout` binds user mode to the real `$HOME`, so a command-layer user-mode test cannot be isolated without polluting the home dir or mutating process-global `XDG_*` (which would race other tests). It stays covered by the `update` unit test.
- Two real-environment observations surfaced during validation, out of #963 scope (noted, not fixed): the default component→RPM name convention (`anolisa-cosh`) does not match the real repo package (`copilot-shell`), so `adopt` needs `--package copilot-shell`; and `forget` on a component already gone from rpmdb still prints "the RPM package remains installed", which is inaccurate in the missing case.

## Test

- Unit / integration (CI, no real dnf): `cargo test -p anolisa-cli` — 261 passed, including the new `mvp_lifecycle::lifecycle_adopt_update_drift_then_uninstall` end-to-end test on a fake, evolving rpmdb world.
- Full gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- Real Alibaba Cloud Linux 4 end-to-end (real dnf/rpmdb): built `anolisa 0.1.10` for x86_64, deployed it to a live Alinux 4 box, and ran the full MVP flow against the real `alinux4-agentic` repo (component `cosh` ↔ RPM `copilot-shell`, versions 2.0.0–2.5.0): `dnf install copilot-shell-2.3.0` → `adopt cosh --package copilot-shell` records `rpm-observed` (evr 2.3.0, `managed=false`) → `update` delegates to dnf, advancing both rpmdb and state EVR to 2.5.0 → out-of-band `dnf downgrade` to 2.4.0 → `status` reports `drifted` ("rpmdb reports 2.4.0 but ANOLISA state records 2.5.0") → `repair` reconciles state to 2.4.0 → `uninstall` (no `--remove-system-package`) drops state but leaves `copilot-shell` installed → re-adopt → `forget` drops state with no package operation → re-adopt → out-of-band `rpm -e` → `status` reports `missing`. Every step matched the fake-world test's assertions.

Closes #963
