### PR TITLE
fix(tokenless): align compression mode serde/db form and dedup config load

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -333,7 +333,8 @@ fn run() -> Result<(), (String, i32)> {
                 after_compact.clone()
             };
 
-            let compression_on = TokenlessConfig::load().is_compression_enabled();
+            let config = TokenlessConfig::load();
+            let compression_on = config.is_compression_enabled();
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             let emit_text = if compression_on {
                 output_text.clone()
@@ -343,6 +344,7 @@ fn run() -> Result<(), (String, i32)> {
             println!("{}", emit_text);
 
             record_compression_stats(
+                &config,
                 OperationType::CompressSchema,
                 agent_id,
                 session_id,
@@ -390,7 +392,8 @@ fn run() -> Result<(), (String, i32)> {
                 after_compact.clone()
             };
 
-            let compression_on = TokenlessConfig::load().is_compression_enabled();
+            let config = TokenlessConfig::load();
+            let compression_on = config.is_compression_enabled();
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             let emit_text = if compression_on {
                 output_text.clone()
@@ -400,6 +403,7 @@ fn run() -> Result<(), (String, i32)> {
             println!("{}", emit_text);
 
             record_compression_stats(
+                &config,
                 OperationType::CompressResponse,
                 agent_id,
                 session_id,
@@ -563,7 +567,8 @@ fn run() -> Result<(), (String, i32)> {
                 );
             }
 
-            let compression_on = TokenlessConfig::load().is_compression_enabled();
+            let config = TokenlessConfig::load();
+            let compression_on = config.is_compression_enabled();
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             // Active: emit the TOON result (or original if no savings).
             // Dry-run: emit the original so context stays uncompressed, but
@@ -579,6 +584,7 @@ fn run() -> Result<(), (String, i32)> {
             // TOON did not reduce size), so dry-run captures the prediction.
             let record_after = if no_savings { input.clone() } else { output };
             record_compression_stats(
+                &config,
                 OperationType::CompressToon,
                 agent_id,
                 session_id,
@@ -658,7 +664,9 @@ fn warn_mode_mismatch(label: &str, records: &[StatsRecord], expected: Compressio
 ///
 /// All metrics (chars, tokens) are derived from actual text content,
 /// never from caller-supplied estimates.
+#[allow(clippy::too_many_arguments)]
 fn record_compression_stats(
+    config: &TokenlessConfig,
     op: OperationType,
     agent_id: Option<String>,
     session_id: Option<String>,
@@ -667,8 +675,6 @@ fn record_compression_stats(
     after_text: String,
     mode: CompressionMode,
 ) {
-    let config = TokenlessConfig::load();
-
     // Short-circuit only if both stats and SLS are disabled.
     if !config.is_stats_enabled() && !config.is_sls_enabled() {
         return;

--- a/src/tokenless/crates/tokenless-stats/src/record.rs
+++ b/src/tokenless/crates/tokenless-stats/src/record.rs
@@ -65,16 +65,17 @@ impl CompressionMode {
     pub fn as_str(&self) -> &'static str {
         match self {
             CompressionMode::Active => "active",
-            CompressionMode::DryRun => "dryrun",
+            CompressionMode::DryRun => "dry-run",
         }
     }
 
     /// Parse a stored mode value. Unknown/empty values (legacy rows with no
     /// `mode` column, or NULLs) fall back to `Active` rather than erroring,
-    /// so historical data remains readable.
+    /// so historical data remains readable. Accepts both `dry-run` (current
+    /// serde/db form) and legacy `dryrun` for backward compatibility.
     pub fn from_db(s: &str) -> Self {
         match s {
-            "dryrun" => CompressionMode::DryRun,
+            "dry-run" | "dryrun" => CompressionMode::DryRun,
             _ => CompressionMode::Active,
         }
     }
@@ -351,8 +352,10 @@ mod tests {
     #[test]
     fn test_compression_mode_roundtrip() {
         assert_eq!(CompressionMode::Active.as_str(), "active");
-        assert_eq!(CompressionMode::DryRun.as_str(), "dryrun");
+        assert_eq!(CompressionMode::DryRun.as_str(), "dry-run");
         assert_eq!(CompressionMode::from_db("active"), CompressionMode::Active);
+        assert_eq!(CompressionMode::from_db("dry-run"), CompressionMode::DryRun);
+        // Legacy "dryrun" form still readable (backward compatibility)
         assert_eq!(CompressionMode::from_db("dryrun"), CompressionMode::DryRun);
         // Unknown / empty (legacy NULL) fall back to Active
         assert_eq!(CompressionMode::from_db(""), CompressionMode::Active);

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -364,11 +364,11 @@ mod tests {
     use super::*;
     use crate::record::OperationType;
 
-    fn new_recorder() -> StatsRecorder {
+    fn new_recorder() -> (StatsRecorder, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("stats.db");
-        std::mem::forget(dir); // keep dir for test lifetime
-        StatsRecorder::new(&db).unwrap()
+        let rec = StatsRecorder::new(&db).unwrap();
+        (rec, dir)
     }
 
     fn sample(op: OperationType, mode: CompressionMode, session: &str) -> StatsRecord {
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn records_and_reads_mode() {
-        let rec = new_recorder();
+        let (rec, _dir) = new_recorder();
         let id = rec
             .record(&sample(
                 OperationType::CompressSchema,
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn default_mode_is_active() {
-        let rec = new_recorder();
+        let (rec, _dir) = new_recorder();
         let id = rec
             .record(&sample(
                 OperationType::CompressSchema,
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn records_by_session_filters() {
-        let rec = new_recorder();
+        let (rec, _dir) = new_recorder();
         rec.record(&sample(
             OperationType::CompressResponse,
             CompressionMode::Active,


### PR DESCRIPTION
## Description

Follow-up fixes for the compression-toggle feature merged in #1071:

- `CompressionMode::as_str()` now returns `"dry-run"` to match its `#[serde(rename_all = "kebab-case")]` serialization; `from_db()` accepts both `"dry-run"` and the legacy `"dryrun"` so historical rows stay readable. Removes a latent mismatch where a future JSON round-trip of `StatsRecord` would have deserialized `"dry-run"` back to `Active`.
- `record_compression_stats` now takes `&TokenlessConfig` instead of reloading config each call, eliminating a duplicate config file read per compression command (consistent with the existing slow-filesystem avoidance rationale). `#[allow(clippy::too_many_arguments)]` follows repo convention (used in anolisa-core/anolisa-cli); the config param is a real dependency, not a band-aid.
- Recorder tests return `(StatsRecorder, TempDir)` instead of `std::mem::forget(dir)`, keeping the temp dir alive via ownership so it is cleaned up on test exit.

## Related Issue

no-issue: small correctness/efficiency hardening of the compression-toggle stats path; no tracked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional change)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/tokenless
cargo fmt --all --check        # clean
cargo clippy --workspace -- -D warnings   # 0 warnings
cargo test --workspace        # 67 passed, 0 failed
```

Updated `test_compression_mode_roundtrip` asserts the new `"dry-run"` string and the legacy `"dryrun"` back-compat path.

## Additional Notes

Backward compatible: existing DBs with `"dryrun"` rows continue to read as `DryRun`; only newly written rows use `"dry-run"`.
