### PR TITLE
feat(sight): add jfeng18 as component:sight maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 # Component paths
 # ---------------------------------------------------------------------------
 /src/copilot-shell/                     @kongche-jbw @samchu-zsl    # auto-label: component:cosh
-/src/agentsight/                        @chengshuyi                 # auto-label: component:sight
+/src/agentsight/                        @chengshuyi @jfeng18        # auto-label: component:sight
 /src/agent-sec-core/                    @edonyzpc @kid9             # auto-label: component:sec-core
 /src/agent-sec-core/agent-sec-cli/      @RemindD @edonyzpc                  # auto-label: component:sec-core
 /src/agent-sec-core/cosh-extension/     @yangdao479                 # auto-label: component:sec-core

--- a/.github/maintainers.json
+++ b/.github/maintainers.json
@@ -64,6 +64,9 @@
             "maintainers": [
                 {
                     "github": "chengshuyi"
+                },
+                {
+                    "github": "jfeng18"
                 }
             ]
         },


### PR DESCRIPTION
## Summary

Add @jfeng18 as a co-maintainer for `component:sight` (AgentSight).

## Changes

- `.github/CODEOWNERS`: add `@jfeng18` to `/src/agentsight/` owner list
- `.github/maintainers.json`: add `jfeng18` to `component:sight` maintainers

## Justification

jfeng18 has contributed **19 merged PRs** to this repository, primarily in AgentSight, covering:

- BPF probes
- GenAI pipeline
- Interruption detection
- Observability tooling

Also actively reviews other contributors' PRs (e.g. #800, #808).

Closes #821