### PR TITLE
fix(sight): fix sslsniff BPF verifier rejection on kernel 5.15

### DIFF
--- a/src/agentsight/src/bpf/sslsniff.bpf.c
+++ b/src/agentsight/src/bpf/sslsniff.bpf.c
@@ -104,20 +104,23 @@ int BPF_UPROBE(probe_SSL_rw_enter, void *ssl, void *buf, int num) {
         _d->ssl_ptr = (ssl_);                                                   \
         _d->truncated = ((u32)(len_) > (u32)(TIER)) ? 1 : 0;                    \
         bpf_get_current_comm(&_d->comm, sizeof(_d->comm));                      \
-        /* Re-clamp the copy length to the tier right before the read. Two      \
+        /* Re-clamp the copy length to the tier right before the read. Three    \
          * verifier traps must be dodged: (1) a length computed earlier is      \
          * spilled across bpf_get_current_comm() and reloaded as an UNBOUNDED   \
          * scalar; (2) the outer tier-selection already proved len_ <= TIER, so \
          * clang folds a plain `if (_n > TIER)` away as dead code -- yet the     \
          * verifier does NOT carry that bound across the spill, so the clamp     \
-         * still has to execute. The asm barrier makes _n opaque to clang so the \
-         * clamp is emitted, handing bpf_probe_read_user a fresh umax=TIER bound \
-         * (TIER is a compile-time constant). Without it the load is rejected:   \
+         * still has to execute; (3) on kernel 5.15, clang may substitute the   \
+         * original signed `len` register for _n at the call site, even after   \
+         * the clamp, because it proves they hold the same value — the second   \
+         * barrier forces clang to use _n's own (clamped, unsigned) register.   \
+         * Without the barriers the load is rejected on 5.15:                   \
          * "R2 min value is negative, either use unsigned or 'var &= const'". */ \
         u32 _n = (u32)(len_);                                                   \
         asm volatile("" : "+r"(_n));                                            \
         if (_n > (u32)(TIER))                                                   \
             _n = (u32)(TIER);                                                   \
+        asm volatile("" : "+r"(_n));                                            \
         int _rc = (src_) ? bpf_probe_read_user(&_d->buf, _n, (const char *)(src_)) : -1; \
         if (_rc) { _d->buf_filled = 0; _d->buf_size = 0; }                      \
         else     { _d->buf_filled = 1; _d->buf_size = _n; }                     \

--- a/src/agentsight/tests/bpf_load.rs
+++ b/src/agentsight/tests/bpf_load.rs
@@ -10,13 +10,15 @@
 //! which BPF program the verifier rejected.
 
 use agentsight::probes::{
-    FileWatch, FileWriteProbe, ProcMon, ProcTrace, Probes, SharedMaps, SslSniff, TcpSniff, UdpDns,
+    FileWatch, FileWriteProbe, Probes, ProcMon, ProcTrace, SharedMaps, SslSniff, TcpSniff, UdpDns,
 };
 
 fn make_shared_maps() -> (ProcTrace, SharedMaps) {
     let pt = ProcTrace::new().expect("proctrace open+load");
-    let shared = SharedMaps::new(pt.rb_handle().expect("rb handle"))
-        .with_traced_processes(pt.traced_processes_handle().expect("traced_processes handle"));
+    let shared = SharedMaps::new(pt.rb_handle().expect("rb handle")).with_traced_processes(
+        pt.traced_processes_handle()
+            .expect("traced_processes handle"),
+    );
     (pt, shared)
 }
 

--- a/src/agentsight/tests/bpf_load.rs
+++ b/src/agentsight/tests/bpf_load.rs
@@ -1,0 +1,75 @@
+//! BPF verifier load tests — verify every eBPF program passes the kernel
+//! verifier on the running kernel.
+//!
+//! These tests require CAP_BPF + CAP_PERFMON (or root). They are `#[ignore]`
+//! by default so `cargo test` skips them; run explicitly with:
+//!
+//!     sudo cargo test --test bpf_load -- --ignored
+//!
+//! Each test names the probe it covers so a failure immediately identifies
+//! which BPF program the verifier rejected.
+
+use agentsight::probes::{
+    FileWatch, FileWriteProbe, ProcMon, ProcTrace, Probes, SharedMaps, SslSniff, TcpSniff, UdpDns,
+};
+
+fn make_shared_maps() -> (ProcTrace, SharedMaps) {
+    let pt = ProcTrace::new().expect("proctrace open+load");
+    let shared = SharedMaps::new(pt.rb_handle().expect("rb handle"))
+        .with_traced_processes(pt.traced_processes_handle().expect("traced_processes handle"));
+    (pt, shared)
+}
+
+#[test]
+#[ignore]
+fn proctrace_bpf_loads() {
+    ProcTrace::new().expect("proctrace BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn sslsniff_bpf_loads() {
+    SslSniff::new().expect("sslsniff BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn procmon_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    ProcMon::new_with_shared(&shared).expect("procmon BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn filewatch_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    FileWatch::new_with_shared(&shared).expect("filewatch BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn filewrite_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    FileWriteProbe::new_with_shared(&shared).expect("filewrite BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn udpdns_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    UdpDns::new_with_shared(&shared).expect("udpdns BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn tcpsniff_bpf_loads() {
+    let (_pt, shared) = make_shared_maps();
+    TcpSniff::new_with_shared(&shared).expect("tcpsniff BPF should load on this kernel");
+}
+
+#[test]
+#[ignore]
+fn all_probes_load() {
+    Probes::new(&[], None, true, true, &[])
+        .expect("unified Probes (all BPF programs) should load on this kernel");
+}


### PR DESCRIPTION
## Description

On kernel 5.15, the sslsniff BPF program is rejected by the verifier with "R2 min value is negative" because clang substitutes the original signed `len` register for the clamped `_n` at the `bpf_probe_read_user` call site — even after the unsigned clamp. This was introduced by PR #1000's tiered ring buffer reservation refactor, which added a single `asm volatile` barrier that is insufficient on 5.15's verifier.

A second `asm volatile("")` barrier after the clamp forces clang to use the clamped register's own (unsigned) value, emitting zero extra BPF instructions while preserving the verifier's bound tracking.

## Related Issue

closes #1113

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/agentsight/src/bpf/sslsniff.bpf.c`: add second `asm volatile` barrier after the length clamp to prevent clang register substitution on kernel 5.15
- `src/agentsight/tests/bpf_load.rs`: add 8 `#[ignore]` integration tests that verify every BPF program passes the kernel verifier (run with `sudo cargo test --test bpf_load -- --ignored`)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] `cargo fmt --check` pass
- [ ] `cargo clippy --all-targets -- -D warnings` pass (pre-existing clippy warnings in unrelated files; no warnings in changed files)
- [ ] `cargo llvm-cov` + `diff-cover --fail-under=80` pass (N/A: changes are a BPF C file and a test file — neither instrumentable by Rust coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- Added `tests/bpf_load.rs` with a dedicated `sslsniff_bpf_loads` test that loads the sslsniff BPF skeleton into the kernel verifier. On kernel 5.15 without the fix, this test fails with verifier rejection; with the fix it passes.
- Run: `sudo cargo test --test bpf_load -- --ignored --nocapture`
- All 8 BPF load tests (proctrace, sslsniff, procmon, filewatch, filewrite, udpdns, tcpsniff, all-unified) pass on the target kernel.