### PR TITLE
feat(sight): read session_id from process environment

### DIFF
--- a/src/agentsight/src/aggregator/proctrace/aggregator.rs
+++ b/src/agentsight/src/aggregator/proctrace/aggregator.rs
@@ -12,6 +12,10 @@ use std::collections::HashMap;
 pub struct ProcessEventAggregator {
     /// Map of PID to aggregated process data
     pub aggregates: HashMap<u32, AggregatedProcess>,
+    /// pid → session_id map for ppid-chain propagation.
+    /// Seeded by direct `/proc/{pid}/environ` reads; children that fail
+    /// the direct read inherit from their parent via ppid lookup.
+    session_map: HashMap<u32, String>,
 }
 
 impl ProcessEventAggregator {
@@ -19,7 +23,13 @@ impl ProcessEventAggregator {
     pub fn new() -> Self {
         ProcessEventAggregator {
             aggregates: HashMap::new(),
+            session_map: HashMap::new(),
         }
+    }
+
+    /// Look up session_id for a pid: try ppid in session_map.
+    fn lookup_parent_session(&self, ppid: u32) -> Option<String> {
+        self.session_map.get(&ppid).cloned()
     }
 
     /// Process a single variable-length event
@@ -34,17 +44,32 @@ impl ProcessEventAggregator {
                 args,
             } => {
                 let pid = header.pid;
+                let ppid = header.ppid;
+                let is_new = !self.aggregates.contains_key(&pid);
+                let parent_session = if is_new {
+                    self.lookup_parent_session(ppid)
+                } else {
+                    None
+                };
                 let aggregated = self.aggregates.entry(pid).or_insert_with(|| {
                     AggregatedProcess::new(
                         pid,
                         header.tid,
-                        header.ppid,
+                        ppid,
                         header.ptid,
                         event.comm_str(),
                         header.timestamp_ns,
                     )
                 });
                 aggregated.add_exec(filename.clone(), args.clone(), header.timestamp_ns);
+                if is_new {
+                    if aggregated.session_id.is_none() {
+                        aggregated.session_id = parent_session;
+                    }
+                    if let Some(sid) = aggregated.session_id.clone() {
+                        self.session_map.insert(pid, sid);
+                    }
+                }
                 None
             }
             VariableEvent::Stdout {
@@ -64,6 +89,7 @@ impl ProcessEventAggregator {
             }
             VariableEvent::Exit { header, .. } => {
                 let pid = header.pid;
+                self.session_map.remove(&pid);
                 if let Some(mut aggregated) = self.aggregates.remove(&pid) {
                     aggregated.mark_complete(header.timestamp_ns);
                     Some(aggregated)
@@ -90,11 +116,19 @@ impl ProcessEventAggregator {
     pub fn process_parsed_event(&mut self, event: &ParsedProcEvent) -> Option<AggregatedProcess> {
         match event.event_type {
             ProcEventType::Exec => {
-                let aggregated = self.aggregates.entry(event.pid).or_insert_with(|| {
+                let pid = event.pid;
+                let ppid = event.ppid;
+                let is_new = !self.aggregates.contains_key(&pid);
+                let parent_session = if is_new {
+                    self.lookup_parent_session(ppid)
+                } else {
+                    None
+                };
+                let aggregated = self.aggregates.entry(pid).or_insert_with(|| {
                     AggregatedProcess::new(
-                        event.pid,
+                        pid,
                         event.tid,
-                        event.ppid,
+                        ppid,
                         event.ptid,
                         event.comm.clone(),
                         event.timestamp_ns,
@@ -103,6 +137,14 @@ impl ProcessEventAggregator {
                 if let Some(ref args) = event.args {
                     let filename = event.comm.clone();
                     aggregated.add_exec(filename, args.clone(), event.timestamp_ns);
+                }
+                if is_new {
+                    if aggregated.session_id.is_none() {
+                        aggregated.session_id = parent_session;
+                    }
+                    if let Some(sid) = aggregated.session_id.clone() {
+                        self.session_map.insert(pid, sid);
+                    }
                 }
                 None
             }
@@ -115,6 +157,7 @@ impl ProcessEventAggregator {
                 None
             }
             ProcEventType::Exit => {
+                self.session_map.remove(&event.pid);
                 if let Some(mut aggregated) = self.aggregates.remove(&event.pid) {
                     aggregated.mark_complete(event.timestamp_ns);
                     Some(aggregated)
@@ -136,6 +179,7 @@ impl ProcessEventAggregator {
     /// Clear all aggregations
     pub fn clear(&mut self) {
         self.aggregates.clear();
+        self.session_map.clear();
     }
 
     /// Check if there are any pending aggregations
@@ -152,5 +196,114 @@ impl ProcessEventAggregator {
 impl Default for ProcessEventAggregator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::proctrace::{ParsedProcEvent, ProcEventType};
+
+    fn exec_event(pid: u32, ppid: u32, comm: &str, args: &str, ts: u64) -> ParsedProcEvent {
+        ParsedProcEvent {
+            event_type: ProcEventType::Exec,
+            pid,
+            tid: pid,
+            ppid,
+            ptid: ppid,
+            comm: comm.to_string(),
+            timestamp_ns: ts,
+            args: Some(args.to_string()),
+            stdout_data: None,
+        }
+    }
+
+    fn exit_event(pid: u32, ts: u64) -> ParsedProcEvent {
+        ParsedProcEvent {
+            event_type: ProcEventType::Exit,
+            pid,
+            tid: pid,
+            ppid: 0,
+            ptid: 0,
+            comm: String::new(),
+            timestamp_ns: ts,
+            args: None,
+            stdout_data: None,
+        }
+    }
+
+    #[test]
+    fn test_ppid_inherits_session_from_parent() {
+        let mut agg = ProcessEventAggregator::new();
+        agg.session_map.insert(100, "sess-abc".to_string());
+
+        agg.process_parsed_event(&exec_event(200, 100, "bash", "echo hi", 1000));
+
+        let proc = agg.aggregates.get(&200).unwrap();
+        assert_eq!(proc.session_id.as_deref(), Some("sess-abc"));
+    }
+
+    #[test]
+    fn test_ppid_chain_propagates_through_grandchild() {
+        let mut agg = ProcessEventAggregator::new();
+        agg.session_map.insert(100, "sess-abc".to_string());
+
+        agg.process_parsed_event(&exec_event(200, 100, "bash", "echo hi", 1000));
+        agg.process_parsed_event(&exec_event(300, 200, "date", "date +%s", 2000));
+
+        let grandchild = agg.aggregates.get(&300).unwrap();
+        assert_eq!(grandchild.session_id.as_deref(), Some("sess-abc"));
+    }
+
+    #[test]
+    fn test_exit_cleans_session_map() {
+        let mut agg = ProcessEventAggregator::new();
+        agg.session_map.insert(100, "sess-abc".to_string());
+
+        agg.process_parsed_event(&exec_event(200, 100, "bash", "echo hi", 1000));
+        assert!(agg.session_map.contains_key(&200));
+
+        agg.process_parsed_event(&exit_event(200, 3000));
+        assert!(!agg.session_map.contains_key(&200));
+    }
+
+    #[test]
+    fn test_no_session_when_ppid_not_in_map() {
+        let mut agg = ProcessEventAggregator::new();
+
+        agg.process_parsed_event(&exec_event(200, 999, "bash", "echo hi", 1000));
+
+        let proc = agg.aggregates.get(&200).unwrap();
+        assert_eq!(proc.session_id, None);
+    }
+
+    #[test]
+    fn test_pid_recycling_does_not_cross_contaminate() {
+        let mut agg = ProcessEventAggregator::new();
+        agg.session_map.insert(100, "sess-abc".to_string());
+
+        // PID 200 exec as child of 100 → inherits sess-abc
+        agg.process_parsed_event(&exec_event(200, 100, "bash", "echo hi", 1000));
+        assert_eq!(
+            agg.aggregates.get(&200).unwrap().session_id.as_deref(),
+            Some("sess-abc")
+        );
+
+        // PID 200 exits → cleaned from session_map
+        agg.process_parsed_event(&exit_event(200, 2000));
+        assert!(!agg.session_map.contains_key(&200));
+
+        // PID 200 recycled as child of 999 (no session) → must NOT inherit old sess-abc
+        agg.process_parsed_event(&exec_event(200, 999, "ls", "ls -la", 3000));
+        let recycled = agg.aggregates.get(&200).unwrap();
+        assert_eq!(recycled.session_id, None);
+    }
+
+    #[test]
+    fn test_clear_resets_session_map() {
+        let mut agg = ProcessEventAggregator::new();
+        agg.session_map.insert(100, "sess-abc".to_string());
+        agg.clear();
+        assert!(agg.session_map.is_empty());
     }
 }

--- a/src/agentsight/src/aggregator/proctrace/process.rs
+++ b/src/agentsight/src/aggregator/proctrace/process.rs
@@ -32,11 +32,14 @@ pub struct AggregatedProcess {
     pub start_timestamp_ns: u64,
     /// Last timestamp when data was added
     pub end_timestamp_ns: u64,
+    /// Session ID read from process environment at exec time
+    pub session_id: Option<String>,
 }
 
 impl AggregatedProcess {
     /// Create a new aggregated process
     pub fn new(pid: u32, tid: u32, ppid: u32, ptid: u32, comm: String, timestamp_ns: u64) -> Self {
+        let session_id = read_session_env(pid);
         AggregatedProcess {
             pid,
             ppid,
@@ -50,6 +53,7 @@ impl AggregatedProcess {
             is_complete: false,
             start_timestamp_ns: timestamp_ns,
             end_timestamp_ns: timestamp_ns,
+            session_id,
         }
     }
 
@@ -226,6 +230,38 @@ impl ToChromeTraceEvent for AggregatedProcess {
     }
 }
 
+const SESSION_ENV_VARS: &[&str] = &[
+    "CLAUDE_CODE_SESSION_ID",
+    "HERMES_SESSION_ID",
+    "AGENT_SEC_SESSION_ID",
+];
+
+fn read_session_env(pid: u32) -> Option<String> {
+    let data = match std::fs::read(format!("/proc/{pid}/environ")) {
+        Ok(d) => d,
+        Err(e) => {
+            log::debug!("read_session_env({pid}): {e}");
+            return None;
+        }
+    };
+    parse_session_from_environ(&data)
+}
+
+fn parse_session_from_environ(data: &[u8]) -> Option<String> {
+    for entry in data.split(|&b| b == 0) {
+        if let Ok(s) = std::str::from_utf8(entry) {
+            for var in SESSION_ENV_VARS {
+                if let Some(val) = s.strip_prefix(var).and_then(|rest| rest.strip_prefix('=')) {
+                    if !val.is_empty() {
+                        return Some(val.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -291,5 +327,74 @@ mod tests {
 
         // Empty first args should have "..." appended
         assert_eq!(proc.args, Some(" ...".to_string()));
+    }
+
+    #[test]
+    fn test_parse_session_claude_code() {
+        let env = b"HOME=/root\0CLAUDE_CODE_SESSION_ID=abc-123\0TERM=xterm\0";
+        assert_eq!(parse_session_from_environ(env), Some("abc-123".to_string()));
+    }
+
+    #[test]
+    fn test_parse_session_hermes() {
+        let env = b"PATH=/usr/bin\0HERMES_SESSION_ID=hermes-42\0";
+        assert_eq!(
+            parse_session_from_environ(env),
+            Some("hermes-42".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_session_priority_first_match_wins() {
+        let env = b"CLAUDE_CODE_SESSION_ID=first\0HERMES_SESSION_ID=second\0";
+        assert_eq!(parse_session_from_environ(env), Some("first".to_string()));
+    }
+
+    #[test]
+    fn test_parse_session_empty_environ() {
+        assert_eq!(parse_session_from_environ(b""), None);
+    }
+
+    #[test]
+    fn test_parse_session_no_session_vars() {
+        let env = b"HOME=/root\0PATH=/usr/bin\0TERM=xterm\0";
+        assert_eq!(parse_session_from_environ(env), None);
+    }
+
+    #[test]
+    fn test_parse_session_empty_value_rejected() {
+        let env = b"CLAUDE_CODE_SESSION_ID=\0OTHER=val\0";
+        assert_eq!(parse_session_from_environ(env), None);
+    }
+
+    #[test]
+    fn test_parse_session_prefix_collision() {
+        // CLAUDE_CODE_SESSION_ID_V2 must NOT match CLAUDE_CODE_SESSION_ID
+        let env = b"CLAUDE_CODE_SESSION_ID_V2=wrong\0";
+        assert_eq!(parse_session_from_environ(env), None);
+    }
+
+    #[test]
+    fn test_parse_session_non_utf8_skipped() {
+        let mut env = Vec::new();
+        env.extend_from_slice(b"BROKEN=");
+        env.extend_from_slice(&[0xFF, 0xFE]); // invalid UTF-8
+        env.push(0);
+        env.extend_from_slice(b"CLAUDE_CODE_SESSION_ID=valid-id");
+        env.push(0);
+        assert_eq!(
+            parse_session_from_environ(&env),
+            Some("valid-id".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_session_no_trailing_null() {
+        // /proc/pid/environ may not end with null
+        let env = b"CLAUDE_CODE_SESSION_ID=no-trailing";
+        assert_eq!(
+            parse_session_from_environ(env),
+            Some("no-trailing".to_string())
+        );
     }
 }

--- a/src/agentsight/src/analyzer/audit/analyzer.rs
+++ b/src/agentsight/src/analyzer/audit/analyzer.rs
@@ -90,6 +90,7 @@ impl AuditAnalyzer {
                 cache_read_tokens,
                 is_sse: true,
             },
+            session_id: None,
         })
     }
 
@@ -134,6 +135,7 @@ impl AuditAnalyzer {
                 cache_read_tokens: 0,
                 is_sse,
             },
+            session_id: None,
         }
     }
 
@@ -150,8 +152,9 @@ impl AuditAnalyzer {
             extra: AuditExtra::ProcessAction {
                 filename: process.filename.clone(),
                 args: process.args.clone(),
-                exit_code: None, // AggregatedProcess doesn't have exit_code yet
+                exit_code: None,
             },
+            session_id: process.session_id.clone(),
         }
     }
 }
@@ -172,4 +175,37 @@ fn detect_model_from_request(pair: &HttpPair) -> Option<String> {
     json.get("model")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aggregator::AggregatedProcess;
+
+    #[test]
+    fn test_extract_process_action_propagates_session_id() {
+        let mut proc = AggregatedProcess::new(100, 100, 50, 50, "bash".to_string(), 1000);
+        proc.session_id = Some("test-session-xyz".to_string());
+        proc.add_exec("/bin/bash".to_string(), "echo hi".to_string(), 2000);
+
+        let analyzer = AuditAnalyzer::new();
+        let record = analyzer.extract_process_action(&proc);
+
+        assert_eq!(
+            record.session_id.as_deref(),
+            Some("test-session-xyz"),
+            "session_id must propagate from AggregatedProcess to AuditRecord"
+        );
+    }
+
+    #[test]
+    fn test_extract_process_action_none_session_id() {
+        let mut proc = AggregatedProcess::new(100, 100, 50, 50, "bash".to_string(), 1000);
+        proc.add_exec("/bin/bash".to_string(), "echo hi".to_string(), 2000);
+
+        let analyzer = AuditAnalyzer::new();
+        let record = analyzer.extract_process_action(&proc);
+
+        assert_eq!(record.session_id, None);
+    }
 }

--- a/src/agentsight/src/analyzer/audit/record.rs
+++ b/src/agentsight/src/analyzer/audit/record.rs
@@ -76,6 +76,9 @@ pub struct AuditRecord {
     pub duration_ns: u64,
     /// Type-specific extra fields (serialized as JSON)
     pub extra: AuditExtra,
+    /// Session ID from agent environment (e.g. CLAUDE_CODE_SESSION_ID).
+    /// Set at capture time when the process exports a known session env var.
+    pub session_id: Option<String>,
 }
 
 /// Summary statistics for audit events

--- a/src/agentsight/src/background.rs
+++ b/src/agentsight/src/background.rs
@@ -432,7 +432,7 @@ mod tests {
     fn tmp_dir(tag: &str) -> PathBuf {
         static C: AtomicU32 = AtomicU32::new(0);
         let n = C.fetch_add(1, Ordering::SeqCst);
-        let dir = std::env::temp_dir().join(format!("bg-test-{}-{n}", tag));
+        let dir = std::env::temp_dir().join(format!("bg-test-{tag}-{n}"));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir

--- a/src/agentsight/src/bin/agentsight.rs
+++ b/src/agentsight/src/bin/agentsight.rs
@@ -6,7 +6,6 @@
 //! - `audit`: Query audit events
 //! - `discover`: Discover running AI agents
 //! - `interruption`: Query and manage session interruption events
-
 use structopt::StructOpt;
 
 mod cli;

--- a/src/agentsight/src/bin/cli/audit.rs
+++ b/src/agentsight/src/bin/cli/audit.rs
@@ -92,6 +92,7 @@ impl AuditCommand {
                         "comm": r.comm,
                         "duration_ns": r.duration_ns,
                         "extra": r.extra,
+                        "session_id": r.session_id,
                     })
                 })
                 .collect();
@@ -109,6 +110,7 @@ impl AuditCommand {
                     "comm": record.comm,
                     "duration_ns": record.duration_ns,
                     "extra": record.extra,
+                    "session_id": record.session_id,
                 });
                 println!("{}", serde_json::to_string(&json_record).unwrap());
             }

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -742,16 +742,16 @@ fn ffi_background_thread(
             match cmd {
                 ProbeCommand::AddCgroup(id) => {
                     if let Err(e) = sight.add_traced_cgroup(id) {
-                        log::warn!("add_traced_cgroup({}) failed: {}", id, e);
+                        log::warn!("add_traced_cgroup({id}) failed: {e}");
                     } else {
-                        log::info!("Added cgroup_id {} to BPF filter", id);
+                        log::info!("Added cgroup_id {id} to BPF filter");
                     }
                 }
                 ProbeCommand::RemoveCgroup(id) => {
                     if let Err(e) = sight.remove_traced_cgroup(id) {
-                        log::warn!("remove_traced_cgroup({}) failed: {}", id, e);
+                        log::warn!("remove_traced_cgroup({id}) failed: {e}");
                     } else {
-                        log::info!("Removed cgroup_id {} from BPF filter", id);
+                        log::info!("Removed cgroup_id {id} from BPF filter");
                     }
                 }
             }

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -473,7 +473,7 @@ fn build_restart_cmd(exe_path: &str, cmdline_args: &[String]) -> Vec<String> {
 /// Read the parent PID (ppid) from /proc/<pid>/stat.
 /// Returns None if the file cannot be read or parsed.
 fn read_ppid(pid: u32) -> Option<u32> {
-    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
     // Format: "pid (comm) state ppid ..."
     // Find the closing ')' first (comm may contain spaces/parens)
     let after_comm = stat.rsplit_once(')')?.1;

--- a/src/agentsight/src/storage/sqlite/audit.rs
+++ b/src/agentsight/src/storage/sqlite/audit.rs
@@ -46,6 +46,10 @@ impl AuditStore {
         );
         conn.execute_batch(&format!("{create_table_sql}{create_index_sql}"))?;
 
+        // Idempotent migration (#1025): add session correlation columns
+        // to pre-existing databases.
+        ensure_correlation_columns(&conn, &table_name)?;
+
         Ok(AuditStore { conn, table_name })
     }
 
@@ -61,8 +65,8 @@ impl AuditStore {
             serde_json::to_string(&record.extra).context("Failed to serialize extra")?;
 
         let sql = format!(
-            "INSERT INTO {} (event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO {} (event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra, session_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             self.table_name
         );
         self.conn.execute(
@@ -75,6 +79,7 @@ impl AuditStore {
                 record.comm,
                 record.duration_ns as i64,
                 extra_json,
+                record.session_id,
             ],
         )?;
 
@@ -93,7 +98,7 @@ impl AuditStore {
         if let Some(et) = event_type {
             type_str = et.to_string();
             sql = format!(
-                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra
+                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra, session_id
                  FROM {} WHERE timestamp_ns >= ?1 AND event_type = ?2
                  ORDER BY timestamp_ns ASC",
                 self.table_name
@@ -101,7 +106,7 @@ impl AuditStore {
             query_params = vec![Box::new(since_ns as i64), Box::new(type_str.clone())];
         } else {
             sql = format!(
-                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra
+                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra, session_id
                  FROM {} WHERE timestamp_ns >= ?1
                  ORDER BY timestamp_ns ASC",
                 self.table_name
@@ -139,7 +144,7 @@ impl AuditStore {
         if let Some(et) = event_type {
             type_str = et.to_string();
             sql = format!(
-                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra
+                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra, session_id
                  FROM {} WHERE pid = ?1 AND event_type = ?2
                  ORDER BY timestamp_ns ASC",
                 self.table_name
@@ -147,7 +152,7 @@ impl AuditStore {
             query_params = vec![Box::new(pid), Box::new(type_str.clone())];
         } else {
             sql = format!(
-                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra
+                "SELECT id, event_type, timestamp_ns, pid, ppid, comm, duration_ns, extra, session_id
                  FROM {} WHERE pid = ?1
                  ORDER BY timestamp_ns ASC",
                 self.table_name
@@ -294,6 +299,7 @@ fn row_to_record(row: &rusqlite::Row) -> Result<AuditRecord> {
     let comm: String = row.get(5).map_err(|e| anyhow::anyhow!("{e}"))?;
     let duration_ns: i64 = row.get(6).map_err(|e| anyhow::anyhow!("{e}"))?;
     let extra_str: String = row.get(7).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let session_id: Option<String> = row.get(8).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let event_type: AuditEventType = event_type_str
         .parse()
@@ -311,7 +317,37 @@ fn row_to_record(row: &rusqlite::Row) -> Result<AuditRecord> {
         comm,
         duration_ns: duration_ns as u64,
         extra,
+        session_id,
     })
+}
+
+/// Idempotent migration: ensure session correlation columns exist.
+///
+/// Databases created before #1025 lack `session_id` and `conversation_id`
+/// columns. Add them via `ALTER TABLE` only when missing (checked through
+/// `pragma_table_info`). Also create an index on `session_id`.
+fn ensure_correlation_columns(conn: &Connection, table_name: &str) -> Result<()> {
+    let existing: std::collections::HashSet<String> = {
+        let mut stmt = conn.prepare(&format!("PRAGMA table_info({table_name})"))?;
+        stmt.query_map([], |row| row.get::<_, String>(1))? // column 1 = name
+            .filter_map(|r| r.ok())
+            .collect()
+    };
+
+    if !existing.contains("session_id") {
+        conn.execute_batch(&format!(
+            "ALTER TABLE {table_name} ADD COLUMN session_id TEXT;"
+        ))?;
+    }
+    if !existing.contains("conversation_id") {
+        conn.execute_batch(&format!(
+            "ALTER TABLE {table_name} ADD COLUMN conversation_id TEXT;"
+        ))?;
+    }
+    conn.execute_batch(&format!(
+        "CREATE INDEX IF NOT EXISTS idx_{table_name}_session_id ON {table_name}(session_id);"
+    ))?;
+    Ok(())
 }
 
 /// Extract full command line from extra JSON (ProcessAction.args or filename)
@@ -338,3 +374,146 @@ fn extract_cmdline_from_extra(extra_str: &str, comm: &str) -> String {
 
 // Backward compatibility alias
 pub type SqliteStore = AuditStore;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_id_round_trip() {
+        // Use an in-memory Connection to avoid tempfile dependency, then manually
+        // replicate what AuditStore::new does (create table + migration).
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                timestamp_ns INTEGER NOT NULL,
+                pid INTEGER NOT NULL,
+                ppid INTEGER,
+                comm TEXT NOT NULL,
+                duration_ns INTEGER DEFAULT 0,
+                extra TEXT
+            );",
+        )
+        .unwrap();
+        ensure_correlation_columns(&conn, "audit_events").unwrap();
+
+        let store = AuditStore {
+            conn,
+            table_name: "audit_events".to_string(),
+        };
+
+        let record = AuditRecord {
+            id: None,
+            event_type: AuditEventType::ProcessAction,
+            timestamp_ns: 1_000_000_000,
+            pid: 42,
+            ppid: Some(1),
+            comm: "bash".to_string(),
+            duration_ns: 500_000,
+            extra: AuditExtra::ProcessAction {
+                filename: Some("/bin/bash".to_string()),
+                args: Some("echo hi".to_string()),
+                exit_code: None,
+            },
+            session_id: Some("sess-abc-123".to_string()),
+        };
+        store.insert(&record).unwrap();
+
+        let results = store.query_since(0, None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].session_id.as_deref(),
+            Some("sess-abc-123"),
+            "session_id must survive insert→query round-trip"
+        );
+    }
+
+    #[test]
+    fn test_session_id_none_round_trip() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                timestamp_ns INTEGER NOT NULL,
+                pid INTEGER NOT NULL,
+                ppid INTEGER,
+                comm TEXT NOT NULL,
+                duration_ns INTEGER DEFAULT 0,
+                extra TEXT
+            );",
+        )
+        .unwrap();
+        ensure_correlation_columns(&conn, "audit_events").unwrap();
+
+        let store = AuditStore {
+            conn,
+            table_name: "audit_events".to_string(),
+        };
+
+        let record = AuditRecord {
+            id: None,
+            event_type: AuditEventType::ProcessAction,
+            timestamp_ns: 2_000_000_000,
+            pid: 43,
+            ppid: None,
+            comm: "ls".to_string(),
+            duration_ns: 100_000,
+            extra: AuditExtra::ProcessAction {
+                filename: Some("/bin/ls".to_string()),
+                args: Some("ls -la".to_string()),
+                exit_code: Some(0),
+            },
+            session_id: None,
+        };
+        store.insert(&record).unwrap();
+
+        let results = store.query_by_pid(43, None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].session_id, None);
+    }
+
+    #[test]
+    fn test_ensure_correlation_columns_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Pre-existing audit table WITHOUT the correlation columns (old DB).
+        conn.execute_batch(
+            "CREATE TABLE audit_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                timestamp_ns INTEGER NOT NULL,
+                pid INTEGER NOT NULL,
+                comm TEXT NOT NULL,
+                extra TEXT
+            );",
+        )
+        .unwrap();
+
+        // Run twice: must be idempotent. A naive ALTER without the pragma guard
+        // would error "duplicate column name" on the second call.
+        ensure_correlation_columns(&conn, "audit_events").unwrap();
+        ensure_correlation_columns(&conn, "audit_events").unwrap();
+
+        let cols: std::collections::HashSet<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(audit_events)").unwrap();
+            stmt.query_map([], |r| r.get::<_, String>(1))
+                .unwrap()
+                .filter_map(|r| r.ok())
+                .collect()
+        };
+        assert!(cols.contains("session_id"));
+        assert!(cols.contains("conversation_id"));
+
+        let idx: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'index' AND name = 'idx_audit_events_session_id'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx, 1);
+    }
+}


### PR DESCRIPTION
## Summary

Read session_id (CLAUDE_CODE_SESSION_ID / HERMES_SESSION_ID / AGENT_SEC_SESSION_ID) from `/proc/{pid}/environ` at exec time and write it directly to audit_events.

Two-layer session resolution:
- **Layer 1**: direct `/proc/{pid}/environ` read in `AggregatedProcess::new()` — works when the process is still alive
- **Layer 2**: ppid-chain inheritance via `session_map` in `ProcessEventAggregator` — short-lived processes that exit before the /proc read inherit session_id from their parent

Closes #1025.

## Changes

| File | What changed |
|------|-------------|
| `process.rs` | `read_session_env(pid)` + `parse_session_from_environ()` pure function, 9 environ parsing tests |
| `aggregator.rs` | `session_map: HashMap<u32, String>` for ppid propagation, 6 tests (inherit, chain, exit cleanup, PID recycling) |
| `audit.rs` | `session_id` column migration + `row_to_record` reads it back + 2 round-trip tests |
| `analyzer.rs` | `extract_process_action` propagates `session_id`, 2 integration tests |
| `record.rs` | `session_id: Option<String>` field on `AuditRecord` |
| `bin/cli/audit.rs` | JSON output includes `session_id` |

Also removes the offline correlator module (1500 lines) — replaced by the direct-read + ppid approach which is simpler and more precise.

## Test plan

- [x] 715 unit tests pass (fmt, clippy, test with toolchain 1.89.0)
- [x] 20 new tests: environ parsing (9), round-trip (2), analyzer propagation (2), ppid chain (6), migration (1)
- [x] Mutation verified: disabling ppid inheritance fails 3 tests, reverting row_to_record fix fails round-trip test
- [x] 3 rounds adversarial review (57 agents total), all actionable findings fixed
- [x] ECS E2E: 2 Claude sessions, session_id correctly written to audit_events (cf85ebc6... and 483acae9...)
