### PR TITLE
feat(skillfs): add mount session metrics log

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -24,9 +24,10 @@ use skillfs_fuse::security::{
     DEFAULT_RELOAD_INTERVAL_MS, DEFAULT_RELOAD_TIMEOUT_MS, DecisionCommand,
     InstallerStagingController, JsonlProtocolEventWriter, JsonlSecurityEventWriter, LedgerAdapter,
     LedgerBackingRoot, NoopProtocolEventWriter, NoopSecurityEventWriter, NotifyController,
-    ProtocolEventWriter, RefreshController, ReloadMode, SecurityConfig, SecurityEventWriter,
-    SecurityModeConfig, SourceDriftObserver, StagingMatcher, TrustedPeerConfig,
-    TrustedWriterConfig, UnixSocketNotifyClient, bootstrap_activation, resolve_events_path,
+    ProtocolEventWriter, RefreshController, ReloadMode, RuntimeDecisionOutcome, SecurityConfig,
+    SecurityEventWriter, SecurityModeConfig, SessionStatsWriter, SkillfsSessionStats,
+    SourceDriftObserver, StagingMatcher, TrustedPeerConfig, TrustedWriterConfig,
+    UnixSocketNotifyClient, bootstrap_activation, resolve_events_path,
     resolve_protocol_events_path, spawn_drift_watcher,
 };
 use skillfs_fuse::{FuseError as FuseErr, MountConfig, MountOptions, mount_configured};
@@ -1743,6 +1744,110 @@ async fn cmd_mount(
     // cmd_mount returns. The Drop impl calls cleanup(), which unmounts
     // the bind mount and removes the temp dir. The bind mount is
     // independent of the FUSE mount, so cleanup order does not matter.
+
+    // --- Session stats: create collector before mount starts ---
+    let session_stats = Arc::new(SkillfsSessionStats::new());
+    {
+        // Load ViewsConfig once; derive all metrics from a single canonical set.
+        let store_guard = shared_store.read();
+        let total_skills = store_guard.len() as u64;
+        let views_config = ViewsConfig::load(&source);
+
+        // Build the canonical "real existing default-view skills" set.
+        // Deduplicates and filters out stale/typo names not in the store.
+        let default_served: std::collections::HashSet<&str> = if let Some(ref cfg) = views_config {
+            cfg.views
+                .iter()
+                .find(|v| v.default)
+                .map(|v| {
+                    v.skills
+                        .iter()
+                        .map(|s| s.as_str())
+                        .filter(|n| store_guard.get(n).is_some())
+                        .collect()
+                })
+                .unwrap_or_else(|| {
+                    // Config exists but no default view — treat all as default.
+                    store_guard.list().into_iter().collect()
+                })
+        } else {
+            // No views config => all skills are default.
+            store_guard.list().into_iter().collect()
+        };
+
+        let default_exposed_count = default_served.len() as u64;
+        session_stats.set_skill_counts(total_skills, default_exposed_count);
+
+        // prompt_token_saved_estimate: body chars of pruned skills / 4.
+        // Pruned = in store but NOT in default_served.
+        let has_views_config = views_config.is_some();
+        let token_estimate = if has_views_config {
+            let mut pruned_chars: u64 = 0;
+            for name in store_guard.list() {
+                if !default_served.contains(name) {
+                    if let Some(entry) = store_guard.get(name) {
+                        pruned_chars += entry.body.len() as u64;
+                    }
+                }
+            }
+            pruned_chars / 4
+        } else {
+            // No views config => nothing pruned => 0.
+            0
+        };
+        session_stats.set_prompt_token_saved_estimate(token_estimate);
+
+        // V1 skill_hit_times: default-view served skills (deduplicated).
+        for name in &default_served {
+            session_stats.record_skill_hit(name);
+        }
+    }
+
+    // Feed initial decision outcomes from activation bootstrap.
+    // When active_resolver exists, count from resolver snapshot.
+    // When absent (non-security / normal mount), all default-served skills
+    // are effectively "allowed" (live source passthrough).
+    if let Some(ref resolver) = active_resolver {
+        for (_name, target) in resolver.snapshot() {
+            match &target {
+                skillfs_fuse::security::ActiveTarget::Current { .. } => {
+                    session_stats.record_decision(RuntimeDecisionOutcome::Allow);
+                }
+                skillfs_fuse::security::ActiveTarget::Snapshot { .. } => {
+                    session_stats.record_decision(RuntimeDecisionOutcome::Fallback);
+                }
+                skillfs_fuse::security::ActiveTarget::Hidden { .. } => {
+                    session_stats.record_decision(RuntimeDecisionOutcome::Deny);
+                }
+            }
+        }
+    } else {
+        // No security resolver => all served skills are implicitly allowed.
+        // Use pruned_skill_count helper: default_exposed = total - pruned.
+        let default_exposed = shared_store.read().len() as u64 - session_stats.pruned_skill_count();
+        for _ in 0..default_exposed {
+            session_stats.record_decision(RuntimeDecisionOutcome::Allow);
+        }
+    }
+
+    // Generate session ID from PID + nanosecond timestamp (collision-resistant).
+    let session_id_for_flush = format!(
+        "{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    // Resolve agent_name: env var ANOLISA_AGENT_NAME, default "agent".
+    let agent_name_for_flush =
+        std::env::var("ANOLISA_AGENT_NAME").unwrap_or_else(|_| "agent".to_string());
+    let stats_for_flush = session_stats.clone();
+
+    // Mark mount ready immediately before spawning — the FUSE session
+    // start is the closest signal we have.
+    session_stats.mark_mount_ready();
+
     let mount_task = tokio::task::spawn_blocking(move || {
         mount_configured(
             &mountpoint,
@@ -1788,6 +1893,31 @@ async fn cmd_mount(
         }
     }
 
+    /// Flush session stats summary to the session metrics log (at most once).
+    /// Best-effort: failure only warns, never changes exit status.
+    fn flush_session_stats(stats: &SkillfsSessionStats, session_id: &str, agent_name: &str) {
+        let Some(summary) = stats.try_build_summary_once(session_id, agent_name) else {
+            // Already flushed by another exit path — skip.
+            return;
+        };
+        let writer = SessionStatsWriter::default_path();
+        if let Err(e) = writer.write_summary(&summary) {
+            warn!(
+                error = %e,
+                path = %writer.path().display(),
+                "session stats: failed to flush summary (non-fatal)"
+            );
+        } else {
+            info!(
+                path = %writer.path().display(),
+                session_id = %session_id,
+                mount_duration_ms = summary.mount_duration_ms,
+                skill_hit_times = summary.skill_hit_times,
+                "session stats: summary flushed to session metrics log"
+            );
+        }
+    }
+
     /// Trigger a clean FUSE unmount by calling fusermount3 -u.
     /// This causes fuser::mount2 event loop to exit, which unblocks the
     /// spawn_blocking thread and allows the process to exit cleanly.
@@ -1807,6 +1937,8 @@ async fn cmd_mount(
         _ = signal::ctrl_c() => {
             info!("received Ctrl+C, unmounting");
             trigger_unmount(&mountpoint_for_signal);
+            // Flush session stats before exit.
+            flush_session_stats(&stats_for_flush, &session_id_for_flush, &agent_name_for_flush);
             if let Some(h) = drift_handle {
                 h.shutdown().await;
             }
@@ -1823,6 +1955,8 @@ async fn cmd_mount(
         } => {
             info!("received SIGTERM, unmounting");
             trigger_unmount(&mountpoint_for_signal);
+            // Flush session stats before exit.
+            flush_session_stats(&stats_for_flush, &session_id_for_flush, &agent_name_for_flush);
             if let Some(h) = drift_handle {
                 h.shutdown().await;
             }
@@ -1851,10 +1985,21 @@ async fn cmd_mount(
 
     match result {
         Ok(()) => {
+            // Only flush session stats on successful mount exit.
+            // Failed mounts must not write mount_times=1.
+            flush_session_stats(
+                &stats_for_flush,
+                &session_id_for_flush,
+                &agent_name_for_flush,
+            );
             info!("filesystem unmounted successfully");
             Ok(())
         }
-        Err(e) => Err(format!("Mount failed: {}", e).into()),
+        Err(e) => {
+            // Mount failed — do NOT write a success summary.
+            info!("mount failed; skipping session stats flush");
+            Err(format!("Mount failed: {}", e).into())
+        }
     }
 }
 

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -110,6 +110,8 @@ pub mod path;
 pub mod policy;
 pub mod protocol_events;
 pub mod refresh;
+pub mod session_stats;
+pub mod session_stats_writer;
 pub mod trusted_writer;
 
 pub use activation::{
@@ -193,6 +195,10 @@ pub use refresh::{
     DEFAULT_REFRESH_DEBOUNCE_MS, FailedResolveBehavior, MutationKind, RefreshController,
     RefreshObservation,
 };
+pub use session_stats::{
+    RuntimeDecisionOutcome, SkillfsSessionStats, SkillfsSessionSummary, serialize_session_summary,
+};
+pub use session_stats_writer::{SKILLFS_SESSION_METRICS_LOG_PATH, SessionStatsWriter};
 pub use trusted_writer::{
     FileId, LinuxProcCommResolver, ProcessIdentity, ProcessIdentityResolver, TrustedWriterConfig,
     TrustedWriterDecision, default_identity_resolver, evaluate_trusted_writer, read_comm_file,

--- a/src/skillfs/crates/skillfs-fuse/src/security/session_stats.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/session_stats.rs
@@ -1,0 +1,459 @@
+//! Mount-session summary statistics for the session metrics log.
+//!
+//! This module provides an in-memory session collector and a serializable
+//! summary record. It is **separate** from the existing audit JSONL sink,
+//! security event stream, and protocol event log.
+//!
+//! ## Decision outcome mapping
+//!
+//! The following mapping converts SkillFS runtime targets into session
+//! outcomes:
+//!
+//! | SkillFS ActiveTarget / state    | Session outcome |
+//! |---------------------------------|--------------------|
+//! | `ActiveTarget::Current`         | allow              |
+//! | `SkillEventAction::Allowed`     | allow              |
+//! | `ActiveTarget::Snapshot`        | fallback           |
+//! | `ActiveTarget::Hidden`          | deny               |
+//! | `SkillEventAction::Rejected`    | deny               |
+//! | `SkillEventKind::PolicyDenied`  | deny               |
+//!
+//! ## `skill_hit_times` rule (V1)
+//!
+//! V1 semantics: count of distinct skills that **exist in the store AND
+//! are listed in the default view** at mount startup. This is a startup
+//! snapshot, NOT a runtime FUSE access counter — no `lookup`/`open`/`read`
+//! callbacks are wired in V1. In practice the value equals
+//! `default_exposed_count` (total skills minus pruned skills when a
+//! `skillfs-views.toml` exists, or total skills when it does not).
+//! Future versions may switch to real per-request FUSE hit counting.
+//!
+//! ## `prompt_token_saved_estimate`
+//!
+//! Estimated as: total character count of pruned (non-default-view) skill
+//! body text, divided by 4 (conservative chars-per-token ratio). The caller
+//! supplies this value; computation happens at the CLI layer where the skill
+//! store is accessible. When no `skillfs-views.toml` exists, all skills are
+//! in the default view and the estimate is 0.
+//!
+//! ## `allow_times` / `fallback_times` / `deny_times` (V1)
+//!
+//! V1 semantics: these are **startup snapshot** counts from the initial
+//! active resolver state at mount time, not running-period decision counters.
+//! Future versions will wire into active resolver refresh, policy deny, and
+//! reload outcome paths for runtime accumulation.
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use serde::Serialize;
+
+// ---------------------------------------------------------------------------
+// RuntimeDecisionOutcome
+// ---------------------------------------------------------------------------
+
+/// Coarse outcome for the session metrics log.
+///
+/// Maps SkillFS runtime decisions into three buckets for session metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeDecisionOutcome {
+    /// ActiveTarget::Current or SkillEventAction::Allowed.
+    Allow,
+    /// ActiveTarget::Snapshot (fallback serving).
+    Fallback,
+    /// ActiveTarget::Hidden / PolicyDenied / Rejected.
+    Deny,
+}
+
+// ---------------------------------------------------------------------------
+// SkillfsSessionStats (in-memory collector)
+// ---------------------------------------------------------------------------
+
+/// In-memory collector for one mount session's statistics.
+///
+/// Thread-safe via interior `Mutex`. All mutation methods are best-effort:
+/// a poisoned lock is silently ignored (the stats may be incomplete, but
+/// FUSE behavior is unaffected).
+///
+/// The collector supports a **flush-once** semantic via
+/// [`SkillfsSessionStats::try_build_summary_once`]: the first call returns
+/// `Some(summary)`, subsequent calls return `None`. This prevents double
+/// writes when multiple exit paths race (e.g. signal handler + normal exit).
+pub struct SkillfsSessionStats {
+    inner: Mutex<StatsInner>,
+    flushed: AtomicBool,
+}
+
+struct StatsInner {
+    /// Instant the collector was created (before mount starts).
+    _created_at: Instant,
+    /// Instant the mount became ready (FUSE session started).
+    mount_ready_at: Option<Instant>,
+    /// Instant the mount exited.
+    mount_end_at: Option<Instant>,
+    /// Deduplicated set of skill names that received a hit.
+    skill_hits: HashSet<String>,
+    /// Total loaded skill count (source).
+    source_skill_count: u64,
+    /// Skills exposed in the default view.
+    default_exposed_count: u64,
+    /// Token savings estimate (caller-supplied).
+    prompt_token_saved_estimate: u64,
+    /// Decision outcome counters.
+    allow_count: u64,
+    fallback_count: u64,
+    deny_count: u64,
+}
+
+impl SkillfsSessionStats {
+    /// Create a new session collector. Call this before mount starts.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(StatsInner {
+                _created_at: Instant::now(),
+                mount_ready_at: None,
+                mount_end_at: None,
+                skill_hits: HashSet::new(),
+                source_skill_count: 0,
+                default_exposed_count: 0,
+                prompt_token_saved_estimate: 0,
+                allow_count: 0,
+                fallback_count: 0,
+                deny_count: 0,
+            }),
+            flushed: AtomicBool::new(false),
+        }
+    }
+
+    /// Mark the mount as ready (FUSE session started successfully).
+    pub fn mark_mount_ready(&self) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.mount_ready_at = Some(Instant::now());
+        }
+    }
+
+    /// Mark the mount as ended.
+    pub fn mark_mount_end(&self) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.mount_end_at = Some(Instant::now());
+        }
+    }
+
+    /// Set source skill count and default exposed count for pruned
+    /// calculation. Should be called once at startup.
+    pub fn set_skill_counts(&self, source_count: u64, default_exposed: u64) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.source_skill_count = source_count;
+            inner.default_exposed_count = default_exposed;
+        }
+    }
+
+    /// Set the prompt token savings estimate.
+    pub fn set_prompt_token_saved_estimate(&self, estimate: u64) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.prompt_token_saved_estimate = estimate;
+        }
+    }
+
+    /// Record a skill hit (session-level deduplicated).
+    pub fn record_skill_hit(&self, skill_name: &str) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.skill_hits.insert(skill_name.to_string());
+        }
+    }
+
+    /// Record a runtime decision outcome.
+    pub fn record_decision(&self, outcome: RuntimeDecisionOutcome) {
+        if let Ok(mut inner) = self.inner.lock() {
+            match outcome {
+                RuntimeDecisionOutcome::Allow => inner.allow_count += 1,
+                RuntimeDecisionOutcome::Fallback => inner.fallback_count += 1,
+                RuntimeDecisionOutcome::Deny => inner.deny_count += 1,
+            }
+        }
+    }
+
+    /// Compute the pruned skill count: source - default exposed.
+    pub fn pruned_skill_count(&self) -> u64 {
+        self.inner
+            .lock()
+            .map(|inner| {
+                inner
+                    .source_skill_count
+                    .saturating_sub(inner.default_exposed_count)
+            })
+            .unwrap_or(0)
+    }
+
+    /// Build the final summary **once**. Returns `None` if already flushed.
+    ///
+    /// This is the primary API for mount-exit paths. The first call atomically
+    /// marks the collector as flushed and returns the summary; all subsequent
+    /// calls return `None`. This prevents double-writes when signal handlers
+    /// and the normal exit path both try to flush.
+    pub fn try_build_summary_once(
+        &self,
+        session_id: &str,
+        agent_name: &str,
+    ) -> Option<SkillfsSessionSummary> {
+        // Atomically flip false -> true. If it was already true, another
+        // caller already flushed.
+        if self
+            .flushed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return None;
+        }
+        self.mark_mount_end();
+        Some(self.build_summary_inner(session_id, agent_name))
+    }
+
+    /// Build the summary without flush-once guard. Test-only.
+    #[cfg(test)]
+    pub fn build_summary(&self, session_id: &str, agent_name: &str) -> SkillfsSessionSummary {
+        self.build_summary_inner(session_id, agent_name)
+    }
+
+    fn build_summary_inner(&self, session_id: &str, agent_name: &str) -> SkillfsSessionSummary {
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+
+        let mount_duration_ms = match (inner.mount_ready_at, inner.mount_end_at) {
+            (Some(start), Some(end)) => end.duration_since(start).as_millis() as u64,
+            (Some(start), None) => Instant::now().duration_since(start).as_millis() as u64,
+            _ => 0,
+        };
+
+        let pruned = inner
+            .source_skill_count
+            .saturating_sub(inner.default_exposed_count);
+
+        SkillfsSessionSummary {
+            component_name: "skillfs".to_string(),
+            component_version: env!("CARGO_PKG_VERSION").to_string(),
+            component_agent_name: agent_name.to_string(),
+            session_id: session_id.to_string(),
+            mount_times: 1,
+            mount_duration_ms,
+            skill_hit_times: inner.skill_hits.len() as u64,
+            pruned_skill_count: pruned,
+            prompt_token_saved_estimate: inner.prompt_token_saved_estimate,
+            allow_times: inner.allow_count,
+            fallback_times: inner.fallback_count,
+            deny_times: inner.deny_count,
+        }
+    }
+}
+
+impl Default for SkillfsSessionStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SkillfsSessionSummary (serializable output)
+// ---------------------------------------------------------------------------
+
+/// Serializable mount-session summary for the session metrics log.
+///
+/// Field naming follows the log rotation contract:
+/// - Fixed component fields use dotted names in the JSON output.
+/// - All field names are lowercase / snake_case.
+/// - Output target: `/var/log/anolisa/sls/ops/skillfs.jsonl`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SkillfsSessionSummary {
+    /// Component name. Always `"skillfs"`.
+    #[serde(rename = "component.name")]
+    pub component_name: String,
+    /// Component version from Cargo.toml.
+    #[serde(rename = "component.version")]
+    pub component_version: String,
+    /// Agent name that this component is serving.
+    #[serde(rename = "component.agent_name")]
+    pub component_agent_name: String,
+    /// Unique session identifier for this mount session.
+    pub session_id: String,
+    /// Number of successful mounts in this summary (always 1 for V1).
+    pub mount_times: u64,
+    /// Total mount duration in milliseconds.
+    pub mount_duration_ms: u64,
+    /// V1: number of distinct skills that exist in the store AND are listed
+    /// in the default view at mount startup. This is a startup snapshot, not
+    /// a runtime FUSE access counter — equals `default_exposed_count` in V1.
+    pub skill_hit_times: u64,
+    /// Number of skills pruned from the default view.
+    pub pruned_skill_count: u64,
+    /// Estimated prompt tokens saved by pruning.
+    pub prompt_token_saved_estimate: u64,
+    /// Decision outcomes: allowed/current serving count (startup snapshot, V1).
+    pub allow_times: u64,
+    /// Decision outcomes: fallback snapshot serving count (startup snapshot, V1).
+    pub fallback_times: u64,
+    /// Decision outcomes: hidden/denied/rejected count (startup snapshot, V1).
+    pub deny_times: u64,
+}
+
+/// Serialize a session summary as a single JSONL line (no trailing newline).
+pub fn serialize_session_summary(summary: &SkillfsSessionSummary) -> String {
+    serde_json::to_string(summary).unwrap_or_else(|_| {
+        String::from("{\"component.name\":\"skillfs\",\"error\":\"unserializable\"}")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn new_collector_has_zero_counts() {
+        let stats = SkillfsSessionStats::new();
+        let summary = stats.build_summary("test-session", "agent");
+        assert_eq!(summary.mount_times, 1);
+        assert_eq!(summary.mount_duration_ms, 0);
+        assert_eq!(summary.skill_hit_times, 0);
+        assert_eq!(summary.pruned_skill_count, 0);
+        assert_eq!(summary.prompt_token_saved_estimate, 0);
+        assert_eq!(summary.allow_times, 0);
+        assert_eq!(summary.fallback_times, 0);
+        assert_eq!(summary.deny_times, 0);
+    }
+
+    #[test]
+    fn mount_duration_is_computed_correctly() {
+        let stats = SkillfsSessionStats::new();
+        stats.mark_mount_ready();
+        thread::sleep(Duration::from_millis(50));
+        stats.mark_mount_end();
+        let summary = stats.build_summary("dur-test", "agent");
+        // Should be at least 50ms but less than 500ms.
+        assert!(
+            summary.mount_duration_ms >= 40,
+            "duration too short: {}ms",
+            summary.mount_duration_ms
+        );
+        assert!(
+            summary.mount_duration_ms < 500,
+            "duration too long: {}ms",
+            summary.mount_duration_ms
+        );
+    }
+
+    #[test]
+    fn skill_hit_is_deduplicated() {
+        let stats = SkillfsSessionStats::new();
+        stats.record_skill_hit("alpha");
+        stats.record_skill_hit("alpha");
+        stats.record_skill_hit("beta");
+        stats.record_skill_hit("alpha");
+        let summary = stats.build_summary("hit-test", "agent");
+        assert_eq!(summary.skill_hit_times, 2);
+    }
+
+    #[test]
+    fn pruned_skill_count_calculation() {
+        let stats = SkillfsSessionStats::new();
+        stats.set_skill_counts(30, 6);
+        assert_eq!(stats.pruned_skill_count(), 24);
+        let summary = stats.build_summary("prune-test", "agent");
+        assert_eq!(summary.pruned_skill_count, 24);
+    }
+
+    #[test]
+    fn pruned_skill_count_saturates_at_zero() {
+        let stats = SkillfsSessionStats::new();
+        stats.set_skill_counts(3, 10);
+        assert_eq!(stats.pruned_skill_count(), 0);
+    }
+
+    #[test]
+    fn decision_outcome_counters() {
+        let stats = SkillfsSessionStats::new();
+        stats.record_decision(RuntimeDecisionOutcome::Allow);
+        stats.record_decision(RuntimeDecisionOutcome::Allow);
+        stats.record_decision(RuntimeDecisionOutcome::Fallback);
+        stats.record_decision(RuntimeDecisionOutcome::Deny);
+        stats.record_decision(RuntimeDecisionOutcome::Deny);
+        stats.record_decision(RuntimeDecisionOutcome::Deny);
+        let summary = stats.build_summary("decision-test", "agent");
+        assert_eq!(summary.allow_times, 2);
+        assert_eq!(summary.fallback_times, 1);
+        assert_eq!(summary.deny_times, 3);
+    }
+
+    #[test]
+    fn summary_json_shape_has_dotted_component_fields() {
+        let stats = SkillfsSessionStats::new();
+        stats.set_skill_counts(10, 4);
+        stats.set_prompt_token_saved_estimate(1200);
+        stats.record_skill_hit("weather");
+        stats.record_decision(RuntimeDecisionOutcome::Allow);
+        let summary = stats.build_summary("json-test", "agent");
+        let json_str = serialize_session_summary(&summary);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_str).expect("must be valid JSON");
+        let obj = parsed.as_object().expect("top-level must be object");
+
+        // Dotted component fields.
+        assert_eq!(obj["component.name"].as_str().unwrap(), "skillfs");
+        assert_eq!(
+            obj["component.version"].as_str().unwrap(),
+            env!("CARGO_PKG_VERSION")
+        );
+        assert_eq!(obj["component.agent_name"].as_str().unwrap(), "agent");
+
+        // Stats fields.
+        assert_eq!(obj["session_id"].as_str().unwrap(), "json-test");
+        assert_eq!(obj["mount_times"].as_u64().unwrap(), 1);
+        assert_eq!(obj["skill_hit_times"].as_u64().unwrap(), 1);
+        assert_eq!(obj["pruned_skill_count"].as_u64().unwrap(), 6);
+        assert_eq!(obj["prompt_token_saved_estimate"].as_u64().unwrap(), 1200);
+        assert_eq!(obj["allow_times"].as_u64().unwrap(), 1);
+        assert_eq!(obj["fallback_times"].as_u64().unwrap(), 0);
+        assert_eq!(obj["deny_times"].as_u64().unwrap(), 0);
+    }
+
+    #[test]
+    fn summary_component_version_matches_cargo_pkg() {
+        let stats = SkillfsSessionStats::new();
+        let summary = stats.build_summary("ver-test", "agent");
+        assert_eq!(summary.component_version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn try_build_summary_once_returns_none_on_second_call() {
+        let stats = SkillfsSessionStats::new();
+        stats.mark_mount_ready();
+        stats.record_skill_hit("alpha");
+        let first = stats.try_build_summary_once("once-test", "agent");
+        assert!(first.is_some(), "first call must return Some");
+        let second = stats.try_build_summary_once("once-test", "agent");
+        assert!(
+            second.is_none(),
+            "second call must return None (flush-once)"
+        );
+    }
+
+    #[test]
+    fn try_build_summary_once_marks_mount_end() {
+        let stats = SkillfsSessionStats::new();
+        stats.mark_mount_ready();
+        std::thread::sleep(Duration::from_millis(20));
+        let summary = stats
+            .try_build_summary_once("end-test", "agent")
+            .expect("must return summary");
+        assert!(
+            summary.mount_duration_ms >= 15,
+            "duration too short: {}ms",
+            summary.mount_duration_ms
+        );
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/src/security/session_stats_writer.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/session_stats_writer.rs
@@ -1,0 +1,164 @@
+//! Dedicated JSONL writer for mount-session summary statistics.
+//!
+//! Writes to the session metrics log path:
+//!   `/var/log/anolisa/sls/ops/skillfs.jsonl`
+//!
+//! Design contract:
+//!
+//! * Every write opens the file, appends one JSONL line, and closes the
+//!   handle. This satisfies the logrotate requirement in the log rotation contract
+//!   (rename-based rotation must not strand writes in a stale fd).
+//! * No background thread, no bounded channel. The summary is written
+//!   synchronously at mount exit — typically once per session.
+//! * Write failures are logged via `tracing::warn` but never propagate as
+//!   FUSE errors or change mount exit status.
+//! * This writer does **not** reuse [`super::audit::JsonlFileAuditSink`].
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+use super::session_stats::{SkillfsSessionSummary, serialize_session_summary};
+
+/// Default session metrics log path per the default deployment convention.
+pub const SKILLFS_SESSION_METRICS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/skillfs.jsonl";
+
+/// Best-effort JSONL summary writer.
+///
+/// Each call to [`SessionStatsWriter::write_summary`] opens the target file
+/// in append mode, writes one JSON line, and closes the handle. Errors are
+/// surfaced as `tracing::warn` and returned as `Err` so callers can decide
+/// whether to retry — but in practice the CLI should not retry or abort.
+pub struct SessionStatsWriter {
+    path: PathBuf,
+}
+
+impl SessionStatsWriter {
+    /// Create a writer targeting the given path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Create a writer targeting the default session metrics log.
+    pub fn default_path() -> Self {
+        Self::new(SKILLFS_SESSION_METRICS_LOG_PATH)
+    }
+
+    /// The target file path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Write one session summary as a JSONL line (open + append + close).
+    ///
+    /// Returns `Ok(())` on success. On failure, logs a warning and returns
+    /// the underlying IO error. Callers should treat failure as non-fatal.
+    pub fn write_summary(&self, summary: &SkillfsSessionSummary) -> std::io::Result<()> {
+        let mut line = serialize_session_summary(summary);
+        line.push('\n');
+
+        // Production: the file should already exist (pre-created with mode
+        // 666 by the deployment setup). create(true) is a
+        // dev/fallback path only — it inherits umask, not the expected 666.
+        let result = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .and_then(|mut file| file.write_all(line.as_bytes()));
+
+        if let Err(ref e) = result {
+            warn!(
+                error = %e,
+                path = %self.path.display(),
+                "skillfs session stats: failed to write summary to session metrics log"
+            );
+        }
+
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::session_stats::SkillfsSessionStats;
+
+    #[test]
+    fn writes_one_valid_json_line_to_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("skillfs.jsonl");
+
+        let writer = SessionStatsWriter::new(&log_path);
+        let stats = SkillfsSessionStats::new();
+        stats.set_skill_counts(20, 6);
+        stats.record_skill_hit("weather");
+        let summary = stats.build_summary("test-write-1", "agent");
+
+        writer.write_summary(&summary).expect("write must succeed");
+
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "expected exactly 1 line, got {}",
+            lines.len()
+        );
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(lines[0]).expect("line must be valid JSON");
+        assert_eq!(parsed["component.name"], "skillfs");
+        assert_eq!(parsed["session_id"], "test-write-1");
+        assert_eq!(parsed["pruned_skill_count"], 14);
+    }
+
+    #[test]
+    fn second_write_appends_another_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("skillfs.jsonl");
+
+        let writer = SessionStatsWriter::new(&log_path);
+
+        let stats1 = SkillfsSessionStats::new();
+        let summary1 = stats1.build_summary("session-a", "agent");
+        writer.write_summary(&summary1).unwrap();
+
+        let stats2 = SkillfsSessionStats::new();
+        stats2.record_decision(crate::security::session_stats::RuntimeDecisionOutcome::Allow);
+        let summary2 = stats2.build_summary("session-b", "agent");
+        writer.write_summary(&summary2).unwrap();
+
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2, "expected 2 lines, got {}", lines.len());
+
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(first["session_id"], "session-a");
+        assert_eq!(second["session_id"], "session-b");
+        assert_eq!(second["allow_times"], 1);
+    }
+
+    #[test]
+    fn write_failure_on_invalid_path_returns_error() {
+        let writer = SessionStatsWriter::new("/nonexistent/deep/skillfs.jsonl");
+        let stats = SkillfsSessionStats::new();
+        let summary = stats.build_summary("fail-test", "agent");
+        let result = writer.write_summary(&summary);
+        assert!(result.is_err(), "expected write to fail on invalid path");
+    }
+
+    #[test]
+    fn default_path_is_session_metrics_path() {
+        let writer = SessionStatsWriter::default_path();
+        assert_eq!(
+            writer.path().to_str().unwrap(),
+            "/var/log/anolisa/sls/ops/skillfs.jsonl"
+        );
+    }
+}


### PR DESCRIPTION

## Summary

Add SkillFS mount-session metrics for SLS collection.

This records one JSONL summary at the end of a successful mount session to:

`/var/log/anolisa/sls/ops/skillfs.jsonl`

The log is intended for product/ops metrics around SkillFS runtime usage, view pruning, and startup decision outcomes.

## Changes

- Add `SkillfsSessionStats` in-memory collector.
- Add `SessionStatsWriter` for append-only JSONL output.
- Wire session stats into `skillfs mount` lifecycle.
- Support `ANOLISA_AGENT_NAME` for agent attribution.
- Flush on clean unmount, Ctrl+C, and SIGTERM.
- Skip summary writes when mount startup fails.
- Keep write failures non-fatal.

## Metrics Fields

- `mount_times`
- `mount_duration_ms`
- `skill_hit_times`
- `pruned_skill_count`
- `prompt_token_saved_estimate`
- `allow_times`
- `fallback_times`
- `deny_times`

## Validation

- `cargo fmt`
- `cargo check -p skillfs -p skillfs-fuse`
- `cargo test -p skillfs-fuse session_stats --lib`
- `cargo test -p skillfs-fuse --lib`
- `cargo build -p skillfs`

Runtime smoke test on lifsea:

- Mounted a two-skill source with one default-view skill and one pruned skill.
- Read through the FUSE mount.
- Unmounted cleanly.
- Confirmed one JSONL line was appended to `/var/log/anolisa/sls/ops/skillfs.jsonl`.

Example output:

```json
{"component.name":"skillfs","component.version":"0.2.0","component.agent_name":"anolisa-skillfs-log-smoke","session_id":"3975729_1782274210830858508","mount_times":1,"mount_duration_ms":100,"skill_hit_times":1,"pruned_skill_count":1,"prompt_token_saved_estimate":15,"allow_times":1,"fallback_times":0,"deny_times":0}
```

## Notes

- The V1 counters are startup/session-level metrics, not per-read runtime hit counters.
- `skill_hit_times` counts distinct default-view served skills at mount startup.
- `allow_times`, `fallback_times`, and `deny_times` reflect the startup active mapping snapshot.
- The writer opens/appends/closes on each summary write for logrotate friendliness.
