### PR TITLE
fix(ckpt)!: unify checkpoint snapshot flag to --snapshot/-s

### DIFF
--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -131,8 +131,8 @@ enum Commands {
         #[arg(long, short = 'w', value_parser = workspace_value_parser())]
         workspace: String,
 
-        /// Snapshot ID (must be unique within the workspace)
-        #[arg(long = "snapshot", short = 's', required_unless_present = "legacy_id", conflicts_with = "legacy_id", value_parser = snapshot_id_value_parser())]
+        /// Snapshot ID (auto-generated if omitted)
+        #[arg(long = "snapshot", short = 's', conflicts_with = "legacy_id", value_parser = snapshot_id_value_parser())]
         snapshot: Option<String>,
 
         #[arg(long = "id", short = 'i', hide = true, value_parser = snapshot_id_value_parser())]
@@ -332,11 +332,13 @@ async fn run(cli: Cli) -> Result<()> {
             message,
             metadata,
         } => {
-            let id = if let Some(legacy) = legacy_id {
-                eprintln!("Warning: --id/-i is deprecated, use --snapshot/-s instead");
-                legacy
-            } else {
-                snapshot.expect("clap should require either snapshot or legacy_id")
+            let id = match (snapshot, legacy_id) {
+                (_, Some(legacy)) => {
+                    eprintln!("Warning: --id/-i is deprecated, use --snapshot/-s instead");
+                    legacy
+                }
+                (Some(s), _) => s,
+                (None, None) => generate_auto_id(),
             };
             // Validate metadata is valid JSON if provided
             if let Some(ref s) = metadata {
@@ -467,6 +469,12 @@ fn snapshot_id_value_parser() -> impl TypedValueParser<Value = String> {
         }
         Ok(s)
     })
+}
+
+fn generate_auto_id() -> String {
+    chrono::Utc::now()
+        .format("ckpt-%Y%m%dT%H%M%S%.3f")
+        .to_string()
 }
 
 /// Resolve workspace identifier: convert filesystem paths to absolute,
@@ -2237,9 +2245,41 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_missing_snapshot_fails() {
-        let result = Cli::try_parse_from(["ws-ckpt", "checkpoint", "--workspace", "/ws"]);
-        assert!(result.is_err(), "checkpoint without --snapshot should fail");
+    fn checkpoint_missing_snapshot_parses_as_none() {
+        let cli = Cli::try_parse_from(["ws-ckpt", "checkpoint", "--workspace", "/ws"]).unwrap();
+        match cli.command {
+            Commands::Checkpoint {
+                snapshot,
+                legacy_id,
+                ..
+            } => {
+                assert!(snapshot.is_none());
+                assert!(legacy_id.is_none());
+            }
+            _ => panic!("expected Checkpoint"),
+        }
+    }
+
+    #[test]
+    fn generate_auto_id_matches_expected_format() {
+        let id = generate_auto_id();
+        assert!(
+            id.starts_with("ckpt-"),
+            "auto id should start with ckpt- prefix"
+        );
+        assert_eq!(
+            id.len(),
+            "ckpt-YYYYMMDDTHHmmss.fff".len(),
+            "auto id {:?} has unexpected length",
+            id
+        );
+        let body = &id[5..];
+        assert!(
+            body.chars()
+                .all(|c| c.is_ascii_digit() || c == 'T' || c == '.'),
+            "auto id body {:?} contains unexpected characters",
+            body
+        );
     }
 
     #[test]

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -132,8 +132,11 @@ enum Commands {
         workspace: String,
 
         /// Snapshot ID (must be unique within the workspace)
-        #[arg(long, short = 'i', value_parser = snapshot_id_value_parser())]
-        id: String,
+        #[arg(long = "snapshot", short = 's', required_unless_present = "legacy_id", conflicts_with = "legacy_id", value_parser = snapshot_id_value_parser())]
+        snapshot: Option<String>,
+
+        #[arg(long = "id", short = 'i', hide = true, value_parser = snapshot_id_value_parser())]
+        legacy_id: Option<String>,
 
         /// Commit message describing the checkpoint
         #[arg(long, short = 'm')]
@@ -324,10 +327,17 @@ async fn run(cli: Cli) -> Result<()> {
         }
         Commands::Checkpoint {
             workspace,
-            id,
+            snapshot,
+            legacy_id,
             message,
             metadata,
         } => {
+            let id = if let Some(legacy) = legacy_id {
+                eprintln!("Warning: --id/-i is deprecated, use --snapshot/-s instead");
+                legacy
+            } else {
+                snapshot.expect("clap should require either snapshot or legacy_id")
+            };
             // Validate metadata is valid JSON if provided
             if let Some(ref s) = metadata {
                 serde_json::from_str::<serde_json::Value>(s)
@@ -1755,7 +1765,7 @@ mod tests {
         // subcommands. Tested independently for each blank value.
         let trailing: &[(&str, &[&str])] = &[
             ("init", &[]),
-            ("checkpoint", &["-i", "snap-1"]),
+            ("checkpoint", &["-s", "snap-1"]),
             ("rollback", &["-s", "snap-1"]),
             ("delete", &["-s", "snap-1"]),
             ("list", &[]),
@@ -1811,7 +1821,7 @@ mod tests {
             "checkpoint",
             "--workspace",
             "/tmp/test",
-            "--id",
+            "--snapshot",
             "msg1-step0",
             "-m",
             "save point",
@@ -1822,12 +1832,13 @@ mod tests {
         match cli.command {
             Commands::Checkpoint {
                 workspace,
-                id,
+                snapshot,
                 message,
                 metadata,
+                ..
             } => {
                 assert_eq!(workspace, "/tmp/test");
-                assert_eq!(id, "msg1-step0");
+                assert_eq!(snapshot.as_deref(), Some("msg1-step0"));
                 assert_eq!(message.as_deref(), Some("save point"));
                 assert_eq!(metadata.as_deref(), Some(r#"{"key":"value"}"#));
             }
@@ -1842,18 +1853,18 @@ mod tests {
             "checkpoint",
             "--workspace",
             "/ws",
-            "--id",
+            "--snapshot",
             "snap-1",
         ])
         .unwrap();
         match cli.command {
             Commands::Checkpoint {
-                id,
+                snapshot,
                 message,
                 metadata,
                 ..
             } => {
-                assert_eq!(id, "snap-1");
+                assert_eq!(snapshot.as_deref(), Some("snap-1"));
                 assert!(message.is_none());
                 assert!(metadata.is_none());
             }
@@ -1868,7 +1879,7 @@ mod tests {
             "checkpoint",
             "--workspace",
             "/ws",
-            "--id",
+            "--snapshot",
             "snap-1",
             "-m",
             "备注",
@@ -1885,7 +1896,7 @@ mod tests {
     #[test]
     fn parse_rejects_empty_or_whitespace_checkpoint_id() {
         for blank in ["", " ", "   ", "\t"] {
-            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", blank])
+            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-s", blank])
                 .err()
                 .unwrap_or_else(|| panic!("expected parse error for id {:?}", blank));
             assert_eq!(
@@ -1901,7 +1912,7 @@ mod tests {
     #[test]
     fn parse_rejects_checkpoint_id_with_path_separators() {
         for bad in ["foo/bar", "..", ".", "a\\b", "/abs"] {
-            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", bad])
+            let err = Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-s", bad])
                 .err()
                 .unwrap_or_else(|| panic!("expected parse error for id {:?}", bad));
             assert_eq!(
@@ -1917,9 +1928,89 @@ mod tests {
     #[test]
     fn parse_accepts_reasonable_checkpoint_ids() {
         for good in ["snap-1", "msg1-step2", "before-refactor", "v1.2.3"] {
-            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", good])
+            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-s", good])
                 .unwrap_or_else(|_| panic!("expected acceptance for id {:?}", good));
         }
+    }
+
+    #[test]
+    fn parse_checkpoint_accepts_snapshot_and_legacy_id_flags() {
+        // Primary: --snapshot / -s → snapshot field
+        let cli =
+            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "--snapshot", "snap-1"])
+                .unwrap();
+        match &cli.command {
+            Commands::Checkpoint {
+                snapshot,
+                legacy_id,
+                ..
+            } => {
+                assert_eq!(snapshot.as_deref(), Some("snap-1"));
+                assert!(legacy_id.is_none());
+            }
+            _ => panic!("expected Checkpoint"),
+        }
+
+        let cli =
+            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-s", "snap-2"]).unwrap();
+        match &cli.command {
+            Commands::Checkpoint {
+                snapshot,
+                legacy_id,
+                ..
+            } => {
+                assert_eq!(snapshot.as_deref(), Some("snap-2"));
+                assert!(legacy_id.is_none());
+            }
+            _ => panic!("expected Checkpoint"),
+        }
+
+        // Legacy alias: --id / -i → legacy_id field (still parses correctly).
+        let cli =
+            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "--id", "snap-3"]).unwrap();
+        match &cli.command {
+            Commands::Checkpoint {
+                snapshot,
+                legacy_id,
+                ..
+            } => {
+                assert!(snapshot.is_none());
+                assert_eq!(legacy_id.as_deref(), Some("snap-3"));
+            }
+            _ => panic!("expected Checkpoint"),
+        }
+
+        let cli =
+            Cli::try_parse_from(["ws-ckpt", "checkpoint", "-w", "/ws", "-i", "snap-4"]).unwrap();
+        match &cli.command {
+            Commands::Checkpoint {
+                snapshot,
+                legacy_id,
+                ..
+            } => {
+                assert!(snapshot.is_none());
+                assert_eq!(legacy_id.as_deref(), Some("snap-4"));
+            }
+            _ => panic!("expected Checkpoint"),
+        }
+    }
+
+    #[test]
+    fn parse_checkpoint_rejects_both_snapshot_and_id() {
+        let result = Cli::try_parse_from([
+            "ws-ckpt",
+            "checkpoint",
+            "-w",
+            "/ws",
+            "--snapshot",
+            "snap-1",
+            "--id",
+            "snap-2",
+        ]);
+        assert!(
+            result.is_err(),
+            "--snapshot and --id should be mutually exclusive"
+        );
     }
 
     // Cases that go through `snapshot_id_value_parser`. Each row is
@@ -2138,7 +2229,7 @@ mod tests {
 
     #[test]
     fn checkpoint_missing_workspace_fails() {
-        let result = Cli::try_parse_from(["ws-ckpt", "checkpoint", "--id", "snap-1"]);
+        let result = Cli::try_parse_from(["ws-ckpt", "checkpoint", "--snapshot", "snap-1"]);
         assert!(
             result.is_err(),
             "checkpoint without --workspace should fail"
@@ -2146,9 +2237,9 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_missing_id_fails() {
+    fn checkpoint_missing_snapshot_fails() {
         let result = Cli::try_parse_from(["ws-ckpt", "checkpoint", "--workspace", "/ws"]);
-        assert!(result.is_err(), "checkpoint without --id should fail");
+        assert!(result.is_err(), "checkpoint without --snapshot should fail");
     }
 
     #[test]
@@ -2177,7 +2268,7 @@ mod tests {
             "checkpoint",
             "--workspace",
             "/ws",
-            "--id",
+            "--snapshot",
             "snap-1",
             "--metadata",
             r#"{"key":"value"}"#,
@@ -2202,7 +2293,7 @@ mod tests {
             "checkpoint",
             "--workspace",
             "/ws",
-            "--id",
+            "--snapshot",
             "snap-1",
             "--metadata",
             "not-json",


### PR DESCRIPTION
## Description

- checkpoint 子命令的快照参数从 `--id/-i` 改为 `--snapshot/-s`，与 rollback、delete 保持一致

用户使用 ws-ckpt 时，创建快照用 `-i/--id`，回滚用 `--snapshot/-s`，参数名不一致导致操作报错。
统一为 `--snapshot/-s` 降低记忆成本，所有快照标识参数现在都使用相同的 flag。

- 无id提供时auto id 自动生成id 方便高频操作

由于该需求和ckpt参数耦合，因此在同一个pr进行

## Related Issue

no-issue: 来源于体验专项反馈，无对应 GitHub issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing


## Additional Notes
