### PR TITLE
fix(sight): merge embedded defaults with user config

### DIFF
--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -366,6 +366,13 @@ pub fn default_cmdline_rules() -> Vec<CmdlineRule> {
     rules
 }
 
+/// Load both default cmdline and https rules from the embedded config.
+pub fn default_rules() -> (Vec<CmdlineRule>, Vec<HttpsRule>) {
+    let (cmdline, https, _) =
+        parse_json_rules(DEFAULT_AGENTS_JSON).expect("embedded DEFAULT_AGENTS_JSON is valid");
+    (cmdline, https)
+}
+
 // ==================== Chrome Trace Export ====================
 
 /// Check if chrome trace export is enabled (set once at startup)
@@ -1161,6 +1168,57 @@ mod tests {
         // https rules: dashscope.aliyuncs.com configured by default
         assert_eq!(https_rules.len(), 1);
         assert!(http_targets.is_empty());
+    }
+
+    #[test]
+    fn test_default_rules_returns_both_cmdline_and_https() {
+        let (cmdline, https) = default_rules();
+        assert!(
+            !cmdline.is_empty(),
+            "embedded defaults must have cmdline rules"
+        );
+        assert!(!https.is_empty(), "embedded defaults must have https rules");
+        let has_claude = cmdline
+            .iter()
+            .any(|r| r.agent_name.as_deref() == Some("Claude"));
+        assert!(has_claude, "embedded defaults must include Claude agent");
+    }
+
+    #[test]
+    fn test_load_extends_defaults_not_replaces() {
+        // Pre-seed with embedded defaults, then load user config via JSON.
+        // The final rules must contain BOTH defaults AND user additions.
+        // Discriminating: initializing cmdline_rules as Vec::new() before
+        // load_from_json would lose the defaults.
+        let mut config = AgentsightConfig::new();
+        let (default_cmdline, default_https) = default_rules();
+        config.cmdline_rules = default_cmdline;
+        config.https_rules = default_https;
+
+        let user_json = r#"{"cmdline":{"allow":[{"rule":["*my-agent*"],"agent_name":"MyAgent"}]},"https":[{"rule":["my-api.example.com"]}]}"#;
+        config.load_from_json(user_json).unwrap();
+
+        let has_claude = config
+            .cmdline_rules
+            .iter()
+            .any(|r| r.agent_name.as_deref() == Some("Claude"));
+        let has_my_agent = config
+            .cmdline_rules
+            .iter()
+            .any(|r| r.agent_name.as_deref() == Some("MyAgent"));
+        assert!(has_claude, "defaults must survive after load_from_json");
+        assert!(has_my_agent, "user rules must be appended");
+
+        let has_default_https = config
+            .https_rules
+            .iter()
+            .any(|r| r.pattern == "dashscope.aliyuncs.com");
+        let has_user_https = config
+            .https_rules
+            .iter()
+            .any(|r| r.pattern == "my-api.example.com");
+        assert!(has_default_https, "default https rules must survive");
+        assert!(has_user_https, "user https rules must be appended");
     }
 
     #[test]

--- a/src/agentsight/src/discovery/scanner.rs
+++ b/src/agentsight/src/discovery/scanner.rs
@@ -113,6 +113,7 @@ impl AgentScanner {
             Err(_) => return discovered,
         };
 
+        let mut scanned = 0u32;
         for entry in entries.flatten() {
             let file_name = entry.file_name();
             let name_str = file_name.to_string_lossy();
@@ -122,13 +123,27 @@ impl AgentScanner {
                 Ok(p) => p,
                 Err(_) => continue,
             };
+            scanned += 1;
+
+            // Read cmdline once for both deny check and match (avoid double /proc read)
+            let cmdline = read_cmdline(&format!("/proc/{pid}/cmdline"));
+            if !cmdline.is_empty() && self.is_denied(&cmdline) {
+                continue;
+            }
 
             // Try to read process info and match against known agents
-            if let Some(discovered_agent) = self.try_match_process(pid) {
+            if let Some(discovered_agent) = self.try_match_process(pid, cmdline) {
                 self.tracked_agents
                     .insert(discovered_agent.pid, discovered_agent.clone());
                 discovered.push(discovered_agent);
             }
+        }
+
+        if discovered.is_empty() && !self.matchers.is_empty() {
+            log::warn!(
+                "Process scan found 0 agents among {scanned} /proc entries — \
+                 verify cmdline.allow rules in config"
+            );
         }
 
         discovered
@@ -224,19 +239,13 @@ impl AgentScanner {
     }
 
     /// Attempt to match a process against known agents
-    fn try_match_process(&self, pid: u32) -> Option<DiscoveredAgent> {
+    fn try_match_process(&self, pid: u32, cmdline_args: Vec<String>) -> Option<DiscoveredAgent> {
         let proc_dir = format!("/proc/{pid}");
 
-        // Read process name from /proc/[pid]/comm
         let comm_path = format!("{proc_dir}/comm");
         let comm = fs::read_to_string(&comm_path).ok()?;
         let process_name = comm.trim().to_string();
 
-        // Read full command line from /proc/[pid]/cmdline
-        let cmdline_path = format!("{proc_dir}/cmdline");
-        let cmdline_args = read_cmdline(&cmdline_path);
-
-        // Read executable path from /proc/[pid]/exe (symlink)
         let exe_path = format!("{proc_dir}/exe");
         let exe = fs::read_link(&exe_path)
             .map(|p| p.to_string_lossy().into_owned())
@@ -379,5 +388,44 @@ mod tests {
         // Deny works
         assert!(scanner.is_denied(&["deny-me-process".to_string()]));
         assert!(!scanner.is_denied(&["node".to_string(), "/path/claude-code".to_string()]));
+    }
+
+    #[test]
+    fn test_scan_zero_match_with_matchers() {
+        // With matchers that cannot match any real process (impossible pattern),
+        // scan() returns empty and the warn! diagnostic fires (matchers non-empty).
+        // Discriminating: removing the warn! condition changes nothing observable
+        // in the test, but the test validates that scan() completes cleanly with
+        // non-empty matchers and zero matches — the exact #1055 incident shape.
+        let rules = vec![CmdlineRule {
+            patterns: vec!["__impossible_agent_pattern_e2e__".to_string()],
+            agent_name: Some("Ghost".to_string()),
+            allow: true,
+        }];
+        let mut scanner = AgentScanner::from_rules(&rules, &[]);
+        assert_eq!(scanner.matcher_count(), 1);
+        let result = scanner.scan();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_is_denied_blocks_allow_match() {
+        // A process matching both allow AND deny rules must be blocked by deny.
+        // This verifies the deny-check logic that scan() now applies.
+        let rules = vec![
+            CmdlineRule {
+                patterns: vec!["*test-agent*".to_string()],
+                agent_name: Some("TestAgent".to_string()),
+                allow: true,
+            },
+            CmdlineRule {
+                patterns: vec!["*test-agent*".to_string()],
+                agent_name: None,
+                allow: false,
+            },
+        ];
+        let scanner = AgentScanner::from_rules(&rules, &[]);
+        assert_eq!(scanner.matcher_count(), 1);
+        assert!(scanner.is_denied(&["test-agent-process".to_string()]));
     }
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -134,6 +134,14 @@ impl AgentSight {
         let mut config_load_ok = false;
         let mut config_load_err: Option<(PathBuf, anyhow::Error)> = None;
         if let Some(path) = config.config_path.clone() {
+            // Pre-seed with embedded defaults so user config EXTENDS rather
+            // than replaces. load_from_json's extend() appends user rules
+            // after these defaults; AgentScanner's first-match semantics mean
+            // defaults apply transparently unless the user overrides.
+            let (default_cmdline, default_https) = crate::config::default_rules();
+            config.cmdline_rules = default_cmdline;
+            config.https_rules = default_https;
+
             let load_result = if path.exists() {
                 config.load_from_file(&path)
             } else {


### PR DESCRIPTION
## Summary

When `/etc/agentsight/config.json` exists, it silently **replaces** the embedded default agent rules (`agentsight.json`) instead of extending them. This caused a real incident where a config with only `cosh` rules and no `*claude*` entry led to hours of debugging zero `genai` capture.

This PR makes user config **extend** the embedded defaults, and adds a zero-match diagnostic.

## Changes

### 1. Pre-seed defaults before config load (~8 lines, `unified.rs`)

Before `load_from_file()`, pre-seed `cmdline_rules` and `https_rules` with embedded defaults. `load_from_json`'s `extend()` appends user rules after defaults. First-match semantics in `AgentScanner` mean defaults apply transparently.

### 2. New `default_rules()` function (~6 lines, `config.rs`)

Returns both cmdline and https rules from embedded JSON. Existing `default_cmdline_rules()` unchanged (used by HealthChecker).

### 3. scan() deny check + diagnostic (~15 lines, `scanner.rs`)

- Added `is_denied()` check in scan loop (was missing; runtime `handle_procmon_event` has it)
- Added `warn!` when 0 agents found with non-empty matchers (default log level is warn, so this is visible)
- Eliminated double `/proc/{pid}/cmdline` read by passing pre-read cmdline to `try_match_process`

## Verification

- `cargo +1.89.0 fmt --check`: pass
- `cargo +1.89.0 clippy -D warnings`: pass  
- `cargo +1.89.0 test --lib`: 699 passed, 0 failed
- **ECS E2E**: old config (cosh-only, no claude) + new binary loaded **21 cmdline rules** (16 defaults + 5 user) instead of old 5. Merge confirmed working.
- **Adversarial review**: 10-agent workflow, 3 dimensions (correctness/backward-compat/security), 7 findings → 5 confirmed (all low, addressed) + 2 refuted

## Test plan

- [x] `test_default_rules_returns_both_cmdline_and_https`: embedded defaults contain Claude + https rules
- [x] `test_load_extends_defaults_not_replaces`: pre-seed + load_from_json preserves both defaults and user rules (discriminating)
- [x] `test_scan_zero_match_with_matchers`: scan with impossible pattern returns empty cleanly
- [x] `test_is_denied_blocks_allow_match`: deny overrides allow
- [x] ECS E2E with old config (no claude entry) verified merge

Fixes #1055
