### PR TITLE
fix(sec-core): add security daemon socket fallback as /run/user/uid

### DIFF
--- a/src/agentsight/src/agent_sec/client.rs
+++ b/src/agentsight/src/agent_sec/client.rs
@@ -190,18 +190,27 @@ fn resolve_socket_path(socket_path: Option<PathBuf>) -> Result<PathBuf, AgentSec
     }
 
     if let Some(path) = env::var_os(SOCKET_ENV) {
-        return Ok(PathBuf::from(path));
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
     }
 
-    let xdg_runtime_dir = env::var_os("XDG_RUNTIME_DIR").ok_or_else(|| {
-        AgentSecClientError::SocketPath(
-            "XDG_RUNTIME_DIR is required when AGENT_SEC_DAEMON_SOCKET is not set".to_string(),
-        )
-    })?;
+    Ok(resolve_socket_path_with_runtime_dir(
+        env::var_os("XDG_RUNTIME_DIR"),
+        unsafe { libc::getuid() },
+    ))
+}
 
-    Ok(PathBuf::from(xdg_runtime_dir)
-        .join(RUNTIME_SUBDIR)
-        .join(SOCKET_FILENAME))
+fn resolve_socket_path_with_runtime_dir(
+    xdg_runtime_dir: Option<std::ffi::OsString>,
+    uid: libc::uid_t,
+) -> PathBuf {
+    let runtime_dir = xdg_runtime_dir
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/run/user").join(uid.to_string()));
+
+    runtime_dir.join(RUNTIME_SUBDIR).join(SOCKET_FILENAME)
 }
 
 fn classify_io_error(action: &str, err: std::io::Error) -> AgentSecClientError {
@@ -280,6 +289,29 @@ mod tests {
             .expect("explicit socket path should resolve");
 
         assert_eq!(path, std::path::PathBuf::from("/tmp/agent-sec-test.sock"));
+    }
+
+    #[test]
+    fn resolve_socket_path_falls_back_to_run_user_uid_when_xdg_runtime_dir_missing() {
+        let path = super::resolve_socket_path_with_runtime_dir(None, 1000);
+
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/run/user/1000/agent-sec-core/daemon.sock")
+        );
+    }
+
+    #[test]
+    fn resolve_socket_path_uses_xdg_runtime_dir_when_present() {
+        let path = super::resolve_socket_path_with_runtime_dir(
+            Some(std::ffi::OsString::from("/tmp/runtime")),
+            1000,
+        );
+
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/tmp/runtime/agent-sec-core/daemon.sock")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
XDG_RUNTIME_DIR may not be set sometimes. Use /run/user/{uid} as the runtime dir as fallback (keep the same as sec-core read logic).
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
