### PR TITLE
fix(ckpt): demote ops log write failure to debug level

### DIFF
--- a/src/ws-ckpt/src/crates/daemon/src/ops_log.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/ops_log.rs
@@ -91,7 +91,7 @@ pub fn log_operation(ops_name: &'static str, agent_name: &str, response: &Respon
     };
 
     if let Err(e) = write_record(&record) {
-        tracing::warn!("ops log write failed: {e}");
+        tracing::debug!("ops log write failed: {e}");
     }
 }
 


### PR DESCRIPTION
## Description

- ops 日志写入失败的日志级别从 warn 降为 debug

没有 ops 日志文件说明未启用日志功能，因此每次操作都打 warn 是不必要的噪音。
日志文件的创建由日志轮转策略统一管理，daemon 只在文件存在时写入，不会主动创建日志文件。

## Related Issue

no-issue: 日志级别调整，无对应 issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

单行日志级别变更，无功能影响。

## Additional Notes
