### PR TITLE
feat(ckpt): add rollback --preview and align plugins with --snapshot/-s flag

### DIFF
--- a/src/ws-ckpt/README.md
+++ b/src/ws-ckpt/README.md
@@ -69,16 +69,19 @@ sudo systemctl start ws-ckpt
 ws-ckpt init --workspace ~/my-workspace
 
 # 创建检查点
-ws-ckpt checkpoint --workspace ~/my-workspace -M 1 -S 1 -m "initial version"
+ws-ckpt checkpoint --workspace ~/my-workspace -s initial -m "initial version"
 
 # 再次修改后创建检查点
-ws-ckpt checkpoint --workspace ~/my-workspace -M 1 -S 2 -m "add feature"
+ws-ckpt checkpoint --workspace ~/my-workspace -s feature -m "add feature"
+
+# 回滚前预览将恢复的文件变更
+ws-ckpt rollback --workspace ~/my-workspace -s initial --preview
 
 # 回滚到指定快照
-ws-ckpt rollback --workspace ~/my-workspace --to msg1-step1
+ws-ckpt rollback --workspace ~/my-workspace -s initial
 
 # 删除快照
-ws-ckpt delete --workspace ~/my-workspace --snapshot msg1-step2
+ws-ckpt delete --workspace ~/my-workspace -s feature
 ```
 
 ### 快照管理
@@ -138,7 +141,7 @@ ws-ckpt reload
 |------|------|
 | `init` | 初始化工作区 |
 | `checkpoint` | 创建快照检查点 |
-| `rollback` | 回滚到指定快照 |
+| `rollback` | 预览或回滚到指定快照 |
 | `delete` | 删除工作区或单个快照 |
 | `list` | 列出工作区所有快照 |
 | `diff` | 查看两个快照间的文件变更 |

--- a/src/ws-ckpt/docs/ws-ckpt-design.md
+++ b/src/ws-ckpt/docs/ws-ckpt-design.md
@@ -220,7 +220,7 @@ ws-ckpt init -w <workspace>
 ### `checkpoint`
 
 ```bash
-ws-ckpt checkpoint -w <workspace> -i <id> [-m <message>] [--metadata <json>]
+ws-ckpt checkpoint -w <workspace> [-s <id>] [-m <message>] [--metadata <json>]
 ```
 
 daemon 端的关键序列（[`snapshot_mgr::checkpoint`](../src/crates/daemon/src/snapshot_mgr.rs)）：
@@ -235,7 +235,7 @@ daemon 端的关键序列（[`snapshot_mgr::checkpoint`](../src/crates/daemon/sr
 设计取舍：
 
 - **不阻塞磁盘满**：btrfs 快照是元数据 + COW，满盘也能成功；空间不足只通过 `status` / health-check 上报，不在 checkpoint 路径上 fail
-- **id 由调用方提供**：plugin 用 `secrets.token_hex(4)` / `crypto.randomUUID().slice(0,8)`，daemon 不替它生成——这样 plugin 失败重试时能用同一个 id 实现幂等
+- **id 在 CLI 边界确定**：CLI 未收到 `-s` 时自动生成 ID；plugin 使用 `secrets.token_hex(4)` / `crypto.randomUUID().slice(0,8)` 显式提供 ID；daemon 不替调用方生成
 - **metadata 用 String 而非 Value**：IPC 走 bincode，`serde_json::Value` 需要 `deserialize_any`，bincode 不支持；daemon 端再解析回 Value 存盘
 
 ### `rollback`
@@ -243,11 +243,14 @@ daemon 端的关键序列（[`snapshot_mgr::checkpoint`](../src/crates/daemon/sr
 ```bash
 ws-ckpt rollback -w <workspace> -s <snapshot>        # 按 snapshot id 回滚
 ws-ckpt rollback -w <workspace> -n 3                  # 沿 parent 链回退 3 个祖先
+ws-ckpt rollback -w <workspace> -s <snapshot> --preview # 仅预览文件变更
 ```
 
 `--snapshot/-s` 和 `--num-ancestors/-n` 互斥（clap `conflicts_with`），至少指定一个。`-n` 值由 `value_parser` 约束 `>= 1`。
 
 `-n` 路径先调用 `SnapshotIndex::ancestor(n)` 沿 `parent_id` 链解析目标 snapshot，然后走与 `-s` 相同的子卷替换流程。
+
+`--preview` 复用相同的目标解析逻辑，但不执行子卷替换。它直接复用 `backend.diff(ws_id, target, None)`，为当前工作区创建短生命周期只读快照并计算目标快照到当前工作区的标准 diff。输出表示目标快照之后发生、rollback 将撤销的变化，不尝试把 `DiffEntry` 反向转换成回滚动作；尤其 `Renamed` 没有结构化的起止路径，不能可靠反转。临时快照在成功或失败路径都会尽力删除。
 
 `backend.rollback()` 的核心是**子卷原地替换**：
 
@@ -681,7 +684,7 @@ Plugin（[Hermes](../src/plugins/hermes/) / [OpenClaw](../src/plugins/openclaw/)
 ```
 LLM Agent runtime
   └── ws-ckpt Plugin (hooks: session_start / pre_llm_call / agent_end)
-        └── subprocess: ws-ckpt checkpoint -w <ws> -i <uuid> -m "<msg>"
+        └── subprocess: ws-ckpt checkpoint -w <ws> -s <uuid> -m "<msg>"
               └── Unix Socket → daemon → btrfs
 ```
 
@@ -729,4 +732,3 @@ LLM Agent runtime
 - CLI / Plugin 不需要 root，只需对 `/run/ws-ckpt/ws-ckpt.sock` 有读写权限（socket 文件 0o666）
 - BtrfsBase 后端：宿主机器必须有 btrfs 格式磁盘
 - BtrfsLoop 后端：宿主在 `/var/lib/ws-ckpt` 有足够空间放镜像（target = `min(30 GB, 宿主总空间 × 40%)`,target 超过当前可用空间时降级为 `可用空间 × 40%`）
-

--- a/src/ws-ckpt/docs/ws-ckpt-plugin-design.md
+++ b/src/ws-ckpt/docs/ws-ckpt-plugin-design.md
@@ -133,7 +133,7 @@ Plugin 把以下七个工具用 OpenAI Function Calling 格式注册到 runtime:
 |------|------|----------|----------|
 | `ws-ckpt-config` | 查看 / 更新 plugin 配置 | — | `action`, `key`, `value` |
 | `ws-ckpt-checkpoint` | 手动创建快照 | `id` | `message`, `workspace` |
-| `ws-ckpt-rollback` | 回滚到指定快照或沿 parent 链回退 | — | `target`, `num_ancestors`/`numAncestors`, `workspace` |
+| `ws-ckpt-rollback` | 回滚到指定快照或沿 parent 链回退或预览回滚 | — | `target`, `num_ancestors`/`numAncestors`, `workspace`, `preview` |
 | `ws-ckpt-list` | 列出工作区所有快照 | — | — |
 | `ws-ckpt-diff` | 对比两个快照 | `from`, `to` | — |
 | `ws-ckpt-delete` | 删除指定快照 | `snapshot` | `workspace` |
@@ -141,7 +141,9 @@ Plugin 把以下七个工具用 OpenAI Function Calling 格式注册到 runtime:
 
 ### ws-ckpt-rollback 的 DAG 祖先回退
 
-`target` 和 `num_ancestors`（hermes snake_case）/ `numAncestors`（openclaw camelCase）互斥，至少提供一个。`num_ancestors` 沿 `SnapshotIndex.head` 的 parent 链回退 N 步（`1` = head 本身），映射到 CLI `ws-ckpt rollback -w <ws> -n <N>`。两个 plugin 各自校验 `>= 1`，与 `ancestor()` 入口校验形成四层防御。
+`target` 和 `num_ancestors`（hermes snake_case）/ `numAncestors`（openclaw camelCase）互斥，至少提供一个。CLI 的 `-n 1` 表示 head 本身；plugin 在每轮结束后已经为当前状态创建 head，因此面向用户的“回退 N 轮”会映射到 CLI `ws-ckpt rollback -w <ws> -n <N+1>`。两个 plugin 各自校验 `>= 1`，与 `ancestor()` 入口校验形成四层防御。
+
+两个 plugin 均暴露可选布尔参数 `preview`。为 `true` 时透传 CLI `--preview`，返回完整文件变更摘要，不刷新 snapshot cache，也不把成功结果描述为已经完成回滚。
 
 ### Workspace 解析:显式参数绕过缓存
 
@@ -161,7 +163,7 @@ plugin 配置和 daemon 配置是两层:plugin 管"开不开自动 checkpoint、
 
 ## CWD 守卫
 
-Plugin 在每次 hook/tool 入口自查 `cwd_inside_workspace`——如果自身进程的 cwd 落在工作区内，立即拒绝并返回 NOT retryable 消息。
+Plugin 在会替换工作区 inode 的 hook/tool 入口自查 `cwd_inside_workspace`——如果自身进程的 cwd 落在工作区内，立即拒绝并返回 NOT retryable 消息。`rollback preview` 只创建临时只读快照并计算差异，不替换工作区 inode，因此不受该守卫限制。
 
 这是 daemon 端 `/proc` guard 的**提前短路优化**（节省一次 RPC 往返 + 给出更友好的错误原因），不是安全边界——即使 plugin 漏检，daemon 也会强制拒绝。
 

--- a/src/ws-ckpt/docs/ws-ckpt-usage.md
+++ b/src/ws-ckpt/docs/ws-ckpt-usage.md
@@ -15,13 +15,13 @@ sudo yum install ws-ckpt
 ### 2.1 创建快照
 
 ```bash
-ws-ckpt checkpoint -w <workspace> -i <id> [-m <message>] [--metadata <json>] [--pin]
+ws-ckpt checkpoint -w <workspace> [-s <id>] [-m <message>] [--metadata <json>]
 ```
 
 | 参数            | 简写   | 必填 | 说明                   |
 | --------------- | ------ | ---- | ---------------------- |
 | `--workspace` | `-w` | 是   | 工作区路径或 ID       |
-| `--id`        | `-i` | 是   | 快照id 唯一标识快照   |
+| `--snapshot`  | `-s` | 否   | 快照 ID；省略时由 CLI 自动生成，显式指定时须在工作区内唯一 |
 | `--message`   | `-m` | 否   | 快照描述信息           |
 | `--metadata`  |        | 否   | JSON 格式的附加元数据 |
 
@@ -29,13 +29,16 @@ ws-ckpt checkpoint -w <workspace> -i <id> [-m <message>] [--metadata <json>] [--
 
 ```bash
 # 基本用法
-ws-ckpt checkpoint -w ./my-project -i test
+ws-ckpt checkpoint -w ./my-project -s test
+
+# 自动生成快照 ID
+ws-ckpt checkpoint -w ./my-project
 
 # 带message
-ws-ckpt checkpoint -w ./my-project -i test -m "initial state"
+ws-ckpt checkpoint -w ./my-project -s test -m "initial state"
 
 # 带元数据
-ws-ckpt checkpoint -w ws-6d5aaa -i test --metadata '{"tool":"write","file":"main.py"}'
+ws-ckpt checkpoint -w ws-6d5aaa -s test --metadata '{"tool":"write","file":"main.py"}'
 
 ```
 
@@ -71,6 +74,17 @@ ws-ckpt rollback -w <workspace> -n <N>
 - `-n 3`：回退到 head.parent.parent
 
 与 `--snapshot/-s` 互斥。
+
+#### 2.2.3 预览回滚变更
+
+在上述两种目标选择方式后增加 `--preview`，可展示回滚将恢复的文件差异，但不会修改工作区：
+
+```bash
+ws-ckpt rollback -w ./my-project -s test --preview
+ws-ckpt rollback -w ./my-project -n 2 --preview
+```
+
+预览与实际回滚使用相同的目标解析规则。输出包含目标快照，以及该快照之后发生、rollback 将撤销的文件变更；标记含义与 `ws-ckpt diff` 相同。
 
 **示例**：
 
@@ -267,19 +281,19 @@ ws-ckpt init --workspace ~/.openclaw/workspace/
 
 # 2. 模拟 OpenClaw tool call 前后的 checkpoint
 echo "v1" > ~/.openclaw/workspace/main.py
-ws-ckpt checkpoint --workspace ~/.openclaw/workspace/ -i test -m "write main.py v1"
+ws-ckpt checkpoint --workspace ~/.openclaw/workspace/ -s test-v1 -m "write main.py v1"
 
 echo "v2 - bad change" > ~/.openclaw/workspace/main.py
-ws-ckpt checkpoint --workspace ~/.openclaw/workspace/ -i test -m "write main.py v2"
+ws-ckpt checkpoint --workspace ~/.openclaw/workspace/ -s test-v2 -m "write main.py v2"
 
 # 3. 发现改坏了，回滚
-ws-ckpt rollback --workspace ~/.openclaw/workspace/ --snapshot test
+ws-ckpt rollback --workspace ~/.openclaw/workspace/ --snapshot test-v1
 
 # 4. 验证回滚成功
 cat ~/.openclaw/workspace/main.py  # 应输出 "v1"
 
 # 5. 清理
-ws-ckpt delete --workspace ~/.openclaw/workspace/ -s test --force
+ws-ckpt delete --workspace ~/.openclaw/workspace/ -s test-v2 --force
 
 ```
 

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -176,6 +176,10 @@ enum Commands {
         /// Roll back N ancestors along parent chain — mutually exclusive with -s
         #[arg(long = "num-ancestors", short = 'n', conflicts_with = "to", value_parser = clap::value_parser!(u32).range(1..))]
         num_ancestors: Option<u32>,
+
+        /// Preview file changes without executing rollback
+        #[arg(long)]
+        preview: bool,
     },
 
     /// Delete a specific snapshot
@@ -402,17 +406,28 @@ async fn run(cli: Cli) -> Result<()> {
             workspace,
             to,
             num_ancestors,
+            preview,
         } => {
             if to.is_none() && num_ancestors.is_none() {
                 anyhow::bail!("either --snapshot/-s or --num-ancestors/-n must be specified");
             }
-            let request = Request::Rollback {
-                workspace: resolve_workspace_arg(&workspace),
-                to,
-                num_ancestors,
-            };
-            let response = send_request_to_daemon(&request).await?;
-            handle_response(response, &request).await?;
+            if preview {
+                let request = Request::RollbackPreview {
+                    workspace: resolve_workspace_arg(&workspace),
+                    to,
+                    num_ancestors,
+                };
+                let response = send_request_to_daemon(&request).await?;
+                handle_rollback_preview_response(response)?;
+            } else {
+                let request = Request::Rollback {
+                    workspace: resolve_workspace_arg(&workspace),
+                    to,
+                    num_ancestors,
+                };
+                let response = send_request_to_daemon(&request).await?;
+                handle_response(response, &request).await?;
+            }
         }
         Commands::Delete {
             workspace,
@@ -938,25 +953,7 @@ fn handle_list_response(response: Response, format: &str) -> Result<()> {
 fn handle_diff_response(response: Response) -> Result<()> {
     match response {
         Response::DiffOk { changes } => {
-            if changes.is_empty() {
-                println!("No differences found.");
-            } else {
-                for entry in &changes {
-                    let marker = match entry.change_type {
-                        ChangeType::Added => "\x1b[32m+",
-                        ChangeType::Deleted => "\x1b[31m-",
-                        ChangeType::Modified => "\x1b[33mM",
-                        ChangeType::Renamed => "\x1b[36mR",
-                    };
-                    let detail = entry
-                        .detail
-                        .as_deref()
-                        .map(|d| format!(" ({})", d))
-                        .unwrap_or_default();
-                    println!("{}  {}{}\x1b[0m", marker, entry.path, detail);
-                }
-                println!("\n{} change(s)", changes.len());
-            }
+            print_diff_entries(&changes);
         }
         Response::Error { code, message } => {
             eprintln!("\x1b[31mError [{:?}]: {}\x1b[0m", code, message);
@@ -967,6 +964,49 @@ fn handle_diff_response(response: Response) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Handle RollbackPreviewOk response, formatting the rollback diff summary.
+fn handle_rollback_preview_response(response: Response) -> Result<()> {
+    match response {
+        Response::RollbackPreviewOk { to, changes } => {
+            println!("\x1b[1mRollback preview (no changes applied)\x1b[0m");
+            println!("Target snapshot: {}\n", to);
+            println!("Changes since target snapshot (rollback will revert these):");
+            print_diff_entries(&changes);
+        }
+        Response::Error { code, message } => {
+            eprintln!("\x1b[31mError [{:?}]: {}\x1b[0m", code, message);
+            process::exit(1);
+        }
+        _ => {
+            eprintln!("\x1b[33mUnexpected response type\x1b[0m");
+        }
+    }
+    Ok(())
+}
+
+fn print_diff_entries(changes: &[ws_ckpt_common::DiffEntry]) {
+    if changes.is_empty() {
+        println!("No differences found.");
+        return;
+    }
+
+    for entry in changes {
+        let marker = match entry.change_type {
+            ChangeType::Added => "\x1b[32m+",
+            ChangeType::Deleted => "\x1b[31m-",
+            ChangeType::Modified => "\x1b[33mM",
+            ChangeType::Renamed => "\x1b[36mR",
+        };
+        let detail = entry
+            .detail
+            .as_deref()
+            .map(|d| format!(" ({})", d))
+            .unwrap_or_default();
+        println!("{}  {}{}\x1b[0m", marker, entry.path, detail);
+    }
+    println!("\n{} change(s)", changes.len());
 }
 
 /// Handle StatusOk response, formatting the status report.
@@ -2149,10 +2189,12 @@ mod tests {
                 workspace,
                 to,
                 num_ancestors,
+                preview,
             } => {
                 assert_eq!(workspace, "/tmp/test");
                 assert_eq!(to.as_deref(), Some("msg1-step1"));
                 assert_eq!(num_ancestors, None);
+                assert!(!preview);
             }
             _ => panic!("expected Rollback"),
         }
@@ -2174,10 +2216,39 @@ mod tests {
                 workspace,
                 to,
                 num_ancestors,
+                preview,
             } => {
                 assert_eq!(workspace, "/tmp/test");
                 assert_eq!(to, None);
                 assert_eq!(num_ancestors, Some(3));
+                assert!(!preview);
+            }
+            _ => panic!("expected Rollback"),
+        }
+    }
+
+    #[test]
+    fn parse_rollback_preview() {
+        let cli = Cli::try_parse_from([
+            "ws-ckpt",
+            "rollback",
+            "--workspace",
+            "/tmp/test",
+            "--snapshot",
+            "msg1-step1",
+            "--preview",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Rollback {
+                workspace,
+                to,
+                preview,
+                ..
+            } => {
+                assert_eq!(workspace, "/tmp/test");
+                assert_eq!(to.as_deref(), Some("msg1-step1"));
+                assert!(preview);
             }
             _ => panic!("expected Rollback"),
         }

--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -129,6 +129,11 @@ pub enum Request {
         auto_cleanup: PolicyFieldOp<bool>,
         auto_cleanup_keep: PolicyFieldOp<CleanupRetention>,
     },
+    RollbackPreview {
+        workspace: String,
+        to: Option<String>,
+        num_ancestors: Option<u32>,
+    },
 }
 
 /// Field-level patch op: `Unchanged` (default) / `Set(v)`.
@@ -219,6 +224,10 @@ pub enum Response {
         config: ConfigReport,
         ws_total: usize,
         ws_with_override: usize,
+    },
+    RollbackPreviewOk {
+        to: String,
+        changes: Vec<DiffEntry>,
     },
 }
 
@@ -1861,6 +1870,28 @@ mod tests {
     }
 
     #[test]
+    fn request_rollback_preview_round_trip() {
+        let req = Request::RollbackPreview {
+            workspace: "/tmp/ws".to_string(),
+            to: Some("msg1-step0".to_string()),
+            num_ancestors: None,
+        };
+        let decoded = round_trip_request(&req);
+        match decoded {
+            Request::RollbackPreview {
+                workspace,
+                to,
+                num_ancestors,
+            } => {
+                assert_eq!(workspace, "/tmp/ws");
+                assert_eq!(to.as_deref(), Some("msg1-step0"));
+                assert_eq!(num_ancestors, None);
+            }
+            _ => panic!("expected RollbackPreview variant"),
+        }
+    }
+
+    #[test]
     fn request_status_round_trip() {
         let req = Request::Status {
             workspace: Some("/tmp/ws".to_string()),
@@ -2063,6 +2094,27 @@ mod tests {
                 assert_eq!(changes[1].change_type, ChangeType::Added);
             }
             _ => panic!("expected DiffOk variant"),
+        }
+    }
+
+    #[test]
+    fn response_rollback_preview_ok_round_trip() {
+        let resp = Response::RollbackPreviewOk {
+            to: "msg1-step0".to_string(),
+            changes: vec![DiffEntry {
+                path: "src/main.rs".to_string(),
+                change_type: ChangeType::Modified,
+                detail: Some("content changed".to_string()),
+            }],
+        };
+        let decoded = round_trip_response(&resp);
+        match decoded {
+            Response::RollbackPreviewOk { to, changes } => {
+                assert_eq!(to, "msg1-step0");
+                assert_eq!(changes.len(), 1);
+                assert_eq!(changes[0].change_type, ChangeType::Modified);
+            }
+            _ => panic!("expected RollbackPreviewOk variant"),
         }
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
@@ -42,6 +42,22 @@ pub async fn dispatch(state: &Arc<DaemonState>, request: Request) -> Response {
                 crate::snapshot_mgr::rollback(state, &workspace, to.as_deref(), num_ancestors).await
             }
         },
+        Request::RollbackPreview {
+            workspace,
+            to,
+            num_ancestors,
+        } => match state.ensure_bootstrapped().await {
+            Err(e) => Err(e),
+            Ok(()) => {
+                crate::snapshot_mgr::rollback_preview(
+                    state,
+                    &workspace,
+                    to.as_deref(),
+                    num_ancestors,
+                )
+                .await
+            }
+        },
         Request::Delete {
             workspace,
             snapshot,

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -276,49 +276,13 @@ pub async fn rollback(
     // 4. Write lock: validate snapshot + execute rollback
     let mut ws = arc.write().await;
 
-    let resolved_id = if let Some(n) = num_ancestors {
-        match ws.index.ancestor(n as usize) {
-            Ok((id, _)) => id.clone(),
-            Err(e) => {
-                return Ok(Response::Error {
-                    code: ErrorCode::SnapshotNotFound,
-                    message: e.to_string(),
-                });
-            }
-        }
-    } else if let Some(target) = to {
-        match ws.index.resolve_by_prefix(target) {
-            Ok((id, _)) => id.clone(),
-            Err(ResolveError::NotFound) => {
-                return Ok(Response::Error {
-                    code: ErrorCode::SnapshotNotFound,
-                    message: format!("snapshot not found: {}", target),
-                });
-            }
-            Err(ResolveError::Ambiguous(n)) => {
-                return Ok(Response::Error {
-                    code: ErrorCode::SnapshotNotFound,
-                    message: format!("ambiguous snapshot prefix '{}': {} matches", target, n),
-                });
-            }
-        }
-    } else {
-        return Ok(Response::Error {
-            code: ErrorCode::SnapshotNotFound,
-            message: "either --snapshot or --num-ancestors must be specified".to_string(),
-        });
+    let resolved_id = match resolve_rollback_target(&ws.index, to, num_ancestors) {
+        Ok(id) => id,
+        Err(resp) => return Ok(*resp),
     };
 
-    if ws
-        .index
-        .snapshots
-        .get(&resolved_id)
-        .is_some_and(|s| s.missing)
-    {
-        return Ok(Response::Error {
-            code: ErrorCode::SnapshotNotFound,
-            message: format!("Snapshot '{}' subvolume is missing (data lost). Use 'ws-ckpt delete --force -w <workspace> -s {}' to remove the record.", resolved_id, resolved_id),
-        });
+    if let Err(resp) = reject_missing_snapshot(&ws.index, &resolved_id) {
+        return Ok(*resp);
     }
 
     // 5. Rollback via backend (includes warmup, snapshot, cleanup)
@@ -351,6 +315,82 @@ pub async fn rollback(
         from: ws.ws_id.clone(),
         to: resolved_id,
     })
+}
+
+/// Preview the file changes a rollback would apply without replacing the live workspace.
+pub async fn rollback_preview(
+    state: &Arc<DaemonState>,
+    workspace: &str,
+    to: Option<&str>,
+    num_ancestors: Option<u32>,
+) -> anyhow::Result<Response> {
+    let arc = match state.resolve_workspace(workspace).await {
+        Some(a) => a,
+        None => return Ok(workspace_not_found(workspace)),
+    };
+
+    let (ws_id, resolved_id) = {
+        let ws = arc.read().await;
+        let id = match resolve_rollback_target(&ws.index, to, num_ancestors) {
+            Ok(id) => id,
+            Err(resp) => return Ok(*resp),
+        };
+        if let Err(resp) = reject_missing_snapshot(&ws.index, &id) {
+            return Ok(*resp);
+        }
+        (ws.ws_id.clone(), id)
+    };
+
+    let changes = state.backend.diff(&ws_id, &resolved_id, None).await?;
+
+    Ok(Response::RollbackPreviewOk {
+        to: resolved_id,
+        changes,
+    })
+}
+
+fn resolve_rollback_target(
+    index: &ws_ckpt_common::SnapshotIndex,
+    to: Option<&str>,
+    num_ancestors: Option<u32>,
+) -> Result<String, Box<Response>> {
+    if let Some(n) = num_ancestors {
+        return index
+            .ancestor(n as usize)
+            .map(|(id, _)| id.clone())
+            .map_err(|e| {
+                Box::new(Response::Error {
+                    code: ErrorCode::SnapshotNotFound,
+                    message: e.to_string(),
+                })
+            });
+    }
+
+    if let Some(target) = to {
+        return index
+            .resolve_by_prefix(target)
+            .map(|(id, _)| id.clone())
+            .map_err(|err| Box::new(snapshot_resolve_error_response(target, err)));
+    }
+
+    Err(Box::new(Response::Error {
+        code: ErrorCode::SnapshotNotFound,
+        message: "either --snapshot or --num-ancestors must be specified".to_string(),
+    }))
+}
+
+fn reject_missing_snapshot(
+    index: &ws_ckpt_common::SnapshotIndex,
+    snapshot_id: &str,
+) -> Result<(), Box<Response>> {
+    if index.snapshots.get(snapshot_id).is_some_and(|s| s.missing) {
+        return Err(Box::new(Response::Error {
+            code: ErrorCode::SnapshotNotFound,
+            message: format!("Snapshot '{}' subvolume is missing (data lost). Use 'ws-ckpt delete --force -w <workspace> -s {}' to remove the record.", snapshot_id, snapshot_id),
+        }));
+    }
+
+    Ok(())
 }
 
 /// Warm up snapshot metadata cache — forwards to backends::btrfs_common.
@@ -1074,7 +1114,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_snapshots_to_none_skips_resolution_and_reaches_backend() {
+    async fn diff_and_rollback_preview_reach_live_diff_backend() {
         use ws_ckpt_common::DiffEntry;
 
         struct DiffStubBackend;
@@ -1092,10 +1132,12 @@ mod tests {
             }
             async fn diff(
                 &self,
-                _ws_id: &str,
-                _from: &str,
+                ws_id: &str,
+                from: &str,
                 to: Option<&str>,
             ) -> anyhow::Result<Vec<DiffEntry>> {
+                assert_eq!(ws_id, "ws-diff-live");
+                assert_eq!(from, "snap-from");
                 assert!(to.is_none(), "expected to=None, got {:?}", to);
                 Ok(vec![DiffEntry {
                     path: "live-change.txt".into(),
@@ -1172,6 +1214,63 @@ mod tests {
                 assert_eq!(changes[0].path, "live-change.txt");
             }
             other => panic!("expected DiffOk, got: {:?}", other),
+        }
+
+        let resp = rollback_preview(&state, "ws-diff-live", Some("snap-from"), None)
+            .await
+            .unwrap();
+        match resp {
+            Response::RollbackPreviewOk { to, changes } => {
+                assert_eq!(to, "snap-from");
+                assert_eq!(changes.len(), 1);
+                assert_eq!(changes[0].path, "live-change.txt");
+            }
+            other => panic!("expected RollbackPreviewOk, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn rollback_preview_workspace_not_found() {
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+
+        let resp = rollback_preview(&state, "missing-workspace", Some("snap1"), None)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::WorkspaceNotFound);
+                assert!(message.contains("missing-workspace"));
+            }
+            other => panic!("expected WorkspaceNotFound, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn rollback_preview_snapshot_not_found() {
+        let state = Arc::new(crate::state::DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        state.register_workspace(
+            "ws-preview".to_string(),
+            PathBuf::from("/home/user/ws"),
+            SnapshotIndex::new(PathBuf::from("/home/user/ws")),
+        );
+
+        let resp = rollback_preview(&state, "ws-preview", Some("missing-snapshot"), None)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::SnapshotNotFound);
+                assert!(message.contains("missing-snapshot"));
+            }
+            other => panic!("expected SnapshotNotFound, got: {:?}", other),
         }
     }
 

--- a/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
+++ b/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
@@ -50,6 +50,14 @@ async fn mock_server_handle(mut stream: tokio::net::UnixStream) {
             from: "ws-test".to_string(),
             to: to.unwrap_or_default(),
         },
+        Request::RollbackPreview { to, .. } => Response::RollbackPreviewOk {
+            to: to.unwrap_or_default(),
+            changes: vec![DiffEntry {
+                path: "src/main.rs".to_string(),
+                change_type: ChangeType::Modified,
+                detail: Some("content changed".to_string()),
+            }],
+        },
         Request::Delete { snapshot, .. } => Response::DeleteOk { target: snapshot },
         Request::List { .. } => Response::ListOk {
             snapshots: vec![SnapshotEntry {
@@ -336,6 +344,47 @@ async fn full_rollback_request_response_over_socket() {
             assert_eq!(to, "msg1-step2");
         }
         _ => panic!("expected RollbackOk, got {:?}", response),
+    }
+
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn full_rollback_preview_request_response_over_socket() {
+    let socket_path = temp_socket_path();
+
+    let listener = UnixListener::bind(&socket_path).expect("bind");
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        mock_server_handle(stream).await;
+    });
+
+    tokio::task::yield_now().await;
+
+    let mut client = UnixStream::connect(&socket_path).await.unwrap();
+
+    let request = Request::RollbackPreview {
+        workspace: "/ws".to_string(),
+        to: Some("msg1-step2".to_string()),
+        num_ancestors: None,
+    };
+    let frame = encode_frame(&request).unwrap();
+    client.write_all(&frame).await.unwrap();
+
+    let mut len_buf = [0u8; 4];
+    client.read_exact(&mut len_buf).await.unwrap();
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut payload = vec![0u8; len];
+    client.read_exact(&mut payload).await.unwrap();
+
+    let response: Response = decode_payload(&payload).unwrap();
+    match response {
+        Response::RollbackPreviewOk { to, changes } => {
+            assert_eq!(to, "msg1-step2");
+            assert_eq!(changes.len(), 1);
+            assert_eq!(changes[0].change_type, ChangeType::Modified);
+        }
+        _ => panic!("expected RollbackPreviewOk, got {:?}", response),
     }
 
     server.await.unwrap();

--- a/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
+++ b/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
@@ -176,12 +176,12 @@ class CheckpointManager:
         """Create a checkpoint (snapshot) of the workspace.
 
         Equivalent to:
-            ws-ckpt checkpoint --workspace <ws> --id <id> [--message <msg>] [--metadata <json>]
+            ws-ckpt checkpoint --workspace <ws> --snapshot <id> [--message <msg>] [--metadata <json>]
         """
         args = [
             "checkpoint",
             "--workspace", self._config.workspace,
-            "--id", snapshot_id,
+            "--snapshot", snapshot_id,
         ]
 
         if message:
@@ -196,6 +196,16 @@ class CheckpointManager:
             return CheckpointResult(
                 success=False,
                 message=map_error_to_message(output.stderr, {"id": snapshot_id}),
+            )
+
+        # CheckpointSkipped is a successful CLI response reported on stderr.
+        combined_output = f"{output.stdout}\n{output.stderr}"
+        if "Empty workspace, no snapshot created." in combined_output:
+            return CheckpointResult(
+                success=True,
+                skipped=True,
+                reason="Empty workspace, no snapshot created.",
+                message="Empty workspace, no snapshot created.",
             )
 
         return CheckpointResult(

--- a/src/ws-ckpt/src/plugins/hermes/cron.py
+++ b/src/ws-ckpt/src/plugins/hermes/cron.py
@@ -21,7 +21,7 @@ def _build_cron_line(workspace: str, schedule: str) -> str:
     quoted_ws = "'" + workspace.replace("'", "'\\''") + "'"
     return (
         f"{schedule} ws-ckpt checkpoint -w {quoted_ws}"
-        f' -i "cron-$(date +\\%s)"'
+        f' -s "cron-$(date +\\%s)"'
         f' -m "scheduled snapshot"'
         f" --metadata '{{\"auto\":true,\"type\":\"cron\"}}'"
         f" >/dev/null 2>&1"

--- a/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_checkpoint_manager.py
+++ b/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_checkpoint_manager.py
@@ -172,6 +172,20 @@ class TestCheckpointManager:
         assert result.snapshot == "abc123"
 
     @patch("hermes.checkpoint_manager.subprocess.run")
+    def test_create_checkpoint_skipped_from_stderr(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="",
+            stderr="\x1b[33m⚠ Empty workspace, no snapshot created.\x1b[0m\n",
+        )
+        mgr = self._make("/ws")
+        result = mgr.create_checkpoint(snapshot_id="empty")
+        assert result.success is True
+        assert result.skipped is True
+        assert result.snapshot == ""
+        assert result.reason == "Empty workspace, no snapshot created."
+
+    @patch("hermes.checkpoint_manager.subprocess.run")
     def test_create_checkpoint_with_metadata(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         mgr = self._make("/ws")

--- a/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_tools.py
@@ -314,6 +314,16 @@ class TestHandlers:
         assert "-n" in cmd_args
         assert "3" in cmd_args  # 2 + 1 offset
 
+    @patch("hermes.tools._run_ws_ckpt_cmd", return_value=(True, "Rollback preview\nM  file.txt"))
+    @patch("hermes.tools._reject_if_cwd_inside_workspace")
+    @patch("hermes.tools._resolve_workspace", return_value=("/ws", None))
+    def test_rollback_preview(self, _ws, mock_cwd, mock_cmd):
+        result = json.loads(handle_ws_ckpt_rollback({"target": "snap1", "preview": True}))
+        assert result["success"] is True
+        assert "M  file.txt" in result["output"]
+        assert "--preview" in mock_cmd.call_args[0][0]
+        mock_cwd.assert_not_called()
+
     @patch("hermes.tools._run_ws_ckpt_cmd", return_value=(True, "snap1 created"))
     @patch("hermes.tools._reject_if_cwd_inside_workspace", return_value=None)
     @patch("hermes.tools._resolve_workspace", return_value=("/ws", None))

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -646,7 +646,7 @@ def handle_ws_ckpt_checkpoint(args: Dict[str, Any], **_kwargs) -> str:
 
     message = (args.get("message") or "").strip() or "manual checkpoint"
 
-    cmd = ["ws-ckpt", "checkpoint", "-w", workspace, "-i", snapshot_id,
+    cmd = ["ws-ckpt", "checkpoint", "-w", workspace, "-s", snapshot_id,
            "-m", message]
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -274,7 +274,8 @@ WS_CKPT_CHECKPOINT_SCHEMA: Dict[str, Any] = {
 WS_CKPT_ROLLBACK_SCHEMA: Dict[str, Any] = {
     "name": "ws-ckpt-rollback",
     "description": (
-        "Roll back the workspace to a specific checkpoint or N ancestors back. "
+        "Preview or roll back the workspace to a specific checkpoint or N ancestors back. "
+        "Set preview=true to inspect file changes without modifying the workspace. "
         "Use ws-ckpt-list first to see available snapshots."
     ),
     "parameters": {
@@ -301,6 +302,12 @@ WS_CKPT_ROLLBACK_SCHEMA: Dict[str, Any] = {
                     "Optional: workspace absolute path. Defaults to the "
                     "configured workspace. If the path is a symlink, use the "
                     "link itself — do NOT replace it with the resolved real path."
+                ),
+            },
+            "preview": {
+                "type": "boolean",
+                "description": (
+                    "Optional: preview the file changes without modifying the workspace."
                 ),
             },
         },
@@ -656,6 +663,7 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
     """Handle ws-ckpt-rollback tool call."""
     target = (args.get("target") or "").strip()
     num_ancestors = args.get("num_ancestors")
+    preview = args.get("preview") is True
 
     if target and num_ancestors is not None:
         return _err("'target' and 'num_ancestors' are mutually exclusive")
@@ -672,9 +680,10 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
     workspace, ws_err = _resolve_workspace(args)
     if ws_err:
         return ws_err
-    rejection = _reject_if_cwd_inside_workspace(workspace)
-    if rejection:
-        return rejection
+    if not preview:
+        rejection = _reject_if_cwd_inside_workspace(workspace)
+        if rejection:
+            return rejection
 
     if num_ancestors is not None:
         # Plugin snapshots after each response, so head == current state;
@@ -682,6 +691,8 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
         cmd = ["ws-ckpt", "rollback", "-w", workspace, "-n", str(int(num_ancestors) + 1)]
     else:
         cmd = ["ws-ckpt", "rollback", "-w", workspace, "-s", target]
+    if preview:
+        cmd.append("--preview")
     success, output = _run_ws_ckpt_cmd(cmd)
     return _ok(output) if success else _err(output)
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/__tests__/btrfs-manager.test.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/__tests__/btrfs-manager.test.ts
@@ -214,10 +214,15 @@ describe("BtrfsManager with mocked executor", () => {
     exec.list = vi.fn().mockResolvedValue(ok("[]"));
     await mgr.initialize("/ws");
 
-    exec.checkpoint = vi.fn().mockResolvedValue(ok("Skipped: Empty workspace"));
+    exec.checkpoint = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "\u001b[33m⚠ Empty workspace, no snapshot created.\u001b[0m\n",
+    });
     const r = await mgr.createCheckpoint({ id: "s1" });
     expect(r.success).toBe(true);
     expect(r.skipped).toBe(true);
+    expect(mgr.getStore().getAll()).toHaveLength(0);
   });
 
   it("createCheckpoint handles exception", async () => {

--- a/src/ws-ckpt/src/plugins/openclaw/src/__tests__/btrfs-manager.test.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/__tests__/btrfs-manager.test.ts
@@ -280,6 +280,22 @@ describe("BtrfsManager with mocked executor", () => {
     expect(r.target).toBe("snap1");
   });
 
+  it("rollback preview returns diff without refreshing cache", async () => {
+    const mgr = new BtrfsManager(cfg);
+    const exec = (mgr as any).executor;
+    exec.init = vi.fn().mockResolvedValue(ok());
+    exec.list = vi.fn().mockResolvedValue(ok("[]"));
+    await mgr.initialize("/ws");
+    exec.list.mockClear();
+
+    exec.rollback = vi.fn().mockResolvedValue(ok("\u001b[1mRollback preview\u001b[0m\nM  file.txt"));
+    const r = await mgr.rollback("snap1", undefined, true);
+    expect(r.success).toBe(true);
+    expect(r.message).toContain("M  file.txt");
+    expect(exec.rollback).toHaveBeenCalledWith("/ws", "snap1", undefined, true);
+    expect(exec.list).not.toHaveBeenCalled();
+  });
+
   it("rollback failure", async () => {
     const mgr = new BtrfsManager(cfg);
     const exec = (mgr as any).executor;

--- a/src/ws-ckpt/src/plugins/openclaw/src/__tests__/commands.test.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/__tests__/commands.test.ts
@@ -80,6 +80,14 @@ describe("CommandExecutor", () => {
       const r = await exec.rollback("/ws", "snap1");
       expect(r.exitCode).toBe(0);
     });
+
+    it("passes preview flag", async () => {
+      mockSuccess("preview");
+      const exec = new CommandExecutor();
+      await exec.rollback("/ws", "snap1", undefined, true);
+      const args = promisifiedMock.mock.calls[0][1];
+      expect(args).toContain("--preview");
+    });
   });
 
   describe("delete", () => {

--- a/src/ws-ckpt/src/plugins/openclaw/src/__tests__/handlers.test.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/__tests__/handlers.test.ts
@@ -333,8 +333,8 @@ describe("handlers — explicit workspace", () => {
 
   it("checkpoint explicit workspace skipped (empty)", async () => {
     promisifiedMock.mockResolvedValue({
-      stdout: "Skipped: Empty workspace",
-      stderr: "",
+      stdout: "",
+      stderr: "\u001b[33m⚠ Empty workspace, no snapshot created.\u001b[0m\n",
     });
     const r = await handleCheckpoint(
       JSON.stringify({ id: "snap1", workspace: "/explicit" }),

--- a/src/ws-ckpt/src/plugins/openclaw/src/__tests__/handlers.test.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/__tests__/handlers.test.ts
@@ -343,6 +343,18 @@ describe("handlers — explicit workspace", () => {
     expect(r.text).toContain("Empty workspace");
   });
 
+  it("rollback explicit workspace preview", async () => {
+    promisifiedMock.mockResolvedValue({
+      stdout: "\u001b[1mRollback preview\u001b[0m\nM  file.txt\n",
+      stderr: "",
+    });
+    const r = await handleRollback("snap1", "/explicit", undefined, true);
+    expect(r.isError).toBe(false);
+    expect(r.text).toContain("M  file.txt");
+    const args = promisifiedMock.mock.calls[0][1];
+    expect(args).toContain("--preview");
+  });
+
   it("checkpoint explicit workspace cwd inside", async () => {
     process.cwd = () => "/explicit/sub";
     const r = await handleCheckpoint(
@@ -829,6 +841,6 @@ describe("handleRollback — numAncestors", () => {
     });
     const r = await handleRollback(undefined, undefined, 2);
     expect(r.isError).toBe(false);
-    expect(mockManager.rollback).toHaveBeenCalledWith(undefined, 2);
+    expect(mockManager.rollback).toHaveBeenCalledWith(undefined, 2, false);
   });
 });

--- a/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
@@ -182,8 +182,8 @@ export class BtrfsManager {
         };
       }
 
-      // Check for skipped checkpoint (empty workspace)
-      if (output.stdout && (output.stdout.includes('Skipped') || output.stdout.includes('Empty workspace'))) {
+      // The CLI reports CheckpointSkipped on stderr while keeping exit code 0.
+      if (`${output.stdout}\n${output.stderr}`.includes("Empty workspace, no snapshot created.")) {
         return { success: true, skipped: true, reason: 'Empty workspace, no snapshot created.', message: 'Empty workspace, no snapshot created.' };
       }
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/btrfs-manager.ts
@@ -220,22 +220,40 @@ export class BtrfsManager {
    *
    * @param target       - Snapshot identifier (mutually exclusive with numAncestors).
    * @param numAncestors - Number of ancestors to traverse (mutually exclusive with target).
+   * @param preview      - Show changes without executing the rollback.
    * @returns A {@link RollbackResult} describing the outcome.
    */
-  public async rollback(target?: string, numAncestors?: number): Promise<RollbackResult> {
+  public async rollback(
+    target?: string,
+    numAncestors?: number,
+    preview: boolean = false,
+  ): Promise<RollbackResult> {
     if (!this.workspacePath) {
       return { success: false, message: "Workspace not initialized" };
     }
 
     const label = target || `ancestors=${numAncestors}`;
     try {
-      const output = await this.executor.rollback(this.workspacePath, target, numAncestors);
+      const output = await this.executor.rollback(
+        this.workspacePath,
+        target,
+        numAncestors,
+        preview,
+      );
 
       if (output.exitCode !== 0) {
         return {
           success: false,
           target,
           message: mapErrorToLLMMessage(output.stderr, { id: label }),
+        };
+      }
+
+      if (preview) {
+        return {
+          success: true,
+          target,
+          message: output.stdout.replace(/\x1b\[[0-9;]*m/g, "").trim(),
         };
       }
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
@@ -60,7 +60,7 @@ export class CommandExecutor {
    *
    * Equivalent to:
    * ```
-   * ws-ckpt checkpoint --workspace <ws> --id <id> [--message <msg>] [--metadata <json>]
+   * ws-ckpt checkpoint --workspace <ws> --snapshot <id> [--message <msg>] [--metadata <json>]
    * ```
    *
    * @param workspace - Workspace directory path.
@@ -75,7 +75,7 @@ export class CommandExecutor {
     const args = [
       "checkpoint",
       "--workspace", workspace,
-      "--id", id,
+      "--snapshot", id,
     ];
 
     if (options?.message) {

--- a/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
@@ -95,11 +95,13 @@ export class CommandExecutor {
    * @param workspace     - Workspace directory path.
    * @param target        - Snapshot identifier (mutually exclusive with numAncestors).
    * @param numAncestors  - Number of ancestors to traverse (mutually exclusive with target).
+   * @param preview       - Show changes without executing the rollback.
    */
   public async rollback(
     workspace: string,
     target?: string,
     numAncestors?: number,
+    preview: boolean = false,
   ): Promise<CommandOutput> {
     if (!target && numAncestors === undefined) {
       throw new Error("Either 'target' or 'numAncestors' is required");
@@ -111,6 +113,9 @@ export class CommandExecutor {
       args.push("--num-ancestors", String(numAncestors + 1));
     } else if (target) {
       args.push("--snapshot", target);
+    }
+    if (preview) {
+      args.push("--preview");
     }
     return this.run(args);
   }

--- a/src/ws-ckpt/src/plugins/openclaw/src/cron.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/cron.ts
@@ -21,7 +21,7 @@ function shellQuote(s: string): string {
 function buildCronLine(workspace: string, schedule: string): string {
   return (
     `${schedule} ws-ckpt checkpoint -w ${shellQuote(workspace)}` +
-    ` -i "cron-$(date +\\%s)"` +
+    ` -s "cron-$(date +\\%s)"` +
     ` -m "scheduled snapshot"` +
     ` --metadata '{"auto":true,"type":"cron"}'` +
     ` >/dev/null 2>&1`

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -60,8 +60,8 @@ export async function handleCheckpoint(
         return { text: mapErrorToLLMMessage(output.stderr, { id }), isError: true };
       }
       const timing = extractTiming(output.stdout);
-      if (output.stdout && (output.stdout.includes('Skipped') || output.stdout.includes('Empty workspace'))) {
-        return { text: `Empty workspace, no snapshot created.${timing}`, isError: false };
+      if (`${output.stdout}\n${output.stderr}`.includes("Empty workspace, no snapshot created.")) {
+        return { text: 'Empty workspace, no snapshot created.', isError: false };
       }
       return { text: `Checkpoint created: ${id}${timing}`, isError: false };
     } catch (error) {

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -92,6 +92,7 @@ export async function handleRollback(
   target?: string,
   workspace?: string,
   numAncestors?: number,
+  preview: boolean = false,
 ): Promise<{ text: string; isError: boolean }> {
   if (!pluginState.manager || !pluginState.environmentReady) {
     return { text: UNAVAILABLE_MSG, isError: true };
@@ -116,16 +117,18 @@ export async function handleRollback(
     return { text: "No workspace configured", isError: true };
   }
 
-  const cwdCheck = cwdInsideWorkspace(resolvedWs);
-  if (cwdCheck.inside) {
-    return { text: cwdInsideWorkspaceReason(cwdCheck.cwd, resolvedWs), isError: true };
+  if (!preview) {
+    const cwdCheck = cwdInsideWorkspace(resolvedWs);
+    if (cwdCheck.inside) {
+      return { text: cwdInsideWorkspaceReason(cwdCheck.cwd, resolvedWs), isError: true };
+    }
   }
 
   if (workspace?.trim()) {
-    return runRollbackViaExecutor(resolvedWs, trimmed || undefined, numAncestors);
+    return runRollbackViaExecutor(resolvedWs, trimmed || undefined, numAncestors, preview);
   }
 
-  const result = await pluginState.manager.rollback(trimmed || undefined, numAncestors);
+  const result = await pluginState.manager.rollback(trimmed || undefined, numAncestors, preview);
   return { text: result.message, isError: !result.success };
 }
 
@@ -133,13 +136,20 @@ async function runRollbackViaExecutor(
   ws: string,
   target?: string,
   numAncestors?: number,
+  preview: boolean = false,
 ): Promise<{ text: string; isError: boolean }> {
   try {
     const executor = new CommandExecutor();
-    const output = await executor.rollback(ws, target, numAncestors);
+    const output = await executor.rollback(ws, target, numAncestors, preview);
     if (output.exitCode !== 0) {
       const label = target || `ancestors=${numAncestors}`;
       return { text: mapErrorToLLMMessage(output.stderr, { id: label }), isError: true };
+    }
+    if (preview) {
+      return {
+        text: output.stdout.replace(/\x1b\[[0-9;]*m/g, "").trim(),
+        isError: false,
+      };
     }
     const timing = extractTiming(output.stdout);
     const desc = target ? `Rolled back to ${target}` : `Rolled back ${numAncestors} ancestor(s)`;

--- a/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/tool-registry.ts
@@ -118,7 +118,8 @@ export function registerTools(api: OpenClawPluginApi): void {
     {
       name: "ws-ckpt-rollback",
       description:
-        "Roll back the workspace to a previous snapshot or N ancestors back. " +
+        "Preview or roll back the workspace to a previous snapshot or N ancestors back. " +
+        "Set preview=true to inspect file changes without modifying the workspace. " +
         "Always call ws-ckpt-list first to confirm the target snapshot id " +
         "exists; never roll back to an id you haven't verified.",
       parameters: {
@@ -143,6 +144,11 @@ export function registerTools(api: OpenClawPluginApi): void {
               "configured workspace. If the path is a symlink, use the " +
               "link itself — do NOT replace it with the resolved real path.",
           },
+          preview: {
+            type: "boolean",
+            description:
+              "Optional: preview the file changes without modifying the workspace.",
+          },
         },
       },
       async execute(_toolCallId, params) {
@@ -150,6 +156,7 @@ export function registerTools(api: OpenClawPluginApi): void {
           params.target as string | undefined,
           params.workspace as string | undefined,
           params.numAncestors as number | undefined,
+          params.preview as boolean | undefined,
         );
         return textToolResult(r.text, r.isError);
       },


### PR DESCRIPTION
## Description

- 新增 `ws-ckpt rollback --preview` 参数，支持在不执行回滚的情况下预览文件变更
- 插件层（openclaw + hermes）同步支持 rollback preview 功能
- 对齐插件的 `--snapshot/-s` 参数（原 `--id/-i`），修复 skip 检测改读 stderr
- 更新参数文档，补充 `--preview` 和 `--snapshot/-s` 说明

### Rollback Preview

CLI 新增 `--preview` flag，走 `RollbackPreview` / `RollbackPreviewOk` 协议变体。daemon 侧提取 `resolve_rollback_target()` 和 `reject_missing_snapshot()` 复用逻辑，返回文件变更列表而不实际执行回滚。

openclaw 通过 tool-registry 暴露 `ws-ckpt-rollback-preview` 工具；hermes 新增对应的 command handler。

### --snapshot/-s 对齐

openclaw 和 hermes 的 checkpoint / cron 命令从 `-i` 迁移到 `-s`（与 CLI 的 `--snapshot/-s` flag 保持一致）。同时修复 skip 检测逻辑，改为读取 stderr 而非 stdout。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue: 体验项目反馈

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
