### PR TITLE
feat(sec-core): support packaging codex-plugin into rpm

### DIFF
--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -95,6 +95,12 @@ jobs:
           ls /usr/lib/systemd/user/agent-sec-core.service
           echo "=== Verify daemon binary ==="
           ls /usr/bin/agent-sec-daemon
+          echo "=== Verify codex plugin ==="
+          ls /opt/agent-sec/codex-plugin/
+          ls /opt/agent-sec/codex-plugin/hooks/
+          ls /opt/agent-sec/codex-plugin/hooks/code_scanner_hook.py
+          ls /opt/agent-sec/codex-plugin/hooks/skill_ledger_hook.py
+          ls /opt/agent-sec/codex-plugin/install.sh
           echo "=== Verify skills ==="
           ls /usr/share/anolisa/skills/
           echo "=== Verify component manifest ==="

--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -101,6 +101,7 @@ jobs:
           ls /opt/agent-sec/codex-plugin/hooks/code_scanner_hook.py
           ls /opt/agent-sec/codex-plugin/hooks/skill_ledger_hook.py
           ls /opt/agent-sec/codex-plugin/install.sh
+          ls /opt/agent-sec/codex-plugin/.agents/plugins/marketplace.json
           echo "=== Verify skills ==="
           ls /usr/share/anolisa/skills/
           echo "=== Verify component manifest ==="

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -249,10 +249,11 @@ build_agent_sec_core() {
         --exclude='__pycache__' \
         hermes-plugin/src hermes-plugin/scripts | tar -xf - -C "$pkg_dir/"
 
-    # codex-plugin (hooks + install script, exclude __pycache__)
+    # codex-plugin (hooks + install script + .agents registry, exclude __pycache__)
     tar -cf - -C "${SEC_DIR}" \
         --exclude='__pycache__' \
-        codex-plugin/hooks-plugin codex-plugin/install.sh | tar -xf - -C "$pkg_dir/"
+        codex-plugin/hooks-plugin codex-plugin/install.sh codex-plugin/.agents | tar -xf - -C "$pkg_dir/"
+
 
     # Include agent-sec-cli source for maturin wheel build
     # Exclude development artifacts (.venv, target, __pycache__, .egg-info, dist)

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -249,6 +249,11 @@ build_agent_sec_core() {
         --exclude='__pycache__' \
         hermes-plugin/src hermes-plugin/scripts | tar -xf - -C "$pkg_dir/"
 
+    # codex-plugin (hooks + install script, exclude __pycache__)
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='__pycache__' \
+        codex-plugin/hooks-plugin codex-plugin/install.sh | tar -xf - -C "$pkg_dir/"
+
     # Include agent-sec-cli source for maturin wheel build
     # Exclude development artifacts (.venv, target, __pycache__, .egg-info, dist)
     tar -cf - -C "${SEC_DIR}" \

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -195,6 +195,12 @@ build-hermes-plugin: ## Stage hermes-plugin Python sources to BUILD_DIR
 	cp -rp hermes-plugin/src/. $(BUILD_DIR)/hermes-plugin/src/
 	cp -rp hermes-plugin/scripts/. $(BUILD_DIR)/hermes-plugin/scripts/
 
+.PHONY: stage-codex-plugin
+stage-codex-plugin: ## Stage codex-plugin hooks and install script to BUILD_DIR
+	install -d -m 0755 $(BUILD_DIR)/codex-plugin
+	cp -rp codex-plugin/hooks-plugin/. $(BUILD_DIR)/codex-plugin/
+	cp -p codex-plugin/install.sh $(BUILD_DIR)/codex-plugin/
+
 .PHONY: stage-cosh-extension
 stage-cosh-extension: ## Stage cosh-extension hooks to BUILD_DIR
 	install -d -m 0755 $(BUILD_DIR)/cosh-extension
@@ -232,7 +238,7 @@ stage-component-manifest: ## Stage component.toml into BUILD_DIR
 		$(BUILD_DIR)/share/anolisa/components/sec-core/component.toml
 
 .PHONY: build-all
-build-all: build-sandbox build-cli build-openclaw-plugin build-hermes-plugin stage-cosh-extension stage-skills stage-adapter-manifest stage-component-manifest ## Build all components
+build-all: build-sandbox build-cli build-openclaw-plugin build-hermes-plugin stage-codex-plugin stage-cosh-extension stage-skills stage-adapter-manifest stage-component-manifest ## Build all components
 	@echo "📦 All artifacts collected to $(BUILD_DIR)/"
 
 .PHONY: export-requirements
@@ -292,6 +298,7 @@ WHEEL_DIR           ?= $(LIBDIR)/wheels
 CLI_STAGED_SITE     ?= $(BUILD_DIR)/site-packages
 CLI_PRIVATE_SITE    ?= /opt/agent-sec/lib/python3.11/site-packages
 RPM_OPENCLAW_PLUGIN_DIR ?= /opt/agent-sec/openclaw-plugin
+RPM_CODEX_PLUGIN_DIR  ?= /opt/agent-sec/codex-plugin
 RPM_HERMES_PLUGIN_DIR ?= /opt/agent-sec/hermes-plugin
 SYSTEMD_USER_UNIT_DIR ?= /usr/lib/systemd/user
 SYSTEMD_USER_UNIT_SOURCE ?= agent-sec-cli/config/systemd/agent-sec-core.service
@@ -367,6 +374,11 @@ install-hermes-plugin: ## Install hermes-plugin to target directory
 	cp -rp $(BUILD_DIR)/hermes-plugin/scripts/. $(DESTDIR)$(HERMES_PLUGIN_DIR)/scripts/
 	chmod 0755 $(DESTDIR)$(HERMES_PLUGIN_DIR)/scripts/*.sh
 
+.PHONY: install-codex-plugin
+install-codex-plugin: ## Install codex-plugin hooks to RPM target
+	install -d -m 0755 $(DESTDIR)$(RPM_CODEX_PLUGIN_DIR)
+	cp -rp $(BUILD_DIR)/codex-plugin/. $(DESTDIR)$(RPM_CODEX_PLUGIN_DIR)/
+
 .PHONY: install-cosh-hook
 install-cosh-hook: ## Install cosh hooks (linux-sandbox + extension)
 	install -d -m 0755 $(DESTDIR)$(BINDIR)
@@ -407,7 +419,7 @@ install-all: install-cli-venv install-cosh-hook install-openclaw-plugin install-
 .PHONY: install-all-for-rpmbuild
 install-all-for-rpmbuild: OPENCLAW_PLUGIN_DIR := $(RPM_OPENCLAW_PLUGIN_DIR)
 install-all-for-rpmbuild: HERMES_PLUGIN_DIR := $(RPM_HERMES_PLUGIN_DIR)
-install-all-for-rpmbuild: install-cli-site install-cosh-hook install-openclaw-plugin install-hermes-plugin install-skills install-adapter-manifest install-component-manifest install-systemd-user ## Install all (RPM build)
+install-all-for-rpmbuild: install-cli-site install-cosh-hook install-codex-plugin install-openclaw-plugin install-hermes-plugin install-skills install-adapter-manifest install-component-manifest install-systemd-user ## Install all (RPM build)
 
 # =============================================================================
 # UNINSTALL

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -200,6 +200,7 @@ stage-codex-plugin: ## Stage codex-plugin hooks and install script to BUILD_DIR
 	install -d -m 0755 $(BUILD_DIR)/codex-plugin
 	cp -rp codex-plugin/hooks-plugin/. $(BUILD_DIR)/codex-plugin/
 	cp -p codex-plugin/install.sh $(BUILD_DIR)/codex-plugin/
+	cp -rp codex-plugin/.agents $(BUILD_DIR)/codex-plugin/
 
 .PHONY: stage-cosh-extension
 stage-cosh-extension: ## Stage cosh-extension hooks to BUILD_DIR

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -49,6 +49,7 @@ BuildRequires:  systemd-rpm-macros
 # Metapackage: pull all subpackages
 Requires:       agent-sec-cli = %{version}-%{release}
 Requires:       agent-sec-cosh-hook = %{version}-%{release}
+Requires:       agent-sec-codex-hook = %{version}-%{release}
 Requires:       agent-sec-openclaw-hook = %{version}-%{release}
 Requires:       agent-sec-hermes-hook = %{version}-%{release}
 Requires:       agent-sec-skills = %{version}-%{release}
@@ -177,6 +178,24 @@ Includes skill-ledger, code-scanner, prompt-scanner and related skill definition
 %files -n agent-sec-skills
 %defattr(0644,root,root,0755)
 %{_datadir}/anolisa/skills/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 6: agent-sec-codex-hook
+# =============================================================================
+%package -n agent-sec-codex-hook
+Summary:        Codex plugin security hooks
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       python3 >= 3.11
+Requires:       python3 < 3.12
+
+%description -n agent-sec-codex-hook
+Codex security hooks providing code scanning, PII checking, prompt scanning
+and skill ledger verification for Codex agent.
+
+%files -n agent-sec-codex-hook
+%defattr(0644,root,root,0755)
+/opt/agent-sec/codex-plugin/
 %license LICENSE
 
 # =============================================================================

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -195,6 +195,7 @@ and skill ledger verification for Codex agent.
 
 %files -n agent-sec-codex-hook
 %defattr(0644,root,root,0755)
+%attr(0755,root,root) /opt/agent-sec/codex-plugin/install.sh
 /opt/agent-sec/codex-plugin/
 %license LICENSE
 


### PR DESCRIPTION
## Background

Follow-up to #1074. That PR added the codex-plugin source code; this PR extends the sec-core packaging configuration so codex-plugin is shipped in the RPM.

## Changes

- `src/agent-sec-core/Makefile`: add codex-plugin install target
- `src/agent-sec-core/agent-sec-core.spec.in`: include codex-plugin files in the manifest

## Status

Draft. Will attach the `sec-core-rpmbuild` workflow run link and RPM artifact once the build succeeds on the fork.

/cc @yangdao479