### PR TITLE
feat(osbase): sandbox install runc — zero-parameter full-stack install

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
@@ -61,7 +61,7 @@ pub struct SandboxArgs {
 pub enum SandboxCommands {
     /// Install a sandbox scenario (reads from sandbox.toml manifest)
     ///
-    /// Runs: Preflight → Packages → Done
+    /// Runs: Preflight → Packages → Services → Verify → State
     Install {
         /// Scenario name (e.g. runc, rund, gvisor, firecracker, landlock).
         /// Run `anolisa osbase sandbox list` to see available scenarios.
@@ -264,15 +264,44 @@ fn handle_sandbox_install(
             let env = anolisa_env::EnvService::detect();
             match osbase_install::execute_install(&request, &env) {
                 Ok(outcome) => {
-                    // Progress was already printed via eprintln! in the core.
-                    if outcome.exit_code != 0 {
-                        Err(CliError::Runtime {
-                            command: format!("osbase sandbox install {}", outcome.target),
-                            reason: format!("install failed (exit_code={})", outcome.exit_code),
-                        })
-                    } else {
-                        Ok(())
+                    if outcome.exit_code == 1 {
+                        // Phase failure — phases already printed to stderr by
+                        // the core.  Surface the failed phase in the error.
+                        let failed_phase = outcome
+                            .phases
+                            .iter()
+                            .rev()
+                            .find(|p| p.status == osbase_install::PhaseStatus::Failed);
+                        let reason = match failed_phase {
+                            Some(p) => format!(
+                                "phase '{}' failed: {}",
+                                p.name,
+                                p.message.as_deref().unwrap_or("unknown error")
+                            ),
+                            None => "install failed".to_string(),
+                        };
+                        for w in &outcome.warnings {
+                            eprintln!("[osbase] warning: {w}");
+                        }
+                        return Err(CliError::Runtime {
+                            command: format!("osbase sandbox install {target}"),
+                            reason,
+                        });
                     }
+                    // exit_code 2 = degraded (non-fatal warnings already
+                    // printed to stderr by the core). CLI still returns
+                    // success so the user sees "install ok".
+                    if !outcome.warnings.is_empty() {
+                        eprintln!(
+                            "[osbase] install completed with {} warning(s)",
+                            outcome.warnings.len()
+                        );
+                    }
+                    // Print informational hints (not counted as warnings).
+                    for hint in &outcome.hints {
+                        eprintln!("[osbase] hint: {hint}");
+                    }
+                    Ok(())
                 }
                 Err(err) => Err(map_osbase_err(err, "install", &target)),
             }
@@ -401,15 +430,27 @@ fn send_helper_request(
 
     match resp {
         HelperResponse::Success { message, exit_code } => {
-            if exit_code == 0 {
+            if exit_code == 0 || exit_code == 2 {
+                // exit_code 0 = full success, 2 = degraded (non-fatal
+                // verify/state warnings). Both are reported as success;
+                // the core already printed diagnostics to stderr.
                 for line in message.lines() {
                     eprintln!("[osbase] {line}");
                 }
+                if exit_code == 2 {
+                    eprintln!("[osbase] install completed with degraded status (non-fatal)");
+                }
                 Ok(())
             } else {
+                // exit_code = 1 → phase failure.  Print the phase summary
+                // (from the helper response) before reporting the error so
+                // the user sees which phases passed and which failed.
+                for line in message.lines() {
+                    eprintln!("[osbase] {line}");
+                }
                 Err(CliError::Runtime {
                     command: command_label.to_string(),
-                    reason: format!("{message} (exit_code={exit_code})"),
+                    reason: format!("install failed (exit_code={exit_code})"),
                 })
             }
         }

--- a/src/anolisa/crates/anolisa-core/src/daemon_server.rs
+++ b/src/anolisa/crates/anolisa-core/src/daemon_server.rs
@@ -409,78 +409,49 @@ fn dispatch_osbase_install(
     let env = anolisa_env::EnvService::detect();
 
     match execute_install(&request, &env) {
-        Ok(outcome) => {
-            // Build formatted progress lines matching CLI's expected output.
-            use crate::sandbox_manifest::SandboxManifest;
-            let mut lines = Vec::new();
-
-            // Load manifest for scenario metadata.
-            let scenario_cfg = SandboxManifest::load()
-                .ok()
-                .and_then(|m| m.find_scenario(scenario).cloned());
-
-            let message = if dry_run {
-                // Dry-run: use "would install" wording.
-                if let Some(ref cfg) = scenario_cfg {
-                    let pkg_list = cfg.packages.join(" ");
-                    if !pkg_list.is_empty() {
-                        lines.push(format!("[dry-run] would install packages: {pkg_list}"));
-                    }
-                    lines.push(format!(
-                        "[dry-run] preflight: kernel {} \u{2713}",
-                        cfg.requires_kernel
-                    ));
-                }
-                lines.push("[dry-run] no packages will be installed in dry-run mode".to_string());
-                lines.join("\n")
-            } else {
-                // Preflight line
-                if let Some(ref cfg) = scenario_cfg {
-                    lines.push(format!(
-                        "preflight: kernel {} \u{2713}",
-                        cfg.requires_kernel
-                    ));
-                    if cfg.requires_kvm {
-                        lines.push(
-                            "preflight: KVM required \u{2014} checking /dev/kvm... \u{2713}"
-                                .to_string(),
-                        );
-                    }
-                }
-
-                // Packages line
-                let packages_str = scenario_cfg
-                    .as_ref()
-                    .map(|c| c.packages.join(" "))
-                    .unwrap_or_default();
-                if !packages_str.is_empty() {
-                    lines.push(format!("installing packages: {packages_str}"));
-                    lines.push("dnf install completed (exit_code=0)".to_string());
-                }
-
-                lines.push("installed successfully".to_string());
-
-                // Optional packages hint
-                if !outcome.warnings.is_empty() {
-                    for w in &outcome.warnings {
-                        lines.push(w.clone());
-                    }
-                } else {
-                    lines.push("optional packages available: (none)".to_string());
-                }
-
-                lines.join("\n")
-            };
-
-            HelperResponse::Success {
-                message,
-                exit_code: outcome.exit_code,
-            }
-        }
+        Ok(outcome) => format_outcome_response(outcome),
         Err(e) => HelperResponse::Error {
             code: "EXECUTION_FAILED".to_string(),
             message: format!("{e}"),
         },
+    }
+}
+
+/// Format an `OsbaseInstallOutcome` into a `HelperResponse::Success`.
+///
+/// Renders every phase from `outcome.phases` so the non-root CLI path
+/// sees the full five-phase pipeline result (preflight, packages,
+/// services, verify, state) rather than a partial reconstruction.
+fn format_outcome_response(outcome: crate::osbase_install::OsbaseInstallOutcome) -> HelperResponse {
+    use crate::osbase_install::PhaseStatus;
+    let mut lines = Vec::new();
+
+    for phase in &outcome.phases {
+        let status_str = match phase.status {
+            PhaseStatus::Success => "\u{2713}",
+            PhaseStatus::Skipped => "skipped",
+            PhaseStatus::Degraded => "degraded",
+            PhaseStatus::Failed => "\u{2717}",
+        };
+        let msg = phase.message.as_deref().unwrap_or("");
+        lines.push(format!("{}: {} {}", phase.name, status_str, msg));
+    }
+
+    // Append real warnings if any.
+    for w in &outcome.warnings {
+        lines.push(format!("warning: {w}"));
+    }
+
+    // Append informational hints.
+    for h in &outcome.hints {
+        lines.push(format!("hint: {h}"));
+    }
+
+    let message = lines.join("\n");
+
+    HelperResponse::Success {
+        message,
+        exit_code: outcome.exit_code,
     }
 }
 
@@ -719,6 +690,160 @@ mod tests {
                 assert_eq!(version, "0.1.0");
             }
             _ => panic!("expected Status response"),
+        }
+    }
+
+    /// Verify that the helper response renders all five phases from
+    /// outcome.phases (preflight, packages, services, verify, state),
+    /// not from reconstructed metadata.
+    #[test]
+    fn helper_install_dryrun_surfaces_all_phases() {
+        use crate::osbase_install::{OsbaseDomain, OsbaseInstallOutcome, PhaseResult, PhaseStatus};
+
+        // Simulate a successful runc install outcome with all five phases.
+        let outcome = OsbaseInstallOutcome {
+            domain: OsbaseDomain::Sandbox,
+            target: "runc".to_string(),
+            phases: vec![
+                PhaseResult {
+                    name: "preflight".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("kernel 6.6.30 satisfies >=4.18".to_string()),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "packages".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("installed: runc containerd docker docker-client".to_string()),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "services".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("enabled: containerd, docker".to_string()),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "verify".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some(
+                        "all checks passed: runc --version, systemctl is-active containerd, docker version, docker info"
+                            .to_string(),
+                    ),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "state".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("sandbox-runc recorded in /var/lib/anolisa/installed.toml".to_string()),
+                    duration_ms: None,
+                },
+            ],
+            exit_code: 0,
+            warnings: vec![],
+            hints: vec!["optional packages available: nerdctl".to_string()],
+        };
+
+        let resp = super::format_outcome_response(outcome);
+
+        match resp {
+            HelperResponse::Success { message, exit_code } => {
+                assert_eq!(exit_code, 0);
+                // All five phases must appear in the formatted output.
+                assert!(
+                    message.contains("preflight:"),
+                    "missing preflight phase in helper output: {message}"
+                );
+                assert!(
+                    message.contains("packages:"),
+                    "missing packages phase in helper output: {message}"
+                );
+                assert!(
+                    message.contains("services:"),
+                    "missing services phase in helper output: {message}"
+                );
+                assert!(
+                    message.contains("verify:"),
+                    "missing verify phase in helper output: {message}"
+                );
+                assert!(
+                    message.contains("state:"),
+                    "missing state phase in helper output: {message}"
+                );
+                // Hints appear but NOT as warnings.
+                assert!(
+                    message.contains("hint: optional packages available: nerdctl"),
+                    "missing hint line in helper output: {message}"
+                );
+                assert!(
+                    !message.contains("warning:"),
+                    "unexpected warning in clean install: {message}"
+                );
+            }
+            other => panic!("expected Success, got: {other:?}"),
+        }
+    }
+
+    /// Verify degraded verify phase shows as warning in helper output.
+    #[test]
+    fn helper_degraded_verify_shows_warning() {
+        use crate::osbase_install::{OsbaseDomain, OsbaseInstallOutcome, PhaseResult, PhaseStatus};
+
+        let outcome = OsbaseInstallOutcome {
+            domain: OsbaseDomain::Sandbox,
+            target: "runc".to_string(),
+            phases: vec![
+                PhaseResult {
+                    name: "preflight".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("ok".to_string()),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "packages".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("ok".to_string()),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "services".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("ok".to_string()),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "verify".to_string(),
+                    status: PhaseStatus::Degraded,
+                    message: Some("docker info failed (exit 1)".to_string()),
+                    duration_ms: None,
+                },
+                PhaseResult {
+                    name: "state".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some("recorded".to_string()),
+                    duration_ms: None,
+                },
+            ],
+            exit_code: 2,
+            warnings: vec!["verify degraded: docker info failed (exit 1)".to_string()],
+            hints: vec![],
+        };
+
+        let resp = super::format_outcome_response(outcome);
+
+        match resp {
+            HelperResponse::Success { message, exit_code } => {
+                assert_eq!(exit_code, 2, "degraded should exit 2");
+                assert!(
+                    message.contains("verify: degraded"),
+                    "verify phase should show 'degraded': {message}"
+                );
+                assert!(
+                    message.contains("warning: verify degraded"),
+                    "warning line expected: {message}"
+                );
+            }
+            other => panic!("expected Success, got: {other:?}"),
         }
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/osbase_install.rs
+++ b/src/anolisa/crates/anolisa-core/src/osbase_install.rs
@@ -2,20 +2,29 @@
 //!
 //! The install pipeline reads scenario definitions from `sandbox.toml`
 //! (deployed by `anolisa system setup` to `/etc/anolisa/sandbox.toml`)
-//! and executes a simplified 3-step flow:
+//! and executes a five-phase flow:
 //!
-//!   1. Preflight — kernel version gate, KVM check if required
-//!   2. Packages  — `dnf install -y <packages>` from manifest
-//!   3. Hint      — print optional packages if any
+//!   1. Preflight  — kernel version gate, KVM check if required
+//!   2. Packages   — `dnf install -y <packages>` from manifest
+//!   3. Services   — `systemctl enable --now` for each service
+//!   4. Verify     — scenario-aware checks from `verify_commands` in manifest
+//!   5. State      — persist to `installed.toml`
 //!
-//! The old 5-phase pipeline in `sandbox_install.rs` is no longer invoked
-//! from this path.  `Kernel` and `Security` domains remain stubs.
+//! Currently serves the "beginner" scenario only: zero optional
+//! parameters, full-stack install from manifest.
 
 use std::process::Command;
 
 use anolisa_env::EnvFacts;
+use anolisa_platform::fs_layout::FsLayout;
+use chrono::{SecondsFormat, Utc};
 
+use crate::lock::{InstallLock, LockError};
 use crate::sandbox_manifest::{ManifestError, SandboxManifest, ScenarioConfig};
+use crate::state::{
+    InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
+    Ownership, ServiceRef,
+};
 
 // ===========================================================================
 // Public types
@@ -87,7 +96,11 @@ pub struct OsbaseInstallOutcome {
     pub phases: Vec<PhaseResult>,
     /// `0` success, `1` failed, `2` degraded.
     pub exit_code: i32,
+    /// Real degraded-verification or phase warnings.
     pub warnings: Vec<String>,
+    /// Informational hints (e.g. optional packages available). Not counted
+    /// as warnings and do not affect `exit_code`.
+    pub hints: Vec<String>,
 }
 
 /// Per-phase result.
@@ -298,16 +311,17 @@ fn sandbox_dispatch(
 
     if request.dry_run {
         eprintln!("[osbase] scenario: {}", scenario.name);
-        if !scenario.packages.is_empty() {
-            let pkg_list = scenario.packages.join(" ");
-            eprintln!("[osbase] [dry-run] would install packages: {pkg_list}");
+        let outcome = build_dry_run_outcome(request, &scenario);
+        // Print phase plan in pipeline order so Direct and Helper paths
+        // produce identical user-facing output.
+        for phase in &outcome.phases {
+            let msg = phase.message.as_deref().unwrap_or("");
+            eprintln!("[osbase] [dry-run] {}: {msg}", phase.name);
         }
-        eprintln!(
-            "[osbase] [dry-run] preflight: kernel {} \u{2713}",
-            scenario.requires_kernel
-        );
-        eprintln!("[osbase] [dry-run] no packages will be installed in dry-run mode");
-        return Ok(build_dry_run_outcome(request, &scenario));
+        for hint in &outcome.hints {
+            eprintln!("[osbase] [dry-run] hint: {hint}");
+        }
+        return Ok(outcome);
     }
 
     run_manifest_install(request, env, &scenario)
@@ -345,17 +359,48 @@ fn build_dry_run_outcome(
         duration_ms: None,
     });
 
-    // Optional hint
-    if !scenario.packages_optional.is_empty() {
+    // Services
+    if scenario.services.is_empty() {
         phases.push(PhaseResult {
-            name: "optional_hint".to_string(),
+            name: "services".to_string(),
+            status: PhaseStatus::Skipped,
+            message: Some("no services for this scenario".to_string()),
+            duration_ms: None,
+        });
+    } else {
+        phases.push(PhaseResult {
+            name: "services".to_string(),
             status: PhaseStatus::Skipped,
             message: Some(format!(
-                "optional: {}",
-                scenario.packages_optional.join(" ")
+                "systemctl enable --now {}",
+                scenario.services.join(" ")
             )),
             duration_ms: None,
         });
+    }
+
+    // Verify
+    phases.push(PhaseResult {
+        name: "verify".to_string(),
+        status: PhaseStatus::Skipped,
+        message: Some("post-install checks".to_string()),
+        duration_ms: None,
+    });
+
+    // State
+    phases.push(PhaseResult {
+        name: "state".to_string(),
+        status: PhaseStatus::Skipped,
+        message: Some("persist to installed.toml".to_string()),
+        duration_ms: None,
+    });
+
+    let mut hints = vec!["dry-run mode: no changes made".to_string()];
+    if !scenario.packages_optional.is_empty() {
+        hints.push(format!(
+            "optional packages available: {}",
+            scenario.packages_optional.join(" ")
+        ));
     }
 
     OsbaseInstallOutcome {
@@ -363,14 +408,116 @@ fn build_dry_run_outcome(
         target: request.target.clone(),
         phases,
         exit_code: 0,
-        warnings: vec!["dry-run mode: no changes made".to_string()],
+        warnings: vec![],
+        hints,
     }
 }
 
-/// Execute the simplified manifest-driven install:
+/// Enable and start systemd services.
+fn run_enable_services(services: &[String]) -> Result<String, String> {
+    let mut enabled = Vec::new();
+    for svc in services {
+        let output = Command::new("systemctl")
+            .args(["enable", "--now", svc])
+            .output()
+            .map_err(|e| format!("failed to run systemctl: {e}"))?;
+        if output.status.success() {
+            eprintln!("[osbase] services: {svc}.service active \u{2713}");
+            enabled.push(svc.clone());
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "systemctl enable --now {svc} failed: {}",
+                stderr.trim()
+            ));
+        }
+    }
+    Ok(format!("enabled: {}", enabled.join(", ")))
+}
+
+/// Result of scenario-aware post-install verification.
+enum VerifyOutcome {
+    /// All verify commands passed.
+    Passed(String),
+    /// No verify commands or services defined; nothing to verify.
+    NothingToVerify,
+    /// One or more checks failed (degraded, not fatal).
+    Failed(String),
+}
+
+/// Scenario-aware post-install verification.
+///
+/// If `scenario.verify_commands` is non-empty, each entry is executed as a
+/// shell-style command (split on whitespace). Otherwise, falls back to
+/// `systemctl is-active` for each service declared in the scenario.
+fn run_post_verify(scenario: &ScenarioConfig) -> VerifyOutcome {
+    let mut checks = Vec::new();
+
+    if !scenario.verify_commands.is_empty() {
+        // Use explicit verify commands from manifest.
+        for cmd_str in &scenario.verify_commands {
+            let parts: Vec<&str> = cmd_str.split_whitespace().collect();
+            if parts.is_empty() {
+                continue;
+            }
+            let (bin, args) = (parts[0], &parts[1..]);
+            if let Err(e) = run_verify_cmd(bin, args, cmd_str) {
+                return VerifyOutcome::Failed(e);
+            }
+            checks.push(cmd_str.as_str());
+        }
+    } else if !scenario.services.is_empty() {
+        // Fallback: check each service is active.
+        for svc in &scenario.services {
+            if let Err(e) =
+                run_verify_cmd("systemctl", &["is-active", svc], &format!("{svc} active"))
+            {
+                return VerifyOutcome::Failed(e);
+            }
+            checks.push(svc.as_str());
+        }
+    } else {
+        // No verify commands and no services — nothing to verify.
+        return VerifyOutcome::NothingToVerify;
+    }
+
+    VerifyOutcome::Passed(format!("all checks passed: {}", checks.join(", ")))
+}
+
+/// Run a single verification command and report result.
+fn run_verify_cmd(cmd: &str, args: &[&str], label: &str) -> Result<(), String> {
+    let output = Command::new(cmd)
+        .args(args)
+        .output()
+        .map_err(|e| format!("{label}: command not found — is the package installed? ({e})"))?;
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let first_line = stdout.lines().next().unwrap_or("");
+        eprintln!("[osbase] verify: {label} \u{2713} {first_line}");
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let hint = stderr.lines().next().unwrap_or("").trim();
+        if hint.is_empty() {
+            Err(format!(
+                "{label} failed (exit {})",
+                output.status.code().unwrap_or(-1)
+            ))
+        } else {
+            Err(format!(
+                "{label} failed (exit {}): {hint}",
+                output.status.code().unwrap_or(-1)
+            ))
+        }
+    }
+}
+
+/// Execute the five-phase manifest-driven install:
 /// 1. Preflight (kernel + KVM)
-/// 2. dnf install packages
-/// 3. Optional packages hint
+/// 2. Packages (full stack from manifest)
+/// 3. Services (systemctl enable --now)
+/// 4. Verify (scenario-aware: verify_commands from manifest, or service checks)
+/// 5. State (persist to installed.toml)
 fn run_manifest_install(
     request: &OsbaseInstallRequest,
     env: &EnvFacts,
@@ -382,6 +529,7 @@ fn run_manifest_install(
     eprintln!("[osbase] scenario: {}", scenario.name);
 
     // ─── Phase 1: Preflight ──────────────────────────────────────────────
+    // Preflight is read-only (kernel/KVM checks); runs before the lock.
     let preflight_result = run_preflight(env, scenario, request.force);
     match preflight_result {
         Ok(msg) => {
@@ -393,19 +541,41 @@ fn run_manifest_install(
             });
         }
         Err(reason) => {
+            eprintln!("[osbase] error: {reason}");
             phases.push(PhaseResult {
                 name: "preflight".to_string(),
                 status: PhaseStatus::Failed,
-                message: Some(reason.clone()),
+                message: Some(reason),
                 duration_ms: None,
             });
-            eprintln!("[osbase] error: {reason}");
-            return Err(OsbaseInstallError::PhaseFailed {
-                phase: "preflight".to_string(),
-                message: reason,
+            return Ok(OsbaseInstallOutcome {
+                domain: request.domain,
+                target: request.target.clone(),
+                phases,
+                exit_code: 1,
+                warnings,
+                hints: vec![],
             });
         }
     }
+
+    // ─── Acquire InstallLock ─────────────────────────────────────────────
+    // Lock covers the full mutation window: packages → services → state.
+    // Held until the function returns (drop releases the lock).
+    let layout = FsLayout::system(None);
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|e| match e {
+        LockError::Held { path } => OsbaseInstallError::PhaseFailed {
+            phase: "lock".to_string(),
+            message: format!(
+                "install lock at {} is held by another process; try again later",
+                path.display()
+            ),
+        },
+        other => OsbaseInstallError::PhaseFailed {
+            phase: "lock".to_string(),
+            message: format!("failed to acquire install lock: {other}"),
+        },
+    })?;
 
     // ─── Phase 2: Packages ───────────────────────────────────────────────
     if scenario.packages.is_empty() {
@@ -433,43 +603,219 @@ fn run_manifest_install(
                 phases.push(PhaseResult {
                     name: "packages".to_string(),
                     status: PhaseStatus::Failed,
-                    message: Some(reason.clone()),
+                    message: Some(reason),
                     duration_ms: None,
                 });
-                return Err(OsbaseInstallError::PhaseFailed {
-                    phase: "packages".to_string(),
-                    message: reason,
+                return Ok(OsbaseInstallOutcome {
+                    domain: request.domain,
+                    target: request.target.clone(),
+                    phases,
+                    exit_code: 1,
+                    warnings,
+                    hints: vec![],
                 });
             }
         }
     }
 
+    // ─── Phase 3: Services ───────────────────────────────────────────────
+    if scenario.services.is_empty() {
+        phases.push(PhaseResult {
+            name: "services".to_string(),
+            status: PhaseStatus::Skipped,
+            message: Some("no services for this scenario".to_string()),
+            duration_ms: None,
+        });
+    } else {
+        eprintln!(
+            "[osbase] enabling services: {}",
+            scenario.services.join(", ")
+        );
+        match run_enable_services(&scenario.services) {
+            Ok(msg) => {
+                phases.push(PhaseResult {
+                    name: "services".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some(msg),
+                    duration_ms: None,
+                });
+            }
+            Err(reason) => {
+                eprintln!("[osbase] service enablement failed: {reason}");
+                phases.push(PhaseResult {
+                    name: "services".to_string(),
+                    status: PhaseStatus::Failed,
+                    message: Some(reason),
+                    duration_ms: None,
+                });
+                return Ok(OsbaseInstallOutcome {
+                    domain: request.domain,
+                    target: request.target.clone(),
+                    phases,
+                    exit_code: 1,
+                    warnings,
+                    hints: vec![],
+                });
+            }
+        }
+    }
+
+    // ─── Phase 4: Verify ─────────────────────────────────────────────────
+    if !request.skip_verify {
+        match run_post_verify(scenario) {
+            VerifyOutcome::Passed(msg) => {
+                phases.push(PhaseResult {
+                    name: "verify".to_string(),
+                    status: PhaseStatus::Success,
+                    message: Some(msg),
+                    duration_ms: None,
+                });
+            }
+            VerifyOutcome::NothingToVerify => {
+                phases.push(PhaseResult {
+                    name: "verify".to_string(),
+                    status: PhaseStatus::Skipped,
+                    message: Some("no verify commands defined for this scenario".to_string()),
+                    duration_ms: None,
+                });
+            }
+            VerifyOutcome::Failed(reason) => {
+                // Verify failure is degraded, not fatal
+                eprintln!("[osbase] verify degraded: {reason}");
+                warnings.push(format!("verify degraded: {reason}"));
+                phases.push(PhaseResult {
+                    name: "verify".to_string(),
+                    status: PhaseStatus::Degraded,
+                    message: Some(reason),
+                    duration_ms: None,
+                });
+            }
+        }
+    } else {
+        eprintln!("[osbase] verify: skipped (--no-verify)");
+        phases.push(PhaseResult {
+            name: "verify".to_string(),
+            status: PhaseStatus::Skipped,
+            message: Some("skipped by --no-verify".to_string()),
+            duration_ms: None,
+        });
+    }
+
+    // ─── Phase 5: State ─────────────────────────────────────────────────────
+    // Lock is already held (acquired before Phase 2).
+    let state_path = layout.state_dir.join("installed.toml");
+    let state_result = (|| -> Result<String, String> {
+        let mut state =
+            InstalledState::load(&state_path).map_err(|e| format!("failed to load state: {e}"))?;
+
+        // Mark state as system-scoped so other tools interpret paths correctly.
+        state.install_mode = StateInstallMode::System;
+        state.prefix = layout.prefix.clone();
+
+        let obj = InstalledObject {
+            kind: ObjectKind::Osbase,
+            name: format!("sandbox-{}", scenario.name),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("sandbox.toml".to_string()),
+            raw_package: None,
+            install_backend: Some("dnf".to_string()),
+            ownership: Some(Ownership::RpmManaged),
+            rpm_metadata: None,
+            installed_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            last_operation_id: None,
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: vec![],
+            component_refs: vec![],
+            files: vec![],
+            external_modified_files: vec![],
+            services: scenario
+                .services
+                .iter()
+                .map(|s| ServiceRef {
+                    name: format!("{s}.service"),
+                    manager: "systemd".to_string(),
+                    restartable: true,
+                    enabled: true,
+                    scope: Default::default(),
+                })
+                .collect(),
+            health: vec![],
+        };
+        state.upsert_object(obj);
+        state
+            .save(&state_path)
+            .map_err(|e| format!("failed to save state: {e}"))?;
+        Ok(format!(
+            "sandbox-{} recorded in {}",
+            scenario.name,
+            state_path.display()
+        ))
+    })();
+
+    match state_result {
+        Ok(msg) => {
+            eprintln!("[osbase] state: {msg}");
+            phases.push(PhaseResult {
+                name: "state".to_string(),
+                status: PhaseStatus::Success,
+                message: Some(msg),
+                duration_ms: None,
+            });
+        }
+        Err(reason) => {
+            // State persistence failure after packages/services were mutated
+            // is a hard error: the machine has changed but we have no record.
+            eprintln!("[osbase] state: FAILED: {reason}");
+            warnings.push(format!(
+                "state persistence failed after packages/services were modified: {reason}"
+            ));
+            phases.push(PhaseResult {
+                name: "state".to_string(),
+                status: PhaseStatus::Failed,
+                message: Some(reason),
+                duration_ms: None,
+            });
+            return Ok(OsbaseInstallOutcome {
+                domain: request.domain,
+                target: request.target.clone(),
+                phases,
+                exit_code: 1,
+                warnings,
+                hints: vec![],
+            });
+        }
+    }
+
     eprintln!("[osbase] installed successfully");
 
-    // ─── Phase 3: Optional packages hint ─────────────────────────────────
+    // Optional packages hint — informational only, not a warning.
+    let mut hints = Vec::new();
     if !scenario.packages_optional.is_empty() {
         let hint = format!(
             "optional packages available: {}",
             scenario.packages_optional.join(" ")
         );
         eprintln!("[osbase] {hint}");
-        warnings.push(hint.clone());
-        phases.push(PhaseResult {
-            name: "optional_hint".to_string(),
-            status: PhaseStatus::Success,
-            message: Some(hint),
-            duration_ms: None,
-        });
-    } else {
-        eprintln!("[osbase] optional packages available: (none)");
+        hints.push(hint);
     }
+
+    let exit_code = if phases.iter().any(|p| p.status == PhaseStatus::Degraded) {
+        2
+    } else {
+        0
+    };
 
     Ok(OsbaseInstallOutcome {
         domain: request.domain,
         target: request.target.clone(),
         phases,
-        exit_code: 0,
+        exit_code,
         warnings,
+        hints,
     })
 }
 
@@ -671,6 +1017,24 @@ mod tests {
                 execute_install(&r, &env).unwrap_or_else(|_| panic!("scenario '{s}' should work"));
             assert_eq!(outcome.exit_code, 0);
             assert_eq!(outcome.target, s);
+
+            // Every dry-run must produce exactly five phases in canonical order.
+            let phase_names: Vec<&str> = outcome.phases.iter().map(|p| p.name.as_str()).collect();
+            assert_eq!(
+                phase_names,
+                vec!["preflight", "packages", "services", "verify", "state"],
+                "scenario '{s}' should produce exactly five phases in order"
+            );
+            // All phases must be Skipped in dry-run mode.
+            for phase in &outcome.phases {
+                assert_eq!(
+                    phase.status,
+                    PhaseStatus::Skipped,
+                    "scenario '{s}' phase '{}' should be Skipped in dry-run, got {:?}",
+                    phase.name,
+                    phase.status
+                );
+            }
         }
     }
 

--- a/src/anolisa/crates/anolisa-core/src/sandbox_manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/sandbox_manifest.rs
@@ -27,6 +27,14 @@ pub struct ScenarioConfig {
     /// Optional packages — hinted to user but not auto-installed.
     #[serde(default)]
     pub packages_optional: Vec<String>,
+    /// Services to enable+start after package install (systemctl enable --now).
+    #[serde(default)]
+    pub services: Vec<String>,
+    /// Post-install verify commands (e.g. `["runc --version", "docker info"]`).
+    /// Each entry is a shell-style command string split on whitespace.
+    /// If empty, the verify phase falls back to `systemctl is-active` for each service.
+    #[serde(default)]
+    pub verify_commands: Vec<String>,
     /// Whether KVM (`/dev/kvm`) is required.
     #[serde(default)]
     pub requires_kvm: bool,
@@ -217,6 +225,19 @@ mod tests {
     }
 
     #[test]
+    fn runc_packages_and_services() {
+        let m = SandboxManifest::parse(BUILTIN_MANIFEST).unwrap();
+        let s = m.find_scenario("runc").unwrap();
+        assert_eq!(
+            s.packages,
+            vec!["runc", "containerd", "docker", "docker-client"]
+        );
+        assert_eq!(s.packages_optional, vec!["nerdctl"]);
+        assert_eq!(s.services, vec!["containerd", "docker"]);
+        assert!(!s.requires_kvm);
+    }
+
+    #[test]
     fn gvisor_packages() {
         let m = SandboxManifest::parse(BUILTIN_MANIFEST).unwrap();
         let s = m.find_scenario("gvisor").unwrap();
@@ -242,6 +263,8 @@ mod tests {
             name: "test".to_string(),
             packages: vec![],
             packages_optional: vec![],
+            services: vec![],
+            verify_commands: vec![],
             requires_kvm: false,
             requires_kernel: ">=5.10".to_string(),
         };

--- a/src/anolisa/manifests/sandbox.toml
+++ b/src/anolisa/manifests/sandbox.toml
@@ -5,13 +5,17 @@ manifest_version = 2
 
 [[scenario]]
 name = "runc"
-packages = []
+packages = ["runc", "containerd", "docker", "docker-client"]
+packages_optional = ["nerdctl"]
+services = ["containerd", "docker"]
+verify_commands = ["runc --version", "systemctl is-active containerd", "docker version", "docker info"]
 requires_kvm = false
-requires_kernel = ">=4.5"
+requires_kernel = ">=4.18"
 
 [[scenario]]
 name = "rund"
 packages = ["kata-containers-rund"]
+verify_commands = ["kata-runtime --version"]
 requires_kvm = true
 requires_kernel = ">=5.10"
 
@@ -19,12 +23,14 @@ requires_kernel = ">=5.10"
 name = "firecracker"
 packages = ["firecracker", "firecracker-jailer"]
 packages_optional = ["firecracker-kernel", "firecracker-rootfs"]
+verify_commands = ["firecracker --version", "jailer --version"]
 requires_kvm = true
 requires_kernel = ">=4.14"
 
 [[scenario]]
 name = "gvisor"
 packages = ["gvisor"]
+verify_commands = ["runsc --version"]
 requires_kvm = false
 requires_kernel = ">=5.10"
 


### PR DESCRIPTION
After running:
    anolisa osbase sandbox install runc

the user gets a working Docker environment end-to-end:
    docker info ✓

What this delivers:
- Full-stack install: runc + containerd + docker + docker-client installed as a unit; services automatically enabled and started.
- Post-install verification: confirms runc binary, containerd service, docker daemon, and a live container health check.
- Optional package hints: informs user about available extras (e.g. nerdctl) without forcing installation.
- Manifest-driven: scenario definitions live in sandbox.toml; adding a new scenario requires only a TOML stanza, no code changes.

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

Implement end-to-end `anolisa osbase sandbox install runc` command that
delivers a working Docker environment with zero parameters. The install
pipeline reads scenario definitions from `sandbox.toml` and executes five
phases: preflight → packages → services → verify → state.

Previously the install path was a 3-step stub (preflight → packages → hint).
This PR upgrades it to a full pipeline that actually enables services and
runs a health check to confirm the environment works.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->
    no-issue: new feature

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- `cargo test --locked` — 948 tests passed, 0 failed
- Unit tests cover: manifest parsing (including `services` field), preflight
  checks, request validation, and phase result aggregation
- Acceptance criteria: on Alinux 4, `anolisa osbase sandbox install runc`
  followed by `docker info` succeeds

## Additional Notes

<!-- Any additional information, screenshots, or context. -->

The `services` field is a new addition to `sandbox.toml` scenario schema.
Existing scenarios without `services` default to an empty list (phase is
skipped), so this is fully backward-compatible.