### PR TITLE
refactor(sight): replace unwrap with if-let

### DIFF
--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -687,7 +687,7 @@ impl AgentSight {
             }
 
             if !output.events.is_empty() {
-                if output.pending_response_id.is_some() {
+                if let Some(pending_resp_id) = output.pending_response_id {
                     // Session_id not yet resolved — queue for deferred resolution.
                     // Write a pending row NOW so crash detection can see this call
                     // during the deferral window (up to PENDING_SESSION_TIMEOUT).
@@ -704,12 +704,12 @@ impl AgentSight {
                     } else {
                         log::warn!(
                             "Deferred GenAI call queued without pending_info (response_id={}), crash detection blind spot remains",
-                            output.pending_response_id.as_deref().unwrap_or("unknown")
+                            pending_resp_id
                         );
                     }
                     self.pending_genai.push(PendingGenAI {
                         events: output.events,
-                        response_id: output.pending_response_id.unwrap(),
+                        response_id: pending_resp_id,
                         created_at: std::time::Instant::now(),
                     });
                     log::debug!("GenAI events queued for deferred session_id resolution");


### PR DESCRIPTION
## Summary

Replace the single non-test `unwrap()` in unified.rs (line 712) with `if let` pattern matching. The `pending_response_id.unwrap()` was guarded by `is_some()` but still violated the no-unwrap-in-production rule.

## Change

Convert `if output.pending_response_id.is_some()` + `.unwrap()` into `if let Some(pending_resp_id) = output.pending_response_id`, eliminating the unwrap while simplifying the surrounding code.

Follow-up from #937 review (chengshuyi).