### PR TITLE
feat(anolisa): execute declared install operations on the raw backend

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -21,12 +21,12 @@
 //! then pick an action by `(backend, rpmdb hit, install mode)`. `npm` remains
 //! NOT_IMPLEMENTED.
 //!
-//! Deliberately out of scope for this milestone: execution-policy gating,
-//! pre/post hooks, health checks, and service start/enable. Installed
-//! services are recorded in state with `enabled: false`.
+//! Deliberately out of scope for this milestone: execution-policy gating and
+//! health checks.
 
 use clap::Parser;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -44,8 +44,11 @@ use anolisa_core::state::{
     ObjectStatus, OperationRecord, OwnedFile, Ownership, RpmMetadata, ServiceRef,
 };
 use anolisa_core::{
-    ArtifactType, ComponentManifest, DistributionEntry, DistributionIndex, FileKind, ResolveQuery,
-    expand_layout_placeholders,
+    ArtifactType, CapabilityRequest, ComponentManifest, DistributionEntry, DistributionIndex,
+    FileKind, HookPhase, HookSpec, ResolveQuery, ServiceActivation, ServiceManager, ServiceRequest,
+    ServiceRunOutcome, apply_capabilities, apply_services, capability_for_install_mode,
+    deactivate_services, expand_layout_placeholders, resolve_manifest_hooks, run_hooks,
+    service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
@@ -118,7 +121,8 @@ pub(crate) struct RawResolution {
 struct InstallPreview {
     resolution: RawResolution,
     files: Vec<ResolvedInstallFile>,
-    services: Vec<String>,
+    services: Vec<ServiceRequest>,
+    capabilities: Vec<CapabilityRequest>,
 }
 
 /// Execution input after the artifact has been verified and its install
@@ -130,7 +134,12 @@ pub(crate) struct PreparedInstall {
     pub(crate) resolution: RawResolution,
     pub(crate) artifact_path: PathBuf,
     pub(crate) files: Vec<ResolvedInstallFile>,
-    pub(crate) services: Vec<String>,
+    /// Declared service activations (unit + scope + enable/start), applied
+    /// after files land. Carried resolved with template instances expanded.
+    pub(crate) services: Vec<ServiceRequest>,
+    /// Linux file capabilities to apply after files land (raw, system mode
+    /// only). Carried resolved — path already layout-expanded and bounded.
+    pub(crate) capabilities: Vec<CapabilityRequest>,
     pub(crate) manifest_toml: String,
 }
 
@@ -168,6 +177,9 @@ struct InstallPlanPayload {
     artifact: ArtifactInfo,
     files: Vec<String>,
     services: Vec<String>,
+    /// Human-readable `path: cap,cap` lines for the capabilities install
+    /// would apply. Rendered for `--dry-run`; setcap is never run here.
+    capabilities: Vec<String>,
     dry_run: bool,
     warnings: Vec<String>,
 }
@@ -1913,10 +1925,11 @@ fn build_install_preview(
             resolution,
             files: Vec::new(),
             services: Vec::new(),
+            capabilities: Vec::new(),
         });
     };
 
-    let (files, services) = match resolve_manifest_contract(
+    let (files, services, capabilities) = match resolve_manifest_contract(
         &contract.manifest,
         layout,
         &resolution,
@@ -1929,7 +1942,7 @@ fn build_install_preview(
                 "local catalog manifest does not match resolved artifact; file and service details are unavailable: {}",
                 err.reason()
             ));
-            (Vec::new(), Vec::new())
+            (Vec::new(), Vec::new(), Vec::new())
         }
         Err(err) => return Err(err),
     };
@@ -1938,6 +1951,7 @@ fn build_install_preview(
         resolution,
         files,
         services,
+        capabilities,
     })
 }
 
@@ -1969,7 +1983,7 @@ pub(crate) fn prepare_raw_execution(
 
     let contract =
         load_execution_install_contract(ctx, layout, &resolution, &artifact.cached_path)?;
-    let (files, services) = resolve_manifest_contract(
+    let (files, services, capabilities) = resolve_manifest_contract(
         &contract.manifest,
         layout,
         &resolution,
@@ -1982,6 +1996,7 @@ pub(crate) fn prepare_raw_execution(
         artifact_path: artifact.cached_path,
         files,
         services,
+        capabilities,
         manifest_toml: contract.toml,
     })
 }
@@ -2161,13 +2176,21 @@ fn sidecar_meta_url(artifact_url: &str, component: &str, version: &str) -> Optio
         .map(|idx| format!("{}/meta.toml", &artifact_url[..idx]))
 }
 
+/// Resolved install contract: laid files, recorded service unit names, and
+/// capability requests to apply once those files are on disk.
+type ResolvedContract = (
+    Vec<ResolvedInstallFile>,
+    Vec<ServiceRequest>,
+    Vec<CapabilityRequest>,
+);
+
 fn resolve_manifest_contract(
     manifest: &ComponentManifest,
     layout: &FsLayout,
     resolution: &RawResolution,
     mode: &str,
     source: InstallContractSource,
-) -> Result<(Vec<ResolvedInstallFile>, Vec<String>), CliError> {
+) -> Result<ResolvedContract, CliError> {
     if manifest.component.name.as_str() != resolution.component {
         return Err(CliError::Runtime {
             command: COMMAND.to_string(),
@@ -2225,7 +2248,49 @@ fn resolve_manifest_contract(
         &resolution.component,
     )?);
 
-    Ok((files, manifest.install.services.clone()))
+    let services = resolve_manifest_services(manifest, &resolution.component)?;
+    let capabilities = resolve_manifest_capabilities(manifest, layout, &resolution.component)?;
+
+    Ok((files, services, capabilities))
+}
+
+/// Render the manifest's `[[component.services]]` into activation requests:
+/// substitute the template instance into the unit name and carry
+/// scope/enable/start through to the executor. No filesystem or layout
+/// expansion — unit names are systemd identifiers, not paths.
+///
+/// # Errors
+///
+/// Returns [`CliError::Runtime`] if a service entry has an empty `unit`.
+fn resolve_manifest_services(
+    manifest: &ComponentManifest,
+    component: &str,
+) -> Result<Vec<ServiceRequest>, CliError> {
+    let mut requests = Vec::with_capacity(manifest.install.services.len());
+    for spec in &manifest.install.services {
+        if spec.unit.trim().is_empty() {
+            return Err(CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!(
+                    "component '{component}' has a [[component.services]] entry with an empty unit"
+                ),
+            });
+        }
+        // Template unit (`name@.service`) + instance → `name@<instance>.service`.
+        let unit = match &spec.instance {
+            Some(instance) if spec.unit.contains("@.") => {
+                spec.unit.replacen("@.", &format!("@{instance}."), 1)
+            }
+            _ => spec.unit.clone(),
+        };
+        requests.push(ServiceRequest {
+            unit,
+            scope: spec.scope,
+            enable: spec.enable,
+            start: spec.start,
+        });
+    }
+    Ok(requests)
 }
 
 /// Render the manifest's `[install.files]` against the layout: expand
@@ -2372,6 +2437,95 @@ fn resolve_adapter_files(
     Ok(files)
 }
 
+/// Render the manifest's `[[component.capabilities]]` against the layout:
+/// expand `{bindir}`-style placeholders in the target path and reject any
+/// path escaping the ANOLISA-owned roots before `setcap` ever runs.
+///
+/// Rows with empty `caps` are skipped — there is nothing to grant. A row
+/// that lists caps but no `path` is a contract error: we will not guess
+/// which binary to harden.
+fn resolve_manifest_capabilities(
+    manifest: &ComponentManifest,
+    layout: &FsLayout,
+    component: &str,
+) -> Result<Vec<CapabilityRequest>, CliError> {
+    let mut requests = Vec::new();
+    for spec in &manifest.install.capabilities {
+        if spec.caps.is_empty() {
+            continue;
+        }
+        let template = spec.path.as_deref().ok_or_else(|| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "component '{component}' has a [[component.capabilities]] entry with caps but no path"
+            ),
+        })?;
+        let path = expand_layout_placeholders(template, layout, &[("component", component)])
+            .map_err(|err| CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!("failed to expand capability path '{template}': {err}"),
+            })?;
+        validate_owned_path(layout, &path).map_err(|err| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "capability target '{}' failed path safety check: {err}",
+                path.display()
+            ),
+        })?;
+        requests.push(CapabilityRequest {
+            path,
+            caps: spec.caps.clone(),
+            optional: spec.optional,
+        });
+    }
+    Ok(requests)
+}
+
+/// Contract-declared lifecycle hooks for the three raw-install phases,
+/// placeholder-expanded with `strict`/`timeout` carried from the contract.
+///
+/// `pre_install` runs before any files are laid down. On a fresh raw install
+/// the hook script ships in the same artifact and is therefore not on disk
+/// yet, so [`run_hook`](anolisa_core::run_hook) reports it as `Missing`. With
+/// `strict = false` — the only sensible choice for `pre_install`, since the
+/// script cannot exist on a first install — that is a silent no-op; a
+/// `strict = true` `pre_install` would instead abort the install (the script
+/// it requires is unreachable). The phase becomes meaningful on the update
+/// path (out of scope here) where a prior version already laid the script.
+#[derive(Debug)]
+struct InstallHooks {
+    pre_install: Vec<HookSpec>,
+    post_install: Vec<HookSpec>,
+    post_enable: Vec<HookSpec>,
+}
+
+/// Resolve a component's `[[component.hooks]]` for the three install phases.
+///
+/// Unlike the uninstall side (which degrades a missing/invalid snapshot to
+/// "no hooks"), install resolves strictly: an unresolvable script path is a
+/// contract authoring bug and aborts before any IO so it surfaces early.
+fn resolve_install_hooks(
+    manifest: &ComponentManifest,
+    layout: &FsLayout,
+    component: &str,
+) -> Result<InstallHooks, CliError> {
+    let resolve = |phase: HookPhase| -> Result<Vec<HookSpec>, CliError> {
+        resolve_manifest_hooks(&manifest.install.hooks, layout, component, phase).map_err(|err| {
+            CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!(
+                    "component '{component}' has an invalid [[component.hooks]] script path: {err}"
+                ),
+            }
+        })
+    };
+    Ok(InstallHooks {
+        pre_install: resolve(HookPhase::PreInstall)?,
+        post_install: resolve(HookPhase::PostInstall)?,
+        post_enable: resolve(HookPhase::PostEnable)?,
+    })
+}
+
 /// Execute the resolved install: download+verify, copy files under the
 /// install lock, persist state, and append the audit record. Files already
 /// on disk are rolled back when a later step fails, so no phantom install
@@ -2387,6 +2541,7 @@ fn execute_raw(
         artifact_path,
         files,
         services,
+        capabilities,
         manifest_toml,
     } = prepared;
     let started_at = now_iso8601();
@@ -2418,6 +2573,37 @@ fn execute_raw(
         lock_ts.timestamp_subsec_nanos()
     );
 
+    // Resolve the contract's lifecycle hooks before any IO so an invalid
+    // script path (a contract authoring bug) aborts the install before files
+    // are touched. The log handle is opened here too: pre_install runs before
+    // file layout, and the capability/service steps below reuse it.
+    let manifest =
+        ComponentManifest::from_toml_str(&manifest_toml).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to parse component manifest for hook resolution: {err}"),
+        })?;
+    let hooks = resolve_install_hooks(&manifest, layout, &resolution.component)?;
+    let log = CentralLog::open(layout.central_log.clone());
+
+    // pre_install hook — before files land, so a strict failure aborts with
+    // nothing on disk to roll back. On a fresh raw install the script ships in
+    // this artifact and is not yet laid, so it skips as Missing (no warning).
+    let pre_install = run_hooks(
+        &hooks.pre_install,
+        layout,
+        Some(&log),
+        &operation_id,
+        "cli",
+        ctx.install_mode.as_str(),
+    );
+    resolution.warnings.extend(pre_install.warnings);
+    if let Some(hf) = pre_install.hard_failure.as_ref() {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("pre_install hook failed: {}", hf.summary()),
+        });
+    }
+
     let runner = InstallRunner::new(layout);
     let outcome = runner
         .install_files(
@@ -2440,6 +2626,115 @@ fn execute_raw(
             }
         };
 
+    // Files and the contract manifest are on disk; apply declared Linux file
+    // capabilities now. The manager gates itself to raw + system + Linux +
+    // non-container — user mode, containers, and non-Linux are quiet skips.
+    // A required (non-optional) failure aborts: roll back files + manifest
+    // while the lock is still held and before any state is persisted, so no
+    // half-installed component survives. Optional failures degrade to
+    // warnings. Reuses the `log` handle opened before file layout.
+    let env = anolisa_env::EnvService::detect();
+    let cap_manager = capability_for_install_mode(ctx.install_mode.as_str(), &env);
+    let cap_outcome = apply_capabilities(
+        cap_manager.as_ref(),
+        &capabilities,
+        Some(&log),
+        &resolution.component,
+        &operation_id,
+        "cli",
+        ctx.install_mode.as_str(),
+    );
+    if let Some(reason) = cap_outcome.aborted {
+        rollback_installed_files(&outcome.files);
+        rollback_installed_manifest(&manifest_path);
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "required capability application failed; rolled back installed files and manifest: {reason}"
+            ),
+        });
+    }
+    resolution.warnings.extend(cap_outcome.warnings);
+
+    // post_install hook — after setcap, before services (§6.2). Files and
+    // capabilities are committed, so a strict failure rolls them back exactly
+    // like a required capability abort.
+    let post_install = run_hooks(
+        &hooks.post_install,
+        layout,
+        Some(&log),
+        &operation_id,
+        "cli",
+        ctx.install_mode.as_str(),
+    );
+    resolution.warnings.extend(post_install.warnings);
+    if let Some(hf) = post_install.hard_failure.as_ref() {
+        rollback_installed_files(&outcome.files);
+        rollback_installed_manifest(&manifest_path);
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "post_install hook failed; rolled back installed files and manifest: {}",
+                hf.summary()
+            ),
+        });
+    }
+
+    // Capabilities done; bring declared services up (issue order: setcap →
+    // service enable/start). The manager gates itself to system + Linux +
+    // non-container; user-scope units and unsupported hosts are quiet skips.
+    // Activation is best-effort — a failed enable/start is a warning, not an
+    // abort: the component's files are installed and an operator can fix the
+    // unit out of band. Reuse the env + log opened for the capability step.
+    let service_manager = service_for_install_mode(ctx.install_mode.as_str(), &env);
+    let service_run = apply_services(
+        service_manager.as_ref(),
+        &services,
+        ServiceActivation::Start,
+        Some(&log),
+        &resolution.component,
+        &operation_id,
+        "cli",
+        ctx.install_mode.as_str(),
+    );
+    resolution
+        .warnings
+        .extend(service_run.warnings.iter().cloned());
+
+    // post_enable hook — after service enable/start (§6.2). A strict failure
+    // rolls back files + manifest like post_install. Because services are an
+    // external side effect, clean up only the units this install successfully
+    // enabled or started before removing their unit files.
+    let post_enable = run_hooks(
+        &hooks.post_enable,
+        layout,
+        Some(&log),
+        &operation_id,
+        "cli",
+        ctx.install_mode.as_str(),
+    );
+    resolution.warnings.extend(post_enable.warnings);
+    if let Some(hf) = post_enable.hard_failure.as_ref() {
+        let cleanup_warnings = rollback_activated_services(
+            service_manager.as_ref(),
+            &service_run,
+            Some(&log),
+            &resolution.component,
+            &operation_id,
+            ctx.install_mode.as_str(),
+        );
+        rollback_installed_files(&outcome.files);
+        rollback_installed_manifest(&manifest_path);
+        let cleanup_suffix = service_cleanup_suffix(&cleanup_warnings);
+        let hook_summary = hf.summary();
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "post_enable hook failed; stopped/disabled activated services and rolled back installed files and manifest{cleanup_suffix}: {hook_summary}",
+            ),
+        });
+    }
+
     let mut owned_files: Vec<OwnedFile> = outcome
         .files
         .iter()
@@ -2461,7 +2756,7 @@ fn execute_raw(
         .collect();
     installed_paths.push(manifest_path.display().to_string());
 
-    let service_manager = match ctx.install_mode {
+    let service_manager_label = match ctx.install_mode {
         crate::context::InstallMode::System => "systemd",
         crate::context::InstallMode::User => "systemd-user",
     };
@@ -2509,11 +2804,11 @@ fn execute_raw(
         services: services
             .iter()
             .map(|svc| ServiceRef {
-                name: svc.clone(),
-                manager: service_manager.to_string(),
+                name: svc.unit.clone(),
+                manager: service_manager_label.to_string(),
                 restartable: true,
-                // Service enablement is deferred to a later milestone.
-                enabled: false,
+                // Reflect what the executor actually enabled this run.
+                enabled: service_run.enabled_units.contains(&svc.unit),
             })
             .collect(),
         health: Vec::new(),
@@ -2528,19 +2823,28 @@ fn execute_raw(
 
     let state_path = layout.state_dir.join("installed.toml");
     if let Err(err) = state.save(&state_path) {
+        let cleanup_warnings = rollback_activated_services(
+            service_manager.as_ref(),
+            &service_run,
+            Some(&log),
+            &resolution.component,
+            &operation_id,
+            ctx.install_mode.as_str(),
+        );
         rollback_installed_files(&outcome.files);
         rollback_installed_manifest(&manifest_path);
+        let cleanup_suffix = service_cleanup_suffix(&cleanup_warnings);
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "failed to save state; attempted best-effort rollback of installed files (some may remain on disk): {err}"
+                "failed to save state; stopped/disabled activated services and attempted best-effort rollback of installed files and manifest{cleanup_suffix} (some files may remain on disk): {err}",
             ),
         });
     }
 
     // Audit log is best-effort: the install already succeeded and state is
     // saved, so a log failure downgrades to a warning instead of unwinding.
-    let log = CentralLog::open(layout.central_log.clone());
+    // `log` was opened above for the capability audit and is reused here.
     if !pruned_legacy.is_empty() {
         // Warn-severity so `logs --level warn` surfaces the migration.
         let prune_record = LogRecord {
@@ -2603,7 +2907,7 @@ fn execute_raw(
         operation_id,
         artifact_url: resolution.artifact_url,
         files_installed: installed_paths,
-        services,
+        services: services.iter().map(|s| s.unit.clone()).collect(),
         warnings: resolution.warnings,
     };
     if ctx.json {
@@ -2680,7 +2984,12 @@ fn render_plan(ctx: &CliContext, preview: &InstallPreview) -> Result<(), CliErro
             .iter()
             .map(|f| f.dest.display().to_string())
             .collect(),
-        services: preview.services.clone(),
+        services: preview.services.iter().map(|s| s.unit.clone()).collect(),
+        capabilities: preview
+            .capabilities
+            .iter()
+            .map(|c| format!("{}: {}", c.path.display(), c.caps.join(",")))
+            .collect(),
         dry_run: true,
         warnings: resolved.warnings.clone(),
     };
@@ -2718,9 +3027,18 @@ fn render_plan(ctx: &CliContext, preview: &InstallPreview) -> Result<(), CliErro
         println!("  - {}", color.path(f));
     }
     if !payload.services.is_empty() {
-        println!("{}", color.header("services (recorded, not started):"));
+        println!(
+            "{}",
+            color.header("services (would enable/start when supported):")
+        );
         for s in &payload.services {
             println!("  - {s}");
+        }
+    }
+    if !payload.capabilities.is_empty() {
+        println!("{}", color.header("capabilities (applied on install):"));
+        for c in &payload.capabilities {
+            println!("  - {c}");
         }
     }
     render_warnings(&payload.warnings, &color);
@@ -2752,7 +3070,10 @@ fn render_result(payload: &InstallResultPayload, no_color: bool) {
         println!("  - {}", color.path(p));
     }
     if !payload.services.is_empty() {
-        println!("{}", color.header("services (recorded, not started):"));
+        println!(
+            "{}",
+            color.header("services (enabled/started when supported):")
+        );
         for s in &payload.services {
             println!("  - {s}");
         }
@@ -2821,6 +3142,40 @@ pub(crate) fn artifact_type_wire(t: &ArtifactType) -> &'static str {
 fn rollback_installed_files(files: &[anolisa_core::InstalledFile]) {
     for f in files {
         let _ = std::fs::remove_file(&f.path);
+    }
+}
+
+/// Best-effort cleanup for service side effects from an install that will
+/// otherwise roll back.
+fn rollback_activated_services(
+    manager: &dyn ServiceManager,
+    service_run: &ServiceRunOutcome,
+    log: Option<&CentralLog>,
+    component: &str,
+    operation_id: &str,
+    install_mode: &str,
+) -> Vec<String> {
+    let units: BTreeSet<String> = service_run
+        .enabled_units
+        .iter()
+        .chain(service_run.started_units.iter())
+        .cloned()
+        .collect();
+    if units.is_empty() {
+        return Vec::new();
+    }
+    let units = units
+        .into_iter()
+        .map(|unit| (component.to_string(), unit))
+        .collect::<Vec<_>>();
+    deactivate_services(manager, &units, log, operation_id, "cli", install_mode).warnings
+}
+
+fn service_cleanup_suffix(warnings: &[String]) -> String {
+    if warnings.is_empty() {
+        String::new()
+    } else {
+        format!("; service cleanup warnings: {}", warnings.join("; "))
     }
 }
 
@@ -2976,6 +3331,7 @@ mod tests {
     use super::*;
 
     use crate::context::InstallMode;
+    use anolisa_core::{FakeServiceManager, ServiceOp};
     use flate2::Compression;
     use flate2::write::GzEncoder;
     use sha2::{Digest, Sha256};
@@ -3012,6 +3368,30 @@ mod tests {
             repo: None,
             package: None,
         }
+    }
+
+    #[test]
+    fn rollback_activated_services_only_cleans_touched_units() {
+        let manager = FakeServiceManager::new();
+        let service_run = ServiceRunOutcome {
+            enabled_units: vec!["enabled.service".to_string()],
+            started_units: vec!["started.service".to_string(), "enabled.service".to_string()],
+            warnings: Vec::new(),
+        };
+
+        let warnings =
+            rollback_activated_services(&manager, &service_run, None, "agentsight", "op", "system");
+
+        assert!(warnings.is_empty());
+        assert_eq!(
+            manager.calls(),
+            vec![
+                (ServiceOp::Stop, "enabled.service".to_string()),
+                (ServiceOp::Disable, "enabled.service".to_string()),
+                (ServiceOp::Stop, "started.service".to_string()),
+                (ServiceOp::Disable, "started.service".to_string()),
+            ]
+        );
     }
 
     /// Single-component [`handle`] seam that injects a fake package query
@@ -3169,6 +3549,75 @@ type = "executable"
         let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
         let files = resolve_adapter_files(&manifest, &layout, "tokenless").expect("resolve");
         assert!(files.is_empty());
+    }
+
+    /// Build a manifest with a single `[[component.capabilities]]` entry,
+    /// optionally overriding the target path and whether it is optional.
+    fn capability_manifest(path: Option<&str>, caps: &[&str], optional: bool) -> String {
+        let mut toml = String::from(
+            "[component]\nname = \"agentsight\"\nversion = \"0.1.0\"\n\n\
+             [component.layout]\nmodes = [\"system\"]\n\n\
+             [[component.layout.files]]\n\
+             source = \"bin/agentsight\"\ntarget = \"{bindir}/agentsight\"\n\
+             mode = \"0755\"\ntype = \"executable\"\n\n\
+             [[component.capabilities]]\n",
+        );
+        if let Some(p) = path {
+            toml.push_str(&format!("path = \"{p}\"\n"));
+        }
+        toml.push_str(&format!("caps = {}\n", toml_string_array(caps)));
+        if optional {
+            toml.push_str("optional = true\n");
+        }
+        toml
+    }
+
+    #[test]
+    fn resolve_manifest_capabilities_expands_bindir_path() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let toml = capability_manifest(Some("{bindir}/agentsight"), &["CAP_BPF"], false);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let reqs =
+            resolve_manifest_capabilities(&manifest, &layout, "agentsight").expect("resolve");
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].path, layout.bin_dir.join("agentsight"));
+        assert_eq!(reqs[0].caps, vec!["CAP_BPF".to_string()]);
+        assert!(!reqs[0].optional);
+    }
+
+    #[test]
+    fn resolve_manifest_capabilities_rejects_out_of_bounds_path() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let toml = capability_manifest(Some("/etc/passwd"), &["CAP_BPF"], false);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let err = resolve_manifest_capabilities(&manifest, &layout, "agentsight")
+            .expect_err("path escaping owned roots must be rejected");
+        assert!(matches!(err, CliError::Runtime { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn resolve_manifest_capabilities_skips_rows_with_empty_caps() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        // A path but nothing to grant — nothing to do, no setcap invocation.
+        let toml = capability_manifest(Some("{bindir}/agentsight"), &[], false);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let reqs =
+            resolve_manifest_capabilities(&manifest, &layout, "agentsight").expect("resolve");
+        assert!(reqs.is_empty());
+    }
+
+    #[test]
+    fn resolve_manifest_capabilities_requires_path_when_caps_present() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let toml = capability_manifest(None, &["CAP_BPF"], false);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let err = resolve_manifest_capabilities(&manifest, &layout, "agentsight")
+            .expect_err("caps without a path is a contract error");
+        assert!(matches!(err, CliError::Runtime { .. }), "got {err:?}");
     }
 
     fn write_empty_repo(root: &Path) -> String {
@@ -3745,6 +4194,598 @@ scope = "@anolisa"
         );
         assert_eq!(state.operations.len(), 1);
         assert!(state.operations[0].id.starts_with("op-install-"));
+    }
+
+    /// Component manifest with a single `[[component.capabilities]]` entry
+    /// appended to the minimal-schema body.
+    fn component_manifest_toml_with_capability(
+        component: &str,
+        version: &str,
+        modes: &[&str],
+        cap_path: &str,
+        caps: &[&str],
+        optional: bool,
+    ) -> String {
+        let mut toml = component_manifest_toml(component, version, modes);
+        toml.push_str("\n[[component.capabilities]]\n");
+        toml.push_str(&format!("path = \"{cap_path}\"\n"));
+        toml.push_str(&format!("caps = {}\n", toml_string_array(caps)));
+        if optional {
+            toml.push_str("optional = true\n");
+        }
+        toml
+    }
+
+    fn build_component_artifact_with_capability(
+        component: &str,
+        version: &str,
+        modes: &[&str],
+        cap_path: &str,
+        caps: &[&str],
+        optional: bool,
+    ) -> Vec<u8> {
+        let manifest = component_manifest_toml_with_capability(
+            component, version, modes, cap_path, caps, optional,
+        );
+        let bin_path = format!("bin/{component}");
+        let payload = format!("#!/bin/sh\necho {component}\n");
+        build_tar_gz(&[
+            (".anolisa/component.toml", manifest.as_bytes()),
+            (bin_path.as_str(), payload.as_bytes()),
+        ])
+    }
+
+    /// Local `file://` repo whose embedded artifact contract declares a
+    /// capability. Mirrors [`write_local_repo_component_with_modes`] but laces
+    /// the artifact's `component.toml` with `[[component.capabilities]]`.
+    fn write_local_repo_component_with_capability(
+        root: &Path,
+        component: &str,
+        version: &str,
+        modes: &[&str],
+        cap_path: &str,
+        caps: &[&str],
+        optional: bool,
+    ) -> String {
+        let v1 = root.join("v1");
+        std::fs::create_dir_all(&v1).expect("create repo dirs");
+
+        let artifact = build_component_artifact_with_capability(
+            component, version, modes, cap_path, caps, optional,
+        );
+        let artifact_name = format!("{component}.tar.gz");
+        std::fs::write(v1.join(&artifact_name), &artifact).expect("write artifact");
+        let sha = format!("{:x}", Sha256::digest(&artifact));
+        let modes_arr = toml_string_array(modes);
+
+        let env = anolisa_env::EnvService::detect();
+        let index = format!(
+            r#"schema_version = 1
+channel = "stable"
+publisher = "test"
+
+[[entries]]
+component = "{component}"
+version = "{version}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "{artifact_name}"
+os = "{os}"
+arch = "{arch}"
+install_modes = {modes_arr}
+sha256 = "{sha}"
+"#,
+            os = env.os,
+            arch = env.arch,
+        );
+        std::fs::write(v1.join("index.toml"), index).expect("write index");
+        format!("file://{}", v1.display())
+    }
+
+    /// `prepare_raw_execution` downloads + parses the embedded contract and
+    /// surfaces declared capabilities into [`PreparedInstall`] — without
+    /// running `setcap` or laying any file. The actual apply happens in
+    /// `execute_raw`; this pins that the resolve path carries them through.
+    #[test]
+    fn prepare_raw_execution_resolves_declared_capabilities() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let repo_url = write_local_repo_component_with_capability(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            &["system"],
+            "{bindir}/agentsight",
+            &["CAP_BPF", "CAP_PERFMON"],
+            true,
+        );
+        let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+        let layout = FsLayout::system(Some(prefix.clone()));
+        let env = anolisa_env::EnvService::detect();
+        let resolution = resolve_raw(
+            &ctx,
+            &layout,
+            &env,
+            ResolveInputs {
+                component: "agentsight".to_string(),
+                package: "agentsight".to_string(),
+                backend: "raw".to_string(),
+                base_url: repo_url,
+                version: None,
+                warnings: Vec::new(),
+            },
+        )
+        .expect("resolve");
+        let prepared = prepare_raw_execution(&ctx, &layout, resolution).expect("prepare");
+
+        assert_eq!(prepared.capabilities.len(), 1);
+        assert_eq!(
+            prepared.capabilities[0].path,
+            layout.bin_dir.join("agentsight")
+        );
+        assert_eq!(
+            prepared.capabilities[0].caps,
+            vec!["CAP_BPF".to_string(), "CAP_PERFMON".to_string()]
+        );
+        assert!(prepared.capabilities[0].optional);
+        // Resolve-only: no setcap, no file laid, no state.
+        assert!(!layout.bin_dir.join("agentsight").exists());
+        assert!(!layout.state_dir.join("installed.toml").exists());
+    }
+
+    /// End-to-end raw install of a component that declares an **optional**
+    /// capability succeeds without root: `setcap` is attempted but, because
+    /// the capability is optional, a non-root / no-xattr failure degrades to
+    /// a warning and the install still completes. We assert the binary and
+    /// state landed; we deliberately do NOT assert the file actually carries
+    /// the capability (root + filesystem xattr support required).
+    #[test]
+    fn install_raw_end_to_end_applies_optional_capability() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let repo_url = write_local_repo_component_with_capability(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            &["system"],
+            "{bindir}/agentsight",
+            &["CAP_BPF"],
+            true,
+        );
+
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install with optional capability must succeed even without root");
+
+        let layout = FsLayout::system(Some(prefix));
+        assert!(
+            layout.bin_dir.join("agentsight").exists(),
+            "binary must be installed even when the optional setcap is skipped"
+        );
+        let state = anolisa_core::InstalledState::load(&layout.state_dir.join("installed.toml"))
+            .expect("state must load");
+        assert!(
+            state
+                .find_object(ObjectKind::Component, "agentsight")
+                .is_some(),
+            "component must be recorded despite optional capability outcome"
+        );
+    }
+
+    /// Component manifest with a single `[[component.services]]` entry
+    /// appended to the minimal-schema body.
+    fn service_manifest(unit: &str, enable: bool, start: bool, instance: Option<&str>) -> String {
+        let mut toml = component_manifest_toml("agentsight", "0.2.0", &["system"]);
+        toml.push_str("\n[[component.services]]\n");
+        toml.push_str(&format!(
+            "unit = \"{unit}\"\nenable = {enable}\nstart = {start}\n"
+        ));
+        if let Some(i) = instance {
+            toml.push_str(&format!("instance = \"{i}\"\n"));
+        }
+        toml
+    }
+
+    #[test]
+    fn resolve_manifest_services_carries_spec_and_expands_instance() {
+        let toml = service_manifest("anolisa-memory@.service", true, false, Some("alice"));
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let reqs = resolve_manifest_services(&manifest, "agentsight").expect("resolve");
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].unit, "anolisa-memory@alice.service");
+        assert!(reqs[0].enable);
+        assert!(!reqs[0].start);
+    }
+
+    #[test]
+    fn resolve_manifest_services_plain_unit_unchanged() {
+        let toml = service_manifest("agentsight.service", true, true, None);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let reqs = resolve_manifest_services(&manifest, "agentsight").expect("resolve");
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].unit, "agentsight.service");
+        assert!(reqs[0].enable && reqs[0].start);
+        assert_eq!(reqs[0].scope, anolisa_core::ServiceScope::System);
+    }
+
+    /// Minimal-schema manifest with the given `[[component.hooks]]` entries
+    /// (phase, script template, strict) appended.
+    fn hooks_manifest(specs: &[(&str, &str, bool)]) -> String {
+        let mut toml = component_manifest_toml("demo", "0.1.0", &["system"]);
+        for (phase, script, strict) in specs {
+            toml.push_str("\n[[component.hooks]]\n");
+            toml.push_str(&format!(
+                "phase = \"{phase}\"\nscript = \"{script}\"\nstrict = {strict}\n"
+            ));
+        }
+        toml
+    }
+
+    #[test]
+    fn resolve_install_hooks_classifies_phases_and_filters_uninstall() {
+        let tmp = tempdir().expect("tmpdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let toml = hooks_manifest(&[
+            ("pre_install", "{datadir}/hooks/demo/pre-install.sh", false),
+            ("post_install", "{datadir}/hooks/demo/post-install.sh", true),
+            ("post_enable", "{datadir}/hooks/demo/post-enable.sh", false),
+            (
+                "pre_uninstall",
+                "{datadir}/hooks/demo/pre-uninstall.sh",
+                false,
+            ),
+        ]);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let hooks = resolve_install_hooks(&manifest, &layout, "demo").expect("resolve");
+
+        assert_eq!(hooks.pre_install.len(), 1);
+        assert_eq!(hooks.post_install.len(), 1);
+        assert!(hooks.post_install[0].strict, "strict carried from contract");
+        assert_eq!(hooks.post_enable.len(), 1);
+        assert_eq!(
+            hooks.pre_install[0].script,
+            layout.datadir.join("hooks/demo/pre-install.sh"),
+        );
+        // The pre_uninstall entry must not leak into any install-phase list.
+        let total = hooks.pre_install.len() + hooks.post_install.len() + hooks.post_enable.len();
+        assert_eq!(total, 3, "uninstall-phase hook must be excluded");
+    }
+
+    #[test]
+    fn resolve_install_hooks_rejects_invalid_placeholder() {
+        let tmp = tempdir().expect("tmpdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let toml = hooks_manifest(&[("post_install", "{nope}/x.sh", false)]);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let err = resolve_install_hooks(&manifest, &layout, "demo").expect_err("must error");
+        assert!(matches!(err, CliError::Runtime { .. }));
+    }
+
+    fn build_component_artifact_with_service(
+        component: &str,
+        version: &str,
+        modes: &[&str],
+        unit: &str,
+        enable: bool,
+        start: bool,
+    ) -> Vec<u8> {
+        let mut manifest = component_manifest_toml(component, version, modes);
+        manifest.push_str("\n[[component.services]]\n");
+        manifest.push_str(&format!(
+            "unit = \"{unit}\"\nenable = {enable}\nstart = {start}\n"
+        ));
+        let bin_path = format!("bin/{component}");
+        let payload = format!("#!/bin/sh\necho {component}\n");
+        build_tar_gz(&[
+            (".anolisa/component.toml", manifest.as_bytes()),
+            (bin_path.as_str(), payload.as_bytes()),
+        ])
+    }
+
+    /// Local `file://` repo whose embedded artifact contract declares a
+    /// service. Mirrors [`write_local_repo_component_with_capability`].
+    fn write_local_repo_component_with_service(
+        root: &Path,
+        component: &str,
+        version: &str,
+        modes: &[&str],
+        unit: &str,
+        enable: bool,
+        start: bool,
+    ) -> String {
+        let v1 = root.join("v1");
+        std::fs::create_dir_all(&v1).expect("create repo dirs");
+
+        let artifact =
+            build_component_artifact_with_service(component, version, modes, unit, enable, start);
+        let artifact_name = format!("{component}.tar.gz");
+        std::fs::write(v1.join(&artifact_name), &artifact).expect("write artifact");
+        let sha = format!("{:x}", Sha256::digest(&artifact));
+        let modes_arr = toml_string_array(modes);
+
+        let env = anolisa_env::EnvService::detect();
+        let index = format!(
+            r#"schema_version = 1
+channel = "stable"
+publisher = "test"
+
+[[entries]]
+component = "{component}"
+version = "{version}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "{artifact_name}"
+os = "{os}"
+arch = "{arch}"
+install_modes = {modes_arr}
+sha256 = "{sha}"
+"#,
+            os = env.os,
+            arch = env.arch,
+        );
+        std::fs::write(v1.join("index.toml"), index).expect("write index");
+        format!("file://{}", v1.display())
+    }
+
+    /// `prepare_raw_execution` carries declared services (unit + enable/start)
+    /// into [`PreparedInstall`] without activating or laying anything.
+    #[test]
+    fn prepare_raw_execution_resolves_declared_services() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let repo_url = write_local_repo_component_with_service(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            &["system"],
+            "agentsight.service",
+            true,
+            true,
+        );
+        let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+        let layout = FsLayout::system(Some(prefix.clone()));
+        let env = anolisa_env::EnvService::detect();
+        let resolution = resolve_raw(
+            &ctx,
+            &layout,
+            &env,
+            ResolveInputs {
+                component: "agentsight".to_string(),
+                package: "agentsight".to_string(),
+                backend: "raw".to_string(),
+                base_url: repo_url,
+                version: None,
+                warnings: Vec::new(),
+            },
+        )
+        .expect("resolve");
+        let prepared = prepare_raw_execution(&ctx, &layout, resolution).expect("prepare");
+
+        assert_eq!(prepared.services.len(), 1);
+        assert_eq!(prepared.services[0].unit, "agentsight.service");
+        assert!(prepared.services[0].enable && prepared.services[0].start);
+        // Resolve-only: nothing activated or laid.
+        assert!(!layout.bin_dir.join("agentsight").exists());
+        assert!(!layout.state_dir.join("installed.toml").exists());
+    }
+
+    /// End-to-end raw install of a component declaring a system service
+    /// succeeds: activation is best-effort, so in a non-systemd / non-root
+    /// test env a failed enable/start degrades to a warning and the install
+    /// still completes. We assert the binary and the ServiceRef landed; we do
+    /// NOT assert the unit was actually enabled (requires real systemd+root).
+    #[test]
+    fn install_raw_end_to_end_records_declared_service() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let repo_url = write_local_repo_component_with_service(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            &["system"],
+            "agentsight.service",
+            true,
+            true,
+        );
+
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install with a declared service must succeed (activation is best-effort)");
+
+        let layout = FsLayout::system(Some(prefix));
+        assert!(
+            layout.bin_dir.join("agentsight").exists(),
+            "binary installed"
+        );
+        let state = anolisa_core::InstalledState::load(&layout.state_dir.join("installed.toml"))
+            .expect("state must load");
+        let obj = state
+            .find_object(ObjectKind::Component, "agentsight")
+            .expect("component recorded");
+        assert_eq!(obj.services.len(), 1);
+        assert_eq!(obj.services[0].name, "agentsight.service");
+    }
+
+    /// Local `file://` repo whose artifact ships a binary plus an executable
+    /// hook script, with the contract declaring that script for `phase`.
+    /// Mirrors [`write_local_repo_component_with_service`].
+    fn write_local_repo_component_with_hook(
+        root: &Path,
+        component: &str,
+        version: &str,
+        phase: &str,
+        strict: bool,
+        script_body: &str,
+    ) -> String {
+        let v1 = root.join("v1");
+        std::fs::create_dir_all(&v1).expect("create repo dirs");
+
+        let script_rel = format!("hooks/{component}/{}.sh", phase.replace('_', "-"));
+        let mut manifest = component_manifest_toml(component, version, &["system"]);
+        // Hook script is itself a laid-down layout file, mode 0755 so the
+        // runner can spawn it.
+        manifest.push_str("\n[[component.layout.files]]\n");
+        manifest.push_str(&format!(
+            "source = \"hook.sh\"\ntarget = \"{{datadir}}/{script_rel}\"\nmode = \"0755\"\n"
+        ));
+        manifest.push_str("\n[[component.hooks]]\n");
+        manifest.push_str(&format!(
+            "phase = \"{phase}\"\nscript = \"{{datadir}}/{script_rel}\"\nstrict = {strict}\n"
+        ));
+
+        let bin_path = format!("bin/{component}");
+        let bin_payload = format!("#!/bin/sh\necho {component}\n");
+        let artifact = build_tar_gz(&[
+            (".anolisa/component.toml", manifest.as_bytes()),
+            (bin_path.as_str(), bin_payload.as_bytes()),
+            ("hook.sh", script_body.as_bytes()),
+        ]);
+        let artifact_name = format!("{component}.tar.gz");
+        std::fs::write(v1.join(&artifact_name), &artifact).expect("write artifact");
+        let sha = format!("{:x}", Sha256::digest(&artifact));
+
+        let env = anolisa_env::EnvService::detect();
+        let index = format!(
+            r#"schema_version = 1
+channel = "stable"
+publisher = "test"
+
+[[entries]]
+component = "{component}"
+version = "{version}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "{artifact_name}"
+os = "{os}"
+arch = "{arch}"
+install_modes = ["system"]
+sha256 = "{sha}"
+"#,
+            os = env.os,
+            arch = env.arch,
+        );
+        std::fs::write(v1.join("index.toml"), index).expect("write index");
+        format!("file://{}", v1.display())
+    }
+
+    /// A declared `post_install` hook runs after files land (§6.2): the script
+    /// touches a sentinel, which must exist after a successful install.
+    #[test]
+    #[cfg(unix)]
+    fn install_raw_runs_post_install_hook() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let sentinel = tmp.path().join("post-install.ran");
+        let body = format!("#!/bin/sh\ntouch {}\n", sentinel.display());
+        let repo_url = write_local_repo_component_with_hook(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            "post_install",
+            false,
+            &body,
+        );
+
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install with a post_install hook must succeed");
+
+        let layout = FsLayout::system(Some(prefix));
+        assert!(
+            layout.bin_dir.join("agentsight").exists(),
+            "binary installed"
+        );
+        assert!(
+            sentinel.exists(),
+            "post_install hook must run after files are laid down"
+        );
+    }
+
+    /// A strict `post_install` failure aborts and rolls back: by then files
+    /// and the manifest snapshot are on disk, so both must be removed.
+    #[test]
+    #[cfg(unix)]
+    fn install_raw_strict_post_install_failure_rolls_back() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let repo_url = write_local_repo_component_with_hook(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            "post_install",
+            true,
+            "#!/bin/sh\nexit 1\n",
+        );
+
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        let err = handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect_err("strict post_install failure must abort the install");
+        assert!(matches!(err, CliError::Runtime { .. }));
+
+        let layout = FsLayout::system(Some(prefix));
+        assert!(
+            !layout.bin_dir.join("agentsight").exists(),
+            "installed files must be rolled back after a strict hook failure"
+        );
+        let snapshot = common::installed_component_manifest_path(&layout, "agentsight", COMMAND)
+            .expect("manifest path");
+        assert!(
+            !snapshot.exists(),
+            "installed manifest snapshot must be rolled back"
+        );
+        let state_path = layout.state_dir.join("installed.toml");
+        if state_path.exists() {
+            let state = anolisa_core::InstalledState::load(&state_path).expect("state load");
+            assert!(
+                state
+                    .find_object(ObjectKind::Component, "agentsight")
+                    .is_none(),
+                "component must not be recorded after rollback"
+            );
+        }
+    }
+
+    /// `pre_install` runs before files land. On a fresh install the script
+    /// ships in the artifact but is not yet on disk, so a `strict = false`
+    /// `pre_install` skips as Missing and the install still succeeds — the
+    /// sentinel it would touch must not appear.
+    #[test]
+    #[cfg(unix)]
+    fn install_raw_pre_install_hook_skipped_as_missing_on_fresh_install() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let sentinel = tmp.path().join("pre-install.ran");
+        let body = format!("#!/bin/sh\ntouch {}\n", sentinel.display());
+        let repo_url = write_local_repo_component_with_hook(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            "pre_install",
+            false,
+            &body,
+        );
+
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+            .expect("install must succeed; pre_install script is not yet laid");
+
+        let layout = FsLayout::system(Some(prefix));
+        assert!(
+            layout.bin_dir.join("agentsight").exists(),
+            "binary installed"
+        );
+        assert!(
+            !sentinel.exists(),
+            "pre_install must skip when its script is not yet on disk"
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -59,7 +59,8 @@ use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Sever
 use anolisa_core::lock::InstallLock;
 use anolisa_core::state::{OperationRecord, Ownership};
 use anolisa_core::{
-    LifecycleError, LifecycleOperation, LifecycleOutcome, LifecyclePlan, ObjectKind, execute_plan,
+    ComponentManifest, HookPhase, LifecycleError, LifecycleOperation, LifecycleOutcome,
+    LifecyclePlan, ObjectKind, ResolvedLifecycleHooks, execute_plan, resolve_manifest_hooks,
 };
 use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
@@ -254,7 +255,35 @@ pub(crate) fn handle_with_deps(
         );
     }
 
-    let outcome = execute_plan(&plan, &layout, &actor, install_mode)
+    // Contract-driven uninstall hooks: read the installed component manifest
+    // snapshot (persisted verbatim at install) and resolve its declared
+    // pre/post-uninstall scripts. Best-effort — a missing or unreadable
+    // snapshot (older installs, RPM-delegated paths) or an unresolvable
+    // script path means no hooks for that phase, never a failed uninstall.
+    let hooks = match common::installed_component_manifest_path(&layout, target, COMMAND)
+        .ok()
+        .and_then(|path| ComponentManifest::from_file(&path).ok())
+    {
+        Some(manifest) => ResolvedLifecycleHooks {
+            pre_uninstall: resolve_manifest_hooks(
+                &manifest.install.hooks,
+                &layout,
+                target,
+                HookPhase::PreUninstall,
+            )
+            .unwrap_or_default(),
+            post_uninstall: resolve_manifest_hooks(
+                &manifest.install.hooks,
+                &layout,
+                target,
+                HookPhase::PostUninstall,
+            )
+            .unwrap_or_default(),
+        },
+        None => ResolvedLifecycleHooks::default(),
+    };
+
+    let outcome = execute_plan(&plan, &layout, &actor, install_mode, &hooks)
         .map_err(|err| lifecycle_err_to_cli(&command, err))?;
 
     if ctx.json {
@@ -1264,6 +1293,117 @@ mod tests {
             layout.central_log.exists(),
             "component uninstall must append a central-log record",
         );
+    }
+
+    /// End-to-end wiring: uninstall reads the installed component-manifest
+    /// snapshot, resolves its `[[component.hooks]]` pre-uninstall script
+    /// (placeholder-expanded, contract `strict`), and runs it before the
+    /// files are removed. Pins that the CLI feeds contract hooks into
+    /// `execute_plan` — the no-snapshot path is covered by
+    /// `uninstall_execute_on_installed_component_removes_owned_files_and_succeeds`.
+    #[test]
+    #[cfg(unix)]
+    fn uninstall_runs_contract_declared_pre_uninstall_hook() {
+        use anolisa_core::{
+            FileOwner, InstalledObject, InstalledState, ObjectKind, ObjectStatus, OwnedFile,
+        };
+        use anolisa_platform::fs_layout::FsLayout;
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tmpdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
+        let owned = layout.bin_dir.join("ws-ckpt");
+        std::fs::write(&owned, b"binary").expect("write owned");
+
+        // Hook script shipped under the datadir, declared by the contract.
+        let hook_dir = layout.datadir.join("hooks").join("ws-ckpt");
+        std::fs::create_dir_all(&hook_dir).expect("mkdir hook dir");
+        let hook_script = hook_dir.join("pre-uninstall.sh");
+        let sentinel = tmp.path().join("pre-uninstall.ran");
+        std::fs::write(
+            &hook_script,
+            format!("#!/bin/sh\ntouch {}\n", sentinel.display()),
+        )
+        .expect("write hook");
+        let mut perm = std::fs::metadata(&hook_script).expect("stat").permissions();
+        perm.set_mode(0o755);
+        std::fs::set_permissions(&hook_script, perm).expect("chmod");
+
+        // Installed component-manifest snapshot carrying the contract hook.
+        let manifest_path =
+            common::installed_component_manifest_path(&layout, "ws-ckpt", "uninstall")
+                .expect("manifest path");
+        std::fs::create_dir_all(manifest_path.parent().unwrap()).expect("mkdir manifest dir");
+        std::fs::write(
+            &manifest_path,
+            r#"
+            [component]
+            name = "ws-ckpt"
+            version = "0.1.0"
+
+            # Hooks parse only on the minimal-schema path, which is gated on
+            # the presence of [component.layout].
+            [component.layout]
+            modes = ["system"]
+
+            [[component.hooks]]
+            phase = "pre_uninstall"
+            script = "{datadir}/hooks/ws-ckpt/pre-uninstall.sh"
+            strict = false
+            "#,
+        )
+        .expect("write installed manifest");
+
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "ws-ckpt".to_string(),
+            version: "0.1.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("file:///fake".to_string()),
+            raw_package: None,
+            install_backend: Some("raw".to_string()),
+            ownership: None,
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: vec![OwnedFile {
+                path: owned.clone(),
+                owner: FileOwner::Anolisa,
+                sha256: Some("0".repeat(64)),
+            }],
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state save");
+
+        handle(
+            args("ws-ckpt", false),
+            &ctx_with_prefix(
+                false,
+                false,
+                InstallMode::System,
+                Some(tmp.path().to_path_buf()),
+            ),
+        )
+        .expect("uninstall with contract hook must succeed");
+
+        assert!(
+            sentinel.exists(),
+            "contract-declared pre_uninstall hook must have run",
+        );
+        assert!(!owned.exists(), "owned file must be removed after the hook");
     }
 
     /// Purge stays gated until manifest-driven config/cache/state

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -47,6 +47,10 @@ use anolisa_core::transaction::{
     RollbackAction, RollbackActionKind, Transaction, TransactionOutcomeStatus, TransactionStep,
     TransactionStepStatus,
 };
+use anolisa_core::{
+    CapabilityRunOutcome, ServiceActivation, ServiceRequest, ServiceRunOutcome, apply_capabilities,
+    apply_services, capability_for_install_mode, service_for_install_mode,
+};
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
@@ -436,7 +440,7 @@ fn update_raw_component(
     // failure must leave the current install untouched.
     let prepared =
         prepare_raw_execution(ctx, &layout, resolution).map_err(|e| e.with_command(command))?;
-    let operation_id = execute_raw_update(
+    let update_result = execute_raw_update(
         ctx,
         &layout,
         component,
@@ -445,6 +449,8 @@ fn update_raw_component(
         command,
         &warnings,
     )?;
+    let mut warnings = warnings;
+    warnings.extend(update_result.warnings);
 
     let payload = ComponentUpdatePayload {
         component: component.to_string(),
@@ -457,17 +463,53 @@ fn update_raw_component(
         updated: true,
         dry_run: false,
         available_candidates: Vec::new(),
-        operation_id: Some(operation_id),
+        operation_id: Some(update_result.operation_id),
         warnings,
     };
     render_component_update(ctx, &payload);
     Ok(())
 }
 
+fn raw_update_service_refs(
+    ctx: &CliContext,
+    services: &[ServiceRequest],
+    service_run: Option<&ServiceRunOutcome>,
+) -> Vec<ServiceRef> {
+    let manager = match ctx.install_mode {
+        crate::context::InstallMode::System => "systemd",
+        crate::context::InstallMode::User => "systemd-user",
+    };
+    services
+        .iter()
+        .map(|svc| ServiceRef {
+            name: svc.unit.clone(),
+            manager: manager.to_string(),
+            restartable: true,
+            enabled: service_run.is_some_and(|run| run.enabled_units.contains(&svc.unit)),
+        })
+        .collect()
+}
+
+struct RawUpdateResult {
+    operation_id: String,
+    warnings: Vec<String>,
+}
+
+fn committed_capability_warnings(outcome: CapabilityRunOutcome) -> Vec<String> {
+    let mut warnings = outcome.warnings;
+    if let Some(reason) = outcome.aborted {
+        warnings.push(format!(
+            "required capability application failed after update commit: {reason}"
+        ));
+    }
+    warnings
+}
+
 /// Apply a prepared raw update transactionally: back up and remove the old
 /// owned files, install the new artifact, rewrite the component manifest, and
 /// refresh state — rolling everything back to the previous version on failure.
-/// Returns the operation id recorded against the refreshed state.
+/// Returns the operation id recorded against the refreshed state plus
+/// committed best-effort warnings.
 ///
 /// `from_version` is the version the lock-free resolve planned against. Because
 /// resolve + download ran outside the lock, this aborts (before any mutation)
@@ -483,12 +525,13 @@ fn execute_raw_update(
     prepared: PreparedInstall,
     command: &str,
     warnings: &[String],
-) -> Result<String, CliError> {
+) -> Result<RawUpdateResult, CliError> {
     let PreparedInstall {
         resolution,
         artifact_path,
         files,
         services,
+        capabilities,
         manifest_toml,
     } = prepared;
     let started_at = now_iso8601();
@@ -748,21 +791,11 @@ fn execute_raw_update(
     obj.last_operation_id = Some(operation_id.clone());
     // A clean replacement matches a fresh install of the new version: services
     // come from the new manifest, status returns to Installed, and stale health
-    // / external-modification rows from the old version no longer apply. The
-    // ServiceRef shaping mirrors the install path (enablement is deferred).
-    let service_manager = match ctx.install_mode {
-        crate::context::InstallMode::System => "systemd",
-        crate::context::InstallMode::User => "systemd-user",
-    };
-    obj.services = services
-        .iter()
-        .map(|svc| ServiceRef {
-            name: svc.clone(),
-            manager: service_manager.to_string(),
-            restartable: true,
-            enabled: false,
-        })
-        .collect();
+    // / external-modification rows from the old version no longer apply.
+    // Service activation happens after this durable state write, so the first
+    // save records the service declarations with conservative `enabled=false`;
+    // a best-effort second save below backfills the actual enable result.
+    obj.services = raw_update_service_refs(ctx, &services, None);
     obj.status = ObjectStatus::Installed;
     obj.health = Vec::new();
     obj.external_modified_files = Vec::new();
@@ -789,13 +822,64 @@ fn execute_raw_update(
     let _ = tx.mark_done(persist_idx);
     let _ = tx.finish(TransactionOutcomeStatus::Ok);
 
+    // Phase 5 — apply external post-commit side effects after state is durable.
+    // Capability xattrs and running systemd processes are not covered by the
+    // file/state rollback journal. Running them before the final state save can
+    // leave an incomplete rollback (for example, old file bytes restored but
+    // old file capabilities lost), so update commits first and surfaces any
+    // side-effect failure as a warning.
+    let log = CentralLog::open(layout.central_log.clone());
+    let env = anolisa_env::EnvService::detect();
+    let cap_manager = capability_for_install_mode(ctx.install_mode.as_str(), &env);
+    let cap_outcome = apply_capabilities(
+        cap_manager.as_ref(),
+        &capabilities,
+        Some(&log),
+        component,
+        &operation_id,
+        "cli",
+        ctx.install_mode.as_str(),
+    );
+    let cap_warnings = committed_capability_warnings(cap_outcome);
+
+    // Upgrade restarts (not just starts) so the new binary is loaded.
+    // Best-effort: failures warn, never roll back, because the component
+    // record and new files are already committed.
+    let service_run = apply_services(
+        service_for_install_mode(ctx.install_mode.as_str(), &env).as_ref(),
+        &services,
+        ServiceActivation::Restart,
+        Some(&log),
+        component,
+        &operation_id,
+        "cli",
+        ctx.install_mode.as_str(),
+    );
+
+    let mut activation_state_warnings = Vec::new();
+    if !services.is_empty() {
+        if let Some(obj) = state.find_object_mut(ObjectKind::Component, component) {
+            obj.services = raw_update_service_refs(ctx, &services, Some(&service_run));
+            if let Err(err) = state.save(&state_path) {
+                activation_state_warnings.push(format!(
+                    "failed to persist service activation result after update: {err}"
+                ));
+            }
+        }
+    }
+
     // The transaction committed; per-operation backups are rollback scratch
     // (as in uninstall), so prune them once the new version is in place.
     let _ = std::fs::remove_dir_all(&backup_root);
 
     // Audit is best-effort: the update already persisted, so a log failure
     // downgrades to a warning rather than unwinding the transaction.
-    let log = CentralLog::open(layout.central_log.clone());
+    // `log` was opened above for the capability audit and is reused here.
+    let mut execution_warnings = cap_warnings;
+    execution_warnings.extend(service_run.warnings);
+    execution_warnings.extend(activation_state_warnings);
+    let mut all_warnings = warnings.to_vec();
+    all_warnings.extend(execution_warnings.clone());
     let record = LogRecord {
         kind: LogKind::Operation,
         operation_id: Some(operation_id.clone()),
@@ -813,7 +897,7 @@ fn execute_raw_update(
         // Backups are pruned on success (the new version is in place), so no
         // backup set is retained for this operation.
         backup_ids: Vec::new(),
-        warnings: warnings.to_vec(),
+        warnings: all_warnings,
         details: serde_json::Value::Null,
     };
     if let Err(err) = log.append(&record)
@@ -822,7 +906,10 @@ fn execute_raw_update(
         eprintln!("warning: failed to append audit log: {err}");
     }
 
-    Ok(operation_id)
+    Ok(RawUpdateResult {
+        operation_id,
+        warnings: execution_warnings,
+    })
 }
 
 /// Everything a rollback exit needs to report the failure, built once in
@@ -1645,6 +1732,53 @@ mod tests {
         let data = build_json_data(&outcome, false);
         assert!(!data.update_available);
         assert!(!data.updated);
+    }
+
+    #[test]
+    fn raw_update_service_refs_are_conservative_until_activation_runs() {
+        let ctx = CliContext {
+            install_mode: InstallMode::System,
+            prefix: None,
+            json: false,
+            dry_run: false,
+            verbose: false,
+            quiet: true,
+            no_color: true,
+        };
+        let services = vec![ServiceRequest {
+            unit: "agentsight.service".to_string(),
+            scope: anolisa_core::ServiceScope::System,
+            enable: true,
+            start: true,
+        }];
+
+        let before_activation = raw_update_service_refs(&ctx, &services, None);
+        assert!(!before_activation[0].enabled);
+
+        let run = ServiceRunOutcome {
+            enabled_units: vec!["agentsight.service".to_string()],
+            started_units: Vec::new(),
+            warnings: Vec::new(),
+        };
+        let after_activation = raw_update_service_refs(&ctx, &services, Some(&run));
+        assert!(after_activation[0].enabled);
+    }
+
+    #[test]
+    fn committed_capability_warnings_include_required_failure() {
+        let warnings = committed_capability_warnings(CapabilityRunOutcome {
+            applied: 0,
+            warnings: vec!["optional capability for /bin/demo failed: no xattr".to_string()],
+            aborted: Some("required capability for /bin/demo failed: EPERM".to_string()),
+        });
+
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings[0].contains("optional capability"));
+        assert!(
+            warnings[1].contains("required capability application failed after update commit"),
+            "got: {}",
+            warnings[1]
+        );
     }
 
     // ── component update (#959): RPM path ───────────────────────────────

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -142,9 +142,10 @@ pub enum AdapterError {
     },
 
     /// The component contract declares a `dest` for the adapter, but the
-    /// expanded path does not exist on disk. Unlike [`ResourceRootNotFound`],
-    /// this means the contract was explicit — the caller should **not**
-    /// silently fall back to convention discovery.
+    /// expanded path does not exist on disk. Unlike
+    /// [`ResourceRootNotFound`](AdapterError::ResourceRootNotFound), this
+    /// means the contract was explicit — the caller should **not** silently
+    /// fall back to convention discovery.
     #[error(
         "adapter resource root from contract does not exist for '{component}/{framework}': {path}"
     )]

--- a/src/anolisa/crates/anolisa-core/src/capability.rs
+++ b/src/anolisa/crates/anolisa-core/src/capability.rs
@@ -1,0 +1,857 @@
+//! Linux file-capability (`setcap`) executor.
+//!
+//! Some components are only usable after an install-time `setcap` —
+//! agentsight needs `cap_bpf,cap_perfmon` on its binary so eBPF loads for
+//! non-root users. File capabilities are xattrs on the target filesystem,
+//! applied after the file lands; packaging (tar) cannot carry them
+//! reliably, so ANOLISA applies them as an install-time operation.
+//!
+//! The trait surface is one operation — [`CapabilityManager::apply`] —
+//! deliberately small so it reads like the [`crate::service`] executor.
+//! Hosts outside the alpha factory rules (non-Linux, `install_mode ==
+//! "user"`, container) get a [`NotSupportedCapabilityManager`] whose
+//! `apply` is a quiet skip (`supported: false`): setcap is meaningless
+//! without root + a system-mode layout, so those installs are no-ops for
+//! capabilities.
+//!
+//! [`FakeCapabilityManager`] is the executor used by this module's unit
+//! tests and by integration tests asserting which binaries were targeted.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+
+use anolisa_env::EnvFacts;
+
+/// What [`CapabilityManager`] returns from a single `apply`.
+#[derive(Debug, Clone)]
+pub struct CapabilityOutcome {
+    /// Backend label, e.g. `"setcap"`, `"not-supported"`, or a fake name.
+    pub manager: String,
+    /// Binary the capabilities were applied to.
+    pub path: PathBuf,
+    /// Capability names requested (e.g. `["cap_bpf", "cap_perfmon"]`).
+    pub caps: Vec<String>,
+    /// `false` when the backend is a deliberate skip (user mode, container).
+    pub supported: bool,
+    /// `true` when capabilities were actually written. Always `false` for
+    /// unsupported backends.
+    pub changed: bool,
+    /// Human-readable description, used for logs / warnings.
+    pub message: String,
+}
+
+/// Failure surface for a single `apply`. Non-fatal by default — the
+/// orchestrator decides warn-vs-abort from the spec's `optional` flag.
+#[derive(Debug, thiserror::Error)]
+pub enum CapabilityError {
+    /// `setcap` could not be spawned (missing binary, no permission).
+    #[error("spawning setcap failed: {source}")]
+    Spawn {
+        /// Underlying spawn error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// `setcap` ran but returned a non-zero exit code (no xattr support,
+    /// not root, malformed capability string).
+    #[error("setcap '{caps}' {path} exited with status {code}: {stderr}")]
+    NonZeroExit {
+        /// Capability string passed to setcap.
+        caps: String,
+        /// Target path.
+        path: String,
+        /// Process exit code.
+        code: i32,
+        /// Captured stderr.
+        stderr: String,
+    },
+}
+
+/// Backend trait every capability-manager impl satisfies.
+pub trait CapabilityManager: Send + Sync {
+    /// Wire label written into log records.
+    fn manager(&self) -> &str;
+    /// `false` when this backend is a deliberate skip — orchestrators
+    /// short-circuit so they don't emit per-binary warnings.
+    fn supported(&self) -> bool;
+    /// Reason text when [`supported`](Self::supported) is false.
+    fn unsupported_reason(&self) -> Option<&str> {
+        None
+    }
+    /// Apply `caps` to `path` (`setcap "cap_bpf,cap_perfmon+ep" <path>`).
+    fn apply(&self, path: &Path, caps: &[String]) -> Result<CapabilityOutcome, CapabilityError>;
+}
+
+/// `setcap` capability string for `caps`: lowercased, comma-joined, with
+/// the `+ep` flag so the binary carries the caps in its effective and
+/// permitted sets for any user who runs it.
+fn setcap_arg(caps: &[String]) -> String {
+    format!("{}+ep", caps.join(",").to_lowercase())
+}
+
+/// Real backend: shells out to `setcap`, mirroring how
+/// [`crate::service::SystemdServiceManager`] drives `systemctl`.
+pub struct SetcapManager {
+    binary: PathBuf,
+}
+
+impl SetcapManager {
+    /// Build a manager that invokes the `setcap` binary from `PATH`.
+    pub fn new() -> Self {
+        Self {
+            binary: PathBuf::from("setcap"),
+        }
+    }
+}
+
+impl Default for SetcapManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CapabilityManager for SetcapManager {
+    fn manager(&self) -> &str {
+        "setcap"
+    }
+    fn supported(&self) -> bool {
+        true
+    }
+    fn apply(&self, path: &Path, caps: &[String]) -> Result<CapabilityOutcome, CapabilityError> {
+        let arg = setcap_arg(caps);
+        let output = Command::new(&self.binary)
+            .arg(&arg)
+            .arg(path)
+            .output()
+            .map_err(|source| CapabilityError::Spawn { source })?;
+        if !output.status.success() {
+            let code = output.status.code().unwrap_or(-1);
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(CapabilityError::NonZeroExit {
+                caps: arg,
+                path: path.display().to_string(),
+                code,
+                stderr,
+            });
+        }
+        Ok(CapabilityOutcome {
+            manager: "setcap".to_string(),
+            path: path.to_path_buf(),
+            caps: caps.to_vec(),
+            supported: true,
+            changed: true,
+            message: format!("setcap {arg} {} ok", path.display()),
+        })
+    }
+}
+
+/// Quiet-skip backend for hosts where setcap is not actionable
+/// (non-Linux, user mode, container).
+pub struct NotSupportedCapabilityManager {
+    reason: String,
+}
+
+impl NotSupportedCapabilityManager {
+    /// Build a skip backend carrying `reason` for the audit log.
+    pub fn new(reason: String) -> Self {
+        Self { reason }
+    }
+}
+
+impl CapabilityManager for NotSupportedCapabilityManager {
+    fn manager(&self) -> &str {
+        "not-supported"
+    }
+    fn supported(&self) -> bool {
+        false
+    }
+    fn unsupported_reason(&self) -> Option<&str> {
+        Some(&self.reason)
+    }
+    fn apply(&self, path: &Path, caps: &[String]) -> Result<CapabilityOutcome, CapabilityError> {
+        Ok(CapabilityOutcome {
+            manager: "not-supported".to_string(),
+            path: path.to_path_buf(),
+            caps: caps.to_vec(),
+            supported: false,
+            changed: false,
+            message: self.reason.clone(),
+        })
+    }
+}
+
+/// Pick a [`CapabilityManager`] for the host + install mode.
+///
+/// Returns a real [`SetcapManager`] only on Linux, in `system` mode, and
+/// outside a container. Root is intentionally *not* gated here: a non-root
+/// host still gets the real manager so an `optional = false` capability
+/// whose `setcap` fails aborts the install — a quiet skip would silently
+/// swallow that failure. user-mode / non-Linux / container hosts get a
+/// [`NotSupportedCapabilityManager`].
+pub fn for_install_mode(install_mode: &str, env: &EnvFacts) -> Box<dyn CapabilityManager> {
+    if env.os != "linux" {
+        return Box::new(NotSupportedCapabilityManager::new(format!(
+            "capability assignment unsupported on os '{}'",
+            env.os,
+        )));
+    }
+    if install_mode != "system" {
+        return Box::new(NotSupportedCapabilityManager::new(
+            "capability assignment unsupported in install_mode='user' (setcap needs system mode + root)"
+                .to_string(),
+        ));
+    }
+    if let Some(rt) = env.container.as_deref() {
+        return Box::new(NotSupportedCapabilityManager::new(format!(
+            "container runtime '{rt}' detected — refusing to setcap inside a container",
+        )));
+    }
+    Box::new(SetcapManager::new())
+}
+
+/// In-memory [`CapabilityManager`] for tests: records every `apply` and
+/// can be told to fail specific paths.
+pub struct FakeCapabilityManager {
+    manager_name: String,
+    supported: bool,
+    calls: Mutex<Vec<(PathBuf, Vec<String>)>>,
+    fail_paths: Mutex<HashSet<PathBuf>>,
+}
+
+impl FakeCapabilityManager {
+    /// Supported fake with no injected failures.
+    pub fn new() -> Self {
+        Self {
+            manager_name: "fake".to_string(),
+            supported: true,
+            calls: Mutex::new(Vec::new()),
+            fail_paths: Mutex::new(HashSet::new()),
+        }
+    }
+    /// Snapshot of every `apply` recorded so far, in dispatch order.
+    pub fn calls(&self) -> Vec<(PathBuf, Vec<String>)> {
+        self.calls.lock().expect("poisoned").clone()
+    }
+    /// Cause `apply` on `path` to return `NonZeroExit` so tests can assert
+    /// the orchestrator's warn / abort paths.
+    pub fn fail(&self, path: &Path) {
+        self.fail_paths
+            .lock()
+            .expect("poisoned")
+            .insert(path.to_path_buf());
+    }
+}
+
+impl Default for FakeCapabilityManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CapabilityManager for FakeCapabilityManager {
+    fn manager(&self) -> &str {
+        &self.manager_name
+    }
+    fn supported(&self) -> bool {
+        self.supported
+    }
+    fn apply(&self, path: &Path, caps: &[String]) -> Result<CapabilityOutcome, CapabilityError> {
+        self.calls
+            .lock()
+            .expect("poisoned")
+            .push((path.to_path_buf(), caps.to_vec()));
+        if self.fail_paths.lock().expect("poisoned").contains(path) {
+            return Err(CapabilityError::NonZeroExit {
+                caps: caps.join(","),
+                path: path.display().to_string(),
+                code: 1,
+                stderr: "fake forced failure".to_string(),
+            });
+        }
+        Ok(CapabilityOutcome {
+            manager: self.manager_name.clone(),
+            path: path.to_path_buf(),
+            caps: caps.to_vec(),
+            supported: self.supported,
+            changed: true,
+            message: format!("fake setcap {} ok", path.display()),
+        })
+    }
+}
+
+/// One resolved capability assignment to apply. `path` is already
+/// layout-expanded and boundary-validated by the caller, so the executor
+/// never touches manifest templates or the filesystem layout.
+#[derive(Debug, Clone)]
+pub struct CapabilityRequest {
+    /// Binary to receive the capabilities (absolute, owned-root-checked).
+    pub path: PathBuf,
+    /// Capability names to grant.
+    pub caps: Vec<String>,
+    /// `true` → failure degrades to a warning; `false` → failure aborts
+    /// the install and the caller rolls back.
+    pub optional: bool,
+}
+
+/// Aggregate result of [`apply_capabilities`].
+#[derive(Debug, Default)]
+pub struct CapabilityRunOutcome {
+    /// Count of capabilities successfully applied.
+    pub applied: usize,
+    /// Per-request warnings from tolerated (`optional`) failures.
+    pub warnings: Vec<String>,
+    /// `Some(reason)` when a required capability failed — the caller must
+    /// roll back the install. Set at the first required failure; no further
+    /// requests are attempted.
+    pub aborted: Option<String>,
+}
+
+/// Apply each request against `manager`, deciding warn-vs-abort from each
+/// request's `optional` flag and recording one central-log line per request.
+///
+/// - `manager.supported() == false`: every request is a quiet skip (one
+///   `Info` audit line each), no warnings, never aborts.
+/// - apply Ok: `Info` audit line, `applied += 1`.
+/// - apply Err && `optional`: warning pushed, `Warn` audit line, continue.
+/// - apply Err && !`optional`: `aborted` set, `Warn` audit line, **stop** —
+///   later requests are not attempted so the caller's rollback is clean.
+#[allow(clippy::too_many_arguments)]
+pub fn apply_capabilities(
+    manager: &dyn CapabilityManager,
+    requests: &[CapabilityRequest],
+    log: Option<&crate::central_log::CentralLog>,
+    component: &str,
+    operation_id: &str,
+    actor: &str,
+    install_mode: &str,
+) -> CapabilityRunOutcome {
+    let mut outcome = CapabilityRunOutcome::default();
+    if !manager.supported() {
+        for req in requests {
+            record_capability_op_unsupported(
+                log,
+                &req.path,
+                &req.caps,
+                component,
+                operation_id,
+                actor,
+                install_mode,
+                manager.manager(),
+                manager.unsupported_reason(),
+            );
+        }
+        return outcome;
+    }
+    for req in requests {
+        match manager.apply(&req.path, &req.caps) {
+            Ok(_) => {
+                record_capability_op(
+                    log,
+                    &req.path,
+                    &req.caps,
+                    component,
+                    operation_id,
+                    actor,
+                    install_mode,
+                    None,
+                );
+                outcome.applied += 1;
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                record_capability_op(
+                    log,
+                    &req.path,
+                    &req.caps,
+                    component,
+                    operation_id,
+                    actor,
+                    install_mode,
+                    Some(&msg),
+                );
+                if req.optional {
+                    outcome.warnings.push(format!(
+                        "optional capability for {} failed: {msg}",
+                        req.path.display()
+                    ));
+                } else {
+                    outcome.aborted = Some(format!(
+                        "required capability for {} failed: {msg}",
+                        req.path.display()
+                    ));
+                    return outcome;
+                }
+            }
+        }
+    }
+    outcome
+}
+
+/// Append a [`crate::central_log::LogKind::Component`] record for one
+/// capability apply. `Info` on success, `Warn` when `error` is set (a
+/// tolerated `optional` failure). Best-effort: log errors are swallowed
+/// because the parent verb has already committed the file write.
+// Capability audit records spell out path/caps/actor/mode so install call
+// sites show the full audit context, mirroring `record_service_op`.
+#[allow(clippy::too_many_arguments)]
+pub fn record_capability_op(
+    log: Option<&crate::central_log::CentralLog>,
+    path: &Path,
+    caps: &[String],
+    component: &str,
+    operation_id: &str,
+    actor: &str,
+    install_mode: &str,
+    error: Option<&str>,
+) {
+    let Some(log) = log else {
+        return;
+    };
+    use crate::central_log::{LogKind, LogRecord, Severity};
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let (severity, message) = match error {
+        None => (
+            Severity::Info,
+            format!("capability apply ok for {}: {}", component, path.display()),
+        ),
+        Some(err) => (
+            Severity::Warn,
+            format!(
+                "capability apply skipped for {}: {} ({err})",
+                component,
+                path.display()
+            ),
+        ),
+    };
+    let _ = log.append(&LogRecord {
+        kind: LogKind::Component,
+        operation_id: Some(operation_id.to_string()),
+        command: "capability:apply".to_string(),
+        source: "anolisa-core".to_string(),
+        component: Some(component.to_string()),
+        severity,
+        message,
+        actor: actor.to_string(),
+        install_mode: Some(install_mode.to_string()),
+        started_at: now.clone(),
+        finished_at: Some(now),
+        status: None,
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: Vec::new(),
+        details: serde_json::json!({"path": path.display().to_string(), "caps": caps}),
+    });
+}
+
+/// Append a [`crate::central_log::LogKind::Component`] record for a
+/// capability that was *skipped* because the resolved manager reports
+/// `supported() == false` (non-Linux, user mode, container). `Info`
+/// severity — this is the documented behavior, not a fault — and the
+/// `details` carry `supported = false` plus the skip reason.
+#[allow(clippy::too_many_arguments)]
+pub fn record_capability_op_unsupported(
+    log: Option<&crate::central_log::CentralLog>,
+    path: &Path,
+    caps: &[String],
+    component: &str,
+    operation_id: &str,
+    actor: &str,
+    install_mode: &str,
+    manager_name: &str,
+    unsupported_reason: Option<&str>,
+) {
+    let Some(log) = log else {
+        return;
+    };
+    use crate::central_log::{LogKind, LogRecord, Severity};
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let reason_str =
+        unsupported_reason.unwrap_or("capability manager not supported on this platform");
+    let message = format!(
+        "capability apply skipped for {}: {} {} ({})",
+        component,
+        path.display(),
+        manager_name,
+        reason_str,
+    );
+    let _ = log.append(&LogRecord {
+        kind: LogKind::Component,
+        operation_id: Some(operation_id.to_string()),
+        command: "capability:apply".to_string(),
+        source: "anolisa-core".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message,
+        actor: actor.to_string(),
+        install_mode: Some(install_mode.to_string()),
+        started_at: now.clone(),
+        finished_at: Some(now),
+        status: None,
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: Vec::new(),
+        details: serde_json::json!({
+            "path": path.display().to_string(),
+            "caps": caps,
+            "supported": false,
+            "manager": manager_name,
+            "reason": reason_str,
+        }),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fake_manager_records_apply_calls_in_order() {
+        let m = FakeCapabilityManager::new();
+        m.apply(Path::new("/a"), &["cap_bpf".to_string()]).unwrap();
+        m.apply(Path::new("/b"), &["cap_net_admin".to_string()])
+            .unwrap();
+        assert_eq!(
+            m.calls(),
+            vec![
+                (PathBuf::from("/a"), vec!["cap_bpf".to_string()]),
+                (PathBuf::from("/b"), vec!["cap_net_admin".to_string()]),
+            ]
+        );
+    }
+
+    #[test]
+    fn fake_manager_can_force_failure_per_path() {
+        let m = FakeCapabilityManager::new();
+        m.fail(Path::new("/a"));
+        let err = m
+            .apply(Path::new("/a"), &["cap_bpf".to_string()])
+            .unwrap_err();
+        match err {
+            CapabilityError::NonZeroExit { path, code, .. } => {
+                assert_eq!(path, "/a");
+                assert_eq!(code, 1);
+            }
+            other => panic!("expected NonZeroExit, got {other:?}"),
+        }
+        // A different path still succeeds.
+        assert!(m.apply(Path::new("/b"), &["cap_bpf".to_string()]).is_ok());
+    }
+
+    fn fake_env(os: &str, container: Option<&str>) -> EnvFacts {
+        EnvFacts {
+            os: os.to_string(),
+            arch: "x86_64".to_string(),
+            libc: None,
+            kernel: None,
+            pkg_base: None,
+            os_id: None,
+            os_version: None,
+            btf: None,
+            cap_bpf: None,
+            container: container.map(|s| s.to_string()),
+            user: "tester".to_string(),
+            uid: 1000,
+            home: PathBuf::from("/home/tester"),
+        }
+    }
+
+    #[test]
+    fn factory_returns_setcap_for_linux_system_no_container() {
+        let m = for_install_mode("system", &fake_env("linux", None));
+        assert!(m.supported());
+        assert_eq!(m.manager(), "setcap");
+    }
+
+    #[test]
+    fn factory_skips_user_mode() {
+        let m = for_install_mode("user", &fake_env("linux", None));
+        assert!(!m.supported());
+        assert!(m.unsupported_reason().unwrap().contains("user"));
+    }
+
+    #[test]
+    fn factory_skips_non_linux() {
+        let m = for_install_mode("system", &fake_env("darwin", None));
+        assert!(!m.supported());
+    }
+
+    #[test]
+    fn factory_skips_in_container() {
+        let m = for_install_mode("system", &fake_env("linux", Some("docker")));
+        assert!(!m.supported());
+        let reason = m.unsupported_reason().unwrap();
+        assert!(reason.contains("container") || reason.contains("docker"));
+    }
+
+    #[test]
+    fn factory_allows_non_root() {
+        // Root is deliberately NOT gated: a non-root host still gets the real
+        // SetcapManager so optional=false failures can abort instead of being
+        // silently skipped (a NotSupported skip would be wrong for "no root").
+        let m = for_install_mode("system", &fake_env("linux", None));
+        assert!(m.supported());
+        assert_eq!(m.manager(), "setcap");
+    }
+
+    #[test]
+    fn not_supported_manager_apply_is_quiet_skip() {
+        let m = NotSupportedCapabilityManager::new("nope".to_string());
+        let out = m.apply(Path::new("/a"), &["cap_bpf".to_string()]).unwrap();
+        assert!(!out.supported);
+        assert!(!out.changed);
+        assert_eq!(out.manager, "not-supported");
+    }
+
+    #[test]
+    fn setcap_arg_joins_caps_with_ep_flag() {
+        assert_eq!(
+            setcap_arg(&["CAP_BPF".to_string(), "CAP_PERFMON".to_string()]),
+            "cap_bpf,cap_perfmon+ep"
+        );
+        assert_eq!(setcap_arg(&["cap_bpf".to_string()]), "cap_bpf+ep");
+    }
+
+    fn req(path: &str, optional: bool) -> CapabilityRequest {
+        CapabilityRequest {
+            path: PathBuf::from(path),
+            caps: vec!["cap_bpf".to_string()],
+            optional,
+        }
+    }
+
+    #[test]
+    fn apply_capabilities_applies_all_and_counts() {
+        let m = FakeCapabilityManager::new();
+        let reqs = vec![req("/a", false), req("/b", false)];
+        let out = apply_capabilities(&m, &reqs, None, "comp", "op1", "cli", "system");
+        assert_eq!(out.applied, 2);
+        assert!(out.warnings.is_empty());
+        assert!(out.aborted.is_none());
+    }
+
+    #[test]
+    fn apply_capabilities_unsupported_manager_skips_silently() {
+        let m = NotSupportedCapabilityManager::new("user mode".to_string());
+        let reqs = vec![req("/a", false)];
+        let out = apply_capabilities(&m, &reqs, None, "comp", "op1", "cli", "user");
+        assert_eq!(out.applied, 0);
+        assert!(out.warnings.is_empty());
+        assert!(out.aborted.is_none());
+    }
+
+    #[test]
+    fn apply_capabilities_optional_failure_warns_and_continues() {
+        let m = FakeCapabilityManager::new();
+        m.fail(Path::new("/a"));
+        let reqs = vec![req("/a", true), req("/b", false)];
+        let out = apply_capabilities(&m, &reqs, None, "comp", "op1", "cli", "system");
+        assert_eq!(out.applied, 1);
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("/a"));
+        assert!(out.aborted.is_none());
+    }
+
+    #[test]
+    fn apply_capabilities_required_failure_aborts_and_stops() {
+        let m = FakeCapabilityManager::new();
+        m.fail(Path::new("/a"));
+        let reqs = vec![req("/a", false), req("/b", false)];
+        let out = apply_capabilities(&m, &reqs, None, "comp", "op1", "cli", "system");
+        let reason = out.aborted.expect("must abort on required failure");
+        assert!(reason.contains("/a"));
+        // Stopped at /a — /b was never attempted (rollback relies on this).
+        let calls = m.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, PathBuf::from("/a"));
+    }
+
+    /// One `LogKind::Component` line per apply with `command:
+    /// "capability:apply"`, the component + install_mode + operation_id
+    /// stamped, and `details.path` / `details.caps` carried. Severity is
+    /// Info on success and Warn when an error is reported (a tolerated
+    /// optional failure) so audit pipelines can grep failed grants.
+    #[test]
+    fn record_capability_op_writes_kind_component_lines_with_correct_severity() {
+        use crate::central_log::CentralLog;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("central.log");
+        let log = CentralLog::open(path.clone());
+
+        record_capability_op(
+            Some(&log),
+            Path::new("/opt/agentsight/bin/agentsight"),
+            &["cap_bpf".to_string(), "cap_perfmon".to_string()],
+            "agentsight",
+            "op-cap-001",
+            "tester",
+            "system",
+            None,
+        );
+        record_capability_op(
+            Some(&log),
+            Path::new("/opt/agentsight/bin/agentsight"),
+            &["cap_bpf".to_string()],
+            "agentsight",
+            "op-cap-001",
+            "tester",
+            "system",
+            Some("setcap exited 1"),
+        );
+
+        let content = std::fs::read_to_string(&path).expect("read log");
+        let lines: Vec<serde_json::Value> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("parse line"))
+            .collect();
+        assert_eq!(lines.len(), 2, "expected one record per apply");
+
+        let ok = &lines[0];
+        assert_eq!(ok.get("kind").and_then(|v| v.as_str()), Some("component"));
+        assert_eq!(
+            ok.get("command").and_then(|v| v.as_str()),
+            Some("capability:apply"),
+        );
+        assert_eq!(
+            ok.get("severity").and_then(|v| v.as_str()),
+            Some("info"),
+            "successful capability applies must be Info",
+        );
+        assert_eq!(
+            ok.get("component").and_then(|v| v.as_str()),
+            Some("agentsight"),
+        );
+        assert_eq!(
+            ok.get("install_mode").and_then(|v| v.as_str()),
+            Some("system"),
+        );
+        assert_eq!(
+            ok.get("operation_id").and_then(|v| v.as_str()),
+            Some("op-cap-001"),
+        );
+        assert_eq!(
+            ok.get("details")
+                .and_then(|v| v.get("path"))
+                .and_then(|v| v.as_str()),
+            Some("/opt/agentsight/bin/agentsight"),
+        );
+        assert_eq!(
+            ok.get("details")
+                .and_then(|v| v.get("caps"))
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(2),
+        );
+
+        let err = &lines[1];
+        assert_eq!(
+            err.get("severity").and_then(|v| v.as_str()),
+            Some("warn"),
+            "capability applies that errored must be Warn so audit pipelines can grep",
+        );
+        let msg = err.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            msg.contains("setcap exited 1") && msg.contains("/opt/agentsight/bin/agentsight"),
+            "warn message must carry the underlying error and path: {msg}",
+        );
+    }
+
+    /// `record_capability_op` is a no-op without a log handle — do not
+    /// panic, do not touch disk. A future regression that unwraps the
+    /// optional log would surface here.
+    #[test]
+    fn record_capability_op_with_no_log_handle_is_a_noop() {
+        record_capability_op(
+            None,
+            Path::new("/opt/agentsight/bin/agentsight"),
+            &["cap_bpf".to_string()],
+            "agentsight",
+            "op-cap-002",
+            "tester",
+            "system",
+            None,
+        );
+    }
+
+    /// When the resolved manager is the not-supported stub (non-Linux,
+    /// user mode, container), the verb still leaves an audit trail so
+    /// operators can tell "no caps declared" from "caps declared but no
+    /// manager available". Pins the wire contract: kind=component,
+    /// command=capability:apply, severity=Info (documented behaviour, not
+    /// a fault), details.supported=false, details.reason verbatim.
+    #[test]
+    fn record_capability_op_unsupported_writes_supported_false_details() {
+        use crate::central_log::CentralLog;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("central.log");
+        let log = CentralLog::open(path.clone());
+
+        record_capability_op_unsupported(
+            Some(&log),
+            Path::new("/opt/agentsight/bin/agentsight"),
+            &["cap_bpf".to_string()],
+            "agentsight",
+            "op-cap-003",
+            "tester",
+            "user",
+            "not-supported",
+            Some("install_mode=user is not supported by setcap manager"),
+        );
+
+        let content = std::fs::read_to_string(&path).expect("read log");
+        let lines: Vec<serde_json::Value> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("parse line"))
+            .collect();
+        assert_eq!(lines.len(), 1);
+        let rec = &lines[0];
+        assert_eq!(rec.get("kind").and_then(|v| v.as_str()), Some("component"));
+        assert_eq!(
+            rec.get("command").and_then(|v| v.as_str()),
+            Some("capability:apply"),
+        );
+        assert_eq!(
+            rec.get("severity").and_then(|v| v.as_str()),
+            Some("info"),
+            "unsupported skip is documented behaviour, not a fault — must be Info",
+        );
+        assert_eq!(
+            rec.get("install_mode").and_then(|v| v.as_str()),
+            Some("user"),
+        );
+        let details = rec.get("details").expect("details present");
+        assert_eq!(
+            details.get("supported").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            details.get("manager").and_then(|v| v.as_str()),
+            Some("not-supported"),
+        );
+        assert!(
+            details
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .contains("install_mode=user"),
+        );
+    }
+
+    /// `record_capability_op_unsupported` is a no-op without a log handle.
+    #[test]
+    fn record_capability_op_unsupported_with_no_log_handle_is_a_noop() {
+        record_capability_op_unsupported(
+            None,
+            Path::new("/opt/agentsight/bin/agentsight"),
+            &["cap_bpf".to_string()],
+            "agentsight",
+            "op-cap-004",
+            "tester",
+            "system",
+            "not-supported",
+            Some("nope"),
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/hooks.rs
+++ b/src/anolisa/crates/anolisa-core/src/hooks.rs
@@ -11,7 +11,9 @@
 //!      outside ANOLISA's owned roots (`/etc/passwd-pre-enable.sh`, a
 //!      symlink-into-`/etc`, etc.) is refused without ever running.
 //!      Components cannot opt out of this guard — third-party packages
-//!      ship hooks under `<datadir>/hooks/<component>/...` and that's it.
+//!      ship hooks under `<datadir>/hooks/<component>/...`, declare them in
+//!      `[[component.hooks]]`, and the runner resolves those declarations
+//!      via [`resolve_manifest_hooks`] before spawning.
 //!   2. **Execution**: the script runs as a child process with a bounded
 //!      timeout. Exit 0 = success, anything else = failure. The runner
 //!      captures stderr (tail) + duration so callers can include the
@@ -36,7 +38,9 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
+use crate::adapter::{AdapterError, expand_layout_placeholders};
 use crate::central_log::{CentralLog, LogKind, LogRecord, Severity};
+use crate::manifest::ManifestHookSpec;
 use crate::path_safety::{PathBoundaryError, validate_owned_path};
 use anolisa_platform::fs_layout::FsLayout;
 
@@ -489,81 +493,46 @@ pub struct HookRunResult {
     pub hard_failure: Option<HookOutcome>,
 }
 
-/// Convention for where a component ships its phase scripts. The runner
-/// only ever looks at `<datadir>/hooks/<component>/<phase>.sh` —
-/// components that don't ship a script for a phase get a silent no-op
-/// (the discovery returns `None`, the executor never calls `run_hook`,
-/// so no log line lands in the central log for that combination).
+/// Resolve a component's contract-declared hooks for one `phase` into
+/// executor inputs.
 ///
-/// This is the alpha contract: hooks are 100% manifest-free and live on
-/// disk under an ANOLISA-owned path. A component shipping a hook is the
-/// same delivery shape as shipping a binary — the install runner drops
-/// the file under `<datadir>/hooks/<component>/...`, and the lifecycle
-/// runner picks it up by phase. Path-safety is enforced by `run_hook`
-/// regardless, so a forged absolute path here is still refused before
-/// spawn.
-pub fn discover_component_phase_hook(
+/// Hooks are **contract-driven**: a component declares them in
+/// `[[component.hooks]]` (parsed into [`ManifestHookSpec`]), and the
+/// installer persists that contract verbatim so the uninstall side can read
+/// the real `script`/`strict`/`timeout` back. This is what lets a component
+/// like ws-ckpt mark its `pre-uninstall` recover `strict = false` (a failed
+/// recover warns instead of rolling back the uninstall) — a guarantee the
+/// old `<phase>.sh` filename convention could not express.
+///
+/// `script` is an unexpanded layout-template path
+/// (e.g. `{datadir}/hooks/ws-ckpt/pre-uninstall.sh`); it is expanded with
+/// the same [`expand_layout_placeholders`] machinery used for adapters,
+/// with `{component}` bound so per-component paths resolve. Path-safety is
+/// enforced downstream by [`run_hook`] regardless, so an expanded path that
+/// escapes ANOLISA's owned roots is still refused before spawn.
+///
+/// # Errors
+///
+/// Returns [`AdapterError::UnknownPlaceholder`] when a `script` template
+/// references a placeholder that is neither a layout field nor `{component}`.
+pub fn resolve_manifest_hooks(
+    manifest_hooks: &[ManifestHookSpec],
     layout: &FsLayout,
     component: &str,
     phase: HookPhase,
-) -> Option<HookSpec> {
-    let script = layout
-        .datadir
-        .join("hooks")
-        .join(component)
-        .join(format!("{}.sh", phase.as_str()));
-    if !script.exists() {
-        return None;
+) -> Result<Vec<HookSpec>, AdapterError> {
+    let mut specs = Vec::new();
+    for h in manifest_hooks.iter().filter(|h| h.phase == phase) {
+        let script = expand_layout_placeholders(&h.script, layout, &[("component", component)])?;
+        specs.push(HookSpec {
+            component: component.to_string(),
+            phase,
+            script,
+            timeout_secs: h.timeout_secs,
+            strict: h.strict,
+        });
     }
-    Some(HookSpec::new(component, phase, script))
-}
-
-/// Convenience over `run_hooks` that handles the common "for each
-/// component in this op, run its `<phase>.sh` if present" pattern. Used
-/// by the lifecycle executors (`install_runner`,
-/// `lifecycle::execute_uninstall_or_purge`) so all three verbs share
-/// hook semantics: same discovery convention, same path-safety guard,
-/// same central-log shape, same warning aggregation.
-///
-/// Components with no script for `phase` produce no log line and no
-/// warning — they are simply absent from `outcomes`.
-///
-/// `strict` controls the failure surface. `pre_*` phases pass `true` so
-/// a failed hook short-circuits the parent verb (the runner stops at
-/// the first hard failure and `HookRunResult.hard_failure` is set). The
-/// caller is expected to translate `hard_failure` into a verb-level
-/// error and append a `failed` audit record. `post_*` phases pass
-/// `false` so a failed hook is recorded as a warning but does not
-/// roll back work the verb has already committed.
-// Keep lifecycle/audit dimensions explicit at call sites; hiding them in
-// a bag struct makes hook phase boundaries harder to audit.
-#[allow(clippy::too_many_arguments)]
-pub fn run_phase_hooks(
-    layout: &FsLayout,
-    components: &[String],
-    phase: HookPhase,
-    log: Option<&CentralLog>,
-    operation_id: &str,
-    actor: &str,
-    install_mode: &str,
-    strict: bool,
-) -> HookRunResult {
-    let specs: Vec<HookSpec> = components
-        .iter()
-        .filter_map(|c| discover_component_phase_hook(layout, c, phase))
-        .map(|mut s| {
-            s.strict = strict;
-            s
-        })
-        .collect();
-    if specs.is_empty() {
-        return HookRunResult {
-            outcomes: Vec::new(),
-            warnings: Vec::new(),
-            hard_failure: None,
-        };
-    }
-    run_hooks(&specs, layout, log, operation_id, actor, install_mode)
+    Ok(specs)
 }
 
 #[cfg(test)]
@@ -756,5 +725,72 @@ mod tests {
             outcome.duration < Duration::from_secs(5),
             "should not wait full 5s"
         );
+    }
+
+    #[test]
+    fn resolve_manifest_hooks_expands_path_and_carries_contract_fields() {
+        let dir = tempdir().expect("tmpdir");
+        let layout = layout_with(dir.path());
+        let manifest_hooks = vec![ManifestHookSpec {
+            phase: HookPhase::PreUninstall,
+            script: "{datadir}/hooks/ws-ckpt/pre-uninstall.sh".to_string(),
+            timeout_secs: 45,
+            strict: false,
+        }];
+        let specs =
+            resolve_manifest_hooks(&manifest_hooks, &layout, "ws-ckpt", HookPhase::PreUninstall)
+                .expect("resolve ok");
+        assert_eq!(specs.len(), 1);
+        let spec = &specs[0];
+        assert_eq!(
+            spec.script,
+            layout.datadir.join("hooks/ws-ckpt/pre-uninstall.sh"),
+        );
+        assert_eq!(spec.component, "ws-ckpt");
+        assert_eq!(spec.phase, HookPhase::PreUninstall);
+        assert_eq!(spec.timeout_secs, 45);
+        // ws-ckpt's recover MUST stay non-strict so a failed recover warns
+        // instead of rolling back the uninstall.
+        assert!(!spec.strict);
+    }
+
+    #[test]
+    fn resolve_manifest_hooks_filters_by_phase() {
+        let dir = tempdir().expect("tmpdir");
+        let layout = layout_with(dir.path());
+        let manifest_hooks = vec![
+            ManifestHookSpec {
+                phase: HookPhase::PreUninstall,
+                script: "{datadir}/hooks/c/pre-uninstall.sh".to_string(),
+                timeout_secs: 30,
+                strict: true,
+            },
+            ManifestHookSpec {
+                phase: HookPhase::PostUninstall,
+                script: "{datadir}/hooks/c/post-uninstall.sh".to_string(),
+                timeout_secs: 30,
+                strict: false,
+            },
+        ];
+        let pre = resolve_manifest_hooks(&manifest_hooks, &layout, "c", HookPhase::PreUninstall)
+            .expect("resolve ok");
+        assert_eq!(pre.len(), 1);
+        assert_eq!(pre[0].phase, HookPhase::PreUninstall);
+        assert!(pre[0].strict);
+    }
+
+    #[test]
+    fn resolve_manifest_hooks_rejects_unknown_placeholder() {
+        let dir = tempdir().expect("tmpdir");
+        let layout = layout_with(dir.path());
+        let manifest_hooks = vec![ManifestHookSpec {
+            phase: HookPhase::PreUninstall,
+            script: "{nope}/pre-uninstall.sh".to_string(),
+            timeout_secs: 30,
+            strict: false,
+        }];
+        let err = resolve_manifest_hooks(&manifest_hooks, &layout, "c", HookPhase::PreUninstall)
+            .expect_err("unknown placeholder must error");
+        assert!(matches!(err, AdapterError::UnknownPlaceholder { .. }));
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod adapter;
 pub mod backup;
+pub mod capability;
 pub mod catalog;
 pub mod central_log;
 pub mod component;
@@ -44,6 +45,11 @@ pub use adapter::manager::{
 pub use adapter::registry::DriverRegistry;
 pub use adapter::{AdapterError, DetectResult, detect_framework, expand_layout_placeholders};
 pub use backup::{BackupEntry, BackupSet};
+pub use capability::{
+    CapabilityError, CapabilityManager, CapabilityOutcome, CapabilityRequest, CapabilityRunOutcome,
+    FakeCapabilityManager, NotSupportedCapabilityManager, SetcapManager, apply_capabilities,
+    for_install_mode as capability_for_install_mode,
+};
 pub use catalog::{Catalog, CatalogError, CatalogLayers};
 pub use central_log::{
     CentralLog, CentralLogError, LogFilter, LogKind, LogRecord, LogStatus, Severity,
@@ -57,8 +63,8 @@ pub use download::{DownloadCache, DownloadError, DownloadedArtifact};
 pub use feature_flags::FeatureStore;
 pub use health::{CheckEnv, CheckOutcome, CheckSpec, CheckStatus, Protocol, run_check};
 pub use hooks::{
-    HookOutcome, HookPhase, HookRunResult, HookSkipReason, HookSpec, discover_component_phase_hook,
-    run_hook, run_hooks, run_phase_hooks,
+    HookOutcome, HookPhase, HookRunResult, HookSkipReason, HookSpec, resolve_manifest_hooks,
+    run_hook, run_hooks,
 };
 pub use install_runner::{
     InstallError, InstallOutcome, InstallRunner, InstalledFile, ResolvedInstallFile,
@@ -68,11 +74,13 @@ pub use integrity::{IntegrityStatus, check_owned_file};
 pub use lifecycle::{
     ComponentLifecyclePlan, FileAction, FileActionKind, FileOwner as LifecycleFileOwner,
     HookAction, LifecycleError, LifecycleMode, LifecycleOperation, LifecycleOutcome,
-    LifecyclePhase, LifecyclePlan, LifecycleTargetKind, RiskLevel, ServiceAction,
-    ServiceActionKind, execute_plan,
+    LifecyclePhase, LifecyclePlan, LifecycleTargetKind, ResolvedLifecycleHooks, RiskLevel,
+    ServiceAction, ServiceActionKind, execute_plan,
 };
 pub use lock::{InstallLock, LockError};
-pub use manifest::{AdapterSpec, ComponentManifest, DistributionSelector, FileKind, HealthSpec};
+pub use manifest::{
+    AdapterSpec, ComponentManifest, DistributionSelector, FileKind, HealthSpec, ServiceScope,
+};
 pub use metadata::MetadataClient;
 pub use register::{
     ConsentState, HistoryAction, HistoryEntry, ProductType, RegisterRecord, RegisterSource,
@@ -87,8 +95,9 @@ pub use self_update::{
     check_update, update_url,
 };
 pub use service::{
-    FakeServiceManager, NotSupportedServiceManager, ServiceError, ServiceManager, ServiceOp,
-    ServiceOutcome, ServiceState, SystemdServiceManager,
+    DeactivationOutcome, FakeServiceManager, NotSupportedServiceManager, ServiceActivation,
+    ServiceError, ServiceManager, ServiceOp, ServiceOutcome, ServiceRequest, ServiceRunOutcome,
+    ServiceState, SystemdServiceManager, apply_services, deactivate_services,
     for_install_mode as service_for_install_mode,
 };
 pub use state::{

--- a/src/anolisa/crates/anolisa-core/src/lifecycle.rs
+++ b/src/anolisa/crates/anolisa-core/src/lifecycle.rs
@@ -67,7 +67,7 @@ use anolisa_env::EnvService;
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::central_log::{CentralLog, CentralLogError, LogKind, LogRecord, LogStatus, Severity};
-use crate::hooks::{HookPhase, run_phase_hooks};
+use crate::hooks::{HookSpec, run_hooks};
 use crate::lock::{InstallLock, LockError};
 use crate::service;
 use crate::state::{
@@ -427,7 +427,7 @@ fn plan_services(services: &[ServiceRef]) -> Vec<ServiceAction> {
             name: s.name.clone(),
             action: ServiceActionKind::Stop,
             reason: Some(
-                "stops via systemd in system mode; skipped on user/non-linux/container hosts"
+                "stops and disables via systemd in system mode; skipped on user/non-linux/container hosts"
                     .to_string(),
             ),
         })
@@ -473,9 +473,17 @@ fn default_hooks_for(operation: LifecycleOperation) -> Vec<HookAction> {
     names
         .iter()
         .map(|n| HookAction {
+            // The plan is built from installed state, which does not carry
+            // the component contract, so build() cannot tell here whether a
+            // script is declared for this phase — the executor resolves that
+            // from the installed manifest at run time. Preview it as Execute
+            // with a reason that names the condition.
             name: (*n).to_string(),
-            mode: LifecycleMode::NotImplemented,
-            reason: Some("hook execution not shipped in alpha".to_string()),
+            mode: LifecycleMode::Execute,
+            reason: Some(
+                "runs the contract [[component.hooks]] script for this phase when declared"
+                    .to_string(),
+            ),
         })
         .collect()
 }
@@ -707,10 +715,34 @@ pub enum LifecycleError {
     },
 }
 
+/// Contract-driven lifecycle hooks the caller pre-resolved from the
+/// installed component manifest, grouped by phase.
+///
+/// The executor takes these as input rather than discovering them itself:
+/// the CLI layer owns the installed-manifest path convention and reads back
+/// each component's `[[component.hooks]]` (placeholder expansion + the real
+/// `strict`/`timeout` already applied by
+/// [`resolve_manifest_hooks`](crate::hooks::resolve_manifest_hooks)). A
+/// caller with no manifest snapshot (older installs, RPM-delegated paths)
+/// passes the [`Default`] empty value and the uninstall simply runs no
+/// hooks.
+#[derive(Debug, Default)]
+pub struct ResolvedLifecycleHooks {
+    /// Hooks to run before service-stop and file removal. A `strict = true`
+    /// hook that fails aborts the uninstall and rolls back; `strict = false`
+    /// (e.g. ws-ckpt's recover) only warns.
+    pub pre_uninstall: Vec<HookSpec>,
+    /// Hooks to run after the lock is released and removal has committed.
+    /// Always best-effort — failures only warn.
+    pub post_uninstall: Vec<HookSpec>,
+}
+
 /// Execute a plan (`Uninstall` or `Purge`).
 ///
 /// `actor` is recorded in every audit record; `install_mode` is mirrored
 /// into the central-log records so audit pipelines can filter by mode.
+/// `hooks` carries the component's contract-declared pre/post-uninstall
+/// scripts (see [`ResolvedLifecycleHooks`]).
 ///
 /// The choice of "remove the component object vs. mark it removed":
 /// the alpha state schema has no `Removed` `ObjectStatus`, so the
@@ -722,8 +754,9 @@ pub fn execute_plan(
     layout: &FsLayout,
     actor: &str,
     install_mode: &str,
+    hooks: &ResolvedLifecycleHooks,
 ) -> Result<LifecycleOutcome, LifecycleError> {
-    execute_uninstall_or_purge(plan, layout, actor, install_mode)
+    execute_uninstall_or_purge(plan, layout, actor, install_mode, hooks)
 }
 
 /// `Purge` is still plan-only. The verb declares "remove ANOLISA-owned
@@ -762,6 +795,7 @@ fn execute_uninstall_or_purge(
     layout: &FsLayout,
     actor: &str,
     install_mode: &str,
+    hooks: &ResolvedLifecycleHooks,
 ) -> Result<LifecycleOutcome, LifecycleError> {
     let state_path = layout.state_dir.join("installed.toml");
     let target_name = plan.component.as_str();
@@ -856,17 +890,16 @@ fn execute_uninstall_or_purge(
     // Step 5.25 — pre_uninstall hooks. Run BEFORE service-stop and
     // file-deletion so hooks can drain state, snapshot data, or notify
     // dependents while the component's binaries and services are still
-    // in place.
-    let hook_components: Vec<String> = vec![target_name.to_string()];
-    let pre_uninstall = run_phase_hooks(
+    // in place. Strictness comes from each hook's contract declaration —
+    // a `strict = true` hook failing sets `hard_failure` (→ rollback),
+    // while a `strict = false` hook (e.g. ws-ckpt's recover) only warns.
+    let pre_uninstall = run_hooks(
+        &hooks.pre_uninstall,
         layout,
-        &hook_components,
-        HookPhase::PreUninstall,
         Some(&central),
         &operation_id,
         actor,
         install_mode,
-        true,
     );
 
     if let Some(hf) = pre_uninstall.hard_failure.as_ref() {
@@ -889,11 +922,12 @@ fn execute_uninstall_or_purge(
         );
     }
 
-    // Step 5.5 — best-effort stop of every owned service unit BEFORE
-    // the delete loop. Stopping a service before unlinking its binary
-    // is the only sequence that lets a still-running daemon shut down
-    // cleanly. Stop failures NEVER fail uninstall — they surface on
-    // `LifecycleOutcome.warnings`.
+    // Step 5.5 — best-effort stop AND disable of every owned service unit
+    // BEFORE the delete loop. Stopping before unlinking the binary lets a
+    // running daemon shut down cleanly; disabling removes the boot symlink
+    // install (P0-c) created via `enable`, so an uninstalled component
+    // leaves no orphan `enabled` unit. Both are best-effort: failures NEVER
+    // fail uninstall — they surface on `LifecycleOutcome.warnings`.
     let mut warnings_pre_delete: Vec<String> = pre_uninstall.warnings;
     {
         let mut units: Vec<(String, String)> = Vec::new();
@@ -905,56 +939,15 @@ fn execute_uninstall_or_purge(
         if !units.is_empty() {
             let env = EnvService::detect();
             let manager = service::for_install_mode(install_mode, &env);
-            if manager.supported() {
-                for (component, unit) in &units {
-                    match manager.stop_service(unit) {
-                        Ok(_) => {
-                            service::record_service_op(
-                                Some(&central),
-                                service::ServiceOp::Stop,
-                                component,
-                                unit,
-                                &operation_id,
-                                actor,
-                                install_mode,
-                                None,
-                            );
-                        }
-                        Err(err) => {
-                            let err_msg = err.to_string();
-                            warnings_pre_delete.push(format!(
-                                "service stop skipped for {component}/{unit}: {err_msg}",
-                            ));
-                            service::record_service_op(
-                                Some(&central),
-                                service::ServiceOp::Stop,
-                                component,
-                                unit,
-                                &operation_id,
-                                actor,
-                                install_mode,
-                                Some(&err_msg),
-                            );
-                        }
-                    }
-                }
-            } else {
-                let manager_name = manager.manager().to_string();
-                let reason = manager.unsupported_reason().map(str::to_string);
-                for (component, unit) in &units {
-                    service::record_service_op_unsupported(
-                        Some(&central),
-                        service::ServiceOp::Stop,
-                        component,
-                        unit,
-                        &operation_id,
-                        actor,
-                        install_mode,
-                        &manager_name,
-                        reason.as_deref(),
-                    );
-                }
-            }
+            let deactivation = service::deactivate_services(
+                manager.as_ref(),
+                &units,
+                Some(&central),
+                &operation_id,
+                actor,
+                install_mode,
+            );
+            warnings_pre_delete.extend(deactivation.warnings);
         }
     }
 
@@ -1398,18 +1391,27 @@ fn execute_uninstall_or_purge(
     // Step 11 — post_uninstall hooks. Run AFTER the lock has been
     // released so cleanup scripts can do their own slow IO (rsync state
     // out, archive logs, notify external systems) without holding up
-    // concurrent CLI calls. Failures only warn — by now the central
-    // log already records `succeeded` and `installed.toml` reflects
-    // removal; downgrading would lie about what is on disk.
-    let post_uninstall = run_phase_hooks(
+    // concurrent CLI calls. post_* hooks are best-effort by design: clear
+    // any contract `strict` flag so a failing cleanup script only warns and
+    // never short-circuits the remaining ones — by now the central log
+    // already records `succeeded` and `installed.toml` reflects removal, so
+    // gating here would lie about what is on disk.
+    let post_specs: Vec<HookSpec> = hooks
+        .post_uninstall
+        .iter()
+        .cloned()
+        .map(|mut s| {
+            s.strict = false;
+            s
+        })
+        .collect();
+    let post_uninstall = run_hooks(
+        &post_specs,
         layout,
-        &hook_components,
-        HookPhase::PostUninstall,
         Some(&central),
         &operation_id,
         actor,
         install_mode,
-        false,
     );
     let mut warnings = warnings;
     warnings.extend(post_uninstall.warnings);
@@ -1922,7 +1924,12 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn write_hook_script(layout: &FsLayout, component: &str, phase: &str, body: &str) {
+    fn write_hook_script(
+        layout: &FsLayout,
+        component: &str,
+        phase: &str,
+        body: &str,
+    ) -> std::path::PathBuf {
         use std::os::unix::fs::PermissionsExt;
         let dir = layout.datadir.join("hooks").join(component);
         std_fs::create_dir_all(&dir).expect("mkdir hook dir");
@@ -1931,17 +1938,18 @@ mod tests {
         let mut perm = std_fs::metadata(&path).expect("stat hook").permissions();
         perm.set_mode(0o755);
         std_fs::set_permissions(&path, perm).expect("chmod hook");
+        path
     }
 
-    /// pre_uninstall + post_uninstall scripts discovered under
-    /// `<datadir>/hooks/<component>/<phase>.sh` must actually run
-    /// during a real uninstall AND emit a `LogKind::Component` record
-    /// per attempt to the central log. This pins the wiring so a
-    /// future refactor of `execute_uninstall_or_purge` cannot drop
-    /// hook execution silently.
+    /// Contract-declared pre_uninstall + post_uninstall scripts, passed in
+    /// via [`ResolvedLifecycleHooks`], must actually run during a real
+    /// uninstall AND emit a `LogKind::Component` record per attempt. This
+    /// pins the wiring so a future refactor of `execute_uninstall_or_purge`
+    /// cannot drop hook execution silently.
     #[test]
     #[cfg(unix)]
     fn uninstall_runs_pre_and_post_hooks_and_records_them_in_central_log() {
+        use crate::hooks::HookPhase;
         let root = tempdir().expect("tempdir");
         let layout = fixture_layout(root.path());
         std_fs::create_dir_all(&layout.bin_dir).unwrap();
@@ -1953,24 +1961,29 @@ mod tests {
 
         seed_state_with_two_files(&layout, "agentsight", &owned_path, &external_path);
 
-        write_hook_script(
+        let pre = write_hook_script(
             &layout,
             "agentsight",
             "pre_uninstall",
             "#!/bin/sh\nexit 0\n",
         );
-        write_hook_script(
+        let post = write_hook_script(
             &layout,
             "agentsight",
             "post_uninstall",
             "#!/bin/sh\nexit 0\n",
         );
+        let hooks = ResolvedLifecycleHooks {
+            pre_uninstall: vec![HookSpec::new("agentsight", HookPhase::PreUninstall, pre)],
+            post_uninstall: vec![HookSpec::new("agentsight", HookPhase::PostUninstall, post)],
+        };
 
         let plan = LifecyclePlan::for_component_uninstall(
             "agentsight",
             &InstalledState::load(&layout.state_dir.join("installed.toml")).unwrap(),
         );
-        let outcome = execute_plan(&plan, &layout, "tester", "system").expect("uninstall ok");
+        let outcome =
+            execute_plan(&plan, &layout, "tester", "system", &hooks).expect("uninstall ok");
 
         let lines = read_log_lines(&layout.central_log);
         // Filter on `command starts with "hook:"` so service-op
@@ -2010,6 +2023,94 @@ mod tests {
                 Some("agentsight"),
             );
         }
+    }
+
+    /// ws-ckpt semantics: a **non-strict** pre_uninstall hook that fails
+    /// (e.g. a `recover || warn` that could not recover) must NOT roll back
+    /// the uninstall — it only warns, and removal proceeds.
+    #[test]
+    #[cfg(unix)]
+    fn uninstall_nonstrict_pre_hook_failure_warns_but_completes() {
+        use crate::hooks::HookPhase;
+        let root = tempdir().expect("tempdir");
+        let layout = fixture_layout(root.path());
+        std_fs::create_dir_all(&layout.bin_dir).unwrap();
+        let owned = layout.bin_dir.join("ws-ckpt");
+        std_fs::write(&owned, b"binary").unwrap();
+        let external = layout.etc_dir.join("foreign.conf");
+        std_fs::create_dir_all(external.parent().unwrap()).unwrap();
+        std_fs::write(&external, b"external").unwrap();
+        let state = seed_state_with_two_files(&layout, "ws-ckpt", &owned, &external);
+
+        let script = write_hook_script(&layout, "ws-ckpt", "pre_uninstall", "#!/bin/sh\nexit 1\n");
+        let mut spec = HookSpec::new("ws-ckpt", HookPhase::PreUninstall, script);
+        spec.strict = false;
+        let hooks = ResolvedLifecycleHooks {
+            pre_uninstall: vec![spec],
+            post_uninstall: vec![],
+        };
+
+        let plan = LifecyclePlan::for_component_uninstall("ws-ckpt", &state);
+        let outcome = execute_plan(&plan, &layout, "tester", "system", &hooks)
+            .expect("non-strict hook failure must not abort uninstall");
+
+        assert!(outcome.state_object_removed);
+        assert!(!owned.exists(), "owned file removed despite hook warning");
+        assert!(
+            outcome.warnings.iter().any(|w| w.contains("pre_uninstall")),
+            "hook failure must surface as a warning: {:?}",
+            outcome.warnings,
+        );
+    }
+
+    /// A **strict** pre_uninstall hook that fails aborts the verb and rolls
+    /// back: the owned file is left in place and the error names the phase.
+    #[test]
+    #[cfg(unix)]
+    fn uninstall_strict_pre_hook_failure_aborts_and_rolls_back() {
+        use crate::hooks::HookPhase;
+        let root = tempdir().expect("tempdir");
+        let layout = fixture_layout(root.path());
+        std_fs::create_dir_all(&layout.bin_dir).unwrap();
+        let owned = layout.bin_dir.join("agentsight");
+        std_fs::write(&owned, b"binary").unwrap();
+        let external = layout.etc_dir.join("foreign.conf");
+        std_fs::create_dir_all(external.parent().unwrap()).unwrap();
+        std_fs::write(&external, b"external").unwrap();
+        let state = seed_state_with_two_files(&layout, "agentsight", &owned, &external);
+
+        let script = write_hook_script(
+            &layout,
+            "agentsight",
+            "pre_uninstall",
+            "#!/bin/sh\nexit 7\n",
+        );
+        let mut spec = HookSpec::new("agentsight", HookPhase::PreUninstall, script);
+        spec.strict = true;
+        let hooks = ResolvedLifecycleHooks {
+            pre_uninstall: vec![spec],
+            post_uninstall: vec![],
+        };
+
+        let plan = LifecyclePlan::for_component_uninstall("agentsight", &state);
+        let err = execute_plan(&plan, &layout, "tester", "system", &hooks)
+            .expect_err("strict hook failure must abort");
+        match err {
+            LifecycleError::HookFailed { phase, .. } => assert_eq!(phase, "pre_uninstall"),
+            other => panic!("expected HookFailed, got {other:?}"),
+        }
+        assert!(
+            owned.exists(),
+            "rollback must leave the owned file in place"
+        );
+        let after =
+            InstalledState::load(&layout.state_dir.join("installed.toml")).expect("reload state");
+        assert!(
+            after
+                .find_object(ObjectKind::Component, "agentsight")
+                .is_some(),
+            "component object must survive a rolled-back uninstall",
+        );
     }
 
     #[test]
@@ -2067,8 +2168,14 @@ mod tests {
         let state = seed_state_with_two_files(&layout, "agentsight", &owned, &external);
         let plan = LifecyclePlan::for_component_uninstall("agentsight", &state);
 
-        let outcome =
-            execute_plan(&plan, &layout, "tester", "system").expect("uninstall must succeed");
+        let outcome = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect("uninstall must succeed");
         assert_eq!(outcome.operation, LifecycleOperation::Uninstall);
         assert!(outcome.state_object_removed);
         assert_eq!(outcome.removed_files, vec![owned.clone()]);
@@ -2133,8 +2240,14 @@ mod tests {
         // Hold the install lock from this test thread before invoking.
         let _held = crate::lock::InstallLock::acquire(&layout.lock_file)
             .expect("first acquire must succeed");
-        let err = execute_plan(&plan, &layout, "tester", "system")
-            .expect_err("must fail while lock is held");
+        let err = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect_err("must fail while lock is held");
         match err {
             LifecycleError::LockHeld { path } => assert_eq!(path, layout.lock_file),
             other => panic!("expected LockHeld, got {other:?}"),
@@ -2203,7 +2316,13 @@ mod tests {
         readonly.set_mode(0o500);
         std_fs::set_permissions(&layout.state_dir, readonly).unwrap();
 
-        let result = execute_plan(&plan, &layout, "tester", "system");
+        let result = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        );
 
         // Restore writable perms so we can inspect on-disk state.
         std_fs::set_permissions(&layout.state_dir, original).unwrap();
@@ -2277,7 +2396,14 @@ mod tests {
         // No state on disk at all.
         let empty = InstalledState::default();
         let plan = LifecyclePlan::for_component_uninstall("agentsight", &empty);
-        let err = execute_plan(&plan, &layout, "tester", "system").expect_err("must error");
+        let err = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect_err("must error");
         match err {
             LifecycleError::ComponentNotInstalled { component } => {
                 assert_eq!(component, "agentsight");
@@ -2308,8 +2434,14 @@ mod tests {
         assert_eq!(plan.operation, LifecycleOperation::Purge);
         assert_eq!(plan.risk, RiskLevel::High);
 
-        let err = execute_plan(&plan, &layout, "tester", "system")
-            .expect_err("purge execute must be gated");
+        let err = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect_err("purge execute must be gated");
         match &err {
             LifecycleError::ExecuteGated { reason } => {
                 assert!(
@@ -2344,8 +2476,14 @@ mod tests {
         let state = seed_state_with_two_files(&layout, "agentsight", &owned, &external);
 
         let plan = LifecyclePlan::for_component_uninstall("agentsight", &state);
-        let err = execute_plan(&plan, &layout, "tester", "system")
-            .expect_err("EISDIR must surface as a Filesystem error");
+        let err = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect_err("EISDIR must surface as a Filesystem error");
         assert!(
             matches!(err, LifecycleError::Filesystem { .. }),
             "expected Filesystem error, got {err:?}",
@@ -2428,8 +2566,14 @@ mod tests {
             "test premise broken: plan unexpectedly contains a Remove action",
         );
 
-        let outcome =
-            execute_plan(&plan, &layout, "tester", "system").expect("must succeed cleanly");
+        let outcome = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect("must succeed cleanly");
         assert!(outcome.removed_files.is_empty());
         assert!(outcome.state_object_removed);
 
@@ -2506,8 +2650,14 @@ mod tests {
         state.save(&state_path).expect("seed state save");
 
         let plan = LifecyclePlan::for_component_uninstall("agentsight", &state);
-        let outcome =
-            execute_plan(&plan, &layout, "tester", "system").expect("must succeed cleanly");
+        let outcome = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect("must succeed cleanly");
 
         assert!(
             outcome
@@ -2587,8 +2737,14 @@ mod tests {
         state.save(&state_path).expect("seed state save");
 
         let plan = LifecyclePlan::for_component_uninstall("agentsight", &state);
-        let outcome =
-            execute_plan(&plan, &layout, "tester", "system").expect("uninstall must succeed");
+        let outcome = execute_plan(
+            &plan,
+            &layout,
+            "tester",
+            "system",
+            &ResolvedLifecycleHooks::default(),
+        )
+        .expect("uninstall must succeed");
 
         assert!(
             victim.exists(),

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -11,6 +11,7 @@
 
 use crate::distribution::ArtifactType;
 use crate::health::CheckSpec;
+use crate::hooks::HookPhase;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -208,10 +209,13 @@ pub struct InstallSpec {
     pub modes: Vec<String>,
     /// Files copied or extracted during install.
     pub files: Vec<InstallFileSpec>,
-    /// Service units managed by lifecycle operations.
-    pub services: Vec<String>,
+    /// Service units managed by lifecycle operations (enable/start on
+    /// install, stop/disable on uninstall).
+    pub services: Vec<ServiceSpec>,
     /// Linux capability assignments requested for installed files.
     pub capabilities: Vec<InstallCapabilitySpec>,
+    /// Lifecycle hook scripts run around install/uninstall phases.
+    pub hooks: Vec<ManifestHookSpec>,
 }
 
 /// Role of an installed file (minimal-schema `type` key).
@@ -282,6 +286,67 @@ impl InstallFileSpec {
     }
 }
 
+/// Manager scope for a declared service unit.
+///
+/// `system` units live under `{unitdir}` and are driven by `systemctl`
+/// (needs root); `user` units live under `{userunitdir}` and are driven by
+/// `systemctl --user` (per-user, no root). System services are only
+/// actionable in system install mode.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceScope {
+    /// System-level unit (`systemctl`, needs root). Default.
+    #[default]
+    System,
+    /// User-level unit (`systemctl --user`, per-user, no root).
+    User,
+}
+
+/// systemd unit lifecycle declaration from `[[component.services]]`.
+///
+/// Drives `enable`/`start` on install and `stop`/`disable` on uninstall.
+/// The unit *file* is an ordinary layout entry; this spec references it by
+/// name and declares how its lifecycle is managed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceSpec {
+    /// Native unit name, e.g. `agentsight.service`, or a template unit
+    /// `anolisa-memory@.service` instantiated via [`instance`](Self::instance).
+    pub unit: String,
+    /// Manager scope. Defaults to [`ServiceScope::System`].
+    #[serde(default)]
+    pub scope: ServiceScope,
+    /// `systemctl enable` on install for boot persistence. Defaults true.
+    #[serde(default = "default_true")]
+    pub enable: bool,
+    /// Ensure the unit is active on install, restarting it when already
+    /// running so upgrades pick up the new binary. Defaults true.
+    #[serde(default = "default_true")]
+    pub start: bool,
+    /// Instance token for template (`@.service`) units — e.g. `%u` expands to
+    /// the caller's username (`anolisa-memory@<user>`). `None` for plain units.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance: Option<String>,
+}
+
+impl ServiceSpec {
+    /// Build a spec from a legacy `[install] services = [...]` unit name:
+    /// system scope, enable + start, no template instance.
+    fn from_legacy_unit(unit: String) -> Self {
+        Self {
+            unit,
+            scope: ServiceScope::System,
+            enable: true,
+            start: true,
+            instance: None,
+        }
+    }
+}
+
+/// Serde default for boolean fields whose absent value is `true`.
+fn default_true() -> bool {
+    true
+}
+
 /// Linux capability assignment for an installed file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InstallCapabilitySpec {
@@ -291,6 +356,13 @@ pub struct InstallCapabilitySpec {
     /// Capability names, e.g. `CAP_BPF`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caps: Vec<String>,
+    /// Best-effort flag. When true, a `setcap` failure (no xattr support,
+    /// non-root, unsupported filesystem) degrades to a warning instead of
+    /// aborting the install. Defaults to false — a strict capability whose
+    /// failure must abort. Skipped on serialize when false so legacy
+    /// manifests round-trip byte-stable.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub optional: bool,
 }
 
 impl InstallCapabilitySpec {
@@ -303,6 +375,37 @@ impl InstallCapabilitySpec {
             (None, true) => "<empty>".to_string(),
         }
     }
+}
+
+/// Lifecycle hook declaration from `[[component.hooks]]`.
+///
+/// Distinct from the executor input [`HookSpec`](crate::hooks::HookSpec):
+/// this is the *contract-level declaration*. `script` is an unexpanded
+/// layout-template path (e.g. `{datadir}/hooks/ws-ckpt/pre-uninstall.sh`),
+/// not a resolved absolute path, and the owning component comes from the
+/// surrounding manifest. The executor input is derived from this at install
+/// time (placeholder expansion + path-safety validation).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManifestHookSpec {
+    /// Lifecycle phase that triggers the script.
+    pub phase: HookPhase,
+    /// Layout-template path to the script, shipped in the package payload as
+    /// an ordinary layout file.
+    pub script: String,
+    /// Maximum wall-clock seconds before the script is killed. Defaults to 30.
+    #[serde(default = "default_hook_timeout")]
+    pub timeout_secs: u32,
+    /// Failure handling. When false (default), a failure warns and the verb
+    /// continues; when true, it aborts and the installer rolls back. ws-ckpt's
+    /// pre-uninstall recover stays false to match the RPM `recover || warn`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub strict: bool,
+}
+
+/// Serde default for [`ManifestHookSpec::timeout_secs`] — matches the
+/// executor's alpha 30-second default.
+fn default_hook_timeout() -> u32 {
+    30
 }
 
 /// Optional feature declared by a component manifest.
@@ -462,7 +565,7 @@ pub struct AdapterConfigSetSpec {
 
 /// One skill entry in an `[[adapters]]` or framework-specific section.
 ///
-/// Two TOML forms are accepted (via [`deserialize_skills`]):
+/// Two TOML forms are accepted (via `deserialize_skills`):
 ///
 /// * **String array** (legacy): `skills = ["code-scanner", "prompt-scanner"]`
 ///   — normalised to `AdapterSkillSpec { name, source: None }`.
@@ -654,6 +757,22 @@ struct ComponentMetaRaw {
     artifact: Option<ArtifactRaw>,
     #[serde(default)]
     layout: Option<LayoutRaw>,
+    // `[[component.services]]` — systemd unit lifecycle declarations, a
+    // sibling of `[component.layout]`. ServiceSpec is simple and tolerant
+    // (every field but `unit` defaults), so it deserializes directly without
+    // a separate Raw mirror — same rationale as `[backends]`.
+    #[serde(default)]
+    services: Vec<ServiceSpec>,
+    // `[[component.capabilities]]` — install-related setcap declarations,
+    // a sibling of `[component.layout]` in the minimal schema (the legacy
+    // schema declares them under `[install.capabilities]` instead).
+    #[serde(default)]
+    capabilities: Vec<InstallCapabilityRaw>,
+    // `[[component.hooks]]` — lifecycle hook declarations, minimal-schema only
+    // (legacy `[install]` predates hooks). ManifestHookSpec deserializes
+    // directly: phase + script are required, the rest defaults.
+    #[serde(default)]
+    hooks: Vec<ManifestHookSpec>,
     // `[component.health_check]` — minimal-schema structured check. Parses
     // directly into the internally-tagged `CheckSpec` (`type = "..."`).
     #[serde(default)]
@@ -796,6 +915,8 @@ struct InstallCapabilityRaw {
     path: Option<String>,
     #[serde(default)]
     caps: Vec<String>,
+    #[serde(default)]
+    optional: bool,
 }
 
 #[derive(Deserialize, Default)]
@@ -905,6 +1026,9 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             platform: platform_raw,
             artifact: artifact_raw,
             layout: layout_raw,
+            services: component_services,
+            capabilities: component_capabilities,
+            hooks: component_hooks,
             health_check,
         } = raw.component;
 
@@ -960,9 +1084,11 @@ impl From<ComponentManifestRaw> for ComponentManifest {
 
         // Prefer the minimal-schema `[component.layout]`; fall back to the
         // legacy top-level `[install]` for not-yet-migrated manifests. The
-        // minimal `target` key maps onto the internal `dest`; nested
-        // service/capabilities arrive in T2.7. Legacy `[install]` files may
-        // carry `type` (e.g. symlink entries); absent defaults to `Data`.
+        // minimal `target` key maps onto the internal `dest`. Services,
+        // capabilities, and hooks are `[component.*]` siblings of
+        // `[component.layout]`, parsed only on this minimal path; legacy
+        // `[install]` carries services/capabilities inline and predates hooks.
+        // Legacy files may carry `type` (e.g. symlinks); absent defaults `Data`.
         let install = if let Some(layout) = layout_raw {
             let files = layout
                 .files
@@ -975,11 +1101,21 @@ impl From<ComponentManifestRaw> for ComponentManifest {
                 })
                 .filter(|f| f.install_path().is_some())
                 .collect();
+            let capabilities = capabilities_from_raw(component_capabilities);
+            let services = component_services
+                .into_iter()
+                .filter(|s| !s.unit.is_empty())
+                .collect();
+            let hooks = component_hooks
+                .into_iter()
+                .filter(|h| !h.script.is_empty())
+                .collect();
             InstallSpec {
                 modes: layout.modes,
                 files,
-                services: Vec::new(),
-                capabilities: Vec::new(),
+                services,
+                capabilities,
+                hooks,
             }
         } else {
             raw.install
@@ -995,20 +1131,21 @@ impl From<ComponentManifestRaw> for ComponentManifest {
                         })
                         .filter(|f| f.install_path().is_some())
                         .collect();
-                    let capabilities = i
-                        .capabilities
+                    let capabilities = capabilities_from_raw(i.capabilities);
+                    let services = i
+                        .services
                         .into_iter()
-                        .map(|c| InstallCapabilitySpec {
-                            path: c.path,
-                            caps: c.caps,
-                        })
-                        .filter(|c| c.path.is_some() || !c.caps.is_empty())
+                        .filter(|u| !u.is_empty())
+                        .map(ServiceSpec::from_legacy_unit)
                         .collect();
                     InstallSpec {
                         modes: i.modes,
                         files,
-                        services: i.services,
+                        services,
                         capabilities,
+                        // Hooks are minimal-schema only; legacy `[install]`
+                        // predates them.
+                        hooks: Vec::new(),
                     }
                 })
                 .unwrap_or_default()
@@ -1097,6 +1234,20 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             health_checks,
         }
     }
+}
+
+/// Map raw capability entries to specs, dropping fully-empty rows. Shared by
+/// the minimal-schema (`[[component.capabilities]]`) and legacy
+/// (`[install.capabilities]`) parse paths so the two cannot drift.
+fn capabilities_from_raw(raw: Vec<InstallCapabilityRaw>) -> Vec<InstallCapabilitySpec> {
+    raw.into_iter()
+        .map(|c| InstallCapabilitySpec {
+            path: c.path,
+            caps: c.caps,
+            optional: c.optional,
+        })
+        .filter(|c| c.path.is_some() || !c.caps.is_empty())
+        .collect()
 }
 
 fn source_from_raw(raw: SourceRaw) -> SourceSpec {
@@ -1645,6 +1796,184 @@ mod tests {
             m.install.capabilities[0].caps,
             vec!["cap_bpf", "cap_perfmon"]
         );
+    }
+
+    #[test]
+    fn install_capability_optional_parses_and_defaults_false() {
+        // `optional = true` marks a setcap as best-effort (warn on failure
+        // rather than aborting the install); absent, it defaults to a strict
+        // capability whose failure must abort.
+        let toml_text = r#"
+            [component]
+            name = "agentsight"
+            version = "0.2.0"
+
+            [install]
+            modes = ["system"]
+
+            [[install.capabilities]]
+            path = "{bindir}/agentsight"
+            caps = ["cap_bpf", "cap_perfmon"]
+            optional = true
+
+            [[install.capabilities]]
+            path = "{bindir}/strict-tool"
+            caps = ["cap_net_admin"]
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+
+        assert_eq!(m.install.capabilities.len(), 2);
+        assert!(m.install.capabilities[0].optional);
+        assert!(!m.install.capabilities[1].optional);
+    }
+
+    #[test]
+    fn minimal_schema_parses_component_capabilities() {
+        // `[[component.capabilities]]` lives in the [component] namespace,
+        // a sibling of [component.layout]; the layout branch must read it
+        // (rather than dropping it on the floor as it did before).
+        let toml_text = r#"
+            [component]
+            name = "agentsight"
+            version = "0.2.0"
+
+            [component.layout]
+            modes = ["system"]
+
+            [[component.layout.files]]
+            source = "bin/agentsight"
+            target = "{bindir}/agentsight"
+            type = "executable"
+
+            [[component.capabilities]]
+            path = "{bindir}/agentsight"
+            caps = ["cap_bpf", "cap_perfmon"]
+            optional = true
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse minimal caps");
+
+        assert_eq!(m.install.capabilities.len(), 1);
+        assert_eq!(
+            m.install.capabilities[0].path.as_deref(),
+            Some("{bindir}/agentsight")
+        );
+        assert_eq!(
+            m.install.capabilities[0].caps,
+            vec!["cap_bpf", "cap_perfmon"]
+        );
+        assert!(m.install.capabilities[0].optional);
+    }
+
+    #[test]
+    fn minimal_schema_parses_component_services_with_defaults() {
+        // `[[component.services]]` parses into ServiceSpec. scope defaults to
+        // system; enable/start default to true; instance is template-only.
+        let toml_text = r#"
+            [component]
+            name = "agentsight"
+            version = "0.2.0"
+
+            [component.layout]
+            modes = ["system"]
+
+            [[component.layout.files]]
+            source = "bin/agentsight"
+            target = "{bindir}/agentsight"
+            type = "executable"
+
+            [[component.services]]
+            unit = "agentsight.service"
+
+            [[component.services]]
+            unit = "anolisa-memory@.service"
+            scope = "user"
+            enable = false
+            start = false
+            instance = "%u"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse services");
+
+        assert_eq!(m.install.services.len(), 2);
+        // First service: every optional field defaulted.
+        assert_eq!(m.install.services[0].unit, "agentsight.service");
+        assert_eq!(m.install.services[0].scope, ServiceScope::System);
+        assert!(m.install.services[0].enable);
+        assert!(m.install.services[0].start);
+        assert_eq!(m.install.services[0].instance, None);
+        // Second service: explicit user-scope opt-in template unit.
+        assert_eq!(m.install.services[1].unit, "anolisa-memory@.service");
+        assert_eq!(m.install.services[1].scope, ServiceScope::User);
+        assert!(!m.install.services[1].enable);
+        assert!(!m.install.services[1].start);
+        assert_eq!(m.install.services[1].instance.as_deref(), Some("%u"));
+    }
+
+    #[test]
+    fn legacy_install_services_map_to_specs_with_defaults() {
+        // Legacy `[install] services = [...]` is a bare unit-name list; each
+        // name becomes a system-scoped ServiceSpec with enable/start true.
+        let toml_text = r#"
+            [component]
+            name = "ws-ckpt"
+            version = "0.1.0"
+
+            [install]
+            modes = ["system"]
+            services = ["ws-ckpt.service"]
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse legacy services");
+
+        assert_eq!(m.install.services.len(), 1);
+        assert_eq!(m.install.services[0].unit, "ws-ckpt.service");
+        assert_eq!(m.install.services[0].scope, ServiceScope::System);
+        assert!(m.install.services[0].enable);
+        assert!(m.install.services[0].start);
+    }
+
+    #[test]
+    fn minimal_schema_parses_component_hooks_with_defaults() {
+        // `[[component.hooks]]` declares lifecycle scripts. strict defaults to
+        // false (warn-and-continue) and timeout_secs to 30; phase reuses the
+        // executor's HookPhase vocabulary. `script` stays an unexpanded
+        // layout-template path — expansion happens at install time.
+        let toml_text = r#"
+            [component]
+            name = "ws-ckpt"
+            version = "0.1.0"
+
+            [component.layout]
+            modes = ["system"]
+
+            [[component.layout.files]]
+            source = "bin/ws-ckpt"
+            target = "{bindir}/ws-ckpt"
+            type = "executable"
+
+            [[component.hooks]]
+            phase = "pre_uninstall"
+            script = "{datadir}/hooks/ws-ckpt/pre-uninstall.sh"
+
+            [[component.hooks]]
+            phase = "post_uninstall"
+            script = "{datadir}/hooks/ws-ckpt/post-uninstall.sh"
+            timeout_secs = 120
+            strict = true
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse hooks");
+
+        assert_eq!(m.install.hooks.len(), 2);
+        // First hook: defaulted timeout + non-strict.
+        assert_eq!(m.install.hooks[0].phase, HookPhase::PreUninstall);
+        assert_eq!(
+            m.install.hooks[0].script,
+            "{datadir}/hooks/ws-ckpt/pre-uninstall.sh"
+        );
+        assert_eq!(m.install.hooks[0].timeout_secs, 30);
+        assert!(!m.install.hooks[0].strict);
+        // Second hook: explicit timeout + strict abort.
+        assert_eq!(m.install.hooks[1].phase, HookPhase::PostUninstall);
+        assert_eq!(m.install.hooks[1].timeout_secs, 120);
+        assert!(m.install.hooks[1].strict);
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/service.rs
+++ b/src/anolisa/crates/anolisa-core/src/service.rs
@@ -24,6 +24,8 @@ use std::sync::Mutex;
 
 use anolisa_env::EnvFacts;
 
+use crate::manifest::ServiceScope;
+
 /// One operation issued against a service manager. Used both to drive
 /// systemctl and to record what a [`FakeServiceManager`] saw.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -602,6 +604,311 @@ pub fn record_service_op_unsupported(
     });
 }
 
+/// One resolved service activation. `unit` is the effective unit name
+/// (template instance already substituted by the caller); `scope`,
+/// `enable`, and `start` are carried verbatim from the component's
+/// `[[component.services]]` contract.
+#[derive(Debug, Clone)]
+pub struct ServiceRequest {
+    /// Effective systemd unit name (e.g. `agentsight.service` or
+    /// `anolisa-memory@alice.service`).
+    pub unit: String,
+    /// `system` drives `systemctl`; `user` is a documented skip for now.
+    pub scope: ServiceScope,
+    /// Enable the unit (persistent across boots) when true.
+    pub enable: bool,
+    /// Start the unit now when true. On upgrade this becomes a restart —
+    /// see [`ServiceActivation`].
+    pub start: bool,
+}
+
+/// How [`apply_services`] brings a unit up: a fresh install starts it; an
+/// upgrade restarts it so the replaced binary is reloaded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceActivation {
+    /// Fresh install — `systemctl start`.
+    Start,
+    /// Upgrade — `systemctl restart` to pick up the new binary.
+    Restart,
+}
+
+/// Aggregate result of [`apply_services`]. Activation is best-effort, so
+/// there is no abort field — every request is attempted and failures are
+/// collected as warnings.
+#[derive(Debug, Default)]
+pub struct ServiceRunOutcome {
+    /// Units successfully enabled — used to backfill `ServiceRef.enabled`.
+    pub enabled_units: Vec<String>,
+    /// Units successfully started or restarted.
+    pub started_units: Vec<String>,
+    /// Per-op warnings from tolerated (best-effort) failures.
+    pub warnings: Vec<String>,
+}
+
+/// Enable/start (or restart) each requested unit, recording one audit line
+/// per attempted op. Activation is **best-effort**: a failed enable or
+/// start degrades to a warning and the run continues — service failures
+/// never abort or roll back the install (a component's files are still
+/// usable, and operators can fix the unit out of band).
+///
+/// Skips, in priority order, each producing a documented `Info` audit line
+/// and no warning:
+/// - `scope == user`: user-scope activation is not yet supported.
+/// - `!manager.supported()`: non-Linux, user mode, or container host.
+#[allow(clippy::too_many_arguments)]
+pub fn apply_services(
+    manager: &dyn ServiceManager,
+    requests: &[ServiceRequest],
+    activation: ServiceActivation,
+    log: Option<&crate::central_log::CentralLog>,
+    component: &str,
+    operation_id: &str,
+    actor: &str,
+    install_mode: &str,
+) -> ServiceRunOutcome {
+    let mut outcome = ServiceRunOutcome::default();
+    for req in requests {
+        // Representative op for skip records: prefer the first op we would
+        // have run so the audit line names a meaningful action.
+        let primary_op = if req.enable {
+            ServiceOp::Enable
+        } else {
+            ServiceOp::Start
+        };
+
+        if req.scope == ServiceScope::User {
+            record_service_op_unsupported(
+                log,
+                primary_op,
+                component,
+                &req.unit,
+                operation_id,
+                actor,
+                install_mode,
+                manager.manager(),
+                Some("user-scope service activation not yet supported"),
+            );
+            continue;
+        }
+
+        if !manager.supported() {
+            record_service_op_unsupported(
+                log,
+                primary_op,
+                component,
+                &req.unit,
+                operation_id,
+                actor,
+                install_mode,
+                manager.manager(),
+                manager.unsupported_reason(),
+            );
+            continue;
+        }
+
+        if req.enable {
+            match manager.enable_service(&req.unit) {
+                Ok(_) => {
+                    record_service_op(
+                        log,
+                        ServiceOp::Enable,
+                        component,
+                        &req.unit,
+                        operation_id,
+                        actor,
+                        install_mode,
+                        None,
+                    );
+                    outcome.enabled_units.push(req.unit.clone());
+                }
+                Err(err) => {
+                    let msg = err.to_string();
+                    record_service_op(
+                        log,
+                        ServiceOp::Enable,
+                        component,
+                        &req.unit,
+                        operation_id,
+                        actor,
+                        install_mode,
+                        Some(&msg),
+                    );
+                    outcome
+                        .warnings
+                        .push(format!("enable {} failed: {msg}", req.unit));
+                }
+            }
+        }
+
+        if req.start {
+            let op = match activation {
+                ServiceActivation::Start => ServiceOp::Start,
+                ServiceActivation::Restart => ServiceOp::Restart,
+            };
+            let result = match activation {
+                ServiceActivation::Start => manager.start_service(&req.unit),
+                ServiceActivation::Restart => manager.restart_service(&req.unit),
+            };
+            match result {
+                Ok(_) => {
+                    record_service_op(
+                        log,
+                        op,
+                        component,
+                        &req.unit,
+                        operation_id,
+                        actor,
+                        install_mode,
+                        None,
+                    );
+                    outcome.started_units.push(req.unit.clone());
+                }
+                Err(err) => {
+                    let msg = err.to_string();
+                    record_service_op(
+                        log,
+                        op,
+                        component,
+                        &req.unit,
+                        operation_id,
+                        actor,
+                        install_mode,
+                        Some(&msg),
+                    );
+                    outcome
+                        .warnings
+                        .push(format!("{} {} failed: {msg}", op.as_str(), req.unit));
+                }
+            }
+        }
+    }
+    outcome
+}
+
+/// Aggregate result of [`deactivate_services`]. Like [`ServiceRunOutcome`]
+/// for the install side, deactivation is best-effort: every unit is
+/// attempted and failures are collected as warnings rather than aborting
+/// the uninstall.
+#[derive(Debug, Default)]
+pub struct DeactivationOutcome {
+    /// Units successfully stopped.
+    pub stopped: Vec<String>,
+    /// Units successfully disabled.
+    pub disabled: Vec<String>,
+    /// Per-op warnings from tolerated (best-effort) failures.
+    pub warnings: Vec<String>,
+}
+
+/// Stop and disable each owned unit before its files are removed, recording
+/// one audit line per attempted op. The uninstall-side mirror of
+/// [`apply_services`]: stopping releases the running daemon so its binary
+/// can be unlinked cleanly, disabling removes the boot-time symlink so an
+/// uninstalled component leaves no orphan `enabled` unit behind.
+///
+/// `disable` is idempotent (a no-op on a unit that was never enabled), so
+/// each unit is stopped *and* disabled unconditionally — the executor does
+/// not need to know which units were enabled at install time.
+///
+/// **Best-effort**: a failed stop still proceeds to disable, and neither
+/// failure aborts or rolls back the uninstall — warnings surface on the
+/// verb's outcome instead. An `!manager.supported()` host produces a
+/// documented `Info` skip line per op (stop and disable) and no warning.
+#[allow(clippy::too_many_arguments)]
+pub fn deactivate_services(
+    manager: &dyn ServiceManager,
+    units: &[(String, String)],
+    log: Option<&crate::central_log::CentralLog>,
+    operation_id: &str,
+    actor: &str,
+    install_mode: &str,
+) -> DeactivationOutcome {
+    let mut outcome = DeactivationOutcome::default();
+    for (component, unit) in units {
+        if !manager.supported() {
+            for op in [ServiceOp::Stop, ServiceOp::Disable] {
+                record_service_op_unsupported(
+                    log,
+                    op,
+                    component,
+                    unit,
+                    operation_id,
+                    actor,
+                    install_mode,
+                    manager.manager(),
+                    manager.unsupported_reason(),
+                );
+            }
+            continue;
+        }
+
+        match manager.stop_service(unit) {
+            Ok(_) => {
+                record_service_op(
+                    log,
+                    ServiceOp::Stop,
+                    component,
+                    unit,
+                    operation_id,
+                    actor,
+                    install_mode,
+                    None,
+                );
+                outcome.stopped.push(unit.clone());
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                record_service_op(
+                    log,
+                    ServiceOp::Stop,
+                    component,
+                    unit,
+                    operation_id,
+                    actor,
+                    install_mode,
+                    Some(&msg),
+                );
+                outcome.warnings.push(format!("stop {unit} failed: {msg}"));
+            }
+        }
+
+        // Disable runs even when stop failed: a still-running unit can
+        // still have its boot symlink removed, and leaving it enabled is
+        // exactly the orphan we are here to prevent.
+        match manager.disable_service(unit) {
+            Ok(_) => {
+                record_service_op(
+                    log,
+                    ServiceOp::Disable,
+                    component,
+                    unit,
+                    operation_id,
+                    actor,
+                    install_mode,
+                    None,
+                );
+                outcome.disabled.push(unit.clone());
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                record_service_op(
+                    log,
+                    ServiceOp::Disable,
+                    component,
+                    unit,
+                    operation_id,
+                    actor,
+                    install_mode,
+                    Some(&msg),
+                );
+                outcome
+                    .warnings
+                    .push(format!("disable {unit} failed: {msg}"));
+            }
+        }
+    }
+    outcome
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -915,5 +1222,400 @@ mod tests {
             "not-supported",
             Some("nope"),
         );
+    }
+
+    fn svc_req(unit: &str, enable: bool, start: bool) -> ServiceRequest {
+        ServiceRequest {
+            unit: unit.to_string(),
+            scope: ServiceScope::System,
+            enable,
+            start,
+        }
+    }
+
+    #[test]
+    fn apply_services_enables_then_starts_in_order() {
+        let m = FakeServiceManager::new();
+        let reqs = vec![svc_req("a.service", true, true)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        assert_eq!(
+            m.calls(),
+            vec![
+                (ServiceOp::Enable, "a.service".to_string()),
+                (ServiceOp::Start, "a.service".to_string()),
+            ]
+        );
+        assert_eq!(out.enabled_units, vec!["a.service".to_string()]);
+        assert_eq!(out.started_units, vec!["a.service".to_string()]);
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn apply_services_skips_enable_when_not_requested() {
+        let m = FakeServiceManager::new();
+        let reqs = vec![svc_req("a.service", false, true)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        assert_eq!(m.calls(), vec![(ServiceOp::Start, "a.service".to_string())]);
+        assert!(out.enabled_units.is_empty());
+        assert_eq!(out.started_units, vec!["a.service".to_string()]);
+    }
+
+    #[test]
+    fn apply_services_skips_start_when_not_requested() {
+        let m = FakeServiceManager::new();
+        let reqs = vec![svc_req("a.service", true, false)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        assert_eq!(
+            m.calls(),
+            vec![(ServiceOp::Enable, "a.service".to_string())]
+        );
+        assert_eq!(out.enabled_units, vec!["a.service".to_string()]);
+        assert!(out.started_units.is_empty());
+    }
+
+    #[test]
+    fn apply_services_restart_activation_uses_restart_not_start() {
+        let m = FakeServiceManager::new();
+        let reqs = vec![svc_req("a.service", false, true)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Restart,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        assert_eq!(
+            m.calls(),
+            vec![(ServiceOp::Restart, "a.service".to_string())]
+        );
+        assert_eq!(out.started_units, vec!["a.service".to_string()]);
+    }
+
+    #[test]
+    fn apply_services_enable_failure_warns_and_still_starts() {
+        let m = FakeServiceManager::new();
+        m.fail(ServiceOp::Enable, "a.service");
+        let reqs = vec![svc_req("a.service", true, true)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        // Best-effort: enable failed but start was still attempted.
+        assert_eq!(
+            m.calls(),
+            vec![
+                (ServiceOp::Enable, "a.service".to_string()),
+                (ServiceOp::Start, "a.service".to_string()),
+            ]
+        );
+        assert!(out.enabled_units.is_empty());
+        assert_eq!(out.started_units, vec!["a.service".to_string()]);
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("a.service"));
+    }
+
+    #[test]
+    fn apply_services_start_failure_warns_without_aborting() {
+        let m = FakeServiceManager::new();
+        m.fail(ServiceOp::Start, "a.service");
+        let reqs = vec![svc_req("a.service", true, true)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        assert_eq!(out.enabled_units, vec!["a.service".to_string()]);
+        assert!(out.started_units.is_empty());
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("a.service"));
+    }
+
+    #[test]
+    fn apply_services_unsupported_manager_is_quiet_skip() {
+        let m = NotSupportedServiceManager::new("install_mode=user".to_string());
+        let reqs = vec![svc_req("a.service", true, true)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "user",
+        );
+        assert!(out.enabled_units.is_empty());
+        assert!(out.started_units.is_empty());
+        // Unsupported is a documented skip, not a fault — no warnings.
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn apply_services_user_scope_is_skipped_without_touching_manager() {
+        let m = FakeServiceManager::new();
+        let reqs = vec![ServiceRequest {
+            unit: "anolisa-memory@alice.service".to_string(),
+            scope: ServiceScope::User,
+            enable: true,
+            start: true,
+        }];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        // user-scope activation is out of scope: the manager is never called.
+        assert!(m.calls().is_empty());
+        assert!(out.enabled_units.is_empty());
+        assert!(out.started_units.is_empty());
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn apply_services_logs_info_on_enable_and_warn_on_start_failure() {
+        use crate::central_log::CentralLog;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("central.log");
+        let log = CentralLog::open(path.clone());
+
+        let m = FakeServiceManager::new();
+        m.fail(ServiceOp::Start, "agentsight.service");
+        let reqs = vec![svc_req("agentsight.service", true, true)];
+        apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            Some(&log),
+            "agentsight",
+            "op-svc-1",
+            "tester",
+            "system",
+        );
+
+        let content = std::fs::read_to_string(&path).expect("read log");
+        let lines: Vec<serde_json::Value> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("parse line"))
+            .collect();
+        assert_eq!(lines.len(), 2, "one record per attempted op");
+
+        assert_eq!(
+            lines[0].get("command").and_then(|v| v.as_str()),
+            Some("service:enable"),
+        );
+        assert_eq!(
+            lines[0].get("severity").and_then(|v| v.as_str()),
+            Some("info"),
+        );
+        assert_eq!(
+            lines[1].get("command").and_then(|v| v.as_str()),
+            Some("service:start"),
+        );
+        assert_eq!(
+            lines[1].get("severity").and_then(|v| v.as_str()),
+            Some("warn"),
+            "a failed start must be Warn so audit pipelines can grep",
+        );
+        let msg = lines[1]
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            msg.contains("agentsight.service"),
+            "warn must name the unit: {msg}"
+        );
+    }
+
+    #[test]
+    fn apply_services_unsupported_logs_supported_false_details() {
+        use crate::central_log::CentralLog;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("central.log");
+        let log = CentralLog::open(path.clone());
+
+        let m = NotSupportedServiceManager::new("install_mode=user is not supported".to_string());
+        let reqs = vec![svc_req("agentsight.service", true, true)];
+        apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            Some(&log),
+            "agentsight",
+            "op-svc-2",
+            "tester",
+            "user",
+        );
+
+        let content = std::fs::read_to_string(&path).expect("read log");
+        let lines: Vec<serde_json::Value> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("parse line"))
+            .collect();
+        assert_eq!(lines.len(), 1, "one skip record per request");
+        let rec = &lines[0];
+        assert_eq!(
+            rec.get("severity").and_then(|v| v.as_str()),
+            Some("info"),
+            "unsupported skip is documented behaviour, not a fault",
+        );
+        let details = rec.get("details").expect("details present");
+        assert_eq!(
+            details.get("supported").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+    }
+
+    fn unit(component: &str, name: &str) -> (String, String) {
+        (component.to_string(), name.to_string())
+    }
+
+    #[test]
+    fn deactivate_services_stops_then_disables_in_order() {
+        let m = FakeServiceManager::new();
+        let units = vec![unit("agentsight", "agentsight.service")];
+        let out = deactivate_services(&m, &units, None, "op1", "cli", "system");
+        assert_eq!(
+            m.calls(),
+            vec![
+                (ServiceOp::Stop, "agentsight.service".to_string()),
+                (ServiceOp::Disable, "agentsight.service".to_string()),
+            ]
+        );
+        assert_eq!(out.stopped, vec!["agentsight.service".to_string()]);
+        assert_eq!(out.disabled, vec!["agentsight.service".to_string()]);
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn deactivate_services_stop_failure_warns_and_still_disables() {
+        let m = FakeServiceManager::new();
+        m.fail(ServiceOp::Stop, "a.service");
+        let units = vec![unit("comp", "a.service")];
+        let out = deactivate_services(&m, &units, None, "op1", "cli", "system");
+        // Best-effort: stop failed but disable was still attempted so the
+        // boot symlink is removed regardless.
+        assert_eq!(
+            m.calls(),
+            vec![
+                (ServiceOp::Stop, "a.service".to_string()),
+                (ServiceOp::Disable, "a.service".to_string()),
+            ]
+        );
+        assert!(out.stopped.is_empty());
+        assert_eq!(out.disabled, vec!["a.service".to_string()]);
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("a.service"));
+    }
+
+    #[test]
+    fn deactivate_services_disable_failure_warns_without_aborting() {
+        let m = FakeServiceManager::new();
+        m.fail(ServiceOp::Disable, "a.service");
+        let units = vec![unit("comp", "a.service")];
+        let out = deactivate_services(&m, &units, None, "op1", "cli", "system");
+        assert_eq!(out.stopped, vec!["a.service".to_string()]);
+        assert!(out.disabled.is_empty());
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("a.service"));
+    }
+
+    #[test]
+    fn deactivate_services_unsupported_manager_is_quiet_skip() {
+        let m = NotSupportedServiceManager::new("install_mode=user".to_string());
+        let units = vec![unit("comp", "a.service")];
+        let out = deactivate_services(&m, &units, None, "op1", "cli", "user");
+        // Unsupported never touches a manager method and never warns.
+        assert!(out.stopped.is_empty());
+        assert!(out.disabled.is_empty());
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn deactivate_services_logs_stop_and_disable_records() {
+        use crate::central_log::CentralLog;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("central.log");
+        let log = CentralLog::open(path.clone());
+
+        let m = FakeServiceManager::new();
+        let units = vec![unit("agentsight", "agentsight.service")];
+        deactivate_services(&m, &units, Some(&log), "op-deact-1", "tester", "system");
+
+        let content = std::fs::read_to_string(&path).expect("read log");
+        let lines: Vec<serde_json::Value> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("parse line"))
+            .collect();
+        assert_eq!(lines.len(), 2, "one record per attempted op");
+        assert_eq!(
+            lines[0].get("command").and_then(|v| v.as_str()),
+            Some("service:stop"),
+        );
+        assert_eq!(
+            lines[1].get("command").and_then(|v| v.as_str()),
+            Some("service:disable"),
+        );
+        for rec in &lines {
+            assert_eq!(rec.get("severity").and_then(|v| v.as_str()), Some("info"));
+            assert_eq!(rec.get("kind").and_then(|v| v.as_str()), Some("component"));
+        }
+    }
+
+    #[test]
+    fn deactivate_services_with_no_log_handle_is_a_noop() {
+        let m = FakeServiceManager::new();
+        let units = vec![unit("comp", "a.service")];
+        // None log handle must not panic and must still drive the manager.
+        let out = deactivate_services(&m, &units, None, "op1", "cli", "system");
+        assert_eq!(out.stopped.len() + out.disabled.len(), 2);
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/telemetry/ilogtail.rs
+++ b/src/anolisa/crates/anolisa-core/src/telemetry/ilogtail.rs
@@ -14,7 +14,7 @@ use crate::metadata::MetadataClient;
 use crate::telemetry::{TelemetryConfig, TelemetryError, validate_sls_account_id};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
 
 // ── RegionProbe ───────────────────────────────────────────────────────
 
@@ -146,14 +146,7 @@ impl<'a> IlogtailInstaller<'a> {
         if !init_script.exists() {
             return Ok(false);
         }
-        let output = Command::new(init_script)
-            .arg("status")
-            .output()
-            .map_err(|e| {
-                TelemetryError::Command(format!(
-                    "failed to check ilogtaild-aliyun-security status: {e}"
-                ))
-            })?;
+        let output = run_init_status(init_script, "ilogtaild-aliyun-security")?;
         Ok(String::from_utf8_lossy(&output.stdout).contains("ilogtail is running"))
     }
 
@@ -162,12 +155,7 @@ impl<'a> IlogtailInstaller<'a> {
         if !init_script.exists() {
             return Ok(false);
         }
-        let output = Command::new(init_script)
-            .arg("status")
-            .output()
-            .map_err(|e| {
-                TelemetryError::Command(format!("failed to check ilogtaild status: {e}"))
-            })?;
+        let output = run_init_status(init_script, "ilogtaild")?;
         Ok(String::from_utf8_lossy(&output.stdout).contains("ilogtail is running"))
     }
 
@@ -436,6 +424,21 @@ impl<'a> IlogtailInstaller<'a> {
     }
 }
 
+fn run_init_status(init_script: &Path, name: &str) -> Result<Output, TelemetryError> {
+    let mut command = Command::new(init_script);
+    command
+        .arg("status")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let child = crate::process::spawn_retry_etxtbsy(&mut command)
+        .map_err(|e| TelemetryError::Command(format!("failed to check {name} status: {e}")))?;
+    child
+        .wait_with_output()
+        .map_err(|e| TelemetryError::Command(format!("failed to check {name} status: {e}")))
+}
+
 // ── Unit tests ─────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -605,6 +608,33 @@ mod tests {
                 .join(&cfg.sls_account_id)
                 .exists()
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_ensure_installed_retries_when_init_script_is_temporarily_busy() {
+        let dir = TempDir::new().unwrap();
+        let cfg = test_config(&dir);
+        write_mock_init_script(&cfg.aliyun_security_init, "ilogtail is running");
+
+        let writer = fs::OpenOptions::new()
+            .write(true)
+            .open(&cfg.aliyun_security_init)
+            .unwrap();
+        let cfg_for_thread = cfg.clone();
+        let handle = std::thread::spawn(move || {
+            let installer = IlogtailInstaller::new(&cfg_for_thread);
+            let region = RegionInfo {
+                region_id: "cn-hangzhou".into(),
+                use_internal: false,
+            };
+            installer.ensure_installed(&region)
+        });
+
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        drop(writer);
+
+        handle.join().unwrap().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implement the **raw (tarball) backend** half of declarative install operations
from #1070: a component declares `[[component.services]]`,
`[[component.capabilities]]`, and `[[component.hooks]]` in its `component.toml`
contract, and anolisa's raw install/uninstall executors honor that single
declaration.

## Background / Motivation

#1070 notes that several components are not usable after a file-only install:
agentsight needs `cap_bpf,cap_perfmon` on its binary and its
`agentsight.service` enabled/started; ws-ckpt must `recover` while its daemon is
still up *before* uninstall removes files. The RPM backend already performs
these via `.spec` scriptlets, so the *same component reached a different system
state* depending on which backend installed it. This PR gives the raw backend
parity for those install-related operations, driven by one declarative contract.

## What changed

- **Contract parsing**: the `[component.layout]` minimal-schema parser now reads
  sibling `[[component.services]]` / `[[component.capabilities]]` /
  `[[component.hooks]]` declarations.
- **Capabilities executor** (`setcap`): applies declared Linux file caps on raw
  install/update; install keeps `optional=false` abort/rollback semantics, while
  raw update applies caps only after the new state is durable and reports any
  failure as a committed warning because xattrs are not transaction-journaled.
- **Service activation**: enables and starts declared systemd units on raw
  install; stops then disables them on uninstall.
- **Lifecycle hooks**: runs the contract's standalone hook scripts in the fixed
  order - install: `pre_install -> lay files -> setcap -> post_install ->
  service enable/start -> post_enable`; uninstall: `pre_uninstall ->
  service stop/disable -> remove files -> post_uninstall`. Hook scripts are
  shipped as ordinary layout files; no shell is inlined into the contract.
  On a fresh raw install, an artifact-local `pre_install` script is not on disk
  yet and is expected to skip as Missing; that phase is mainly useful when a
  prior version already laid the script.
- **Failure semantics**: file/symlink -> transactional rollback; install
  `setcap` optional -> warn, required -> abort/rollback; service activation ->
  best-effort warn; hook `strict=false` -> warn-and-continue, `strict=true` ->
  abort and roll back laid files and the manifest snapshot. Post-service hard
  failures best-effort stop/disable units activated by the failed install before
  rolling back files; raw update applies capability/service side effects only
  after the new state has been persisted, so those failures are reported as
  committed warnings instead of triggering an incomplete rollback.
- **Backend gating (no double-execution)**: these executors run **only for
  raw-managed** components; rpm-managed / rpm-observed teardown returns early
  and is left to `.spec` scriptlets.
- **Mode gating**: `setcap` and `scope=system` services run only in system mode;
  user mode / containers / non-Linux skip silently (treated as "not supported").

## Not addressed in this PR (follow-ups to #1070)

This PR intentionally covers only the raw backend, so #1070 stays open for:

- **`scope=user` service activation** via `systemctl --user` (needed by
  agent-memory); service enable/start currently handles system scope only.
- **`{unitdir}` / `{userunitdir}` layout template variables.**

(agent-sec-core stays RPM-only by design, per #1070.)

## Test

- Unit (core): capability executor (apply / optional-warn / required-abort /
  unsupported-skip); service activate and deactivate (enable+start, stop+disable,
  not-supported skip); hook resolution with phase filtering.
- Unit (cli): install-side hook phase classification and invalid-placeholder
  rejection.
- E2E (cli, raw backend): post_install hook runs; a strict post_install failure
  rolls back installed files and the manifest snapshot; pre_install is silently
  skipped as Missing on fresh install (script not yet laid); a contract-declared
  pre_uninstall hook runs on uninstall.
- Full gate green: `cargo fmt --all -- --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace`, `cargo doc --workspace --no-deps`.

Refs #1070
