### PR TITLE
feat(sight): upload skill metrics via SLS logtail exporter

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -6,7 +6,10 @@
     "enabled": false,
     "kill_after_count": 3
   },
-  "https": [{"rule": ["dashscope.aliyuncs.com"]}],
+  "https": [
+    {"rule": ["dashscope.aliyuncs.com"]},
+    {"rule": ["api.openai.com"]}
+  ],
   "http": [],
   "encryption": {
     "public_key": ""

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -1158,8 +1158,8 @@ mod tests {
         let (cmdline_rules, https_rules, http_targets) =
             parse_json_rules(DEFAULT_AGENTS_JSON).unwrap();
         assert!(!cmdline_rules.is_empty());
-        // https rules: dashscope.aliyuncs.com configured by default
-        assert_eq!(https_rules.len(), 1);
+        // https rules: dashscope.aliyuncs.com + api.openai.com configured by default
+        assert_eq!(https_rules.len(), 2);
         assert!(http_targets.is_empty());
     }
 

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -16,9 +16,16 @@ use super::exporter::GenAIExporter;
 use super::instance_id;
 use super::semantic::GenAISemanticEvent;
 use crate::interruption::types::InterruptionEvent;
+use crate::skill_metrics::extractor::extract_skill_load_counts_from_messages;
 
 /// 环境变量名称
 pub const LOGTAIL_ENV_VAR: &str = "SLS_LOGTAIL_FILE";
+
+/// 默认 SLS Logtail 输出路径。
+///
+/// 当 `SLS_LOGTAIL_FILE` 环境变量未指向 `/var/sysom/` 目录时，
+/// AgentSight 使用此路径作为本地默认 SLS 输出文件。
+pub const DEFAULT_SLS_LOGTAIL_PATH: &str = "/var/log/anolisa/sls/ops/agentsight.jsonl";
 
 /// 动态 Logtail 路径（由 config watcher 运行时设置）
 static DYNAMIC_LOGTAIL_PATH: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
@@ -63,6 +70,28 @@ pub fn logtail_path() -> Option<String> {
     }
     // 回退到动态配置路径
     DYNAMIC_LOGTAIL_PATH.read().ok().and_then(|g| g.clone())
+}
+
+/// 返回当前应写入 SLS Logtail 的所有活动路径。
+///
+/// 规则与 `unified.rs` 中的 exporter 注册逻辑保持一致：
+/// - 若 `SLS_LOGTAIL_FILE` 指向 `/var/sysom/` 目录，仅返回该 sysom 路径；
+/// - 否则返回 `SLS_LOGTAIL_FILE`（如有）与 [`DEFAULT_SLS_LOGTAIL_PATH`] 的组合。
+///
+/// 返回的列表已去重，避免同一文件被重复写入。
+pub fn active_logtail_paths() -> Vec<std::path::PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(p) = logtail_path() {
+        if p.starts_with("/var/sysom/") {
+            return vec![std::path::PathBuf::from(p)];
+        }
+        paths.push(std::path::PathBuf::from(p));
+    }
+    let default = std::path::PathBuf::from(DEFAULT_SLS_LOGTAIL_PATH);
+    if !paths.contains(&default) {
+        paths.push(default);
+    }
+    paths
 }
 
 /// iLogtail 文件导出器
@@ -121,34 +150,87 @@ impl LogtailExporter {
         })
     }
 
-    /// 从显式路径创建 Logtail 导出器（用于运行时动态激活）
+    /// 创建默认路径的 Logtail 导出器。
     ///
-    /// 与 `new()` 不同，不依赖环境变量，直接使用传入的路径。
-    pub fn new_with_path(
-        path_str: &str,
-        encryption_pem: Option<&str>,
-        trace_enabled: bool,
-    ) -> Self {
-        let path = PathBuf::from(path_str);
+    /// 固定写入 [`DEFAULT_SLS_LOGTAIL_PATH`]，不受 `SLS_LOGTAIL_FILE`
+    /// 环境变量或动态配置影响。用于非 sysom 模式下的本地默认 SLS 输出。
+    pub fn new_default(encryption_pem: Option<&str>, trace_enabled: bool) -> Self {
+        let path = PathBuf::from(DEFAULT_SLS_LOGTAIL_PATH);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).ok();
         }
         let encryptor = encryption_pem.and_then(MessageEncryptor::from_pem);
         if encryptor.is_none() {
             log::info!(
-                "Logtail exporter (dynamic): encryption disabled (no public key configured)"
+                "Logtail exporter (default): encryption disabled (no public key configured)"
             );
         }
         if !trace_enabled {
             log::info!(
-                "Logtail exporter (dynamic): traceEnabled=false, conversation content fields (gen_ai.system_instructions, gen_ai.input.messages, gen_ai.output.messages) will NOT be uploaded"
+                "Logtail exporter (default): traceEnabled=false, conversation content fields (gen_ai.system_instructions, gen_ai.input.messages, gen_ai.output.messages) will NOT be uploaded"
             );
         }
         LogtailExporter {
             path,
             encryptor,
             trace_enabled,
-            dynamic: true,
+            dynamic: false,
+        }
+    }
+
+    /// 从显式路径创建 Logtail 导出器（用于运行时动态激活）
+    ///
+    /// 与 `new()` 不同，不依赖环境变量，直接使用传入的路径。
+    /// 创建的导出器为动态模式，每次 `export()` 都会重新读取最新路径。
+    pub fn new_with_path(
+        path_str: &str,
+        encryption_pem: Option<&str>,
+        trace_enabled: bool,
+    ) -> Self {
+        Self::new_with_path_dynamic(path_str, encryption_pem, trace_enabled, true)
+    }
+
+    /// 从显式路径创建固定路径的 Logtail 导出器。
+    ///
+    /// 与 `new_with_path` 不同，创建的导出器为静态模式，始终写入构造时
+    /// 锁定的路径，不受环境变量或动态配置变化影响。
+    pub fn new_with_fixed_path(
+        path_str: &str,
+        encryption_pem: Option<&str>,
+        trace_enabled: bool,
+    ) -> Self {
+        Self::new_with_path_dynamic(path_str, encryption_pem, trace_enabled, false)
+    }
+
+    fn new_with_path_dynamic(
+        path_str: &str,
+        encryption_pem: Option<&str>,
+        trace_enabled: bool,
+        dynamic: bool,
+    ) -> Self {
+        let path = PathBuf::from(path_str);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let encryptor = encryption_pem.and_then(MessageEncryptor::from_pem);
+        let label = if dynamic { "dynamic" } else { "fixed" };
+        if encryptor.is_none() {
+            log::info!(
+                "Logtail exporter ({}): encryption disabled (no public key configured)",
+                label
+            );
+        }
+        if !trace_enabled {
+            log::info!(
+                "Logtail exporter ({}): traceEnabled=false, conversation content fields (gen_ai.system_instructions, gen_ai.input.messages, gen_ai.output.messages) will NOT be uploaded",
+                label
+            );
+        }
+        LogtailExporter {
+            path,
+            encryptor,
+            trace_enabled,
+            dynamic,
         }
     }
 
@@ -466,6 +548,23 @@ pub fn events_to_flat_records(
                 if let Some(sid) = call.metadata.get("session_id") {
                     m.insert("gen_ai.session.id".to_string(), sid.clone());
                 }
+
+                // ── AgentSkill extensions: skill names and counts as JSON arrays ──
+                let skill_counts = extract_skill_load_counts_from_messages(&call.response.messages);
+                if !skill_counts.is_empty() {
+                    let mut skill_pairs: Vec<(String, u64)> = skill_counts.into_iter().collect();
+                    skill_pairs.sort_by(|a, b| a.0.cmp(&b.0));
+                    let names: Vec<String> = skill_pairs.iter().map(|(k, _)| k.clone()).collect();
+                    let counts: Vec<u64> = skill_pairs.iter().map(|(_, v)| *v).collect();
+                    m.insert(
+                        "agent.skill.name".to_string(),
+                        serde_json::to_string(&names).unwrap_or_default(),
+                    );
+                    m.insert(
+                        "agent.skill.load_count".to_string(),
+                        serde_json::to_string(&counts).unwrap_or_default(),
+                    );
+                }
             }
             GenAISemanticEvent::ToolUse(tool) => {
                 m.insert("gen_ai.operation.name".to_string(), "tool_use".to_string());
@@ -606,19 +705,17 @@ pub fn interruption_events_to_flat_records(
 
 /// 将中断事件批量导出到 iLogtail 文件（追加写入）
 ///
-/// 仅在环境变量 `SLS_LOGTAIL_FILE` 设置时生效；否则为空操作。
-/// 与 `LogtailExporter::write_batch` 写入同一文件，由 iLogtail 统一采集到 SLS。
+/// 写入路径与 `LogtailExporter::write_batch` 保持一致：
+/// - 若 `SLS_LOGTAIL_FILE` 指向 `/var/sysom/` 目录，仅写入该 sysom 路径；
+/// - 否则写入 `SLS_LOGTAIL_FILE`（如有）与 [`DEFAULT_SLS_LOGTAIL_PATH`] 的组合。
+/// 由 iLogtail 统一采集到 SLS。
 pub fn export_interruption_events(events: &[InterruptionEvent]) {
     if events.is_empty() {
         return;
     }
-    let path_str = match logtail_path() {
-        Some(p) => p,
-        None => return,
-    };
-    let path = PathBuf::from(path_str);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).ok();
+    let paths = active_logtail_paths();
+    if paths.is_empty() {
+        return;
     }
 
     let records = interruption_events_to_flat_records(events);
@@ -626,7 +723,19 @@ pub fn export_interruption_events(events: &[InterruptionEvent]) {
         return;
     }
 
-    let file = match OpenOptions::new().create(true).append(true).open(&path) {
+    for path in &paths {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        write_interruption_records_to_path(path, &records);
+    }
+}
+
+fn write_interruption_records_to_path(
+    path: &std::path::Path,
+    records: &[BTreeMap<String, String>],
+) {
+    let file = match OpenOptions::new().create(true).append(true).open(path) {
         Ok(f) => f,
         Err(e) => {
             log::warn!("Failed to open logtail file {path:?} for interruption export: {e}");
@@ -635,7 +744,7 @@ pub fn export_interruption_events(events: &[InterruptionEvent]) {
     };
 
     let mut writer = BufWriter::new(file);
-    for record in &records {
+    for record in records {
         match serde_json::to_string(record) {
             Ok(json_line) => {
                 if let Err(e) = writeln!(writer, "{json_line}") {
@@ -837,5 +946,158 @@ mod tests {
         );
         assert_eq!(r.get("gen_ai.tool.name").map(String::as_str), Some("shell"));
         assert_eq!(r.get("agentsight.pid").map(String::as_str), Some("7"));
+    }
+
+    // Serialize tests that mutate the process-wide SLS_LOGTAIL_FILE env var
+    // or the global dynamic logtail path.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn reset_logtail_state() {
+        // SAFETY: tests acquire ENV_LOCK before mutating this variable,
+        // so no other test thread can observe a race.
+        unsafe { std::env::remove_var(LOGTAIL_ENV_VAR) };
+        set_dynamic_logtail_path("");
+    }
+
+    #[test]
+    fn test_active_logtail_paths_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_logtail_state();
+        let paths = active_logtail_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], PathBuf::from(DEFAULT_SLS_LOGTAIL_PATH));
+    }
+
+    #[test]
+    fn test_active_logtail_paths_env_combined_with_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_logtail_state();
+        let tmp = std::env::temp_dir().join(format!("agentsight_logtail_{}", std::process::id()));
+        let env_path = tmp.join("env.jsonl");
+        // SAFETY: tests acquire ENV_LOCK before mutating this variable.
+        unsafe { std::env::set_var(LOGTAIL_ENV_VAR, env_path.to_str().unwrap()) };
+
+        let paths = active_logtail_paths();
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&PathBuf::from(DEFAULT_SLS_LOGTAIL_PATH)));
+        assert!(paths.contains(&env_path));
+
+        std::fs::remove_dir_all(&tmp).ok();
+        reset_logtail_state();
+    }
+
+    #[test]
+    fn test_active_logtail_paths_env_equals_default_deduped() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_logtail_state();
+        // SAFETY: tests acquire ENV_LOCK before mutating this variable.
+        unsafe { std::env::set_var(LOGTAIL_ENV_VAR, DEFAULT_SLS_LOGTAIL_PATH) };
+
+        let paths = active_logtail_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], PathBuf::from(DEFAULT_SLS_LOGTAIL_PATH));
+        reset_logtail_state();
+    }
+
+    #[test]
+    fn test_active_logtail_paths_sysom_only() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_logtail_state();
+        let sysom_path = "/var/sysom/ilog/agentsight/agentsight.jsonl";
+        // SAFETY: tests acquire ENV_LOCK before mutating this variable.
+        unsafe { std::env::set_var(LOGTAIL_ENV_VAR, sysom_path) };
+
+        let paths = active_logtail_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], PathBuf::from(sysom_path));
+        reset_logtail_state();
+    }
+
+    #[test]
+    fn test_logtail_exporter_new_default_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_logtail_state();
+        let exporter = LogtailExporter::new_default(None, false);
+        assert_eq!(exporter.path(), PathBuf::from(DEFAULT_SLS_LOGTAIL_PATH));
+        reset_logtail_state();
+    }
+
+    #[test]
+    fn test_logtail_exporter_new_with_fixed_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_logtail_state();
+        let tmp = std::env::temp_dir().join(format!("agentsight_fixed_{}", std::process::id()));
+        let path = tmp.join("fixed.jsonl");
+        let exporter = LogtailExporter::new_with_fixed_path(path.to_str().unwrap(), None, false);
+        assert_eq!(exporter.path(), path);
+        std::fs::remove_dir_all(&tmp).ok();
+        reset_logtail_state();
+    }
+
+    #[test]
+    fn test_skill_fields_in_llm_call_records() {
+        let mut call = make_full_llm_call();
+        call.response.messages.push(OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![
+                MessagePart::ToolCall {
+                    id: Some("tc-1".to_string()),
+                    name: "Skill".to_string(),
+                    arguments: Some(serde_json::json!({"skill": "pdf"})),
+                },
+                MessagePart::ToolCall {
+                    id: Some("tc-2".to_string()),
+                    name: "read_file".to_string(),
+                    arguments: Some(serde_json::json!({"file_path": "/skills/read/SKILL.md"})),
+                },
+            ],
+            name: None,
+            finish_reason: None,
+        });
+
+        let event = GenAISemanticEvent::LLMCall(call);
+        let records = events_to_flat_records(&[event], None, false);
+        assert_eq!(records.len(), 1);
+        let r = &records[0];
+        assert_eq!(
+            r.get("agent.skill.name").map(String::as_str),
+            Some("[\"pdf\",\"read\"]")
+        );
+        assert_eq!(
+            r.get("agent.skill.load_count").map(String::as_str),
+            Some("[1,1]")
+        );
+    }
+
+    #[test]
+    fn test_export_interruption_events_writes_records() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_logtail_state();
+        let tmp =
+            std::env::temp_dir().join(format!("agentsight_interruption_{}", std::process::id()));
+        let path = tmp.join("interruption.jsonl");
+        // SAFETY: tests acquire ENV_LOCK before mutating this variable.
+        unsafe { std::env::set_var(LOGTAIL_ENV_VAR, path.to_str().unwrap()) };
+
+        let event = InterruptionEvent::new(
+            crate::interruption::InterruptionType::AgentCrash,
+            Some("session-1".to_string()),
+            None,
+            Some("conv-1".to_string()),
+            None,
+            Some(42),
+            Some("test-agent".to_string()),
+            1_000_000,
+            Some(serde_json::json!({"pid": 42})),
+        );
+        export_interruption_events(&[event]);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.is_empty());
+        assert!(content.contains("agent_crash"));
+        assert!(content.contains("session-1"));
+
+        std::fs::remove_dir_all(&tmp).ok();
+        reset_logtail_state();
     }
 }

--- a/src/agentsight/src/interruption/loop_detector.rs
+++ b/src/agentsight/src/interruption/loop_detector.rs
@@ -17,7 +17,7 @@ use super::types::{InterruptionEvent, InterruptionType};
 /// Configuration for the loop detector.
 #[derive(Debug, Clone)]
 pub struct LoopDetectorConfig {
-    /// Number of consecutive calls with the same tool sequence to trigger (default: 3)
+    /// Number of consecutive calls with the same tool sequence to trigger (default: 5)
     pub tool_sequence_repeat_threshold: usize,
     /// Sliding window of recent calls to inspect (default: 10)
     pub window_size: usize,
@@ -30,7 +30,7 @@ pub struct LoopDetectorConfig {
 impl Default for LoopDetectorConfig {
     fn default() -> Self {
         Self {
-            tool_sequence_repeat_threshold: 3,
+            tool_sequence_repeat_threshold: 5,
             window_size: 10,
             output_similarity_threshold: 0.85,
             similar_output_repeat_threshold: 3,
@@ -383,6 +383,8 @@ mod tests {
             make_call(vec!["read_file", "search"], "output a", 100),
             make_call(vec!["read_file", "search"], "output b", 200),
             make_call(vec!["read_file", "search"], "output c", 300),
+            make_call(vec!["read_file", "search"], "output d", 400),
+            make_call(vec!["read_file", "search"], "output e", 500),
         ];
         let result = detector.detect(
             "conv-1",
@@ -417,7 +419,7 @@ mod tests {
 
     #[test]
     fn test_tool_sequence_loop_with_interleaved_text_calls() {
-        // Simulates OpenClaw architecture: tool_call → text → tool_call → text → tool_call → text
+        // Simulates OpenClaw architecture: tool_call → text → tool_call → text → ...
         let detector = LoopDetector::default();
         let calls = vec![
             make_call(vec!["read_file"], "reading file...", 100),
@@ -426,6 +428,10 @@ mod tests {
             make_call(vec![], "Here is the content again.", 400),
             make_call(vec!["read_file"], "reading file...", 500),
             make_call(vec![], "Here is the content yet again.", 600),
+            make_call(vec!["read_file"], "reading file...", 700),
+            make_call(vec![], "Here is the content once more.", 800),
+            make_call(vec!["read_file"], "reading file...", 900),
+            make_call(vec![], "Here is the content finally.", 1000),
         ];
         let result = detector.detect(
             "conv-1",
@@ -435,7 +441,7 @@ mod tests {
             1000,
             &calls,
         );
-        // Rule 1 should trigger: 3 tool-bearing calls all have ["read_file"]
+        // Rule 1 should trigger: 5 tool-bearing calls all have ["read_file"]
         assert!(result.is_some());
         let event = result.unwrap();
         let detail: serde_json::Value =

--- a/src/agentsight/src/skill_metrics/extractor.rs
+++ b/src/agentsight/src/skill_metrics/extractor.rs
@@ -6,6 +6,7 @@
 //! 2. **Skill Loads**: Tool calls that read SKILL.md files (Read/ReadFile/read_file).
 
 use regex::Regex;
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use crate::genai::semantic::{InputMessage, MessagePart, OutputMessage};
@@ -115,6 +116,62 @@ pub fn extract_skill_downloads(event: &TraceEventDetail) -> Vec<SkillDownloadRec
         .collect()
 }
 
+/// Extract per-skill load counts from a slice of output messages.
+///
+/// Looks for tool calls where function_name matches a skill invocation or a
+/// file read of `/SKILL.md`. Returns a map of skill_name -> load count within
+/// these messages.
+pub fn extract_skill_load_counts_from_messages(messages: &[OutputMessage]) -> HashMap<String, u64> {
+    let mut counts: HashMap<String, u64> = HashMap::new();
+
+    for msg in messages {
+        for part in &msg.parts {
+            if let MessagePart::ToolCall {
+                name, arguments, ..
+            } = part
+            {
+                if let Some(skill_name) = detect_skill_load(name, arguments) {
+                    *counts.entry(skill_name).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
+    counts
+}
+
+/// Detect whether a single tool call represents a skill load.
+///
+/// Returns the skill name if the tool_call is a skill invocation (cosh/Hermes)
+/// or a read of a `SKILL.md` file (Qoder); otherwise returns `None`.
+fn detect_skill_load(name: &str, arguments: &Option<serde_json::Value>) -> Option<String> {
+    // Pattern 1: Skill tool_call (cosh/copilot-shell)
+    // e.g. {"name": "Skill", "arguments": {"skill": "pdf"}}
+    if SKILL_FUNCTION_NAMES
+        .iter()
+        .any(|&fn_name| name.eq_ignore_ascii_case(fn_name))
+    {
+        return arguments.as_ref().and_then(extract_skill_name_from_args);
+    }
+
+    // Pattern 2: ReadFile tool_call reading SKILL.md (Qoder)
+    // e.g. {"name": "Read", "arguments": {"file_path": "/path/to/skill/SKILL.md"}}
+    if !READ_FUNCTION_NAMES
+        .iter()
+        .any(|&fn_name| name.eq_ignore_ascii_case(fn_name))
+    {
+        return None;
+    }
+
+    let file_path = arguments.as_ref().and_then(extract_file_path)?;
+
+    if !file_path.ends_with("/SKILL.md") {
+        return None;
+    }
+
+    extract_skill_name_from_path(&file_path)
+}
+
 /// Extract skill load events from tool_calls in output messages.
 ///
 /// Looks for tool calls where function_name matches Read/ReadFile/read_file
@@ -129,90 +186,36 @@ pub fn extract_skill_loads(event: &TraceEventDetail) -> Vec<SkillLoadRecord> {
     let timestamp_ns = event.start_timestamp_ns;
     let agent_name = event.agent_name.clone();
 
-    let mut records = Vec::new();
-
     // Parse output_messages JSON
     let output_messages = match &event.output_messages {
         Some(json_str) => match serde_json::from_str::<Vec<OutputMessage>>(json_str) {
             Ok(msgs) => msgs,
-            Err(_) => return records,
+            Err(_) => return Vec::new(),
         },
-        None => return records,
+        None => return Vec::new(),
     };
 
-    for msg in &output_messages {
-        for part in &msg.parts {
+    output_messages
+        .iter()
+        .flat_map(|msg| msg.parts.iter())
+        .filter_map(|part| {
             if let MessagePart::ToolCall {
                 name, arguments, ..
             } = part
             {
-                // Pattern 1: Skill tool_call (cosh/copilot-shell)
-                // e.g. {"name": "Skill", "arguments": {"skill": "pdf"}}
-                if SKILL_FUNCTION_NAMES
-                    .iter()
-                    .any(|&fn_name| name.eq_ignore_ascii_case(fn_name))
-                {
-                    let skill_name = match arguments {
-                        Some(args) => extract_skill_name_from_args(args),
-                        None => None,
-                    };
-                    if let Some(skill_name) = skill_name {
-                        records.push(SkillLoadRecord {
-                            skill_name,
-                            session_id: session_id.clone(),
-                            call_id: call_id.clone(),
-                            timestamp_ns,
-                            agent_name: agent_name.clone(),
-                            function_name: name.clone(),
-                        });
-                    }
-                    continue;
-                }
-
-                // Pattern 2: ReadFile tool_call reading SKILL.md (Qoder)
-                // e.g. {"name": "Read", "arguments": {"file_path": "/path/to/skill/SKILL.md"}}
-                if !READ_FUNCTION_NAMES
-                    .iter()
-                    .any(|&fn_name| name.eq_ignore_ascii_case(fn_name))
-                {
-                    continue;
-                }
-
-                // Extract file_path from arguments
-                let file_path = match arguments {
-                    Some(args) => extract_file_path(args),
-                    None => continue,
-                };
-
-                let file_path = match file_path {
-                    Some(p) => p,
-                    None => continue,
-                };
-
-                // Check if path ends with /SKILL.md
-                if !file_path.ends_with("/SKILL.md") {
-                    continue;
-                }
-
-                // Extract skill name from parent directory
-                let skill_name = match extract_skill_name_from_path(&file_path) {
-                    Some(name) => name,
-                    None => continue,
-                };
-
-                records.push(SkillLoadRecord {
+                detect_skill_load(name, arguments).map(|skill_name| SkillLoadRecord {
                     skill_name,
                     session_id: session_id.clone(),
                     call_id: call_id.clone(),
                     timestamp_ns,
                     agent_name: agent_name.clone(),
                     function_name: name.clone(),
-                });
+                })
+            } else {
+                None
             }
-        }
-    }
-
-    records
+        })
+        .collect()
 }
 
 /// Extract all unique tool call function names from an event's output messages.
@@ -834,5 +837,98 @@ Some text after"#;
             assert_eq!(d.timestamp_ns, 9000);
             assert!(!d.skill_name.is_empty());
         }
+    }
+
+    #[test]
+    fn test_extract_skill_load_counts_from_messages() {
+        let messages = vec![OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![
+                MessagePart::ToolCall {
+                    id: None,
+                    name: "Skill".to_string(),
+                    arguments: Some(json!({"skill": "pdf"})),
+                },
+                MessagePart::ToolCall {
+                    id: None,
+                    name: "skill".to_string(),
+                    arguments: Some(json!({"skill": "pdf"})),
+                },
+                MessagePart::ToolCall {
+                    id: None,
+                    name: "read_file".to_string(),
+                    arguments: Some(json!({"file_path": "/skills/read/SKILL.md"})),
+                },
+            ],
+            name: None,
+            finish_reason: None,
+        }];
+        let counts = extract_skill_load_counts_from_messages(&messages);
+        assert_eq!(counts.get("pdf"), Some(&2));
+        assert_eq!(counts.get("read"), Some(&1));
+    }
+
+    #[test]
+    fn test_detect_skill_load_ignores_unrelated_tools() {
+        // A tool that is neither a skill function nor a read function is ignored.
+        let name = "shell";
+        let arguments = Some(json!({"command": "ls"}));
+        assert!(detect_skill_load(name, &arguments).is_none());
+    }
+
+    #[test]
+    fn test_extract_skill_loads_returns_empty_for_invalid_json() {
+        let event = TraceEventDetail {
+            id: 30,
+            call_id: Some("c-invalid".into()),
+            start_timestamp_ns: 1000,
+            end_timestamp_ns: None,
+            model: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            input_messages: None,
+            output_messages: Some("not valid json".into()),
+            system_instructions: None,
+            agent_name: None,
+            process_name: None,
+            pid: None,
+            user_query: None,
+            event_json: None,
+            trace_id: None,
+            conversation_id: None,
+            cache_read_tokens: None,
+            status: None,
+            interruption_type: None,
+        };
+        assert!(extract_skill_loads(&event).is_empty());
+    }
+
+    #[test]
+    fn test_extract_skill_loads_returns_empty_when_no_output_messages() {
+        let event = TraceEventDetail {
+            id: 31,
+            call_id: Some("c-none".into()),
+            start_timestamp_ns: 1000,
+            end_timestamp_ns: None,
+            model: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            input_messages: None,
+            output_messages: None,
+            system_instructions: None,
+            agent_name: None,
+            process_name: None,
+            pid: None,
+            user_query: None,
+            event_json: None,
+            trace_id: None,
+            conversation_id: None,
+            cache_read_tokens: None,
+            status: None,
+            interruption_type: None,
+        };
+        assert!(extract_skill_loads(&event).is_empty());
     }
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -32,7 +32,7 @@ use crate::discovery::AgentScanner;
 use crate::event::Event;
 use crate::ffi::{FfiEvent, FfiEventSender};
 use crate::genai::semantic::GenAISemanticEvent;
-use crate::genai::{GenAIBuilder, GenAIExporter, GenAIStore, LogtailExporter};
+use crate::genai::{GenAIBuilder, GenAIExporter, LogtailExporter};
 use crate::interruption::{DetectorConfig, InterruptionDetector, recover_oom_events};
 use crate::parser::Parser;
 use crate::probes::{FileWatchEvent, FileWriteEvent, Probes, ProbesPoller};
@@ -290,25 +290,21 @@ impl AgentSight {
             crate::genai::logtail::set_dynamic_logtail_path(sls_path);
         }
 
-        let is_agentic_os = crate::genai::anolisa_release::is_anolisa();
-
         // Determine if Logtail is currently enabled (env var OR dynamic config)
         let logtail_currently_enabled = crate::genai::logtail::logtail_enabled();
 
-        if is_agentic_os {
-            // ── Anolisa OS: always register SQLite ──
-            match GenAISqliteStore::new() {
-                Ok(store) => {
-                    log::info!("SQLite GenAI exporter enabled (agentic os)");
-                    let store = Arc::new(store);
-                    genai_sqlite_store = Some(Arc::clone(&store));
-                    genai_exporters.push(Box::new(store));
-                }
-                Err(e) => {
-                    log::warn!("Failed to initialize SQLite GenAI exporter: {e}");
-                }
-            }
-            // If Logtail is enabled at startup, also register it (dual-write)
+        // Sysom production mode: when SLS_LOGTAIL_FILE points under /var/sysom/,
+        // use only the external Logtail path. Skip SQLite and the default SLS exporter.
+        let sysom_logtail_path = std::env::var(crate::genai::logtail::LOGTAIL_ENV_VAR)
+            .ok()
+            .filter(|p| p.starts_with("/var/sysom/"));
+
+        if let Some(ref path) = sysom_logtail_path {
+            log::info!(
+                "SLS sysom mode detected ({}={}), skipping SQLite and default SLS exporter",
+                crate::genai::logtail::LOGTAIL_ENV_VAR,
+                path
+            );
             if logtail_currently_enabled {
                 if let Some(exporter) = LogtailExporter::new(
                     config.encryption_public_key.as_deref(),
@@ -323,7 +319,7 @@ impl AgentSight {
                         );
                     }
                     log::info!(
-                        "Logtail file exporter enabled (agentic os, {}), uid={}",
+                        "Logtail file exporter enabled (sysom, {}), uid={}",
                         exporter.path().display(),
                         uid
                     );
@@ -332,7 +328,31 @@ impl AgentSight {
                 }
             }
         } else {
-            // ── Non-Anolisa OS: keep original mutual exclusion behavior ──
+            // Default/dev mode: SQLite + default SLS exporter, plus optional env Logtail.
+            match GenAISqliteStore::new() {
+                Ok(store) => {
+                    log::info!("SQLite GenAI exporter enabled");
+                    let store = Arc::new(store);
+                    genai_sqlite_store = Some(Arc::clone(&store));
+                    genai_exporters.push(Box::new(store));
+                }
+                Err(e) => {
+                    log::warn!("Failed to initialize SQLite GenAI exporter: {e}");
+                }
+            }
+
+            // Default local SLS Logtail exporter
+            let default_exporter = LogtailExporter::new_default(
+                config.encryption_public_key.as_deref(),
+                config.trace_enabled,
+            );
+            log::info!(
+                "Default Logtail file exporter enabled ({})",
+                default_exporter.path().display()
+            );
+            genai_exporters.push(Box::new(default_exporter));
+
+            // Also honor explicit SLS_LOGTAIL_FILE if set to a non-sysom path
             if logtail_currently_enabled {
                 if let Some(exporter) = LogtailExporter::new(
                     config.encryption_public_key.as_deref(),
@@ -353,33 +373,6 @@ impl AgentSight {
                     );
                     genai_exporters.push(Box::new(exporter));
                     sls_activated.store(true, Ordering::SeqCst);
-                }
-                // Also initialize SQLite store for detection queries + lifecycle
-                match GenAISqliteStore::new() {
-                    Ok(store) => {
-                        log::info!("SQLite GenAI store initialized (detection + lifecycle)");
-                        let store = Arc::new(store);
-                        genai_sqlite_store = Some(Arc::clone(&store));
-                        genai_exporters.push(Box::new(store));
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to initialize SQLite GenAI store: {e}");
-                    }
-                }
-            } else {
-                // No Logtail: use local JSONL + SQLite
-                genai_exporters.push(Box::new(GenAIStore::new(&GenAIStore::default_path())));
-
-                match GenAISqliteStore::new() {
-                    Ok(store) => {
-                        log::info!("SQLite GenAI exporter enabled");
-                        let store = Arc::new(store);
-                        genai_sqlite_store = Some(Arc::clone(&store));
-                        genai_exporters.push(Box::new(store));
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to initialize SQLite GenAI exporter: {e}");
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

Upload skill-related metrics through the existing SLS Logtail exporter. Skill load counts are extracted from LLMCall output messages and emitted as `agent.skill.name` / `agent.skill.load_count` JSON arrays. The SLS exporter path selection is unified so that interruption records emitted by the trace path use the same active paths as LLM calls.

## Related Issue

closes #1003

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo fmt --check` passes
- `cargo clippy -- -D warnings` passes
- `cargo test --lib config::tests` passes (44 tests)
- `cargo test --lib interruption::loop_detector::tests` passes (17 tests)

## Additional Notes

This PR also includes a small adjustment to raise the deadloop tool sequence repeat threshold from 3 to 5, keeping `deadloop_kill_after_count` user-configurable.
