### PR TITLE
feat(tokenless): add compression toggle with dry-run compare mode

### DIFF
--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- add compression toggle with dry-run compare mode (`TOKENLESS_COMPRESSION_ENABLED`, `stats summary --compare`)
+
 ## 0.5.1
 
 - add --json output to stats summary

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -6,9 +6,13 @@ use std::fs;
 use std::io::{self, Read};
 use std::process;
 use tokenless_schema::{ResponseCompressor, SchemaCompressor};
-use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, TokenlessConfig};
+use tokenless_stats::{
+    CompressionMode, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
+};
 use tokenless_stats::{estimate_tokens, estimate_tokens_from_bytes};
-use tokenless_stats::{format_list, format_show, format_summary};
+use tokenless_stats::{
+    format_compare, format_compare_json, format_list, format_show, format_summary,
+};
 
 #[derive(Parser)]
 #[command(
@@ -114,6 +118,10 @@ enum StatsCommands {
         /// Output machine-readable JSON
         #[arg(long)]
         json: bool,
+        /// Compare two runs by session: baseline (compression-off) vs tokenless (compression-on).
+        /// Provide exactly two session IDs.
+        #[arg(long, num_args = 2, value_names = ["BASELINE_SESSION", "TOKENLESS_SESSION"])]
+        compare: Option<Vec<String>>,
     },
     /// List recent records
     List {
@@ -325,7 +333,14 @@ fn run() -> Result<(), (String, i32)> {
                 after_compact.clone()
             };
 
-            println!("{}", output_text);
+            let compression_on = TokenlessConfig::load().is_compression_enabled();
+            let mode = resolve_mode(compression_on, before_tokens, after_tokens);
+            let emit_text = if compression_on {
+                output_text.clone()
+            } else {
+                input.clone()
+            };
+            println!("{}", emit_text);
 
             record_compression_stats(
                 OperationType::CompressSchema,
@@ -334,6 +349,7 @@ fn run() -> Result<(), (String, i32)> {
                 tool_use_id,
                 input,
                 output_text,
+                mode,
             );
         }
         Commands::CompressResponse {
@@ -374,7 +390,14 @@ fn run() -> Result<(), (String, i32)> {
                 after_compact.clone()
             };
 
-            println!("{}", output_text);
+            let compression_on = TokenlessConfig::load().is_compression_enabled();
+            let mode = resolve_mode(compression_on, before_tokens, after_tokens);
+            let emit_text = if compression_on {
+                output_text.clone()
+            } else {
+                input.clone()
+            };
+            println!("{}", emit_text);
 
             record_compression_stats(
                 OperationType::CompressResponse,
@@ -383,13 +406,38 @@ fn run() -> Result<(), (String, i32)> {
                 tool_use_id,
                 input,
                 output_text,
+                mode,
             );
         }
         Commands::Stats(stats_cmd) => {
             let recorder = open_recorder()?;
 
             match stats_cmd {
-                StatsCommands::Summary { limit, json } => {
+                StatsCommands::Summary {
+                    limit,
+                    json,
+                    compare,
+                } => {
+                    if let Some(sessions) = compare {
+                        let baseline_sid = sessions[0].as_str();
+                        let tokenless_sid = sessions[1].as_str();
+                        let baseline = recorder
+                            .records_by_session(baseline_sid, limit)
+                            .map_err(|e| (format!("Failed to query baseline: {}", e), 1))?;
+                        let tokenless = recorder
+                            .records_by_session(tokenless_sid, limit)
+                            .map_err(|e| (format!("Failed to query tokenless: {}", e), 1))?;
+                        // Warn if a session's records do not match the expected mode,
+                        // i.e. the baseline run was not recorded as dry-run.
+                        warn_mode_mismatch("baseline", &baseline, CompressionMode::DryRun);
+                        warn_mode_mismatch("tokenless", &tokenless, CompressionMode::Active);
+                        if json {
+                            println!("{}", format_compare_json(&baseline, &tokenless));
+                        } else {
+                            println!("{}", format_compare(&baseline, &tokenless));
+                        }
+                        return Ok(());
+                    }
                     let records = recorder
                         .all_records(limit)
                         .map_err(|e| (format!("Failed to query records: {}", e), 1))?;
@@ -507,24 +555,37 @@ fn run() -> Result<(), (String, i32)> {
             // If no token savings, output original instead of TOON result
             let before_tokens = estimate_tokens_from_bytes(input.len());
             let after_tokens = estimate_tokens_from_bytes(output.len());
-            let display = if output.is_empty() || after_tokens >= before_tokens {
+            let no_savings = output.is_empty() || after_tokens >= before_tokens;
+            if no_savings {
                 eprintln!(
                     "tokenless: TOON encoding did not reduce size ({} -> {} est. tokens), outputting original JSON",
                     before_tokens, after_tokens
                 );
-                input.clone()
-            } else {
-                output
-            };
-            println!("{}", display);
+            }
 
+            let compression_on = TokenlessConfig::load().is_compression_enabled();
+            let mode = resolve_mode(compression_on, before_tokens, after_tokens);
+            // Active: emit the TOON result (or original if no savings).
+            // Dry-run: emit the original so context stays uncompressed, but
+            // still record the TOON result as the predicted savings below.
+            let emit_text = if compression_on && !no_savings {
+                output.clone()
+            } else {
+                input.clone()
+            };
+            println!("{}", emit_text);
+
+            // Recorded `after` = the predicted TOON result (or original when
+            // TOON did not reduce size), so dry-run captures the prediction.
+            let record_after = if no_savings { input.clone() } else { output };
             record_compression_stats(
                 OperationType::CompressToon,
                 agent_id,
                 session_id,
                 tool_use_id,
                 input,
-                display,
+                record_after,
+                mode,
             );
         }
         Commands::DecompressToon { file } => {
@@ -552,6 +613,46 @@ fn run() -> Result<(), (String, i32)> {
     Ok(())
 }
 
+/// Resolve the recording mode from the compression toggle.
+///
+/// When compression is disabled (dry-run), the original input is emitted so
+/// the LLM context stays uncompressed, but the predicted savings are still
+/// recorded — enabling A/B comparison of the same task with/without
+/// compression.
+fn resolve_mode(
+    compression_on: bool,
+    before_tokens: usize,
+    after_tokens: usize,
+) -> CompressionMode {
+    if compression_on {
+        CompressionMode::Active
+    } else {
+        eprintln!(
+            "tokenless: dry-run mode (compression disabled) — emitted original, predicted {} -> {} est. tokens",
+            before_tokens, after_tokens
+        );
+        CompressionMode::DryRun
+    }
+}
+
+/// Warn (to stderr) when a session's records were not recorded in the expected
+/// mode, e.g. a "baseline" session that was not run with compression disabled.
+/// A non-blocking sanity hint — comparison still proceeds.
+fn warn_mode_mismatch(label: &str, records: &[StatsRecord], expected: CompressionMode) {
+    if records.is_empty() {
+        return;
+    }
+    let mismatched = records.iter().filter(|r| r.mode != expected).count();
+    if mismatched > 0 {
+        eprintln!(
+            "tokenless: warning — {} session has {} record(s) not in {} mode (comparison may be inaccurate)",
+            label,
+            mismatched,
+            expected.as_str()
+        );
+    }
+}
+
 /// Record compression stats — fail-silent so compression output
 /// is never blocked by database errors.
 ///
@@ -564,6 +665,7 @@ fn record_compression_stats(
     tool_use_id: Option<String>,
     before_text: String,
     after_text: String,
+    mode: CompressionMode,
 ) {
     let config = TokenlessConfig::load();
 
@@ -603,7 +705,7 @@ fn record_compression_stats(
     if let Some(tuid) = tool_use_id {
         record = record.with_tool_use_id(tuid);
     }
-    record = record.with_source_pid(pid as i64);
+    record = record.with_source_pid(pid as i64).with_mode(mode);
 
     // SQLite stats recording — gated by stats_enabled
     if config.is_stats_enabled()

--- a/src/tokenless/crates/tokenless-stats/src/config.rs
+++ b/src/tokenless/crates/tokenless-stats/src/config.rs
@@ -16,6 +16,12 @@ pub struct TokenlessConfig {
     /// Whether SLS integration is enabled (default: false)
     #[serde(default)]
     pub sls_enabled: bool,
+    /// Whether compression is actually applied (default: true).
+    /// When false, tokenless runs in dry-run mode: it computes and records
+    /// the predicted savings but emits the original (uncompressed) text,
+    /// enabling A/B comparison of the same task with/without compression.
+    #[serde(default = "default_true")]
+    pub compression_enabled: bool,
 }
 
 fn default_true() -> bool {
@@ -27,6 +33,7 @@ impl Default for TokenlessConfig {
         Self {
             stats_enabled: true,
             sls_enabled: false,
+            compression_enabled: true,
         }
     }
 }
@@ -59,26 +66,30 @@ impl TokenlessConfig {
         Self::config_path().exists()
     }
 
-    /// Load config with explicit env overrides for both toggles and optional custom path.
+    /// Load config with explicit env overrides for all toggles and optional custom path.
     /// Priority (per toggle): env > config.json file > default
     /// Empty env var values are normalized to None (treated as unset).
-    /// When both env vars are set, skips the config file read entirely.
+    /// When stats and sls envs are both set, skips the config file read entirely
+    /// (compression still defaults to true unless its own env is set).
     pub fn load_with_envs_and_path(
         stats_env: Option<&str>,
         sls_env: Option<&str>,
+        compression_env: Option<&str>,
         path: Option<&PathBuf>,
     ) -> Self {
         // Normalize empty strings to None — an empty env var means "unset".
         let stats_env = stats_env.filter(|v| !v.is_empty());
         let sls_env = sls_env.filter(|v| !v.is_empty());
+        let compression_env = compression_env.filter(|v| !v.is_empty());
 
-        // When both env vars are set, skip the file read entirely.
+        // When both stats and sls env vars are set, skip the file read entirely.
         // This avoids unnecessary I/O when the config file is on a slow
         // or unavailable filesystem (e.g. broken NFS mount).
         if let (Some(stats_val), Some(sls_val)) = (stats_env, sls_env) {
             return Self {
                 stats_enabled: parse_env_bool(stats_val),
                 sls_enabled: parse_env_bool(sls_val),
+                compression_enabled: compression_env.map(parse_env_bool).unwrap_or(true),
             };
         }
 
@@ -101,21 +112,28 @@ impl TokenlessConfig {
             base.sls_enabled
         };
 
+        let compression_enabled = if let Some(val) = compression_env {
+            parse_env_bool(val)
+        } else {
+            base.compression_enabled
+        };
+
         Self {
             stats_enabled,
             sls_enabled,
+            compression_enabled,
         }
     }
 
-    /// Load config with explicit env overrides for both toggles.
+    /// Load config with explicit env overrides for stats and sls toggles.
     pub fn load_with_envs(stats_env: Option<&str>, sls_env: Option<&str>) -> Self {
-        Self::load_with_envs_and_path(stats_env, sls_env, None)
+        Self::load_with_envs_and_path(stats_env, sls_env, None, None)
     }
 
     /// Load config with an explicit env override value and optional custom path.
     /// Backward-compatible wrapper: only overrides stats_enabled.
     pub fn load_with_env_and_path(env_val: Option<&str>, path: Option<&PathBuf>) -> Self {
-        Self::load_with_envs_and_path(env_val, None, path)
+        Self::load_with_envs_and_path(env_val, None, None, path)
     }
 
     /// Load config with an explicit env override value.
@@ -134,7 +152,15 @@ impl TokenlessConfig {
         let sls_env = std::env::var("TOKENLESS_SLS_ENABLED")
             .ok()
             .filter(|v| !v.is_empty());
-        Self::load_with_envs(stats_env.as_deref(), sls_env.as_deref())
+        let compression_env = std::env::var("TOKENLESS_COMPRESSION_ENABLED")
+            .ok()
+            .filter(|v| !v.is_empty());
+        Self::load_with_envs_and_path(
+            stats_env.as_deref(),
+            sls_env.as_deref(),
+            compression_env.as_deref(),
+            None,
+        )
     }
 
     /// Save config to disk.
@@ -163,6 +189,12 @@ impl TokenlessConfig {
     /// Returns true if SLS integration is enabled (env override or file config).
     pub fn is_sls_enabled(&self) -> bool {
         self.sls_enabled
+    }
+
+    /// Returns true if compression is applied (env override or file config).
+    /// When false, tokenless runs in dry-run mode.
+    pub fn is_compression_enabled(&self) -> bool {
+        self.compression_enabled
     }
 }
 
@@ -233,7 +265,7 @@ mod tests {
     fn test_load_sls_missing_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.json");
-        let config = TokenlessConfig::load_with_envs_and_path(None, None, Some(&path));
+        let config = TokenlessConfig::load_with_envs_and_path(None, None, None, Some(&path));
         assert!(!config.is_sls_enabled());
         assert!(config.is_stats_enabled());
     }
@@ -269,7 +301,7 @@ mod tests {
         // Write file config with sls_enabled=true
         let _ = std::fs::write(&path, "{\"stats_enabled\":true,\"sls_enabled\":true}");
         // Env override to disable sls
-        let config = TokenlessConfig::load_with_envs_and_path(None, Some("0"), Some(&path));
+        let config = TokenlessConfig::load_with_envs_and_path(None, Some("0"), None, Some(&path));
         assert!(config.is_stats_enabled());
         assert!(!config.is_sls_enabled());
     }
@@ -292,7 +324,49 @@ mod tests {
         // File config has stats_enabled=true
         let _ = std::fs::write(&path, "{\"stats_enabled\":true}");
         // Empty string should fall through to file config (true), not override to false
-        let config = TokenlessConfig::load_with_envs_and_path(Some(""), None, Some(&path));
+        let config = TokenlessConfig::load_with_envs_and_path(Some(""), None, None, Some(&path));
         assert!(config.is_stats_enabled());
+    }
+
+    #[test]
+    fn test_compression_default_true() {
+        let config = TokenlessConfig::default();
+        assert!(config.is_compression_enabled());
+    }
+
+    #[test]
+    fn test_compression_env_override() {
+        let config = TokenlessConfig::load_with_envs_and_path(None, None, Some("0"), None);
+        assert!(!config.is_compression_enabled());
+
+        let config = TokenlessConfig::load_with_envs_and_path(None, None, Some("1"), None);
+        assert!(config.is_compression_enabled());
+    }
+
+    #[test]
+    fn test_compression_env_overrides_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let _ = std::fs::write(&path, "{\"compression_enabled\":false}");
+        let config = TokenlessConfig::load_with_envs_and_path(None, None, Some("1"), Some(&path));
+        assert!(config.is_compression_enabled());
+    }
+
+    #[test]
+    fn test_compression_file_config_honored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let _ = std::fs::write(&path, "{\"compression_enabled\":false}");
+        let config = TokenlessConfig::load_with_envs_and_path(None, None, None, Some(&path));
+        assert!(!config.is_compression_enabled());
+    }
+
+    #[test]
+    fn test_compression_empty_env_treated_as_unset() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let _ = std::fs::write(&path, "{\"compression_enabled\":false}");
+        let config = TokenlessConfig::load_with_envs_and_path(None, None, Some(""), Some(&path));
+        assert!(!config.is_compression_enabled());
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -12,11 +12,14 @@ pub mod recorder;
 pub mod sls;
 pub mod tokenizer;
 
-pub use record::{OperationType, StatsRecord};
+pub use record::{CompressionMode, OperationType, StatsRecord};
 
 pub use recorder::{StatsError, StatsRecorder, StatsResult, StatsSummary};
 
-pub use query::{format_list, format_show, format_summary, format_summary_json};
+pub use query::{
+    format_compare, format_compare_json, format_list, format_show, format_summary,
+    format_summary_json,
+};
 
 pub use tokenizer::{Tokenizer, count_chars, estimate_tokens, estimate_tokens_from_bytes};
 

--- a/src/tokenless/crates/tokenless-stats/src/query.rs
+++ b/src/tokenless/crates/tokenless-stats/src/query.rs
@@ -215,10 +215,119 @@ pub fn format_show(record: &StatsRecord) -> String {
     output
 }
 
+/// Sum tokens by operation type. `use_before` selects `before_tokens` (the
+/// raw/baseline context) when true, else `after_tokens` (the compressed
+/// context actually seen under tokenless).
+fn tokens_by_op(records: &[StatsRecord], use_before: bool) -> BTreeMap<&'static str, usize> {
+    let mut map: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for r in records {
+        let t = if use_before {
+            r.before_tokens
+        } else {
+            r.after_tokens
+        };
+        *map.entry(r.operation.as_str()).or_default() += t;
+    }
+    map
+}
+
+/// Format a side-by-side comparison between a baseline (compression-off /
+/// dry-run) run and a tokenless (compression-on / active) run.
+///
+/// Baseline context uses each record's `before_tokens` (the raw text that
+/// reached the LLM); the tokenless side uses `after_tokens` (the compressed
+/// text). Savings = baseline − tokenless.
+pub fn format_compare(baseline: &[StatsRecord], tokenless: &[StatsRecord]) -> String {
+    let base_by_op = tokens_by_op(baseline, true);
+    let tls_by_op = tokens_by_op(tokenless, false);
+
+    let base_total: usize = base_by_op.values().sum();
+    let tls_total: usize = tls_by_op.values().sum();
+
+    let mut ops: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    ops.extend(base_by_op.keys().copied());
+    ops.extend(tls_by_op.keys().copied());
+
+    let saved_total = base_total.saturating_sub(tls_total);
+    let saved_pct = if base_total > 0 {
+        (saved_total as f64 / base_total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    let mut output = String::new();
+    output.push_str("Tokenless Comparison Report\n");
+    output.push_str(&"=".repeat(60));
+    output.push('\n');
+    output.push_str(&format!(
+        "{:<22}{:>12}{:>14}{:>10}{:>12}\n",
+        "operation", "baseline", "tokenless", "saved", "saved%"
+    ));
+    output.push_str(&"-".repeat(68));
+    output.push('\n');
+
+    for op in ops {
+        let b = *base_by_op.get(op).unwrap_or(&0);
+        let t = *tls_by_op.get(op).unwrap_or(&0);
+        let saved = b.saturating_sub(t);
+        let pct = if b > 0 {
+            (saved as f64 / b as f64) * 100.0
+        } else {
+            0.0
+        };
+        output.push_str(&format!(
+            "{:<22}{:>12}{:>14}{:>10}{:>11.1}%\n",
+            op, b, t, saved, pct
+        ));
+    }
+
+    output.push_str(&"-".repeat(68));
+    output.push('\n');
+    output.push_str(&format!(
+        "{:<22}{:>12}{:>14}{:>10}{:>11.1}%\n",
+        "TOTAL", base_total, tls_total, saved_total, saved_pct
+    ));
+
+    output
+}
+
+/// Format the comparison as machine-readable JSON.
+pub fn format_compare_json(baseline: &[StatsRecord], tokenless: &[StatsRecord]) -> String {
+    let base_by_op = tokens_by_op(baseline, true);
+    let tls_by_op = tokens_by_op(tokenless, false);
+
+    let base_total: usize = base_by_op.values().sum();
+    let tls_total: usize = tls_by_op.values().sum();
+    let saved_total = base_total.saturating_sub(tls_total);
+    let saved_pct = if base_total > 0 {
+        (saved_total as f64 / base_total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    let by_op_json = |map: &BTreeMap<&str, usize>| -> serde_json::Map<String, serde_json::Value> {
+        map.iter()
+            .map(|(op, &v)| (op.to_string(), serde_json::json!(v)))
+            .collect()
+    };
+
+    let output = serde_json::json!({
+        "schema_version": "1.0",
+        "baseline_tokens": base_total,
+        "tokenless_tokens": tls_total,
+        "saved_tokens": saved_total,
+        "saved_percent": saved_pct,
+        "baseline_by_operation": by_op_json(&base_by_op),
+        "tokenless_by_operation": by_op_json(&tls_by_op),
+    });
+
+    serde_json::to_string_pretty(&output).unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::record::{OperationType, StatsRecord};
+    use crate::record::{CompressionMode, OperationType, StatsRecord};
     use chrono::Local;
 
     fn test_record() -> StatsRecord {
@@ -419,5 +528,92 @@ mod tests {
 
         let output = format_show(&r);
         assert!(output.contains("no text content stored"));
+    }
+
+    fn compare_record(
+        op: OperationType,
+        mode: CompressionMode,
+        before: usize,
+        after: usize,
+    ) -> StatsRecord {
+        let mut r = StatsRecord::new(op, "cli".to_string(), before * 4, before, after * 4, after)
+            .with_mode(mode);
+        r.timestamp = Local::now();
+        r
+    }
+
+    #[test]
+    fn test_format_compare_totals_and_delta() {
+        // Baseline (dry-run): context reached = before_tokens.
+        // Tokenless (active): context reached = after_tokens.
+        let baseline = vec![
+            compare_record(
+                OperationType::CompressSchema,
+                CompressionMode::DryRun,
+                400,
+                200,
+            ),
+            compare_record(
+                OperationType::CompressResponse,
+                CompressionMode::DryRun,
+                1000,
+                300,
+            ),
+        ];
+        let tokenless = vec![
+            compare_record(
+                OperationType::CompressSchema,
+                CompressionMode::Active,
+                400,
+                200,
+            ),
+            compare_record(
+                OperationType::CompressResponse,
+                CompressionMode::Active,
+                1000,
+                300,
+            ),
+        ];
+
+        let out = format_compare(&baseline, &tokenless);
+        // baseline total = 400+1000 = 1400; tokenless total = 200+300 = 500
+        assert!(out.contains("TOTAL"));
+        assert!(out.contains(&format!("{:>12}", 1400)));
+        assert!(out.contains(&format!("{:>14}", 500)));
+        assert!(out.contains("compress-schema"));
+        assert!(out.contains("compress-response"));
+    }
+
+    #[test]
+    fn test_format_compare_json_fields() {
+        let baseline = vec![compare_record(
+            OperationType::CompressSchema,
+            CompressionMode::DryRun,
+            400,
+            200,
+        )];
+        let tokenless = vec![compare_record(
+            OperationType::CompressSchema,
+            CompressionMode::Active,
+            400,
+            200,
+        )];
+        let parsed: serde_json::Value =
+            serde_json::from_str(&format_compare_json(&baseline, &tokenless)).unwrap();
+        assert_eq!(parsed.get("schema_version").unwrap(), "1.0");
+        assert_eq!(parsed.get("baseline_tokens").unwrap(), 400);
+        assert_eq!(parsed.get("tokenless_tokens").unwrap(), 200);
+        assert_eq!(parsed.get("saved_tokens").unwrap(), 200);
+        assert!(parsed.get("saved_percent").unwrap().as_f64().unwrap() > 0.0);
+    }
+
+    #[test]
+    fn test_format_compare_empty() {
+        let out = format_compare(&[], &[]);
+        assert!(out.contains("TOTAL"));
+        // no baseline tokens → saved 0%, no panic
+        let parsed: serde_json::Value =
+            serde_json::from_str(&format_compare_json(&[], &[])).unwrap();
+        assert_eq!(parsed.get("saved_percent").unwrap().as_f64().unwrap(), 0.0);
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/record.rs
+++ b/src/tokenless/crates/tokenless-stats/src/record.rs
@@ -22,7 +22,7 @@ pub enum OperationType {
 }
 
 impl OperationType {
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             OperationType::CompressSchema => "compress-schema",
             OperationType::CompressResponse => "compress-response",
@@ -42,6 +42,40 @@ impl FromStr for OperationType {
             "rewrite-command" => Ok(OperationType::RewriteCommand),
             "compress-toon" => Ok(OperationType::CompressToon),
             other => Err(format!("unknown operation type: {}", other)),
+        }
+    }
+}
+
+/// Whether the compression result was actually applied or only predicted.
+///
+/// `Active` is the normal mode: the compressed output is emitted and reaches
+/// the LLM context. `DryRun` is the toggle-off mode: the compression is
+/// computed (so the predicted savings are recorded) but the original text is
+/// emitted instead — letting the same task run with/without compression to
+/// compare E2E effect.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum CompressionMode {
+    #[default]
+    Active,
+    DryRun,
+}
+
+impl CompressionMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CompressionMode::Active => "active",
+            CompressionMode::DryRun => "dryrun",
+        }
+    }
+
+    /// Parse a stored mode value. Unknown/empty values (legacy rows with no
+    /// `mode` column, or NULLs) fall back to `Active` rather than erroring,
+    /// so historical data remains readable.
+    pub fn from_db(s: &str) -> Self {
+        match s {
+            "dryrun" => CompressionMode::DryRun,
+            _ => CompressionMode::Active,
         }
     }
 }
@@ -79,6 +113,8 @@ pub struct StatsRecord {
     pub before_output: Option<String>,
     /// Rewritten command output (for rewrite-command output comparison)
     pub after_output: Option<String>,
+    /// Whether compression was applied (Active) or only predicted (DryRun)
+    pub mode: CompressionMode,
 }
 
 impl StatsRecord {
@@ -107,6 +143,7 @@ impl StatsRecord {
             after_text: None,
             before_output: None,
             after_output: None,
+            mode: CompressionMode::default(),
         }
     }
 
@@ -125,6 +162,12 @@ impl StatsRecord {
     /// Set the source PID
     pub fn with_source_pid(mut self, pid: i64) -> Self {
         self.source_pid = Some(pid);
+        self
+    }
+
+    /// Set whether compression was applied (Active) or only predicted (DryRun)
+    pub fn with_mode(mut self, mode: CompressionMode) -> Self {
+        self.mode = mode;
         self
     }
 
@@ -303,5 +346,32 @@ mod tests {
         let line = record.format_summary_line();
         assert!(line.contains("copilot-shell"));
         assert!(line.contains("pid:12345"));
+    }
+
+    #[test]
+    fn test_compression_mode_roundtrip() {
+        assert_eq!(CompressionMode::Active.as_str(), "active");
+        assert_eq!(CompressionMode::DryRun.as_str(), "dryrun");
+        assert_eq!(CompressionMode::from_db("active"), CompressionMode::Active);
+        assert_eq!(CompressionMode::from_db("dryrun"), CompressionMode::DryRun);
+        // Unknown / empty (legacy NULL) fall back to Active
+        assert_eq!(CompressionMode::from_db(""), CompressionMode::Active);
+        assert_eq!(CompressionMode::from_db("???"), CompressionMode::Active);
+    }
+
+    #[test]
+    fn test_record_default_mode_active() {
+        let record = StatsRecord::new(
+            OperationType::CompressSchema,
+            "test".to_string(),
+            100,
+            25,
+            80,
+            20,
+        );
+        assert_eq!(record.mode, CompressionMode::Active);
+
+        let record = record.with_mode(CompressionMode::DryRun);
+        assert_eq!(record.mode, CompressionMode::DryRun);
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides SQLite-based storage for compression and rewriting metrics.
 
-use crate::record::{OperationType, StatsRecord};
+use crate::record::{CompressionMode, OperationType, StatsRecord};
 use chrono::DateTime;
 use rusqlite::Connection;
 use std::path::Path;
@@ -63,7 +63,8 @@ impl StatsRecorder {
                 before_text TEXT,
                 after_text TEXT,
                 before_output TEXT,
-                after_output TEXT
+                after_output TEXT,
+                mode TEXT
             )",
             [],
         )?;
@@ -89,7 +90,7 @@ impl StatsRecorder {
         // Use PRAGMA table_info to check column existence before ALTER TABLE
         // instead of relying on error-message string matching, which is
         // fragile across SQLite versions and locales.
-        for col in &["before_output", "after_output"] {
+        for col in &["before_output", "after_output", "mode"] {
             let exists: bool = conn
                 .query_row(
                     "SELECT COUNT(*) FROM pragma_table_info('stats') WHERE name = ?",
@@ -136,8 +137,8 @@ impl StatsRecorder {
                 timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
                 before_chars, before_tokens, after_chars, after_tokens,
                 before_text, after_text,
-                before_output, after_output
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                before_output, after_output, mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             rusqlite::params![
                 record.timestamp.to_rfc3339(),
                 record.operation.as_str(),
@@ -153,6 +154,7 @@ impl StatsRecorder {
                 record.after_text,
                 record.before_output,
                 record.after_output,
+                record.mode.as_str(),
             ],
         )?;
 
@@ -170,7 +172,7 @@ impl StatsRecorder {
         const SELECT_COLS: &str =
             "id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
                         before_chars, before_tokens, after_chars, after_tokens,
-                        before_text, after_text, before_output, after_output";
+                        before_text, after_text, before_output, after_output, mode";
 
         let n = limit.unwrap_or(Self::DEFAULT_LIMIT);
         let mut stmt = conn.prepare(&format!(
@@ -205,7 +207,7 @@ impl StatsRecorder {
         let mut stmt = conn.prepare(
             "SELECT id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
                     before_chars, before_tokens, after_chars, after_tokens,
-                    before_text, after_text, before_output, after_output
+                    before_text, after_text, before_output, after_output, mode
              FROM stats WHERE id = ?",
         )?;
 
@@ -216,6 +218,28 @@ impl StatsRecorder {
         } else {
             Ok(None)
         }
+    }
+
+    /// Query all records for a given session, newest first, with optional limit.
+    pub fn records_by_session(
+        &self,
+        session_id: &str,
+        limit: Option<usize>,
+    ) -> StatsResult<Vec<StatsRecord>> {
+        let conn = self.lock_conn();
+
+        const SELECT_COLS: &str =
+            "id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
+                        before_chars, before_tokens, after_chars, after_tokens,
+                        before_text, after_text, before_output, after_output, mode";
+
+        let n = limit.unwrap_or(Self::DEFAULT_LIMIT);
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {} FROM stats WHERE session_id = ? ORDER BY timestamp DESC LIMIT ?",
+            SELECT_COLS
+        ))?;
+        let rows = stmt.query_map(rusqlite::params![session_id, n as i64], Self::row_to_record)?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
     /// Get record count
@@ -270,6 +294,7 @@ impl StatsRecorder {
             after_text: row.get(12)?,
             before_output: row.get(13)?,
             after_output: row.get(14)?,
+            mode: CompressionMode::from_db(&row.get::<_, Option<String>>(15)?.unwrap_or_default()),
         })
     }
 }
@@ -331,5 +356,82 @@ impl StatsSummary {
         }
 
         summary
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::OperationType;
+
+    fn new_recorder() -> StatsRecorder {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("stats.db");
+        std::mem::forget(dir); // keep dir for test lifetime
+        StatsRecorder::new(&db).unwrap()
+    }
+
+    fn sample(op: OperationType, mode: CompressionMode, session: &str) -> StatsRecord {
+        StatsRecord::new(op, "cli".to_string(), 1000, 400, 500, 200)
+            .with_session_id(session)
+            .with_mode(mode)
+    }
+
+    #[test]
+    fn records_and_reads_mode() {
+        let rec = new_recorder();
+        let id = rec
+            .record(&sample(
+                OperationType::CompressSchema,
+                CompressionMode::DryRun,
+                "s1",
+            ))
+            .unwrap();
+        let got = rec.record_by_id(id).unwrap().unwrap();
+        assert_eq!(got.mode, CompressionMode::DryRun);
+        assert_eq!(got.session_id.as_deref(), Some("s1"));
+    }
+
+    #[test]
+    fn default_mode_is_active() {
+        let rec = new_recorder();
+        let id = rec
+            .record(&sample(
+                OperationType::CompressSchema,
+                CompressionMode::Active,
+                "s1",
+            ))
+            .unwrap();
+        let got = rec.record_by_id(id).unwrap().unwrap();
+        assert_eq!(got.mode, CompressionMode::Active);
+    }
+
+    #[test]
+    fn records_by_session_filters() {
+        let rec = new_recorder();
+        rec.record(&sample(
+            OperationType::CompressResponse,
+            CompressionMode::Active,
+            "baseline",
+        ))
+        .unwrap();
+        rec.record(&sample(
+            OperationType::CompressResponse,
+            CompressionMode::DryRun,
+            "tokenless",
+        ))
+        .unwrap();
+        rec.record(&sample(
+            OperationType::CompressResponse,
+            CompressionMode::Active,
+            "baseline",
+        ))
+        .unwrap();
+
+        let baseline = rec.records_by_session("baseline", None).unwrap();
+        let tokenless = rec.records_by_session("tokenless", None).unwrap();
+        assert_eq!(baseline.len(), 2);
+        assert_eq!(tokenless.len(), 1);
+        assert_eq!(tokenless[0].mode, CompressionMode::DryRun);
     }
 }

--- a/src/tokenless/docs/tokenless-user-manual-en.md
+++ b/src/tokenless/docs/tokenless-user-manual-en.md
@@ -798,6 +798,28 @@ tokenless stats show <record-id>  # Show before/after text for a record
 tokenless stats summary           # Aggregate savings across all operations
 ```
 
+#### Compression toggle and dry-run comparison (dual-run)
+
+Control whether compression is actually applied via `TOKENLESS_COMPRESSION_ENABLED` (or `compression_enabled` in `~/.tokenless/config.json`):
+
+- `1` (default): normal compression; the compressed output reaches the LLM context, recorded with `mode=active`.
+- `0` (**dry-run mode**): compression is computed and the predicted savings are recorded (`mode=dryrun`), but the **original text is emitted**, leaving the LLM context uncompressed.
+
+Run the same task twice (once with compression off, once on) to produce a comparison chart that accurately reflects tokenless savings:
+
+```bash
+# Run 1: compression off (dry-run baseline, emits original)
+TOKENLESS_COMPRESSION_ENABLED=0  <run the same task>   # recorded under session A
+# Run 2: compression on (real compression)
+TOKENLESS_COMPRESSION_ENABLED=1  <run the same task>   # recorded under session B
+
+# Comparison chart: baseline = context reached (raw), tokenless = compressed
+tokenless stats summary --compare <session-A> <session-B>
+tokenless stats summary --compare <session-A> <session-B> --json   # machine-readable
+```
+
+> Note: tokenless only measures the compressible content it processes; model reasoning tokens / real billed tokens are out of scope.
+
 ### 6.3 Verify Installation
 
 ```bash

--- a/src/tokenless/docs/tokenless-user-manual-zh.md
+++ b/src/tokenless/docs/tokenless-user-manual-zh.md
@@ -728,6 +728,28 @@ tokenless stats show <记录ID>     # 查看某条记录的压缩前后文本
 tokenless stats summary           # 查看所有操作的汇总节省数据
 ```
 
+#### 压缩开关与 dry-run 对照（双跑对比）
+
+通过环境变量 `TOKENLESS_COMPRESSION_ENABLED`（或 `~/.tokenless/config.json` 的 `compression_enabled`）控制压缩是否真正生效：
+
+- `1`（默认）：正常压缩，压缩结果进入 LLM 上下文，记录 `mode=active`。
+- `0`（**dry-run 模式**）：算出压缩效果并记录预测值（`mode=dryrun`），但**原样输出原文**，不改变 LLM 上下文。
+
+对同一任务跑两次（一次关闭、一次开启），即可输出对照图，准确评估 tokenless 的真实节省效果：
+
+```bash
+# 跑 1：关闭压缩（dry-run 基线，输出原文）
+TOKENLESS_COMPRESSION_ENABLED=0  <跑同一任务>   # 记录于 session A
+# 跑 2：开启压缩（真实压缩）
+TOKENLESS_COMPRESSION_ENABLED=1  <跑同一任务>   # 记录于 session B
+
+# 对照图：baseline=context 上下文（原文），tokenless=压缩后
+tokenless stats summary --compare <session-A> <session-B>
+tokenless stats summary --compare <session-A> <session-B> --json   # 机器可读
+```
+
+> 注：tokenless 仅度量它经手的可压缩内容；模型推理 token / 真实计费 token 不在其内。
+
 ### 6.3 验证安装
 
 ```bash


### PR DESCRIPTION
## Description

Add a compression on/off toggle to tokenless, plus a dry-run compare mode that enables end-to-end A/B measurement of compression savings on the same task.

- New `TOKENLESS_COMPRESSION_ENABLED` config field (default `true`) with env override; priority: env > config.json > default. Empty env values are treated as unset, consistent with the existing `stats`/`sls` toggles.
- `CompressionMode` enum (`Active`/`DryRun`) persisted per stats record; the `stats` SQLite table gains a `mode` column (migrated via `pragma_table_info`), and legacy NULL/unknown rows fall back to `Active` so historical data stays readable.
- In `compress-schema`/`compress-response`/`compress-toon`, the predicted savings are always computed and recorded. When compression is disabled, the original (uncompressed) text is emitted so the LLM context stays uncompressed, while the predicted savings are still captured — enabling same-task A/B comparison.
- New `stats summary --compare BASELINE_SESSION TOKENLESS_SESSION [--json]` reports side-by-side token usage by operation, with a warning when a session's recorded mode does not match the expected baseline=DryRun / tokenless=Active.

## Related Issue

no-issue: standalone observability feature; no tracked issue. Adds a toggle + measurement tooling to quantify tokenless compression savings.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran the tokenless pre-commit gate locally on the rebased branch:

```bash
cd src/tokenless
cargo fmt --all --check      # clean
cargo clippy --workspace -- -D warnings   # 0 warnings
cargo test --workspace      # 67 passed, 0 failed
```

New unit tests added: `CompressionMode` roundtrip / `from_db` legacy fallback, default-mode-active, env/file override precedence, empty-env-as-unset, and `records_by_session` filtering for the compare flow.

## Additional Notes

Backward compatible: `compression_enabled` defaults to `true` (preserves existing behavior). Existing stats DBs are migrated in place; old rows read as `Active`.
