### PR TITLE
feat(sight): add call_kind classification

### DIFF
--- a/src/agentsight/src/background.rs
+++ b/src/agentsight/src/background.rs
@@ -651,6 +651,7 @@ mod tests {
                 is_sse: false,
                 model: None,
                 provider: None,
+                call_kind: "main".to_string(),
             })
             .unwrap();
 

--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -145,6 +145,11 @@ impl GenAIBuilder {
                 is_sse: llm_call.request.stream,
                 model: Some(llm_call.model.clone()),
                 provider: Some(llm_call.provider.clone()),
+                call_kind: llm_call
+                    .metadata
+                    .get("call_kind")
+                    .cloned()
+                    .unwrap_or_else(|| "main".to_string()),
             });
 
             events.push(GenAISemanticEvent::LLMCall(llm_call));
@@ -300,6 +305,10 @@ impl GenAIBuilder {
                 (None, None, None, String::new(), String::new())
             };
 
+        // Classify call_kind from request content
+        let call_kind =
+            super::helpers::classify_call_kind_from_raw(&system_instructions, &first_user_text);
+
         // Extract model from request body JSON "model" field
         let model = body
             .as_ref()
@@ -379,6 +388,7 @@ impl GenAIBuilder {
             is_sse,
             model,
             provider,
+            call_kind: call_kind.to_string(),
         })
     }
 

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -91,6 +91,9 @@ impl GenAIBuilder {
         let first_user_raw = Self::extract_first_user_raw(&request).unwrap_or_default();
         let last_user_raw = Self::extract_last_user_raw(&request).unwrap_or_default();
 
+        // Classify call_kind from request content
+        let call_kind = super::helpers::classify_call_kind(&request);
+
         // 提取 LLM API 的 response_id（如 chatcmpl-xxx），用作 trace_id
         // 同时作为 call_id 的首选值：trace_id 有值时直接复用，避免两套 ID；
         // SysOM / 解析失败等无 response_id 的场景 fallback 到内部生成的 internal_id。
@@ -239,6 +242,7 @@ impl GenAIBuilder {
                 } else if http.path.contains("/api/v1/copilot/generate_copilot") {
                     meta.insert("operation_name".to_string(), "chat".to_string());
                 }
+                meta.insert("call_kind".to_string(), call_kind.as_str().to_string());
                 // conversation_id: 对话ID，同一 user query 触发的所有调用共享
                 if let Some(ref cid) = conversation_id {
                     meta.insert("conversation_id".to_string(), cid.clone());

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -11,6 +11,148 @@ use crate::analyzer::ParsedApiMessage;
 use crate::config::default_cmdline_rules;
 use crate::discovery::matcher::{CmdlineGlobMatcher, ProcessContext};
 
+/// LLM call classification: Main (normal), Recap (compaction/summary), WebSearch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CallKind {
+    Main,
+    Recap,
+    WebSearch,
+}
+
+impl CallKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CallKind::Main => "main",
+            CallKind::Recap => "recap",
+            CallKind::WebSearch => "web_search",
+        }
+    }
+}
+
+/// Classify an LLM call based on request content (dual-path: system + first-user).
+///
+/// Conservative: unmatched → Main (zero false positives > recall).
+/// Signatures are from real captures (case-sensitive .contains()).
+pub(super) fn classify_call_kind(request: &LLMRequest) -> CallKind {
+    // Collect system instructions text
+    let system_text: String = request
+        .messages
+        .iter()
+        .filter(|m| m.role == "system")
+        .filter_map(|m| m.parts.first())
+        .filter_map(|p| match p {
+            MessagePart::Text { content } => Some(content.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // ① Check system_instructions (Cosh patterns)
+    if !system_text.is_empty() {
+        // Cosh recap/compaction: both markers present
+        if system_text.contains("summarizes internal chat history")
+            && system_text.contains("<state_snapshot>")
+        {
+            return CallKind::Recap;
+        }
+        // Cosh recap/project-summary
+        if system_text.contains("specialized context summarizer") {
+            return CallKind::Recap;
+        }
+    }
+
+    // ② Check first-user text (Claude Code patterns + Cosh tool-output)
+    let first_user_text: Option<&str> = request
+        .messages
+        .iter()
+        .filter(|m| m.role == "user")
+        .filter_map(|m| m.parts.first())
+        .filter_map(|p| match p {
+            MessagePart::Text { content } => Some(content.as_str()),
+            _ => None,
+        })
+        .next();
+
+    if let Some(text) = first_user_text {
+        // Cosh tool-output + Claude Code recap (both → Recap)
+        if text.starts_with("Summarize the following tool output to be a maximum of")
+            || (text
+                .contains("Your task is to create a detailed summary of the conversation so far")
+                && text.contains("Do NOT call any tools"))
+        {
+            return CallKind::Recap;
+        }
+        // Claude Code web_search
+        if text.contains("Perform a web search for the query:") {
+            return CallKind::WebSearch;
+        }
+    }
+
+    // ③ Default: Main (conservative, zero false positives)
+    CallKind::Main
+}
+
+/// Classify an LLM call from raw JSON strings (pending-write path).
+///
+/// `system_instructions` is the serialized JSON array of system messages.
+/// `first_user_text` is the extracted first user message text.
+///
+/// This mirrors [`classify_call_kind`] but operates on raw strings from the
+/// HTTP body rather than the structured `LLMRequest`, used in
+/// `build_pending_from_request` where full semantic parsing has not occurred.
+pub(super) fn classify_call_kind_from_raw(
+    system_instructions: &Option<String>,
+    first_user_text: &str,
+) -> &'static str {
+    let sys_text = system_instructions
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(s).ok())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    let c = m.get("content")?;
+                    if let Some(s) = c.as_str() {
+                        return Some(s.to_string());
+                    }
+                    if let Some(arr) = c.as_array() {
+                        let text: String = arr
+                            .iter()
+                            .filter_map(|item| {
+                                if item.get("type").and_then(|t| t.as_str()) == Some("text") {
+                                    item.get("text").and_then(|t| t.as_str())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        if !text.is_empty() {
+                            return Some(text);
+                        }
+                    }
+                    None
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+
+    if (sys_text.contains("summarizes internal chat history")
+        && sys_text.contains("<state_snapshot>"))
+        || sys_text.contains("specialized context summarizer")
+        || first_user_text.starts_with("Summarize the following tool output to be a maximum of")
+        || (first_user_text
+            .contains("Your task is to create a detailed summary of the conversation so far")
+            && first_user_text.contains("Do NOT call any tools"))
+    {
+        "recap"
+    } else if first_user_text.contains("Perform a web search for the query:") {
+        "web_search"
+    } else {
+        "main"
+    }
+}
+
 impl GenAIBuilder {
     /// Check if the path indicates an LLM API call
     pub(super) fn is_llm_api_path(&self, path: &str) -> bool {
@@ -285,6 +427,112 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    fn make_llm_request(messages: Vec<InputMessage>) -> LLMRequest {
+        LLMRequest {
+            messages,
+            temperature: None,
+            max_tokens: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            top_p: None,
+            top_k: None,
+            seed: None,
+            stop_sequences: None,
+            stream: false,
+            tools: None,
+            raw_body: None,
+        }
+    }
+
+    #[test]
+    fn test_classify_cosh_compaction_recap() {
+        let req = make_llm_request(vec![InputMessage {
+            role: "system".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "This summarizes internal chat history with <state_snapshot> data"
+                    .to_string(),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Recap);
+    }
+
+    #[test]
+    fn test_classify_cosh_project_summary_recap() {
+        let req = make_llm_request(vec![InputMessage {
+            role: "system".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "You are a specialized context summarizer for project files".to_string(),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Recap);
+    }
+
+    #[test]
+    fn test_classify_cosh_tool_output_recap() {
+        let req = make_llm_request(vec![InputMessage {
+            role: "user".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "Summarize the following tool output to be a maximum of 500 tokens: ..."
+                    .to_string(),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Recap);
+    }
+
+    #[test]
+    fn test_classify_claude_web_search() {
+        let req = make_llm_request(vec![InputMessage {
+            role: "user".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "Perform a web search for the query: rust async programming".to_string(),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::WebSearch);
+    }
+
+    #[test]
+    fn test_classify_claude_recap() {
+        let req = make_llm_request(vec![InputMessage {
+            role: "user".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "Your task is to create a detailed summary of the conversation so far. Do NOT call any tools during this.".to_string(),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Recap);
+    }
+
+    #[test]
+    fn test_classify_normal_call_not_misclassified() {
+        let req = make_llm_request(vec![
+            InputMessage {
+                role: "system".to_string(),
+                parts: vec![MessagePart::Text {
+                    content: "You are Copilot Shell, a helpful assistant.".to_string(),
+                }],
+                name: None,
+            },
+            InputMessage {
+                role: "user".to_string(),
+                parts: vec![MessagePart::Text {
+                    content: "explain this code".to_string(),
+                }],
+                name: None,
+            },
+        ]);
+        assert_eq!(classify_call_kind(&req), CallKind::Main);
+    }
+
+    #[test]
+    fn test_classify_empty_request_is_main() {
+        let req = make_llm_request(vec![]);
+        assert_eq!(classify_call_kind(&req), CallKind::Main);
+    }
+
     #[test]
     fn test_is_llm_api_path() {
         let builder = GenAIBuilder::new();
@@ -454,6 +702,131 @@ mod tests {
         let cache = HashMap::new();
         let result = GenAIBuilder::resolve_agent_name_from_comm("random_process", 99, &cache);
         assert!(result.is_none());
+    }
+
+    // ─── classify_call_kind_from_raw tests ─────────────────────────────────────
+
+    use super::classify_call_kind_from_raw;
+
+    #[test]
+    fn test_raw_classify_recap_cosh_compaction() {
+        // system_instructions contains both markers
+        let sys = Some(
+            serde_json::to_string(&serde_json::json!([
+                {"content": "This summarizes internal chat history and <state_snapshot> data"}
+            ]))
+            .unwrap(),
+        );
+        assert_eq!(classify_call_kind_from_raw(&sys, ""), "recap");
+    }
+
+    #[test]
+    fn test_raw_classify_recap_specialized_summarizer() {
+        let sys = Some(
+            serde_json::to_string(&serde_json::json!([
+                {"content": "You are a specialized context summarizer"}
+            ]))
+            .unwrap(),
+        );
+        assert_eq!(classify_call_kind_from_raw(&sys, ""), "recap");
+    }
+
+    #[test]
+    fn test_raw_classify_recap_tool_output() {
+        let first_user = "Summarize the following tool output to be a maximum of 500 tokens: ...";
+        assert_eq!(classify_call_kind_from_raw(&None, first_user), "recap");
+    }
+
+    #[test]
+    fn test_raw_classify_recap_claude_code() {
+        let first_user = "Your task is to create a detailed summary of the conversation so far. Please Do NOT call any tools in this turn.";
+        assert_eq!(classify_call_kind_from_raw(&None, first_user), "recap");
+    }
+
+    #[test]
+    fn test_raw_classify_web_search() {
+        let first_user = "Perform a web search for the query: rust async";
+        assert_eq!(classify_call_kind_from_raw(&None, first_user), "web_search");
+    }
+
+    #[test]
+    fn test_raw_classify_main_default() {
+        assert_eq!(
+            classify_call_kind_from_raw(&None, "explain this code"),
+            "main"
+        );
+    }
+
+    #[test]
+    fn test_raw_classify_main_no_sys_instructions() {
+        assert_eq!(classify_call_kind_from_raw(&None, ""), "main");
+    }
+
+    #[test]
+    fn test_raw_classify_content_array_format() {
+        // system_instructions with content as array of {type, text} objects
+        let sys = Some(
+            serde_json::to_string(&serde_json::json!([
+                {"content": [{"type": "text", "text": "This summarizes internal chat history"}, {"type": "text", "text": "and <state_snapshot> data"}]}
+            ]))
+            .unwrap(),
+        );
+        assert_eq!(classify_call_kind_from_raw(&sys, ""), "recap");
+    }
+
+    #[test]
+    fn test_raw_classify_invalid_json_sys_instructions() {
+        // Invalid JSON in system_instructions → falls through to first_user_text
+        let sys = Some("not valid json".to_string());
+        assert_eq!(classify_call_kind_from_raw(&sys, ""), "main");
+    }
+
+    #[test]
+    fn test_raw_classify_partial_recap_markers_not_enough() {
+        // Only one of the two markers → not recap
+        let sys = Some(
+            serde_json::to_string(&serde_json::json!([
+                {"content": "This summarizes internal chat history without snapshot"}
+            ]))
+            .unwrap(),
+        );
+        assert_eq!(classify_call_kind_from_raw(&sys, ""), "main");
+    }
+
+    #[test]
+    fn test_call_kind_as_str() {
+        assert_eq!(CallKind::Main.as_str(), "main");
+        assert_eq!(CallKind::Recap.as_str(), "recap");
+        assert_eq!(CallKind::WebSearch.as_str(), "web_search");
+    }
+
+    #[test]
+    fn test_classify_with_non_text_parts_system() {
+        // System message with only a ToolCall part → no text extracted → Main
+        let req = make_llm_request(vec![InputMessage {
+            role: "system".to_string(),
+            parts: vec![MessagePart::ToolCall {
+                id: None,
+                name: "read_file".to_string(),
+                arguments: None,
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Main);
+    }
+
+    #[test]
+    fn test_classify_with_non_text_parts_user() {
+        // User message with ToolCallResponse part → first_user_text is None → Main
+        let req = make_llm_request(vec![InputMessage {
+            role: "user".to_string(),
+            parts: vec![MessagePart::ToolCallResponse {
+                id: Some("tc-1".to_string()),
+                response: serde_json::json!({"result": "ok"}),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Main);
     }
 
     #[test]

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -216,14 +216,12 @@ impl LogtailExporter {
         let label = if dynamic { "dynamic" } else { "fixed" };
         if encryptor.is_none() {
             log::info!(
-                "Logtail exporter ({}): encryption disabled (no public key configured)",
-                label
+                "Logtail exporter ({label}): encryption disabled (no public key configured)"
             );
         }
         if !trace_enabled {
             log::info!(
-                "Logtail exporter ({}): traceEnabled=false, conversation content fields (gen_ai.system_instructions, gen_ai.input.messages, gen_ai.output.messages) will NOT be uploaded",
-                label
+                "Logtail exporter ({label}): traceEnabled=false, conversation content fields (gen_ai.system_instructions, gen_ai.input.messages, gen_ai.output.messages) will NOT be uploaded"
             );
         }
         LogtailExporter {

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -42,6 +42,8 @@ pub struct SessionQuery {
     pub start_ns: Option<i64>,
     /// End of time range in nanoseconds (default: now)
     pub end_ns: Option<i64>,
+    /// Include auxiliary calls (recap, web_search) in results (default: false)
+    pub include_auxiliary: Option<bool>,
 }
 
 /// GET /api/sessions?start_ns=<i64>&end_ns=<i64>
@@ -60,11 +62,13 @@ pub async fn list_sessions(
         .unwrap_or_else(|| end_ns - 86_400_000_000_000i64); // 24 h
 
     match GenAISqliteStore::new_with_path(db_path) {
-        Ok(store) => match store.list_sessions(start_ns, end_ns) {
-            Ok(sessions) => HttpResponse::Ok().json(sessions),
-            Err(e) => HttpResponse::InternalServerError()
-                .json(serde_json::json!({"error": e.to_string()})),
-        },
+        Ok(store) => {
+            match store.list_sessions(start_ns, end_ns, query.include_auxiliary.unwrap_or(false)) {
+                Ok(sessions) => HttpResponse::Ok().json(sessions),
+                Err(e) => HttpResponse::InternalServerError()
+                    .json(serde_json::json!({"error": e.to_string()})),
+            }
+        }
         Err(e) => {
             HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
         }
@@ -88,7 +92,12 @@ pub async fn list_traces_by_session(
     let end_ns = query.end_ns;
 
     match GenAISqliteStore::new_with_path(db_path) {
-        Ok(store) => match store.list_traces_by_session(&session_id, start_ns, end_ns) {
+        Ok(store) => match store.list_traces_by_session(
+            &session_id,
+            start_ns,
+            end_ns,
+            query.include_auxiliary.unwrap_or(false),
+        ) {
             Ok(traces) => HttpResponse::Ok().json(traces),
             Err(e) => HttpResponse::InternalServerError()
                 .json(serde_json::json!({"error": e.to_string()})),
@@ -152,6 +161,8 @@ pub async fn get_conversation_events(
 pub struct TimeRangeQuery {
     pub start_ns: Option<i64>,
     pub end_ns: Option<i64>,
+    /// Include auxiliary calls (recap, web_search) in results (default: false)
+    pub include_auxiliary: Option<bool>,
 }
 
 /// Query parameters for time-series endpoints

--- a/src/agentsight/src/storage/sqlite/genai/events.rs
+++ b/src/agentsight/src/storage/sqlite/genai/events.rs
@@ -448,12 +448,12 @@ impl GenAISqliteStore {
                         cache_creation_tokens, cache_read_tokens,
                         system_instructions, input_messages, output_messages,
                         user_query, http_method, http_path, status_code,
-                        is_sse, sse_event_count, event_json, tool_call_ids
+                        is_sse, sse_event_count, event_json, tool_call_ids, call_kind
                     ) VALUES (
                         ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
                         ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22,
                         ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32,
-                        ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40
+                        ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41
                     )",
                     params![
                         "llm_call",
@@ -496,6 +496,7 @@ impl GenAISqliteStore {
                         call.metadata.get("sse_event_count").and_then(|s| s.parse::<i64>().ok()),
                         event_json,
                         tool_call_ids,
+                        call.metadata.get("call_kind").map(|s| s.as_str()).unwrap_or("main"),
                     ],
                 )?;
             }

--- a/src/agentsight/src/storage/sqlite/genai/pending.rs
+++ b/src/agentsight/src/storage/sqlite/genai/pending.rs
@@ -41,6 +41,8 @@ pub struct PendingCallInfo {
     pub model: Option<String>,
     /// Provider name (extracted from request path)
     pub provider: Option<String>,
+    /// Call kind classification: "main" | "recap" | "web_search"
+    pub call_kind: String,
 }
 
 /// Data extracted from captured SSE events for enriching a pending record.
@@ -71,14 +73,14 @@ impl GenAISqliteStore {
                 start_timestamp_ns, pid, process_name, agent_name,
                 http_method, http_path, is_sse,
                 input_messages, system_instructions, user_query,
-                model, provider,
+                model, provider, call_kind,
                 event_json
             ) VALUES (
                 'llm_call', 'pending', ?1, ?2, ?3, ?4, ?5,
                 ?6, ?7, ?8, ?9,
                 ?10, ?11, ?12,
                 ?13, ?14, ?15,
-                ?16, ?17,
+                ?16, ?17, ?18,
                 '{}'
             )",
             params![
@@ -99,6 +101,7 @@ impl GenAISqliteStore {
                 info.user_query,
                 info.model,
                 info.provider,
+                info.call_kind,
             ],
         )?;
         Ok(())
@@ -233,8 +236,9 @@ impl GenAISqliteStore {
                         status_code         = ?25,
                         sse_event_count     = ?26,
                         event_json          = ?27,
-                        tool_call_ids       = ?28
-                    WHERE call_id = ?29 AND status IN ('pending', 'interrupted')",
+                        tool_call_ids       = ?28,
+                        call_kind           = ?29
+                    WHERE call_id = ?30 AND status IN ('pending', 'interrupted')",
                     params![
                         call.metadata.get("response_id"),
                         call.metadata.get("conversation_id"),
@@ -268,6 +272,10 @@ impl GenAISqliteStore {
                             .and_then(|s| s.parse::<i64>().ok()),
                         event_json,
                         tool_call_ids,
+                        call.metadata
+                            .get("call_kind")
+                            .map(|s| s.as_str())
+                            .unwrap_or("main"),
                         call.call_id,
                     ],
                 )?;

--- a/src/agentsight/src/storage/sqlite/genai/schema.rs
+++ b/src/agentsight/src/storage/sqlite/genai/schema.rs
@@ -86,6 +86,8 @@ impl GenAISqliteStore {
                 sse_event_count INTEGER,
                 -- Interruption type detected for this call (nullable)
                 interruption_type TEXT,
+                -- Call kind classification (main/recap/web_search)
+                call_kind TEXT NOT NULL DEFAULT 'main',
                 -- Full event as JSON (fallback)
                 event_json TEXT NOT NULL,
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -175,6 +177,13 @@ impl GenAISqliteStore {
 
         // v5: tool_call_ids JSON array for output tool calls
         ensure_col!("tool_call_ids", "TEXT");
+
+        // v6: call_kind classification (main/recap/web_search)
+        ensure_col!(
+            "call_kind",
+            "TEXT NOT NULL DEFAULT 'main'",
+            "idx_genai_call_kind"
+        );
 
         Ok(())
     }

--- a/src/agentsight/src/storage/sqlite/genai/session.rs
+++ b/src/agentsight/src/storage/sqlite/genai/session.rs
@@ -59,9 +59,15 @@ impl GenAISqliteStore {
         &self,
         start_ns: i64,
         end_ns: i64,
+        include_auxiliary: bool,
     ) -> Result<Vec<SessionSummary>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let call_kind_filter = if include_auxiliary {
+            ""
+        } else {
+            " AND (call_kind = 'main' OR call_kind IS NULL)"
+        };
+        let sql = format!(
             "SELECT session_id,
                     COUNT(DISTINCT conversation_id) AS conversation_count,
                     MIN(start_timestamp_ns)  AS first_seen_ns,
@@ -73,10 +79,11 @@ impl GenAISqliteStore {
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND session_id IS NOT NULL
-               AND start_timestamp_ns BETWEEN ?1 AND ?2
+               AND start_timestamp_ns BETWEEN ?1 AND ?2{call_kind_filter}
              GROUP BY session_id
-             ORDER BY last_seen_ns DESC",
-        )?;
+             ORDER BY last_seen_ns DESC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(params![start_ns, end_ns], |row| {
             Ok(SessionSummary {
                 session_id: row.get(0)?,
@@ -298,63 +305,19 @@ impl GenAISqliteStore {
         session_id: &str,
         start_ns: Option<i64>,
         end_ns: Option<i64>,
+        include_auxiliary: bool,
     ) -> Result<Vec<TraceSummary>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap();
 
+        let call_kind_filter = if include_auxiliary {
+            ""
+        } else {
+            " AND (call_kind = 'main' OR call_kind IS NULL)"
+        };
+
         // When both start_ns and end_ns are present, rewrite with BETWEEN
         let sql = if start_ns.is_some() && end_ns.is_some() {
-            "SELECT conversation_id,
-                        COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens), 0)  AS total_input,
-                        COALESCE(SUM(output_tokens), 0) AS total_output,
-                        MIN(start_timestamp_ns)         AS start_ns,
-                        MAX(end_timestamp_ns)           AS end_ns,
-                        MAX(model)                      AS model,
-                        MIN(user_query)                 AS user_query
-                 FROM genai_events
-                 WHERE event_type = 'llm_call'
-                   AND session_id = ?1
-                   AND conversation_id IS NOT NULL
-                   AND start_timestamp_ns BETWEEN ?2 AND ?3
-                 GROUP BY conversation_id
-                 ORDER BY start_ns DESC"
-                .to_string()
-        } else if start_ns.is_some() {
-            "SELECT conversation_id,
-                        COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens), 0)  AS total_input,
-                        COALESCE(SUM(output_tokens), 0) AS total_output,
-                        MIN(start_timestamp_ns)         AS start_ns,
-                        MAX(end_timestamp_ns)           AS end_ns,
-                        MAX(model)                      AS model,
-                        MIN(user_query)                 AS user_query
-                 FROM genai_events
-                 WHERE event_type = 'llm_call'
-                   AND session_id = ?1
-                   AND conversation_id IS NOT NULL
-                   AND start_timestamp_ns >= ?2
-                 GROUP BY conversation_id
-                 ORDER BY start_ns DESC"
-                .to_string()
-        } else if end_ns.is_some() {
-            "SELECT conversation_id,
-                        COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens), 0)  AS total_input,
-                        COALESCE(SUM(output_tokens), 0) AS total_output,
-                        MIN(start_timestamp_ns)         AS start_ns,
-                        MAX(end_timestamp_ns)           AS end_ns,
-                        MAX(model)                      AS model,
-                        MIN(user_query)                 AS user_query
-                 FROM genai_events
-                 WHERE event_type = 'llm_call'
-                   AND session_id = ?1
-                   AND conversation_id IS NOT NULL
-                   AND start_timestamp_ns <= ?2
-                 GROUP BY conversation_id
-                 ORDER BY start_ns DESC"
-                .to_string()
-        } else {
-            String::from(
+            format!(
                 "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
                         COALESCE(SUM(input_tokens), 0)  AS total_input,
@@ -367,8 +330,62 @@ impl GenAISqliteStore {
                  WHERE event_type = 'llm_call'
                    AND session_id = ?1
                    AND conversation_id IS NOT NULL
+                   AND start_timestamp_ns BETWEEN ?2 AND ?3{call_kind_filter}
                  GROUP BY conversation_id
-                 ORDER BY start_ns DESC",
+                 ORDER BY start_ns DESC"
+            )
+        } else if start_ns.is_some() {
+            format!(
+                "SELECT conversation_id,
+                        COUNT(*)                        AS call_count,
+                        COALESCE(SUM(input_tokens), 0)  AS total_input,
+                        COALESCE(SUM(output_tokens), 0) AS total_output,
+                        MIN(start_timestamp_ns)         AS start_ns,
+                        MAX(end_timestamp_ns)           AS end_ns,
+                        MAX(model)                      AS model,
+                        MIN(user_query)                 AS user_query
+                 FROM genai_events
+                 WHERE event_type = 'llm_call'
+                   AND session_id = ?1
+                   AND conversation_id IS NOT NULL
+                   AND start_timestamp_ns >= ?2{call_kind_filter}
+                 GROUP BY conversation_id
+                 ORDER BY start_ns DESC"
+            )
+        } else if end_ns.is_some() {
+            format!(
+                "SELECT conversation_id,
+                        COUNT(*)                        AS call_count,
+                        COALESCE(SUM(input_tokens), 0)  AS total_input,
+                        COALESCE(SUM(output_tokens), 0) AS total_output,
+                        MIN(start_timestamp_ns)         AS start_ns,
+                        MAX(end_timestamp_ns)           AS end_ns,
+                        MAX(model)                      AS model,
+                        MIN(user_query)                 AS user_query
+                 FROM genai_events
+                 WHERE event_type = 'llm_call'
+                   AND session_id = ?1
+                   AND conversation_id IS NOT NULL
+                   AND start_timestamp_ns <= ?2{call_kind_filter}
+                 GROUP BY conversation_id
+                 ORDER BY start_ns DESC"
+            )
+        } else {
+            format!(
+                "SELECT conversation_id,
+                        COUNT(*)                        AS call_count,
+                        COALESCE(SUM(input_tokens), 0)  AS total_input,
+                        COALESCE(SUM(output_tokens), 0) AS total_output,
+                        MIN(start_timestamp_ns)         AS start_ns,
+                        MAX(end_timestamp_ns)           AS end_ns,
+                        MAX(model)                      AS model,
+                        MIN(user_query)                 AS user_query
+                 FROM genai_events
+                 WHERE event_type = 'llm_call'
+                   AND session_id = ?1
+                   AND conversation_id IS NOT NULL{call_kind_filter}
+                 GROUP BY conversation_id
+                 ORDER BY start_ns DESC"
             )
         };
 

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -436,7 +436,9 @@ fn test_get_agent_token_summary_empty() {
 #[test]
 fn test_list_sessions() {
     let (store, path) = create_populated_store("list_sess");
-    let r = store.list_sessions(BASE_NS, BASE_NS + 6 * STEP_NS).unwrap();
+    let r = store
+        .list_sessions(BASE_NS, BASE_NS + 6 * STEP_NS, true)
+        .unwrap();
     assert_eq!(r.len(), 2);
     // sess-1 last_seen=base+5s > sess-2 base+4s
     assert_eq!(r[0].session_id, "sess-1");
@@ -518,7 +520,9 @@ fn test_get_tool_call_turn_indices() {
 #[test]
 fn test_list_traces_by_session() {
     let (store, path) = create_populated_store("traces");
-    let r = store.list_traces_by_session("sess-1", None, None).unwrap();
+    let r = store
+        .list_traces_by_session("sess-1", None, None, true)
+        .unwrap();
     assert_eq!(r.len(), 2);
     let c1 = r.iter().find(|t| t.conversation_id == "conv-1").unwrap();
     assert_eq!(c1.call_count, 3);
@@ -533,7 +537,7 @@ fn test_list_traces_by_session() {
 fn test_list_traces_by_session_with_time_range() {
     let (store, path) = create_populated_store("traces_range");
     let r = store
-        .list_traces_by_session("sess-1", Some(BASE_NS), Some(BASE_NS + STEP_NS))
+        .list_traces_by_session("sess-1", Some(BASE_NS), Some(BASE_NS + STEP_NS), true)
         .unwrap();
     assert_eq!(r.len(), 1); // only conv-1
     assert_eq!(r[0].call_count, 2); // call-1, call-2
@@ -654,6 +658,7 @@ fn test_insert_pending() {
         is_sse: true,
         model: Some("gpt-4".to_string()),
         provider: Some("openai".to_string()),
+        call_kind: "main".to_string(),
     };
     store.insert_pending(&info).unwrap();
     let conn = store.conn.lock().unwrap();
@@ -793,4 +798,111 @@ fn test_wal_checkpoint_methods() {
     store.checkpoint().unwrap();
     store.wal_checkpoint().unwrap();
     cleanup_db(&path);
+}
+
+// ─── list_sessions / list_traces call_kind filter tests ──────────────────────
+
+fn make_store_with_pending(records: &[(&str, &str, &str, &str, i64)]) -> GenAISqliteStore {
+    let path = std::env::temp_dir().join(format!(
+        "test_ck_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+    for (call_id, sid, cid, kind, ts) in records {
+        let info = PendingCallInfo {
+            call_id: call_id.to_string(),
+            trace_id: None,
+            conversation_id: Some(cid.to_string()),
+            session_id: Some(sid.to_string()),
+            start_timestamp_ns: *ts as u64,
+            pid: 1,
+            process_name: "test".to_string(),
+            agent_name: Some("test-agent".to_string()),
+            http_method: None,
+            http_path: None,
+            input_messages: None,
+            system_instructions: None,
+            user_query: None,
+            is_sse: false,
+            model: Some("gpt-4".to_string()),
+            provider: Some("openai".to_string()),
+            call_kind: kind.to_string(),
+        };
+        store.insert_pending(&info).unwrap();
+    }
+    store
+}
+
+#[test]
+fn test_list_sessions_excludes_auxiliary() {
+    let store = make_store_with_pending(&[
+        ("c1", "sess-a", "conv-1", "main", 1000),
+        ("c2", "sess-a", "conv-2", "recap", 2000),
+        ("c3", "sess-b", "conv-3", "web_search", 3000),
+        ("c4", "sess-b", "conv-4", "main", 4000),
+    ]);
+    let sessions = store.list_sessions(0, 10000, false).unwrap();
+    assert_eq!(sessions.len(), 2);
+    for s in &sessions {
+        assert!(s.conversation_count >= 1);
+    }
+    let sessions_all = store.list_sessions(0, 10000, true).unwrap();
+    assert_eq!(sessions_all.len(), 2);
+    let total_convs: i64 = sessions_all.iter().map(|s| s.conversation_count).sum();
+    assert_eq!(total_convs, 4);
+}
+
+#[test]
+fn test_list_sessions_only_auxiliary_hidden() {
+    let store = make_store_with_pending(&[
+        ("c1", "sess-recap", "conv-1", "recap", 1000),
+        ("c2", "sess-recap", "conv-2", "web_search", 2000),
+    ]);
+    let sessions = store.list_sessions(0, 10000, false).unwrap();
+    assert!(
+        sessions.is_empty(),
+        "sessions with only auxiliary calls should be hidden"
+    );
+    let sessions_all = store.list_sessions(0, 10000, true).unwrap();
+    assert_eq!(sessions_all.len(), 1);
+}
+
+#[test]
+fn test_list_traces_by_session_excludes_auxiliary() {
+    let store = make_store_with_pending(&[
+        ("c1", "sess-x", "conv-main", "main", 1000),
+        ("c2", "sess-x", "conv-recap", "recap", 2000),
+        ("c3", "sess-x", "conv-main", "main", 3000),
+    ]);
+    let traces = store
+        .list_traces_by_session("sess-x", None, None, false)
+        .unwrap();
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0].conversation_id, "conv-main");
+    assert_eq!(traces[0].call_count, 2);
+    let traces_all = store
+        .list_traces_by_session("sess-x", None, None, true)
+        .unwrap();
+    assert_eq!(traces_all.len(), 2);
+}
+
+#[test]
+fn test_list_traces_call_kind_filter_with_time_range() {
+    let store = make_store_with_pending(&[
+        ("c1", "sess-t", "conv-a", "main", 1000),
+        ("c2", "sess-t", "conv-b", "recap", 2000),
+        ("c3", "sess-t", "conv-c", "main", 5000),
+    ]);
+    let traces = store
+        .list_traces_by_session("sess-t", Some(0), Some(3000), false)
+        .unwrap();
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0].conversation_id, "conv-a");
+    let traces_all = store
+        .list_traces_by_session("sess-t", Some(0), Some(3000), true)
+        .unwrap();
+    assert_eq!(traces_all.len(), 2);
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -696,8 +696,7 @@ impl AgentSight {
                         }
                     } else {
                         log::warn!(
-                            "Deferred GenAI call queued without pending_info (response_id={}), crash detection blind spot remains",
-                            pending_resp_id
+                            "Deferred GenAI call queued without pending_info (response_id={pending_resp_id}), crash detection blind spot remains"
                         );
                     }
                     self.pending_genai.push(PendingGenAI {
@@ -1905,6 +1904,7 @@ mod tests {
             is_sse: false,
             model: Some("gpt-4".to_string()),
             provider: Some("openai".to_string()),
+            call_kind: "main".to_string(),
         }
     }
 


### PR DESCRIPTION
## Summary

Classify LLM calls as `main` / `recap` / `web_search` based on request content signatures from real captures (Cosh + Claude Code). Persist to SQLite with idempotent migration; default listing hides auxiliary calls unless `include_auxiliary=true`.

## Classifier (dual-path)

- **System instructions** (Cosh): compaction recap, project-summary recap
- **First-user text** (Claude Code + Cosh tool-output): web_search, recap, tool-output summary
- **Default**: Main (conservative, zero false positives)

## Changes

- `helpers.rs`: `CallKind` enum + `classify_call_kind()` pure function
- `call_builder.rs` / `builder.rs`: wire call_kind into metadata
- `genai.rs`: schema migration (`ensure_col!`), 3 write points, filtered queries
- `handlers.rs`: `include_auxiliary` API param

## Tests

7 discriminating tests: each kind correct + normal calls not misclassified + empty request → Main

Closes #1014