### PR TITLE
fix(agentsight): use namespace PID in udpdns and tcpsniff probes

### DIFF
--- a/src/agentsight/src/bpf/tcpsniff.bpf.c
+++ b/src/agentsight/src/bpf/tcpsniff.bpf.c
@@ -207,7 +207,7 @@ static __always_inline int emit_tcp_event_buf(
     data->source = EVENT_SOURCE_SSL;  // reuse SSL source for seamless pipeline
     data->timestamp_ns = now;
     data->delta_ns = (start_ns > 0) ? (now - start_ns) : 0;
-    data->pid = (u32)(pid_tgid >> 32);
+    data->pid = current_ns_pid();
     data->tid = (u32)pid_tgid;
     data->uid = bpf_get_current_uid_gid();
     data->len = data_len;
@@ -306,7 +306,7 @@ int BPF_PROG(trace_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
     data->source = EVENT_SOURCE_SSL;
     data->timestamp_ns = now;
     data->delta_ns = 0;
-    data->pid = (u32)(pid_tgid >> 32);
+    data->pid = current_ns_pid();
     data->tid = (u32)pid_tgid;
     data->uid = bpf_get_current_uid_gid();
     data->len = (u32)size;

--- a/src/agentsight/src/bpf/udpdns.bpf.c
+++ b/src/agentsight/src/bpf/udpdns.bpf.c
@@ -89,7 +89,7 @@ int BPF_PROG(trace_udp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
     __u32 tid = (__u32)pid_tgid;
 
     // Skip processes already being traced - no need to discover them again
-    if (bpf_map_lookup_elem(&traced_processes, &pid))
+    if (is_pid_traced(pid))
         return 0;
 
     struct dns_buf_info buf = get_dns_buf_info(msg);
@@ -130,7 +130,7 @@ int BPF_PROG(trace_udp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size
     // Fill event metadata
     event->source = EVENT_SOURCE_UDPDNS;
     event->timestamp_ns = bpf_ktime_get_ns();
-    event->pid = pid;
+    event->pid = current_ns_pid();
     event->tid = tid;
     event->uid = bpf_get_current_uid_gid();
     event->payload_len = read_len;


### PR DESCRIPTION
## Summary
- Fix UDP-DNS probe to use `is_pid_traced()` for traced-process filtering and `current_ns_pid()` for event PID, matching procmon/sslsniff behavior.
- Fix tcpsniff to emit namespace PID via `current_ns_pid()` instead of host PID from `pid_tgid >> 32`.
- Resolves K8s sidecar (`shareProcessNamespace: true`) scenarios where userspace could not read `/proc/<pid>/cmdline`, causing 0 attach and 0 GenAI data.

## Test plan
- [ ] Deploy in swe-agent K8s sidecar pod with `shareProcessNamespace: true`
- [ ] Verify udpdns events report pod-namespace PID (readable cmdline)
- [ ] Confirm `[attach_process]` logs appear after DNS discovery
- [ ] Verify DashScope LLM calls produce GenAI semantic events in SLS