### PR TITLE
fix(sight): fix sslsniff BPF verifier rejection on kernel 5.15

### DIFF
--- a/src/agentsight/src/bpf/sslsniff.bpf.c
+++ b/src/agentsight/src/bpf/sslsniff.bpf.c
@@ -104,20 +104,23 @@ int BPF_UPROBE(probe_SSL_rw_enter, void *ssl, void *buf, int num) {
         _d->ssl_ptr = (ssl_);                                                   \
         _d->truncated = ((u32)(len_) > (u32)(TIER)) ? 1 : 0;                    \
         bpf_get_current_comm(&_d->comm, sizeof(_d->comm));                      \
-        /* Re-clamp the copy length to the tier right before the read. Two      \
+        /* Re-clamp the copy length to the tier right before the read. Three    \
          * verifier traps must be dodged: (1) a length computed earlier is      \
          * spilled across bpf_get_current_comm() and reloaded as an UNBOUNDED   \
          * scalar; (2) the outer tier-selection already proved len_ <= TIER, so \
          * clang folds a plain `if (_n > TIER)` away as dead code -- yet the     \
          * verifier does NOT carry that bound across the spill, so the clamp     \
-         * still has to execute. The asm barrier makes _n opaque to clang so the \
-         * clamp is emitted, handing bpf_probe_read_user a fresh umax=TIER bound \
-         * (TIER is a compile-time constant). Without it the load is rejected:   \
+         * still has to execute; (3) on kernel 5.15, clang may substitute the   \
+         * original signed `len` register for _n at the call site, even after   \
+         * the clamp, because it proves they hold the same value — the second   \
+         * barrier forces clang to use _n's own (clamped, unsigned) register.   \
+         * Without the barriers the load is rejected on 5.15:                   \
          * "R2 min value is negative, either use unsigned or 'var &= const'". */ \
         u32 _n = (u32)(len_);                                                   \
         asm volatile("" : "+r"(_n));                                            \
         if (_n > (u32)(TIER))                                                   \
             _n = (u32)(TIER);                                                   \
+        asm volatile("" : "+r"(_n));                                            \
         int _rc = (src_) ? bpf_probe_read_user(&_d->buf, _n, (const char *)(src_)) : -1; \
         if (_rc) { _d->buf_filled = 0; _d->buf_size = 0; }                      \
         else     { _d->buf_filled = 1; _d->buf_size = _n; }                     \

--- a/src/agentsight/tests/bpf_load.rs
+++ b/src/agentsight/tests/bpf_load.rs
@@ -1,0 +1,75 @@
+//! BPF verifier load tests — verify every eBPF program passes the kernel
+//! verifier on the running kernel.
+//!
+//! These tests require CAP_BPF + CAP_PERFMON (or root). They are `#[ignore]`
+//! by default so `cargo test` skips them; run explicitly with:
+//!
+//!     sudo cargo test --test bpf_load -- --ignored
+//!
+//! Each test names the probe it covers so a failure immediately identifies
+//! which BPF program the verifier rejected.
+
+use agentsight::probes::{
+    FileWatch, FileWriteProbe, ProcMon, ProcTrace, Probes, SharedMaps, SslSniff, TcpSniff, UdpDns,
+};
+
+fn make_shared_maps() -> (ProcTrace, SharedMaps) {
+    let pt = ProcTrace::new().expect("proctrace open+load");
+    let shared = SharedMaps::new(pt.rb_handle().expect("rb handle"))
+        .with_traced_processes(pt.traced_processes_handle().expect("traced_processes handle"));
+    (pt, shared)
+}
+
+#[test]
+#[ignore]
+fn proctrace_bpf_loads() {
+    ProcTrace::new().expect("proctrace BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn sslsniff_bpf_loads() {
+    SslSniff::new().expect("sslsniff BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn procmon_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    ProcMon::new_with_shared(&shared).expect("procmon BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn filewatch_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    FileWatch::new_with_shared(&shared).expect("filewatch BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn filewrite_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    FileWriteProbe::new_with_shared(&shared).expect("filewrite BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn udpdns_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    UdpDns::new_with_shared(&shared).expect("udpdns BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn tcpsniff_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    TcpSniff::new_with_shared(&shared).expect("tcpsniff BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn all_probes_load() {
+    Probes::new(&[], None, true, true, &[])
+        .expect("unified Probes (all BPF programs) should load on this kernel");
+}


### PR DESCRIPTION
## Description

PR #1000 (tiered SSL ring buffer reservations) introduced a BPF verifier regression on kernel 5.15. The `SSL_EMIT_ONE` macro's copy-length clamping was defeated by clang register aliasing: after the `if (_n > TIER) _n = TIER;` clamp, clang proved `_n` and the original signed `len` hold the same value and substituted the original register (r6, signed `int`) at the `bpf_probe_read_user` call site. The verifier on 5.15 then rejected the program with **"R2 min value is negative"** because it tracked the signed scalar bounds of r6, not the clamped unsigned `_n`.

The fix adds a second `asm volatile("" : "+r"(_n))` barrier after the conditional clamp, forcing clang to use `_n`'s own (clamped, unsigned) register at the call site. This generates zero BPF instructions — it only prevents the compiler optimization that aliases registers across the barrier.

Additionally, this PR adds **8 BPF verifier load tests** (`tests/bpf_load.rs`) covering every eBPF program. These tests would have caught the regression immediately. They are `#[ignore]` by default (require CAP_BPF/root) and can be run with `sudo cargo test --test bpf_load -- --ignored`.

## Related Issue

no-issue: regression from #1000, discovered via production startup failure on kernel 5.15

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

**Automated checks (all pass with CI toolchain 1.89.0):**
```bash
cargo +1.89.0 fmt --all --check          # ✅
cargo +1.89.0 clippy --all-targets -- -D warnings  # ✅
cargo +1.89.0 test --lib --bins          # ✅ 807 tests pass
python3 scripts/check-arch-boundaries.py # ✅ 0 violations
cargo +1.89.0 test --test bpf_load --no-run  # ✅ compiles
```

**BPF load tests (require root, verified on two kernels):**
```bash
sudo cargo test --test bpf_load -- --ignored --nocapture
```
- ✅ All 8 tests pass on kernel 5.10 (local)
- ✅ All 8 tests pass on kernel 5.15 (remote 8.139.132.10)

## Additional Notes

### Root cause analysis

The BPF verifier rejection trace showed:

```
R2 min value is negative, either use unsigned or 'var &= const'
```

at the `bpf_probe_read_user(&_d->buf, _n, src)` call. Despite `_n` being declared `u32` and clamped to `TIER`, the generated BPF bytecode used register r6 (which held the original signed `int len` parameter) instead of the register holding the clamped `_n`. This is because clang's optimizer proved `len == _n` at that point and chose to reuse r6 as an alias.

The first `asm volatile("" : "+r"(_n))` barrier (already present) prevented dead-code elimination of the clamp. The second barrier (added in this PR) prevents the register substitution by making `_n`'s register opaque to the optimizer after the clamp.

### BPF load test coverage

| Test | Probe | Constructor |
|------|-------|-------------|
| `proctrace_bpf_loads` | ProcTrace | `ProcTrace::new()` |
| `sslsniff_bpf_loads` | SslSniff | `SslSniff::new()` |
| `procmon_bpf_loads` | ProcMon | `ProcMon::new_with_shared()` |
| `filewatch_bpf_loads` | FileWatch | `FileWatch::new_with_shared()` |
| `filewrite_bpf_loads` | FileWriteProbe | `FileWriteProbe::new_with_shared()` |
| `udpdns_bpf_loads` | UdpDns | `UdpDns::new_with_shared()` |
| `tcpsniff_bpf_loads` | TcpSniff | `TcpSniff::new_with_shared()` |
| `all_probes_load` | All (unified) | `Probes::new()` |