### PR TITLE
feat(sight): use request metadata for session_id

### DIFF
--- a/src/agentsight/src/analyzer/message/types.rs
+++ b/src/agentsight/src/analyzer/message/types.rs
@@ -778,6 +778,21 @@ impl ParsedApiMessage {
         }
     }
 
+    /// Extract session_id from request metadata (Anthropic only).
+    ///
+    /// Priority:
+    /// 1. `metadata.session_id` or `metadata.sessionId` (direct string)
+    /// 2. `metadata.user_id` — JSON-encoded object with `session_id`, or `_session_<UUID>` pattern
+    pub fn request_metadata_session_id(&self) -> Option<String> {
+        match self {
+            ParsedApiMessage::AnthropicMessage { request, .. } => {
+                let meta = request.as_ref()?.metadata.as_ref()?;
+                session_id_from_metadata(meta)
+            }
+            _ => None,
+        }
+    }
+
     /// Check if streaming was requested
     pub fn is_streaming(&self) -> Option<bool> {
         match self {
@@ -792,6 +807,44 @@ impl ParsedApiMessage {
             }
         }
     }
+}
+
+/// Extract session_id from a metadata JSON value (Anthropic format).
+///
+/// Priority:
+/// 1. `metadata.session_id` or `metadata.sessionId` (direct string)
+/// 2. `metadata.user_id` — JSON-encoded object with `session_id`, or `_session_<UUID>` pattern
+pub(crate) fn session_id_from_metadata(meta: &serde_json::Value) -> Option<String> {
+    // 1. Direct session_id / sessionId
+    if let Some(sid) = meta.get("session_id").and_then(|v| v.as_str()) {
+        if !sid.is_empty() {
+            return Some(sid.to_string());
+        }
+    }
+    if let Some(sid) = meta.get("sessionId").and_then(|v| v.as_str()) {
+        if !sid.is_empty() {
+            return Some(sid.to_string());
+        }
+    }
+    // 2. user_id field — try JSON decode, then substring pattern
+    if let Some(user_id) = meta.get("user_id").and_then(|v| v.as_str()) {
+        // 2a. JSON-encoded object: {"session_id": "..."}
+        if let Ok(obj) = serde_json::from_str::<serde_json::Value>(user_id) {
+            if let Some(sid) = obj.get("session_id").and_then(|v| v.as_str()) {
+                if !sid.is_empty() {
+                    return Some(sid.to_string());
+                }
+            }
+        }
+        // 2b. Pattern: ..._session_<UUID>
+        if let Some(pos) = user_id.find("_session_") {
+            let after = &user_id[pos + "_session_".len()..];
+            if !after.is_empty() {
+                return Some(after.to_string());
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -1102,5 +1155,135 @@ mod tests {
         let msg: OpenAIChatMessage = serde_json::from_str(json_str).unwrap();
         assert!(msg.content.is_none());
         assert_eq!(msg.tool_calls.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_request_metadata_session_id_direct() {
+        // Anthropic metadata.session_id 直接取
+        let msg = ParsedApiMessage::AnthropicMessage {
+            request: Some(AnthropicRequest {
+                model: "claude-3".to_string(),
+                messages: vec![],
+                max_tokens: 4096,
+                system: None,
+                stream: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                tools: None,
+                tool_choice: None,
+                metadata: Some(serde_json::json!({"session_id": "abc-123"})),
+            }),
+            response: None,
+        };
+        assert_eq!(
+            msg.request_metadata_session_id(),
+            Some("abc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_request_metadata_session_id_user_id_json() {
+        // metadata.user_id 是 JSON 编码的对象
+        let msg = ParsedApiMessage::AnthropicMessage {
+            request: Some(AnthropicRequest {
+                model: "claude-3".to_string(),
+                messages: vec![],
+                max_tokens: 4096,
+                system: None,
+                stream: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                tools: None,
+                tool_choice: None,
+                metadata: Some(serde_json::json!({"user_id": "{\"session_id\":\"sess-456\"}"})),
+            }),
+            response: None,
+        };
+        assert_eq!(
+            msg.request_metadata_session_id(),
+            Some("sess-456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_request_metadata_session_id_user_id_pattern() {
+        // metadata.user_id 是 ..._session_<UUID> 格式
+        let msg = ParsedApiMessage::AnthropicMessage {
+            request: Some(AnthropicRequest {
+                model: "claude-3".to_string(),
+                messages: vec![],
+                max_tokens: 4096,
+                system: None,
+                stream: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                tools: None,
+                tool_choice: None,
+                metadata: Some(serde_json::json!({"user_id": "proj_abc_session_uuid-789-xyz"})),
+            }),
+            response: None,
+        };
+        assert_eq!(
+            msg.request_metadata_session_id(),
+            Some("uuid-789-xyz".to_string())
+        );
+    }
+
+    #[test]
+    fn test_request_metadata_session_id_none_fallback() {
+        // 无 metadata 时返回 None（反向：不误报）
+        let msg = ParsedApiMessage::AnthropicMessage {
+            request: Some(AnthropicRequest {
+                model: "claude-3".to_string(),
+                messages: vec![],
+                max_tokens: 4096,
+                system: None,
+                stream: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                tools: None,
+                tool_choice: None,
+                metadata: None,
+            }),
+            response: None,
+        };
+        assert_eq!(msg.request_metadata_session_id(), None);
+    }
+
+    #[test]
+    fn test_request_metadata_session_id_openai_returns_none() {
+        // OpenAI 不走 metadata 抽取，始终返回 None
+        let msg = ParsedApiMessage::OpenAICompletion {
+            request: Some(OpenAIRequest {
+                model: "gpt-4".to_string(),
+                messages: vec![],
+                max_tokens: None,
+                temperature: None,
+                top_p: None,
+                frequency_penalty: None,
+                presence_penalty: None,
+                n: None,
+                stream: None,
+                stop: None,
+                user: Some("user-session-abc".to_string()),
+                tools: None,
+                tool_choice: None,
+                response_format: None,
+                seed: None,
+                logprobs: None,
+                top_logprobs: None,
+                parallel_tool_calls: None,
+            }),
+            response: None,
+        };
+        assert_eq!(msg.request_metadata_session_id(), None);
     }
 }

--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -319,15 +319,23 @@ impl GenAIBuilder {
         )
         .or_else(|| Some(request.source_event.comm_str()));
 
-        // 双层兑底计算 session_id / conversation_id（详见上方注释）。
-        // 这里不使用 unwrap_or_else(|| “”) 是为了让“同 PID 同 agent”上下文下
+        // 从 request body.metadata 提取 session_id（复用 types.rs 共享函数）
+        let metadata_session: Option<String> = body
+            .as_ref()
+            .and_then(|b| b.get("metadata"))
+            .and_then(crate::analyzer::message::types::session_id_from_metadata);
+
+        // 双层兜底计算 session_id / conversation_id（详见上方注释）。
+        // 这里不使用 unwrap_or_else(|| "") 是为了让“同 PID 同 agent”上下文下
         // crash_fallback_id 输入始终相同。
         let agent_name_str = agent_name.as_deref().unwrap_or("");
         let pid_i32 = conn_id.pid as i32;
 
-        let session_id = self
-            .id_resolver
-            .peek_session_id(agent_name_str, pid_i32, &first_user_text)
+        let session_id = metadata_session
+            .or_else(|| {
+                self.id_resolver
+                    .peek_session_id(agent_name_str, pid_i32, &first_user_text)
+            })
             .or_else(|| {
                 Some(super::id_resolver::crash_fallback_id(
                     "session",

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -104,8 +104,12 @@ impl GenAIBuilder {
             .unwrap_or_else(|| http.comm.clone());
         let pid_i32 = http.pid as i32;
 
-        // session_id: 优先从 agent 自身的 session 获取（通过 response ID → .jsonl UUID 映射），
-        // 未命中时 fallback 到 `SHA256("session" + 该 session 内最早 response_id)`。
+        // session_id: 优先从 request metadata 获取（Claude Code），
+        // 次优先 response ID → .jsonl UUID 映射，
+        // 兜底 hash。
+        let metadata_session = parsed_message
+            .as_ref()
+            .and_then(|m| m.request_metadata_session_id());
         let parsed_response_id = parsed_message
             .as_ref()
             .and_then(|m| m.response_id())
@@ -114,15 +118,10 @@ impl GenAIBuilder {
             .as_deref()
             .and_then(|rid| response_mapper.get_session_by_response_id(rid))
             .map(|s| s.to_string());
-        let session_id = match mapper_session {
-            Some(uuid) => Some(uuid),
-            None => self.id_resolver.resolve_session_id(
-                &agent_name,
-                pid_i32,
-                &first_user_raw,
-                &response_id,
-            ),
-        };
+        let session_id = metadata_session.or(mapper_session).or_else(|| {
+            self.id_resolver
+                .resolve_session_id(&agent_name, pid_i32, &first_user_raw, &response_id)
+        });
 
         // conversation_id: SHA256("conversation" + 该 conversation 内最早 response_id)
         let conversation_id = self.id_resolver.resolve_conversation_id(


### PR DESCRIPTION
## Summary

Add `ParsedApiMessage::request_metadata_session_id()` and shared `session_id_from_metadata()` helper to extract session info from Anthropic request metadata. Used as highest-priority source for `session_id` in both normal (call_builder) and pending/crash (builder) paths.

**Priority chain**: metadata.session_id > metadata.user_id (JSON/pattern) > response mapper > hash

**conversation_id** remains hash-based (unchanged).

## Changes

- `types.rs`: new `session_id_from_metadata()` pub(crate) pure function + `request_metadata_session_id()` accessor
- `call_builder.rs`: session_id uses metadata as top priority
- `builder.rs`: pending/crash path mirrors same logic via shared function

## Tests

5 discriminating tests:
- Direct `metadata.session_id`
- JSON-encoded `metadata.user_id`
- `_session_<UUID>` pattern in `user_id`
- None fallback (no metadata → returns None)
- OpenAI returns None (reverse-lock: user field is NOT session)

part of #1014