### PR TITLE
feat(sec-core): update Skill Ledger hook defaults and reconcile notify

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/skill_ledger_activation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/skill_ledger_activation.py
@@ -25,7 +25,17 @@ DEFAULT_DEBOUNCE_SECONDS = 0.5
 _SKILL_MANIFEST = "SKILL.md"
 _SKILL_META = ".skill-meta"
 _ALLOWED_EVENT_KINDS = frozenset(
-    {"mkdir", "create", "write", "rename", "unlink", "rmdir", "setattr", "truncate"}
+    {
+        "mkdir",
+        "create",
+        "write",
+        "rename",
+        "unlink",
+        "rmdir",
+        "setattr",
+        "truncate",
+        "reconcile",
+    }
 )
 
 

--- a/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
@@ -19,14 +19,11 @@ Input schema::
 
 Output mapping:
 
-    status "pass"     → { "decision": "allow" }
-    status "none"     → { "decision": "ask", "reason": "⚠️ ..." }
-    status "drifted"  → { "decision": "ask", "reason": "⚠️ ..." }
-    status "deny"     → { "decision": "ask", "reason": "🚨 ..." }
-    status "tampered" → { "decision": "ask", "reason": "🚨 ..." }
-    status otherwise  → { "decision": "allow", "reason": "⚠️ ..." }
+    policy "debug" (default) → always allow; non-pass states only write debug stderr
+    policy "warn"            → non-pass states allow with a visible reason
+    policy "block"           → none/drifted/deny/tampered ask; other non-pass states warn
 
-Copilot-shell settings.json configuration::
+Optional copilot-shell settings.json configuration::
 
     {
       "hooks": {
@@ -62,6 +59,8 @@ _TOOL_NAME = "skill"
 _CHECK_TIMEOUT = 5  # seconds for the CLI check call
 _INIT_TIMEOUT = 3  # seconds for key initialization
 
+_DEFAULT_POLICY = "debug"
+_VALID_POLICIES = frozenset({"debug", "warn", "block"})
 _ASK_STATUSES = frozenset({"none", "drifted", "deny", "tampered"})
 
 _STATUS_MESSAGES = {
@@ -107,6 +106,27 @@ def _ask_with_reason(reason: str) -> str:
 def _debug(message: str) -> None:
     """Write debug-only hook details to stderr."""
     print(f"[skill-ledger debug] {message}", file=sys.stderr)
+
+
+def _allow_or_warn(reason: str, policy: str) -> str:
+    """Allow silently in debug policy; otherwise allow with a visible reason."""
+    if policy == "debug":
+        _debug(reason)
+        return _allow()
+    return _allow_with_reason(reason)
+
+
+def _read_policy() -> str:
+    """Return the configured hook policy."""
+    policy = os.environ.get("SKILL_LEDGER_HOOK_POLICY", _DEFAULT_POLICY).strip().lower()
+    if policy in _VALID_POLICIES:
+        return policy
+    _debug(
+        "invalid SKILL_LEDGER_HOOK_POLICY={!r}; using {}".format(
+            policy, _DEFAULT_POLICY
+        )
+    )
+    return _DEFAULT_POLICY
 
 
 def _supported_skill_bases(cwd: str) -> list[Path]:
@@ -241,24 +261,30 @@ def _ensure_keys(input_data: dict[str, Any]) -> None:
             ["agent-sec-cli", "skill-ledger", "init", "--no-baseline"],
             input_data,
         )
-        subprocess.run(
+        result = subprocess.run(
             cmd,
             capture_output=True,
             check=False,
             text=True,
             timeout=_INIT_TIMEOUT,
         )
-    except Exception:
-        pass
+        if result.returncode != 0:
+            _debug(
+                "key init failed, exit_code={}, stderr={!r}".format(
+                    result.returncode, result.stderr
+                )
+            )
+    except Exception as exc:
+        _debug("key init failed: {}".format(exc))
 
 
-def _format_cosh(check_result: dict, skill_name: str) -> str:
+def _format_cosh(check_result: dict, skill_name: str, policy: str) -> str:
     """Convert a check-result dict into a cosh HookOutput JSON string.
 
     Mapping:
-        status == "pass"                         → decision "allow" (silent)
-        none / drifted / deny / tampered         → decision "ask" + reason
-        warn / error / unknown / other statuses  → decision "allow" + reason
+        policy == "debug"                        → decision "allow" (silent)
+        policy == "block" and status is strong   → decision "ask" + reason
+        policy == "warn" or non-strong block     → decision "allow" + reason
     """
     status = check_result.get("status", "unknown")
 
@@ -273,7 +299,11 @@ def _format_cosh(check_result: dict, skill_name: str) -> str:
             skill_name, status
         )
 
-    if status in _ASK_STATUSES:
+    if policy == "debug":
+        _debug("skill='{}' status={}: {}".format(skill_name, status, reason))
+        return _allow()
+
+    if policy == "block" and status in _ASK_STATUSES:
         return _ask_with_reason(reason)
 
     return _allow_with_reason(reason)
@@ -297,20 +327,24 @@ def main() -> None:
         print(_allow())
         return
 
+    policy = _read_policy()
+
     tool_input = input_data.get("tool_input", {})
     skill_name = tool_input.get("skill", "")
     if not isinstance(skill_name, str):
         print(
-            _allow_with_reason(
-                "\u26a0\ufe0f Skill check skipped: skill name must be a string"
+            _allow_or_warn(
+                "\u26a0\ufe0f Skill check skipped: skill name must be a string",
+                policy,
             )
         )
         return
     skill_name = skill_name.strip()
     if not skill_name:
         print(
-            _allow_with_reason(
-                "\u26a0\ufe0f Skill check skipped: skill name is empty or missing"
+            _allow_or_warn(
+                "\u26a0\ufe0f Skill check skipped: skill name is empty or missing",
+                policy,
             )
         )
         return
@@ -334,7 +368,7 @@ def main() -> None:
         reason = "\U0001f6a8 Skill '{}' rejected: path traversal detected".format(
             skill_name
         )
-        print(_allow_with_reason(reason))
+        print(_allow_or_warn(reason, policy))
         return
     if skill_dir is None:
         # Not found in any supported location (project/user/system) → fail-open
@@ -343,7 +377,7 @@ def main() -> None:
                 skill_name
             )
         )
-        print(_allow_with_reason(reason))
+        print(_allow_or_warn(reason, policy))
         return
 
     # 4. Ensure signing keys exist (auto-init if missing)
@@ -364,6 +398,7 @@ def main() -> None:
         )
     except Exception:
         # Timeout or CLI not found → fail-open
+        _debug("skill='{}' check failed before CLI output".format(skill_name))
         print(_allow())
         return
 
@@ -371,10 +406,15 @@ def main() -> None:
     try:
         check_result = json.loads(proc.stdout)
     except (json.JSONDecodeError, ValueError):
+        _debug(
+            "skill='{}' invalid CLI JSON, exit_code={}, stderr={!r}".format(
+                skill_name, proc.returncode, proc.stderr
+            )
+        )
         print(_allow())
         return
 
-    print(_format_cosh(check_result, skill_name))
+    print(_format_cosh(check_result, skill_name, policy))
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
@@ -658,7 +658,7 @@ fail-open 仅用于基础设施异常：CLI 不可用、执行失败、超时或
 
 ### 6.2 copilot-shell（Command Hook）
 
-独立 Python 脚本 `cosh-extension/hooks/skill_ledger_hook.py`，专为 stdin/stdout 协议设计，不依赖 `agent_sec_cli` 包。默认 Cosh manifest 挂载该 hook，默认 `SKILL_LEDGER_HOOK_POLICY=debug`：
+独立 Python 脚本 `cosh-extension/hooks/skill_ledger_hook.py`，专为 stdin/stdout 协议设计，不依赖 `agent_sec_cli` 包。默认 Cosh manifest 挂载该 hook，默认 `SKILL_LEDGER_HOOK_POLICY=debug`。该环境变量属于可信宿主或部署环境配置，不应由 Skill、项目脚本或不可信 shell 启动逻辑设置；若需要防止本地 shell profile 被篡改后降级策略，后续应迁移到可信宿主配置源：
 
 配置：
 ```jsonc

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_CN.md
@@ -10,7 +10,7 @@ AI Agent 通过加载 Skill（结构化指令 + 辅助脚本）扩展能力。Sk
 
 1. **防篡改**：通过密码学签名的版本链（SignedManifest）保护 Skill 元数据，使篡改可被检测
 2. **安全扫描集成**：提供可扩展的扫描器框架，支持 Agent 驱动（skill-vetter）和 CLI 自动调用两种模式
-3. **实时守卫**：在 Skill 加载时自动执行完整性检查（hook 层），默认对异常状态输出可见告警并放行；需要强门禁时可通过宿主侧配置升级为阻断
+3. **运行态激活**：推荐与 SkillFS 联合使用，由 SkillFS 捕获 Skill 变更并通知 Skill Ledger daemon 刷新 activation metadata
 4. **可用性优先**：CLI 异常、超时、输出不可解析时保持 fail-open；检查成功后按状态分级处理
 
 ### 非目标
@@ -25,22 +25,21 @@ AI Agent 通过加载 Skill（结构化指令 + 辅助脚本）扩展能力。Sk
 
 ```
 ┌───────────────────────────────────────────────────────┐
-│              宿主系统 (OpenClaw / copilot-shell)        │
+│              宿主系统 + SkillFS                         │
 │                                                       │
 │  ┌──────────────┐       ┌──────────────────────────┐ │
-│  │  Hook 层      │       │  Agent 工作区              │ │
-│  │  (门禁)       │       │                          │ │
-│  │               │       │  ┌──────────────────┐   │ │
-│  │ skill-ledger  │       │  │  skill-ledger    │   │ │
-│  │  check (CLI)  │       │  │  (Skill)         │   │ │
-│  │               │       │  │                  │   │ │
-│  │ 读 latest.json│       │  │  Phase 1: 状态   │   │ │
-│  │ 验签名       │       │  │  Phase 2: 快扫   │   │ │
-│  │ 比 fileHashes │       │  │  Phase 3: 深扫   │   │ │
-│  │ 查 scanStatus  │       │  │  scan/certify 签名 │   │ │
-│  │       │       │       │  │                  │   │ │
-│  │       ▼       │       │  └──────────────────┘   │ │
-│  │ allow / 告警 / 确认 │  │                          │ │
+│  │  SkillFS     │       │  Agent 工作区              │ │
+│  │  捕获变更     │       │                          │ │
+│  │      │        │       │  ┌──────────────────┐   │ │
+│  │      ▼        │       │  │  skill-ledger    │   │ │
+│  │ daemon notify │       │  │  (Skill)         │   │ │
+│  │      │        │       │  │                  │   │ │
+│  │      ▼        │       │  │  Phase 1: 状态   │   │ │
+│  │ activation    │       │  │  Phase 2: 快扫   │   │ │
+│  │ refresh       │       │  │  Phase 3: 深扫   │   │ │
+│  │      │        │       │  │  scan/certify 签名 │   │ │
+│  │      ▼        │       │  │                  │   │ │
+│  │ activation.json/xattr │  └──────────────────┘   │ │
 │  └───────────────┘       └──────────────────────────┘ │
 │          │                          │                  │
 │          └──── .skill-meta/ ────────┘                  │
@@ -54,10 +53,11 @@ AI Agent 通过加载 Skill（结构化指令 + 辅助脚本）扩展能力。Sk
 
 **组件职责**：
 
-- **skill-ledger CLI**：核心基础设施。提供 `init`（初始化密钥并可为已覆盖 Skill 建立快速扫描 baseline）、`scan`（运行内置快速扫描器并签名入账）、`check`（hook 调用，只读检查 JSON + 验签 + 比哈希 + 输出状态）、`certify`（导入外部 findings 并签名）等子命令。`scan` / `certify` 写入的 manifest 经 Ed25519 数字签名保护，防止篡改；`check` 在无 manifest 时返回 `none`，不创建版本或 snapshot。确定性逻辑不依赖 LLM，不可被 prompt injection 绕过。
+- **skill-ledger CLI**：核心基础设施。提供 `init`（初始化密钥并可为已覆盖 Skill 建立快速扫描 baseline）、`scan`（运行内置快速扫描器并签名入账）、`check`（只读检查 JSON + 验签 + 比哈希 + 输出状态，可供宿主 hook/capability 调用）、`certify`（导入外部 findings 并签名）等子命令。`scan` / `certify` 写入的 manifest 经 Ed25519 数字签名保护，防止篡改；`check` 在无 manifest 时返回 `none`，不创建版本或 snapshot。确定性逻辑不依赖 LLM，不可被 prompt injection 绕过。
 - **Scanner Registry**：可扩展扫描框架。通过配置注册扫描器（`builtin`/`cli`/`skill`/`api` 四种调用类型）和结果解析器（将异构扫描输出归一化为统一 `NormalizedFinding` 格式）。本版本默认注册 `skill-vetter`（`type: "skill"`，由 Agent 深度扫描后通过 `certify --findings` 消费）、`code-scanner` 和 `static-scanner`（均为 `type: "builtin"`，可由 `scan` 自动调用）。当前仅实现 `findings-array` parser；`cli`/`api` adapter 及其它 parser 类型为预留扩展点。旧名称 `skill-code-scanner`、`cisco-static-scanner` 仅作为兼容 alias 读取，不再作为公开名称展示或写入新 manifest。
 - **skill-ledger Skill**：一个 Skill，三个阶段。Phase 1 做环境准备与状态查看；Phase 2 默认执行快速扫描认证（`scan` 调用内置 `code-scanner` 与 `static-scanner`）；Phase 3 在用户显式要求或确认后执行 Agent 驱动深度扫描（`skill-vetter`），再用 `certify --findings ... --delete-findings` 写入版本链。
-- **Hook 层**：门禁。调用 `skill-ledger check`，默认 `pass` 静默放行、非 `pass` 告警放行；宿主配置开启阻断后，可对指定状态直接阻断。CLI 不可用、执行失败、超时或输出不可解析时保持 fail-open。
+- **SkillFS + daemon activation**：推荐运行态入口。SkillFS 捕获 Skill 文件变化后调用 daemon 的 `skill_ledger.skillfs_notify_change` 接口，daemon 根据签名 manifest 和 activation policy 刷新 `.skill-meta/activation.json`，并尽力同步写入 xattr。
+- **Hook / capability 兼容层**：宿主可挂载 `skill-ledger check` 作为兼容入口。默认发行配置继续挂载/注册，但 `policy = "debug"`，只写 debug 诊断，不阻断、不产生用户可见 warning；无 SkillFS 且需要可见提示或强门禁时，可显式配置 `policy = "warn"` 或 `policy = "block"`。
 
 ---
 
@@ -597,38 +597,38 @@ agent-sec-cli skill-ledger certify <skill_dir> --findings /tmp/skill-vetter-find
 
 ---
 
-## 5. Hook 默认策略
+## 5. 可选 Hook / capability 兼容策略
 
 ### 设计原则
 
-hook 层（`skill-ledger check`）采用默认观察策略：
+推荐部署模式是 SkillFS 捕获变更并触发 daemon activation refresh。宿主 hook/capability 作为兼容入口保留并默认挂载，但默认 `policy = "debug"` 不改变用户可见行为。没有部署 SkillFS、且希望在 Skill 加载前给用户提示或要求确认时，可显式配置 `policy = "warn"` 或 `policy = "block"`。
 
-- `pass`：静默放行。
-- 非 `pass`：放行 + 告警，提示用户后续复查或重新扫描。
-- `enable_block = true` 时，命中宿主配置的阻断状态才阻断；默认阻断状态建议为 `none` / `drifted` / `deny` / `tampered`。
+- `debug`：`pass` 静默放行；非 `pass`、CLI 失败、超时、输出不可解析、key init 失败等都 fail-open，只写 debug 诊断，不返回 reason、不注入回复、不写 warning 级日志。
+- `warn`：恢复 warning-only 行为；非 `pass` 放行，但通过宿主 warning 机制提示用户复查或重新扫描。
+- `block`：命中配置的强门禁状态可升级为确认或阻断；其它非 `pass` 状态按 warning 诊断处理。
 
-fail-open 仅用于基础设施异常：CLI 不可用、执行失败、超时或输出不可解析时，hook 不阻断 Skill 加载，并通过宿主日志记录诊断信息。
+`block_statuses` / `blockStatuses` 仅在 `policy = "block"` 下生效；推荐强门禁状态为 `none` / `drifted` / `deny` / `tampered`。旧配置兼容规则是：显式 `policy` 优先；未配置 `policy` 时，`enable_block` / `enableBlock = true` 映射为 `block`，`false` 映射为 `warn`。
 
-### 各状态的行为
+fail-open 仅用于基础设施异常：CLI 不可用、执行失败、超时或输出不可解析时，hook/capability 不阻断 Skill 加载。`debug` policy 只写 debug；`warn` / `block` 可通过 warning 级诊断提示运维侧。
 
-| 状态 | 行为 | 告警内容 |
-|------|------|---------|
-| `pass` | 静默放行 | 无 |
-| `warn` | 放行 + 告警 | `⚠️ Skill '<name>' 存在低风险项，建议关注` |
-| `error` | 放行 + 告警 | `⚠️ Skill '<name>' 状态检查返回错误，建议复查` |
-| `unknown` | 放行 + 告警 | `⚠️ Skill '<name>' 返回未知状态，建议复查` |
-| `drifted` | 放行 + 告警；可配置阻断 | `⚠️ Skill '<name>' 内容已变更，尚未重新扫描` |
-| `none` | 放行 + 告警；可配置阻断 | `⚠️ Skill '<name>' 尚未经过安全扫描` |
-| `deny` | 放行 + 告警；可配置阻断 | `🚨 Skill '<name>' 上次扫描存在高危项，请尽快处理` |
-| `tampered` | 放行 + 告警；可配置阻断 | `🚨 Skill '<name>' 元数据签名校验失败，建议重新扫描建版` |
+### 各状态的兼容行为
 
-`none` / `drifted` / `deny` / `tampered` 是推荐的强门禁状态，但仍采用放行 + 告警，避免安全能力自身影响 Agent 可用性。需要强门禁的部署可显式开启 `enable_block`，并用 `block_statuses` 控制哪些状态直接阻断。`tampered` 触发条件较窄（内容未变但 manifest 被伪造），属于元数据可信度问题；告警中应建议重新执行扫描建版。
+| 状态 | `debug` | `warn` | `block` |
+|------|---------|--------|---------|
+| `pass` | 静默放行 | 静默放行 | 静默放行 |
+| `warn` | debug 诊断后放行 | warning 告警后放行 | warning 诊断后放行 |
+| `error` | debug 诊断后放行 | warning 告警后放行 | warning 诊断后放行 |
+| `unknown` | debug 诊断后放行 | warning 告警后放行 | warning 诊断后放行 |
+| `drifted` | debug 诊断后放行 | warning 告警后放行 | 命中 `block_statuses` 时确认/阻断 |
+| `none` | debug 诊断后放行 | warning 告警后放行 | 命中 `block_statuses` 时确认/阻断 |
+| `deny` | debug 诊断后放行 | warning 告警后放行 | 命中 `block_statuses` 时确认/阻断 |
+| `tampered` | debug 诊断后放行 | warning 告警后放行 | 命中 `block_statuses` 时确认/阻断 |
 
-所有告警均通过宿主系统日志/消息通道输出，保证可追溯。
+`tampered` 触发条件较窄（内容未变但 manifest 被伪造），属于元数据可信度问题；warning/block 文案中应建议重新执行扫描建版。`debug` policy 下只保留调试诊断，避免默认路径打扰用户。
 
 ### 后续升级路径
 
-当前策略为默认观察、可配置阻断。后续可按需扩展为更细粒度策略，例如对不同 Skill 来源设置不同阻断门槛，或对 `drifted`/`none` 状态配置自动触发扫描建版。升级时仅需修改 hook handler 的返回值，不影响 CLI 和 Skill 侧逻辑。
+兼容 hook/capability 策略由统一 `policy` 控制。后续可按需扩展为更细粒度策略，例如对不同 Skill 来源设置不同阻断门槛，或对 `drifted`/`none` 状态配置自动触发扫描建版。升级时仅需修改 hook handler 的返回值，不影响 CLI、daemon activation 和 Skill 侧逻辑。
 
 ### 向后兼容
 
@@ -638,25 +638,27 @@ fail-open 仅用于基础设施异常：CLI 不可用、执行失败、超时或
 
 ## 6. 宿主集成
 
-skill-ledger 需适配多个宿主系统，各宿主的 Skill 模型和 Hook 机制存在差异：
+推荐宿主集成由 SkillFS 驱动：SkillFS 负责捕获 Skill 目录变更，通知 Skill Ledger daemon 扫描并刷新 `.skill-meta/activation.json`/xattr。宿主 hook/capability 作为兼容路径保留并默认使用 debug policy，各宿主的 Skill 模型和 Hook 机制存在差异：
 
 | 维度 | OpenClaw | copilot-shell | Hermes |
 |------|---------|---------------|--------|
 | Skill 调用方式 | Agent 通过 read tool 读取 SKILL.md | Agent 调用 `Skill` tool，框架加载返回内容 | Agent 调用 `skill_view` 读取 Skill |
 | Hook 机制 | Plugin Hook（进程内 async handler） | Command Hook（fork 子进程，stdin/stdout JSON） | Plugin Hook（`pre_tool_call` + `transform_llm_output`） |
-| 默认告警输出 | `api.logger.warn` / 宿主消息通道 | `decision: "allow"` + `reason` | 缓存本轮 warning，并追加到最终回复开头 |
-| 强门禁方式 | 可返回 `requireApproval` | 可返回 `decision: "ask"` | `enable_block = true` 时返回 `{"action": "block"}` |
+| `debug` policy | `api.logger.debug`，无 `requireApproval` | stderr debug，无 `reason` | logger debug，不注入回复 |
+| `warn` policy | `api.logger.warn` 后放行 | `decision: "allow"` + `reason` | 缓存本轮 warning，并追加到最终回复开头 |
+| `block` policy | 可返回 `requireApproval` | 可返回 `decision: "ask"` | 命中 `block_statuses` 时返回 `{"action": "block"}` |
 | Skill 安装路径 | `~/.openclaw/skills/` | `~/.copilot-shell/skills/` | 当前 hook 覆盖 `~/.hermes/skills/**` |
+| 默认启用状态 | `enabled=true, policy="debug"` | 默认 manifest 注册 hook，`SKILL_LEDGER_HOOK_POLICY=debug` | `enabled=true, policy="debug"` |
 
-各实现共享相同的默认语义：拦截 Skill 加载 → 调用 `skill-ledger check` → `pass` 静默放行，非 `pass` 告警放行；需要强门禁时，由宿主侧配置把 `none` / `drifted` / `deny` / `tampered` 等状态升级为确认或阻断。
+各实现共享相同基础流程：拦截 Skill 加载 → 调用 `skill-ledger check` → `pass` 静默放行。默认 `debug` 只输出调试诊断；显式 `warn` 输出用户可见告警；显式 `block` 可把 `none` / `drifted` / `deny` / `tampered` 等状态升级为确认或阻断。
 
 ### 6.1 OpenClaw（Plugin Hook）
 
-以 OpenClaw Plugin 形式分发。`before_tool_call` handler 过滤 read tool 对 `*/SKILL.md` 的访问，解析 `skill_dir` 后调用 `agent-sec-cli skill-ledger check`。告警通过 `api.logger.warn` 输出。
+以 OpenClaw Plugin 形式分发，默认注册 `skill-ledger` capability，`capabilities.skill-ledger.policy` 默认为 `debug`。`before_tool_call` handler 过滤 read tool 对 `*/SKILL.md` 的访问，解析 `skill_dir` 后调用 `agent-sec-cli skill-ledger check`。`enabled=false` 时完全不注册；`policy=warn` 时通过 `api.logger.warn` 输出告警；`policy=block` 且状态命中 `blockStatuses` 时返回 `requireApproval`。旧 `enableBlock` 仅在未配置 `policy` 时作为兼容映射。
 
 ### 6.2 copilot-shell（Command Hook）
 
-独立 Python 脚本 `cosh-extension/hooks/skill_ledger_hook.py`，专为 stdin/stdout 协议设计，不依赖 `agent_sec_cli` 包。
+独立 Python 脚本 `cosh-extension/hooks/skill_ledger_hook.py`，专为 stdin/stdout 协议设计，不依赖 `agent_sec_cli` 包。默认 Cosh manifest 挂载该 hook，默认 `SKILL_LEDGER_HOOK_POLICY=debug`：
 
 配置：
 ```jsonc
@@ -687,4 +689,6 @@ skill-ledger 需适配多个宿主系统，各宿主的 Skill 模型和 Hook 机
 
 ### 6.3 Hermes（Plugin Hook）
 
-以 Hermes Plugin 形式分发。`pre_tool_call` handler 过滤 `skill_view`，仅根据 `name` / `skill` / `skill_name` 在 Hermes 默认本地目录 `~/.hermes/skills` 下解析 Skill 目录后调用 `agent-sec-cli skill-ledger check`。`file_path` / `path` 在 Hermes 中表示 Skill 内 supporting file，不作为 Skill 身份来源。若无法解析、匹配到多个候选、命中 `~/.hermes/config.yaml` 的 `skills.external_dirs` 或 plugin-provided skills 等当前未覆盖来源，hook 采用 fail-open 并仅记录日志；未来如需覆盖这些来源，应单独补充 resolver、信任边界与测试。默认 `enable_block = false`，非 `pass` 状态记录为本轮 warning，并由 `transform_llm_output` 追加到最终回复开头，保证用户可见；当 `enable_block = true` 且状态命中 `block_statuses` 时直接阻断本次 `skill_view`。`max_warnings_per_turn = 0` 可关闭用户可见 warning 注入，仅保留日志。
+以 Hermes Plugin 形式分发，默认 `capabilities.skill-ledger.enabled=true` 且 `policy="debug"`。`pre_tool_call` handler 过滤 `skill_view`，仅根据 `name` / `skill` / `skill_name` 在 Hermes 默认本地目录 `~/.hermes/skills` 下解析 Skill 目录后调用 `agent-sec-cli skill-ledger check`。`file_path` / `path` 在 Hermes 中表示 Skill 内 supporting file，不作为 Skill 身份来源。若无法解析、匹配到多个候选、命中 `~/.hermes/config.yaml` 的 `skills.external_dirs` 或 plugin-provided skills 等当前未覆盖来源，hook 采用 fail-open；默认 policy 仅记录 debug。`policy=warn` 时，非 `pass` 状态记录为本轮 warning，并由 `transform_llm_output` 追加到最终回复开头；`policy=block` 且状态命中 `block_statuses` 时直接阻断本次 `skill_view`。`max_warnings_per_turn = 0` 只影响 `policy=warn` 的用户可见 warning 注入。旧 `enable_block` 仅在未配置 `policy` 时作为兼容映射。
+
+Skill Ledger 全局 `activationPolicy` 属于 SkillFS/daemon activation，宿主 hook 的 `policy` 只控制 hook/capability 的用户可见行为和日志等级。

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_SKILLFS_ACTIVATION_CN.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_SKILLFS_ACTIVATION_CN.md
@@ -72,6 +72,7 @@ Skill Ledger 不提供面向用户或 SkillFS 的 `resolve` CLI。activation ref
 ## SkillFS 变更通知接口
 
 SkillFS 发现 source/current workspace 写变化后，通过现有 `agent-sec-daemon` 协议通知 Skill Ledger daemon。本接口已经由 Skill Ledger 侧实现；SkillFS 侧只需要按该协议发送事件。
+启动或重启后，SkillFS 也可以对已加载的普通 skill 发送 `eventKind="reconcile"`、`paths=[]`，请求 Ledger 以当前磁盘状态重新对齐扫描与 activation。
 
 传输形式固定为当前 `agent-sec-daemon` 机制：
 
@@ -105,6 +106,24 @@ skill_ledger.skillfs_notify_change
 }
 ```
 
+启动对齐请求示例：
+
+```json
+{
+  "id": "skillfs-01HY...",
+  "method": "skill_ledger.skillfs_notify_change",
+  "params": {
+    "schemaVersion": 1,
+    "skillDir": "/path/to/source/tianqi-weather",
+    "skillName": "tianqi-weather",
+    "eventKind": "reconcile",
+    "paths": []
+  },
+  "trace_context": {},
+  "timeout_ms": 5000
+}
+```
+
 外层字段说明：
 
 | 字段 | 类型 | 枚举 / 约束 | 说明 |
@@ -122,7 +141,7 @@ skill_ledger.skillfs_notify_change
 | `schemaVersion` | number | `1` | 当前固定为 `1` |
 | `skillDir` | string | 绝对路径；不支持 `~` 展开 | source/current workspace 中的 skill 根目录 |
 | `skillName` | string | 非空字符串 | skill 名称；应与 `skillDir` basename 一致 |
-| `eventKind` | string | `mkdir` / `create` / `write` / `rename` / `unlink` / `rmdir` / `setattr` / `truncate` | SkillFS 观察到的文件系统变化类型 |
+| `eventKind` | string | `mkdir` / `create` / `write` / `rename` / `unlink` / `rmdir` / `setattr` / `truncate` / `reconcile` | SkillFS 观察到的文件系统变化类型；`reconcile` 表示启动后状态对齐，不代表具体文件操作 |
 | `paths` | string[] | 相对 `skillDir` 的路径数组，可为空；不得是绝对路径，不得包含 `..` | 触发变化的相对路径 |
 
 响应示例：
@@ -160,8 +179,9 @@ skill_ledger.skillfs_notify_change
 通知语义：
 
 - 通知表示“某个 skill 的 source workspace 可能已变化”，不是安全结论。
+- `reconcile` 表示“请将 Ledger 侧状态与当前 skill 目录状态对齐”，不是具体文件操作；它应使用 `paths=[]`，且进入同一 notify queue。
 - SkillFS 是受信任事件来源；daemon 对 `skillDir` 做格式、存在性和 `SKILL.md` 检查，不要求该目录预先存在于 `managedSkillDirs`。
-- 对未被当前配置覆盖的新 skill，daemon 执行 scan 时会沿用 Skill Ledger 现有自动记忆逻辑，将该 skill 目录或父目录 glob 写入 `managedSkillDirs`，供后续 reconcile 使用。
+- 对未被当前配置覆盖的新 skill，包括 SkillFS 启动时发来的 `reconcile` skill，daemon 执行 scan 时会沿用 Skill Ledger 现有自动记忆逻辑，将该 skill 目录或父目录 glob 写入 `managedSkillDirs`，供后续 reconcile 使用。
 - 通知成功只表示 daemon 已接收事件，不表示 scan 已完成，也不表示 activation 已刷新。
 - `.skill-meta/**` only 事件会返回 `accepted=true, ignored=true`，不触发扫描，避免 Ledger 写 metadata 时形成循环。SkillFS 也可以选择不发送这类事件。
 - 事件可以重复、乱序或合并；daemon 必须按 skill 维度 debounce，并以当前磁盘状态重新计算。
@@ -170,6 +190,7 @@ Skill Ledger daemon 侧执行的逻辑：
 
 - 接收事件并按 `skillDir` debounce，默认 debounce 窗口为 500ms。
 - 对 source/current workspace 执行 `scan`。如果扫描为 `noop`，仍继续刷新 activation。
+- `reconcile` 不走独立扫描链路；它与安装、修改、rename 等事件一样进入同一 debounced worker，执行同一套 scan + activation refresh。
 - 如果 scan 失败，仍尝试刷新 activation，以便 `drifted`、`tampered` 等状态可以回退到历史 pass snapshot。
 - 调用内部 resolver，写入新的 `.skill-meta/activation.json` 与 xattr。
 - 启动或重启时 reconcile `managedSkillDirs`，补处理 daemon 下线期间错过的变化。
@@ -203,7 +224,7 @@ SkillFS 应维护 append-only JSONL 事件日志，供 daemon reconcile、观测
 | `time` | string | RFC 3339 UTC timestamp | SkillFS 记录事件的时间 |
 | `skillDir` | string | 绝对路径 | source/current workspace 中的 skill 根目录 |
 | `skillName` | string | 非空字符串 | skill 名称；应与 `skillDir` basename 一致 |
-| `eventKind` | string | `mkdir` / `create` / `write` / `rename` / `unlink` / `rmdir` / `setattr` / `truncate` | SkillFS 观察到的文件系统变化类型 |
+| `eventKind` | string | `mkdir` / `create` / `write` / `rename` / `unlink` / `rmdir` / `setattr` / `truncate` / `reconcile` | SkillFS 观察到的文件系统变化类型；`reconcile` 表示启动后状态对齐 |
 | `paths` | string[] | 相对 `skillDir` 的路径数组，可为空；不得是绝对路径，不得包含 `..` | 触发变化的相对路径 |
 
 日志要求：

--- a/src/agent-sec-core/docs/guide/SKILL_LEDGER_USER_GUIDE_CN.md
+++ b/src/agent-sec-core/docs/guide/SKILL_LEDGER_USER_GUIDE_CN.md
@@ -250,7 +250,7 @@ policy = "debug"
 enable_block = false
 ```
 
-**copilot-shell 配置方式**：默认 Cosh manifest 已注册 `skill-ledger` hook。默认 policy 为 `debug`；无 SkillFS 且希望可见提示或强门禁时，设置 `SKILL_LEDGER_HOOK_POLICY=warn` 或 `SKILL_LEDGER_HOOK_POLICY=block`。
+**copilot-shell 配置方式**：默认 Cosh manifest 已注册 `skill-ledger` hook。默认 policy 为 `debug`；无 SkillFS 且希望可见提示或强门禁时，设置 `SKILL_LEDGER_HOOK_POLICY=warn` 或 `SKILL_LEDGER_HOOK_POLICY=block`。该环境变量应由可信宿主或部署环境设置，不应由 Skill、项目脚本或不可信 shell 启动逻辑设置；如需防止本地 shell profile 被篡改后降级策略，后续应迁移到可信宿主配置源。
 
 Skill Ledger 全局 `activationPolicy` 属于 SkillFS/daemon activation；这里的 hook `policy` 只控制宿主 hook/capability 的用户可见行为和日志等级。
 

--- a/src/agent-sec-core/docs/guide/SKILL_LEDGER_USER_GUIDE_CN.md
+++ b/src/agent-sec-core/docs/guide/SKILL_LEDGER_USER_GUIDE_CN.md
@@ -148,28 +148,28 @@ Skill 工作流：
 
 ---
 
-## 第二部分：通过 Skill 调用与 Hook 保护 Skill 安全
+## 第二部分：通过 SkillFS 激活与宿主 Hook Policy 保护 Skill 安全
 
 ### 架构概览
 
-Skill Ledger 提供**两层防护**协同工作：
+Skill Ledger 推荐与 SkillFS 联合使用：SkillFS 捕获 Skill 变更，通知 Skill Ledger daemon 扫描并刷新 `.skill-meta/activation.json`/xattr。宿主 hook/capability 默认仍可挂载，但默认 `policy = "debug"`，只做静默诊断；没有部署 SkillFS 且希望用户可见保护时，可显式切换为 `warn` 或 `block`。
 
 ```
 ┌──────────────────────────────────────────────────┐
 │                  Agent 运行时                      │
 │                                                   │
 │  ┌──────────────┐      ┌──────────────────────┐   │
-│  │  Hook 层      │      │  skill-ledger        │   │
-│  │  (自动守卫)    │      │  SKILL.md            │   │
+│  │  SkillFS     │      │  skill-ledger        │   │
+│  │  变更捕获      │      │  SKILL.md            │   │
 │  │               │      │  (按需深度扫描)       │   │
-│  │ ┌──────────┐  │      └──────────┬───────────┘   │
-│  │ │ OpenClaw  │  │               │               │
-│  │ │ Plugin    │  │               │               │
-│  │ ├──────────┤  │               │               │
-│  │ │ cosh Hook │  │               │               │
-│  │ │ (Python)  │  │               │               │
-│  │ └────┬─────┘  │               │               │
-│  └──────┤────────┘               │               │
+│  │      │        │      └──────────┬───────────┘   │
+│  │      ▼        │                 │               │
+│  │ daemon notify │                 │               │
+│  │      │        │                 │               │
+│  │      ▼        │                 │               │
+│  │ activation    │                 │               │
+│  │ refresh       │                 │               │
+│  └──────┤────────┘                 │               │
 │         ▼                         ▼               │
 │  ┌──────────────────────────────────────────┐     │
 │  │       agent-sec-cli skill-ledger          │     │
@@ -178,55 +178,83 @@ Skill Ledger 提供**两层防护**协同工作：
 │                      │                            │
 │                      ▼                            │
 │           .skill-meta/latest.json                 │
-│           (SignedManifest + 版本链)                 │
+│           .skill-meta/activation.json + xattr     │
 └───────────────────────────────────────────────────┘
 ```
 
-- **第一层——自动 Hook（实时守卫）**：
-  - **OpenClaw**：插件拦截所有对 `SKILL.md` 的 `read` 调用，在 Skill 加载前自动运行 `check`。
-  - **copilot-shell**：Python hook 脚本（`cosh-extension/hooks/skill_ledger_hook.py`）通过 `PreToolUse` 事件在 Skill 调用前自动运行 `check`。
-  - 两者采用相同默认策略：`pass` 静默放行，`warn`/`error`/`unknown` 告警放行，`none`/`drifted`/`deny`/`tampered` 要求用户确认。插件或扩展加载且能力未禁用时生效。
-- **第二层——Agent 驱动扫描**：`scan` 执行内置快速扫描并签名；`skill-ledger` Skill 在用户要求深度扫描时驱动完整的四阶段安全审查，并通过 `certify --findings` 导入结果。**按需触发**，由用户请求发起。
+- **推荐路径——SkillFS + daemon activation**：SkillFS 负责发现 Skill 文件变化；daemon 根据最新签名 manifest 和 activation policy 刷新可执行 activation 目标。Agent 运行时读取 activation metadata，而不是默认依赖宿主 hook 前置检查。
+- **兼容路径——宿主 hook/capability policy**：OpenClaw、Hermes 和 copilot-shell 可在 Skill 加载前调用 `agent-sec-cli skill-ledger check`。默认 `debug` 不打扰用户；无 SkillFS 且需要可见提示或阻断时，显式配置 `warn` / `block`。
+- **Agent 驱动扫描**：`scan` 执行内置快速扫描并签名；`skill-ledger` Skill 在用户要求深度扫描时驱动完整的四阶段安全审查，并通过 `certify --findings` 导入结果。**按需触发**，由用户请求发起。
 
-### 第一层：自动 Hook 防护
+### 推荐路径：SkillFS + daemon activation
 
 **工作原理：**
 
-OpenClaw 安全插件注册了一个 `before_tool_call` hook（优先级 80）。当 Agent 调用 `read` 读取任何 `SKILL.md` 文件时：
+启用 SkillFS 后，Skill Ledger 的运行态入口由 daemon 处理：
 
-1. Hook 从文件路径提取 Skill 目录
-2. 确保签名密钥存在（缺失时自动初始化）
-3. 执行 `agent-sec-cli skill-ledger check <skill_dir>`
-4. 根据状态执行默认策略：
+1. SkillFS 捕获 Skill 目录创建、更新、删除或内容变更。
+2. SkillFS 通知 Skill Ledger daemon 的 `skill_ledger.skillfs_notify_change` 接口。
+3. daemon 根据签名 manifest、当前文件状态和 activation policy 刷新 `.skill-meta/activation.json`，并尽力同步写入 xattr。
+4. 若当前版本不可激活，activation metadata 会指向 `target: null` 或上一个符合策略的 snapshot。
 
-| 状态 | 默认行为 | 输出 |
+### 兼容路径：Hook / capability policy
+
+当 Agent 加载 Skill 时，宿主 hook 会解析 Skill 目录，执行 `agent-sec-cli skill-ledger check <skill_dir>`，并由统一 `policy` 控制可见行为：
+
+| Policy | 行为 |
+|--------|------|
+| `debug` | 默认值。`pass` 静默放行；非 `pass`、CLI 失败、超时或输出不可解析都 fail-open，只写 debug 诊断，不返回 reason、不追加 warning、不写 warning 级日志。 |
+| `warn` | 恢复 warning-only 兼容行为；非 `pass` 放行，但通过宿主 warning 机制提示用户。 |
+| `block` | 对强门禁状态返回确认/阻断；其它非 `pass` 状态按 warning 诊断处理。 |
+
+`none` / `drifted` / `deny` / `tampered` 是默认强门禁状态。`block_statuses` / `blockStatuses` 只在 `policy = "block"` 时生效。
+
+| 状态 | 兼容行为 | 输出 |
 |------|---------|------|
 | `pass` | 静默放行 | 无 |
-| `warn` | 放行 + 告警 | `⚠️ Skill 'skill-name' has low-risk findings — review recommended` |
-| `error` | 放行 + 告警 | `⚠️ Skill 'skill-name' check returned an error — review recommended` |
-| `unknown` | 放行 + 告警 | `⚠️ Skill 'skill-name' returned an unknown status — review recommended` |
-| `none` | 用户确认 | `⚠️ Skill 'skill-name' has not been security-scanned yet` |
-| `drifted` | 用户确认 | `⚠️ Skill 'skill-name' content has changed since last scan` |
-| `deny` | 用户确认 | `🚨 Skill 'skill-name' has high-risk findings — immediate review recommended` |
-| `tampered` | 用户确认 | `🚨 Skill 'skill-name' metadata signature verification failed` |
+| `warn` | `debug` 静默；`warn` 告警；`block` 告警放行 | `⚠️ Skill 'skill-name' has low-risk findings — review recommended` |
+| `error` | `debug` 静默；`warn` 告警；`block` 告警放行 | `⚠️ Skill 'skill-name' check returned an error — review recommended` |
+| `unknown` | `debug` 静默；`warn` 告警；`block` 告警放行 | `⚠️ Skill 'skill-name' returned an unknown status — review recommended` |
+| `none` | `debug` 静默；`warn` 告警；`block` 确认/阻断 | `⚠️ Skill 'skill-name' has not been security-scanned yet` |
+| `drifted` | `debug` 静默；`warn` 告警；`block` 确认/阻断 | `⚠️ Skill 'skill-name' content has changed since last scan` |
+| `deny` | `debug` 静默；`warn` 告警；`block` 确认/阻断 | `🚨 Skill 'skill-name' has high-risk findings — immediate review recommended` |
+| `tampered` | `debug` 静默；`warn` 告警；`block` 确认/阻断 | `🚨 Skill 'skill-name' metadata signature verification failed` |
 
-OpenClaw 在需要确认时返回 `requireApproval`；copilot-shell 在需要确认时返回 `decision: "ask"`。CLI 不可用、执行失败、超时或输出不可解析时保持 fail-open，避免基础设施异常阻断 Skill 加载。
+OpenClaw 默认 `enabled=true, policy="debug"`；Hermes 默认 `enabled=true, policy="debug"`；copilot-shell 默认 manifest 注册 `skill-ledger` PreToolUse hook，并通过 `SKILL_LEDGER_HOOK_POLICY` 控制 policy。CLI 不可用、执行失败、超时或输出不可解析时始终保持 fail-open，避免基础设施异常阻断 Skill 加载。
 
 copilot-shell hook 当前仅覆盖 project / user / system 三类目录：`<cwd>/.copilot-shell/skills/`、`~/.copilot-shell/skills/`、`/usr/share/anolisa/skills/`。若 Skill 来自 custom、extension、remote 或其它路径，hook 会 fail-open 并跳过 skill-ledger 检查；OpenClaw 插件则按读取到的 `SKILL.md` 路径提取 Skill 目录。
 
 批量认证或安装后认证场景中，建议先完成目录定位和认证，再让 Agent 读取未认证 Skill 内容：批量认证前避免主动读取未认证 Skill 的 `SKILL.md` 或辅助文件；安装成功后应先定位最终本地目录，确认包含 `SKILL.md`，再执行快速扫描认证。
 
-**启用方式**：确保 `agent-sec` 插件已加载，且 `skill-ledger` 能力未被显式禁用。插件配置中可通过以下方式禁用：
+**OpenClaw 启用方式**：
 
 ```json
 {
   "capabilities": {
-    "skill-ledger": { "enabled": false }
+    "skill-ledger": {
+      "enabled": true,
+      "policy": "debug",
+      "blockStatuses": ["none", "drifted", "deny", "tampered"]
+    }
   }
 }
 ```
 
-### 第二层：Agent 驱动深度扫描
+**Hermes 启用方式**：
+
+```toml
+[capabilities.skill-ledger]
+enabled = true
+timeout = 5
+policy = "debug"
+enable_block = false
+```
+
+**copilot-shell 配置方式**：默认 Cosh manifest 已注册 `skill-ledger` hook。默认 policy 为 `debug`；无 SkillFS 且希望可见提示或强门禁时，设置 `SKILL_LEDGER_HOOK_POLICY=warn` 或 `SKILL_LEDGER_HOOK_POLICY=block`。
+
+Skill Ledger 全局 `activationPolicy` 属于 SkillFS/daemon activation；这里的 hook `policy` 只控制宿主 hook/capability 的用户可见行为和日志等级。
+
+### Agent 驱动深度扫描
 
 #### 配置 Skill 目录（批量扫描使用）
 
@@ -309,7 +337,7 @@ crontab -l
 #### 场景 A：加载第三方 Skill 时检测篡改
 
 ```
-# Agent 加载 Skill → hook 自动触发
+# SkillFS/daemon 或宿主 hook 检测到异常状态
 [skill-ledger] 🚨 Skill 'third-party-tool' metadata signature verification failed
 ```
 

--- a/src/agent-sec-core/hermes-plugin/README.md
+++ b/src/agent-sec-core/hermes-plugin/README.md
@@ -122,17 +122,21 @@ Hermes 支持的 hook 及其回调签名：
 
 ### Skill Ledger
 
-`skill-ledger` 在 Hermes `skill_view` 读取技能前执行完整性检查：
+推荐部署模式是 SkillFS + Skill Ledger daemon activation：SkillFS 捕获 skill 变更，daemon 刷新 `.skill-meta/activation.json`/xattr。Hermes `skill-ledger` capability 默认仍注册，但默认 `policy = "debug"`：在 Hermes `skill_view` 读取技能前执行完整性检查，只写 debug 诊断，不阻断、不向最终回复追加 warning。
 
-- 默认 `enable_block = false`：不阻断读取；非 `pass` 状态会缓存为本轮告警，并通过
+- `enabled = false`：完全不注册 Hermes hook。
+- `policy = "debug"`：默认静默兼容模式；非 `pass`、CLI 失败或 JSON 解析失败都 fail-open，只写 debug。
+- `policy = "warn"`：恢复 warning-only 兼容模式；非 `pass` 状态会缓存为本轮告警，并通过
   `transform_llm_output` 追加到最终回复开头，确保用户可见。
-- `enable_block = true`：命中 `block_statuses` 时直接返回 Hermes block 结果；此模式不再追加
-  warning。
+- `policy = "block"`：命中 `block_statuses` 时直接返回 Hermes block 结果；未命中状态仅写 warning 诊断。
+- 未配置 `policy` 的旧配置仍兼容：`enable_block = true` 映射为 `block`，`enable_block = false` 映射为 `warn`。
 - 当前版本仅覆盖 Hermes 默认本地技能目录 `~/.hermes/skills`，按 Hermes `skill_view`
   的本地目录规则解析 `category/skill` 或裸 skill 名称；`skills.external_dirs` 和
   plugin-provided skills 暂不覆盖，hook 会 fail-open 跳过。
 - `file_path` / `path` 仅表示 skill 内 supporting file，不参与 skill 目录定位。
-- `max_warnings_per_turn = 0` 表示关闭用户可见 warning 注入，仅保留日志。
+- `max_warnings_per_turn = 0` 仅影响 `policy = "warn"` 的用户可见 warning 注入。
+- Skill Ledger 全局 `activationPolicy` 属于 SkillFS/daemon activation；这里的 hook `policy`
+  只控制宿主 hook 的可见行为和日志等级。
 
 配置示例：
 
@@ -140,11 +144,14 @@ Hermes 支持的 hook 及其回调签名：
 [capabilities.skill-ledger]
 enabled = true
 timeout = 5
+policy = "debug"
 enable_block = false
 block_statuses = ["none", "drifted", "deny", "tampered"]
 max_warnings_per_turn = 5
 max_warning_contexts = 128
 ```
+
+无 SkillFS 且希望用户可见提示或阻断时，将 `policy` 显式改为 `warn` 或 `block`。
 
 ### observability
 

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/skill_ledger.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/skill_ledger.py
@@ -18,6 +18,11 @@ _TOOL_NAME = "skill_view"
 _SKILL_MANIFEST = "SKILL.md"
 _DEFAULT_HERMES_SKILLS_DIR = Path("~/.hermes/skills")
 _DEFAULT_BLOCK_STATUSES = ["none", "drifted", "deny", "tampered"]
+_POLICY_DEBUG = "debug"
+_POLICY_WARN = "warn"
+_POLICY_BLOCK = "block"
+_DEFAULT_POLICY = _POLICY_DEBUG
+_VALID_POLICIES = frozenset({_POLICY_DEBUG, _POLICY_WARN, _POLICY_BLOCK})
 _SKIP_DIRS = frozenset({".git", ".github", ".hub", ".archive", ".skill-meta"})
 _CONTEXT_KEY_FIELDS = ("session_id", "task_id", "run_id")
 _HERMES_SESSION_ENV = "HERMES_SESSION_ID"
@@ -56,7 +61,8 @@ class SkillLedgerCapability(AgentSecCoreCapability):
 
     def _on_register(self, config: dict) -> None:
         """Read skill-ledger specific config."""
-        self._enable_block = bool(config.get("enable_block", False))
+        self._policy = self._read_policy(config)
+        self._enable_block = self._policy == _POLICY_BLOCK
         statuses = config.get("block_statuses", _DEFAULT_BLOCK_STATUSES)
         if not isinstance(statuses, list):
             statuses = _DEFAULT_BLOCK_STATUSES
@@ -80,12 +86,12 @@ class SkillLedgerCapability(AgentSecCoreCapability):
         if tool_name != _TOOL_NAME:
             return None
         if not isinstance(args, dict):
-            logger.warning("[agent-sec-core] skill-ledger missing args, fail-open")
+            self._diagnostic("[agent-sec-core] skill-ledger missing args, fail-open")
             return None
 
         skill_dir = self._resolve_skill_dir(args)
         if skill_dir is None:
-            logger.warning(
+            self._diagnostic(
                 "[agent-sec-core] skill-ledger could not resolve skill_dir, fail-open"
             )
             return None
@@ -97,7 +103,7 @@ class SkillLedgerCapability(AgentSecCoreCapability):
             trace_context=trace_context(kwargs),
         )
         if not result.stdout.strip():
-            logger.warning(
+            self._diagnostic(
                 "[agent-sec-core] skill-ledger empty CLI output, fail-open skill_dir=%s exit_code=%s",
                 skill_dir,
                 result.exit_code,
@@ -107,7 +113,7 @@ class SkillLedgerCapability(AgentSecCoreCapability):
         try:
             check_result = json.loads(result.stdout)
         except (json.JSONDecodeError, ValueError):
-            logger.warning(
+            self._diagnostic(
                 "[agent-sec-core] skill-ledger invalid CLI JSON, fail-open skill_dir=%s exit_code=%s",
                 skill_dir,
                 result.exit_code,
@@ -115,7 +121,7 @@ class SkillLedgerCapability(AgentSecCoreCapability):
             return None
 
         if not isinstance(check_result, dict):
-            logger.warning(
+            self._diagnostic(
                 "[agent-sec-core] skill-ledger CLI JSON is not an object, fail-open skill_dir=%s",
                 skill_dir,
             )
@@ -127,9 +133,14 @@ class SkillLedgerCapability(AgentSecCoreCapability):
 
         skill_name = str(check_result.get("skillName") or skill_dir.name)
         message = self._format_message(status, skill_name, skill_dir)
+
+        if self._policy == _POLICY_DEBUG:
+            logger.debug("[agent-sec-core] skill-ledger %s", message)
+            return None
+
         logger.warning("[agent-sec-core] skill-ledger %s", message)
 
-        if self._enable_block:
+        if self._policy == _POLICY_BLOCK:
             if status in self._block_statuses:
                 return {"action": "block", "message": message}
             return None
@@ -144,7 +155,7 @@ class SkillLedgerCapability(AgentSecCoreCapability):
         **kwargs,
     ):
         """Prepend user-visible skill-ledger warnings to the final response."""
-        if self._enable_block:
+        if self._policy != _POLICY_WARN:
             return None
         if self._max_warnings_per_turn == 0:
             return None
@@ -223,7 +234,7 @@ class SkillLedgerCapability(AgentSecCoreCapability):
                     record(skill_file.parent, skill_file)
 
         if len(candidates) > 1:
-            logger.warning(
+            self._diagnostic(
                 "[agent-sec-core] skill-ledger ambiguous Hermes skill name=%s matches=%s, fail-open",
                 wanted,
                 [str(path) for path in candidates],
@@ -235,7 +246,7 @@ class SkillLedgerCapability(AgentSecCoreCapability):
         try:
             return self._skills_dir.expanduser().resolve()
         except (OSError, ValueError):
-            logger.warning(
+            self._diagnostic(
                 "[agent-sec-core] skill-ledger invalid Hermes skills dir: %s",
                 self._skills_dir,
             )
@@ -282,6 +293,31 @@ class SkillLedgerCapability(AgentSecCoreCapability):
             if isinstance(value, str) and value.strip():
                 return value.strip()
         return None
+
+    @staticmethod
+    def _read_policy(config: dict) -> str:
+        raw_policy = config.get("policy")
+        if isinstance(raw_policy, str) and raw_policy.strip():
+            policy = raw_policy.strip().lower()
+            if policy in _VALID_POLICIES:
+                return policy
+            logger.debug(
+                "[agent-sec-core] skill-ledger invalid policy=%r; using %s",
+                raw_policy,
+                _DEFAULT_POLICY,
+            )
+            return _DEFAULT_POLICY
+
+        if "enable_block" in config:
+            return _POLICY_BLOCK if bool(config.get("enable_block")) else _POLICY_WARN
+
+        return _DEFAULT_POLICY
+
+    def _diagnostic(self, message: str, *args: Any) -> None:
+        if self._policy == _POLICY_DEBUG:
+            logger.debug(message, *args)
+        else:
+            logger.warning(message, *args)
 
     def _remember_warning(
         self,

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/skill_ledger.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/skill_ledger.py
@@ -62,7 +62,6 @@ class SkillLedgerCapability(AgentSecCoreCapability):
     def _on_register(self, config: dict) -> None:
         """Read skill-ledger specific config."""
         self._policy = self._read_policy(config)
-        self._enable_block = self._policy == _POLICY_BLOCK
         statuses = config.get("block_statuses", _DEFAULT_BLOCK_STATUSES)
         if not isinstance(statuses, list):
             statuses = _DEFAULT_BLOCK_STATUSES

--- a/src/agent-sec-core/hermes-plugin/src/config.toml
+++ b/src/agent-sec-core/hermes-plugin/src/config.toml
@@ -21,6 +21,7 @@ warning_ttl_seconds = 300
 [capabilities.skill-ledger]
 enabled = true
 timeout = 5
+policy = "debug"
 enable_block = false
 block_statuses = ["none", "drifted", "deny", "tampered"]
 max_warnings_per_turn = 5

--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -235,7 +235,7 @@ AGENT_SEC_LIVE=1 npm run smoke
 | `pii-scan-user-input` | `before_dispatch`, `before_tool_call`, `after_tool_call`, `llm_output` | 200 before dispatch/tool call | Scans user text, tool parameters, tool output, and model output for PII/credentials; optionally blocks pre-execution `deny` verdicts |
 | `prompt-scan`      | `before_dispatch`     | 190      | Scans inbound messages for prompt injection attacks   |
 | `scan-code`        | `before_tool_call`    | 0 (default) | Scans tool commands for security issues              |
-| `skill-ledger`     | `before_tool_call`    | 80       | Checks skill integrity when SKILL.md is read and optionally asks on risky states |
+| `skill-ledger`     | `before_tool_call`    | 80       | Checks skill integrity when SKILL.md is read; default policy is debug-only |
 | `observability`    | selected typed hooks  | varies   | Sends observability records to agent-sec-cli          |
 
 ### Configuring `code-scan`
@@ -298,7 +298,11 @@ Supported OpenClaw plugin entry config:
             "scan-code": { "enabled": true },
             "prompt-scan": { "enabled": true },
             "pii-scan-user-input": { "enabled": true, "enableBlock": false },
-            "skill-ledger": { "enabled": true, "enableBlock": true },
+            "skill-ledger": {
+              "enabled": true,
+              "policy": "debug",
+              "blockStatuses": ["none", "drifted", "deny", "tampered"]
+            },
             "observability": { "enabled": true }
           }
         },
@@ -311,22 +315,36 @@ Supported OpenClaw plugin entry config:
 }
 ```
 
-Set a capability's `enabled` value to `false` to skip registering only that capability while keeping the rest of the `agent-sec` plugin active.
+Set a capability's `enabled` value to `false` to skip registering only that capability while keeping the rest of the `agent-sec` plugin active. `skill-ledger` is enabled by default with `policy: "debug"` so it can run integrity checks without blocking, warning the user, or writing warning-level logs.
 Set `enableBlock` on supported capabilities to control whether matching security findings block or ask the user for approval.
 
 `llm_input`, `llm_output`, and `agent_end` require OpenClaw to allow conversation access for this external plugin with `plugins.entries.agent-sec.hooks.allowConversationAccess=true`. Without that OpenClaw setting, those hooks are blocked by OpenClaw before this plugin sees them.
 
 ### Configuring `skill-ledger`
 
-The `skill-ledger` capability checks skill integrity by invoking `agent-sec-cli skill-ledger check` when the agent reads a `SKILL.md` file. It automatically initializes signing keys on first use.
+The recommended Skill Ledger deployment is SkillFS + Skill Ledger daemon activation: SkillFS observes skill changes and the daemon refreshes `.skill-meta/activation.json`/xattr. The OpenClaw `skill-ledger` capability is still mounted by default, but its default `policy: "debug"` is intentionally silent.
 
-By default, `capabilities["skill-ledger"].enableBlock` is `true`. In this mode, `none`, `drifted`, `deny`, and `tampered` statuses return an OpenClaw approval request. `warn`, `error`, and unknown statuses are logged only.
+Default behavior:
 
-Set `enableBlock: false` to log all non-`pass` statuses without asking:
+- `enabled: false` fully disables registration.
+- `policy: "debug"` runs `agent-sec-cli skill-ledger check`, fail-opens on non-`pass` or CLI failures, and writes debug diagnostics only.
+- `policy: "warn"` logs warning-level diagnostics but allows the read.
+- `policy: "block"` returns OpenClaw `requireApproval` for `blockStatuses` (`none`, `drifted`, `deny`, `tampered` by default); other non-`pass` statuses are warning diagnostics only.
+- Legacy configs without `policy` still map `enableBlock: true` to `block` and `enableBlock: false` to `warn`.
+
+Set `policy: "warn"` when running without SkillFS but wanting visible diagnostics:
 
 ```bash
-openclaw config set 'plugins.entries.agent-sec.config.capabilities.skill-ledger.enableBlock' false
+openclaw config set 'plugins.entries.agent-sec.config.capabilities.skill-ledger.policy' warn
 ```
+
+Set `policy: "block"` to ask for approval on strong gate statuses:
+
+```bash
+openclaw config set 'plugins.entries.agent-sec.config.capabilities.skill-ledger.policy' block
+```
+
+Skill Ledger global `activationPolicy` belongs to SkillFS/daemon activation. OpenClaw `policy` only controls this host hook's user-visible behavior and log level.
 
 **Prerequisites**: `agent-sec-cli skill-ledger check` must be available. Signing keys are auto-initialized (no passphrase) if not present.
 

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -69,7 +69,6 @@
               },
               "enableBlock": {
                 "type": "boolean",
-                "default": false,
                 "description": "Deprecated: 未配置 policy 时兼容旧配置；true 映射为 block，false 映射为 warn"
               },
               "blockStatuses": {

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -61,10 +61,22 @@
             "type": "object",
             "properties": {
               "enabled": { "type": "boolean", "default": true },
+              "policy": {
+                "type": "string",
+                "enum": ["debug", "warn", "block"],
+                "default": "debug",
+                "description": "控制已挂载 Skill Ledger hook 的用户可见行为：debug 仅调试日志，warn 告警放行，block 对强门禁状态要求确认"
+              },
               "enableBlock": {
                 "type": "boolean",
-                "default": true,
-                "description": "检测到 none、drifted、deny 或 tampered skill 状态时是否要求用户确认"
+                "default": false,
+                "description": "Deprecated: 未配置 policy 时兼容旧配置；true 映射为 block，false 映射为 warn"
+              },
+              "blockStatuses": {
+                "type": "array",
+                "default": ["none", "drifted", "deny", "tampered"],
+                "items": { "type": "string" },
+                "description": "policy=block 时要求确认的 Skill Ledger 状态"
               }
             }
           },

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
@@ -129,12 +129,18 @@ function confirmationSeverity(status: string): "warning" | "critical" | undefine
   return CONFIRMATION_SEVERITY[status];
 }
 
-function readPolicy(capabilityConfig: Record<string, any>): SkillLedgerPolicy {
+function readPolicy(
+  capabilityConfig: Record<string, any>,
+  api: any,
+): SkillLedgerPolicy {
   if (typeof capabilityConfig.policy === "string") {
     const policy = capabilityConfig.policy.trim().toLowerCase();
     if (VALID_POLICIES.has(policy as SkillLedgerPolicy)) {
       return policy as SkillLedgerPolicy;
     }
+    api.logger.warn(
+      `[skill-ledger] invalid policy="${capabilityConfig.policy}"; using ${DEFAULT_POLICY}`,
+    );
     return DEFAULT_POLICY;
   }
 
@@ -159,10 +165,10 @@ function readBlockStatuses(capabilityConfig: Record<string, any>): Set<string> {
   return new Set(statuses.length ? statuses : DEFAULT_BLOCK_STATUSES);
 }
 
-function readConfig(pluginConfig: Record<string, any>): SkillLedgerConfig {
+function readConfig(pluginConfig: Record<string, any>, api: any): SkillLedgerConfig {
   const capabilityConfig = pluginConfig.capabilities?.["skill-ledger"] ?? {};
   return {
-    policy: readPolicy(capabilityConfig),
+    policy: readPolicy(capabilityConfig, api),
     blockStatuses: readBlockStatuses(capabilityConfig),
   };
 }
@@ -196,7 +202,7 @@ export const skillLedger: SecurityCapability = {
   name: "Skill Ledger",
   hooks: ["before_tool_call"],
   register(api) {
-    const cfg = readConfig((api.pluginConfig as Record<string, any>) ?? {});
+    const cfg = readConfig((api.pluginConfig as Record<string, any>) ?? {}, api);
 
     /** Ensure signing keys exist; auto-init if missing. */
     let ensureKeysPromise: Promise<void> | null = null;

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/skill-ledger.ts
@@ -19,8 +19,11 @@ type CheckResult = {
   [key: string]: unknown;
 };
 
+type SkillLedgerPolicy = "debug" | "warn" | "block";
+
 type SkillLedgerConfig = {
-  enableBlock: boolean;
+  policy: SkillLedgerPolicy;
+  blockStatuses: Set<string>;
 };
 
 // ---------------------------------------------------------------------------
@@ -30,6 +33,9 @@ type SkillLedgerConfig = {
 const READ_TOOL_NAMES = ["read"];
 const PATH_PARAM_NAMES = ["file_path", "path"];
 const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_POLICY: SkillLedgerPolicy = "debug";
+const VALID_POLICIES = new Set<SkillLedgerPolicy>(["debug", "warn", "block"]);
+const DEFAULT_BLOCK_STATUSES = ["none", "drifted", "deny", "tampered"];
 
 // ---------------------------------------------------------------------------
 // Status messages and confirmation policy
@@ -123,11 +129,62 @@ function confirmationSeverity(status: string): "warning" | "critical" | undefine
   return CONFIRMATION_SEVERITY[status];
 }
 
+function readPolicy(capabilityConfig: Record<string, any>): SkillLedgerPolicy {
+  if (typeof capabilityConfig.policy === "string") {
+    const policy = capabilityConfig.policy.trim().toLowerCase();
+    if (VALID_POLICIES.has(policy as SkillLedgerPolicy)) {
+      return policy as SkillLedgerPolicy;
+    }
+    return DEFAULT_POLICY;
+  }
+
+  if (typeof capabilityConfig.enableBlock === "boolean") {
+    return capabilityConfig.enableBlock ? "block" : "warn";
+  }
+
+  return DEFAULT_POLICY;
+}
+
+function readBlockStatuses(capabilityConfig: Record<string, any>): Set<string> {
+  const raw = capabilityConfig.blockStatuses ?? capabilityConfig.block_statuses;
+  if (!Array.isArray(raw)) {
+    return new Set(DEFAULT_BLOCK_STATUSES);
+  }
+  const statuses = raw
+    .filter(
+      (status): status is string =>
+        typeof status === "string" && status.trim().length > 0,
+    )
+    .map((status) => status.trim());
+  return new Set(statuses.length ? statuses : DEFAULT_BLOCK_STATUSES);
+}
+
 function readConfig(pluginConfig: Record<string, any>): SkillLedgerConfig {
   const capabilityConfig = pluginConfig.capabilities?.["skill-ledger"] ?? {};
   return {
-    enableBlock: capabilityConfig.enableBlock !== false,
+    policy: readPolicy(capabilityConfig),
+    blockStatuses: readBlockStatuses(capabilityConfig),
   };
+}
+
+function logDebug(api: any, message: string): void {
+  api.logger.debug?.(`[skill-ledger] ${message}`);
+}
+
+function logDiagnostic(api: any, cfg: SkillLedgerConfig, message: string): void {
+  if (cfg.policy === "debug") {
+    logDebug(api, message);
+  } else {
+    api.logger.warn(`[skill-ledger] ${message}`);
+  }
+}
+
+function logLifecycle(api: any, cfg: SkillLedgerConfig, message: string): void {
+  if (cfg.policy === "debug") {
+    logDebug(api, message);
+  } else {
+    api.logger.info(`[skill-ledger] ${message}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -150,8 +207,10 @@ export const skillLedger: SecurityCapability = {
       ensureKeysPromise = (async () => {
         if (keysExist()) return;
 
-        api.logger.info(
-          "[skill-ledger] signing keys not found — running init --no-baseline",
+        logLifecycle(
+          api,
+          cfg,
+          "signing keys not found — running init --no-baseline",
         );
         const result = await callAgentSecCli(
           ["skill-ledger", "init", "--no-baseline"],
@@ -159,14 +218,17 @@ export const skillLedger: SecurityCapability = {
         );
 
         if (result.exitCode === 0) {
-          api.logger.info("[skill-ledger] signing keys initialized successfully");
+          logLifecycle(api, cfg, "signing keys initialized successfully");
         } else if (!keysExist()) {
-          api.logger.warn(
-            `[skill-ledger] init --no-baseline failed: ${result.stderr}`,
+          logDiagnostic(
+            api,
+            cfg,
+            `init --no-baseline failed: ${result.stderr}`,
           );
           ensureKeysPromise = null; // allow retry on next call
         }
-      })().catch(() => {
+      })().catch((err) => {
+        logDiagnostic(api, cfg, `init --no-baseline error: ${err}`);
         ensureKeysPromise = null; // unexpected error — allow retry
       });
 
@@ -204,14 +266,17 @@ export const skillLedger: SecurityCapability = {
           try {
             checkResult = JSON.parse(result.stdout) as CheckResult;
           } catch {
-            // Only log warning if parsing fails AND exit code is non-zero
             if (result.exitCode !== 0) {
-              api.logger.warn(
-                `[skill-ledger] CLI error (exit ${result.exitCode}): ${result.stderr}`,
+              logDiagnostic(
+                api,
+                cfg,
+                `CLI error (exit ${result.exitCode}): ${result.stderr}`,
               );
             } else {
-              api.logger.warn(
-                `[skill-ledger] failed to parse CLI output: ${result.stdout}`,
+              logDiagnostic(
+                api,
+                cfg,
+                `failed to parse CLI output: ${result.stdout}`,
               );
             }
             return undefined;
@@ -224,23 +289,21 @@ export const skillLedger: SecurityCapability = {
           }
 
           const message = formatSkillLedgerMessage(status, skillName);
+          if (cfg.policy === "debug") {
+            logDebug(api, `skill='${skillName}' status=${status}: ${message}`);
+            return undefined;
+          }
+
           api.logger.warn(`[skill-ledger] ${message}`);
-
           const severity = confirmationSeverity(status);
-          if (severity) {
-            if (cfg.enableBlock) {
-              return {
-                requireApproval: {
-                  title: "Skill Ledger Security Check",
-                  description: message,
-                  severity,
-                },
-              };
-            }
-
-            api.logger.warn(
-              `[skill-ledger] ${status.toUpperCase()} (enableBlock=false) — allowing`,
-            );
+          if (cfg.policy === "block" && severity && cfg.blockStatuses.has(status)) {
+            return {
+              requireApproval: {
+                title: "Skill Ledger Security Check",
+                description: message,
+                severity,
+              },
+            };
           }
 
           // For warn/error/unknown states, log and allow. Fail-open behavior for
@@ -248,7 +311,7 @@ export const skillLedger: SecurityCapability = {
           return undefined;
         } catch (err) {
           // Fail-open: uncaught errors must never block tool calls
-          api.logger.warn(`[skill-ledger] error: ${err}`);
+          logDiagnostic(api, cfg, `error: ${err}`);
           return undefined;
         }
       },

--- a/src/agent-sec-core/openclaw-plugin/src/index.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/index.ts
@@ -6,6 +6,7 @@ import { observability } from "./capabilities/observability.js";
 import { piiScan } from "./capabilities/pii-scan.js";
 import { promptScan } from "./capabilities/prompt-scan.js";
 import { skillLedger } from "./capabilities/skill-ledger.js";
+import { isCapabilityEnabled } from "./registration.js";
 
 const capabilities: SecurityCapability[] = [
   codeScan,
@@ -23,7 +24,7 @@ export default definePluginEntry({
     const cfg = (api.pluginConfig as Record<string, any>)?.capabilities ?? {};
     let count = 0;
     for (const cap of capabilities) {
-      if (cfg[cap.id]?.enabled === false) {
+      if (!isCapabilityEnabled(cap, cfg)) {
         api.logger.info(`[agent-sec] skipped (disabled): ${cap.id}`);
         continue;
       }

--- a/src/agent-sec-core/openclaw-plugin/src/registration.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/registration.ts
@@ -1,0 +1,12 @@
+import type { SecurityCapability } from "./types.js";
+
+export function isCapabilityEnabled(
+  capability: SecurityCapability,
+  config: Record<string, any>,
+): boolean {
+  const capabilityConfig = config[capability.id] ?? {};
+  if (typeof capabilityConfig.enabled === "boolean") {
+    return capabilityConfig.enabled;
+  }
+  return true;
+}

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isCapabilityEnabled } from "../../src/registration.js";
+import type { SecurityCapability } from "../../src/types.js";
+import { skillLedger } from "../../src/capabilities/skill-ledger.js";
+
+function capability(id: string): SecurityCapability {
+  return {
+    id,
+    name: id,
+    hooks: [],
+    register: () => {},
+  };
+}
+
+describe("capability registration defaults", () => {
+  it("enables capabilities by default", () => {
+    assert.equal(isCapabilityEnabled(capability("scan-code"), {}), true);
+  });
+
+  it("enables skill-ledger by default", () => {
+    assert.equal(isCapabilityEnabled(skillLedger, {}), true);
+  });
+
+  it("lets explicit config disable capabilities", () => {
+    assert.equal(
+      isCapabilityEnabled(capability("prompt-scan"), {
+        "prompt-scan": { enabled: false },
+      }),
+      false,
+    );
+  });
+});

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { isCapabilityEnabled } from "../../src/registration.js";
 import type { SecurityCapability } from "../../src/types.js";
 import { skillLedger } from "../../src/capabilities/skill-ledger.js";
@@ -29,5 +31,17 @@ describe("capability registration defaults", () => {
       }),
       false,
     );
+  });
+
+  it("does not give deprecated skill-ledger enableBlock a schema default", () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve("openclaw.plugin.json"), "utf8"),
+    );
+    const enableBlock =
+      manifest.configSchema.properties.capabilities.properties[
+        "skill-ledger"
+      ].properties.enableBlock;
+
+    assert.equal(Object.hasOwn(enableBlock, "default"), false);
   });
 });

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
@@ -41,7 +41,15 @@ function registerHandlers(pluginConfig: Record<string, any> = {}) {
   return { beforeToolCall, hooks, logs };
 }
 
-function enableBlockConfig(enableBlock: boolean): Record<string, any> {
+function policyConfig(policy: "debug" | "warn" | "block"): Record<string, any> {
+  return {
+    capabilities: {
+      "skill-ledger": { policy },
+    },
+  };
+}
+
+function legacyEnableBlockConfig(enableBlock: boolean): Record<string, any> {
   return {
     capabilities: {
       "skill-ledger": { enableBlock },
@@ -361,8 +369,8 @@ describe("skill-ledger", () => {
     assert.equal(await beforeToolCall.handler(null, {}), undefined);
     assert.equal(await beforeToolCall.handler({ toolName: "read" }, {}), undefined);
 
-    assert.ok(logs.some((log) => log.includes("CLI error")));
-    assert.ok(logs.some((log) => log.includes("[skill-ledger] error:")));
+    assert.ok(logs.some((log) => log.includes("[DEBUG] [skill-ledger]")));
+    assert.ok(!logs.some((log) => log.includes("[WARN] [skill-ledger]")));
   });
 
   it("pass allows silently", async () => {
@@ -373,9 +381,25 @@ describe("skill-ledger", () => {
   });
 
   for (const status of ["none", "drifted", "deny", "tampered"]) {
-    it(`${status} asks for approval by default`, async () => {
+    it(`${status} logs debug and allows by default`, async () => {
       mockSkillLedgerStatus(status, status === "none" ? 0 : 1);
-      const { beforeToolCall } = registerHandlers();
+      const { beforeToolCall, logs } = registerHandlers();
+
+      const result = await beforeToolCall.handler(
+        readSkillEvent(`/skills/${status}/SKILL.md`, "run-1"),
+        { runId: "run-1" },
+      );
+
+      assert.equal(result, undefined);
+      assert.ok(logs.some((log) => log.includes("[DEBUG] [skill-ledger]")));
+      assert.ok(!logs.some((log) => log.includes("[WARN] [skill-ledger]")));
+    });
+  }
+
+  for (const status of ["none", "drifted", "deny", "tampered"]) {
+    it(`${status} asks for approval with block policy`, async () => {
+      mockSkillLedgerStatus(status, status === "none" ? 0 : 1);
+      const { beforeToolCall } = registerHandlers(policyConfig("block"));
 
       const result = await beforeToolCall.handler(
         readSkillEvent(`/skills/${status}/SKILL.md`, "run-1"),
@@ -391,10 +415,10 @@ describe("skill-ledger", () => {
     });
   }
 
-  for (const status of ["none", "drifted", "deny", "tampered"]) {
-    it(`${status} logs and allows when enableBlock=false`, async () => {
-      mockSkillLedgerStatus(status, status === "none" ? 0 : 1);
-      const { beforeToolCall, logs } = registerHandlers(enableBlockConfig(false));
+  for (const status of ["warn", "error", "mystery"]) {
+    it(`${status} logs debug only by default`, async () => {
+      mockSkillLedgerStatus(status, status === "error" ? 1 : 0);
+      const { beforeToolCall, logs } = registerHandlers();
 
       const result = await beforeToolCall.handler(
         readSkillEvent(`/skills/${status}/SKILL.md`, "run-1"),
@@ -402,13 +426,12 @@ describe("skill-ledger", () => {
       );
 
       assert.equal(result, undefined);
-      assert.ok(logs.some((log) => log.includes(`[skill-ledger] ${status.toUpperCase()} (enableBlock=false)`)));
+      assert.ok(logs.some((log) => log.includes("[DEBUG] [skill-ledger]")));
+      assert.ok(!logs.some((log) => log.includes("[WARN] [skill-ledger]")));
     });
-  }
 
-  for (const status of ["warn", "error", "mystery"]) {
-    it(`${status} logs only in default and enableBlock=false modes`, async () => {
-      for (const pluginConfig of [{}, enableBlockConfig(false)]) {
+    it(`${status} logs warning with warn policy`, async () => {
+      for (const pluginConfig of [policyConfig("warn"), legacyEnableBlockConfig(false)]) {
         mockSkillLedgerStatus(status, status === "error" ? 1 : 0);
         const { beforeToolCall, logs } = registerHandlers(pluginConfig);
 
@@ -418,8 +441,17 @@ describe("skill-ledger", () => {
         );
 
         assert.equal(result, undefined);
-        assert.ok(logs.some((log) => log.includes("[skill-ledger]")));
+        assert.ok(logs.some((log) => log.includes("[WARN] [skill-ledger]")));
       }
     });
   }
+
+  it("maps legacy enableBlock=true to block policy", async () => {
+    mockSkillLedgerStatus("deny", 1);
+    const { beforeToolCall } = registerHandlers(legacyEnableBlockConfig(true));
+
+    const result = await beforeToolCall.handler(readSkillEvent("/skills/deny/SKILL.md"), {});
+
+    assert.ok(result?.requireApproval);
+  });
 });

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
@@ -415,6 +415,28 @@ describe("skill-ledger", () => {
     });
   }
 
+  it("invalid explicit policy falls back to debug and logs a config warning", async () => {
+    mockSkillLedgerStatus("deny", 1);
+    const { beforeToolCall, logs } = registerHandlers({
+      capabilities: {
+        "skill-ledger": { policy: "blcok" },
+      },
+    });
+
+    const result = await beforeToolCall.handler(
+      readSkillEvent("/skills/deny/SKILL.md"),
+      {},
+    );
+
+    assert.equal(result, undefined);
+    assert.ok(
+      logs.some((log) =>
+        log.includes("[WARN] [skill-ledger] invalid policy=\"blcok\"; using debug"),
+      ),
+    );
+    assert.ok(logs.some((log) => log.includes("[DEBUG] [skill-ledger]")));
+  });
+
   for (const status of ["warn", "error", "mystery"]) {
     it(`${status} logs debug only by default`, async () => {
       mockSkillLedgerStatus(status, status === "error" ? 1 : 0);

--- a/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
@@ -1164,6 +1164,13 @@ def _run_hook(input_data, env_extra=None):
     return json.loads(proc.stdout)
 
 
+def _hook_env(env_extra: dict | None = None, *, policy: str) -> dict:
+    """Return a hook environment with an explicit Skill Ledger hook policy."""
+    env = dict(env_extra or {})
+    env["SKILL_LEDGER_HOOK_POLICY"] = policy
+    return env
+
+
 def _make_cosh_event(skill_name: str, cwd: str) -> dict:
     """Build a minimal cosh PreToolUse JSON event."""
     return {
@@ -1192,9 +1199,15 @@ def case_hook_wrong_tool_allows():
     assert output == {"decision": "allow"}
 
 
-def case_hook_unknown_skill_warns():
-    """Skill not found on disk → allow with warning."""
+def case_hook_unknown_skill_policy_modes():
+    """Skill not found: default debug is silent, warn policy emits reason."""
     output = _run_hook(_make_cosh_event("nonexistent-skill-xyz", "/tmp"))
+    assert output == {"decision": "allow"}
+
+    output = _run_hook(
+        _make_cosh_event("nonexistent-skill-xyz", "/tmp"),
+        env_extra=_hook_env(policy="warn"),
+    )
     assert output["decision"] == "allow"
     assert "not found" in output.get("reason", "").lower()
 
@@ -1219,8 +1232,8 @@ def case_hook_pass_status_silent(ws: Workspace):
     assert "reason" not in output, f"Expected silent allow, got reason: {output}"
 
 
-def case_hook_drifted_requires_confirmation(ws: Workspace):
-    """Hook on a drifted skill → ask with warning reason."""
+def case_hook_drifted_policy_modes(ws: Workspace):
+    """Hook on a drifted skill: debug allows silently, block asks."""
     skill = make_skill(ws.hook_skills_dir, "hook-drift", {"f.txt": "original"})
     env = ws.env()
     findings = write_findings_file(
@@ -1236,6 +1249,12 @@ def case_hook_drifted_requires_confirmation(ws: Workspace):
         _make_cosh_event("hook-drift", str(ws.root)),
         env_extra=env,
     )
+    assert output == {"decision": "allow"}
+
+    output = _run_hook(
+        _make_cosh_event("hook-drift", str(ws.root)),
+        env_extra=_hook_env(env, policy="block"),
+    )
     assert output["decision"] == "ask"
     assert "reason" in output, f"Expected confirmation reason for drifted: {output}"
     assert (
@@ -1243,11 +1262,17 @@ def case_hook_drifted_requires_confirmation(ws: Workspace):
     )
 
 
-def case_hook_path_traversal_rejected(ws: Workspace):
-    """Path traversal in skill name → rejected with reason."""
+def case_hook_path_traversal_policy_modes(ws: Workspace):
+    """Path traversal: default debug allows silently, warn emits reason."""
     output = _run_hook(
         _make_cosh_event("../../etc/passwd", "/tmp"),
         env_extra=ws.env(),
+    )
+    assert output == {"decision": "allow"}
+
+    output = _run_hook(
+        _make_cosh_event("../../etc/passwd", "/tmp"),
+        env_extra=_hook_env(ws.env(), policy="warn"),
     )
     assert output["decision"] == "allow"
     assert "reason" in output
@@ -1258,7 +1283,7 @@ def case_hook_path_traversal_rejected(ws: Workspace):
 
 
 def case_full_pipeline_vetter_to_hook(ws: Workspace):
-    """End-to-end: create → check(none) → certify(pass) → hook(silent allow)."""
+    """End-to-end: create → certify(pass) → hook policy behavior."""
     skill = make_skill(ws.hook_skills_dir, "pipeline-full", {"app.py": "print(1)\n"})
     env = ws.env()
 
@@ -1291,11 +1316,19 @@ def case_full_pipeline_vetter_to_hook(ws: Workspace):
     # Modify file → drifted
     (skill / "app.py").write_text("print(2)\n")
 
-    # hook → ask with warning reason
+    # default hook policy → silent allow for drifted status
     if HOOK_SCRIPT:
         output = _run_hook(
             _make_cosh_event("pipeline-full", str(ws.root)),
             env_extra=env,
+        )
+        assert output == {"decision": "allow"}, f"Expected debug allow: {output}"
+
+    # block hook policy → ask with warning reason
+    if HOOK_SCRIPT:
+        output = _run_hook(
+            _make_cosh_event("pipeline-full", str(ws.root)),
+            env_extra=_hook_env(env, policy="block"),
         )
         assert output["decision"] == "ask"
         assert "reason" in output, f"Expected drift confirmation: {output}"
@@ -1419,8 +1452,8 @@ E2E_CASES = [
         init_default_keys=False,
     ),
     E2ECase(
-        "G12: hook unknown skill warns",
-        _without_workspace(case_hook_unknown_skill_warns),
+        "G12: hook unknown skill debug/warn",
+        _without_workspace(case_hook_unknown_skill_policy_modes),
         requires_hook=True,
         init_default_keys=False,
     ),
@@ -1430,13 +1463,13 @@ E2E_CASES = [
         requires_hook=True,
     ),
     E2ECase(
-        "G12: hook drifted → ask",
-        case_hook_drifted_requires_confirmation,
+        "G12: hook drifted debug/block",
+        case_hook_drifted_policy_modes,
         requires_hook=True,
     ),
     E2ECase(
-        "G12: hook path traversal",
-        case_hook_path_traversal_rejected,
+        "G12: hook path traversal debug/warn",
+        case_hook_path_traversal_policy_modes,
         requires_hook=True,
         init_default_keys=False,
     ),

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -67,15 +67,25 @@ async def wait_for(
     raise AssertionError("timed out waiting for daemon activation update")
 
 
-def notify_payload(skill_dir: Path, paths: list[str] | None = None) -> dict[str, Any]:
+def notify_payload(
+    skill_dir: Path,
+    paths: list[str] | None = None,
+    *,
+    event_kind: str = "write",
+) -> dict[str, Any]:
     """Build daemon params for SkillFS notify."""
     return {
         "schemaVersion": 1,
         "skillDir": str(skill_dir),
         "skillName": skill_dir.name,
-        "eventKind": "write",
-        "paths": paths or ["SKILL.md"],
+        "eventKind": event_kind,
+        "paths": paths if paths is not None else ["SKILL.md"],
     }
+
+
+def reconcile_payload(skill_dir: Path) -> dict[str, Any]:
+    """Build daemon params for SkillFS startup reconcile."""
+    return notify_payload(skill_dir, paths=[], event_kind="reconcile")
 
 
 def write_isolated_config(root: Path, extra: dict[str, Any] | None = None) -> None:
@@ -140,6 +150,167 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
     assert (skill_dir / activation["target"]).is_dir()
     jobs = {job["name"]: job for job in health.data["jobs"]}
     assert jobs["skill-ledger-activation"]["state"] == "running"
+
+
+def test_daemon_reconcile_scans_unmanaged_skill_and_remembers_it(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg_data"))
+    write_isolated_config(tmp_path)
+    skill_dir = make_skill(tmp_path / "skills", "weather", {"run.sh": "echo ok\n"})
+    socket_path = daemon_socket_path(tmp_path)
+
+    async def scenario():
+        server = DaemonServer(socket_path=socket_path)
+        await server.start()
+        try:
+            client = DaemonClient(socket_path=socket_path, timeout_ms=3000)
+            response = await asyncio.to_thread(
+                client.call,
+                METHOD_SKILLFS_NOTIFY_CHANGE,
+                reconcile_payload(skill_dir),
+                trace_context={},
+            )
+            activation = await wait_for(
+                lambda: (
+                    read_activation(skill_dir)
+                    if (skill_dir / ".skill-meta" / "activation.json").is_file()
+                    else None
+                )
+            )
+            config = read_skill_ledger_config(tmp_path)
+        finally:
+            await server.stop()
+        return response, activation, config
+
+    response, activation, config = asyncio.run(scenario())
+
+    assert response.ok is True
+    assert response.data["accepted"] is True
+    assert response.data["ignored"] is False
+    assert response.data["skill"]["eventKinds"] == ["reconcile"]
+    assert response.data["skill"]["paths"] == []
+    assert str(skill_dir) in config["managedSkillDirs"]
+    assert activation["schemaVersion"] == 1
+    assert activation["target"] == ".skill-meta/versions/v000001.snapshot"
+
+
+def test_daemon_reconcile_existing_clean_skill_keeps_existing_version(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg_data"))
+    write_isolated_config(tmp_path)
+    skill_dir = make_skill(tmp_path / "skills", "weather", {"run.sh": "echo ok\n"})
+    socket_path = daemon_socket_path(tmp_path)
+    scan_calls = {"count": 0}
+
+    from agent_sec_cli.daemon import skill_ledger_activation
+
+    real_scan = skill_ledger_activation._scan_skill
+
+    def spy_scan(skill_path: str, backend: Any) -> dict[str, Any]:
+        scan_calls["count"] += 1
+        return real_scan(skill_path, backend)
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        spy_scan,
+    )
+
+    async def scenario():
+        server = DaemonServer(socket_path=socket_path)
+        await server.start()
+        try:
+            client = DaemonClient(socket_path=socket_path, timeout_ms=3000)
+            await asyncio.to_thread(
+                client.call,
+                METHOD_SKILLFS_NOTIFY_CHANGE,
+                reconcile_payload(skill_dir),
+                trace_context={},
+            )
+            first_latest = await wait_for(
+                lambda: (
+                    read_latest(skill_dir)
+                    if (skill_dir / ".skill-meta" / "latest.json").is_file()
+                    else None
+                )
+            )
+            await asyncio.to_thread(
+                client.call,
+                METHOD_SKILLFS_NOTIFY_CHANGE,
+                reconcile_payload(skill_dir),
+                trace_context={},
+            )
+            await wait_for(lambda: scan_calls["count"] >= 2)
+            latest = read_latest(skill_dir)
+            activation = read_activation(skill_dir)
+        finally:
+            await server.stop()
+        return first_latest, latest, activation
+
+    first_latest, latest, activation = asyncio.run(scenario())
+
+    assert first_latest["versionId"] == "v000001"
+    assert latest["versionId"] == "v000001"
+    assert activation["target"] == ".skill-meta/versions/v000001.snapshot"
+
+
+def test_daemon_reconcile_drifted_skill_creates_new_version(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg_data"))
+    write_isolated_config(tmp_path)
+    skill_dir = make_skill(tmp_path / "skills", "weather", {"run.sh": "echo v1\n"})
+    socket_path = daemon_socket_path(tmp_path)
+
+    async def scenario():
+        server = DaemonServer(socket_path=socket_path)
+        await server.start()
+        try:
+            client = DaemonClient(socket_path=socket_path, timeout_ms=3000)
+            await asyncio.to_thread(
+                client.call,
+                METHOD_SKILLFS_NOTIFY_CHANGE,
+                reconcile_payload(skill_dir),
+                trace_context={},
+            )
+            await wait_for(
+                lambda: (
+                    read_latest(skill_dir)
+                    if (skill_dir / ".skill-meta" / "latest.json").is_file()
+                    else None
+                )
+            )
+            (skill_dir / "run.sh").write_text("echo v2\n", encoding="utf-8")
+            response = await asyncio.to_thread(
+                client.call,
+                METHOD_SKILLFS_NOTIFY_CHANGE,
+                reconcile_payload(skill_dir),
+                trace_context={},
+            )
+            latest = await wait_for(
+                lambda: (
+                    read_latest(skill_dir)
+                    if read_latest(skill_dir).get("versionId") == "v000002"
+                    else None
+                )
+            )
+            activation = read_activation(skill_dir)
+        finally:
+            await server.stop()
+        return response, latest, activation
+
+    response, latest, activation = asyncio.run(scenario())
+
+    assert response.ok is True
+    assert latest["versionId"] == "v000002"
+    assert activation["target"] == ".skill-meta/versions/v000002.snapshot"
 
 
 def test_daemon_metadata_only_notify_does_not_change_activation(

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
@@ -37,6 +37,9 @@ _COSH_HOOK = str(
 sys.path.insert(0, str(Path(_COSH_HOOK).parent))
 import skill_ledger_hook  # noqa: E402
 
+_COSH_MANIFEST = Path(_COSH_HOOK).parents[1] / "cosh-extension.json"
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -94,6 +97,19 @@ def _create_skill_dir(parent, name="test-skill", manifest_name=None):
         f"---\nname: {manifest_name}\ndescription: A test skill\n---\nHello\n"
     )
     return str(skill_dir)
+
+
+def test_cosh_manifest_registers_skill_ledger_by_default():
+    """Default Cosh installs keep the hook mounted in debug policy."""
+    manifest = json.loads(_COSH_MANIFEST.read_text(encoding="utf-8"))
+    registered_hook_names = [
+        hook.get("name")
+        for event_hooks in manifest.get("hooks", {}).values()
+        for matcher_hooks in event_hooks
+        for hook in matcher_hooks.get("hooks", [])
+    ]
+
+    assert "skill-ledger" in registered_hook_names
 
 
 def test_injects_trace_context_into_skill_ledger_check_command(monkeypatch, capsys):
@@ -192,31 +208,51 @@ class TestFailOpen:
         assert output == {"decision": "allow"}
 
     def test_missing_skill_name_allows(self):
-        output = _run_hook({"tool_name": "skill", "tool_input": {}})
-        assert output["decision"] == "allow"
-        assert "empty or missing" in output["reason"]
+        output, stderr = _run_hook(
+            {"tool_name": "skill", "tool_input": {}},
+            return_stderr=True,
+        )
+        assert output == {"decision": "allow"}
+        assert "reason" not in output
+        assert "empty or missing" in stderr
 
     def test_empty_skill_name_allows(self):
-        output = _run_hook({"tool_name": "skill", "tool_input": {"skill": ""}})
-        assert output["decision"] == "allow"
-        assert "empty or missing" in output["reason"]
+        output, stderr = _run_hook(
+            {"tool_name": "skill", "tool_input": {"skill": ""}},
+            return_stderr=True,
+        )
+        assert output == {"decision": "allow"}
+        assert "reason" not in output
+        assert "empty or missing" in stderr
 
     def test_whitespace_skill_name_allows(self):
-        output = _run_hook({"tool_name": "skill", "tool_input": {"skill": "   "}})
-        assert output["decision"] == "allow"
-        assert "empty or missing" in output["reason"]
+        output, stderr = _run_hook(
+            {"tool_name": "skill", "tool_input": {"skill": "   "}},
+            return_stderr=True,
+        )
+        assert output == {"decision": "allow"}
+        assert "reason" not in output
+        assert "empty or missing" in stderr
 
     def test_nonstring_skill_name_allows(self):
-        output = _run_hook({"tool_name": "skill", "tool_input": {"skill": 42}})
-        assert output["decision"] == "allow"
-        assert "must be a string" in output["reason"]
+        output, stderr = _run_hook(
+            {"tool_name": "skill", "tool_input": {"skill": 42}},
+            return_stderr=True,
+        )
+        assert output == {"decision": "allow"}
+        assert "reason" not in output
+        assert "must be a string" in stderr
 
     def test_skill_dir_not_found_allows(self):
         """Skill name that resolves to no on-disk directory → fail-open."""
-        output = _run_hook(_make_skill_event("nonexistent-skill-xyz", "/tmp"))
-        assert output["decision"] == "allow"
-        assert "not found on disk" in output["reason"]
-        assert "nonexistent-skill-xyz" in output["reason"]
+        output, stderr = _run_hook(
+            _make_skill_event("nonexistent-skill-xyz", "/tmp"),
+            return_stderr=True,
+        )
+        assert output == {"decision": "allow"}
+        assert "reason" not in output
+        assert "not found on disk" in stderr
+        assert "nonexistent-skill-xyz" in stderr
 
     def test_path_traversal_blocked(self, tmp_path):
         """A ``../`` skill name that escapes the skills base emits a warning.
@@ -235,10 +271,14 @@ class TestFailOpen:
         evil.mkdir()
         (evil / "SKILL.md").write_text("---\nname: evil\n---\n")
 
-        output = _run_hook(_make_skill_event("../evil", str(project)))
-        assert output["decision"] == "allow"
-        assert "path traversal" in output["reason"]
-        assert "../evil" in output["reason"]
+        output, stderr = _run_hook(
+            _make_skill_event("../evil", str(project)),
+            return_stderr=True,
+        )
+        assert output == {"decision": "allow"}
+        assert "reason" not in output
+        assert "path traversal" in stderr
+        assert "../evil" in stderr
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +298,7 @@ class TestSkillDirResolution:
         return plain allow with no ``reason`` at all.
         """
         env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        env["SKILL_LEDGER_HOOK_POLICY"] = "warn"
         output = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
@@ -277,6 +318,7 @@ class TestSkillDirResolution:
             manifest_name="frontmatter-name",
         )
         env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        env["SKILL_LEDGER_HOOK_POLICY"] = "warn"
         output = _run_hook(
             _make_skill_event(
                 "frontmatter-name",
@@ -300,6 +342,7 @@ class TestSkillDirResolution:
 
         env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
         env["HOME"] = str(home)
+        env["SKILL_LEDGER_HOOK_POLICY"] = "warn"
         output = _run_hook(
             _make_skill_event("user-skill", "\0bad-project", skill_file),
             env_override=env,
@@ -356,10 +399,14 @@ class TestSkillDirResolution:
             skill_dir = Path(tmpdir) / ".copilot-shell" / "skills" / "bad"
             skill_dir.mkdir(parents=True)
             # No SKILL.md file
-            output = _run_hook(_make_skill_event("bad", tmpdir))
-            assert output["decision"] == "allow"
-            assert "not found on disk" in output["reason"]
-            assert "bad" in output["reason"]
+            output, stderr = _run_hook(
+                _make_skill_event("bad", tmpdir),
+                return_stderr=True,
+            )
+            assert output == {"decision": "allow"}
+            assert "reason" not in output
+            assert "not found on disk" in stderr
+            assert "bad" in stderr
 
 
 # A tiny script that pretends to be agent-sec-cli.
@@ -433,19 +480,32 @@ class TestOutputMapping:
         assert output == {"decision": "allow"}
 
     def test_none_requires_confirmation(self, mock_cli_env):
-        """status=none → ask + 'not been security-scanned'."""
+        """Default policy: status=none → silent allow with debug stderr."""
         env = mock_cli_env["make_env"](json.dumps({"status": "none"}))
-        output = _run_hook(
+        output, stderr = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
+            return_stderr=True,
         )
-        assert output["decision"] == "ask"
-        assert "not been security-scanned" in output["reason"]
-        assert "test-skill" in output["reason"]
+        assert output == {"decision": "allow"}
+        assert "status=none" in stderr
+        assert "test-skill" in stderr
 
     def test_warn_returns_warning(self, mock_cli_env):
-        """status=warn → allow + 'low-risk findings'."""
+        """Default policy: status=warn → silent allow with debug stderr."""
         env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        output, stderr = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+            return_stderr=True,
+        )
+        assert output == {"decision": "allow"}
+        assert "status=warn" in stderr
+
+    def test_warn_policy_returns_warning(self, mock_cli_env):
+        """SKILL_LEDGER_HOOK_POLICY=warn restores allow + reason."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "warn"}))
+        env["SKILL_LEDGER_HOOK_POLICY"] = "warn"
         output = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
@@ -453,9 +513,21 @@ class TestOutputMapping:
         assert output["decision"] == "allow"
         assert "low-risk" in output["reason"]
 
+    def test_block_policy_requires_confirmation(self, mock_cli_env):
+        """SKILL_LEDGER_HOOK_POLICY=block restores ask for strong statuses."""
+        env = mock_cli_env["make_env"](json.dumps({"status": "none"}))
+        env["SKILL_LEDGER_HOOK_POLICY"] = "block"
+        output = _run_hook(
+            _make_skill_event("test-skill", mock_cli_env["cwd"]),
+            env_override=env,
+        )
+        assert output["decision"] == "ask"
+        assert "not been security-scanned" in output["reason"]
+
     def test_deny_requires_confirmation(self, mock_cli_env):
-        """status=deny → ask + 'high-risk findings'."""
+        """SKILL_LEDGER_HOOK_POLICY=block: status=deny → ask."""
         env = mock_cli_env["make_env"](json.dumps({"status": "deny"}), rc=1)
+        env["SKILL_LEDGER_HOOK_POLICY"] = "block"
         output = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
@@ -464,8 +536,9 @@ class TestOutputMapping:
         assert "high-risk" in output["reason"]
 
     def test_drifted_requires_confirmation(self, mock_cli_env):
-        """status=drifted → ask + 'content has changed'."""
+        """SKILL_LEDGER_HOOK_POLICY=block: status=drifted → ask."""
         env = mock_cli_env["make_env"](json.dumps({"status": "drifted"}), rc=1)
+        env["SKILL_LEDGER_HOOK_POLICY"] = "block"
         output = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
@@ -474,8 +547,9 @@ class TestOutputMapping:
         assert "changed" in output["reason"]
 
     def test_tampered_requires_confirmation(self, mock_cli_env):
-        """status=tampered → ask + 'signature verification failed'."""
+        """SKILL_LEDGER_HOOK_POLICY=block: status=tampered → ask."""
         env = mock_cli_env["make_env"](json.dumps({"status": "tampered"}), rc=1)
+        env["SKILL_LEDGER_HOOK_POLICY"] = "block"
         output = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
@@ -484,15 +558,15 @@ class TestOutputMapping:
         assert "signature verification failed" in output["reason"]
 
     def test_unknown_status_returns_warning(self, mock_cli_env):
-        """Unrecognized status → allow + generic warning with status name."""
+        """Default policy: unrecognized status → silent allow with debug stderr."""
         env = mock_cli_env["make_env"](json.dumps({"status": "banana"}))
-        output = _run_hook(
+        output, stderr = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
+            return_stderr=True,
         )
-        assert output["decision"] == "allow"
-        assert "banana" in output["reason"]
-        assert "unknown status" in output["reason"]
+        assert output == {"decision": "allow"}
+        assert "status=banana" in stderr
 
     def test_cli_invalid_json_stdout_allows(self, mock_cli_env):
         """CLI returns non-JSON stdout → fail-open."""
@@ -513,11 +587,12 @@ class TestOutputMapping:
         assert output == {"decision": "allow"}
 
     def test_cli_missing_status_field_returns_unknown(self, mock_cli_env):
-        """CLI returns JSON without 'status' → treated as unknown status."""
+        """CLI returns JSON without 'status' → default debug-only unknown."""
         env = mock_cli_env["make_env"](json.dumps({"result": "ok"}))
-        output = _run_hook(
+        output, stderr = _run_hook(
             _make_skill_event("test-skill", mock_cli_env["cwd"]),
             env_override=env,
+            return_stderr=True,
         )
-        assert output["decision"] == "allow"
-        assert "unknown" in output["reason"]
+        assert output == {"decision": "allow"}
+        assert "status=unknown" in stderr

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -56,6 +56,19 @@ def test_parse_skillfs_change_validates_request(tmp_path: Path):
     assert change.paths == {"SKILL.md"}
 
 
+def test_parse_skillfs_change_accepts_reconcile_with_empty_paths(tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+
+    change = parse_skillfs_change(
+        request_for(skill_dir, eventKind="reconcile", paths=[]).params
+    )
+
+    assert change.skill_dir == skill_dir.resolve()
+    assert change.skill_name == "weather"
+    assert change.event_kinds == {"reconcile"}
+    assert change.paths == set()
+
+
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
@@ -132,6 +145,38 @@ def test_notify_enqueues_registered_activation_job(monkeypatch, tmp_path: Path):
     assert response.data["skill"]["skillName"] == "weather"
 
 
+def test_notify_enqueues_reconcile_with_empty_paths(monkeypatch, tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
+    job = SkillLedgerActivationJob(debounce_seconds=0)
+    runtime.jobs.register(job)
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._resolve_managed_skill_dirs",
+        lambda: [],
+    )
+
+    async def scenario():
+        await job.start()
+        try:
+            response = skillfs_notify_change_handler(
+                request_for(skill_dir, eventKind="reconcile", paths=[]),
+                runtime,
+            )
+        finally:
+            await job.stop()
+        return response
+
+    response = asyncio.run(scenario())
+
+    assert response.data["schemaVersion"] == 1
+    assert response.data["accepted"] is True
+    assert response.data["ignored"] is False
+    assert response.data["queued"] is True
+    assert response.data["coalesced"] is False
+    assert response.data["skill"]["eventKinds"] == ["reconcile"]
+    assert response.data["skill"]["paths"] == []
+
+
 def test_activation_job_debounces_same_skill(monkeypatch, tmp_path: Path):
     skill_dir = make_skill(tmp_path, "weather")
     calls = []
@@ -170,6 +215,14 @@ def test_activation_job_debounces_same_skill(monkeypatch, tmp_path: Path):
                     paths={"scripts/run.sh"},
                 )
             )
+            job.enqueue(
+                SkillFsChange(
+                    skill_dir=skill_dir.resolve(),
+                    skill_name=skill_dir.name,
+                    event_kinds={"reconcile"},
+                    paths=set(),
+                )
+            )
             deadline = asyncio.get_running_loop().time() + 1.0
             while len(calls) < 1 and asyncio.get_running_loop().time() < deadline:
                 await asyncio.sleep(0.01)
@@ -179,7 +232,7 @@ def test_activation_job_debounces_same_skill(monkeypatch, tmp_path: Path):
     asyncio.run(scenario())
 
     assert len(calls) == 1
-    assert calls[0].event_kinds == {"write", "rename"}
+    assert calls[0].event_kinds == {"write", "rename", "reconcile"}
     assert calls[0].paths == {"SKILL.md", "scripts/run.sh"}
 
 

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_skill_ledger.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_skill_ledger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+import tomllib
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import patch
@@ -16,11 +17,14 @@ sys.path.insert(0, str(_HERMES_PLUGIN_DIR))
 
 from src.capabilities.skill_ledger import SkillLedgerCapability  # noqa: E402
 from src.cli_runner import CliResult  # noqa: E402
+from src.registry import load_config, register_capabilities  # noqa: E402
 
 
 def _make_capability(
     root: Path,
     *,
+    policy: str = "debug",
+    include_policy: bool = True,
     enable_block: bool = False,
     block_statuses: list[str] | None = None,
     max_warnings_per_turn: int | str = 5,
@@ -28,14 +32,15 @@ def _make_capability(
 ) -> SkillLedgerCapability:
     cap = SkillLedgerCapability()
     cap._timeout = 5.0
-    cap._on_register(
-        {
-            "enable_block": enable_block,
-            "block_statuses": block_statuses or ["none", "drifted", "deny", "tampered"],
-            "max_warnings_per_turn": max_warnings_per_turn,
-            "max_warning_contexts": max_warning_contexts,
-        }
-    )
+    config = {
+        "enable_block": enable_block,
+        "block_statuses": block_statuses or ["none", "drifted", "deny", "tampered"],
+        "max_warnings_per_turn": max_warnings_per_turn,
+        "max_warning_contexts": max_warning_contexts,
+    }
+    if include_policy:
+        config["policy"] = policy
+    cap._on_register(config)
     cap._skills_dir = root
     return cap
 
@@ -74,6 +79,33 @@ def _install_gateway_session_context(monkeypatch, session_id: str) -> None:
     gateway_module.session_context = session_context_module
     monkeypatch.setitem(sys.modules, "gateway", gateway_module)
     monkeypatch.setitem(sys.modules, "gateway.session_context", session_context_module)
+
+
+class _RecordingHermesContext:
+    def __init__(self) -> None:
+        self.hooks: list[str] = []
+
+    def register_hook(self, hook_name, _callback):
+        self.hooks.append(hook_name)
+
+
+def test_default_config_enables_skill_ledger_debug_policy():
+    """Default Hermes installs keep the hook mounted in debug policy."""
+    config = tomllib.loads(
+        (_HERMES_PLUGIN_DIR / "src" / "config.toml").read_text(encoding="utf-8")
+    )
+
+    assert config["capabilities"]["skill-ledger"]["enabled"] is True
+    assert config["capabilities"]["skill-ledger"]["policy"] == "debug"
+
+
+def test_default_config_registers_skill_ledger_hooks():
+    ctx = _RecordingHermesContext()
+    config = load_config(_HERMES_PLUGIN_DIR / "src")
+
+    register_capabilities(ctx, [SkillLedgerCapability()], config)
+
+    assert ctx.hooks == ["pre_tool_call", "transform_llm_output"]
 
 
 class TestSkillLedgerHooks:
@@ -122,12 +154,35 @@ class TestSkillLedgerHooks:
         ["none", "warn", "drifted", "deny", "tampered", "error", "unknown"],
     )
     @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
-    def test_non_pass_default_allows_and_prepends_warning(
-        self, mock_cli, tmp_path, status
+    def test_non_pass_default_allows_debug_only(
+        self, mock_cli, tmp_path, status, caplog
     ):
         root = tmp_path / "skills"
         _make_skill(root, "devops/risky")
         cap = _make_capability(root)
+        mock_cli.return_value = _cli_status(status, exit_code=1)
+        caplog.set_level(logging.DEBUG, logger="agent-sec-core")
+
+        result = cap._on_pre_tool_call("skill_view", {"name": "risky"}, task_id="t1")
+        output = cap._on_transform_llm_output(
+            response_text="assistant response", task_id="t1"
+        )
+
+        assert result is None
+        assert output is None
+        assert not cap._warnings_by_context
+        assert any(f"status={status}" in record.message for record in caplog.records)
+        assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+    @pytest.mark.parametrize(
+        "status",
+        ["none", "warn", "drifted", "deny", "tampered", "error", "unknown"],
+    )
+    @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
+    def test_warn_policy_allows_and_prepends_warning(self, mock_cli, tmp_path, status):
+        root = tmp_path / "skills"
+        _make_skill(root, "devops/risky")
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = _cli_status(status, exit_code=1)
 
         result = cap._on_pre_tool_call("skill_view", {"name": "risky"}, task_id="t1")
@@ -141,12 +196,41 @@ class TestSkillLedgerHooks:
         assert output.endswith("assistant response")
 
     @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
+    def test_legacy_enable_block_false_maps_to_warn(self, mock_cli, tmp_path):
+        root = tmp_path / "skills"
+        _make_skill(root, "devops/risky")
+        cap = _make_capability(root, include_policy=False, enable_block=False)
+        mock_cli.return_value = _cli_status("warn")
+
+        result = cap._on_pre_tool_call("skill_view", {"name": "risky"}, task_id="t1")
+        output = cap._on_transform_llm_output(
+            response_text="assistant response", task_id="t1"
+        )
+
+        assert result is None
+        assert output.startswith("[agent-sec-core skill-ledger warning]")
+        assert "status=warn" in output
+
+    @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
+    def test_legacy_enable_block_true_maps_to_block(self, mock_cli, tmp_path):
+        root = tmp_path / "skills"
+        _make_skill(root, "security/blocked")
+        cap = _make_capability(root, include_policy=False, enable_block=True)
+        mock_cli.return_value = _cli_status("deny", exit_code=1)
+
+        result = cap._on_pre_tool_call("skill_view", {"name": "blocked"}, run_id="r1")
+
+        assert result is not None
+        assert result["action"] == "block"
+        assert "status=deny" in result["message"]
+
+    @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
     def test_drifted_warning_uses_response_text_and_logs_status(
         self, mock_cli, tmp_path, caplog
     ):
         root = tmp_path / "skills"
         _make_skill(root, "devops/drifted")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = _cli_status("drifted", exit_code=1)
         caplog.set_level(logging.WARNING, logger="agent-sec-core")
 
@@ -169,7 +253,7 @@ class TestSkillLedgerHooks:
     ):
         root = tmp_path / "skills"
         _make_skill(root, "devops/risky")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = _cli_status("drifted", exit_code=1)
         _install_gateway_session_context(monkeypatch, "hermes-session-1")
 
@@ -195,7 +279,7 @@ class TestSkillLedgerHooks:
     ):
         root = tmp_path / "skills"
         _make_skill(root, "devops/risky")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = _cli_status("drifted", exit_code=1)
         _install_gateway_session_context(monkeypatch, "")
 
@@ -215,7 +299,7 @@ class TestSkillLedgerHooks:
     ):
         root = tmp_path / "skills"
         _make_skill(root, "security/blocked")
-        cap = _make_capability(root, enable_block=True)
+        cap = _make_capability(root, policy="block")
         mock_cli.return_value = _cli_status("deny", exit_code=1)
 
         result = cap._on_pre_tool_call("skill_view", {"name": "blocked"}, run_id="r1")
@@ -231,7 +315,7 @@ class TestSkillLedgerHooks:
     ):
         root = tmp_path / "skills"
         _make_skill(root, "security/warn-only")
-        cap = _make_capability(root, enable_block=True)
+        cap = _make_capability(root, policy="block")
         mock_cli.return_value = _cli_status("warn")
 
         result = cap._on_pre_tool_call("skill_view", {"name": "warn-only"})
@@ -243,7 +327,7 @@ class TestSkillLedgerHooks:
     def test_nonzero_exit_with_valid_json_still_uses_status(self, mock_cli, tmp_path):
         root = tmp_path / "skills"
         _make_skill(root, "devops/drifted")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = _cli_status("drifted", exit_code=1)
 
         cap._on_pre_tool_call("skill_view", {"name": "drifted"}, session_id="s1")
@@ -262,7 +346,7 @@ class TestSkillLedgerHooks:
     def test_cli_failure_paths_fail_open(self, mock_cli, tmp_path, cli_result):
         root = tmp_path / "skills"
         _make_skill(root, "devops/flaky")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = cli_result
 
         result = cap._on_pre_tool_call("skill_view", {"name": "flaky"})
@@ -273,7 +357,7 @@ class TestSkillLedgerHooks:
     @patch("src.capabilities.skill_ledger.call_agent_sec_cli")
     def test_unresolved_skill_fails_open_without_cli(self, mock_cli, tmp_path):
         root = tmp_path / "skills"
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
 
         result = cap._on_pre_tool_call("skill_view", {"name": "missing"})
 
@@ -284,7 +368,7 @@ class TestSkillLedgerHooks:
     def test_warning_context_cache_is_bounded(self, mock_cli, tmp_path):
         root = tmp_path / "skills"
         _make_skill(root, "devops/risky")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         cap._max_warning_contexts = 2
         mock_cli.return_value = _cli_status("warn")
 
@@ -304,7 +388,7 @@ class TestSkillLedgerHooks:
     ):
         root = tmp_path / "skills"
         _make_skill(root, "devops/risky")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = _cli_status("warn")
 
         cap._on_pre_tool_call("skill_view", {"name": "risky"})
@@ -319,7 +403,7 @@ class TestSkillLedgerHooks:
     ):
         root = tmp_path / "skills"
         _make_skill(root, "devops/risky")
-        cap = _make_capability(root)
+        cap = _make_capability(root, policy="warn")
         mock_cli.return_value = _cli_status("warn")
 
         cap._on_pre_tool_call("skill_view", {"name": "risky"}, session_id="s1")
@@ -332,7 +416,7 @@ class TestSkillLedgerHooks:
     def test_zero_max_warnings_disables_visible_injection(self, mock_cli, tmp_path):
         root = tmp_path / "skills"
         _make_skill(root, "devops/risky")
-        cap = _make_capability(root, max_warnings_per_turn=0)
+        cap = _make_capability(root, policy="warn", max_warnings_per_turn=0)
         mock_cli.return_value = _cli_status("warn")
 
         cap._on_pre_tool_call("skill_view", {"name": "risky"}, session_id="s1")


### PR DESCRIPTION
## Description

This PR updates Skill Ledger host hook defaults and SkillFS notify handling:

- Adds a unified Skill Ledger hook/capability `policy` with `debug` as the default while preserving explicit `warn` and `block` behavior.
- Keeps Cosh, Hermes, and OpenClaw Skill Ledger hooks/capabilities registered by default, but makes default non-pass results fail-open with debug-only diagnostics.
- Accepts SkillFS `eventKind="reconcile"` notifications through the existing Skill Ledger daemon notify queue, debounce worker, scan, and activation flow.
- Updates Skill Ledger, Hermes, and OpenClaw documentation for hook policy and reconcile notify semantics.

## Related Issue

no-issue: user-requested Skill Ledger default policy and SkillFS reconcile compatibility update

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `uv run --project src/agent-sec-core/agent-sec-cli pytest src/agent-sec-core/tests/unit-test/cosh_hooks src/agent-sec-core/tests/unit-test/hermes-plugin src/agent-sec-core/tests/unit-test/daemon src/agent-sec-core/tests/integration-test/skill-ledger -q` (`466 passed`)
- `env npm_config_offline=true npm test` from `src/agent-sec-core/openclaw-plugin` (`99 passed`)
- `env npm_config_offline=true npm run build` from `src/agent-sec-core/openclaw-plugin`
- `git diff --check`

## Additional Notes

- This PR intentionally does not modify `src/skillfs`; it only updates Skill Ledger receiving-side behavior and related host integrations.
- Repository-wide `ruff format --check` is not marked as passed because the current tree reports pre-existing formatting drift across many unrelated files.
- The PR is opened as draft for maintainer review.
