### PR TITLE
fix(sight): don't exit on transient metadata failure

### DIFF
--- a/src/agentsight/src/background.rs
+++ b/src/agentsight/src/background.rs
@@ -54,17 +54,18 @@ pub(crate) fn path_matches_target(paths: &[PathBuf], target: &Option<OsString>) 
 /// Decision produced by [`decide_sls_config_change`]: what the config watcher
 /// should do in response to a parsed `runtime.sls_logtail_path` value.
 ///
-/// Side effects (process exit, exporter construction, mailbox write, dynamic
-/// logtail-path update) are carried out by the thread shell so the decision
-/// logic stays pure and testable.
+/// Side effects (exporter construction, mailbox write, dynamic logtail-path
+/// update) are carried out by the thread shell so the decision logic stays
+/// pure and testable.
 #[derive(Debug, PartialEq)]
 pub(crate) enum SlsConfigAction {
     /// Field missing / parse error, or empty path while already inactive: no-op.
     NoChange,
     /// Empty path while active: SLS was just deactivated (dynamic path cleared).
     Deactivated,
-    /// Non-empty path but uid fetch failed: the shell must abort the process.
-    AbortUidMissing,
+    /// Non-empty path but uid fetch failed: SLS activation deferred until
+    /// the next config event (when the metadata endpoint may be reachable).
+    UidUnavailable,
     /// Non-empty path, first activation: shell should build a LogtailExporter for
     /// `path` and deposit it into the mailbox.
     Activate { path: String },
@@ -97,7 +98,7 @@ pub(crate) fn decide_sls_config_change(
         }
         Some(Some(new_path)) => {
             if uid.is_empty() {
-                return SlsConfigAction::AbortUidMissing;
+                return SlsConfigAction::UidUnavailable;
             }
             if !sls_activated.swap(true, Ordering::SeqCst) {
                 SlsConfigAction::Activate { path: new_path }
@@ -113,10 +114,9 @@ pub(crate) fn decide_sls_config_change(
 /// process-global dynamic logtail path, and on first activation build a
 /// LogtailExporter and deposit it into the mailbox).
 ///
-/// Returns the [`SlsConfigAction`] so the thread shell can perform the only
-/// non-testable action (`process::exit` on uid failure). `fetch_uid` is injected
+/// Returns the [`SlsConfigAction`] for logging/tracing. `fetch_uid` is injected
 /// so tests can supply a uid without invoking `get_owner_account_id`, which
-/// blocks on ECS metadata and would `process::exit` the test harness.
+/// blocks on ECS metadata.
 pub(crate) fn handle_config_event(
     content: &str,
     sls_activated: &AtomicBool,
@@ -140,10 +140,10 @@ pub(crate) fn handle_config_event(
                  (runtime.sls_logtail_path cleared)"
             );
         }
-        SlsConfigAction::AbortUidMissing => {
-            log::error!(
-                "Config watcher: SLS activation requested but uid fetch failed. \
-                 Terminating process."
+        SlsConfigAction::UidUnavailable => {
+            log::warn!(
+                "Config watcher: SLS activation deferred — uid fetch failed \
+                 (metadata endpoint unreachable). Will retry on next config event."
             );
         }
         SlsConfigAction::Activate { path } => {
@@ -234,9 +234,9 @@ pub(crate) fn start_config_watcher(
                     trace_enabled,
                     &pending_logtail,
                 );
-                if action == SlsConfigAction::AbortUidMissing {
-                    std::process::exit(1);
-                }
+                // UidUnavailable is logged inside handle_config_event;
+                // the process continues and retries on the next config event.
+                let _ = action;
             }
 
             log::info!("Config watcher exiting");
@@ -757,11 +757,11 @@ mod tests {
     }
 
     #[test]
-    fn test_decide_sls_path_but_no_uid_aborts() {
+    fn test_decide_sls_path_but_no_uid_defers() {
         let flag = AtomicBool::new(false);
         assert_eq!(
             decide_sls_config_change(Some(Some("/p.log".into())), &flag, ""),
-            SlsConfigAction::AbortUidMissing
+            SlsConfigAction::UidUnavailable
         );
         // Flag must NOT be set when uid is missing.
         assert!(!flag.load(Ordering::SeqCst));
@@ -1119,10 +1119,10 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_event_abort_when_uid_missing() {
+    fn test_handle_event_defers_when_uid_missing() {
         let flag = AtomicBool::new(false);
         let mailbox = empty_mailbox();
-        // Non-empty path but uid fetch returns empty -> AbortUidMissing.
+        // Non-empty path but uid fetch returns empty -> UidUnavailable.
         let action = handle_config_event(
             r#"{"runtime":{"sls_logtail_path":"/p.log"}}"#,
             &flag,
@@ -1131,7 +1131,7 @@ mod tests {
             false,
             &mailbox,
         );
-        assert_eq!(action, SlsConfigAction::AbortUidMissing);
+        assert_eq!(action, SlsConfigAction::UidUnavailable);
         // No exporter built, flag not set.
         assert!(mailbox.lock().unwrap().is_none());
         assert!(!flag.load(Ordering::SeqCst));

--- a/src/agentsight/src/bin/cli/summary.rs
+++ b/src/agentsight/src/bin/cli/summary.rs
@@ -188,7 +188,7 @@ fn gather_sessions(path: &Path, start_ns: i64, end_ns: i64) -> SessionStats {
             return SessionStats::default();
         }
     };
-    let sessions = match store.list_sessions(start_ns, end_ns) {
+    let sessions = match store.list_sessions(start_ns, end_ns, true) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("warning: cannot query sessions: {e}");

--- a/src/agentsight/src/server/token_savings.rs
+++ b/src/agentsight/src/server/token_savings.rs
@@ -171,22 +171,18 @@ fn generate_optimization_reason(operation: &str, before_tokens: i64, after_token
     };
     match operation {
         "compress-response" => format!(
-            "MCP 服务器返回的响应内容经过压缩处理，移除冗余字段和重复信息，节省 {}%（{} tokens）",
-            pct, saved
+            "MCP 服务器返回的响应内容经过压缩处理，移除冗余字段和重复信息，节省 {pct}%（{saved} tokens）"
         ),
         "rewrite-command" => format!(
-            "工具调用的输出内容经过精简重写，保留关键语义同时降低 token 开销，节省 {}%（{} tokens）",
-            pct, saved
+            "工具调用的输出内容经过精简重写，保留关键语义同时降低 token 开销，节省 {pct}%（{saved} tokens）"
         ),
         "compress-schema" => format!(
-            "工具的 JSON Schema 定义经过压缩，移除描述性文本和可选字段，节省 {}%（{} tokens）",
-            pct, saved
+            "工具的 JSON Schema 定义经过压缩，移除描述性文本和可选字段，节省 {pct}%（{saved} tokens）"
         ),
         "compress-toon" => format!(
-            "使用 TOON 结构化编码替代原始 JSON，大幅缩减 token 占用，节省 {}%（{} tokens）",
-            pct, saved
+            "使用 TOON 结构化编码替代原始 JSON，大幅缩减 token 占用，节省 {pct}%（{saved} tokens）"
         ),
-        _ => format!("内容经过优化处理，节省 {}%（{} tokens）", pct, saved),
+        _ => format!("内容经过优化处理，节省 {pct}%（{saved} tokens）"),
     }
 }
 
@@ -1139,11 +1135,11 @@ mod tests {
     #[test]
     fn test_diff_large_input_fallback() {
         let big_before = (0..1200)
-            .map(|i| format!("line{}", i))
+            .map(|i| format!("line{i}"))
             .collect::<Vec<_>>()
             .join("\n");
         let big_after = (0..1000)
-            .map(|i| format!("new{}", i))
+            .map(|i| format!("new{i}"))
             .collect::<Vec<_>>()
             .join("\n");
         let result = compute_diff_lines(Some(&big_before), Some(&big_after));
@@ -1163,11 +1159,11 @@ mod tests {
     fn test_diff_max_lines_cap() {
         // Create input that would generate many diff lines
         let before = (0..150)
-            .map(|i| format!("old_{}", i))
+            .map(|i| format!("old_{i}"))
             .collect::<Vec<_>>()
             .join("\n");
         let after = (0..150)
-            .map(|i| format!("new_{}", i))
+            .map(|i| format!("new_{i}"))
             .collect::<Vec<_>>()
             .join("\n");
         let result = compute_diff_lines(Some(&before), Some(&after));


### PR DESCRIPTION
## Summary

Config watcher called `process::exit(1)` when ECS metadata endpoint was unreachable during SLS activation. This killed the entire agentsight process on a transient network blip, skipping Drop impls and potentially losing buffered data.

Now the process continues running and defers SLS activation until the next config event, when the metadata endpoint may be reachable.

## Changes

- `background.rs`: Renamed `AbortUidMissing` → `UidUnavailable`, removed `process::exit(1)`, changed log from error to warn
- `summary.rs`: Fixed pre-existing compile error (`list_sessions` 2-arg → 3-arg from #1027 + #796 merge order)

## Test plan

- [x] 869 tests pass (fmt, clippy, test)
- [x] Existing tests verify SLS is NOT activated when uid missing (flag stays false, no exporter built)
- [x] Adversarial review (2 agents): no blocking findings

Fixes #782
