### PR TITLE
feat(tokenless): expand RPM component contract (bundle.entry + hermes)

### DIFF
--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -14,3 +14,25 @@ adapter_type = "plugin"
 plugin_id = "tokenless"
 source = "adapters/openclaw"
 dest = "{datadir}/adapters/{component}/openclaw/"
+
+[adapters.bundle]
+# Entry-point manifest inside the bundle directory (the file the OpenClaw
+# driver reads to identify the plugin). Declared explicitly rather than
+# relying on the driver's "openclaw.plugin.json" default, so the contract is
+# self-describing and survives driver default changes.
+entry = "openclaw.plugin.json"
+
+[[adapters]]
+framework = "hermes"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/hermes"
+dest = "{datadir}/adapters/{component}/hermes/"
+
+[adapters.bundle]
+# Hermes-native plugin manifest at the bundle root. The driver scans this
+# file for the plugin id when plugin_id is not declared; we declare
+# plugin_id above so the driver need not parse it, but keep entry explicit
+# so the contract names the platform entry manifest (matches the file
+# shipped at the dest root: adapters/<component>/hermes/plugin.yaml).
+entry = "plugin.yaml"

--- a/src/tokenless/.anolisa/component.toml.in
+++ b/src/tokenless/.anolisa/component.toml.in
@@ -14,3 +14,25 @@ adapter_type = "plugin"
 plugin_id = "tokenless"
 source = "adapters/openclaw"
 dest = "{datadir}/adapters/{component}/openclaw/"
+
+[adapters.bundle]
+# Entry-point manifest inside the bundle directory (the file the OpenClaw
+# driver reads to identify the plugin). Declared explicitly rather than
+# relying on the driver's "openclaw.plugin.json" default, so the contract is
+# self-describing and survives driver default changes.
+entry = "openclaw.plugin.json"
+
+[[adapters]]
+framework = "hermes"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/hermes"
+dest = "{datadir}/adapters/{component}/hermes/"
+
+[adapters.bundle]
+# Hermes-native plugin manifest at the bundle root. The driver scans this
+# file for the plugin id when plugin_id is not declared; we declare
+# plugin_id above so the driver need not parse it, but keep entry explicit
+# so the contract names the platform entry manifest (matches the file
+# shipped at the dest root: adapters/<component>/hermes/plugin.yaml).
+entry = "plugin.yaml"


### PR DESCRIPTION
Extends the tokenless RPM component contract (from #999 / 260471f7) so it is fully self-describing and covers both framework adapters tokenless ships through the anolisa adapter-contract flow.

## Changes

1. **Explicit `bundle.entry` for openclaw.** Declare `[adapters.bundle] entry = "openclaw.plugin.json"` instead of relying on the OpenClaw driver's hard-coded default (`openclaw.rs` `read_bundle`). The contract now names the platform entry manifest itself and survives driver default changes. Value matches the file installed at the dest root (id = `tokenless`).

2. **Add hermes adapter.** Previously the contract declared only openclaw, so `enable`/`scan` via `resolve_component_contract` did not cover hermes even though tokenless ships a hermes plugin bundle. New entry mirrors the openclaw shape:
   ```toml
   [[adapters]]
   framework    = "hermes"
   adapter_type = "plugin"
   plugin_id    = "tokenless"
   source       = "adapters/hermes"
   dest         = "{datadir}/adapters/{component}/hermes/"

   [adapters.bundle]
   entry = "plugin.yaml"
   ```
   - `dest` → `/usr/share/anolisa/adapters/tokenless/hermes/`, which the spec already populates (`__init__.py`, `plugin.yaml`, `scripts/*`) and declares in `%files`, so `resolve_resource_root` finds a real, non-empty bundle.
   - `plugin_id = "tokenless"` matches the hermes identity used by the spec's `%postun` cleanup (`~/.hermes/plugins/tokenless`) and `plugin.yaml`'s `name`; declaring it lets the driver skip manifest parsing.
   - `bundle.entry = "plugin.yaml"` names the Hermes-native entry manifest (the driver's default fallback chain looks for `hermes.plugin.json` / `hermes.manifest.yaml`, neither of which tokenless ships).

Both `.in` template and generated artifact updated, mirroring the `manifest.json` template pattern in the Makefile.

## Verification

Built the tokenless RPM via `scripts/rpm-build.sh tokenless` and inspected the installed `component.toml`:

- `PASS: hermes adapter declared`
- `PASS: hermes bundle.entry` (`entry = "plugin.yaml"`)
- `PASS: openclaw bundle.entry retained` (`entry = "openclaw.plugin.json"`)
- `PASS: hermes plugin.yaml packaged` at dest root
- `PASS: hermes __init__.py packaged` at dest root

TOML parse-checked: 2 `[[adapters]]` elements, each with its own `[adapters.bundle].entry` correctly attached.

## Notes

- Contract still covers only `openclaw` + `hermes` via the new model; the remaining frameworks tokenless ships (cosh/qoder/claude-code/codex/qwencode) continue to use the legacy `manifest.json`/bundle path. Expanding those is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)