### PR TITLE
feat(sec-core): expose sql query endpoint at daemon

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -24,6 +24,10 @@ from agent_sec_cli.security_middleware.backends.hardening import (
 )
 from agent_sec_cli.security_middleware.lifecycle import _ACTION_CATEGORY
 from agent_sec_cli.skill_ledger.cli import app as skill_ledger_app
+from agent_sec_cli.utils.timestamp import (
+    epoch_to_utc_iso,
+    optional_iso_to_utc_iso,
+)
 
 # Get version from package metadata
 try:
@@ -336,31 +340,16 @@ def _resolve_time_range(
     ValueError
         If since or until parameters are not valid ISO-8601 format.
     """
-    # Validate since parameter if provided
-    if since is not None:
-        try:
-            datetime.fromisoformat(since)
-        except ValueError:
-            raise ValueError(
-                f"Invalid time format for --since: {since!r}. "
-                "Expected ISO 8601 format (e.g., 2024-01-01 or 2024-01-01T12:00:00)"
-            )
-
-    # Validate until parameter if provided
-    if until is not None:
-        try:
-            datetime.fromisoformat(until)
-        except ValueError:
-            raise ValueError(
-                f"Invalid time format for --until: {until!r}. "
-                "Expected ISO 8601 format (e.g., 2024-01-01 or 2024-01-01T12:00:00)"
-            )
-
     if last_hours is not None:
         now = time.time()
         since_epoch = now - last_hours * 3600
-        since = datetime.fromtimestamp(since_epoch, tz=timezone.utc).isoformat()
-        until = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+        # Relative ranges are epoch-based already; emit UTC before querying SQLite.
+        since = epoch_to_utc_iso(since_epoch)
+        until = epoch_to_utc_iso(now)
+    else:
+        # Explicit CLI timestamps may be naive local time; normalize at the CLI boundary.
+        since = optional_iso_to_utc_iso(since, field_name="--since")
+        until = optional_iso_to_utc_iso(until, field_name="--until")
     return since, until
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
@@ -77,26 +77,21 @@ def security_summary_handler(
     )
     reader = SqliteEventReader()
     try:
-        total = reader.count(**filters)
-        by_category = reader.count_by("category", **filters)
-        by_event_type = reader.count_by("event_type", **filters)
-        by_result = reader.count_by("result", **filters)
-        by_session = reader.count_by("session_id", **filters)
-        by_run = reader.count_by("run_id", **filters)
-        latest_events = reader.query(**filters, limit=latest_limit, offset=0)
+        summary = reader.summary(**filters, latest_limit=latest_limit)
     finally:
         reader.close()
 
     return HandlerResult(
         data={
-            "total": total,
-            "by_category": _count_map(by_category),
-            "by_event_type": _count_map(by_event_type),
-            "by_result": _count_map(by_result),
-            "affected_sessions": _non_empty_group_count(by_session),
-            "affected_runs": _non_empty_group_count(by_run),
+            "total": summary.total,
+            "by_category": _count_map(summary.by_category),
+            "by_event_type": _count_map(summary.by_event_type),
+            "by_result": _count_map(summary.by_result),
+            "affected_sessions": _non_empty_group_count(summary.by_session),
+            "affected_runs": _non_empty_group_count(summary.by_run),
             "latest_events": [
-                _event_payload(event, include_details=False) for event in latest_events
+                _event_payload(event, include_details=False)
+                for event in summary.latest_events
             ],
         }
     )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
@@ -553,7 +553,11 @@ def _json_object(raw: str) -> dict[str, Any]:
 
 
 def _count_map(groups: dict[Any, int]) -> dict[str, int]:
-    return {str(key): int(value) for key, value in groups.items() if key}
+    return {
+        str(key): int(value)
+        for key, value in groups.items()
+        if key is not None and key != ""
+    }
 
 
 def _count_items(groups: dict[Any, int]) -> list[dict[str, Any]]:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
@@ -1,7 +1,6 @@
 """Read-only daemon handlers for security and observability SQLite data."""
 
 import json
-from datetime import datetime, timezone
 from typing import Any
 
 from agent_sec_cli.daemon.errors import BadRequestError
@@ -20,6 +19,11 @@ from agent_sec_cli.observability.models import ObservabilityEventRecord
 from agent_sec_cli.observability.sqlite_reader import ObservabilityReader
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
+from agent_sec_cli.utils.timestamp import (
+    normalize_iso_to_utc_iso,
+    ns_to_utc_iso,
+    utc_iso_to_epoch,
+)
 
 _DEFAULT_LIMIT = 100
 _MAX_LIMIT = 1000
@@ -443,36 +447,32 @@ def _iso_range(params: dict[str, Any]) -> tuple[str | None, str | None]:
     if until is not None and end_ns is not None:
         raise BadRequestError("until and end_ns are mutually exclusive")
     if start_ns is not None:
-        since = _ns_to_iso(_integer_param(params, "start_ns"))
+        # Nanosecond filters are absolute epoch time, so convert directly to UTC.
+        since = ns_to_utc_iso(_integer_param(params, "start_ns"))
+    elif since is not None:
+        # String filters may be naive local time; normalize before reader/repository calls.
+        since = _normalize_iso_timestamp(since, "since")
     if end_ns is not None:
-        until = _ns_to_iso(_integer_param(params, "end_ns"))
-    if since is not None:
-        _validate_iso_timestamp(since, "since")
-    if until is not None:
-        _validate_iso_timestamp(until, "until")
+        until = ns_to_utc_iso(_integer_param(params, "end_ns"))
+    elif until is not None:
+        until = _normalize_iso_timestamp(until, "until")
     return since, until
 
 
 def _epoch_range(params: dict[str, Any]) -> tuple[float | None, float | None]:
     since, until = _iso_range(params)
     start_epoch = (
-        datetime.fromisoformat(since).timestamp() if since is not None else None
+        utc_iso_to_epoch(since, field_name="since") if since is not None else None
     )
-    end_epoch = datetime.fromisoformat(until).timestamp() if until is not None else None
+    end_epoch = (
+        utc_iso_to_epoch(until, field_name="until") if until is not None else None
+    )
     return start_epoch, end_epoch
 
 
-def _ns_to_iso(value: int) -> str:
-    return datetime.fromtimestamp(_ns_to_epoch(value), tz=timezone.utc).isoformat()
-
-
-def _ns_to_epoch(value: int) -> float:
-    return value / 1_000_000_000
-
-
-def _validate_iso_timestamp(value: str, name: str) -> None:
+def _normalize_iso_timestamp(value: str, name: str) -> str:
     try:
-        datetime.fromisoformat(value)
+        return normalize_iso_to_utc_iso(value, field_name=name)
     except ValueError as exc:
         raise BadRequestError(f"{name} must be an ISO-8601 timestamp") from exc
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
@@ -1,0 +1,569 @@
+"""Read-only daemon handlers for security and observability SQLite data."""
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_sec_cli.daemon.errors import BadRequestError
+from agent_sec_cli.daemon.protocol import DaemonRequest
+from agent_sec_cli.daemon.registry import (
+    HandlerResult,
+    MethodRegistry,
+    MethodSpec,
+)
+from agent_sec_cli.daemon.runtime import DaemonRuntime
+from agent_sec_cli.observability.correlation import (
+    ObservabilityRecordFields,
+    SecurityCorrelationService,
+)
+from agent_sec_cli.observability.models import ObservabilityEventRecord
+from agent_sec_cli.observability.sqlite_reader import ObservabilityReader
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
+
+_DEFAULT_LIMIT = 100
+_MAX_LIMIT = 1000
+_SUMMARY_LATEST_LIMIT = 5
+_EVENT_GROUP_FIELDS = {
+    "category",
+    "event_type",
+    "result",
+    "trace_id",
+    "session_id",
+    "run_id",
+    "call_id",
+    "tool_call_id",
+    "verdict",
+}
+
+
+def register_security_query_methods(registry: MethodRegistry) -> None:
+    """Register dashboard-oriented read-only query methods."""
+    for method, handler in (
+        ("sec.summary", security_summary_handler),
+        ("sec.events.list", security_events_list_handler),
+        ("sec.events.get", security_events_get_handler),
+        ("sec.events.count_by", security_events_count_by_handler),
+        ("obs.sessions.list", observability_sessions_list_handler),
+        ("obs.runs.list", observability_runs_list_handler),
+        ("obs.timeline.get", observability_timeline_get_handler),
+    ):
+        registry.register(
+            MethodSpec(
+                method=method,
+                handler=handler,
+                lifecycle="dashboard query",
+                queue="dashboard",
+                timeout_ms=5000,
+                access_log=True,
+            )
+        )
+
+
+def security_summary_handler(
+    request: DaemonRequest, _runtime: DaemonRuntime
+) -> HandlerResult:
+    """Return aggregate security event data for dashboard summary cards."""
+    filters = _security_filters(request.params)
+    latest_limit = _limit_param(
+        request.params,
+        "latest_limit",
+        default=_SUMMARY_LATEST_LIMIT,
+        max_value=50,
+    )
+    reader = SqliteEventReader()
+    try:
+        total = reader.count(**filters)
+        by_category = reader.count_by("category", **filters)
+        by_event_type = reader.count_by("event_type", **filters)
+        by_result = reader.count_by("result", **filters)
+        by_session = reader.count_by("session_id", **filters)
+        by_run = reader.count_by("run_id", **filters)
+        latest_events = reader.query(**filters, limit=latest_limit, offset=0)
+    finally:
+        reader.close()
+
+    return HandlerResult(
+        data={
+            "total": total,
+            "by_category": _count_map(by_category),
+            "by_event_type": _count_map(by_event_type),
+            "by_result": _count_map(by_result),
+            "affected_sessions": _non_empty_group_count(by_session),
+            "affected_runs": _non_empty_group_count(by_run),
+            "latest_events": [
+                _event_payload(event, include_details=False) for event in latest_events
+            ],
+        }
+    )
+
+
+def security_events_list_handler(
+    request: DaemonRequest, _runtime: DaemonRuntime
+) -> HandlerResult:
+    """Return paginated security event rows from SQLite."""
+    params = request.params
+    filters = _security_filters(params)
+    limit = _limit_param(params, "limit", default=_DEFAULT_LIMIT)
+    offset = _offset_param(params)
+    include_details = _bool_param(params, "include_details", default=False)
+
+    reader = SqliteEventReader()
+    try:
+        items = reader.query(**filters, limit=limit, offset=offset)
+        total = reader.count(**filters)
+    finally:
+        reader.close()
+
+    next_offset = offset + limit if offset + len(items) < total else None
+    return HandlerResult(
+        data={
+            "items": [
+                _event_payload(event, include_details=include_details)
+                for event in items
+            ],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "next_offset": next_offset,
+        }
+    )
+
+
+def security_events_get_handler(
+    request: DaemonRequest, _runtime: DaemonRuntime
+) -> HandlerResult:
+    """Return one security event by event_id."""
+    event_id = _required_string_param(request.params, "event_id")
+    reader = SqliteEventReader()
+    try:
+        event = reader.get(event_id)
+    finally:
+        reader.close()
+
+    return HandlerResult(
+        data={
+            "found": event is not None,
+            "event": (
+                None if event is None else _event_payload(event, include_details=True)
+            ),
+        }
+    )
+
+
+def security_events_count_by_handler(
+    request: DaemonRequest, _runtime: DaemonRuntime
+) -> HandlerResult:
+    """Return grouped security event counts from SQLite."""
+    params = request.params
+    group_by = _required_string_param(params, "group_by")
+    if group_by not in _EVENT_GROUP_FIELDS:
+        allowed = ", ".join(sorted(_EVENT_GROUP_FIELDS))
+        raise BadRequestError(f"group_by must be one of: {allowed}")
+    _reject_params(params, ("limit", "offset"), "sec.events.count_by")
+
+    filters = _security_filters(params)
+    reader = SqliteEventReader()
+    try:
+        groups = reader.count_by(group_by, **filters)
+    finally:
+        reader.close()
+
+    return HandlerResult(
+        data={
+            "group_by": group_by,
+            "items": _count_items(groups),
+        }
+    )
+
+
+def observability_sessions_list_handler(
+    request: DaemonRequest, _runtime: DaemonRuntime
+) -> HandlerResult:
+    """Return observability session summaries from SQLite."""
+    params = request.params
+    start_epoch, end_epoch = _epoch_range(params)
+    since, until = _iso_range(params)
+    limit = _limit_param(params, "limit", default=_DEFAULT_LIMIT)
+    offset = _offset_param(params)
+
+    obs_reader = ObservabilityReader()
+    sec_reader = SqliteEventReader()
+    try:
+        sessions = obs_reader.list_sessions(
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+            limit=limit,
+            offset=offset,
+        )
+        total = obs_reader.count_sessions(
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+        )
+        security_counts = sec_reader.count_by(
+            "session_id",
+            since=since,
+            until=until,
+        )
+    finally:
+        obs_reader.close()
+        sec_reader.close()
+
+    return HandlerResult(
+        data={
+            "items": [
+                {
+                    "session_id": session.session_id,
+                    "first_seen_epoch": session.first_seen_epoch,
+                    "last_seen_epoch": session.last_seen_epoch,
+                    "turn_count": session.turn_count,
+                    "observability_event_count": session.event_count,
+                    "security_event_count": int(
+                        security_counts.get(session.session_id, 0)
+                    ),
+                }
+                for session in sessions
+            ],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "next_offset": offset + limit if offset + len(sessions) < total else None,
+        }
+    )
+
+
+def observability_runs_list_handler(
+    request: DaemonRequest, _runtime: DaemonRuntime
+) -> HandlerResult:
+    """Return observability run summaries for one session."""
+    params = request.params
+    session_id = _required_string_param(params, "session_id")
+    start_epoch, end_epoch = _epoch_range(params)
+    since, until = _iso_range(params)
+    limit = _limit_param(params, "limit", default=_DEFAULT_LIMIT)
+    offset = _offset_param(params)
+
+    obs_reader = ObservabilityReader()
+    sec_reader = SqliteEventReader()
+    try:
+        runs = obs_reader.list_runs(
+            session_id,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+            limit=limit,
+            offset=offset,
+        )
+        total = obs_reader.count_runs(
+            session_id,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+        )
+        security_counts = sec_reader.count_by(
+            "run_id",
+            session_id=session_id,
+            since=since,
+            until=until,
+        )
+    finally:
+        obs_reader.close()
+        sec_reader.close()
+
+    return HandlerResult(
+        data={
+            "session_id": session_id,
+            "items": [
+                {
+                    "run_id": run.run_id,
+                    "started_at_epoch": run.started_at_epoch,
+                    "ended_at_epoch": run.ended_at_epoch,
+                    "user_input_preview": run.user_input_preview,
+                    "observability_event_count": run.event_count,
+                    "security_event_count": int(security_counts.get(run.run_id, 0)),
+                }
+                for run in runs
+            ],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "next_offset": offset + limit if offset + len(runs) < total else None,
+        }
+    )
+
+
+def observability_timeline_get_handler(
+    request: DaemonRequest, _runtime: DaemonRuntime
+) -> HandlerResult:
+    """Return one run's observability timeline plus correlated security events."""
+    params = request.params
+    session_id = _required_string_param(params, "session_id")
+    run_id = _required_string_param(params, "run_id")
+    start_epoch, end_epoch = _epoch_range(params)
+    limit = _limit_param(params, "limit", default=_MAX_LIMIT)
+    offset = _offset_param(params)
+    include_security = _bool_param(params, "include_security", default=True)
+
+    obs_reader = ObservabilityReader()
+    sec_reader = SqliteEventReader()
+    try:
+        obs_rows = obs_reader.list_events(
+            session_id,
+            run_id,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+            limit=limit,
+            offset=offset,
+        )
+        items = [_observability_item(row) for row in obs_rows]
+        if include_security:
+            items.extend(_correlated_security_items(obs_rows, sec_reader))
+    finally:
+        obs_reader.close()
+        sec_reader.close()
+
+    items.sort(key=lambda item: (item["timestamp_epoch"], item["kind"]))
+    return HandlerResult(
+        data={
+            "session_id": session_id,
+            "run_id": run_id,
+            "limit": limit,
+            "offset": offset,
+            "items": items,
+        }
+    )
+
+
+def _security_filters(params: dict[str, Any]) -> dict[str, str | None]:
+    since, until = _iso_range(params)
+    return {
+        "event_type": _optional_string_param(params, "event_type"),
+        "category": _optional_string_param(params, "category"),
+        "result": _optional_string_param(params, "result"),
+        "trace_id": _optional_string_param(params, "trace_id"),
+        "session_id": _optional_string_param(params, "session_id"),
+        "run_id": _optional_string_param(params, "run_id"),
+        "call_id": _optional_string_param(params, "call_id"),
+        "tool_call_id": _optional_string_param(params, "tool_call_id"),
+        "verdict": _optional_string_param(params, "verdict"),
+        "since": since,
+        "until": until,
+    }
+
+
+def _event_payload(event: SecurityEvent, *, include_details: bool) -> dict[str, Any]:
+    payload = event.to_dict()
+    if not include_details:
+        payload.pop("details", None)
+    return payload
+
+
+def _observability_item(row: ObservabilityEventRecord) -> dict[str, Any]:
+    return {
+        "kind": "observability",
+        "id": row.id,
+        "hook": row.hook,
+        "timestamp": row.observed_at,
+        "timestamp_epoch": row.observed_at_epoch,
+        "session_id": row.session_id,
+        "run_id": row.run_id,
+        "call_id": row.call_id,
+        "tool_call_id": row.tool_call_id,
+        "metadata": _json_object(row.metadata_json),
+        "metrics": _json_object(row.metrics_json),
+    }
+
+
+def _observability_context(row: ObservabilityEventRecord) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "hook": row.hook,
+        "timestamp": row.observed_at,
+        "timestamp_epoch": row.observed_at_epoch,
+        "session_id": row.session_id,
+        "run_id": row.run_id,
+        "call_id": row.call_id,
+        "tool_call_id": row.tool_call_id,
+        "metadata": _json_object(row.metadata_json),
+        "metrics": _json_object(row.metrics_json),
+    }
+
+
+def _correlated_security_items(
+    rows: list[ObservabilityEventRecord],
+    reader: SqliteEventReader,
+) -> list[dict[str, Any]]:
+    correlation = SecurityCorrelationService(reader)
+    results = correlation.find_correlated_many([_record_fields(row) for row in rows])
+    items: list[dict[str, Any]] = []
+    for row, correlated_events in zip(rows, results, strict=True):
+        for correlated in correlated_events:
+            items.append(
+                {
+                    "kind": "security",
+                    "observability_event_id": row.id,
+                    "observability": _observability_context(row),
+                    "hook": row.hook,
+                    "session_id": row.session_id,
+                    "run_id": row.run_id,
+                    "call_id": row.call_id,
+                    "tool_call_id": row.tool_call_id,
+                    "timestamp": correlated.event.timestamp,
+                    "timestamp_epoch": correlated.security_timestamp_epoch,
+                    "event": _event_payload(
+                        correlated.event,
+                        include_details=True,
+                    ),
+                    "match": {
+                        "reason": correlated.match_reason,
+                        "rank": correlated.match_rank,
+                        "time_delta_seconds": correlated.time_delta_seconds,
+                    },
+                }
+            )
+    return items
+
+
+def _record_fields(row: ObservabilityEventRecord) -> ObservabilityRecordFields:
+    return ObservabilityRecordFields(
+        hook=row.hook,
+        session_id=row.session_id,
+        run_id=row.run_id,
+        tool_call_id=row.tool_call_id,
+        observed_at_epoch=row.observed_at_epoch,
+        metrics=_json_object(row.metrics_json),
+    )
+
+
+def _iso_range(params: dict[str, Any]) -> tuple[str | None, str | None]:
+    since = _optional_string_param(params, "since")
+    until = _optional_string_param(params, "until")
+    start_ns = params.get("start_ns")
+    end_ns = params.get("end_ns")
+    if since is not None and start_ns is not None:
+        raise BadRequestError("since and start_ns are mutually exclusive")
+    if until is not None and end_ns is not None:
+        raise BadRequestError("until and end_ns are mutually exclusive")
+    if start_ns is not None:
+        since = _ns_to_iso(_integer_param(params, "start_ns"))
+    if end_ns is not None:
+        until = _ns_to_iso(_integer_param(params, "end_ns"))
+    if since is not None:
+        _validate_iso_timestamp(since, "since")
+    if until is not None:
+        _validate_iso_timestamp(until, "until")
+    return since, until
+
+
+def _epoch_range(params: dict[str, Any]) -> tuple[float | None, float | None]:
+    since, until = _iso_range(params)
+    start_epoch = (
+        datetime.fromisoformat(since).timestamp() if since is not None else None
+    )
+    end_epoch = datetime.fromisoformat(until).timestamp() if until is not None else None
+    return start_epoch, end_epoch
+
+
+def _ns_to_iso(value: int) -> str:
+    return datetime.fromtimestamp(_ns_to_epoch(value), tz=timezone.utc).isoformat()
+
+
+def _ns_to_epoch(value: int) -> float:
+    return value / 1_000_000_000
+
+
+def _validate_iso_timestamp(value: str, name: str) -> None:
+    try:
+        datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise BadRequestError(f"{name} must be an ISO-8601 timestamp") from exc
+
+
+def _required_string_param(params: dict[str, Any], name: str) -> str:
+    value = _optional_string_param(params, name)
+    if value is None:
+        raise BadRequestError(f"{name} is required")
+    return value
+
+
+def _optional_string_param(params: dict[str, Any], name: str) -> str | None:
+    value = params.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise BadRequestError(f"{name} must be a string")
+    value = value.strip()
+    return value or None
+
+
+def _limit_param(
+    params: dict[str, Any],
+    name: str,
+    *,
+    default: int,
+    max_value: int = _MAX_LIMIT,
+) -> int:
+    value = params.get(name, default)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise BadRequestError(f"{name} must be an integer")
+    if value <= 0:
+        raise BadRequestError(f"{name} must be positive")
+    if value > max_value:
+        raise BadRequestError(f"{name} must not exceed {max_value}")
+    return value
+
+
+def _offset_param(params: dict[str, Any]) -> int:
+    value = params.get("offset", 0)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise BadRequestError("offset must be an integer")
+    if value < 0:
+        raise BadRequestError("offset must not be negative")
+    return value
+
+
+def _integer_param(params: dict[str, Any], name: str) -> int:
+    value = params.get(name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise BadRequestError(f"{name} must be an integer")
+    return value
+
+
+def _bool_param(params: dict[str, Any], name: str, *, default: bool) -> bool:
+    value = params.get(name, default)
+    if not isinstance(value, bool):
+        raise BadRequestError(f"{name} must be a boolean")
+    return value
+
+
+def _reject_params(
+    params: dict[str, Any],
+    names: tuple[str, ...],
+    method: str,
+) -> None:
+    for name in names:
+        if name in params:
+            raise BadRequestError(f"{name} is not supported for {method}")
+
+
+def _json_object(raw: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _count_map(groups: dict[Any, int]) -> dict[str, int]:
+    return {str(key): int(value) for key, value in groups.items() if key}
+
+
+def _count_items(groups: dict[Any, int]) -> list[dict[str, Any]]:
+    items = [
+        {"value": key, "count": int(value)}
+        for key, value in groups.items()
+        if key is not None and key != ""
+    ]
+    return sorted(items, key=lambda item: (-item["count"], str(item["value"])))
+
+
+def _non_empty_group_count(groups: dict[Any, int]) -> int:
+    return sum(1 for key in groups if key is not None and key != "")

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
@@ -32,6 +32,9 @@ from agent_sec_cli.daemon.gateway import (
 from agent_sec_cli.daemon.handlers.prompt_scan import (
     register_prompt_scan_methods,
 )
+from agent_sec_cli.daemon.handlers.security_query import (
+    register_security_query_methods,
+)
 from agent_sec_cli.daemon.health import register_health_methods
 from agent_sec_cli.daemon.jobs.registry import register_default_jobs
 from agent_sec_cli.daemon.logging import log_daemon_event, setup_daemon_logging
@@ -69,6 +72,7 @@ def create_default_registry() -> MethodRegistry:
     register_health_methods(registry)
     register_prompt_scan_methods(registry)
     registry.register(skillfs_notify_method_spec())
+    register_security_query_methods(registry)
     return registry
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/repositories.py
@@ -87,11 +87,81 @@ class ObservabilityEventRepository:
             self._store.dispose()
             return 0
 
-    def list_sessions(self) -> list[SessionSummary]:
+    def count_sessions(
+        self,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+    ) -> int:
+        """Return the number of distinct sessions matching optional time filters."""
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return 0
+
+        conditions: list[Any] = []
+        if start_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch >= start_epoch)
+        if end_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch < end_epoch)
+
+        stmt = select(
+            func.count(func.distinct(ObservabilityEventRecord.session_id))
+        ).where(*conditions)
+
+        try:
+            with session_factory() as session:
+                return int(session.execute(stmt).scalar_one())
+        except SQLAlchemyError:
+            self._store.dispose()
+            return 0
+
+    def count_runs(
+        self,
+        session_id: str,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+    ) -> int:
+        """Return the number of distinct runs in a session matching time filters."""
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return 0
+
+        conditions: list[Any] = [ObservabilityEventRecord.session_id == session_id]
+        if start_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch >= start_epoch)
+        if end_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch < end_epoch)
+
+        stmt = select(func.count(func.distinct(ObservabilityEventRecord.run_id))).where(
+            *conditions
+        )
+
+        try:
+            with session_factory() as session:
+                return int(session.execute(stmt).scalar_one())
+        except SQLAlchemyError:
+            self._store.dispose()
+            return 0
+
+    def list_sessions(
+        self,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[SessionSummary]:
         """Return all sessions ordered by most recent activity descending."""
         session_factory = self._store.session_factory()
         if session_factory is None:
             return []
+
+        conditions: list[Any] = []
+        if start_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch >= start_epoch)
+        if end_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch < end_epoch)
 
         stmt = (
             select(
@@ -105,9 +175,14 @@ class ObservabilityEventRepository:
                 ),
                 func.count().label("event_count"),
             )
+            .where(*conditions)
             .group_by(ObservabilityEventRecord.session_id)
             .order_by(func.max(ObservabilityEventRecord.observed_at_epoch).desc())
         )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        if offset:
+            stmt = stmt.offset(offset)
 
         try:
             with session_factory() as session:
@@ -127,7 +202,15 @@ class ObservabilityEventRepository:
             for row in rows
         ]
 
-    def list_runs(self, session_id: str) -> list[RunSummary]:
+    def list_runs(
+        self,
+        session_id: str,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[RunSummary]:
         """Return all runs in *session_id* ordered chronologically.
 
         Two queries (constant, not N+1):
@@ -138,6 +221,12 @@ class ObservabilityEventRepository:
         if session_factory is None:
             return []
 
+        conditions: list[Any] = [ObservabilityEventRecord.session_id == session_id]
+        if start_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch >= start_epoch)
+        if end_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch < end_epoch)
+
         stats_stmt = (
             select(
                 ObservabilityEventRecord.run_id,
@@ -147,10 +236,14 @@ class ObservabilityEventRepository:
                 func.max(ObservabilityEventRecord.observed_at_epoch).label("ended_at"),
                 func.count().label("event_count"),
             )
-            .where(ObservabilityEventRecord.session_id == session_id)
+            .where(*conditions)
             .group_by(ObservabilityEventRecord.run_id)
             .order_by(func.min(ObservabilityEventRecord.observed_at_epoch).asc())
         )
+        if limit is not None:
+            stats_stmt = stats_stmt.limit(limit)
+        if offset:
+            stats_stmt = stats_stmt.offset(offset)
 
         first_before_run_subq = (
             select(
@@ -166,10 +259,7 @@ class ObservabilityEventRepository:
                 )
                 .label("rn"),
             )
-            .where(
-                ObservabilityEventRecord.session_id == session_id,
-                ObservabilityEventRecord.hook == "before_agent_run",
-            )
+            .where(*conditions, ObservabilityEventRecord.hook == "before_agent_run")
             .subquery()
         )
         before_run_stmt = select(
@@ -200,21 +290,38 @@ class ObservabilityEventRepository:
         ]
 
     def list_events(
-        self, session_id: str, run_id: str
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[ObservabilityEventRecord]:
         """Return all events for *run_id* in *session_id* ordered ascending."""
         session_factory = self._store.session_factory()
         if session_factory is None:
             return []
 
+        conditions: list[Any] = [
+            ObservabilityEventRecord.session_id == session_id,
+            ObservabilityEventRecord.run_id == run_id,
+        ]
+        if start_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch >= start_epoch)
+        if end_epoch is not None:
+            conditions.append(ObservabilityEventRecord.observed_at_epoch < end_epoch)
+
         stmt = (
             select(ObservabilityEventRecord)
-            .where(
-                ObservabilityEventRecord.session_id == session_id,
-                ObservabilityEventRecord.run_id == run_id,
-            )
+            .where(*conditions)
             .order_by(ObservabilityEventRecord.observed_at_epoch.asc())
         )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        if offset:
+            stmt = stmt.offset(offset)
 
         try:
             with session_factory() as session:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/observability/sqlite_reader.py
@@ -42,19 +42,85 @@ class ObservabilityReader:
         )
         self._repository = ObservabilityEventRepository(self._store)
 
-    def list_sessions(self) -> list[SessionSummary]:
-        """Return all sessions ordered by most recent activity descending."""
-        return self._repository.list_sessions()
+    def count_sessions(
+        self,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+    ) -> int:
+        """Return the number of distinct sessions matching optional time filters."""
+        return self._repository.count_sessions(
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+        )
 
-    def list_runs(self, session_id: str) -> list[RunSummary]:
+    def count_runs(
+        self,
+        session_id: str,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+    ) -> int:
+        """Return the number of distinct runs in a session matching time filters."""
+        return self._repository.count_runs(
+            session_id,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+        )
+
+    def list_sessions(
+        self,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[SessionSummary]:
+        """Return all sessions ordered by most recent activity descending."""
+        return self._repository.list_sessions(
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+            limit=limit,
+            offset=offset,
+        )
+
+    def list_runs(
+        self,
+        session_id: str,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[RunSummary]:
         """Return all runs in *session_id* ordered chronologically."""
-        return self._repository.list_runs(session_id)
+        return self._repository.list_runs(
+            session_id,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+            limit=limit,
+            offset=offset,
+        )
 
     def list_events(
-        self, session_id: str, run_id: str
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        start_epoch: float | None = None,
+        end_epoch: float | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[ObservabilityEventRecord]:
         """Return all events for *run_id* in *session_id* ordered ASC."""
-        return self._repository.list_events(session_id, run_id)
+        return self._repository.list_events(
+            session_id,
+            run_id,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+            limit=limit,
+            offset=offset,
+        )
 
     def close(self) -> None:
         """Dispose cached read-only connections."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/models.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/models.py
@@ -14,6 +14,8 @@ from sqlalchemy import Float, Index, Integer, Text, inspect, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Mapped, mapped_column
 
+_VERDICT_MIGRATION_BATCH_SIZE = 5000
+
 
 class SecurityEventRecord(Base):
     """ORM mapping for the queryable security event index."""
@@ -76,25 +78,46 @@ def _migrate_verdict_column(conn: Connection) -> None:
     inspector = inspect(conn)
     table_name = SecurityEventRecord.__tablename__
     if not inspector.has_table(table_name):
+        conn.commit()
         return
 
     existing = {column["name"] for column in inspector.get_columns(table_name)}
     if "verdict" not in existing:
         conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN verdict TEXT"))
+        conn.commit()
 
-    rows = conn.execute(
-        text("SELECT event_id, details FROM security_events WHERE verdict IS NULL")
-    ).all()
-    updates = _verdict_updates(rows)
-    if updates:
-        conn.execute(
+    last_rowid = 0
+    while True:
+        rows = conn.execute(
             text(
-                "UPDATE security_events "
-                "SET verdict = :verdict "
-                "WHERE event_id = :event_id"
+                "SELECT rowid AS row_id, event_id, details "
+                "FROM security_events "
+                "WHERE verdict IS NULL AND rowid > :last_rowid "
+                "ORDER BY rowid "
+                "LIMIT :limit"
             ),
-            updates,
-        )
+            {
+                "last_rowid": last_rowid,
+                "limit": _VERDICT_MIGRATION_BATCH_SIZE,
+            },
+        ).all()
+        if not rows:
+            conn.commit()
+            break
+
+        last_rowid = max(int(row._mapping["row_id"]) for row in rows)
+        updates = _verdict_updates(rows)
+        if updates:
+            conn.execute(
+                text(
+                    "UPDATE security_events "
+                    "SET verdict = :verdict "
+                    "WHERE event_id = :event_id"
+                ),
+                updates,
+            )
+        # Commit each bounded batch so large migrations do not hold a write lock.
+        conn.commit()
 
 
 def _verdict_updates(rows: list[Any]) -> list[dict[str, str]]:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/models.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/models.py
@@ -1,8 +1,17 @@
 """SQLAlchemy ORM models for queryable security event storage."""
 
+import json
+from typing import Any
+
 from agent_sec_cli.security_events.orm_base import Base
 from agent_sec_cli.security_events.orm_store import register_orm_models
-from sqlalchemy import Float, Index, Integer, Text
+from agent_sec_cli.security_events.schema import extract_verdict
+from agent_sec_cli.security_events.schema_version import (
+    SECURITY_EVENTS_SQLITE_SCHEMA_VERSION,
+    SECURITY_EVENTS_VERDICT_SCHEMA_VERSION,
+)
+from sqlalchemy import Float, Index, Integer, Text, inspect, text
+from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -15,6 +24,7 @@ class SecurityEventRecord(Base):
         Index("idx_category_epoch", "category", "timestamp_epoch"),
         Index("idx_trace_id", "trace_id"),
         Index("idx_timestamp_epoch", "timestamp_epoch"),
+        Index("idx_verdict_timestamp_epoch", "verdict", "timestamp_epoch"),
         Index("idx_session_id_timestamp_epoch", "session_id", "timestamp_epoch"),
         Index("idx_run_id_timestamp_epoch", "run_id", "timestamp_epoch"),
         Index(
@@ -28,6 +38,7 @@ class SecurityEventRecord(Base):
         "run_id": "TEXT",
         "call_id": "TEXT",
         "tool_call_id": "TEXT",
+        "verdict": "TEXT",
     }
 
     event_id: Mapped[str] = mapped_column(Text, primary_key=True)
@@ -45,8 +56,70 @@ class SecurityEventRecord(Base):
     run_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     call_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     tool_call_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    verdict: Mapped[str | None] = mapped_column(Text, nullable=True)
     details: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+def migrate_security_events_schema(
+    conn: Connection,
+    from_version: int,
+    to_version: int,
+    _models: tuple[type[Base], ...],
+    _log_prefix: str,
+) -> None:
+    """Apply security event schema migrations before generic convergence."""
+    if from_version < SECURITY_EVENTS_VERDICT_SCHEMA_VERSION <= to_version:
+        _migrate_verdict_column(conn)
+
+
+def _migrate_verdict_column(conn: Connection) -> None:
+    inspector = inspect(conn)
+    table_name = SecurityEventRecord.__tablename__
+    if not inspector.has_table(table_name):
+        return
+
+    existing = {column["name"] for column in inspector.get_columns(table_name)}
+    if "verdict" not in existing:
+        conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN verdict TEXT"))
+
+    rows = conn.execute(
+        text("SELECT event_id, details FROM security_events WHERE verdict IS NULL")
+    ).all()
+    updates = _verdict_updates(rows)
+    if updates:
+        conn.execute(
+            text(
+                "UPDATE security_events "
+                "SET verdict = :verdict "
+                "WHERE event_id = :event_id"
+            ),
+            updates,
+        )
+
+
+def _verdict_updates(rows: list[Any]) -> list[dict[str, str]]:
+    updates: list[dict[str, str]] = []
+    for row in rows:
+        mapping = row._mapping
+        try:
+            details = json.loads(mapping["details"])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(details, dict):
+            continue
+        verdict = extract_verdict(details)
+        if verdict is not None:
+            updates.append({"event_id": str(mapping["event_id"]), "verdict": verdict})
+    return updates
 
 
 ORM_MODELS = (SecurityEventRecord,)
 register_orm_models(ORM_MODELS)
+
+
+__all__ = [
+    "ORM_MODELS",
+    "SECURITY_EVENTS_SQLITE_SCHEMA_VERSION",
+    "SecurityEventRecord",
+    "migrate_security_events_schema",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/orm_store.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/orm_store.py
@@ -148,10 +148,10 @@ def ensure_schema(
     model_tuple = _coerce_models(models)
     with engine.connect() as conn:
         conn.execute(text("PRAGMA journal_mode=WAL"))
-    with engine.begin() as conn:
         version = conn.execute(text("PRAGMA user_version")).scalar_one()
         if version > schema_version:
             _warn_newer_schema_version(int(version), schema_version, log_prefix)
+            conn.commit()
             return
 
         conn.execute(text("PRAGMA auto_vacuum = INCREMENTAL"))
@@ -163,6 +163,15 @@ def ensure_schema(
                 model_tuple,
                 log_prefix,
             )
+        conn.commit()
+
+    with engine.begin() as conn:
+        version = conn.execute(text("PRAGMA user_version")).scalar_one()
+        if version > schema_version:
+            _warn_newer_schema_version(int(version), schema_version, log_prefix)
+            return
+
+        conn.execute(text("PRAGMA auto_vacuum = INCREMENTAL"))
 
         for model in model_tuple:
             table = model.__table__

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/orm_store.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/orm_store.py
@@ -9,13 +9,16 @@ from pathlib import Path
 from typing import Any
 
 from agent_sec_cli.security_events.orm_base import Base
+from agent_sec_cli.security_events.schema_version import (
+    SECURITY_EVENTS_SQLITE_SCHEMA_VERSION,
+)
 from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.engine import URL, Connection, Engine
 from sqlalchemy.exc import DatabaseError, SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.schema import CreateIndex, CreateTable
 
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = SECURITY_EVENTS_SQLITE_SCHEMA_VERSION
 _SQLITE_PRIMARY_CODE_MASK = 0xFF
 _SQLITE_CORRUPTION_CODES = {
     sqlite3.SQLITE_CORRUPT,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -11,13 +11,14 @@ from agent_sec_cli.security_events.models import SecurityEventRecord
 from agent_sec_cli.security_events.orm_store import SqliteStore
 from agent_sec_cli.security_events.schema import SecurityEvent, extract_verdict
 from agent_sec_cli.utils.timestamp import utc_iso_to_epoch
-from sqlalchemy import Select, delete, func, select, text
+from sqlalchemy import Select, delete, func, literal, select, text, union_all
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import SQLAlchemyError
 
 logger = logging.getLogger(__name__)
 
 _CORRELATION_CANDIDATE_LIMIT = 1000
+_SUMMARY_GROUP_FIELDS = ("category", "event_type", "result", "session_id", "run_id")
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,19 @@ class CorrelationCandidate:
 
     event: SecurityEvent
     timestamp_epoch: float
+
+
+@dataclass(frozen=True)
+class SecurityEventsSummary:
+    """Dashboard summary data returned by one repository call."""
+
+    total: int
+    by_category: dict[Any, int]
+    by_event_type: dict[Any, int]
+    by_result: dict[Any, int]
+    by_session: dict[Any, int]
+    by_run: dict[Any, int]
+    latest_events: list[SecurityEvent]
 
 
 class SecurityEventRepository:
@@ -377,6 +391,72 @@ class SecurityEventRepository:
             self._store.dispose()
             return {}
 
+    def summary(
+        self,
+        event_type: str | None = None,
+        category: str | None = None,
+        result: str | None = None,
+        trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        verdict: str | None = None,
+        latest_limit: int = 5,
+    ) -> SecurityEventsSummary:
+        """Return dashboard aggregates and latest rows in one session."""
+        conditions = self._build_filters(
+            event_type=event_type,
+            category=category,
+            result=result,
+            trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
+            since=since,
+            until=until,
+            verdict=verdict,
+        )
+        group_stmt = self._summary_group_counts_stmt(conditions)
+        latest_stmt = (
+            select(SecurityEventRecord)
+            .where(*conditions)
+            .order_by(SecurityEventRecord.timestamp_epoch.desc())
+            .limit(latest_limit)
+        )
+
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return _empty_summary()
+
+        try:
+            with session_factory() as session:
+                group_rows = session.execute(group_stmt).all()
+                records = list(session.scalars(latest_stmt).all())
+        except SQLAlchemyError:
+            self._store.dispose()
+            return _empty_summary()
+
+        groups = _summary_groups_from_rows(group_rows)
+        latest_events: list[SecurityEvent] = []
+        for record in records:
+            event = self._record_to_event(record)
+            if event is not None:
+                latest_events.append(event)
+
+        return SecurityEventsSummary(
+            total=sum(groups["category"].values()),
+            by_category=groups["category"],
+            by_event_type=groups["event_type"],
+            by_result=groups["result"],
+            by_session=groups["session_id"],
+            by_run=groups["run_id"],
+            latest_events=latest_events,
+        )
+
     def prune(self, max_age_days: int) -> None:
         """Delete rows older than max_age_days."""
         session_factory = self._store.session_factory()
@@ -456,6 +536,21 @@ class SecurityEventRepository:
             )
         return conditions
 
+    def _summary_group_counts_stmt(self, conditions: list[Any]) -> Any:
+        statements = []
+        for group_field in _SUMMARY_GROUP_FIELDS:
+            column = self._COUNT_BY_COLUMNS[group_field]
+            statements.append(
+                select(
+                    literal(group_field).label("group_field"),
+                    column.label("group_value"),
+                    func.count().label("count"),
+                )
+                .where(*conditions)
+                .group_by(column)
+            )
+        return union_all(*statements)
+
     @staticmethod
     def _record_to_event(record: SecurityEventRecord) -> SecurityEvent | None:
         """Convert an ORM record to SecurityEvent. Returns None on parse error."""
@@ -478,3 +573,27 @@ class SecurityEventRepository:
         except (json.JSONDecodeError, TypeError, ValueError) as exc:
             print(f"[security_events] malformed row skipped: {exc}", file=sys.stderr)
             return None
+
+
+def _empty_summary() -> SecurityEventsSummary:
+    return SecurityEventsSummary(
+        total=0,
+        by_category={},
+        by_event_type={},
+        by_result={},
+        by_session={},
+        by_run={},
+        latest_events=[],
+    )
+
+
+def _summary_groups_from_rows(rows: list[Any]) -> dict[str, dict[Any, int]]:
+    groups: dict[str, dict[Any, int]] = {
+        group_field: {} for group_field in _SUMMARY_GROUP_FIELDS
+    }
+    for row in rows:
+        group_field = str(row[0])
+        if group_field not in groups:
+            continue
+        groups[group_field][row[1]] = int(row[2])
+    return groups

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -5,12 +5,12 @@ import logging
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, Sequence
 
 from agent_sec_cli.security_events.models import SecurityEventRecord
 from agent_sec_cli.security_events.orm_store import SqliteStore
 from agent_sec_cli.security_events.schema import SecurityEvent, extract_verdict
+from agent_sec_cli.utils.timestamp import utc_iso_to_epoch
 from sqlalchemy import Select, delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import SQLAlchemyError
@@ -74,7 +74,8 @@ class SecurityEventRepository:
             "category": event.category,
             "result": event.result,
             "timestamp": event.timestamp,
-            "timestamp_epoch": datetime.fromisoformat(event.timestamp).timestamp(),
+            # SecurityEvent validation normalizes timestamps before repository entry.
+            "timestamp_epoch": utc_iso_to_epoch(event.timestamp),
             "trace_id": event.trace_id,
             "pid": event.pid,
             "uid": event.uid,
@@ -407,8 +408,8 @@ class SecurityEventRepository:
 
     @staticmethod
     def _timestamp_epoch(value: str) -> float:
-        """Parse an ISO timestamp using local time when timezone is absent."""
-        return datetime.fromisoformat(value).timestamp()
+        """Convert a repository-bound UTC ISO timestamp to epoch seconds."""
+        return utc_iso_to_epoch(value)
 
     def _build_filters(
         self,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/repositories.py
@@ -5,12 +5,12 @@ import logging
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Sequence
 
 from agent_sec_cli.security_events.models import SecurityEventRecord
 from agent_sec_cli.security_events.orm_store import SqliteStore
-from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.schema import SecurityEvent, extract_verdict
 from sqlalchemy import Select, delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import SQLAlchemyError
@@ -34,7 +34,13 @@ class SecurityEventRepository:
     _COUNT_BY_COLUMNS = {
         "category": SecurityEventRecord.category,
         "event_type": SecurityEventRecord.event_type,
+        "result": SecurityEventRecord.result,
         "trace_id": SecurityEventRecord.trace_id,
+        "session_id": SecurityEventRecord.session_id,
+        "run_id": SecurityEventRecord.run_id,
+        "call_id": SecurityEventRecord.call_id,
+        "tool_call_id": SecurityEventRecord.tool_call_id,
+        "verdict": SecurityEventRecord.verdict,
     }
 
     def __init__(self, store: SqliteStore) -> None:
@@ -76,6 +82,7 @@ class SecurityEventRepository:
             "run_id": event.run_id,
             "call_id": event.call_id,
             "tool_call_id": event.tool_call_id,
+            "verdict": extract_verdict(event.details),
             "details": json.dumps(event.details, ensure_ascii=False),
         }
 
@@ -83,19 +90,34 @@ class SecurityEventRepository:
         self,
         event_type: str | None = None,
         category: str | None = None,
+        result: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        verdict: str | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[SecurityEvent]:
-        """Query security events with optional filters."""
+        """Query security events with optional filters.
+
+        All filters, including verdict, are applied in SQL.
+        """
         conditions = self._build_filters(
             event_type=event_type,
             category=category,
+            result=result,
             trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
             since=since,
             until=until,
+            verdict=verdict,
         )
         stmt = (
             select(SecurityEventRecord)
@@ -121,7 +143,28 @@ class SecurityEventRepository:
             event = self._record_to_event(record)
             if event is not None:
                 events.append(event)
+
         return events
+
+    def get(self, event_id: str) -> SecurityEvent | None:
+        """Return one security event by id."""
+        session_factory = self._store.session_factory()
+        if session_factory is None:
+            return None
+
+        stmt = select(SecurityEventRecord).where(
+            SecurityEventRecord.event_id == event_id
+        )
+        try:
+            with session_factory() as session:
+                record = session.execute(stmt).scalar_one_or_none()
+        except SQLAlchemyError:
+            self._store.dispose()
+            return None
+
+        if record is None:
+            return None
+        return self._record_to_event(record)
 
     def query_correlation_candidates(
         self,
@@ -203,32 +246,48 @@ class SecurityEventRepository:
         self,
         event_type: str | None = None,
         category: str | None = None,
+        result: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        verdict: str | None = None,
         offset: int = 0,
     ) -> int:
-        """Count events matching the given filters."""
+        """Count events matching the given filters.
+
+        All filters, including verdict, are applied in SQL.
+        """
         conditions = self._build_filters(
             event_type=event_type,
             category=category,
+            result=result,
             trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
             since=since,
             until=until,
+            verdict=verdict,
         )
-        if offset == 0:
-            stmt: Select[tuple[int]] = (
-                select(func.count()).select_from(SecurityEventRecord).where(*conditions)
-            )
-        else:
-            subquery = (
+
+        if offset:
+            source = (
                 select(SecurityEventRecord.event_id)
                 .where(*conditions)
-                .limit(-1)
+                .order_by(SecurityEventRecord.timestamp_epoch.desc())
                 .offset(offset)
                 .subquery()
             )
-            stmt = select(func.count()).select_from(subquery)
+            stmt: Select[tuple[int]] = select(func.count()).select_from(source)
+        else:
+            stmt = (
+                select(func.count()).select_from(SecurityEventRecord).where(*conditions)
+            )
 
         session_factory = self._store.session_factory()
         if session_factory is None:
@@ -246,38 +305,64 @@ class SecurityEventRepository:
         group_field: str,
         event_type: str | None = None,
         category: str | None = None,
+        result: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        verdict: str | None = None,
         offset: int = 0,
     ) -> dict[str, int]:
-        """Count events grouped by a specific allowlisted field."""
-        column = self._COUNT_BY_COLUMNS.get(group_field)
-        if column is None:
+        """Count events grouped by a specific allowlisted field.
+
+        All filters and group fields, including verdict, are handled in SQL.
+        """
+        if group_field not in self._COUNT_BY_COLUMNS:
             raise ValueError(
                 f"Invalid group_field: {group_field!r}. "
-                "Must be one of: category, event_type, trace_id"
+                "Must be one of: call_id, category, event_type, result, "
+                "run_id, session_id, tool_call_id, trace_id, verdict"
             )
 
         conditions = self._build_filters(
             event_type=event_type,
             category=category,
+            result=result,
             trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
             since=since,
             until=until,
+            verdict=verdict,
         )
-        if offset == 0:
-            stmt = select(column, func.count()).where(*conditions).group_by(column)
-        else:
-            subquery = (
-                select(column.label(group_field))
+
+        column = self._COUNT_BY_COLUMNS[group_field]
+        if group_field == "verdict" and verdict is None:
+            conditions = [
+                *conditions,
+                SecurityEventRecord.verdict.is_not(None),
+                SecurityEventRecord.verdict != "",
+            ]
+        if offset:
+            source = (
+                select(column.label("group_value"))
                 .where(*conditions)
-                .limit(-1)
+                .order_by(SecurityEventRecord.timestamp_epoch.desc())
                 .offset(offset)
                 .subquery()
             )
-            subquery_column = getattr(subquery.c, group_field)
-            stmt = select(subquery_column, func.count()).group_by(subquery_column)
+            stmt = (
+                select(source.c.group_value, func.count())
+                .select_from(source)
+                .group_by(source.c.group_value)
+            )
+        else:
+            stmt = select(column, func.count()).where(*conditions).group_by(column)
 
         session_factory = self._store.session_factory()
         if session_factory is None:
@@ -322,20 +407,23 @@ class SecurityEventRepository:
 
     @staticmethod
     def _timestamp_epoch(value: str) -> float:
-        """Parse an ISO timestamp as UTC when timezone information is absent."""
-        dt = datetime.fromisoformat(value)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.timestamp()
+        """Parse an ISO timestamp using local time when timezone is absent."""
+        return datetime.fromisoformat(value).timestamp()
 
     def _build_filters(
         self,
         *,
         event_type: str | None = None,
         category: str | None = None,
+        result: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        verdict: str | None = None,
     ) -> list[Any]:
         """Build SQLAlchemy filter expressions from non-None filters."""
         conditions: list[Any] = []
@@ -343,8 +431,20 @@ class SecurityEventRepository:
             conditions.append(SecurityEventRecord.event_type == event_type)
         if category is not None:
             conditions.append(SecurityEventRecord.category == category)
+        if result is not None:
+            conditions.append(SecurityEventRecord.result == result)
         if trace_id is not None:
             conditions.append(SecurityEventRecord.trace_id == trace_id)
+        if session_id is not None:
+            conditions.append(SecurityEventRecord.session_id == session_id)
+        if run_id is not None:
+            conditions.append(SecurityEventRecord.run_id == run_id)
+        if call_id is not None:
+            conditions.append(SecurityEventRecord.call_id == call_id)
+        if tool_call_id is not None:
+            conditions.append(SecurityEventRecord.tool_call_id == tool_call_id)
+        if verdict is not None:
+            conditions.append(SecurityEventRecord.verdict == verdict)
         if since is not None:
             conditions.append(
                 SecurityEventRecord.timestamp_epoch >= self._timestamp_epoch(since)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
@@ -5,7 +5,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from agent_sec_cli.utils.timestamp import normalize_iso_to_utc_iso
+from pydantic import BaseModel, Field, field_validator
 
 
 def extract_verdict(details: dict[str, Any]) -> str | None:
@@ -64,6 +65,14 @@ class SecurityEvent(BaseModel):
     run_id: str | None = None
     call_id: str | None = None
     tool_call_id: str | None = None
+
+    @field_validator("timestamp")
+    @classmethod
+    def _normalize_timestamp(cls, value: str) -> str:
+        if not value:
+            return _now_iso()
+        # Keep JSONL and SQLite writers aligned: SecurityEvent timestamps are stored as UTC.
+        return normalize_iso_to_utc_iso(value, field_name="timestamp")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a plain ``dict`` suitable for ``json.dumps``."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
@@ -8,6 +8,21 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 
+def extract_verdict(details: dict[str, Any]) -> str | None:
+    """Return the event verdict embedded in *details*, if present."""
+    direct = details.get("verdict")
+    if isinstance(direct, str):
+        return direct
+
+    result = details.get("result")
+    if isinstance(result, dict):
+        nested = result.get("verdict")
+        if isinstance(nested, str):
+            return nested
+
+    return None
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema_version.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema_version.py
@@ -1,0 +1,17 @@
+"""SQLite schema version metadata for security event storage."""
+
+SECURITY_EVENTS_SQLITE_SCHEMA_REVISIONS = {
+    1: "initial security_events table",
+    2: "add run_id, call_id, and tool_call_id correlation columns",
+    3: "add verdict column and backfill from event details",
+}
+
+SECURITY_EVENTS_VERDICT_SCHEMA_VERSION = 3
+SECURITY_EVENTS_SQLITE_SCHEMA_VERSION = max(SECURITY_EVENTS_SQLITE_SCHEMA_REVISIONS)
+
+
+__all__ = [
+    "SECURITY_EVENTS_SQLITE_SCHEMA_REVISIONS",
+    "SECURITY_EVENTS_SQLITE_SCHEMA_VERSION",
+    "SECURITY_EVENTS_VERDICT_SCHEMA_VERSION",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
@@ -7,6 +7,7 @@ from agent_sec_cli.security_events.orm_store import SqliteStore
 from agent_sec_cli.security_events.repositories import (
     CorrelationCandidate,
     SecurityEventRepository,
+    SecurityEventsSummary,
 )
 from agent_sec_cli.security_events.schema import SecurityEvent
 from sqlalchemy.engine import Engine
@@ -161,4 +162,35 @@ class SqliteEventReader:
             until=until,
             verdict=verdict,
             offset=offset,
+        )
+
+    def summary(
+        self,
+        event_type: str | None = None,
+        category: str | None = None,
+        result: str | None = None,
+        trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        verdict: str | None = None,
+        latest_limit: int = 5,
+    ) -> SecurityEventsSummary:
+        """Return dashboard summary aggregates and latest events."""
+        return self._repository.summary(
+            event_type=event_type,
+            category=category,
+            result=result,
+            trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
+            since=since,
+            until=until,
+            verdict=verdict,
+            latest_limit=latest_limit,
         )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
@@ -44,9 +44,15 @@ class SqliteEventReader:
         self,
         event_type: str | None = None,
         category: str | None = None,
+        result: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        verdict: str | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[SecurityEvent]:
@@ -54,12 +60,22 @@ class SqliteEventReader:
         return self._repository.query(
             event_type=event_type,
             category=category,
+            result=result,
             trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
             since=since,
             until=until,
+            verdict=verdict,
             limit=limit,
             offset=offset,
         )
+
+    def get(self, event_id: str) -> SecurityEvent | None:
+        """Return one security event by id."""
+        return self._repository.get(event_id)
 
     def query_correlation_candidates(
         self,
@@ -87,18 +103,30 @@ class SqliteEventReader:
         self,
         event_type: str | None = None,
         category: str | None = None,
+        result: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        verdict: str | None = None,
         offset: int = 0,
     ) -> int:
         """Count events matching the given filters."""
         return self._repository.count(
             event_type=event_type,
             category=category,
+            result=result,
             trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
             since=since,
             until=until,
+            verdict=verdict,
             offset=offset,
         )
 
@@ -107,9 +135,15 @@ class SqliteEventReader:
         group_field: str,
         event_type: str | None = None,
         category: str | None = None,
+        result: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        call_id: str | None = None,
+        tool_call_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        verdict: str | None = None,
         offset: int = 0,
     ) -> dict[str, int]:
         """Count events grouped by a specific field."""
@@ -117,8 +151,14 @@ class SqliteEventReader:
             group_field,
             event_type=event_type,
             category=category,
+            result=result,
             trace_id=trace_id,
+            session_id=session_id,
+            run_id=run_id,
+            call_id=call_id,
+            tool_call_id=tool_call_id,
             since=since,
             until=until,
+            verdict=verdict,
             offset=offset,
         )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
@@ -9,6 +9,7 @@ import threading
 from pathlib import Path
 
 from agent_sec_cli.security_events.config import get_db_path
+from agent_sec_cli.security_events.models import migrate_security_events_schema
 from agent_sec_cli.security_events.orm_store import (
     SqliteStore,
     _is_sqlite_busy_error,
@@ -35,7 +36,10 @@ class SqliteEventWriter:
         path: str | Path | None = None,
         max_age_days: int | None = 30,
     ) -> None:
-        self._store = SqliteStore(path or get_db_path())
+        self._store = SqliteStore(
+            path or get_db_path(),
+            schema_migrations=migrate_security_events_schema,
+        )
         self._repository = SecurityEventRepository(self._store)
         self._max_age_days = max_age_days
         self._write_lock = threading.Lock()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/utils/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utility helpers for agent-sec-cli."""

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/utils/timestamp.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/utils/timestamp.py
@@ -1,0 +1,120 @@
+"""Timestamp normalization helpers used at CLI/API boundaries."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+NaiveTimestampPolicy = Literal["local", "utc", "reject"]
+
+
+def normalize_iso_to_utc_iso(
+    value: str,
+    *,
+    field_name: str = "timestamp",
+    naive: NaiveTimestampPolicy = "local",
+) -> str:
+    """Parse an ISO timestamp and return a UTC-aware ISO timestamp.
+
+    Naive timestamps are interpreted according to *naive*. User-facing entry
+    points use ``local`` so ``2026-01-01T09:00:00`` means local wall-clock time.
+    Repository-facing checks use ``reject`` to keep storage/query layers from
+    silently choosing a timezone.
+    """
+    return datetime_to_utc_iso(
+        parse_iso_datetime(value, field_name=field_name, naive=naive),
+        field_name=field_name,
+        naive="reject",
+    )
+
+
+def optional_iso_to_utc_iso(
+    value: str | None,
+    *,
+    field_name: str,
+    naive: NaiveTimestampPolicy = "local",
+) -> str | None:
+    """Normalize an optional ISO timestamp to UTC."""
+    if value is None:
+        return None
+    return normalize_iso_to_utc_iso(value, field_name=field_name, naive=naive)
+
+
+def parse_iso_datetime(
+    value: str,
+    *,
+    field_name: str = "timestamp",
+    naive: NaiveTimestampPolicy = "local",
+) -> datetime:
+    """Parse an ISO-8601 timestamp and apply the requested naive-time policy."""
+    try:
+        parsed = datetime.fromisoformat(_normalize_z_suffix(value))
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid time format for {field_name}: {value!r}. "
+            "Expected ISO 8601 format."
+        ) from exc
+    return ensure_aware_datetime(parsed, field_name=field_name, naive=naive)
+
+
+def ensure_aware_datetime(
+    value: datetime,
+    *,
+    field_name: str = "timestamp",
+    naive: NaiveTimestampPolicy = "local",
+) -> datetime:
+    """Return an aware datetime using the configured policy for naive values."""
+    if value.tzinfo is not None and value.tzinfo.utcoffset(value) is not None:
+        return value
+    if naive == "local":
+        # For user input, a naive timestamp is local wall-clock time.
+        return value.astimezone()
+    if naive == "utc":
+        return value.replace(tzinfo=timezone.utc)
+    raise ValueError(f"{field_name} must include timezone information.")
+
+
+def datetime_to_utc_iso(
+    value: datetime,
+    *,
+    field_name: str = "timestamp",
+    naive: NaiveTimestampPolicy = "local",
+) -> str:
+    """Convert a datetime to a UTC-aware ISO timestamp."""
+    return (
+        ensure_aware_datetime(
+            value,
+            field_name=field_name,
+            naive=naive,
+        )
+        .astimezone(timezone.utc)
+        .isoformat()
+    )
+
+
+def epoch_to_utc_iso(epoch: float) -> str:
+    """Convert epoch seconds to a UTC-aware ISO timestamp."""
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
+
+
+def ns_to_utc_iso(value: int) -> str:
+    """Convert nanoseconds since epoch to a UTC-aware ISO timestamp."""
+    return epoch_to_utc_iso(value / 1_000_000_000)
+
+
+def utc_iso_to_epoch(value: str, *, field_name: str = "timestamp") -> float:
+    """Convert a UTC-aware ISO timestamp to epoch seconds.
+
+    This is intentionally stricter than user-facing parsing: repository callers
+    should normalize local/offset timestamps before crossing the repository
+    boundary.
+    """
+    parsed = parse_iso_datetime(value, field_name=field_name, naive="reject")
+    # Repository-facing timestamps must already be normalized to UTC.
+    if parsed.utcoffset() != timedelta(0):
+        raise ValueError(f"{field_name} must be normalized to UTC.")
+    return parsed.timestamp()
+
+
+def _normalize_z_suffix(value: str) -> str:
+    if value.endswith("Z"):
+        return f"{value[:-1]}+00:00"
+    return value

--- a/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
@@ -14,10 +14,12 @@ shared state, no ordering dependency, no cascade failures.
 """
 
 import json
+import os
+import sqlite3
 import time
+from pathlib import Path
 
-# Import shared helpers from conftest.py
-from .conftest import iso_now, require_loongshield, run_cli
+from cli.conftest import iso_now, require_loongshield, run_cli
 
 
 def _run_harden_and_expected_event_result() -> str:
@@ -33,6 +35,99 @@ def _run_harden_and_expected_event_result() -> str:
 
 def _expected_event_result(cli_result):
     return "succeeded" if cli_result.returncode == 0 else "failed"
+
+
+def _extract_verdict(details: dict) -> str | None:
+    """Return verdict from event details without importing agent_sec_cli internals."""
+    direct = details.get("verdict")
+    if isinstance(direct, str):
+        return direct
+
+    nested_result = details.get("result")
+    if isinstance(nested_result, dict):
+        nested = nested_result.get("verdict")
+        if isinstance(nested, str):
+            return nested
+
+    return None
+
+
+def _write_security_event_row(
+    *,
+    event_id: str,
+    event_type: str,
+    category: str,
+    result: str,
+    trace_id: str,
+    details: dict,
+) -> None:
+    data_dir = Path(os.environ["AGENT_SEC_DATA_DIR"])
+    db_path = data_dir / "security-events.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript("""
+            PRAGMA user_version = 3;
+            CREATE TABLE IF NOT EXISTS security_events (
+                event_id TEXT PRIMARY KEY,
+                event_type TEXT NOT NULL,
+                category TEXT NOT NULL,
+                result TEXT NOT NULL DEFAULT 'succeeded',
+                timestamp TEXT NOT NULL,
+                timestamp_epoch FLOAT NOT NULL,
+                trace_id TEXT NOT NULL DEFAULT '',
+                pid INTEGER NOT NULL,
+                uid INTEGER NOT NULL,
+                session_id TEXT,
+                run_id TEXT,
+                call_id TEXT,
+                tool_call_id TEXT,
+                verdict TEXT,
+                details TEXT NOT NULL
+            );
+            """)
+        conn.execute(
+            """
+            INSERT INTO security_events (
+                event_id,
+                event_type,
+                category,
+                result,
+                timestamp,
+                timestamp_epoch,
+                trace_id,
+                pid,
+                uid,
+                session_id,
+                run_id,
+                call_id,
+                tool_call_id,
+                verdict,
+                details
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                event_type,
+                category,
+                result,
+                "2026-06-09T00:00:00+00:00",
+                1780963200.0,
+                trace_id,
+                os.getpid(),
+                os.getuid(),
+                None,
+                None,
+                None,
+                None,
+                _extract_verdict(details),
+                json.dumps(details),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 class TestHardenEventLogging:
@@ -365,16 +460,13 @@ class TestEventsSummaryFlag:
 # ---------------------------------------------------------------------------
 
 
-class TestErrorEventPersistence:
-    """Verify that error events are correctly persisted to SQLite."""
+class TestFailedEventQuery:
+    """Verify that persisted failed events are returned by the events CLI."""
 
-    def test_error_event_writes_to_sqlite(self):
-        """Integration test: verify that error events are actually written to SQLite with result='failed'."""
-        from agent_sec_cli.security_events import get_reader, log_event
-        from agent_sec_cli.security_events.schema import SecurityEvent
-
-        # Create an error event (simulating what lifecycle.on_error does)
-        error_event = SecurityEvent(
+    def test_failed_event_reads_from_sqlite(self):
+        """Verify that failed events are read from SQLite with result='failed'."""
+        _write_security_event_row(
+            event_id="error-event-e2e",
             event_type="harden",
             category="hardening",
             result="failed",
@@ -386,23 +478,19 @@ class TestErrorEventPersistence:
             trace_id="error-trace-123",
         )
 
-        # Write it via log_event (dual-write)
-        log_event(error_event)
+        result = run_cli("events", "--event-type", "harden", "--output", "json")
+        assert result.returncode == 0, f"events query failed: {result.stderr}"
 
-        # Read it back from SQLite
-        reader = get_reader()
-        events = reader.query(event_type="harden")
-
+        events = json.loads(result.stdout)
         assert len(events) == 1
         event = events[0]
 
-        # Verify error event was written correctly
-        assert event.event_type == "harden"  # NOT "harden_error"
-        assert event.result == "failed"
-        assert event.category == "hardening"
-        assert event.details["error"] == "loongshield not found"
-        assert event.details["error_type"] == "FileNotFoundError"
-        assert event.trace_id == "error-trace-123"
+        assert event["event_type"] == "harden"  # NOT "harden_error"
+        assert event["result"] == "failed"
+        assert event["category"] == "hardening"
+        assert event["details"]["error"] == "loongshield not found"
+        assert event["details"]["error_type"] == "FileNotFoundError"
+        assert event["trace_id"] == "error-trace-123"
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
+++ b/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import signal
 import socket
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -78,6 +79,95 @@ def test_daemon_health_over_unix_socket(
     assert not socket_path.exists()
     assert output.returncode == 0
     assert not _has_request_log(tmp_path, response["request_id"], "daemon.health")
+
+
+def test_daemon_security_events_list_reads_sqlite_over_unix_socket(
+    daemon_command: list[str], tmp_path: Path
+) -> None:
+    socket_path = tmp_path / "runtime" / "daemon.sock"
+    _write_security_event(tmp_path / "data" / "security-events.db")
+    process = _start_daemon(daemon_command, socket_path, tmp_path)
+
+    try:
+        response = _call_daemon(
+            socket_path,
+            {
+                "method": "sec.events.list",
+                "params": {
+                    "session_id": "session-e2e",
+                    "include_details": True,
+                },
+            },
+        )
+    finally:
+        output = _stop_daemon(process)
+
+    assert response["ok"] is True
+    assert response["data"]["total"] == 1
+    assert response["data"]["items"][0]["event_id"] == "event-e2e"
+    assert response["data"]["items"][0]["details"]["request"]["code"] == "echo e2e"
+    assert output.returncode == 0
+    assert _has_request_log(tmp_path, response["request_id"], "sec.events.list")
+
+
+def test_daemon_security_query_methods_read_sqlite_over_unix_socket(
+    daemon_command: list[str], tmp_path: Path
+) -> None:
+    socket_path = tmp_path / "runtime" / "daemon.sock"
+    _write_security_event(tmp_path / "data" / "security-events.db")
+    process = _start_daemon(daemon_command, socket_path, tmp_path)
+
+    try:
+        summary_response = _call_daemon(
+            socket_path,
+            {
+                "method": "sec.summary",
+                "params": {"session_id": "session-e2e"},
+            },
+        )
+        get_response = _call_daemon(
+            socket_path,
+            {
+                "method": "sec.events.get",
+                "params": {"event_id": "event-e2e"},
+            },
+        )
+        count_response = _call_daemon(
+            socket_path,
+            {
+                "method": "sec.events.count_by",
+                "params": {
+                    "group_by": "run_id",
+                    "session_id": "session-e2e",
+                },
+            },
+        )
+    finally:
+        output = _stop_daemon(process)
+
+    assert summary_response["ok"] is True
+    assert summary_response["data"]["total"] == 1
+    assert summary_response["data"]["by_category"] == {"code_scan": 1}
+    assert summary_response["data"]["affected_runs"] == 1
+    assert summary_response["data"]["latest_events"][0]["event_id"] == "event-e2e"
+
+    assert get_response["ok"] is True
+    assert get_response["data"]["found"] is True
+    assert get_response["data"]["event"]["event_id"] == "event-e2e"
+    assert get_response["data"]["event"]["details"]["request"]["code"] == "echo e2e"
+
+    assert count_response["ok"] is True
+    assert count_response["data"]["group_by"] == "run_id"
+    assert count_response["data"]["items"] == [{"value": "run-e2e", "count": 1}]
+
+    assert output.returncode == 0
+    assert _has_request_log(tmp_path, summary_response["request_id"], "sec.summary")
+    assert _has_request_log(tmp_path, get_response["request_id"], "sec.events.get")
+    assert _has_request_log(
+        tmp_path,
+        count_response["request_id"],
+        "sec.events.count_by",
+    )
 
 
 def test_daemon_uses_xdg_runtime_dir_by_default(
@@ -285,6 +375,74 @@ def test_daemon_skillfs_notify_refreshes_skill_ledger_activation(
         response["request_id"],
         "skill_ledger.skillfs_notify_change",
     )
+
+
+def _write_security_event(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript("""
+            PRAGMA user_version = 3;
+            CREATE TABLE IF NOT EXISTS security_events (
+                event_id TEXT PRIMARY KEY,
+                event_type TEXT NOT NULL,
+                category TEXT NOT NULL,
+                result TEXT NOT NULL DEFAULT 'succeeded',
+                timestamp TEXT NOT NULL,
+                timestamp_epoch FLOAT NOT NULL,
+                trace_id TEXT NOT NULL DEFAULT '',
+                pid INTEGER NOT NULL,
+                uid INTEGER NOT NULL,
+                session_id TEXT,
+                run_id TEXT,
+                call_id TEXT,
+                tool_call_id TEXT,
+                verdict TEXT,
+                details TEXT NOT NULL
+            );
+            """)
+        conn.execute(
+            """
+            INSERT INTO security_events (
+                event_id,
+                event_type,
+                category,
+                result,
+                timestamp,
+                timestamp_epoch,
+                trace_id,
+                pid,
+                uid,
+                session_id,
+                run_id,
+                call_id,
+                tool_call_id,
+                verdict,
+                details
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "event-e2e",
+                "code_scan",
+                "code_scan",
+                "succeeded",
+                "2026-06-09T00:00:00+00:00",
+                1780963200.0,
+                "trace-e2e",
+                os.getpid(),
+                os.getuid(),
+                "session-e2e",
+                "run-e2e",
+                None,
+                "tool-e2e",
+                None,
+                json.dumps({"request": {"code": "echo e2e"}}),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def _start_daemon(

--- a/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
@@ -838,7 +838,14 @@ def test_health_does_not_import_heavy_modules(tmp_path: Path):
     assert snapshot["prompt_scan"]["status"] == "pending"
     assert registry.methods() == (
         "daemon.health",
+        "obs.runs.list",
+        "obs.sessions.list",
+        "obs.timeline.get",
         "scan-prompt",
+        "sec.events.count_by",
+        "sec.events.get",
+        "sec.events.list",
+        "sec.summary",
         "skill_ledger.skillfs_notify_change",
     )
     assert _matching_modules(heavy_prefixes) == before

--- a/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
@@ -4,6 +4,7 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
+import agent_sec_cli.daemon.handlers.security_query as security_query
 import pytest
 from agent_sec_cli.daemon.protocol import DaemonRequest, DaemonResponse
 from agent_sec_cli.daemon.registry import dispatch_request
@@ -11,6 +12,7 @@ from agent_sec_cli.daemon.runtime import DaemonRuntime
 from agent_sec_cli.daemon.server import create_default_registry
 from agent_sec_cli.observability.schema import validate_observability_record
 from agent_sec_cli.observability.sqlite_writer import ObservabilitySqliteWriter
+from agent_sec_cli.security_events.repositories import SecurityEventsSummary
 from agent_sec_cli.security_events.schema import SecurityEvent
 from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
 
@@ -175,6 +177,80 @@ def test_security_event_queries_read_sqlite_data(tmp_path: Path) -> None:
     }
     assert summary_response.data["affected_sessions"] == 1
     assert summary_response.data["affected_runs"] == 2
+
+
+def test_security_summary_handler_uses_repository_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any] | str] = []
+
+    class SummaryReader:
+        def summary(self, **kwargs: Any) -> SecurityEventsSummary:
+            calls.append(kwargs)
+            return SecurityEventsSummary(
+                total=2,
+                by_category={"code_scan": 2},
+                by_event_type={"scan": 2},
+                by_result={"succeeded": 2},
+                by_session={"session-1": 1, None: 1},
+                by_run={"run-1": 1, "": 1},
+                latest_events=[
+                    SecurityEvent(
+                        event_id="latest-event",
+                        event_type="scan",
+                        category="code_scan",
+                        details={"hidden": True},
+                    )
+                ],
+            )
+
+        def count(self, **_kwargs: Any) -> int:
+            raise AssertionError("summary handler should not call count")
+
+        def count_by(self, *_args: Any, **_kwargs: Any) -> dict[str, int]:
+            raise AssertionError("summary handler should not call count_by")
+
+        def query(self, **_kwargs: Any) -> list[SecurityEvent]:
+            raise AssertionError("summary handler should not call query")
+
+        def close(self) -> None:
+            calls.append("close")
+
+    monkeypatch.setattr(security_query, "SqliteEventReader", SummaryReader)
+
+    result = security_query.security_summary_handler(
+        DaemonRequest(
+            method="sec.summary",
+            params={"session_id": "session-1", "latest_limit": 7},
+        ),
+        DaemonRuntime(socket_path=tmp_path / "daemon.sock"),
+    )
+
+    assert calls == [
+        {
+            "event_type": None,
+            "category": None,
+            "result": None,
+            "trace_id": None,
+            "session_id": "session-1",
+            "run_id": None,
+            "call_id": None,
+            "tool_call_id": None,
+            "verdict": None,
+            "since": None,
+            "until": None,
+            "latest_limit": 7,
+        },
+        "close",
+    ]
+    assert result.data["total"] == 2
+    assert result.data["affected_sessions"] == 1
+    assert result.data["affected_runs"] == 1
+    latest_event = result.data["latest_events"][0]
+    assert latest_event["event_id"] == "latest-event"
+    assert latest_event["event_type"] == "scan"
+    assert "details" not in latest_event
 
 
 def test_observability_queries_read_sqlite_data(tmp_path: Path) -> None:

--- a/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
@@ -356,6 +356,31 @@ def test_security_events_list_filters_by_verdict(tmp_path: Path) -> None:
     assert returned_ids == {"deny-1", "deny-2"}
 
 
+def test_security_events_list_normalizes_explicit_since_until(tmp_path: Path) -> None:
+    _write_security_event(
+        tmp_path,
+        event_id="offset-window",
+        timestamp="2026-05-20T04:00:00+00:00",
+    )
+    _write_security_event(
+        tmp_path,
+        event_id="outside-window",
+        timestamp="2026-05-20T06:00:00+00:00",
+    )
+
+    response = _call_daemon(
+        tmp_path,
+        "sec.events.list",
+        {
+            "since": "2026-05-20T11:59:00+08:00",
+            "until": "2026-05-20T12:01:00+08:00",
+        },
+    )
+
+    assert response.ok is True
+    assert [item["event_id"] for item in response.data["items"]] == ["offset-window"]
+
+
 def test_security_events_count_by_verdict_group(tmp_path: Path) -> None:
     """Count-by with group_by=verdict returns correct grouped counts."""
     _write_security_event(tmp_path, event_id="d1", details={"verdict": "deny"})

--- a/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
@@ -1,0 +1,408 @@
+"""Tests for daemon security/observability SQLite query handlers."""
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from agent_sec_cli.daemon.protocol import DaemonRequest, DaemonResponse
+from agent_sec_cli.daemon.registry import dispatch_request
+from agent_sec_cli.daemon.runtime import DaemonRuntime
+from agent_sec_cli.daemon.server import create_default_registry
+from agent_sec_cli.observability.schema import validate_observability_record
+from agent_sec_cli.observability.sqlite_writer import ObservabilitySqliteWriter
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
+
+
+def _call_daemon(
+    tmp_path: Path,
+    method: str,
+    params: dict[str, Any] | None = None,
+) -> DaemonResponse:
+    async def scenario() -> DaemonResponse:
+        return await dispatch_request(
+            DaemonRequest(
+                method=method,
+                params={} if params is None else params,
+            ),
+            create_default_registry(),
+            DaemonRuntime(socket_path=tmp_path / "daemon.sock"),
+        )
+
+    return asyncio.run(scenario())
+
+
+def _write_security_event(
+    tmp_path: Path,
+    *,
+    event_id: str = "event-1",
+    event_type: str = "code_scan",
+    category: str = "code_scan",
+    result: str = "succeeded",
+    timestamp: str = "2026-06-09T00:00:00+00:00",
+    session_id: str = "session-1",
+    run_id: str = "run-1",
+    tool_call_id: str | None = "tool-1",
+    details: dict[str, Any] | None = None,
+) -> None:
+    writer = SqliteEventWriter(path=tmp_path / "security-events.db", max_age_days=None)
+    try:
+        writer.write(
+            SecurityEvent(
+                event_id=event_id,
+                event_type=event_type,
+                category=category,
+                result=result,  # type: ignore[arg-type]
+                timestamp=timestamp,
+                trace_id="trace-1",
+                session_id=session_id,
+                run_id=run_id,
+                tool_call_id=tool_call_id,
+                details=(
+                    details
+                    if details is not None
+                    else {"request": {"code": "echo hi"}, "result": {"valid": True}}
+                ),
+            )
+        )
+    finally:
+        writer.close()
+
+
+def _write_observability_event(
+    tmp_path: Path,
+    *,
+    hook: str = "before_tool_call",
+    observed_at: str = "2026-06-09T00:00:00Z",
+    session_id: str = "session-1",
+    run_id: str = "run-1",
+    tool_call_id: str | None = "tool-1",
+    metrics: dict[str, Any] | None = None,
+) -> None:
+    metadata: dict[str, Any] = {"sessionId": session_id, "runId": run_id}
+    if tool_call_id is not None:
+        metadata["toolCallId"] = tool_call_id
+    writer = ObservabilitySqliteWriter(
+        path=tmp_path / "observability.db",
+        max_age_days=None,
+    )
+    try:
+        writer.write_or_raise(
+            validate_observability_record(
+                {
+                    "hook": hook,
+                    "observedAt": observed_at,
+                    "metadata": metadata,
+                    "metrics": metrics or {"parameters": {"command": "echo hi"}},
+                }
+            )
+        )
+    finally:
+        writer.close()
+
+
+@pytest.fixture(autouse=True)
+def _agent_sec_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
+
+
+def test_default_registry_exposes_dashboard_query_methods(tmp_path: Path) -> None:
+    methods = set(create_default_registry().methods())
+
+    assert "sec.status" not in methods
+    assert {
+        "sec.summary",
+        "sec.events.list",
+        "sec.events.get",
+        "sec.events.count_by",
+        "obs.sessions.list",
+        "obs.runs.list",
+        "obs.timeline.get",
+    }.issubset(methods)
+
+
+def test_security_event_queries_read_sqlite_data(tmp_path: Path) -> None:
+    _write_security_event(tmp_path)
+    _write_security_event(
+        tmp_path,
+        event_id="event-2",
+        event_type="prompt_scan",
+        category="prompt_scan",
+        run_id="run-2",
+        tool_call_id=None,
+    )
+
+    list_response = _call_daemon(
+        tmp_path,
+        "sec.events.list",
+        {"session_id": "session-1", "limit": 10},
+    )
+    assert list_response.ok is True
+    assert list_response.data["total"] == 2
+    assert {item["event_id"] for item in list_response.data["items"]} == {
+        "event-1",
+        "event-2",
+    }
+    assert "details" not in list_response.data["items"][0]
+
+    get_response = _call_daemon(
+        tmp_path,
+        "sec.events.get",
+        {"event_id": "event-1"},
+    )
+    assert get_response.ok is True
+    assert get_response.data["found"] is True
+    assert get_response.data["event"]["details"]["request"]["code"] == "echo hi"
+
+    count_response = _call_daemon(
+        tmp_path,
+        "sec.events.count_by",
+        {"group_by": "run_id", "session_id": "session-1"},
+    )
+    assert count_response.ok is True
+    assert count_response.data["items"] == [
+        {"value": "run-1", "count": 1},
+        {"value": "run-2", "count": 1},
+    ]
+
+    summary_response = _call_daemon(tmp_path, "sec.summary")
+    assert summary_response.ok is True
+    assert summary_response.data["total"] == 2
+    assert summary_response.data["by_category"] == {
+        "code_scan": 1,
+        "prompt_scan": 1,
+    }
+    assert summary_response.data["affected_sessions"] == 1
+    assert summary_response.data["affected_runs"] == 2
+
+
+def test_observability_queries_read_sqlite_data(tmp_path: Path) -> None:
+    _write_security_event(tmp_path)
+    _write_observability_event(
+        tmp_path,
+        hook="before_agent_run",
+        tool_call_id=None,
+        metrics={"user_input": "inspect coverage"},
+    )
+    _write_observability_event(tmp_path)
+
+    sessions_response = _call_daemon(tmp_path, "obs.sessions.list")
+    assert sessions_response.ok is True
+    assert sessions_response.data["items"] == [
+        {
+            "session_id": "session-1",
+            "first_seen_epoch": 1780963200.0,
+            "last_seen_epoch": 1780963200.0,
+            "turn_count": 1,
+            "observability_event_count": 2,
+            "security_event_count": 1,
+        }
+    ]
+
+    runs_response = _call_daemon(
+        tmp_path,
+        "obs.runs.list",
+        {"session_id": "session-1"},
+    )
+    assert runs_response.ok is True
+    assert runs_response.data["items"][0]["run_id"] == "run-1"
+    assert runs_response.data["items"][0]["user_input_preview"] == "inspect coverage"
+    assert runs_response.data["items"][0]["security_event_count"] == 1
+
+    timeline_response = _call_daemon(
+        tmp_path,
+        "obs.timeline.get",
+        {"session_id": "session-1", "run_id": "run-1"},
+    )
+    assert timeline_response.ok is True
+    kinds = [item["kind"] for item in timeline_response.data["items"]]
+    assert kinds.count("observability") == 2
+    assert kinds.count("security") == 1
+    security_item = next(
+        item for item in timeline_response.data["items"] if item["kind"] == "security"
+    )
+    assert security_item["event"]["event_id"] == "event-1"
+    assert security_item["match"]["reason"] == "tool_call_id"
+    assert (
+        security_item["observability_event_id"] == security_item["observability"]["id"]
+    )
+    assert security_item["hook"] == "before_tool_call"
+    assert security_item["session_id"] == "session-1"
+    assert security_item["run_id"] == "run-1"
+    assert security_item["tool_call_id"] == "tool-1"
+    assert security_item["observability"]["hook"] == "before_tool_call"
+    assert security_item["observability"]["metadata"]["toolCallId"] == "tool-1"
+
+
+def test_observability_security_counts_respect_time_window(tmp_path: Path) -> None:
+    _write_observability_event(
+        tmp_path,
+        hook="before_agent_run",
+        observed_at="2026-06-09T00:00:00Z",
+        tool_call_id=None,
+        metrics={"user_input": "current"},
+    )
+    _write_observability_event(
+        tmp_path,
+        hook="before_agent_run",
+        observed_at="2026-06-08T00:00:00Z",
+        run_id="run-old",
+        tool_call_id=None,
+        metrics={"user_input": "old"},
+    )
+    _write_security_event(
+        tmp_path,
+        event_id="current-security",
+        timestamp="2026-06-09T00:00:00+00:00",
+    )
+    _write_security_event(
+        tmp_path,
+        event_id="old-security",
+        timestamp="2026-06-08T00:00:00+00:00",
+        run_id="run-old",
+        tool_call_id=None,
+    )
+
+    start_ns = 1_780_963_199_000_000_000
+    end_ns = 1_780_963_201_000_000_000
+    sessions_response = _call_daemon(
+        tmp_path,
+        "obs.sessions.list",
+        {"start_ns": start_ns, "end_ns": end_ns},
+    )
+    runs_response = _call_daemon(
+        tmp_path,
+        "obs.runs.list",
+        {"session_id": "session-1", "start_ns": start_ns, "end_ns": end_ns},
+    )
+
+    assert sessions_response.ok is True
+    assert sessions_response.data["total"] == 1
+    assert sessions_response.data["items"][0]["turn_count"] == 1
+    assert sessions_response.data["items"][0]["security_event_count"] == 1
+
+    assert runs_response.ok is True
+    assert runs_response.data["total"] == 1
+    assert runs_response.data["items"][0]["run_id"] == "run-1"
+    assert runs_response.data["items"][0]["security_event_count"] == 1
+
+
+def test_security_query_validation_errors_are_bad_request(tmp_path: Path) -> None:
+    invalid_group = _call_daemon(
+        tmp_path,
+        "sec.events.count_by",
+        {"group_by": "invalid"},
+    )
+    assert invalid_group.ok is False
+    assert invalid_group.error is not None
+    assert invalid_group.error["code"] == "bad_request"
+
+    invalid_limit = _call_daemon(
+        tmp_path,
+        "sec.events.list",
+        {"limit": 5000},
+    )
+    assert invalid_limit.ok is False
+    assert invalid_limit.error is not None
+    assert invalid_limit.error["code"] == "bad_request"
+
+    invalid_since = _call_daemon(
+        tmp_path,
+        "sec.events.list",
+        {"since": "not-a-time"},
+    )
+    assert invalid_since.ok is False
+    assert invalid_since.error is not None
+    assert invalid_since.error["code"] == "bad_request"
+
+    count_by_offset = _call_daemon(
+        tmp_path,
+        "sec.events.count_by",
+        {"group_by": "category", "offset": 1},
+    )
+    assert count_by_offset.ok is False
+    assert count_by_offset.error is not None
+    assert count_by_offset.error["code"] == "bad_request"
+
+
+def test_security_events_list_filters_by_verdict(tmp_path: Path) -> None:
+    """Events list filtered by verdict returns only matching events."""
+    _write_security_event(
+        tmp_path,
+        event_id="deny-1",
+        details={"verdict": "deny"},
+    )
+    _write_security_event(
+        tmp_path,
+        event_id="deny-2",
+        details={"verdict": "deny"},
+    )
+    _write_security_event(
+        tmp_path,
+        event_id="pass-1",
+        details={"verdict": "pass"},
+    )
+
+    response = _call_daemon(
+        tmp_path,
+        "sec.events.list",
+        {"verdict": "deny", "include_details": True},
+    )
+    assert response.ok is True
+    assert response.data["total"] == 2
+    assert len(response.data["items"]) == 2
+    returned_ids = {item["event_id"] for item in response.data["items"]}
+    assert returned_ids == {"deny-1", "deny-2"}
+
+
+def test_security_events_count_by_verdict_group(tmp_path: Path) -> None:
+    """Count-by with group_by=verdict returns correct grouped counts."""
+    _write_security_event(tmp_path, event_id="d1", details={"verdict": "deny"})
+    _write_security_event(tmp_path, event_id="d2", details={"verdict": "deny"})
+    _write_security_event(tmp_path, event_id="p1", details={"verdict": "pass"})
+    _write_security_event(tmp_path, event_id="n1", details={})
+
+    response = _call_daemon(
+        tmp_path,
+        "sec.events.count_by",
+        {"group_by": "verdict"},
+    )
+    assert response.ok is True
+    items = {item["value"]: item["count"] for item in response.data["items"]}
+    assert items["deny"] == 2
+    assert items["pass"] == 1
+    # Event with no verdict should not appear in groups
+    assert "" not in items
+
+
+def test_security_summary_respects_verdict_filter(tmp_path: Path) -> None:
+    """Summary with verdict filter only counts matching events."""
+    _write_security_event(
+        tmp_path,
+        event_id="deny-1",
+        category="code_scan",
+        details={"verdict": "deny"},
+    )
+    _write_security_event(
+        tmp_path,
+        event_id="deny-2",
+        category="prompt_scan",
+        event_type="prompt_scan",
+        details={"verdict": "deny"},
+    )
+    _write_security_event(
+        tmp_path,
+        event_id="pass-1",
+        category="code_scan",
+        details={"verdict": "pass"},
+    )
+
+    response = _call_daemon(
+        tmp_path,
+        "sec.summary",
+        {"verdict": "deny"},
+    )
+    assert response.ok is True
+    assert response.data["total"] == 2
+    assert response.data["by_category"] == {"code_scan": 1, "prompt_scan": 1}

--- a/src/agent-sec-core/tests/unit-test/observability/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/observability/test_sqlite_reader.py
@@ -62,6 +62,52 @@ def test_observability_reader_lists_sessions_runs_and_events(tmp_path: Path) -> 
     assert json.loads(events[1].metrics_json)["tool_name"] == "pytest"
 
 
+def test_observability_reader_counts_sessions_and_runs(tmp_path: Path) -> None:
+    db_path = tmp_path / "observability.db"
+    writer = ObservabilitySqliteWriter(path=db_path, max_age_days=None)
+    _seed(
+        writer,
+        session_id="session-A",
+        run_id="run-A",
+        observed_at="2026-05-16T12:00:00Z",
+    )
+    _seed(
+        writer,
+        session_id="session-A",
+        run_id="run-B",
+        observed_at="2026-05-16T12:00:01Z",
+    )
+    _seed(
+        writer,
+        session_id="session-B",
+        run_id="run-C",
+        observed_at="2026-05-17T12:00:00Z",
+    )
+    writer.close()
+
+    reader = ObservabilityReader(path=db_path)
+    try:
+        assert reader.count_sessions() == 2
+        assert reader.count_runs("session-A") == 2
+        assert (
+            reader.count_sessions(
+                start_epoch=1778932800.0,
+                end_epoch=1779019200.0,
+            )
+            == 1
+        )
+        assert (
+            reader.count_runs(
+                "session-A",
+                start_epoch=1778932800.0,
+                end_epoch=1779019200.0,
+            )
+            == 2
+        )
+    finally:
+        reader.close()
+
+
 def test_observability_reader_close_disposes_store(tmp_path: Path) -> None:
     db_path = tmp_path / "observability.db"
     writer = ObservabilitySqliteWriter(path=db_path, max_age_days=None)

--- a/src/agent-sec-core/tests/unit-test/security_events/test_orm_store.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_orm_store.py
@@ -24,6 +24,11 @@ from agent_sec_cli.security_events.orm_store import (
 )
 from agent_sec_cli.security_events.repositories import SecurityEventRepository
 from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.schema_version import (
+    SECURITY_EVENTS_SQLITE_SCHEMA_REVISIONS,
+    SECURITY_EVENTS_SQLITE_SCHEMA_VERSION,
+    SECURITY_EVENTS_VERDICT_SCHEMA_VERSION,
+)
 from sqlalchemy import Index, Integer, Text, inspect, text
 from sqlalchemy.exc import DatabaseError, SQLAlchemyError
 from sqlalchemy.orm import Mapped, mapped_column, sessionmaker
@@ -87,6 +92,18 @@ class _SchemaRepairRaceStore(SqliteStore):
         self._db_identity = db_identity
         self._session_factory = sessionmaker(expire_on_commit=False, future=True)
         self._force_schema_convergence = False
+
+
+def test_schema_version_tracks_revision_history() -> None:
+    revisions = SECURITY_EVENTS_SQLITE_SCHEMA_REVISIONS
+
+    assert SECURITY_EVENTS_SQLITE_SCHEMA_VERSION == max(revisions)
+    assert sorted(revisions) == list(
+        range(1, SECURITY_EVENTS_SQLITE_SCHEMA_VERSION + 1)
+    )
+    assert orm_store._SCHEMA_VERSION == SECURITY_EVENTS_SQLITE_SCHEMA_VERSION
+    assert SECURITY_EVENTS_VERDICT_SCHEMA_VERSION in revisions
+    assert "verdict" in revisions[SECURITY_EVENTS_VERDICT_SCHEMA_VERSION]
 
 
 def test_sqlite_corruption_classification_uses_result_code(tmp_path: Path) -> None:

--- a/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime
 
 from agent_sec_cli.security_events.schema import SecurityEvent
+from pydantic import ValidationError
 
 
 class TestSecurityEventRequiredFields(unittest.TestCase):
@@ -31,6 +32,31 @@ class TestSecurityEventAutoFill(unittest.TestCase):
         evt = SecurityEvent(event_type="t", category="c", details={})
         ts = datetime.fromisoformat(evt.timestamp)
         self.assertIsNotNone(ts.tzinfo)
+
+    def test_timestamp_is_normalized_to_utc(self):
+        evt = SecurityEvent(
+            event_type="t",
+            category="c",
+            details={},
+            timestamp="2026-05-20T12:00:00+08:00",
+        )
+
+        self.assertEqual(evt.timestamp, "2026-05-20T04:00:00+00:00")
+
+    def test_empty_timestamp_uses_generated_utc_timestamp(self):
+        evt = SecurityEvent(event_type="t", category="c", details={}, timestamp="")
+
+        ts = datetime.fromisoformat(evt.timestamp)
+        self.assertIsNotNone(ts.tzinfo)
+
+    def test_invalid_timestamp_is_rejected(self):
+        with self.assertRaises(ValidationError):
+            SecurityEvent(
+                event_type="t",
+                category="c",
+                details={},
+                timestamp="not-a-valid-timestamp",
+            )
 
     def test_pid_matches_current(self):
         evt = SecurityEvent(event_type="t", category="c", details={})

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -330,6 +330,53 @@ class TestSqliteEventReader:
 
         assert reader.count_by("category", offset=1) == {"alpha": 1, "beta": 1}
 
+    def test_summary_returns_aggregates_and_latest_events(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(
+            SecurityEvent(
+                event_id="older-deny",
+                event_type="scan",
+                category="code_scan",
+                timestamp="2026-05-19T00:00:00+00:00",
+                session_id="session-1",
+                run_id="run-1",
+                details={"verdict": "deny"},
+            )
+        )
+        writer.write(
+            SecurityEvent(
+                event_id="pass-event",
+                event_type="scan",
+                category="code_scan",
+                timestamp="2026-05-19T00:01:00+00:00",
+                session_id="session-1",
+                run_id="run-1",
+                details={"verdict": "pass"},
+            )
+        )
+        writer.write(
+            SecurityEvent(
+                event_id="newer-deny",
+                event_type="prompt",
+                category="prompt_scan",
+                timestamp="2026-05-19T00:02:00+00:00",
+                session_id="session-2",
+                run_id="run-2",
+                details={"verdict": "deny"},
+            )
+        )
+
+        summary = reader.summary(verdict="deny", latest_limit=1)
+
+        assert summary.total == 2
+        assert summary.by_category == {"code_scan": 1, "prompt_scan": 1}
+        assert summary.by_event_type == {"scan": 1, "prompt": 1}
+        assert summary.by_result == {"succeeded": 2}
+        assert summary.by_session == {"session-1": 1, "session-2": 1}
+        assert summary.by_run == {"run-1": 1, "run-2": 1}
+        assert [event.event_id for event in summary.latest_events] == ["newer-deny"]
+
     def test_query_rejects_naive_time_range_at_repository_boundary(
         self, writer: SqliteEventWriter, reader: SqliteEventReader
     ) -> None:

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -1,7 +1,6 @@
 """Unit tests for security_events.sqlite_reader — SqliteEventReader."""
 
 import io
-import os
 import sqlite3
 import sys
 import time
@@ -331,53 +330,24 @@ class TestSqliteEventReader:
 
         assert reader.count_by("category", offset=1) == {"alpha": 1, "beta": 1}
 
-    def test_query_naive_time_range_uses_local_timezone(
-        self,
-        writer: SqliteEventWriter,
-        reader: SqliteEventReader,
-        monkeypatch: pytest.MonkeyPatch,
+    def test_query_rejects_naive_time_range_at_repository_boundary(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
     ) -> None:
-        if not hasattr(time, "tzset"):
-            pytest.skip("time.tzset is required to validate local timezone parsing")
-
-        old_tz = os.environ.get("TZ")
-        monkeypatch.setenv("TZ", "Asia/Shanghai")
-        time.tzset()
-        try:
-            writer.write(
-                SecurityEvent(
-                    event_type="scan",
-                    category="prompt_scan",
-                    timestamp=datetime(
-                        2026, 5, 20, 4, 0, tzinfo=timezone.utc
-                    ).isoformat(),
-                    trace_id="local-match",
-                    details={},
-                )
+        writer.write(
+            SecurityEvent(
+                event_type="scan",
+                category="prompt_scan",
+                timestamp=datetime(2026, 5, 20, 4, 0, tzinfo=timezone.utc).isoformat(),
+                trace_id="local-match",
+                details={},
             )
-            writer.write(
-                SecurityEvent(
-                    event_type="scan",
-                    category="prompt_scan",
-                    timestamp=datetime(
-                        2026, 5, 20, 6, 0, tzinfo=timezone.utc
-                    ).isoformat(),
-                    trace_id="outside-window",
-                    details={},
-                )
-            )
+        )
 
-            events = reader.query(
+        with pytest.raises(ValueError, match="timezone information"):
+            reader.query(
                 since="2026-05-20T11:59:00",
                 until="2026-05-20T12:01:00",
             )
-            assert [event.trace_id for event in events] == ["local-match"]
-        finally:
-            if old_tz is None:
-                monkeypatch.delenv("TZ", raising=False)
-            else:
-                monkeypatch.setenv("TZ", old_tz)
-            time.tzset()
 
     def test_query_count_and_count_by_support_dashboard_filters(
         self, writer: SqliteEventWriter, reader: SqliteEventReader

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -1,6 +1,7 @@
 """Unit tests for security_events.sqlite_reader — SqliteEventReader."""
 
 import io
+import os
 import sqlite3
 import sys
 import time
@@ -9,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.schema import SecurityEvent, extract_verdict
 from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
 from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
 
@@ -295,6 +296,169 @@ class TestSqliteEventReader:
 
         assert reader.count(trace_id="trace-abc") == 2
 
+    def test_count_respects_offset(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        for idx, category in enumerate(("alpha", "beta", "alpha")):
+            writer.write(
+                SecurityEvent(
+                    event_type="scan",
+                    category=category,
+                    timestamp=(base + timedelta(seconds=idx)).isoformat(),
+                    trace_id=f"trace-{idx}",
+                    details={},
+                )
+            )
+
+        assert reader.count(offset=1) == 2
+        assert reader.count(category="alpha", offset=1) == 1
+
+    def test_count_by_respects_offset(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        for idx, category in enumerate(("alpha", "beta", "alpha")):
+            writer.write(
+                SecurityEvent(
+                    event_type="scan",
+                    category=category,
+                    timestamp=(base + timedelta(seconds=idx)).isoformat(),
+                    trace_id=f"trace-{idx}",
+                    details={},
+                )
+            )
+
+        assert reader.count_by("category", offset=1) == {"alpha": 1, "beta": 1}
+
+    def test_query_naive_time_range_uses_local_timezone(
+        self,
+        writer: SqliteEventWriter,
+        reader: SqliteEventReader,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if not hasattr(time, "tzset"):
+            pytest.skip("time.tzset is required to validate local timezone parsing")
+
+        old_tz = os.environ.get("TZ")
+        monkeypatch.setenv("TZ", "Asia/Shanghai")
+        time.tzset()
+        try:
+            writer.write(
+                SecurityEvent(
+                    event_type="scan",
+                    category="prompt_scan",
+                    timestamp=datetime(
+                        2026, 5, 20, 4, 0, tzinfo=timezone.utc
+                    ).isoformat(),
+                    trace_id="local-match",
+                    details={},
+                )
+            )
+            writer.write(
+                SecurityEvent(
+                    event_type="scan",
+                    category="prompt_scan",
+                    timestamp=datetime(
+                        2026, 5, 20, 6, 0, tzinfo=timezone.utc
+                    ).isoformat(),
+                    trace_id="outside-window",
+                    details={},
+                )
+            )
+
+            events = reader.query(
+                since="2026-05-20T11:59:00",
+                until="2026-05-20T12:01:00",
+            )
+            assert [event.trace_id for event in events] == ["local-match"]
+        finally:
+            if old_tz is None:
+                monkeypatch.delenv("TZ", raising=False)
+            else:
+                monkeypatch.setenv("TZ", old_tz)
+            time.tzset()
+
+    def test_query_count_and_count_by_support_dashboard_filters(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        in_window = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
+        old = in_window - timedelta(days=1)
+        writer.write(
+            SecurityEvent(
+                event_type="code_scan",
+                category="code_scan",
+                result="failed",
+                timestamp=in_window.isoformat(),
+                trace_id="trace-1",
+                session_id="session-1",
+                run_id="run-1",
+                call_id="call-1",
+                tool_call_id="tool-1",
+                details={"request": {}, "result": {"verdict": "deny"}},
+            )
+        )
+        writer.write(
+            SecurityEvent(
+                event_type="prompt_scan",
+                category="prompt_scan",
+                result="succeeded",
+                timestamp=in_window.isoformat(),
+                trace_id="trace-2",
+                session_id="session-1",
+                run_id="run-2",
+                call_id="call-2",
+                tool_call_id="tool-2",
+                details={},
+            )
+        )
+        writer.write(
+            SecurityEvent(
+                event_type="code_scan",
+                category="code_scan",
+                result="failed",
+                timestamp=old.isoformat(),
+                trace_id="trace-old",
+                session_id="session-1",
+                run_id="run-old",
+                call_id="call-old",
+                tool_call_id="tool-old",
+                details={},
+            )
+        )
+
+        events = reader.query(
+            result="failed",
+            session_id="session-1",
+            run_id="run-1",
+            call_id="call-1",
+            tool_call_id="tool-1",
+            since=(in_window - timedelta(seconds=1)).isoformat(),
+            until=(in_window + timedelta(seconds=1)).isoformat(),
+        )
+
+        assert [event.trace_id for event in events] == ["trace-1"]
+        assert (
+            reader.count(
+                session_id="session-1",
+                since=(in_window - timedelta(seconds=1)).isoformat(),
+                until=(in_window + timedelta(seconds=1)).isoformat(),
+            )
+            == 2
+        )
+        assert reader.count_by(
+            "result",
+            session_id="session-1",
+            since=(in_window - timedelta(seconds=1)).isoformat(),
+            until=(in_window + timedelta(seconds=1)).isoformat(),
+        ) == {"failed": 1, "succeeded": 1}
+        assert reader.count_by(
+            "run_id",
+            session_id="session-1",
+            since=(in_window - timedelta(seconds=1)).isoformat(),
+            until=(in_window + timedelta(seconds=1)).isoformat(),
+        ) == {"run-1": 1, "run-2": 1}
+
     def test_count_by_category(
         self, writer: SqliteEventWriter, reader: SqliteEventReader
     ) -> None:
@@ -475,7 +639,7 @@ class TestSqliteEventReader:
 
         assert SqliteEventReader(path=db_path).query(limit=10) == []
         stderr = capsys.readouterr().err
-        assert "sqlite schema is v1, this binary expects v2" in stderr
+        assert "sqlite schema is v1, this binary expects v3" in stderr
         assert "run any write command" in stderr
         assert "read-only queries may return empty results until then" in stderr
 
@@ -736,3 +900,91 @@ class TestCorrelationCandidateQuery:
             )
             == []
         )
+
+
+class TestVerdictSqlFilter:
+    """Tests for SQL-backed verdict filtering."""
+
+    @pytest.fixture(autouse=True)
+    def _seed_events(self, writer: SqliteEventWriter) -> None:
+        """Seed events with varying verdicts."""
+        for idx, (verdict, category) in enumerate(
+            [
+                ("pass", "prompt_scan"),
+                ("deny", "prompt_scan"),
+                ("warn", "code_scan"),
+                ("pass", "pii_scan"),
+                (None, "skill_ledger"),  # no verdict
+                ("deny", "prompt_scan"),
+                ("deny", "code_scan"),
+            ]
+        ):
+            details: dict[str, Any] = {}
+            if verdict is not None:
+                if category == "code_scan" and verdict == "deny":
+                    details["result"] = {"verdict": verdict}
+                else:
+                    details["verdict"] = verdict
+            writer.write(
+                SecurityEvent(
+                    event_type=f"{category}_event",
+                    category=category,
+                    details=details,
+                    timestamp=(
+                        datetime(2025, 1, 1, tzinfo=timezone.utc)
+                        + timedelta(seconds=idx)
+                    ).isoformat(),
+                )
+            )
+        writer.close()
+
+    def test_query_filter_by_verdict(self, reader: SqliteEventReader) -> None:
+        events = reader.query(verdict="deny")
+        assert len(events) == 3
+        assert all(_details_verdict(e.details) == "deny" for e in events)
+
+    def test_query_verdict_with_pagination(self, reader: SqliteEventReader) -> None:
+        events = reader.query(verdict="pass", limit=1, offset=0)
+        assert len(events) == 1
+        assert _details_verdict(events[0].details) == "pass"
+
+        events_page2 = reader.query(verdict="pass", limit=1, offset=1)
+        assert len(events_page2) == 1
+
+    def test_count_with_verdict_filter(self, reader: SqliteEventReader) -> None:
+        assert reader.count(verdict="deny") == 3
+        assert reader.count(verdict="deny", offset=1) == 2
+        assert reader.count(verdict="pass") == 2
+        assert reader.count(verdict="warn") == 1
+        assert reader.count(verdict="nonexistent") == 0
+
+    def test_count_by_verdict(self, reader: SqliteEventReader) -> None:
+        groups = reader.count_by("verdict")
+        assert groups == {"pass": 2, "deny": 3, "warn": 1}
+        offset_groups = reader.count_by("verdict", offset=1)
+        assert offset_groups == {"pass": 2, "deny": 2, "warn": 1}
+
+    def test_count_by_verdict_with_category_filter(
+        self, reader: SqliteEventReader
+    ) -> None:
+        groups = reader.count_by("verdict", category="prompt_scan")
+        assert groups == {"pass": 1, "deny": 2}
+
+    def test_count_by_category_with_verdict_filter(
+        self, reader: SqliteEventReader
+    ) -> None:
+        groups = reader.count_by("category", verdict="deny")
+        assert groups == {"prompt_scan": 2, "code_scan": 1}
+        offset_groups = reader.count_by("category", verdict="deny", offset=1)
+        assert offset_groups == {"prompt_scan": 2}
+
+    def test_query_without_verdict_unchanged(self, reader: SqliteEventReader) -> None:
+        """Ensure queries without verdict still work via the SQL path."""
+        events = reader.query(limit=3)
+        assert len(events) == 3
+        total = reader.count()
+        assert total == 7
+
+
+def _details_verdict(details: dict[str, Any]) -> str | None:
+    return extract_verdict(details)

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import agent_sec_cli.security_events.models as security_event_models
 import agent_sec_cli.security_events.sqlite_writer as sqlite_writer_module
 import pytest
 from agent_sec_cli.security_events.schema import SecurityEvent
@@ -732,6 +733,76 @@ class TestSqliteEventWriter:
             "nested-verdict": "pass",
             "new-event": "warn",
             "no-verdict": None,
+        }
+
+    def test_v2_database_migrates_verdict_column_in_batches(
+        self,
+        db_path: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            security_event_models,
+            "_VERDICT_MIGRATION_BATCH_SIZE",
+            2,
+        )
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            CREATE TABLE security_events (
+                event_id TEXT PRIMARY KEY,
+                event_type TEXT NOT NULL,
+                category TEXT NOT NULL,
+                result TEXT NOT NULL DEFAULT 'succeeded',
+                timestamp TEXT NOT NULL,
+                timestamp_epoch FLOAT NOT NULL,
+                trace_id TEXT NOT NULL DEFAULT '',
+                pid INTEGER NOT NULL,
+                uid INTEGER NOT NULL,
+                session_id TEXT,
+                run_id TEXT,
+                call_id TEXT,
+                tool_call_id TEXT,
+                details TEXT NOT NULL
+            );
+            PRAGMA user_version = 2;
+            """)
+        conn.executemany(
+            """
+            INSERT INTO security_events (
+                event_id, event_type, category, result, timestamp, timestamp_epoch,
+                trace_id, pid, uid, session_id, run_id, call_id, tool_call_id, details
+            ) VALUES (?, 'scan', 'prompt_scan', 'succeeded',
+                '2026-05-19T00:00:00+00:00', ?, '', 1, 1, NULL, NULL, NULL, NULL, ?)
+            """,
+            [
+                ("row-1", 1779148800.0, '{"verdict": "deny"}'),
+                ("row-2-no-verdict", 1779148801.0, "{}"),
+                ("row-3", 1779148802.0, '{"verdict": "pass"}'),
+                ("row-4", 1779148803.0, '{"result": {"verdict": "warn"}}'),
+                ("row-5", 1779148804.0, '{"verdict": "deny"}'),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        writer = SqliteEventWriter(path=db_path, max_age_days=None)
+        writer.write(_make_event(event_id="new-event"))
+        writer.close()
+
+        conn = sqlite3.connect(db_path)
+        rows = dict(
+            conn.execute(
+                "SELECT event_id, verdict FROM security_events "
+                "WHERE event_id LIKE 'row-%' ORDER BY event_id"
+            ).fetchall()
+        )
+        conn.close()
+
+        assert rows == {
+            "row-1": "deny",
+            "row-2-no-verdict": None,
+            "row-3": "pass",
+            "row-4": "warn",
+            "row-5": "deny",
         }
 
     def test_schema_repairs_missing_indexes(self, db_path: str) -> None:

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -62,12 +62,22 @@ class TestSqliteEventWriter:
         """Invalid timestamps are dropped without writing to stderr."""
         writer = SqliteEventWriter(path=db_path)
 
-        # Create event with malformed timestamp
-        evt = SecurityEvent(
+        # Bypass schema validation to exercise writer drop behavior for
+        # corrupted/in-memory events.
+        evt = SecurityEvent.model_construct(
+            event_id="invalid-timestamp-event",
             event_type="test",
             category="test",
+            result="succeeded",
+            trace_id="",
             details={"key": "value"},
             timestamp="not-a-valid-timestamp",
+            pid=1,
+            uid=1,
+            session_id=None,
+            run_id=None,
+            call_id=None,
+            tool_call_id=None,
         )
 
         with caplog.at_level(logging.WARNING, logger=SQLITE_WRITER_LOGGER):
@@ -205,6 +215,26 @@ class TestSqliteEventWriter:
         conn.close()
         assert len(rows) == 1
         writer.close()
+
+    def test_write_persists_schema_normalized_utc_timestamp(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path, max_age_days=None)
+        writer.write(
+            SecurityEvent(
+                event_type="offset_timestamp",
+                category="test",
+                timestamp="2026-05-20T12:00:00+08:00",
+                details={},
+            )
+        )
+        writer.close()
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT timestamp, timestamp_epoch FROM security_events"
+        ).fetchone()
+        conn.close()
+
+        assert row == ("2026-05-20T04:00:00+00:00", 1779249600.0)
 
     def test_db_file_permissions_are_restrictive(self, db_path: str) -> None:
         """Verify that the database file is created with 0o600 permissions."""

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -147,6 +147,7 @@ class TestSqliteEventWriter:
             call_id="call-abc",
             tool_call_id="tool-abc",
             details={
+                "result": {"verdict": "deny"},
                 "nested": {"key": "value"},
                 "list": [1, 2, 3],
                 "unicode": "测试中文",
@@ -178,6 +179,7 @@ class TestSqliteEventWriter:
         assert row["run_id"] == "run-abc"
         assert row["call_id"] == "call-abc"
         assert row["tool_call_id"] == "tool-abc"
+        assert row["verdict"] == "deny"
 
         # Verify timestamp_epoch is correct
         expected_epoch = datetime.fromisoformat(evt.timestamp).timestamp()
@@ -508,8 +510,15 @@ class TestSqliteEventWriter:
         user_version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
 
-        assert user_version == 2
-        assert {"session_id", "run_id", "call_id", "tool_call_id"}.issubset(columns)
+        assert user_version == 3
+        assert {
+            "session_id",
+            "run_id",
+            "call_id",
+            "tool_call_id",
+            "verdict",
+        }.issubset(columns)
+        assert "idx_verdict_timestamp_epoch" in indexes
         assert "idx_session_id_timestamp_epoch" in indexes
         assert "idx_run_id_timestamp_epoch" in indexes
         assert "idx_session_run_timestamp_epoch" in indexes
@@ -543,7 +552,8 @@ class TestSqliteEventWriter:
             ) VALUES (
                 'old-event', 'code_scan', 'code_scan', 'succeeded',
                 '2026-05-19T00:00:00+00:00', 1779148800.0,
-                'old-trace', 1, 1, 'old-session', '{}'
+                'old-trace', 1, 1, 'old-session',
+                '{"result": {"verdict": "warn"}}'
             )
             """)
         conn.commit()
@@ -566,16 +576,133 @@ class TestSqliteEventWriter:
 
         conn = sqlite3.connect(db_path)
         rows = conn.execute(
-            "SELECT event_id, run_id FROM security_events ORDER BY event_id"
+            "SELECT event_id, run_id, verdict FROM security_events ORDER BY event_id"
         ).fetchall()
         user_version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
 
-        assert user_version == 2
-        assert ("old-event", None) in rows
+        assert user_version == 3
+        assert ("old-event", None, "warn") in rows
         assert any(
-            event_id != "old-event" and run_id == "new-run" for event_id, run_id in rows
+            event_id != "old-event" and run_id == "new-run"
+            for event_id, run_id, _verdict in rows
         )
+
+    def test_v2_database_migrates_verdict_column_and_backfills(
+        self, db_path: str
+    ) -> None:
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            CREATE TABLE security_events (
+                event_id TEXT PRIMARY KEY,
+                event_type TEXT NOT NULL,
+                category TEXT NOT NULL,
+                result TEXT NOT NULL DEFAULT 'succeeded',
+                timestamp TEXT NOT NULL,
+                timestamp_epoch FLOAT NOT NULL,
+                trace_id TEXT NOT NULL DEFAULT '',
+                pid INTEGER NOT NULL,
+                uid INTEGER NOT NULL,
+                session_id TEXT,
+                run_id TEXT,
+                call_id TEXT,
+                tool_call_id TEXT,
+                details TEXT NOT NULL
+            );
+            PRAGMA user_version = 2;
+            """)
+        conn.executemany(
+            """
+            INSERT INTO security_events (
+                event_id, event_type, category, result, timestamp, timestamp_epoch,
+                trace_id, pid, uid, session_id, run_id, call_id, tool_call_id, details
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "direct-verdict",
+                    "prompt_scan",
+                    "prompt_scan",
+                    "succeeded",
+                    "2026-05-19T00:00:00+00:00",
+                    1779148800.0,
+                    "trace-1",
+                    1,
+                    1,
+                    "session-1",
+                    "run-1",
+                    None,
+                    None,
+                    '{"verdict": "deny"}',
+                ),
+                (
+                    "nested-verdict",
+                    "code_scan",
+                    "code_scan",
+                    "succeeded",
+                    "2026-05-19T00:00:01+00:00",
+                    1779148801.0,
+                    "trace-2",
+                    1,
+                    1,
+                    "session-1",
+                    "run-1",
+                    None,
+                    None,
+                    '{"result": {"verdict": "pass"}}',
+                ),
+                (
+                    "no-verdict",
+                    "harden",
+                    "hardening",
+                    "succeeded",
+                    "2026-05-19T00:00:02+00:00",
+                    1779148802.0,
+                    "trace-3",
+                    1,
+                    1,
+                    "session-1",
+                    "run-1",
+                    None,
+                    None,
+                    "{}",
+                ),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        writer = SqliteEventWriter(path=db_path, max_age_days=None)
+        writer.write(
+            SecurityEvent(
+                event_id="new-event",
+                event_type="pii_scan",
+                category="pii_scan",
+                details={"verdict": "warn"},
+            )
+        )
+        writer.close()
+
+        conn = sqlite3.connect(db_path)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(security_events)")}
+        indexes = {row[1] for row in conn.execute("PRAGMA index_list(security_events)")}
+        rows = dict(
+            conn.execute(
+                "SELECT event_id, verdict FROM security_events ORDER BY event_id"
+            ).fetchall()
+        )
+        user_version = conn.execute("PRAGMA user_version").fetchone()[0]
+        conn.close()
+
+        assert user_version == 3
+        assert "verdict" in columns
+        assert "idx_verdict_timestamp_epoch" in indexes
+        assert rows == {
+            "direct-verdict": "deny",
+            "nested-verdict": "pass",
+            "new-event": "warn",
+            "no-verdict": None,
+        }
 
     def test_schema_repairs_missing_indexes(self, db_path: str) -> None:
         conn = sqlite3.connect(db_path)
@@ -612,11 +739,12 @@ class TestSqliteEventWriter:
             "idx_category_epoch",
             "idx_trace_id",
             "idx_timestamp_epoch",
+            "idx_verdict_timestamp_epoch",
         }.issubset(index_names)
 
     def test_schema_error_requests_repair_for_next_write(self, db_path: str) -> None:
         conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA user_version = 2")
+        conn.execute("PRAGMA user_version = 3")
         conn.commit()
         conn.close()
 

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -1,11 +1,17 @@
 """Unit tests for the top-level CLI entry points."""
 
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from agent_sec_cli.cli import _extract_trace_context_arg, app, main
+from agent_sec_cli.cli import (
+    _extract_trace_context_arg,
+    _resolve_time_range,
+    app,
+    main,
+)
 from agent_sec_cli.correlation_context import (
     TraceContext,
     clear_process_trace_context,
@@ -117,6 +123,34 @@ def test_extract_trace_context_arg_uses_last_top_level_value():
         )
         == '{"session_id":"session-2"}'
     )
+
+
+def test_resolve_time_range_normalizes_explicit_offsets_to_utc() -> None:
+    since, until = _resolve_time_range(
+        None,
+        "2026-05-20T12:00:00+08:00",
+        "2026-05-20T13:00:00+08:00",
+    )
+
+    assert since == "2026-05-20T04:00:00+00:00"
+    assert until == "2026-05-20T05:00:00+00:00"
+
+
+def test_resolve_time_range_last_hours_returns_utc_iso(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agent_sec_cli.cli.time.time", lambda: 1_800_000_000.0)
+
+    since, until = _resolve_time_range(1.5, None, None)
+
+    assert (
+        since
+        == datetime.fromtimestamp(
+            1_800_000_000.0 - 5400,
+            tz=timezone.utc,
+        ).isoformat()
+    )
+    assert until == "2027-01-15T08:00:00+00:00"
 
 
 def test_extract_trace_context_arg_stops_at_posix_double_dash():

--- a/src/agent-sec-core/tests/unit-test/utils/test_timestamp.py
+++ b/src/agent-sec-core/tests/unit-test/utils/test_timestamp.py
@@ -1,0 +1,57 @@
+"""Unit tests for shared timestamp helpers."""
+
+import os
+import time
+from datetime import datetime, timezone
+
+import pytest
+from agent_sec_cli.utils.timestamp import (
+    epoch_to_utc_iso,
+    normalize_iso_to_utc_iso,
+    ns_to_utc_iso,
+    utc_iso_to_epoch,
+)
+
+
+def test_normalize_iso_to_utc_iso_converts_offset_timestamp() -> None:
+    assert (
+        normalize_iso_to_utc_iso("2026-05-20T12:00:00+08:00")
+        == "2026-05-20T04:00:00+00:00"
+    )
+
+
+def test_normalize_iso_to_utc_iso_treats_naive_as_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset is required to validate local timezone parsing")
+
+    old_tz = os.environ.get("TZ")
+    monkeypatch.setenv("TZ", "Asia/Shanghai")
+    time.tzset()
+    try:
+        assert (
+            normalize_iso_to_utc_iso("2026-05-20T12:00:00")
+            == "2026-05-20T04:00:00+00:00"
+        )
+    finally:
+        if old_tz is None:
+            monkeypatch.delenv("TZ", raising=False)
+        else:
+            monkeypatch.setenv("TZ", old_tz)
+        time.tzset()
+
+
+def test_utc_iso_to_epoch_requires_utc_aware_input() -> None:
+    epoch = datetime(2026, 5, 20, 4, 0, tzinfo=timezone.utc).timestamp()
+
+    assert utc_iso_to_epoch("2026-05-20T04:00:00+00:00") == epoch
+    with pytest.raises(ValueError, match="timezone information"):
+        utc_iso_to_epoch("2026-05-20T12:00:00")
+    with pytest.raises(ValueError, match="normalized to UTC"):
+        utc_iso_to_epoch("2026-05-20T12:00:00+08:00")
+
+
+def test_epoch_and_ns_helpers_emit_utc_iso() -> None:
+    assert epoch_to_utc_iso(1_768_000_000.0).endswith("+00:00")
+    assert ns_to_utc_iso(1_768_000_000_000_000_000).endswith("+00:00")


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Add a daemon handler for SQL-backed security and observability queries,
  including list, get, count, and count_by support for dashboard filters.

  Extend security_events SQLite storage with a v3 verdict column/index,
  backfill verdict values during migration, and move verdict filtering/counting
  onto the SQL path.

  Cover the daemon handler, CLI e2e flow, observability reader, and security
  event reader/writer schema behavior with tests.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
