### PR TITLE
feat(sight): add security observability server proxy

### DIFF
--- a/src/agentsight/docs/ARCHITECTURE.md
+++ b/src/agentsight/docs/ARCHITECTURE.md
@@ -86,7 +86,7 @@ graph TB
 | **L4: Analyze** | `src/analyzer/`, `src/tokenizer/` | Token 提取、审计记录、消息解析 | → L3, L2 |
 | **L5: Semantic** | `src/genai/`, `src/atif/` | 语义事件构建、轨迹格式导出 | → L4, L3, L2, Cross |
 | **L6: Persist** | `src/storage/` | SQLite 持久化、SLS 远程导出 | → L4, L5 |
-| **L7: Serve** | `src/server/`, `src/health/` | HTTP API、前端、健康检查 | → L6, L5 |
+| **L7: Serve** | `src/server/`, `src/health/`, `src/agent_sec/` | HTTP API、前端、agent-sec daemon 代理、健康检查 | → L6, L5 |
 | **L8: Entry** | `src/bin/`, `src/unified.rs`, `src/config.rs` | CLI 入口、编排器、配置 | → L1-L7 |
 | **Cross** | `src/discovery/` | Agent 进程发现与匹配 | 被 L1, L8 使用 |
 
@@ -106,6 +106,7 @@ graph LR
     discovery[discovery]
     health[health]
     atif[atif]
+    agent_sec[agent_sec]
     server[server]
     unified[unified]
 
@@ -137,6 +138,7 @@ graph LR
     server --> storage
     server --> health
     server --> atif
+    server --> agent_sec
     health --> storage
     atif --> genai
     atif --> storage
@@ -273,6 +275,9 @@ src/
 ├── atif/                  # ATIF 轨迹格式
 │   ├── schema.rs          # ATIF v1.6 数据结构
 │   └── converter.rs       # GenAI → ATIF 转换
+├── agent_sec/             # agent-sec daemon 查询代理
+│   ├── mod.rs             # 模块导出
+│   └── client.rs          # Unix socket NDJSON client
 ├── server/                # HTTP 服务器（feature=server）
 │   ├── mod.rs             # Actix-web 服务器 + 前端嵌入
 │   └── handlers.rs        # API 处理函数

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -25,6 +25,7 @@ LAYER_MAP = {
     "genai":       5,   # L5: Semantic
     "atif":        5,   # L5: Semantic
     "storage":     6,   # L6: Persist
+    "agent_sec":   7,   # L7: Serve
     "server":      7,   # L7: Serve
     "health":      7,   # L7: Serve
     "bin":         8,   # L8: Entry
@@ -44,7 +45,8 @@ ALLOWED_DEPS = {
     "genai":       {"analyzer", "aggregator", "parser"},
     "atif":        {"genai", "storage"},
     "storage":     {"analyzer", "genai"},
-    "server":      {"storage", "health", "atif"},
+    "server":      {"storage", "health", "atif", "agent_sec"},
+    "agent_sec":   set(),
     "health":      {"storage"},
     "unified":     "*",
     "config":      set(),

--- a/src/agentsight/src/agent_sec/client.rs
+++ b/src/agentsight/src/agent_sec/client.rs
@@ -1,0 +1,364 @@
+//! Unix socket NDJSON client for the agent-sec daemon.
+
+use std::env;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use thiserror::Error;
+
+const SOCKET_ENV: &str = "AGENT_SEC_DAEMON_SOCKET";
+const RUNTIME_SUBDIR: &str = "agent-sec-core";
+const SOCKET_FILENAME: &str = "daemon.sock";
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct AgentSecClient {
+    socket_path: PathBuf,
+    timeout_ms: u64,
+    timeout: Duration,
+    max_response_bytes: usize,
+}
+
+impl AgentSecClient {
+    pub fn new(socket_path: Option<PathBuf>) -> Result<Self, AgentSecClientError> {
+        Self::with_timeout(socket_path, DEFAULT_TIMEOUT_MS)
+    }
+
+    pub fn with_timeout(
+        socket_path: Option<PathBuf>,
+        timeout_ms: u64,
+    ) -> Result<Self, AgentSecClientError> {
+        if timeout_ms == 0 {
+            return Err(AgentSecClientError::Protocol(
+                "agent-sec daemon timeout must be positive".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            socket_path: resolve_socket_path(socket_path)?,
+            timeout_ms,
+            timeout: Duration::from_millis(timeout_ms),
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+        })
+    }
+
+    pub fn socket_path(&self) -> &PathBuf {
+        &self.socket_path
+    }
+
+    pub fn call(&self, method: &str, params: Value) -> Result<DaemonResponse, AgentSecClientError> {
+        let payload = self.build_request_payload(method, params)?;
+
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .map_err(|err| classify_io_error("connect", err))?;
+        self.send_payload_and_read_response(&mut stream, &payload)
+    }
+
+    fn send_payload_and_read_response(
+        &self,
+        stream: &mut UnixStream,
+        payload: &[u8],
+    ) -> Result<DaemonResponse, AgentSecClientError> {
+        stream
+            .set_read_timeout(Some(self.timeout))
+            .map_err(|err| classify_io_error("set read timeout", err))?;
+        stream
+            .set_write_timeout(Some(self.timeout))
+            .map_err(|err| classify_io_error("set write timeout", err))?;
+        stream
+            .write_all(payload)
+            .map_err(|err| classify_io_error("write request", err))?;
+
+        let response_line = self.read_response_line(stream)?;
+        self.decode_response_line(&response_line)
+    }
+
+    fn build_request_payload(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> Result<Vec<u8>, AgentSecClientError> {
+        if !params.is_object() {
+            return Err(AgentSecClientError::Protocol(
+                "daemon params must be a JSON object".to_string(),
+            ));
+        }
+
+        let request = json!({
+            "method": method,
+            "params": params,
+            "trace_context": {},
+            "caller": "agentsight",
+            "timeout_ms": self.timeout_ms,
+        });
+
+        let mut payload = serde_json::to_vec(&request).map_err(|err| {
+            AgentSecClientError::Protocol(format!("failed to encode daemon request: {err}"))
+        })?;
+        payload.push(b'\n');
+
+        Ok(payload)
+    }
+
+    fn read_response_line<R: Read>(&self, reader: &mut R) -> Result<Vec<u8>, AgentSecClientError> {
+        let mut chunks = Vec::new();
+        let mut buffer = [0_u8; 4096];
+
+        loop {
+            let n = reader
+                .read(&mut buffer)
+                .map_err(|err| classify_io_error("read response", err))?;
+            if n == 0 {
+                break;
+            }
+
+            chunks.extend_from_slice(&buffer[..n]);
+            if chunks.len() > self.max_response_bytes {
+                return Err(AgentSecClientError::ResponseTooLarge(
+                    self.max_response_bytes,
+                ));
+            }
+            if let Some(newline) = chunks.iter().position(|byte| *byte == b'\n') {
+                chunks.truncate(newline);
+                break;
+            }
+        }
+
+        if chunks.is_empty() {
+            return Err(AgentSecClientError::Transport(
+                "daemon returned an empty response".to_string(),
+            ));
+        }
+
+        Ok(chunks)
+    }
+
+    fn decode_response_line(
+        &self,
+        response_line: &[u8],
+    ) -> Result<DaemonResponse, AgentSecClientError> {
+        serde_json::from_slice(response_line).map_err(|err| {
+            AgentSecClientError::Protocol(format!("daemon returned invalid JSON: {err}"))
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DaemonResponse {
+    pub request_id: String,
+    pub ok: bool,
+    #[serde(default)]
+    pub data: Value,
+    #[serde(default)]
+    pub stdout: String,
+    #[serde(default)]
+    pub stderr: String,
+    #[serde(default)]
+    pub exit_code: i64,
+    #[serde(default)]
+    pub error: Option<DaemonErrorPayload>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DaemonErrorPayload {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Error)]
+pub enum AgentSecClientError {
+    #[error("agent-sec daemon socket path could not be resolved: {0}")]
+    SocketPath(String),
+    #[error("agent-sec daemon is unavailable: {0}")]
+    Transport(String),
+    #[error("agent-sec daemon request timed out: {0}")]
+    Timeout(String),
+    #[error("agent-sec daemon response exceeds {0} bytes")]
+    ResponseTooLarge(usize),
+    #[error("agent-sec daemon protocol error: {0}")]
+    Protocol(String),
+}
+
+fn resolve_socket_path(socket_path: Option<PathBuf>) -> Result<PathBuf, AgentSecClientError> {
+    if let Some(path) = socket_path {
+        return Ok(path);
+    }
+
+    if let Some(path) = env::var_os(SOCKET_ENV) {
+        return Ok(PathBuf::from(path));
+    }
+
+    let xdg_runtime_dir = env::var_os("XDG_RUNTIME_DIR").ok_or_else(|| {
+        AgentSecClientError::SocketPath(
+            "XDG_RUNTIME_DIR is required when AGENT_SEC_DAEMON_SOCKET is not set".to_string(),
+        )
+    })?;
+
+    Ok(PathBuf::from(xdg_runtime_dir)
+        .join(RUNTIME_SUBDIR)
+        .join(SOCKET_FILENAME))
+}
+
+fn classify_io_error(action: &str, err: std::io::Error) -> AgentSecClientError {
+    match err.kind() {
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock => {
+            AgentSecClientError::Timeout(format!("{action}: {err}"))
+        }
+        _ => AgentSecClientError::Transport(format!("{action}: {err}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::time::Duration;
+
+    use serde_json::{Value, json};
+
+    use super::{AgentSecClient, AgentSecClientError};
+
+    fn test_client(max_response_bytes: usize) -> AgentSecClient {
+        AgentSecClient {
+            socket_path: "/tmp/agent-sec-test.sock".into(),
+            timeout_ms: 123,
+            timeout: Duration::from_millis(123),
+            max_response_bytes,
+        }
+    }
+
+    #[test]
+    fn call_rejects_non_object_params_before_connecting() {
+        let client = AgentSecClient::new(Some("/tmp/agent-sec-test.sock".into()))
+            .expect("client with explicit socket path should be created");
+
+        let err = client
+            .call("daemon.health", Value::String("bad".to_string()))
+            .expect_err("non-object params should be rejected");
+
+        assert!(
+            matches!(err, AgentSecClientError::Protocol(message) if message.contains("params"))
+        );
+    }
+
+    #[test]
+    fn build_request_payload_serializes_daemon_ndjson() {
+        let client = AgentSecClient::with_timeout(Some("/tmp/agent-sec-test.sock".into()), 123)
+            .expect("client should be created");
+        let payload = client
+            .build_request_payload("sec.summary", json!({ "limit": 10 }))
+            .expect("request payload should serialize");
+
+        assert_eq!(payload.last(), Some(&b'\n'));
+
+        let request: Value =
+            serde_json::from_slice(&payload[..payload.len() - 1]).expect("payload should be JSON");
+        assert_eq!(request["method"], "sec.summary");
+        assert_eq!(request["caller"], "agentsight");
+        assert_eq!(request["timeout_ms"], 123);
+        assert_eq!(request["trace_context"], json!({}));
+        assert_eq!(request["params"], json!({ "limit": 10 }));
+    }
+
+    #[test]
+    fn with_timeout_rejects_zero_timeout() {
+        let err = AgentSecClient::with_timeout(Some("/tmp/agent-sec-test.sock".into()), 0)
+            .expect_err("zero timeout should be rejected");
+
+        assert!(
+            matches!(err, AgentSecClientError::Protocol(message) if message.contains("positive"))
+        );
+    }
+
+    #[test]
+    fn resolve_socket_path_uses_explicit_path() {
+        let path = super::resolve_socket_path(Some("/tmp/agent-sec-test.sock".into()))
+            .expect("explicit socket path should resolve");
+
+        assert_eq!(path, std::path::PathBuf::from("/tmp/agent-sec-test.sock"));
+    }
+
+    #[test]
+    fn read_response_line_reads_until_newline() {
+        let client = test_client(1024);
+        let mut reader = Cursor::new(
+            br#"{"request_id":"req-1","ok":true}
+ignored"#,
+        );
+
+        let line = client
+            .read_response_line(&mut reader)
+            .expect("response line should be read");
+
+        assert_eq!(line, br#"{"request_id":"req-1","ok":true}"#);
+    }
+
+    #[test]
+    fn decode_response_line_returns_daemon_json() {
+        let client = test_client(1024);
+        let response = client
+            .decode_response_line(br#"{"request_id":"req-1","ok":true,"data":{"total":1}}"#)
+            .expect("valid daemon response should parse");
+
+        assert!(response.ok);
+        assert_eq!(response.data, json!({ "total": 1 }));
+    }
+
+    #[test]
+    fn decode_response_line_rejects_invalid_json() {
+        let client = test_client(1024);
+
+        let err = client
+            .decode_response_line(b"not-json")
+            .expect_err("invalid daemon JSON should fail");
+
+        assert!(
+            matches!(err, AgentSecClientError::Protocol(message) if message.contains("invalid JSON"))
+        );
+    }
+
+    #[test]
+    fn read_response_line_rejects_empty_response() {
+        let client = test_client(1024);
+        let mut reader = Cursor::new(Vec::<u8>::new());
+
+        let err = client
+            .read_response_line(&mut reader)
+            .expect_err("empty daemon response should fail");
+
+        assert!(
+            matches!(err, AgentSecClientError::Transport(message) if message.contains("empty"))
+        );
+    }
+
+    #[test]
+    fn read_response_line_rejects_oversized_response() {
+        let client = test_client(4);
+        let mut reader = Cursor::new(b"12345".to_vec());
+
+        let err = client
+            .read_response_line(&mut reader)
+            .expect_err("oversized daemon response should fail");
+
+        assert!(matches!(err, AgentSecClientError::ResponseTooLarge(4)));
+    }
+
+    #[test]
+    fn classify_io_error_maps_timeout_and_transport_errors() {
+        let timeout = super::classify_io_error(
+            "read response",
+            std::io::Error::from(std::io::ErrorKind::TimedOut),
+        );
+        let transport = super::classify_io_error(
+            "connect",
+            std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+        );
+
+        assert!(matches!(timeout, AgentSecClientError::Timeout(_)));
+        assert!(matches!(transport, AgentSecClientError::Transport(_)));
+    }
+}

--- a/src/agentsight/src/agent_sec/mod.rs
+++ b/src/agentsight/src/agent_sec/mod.rs
@@ -1,0 +1,31 @@
+//! agent-sec daemon integration.
+
+pub mod client;
+
+pub use client::{AgentSecClient, AgentSecClientError, DaemonErrorPayload, DaemonResponse};
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{AgentSecClient, DaemonResponse};
+
+    #[test]
+    fn module_reexports_client_types() {
+        let socket_path = PathBuf::from("agent-sec-daemon.sock");
+        let client = AgentSecClient::new(Some(socket_path.clone()))
+            .expect("explicit socket path should create a client");
+        let response = DaemonResponse {
+            request_id: "req-1".to_string(),
+            ok: true,
+            data: serde_json::Value::Null,
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+            error: None,
+        };
+
+        assert_eq!(client.socket_path(), &socket_path);
+        assert!(response.ok);
+    }
+}

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -40,6 +40,8 @@ pub mod probes;
 
 // Re-export config types
 pub use config::{AgentsightConfig, default_base_path};
+#[cfg(feature = "server")]
+pub mod agent_sec;
 pub mod aggregator;
 pub mod analyzer;
 pub mod atif;
@@ -60,6 +62,18 @@ pub mod storage;
 pub mod tokenizer;
 mod unified;
 pub mod utils;
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    #[test]
+    fn agent_sec_module_is_available_with_server_feature() {
+        let socket_path = std::path::PathBuf::from("agent-sec-daemon.sock");
+        let client = crate::agent_sec::AgentSecClient::new(Some(socket_path.clone()))
+            .expect("server feature should expose the agent-sec client");
+
+        assert_eq!(client.socket_path(), &socket_path);
+    }
+}
 
 // Re-export common types for convenience
 pub use aggregator::{

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -1,9 +1,14 @@
 //! API request handlers
 
+use std::collections::HashMap;
+
+use actix_web::http::StatusCode;
 use actix_web::{HttpResponse, Responder, get, post, web};
 use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 
 use super::AppState;
+use crate::agent_sec::{AgentSecClient, AgentSecClientError, DaemonResponse};
 use crate::health::AgentHealthStatus;
 use crate::storage::sqlite::GenAISqliteStore;
 use crate::storage::sqlite::genai::{ModelTimeseriesBucket, TimeseriesBucket};
@@ -249,6 +254,595 @@ fn now_ns() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos() as u64
+}
+
+// ─── agent-sec Security Observability endpoints ─────────────────────────────
+
+/// GET /api/security/status
+///
+/// Reports only whether the agent-sec daemon is reachable. Data-plane failures
+/// are surfaced by the individual security query endpoints.
+#[get("/api/security/status")]
+pub async fn security_status(data: web::Data<AppState>) -> impl Responder {
+    let client = match agent_sec_client(&data) {
+        Ok(client) => client,
+        Err(err) => {
+            return security_state_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "daemon_unreachable",
+                json!({ "error": err.to_string() }),
+                Some("agent-sec daemon is unavailable"),
+            );
+        }
+    };
+
+    let daemon_health = match call_daemon(client, "daemon.health", json!({})).await {
+        Ok(response) if response.ok => response,
+        Ok(response) => return daemon_error_response(response),
+        Err(err) => {
+            return security_state_response(
+                client_error_status(&err),
+                "daemon_unreachable",
+                json!({ "error": err.to_string() }),
+                Some("agent-sec daemon is unavailable"),
+            );
+        }
+    };
+
+    security_state_response(
+        StatusCode::OK,
+        "daemon_reachable",
+        json!({
+            "daemon": daemon_health.data,
+            "socket_path": client_socket_path(&data),
+        }),
+        None,
+    )
+}
+
+/// GET /api/security/summary
+#[get("/api/security/summary")]
+pub async fn security_summary(
+    data: web::Data<AppState>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    proxy_security_query(data, "sec.summary", query_to_params(&query)).await
+}
+
+/// GET /api/security/events/count-by
+#[get("/api/security/events/count-by")]
+pub async fn security_events_count_by(
+    data: web::Data<AppState>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    proxy_security_query(data, "sec.events.count_by", query_to_params(&query)).await
+}
+
+/// GET /api/security/events
+#[get("/api/security/events")]
+pub async fn security_events_list(
+    data: web::Data<AppState>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    proxy_security_query(data, "sec.events.list", query_to_params(&query)).await
+}
+
+/// GET /api/security/events/{event_id}
+#[get("/api/security/events/{event_id}")]
+pub async fn security_event_detail(
+    data: web::Data<AppState>,
+    path: web::Path<String>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    let params = query_to_params(&query).map(|mut params| {
+        params["event_id"] = Value::String(path.into_inner());
+        params
+    });
+    proxy_security_query(data, "sec.events.get", params).await
+}
+
+/// GET /api/security/observability/sessions
+#[get("/api/security/observability/sessions")]
+pub async fn security_observability_sessions(
+    data: web::Data<AppState>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    proxy_security_query(data, "obs.sessions.list", query_to_params(&query)).await
+}
+
+/// GET /api/security/observability/sessions/{session_id}/runs
+#[get("/api/security/observability/sessions/{session_id}/runs")]
+pub async fn security_observability_runs(
+    data: web::Data<AppState>,
+    path: web::Path<String>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    let params = query_to_params(&query).map(|mut params| {
+        params["session_id"] = Value::String(path.into_inner());
+        params
+    });
+    proxy_security_query(data, "obs.runs.list", params).await
+}
+
+/// GET /api/security/observability/timeline
+#[get("/api/security/observability/timeline")]
+pub async fn security_observability_timeline(
+    data: web::Data<AppState>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    proxy_security_query(data, "obs.timeline.get", query_to_params(&query)).await
+}
+
+async fn proxy_security_query(
+    data: web::Data<AppState>,
+    method: &'static str,
+    params: Result<Value, HttpResponse>,
+) -> HttpResponse {
+    let params = match params {
+        Ok(params) => params,
+        Err(response) => return response,
+    };
+
+    let client = match agent_sec_client(&data) {
+        Ok(client) => client,
+        Err(err) => return client_error_response(err),
+    };
+
+    match call_daemon(client, method, params).await {
+        Ok(response) if response.ok => {
+            let state = derive_security_query_state(method, &response.data);
+            security_state_response(StatusCode::OK, state, response.data, None)
+        }
+        Ok(response) => daemon_error_response(response),
+        Err(err) => client_error_response(err),
+    }
+}
+
+async fn call_daemon(
+    client: AgentSecClient,
+    method: &'static str,
+    params: Value,
+) -> Result<DaemonResponse, AgentSecClientError> {
+    let method = method.to_string();
+    match web::block(move || client.call(&method, params)).await {
+        Ok(result) => result,
+        Err(err) => Err(AgentSecClientError::Transport(format!(
+            "daemon client task failed: {err}"
+        ))),
+    }
+}
+
+fn agent_sec_client(data: &web::Data<AppState>) -> Result<AgentSecClient, AgentSecClientError> {
+    AgentSecClient::with_timeout(None, data.security_observability.timeout_ms)
+}
+
+fn client_socket_path(data: &web::Data<AppState>) -> Option<String> {
+    agent_sec_client(data)
+        .ok()
+        .map(|client| client.socket_path().display().to_string())
+}
+
+fn query_to_params(query: &web::Query<HashMap<String, String>>) -> Result<Value, HttpResponse> {
+    let mut params = serde_json::Map::new();
+    for (key, raw_value) in query.iter() {
+        let value = parse_security_query_value(key, raw_value)?;
+        params.insert(key.clone(), value);
+    }
+    Ok(Value::Object(params))
+}
+
+fn parse_security_query_value(key: &str, raw_value: &str) -> Result<Value, HttpResponse> {
+    match key {
+        "start_ns" | "end_ns" | "limit" | "offset" | "latest_limit" => {
+            let value = raw_value
+                .parse::<i64>()
+                .map_err(|_| bad_request_response(format!("{key} must be an integer")))?;
+            Ok(Value::Number(value.into()))
+        }
+        "include_details" | "include_security" => parse_bool(raw_value)
+            .map(Value::Bool)
+            .ok_or_else(|| bad_request_response(format!("{key} must be a boolean"))),
+        _ => Ok(Value::String(raw_value.to_string())),
+    }
+}
+
+fn parse_bool(raw_value: &str) -> Option<bool> {
+    match raw_value {
+        "true" | "1" => Some(true),
+        "false" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+fn derive_security_query_state(method: &str, data: &Value) -> &'static str {
+    match method {
+        "sec.summary" if data.get("total").and_then(Value::as_i64).unwrap_or(0) == 0 => "empty",
+        "sec.events.list" | "obs.sessions.list" | "obs.runs.list"
+            if data.get("total").and_then(Value::as_i64).unwrap_or(0) == 0 =>
+        {
+            "empty"
+        }
+        "sec.events.count_by"
+            if data
+                .get("items")
+                .and_then(Value::as_array)
+                .map(|items| items.is_empty())
+                .unwrap_or(true) =>
+        {
+            "empty"
+        }
+        "sec.events.get" if !data.get("found").and_then(Value::as_bool).unwrap_or(false) => {
+            "not_found"
+        }
+        "sec.events.get" => "found",
+        "obs.timeline.get"
+            if data
+                .get("items")
+                .and_then(Value::as_array)
+                .map(|items| items.is_empty())
+                .unwrap_or(true) =>
+        {
+            "empty"
+        }
+        _ => "ok",
+    }
+}
+
+fn security_state_response(
+    status: StatusCode,
+    state: &str,
+    data: Value,
+    message: Option<&str>,
+) -> HttpResponse {
+    let mut body = json!({
+        "state": state,
+        "data": data,
+        "meta": {
+            "source": "agent-sec-daemon",
+        },
+    });
+    if let Some(message) = message {
+        body["message"] = Value::String(message.to_string());
+    }
+    HttpResponse::build(status).json(body)
+}
+
+fn bad_request_response(message: String) -> HttpResponse {
+    HttpResponse::BadRequest().json(json!({
+        "error": {
+            "code": "bad_request",
+            "message": message,
+            "retryable": false,
+        }
+    }))
+}
+
+fn client_error_response(err: AgentSecClientError) -> HttpResponse {
+    let status = client_error_status(&err);
+    let (code, retryable) = match &err {
+        AgentSecClientError::SocketPath(_) | AgentSecClientError::Transport(_) => {
+            ("daemon_unavailable", true)
+        }
+        AgentSecClientError::Timeout(_) => ("daemon_timeout", true),
+        AgentSecClientError::ResponseTooLarge(_) => ("payload_too_large", false),
+        AgentSecClientError::Protocol(_) => ("daemon_protocol_mismatch", false),
+    };
+
+    HttpResponse::build(status).json(json!({
+        "error": {
+            "code": code,
+            "message": err.to_string(),
+            "retryable": retryable,
+        }
+    }))
+}
+
+fn client_error_status(err: &AgentSecClientError) -> StatusCode {
+    match err {
+        AgentSecClientError::SocketPath(_) | AgentSecClientError::Transport(_) => {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+        AgentSecClientError::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
+        AgentSecClientError::ResponseTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
+        AgentSecClientError::Protocol(_) => StatusCode::BAD_GATEWAY,
+    }
+}
+
+fn daemon_error_response(response: DaemonResponse) -> HttpResponse {
+    let daemon_error = response.error.clone();
+    let daemon_code = daemon_error
+        .as_ref()
+        .map(|error| error.code.as_str())
+        .unwrap_or("internal_error");
+    let message = daemon_error
+        .as_ref()
+        .map(|error| error.message.clone())
+        .unwrap_or_else(|| response.stderr.clone());
+
+    let (status, code, retryable) = match daemon_code {
+        "bad_request" => (StatusCode::BAD_REQUEST, "bad_request", false),
+        "unknown_method" => (StatusCode::BAD_GATEWAY, "daemon_protocol_mismatch", false),
+        "payload_too_large" => (StatusCode::PAYLOAD_TOO_LARGE, "payload_too_large", false),
+        "timeout" => (StatusCode::GATEWAY_TIMEOUT, "daemon_timeout", true),
+        "busy" => (StatusCode::SERVICE_UNAVAILABLE, "daemon_busy", true),
+        "unavailable" => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "daemon_capability_unavailable",
+            true,
+        ),
+        "shutdown" => (StatusCode::SERVICE_UNAVAILABLE, "daemon_shutdown", true),
+        _ => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "daemon_internal_error",
+            false,
+        ),
+    };
+
+    HttpResponse::build(status).json(json!({
+        "error": {
+            "code": code,
+            "message": message,
+            "retryable": retryable,
+            "daemon_code": daemon_code,
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::{Arc, RwLock};
+    use std::time::Instant;
+
+    use actix_web::App;
+    use actix_web::body::to_bytes;
+    use actix_web::test as awtest;
+
+    use crate::agent_sec::DaemonErrorPayload;
+    use crate::health::HealthStore;
+
+    use super::*;
+
+    #[test]
+    fn query_to_params_parses_security_query_types() {
+        let query = web::Query(HashMap::from([
+            ("start_ns".to_string(), "100".to_string()),
+            ("limit".to_string(), "25".to_string()),
+            ("include_details".to_string(), "true".to_string()),
+            ("agent_name".to_string(), "codex".to_string()),
+        ]));
+
+        let params = query_to_params(&query).expect("valid query should parse");
+
+        assert_eq!(
+            params,
+            json!({
+                "start_ns": 100,
+                "limit": 25,
+                "include_details": true,
+                "agent_name": "codex",
+            })
+        );
+    }
+
+    #[actix_web::test]
+    async fn query_to_params_rejects_invalid_security_query_types() {
+        let query = web::Query(HashMap::from([(
+            "include_security".to_string(),
+            "sometimes".to_string(),
+        )]));
+
+        let response = query_to_params(&query).expect_err("invalid boolean should fail");
+        let body = response_json(response).await;
+
+        assert_eq!(body["error"]["code"], "bad_request");
+        assert_eq!(body["error"]["retryable"], false);
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("include_security"))
+        );
+    }
+
+    #[test]
+    fn derive_security_query_state_maps_empty_and_found_states() {
+        assert_eq!(
+            derive_security_query_state("sec.summary", &json!({})),
+            "empty"
+        );
+        assert_eq!(
+            derive_security_query_state("sec.events.list", &json!({ "total": 0 })),
+            "empty"
+        );
+        assert_eq!(
+            derive_security_query_state("sec.events.get", &json!({ "found": false })),
+            "not_found"
+        );
+        assert_eq!(
+            derive_security_query_state("sec.events.get", &json!({ "found": true })),
+            "found"
+        );
+        assert_eq!(
+            derive_security_query_state("obs.timeline.get", &json!({ "items": [] })),
+            "empty"
+        );
+        assert_eq!(
+            derive_security_query_state("obs.timeline.get", &json!({ "items": [{}] })),
+            "ok"
+        );
+    }
+
+    #[actix_web::test]
+    async fn daemon_error_response_maps_daemon_codes_to_http_errors() {
+        for (daemon_code, status, code, retryable) in [
+            ("bad_request", StatusCode::BAD_REQUEST, "bad_request", false),
+            (
+                "unknown_method",
+                StatusCode::BAD_GATEWAY,
+                "daemon_protocol_mismatch",
+                false,
+            ),
+            (
+                "payload_too_large",
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "payload_too_large",
+                false,
+            ),
+            (
+                "timeout",
+                StatusCode::GATEWAY_TIMEOUT,
+                "daemon_timeout",
+                true,
+            ),
+            ("busy", StatusCode::SERVICE_UNAVAILABLE, "daemon_busy", true),
+            (
+                "unavailable",
+                StatusCode::SERVICE_UNAVAILABLE,
+                "daemon_capability_unavailable",
+                true,
+            ),
+            (
+                "shutdown",
+                StatusCode::SERVICE_UNAVAILABLE,
+                "daemon_shutdown",
+                true,
+            ),
+            (
+                "internal_error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "daemon_internal_error",
+                false,
+            ),
+        ] {
+            let response = daemon_error_response(daemon_response_with_error(daemon_code));
+            assert_eq!(response.status(), status);
+
+            let body = response_json(response).await;
+            assert_eq!(body["error"]["code"], code);
+            assert_eq!(body["error"]["daemon_code"], daemon_code);
+            assert_eq!(body["error"]["retryable"], retryable);
+        }
+    }
+
+    #[actix_web::test]
+    async fn client_error_response_maps_protocol_errors_to_bad_gateway() {
+        for (err, status, code, retryable) in [
+            (
+                AgentSecClientError::SocketPath("missing runtime dir".to_string()),
+                StatusCode::SERVICE_UNAVAILABLE,
+                "daemon_unavailable",
+                true,
+            ),
+            (
+                AgentSecClientError::Transport("connect refused".to_string()),
+                StatusCode::SERVICE_UNAVAILABLE,
+                "daemon_unavailable",
+                true,
+            ),
+            (
+                AgentSecClientError::Timeout("read response".to_string()),
+                StatusCode::GATEWAY_TIMEOUT,
+                "daemon_timeout",
+                true,
+            ),
+            (
+                AgentSecClientError::ResponseTooLarge(128),
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "payload_too_large",
+                false,
+            ),
+            (
+                AgentSecClientError::Protocol("unexpected response".to_string()),
+                StatusCode::BAD_GATEWAY,
+                "daemon_protocol_mismatch",
+                false,
+            ),
+        ] {
+            let response = client_error_response(err);
+            assert_eq!(response.status(), status);
+
+            let body = response_json(response).await;
+            assert_eq!(body["error"]["code"], code);
+            assert_eq!(body["error"]["retryable"], retryable);
+        }
+    }
+
+    #[actix_web::test]
+    async fn security_endpoints_report_client_errors_when_daemon_config_is_invalid() {
+        let app = awtest::init_service(
+            App::new()
+                .app_data(test_app_state(0))
+                .service(security_status)
+                .service(security_summary)
+                .service(security_events_count_by)
+                .service(security_events_list)
+                .service(security_event_detail)
+                .service(security_observability_sessions)
+                .service(security_observability_runs)
+                .service(security_observability_timeline),
+        )
+        .await;
+
+        for (uri, status) in [
+            ("/api/security/status", StatusCode::SERVICE_UNAVAILABLE),
+            ("/api/security/summary?limit=1", StatusCode::BAD_GATEWAY),
+            (
+                "/api/security/events/count-by?include_security=true",
+                StatusCode::BAD_GATEWAY,
+            ),
+            ("/api/security/events?offset=1", StatusCode::BAD_GATEWAY),
+            ("/api/security/events/event-1", StatusCode::BAD_GATEWAY),
+            (
+                "/api/security/observability/sessions?latest_limit=1",
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                "/api/security/observability/sessions/session-1/runs",
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                "/api/security/observability/timeline?end_ns=2",
+                StatusCode::BAD_GATEWAY,
+            ),
+        ] {
+            let response =
+                awtest::call_service(&app, awtest::TestRequest::get().uri(uri).to_request()).await;
+
+            assert_eq!(response.status(), status);
+        }
+    }
+
+    async fn response_json(response: HttpResponse) -> Value {
+        let body = to_bytes(response.into_body())
+            .await
+            .expect("response body should be readable");
+        serde_json::from_slice(&body).expect("response body should be JSON")
+    }
+
+    fn daemon_response_with_error(code: &str) -> DaemonResponse {
+        DaemonResponse {
+            request_id: "req-1".to_string(),
+            ok: false,
+            data: Value::Null,
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 1,
+            error: Some(DaemonErrorPayload {
+                code: code.to_string(),
+                message: format!("{code} message"),
+            }),
+        }
+    }
+
+    fn test_app_state(timeout_ms: u64) -> web::Data<AppState> {
+        web::Data::new(AppState {
+            storage_path: PathBuf::from(":memory:"),
+            start_time: Instant::now(),
+            health_store: Arc::new(RwLock::new(HealthStore::new())),
+            interruption_store: None,
+            security_observability: super::super::SecurityObservabilityConfig { timeout_ms },
+        })
+    }
 }
 
 // ─── Prometheus metrics endpoint ─────────────────────────────────────────────

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -21,6 +21,19 @@ use crate::storage::sqlite::InterruptionStore;
 /// (e.g. first build before running npm), Rust will use an empty dir.
 static FRONTEND: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/frontend-dist");
 
+/// agent-sec security observability integration configuration.
+#[derive(Clone, Debug)]
+pub struct SecurityObservabilityConfig {
+    /// Per-request daemon timeout.
+    pub timeout_ms: u64,
+}
+
+impl Default for SecurityObservabilityConfig {
+    fn default() -> Self {
+        Self { timeout_ms: 5_000 }
+    }
+}
+
 /// Shared application state accessible from all handlers
 pub struct AppState {
     /// Path to the SQLite database file
@@ -31,6 +44,8 @@ pub struct AppState {
     pub health_store: Arc<RwLock<HealthStore>>,
     /// Interruption events store
     pub interruption_store: Option<Arc<InterruptionStore>>,
+    /// agent-sec security observability integration configuration
+    pub security_observability: SecurityObservabilityConfig,
 }
 
 // ─── Static file handler ─────────────────────────────────────────────────────
@@ -38,10 +53,18 @@ pub struct AppState {
 /// Serve embedded frontend files.
 /// Any path that doesn't start with /api or /health is treated as a static
 /// asset; unknown paths fall back to index.html (SPA client-side routing).
+#[get("/")]
+async fn serve_frontend_root() -> impl Responder {
+    serve_frontend_path("")
+}
+
 #[get("/{tail:.*}")]
 async fn serve_frontend(req: HttpRequest) -> impl Responder {
     let path = req.match_info().get("tail").unwrap_or("");
+    serve_frontend_path(path)
+}
 
+fn serve_frontend_path(path: &str) -> HttpResponse {
     // Try exact match first
     let file = if path.is_empty() {
         FRONTEND.get_file("index.html")
@@ -93,6 +116,55 @@ fn mime_for_path(path: &str) -> &'static str {
     }
 }
 
+fn configure_routes(cfg: &mut web::ServiceConfig) {
+    cfg
+        // API routes (registered before the catch-all static handler)
+        .service(handlers::health)
+        .service(handlers::metrics)
+        .service(handlers::list_sessions)
+        .service(handlers::list_traces_by_session)
+        .service(handlers::get_trace_detail)
+        .service(handlers::get_conversation_events)
+        .service(handlers::list_agent_names)
+        .service(handlers::get_timeseries)
+        .service(handlers::export_atif_trace)
+        .service(handlers::export_atif_session)
+        .service(handlers::export_atif_conversation)
+        .service(handlers::get_agent_health)
+        .service(handlers::delete_agent_health)
+        .service(handlers::restart_agent_health)
+        // Interruption API routes
+        .service(handlers::list_interruptions)
+        .service(handlers::interruption_count)
+        .service(handlers::interruption_stats)
+        .service(handlers::interruption_session_counts)
+        .service(handlers::interruption_conversation_counts)
+        .service(handlers::list_session_interruptions)
+        .service(handlers::list_conversation_interruptions)
+        .service(handlers::resolve_interruption)
+        .service(handlers::get_interruption)
+        .service(handlers::get_token_savings)
+        // agent-sec Security Observability API routes
+        .service(handlers::security_status)
+        .service(handlers::security_summary)
+        .service(handlers::security_events_count_by)
+        .service(handlers::security_events_list)
+        .service(handlers::security_event_detail)
+        .service(handlers::security_observability_sessions)
+        .service(handlers::security_observability_runs)
+        .service(handlers::security_observability_timeline)
+        // Skill Metrics API routes
+        .service(handlers::skill_metrics_all)
+        .service(handlers::skill_metrics_downloads)
+        .service(handlers::skill_metrics_loads)
+        .service(handlers::skill_metrics_usage_ratio)
+        .service(handlers::skill_metrics_distribution)
+        .service(handlers::skill_metrics_hotness)
+        // Frontend static files (catch-all, must be last)
+        .service(serve_frontend_root)
+        .service(serve_frontend);
+}
+
 // ─── Server entry point ───────────────────────────────────────────────────────
 
 /// Start the API server
@@ -100,6 +172,8 @@ fn mime_for_path(path: &str) -> &'static str {
 /// Binds to the given host:port and serves API endpoints + embedded frontend.
 /// This function blocks until the server is shut down.
 pub async fn run_server(host: &str, port: u16, storage_path: PathBuf) -> std::io::Result<()> {
+    let security_observability = SecurityObservabilityConfig::default();
+
     // Initialize GenAI SQLite store (needed for HealthChecker to query pending calls)
     let genai_store: Option<Arc<crate::storage::sqlite::GenAISqliteStore>> =
         match crate::storage::sqlite::GenAISqliteStore::new() {
@@ -148,6 +222,7 @@ pub async fn run_server(host: &str, port: u16, storage_path: PathBuf) -> std::io
         start_time: Instant::now(),
         health_store,
         interruption_store,
+        security_observability,
     });
 
     let has_frontend = FRONTEND.get_file("index.html").is_some();
@@ -171,43 +246,82 @@ pub async fn run_server(host: &str, port: u16, storage_path: PathBuf) -> std::io
         App::new()
             .wrap(cors)
             .app_data(data.clone())
-            // API routes (registered before the catch-all static handler)
-            .service(handlers::health)
-            .service(handlers::metrics)
-            .service(handlers::list_sessions)
-            .service(handlers::list_traces_by_session)
-            .service(handlers::get_trace_detail)
-            .service(handlers::get_conversation_events)
-            .service(handlers::list_agent_names)
-            .service(handlers::get_timeseries)
-            .service(handlers::export_atif_trace)
-            .service(handlers::export_atif_session)
-            .service(handlers::export_atif_conversation)
-            .service(handlers::get_agent_health)
-            .service(handlers::delete_agent_health)
-            .service(handlers::restart_agent_health)
-            // Interruption API routes
-            .service(handlers::list_interruptions)
-            .service(handlers::interruption_count)
-            .service(handlers::interruption_stats)
-            .service(handlers::interruption_session_counts)
-            .service(handlers::interruption_conversation_counts)
-            .service(handlers::list_session_interruptions)
-            .service(handlers::list_conversation_interruptions)
-            .service(handlers::resolve_interruption)
-            .service(handlers::get_interruption)
-            .service(handlers::get_token_savings)
-            // Skill Metrics API routes
-            .service(handlers::skill_metrics_all)
-            .service(handlers::skill_metrics_downloads)
-            .service(handlers::skill_metrics_loads)
-            .service(handlers::skill_metrics_usage_ratio)
-            .service(handlers::skill_metrics_distribution)
-            .service(handlers::skill_metrics_hotness)
-            // Frontend static files (catch-all, must be last)
-            .service(serve_frontend)
+            .configure(configure_routes)
     })
     .bind((host, port))?
     .run()
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::{Arc, RwLock};
+    use std::time::Instant;
+
+    use actix_web::http::StatusCode;
+    use actix_web::test as awtest;
+    use actix_web::{App, web};
+
+    use crate::health::HealthStore;
+
+    use super::{
+        AppState, SecurityObservabilityConfig, configure_routes, serve_frontend,
+        serve_frontend_root,
+    };
+
+    #[test]
+    fn security_observability_config_defaults_to_five_seconds() {
+        let config = SecurityObservabilityConfig::default();
+
+        assert_eq!(config.timeout_ms, 5_000);
+    }
+
+    #[actix_web::test]
+    async fn configure_routes_registers_security_routes_before_static_fallback() {
+        let app = awtest::init_service(
+            App::new()
+                .app_data(test_app_state(0))
+                .configure(configure_routes),
+        )
+        .await;
+        let request = awtest::TestRequest::get()
+            .uri("/api/security/summary?limit=bad")
+            .to_request();
+
+        let response = awtest::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn frontend_routes_handle_root_and_tail_paths() {
+        let app = awtest::init_service(
+            App::new()
+                .service(serve_frontend_root)
+                .service(serve_frontend),
+        )
+        .await;
+
+        let root =
+            awtest::call_service(&app, awtest::TestRequest::get().uri("/").to_request()).await;
+        let tail = awtest::call_service(
+            &app,
+            awtest::TestRequest::get().uri("/missing").to_request(),
+        )
+        .await;
+
+        assert!(root.status().is_success() || root.status() == StatusCode::NOT_FOUND);
+        assert!(tail.status().is_success() || tail.status() == StatusCode::NOT_FOUND);
+    }
+
+    fn test_app_state(timeout_ms: u64) -> web::Data<AppState> {
+        web::Data::new(AppState {
+            storage_path: PathBuf::from(":memory:"),
+            start_time: Instant::now(),
+            health_store: Arc::new(RwLock::new(HealthStore::new())),
+            interruption_store: None,
+            security_observability: SecurityObservabilityConfig { timeout_ms },
+        })
+    }
 }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Adds an AgentSight server-side proxy for agent-sec security observability data.

  This change introduces a Unix socket NDJSON client for the agent-sec daemon and exposes read-only security endpoints through the AgentSight HTTP server,
  including daemon status, security summaries, event queries, and observability session/run/timeline data.

  ## Changes

  - Add `agent_sec` client module for daemon calls over Unix socket
  - Add `/api/security/*` server endpoints that proxy supported daemon methods
  - Normalize daemon/client errors into HTTP responses with retry metadata
  - Register new server routes and module exports
  - Update architecture boundary documentation and checker allowlist for the new dependency path

  ## Test Coverage

  - Added a focused unit test for daemon response deserialization, covering daemon-owned `request_id` handling.
  - Existing server, pipeline, storage, parser, analyzer, and doctest coverage was exercised through the full `cargo test` suite.


## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
