### PR TITLE
fix(ci): use RELEASE_TOKEN for GitHub release creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           COMPONENT="${{ needs.package.outputs.component }}"
           VERSION="${{ needs.package.outputs.version }}"


### PR DESCRIPTION
## Summary

Fix release workflow failure caused by `GITHUB_TOKEN` permission restriction.

**Root cause**: The default `GITHUB_TOKEN` is restricted by org-level policies and cannot access the Releases API (`HTTP 403: Resource not accessible by integration`), even with `contents: write` declared in the workflow permissions.

**Fix**: Switch to a dedicated `RELEASE_TOKEN` (Classic PAT with `repo` scope) stored in the `release` environment secret.

## Related

- Failed run: https://github.com/alibaba/anolisa/actions/runs/28155908200

## Checklist

- [x] `RELEASE_TOKEN` secret needs to be added to the `release` environment before merging
