### PR TITLE
fix(anolisa): isolate user-layout tests from host environment

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -910,7 +910,9 @@ mod tests {
     #[test]
     fn repair_raw_component_is_not_implemented() {
         let tmp = tempfile::tempdir().expect("tmpdir");
-        let c = ctx(tmp.path().to_path_buf(), InstallMode::User, false);
+        // User mode ignores `prefix` and resolves from the process home, so
+        // this test uses system mode to keep the seeded state under `tmp`.
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         seed(&c, raw_object("copilot-shell", "9.9.9"));
         let rpm = FakeQuery::new("anolisa-copilot-shell", None);
         let err = repair_with_query("copilot-shell", &c, &rpm)

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -1254,8 +1254,15 @@ fn run_capture(cmd: &FrameworkCommand) -> Result<CliOutput, AdapterError> {
 
 /// Build a `PATH` value with `prepend` dirs in front of the current one.
 fn prepend_path(prepend: &[PathBuf]) -> std::ffi::OsString {
+    prepend_path_with_existing(prepend, std::env::var_os("PATH"))
+}
+
+fn prepend_path_with_existing(
+    prepend: &[PathBuf],
+    existing: Option<std::ffi::OsString>,
+) -> std::ffi::OsString {
     let mut parts: Vec<PathBuf> = prepend.to_vec();
-    if let Some(existing) = std::env::var_os("PATH") {
+    if let Some(existing) = existing {
         parts.extend(std::env::split_paths(&existing));
     }
     // join_paths only fails if a component contains the path separator,
@@ -1545,22 +1552,14 @@ mod tests {
 
     #[test]
     fn prepend_path_puts_dirs_in_front() {
-        // SAFETY: single-threaded test mutating PATH; restored after.
-        let saved = std::env::var_os("PATH");
-        unsafe {
-            std::env::set_var("PATH", "/usr/bin:/bin");
-        }
-        let joined = prepend_path(&[PathBuf::from("/opt/a"), PathBuf::from("/opt/b")]);
+        let joined = prepend_path_with_existing(
+            &[PathBuf::from("/opt/a"), PathBuf::from("/opt/b")],
+            Some(std::ffi::OsString::from("/usr/bin:/bin")),
+        );
         let dirs: Vec<PathBuf> = std::env::split_paths(&joined).collect();
         assert_eq!(dirs[0], PathBuf::from("/opt/a"));
         assert_eq!(dirs[1], PathBuf::from("/opt/b"));
         assert!(dirs.contains(&PathBuf::from("/usr/bin")));
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("PATH", v),
-                None => std::env::remove_var("PATH"),
-            }
-        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/health/engine.rs
+++ b/src/anolisa/crates/anolisa-core/src/health/engine.rs
@@ -507,7 +507,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn layout_for(home: &Path) -> FsLayout {
-        FsLayout::user(home.to_path_buf())
+        FsLayout::user_with_overrides(home.to_path_buf(), None, None, None, None, None)
     }
 
     /// Write a 0755 shell script under `dir` and return its absolute path.

--- a/src/anolisa/crates/anolisa-core/src/install_runner.rs
+++ b/src/anolisa/crates/anolisa-core/src/install_runner.rs
@@ -815,7 +815,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn layout_for(home: &Path) -> FsLayout {
-        FsLayout::user(home.to_path_buf())
+        FsLayout::user_with_overrides(home.to_path_buf(), None, None, None, None, None)
     }
 
     fn write_cached(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -9,12 +9,14 @@
 //! The fake CLI is controlled entirely through the same env contract the
 //! real driver uses (`OPENCLAW_BIN`, `OPENCLAW_HOME`, plus a test-only
 //! `FAKE_OPENCLAW_FAIL` knob). Because those are process-global, every test
-//! serializes on [`ENV_LOCK`].
+//! serializes on [`ENV_LOCK`], starts from a clean env contract, and
+//! restores the prior environment on exit.
 #![cfg(unix)]
 
+use std::ffi::OsString;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 use anolisa_core::adapter::AdapterError;
 use anolisa_core::adapter::claim::{ClaimResourceKind, ClaimStatus};
@@ -49,10 +51,9 @@ impl World {
         )
     }
 
-    /// Apply this world's env contract. Must be called while holding
-    /// [`ENV_LOCK`].
-    fn apply_env(&self, fail: Option<&str>) {
-        apply_openclaw_env(&self.fake_bin, &self.openclaw_home, fail);
+    /// Apply this world's env contract through the process-env guard.
+    fn apply_env(&self, guard: &OpenClawEnvGuard, fail: Option<&str>) {
+        guard.apply(&self.fake_bin, &self.openclaw_home, fail);
     }
 
     fn load_state(&self) -> InstalledState {
@@ -60,15 +61,71 @@ impl World {
     }
 }
 
-fn apply_openclaw_env(fake_bin: &Path, openclaw_home: &Path, fail: Option<&str>) {
-    // SAFETY: callers hold ENV_LOCK, so no other test thread in this
-    // binary reads these vars concurrently.
+struct OpenClawEnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved_bin: Option<OsString>,
+    saved_home: Option<OsString>,
+    saved_fail: Option<OsString>,
+}
+
+impl OpenClawEnvGuard {
+    fn acquire() -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = Self {
+            _lock: lock,
+            saved_bin: std::env::var_os("OPENCLAW_BIN"),
+            saved_home: std::env::var_os("OPENCLAW_HOME"),
+            saved_fail: std::env::var_os("FAKE_OPENCLAW_FAIL"),
+        };
+        guard.clear();
+        guard
+    }
+
+    fn clear(&self) {
+        // SAFETY: this guard holds ENV_LOCK, so tests in this binary cannot
+        // observe a half-mutated OpenClaw env contract.
+        unsafe {
+            std::env::remove_var("OPENCLAW_BIN");
+            std::env::remove_var("OPENCLAW_HOME");
+            std::env::remove_var("FAKE_OPENCLAW_FAIL");
+        }
+    }
+
+    fn apply(&self, fake_bin: &Path, openclaw_home: &Path, fail: Option<&str>) {
+        // SAFETY: this guard holds ENV_LOCK, so no other test thread in this
+        // binary reads these vars concurrently.
+        unsafe {
+            std::env::set_var("OPENCLAW_BIN", fake_bin);
+            std::env::set_var("OPENCLAW_HOME", openclaw_home);
+            match fail {
+                Some(stage) => std::env::set_var("FAKE_OPENCLAW_FAIL", stage),
+                None => std::env::remove_var("FAKE_OPENCLAW_FAIL"),
+            }
+        }
+    }
+
+    fn set_openclaw_bin(&self, value: &Path) {
+        // SAFETY: this guard holds ENV_LOCK.
+        unsafe {
+            std::env::set_var("OPENCLAW_BIN", value);
+        }
+    }
+}
+
+impl Drop for OpenClawEnvGuard {
+    fn drop(&mut self) {
+        restore_env("OPENCLAW_BIN", self.saved_bin.as_ref());
+        restore_env("OPENCLAW_HOME", self.saved_home.as_ref());
+        restore_env("FAKE_OPENCLAW_FAIL", self.saved_fail.as_ref());
+    }
+}
+
+fn restore_env(key: &str, value: Option<&OsString>) {
+    // SAFETY: callers hold ENV_LOCK until after the saved values are restored.
     unsafe {
-        std::env::set_var("OPENCLAW_BIN", fake_bin);
-        std::env::set_var("OPENCLAW_HOME", openclaw_home);
-        match fail {
-            Some(stage) => std::env::set_var("FAKE_OPENCLAW_FAIL", stage),
-            None => std::env::remove_var("FAKE_OPENCLAW_FAIL"),
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
         }
     }
 }
@@ -216,9 +273,9 @@ dest = "{{datadir}}/adapters/{{component}}/{framework}/"
 
 #[test]
 fn enable_status_disable_happy_path() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(None);
+    world.apply_env(&guard, None);
     let manager = world.manager();
 
     // enable
@@ -278,14 +335,15 @@ fn enable_status_disable_happy_path() {
 
 #[test]
 fn user_layout_enable_accepts_system_installed_component() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let root = tempfile::tempdir().expect("tempdir");
     let prefix = root.path().to_path_buf();
     let system_prefix = prefix.join("system");
     let system_layout = FsLayout::system(Some(system_prefix.clone()));
     let user_home = prefix.join("home");
     std::fs::create_dir_all(&user_home).expect("home");
-    let user_layout = FsLayout::user(user_home.clone());
+    let user_layout =
+        FsLayout::user_with_overrides(user_home.clone(), None, None, None, None, None);
 
     let openclaw_home = prefix.join("openclaw-home");
     std::fs::create_dir_all(&openclaw_home).expect("openclaw home");
@@ -302,7 +360,7 @@ fn user_layout_enable_accepts_system_installed_component() {
     .expect("plugin manifest");
     seed_state(&system_layout, &system_prefix);
     let fake_bin = write_fake_openclaw(&prefix);
-    apply_openclaw_env(&fake_bin, &openclaw_home, None);
+    guard.apply(&fake_bin, &openclaw_home, None);
 
     let mut manager =
         AdapterManager::new(user_layout.clone(), Some(user_home), "tester".to_string());
@@ -335,10 +393,10 @@ fn user_layout_enable_accepts_system_installed_component() {
 
 #[test]
 fn enable_rejects_resource_directory_not_declared_by_manifest() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
     write_installed_manifest(&world.layout, "hermes");
-    world.apply_env(None);
+    world.apply_env(&guard, None);
     let manager = world.manager();
 
     let err = manager
@@ -367,9 +425,9 @@ fn enable_rejects_resource_directory_not_declared_by_manifest() {
 
 #[test]
 fn failed_enable_keeps_cleanup_receipt_for_retry() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(Some("install"));
+    world.apply_env(&guard, Some("install"));
     let manager = world.manager();
 
     let err = manager
@@ -389,9 +447,9 @@ fn failed_enable_keeps_cleanup_receipt_for_retry() {
 
 #[test]
 fn failed_enable_after_framework_side_effect_keeps_visible_receipt() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(Some("install_after_register"));
+    world.apply_env(&guard, Some("install_after_register"));
     let manager = world.manager();
 
     let err = manager
@@ -419,9 +477,9 @@ fn failed_enable_after_framework_side_effect_keeps_visible_receipt() {
 
 #[test]
 fn dry_run_enable_does_not_register_or_persist() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(None);
+    world.apply_env(&guard, None);
     let manager = world.manager();
 
     let outcome = manager
@@ -454,16 +512,16 @@ fn dry_run_enable_does_not_register_or_persist() {
 
 #[test]
 fn disable_keeps_receipt_when_uninstall_fails() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(None);
+    world.apply_env(&guard, None);
     let manager = world.manager();
     manager
         .enable(COMPONENT, Some(FRAMEWORK), false)
         .expect("enable");
 
     // Now force uninstall to fail.
-    world.apply_env(Some("uninstall"));
+    world.apply_env(&guard, Some("uninstall"));
     let disabled = manager
         .disable(COMPONENT, Some(FRAMEWORK))
         .expect("disable runs");
@@ -483,9 +541,9 @@ fn disable_keeps_receipt_when_uninstall_fails() {
 
 #[test]
 fn disable_without_cli_keeps_receipt_for_retry() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(None);
+    world.apply_env(&guard, None);
     let manager = world.manager();
     manager
         .enable(COMPONENT, Some(FRAMEWORK), false)
@@ -495,10 +553,7 @@ fn disable_without_cli_keeps_receipt_for_retry() {
     // the CLI, so it must keep the receipt for a later retry instead of
     // pretending cleanup completed.
     let missing = world._root.path().join("no-such-openclaw");
-    // SAFETY: ENV_LOCK held.
-    unsafe {
-        std::env::set_var("OPENCLAW_BIN", &missing);
-    }
+    guard.set_openclaw_bin(&missing);
     let disabled = manager
         .disable(COMPONENT, Some(FRAMEWORK))
         .expect("disable");
@@ -513,9 +568,9 @@ fn disable_without_cli_keeps_receipt_for_retry() {
 
 #[test]
 fn forged_external_path_receipt_is_rejected_by_status() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(None);
+    world.apply_env(&guard, None);
     let manager = world.manager();
     manager
         .enable(COMPONENT, Some(FRAMEWORK), false)
@@ -550,7 +605,7 @@ fn forged_external_path_receipt_is_rejected_by_status() {
 
 #[test]
 fn scan_includes_manifest_declaration_without_resource_directory() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = OpenClawEnvGuard::acquire();
     let root = tempfile::tempdir().expect("tempdir");
     let prefix = root.path().to_path_buf();
     let layout = FsLayout::system(Some(prefix.clone()));
@@ -575,7 +630,7 @@ fn scan_includes_manifest_declaration_without_resource_directory() {
 
 #[test]
 fn user_scan_includes_system_state_declaration() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = OpenClawEnvGuard::acquire();
     let root = tempfile::tempdir().expect("tempdir");
     let prefix = root.path().to_path_buf();
     let system_prefix = prefix.join("system");
@@ -584,7 +639,8 @@ fn user_scan_includes_system_state_declaration() {
 
     let user_home = prefix.join("home");
     std::fs::create_dir_all(&user_home).expect("home");
-    let user_layout = FsLayout::user(user_home.clone());
+    let user_layout =
+        FsLayout::user_with_overrides(user_home.clone(), None, None, None, None, None);
     let mut manager = AdapterManager::new(user_layout, Some(user_home), "tester".to_string());
     manager.push_visible_root(anolisa_core::adapter::manager::VisibleRoot {
         state_dir: system_layout.state_dir.clone(),
@@ -604,9 +660,9 @@ fn user_scan_includes_system_state_declaration() {
 
 #[test]
 fn scan_lists_resource_with_detection_and_receipt_state() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let guard = OpenClawEnvGuard::acquire();
     let world = stage();
-    world.apply_env(None);
+    world.apply_env(&guard, None);
     let manager = world.manager();
 
     // Before enable: discovered, driver available, detected, not enabled.

--- a/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
+++ b/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
@@ -210,7 +210,7 @@ impl FsLayout {
     ///
     /// Each `Option` is one home-root override; `None` selects the
     /// `$HOME`-based home root that `file-hierarchy(7)` defines.
-    pub(crate) fn user_with_overrides(
+    pub fn user_with_overrides(
         home: PathBuf,
         data_override: Option<PathBuf>,
         config_override: Option<PathBuf>,


### PR DESCRIPTION
## Description

Fixes several test-isolation leaks where tests could depend on, mutate, or write through the developer's real process environment.

The main issue is user-mode layout resolution: `FsLayout::user(home)` intentionally honors process-level `XDG_*` overrides, so passing a temp `home` is not enough for tests. If `XDG_STATE_HOME` is set, tests can still write ANOLISA state under that real XDG root.

Behavior:
- User-mode test layouts that need isolation now use explicit override inputs instead of reading process `XDG_*`.
- The `repair` raw-component test uses a system-mode temp prefix, because user mode ignores `prefix`.
- `adapter_manager` tests start from a clean `OPENCLAW_*` contract and restore the previous env on drop.
- The `PATH` helper test no longer mutates process-global `PATH`.

## Design Note

`FsLayout::user_with_overrides(...)` is made public so cross-crate tests can construct user layouts without reading process-global XDG variables. Production `FsLayout::user(home)` is unchanged and still honors `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, and `XDG_RUNTIME_DIR`.

For OpenClaw adapter integration tests, env mutation is wrapped in a guard that serializes on `ENV_LOCK`, clears `OPENCLAW_BIN`, `OPENCLAW_HOME`, and `FAKE_OPENCLAW_FAIL` at test start, and restores the original values on drop. This prevents both test-to-test leakage and accidental dependence on a developer's real OpenClaw installation.

## Ship Note

- No production layout behavior changes are intended.
- System command paths such as `/run/anolisa`, `/var/log/anolisa`, and `/etc/anolisa` remain production behavior and are not exercised by these tests.
- The remaining absolute paths in tests are either pure path assertions or hostile-path rejection fixtures; they do not write to those real paths.

## Test

- Unit/workspace gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- Isolation run: `cargo test --workspace` with fresh isolated `HOME`, `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, `XDG_RUNTIME_DIR`, and `TMPDIR`.
- Post-run verification: inspected the isolated HOME/XDG roots and confirmed no ANOLISA state/config/cache files were left behind.

close #1050