### PR TITLE
feat(ckpt): add SLS ops log output for dashboard metrics

### DIFF
--- a/src/ws-ckpt/src/Cargo.lock
+++ b/src/ws-ckpt/src/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "nix",
  "notify",
  "seccompiler",
+ "serde",
  "serde_json",
  "sha2",
  "tempfile",

--- a/src/ws-ckpt/src/crates/daemon/Cargo.toml
+++ b/src/ws-ckpt/src/crates/daemon/Cargo.toml
@@ -18,11 +18,14 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 async-trait = "0.1"
 nix = { version = "0.29", features = ["user", "fs"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
-seccompiler = "0.5"
 libc = "0.2"
 notify = "6"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+seccompiler = "0.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/ws-ckpt/src/crates/daemon/src/lib.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/lib.rs
@@ -5,7 +5,9 @@ pub mod fs_watcher;
 pub mod index_store;
 pub mod listener;
 mod lockfile;
+pub mod ops_log;
 pub mod scheduler;
+#[cfg(target_os = "linux")]
 pub mod seccomp;
 pub mod snapshot_mgr;
 mod startup;
@@ -69,6 +71,7 @@ pub async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
     util::ensure_symlinks(&state).await;
 
     // 8. Apply seccomp-bpf syscall filter (after bootstrap, before listener)
+    #[cfg(target_os = "linux")]
     if let Err(e) = seccomp::apply_seccomp_filter() {
         tracing::warn!(
             "Failed to apply seccomp filter: {:#}. Continuing without syscall filtering.",

--- a/src/ws-ckpt/src/crates/daemon/src/listener.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/listener.rs
@@ -112,8 +112,20 @@ async fn handle_connection(
     // Decode request
     let request: Request = decode_payload(&payload).context("Failed to decode request")?;
 
+    let agent_name = stream
+        .peer_cred()
+        .ok()
+        .and_then(|cred| cred.pid().map(|p| p as u32))
+        .map(crate::ops_log::detect_agent_name)
+        .unwrap_or_else(|| "user".to_string());
+    let ops_name = crate::ops_log::ops_name_from_request(&request);
+
     // Dispatch
     let response = crate::dispatcher::dispatch(&state, request).await;
+
+    if let Some(name) = ops_name {
+        crate::ops_log::log_operation(name, &agent_name, &response);
+    }
 
     // Encode and write response
     let frame = encode_frame(&response).context("Failed to encode response")?;

--- a/src/ws-ckpt/src/crates/daemon/src/ops_log.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/ops_log.rs
@@ -1,0 +1,252 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::Serialize;
+use ws_ckpt_common::{Request, Response};
+
+const OPS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/ws-ckpt.jsonl";
+const KNOWN_AGENTS: &[&str] = &["user", "hermes", "openclaw"];
+static OPS_SEQ: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Serialize)]
+struct OpsRecord<'a> {
+    #[serde(rename = "component.name")]
+    component_name: &'static str,
+    #[serde(rename = "component.version")]
+    component_version: &'static str,
+    #[serde(rename = "component.agent_name")]
+    component_agent_name: &'a str,
+    ops_id: String,
+    ops_name: &'static str,
+    ckpt_time: u32,
+    roll_time: u32,
+    diff_time: u32,
+    list_time: u32,
+    ops_time: u32,
+    err_reason: &'a str,
+    supply: &'a str,
+}
+
+pub fn ops_name_from_request(req: &Request) -> Option<&'static str> {
+    match req {
+        Request::Checkpoint { .. } => Some("ckpt"),
+        Request::Rollback { .. } => Some("roll"),
+        Request::Diff { .. } => Some("diff"),
+        Request::List { .. } => Some("list"),
+        Request::Config
+        | Request::ReloadConfig
+        | Request::ReloadGlobalConfig
+        | Request::ConfigOverview
+        | Request::GetWorkspacePolicy { .. }
+        | Request::ResetWorkspacePolicy { .. }
+        | Request::PatchWorkspacePolicy { .. }
+        | Request::ReloadWorkspacePolicy { .. } => Some("config"),
+        _ => None,
+    }
+}
+
+/// Read `WS_CKPT_AGENT_NAME` from `/proc/{pid}/environ`.
+/// Env unset → `"user"` (direct CLI). Env set but not in whitelist → `"unknown"`.
+pub fn detect_agent_name(pid: u32) -> String {
+    let path = format!("/proc/{pid}/environ");
+    let Ok(data) = std::fs::read(&path) else {
+        return "user".to_string();
+    };
+    for entry in data.split(|&b| b == 0) {
+        if let Some(val) = entry.strip_prefix(b"WS_CKPT_AGENT_NAME=") {
+            return match std::str::from_utf8(val) {
+                Ok(s) if KNOWN_AGENTS.contains(&s) => s.to_string(),
+                _ => "unknown".to_string(),
+            };
+        }
+    }
+    "user".to_string()
+}
+
+pub fn log_operation(ops_name: &'static str, agent_name: &str, response: &Response) {
+    let err_reason = match response {
+        Response::Error { message, .. } => message.as_str(),
+        _ => "none",
+    };
+
+    let record = OpsRecord {
+        component_name: "ws-ckpt",
+        component_version: env!("CARGO_PKG_VERSION"),
+        component_agent_name: agent_name,
+        ops_id: format!(
+            "{}-{}-{}",
+            chrono::Utc::now().timestamp_millis(),
+            std::process::id(),
+            OPS_SEQ.fetch_add(1, Ordering::Relaxed),
+        ),
+        ops_name,
+        ckpt_time: u32::from(ops_name == "ckpt"),
+        roll_time: u32::from(ops_name == "roll"),
+        diff_time: u32::from(ops_name == "diff"),
+        list_time: u32::from(ops_name == "list"),
+        ops_time: 1,
+        err_reason,
+        supply: "none",
+    };
+
+    if let Err(e) = write_record(&record) {
+        tracing::warn!("ops log write failed: {e}");
+    }
+}
+
+fn write_record(record: &OpsRecord<'_>) -> std::io::Result<()> {
+    let mut line = serde_json::to_string(record)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    line.push('\n');
+
+    let mut file = OpenOptions::new().append(true).open(OPS_LOG_PATH)?;
+    file.write_all(line.as_bytes())?;
+    file.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ops_name_mapping() {
+        let ckpt = Request::Checkpoint {
+            workspace: "w".into(),
+            id: "id".into(),
+            message: None,
+            metadata: None,
+            pin: false,
+        };
+        assert_eq!(ops_name_from_request(&ckpt), Some("ckpt"));
+
+        let roll = Request::Rollback {
+            workspace: "w".into(),
+            to: None,
+            num_ancestors: None,
+        };
+        assert_eq!(ops_name_from_request(&roll), Some("roll"));
+
+        let diff = Request::Diff {
+            workspace: "w".into(),
+            from: "a".into(),
+            to: None,
+        };
+        assert_eq!(ops_name_from_request(&diff), Some("diff"));
+
+        let list = Request::List {
+            workspace: Some("w".into()),
+            format: None,
+        };
+        assert_eq!(ops_name_from_request(&list), Some("list"));
+
+        assert_eq!(ops_name_from_request(&Request::Config), Some("config"));
+        assert_eq!(
+            ops_name_from_request(&Request::ReloadConfig),
+            Some("config")
+        );
+        assert_eq!(
+            ops_name_from_request(&Request::ConfigOverview),
+            Some("config")
+        );
+
+        let init = Request::Init {
+            workspace: "w".into(),
+        };
+        assert_eq!(ops_name_from_request(&init), None);
+
+        assert_eq!(ops_name_from_request(&Request::HealthAdvisory), None);
+    }
+
+    #[test]
+    fn record_serialization() {
+        let record = OpsRecord {
+            component_name: "ws-ckpt",
+            component_version: "0.3.3",
+            component_agent_name: "user",
+            ops_id: "1719100800000-1234".to_string(),
+            ops_name: "ckpt",
+            ckpt_time: 1,
+            roll_time: 0,
+            diff_time: 0,
+            list_time: 0,
+            ops_time: 1,
+            err_reason: "none",
+            supply: "none",
+        };
+
+        let json = serde_json::to_string(&record).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+
+        assert_eq!(parsed["component.name"], "ws-ckpt");
+        assert_eq!(parsed["component.version"], "0.3.3");
+        assert_eq!(parsed["component.agent_name"], "user");
+        assert_eq!(parsed["ops_name"], "ckpt");
+        assert_eq!(parsed["ckpt_time"], 1);
+        assert_eq!(parsed["roll_time"], 0);
+        assert_eq!(parsed["ops_time"], 1);
+        assert_eq!(parsed["err_reason"], "none");
+    }
+
+    #[test]
+    fn record_with_error() {
+        let record = OpsRecord {
+            component_name: "ws-ckpt",
+            component_version: "0.3.3",
+            component_agent_name: "hermes",
+            ops_id: "1719100800000-1234".to_string(),
+            ops_name: "roll",
+            ckpt_time: 0,
+            roll_time: 1,
+            diff_time: 0,
+            list_time: 0,
+            ops_time: 1,
+            err_reason: "snapshot not found",
+            supply: "none",
+        };
+
+        let json = serde_json::to_string(&record).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+
+        assert_eq!(parsed["component.agent_name"], "hermes");
+        assert_eq!(parsed["ops_name"], "roll");
+        assert_eq!(parsed["roll_time"], 1);
+        assert_eq!(parsed["ckpt_time"], 0);
+        assert_eq!(parsed["err_reason"], "snapshot not found");
+    }
+
+    #[test]
+    fn write_to_tempfile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ws-ckpt.jsonl");
+        std::fs::File::create(&path).expect("create");
+
+        let record = OpsRecord {
+            component_name: "ws-ckpt",
+            component_version: "0.3.3",
+            component_agent_name: "user",
+            ops_id: "test-id".to_string(),
+            ops_name: "list",
+            ckpt_time: 0,
+            roll_time: 0,
+            diff_time: 0,
+            list_time: 1,
+            ops_time: 1,
+            err_reason: "none",
+            supply: "none",
+        };
+
+        let mut line = serde_json::to_string(&record).expect("serialize");
+        line.push('\n');
+        let mut file = OpenOptions::new().append(true).open(&path).expect("open");
+        file.write_all(line.as_bytes()).expect("write");
+        file.flush().expect("flush");
+
+        let contents = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(contents.lines().count(), 1);
+        let parsed: serde_json::Value =
+            serde_json::from_str(contents.lines().next().unwrap()).expect("parse");
+        assert_eq!(parsed["ops_name"], "list");
+        assert_eq!(parsed["list_time"], 1);
+    }
+}

--- a/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
+++ b/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
@@ -130,6 +130,7 @@ class CheckpointManager:
                 capture_output=True,
                 text=True,
                 timeout=DEFAULT_TIMEOUT_S,
+                env={**os.environ, "WS_CKPT_AGENT_NAME": "hermes"},
             )
             return CommandOutput(
                 exit_code=result.returncode,

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -14,6 +14,7 @@ Tool surface mirrors the OpenClaw plugin (`ws-ckpt-*`):
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from typing import Any, Dict, Optional, Tuple
@@ -58,7 +59,10 @@ def _reject_if_cwd_inside_workspace(workspace: str) -> Optional[str]:
 def _run_ws_ckpt_cmd(cmd: list) -> Tuple[bool, str]:
     """Execute a ws-ckpt CLI command and return (success, output)."""
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=30,
+            env={**os.environ, "WS_CKPT_AGENT_NAME": "hermes"},
+        )
         return result.returncode == 0, result.stdout.strip() or result.stderr.strip()
     except subprocess.TimeoutExpired:
         return False, "Command timed out (30s)"

--- a/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
@@ -266,6 +266,7 @@ export class CommandExecutor {
       const { stdout, stderr } = await execFileAsync(WS_CKPT_BIN, args, {
         timeout: this.timeoutMs,
         encoding: "utf-8",
+        env: { ...process.env, WS_CKPT_AGENT_NAME: "openclaw" },
       });
 
       return {


### PR DESCRIPTION
## Description

daemon 新增 ops_log 模块，每次用户操作（ckpt/roll/diff/list/config）向
`/var/log/anolisa/sls/ops/ws-ckpt.jsonl` 写入 JSONL 记录，字段符合
Agentic OS 采集数据规范。

通过 `peer_cred()` + `/proc/{pid}/environ` 探测调用者身份，白名单校验
（user/hermes/openclaw），env 未设置回退 "user"，未知值回退 "unknown"。
hermes/openclaw 插件 spawn CLI 时设置 `WS_CKPT_AGENT_NAME` 环境变量。

附带修复：seccompiler 依赖限定 `cfg(target_os = "linux")`，daemon crate
可在 macOS 编译测试。

## Related Issue

no-issue: 新功能，按 Agentic OS 采集数据规范接入 SLS 大盘

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [x] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all --check` 通过
- `cargo clippy --workspace --locked -- -D warnings` 通过
- `cargo test --workspace --locked` 全部 393 测试通过（含 4 个新增 ops_log 测试）
- 已部署验证：JSONL 输出格式正确，示例：
  `{"component.name":"ws-ckpt","component.version":"0.3.3","component.agent_name":"user","ops_id":"1782196720016-242955-52","ops_name":"ckpt","ckpt_time":1,"roll_time":0,"diff_time":0,"list_time":0,"ops_time":1,"err_reason":"none","supply":"none"}`
- 已验证 `WS_CKPT_AGENT_NAME=hermes` 探测正确：
  `{"component.name":"ws-ckpt","component.version":"0.3.3","component.agent_name":"hermes","ops_id":"1782196769688-242955-53","ops_name":"list","ckpt_time":0,"roll_time":0,"diff_time":0,"list_time":1,"ops_time":1,"err_reason":"none","supply":"none"}`

## Additional Notes

插件侧改动极小（各加一行 env 设置），后续如有新 agent 接入，
只需在 ops_log.rs 的 `KNOWN_AGENTS` 白名单中追加即可。