### PR TITLE
feat(cosh): add SLS JSONL session telemetry with expanded metrics

### DIFF
--- a/src/copilot-shell/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.test.ts
+++ b/src/copilot-shell/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.test.ts
@@ -1197,6 +1197,15 @@ describe('BaseJsonOutputAdapter', () => {
           totalRuns: 0,
           totalBlocked: 0,
         },
+        toolErrorCounts: {
+          modelError: 0,
+          executionError: 0,
+          denied: 0,
+        },
+        awaitApproval: {
+          totalDurationMs: 0,
+          count: 0,
+        },
       };
       const options: ResultOptions = {
         isError: false,

--- a/src/copilot-shell/packages/cli/src/nonInteractive/io/JsonOutputAdapter.test.ts
+++ b/src/copilot-shell/packages/cli/src/nonInteractive/io/JsonOutputAdapter.test.ts
@@ -584,6 +584,15 @@ describe('JsonOutputAdapter', () => {
           totalRuns: 0,
           totalBlocked: 0,
         },
+        toolErrorCounts: {
+          modelError: 0,
+          executionError: 0,
+          denied: 0,
+        },
+        awaitApproval: {
+          totalDurationMs: 0,
+          count: 0,
+        },
       };
 
       adapter.emitResult({

--- a/src/copilot-shell/packages/cli/src/nonInteractiveCli.test.ts
+++ b/src/copilot-shell/packages/cli/src/nonInteractiveCli.test.ts
@@ -138,6 +138,7 @@ describe('runNonInteractive', () => {
       getFolderTrust: vi.fn().mockReturnValue(false),
       getIncludePartialMessages: vi.fn().mockReturnValue(false),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getAuthType: vi.fn().mockReturnValue('dashscope'),
       getModel: vi.fn(() => currentModel),
       setModel: vi.fn(async (model: string) => {
         currentModel = model;

--- a/src/copilot-shell/packages/cli/src/nonInteractiveCli.ts
+++ b/src/copilot-shell/packages/cli/src/nonInteractiveCli.ts
@@ -18,6 +18,7 @@ import {
   InputFormat,
   uiTelemetryService,
   parseAndFormatApiError,
+  logSessionSummary,
 } from '@copilot-shell/core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -414,6 +415,7 @@ export async function runNonInteractive(
       // Cleanup signal handlers
       process.removeListener('SIGINT', shutdownHandler);
       process.removeListener('SIGTERM', shutdownHandler);
+      logSessionSummary(config);
       if (isTelemetrySdkInitialized()) {
         await shutdownTelemetry(config);
       }

--- a/src/copilot-shell/packages/cli/src/ui/commands/clearCommand.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/clearCommand.test.ts
@@ -17,6 +17,7 @@ vi.mock('@copilot-shell/core', async () => {
     uiTelemetryService: {
       reset: vi.fn(),
     },
+    logSessionSummary: vi.fn(),
   };
 });
 

--- a/src/copilot-shell/packages/cli/src/ui/commands/clearCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/clearCommand.ts
@@ -7,7 +7,7 @@
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
-import { uiTelemetryService } from '@copilot-shell/core';
+import { uiTelemetryService, logSessionSummary } from '@copilot-shell/core';
 
 export const clearCommand: SlashCommand = {
   name: 'clear',
@@ -20,6 +20,8 @@ export const clearCommand: SlashCommand = {
     const { config } = context.services;
 
     if (config) {
+      // Flush current session summary before resetting metrics
+      logSessionSummary(config);
       const newSessionId = config.startNewSession();
 
       // Reset UI telemetry metrics for the new session

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.test.ts
@@ -61,6 +61,7 @@ vi.mock('@copilot-shell/core', () => {
 
   return {
     SessionService,
+    logSessionSummary: vi.fn(),
     uiTelemetryService: {
       getMetrics: () => ({ models: {}, tools: {}, files: {} }),
       getLastPromptTokenCount: () => 0,

--- a/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/useResumeCommand.ts
@@ -5,7 +5,11 @@
  */
 
 import { useState, useCallback } from 'react';
-import { SessionService, type Config } from '@copilot-shell/core';
+import {
+  SessionService,
+  logSessionSummary,
+  type Config,
+} from '@copilot-shell/core';
 import { buildResumedHistoryItems } from '../utils/resumeHistoryUtils.js';
 import { getPromptCountFromSessionData } from '../contexts/SessionContext.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -66,6 +70,8 @@ export function useResumeCommand(
       historyManager.loadHistory(uiHistoryItems);
 
       // Update session history core.
+      // Flush current session summary before switching to the resumed session
+      logSessionSummary(config);
       config.startNewSession(sessionId, sessionData);
       await config.getGeminiClient()?.initialize?.();
 

--- a/src/copilot-shell/packages/cli/src/utils/nonInteractiveHelpers.test.ts
+++ b/src/copilot-shell/packages/cli/src/utils/nonInteractiveHelpers.test.ts
@@ -366,6 +366,15 @@ describe('computeUsageFromMetrics', () => {
         totalRuns: 0,
         totalBlocked: 0,
       },
+      toolErrorCounts: {
+        modelError: 0,
+        executionError: 0,
+        denied: 0,
+      },
+      awaitApproval: {
+        totalDurationMs: 0,
+        count: 0,
+      },
     };
     const result = computeUsageFromMetrics(metrics);
     expect(result).toEqual({
@@ -423,6 +432,15 @@ describe('computeUsageFromMetrics', () => {
         totalRuns: 0,
         totalBlocked: 0,
       },
+      toolErrorCounts: {
+        modelError: 0,
+        executionError: 0,
+        denied: 0,
+      },
+      awaitApproval: {
+        totalDurationMs: 0,
+        count: 0,
+      },
     };
     const result = computeUsageFromMetrics(metrics);
     expect(result).toEqual({
@@ -469,6 +487,15 @@ describe('computeUsageFromMetrics', () => {
         totalRuns: 0,
         totalBlocked: 0,
       },
+      toolErrorCounts: {
+        modelError: 0,
+        executionError: 0,
+        denied: 0,
+      },
+      awaitApproval: {
+        totalDurationMs: 0,
+        count: 0,
+      },
     };
     const result = computeUsageFromMetrics(metrics);
     expect(result).not.toHaveProperty('total_tokens');
@@ -502,6 +529,15 @@ describe('computeUsageFromMetrics', () => {
       sandbox: {
         totalRuns: 0,
         totalBlocked: 0,
+      },
+      toolErrorCounts: {
+        modelError: 0,
+        executionError: 0,
+        denied: 0,
+      },
+      awaitApproval: {
+        totalDurationMs: 0,
+        count: 0,
       },
     };
     const result = computeUsageFromMetrics(metrics);

--- a/src/copilot-shell/packages/core/src/core/client.ts
+++ b/src/copilot-shell/packages/core/src/core/client.ts
@@ -53,6 +53,7 @@ import { TaskTool } from '../tools/task.js';
 import {
   NextSpeakerCheckEvent,
   logNextSpeakerCheck,
+  logSessionSummary,
 } from '../telemetry/index.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
 
@@ -188,6 +189,7 @@ export class GeminiClient {
   async shutdown(): Promise<void> {
     if (this.hasShutdown) return;
     this.hasShutdown = true;
+    logSessionSummary(this.config);
     await this.fireSessionEndHook(SessionEndReason.PromptInputExit);
   }
 

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -31,6 +31,7 @@ import {
   InputFormat,
   SkillTool,
 } from '../index.js';
+import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
 import type { SandboxBypassApprovalRequest } from '../index.js';
 import type { HookDecision } from '../hooks/types.js';
 import type {
@@ -132,6 +133,12 @@ export type WaitingToolCall = {
    */
   hookForceAsk?: boolean;
   startTime?: number;
+  /**
+   * Timestamp when the tool call entered awaiting_approval state.
+   * Used to accurately measure user approval wait duration (excludes
+   * validation and hook execution time).
+   */
+  awaitStartTime?: number;
   outcome?: ToolConfirmationOutcome;
 };
 
@@ -492,6 +499,8 @@ export class CoreToolScheduler {
             confirmationDetails: auxiliaryData as ToolCallConfirmationDetails,
             hookForceAsk,
             startTime: existingStartTime,
+            awaitStartTime:
+              (currentCall as WaitingToolCall).awaitStartTime ?? Date.now(),
             outcome,
             invocation,
           } as WaitingToolCall;
@@ -1197,6 +1206,17 @@ export class CoreToolScheduler {
     const toolCall = this.toolCalls.find(
       (c) => c.request.callId === callId && c.status === 'awaiting_approval',
     );
+
+    // Record await duration for SLS telemetry (use awaitStartTime for accuracy)
+    if (toolCall) {
+      const awaitStart =
+        ('awaitStartTime' in toolCall && toolCall.awaitStartTime) ||
+        ('startTime' in toolCall && toolCall.startTime);
+      if (awaitStart) {
+        const awaitDuration = Date.now() - awaitStart;
+        uiTelemetryService.recordAwaitDuration(awaitDuration);
+      }
+    }
 
     await originalOnConfirm(outcome, payload);
 

--- a/src/copilot-shell/packages/core/src/output/json-formatter.test.ts
+++ b/src/copilot-shell/packages/core/src/output/json-formatter.test.ts
@@ -117,6 +117,15 @@ describe('JsonFormatter', () => {
         totalRuns: 0,
         totalBlocked: 0,
       },
+      toolErrorCounts: {
+        modelError: 0,
+        executionError: 0,
+        denied: 0,
+      },
+      awaitApproval: {
+        totalDurationMs: 0,
+        count: 0,
+      },
     };
     const formatted = formatter.format(response, stats);
     const expected = {
@@ -217,6 +226,15 @@ describe('JsonFormatter', () => {
       sandbox: {
         totalRuns: 0,
         totalBlocked: 0,
+      },
+      toolErrorCounts: {
+        modelError: 0,
+        executionError: 0,
+        denied: 0,
+      },
+      awaitApproval: {
+        totalDurationMs: 0,
+        count: 0,
       },
     };
     const error: JsonError = {

--- a/src/copilot-shell/packages/core/src/telemetry/index.ts
+++ b/src/copilot-shell/packages/core/src/telemetry/index.ts
@@ -48,6 +48,7 @@ export {
   logAuth,
   logSkillLaunch,
   logUserFeedback,
+  logSessionSummary,
 } from './loggers.js';
 export type { SlashCommandEvent, ChatCompressionEvent } from './types.js';
 export {

--- a/src/copilot-shell/packages/core/src/telemetry/loggers.ts
+++ b/src/copilot-shell/packages/core/src/telemetry/loggers.ts
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import os from 'node:os';
 import type { LogAttributes, LogRecord } from '@opentelemetry/api-logs';
 import { logs } from '@opentelemetry/api-logs';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import type { Config } from '../config/config.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { appendSlsLog } from './sls-logger.js';
+import { ToolCallDecision } from './tool-call-decision.js';
+import { InstallationManager } from '../utils/installationManager.js';
 import {
   EVENT_API_ERROR,
   EVENT_API_CANCEL,
@@ -944,4 +948,109 @@ export function logUserFeedback(
     attributes,
   };
   logger.emit(logRecord);
+}
+
+/**
+ * Write session summary to SLS JSONL log file at session end.
+ * Data is collected from uiTelemetryService metrics and config.
+ * Idempotent: only emits once per process to avoid duplicate records.
+ */
+const loggedSessionIds = new Set<string>();
+export function logSessionSummary(config: Config): void {
+  const sessionId = config.getSessionId();
+  if (loggedSessionIds.has(sessionId)) return;
+  loggedSessionIds.add(sessionId);
+
+  const metrics = uiTelemetryService.getMetrics();
+  const installationManager = new InstallationManager();
+
+  const awaitStats = metrics.awaitApproval;
+  const avgAwaitSeconds =
+    awaitStats.count > 0
+      ? awaitStats.totalDurationMs / awaitStats.count / 1000
+      : 0;
+
+  // Aggregate token and API stats across all models
+  let tokensInput = 0;
+  let tokensOutput = 0;
+  let tokensCached = 0;
+  let tokensTotal = 0;
+  let apiTotalRequests = 0;
+  let apiTotalErrors = 0;
+  let apiTotalLatencyMs = 0;
+  for (const model of Object.values(metrics.models)) {
+    tokensInput += model.tokens.prompt;
+    tokensOutput += model.tokens.candidates;
+    tokensCached += model.tokens.cached;
+    tokensTotal += model.tokens.total;
+    apiTotalRequests += model.api.totalRequests;
+    apiTotalErrors += model.api.totalErrors;
+    apiTotalLatencyMs += model.api.totalLatencyMs;
+  }
+
+  const record = {
+    // Component identification
+    'component.name': 'cosh',
+    'component.version': config.getCliVersion() || 'unknown',
+    'component.agent_name': 'copilot-shell',
+    'session.id': config.getSessionId(),
+    installation_id: installationManager.getInstallationId(),
+
+    // Session configuration
+    'session.model': config.getModel() || 'unknown',
+    'session.auth_type': config.getAuthType() || 'unknown',
+    'session.approval_mode': config.getApprovalMode(),
+
+    // Audit decision counts
+    'session.audit_decision_counts.approve':
+      metrics.tools.totalDecisions[ToolCallDecision.ACCEPT] +
+      metrics.tools.totalDecisions[ToolCallDecision.AUTO_ACCEPT],
+    'session.audit_decision_counts.deny':
+      metrics.tools.totalDecisions[ToolCallDecision.REJECT],
+    'session.audit_decision_counts.modify':
+      metrics.tools.totalDecisions[ToolCallDecision.MODIFY],
+
+    // Tool call counts
+    'session.tool_call_counts.total': metrics.tools.totalCalls,
+    'session.tool_call_counts.success': metrics.tools.totalSuccess,
+    'session.tool_call_counts.fail': metrics.tools.totalFail,
+    'session.tool_call_total_duration_seconds':
+      Math.round((metrics.tools.totalDurationMs / 1000) * 100) / 100,
+
+    // Tool error counts by category
+    'session.tool_error_counts.model_error': metrics.toolErrorCounts.modelError,
+    'session.tool_error_counts.execution_error':
+      metrics.toolErrorCounts.executionError,
+    'session.tool_error_counts.denied': metrics.toolErrorCounts.denied,
+
+    // Await approval
+    'session.avg_await_duration_seconds':
+      Math.round(avgAwaitSeconds * 100) / 100,
+
+    // File operation stats
+    'session.files.lines_added': metrics.files.totalLinesAdded,
+    'session.files.lines_removed': metrics.files.totalLinesRemoved,
+
+    // Sandbox stats
+    'session.sandbox.total_runs': metrics.sandbox.totalRuns,
+    'session.sandbox.total_blocked': metrics.sandbox.totalBlocked,
+
+    // Token usage (aggregated across all models)
+    'session.tokens.input': tokensInput,
+    'session.tokens.output': tokensOutput,
+    'session.tokens.cached': tokensCached,
+    'session.tokens.total': tokensTotal,
+
+    // API stats (aggregated across all models)
+    'session.api.total_requests': apiTotalRequests,
+    'session.api.total_errors': apiTotalErrors,
+    'session.api.total_latency_seconds':
+      Math.round((apiTotalLatencyMs / 1000) * 100) / 100,
+
+    // Environment info
+    'os.type': os.platform(),
+    'os.arch': process.arch,
+  };
+
+  appendSlsLog(record);
 }

--- a/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts
+++ b/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+
+/**
+ * Path to the SLS JSONL log file.
+ * SLS agent will collect and upload logs from this file.
+ */
+const SLS_LOG_PATH = '/var/log/anolisa/sls/ops/cosh.jsonl';
+
+/**
+ * Append a single JSON record as one line to the SLS log file.
+ * Uses open→write→close pattern to support logrotate rename.
+ * Silently fails if the file cannot be written (e.g., directory does not exist).
+ */
+export function appendSlsLog(record: Record<string, unknown>): void {
+  try {
+    const line = JSON.stringify(record) + '\n';
+    const fd = fs.openSync(SLS_LOG_PATH, 'a');
+    try {
+      fs.writeSync(fd, line);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    // Silently fail - SLS logging should never break the main process
+  }
+}

--- a/src/copilot-shell/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/src/copilot-shell/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -146,6 +146,15 @@ describe('UiTelemetryService', () => {
         totalRuns: 0,
         totalBlocked: 0,
       },
+      toolErrorCounts: {
+        modelError: 0,
+        executionError: 0,
+        denied: 0,
+      },
+      awaitApproval: {
+        totalDurationMs: 0,
+        count: 0,
+      },
     });
     expect(service.getLastPromptTokenCount()).toBe(0);
   });

--- a/src/copilot-shell/packages/core/src/telemetry/uiTelemetry.ts
+++ b/src/copilot-shell/packages/core/src/telemetry/uiTelemetry.ts
@@ -12,11 +12,25 @@ import {
 } from './constants.js';
 
 import { ToolCallDecision } from './tool-call-decision.js';
+import { ToolErrorType } from '../tools/tool-error.js';
 import type {
   ApiErrorEvent,
   ApiResponseEvent,
   ToolCallEvent,
 } from './types.js';
+
+/**
+ * ToolErrorType values classified as model output errors.
+ */
+const MODEL_ERROR_TYPES: ReadonlySet<string> = new Set([
+  ToolErrorType.INVALID_TOOL_PARAMS,
+  ToolErrorType.TOOL_NOT_REGISTERED,
+]);
+
+/**
+ * ToolErrorType value classified as execution denied.
+ */
+const DENIED_ERROR_TYPE = ToolErrorType.EXECUTION_DENIED;
 
 export type UiEvent =
   | (ApiResponseEvent & { 'event.name': typeof EVENT_API_RESPONSE })
@@ -81,6 +95,15 @@ export interface SessionMetrics {
     totalRuns: number;
     totalBlocked: number;
   };
+  toolErrorCounts: {
+    modelError: number;
+    executionError: number;
+    denied: number;
+  };
+  awaitApproval: {
+    totalDurationMs: number;
+    count: number;
+  };
 }
 
 const createInitialModelMetrics = (): ModelMetrics => ({
@@ -121,6 +144,15 @@ const createInitialMetrics = (): SessionMetrics => ({
   sandbox: {
     totalRuns: 0,
     totalBlocked: 0,
+  },
+  toolErrorCounts: {
+    modelError: 0,
+    executionError: 0,
+    denied: 0,
+  },
+  awaitApproval: {
+    totalDurationMs: 0,
+    count: 0,
   },
 });
 
@@ -164,6 +196,15 @@ export class UiTelemetryService extends EventEmitter {
       metrics: this.#metrics,
       lastPromptTokenCount: this.#lastPromptTokenCount,
     });
+  }
+
+  /**
+   * Records the duration a tool call spent awaiting user approval.
+   * Called by coreToolScheduler when a confirmation response is received.
+   */
+  recordAwaitDuration(durationMs: number): void {
+    this.#metrics.awaitApproval.totalDurationMs += durationMs;
+    this.#metrics.awaitApproval.count++;
   }
 
   /**
@@ -215,6 +256,18 @@ export class UiTelemetryService extends EventEmitter {
       tools.totalSuccess++;
     } else {
       tools.totalFail++;
+      // Classify error type into aggregated categories
+      if (event.error_type) {
+        if (MODEL_ERROR_TYPES.has(event.error_type)) {
+          this.#metrics.toolErrorCounts.modelError++;
+        } else if (event.error_type === DENIED_ERROR_TYPE) {
+          this.#metrics.toolErrorCounts.denied++;
+        } else {
+          this.#metrics.toolErrorCounts.executionError++;
+        }
+      } else {
+        this.#metrics.toolErrorCounts.executionError++;
+      }
     }
 
     if (!tools.byName[event.function_name]) {


### PR DESCRIPTION
## Description

Add local JSONL-based session telemetry for SLS agent collection. At session end, `logSessionSummary` writes a comprehensive 32-field record to `/var/log/anolisa/sls/ops/cosh.jsonl`. Fields cover component identification, session configuration, audit decisions, tool call statistics with error classification, file/sandbox metrics, token usage, API stats, and environment info. Uses open→write→close pattern to support logrotate.

## Related Issue

no-issue: New telemetry capability per Agentic OS data collection specification

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```
npm run test --workspace=packages/core   → 179 files, 3765 passed
npm run test --workspace=packages/cli    → 219 files, 3454 passed
```

## Additional Notes

Key files:
- `packages/core/src/telemetry/sls-logger.ts` — new JSONL append writer
- `packages/core/src/telemetry/loggers.ts` — `logSessionSummary` with 32 fields
- `packages/core/src/telemetry/uiTelemetry.ts` — `toolErrorCounts` metrics
- `packages/core/src/core/coreToolScheduler.ts` — await duration tracking
