### PR TITLE
feat(sec-core): pass agent_name to telemetry data

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/correlation_context.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/correlation_context.py
@@ -18,6 +18,7 @@ _FIELD_ALIASES: dict[str, tuple[str, str]] = {
     "run_id": ("run_id", "runId"),
     "call_id": ("call_id", "callId"),
     "tool_call_id": ("tool_call_id", "toolCallId"),
+    "agent_name": ("agent_name", "agentName"),
 }
 CORRELATION_FIELD_NAMES: tuple[str, ...] = tuple(_FIELD_ALIASES)
 
@@ -40,6 +41,7 @@ class TraceContext:
     run_id: str | None = None
     call_id: str | None = None
     tool_call_id: str | None = None
+    agent_name: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/client.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/client.py
@@ -6,9 +6,7 @@ from typing import Any
 
 from agent_sec_cli.correlation_context import (
     clean_correlation_value,
-    get_current_trace_context,
     get_invocation_id,
-    trace_context_to_payload,
 )
 from agent_sec_cli.daemon.errors import (
     DaemonClientTimeoutError,
@@ -43,20 +41,17 @@ class DaemonClient:
         self,
         method: str,
         params: dict[str, Any] | None = None,
-        trace_context: dict[str, Any] | None = None,
+        *,
+        trace_context: dict[str, Any],
         timeout_ms: int | None = None,
         caller: str | None = None,
     ) -> DaemonResponse:
         """Send one request and return the daemon response.
 
-        When *trace_context* is ``None`` (the default), the current
-        process-level trace context is automatically inherited.  Pass
-        an explicit empty dict ``{}`` to suppress inheritance (e.g. for
-        health checks).
+        Callers must pass *trace_context* explicitly. Pass an empty dict
+        ``{}`` when no caller correlation fields should be forwarded.
         """
         effective_timeout_ms = timeout_ms or self.timeout_ms
-        if trace_context is None:
-            trace_context = trace_context_to_payload(get_current_trace_context())
         request = DaemonRequest(
             method=method,
             params={} if params is None else params,
@@ -122,9 +117,9 @@ def daemon_health_reachable(socket_path: Path, timeout_ms: int = 250) -> bool:
 
 
 def _trace_context_with_fallback_trace_id(
-    trace_context: dict[str, Any] | None,
+    trace_context: dict[str, Any],
 ) -> dict[str, Any]:
-    payload = {} if trace_context is None else dict(trace_context)
+    payload = dict(trace_context)
     trace_id = clean_correlation_value("trace_id", payload.get("trace_id"))
     if trace_id is None:
         trace_id = clean_correlation_value("trace_id", payload.get("traceId"))

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/client.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/client.py
@@ -6,7 +6,9 @@ from typing import Any
 
 from agent_sec_cli.correlation_context import (
     clean_correlation_value,
+    get_current_trace_context,
     get_invocation_id,
+    trace_context_to_payload,
 )
 from agent_sec_cli.daemon.errors import (
     DaemonClientTimeoutError,
@@ -45,8 +47,16 @@ class DaemonClient:
         timeout_ms: int | None = None,
         caller: str | None = None,
     ) -> DaemonResponse:
-        """Send one request and return the daemon response."""
+        """Send one request and return the daemon response.
+
+        When *trace_context* is ``None`` (the default), the current
+        process-level trace context is automatically inherited.  Pass
+        an explicit empty dict ``{}`` to suppress inheritance (e.g. for
+        health checks).
+        """
         effective_timeout_ms = timeout_ms or self.timeout_ms
+        if trace_context is None:
+            trace_context = trace_context_to_payload(get_current_trace_context())
         request = DaemonRequest(
             method=method,
             params={} if params is None else params,
@@ -104,6 +114,7 @@ def daemon_health_reachable(socket_path: Path, timeout_ms: int = 250) -> bool:
         response = DaemonClient(socket_path=socket_path, timeout_ms=timeout_ms).call(
             "daemon.health",
             timeout_ms=timeout_ms,
+            trace_context={},
         )
     except (DaemonProtocolError, DaemonTransportError):
         return False

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
@@ -6,6 +6,10 @@ from pathlib import Path
 from typing import Any
 
 import typer
+from agent_sec_cli.correlation_context import (
+    get_current_trace_context,
+    trace_context_to_payload,
+)
 from agent_sec_cli.daemon.client import DaemonClient
 from agent_sec_cli.daemon.env import daemon_disabled
 from agent_sec_cli.daemon.protocol import DaemonResponse
@@ -232,6 +236,7 @@ def _call_scan_prompt_daemon(
     return DaemonClient(timeout_ms=DAEMON_REQUEST_TIMEOUT_MS).call(
         "scan-prompt",
         params={"text": text, "mode": mode, "source": source},
+        trace_context=trace_context_to_payload(get_current_trace_context()),
         caller="cli",
         timeout_ms=DAEMON_REQUEST_TIMEOUT_MS,
     )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
@@ -6,10 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import typer
-from agent_sec_cli.correlation_context import (
-    get_current_trace_context,
-    trace_context_to_payload,
-)
 from agent_sec_cli.daemon.client import DaemonClient
 from agent_sec_cli.daemon.env import daemon_disabled
 from agent_sec_cli.daemon.protocol import DaemonResponse
@@ -236,7 +232,6 @@ def _call_scan_prompt_daemon(
     return DaemonClient(timeout_ms=DAEMON_REQUEST_TIMEOUT_MS).call(
         "scan-prompt",
         params={"text": text, "mode": mode, "source": source},
-        trace_context=trace_context_to_payload(get_current_trace_context()),
         caller="cli",
         timeout_ms=DAEMON_REQUEST_TIMEOUT_MS,
     )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/context.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/context.py
@@ -31,6 +31,7 @@ class RequestContext:
         run_id:      Optional agent run or turn correlation ID.
         call_id:     Optional LLM call correlation ID.
         tool_call_id: Optional tool call correlation ID.
+        agent_name:  Optional agent runtime name for telemetry metadata.
         timestamp:   ISO-8601 timestamp of request creation.  Auto-filled.
         invocation_id: Process-wide CLI invocation ID. Auto-filled.
     """
@@ -42,6 +43,7 @@ class RequestContext:
     run_id: str | None = None
     call_id: str | None = None
     tool_call_id: str | None = None
+    agent_name: str | None = None
     timestamp: str = ""
     invocation_id: str = ""
 
@@ -60,6 +62,8 @@ class RequestContext:
                 self.call_id = trace_ctx.call_id
             if self.tool_call_id is None:
                 self.tool_call_id = trace_ctx.tool_call_id
+            if self.agent_name is None:
+                self.agent_name = trace_ctx.agent_name
         if not self.trace_id:
             self.trace_id = _new_uuid()
         if not self.timestamp:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
@@ -29,14 +29,14 @@ def _category_for(action: str) -> str:
     return _ACTION_CATEGORY.get(action, action)
 
 
-def _emit_event(event: SecurityEvent) -> None:
+def _emit_event(ctx: RequestContext, event: SecurityEvent) -> None:
     """Best-effort emit of security event and derived telemetry."""
     try:
         log_event(event)
     except Exception:  # noqa: BLE001
         pass
     try:
-        record_security_event_telemetry(event)
+        record_security_event_telemetry(event, ctx)
     except Exception:  # noqa: BLE001
         pass
 
@@ -81,7 +81,7 @@ def post_action(
             call_id=ctx.call_id,
             tool_call_id=ctx.tool_call_id,
         )
-        _emit_event(event)
+        _emit_event(ctx, event)
     except Exception:  # noqa: BLE001
         pass
 
@@ -110,6 +110,6 @@ def on_error(
             call_id=ctx.call_id,
             tool_call_id=ctx.tool_call_id,
         )
-        _emit_event(event)
+        _emit_event(ctx, event)
     except Exception:  # noqa: BLE001
         pass

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/config.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 from agent_sec_cli import __version__
+from agent_sec_cli.correlation_context import get_current_trace_context
 
 COMPONENT_NAME = "agent-sec-core"
 COMPONENT_AGENT_NAME = ""
@@ -25,9 +26,19 @@ def telemetry_log_path_exists() -> bool:
 
 
 def get_component_fields() -> dict[str, str]:
-    """Return fixed Agentic OS component fields for telemetry records."""
+    """Return fixed Agentic OS component fields for telemetry records.
+
+    ``component.agent_name`` is read from the ambient trace context
+    (process-level or request-local ContextVar).  Falls back to the
+    build-time default when no trace context is active.
+    """
+    trace_ctx = get_current_trace_context()
+    raw_agent_name = trace_ctx.agent_name if trace_ctx else None
+    component_agent_name = (
+        raw_agent_name.strip() if raw_agent_name else COMPONENT_AGENT_NAME
+    )
     return {
         "component.name": COMPONENT_NAME,
         "component.version": __version__,
-        "component.agent_name": COMPONENT_AGENT_NAME,
+        "component.agent_name": component_agent_name,
     }

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/config.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 
 from agent_sec_cli import __version__
-from agent_sec_cli.correlation_context import get_current_trace_context
 
 COMPONENT_NAME = "agent-sec-core"
 COMPONENT_AGENT_NAME = ""
@@ -26,19 +25,9 @@ def telemetry_log_path_exists() -> bool:
 
 
 def get_component_fields() -> dict[str, str]:
-    """Return fixed Agentic OS component fields for telemetry records.
-
-    ``component.agent_name`` is read from the ambient trace context
-    (process-level or request-local ContextVar).  Falls back to the
-    build-time default when no trace context is active.
-    """
-    trace_ctx = get_current_trace_context()
-    raw_agent_name = trace_ctx.agent_name if trace_ctx else None
-    component_agent_name = (
-        raw_agent_name.strip() if raw_agent_name else COMPONENT_AGENT_NAME
-    )
+    """Return fixed Agentic OS component fields for telemetry records."""
     return {
         "component.name": COMPONENT_NAME,
         "component.version": __version__,
-        "component.agent_name": component_agent_name,
+        "component.agent_name": COMPONENT_AGENT_NAME,
     }

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/schema.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/schema.py
@@ -1,10 +1,13 @@
 """Build telemetry records from SecurityEvent values."""
 
 import uuid
-from typing import Any
+from typing import Any, Protocol
 
 from agent_sec_cli.security_events.schema import SecurityEvent
-from agent_sec_cli.telemetry.config import get_component_fields
+from agent_sec_cli.telemetry.config import (
+    COMPONENT_AGENT_NAME,
+    get_component_fields,
+)
 from agent_sec_cli.telemetry.sanitizer import (
     details_dict,
     error_type_value,
@@ -19,19 +22,31 @@ from agent_sec_cli.telemetry.sanitizer import (
 _BASELINE_ACTION = "harden"
 
 
-def build_telemetry_security_event(event: SecurityEvent) -> dict[str, Any]:
+class TelemetryContext(Protocol):
+    """Context fields consumed by telemetry mapping."""
+
+    agent_name: str | None
+
+
+def build_telemetry_security_event(
+    event: SecurityEvent,
+    ctx: TelemetryContext,
+) -> dict[str, Any]:
     """Build a telemetry JSON record from a canonical SecurityEvent."""
     if event.event_type == _BASELINE_ACTION:
-        return _build_baseline_record(event)
-    return _build_seccore_record(event)
+        return _build_baseline_record(event, ctx)
+    return _build_seccore_record(event, ctx)
 
 
-def _build_seccore_record(event: SecurityEvent) -> dict[str, Any]:
+def _build_seccore_record(
+    event: SecurityEvent,
+    ctx: TelemetryContext,
+) -> dict[str, Any]:
     """Build a seccore.* telemetry record."""
     details = details_dict(event.details)
     result = result_dict(details)
 
-    record: dict[str, Any] = get_component_fields()
+    record = _component_fields(ctx)
     record.update(
         {
             "seccore.event_id": _event_id(event),
@@ -58,12 +73,15 @@ def _build_seccore_record(event: SecurityEvent) -> dict[str, Any]:
     return record
 
 
-def _build_baseline_record(event: SecurityEvent) -> dict[str, Any]:
+def _build_baseline_record(
+    event: SecurityEvent,
+    ctx: TelemetryContext,
+) -> dict[str, Any]:
     """Build a baseline.* telemetry record."""
     details = details_dict(event.details)
     result = result_dict(details)
 
-    record: dict[str, Any] = get_component_fields()
+    record = _component_fields(ctx)
     record.update(
         {
             "baseline.event_id": _event_id(event),
@@ -80,6 +98,19 @@ def _build_baseline_record(event: SecurityEvent) -> dict[str, Any]:
         }
     )
     return record
+
+
+def _component_fields(ctx: TelemetryContext) -> dict[str, str]:
+    """Return component fields with runtime agent_name resolved at mapping time."""
+    fields = get_component_fields()
+    fields["component.agent_name"] = _component_agent_name(ctx)
+    return fields
+
+
+def _component_agent_name(ctx: TelemetryContext) -> str:
+    if ctx.agent_name:
+        return ctx.agent_name.strip() or COMPONENT_AGENT_NAME
+    return COMPONENT_AGENT_NAME
 
 
 def _event_id(event: SecurityEvent) -> str:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
@@ -12,7 +12,10 @@ from typing import Any
 
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.telemetry.config import get_telemetry_log_path
-from agent_sec_cli.telemetry.schema import build_telemetry_security_event
+from agent_sec_cli.telemetry.schema import (
+    TelemetryContext,
+    build_telemetry_security_event,
+)
 
 _logger = logging.getLogger("agent_sec_cli.telemetry.writer")
 _writer: "TelemetryWriter | None" = None
@@ -151,12 +154,15 @@ def get_writer() -> TelemetryWriter:
     return _writer
 
 
-def record_security_event_telemetry(event: SecurityEvent) -> None:
+def record_security_event_telemetry(
+    event: SecurityEvent,
+    ctx: TelemetryContext,
+) -> None:
     """Best-effort write of telemetry mapped from a SecurityEvent."""
     try:
         writer = get_writer()
         if not writer.exists():
             return
-        writer.write(build_telemetry_security_event(event))
+        writer.write(build_telemetry_security_event(event, ctx))
     except Exception as exc:  # noqa: BLE001
         _log_telemetry_write_failure(exc)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/writer.py
@@ -35,6 +35,32 @@ def _log_telemetry_write_failure(exc: Exception) -> None:
         pass
 
 
+def _log_telemetry_write_skipped(
+    record: Mapping[str, Any],
+    *,
+    reason: str,
+    path: Path,
+) -> None:
+    """Best-effort diagnostic logging for intentionally skipped telemetry writes."""
+    try:
+        _logger.warning(
+            "telemetry JSONL write skipped",
+            extra={
+                "data": {
+                    "reason": reason,
+                    "path": str(path),
+                    "event_id": record.get("seccore.event_id")
+                    or record.get("baseline.event_id"),
+                    "event_type": record.get("seccore.event_type"),
+                    "category": record.get("seccore.category"),
+                    "agent_name": record.get("component.agent_name"),
+                }
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
 class TelemetryWriter:
     """Append telemetry records to an existing JSONL file.
 
@@ -73,7 +99,11 @@ class TelemetryWriter:
         except FileNotFoundError:
             pass
         except BlockingIOError:
-            pass
+            _log_telemetry_write_skipped(
+                record,
+                reason="target_flock_busy",
+                path=self._path,
+            )
         except Exception as exc:  # noqa: BLE001
             _log_telemetry_write_failure(exc)
         finally:

--- a/src/agent-sec-core/cosh-extension/hooks/trace_context.py
+++ b/src/agent-sec-core/cosh-extension/hooks/trace_context.py
@@ -25,6 +25,8 @@ def trace_context(input_data: dict[str, Any]) -> dict[str, str]:
 def with_trace_context(args: list[str], input_data: dict[str, Any]) -> list[str]:
     """Prepend hidden agent-sec-cli trace-context args when hook input has tracing."""
     context = trace_context(input_data)
+    if context is None:
+        return args
     return [
         args[0],
         "--trace-context",

--- a/src/agent-sec-core/cosh-extension/hooks/trace_context.py
+++ b/src/agent-sec-core/cosh-extension/hooks/trace_context.py
@@ -12,21 +12,19 @@ _FIELD_MAP = {
 }
 
 
-def trace_context(input_data: dict[str, Any]) -> dict[str, str] | None:
+def trace_context(input_data: dict[str, Any]) -> dict[str, str]:
     """Build canonical trace context from fields directly present on hook input."""
-    context: dict[str, str] = {}
+    context: dict[str, str] = {"agent_name": "cosh"}
     for output_key, input_key in _FIELD_MAP.items():
         value = input_data.get(input_key)
         if isinstance(value, str) and value.strip():
             context[output_key] = value.strip()
-    return context or None
+    return context
 
 
 def with_trace_context(args: list[str], input_data: dict[str, Any]) -> list[str]:
     """Prepend hidden agent-sec-cli trace-context args when hook input has tracing."""
     context = trace_context(input_data)
-    if context is None:
-        return args
     return [
         args[0],
         "--trace-context",

--- a/src/agent-sec-core/hermes-plugin/src/cli_runner.py
+++ b/src/agent-sec-core/hermes-plugin/src/cli_runner.py
@@ -72,16 +72,16 @@ _TRACE_FIELD_SPECS = (
 )
 
 
-def trace_context(data: dict[str, Any]) -> dict[str, str] | None:
+def trace_context(data: dict[str, Any]) -> dict[str, str]:
     """Build agent-sec-cli trace context from Hermes hook kwargs."""
-    context: dict[str, str] = {}
+    context: dict[str, str] = {"agent_name": "hermes"}
     for output_key, input_keys in _TRACE_FIELD_SPECS:
         for input_key in input_keys:
             value = data.get(input_key)
             if isinstance(value, str) and value.strip():
                 context[output_key] = value.strip()
                 break
-    return context or None
+    return context
 
 
 def _json_dumps(value: Any) -> str:

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
@@ -1,5 +1,5 @@
 import type { SecurityCapability } from "../types.js";
-import { callAgentSecCli } from "../utils.js";
+import { buildTraceContext, callAgentSecCli } from "../utils.js";
 
 /**
  * 用户输入 Prompt 注入 / 越狱检测。
@@ -21,7 +21,7 @@ export const promptScan: SecurityCapability = {
   hooks: ["before_dispatch"],
   register(api) {
     const cfg = (api.pluginConfig as Record<string, any>) ?? {};
-    api.on("before_dispatch", async (event: any) => {
+    api.on("before_dispatch", async (event: any, ctx: any) => {
       try {
         const text = String(event.content ?? event.body ?? "");
         if (!text.trim()) {
@@ -30,7 +30,7 @@ export const promptScan: SecurityCapability = {
 
         const result = await callAgentSecCli(
           ["scan-prompt", "--text", text, "--mode", "standard", "--format", "json", "--source", "user_input"],
-          { timeout: 10000 },
+          { timeout: 10000, traceContext: buildTraceContext(event, ctx) },
         );
 
         if (result.exitCode !== 0) {

--- a/src/agent-sec-core/openclaw-plugin/src/utils.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/utils.ts
@@ -16,6 +16,7 @@ export type CliCallOptions = {
 };
 
 export type TraceContext = {
+  agent_name?: string;
   trace_id?: string;
   session_id?: string;
   run_id?: string;
@@ -62,11 +63,11 @@ function traceValue(record: UnknownRecord | undefined, keys: string[]): string |
   return undefined;
 }
 
-export function buildTraceContext(event: unknown, ctx: unknown): TraceContext | undefined {
+export function buildTraceContext(event: unknown, ctx: unknown): TraceContext {
   const eventRecord = asRecord(event);
   const ctxRecord = asRecord(ctx);
   const sources = [eventRecord, ctxRecord];
-  const traceContext: TraceContext = {};
+  const traceContext: TraceContext = { agent_name: "openclaw" };
 
   for (const spec of TRACE_FIELD_SPECS) {
     for (const source of sources) {
@@ -78,7 +79,7 @@ export function buildTraceContext(event: unknown, ctx: unknown): TraceContext | 
     }
   }
 
-  return Object.keys(traceContext).length > 0 ? traceContext : undefined;
+  return traceContext;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/code-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/code-scan-test.ts
@@ -109,7 +109,11 @@ describe("scan-code", () => {
 
       await handler(execEvent("rm -rf /"), {});
 
-      assert.deepEqual(lastCliArgs, ["scan-code", "--code", "rm -rf /", "--language", "bash"]);
+      assert.deepEqual(lastCliArgs?.slice(0, 2), [
+        "--trace-context",
+        JSON.stringify({ agent_name: "openclaw" }),
+      ]);
+      assert.deepEqual(lastCliArgs?.slice(2), ["scan-code", "--code", "rm -rf /", "--language", "bash"]);
       assert.equal(lastCliOpts?.timeout, 10000);
     });
 
@@ -131,6 +135,7 @@ describe("scan-code", () => {
       assert.deepEqual(lastCliArgs?.slice(0, 2), [
         "--trace-context",
         JSON.stringify({
+          agent_name: "openclaw",
           session_id: "session-1",
           run_id: "run-1",
           tool_call_id: "tool-1",
@@ -185,7 +190,11 @@ describe("scan-code", () => {
 
       await handler(execEvent('echo "hello world"'), {});
 
-      assert.deepEqual(lastCliArgs, ["scan-code", "--code", 'echo "hello world"', "--language", "bash"]);
+      assert.deepEqual(lastCliArgs?.slice(0, 2), [
+        "--trace-context",
+        JSON.stringify({ agent_name: "openclaw" }),
+      ]);
+      assert.deepEqual(lastCliArgs?.slice(2), ["scan-code", "--code", 'echo "hello world"', "--language", "bash"]);
     });
   });
 

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
@@ -124,7 +124,11 @@ describe("pii-scan-user-input", () => {
 
     await beforeDispatch.handler({ content: "hello", body: "fallback" });
 
-    assert.deepEqual(lastCliArgs, [
+    assert.deepEqual(lastCliArgs?.slice(0, 2), [
+      "--trace-context",
+      JSON.stringify({ agent_name: "openclaw" }),
+    ]);
+    assert.deepEqual(lastCliArgs?.slice(2), [
       "scan-pii",
       "--stdin",
       "--format",
@@ -227,7 +231,11 @@ describe("pii-scan-user-input", () => {
     assert.doesNotMatch(result?.blockReason, /password=secret/);
     assert.deepEqual(lastCliArgs, [
       "--trace-context",
-      '{"session_id":"session-1","tool_call_id":"tool-1"}',
+      JSON.stringify({
+        agent_name: "openclaw",
+        session_id: "session-1",
+        tool_call_id: "tool-1",
+      }),
       "scan-pii",
       "--stdin",
       "--format",

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
@@ -243,6 +243,7 @@ describe("skill-ledger", () => {
       assert.equal(
         lastInitArgs?.[1],
         JSON.stringify({
+          agent_name: "openclaw",
           session_id: "session-1",
           run_id: "run-1",
           tool_call_id: "tool-1",
@@ -327,6 +328,7 @@ describe("skill-ledger", () => {
     assert.equal(
       lastCheckArgs?.[1],
       JSON.stringify({
+        agent_name: "openclaw",
         session_id: "session-1",
         run_id: "run-1",
         tool_call_id: "tool-1",

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/utils-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/utils-test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../src/utils.js";
 
 const _validTraceContextTypeCheck: TraceContext = {
+  agent_name: "openclaw",
   trace_id: "trace-1",
   session_id: "session-1",
   run_id: "run-1",
@@ -58,11 +59,13 @@ describe("utils", () => {
         runId: "camel-run",
         run_id: "snake-run",
         traceId: "trace-1",
+        agentName: "spoofed",
       },
       {},
     );
 
     assert.deepEqual(context, {
+      agent_name: "openclaw",
       trace_id: "trace-1",
       session_id: "snake-session",
       run_id: "snake-run",
@@ -96,6 +99,7 @@ describe("utils", () => {
     );
 
     assert.deepEqual(context, {
+      agent_name: "openclaw",
       trace_id: "direct-ctx-trace",
       session_id: "event-session",
       run_id: "event-run",
@@ -103,7 +107,7 @@ describe("utils", () => {
     });
   });
 
-  it("buildTraceContext does not create context from nested trace-only input", () => {
+  it("buildTraceContext ignores nested trace-only input except fixed agent name", () => {
     const context = buildTraceContext(
       {
         trace: {
@@ -115,10 +119,10 @@ describe("utils", () => {
       {},
     );
 
-    assert.equal(context, undefined);
+    assert.deepEqual(context, { agent_name: "openclaw" });
   });
 
-  it("buildTraceContext ignores empty and non-string values", () => {
+  it("buildTraceContext ignores empty and non-string values except fixed agent name", () => {
     const context = buildTraceContext(
       {
         trace_id: "",
@@ -129,7 +133,16 @@ describe("utils", () => {
       {},
     );
 
-    assert.equal(context, undefined);
+    assert.deepEqual(context, { agent_name: "openclaw" });
+  });
+
+  it("buildTraceContext always returns fixed OpenClaw agent name", () => {
+    const context = buildTraceContext(
+      { agent_name: "hermes", agentName: "cosh" },
+      { agent_name: "spoofed" },
+    );
+
+    assert.deepEqual(context, { agent_name: "openclaw" });
   });
 
   it("callAgentSecCli injects trace context before the subcommand for mocks", async () => {

--- a/src/agent-sec-core/tests/e2e/_helpers/telemetry_jsonl.py
+++ b/src/agent-sec-core/tests/e2e/_helpers/telemetry_jsonl.py
@@ -1,0 +1,44 @@
+"""Shared JSONL helpers for e2e telemetry assertions."""
+
+import json
+import time
+from pathlib import Path
+
+
+def read_jsonl_payloads(path: Path) -> list[dict]:
+    """Read JSONL payloads, ignoring malformed diagnostic lines."""
+    if not path.exists():
+        return []
+
+    payloads = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads
+
+
+def wait_for_telemetry_record(
+    path: Path,
+    *,
+    trace_id: str,
+    event_type: str,
+    timeout_seconds: float = 5,
+) -> dict:
+    """Return a telemetry record matching the trace id and event type."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        for payload in read_jsonl_payloads(path):
+            if (
+                payload.get("seccore.trace_id") == trace_id
+                and payload.get("seccore.event_type") == event_type
+            ):
+                return payload
+        time.sleep(0.1)
+    raise AssertionError(
+        f"telemetry record not written for trace_id={trace_id!r} "
+        f"event_type={event_type!r}; payloads={read_jsonl_payloads(path)!r}"
+    )

--- a/src/agent-sec-core/tests/e2e/code-scanner/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/code-scanner/e2e_test.py
@@ -20,7 +20,6 @@ import pathlib
 import shutil
 import subprocess
 import sys
-import time
 import uuid
 from typing import List, Tuple
 
@@ -35,7 +34,12 @@ _TESTDATA_DIR = (
 if str(_TESTDATA_DIR) not in sys.path:
     sys.path.insert(0, str(_TESTDATA_DIR))
 
-from testdata.scan_test_data import SCAN_TEST_CASES
+_HELPERS_DIR = pathlib.Path(__file__).resolve().parents[1] / "_helpers"
+if str(_HELPERS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HELPERS_DIR))
+
+from telemetry_jsonl import wait_for_telemetry_record  # noqa: E402
+from testdata.scan_test_data import SCAN_TEST_CASES  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # CLI resolution — supports both installed and dev-mode environments
@@ -106,41 +110,6 @@ def _make_parametrize_id(tc: tuple) -> str:
     return f"{rule_id}-{label}-{snippet}"
 
 
-def _read_jsonl(path: pathlib.Path) -> list[dict]:
-    """Read JSONL payloads, ignoring malformed diagnostic lines."""
-    payloads = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            payloads.append(payload)
-    return payloads
-
-
-def _wait_for_telemetry_record(
-    path: pathlib.Path,
-    *,
-    trace_id: str,
-    event_type: str,
-) -> dict:
-    """Return a telemetry record matching the trace id and event type."""
-    deadline = time.monotonic() + 5
-    while time.monotonic() < deadline:
-        for payload in _read_jsonl(path):
-            if (
-                payload.get("seccore.trace_id") == trace_id
-                and payload.get("seccore.event_type") == event_type
-            ):
-                return payload
-        time.sleep(0.1)
-    raise AssertionError(
-        f"telemetry record not written for trace_id={trace_id!r} "
-        f"event_type={event_type!r}; payloads={_read_jsonl(path)!r}"
-    )
-
-
 # ---------------------------------------------------------------------------
 # A. Basic functionality
 # ---------------------------------------------------------------------------
@@ -189,7 +158,7 @@ class TestBasicScan:
         )
 
         assert result["verdict"] == "pass"
-        telemetry = _wait_for_telemetry_record(
+        telemetry = wait_for_telemetry_record(
             telemetry_path,
             trace_id=trace_id,
             event_type="code_scan",

--- a/src/agent-sec-core/tests/e2e/code-scanner/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/code-scanner/e2e_test.py
@@ -20,9 +20,13 @@ import pathlib
 import shutil
 import subprocess
 import sys
+import time
+import uuid
 from typing import List, Tuple
 
 import pytest
+
+TELEMETRY_LOG_PATH_ENV = "AGENT_SEC_TELEMETRY_LOG_PATH"
 
 # Ensure the testdata package under unit-test/code_scanner is importable.
 _TESTDATA_DIR = (
@@ -41,15 +45,31 @@ _CLI_BIN = shutil.which("agent-sec-cli")
 _CLI_MODE = "binary" if _CLI_BIN else "python -m"
 
 
-def _run_scan(code: str, language: str = "bash") -> subprocess.CompletedProcess:
+def _run_scan(
+    code: str,
+    language: str = "bash",
+    *,
+    top_level_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
     """Run ``agent-sec-cli scan-code`` and return CompletedProcess."""
+    top_level = [] if top_level_args is None else top_level_args
     if _CLI_BIN:
-        cmd = [_CLI_BIN, "scan-code", "--code", code, "--language", language]
+        cmd = [
+            _CLI_BIN,
+            *top_level,
+            "scan-code",
+            "--code",
+            code,
+            "--language",
+            language,
+        ]
     else:
         cmd = [
             sys.executable,
             "-m",
             "agent_sec_cli.cli",
+            *top_level,
             "scan-code",
             "--code",
             code,
@@ -61,7 +81,7 @@ def _run_scan(code: str, language: str = "bash") -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         timeout=30,
-        env=os.environ.copy(),
+        env=os.environ.copy() if env is None else env,
     )
     print(f"\n[CLI mode={_CLI_MODE}] cmd={' '.join(cmd)}")
     print(f"[exit={proc.returncode}] stdout={proc.stdout[:200]}")
@@ -84,6 +104,41 @@ def _make_parametrize_id(tc: tuple) -> str:
     label = "TP" if expected else "TN"
     snippet = code[:30].replace("\n", "\\n")
     return f"{rule_id}-{label}-{snippet}"
+
+
+def _read_jsonl(path: pathlib.Path) -> list[dict]:
+    """Read JSONL payloads, ignoring malformed diagnostic lines."""
+    payloads = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads
+
+
+def _wait_for_telemetry_record(
+    path: pathlib.Path,
+    *,
+    trace_id: str,
+    event_type: str,
+) -> dict:
+    """Return a telemetry record matching the trace id and event type."""
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        for payload in _read_jsonl(path):
+            if (
+                payload.get("seccore.trace_id") == trace_id
+                and payload.get("seccore.event_type") == event_type
+            ):
+                return payload
+        time.sleep(0.1)
+    raise AssertionError(
+        f"telemetry record not written for trace_id={trace_id!r} "
+        f"event_type={event_type!r}; payloads={_read_jsonl(path)!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +168,39 @@ class TestBasicScan:
         result = _parse_result(_run_scan("rm -rf /tmp/test"))
         assert result["verdict"] in ("warn", "deny")
         assert len(result["findings"]) > 0
+
+    def test_scan_code_cli_writes_telemetry(self, tmp_path: pathlib.Path) -> None:
+        telemetry_path = tmp_path / "agent-sec-core.jsonl"
+        telemetry_path.write_text("", encoding="utf-8")
+        trace_id = f"e2e-code-telemetry-{uuid.uuid4()}"
+        trace_context = {
+            "trace_id": trace_id,
+            "agent_name": "cosh",
+        }
+        env = os.environ.copy()
+        env[TELEMETRY_LOG_PATH_ENV] = str(telemetry_path)
+
+        result = _parse_result(
+            _run_scan(
+                "echo telemetry",
+                top_level_args=["--trace-context", json.dumps(trace_context)],
+                env=env,
+            )
+        )
+
+        assert result["verdict"] == "pass"
+        telemetry = _wait_for_telemetry_record(
+            telemetry_path,
+            trace_id=trace_id,
+            event_type="code_scan",
+        )
+        assert telemetry["component.name"] == "agent-sec-core"
+        assert telemetry["component.agent_name"] == "cosh"
+        assert telemetry["seccore.category"] == "code_scan"
+        assert telemetry["seccore.request"] == {
+            "code": "echo telemetry",
+            "language": "bash",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/e2e/prompt-scanner/conftest.py
+++ b/src/agent-sec-core/tests/e2e/prompt-scanner/conftest.py
@@ -15,6 +15,7 @@ from typing import Any, TextIO
 
 import pytest
 from agent_sec_cli.daemon.env import DAEMON_DISABLED_ENV, SOCKET_ENV
+from agent_sec_cli.telemetry.config import TELEMETRY_LOG_PATH_ENV
 
 DATA_DIR_ENV = "AGENT_SEC_DATA_DIR"
 PROMPT_PRELOAD_ENV = "AGENT_SEC_DAEMON_PROMPT_PRELOAD"
@@ -45,6 +46,7 @@ class PromptScanExecutionContext:
     execution_path: str
     socket_path: Path
     data_dir: Path
+    telemetry_path: Path
 
 
 def _resolve_daemon_command() -> list[str]:
@@ -84,18 +86,27 @@ def prompt_scan_execution_path(
     tmp_path = tmp_path_factory.mktemp(f"prompt_scan_{execution_path}")
     socket_path = tmp_path / "runtime" / "daemon.sock"
     data_dir = tmp_path / "data"
+    telemetry_path = data_dir / "telemetry.jsonl"
+    telemetry_path.parent.mkdir(parents=True, exist_ok=True)
+    telemetry_path.write_text("", encoding="utf-8")
 
     saved_env = {
         SOCKET_ENV: os.environ.get(SOCKET_ENV),
         DAEMON_DISABLED_ENV: os.environ.get(DAEMON_DISABLED_ENV),
         DATA_DIR_ENV: os.environ.get(DATA_DIR_ENV),
+        TELEMETRY_LOG_PATH_ENV: os.environ.get(TELEMETRY_LOG_PATH_ENV),
     }
 
     daemon: DaemonProcess | None = None
     output: DaemonOutput | None = None
     try:
         if execution_path == "daemon":
-            daemon = _start_daemon(_resolve_daemon_command(), socket_path, data_dir)
+            daemon = _start_daemon(
+                _resolve_daemon_command(),
+                socket_path,
+                data_dir,
+                telemetry_path,
+            )
             _wait_for_prompt_scan_ready(socket_path, daemon)
             os.environ[SOCKET_ENV] = str(socket_path)
             os.environ.pop(DAEMON_DISABLED_ENV, None)
@@ -107,10 +118,12 @@ def prompt_scan_execution_path(
             os.environ[DAEMON_DISABLED_ENV] = "1"
 
         os.environ[DATA_DIR_ENV] = str(data_dir)
+        os.environ[TELEMETRY_LOG_PATH_ENV] = str(telemetry_path)
         yield PromptScanExecutionContext(
             execution_path=execution_path,
             socket_path=socket_path,
             data_dir=data_dir,
+            telemetry_path=telemetry_path,
         )
     finally:
         if daemon is not None:
@@ -129,11 +142,13 @@ def _start_daemon(
     daemon_command: list[str],
     socket_path: Path,
     data_dir: Path,
+    telemetry_path: Path,
 ) -> DaemonProcess:
     env = os.environ.copy()
     env.pop(SOCKET_ENV, None)
     env.pop(DAEMON_DISABLED_ENV, None)
     env[DATA_DIR_ENV] = str(data_dir)
+    env[TELEMETRY_LOG_PATH_ENV] = str(telemetry_path)
     env[PROMPT_PRELOAD_ENV] = "1"
     env["PYTHONUNBUFFERED"] = "1"
 

--- a/src/agent-sec-core/tests/e2e/prompt-scanner/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/prompt-scanner/e2e_test.py
@@ -235,6 +235,44 @@ def _wait_for_security_event(trace_context: dict[str, str]) -> dict:
     )
 
 
+def _read_telemetry_payloads(path: Path) -> list[dict]:
+    """Read telemetry JSONL payloads from an e2e-owned file."""
+    if not path.exists():
+        return []
+
+    payloads = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads
+
+
+def _wait_for_telemetry_record(
+    path: Path,
+    *,
+    trace_id: str,
+    event_type: str,
+) -> dict:
+    """Return a telemetry record matching the trace id and event type."""
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        for payload in _read_telemetry_payloads(path):
+            if (
+                payload.get("seccore.trace_id") == trace_id
+                and payload.get("seccore.event_type") == event_type
+            ):
+                return payload
+        time.sleep(0.1)
+    raise AssertionError(
+        f"telemetry record not written for trace_id={trace_id!r} "
+        f"event_type={event_type!r}; payloads={_read_telemetry_payloads(path)!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # A. Basic functionality
 # ---------------------------------------------------------------------------
@@ -320,6 +358,43 @@ class TestTraceContextPropagation:
         event = _wait_for_security_event(trace_context)
         assert event["event_type"] == "prompt_scan"
         assert event["category"] == "prompt_scan"
+
+    def test_daemon_path_writes_prompt_scan_telemetry(
+        self,
+        prompt_scan_execution_path,
+    ) -> None:
+        if prompt_scan_execution_path.execution_path != "daemon":
+            pytest.skip("daemon telemetry assertion runs on the daemon-backed path")
+
+        trace_id = f"e2e-daemon-telemetry-{time.time_ns()}"
+        trace_context = {
+            "trace_id": trace_id,
+            "agent_name": "cosh",
+        }
+
+        proc = _run_scan(
+            "Hello daemon telemetry",
+            mode="fast",
+            fmt="json",
+            top_level_args=["--trace-context", json.dumps(trace_context)],
+            extra_args=["--source", "e2e_daemon_telemetry"],
+        )
+        result = _parse_result(proc)
+        assert result["verdict"] == "pass"
+
+        telemetry = _wait_for_telemetry_record(
+            prompt_scan_execution_path.telemetry_path,
+            trace_id=trace_id,
+            event_type="prompt_scan",
+        )
+        assert telemetry["component.name"] == "agent-sec-core"
+        assert telemetry["component.agent_name"] == "cosh"
+        assert telemetry["seccore.category"] == "prompt_scan"
+        assert telemetry["seccore.request"] == {
+            "text": "Hello daemon telemetry",
+            "mode": "fast",
+            "source": "e2e_daemon_telemetry",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/e2e/prompt-scanner/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/prompt-scanner/e2e_test.py
@@ -32,6 +32,12 @@ from typing import List, Tuple
 import pytest
 from agent_sec_cli.daemon.env import DAEMON_DISABLED_ENV, SOCKET_ENV
 
+_HELPERS_DIR = Path(__file__).resolve().parents[1] / "_helpers"
+if str(_HELPERS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HELPERS_DIR))
+
+from telemetry_jsonl import wait_for_telemetry_record  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # CLI resolution — supports both installed and dev-mode environments
 # ---------------------------------------------------------------------------
@@ -235,44 +241,6 @@ def _wait_for_security_event(trace_context: dict[str, str]) -> dict:
     )
 
 
-def _read_telemetry_payloads(path: Path) -> list[dict]:
-    """Read telemetry JSONL payloads from an e2e-owned file."""
-    if not path.exists():
-        return []
-
-    payloads = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            payloads.append(payload)
-    return payloads
-
-
-def _wait_for_telemetry_record(
-    path: Path,
-    *,
-    trace_id: str,
-    event_type: str,
-) -> dict:
-    """Return a telemetry record matching the trace id and event type."""
-    deadline = time.monotonic() + 5
-    while time.monotonic() < deadline:
-        for payload in _read_telemetry_payloads(path):
-            if (
-                payload.get("seccore.trace_id") == trace_id
-                and payload.get("seccore.event_type") == event_type
-            ):
-                return payload
-        time.sleep(0.1)
-    raise AssertionError(
-        f"telemetry record not written for trace_id={trace_id!r} "
-        f"event_type={event_type!r}; payloads={_read_telemetry_payloads(path)!r}"
-    )
-
-
 # ---------------------------------------------------------------------------
 # A. Basic functionality
 # ---------------------------------------------------------------------------
@@ -382,7 +350,7 @@ class TestTraceContextPropagation:
         result = _parse_result(proc)
         assert result["verdict"] == "pass"
 
-        telemetry = _wait_for_telemetry_record(
+        telemetry = wait_for_telemetry_record(
             prompt_scan_execution_path.telemetry_path,
             trace_id=trace_id,
             event_type="prompt_scan",

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -110,6 +110,7 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
+                trace_context={},
             )
             activation = await wait_for(
                 lambda: (
@@ -121,6 +122,7 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
             health = await asyncio.to_thread(
                 client.call,
                 "daemon.health",
+                trace_context={},
             )
             config = read_skill_ledger_config(tmp_path)
         finally:
@@ -159,6 +161,7 @@ def test_daemon_metadata_only_notify_does_not_change_activation(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
+                trace_context={},
             )
             activation = await wait_for(
                 lambda: (
@@ -171,6 +174,7 @@ def test_daemon_metadata_only_notify_does_not_change_activation(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, [".skill-meta/latest.json"]),
+                trace_context={},
             )
             after_ignored = read_activation(skill_dir)
         finally:
@@ -205,6 +209,7 @@ def test_daemon_notify_updates_activation_after_safe_drift(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
+                trace_context={},
             )
             activation_v1 = await wait_for(
                 lambda: (
@@ -219,6 +224,7 @@ def test_daemon_notify_updates_activation_after_safe_drift(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["run.sh"]),
+                trace_context={},
             )
             activation_v2 = await wait_for(
                 lambda: (
@@ -257,6 +263,7 @@ def test_daemon_default_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
+                trace_context={},
             )
             activation_v1 = await wait_for(
                 lambda: (
@@ -279,6 +286,7 @@ def test_daemon_default_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["SKILL.md"]),
+                trace_context={},
             )
             activation_after_risk = await wait_for(
                 lambda: (
@@ -321,6 +329,7 @@ def test_daemon_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
+                trace_context={},
             )
             await wait_for(
                 lambda: (
@@ -343,6 +352,7 @@ def test_daemon_latest_scanned_policy_activates_risky_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["SKILL.md"]),
+                trace_context={},
             )
             activation_after_risk = await wait_for(
                 lambda: (
@@ -404,6 +414,7 @@ def test_daemon_pass_warn_only_policy_hides_deny_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
+                trace_context={},
             )
             activation_v1 = await wait_for(
                 lambda: (
@@ -420,6 +431,7 @@ def test_daemon_pass_warn_only_policy_hides_deny_snapshot(
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir, ["run.sh"]),
+                trace_context={},
             )
             activation_after_deny = await wait_for(
                 lambda: (
@@ -459,6 +471,7 @@ def test_daemon_invalid_activation_policy_sets_job_error(monkeypatch, tmp_path: 
                 client.call,
                 METHOD_SKILLFS_NOTIFY_CHANGE,
                 notify_payload(skill_dir),
+                trace_context={},
             )
             deadline = asyncio.get_running_loop().time() + 5.0
             health = None
@@ -466,6 +479,7 @@ def test_daemon_invalid_activation_policy_sets_job_error(monkeypatch, tmp_path: 
                 candidate = await asyncio.to_thread(
                     client.call,
                     "daemon.health",
+                    trace_context={},
                 )
                 jobs = {job["name"]: job for job in candidate.data["jobs"]}
                 last_error = jobs["skill-ledger-activation"].get("last_error") or ""

--- a/src/agent-sec-core/tests/unit-test/code_scanner/test_hook_adapter.py
+++ b/src/agent-sec-core/tests/unit-test/code_scanner/test_hook_adapter.py
@@ -665,6 +665,7 @@ class TestCoshHook:
         output = json.loads(capsys.readouterr().out)
         expected_context = json.dumps(
             {
+                "agent_name": "cosh",
                 "session_id": "session-1",
                 "run_id": "run-1",
                 "tool_call_id": "tool-1",

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
@@ -145,8 +145,15 @@ class TestCoshHookMain:
             json.dumps({"prompt": "Phone: 13800138000"}),
         )
 
+        expected_context = json.dumps(
+            {"agent_name": "cosh"},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
         assert captured["args"] == [
             "agent-sec-cli",
+            "--trace-context",
+            expected_context,
             "scan-pii",
             "--stdin",
             "--format",
@@ -192,6 +199,7 @@ class TestCoshHookMain:
 
         expected_context = json.dumps(
             {
+                "agent_name": "cosh",
                 "trace_id": "trace-1",
                 "session_id": "session-1",
                 "run_id": "run-1",
@@ -284,8 +292,15 @@ class TestCoshHookMain:
 
         output = self._run_main(monkeypatch, capsys, json.dumps(payload))
 
+        expected_context = json.dumps(
+            {"agent_name": "cosh"},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
         assert captured["args"] == [
             "agent-sec-cli",
+            "--trace-context",
+            expected_context,
             "scan-pii",
             "--stdin",
             "--format",

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_prompt_scanner_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_prompt_scanner_hook.py
@@ -198,6 +198,7 @@ class TestCoshHookSubprocess:
         output = json.loads(capsys.readouterr().out)
         expected_context = json.dumps(
             {
+                "agent_name": "cosh",
                 "session_id": "session-1",
                 "run_id": "run-1",
             },

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_sandbox_guard_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_sandbox_guard_hook.py
@@ -58,6 +58,7 @@ def test_sandbox_guard_log_injects_trace_context_into_logging_command(monkeypatc
 
     expected_context = json.dumps(
         {
+            "agent_name": "cosh",
             "session_id": "session-1",
             "run_id": "run-1",
             "tool_call_id": "tool-1",

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
@@ -140,6 +140,7 @@ def test_injects_trace_context_into_skill_ledger_check_command(monkeypatch, caps
     output = json.loads(capsys.readouterr().out)
     expected_context = json.dumps(
         {
+            "agent_name": "cosh",
             "trace_id": "trace-1",
             "session_id": "session-1",
             "run_id": "run-1",

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_trace_context_helper.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_trace_context_helper.py
@@ -18,8 +18,11 @@ def test_trace_context_uses_fixed_cosh_hook_input_fields():
             "run_id": "run-1",
             "call_id": "call-1",
             "tool_use_id": "tool-1",
+            "agent_name": "spoofed",
+            "agentName": "spoofed",
         }
     ) == {
+        "agent_name": "cosh",
         "trace_id": "trace-1",
         "session_id": "session-1",
         "run_id": "run-1",
@@ -29,19 +32,16 @@ def test_trace_context_uses_fixed_cosh_hook_input_fields():
 
 
 def test_trace_context_ignores_camel_case_and_empty_values():
-    assert (
-        trace_context(
-            {
-                "trace_id": "",
-                "traceId": "trace-1",
-                "sessionId": "session-1",
-                "runId": "run-1",
-                "callId": "call-1",
-                "toolUseId": "tool-1",
-            }
-        )
-        is None
-    )
+    assert trace_context(
+        {
+            "trace_id": "",
+            "traceId": "trace-1",
+            "sessionId": "session-1",
+            "runId": "run-1",
+            "callId": "call-1",
+            "toolUseId": "tool-1",
+        }
+    ) == {"agent_name": "cosh"}
 
 
 def test_with_trace_context_serializes_fixed_fields():
@@ -54,7 +54,22 @@ def test_with_trace_context_serializes_fixed_fields():
         "agent-sec-cli",
         "--trace-context",
         json.dumps(
-            {"session_id": "session-1", "run_id": "run-1"},
+            {"agent_name": "cosh", "session_id": "session-1", "run_id": "run-1"},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ),
+        "scan-code",
+    ]
+
+
+def test_with_trace_context_serializes_agent_name_without_other_fields():
+    args = with_trace_context(["agent-sec-cli", "scan-code"], {"foo": "bar"})
+
+    assert args == [
+        "agent-sec-cli",
+        "--trace-context",
+        json.dumps(
+            {"agent_name": "cosh"},
             ensure_ascii=False,
             separators=(",", ":"),
         ),

--- a/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
@@ -15,10 +15,12 @@ from pathlib import Path
 from agent_sec_cli.correlation_context import (
     TraceContext,
     clear_invocation_context_for_tests,
+    clear_process_trace_context,
     get_current_trace_context,
     init_invocation_context,
+    init_process_trace_context,
 )
-from agent_sec_cli.daemon.client import DaemonClient
+from agent_sec_cli.daemon.client import DaemonClient, daemon_health_reachable
 from agent_sec_cli.daemon.errors import (
     DaemonProtocolError,
     DaemonRuntimePathError,
@@ -187,6 +189,124 @@ def test_daemon_client_preserves_explicit_trace_id(
         "session_id": "session-1",
     }
     assert trace_context == {"trace_id": "trace-1", "session_id": "session-1"}
+
+
+def test_daemon_client_inherits_ambient_trace_context_by_default(
+    monkeypatch,
+    tmp_path: Path,
+):
+    clear_process_trace_context()
+    init_process_trace_context(
+        TraceContext(
+            trace_id="trace-ambient",
+            session_id="session-ambient",
+            agent_name="hermes",
+        )
+    )
+    client = DaemonClient(socket_path=tmp_path / "unused.sock")
+    captured = {}
+
+    def fake_send_request(request: DaemonRequest, _timeout_ms: int) -> DaemonResponse:
+        captured["request"] = request
+        return DaemonResponse(request_id=request.request_id, ok=True)
+
+    monkeypatch.setattr(client, "_send_request", fake_send_request)
+
+    try:
+        client.call("scan-prompt")
+    finally:
+        clear_process_trace_context()
+
+    request = captured["request"]
+    assert request.trace_context == {
+        "trace_id": "trace-ambient",
+        "session_id": "session-ambient",
+        "agent_name": "hermes",
+    }
+
+
+def test_daemon_client_explicit_trace_context_overrides_ambient_context(
+    monkeypatch,
+    tmp_path: Path,
+):
+    clear_process_trace_context()
+    init_process_trace_context(
+        TraceContext(
+            trace_id="trace-ambient",
+            session_id="session-ambient",
+            agent_name="hermes",
+        )
+    )
+    client = DaemonClient(socket_path=tmp_path / "unused.sock")
+    captured = {}
+
+    def fake_send_request(request: DaemonRequest, _timeout_ms: int) -> DaemonResponse:
+        captured["request"] = request
+        return DaemonResponse(request_id=request.request_id, ok=True)
+
+    monkeypatch.setattr(client, "_send_request", fake_send_request)
+
+    try:
+        client.call(
+            "scan-prompt",
+            trace_context={"trace_id": "trace-explicit", "agent_name": "cosh"},
+        )
+    finally:
+        clear_process_trace_context()
+
+    request = captured["request"]
+    assert request.trace_context == {
+        "trace_id": "trace-explicit",
+        "agent_name": "cosh",
+    }
+
+
+def test_daemon_client_can_disable_ambient_trace_context_inheritance(
+    monkeypatch,
+    tmp_path: Path,
+):
+    clear_process_trace_context()
+    clear_invocation_context_for_tests()
+    monkeypatch.setenv("AGENT_SEC_INVOCATION_ID", "invocation-1")
+    init_invocation_context()
+    init_process_trace_context(
+        TraceContext(
+            trace_id="trace-ambient",
+            session_id="session-ambient",
+            agent_name="hermes",
+        )
+    )
+    client = DaemonClient(socket_path=tmp_path / "unused.sock")
+    captured = {}
+
+    def fake_send_request(request: DaemonRequest, _timeout_ms: int) -> DaemonResponse:
+        captured["request"] = request
+        return DaemonResponse(request_id=request.request_id, ok=True)
+
+    monkeypatch.setattr(client, "_send_request", fake_send_request)
+
+    try:
+        client.call("daemon.health", trace_context={})
+    finally:
+        clear_process_trace_context()
+        clear_invocation_context_for_tests()
+
+    request = captured["request"]
+    assert request.trace_context == {"trace_id": "invocation-1"}
+
+
+def test_daemon_health_reachable_disables_ambient_trace_context(monkeypatch) -> None:
+    calls = []
+
+    def fake_call(self, method: str, **kwargs) -> DaemonResponse:
+        calls.append((self, method, kwargs))
+        return DaemonResponse(request_id="req-health", ok=True)
+
+    monkeypatch.setattr(DaemonClient, "call", fake_call)
+
+    assert daemon_health_reachable(Path("/unused/daemon.sock")) is True
+    assert calls[0][1] == "daemon.health"
+    assert calls[0][2]["trace_context"] == {}
 
 
 def test_daemon_client_allows_caller_override(
@@ -1017,7 +1137,10 @@ def test_gateway_preserves_missing_trace_id(tmp_path: Path, caplog):
                 socket_path,
                 DaemonRequest(
                     method="capture",
-                    trace_context={"session_id": "session-default"},
+                    trace_context={
+                        "session_id": "session-default",
+                        "agent_name": "hermes",
+                    },
                 ),
             )
         finally:
@@ -1028,14 +1151,17 @@ def test_gateway_preserves_missing_trace_id(tmp_path: Path, caplog):
     assert response.ok is True
     assert response.data["trace_context"] == {
         "session_id": "session-default",
+        "agent_name": "hermes",
     }
     assert observed_contexts == [
         (
             {
                 "session_id": "session-default",
+                "agent_name": "hermes",
             },
             TraceContext(
                 session_id="session-default",
+                agent_name="hermes",
             ),
         )
     ]

--- a/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
@@ -191,38 +191,16 @@ def test_daemon_client_preserves_explicit_trace_id(
     assert trace_context == {"trace_id": "trace-1", "session_id": "session-1"}
 
 
-def test_daemon_client_inherits_ambient_trace_context_by_default(
-    monkeypatch,
-    tmp_path: Path,
-):
-    clear_process_trace_context()
-    init_process_trace_context(
-        TraceContext(
-            trace_id="trace-ambient",
-            session_id="session-ambient",
-            agent_name="hermes",
-        )
-    )
+def test_daemon_client_requires_explicit_trace_context(tmp_path: Path):
     client = DaemonClient(socket_path=tmp_path / "unused.sock")
-    captured = {}
-
-    def fake_send_request(request: DaemonRequest, _timeout_ms: int) -> DaemonResponse:
-        captured["request"] = request
-        return DaemonResponse(request_id=request.request_id, ok=True)
-
-    monkeypatch.setattr(client, "_send_request", fake_send_request)
 
     try:
+        # Runtime guard for callers that bypass static type checking.
         client.call("scan-prompt")
-    finally:
-        clear_process_trace_context()
-
-    request = captured["request"]
-    assert request.trace_context == {
-        "trace_id": "trace-ambient",
-        "session_id": "session-ambient",
-        "agent_name": "hermes",
-    }
+    except TypeError as exc:
+        assert "trace_context" in str(exc)
+    else:
+        raise AssertionError("expected missing trace_context to fail")
 
 
 def test_daemon_client_explicit_trace_context_overrides_ambient_context(
@@ -322,7 +300,7 @@ def test_daemon_client_allows_caller_override(
 
     monkeypatch.setattr(client, "_send_request", fake_send_request)
 
-    client.call("daemon.health", caller="health-check")
+    client.call("daemon.health", trace_context={}, caller="health-check")
 
     request = captured["request"]
     assert request.caller == "health-check"
@@ -400,6 +378,7 @@ def test_daemon_client_calls_health_over_temp_socket(tmp_path: Path):
             response = await asyncio.to_thread(
                 client.call,
                 "daemon.health",
+                trace_context={},
             )
             runtime_dir_mode = stat.S_IMODE(socket_path.parent.stat().st_mode)
             socket_mode = stat.S_IMODE(socket_path.stat().st_mode)

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_code_scan.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_code_scan.py
@@ -89,6 +89,7 @@ class TestCodeScanPreToolCall:
 
         assert result is None
         assert mock_cli.call_args.kwargs["trace_context"] == {
+            "agent_name": "hermes",
             "session_id": "session-1",
             "tool_call_id": "tool-1",
         }

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_observability_cli_runner.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_observability_cli_runner.py
@@ -119,8 +119,14 @@ def test_trace_context_normalizes_camelcase_and_strips_whitespace():
             "runId": "",
             "callId": "  ",
             "toolUseId": "u1",
+            "agentName": "spoofed",
         }
-    ) == {"trace_id": "t1", "session_id": "s1", "tool_call_id": "u1"}
+    ) == {
+        "agent_name": "hermes",
+        "trace_id": "t1",
+        "session_id": "s1",
+        "tool_call_id": "u1",
+    }
 
 
 def test_trace_context_uses_first_non_empty_alias():
@@ -132,9 +138,10 @@ def test_trace_context_uses_first_non_empty_alias():
             "toolCallId": "  ",
             "tool_use_id": " u1 ",
             "toolUseId": "u2",
+            "agent_name": "spoofed",
         }
-    ) == {"call_id": "c1", "tool_call_id": "u1"}
+    ) == {"agent_name": "hermes", "call_id": "c1", "tool_call_id": "u1"}
 
 
-def test_trace_context_returns_none_when_all_fields_missing():
-    assert trace_context({"foo": "bar"}) is None
+def test_trace_context_returns_fixed_agent_name_when_all_fields_missing():
+    assert trace_context({"foo": "bar"}) == {"agent_name": "hermes"}

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
@@ -124,7 +124,10 @@ class TestPiiScanCapability:
         )
 
         assert result is None
-        assert mock_cli.call_args.kwargs["trace_context"] == {"session_id": "session-1"}
+        assert mock_cli.call_args.kwargs["trace_context"] == {
+            "agent_name": "hermes",
+            "session_id": "session-1",
+        }
         assert "run_id" not in mock_cli.call_args.kwargs["trace_context"]
 
     @patch("src.capabilities.pii_scan.call_agent_sec_cli")

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_prompt_scan.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_prompt_scan.py
@@ -118,7 +118,10 @@ class TestPromptScanCapability:
         )
 
         assert result is None
-        assert mock_cli.call_args.kwargs["trace_context"] == {"session_id": "session-1"}
+        assert mock_cli.call_args.kwargs["trace_context"] == {
+            "agent_name": "hermes",
+            "session_id": "session-1",
+        }
         assert "run_id" not in mock_cli.call_args.kwargs["trace_context"]
 
     @patch("src.capabilities.prompt_scan.call_agent_sec_cli")

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_skill_ledger.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_skill_ledger.py
@@ -111,6 +111,7 @@ class TestSkillLedgerHooks:
 
         assert result is None
         assert mock_cli.call_args.kwargs["trace_context"] == {
+            "agent_name": "hermes",
             "session_id": "session-1",
             "tool_call_id": "tool-1",
         }

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
@@ -615,7 +615,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
         self.assertEqual(out.stderr, "")
 
     @patch("agent_sec_cli.prompt_scanner.cli.DaemonClient")
-    def test_daemon_call_uses_daemon_client_default_trace_context_inheritance(
+    def test_daemon_call_passes_current_trace_context_to_daemon_client(
         self, mock_client_cls
     ) -> None:
         init_process_trace_context(
@@ -641,14 +641,20 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
         mock_client.call.assert_called_once_with(
             "scan-prompt",
             params={"text": "hello", "mode": "standard", "source": "user_input"},
+            trace_context={
+                "trace_id": "trace-1",
+                "session_id": "session-1",
+                "run_id": "run-1",
+                "call_id": "call-1",
+                "tool_call_id": "tool-1",
+                "agent_name": "hermes",
+            },
             caller="cli",
             timeout_ms=30_000,
         )
 
     @patch("agent_sec_cli.prompt_scanner.cli.DaemonClient")
-    def test_daemon_call_does_not_manually_build_trace_context_payload(
-        self, mock_client_cls
-    ) -> None:
+    def test_daemon_call_sanitizes_trace_context_payload(self, mock_client_cls) -> None:
         init_process_trace_context(
             TraceContext(
                 trace_id=" trace-1 ",
@@ -667,7 +673,10 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
 
         _call_scan_prompt_daemon("hello", "standard", "user_input")
 
-        self.assertNotIn("trace_context", mock_client.call.call_args.kwargs)
+        self.assertEqual(
+            mock_client.call.call_args.kwargs["trace_context"],
+            {"trace_id": "trace-1", "run_id": "run-1", "agent_name": "hermes"},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
@@ -615,7 +615,9 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
         self.assertEqual(out.stderr, "")
 
     @patch("agent_sec_cli.prompt_scanner.cli.DaemonClient")
-    def test_daemon_call_passes_trace_context_payload(self, mock_client_cls) -> None:
+    def test_daemon_call_uses_daemon_client_default_trace_context_inheritance(
+        self, mock_client_cls
+    ) -> None:
         init_process_trace_context(
             TraceContext(
                 trace_id="trace-1",
@@ -623,6 +625,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
                 run_id="run-1",
                 call_id="call-1",
                 tool_call_id="tool-1",
+                agent_name="hermes",
             )
         )
         mock_client = mock_client_cls.return_value
@@ -638,19 +641,12 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
         mock_client.call.assert_called_once_with(
             "scan-prompt",
             params={"text": "hello", "mode": "standard", "source": "user_input"},
-            trace_context={
-                "trace_id": "trace-1",
-                "session_id": "session-1",
-                "run_id": "run-1",
-                "call_id": "call-1",
-                "tool_call_id": "tool-1",
-            },
             caller="cli",
             timeout_ms=30_000,
         )
 
     @patch("agent_sec_cli.prompt_scanner.cli.DaemonClient")
-    def test_daemon_call_uses_canonical_trace_context_payload(
+    def test_daemon_call_does_not_manually_build_trace_context_payload(
         self, mock_client_cls
     ) -> None:
         init_process_trace_context(
@@ -658,6 +654,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
                 trace_id=" trace-1 ",
                 session_id="   ",
                 run_id="run-1",
+                agent_name=" hermes ",
             )
         )
         mock_client = mock_client_cls.return_value
@@ -670,13 +667,7 @@ class TestCliDaemonFallbackHandling(unittest.TestCase):
 
         _call_scan_prompt_daemon("hello", "standard", "user_input")
 
-        self.assertEqual(
-            mock_client.call.call_args.kwargs["trace_context"],
-            {
-                "trace_id": "trace-1",
-                "run_id": "run-1",
-            },
-        )
+        self.assertNotIn("trace_context", mock_client.call.call_args.kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
@@ -83,6 +83,17 @@ class TestSecurityEventToDict(unittest.TestCase):
             "details",
         }
         self.assertEqual(set(d.keys()), expected_keys)
+        self.assertNotIn("agent_name", d)
+
+    def test_to_dict_omits_agent_name_extra_field(self):
+        evt = SecurityEvent(
+            event_type="t",
+            category="c",
+            details={"a": 1},
+            agent_name="hermes",
+        )
+
+        self.assertNotIn("agent_name", evt.to_dict())
 
     def test_to_dict_includes_top_level_tracing_fields(self):
         evt = SecurityEvent(

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_context.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_context.py
@@ -63,6 +63,7 @@ class TestRequestContext(unittest.TestCase):
                 run_id="run-1",
                 call_id="call-1",
                 tool_call_id="tool-1",
+                agent_name="hermes",
             )
         )
 
@@ -73,6 +74,7 @@ class TestRequestContext(unittest.TestCase):
         self.assertEqual(ctx.run_id, "run-1")
         self.assertEqual(ctx.call_id, "call-1")
         self.assertEqual(ctx.tool_call_id, "tool-1")
+        self.assertEqual(ctx.agent_name, "hermes")
 
     def test_generates_trace_id_when_caller_does_not_supply_one(self):
         init_process_trace_context(TraceContext(session_id="session-1"))
@@ -83,7 +85,9 @@ class TestRequestContext(unittest.TestCase):
         self.assertEqual(ctx.session_id, "session-1")
 
     def test_explicit_tracing_fields_are_preserved(self):
-        init_process_trace_context(TraceContext(session_id="process-session"))
+        init_process_trace_context(
+            TraceContext(session_id="process-session", agent_name="process-agent")
+        )
 
         ctx = RequestContext(
             action="code_scan",
@@ -92,6 +96,7 @@ class TestRequestContext(unittest.TestCase):
             run_id="explicit-run",
             call_id="explicit-call",
             tool_call_id="explicit-tool",
+            agent_name="explicit-agent",
         )
 
         self.assertEqual(ctx.trace_id, "explicit-trace")
@@ -99,6 +104,7 @@ class TestRequestContext(unittest.TestCase):
         self.assertEqual(ctx.run_id, "explicit-run")
         self.assertEqual(ctx.call_id, "explicit-call")
         self.assertEqual(ctx.tool_call_id, "explicit-tool")
+        self.assertEqual(ctx.agent_name, "explicit-agent")
 
     def test_invocation_id_comes_from_process_context(self):
         init_invocation_context()

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -137,6 +137,21 @@ class TestPostAction(unittest.TestCase):
         event = mock_log.call_args[0][0]
         self.mock_telemetry.assert_called_once_with(event)
 
+    def test_post_action_passes_agent_name_to_telemetry(self):
+        ctx = RequestContext(
+            action="code_scan",
+            trace_id="trace-telemetry",
+            agent_name="hermes",
+        )
+        result = ActionResult(success=True, data={"verdict": "pass"})
+
+        with patch("agent_sec_cli.security_middleware.lifecycle.log_event") as mock_log:
+            post_action(ctx, result, {"code": "echo ok"}, DummyBackend())
+
+        event = mock_log.call_args[0][0]
+        # agent_name is read from ambient context, not passed explicitly
+        self.mock_telemetry.assert_called_once_with(event)
+
     def test_post_action_swallows_telemetry_failure(self):
         ctx = RequestContext(action="code_scan", trace_id="trace-telemetry-fail")
         result = ActionResult(success=True, data={"verdict": "pass"})
@@ -260,6 +275,21 @@ class TestOnError(unittest.TestCase):
             on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
 
         event = mock_log.call_args[0][0]
+        self.mock_telemetry.assert_called_once_with(event)
+
+    def test_on_error_passes_agent_name_to_telemetry(self):
+        ctx = RequestContext(
+            action="verify",
+            trace_id="trace-error-telemetry",
+            agent_name="cosh",
+        )
+        exc = RuntimeError("boom")
+
+        with patch("agent_sec_cli.security_middleware.lifecycle.log_event") as mock_log:
+            on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
+
+        event = mock_log.call_args[0][0]
+        # agent_name is read from ambient context, not passed explicitly
         self.mock_telemetry.assert_called_once_with(event)
 
     def test_on_error_swallows_telemetry_failure(self):

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -135,7 +135,7 @@ class TestPostAction(unittest.TestCase):
             post_action(ctx, result, {"code": "echo ok"}, DummyBackend())
 
         event = mock_log.call_args[0][0]
-        self.mock_telemetry.assert_called_once_with(event)
+        self.mock_telemetry.assert_called_once_with(event, ctx)
 
     def test_post_action_passes_agent_name_to_telemetry(self):
         ctx = RequestContext(
@@ -149,8 +149,7 @@ class TestPostAction(unittest.TestCase):
             post_action(ctx, result, {"code": "echo ok"}, DummyBackend())
 
         event = mock_log.call_args[0][0]
-        # agent_name is read from ambient context, not passed explicitly
-        self.mock_telemetry.assert_called_once_with(event)
+        self.mock_telemetry.assert_called_once_with(event, ctx)
 
     def test_post_action_swallows_telemetry_failure(self):
         ctx = RequestContext(action="code_scan", trace_id="trace-telemetry-fail")
@@ -275,7 +274,7 @@ class TestOnError(unittest.TestCase):
             on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
 
         event = mock_log.call_args[0][0]
-        self.mock_telemetry.assert_called_once_with(event)
+        self.mock_telemetry.assert_called_once_with(event, ctx)
 
     def test_on_error_passes_agent_name_to_telemetry(self):
         ctx = RequestContext(
@@ -289,8 +288,7 @@ class TestOnError(unittest.TestCase):
             on_error(ctx, exc, {"skill": "/path"}, DummyBackend())
 
         event = mock_log.call_args[0][0]
-        # agent_name is read from ambient context, not passed explicitly
-        self.mock_telemetry.assert_called_once_with(event)
+        self.mock_telemetry.assert_called_once_with(event, ctx)
 
     def test_on_error_swallows_telemetry_failure(self):
         ctx = RequestContext(action="verify", trace_id="trace-error-telemetry-fail")

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_config.py
@@ -3,11 +3,6 @@
 from pathlib import Path
 
 from agent_sec_cli import __version__
-from agent_sec_cli.correlation_context import (
-    TraceContext,
-    clear_process_trace_context,
-    init_process_trace_context,
-)
 from agent_sec_cli.telemetry.config import (
     DEFAULT_TELEMETRY_LOG_PATH,
     TELEMETRY_LOG_PATH_ENV,
@@ -44,25 +39,8 @@ def test_telemetry_log_path_exists_only_for_existing_file(
 
 
 def test_component_fields_are_fixed() -> None:
-    clear_process_trace_context()
-    try:
-        assert get_component_fields() == {
-            "component.name": "agent-sec-core",
-            "component.version": __version__,
-            "component.agent_name": "",
-        }
-    finally:
-        clear_process_trace_context()
-
-
-def test_component_fields_use_runtime_agent_name_from_ambient_context() -> None:
-    clear_process_trace_context()
-    init_process_trace_context(TraceContext(agent_name="hermes"))
-    try:
-        assert get_component_fields() == {
-            "component.name": "agent-sec-core",
-            "component.version": __version__,
-            "component.agent_name": "hermes",
-        }
-    finally:
-        clear_process_trace_context()
+    assert get_component_fields() == {
+        "component.name": "agent-sec-core",
+        "component.version": __version__,
+        "component.agent_name": "",
+    }

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_config.py
@@ -3,6 +3,11 @@
 from pathlib import Path
 
 from agent_sec_cli import __version__
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    clear_process_trace_context,
+    init_process_trace_context,
+)
 from agent_sec_cli.telemetry.config import (
     DEFAULT_TELEMETRY_LOG_PATH,
     TELEMETRY_LOG_PATH_ENV,
@@ -39,8 +44,25 @@ def test_telemetry_log_path_exists_only_for_existing_file(
 
 
 def test_component_fields_are_fixed() -> None:
-    assert get_component_fields() == {
-        "component.name": "agent-sec-core",
-        "component.version": __version__,
-        "component.agent_name": "",
-    }
+    clear_process_trace_context()
+    try:
+        assert get_component_fields() == {
+            "component.name": "agent-sec-core",
+            "component.version": __version__,
+            "component.agent_name": "",
+        }
+    finally:
+        clear_process_trace_context()
+
+
+def test_component_fields_use_runtime_agent_name_from_ambient_context() -> None:
+    clear_process_trace_context()
+    init_process_trace_context(TraceContext(agent_name="hermes"))
+    try:
+        assert get_component_fields() == {
+            "component.name": "agent-sec-core",
+            "component.version": __version__,
+            "component.agent_name": "hermes",
+        }
+    finally:
+        clear_process_trace_context()

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_schema.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_schema.py
@@ -3,15 +3,11 @@
 import copy
 import json
 import uuid
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from agent_sec_cli import __version__
-from agent_sec_cli.correlation_context import (
-    TraceContext,
-    clear_process_trace_context,
-    init_process_trace_context,
-)
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.telemetry.schema import build_telemetry_security_event
 
@@ -58,6 +54,11 @@ BASELINE_FIELDS = {
 }
 
 
+@dataclass
+class _TelemetryCtx:
+    agent_name: str | None = None
+
+
 def _event(**overrides: Any) -> SecurityEvent:
     defaults: dict[str, Any] = {
         "event_id": "event-1",
@@ -76,22 +77,6 @@ def _assert_component_fields(record: dict[str, Any], agent_name: str = "") -> No
     assert record["component.name"] == "agent-sec-core"
     assert record["component.version"] == __version__
     assert record["component.agent_name"] == agent_name
-
-
-def _with_ambient_agent_name(agent_name: str):
-    """Context manager: set ambient trace context with agent_name for the block."""
-    import contextlib
-
-    @contextlib.contextmanager
-    def _ctx():
-        clear_process_trace_context()
-        init_process_trace_context(TraceContext(agent_name=agent_name))
-        try:
-            yield
-        finally:
-            clear_process_trace_context()
-
-    return _ctx()
 
 
 def test_builds_seccore_record_with_component_and_prefixed_fields() -> None:
@@ -113,7 +98,7 @@ def test_builds_seccore_record_with_component_and_prefixed_fields() -> None:
         },
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     assert set(record) == COMPONENT_FIELDS | SECCORE_FIELDS
     _assert_component_fields(record)
@@ -149,7 +134,7 @@ def test_builds_asset_verify_counts_as_seccore_fields() -> None:
         details={"request": {"skill": "/path"}, "result": {"passed": 12, "failed": 1}},
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     _assert_component_fields(record)
     assert record["seccore.asset_passed_count"] == 12
@@ -157,11 +142,18 @@ def test_builds_asset_verify_counts_as_seccore_fields() -> None:
     assert record["seccore.verdict"] is None
 
 
-def test_builds_seccore_record_with_runtime_agent_name() -> None:
-    with _with_ambient_agent_name("cosh"):
-        record = build_telemetry_security_event(_event())
+def test_builds_seccore_record_with_ctx_agent_name() -> None:
+    record = build_telemetry_security_event(_event(), _TelemetryCtx(agent_name="cosh"))
 
     _assert_component_fields(record, agent_name="cosh")
+
+
+def test_builds_seccore_record_strips_ctx_agent_name() -> None:
+    record = build_telemetry_security_event(
+        _event(), _TelemetryCtx(agent_name=" hermes ")
+    )
+
+    _assert_component_fields(record, agent_name="hermes")
 
 
 def test_builds_baseline_record_with_component_and_prefixed_fields() -> None:
@@ -175,7 +167,7 @@ def test_builds_baseline_record_with_component_and_prefixed_fields() -> None:
         },
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     assert set(record) == COMPONENT_FIELDS | BASELINE_FIELDS
     _assert_component_fields(record)
@@ -198,11 +190,10 @@ def test_builds_baseline_record_with_component_and_prefixed_fields() -> None:
     json.dumps(record)
 
 
-def test_builds_baseline_record_with_runtime_agent_name() -> None:
+def test_builds_baseline_record_with_ctx_agent_name() -> None:
     event = _event(event_type="harden", category="hardening")
 
-    with _with_ambient_agent_name("cosh"):
-        record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx(agent_name="cosh"))
 
     _assert_component_fields(record, agent_name="cosh")
 
@@ -219,7 +210,7 @@ def test_error_fields_map_from_exception_details() -> None:
         },
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     assert record["seccore.error"] == "boom"
     assert record["seccore.error_type"] == "RuntimeError"
@@ -239,7 +230,7 @@ def test_error_fields_do_not_fallback_to_result_summary() -> None:
         },
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     assert record["seccore.error"] is None
     assert record["seccore.error_type"] is None
@@ -265,7 +256,7 @@ def test_error_fields_preserve_explicit_details_null_over_result_values() -> Non
         },
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     assert record["seccore.error"] is None
     assert record["seccore.error_type"] is None
@@ -281,7 +272,7 @@ def test_missing_fields_use_null_except_generated_event_id_timestamp_and_details
         details={},
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     uuid.UUID(record["seccore.event_id"])
     datetime.fromisoformat(record["seccore.timestamp"])
@@ -299,7 +290,7 @@ def test_mapping_does_not_mutate_input_and_converts_values_to_json_safe() -> Non
     original = copy.deepcopy(details)
     event = _event(details=details)
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     assert details == original
     assert record["seccore.request"] == {"items": ["a", "b"]}
@@ -322,7 +313,7 @@ def test_mapping_converts_non_finite_floats_to_null_for_strict_json() -> None:
         }
     )
 
-    record = build_telemetry_security_event(event)
+    record = build_telemetry_security_event(event, _TelemetryCtx())
 
     assert record["seccore.request"] == {"nan": None, "values": [None, None, 1.25]}
     assert record["seccore.error"] is None

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_schema.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_schema.py
@@ -7,6 +7,11 @@ from datetime import datetime
 from typing import Any
 
 from agent_sec_cli import __version__
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    clear_process_trace_context,
+    init_process_trace_context,
+)
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.telemetry.schema import build_telemetry_security_event
 
@@ -67,10 +72,26 @@ def _event(**overrides: Any) -> SecurityEvent:
     return SecurityEvent(**defaults)
 
 
-def _assert_component_fields(record: dict[str, Any]) -> None:
+def _assert_component_fields(record: dict[str, Any], agent_name: str = "") -> None:
     assert record["component.name"] == "agent-sec-core"
     assert record["component.version"] == __version__
-    assert record["component.agent_name"] == ""
+    assert record["component.agent_name"] == agent_name
+
+
+def _with_ambient_agent_name(agent_name: str):
+    """Context manager: set ambient trace context with agent_name for the block."""
+    import contextlib
+
+    @contextlib.contextmanager
+    def _ctx():
+        clear_process_trace_context()
+        init_process_trace_context(TraceContext(agent_name=agent_name))
+        try:
+            yield
+        finally:
+            clear_process_trace_context()
+
+    return _ctx()
 
 
 def test_builds_seccore_record_with_component_and_prefixed_fields() -> None:
@@ -136,6 +157,13 @@ def test_builds_asset_verify_counts_as_seccore_fields() -> None:
     assert record["seccore.verdict"] is None
 
 
+def test_builds_seccore_record_with_runtime_agent_name() -> None:
+    with _with_ambient_agent_name("cosh"):
+        record = build_telemetry_security_event(_event())
+
+    _assert_component_fields(record, agent_name="cosh")
+
+
 def test_builds_baseline_record_with_component_and_prefixed_fields() -> None:
     event = _event(
         event_type="harden",
@@ -168,6 +196,15 @@ def test_builds_baseline_record_with_component_and_prefixed_fields() -> None:
     assert record["baseline.total"] == 13
     assert record["baseline.details"] == {}
     json.dumps(record)
+
+
+def test_builds_baseline_record_with_runtime_agent_name() -> None:
+    event = _event(event_type="harden", category="hardening")
+
+    with _with_ambient_agent_name("cosh"):
+        record = build_telemetry_security_event(event)
+
+    _assert_component_fields(record, agent_name="cosh")
 
 
 def test_error_fields_map_from_exception_details() -> None:

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
@@ -6,15 +6,11 @@ import subprocess
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import agent_sec_cli.telemetry as telemetry
-from agent_sec_cli.correlation_context import (
-    TraceContext,
-    clear_process_trace_context,
-    init_process_trace_context,
-)
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.telemetry import writer as telemetry_writer
 from agent_sec_cli.telemetry.writer import (
@@ -22,6 +18,11 @@ from agent_sec_cli.telemetry.writer import (
     get_writer,
     record_security_event_telemetry,
 )
+
+
+@dataclass
+class _TelemetryCtx:
+    agent_name: str | None = None
 
 
 def _event() -> SecurityEvent:
@@ -242,7 +243,7 @@ def test_record_security_event_telemetry_uses_mapping_and_writer(
     monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
     monkeypatch.setattr(telemetry_writer, "_writer", None)
 
-    record_security_event_telemetry(_event())
+    record_security_event_telemetry(_event(), _TelemetryCtx())
 
     record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
     assert record["component.name"] == "agent-sec-core"
@@ -251,7 +252,7 @@ def test_record_security_event_telemetry_uses_mapping_and_writer(
     assert record["component.agent_name"] == ""
 
 
-def test_record_security_event_telemetry_writes_runtime_agent_name(
+def test_record_security_event_telemetry_writes_ctx_agent_name(
     monkeypatch, tmp_path: Path
 ) -> None:
     path = tmp_path / "agent-sec-core.jsonl"
@@ -259,15 +260,24 @@ def test_record_security_event_telemetry_writes_runtime_agent_name(
     monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
     monkeypatch.setattr(telemetry_writer, "_writer", None)
 
-    clear_process_trace_context()
-    init_process_trace_context(TraceContext(agent_name="hermes"))
-    try:
-        record_security_event_telemetry(_event())
-    finally:
-        clear_process_trace_context()
+    record_security_event_telemetry(_event(), _TelemetryCtx(agent_name="hermes"))
 
     record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
     assert record["component.agent_name"] == "hermes"
+
+
+def test_record_security_event_telemetry_strips_ctx_agent_name(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
+    monkeypatch.setattr(telemetry_writer, "_writer", None)
+
+    record_security_event_telemetry(_event(), _TelemetryCtx(agent_name=" cosh "))
+
+    record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["component.agent_name"] == "cosh"
 
 
 def test_record_security_event_telemetry_skips_mapping_when_target_missing(
@@ -279,7 +289,7 @@ def test_record_security_event_telemetry_skips_mapping_when_target_missing(
     mapper = MagicMock(return_value={"component.name": "agent-sec-core"})
     monkeypatch.setattr(telemetry_writer, "build_telemetry_security_event", mapper)
 
-    record_security_event_telemetry(_event())
+    record_security_event_telemetry(_event(), _TelemetryCtx())
 
     mapper.assert_not_called()
     assert not path.exists()
@@ -293,14 +303,14 @@ def test_record_security_event_telemetry_swallows_mapping_errors(
     monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
     monkeypatch.setattr(telemetry_writer, "_writer", None)
 
-    def fail_mapping(event: SecurityEvent) -> dict[str, object]:
+    def fail_mapping(event: SecurityEvent, ctx: _TelemetryCtx) -> dict[str, object]:
         raise RuntimeError("mapping failed")
 
     monkeypatch.setattr(
         telemetry_writer, "build_telemetry_security_event", fail_mapping
     )
 
-    record_security_event_telemetry(_event())
+    record_security_event_telemetry(_event(), _TelemetryCtx())
 
     assert path.read_text(encoding="utf-8") == ""
 

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_writer.py
@@ -1,6 +1,7 @@
 """Unit tests for telemetry writer."""
 
 import json
+import logging
 import subprocess
 import sys
 import threading
@@ -9,6 +10,11 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import agent_sec_cli.telemetry as telemetry
+from agent_sec_cli.correlation_context import (
+    TraceContext,
+    clear_process_trace_context,
+    init_process_trace_context,
+)
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.telemetry import writer as telemetry_writer
 from agent_sec_cli.telemetry.writer import (
@@ -136,12 +142,15 @@ def test_writer_uses_short_lived_flock_on_target_fd(
     assert not Path(f"{path}.lock").exists()
 
 
-def test_writer_skips_when_target_flock_is_busy(monkeypatch, tmp_path: Path) -> None:
+def test_writer_skips_and_logs_when_target_flock_is_busy(
+    monkeypatch, tmp_path: Path, caplog
+) -> None:
     path = tmp_path / "agent-sec-core.jsonl"
     path.write_text("", encoding="utf-8")
     writer = TelemetryWriter(path=path)
     log_failure = MagicMock()
     monkeypatch.setattr(telemetry_writer, "_log_telemetry_write_failure", log_failure)
+    caplog.set_level(logging.WARNING, logger="agent_sec_cli.telemetry.writer")
 
     def busy_flock(fd: int, operation: int) -> None:
         if operation & telemetry_writer.fcntl.LOCK_EX:
@@ -149,10 +158,28 @@ def test_writer_skips_when_target_flock_is_busy(monkeypatch, tmp_path: Path) -> 
 
     monkeypatch.setattr(telemetry_writer.fcntl, "flock", busy_flock)
 
-    writer.write({"seq": 1})
+    writer.write(
+        {
+            "component.agent_name": "cosh",
+            "seccore.event_id": "event-1",
+            "seccore.event_type": "code_scan",
+            "seccore.category": "code_scan",
+        }
+    )
 
     assert path.read_text(encoding="utf-8") == ""
     log_failure.assert_not_called()
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.message == "telemetry JSONL write skipped"
+    assert record.data == {
+        "reason": "target_flock_busy",
+        "path": str(path),
+        "event_id": "event-1",
+        "event_type": "code_scan",
+        "category": "code_scan",
+        "agent_name": "cosh",
+    }
 
 
 def test_writer_skips_when_process_lock_is_busy(tmp_path: Path) -> None:
@@ -221,6 +248,26 @@ def test_record_security_event_telemetry_uses_mapping_and_writer(
     assert record["component.name"] == "agent-sec-core"
     assert record["seccore.event_id"] == "event-1"
     assert record["seccore.verdict"] == "deny"
+    assert record["component.agent_name"] == ""
+
+
+def test_record_security_event_telemetry_writes_runtime_agent_name(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "agent-sec-core.jsonl"
+    path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("AGENT_SEC_TELEMETRY_LOG_PATH", str(path))
+    monkeypatch.setattr(telemetry_writer, "_writer", None)
+
+    clear_process_trace_context()
+    init_process_trace_context(TraceContext(agent_name="hermes"))
+    try:
+        record_security_event_telemetry(_event())
+    finally:
+        clear_process_trace_context()
+
+    record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["component.agent_name"] == "hermes"
 
 
 def test_record_security_event_telemetry_skips_mapping_when_target_missing(

--- a/src/agent-sec-core/tests/unit-test/test_correlation_context.py
+++ b/src/agent-sec-core/tests/unit-test/test_correlation_context.py
@@ -17,12 +17,13 @@ from agent_sec_cli.correlation_context import (
     parse_trace_context_payload,
     reset_current_trace_context,
     set_current_trace_context,
+    trace_context_to_payload,
 )
 
 
 def test_parse_trace_context_accepts_snake_case_json():
     ctx = parse_trace_context(
-        '{"trace_id":"trace-1","session_id":"session-1","run_id":"run-1","call_id":"call-1","tool_call_id":"tool-1"}'
+        '{"trace_id":"trace-1","session_id":"session-1","run_id":"run-1","call_id":"call-1","tool_call_id":"tool-1","agent_name":"hermes"}'
     )
 
     assert ctx == TraceContext(
@@ -31,12 +32,13 @@ def test_parse_trace_context_accepts_snake_case_json():
         run_id="run-1",
         call_id="call-1",
         tool_call_id="tool-1",
+        agent_name="hermes",
     )
 
 
 def test_parse_trace_context_accepts_camel_case_json():
     ctx = parse_trace_context(
-        '{"traceId":"trace-1","sessionId":"session-1","runId":"run-1","callId":"call-1","toolCallId":"tool-1"}'
+        '{"traceId":"trace-1","sessionId":"session-1","runId":"run-1","callId":"call-1","toolCallId":"tool-1","agentName":"openclaw"}'
     )
 
     assert ctx == TraceContext(
@@ -45,21 +47,23 @@ def test_parse_trace_context_accepts_camel_case_json():
         run_id="run-1",
         call_id="call-1",
         tool_call_id="tool-1",
+        agent_name="openclaw",
     )
 
 
 def test_parse_trace_context_prefers_snake_case_when_both_are_present():
     ctx = parse_trace_context(
-        '{"sessionId":"camel-session","session_id":"snake-session","runId":"camel-run","run_id":"snake-run"}'
+        '{"sessionId":"camel-session","session_id":"snake-session","runId":"camel-run","run_id":"snake-run","agentName":"camel-agent","agent_name":"snake-agent"}'
     )
 
     assert ctx.session_id == "snake-session"
     assert ctx.run_id == "snake-run"
+    assert ctx.agent_name == "snake-agent"
 
 
 def test_parse_trace_context_ignores_unknown_empty_and_non_string_values():
     ctx = parse_trace_context(
-        '{"session_id":"","run_id":42,"call_id":"call-1","unknown":"ignored"}'
+        '{"session_id":"","run_id":42,"call_id":"call-1","agent_name":false,"agentName":"","unknown":"ignored"}'
     )
 
     assert ctx == TraceContext(call_id="call-1")
@@ -67,10 +71,10 @@ def test_parse_trace_context_ignores_unknown_empty_and_non_string_values():
 
 def test_parse_trace_context_ignores_whitespace_only_values_and_strips_values():
     ctx = parse_trace_context(
-        '{"session_id":"   ","run_id":" run-1 ","call_id":"call-1"}'
+        '{"session_id":"   ","run_id":" run-1 ","call_id":"call-1","agent_name":" hermes "}'
     )
 
-    assert ctx == TraceContext(run_id="run-1", call_id="call-1")
+    assert ctx == TraceContext(run_id="run-1", call_id="call-1", agent_name="hermes")
 
 
 def test_parse_trace_context_truncates_long_values_with_suffix():
@@ -132,6 +136,7 @@ def test_parse_trace_context_payload_accepts_structured_mapping():
             "session_id": "session-1",
             "run_id": " run-1 ",
             "toolCallId": "tool-1",
+            "agentName": "cosh",
             "ignored": "value",
         }
     )
@@ -141,7 +146,22 @@ def test_parse_trace_context_payload_accepts_structured_mapping():
         session_id="session-1",
         run_id="run-1",
         tool_call_id="tool-1",
+        agent_name="cosh",
     )
+
+
+def test_trace_context_to_payload_emits_agent_name() -> None:
+    assert trace_context_to_payload(
+        TraceContext(
+            trace_id="trace-1",
+            session_id="session-1",
+            agent_name=" hermes ",
+        )
+    ) == {
+        "trace_id": "trace-1",
+        "session_id": "session-1",
+        "agent_name": "hermes",
+    }
 
 
 def test_process_trace_context_is_visible_from_worker_threads():


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

- Add agent_name to trace context parsing, payload serialization, and request context so security-event telemetry can populate component.agent_name.

-   Have Cosh, Hermes, and OpenClaw hooks inject fixed agent names, and make the daemon client inherit ambient trace context by default for daemon-backed scans.

-   Cover agent_name propagation with unit tests and CLI/daemon telemetry e2e tests.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
