### PR TITLE
fix(anolisa): use bare component name for rpm package default

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -246,7 +246,7 @@ mod tests {
             install_backend: Some(if is_rpm { "rpm" } else { "raw" }.to_string()),
             ownership: Some(ownership),
             rpm_metadata: is_rpm.then(|| RpmMetadata {
-                package_name: format!("anolisa-{name}"),
+                package_name: name.to_string(),
                 evr: Some("1.0.0-1.al8".to_string()),
                 arch: Some("x86_64".to_string()),
                 source_repo: Some("@System".to_string()),
@@ -296,10 +296,10 @@ mod tests {
         seed(&c, Vec::new());
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
         adopt_with_query("copilot-shell", None, &c, &q).expect("adopt ok");
@@ -311,7 +311,7 @@ mod tests {
         assert_eq!(obj.effective_ownership(), Ownership::RpmObserved);
         assert_eq!(obj.status, ObjectStatus::Adopted);
         let meta = obj.rpm_metadata.as_ref().expect("rpm metadata");
-        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+        assert_eq!(meta.package_name, "copilot-shell");
         assert_eq!(meta.evr.as_deref(), Some("2.2.0-1.al8"));
         assert!(
             after
@@ -338,8 +338,8 @@ mod tests {
         );
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.0.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.0.0", Some("1.al8"), "x86_64"),
             )],
             ..Default::default()
         };
@@ -373,7 +373,7 @@ mod tests {
                 ObjectStatus::Adopted,
             )],
         );
-        // Existing observed package is `anolisa-copilot-shell`; the user pins a
+        // Existing observed package is `copilot-shell`; the user pins a
         // different installed package via --package.
         let q = FakeQuery {
             installed: vec![(
@@ -387,7 +387,7 @@ mod tests {
 
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
-            err.reason().contains("anolisa-copilot-shell")
+            err.reason().contains("copilot-shell")
                 && err.reason().contains("anolisa-other")
                 && err.reason().contains("forget"),
             "refusal must name both packages and point at forget: {}",
@@ -401,7 +401,7 @@ mod tests {
             .clone()
             .expect("rpm metadata");
         assert_eq!(
-            meta.package_name, "anolisa-copilot-shell",
+            meta.package_name, "copilot-shell",
             "package identity must be preserved when the repoint is refused",
         );
         assert_eq!(meta.evr.as_deref(), Some("1.0.0-1.al8"), "EVR unchanged");
@@ -434,7 +434,7 @@ mod tests {
 
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
-            err.reason().contains("anolisa-copilot-shell")
+            err.reason().contains("copilot-shell")
                 && err.reason().contains("anolisa-other")
                 && err.reason().contains("forget"),
             "dry-run refusal must match the real run: {}",
@@ -447,7 +447,7 @@ mod tests {
             .rpm_metadata
             .clone()
             .expect("rpm metadata");
-        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+        assert_eq!(meta.package_name, "copilot-shell");
     }
 
     /// A raw-managed component is not silently downgraded; adopt points at
@@ -556,10 +556,10 @@ mod tests {
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
-            multi_version: vec!["anolisa-copilot-shell".to_string()],
+            multi_version: vec!["copilot-shell".to_string()],
             ..Default::default()
         };
         let err = adopt_with_query("copilot-shell", None, &c, &q)
@@ -575,8 +575,8 @@ mod tests {
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
             ..Default::default()
         };

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -422,7 +422,7 @@ mod tests {
             &c,
             vec![rpm_observed_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
             )],
             Vec::new(),
@@ -484,7 +484,7 @@ mod tests {
             &c,
             vec![rpm_observed_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
             )],
             vec![sample_claim("copilot-shell", "openclaw")],
@@ -524,7 +524,7 @@ mod tests {
             &c,
             vec![rpm_observed_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
             )],
             vec![sample_claim("copilot-shell", "openclaw")],
@@ -554,7 +554,7 @@ mod tests {
             &c,
             vec![rpm_observed_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
             )],
             Vec::new(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -667,7 +667,7 @@ pub(crate) fn probe_rpm_situation(
     let package = candidates
         .into_iter()
         .next()
-        .unwrap_or_else(|| format!("anolisa-{component}"));
+        .unwrap_or_else(|| component.to_string());
 
     match query.query_installed(&package) {
         Ok(Some(info)) => Ok(RpmSituation::Adoptable { package, info }),
@@ -682,11 +682,13 @@ pub(crate) fn probe_rpm_situation(
 
 /// Resolve candidate RPM package names for `component`, highest precedence
 /// first (§5): CLI `--package` > manifest `[backends.rpm].package` > repo.toml
-/// `package_map` > RPM `provides` reverse-lookup > default `anolisa-<name>`.
+/// `package_map` > RPM `provides` reverse-lookup > the bare component name.
 ///
 /// The first four levels short-circuit to a single candidate; only the
-/// `provides` level can yield several (the ambiguous case, §5.5). The default
-/// name backfills whenever `provides` is empty, so the result is never empty.
+/// `provides` level can yield several (the ambiguous case, §5.5). The bare
+/// component name backfills whenever `provides` is empty, so the result is
+/// never empty. The component name matches the RPM spec `Name:` (e.g.
+/// `tokenless`), which carries no `anolisa-` prefix.
 ///
 /// # Errors
 /// Propagates a hard [`PackageQueryError`] from the `provides` query; an empty
@@ -715,7 +717,10 @@ pub(crate) fn rpm_package_candidates(
     if !provides.is_empty() {
         return Ok(provides);
     }
-    Ok(vec![format!("anolisa-{component}")])
+    // Default to the bare component name: it matches the published RPM spec
+    // `Name:` (no `anolisa-` prefix) and mirrors the raw backend's default in
+    // `RepoConfig::package_name`.
+    Ok(vec![component.to_string()])
 }
 
 /// Best-effort lookup of a component's manifest from the bundled catalog, for
@@ -5552,7 +5557,7 @@ scope = "@anolisa"
             &self,
             _capability: &str,
         ) -> Result<Vec<String>, PackageQueryError> {
-            // Default-naming path: the probe falls through to `anolisa-<name>`.
+            // Default-naming path: the probe falls through to the bare component name.
             Ok(Vec::new())
         }
     }
@@ -5736,12 +5741,12 @@ scope = "@anolisa"
         let q = FakeQuery {
             provides: vec![(
                 "anolisa-component(copilot-shell)".to_string(),
-                vec!["anolisa-copilot-shell".to_string()],
+                vec!["copilot-shell".to_string()],
             )],
             ..Default::default()
         };
         let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["anolisa-copilot-shell".to_string()]);
+        assert_eq!(got, vec!["copilot-shell".to_string()]);
     }
 
     #[test]
@@ -5761,7 +5766,7 @@ scope = "@anolisa"
     fn candidates_falls_back_to_default_naming() {
         let q = FakeQuery::default();
         let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["anolisa-copilot-shell".to_string()]);
+        assert_eq!(got, vec!["copilot-shell".to_string()]);
     }
 
     // ── §5/§7.1 situation probe ──
@@ -5772,8 +5777,8 @@ scope = "@anolisa"
         let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
             ..Default::default()
         };
@@ -5788,7 +5793,7 @@ scope = "@anolisa"
         .expect("probe");
         match situation {
             RpmSituation::Adoptable { package, info } => {
-                assert_eq!(package, "anolisa-copilot-shell");
+                assert_eq!(package, "copilot-shell");
                 assert_eq!(info.version.to_string(), "2.3.0-1.al8");
             }
             other => panic!(
@@ -5843,7 +5848,7 @@ scope = "@anolisa"
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
         let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
         let q = FakeQuery {
-            multi_version: vec!["anolisa-copilot-shell".to_string()],
+            multi_version: vec!["copilot-shell".to_string()],
             ..Default::default()
         };
         let situation = probe_rpm_situation(
@@ -5874,10 +5879,10 @@ scope = "@anolisa"
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
         let outcome =
@@ -5897,7 +5902,7 @@ scope = "@anolisa"
         assert!(obj.files.is_empty(), "RPM-owned files stay out of state");
         assert_eq!(obj.version, "2.3.0-1.al8");
         let meta = obj.rpm_metadata.as_ref().expect("rpm metadata");
-        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+        assert_eq!(meta.package_name, "copilot-shell");
         assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
         assert_eq!(meta.arch.as_deref(), Some("x86_64"));
         assert_eq!(meta.source_repo.as_deref(), Some("@System"));
@@ -5908,8 +5913,8 @@ scope = "@anolisa"
         let (_tmp, ctx) = system_ctx_with_raw_repo(true);
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
             ..Default::default()
         };
@@ -5946,7 +5951,7 @@ scope = "@anolisa"
             install_backend: Some("rpm".to_string()),
             ownership: Some(Ownership::RpmObserved),
             rpm_metadata: Some(RpmMetadata {
-                package_name: "anolisa-copilot-shell".to_string(),
+                package_name: "copilot-shell".to_string(),
                 evr: Some("2.2.0-1.al8".to_string()),
                 arch: Some("x86_64".to_string()),
                 source_repo: Some("@System".to_string()),
@@ -5974,10 +5979,10 @@ scope = "@anolisa"
         // rpmdb now reports a newer EVR.
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
         // No --backend: existing rpm-observed state must route to adopt-refresh,
@@ -6046,8 +6051,8 @@ scope = "@anolisa"
             &layout,
             "install copilot-shell",
             "copilot-shell",
-            "anolisa-copilot-shell".to_string(),
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell".to_string(),
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             &q,
         )
         .expect_err("must refuse to clobber a concurrent raw install");
@@ -6119,7 +6124,7 @@ scope = "@anolisa"
             install_backend: Some("rpm".to_string()),
             ownership: Some(Ownership::RpmManaged),
             rpm_metadata: Some(RpmMetadata {
-                package_name: "anolisa-copilot-shell".to_string(),
+                package_name: "copilot-shell".to_string(),
                 evr: Some("2.3.0-1.al8".to_string()),
                 arch: Some("x86_64".to_string()),
                 source_repo: Some("alinux-updates".to_string()),
@@ -6146,8 +6151,8 @@ scope = "@anolisa"
             &layout,
             "adopt copilot-shell",
             "copilot-shell",
-            "anolisa-copilot-shell".to_string(),
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell".to_string(),
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             &q,
         )
         .expect_err("must refuse to downgrade an rpm-managed component");
@@ -6187,7 +6192,7 @@ scope = "@anolisa"
             install_backend: Some("rpm".to_string()),
             ownership: Some(Ownership::RpmManaged),
             rpm_metadata: Some(RpmMetadata {
-                package_name: "anolisa-copilot-shell".to_string(),
+                package_name: "copilot-shell".to_string(),
                 evr: Some("2.3.0-1.al8".to_string()),
                 arch: Some("x86_64".to_string()),
                 source_repo: Some("alinux-updates".to_string()),
@@ -6211,8 +6216,8 @@ scope = "@anolisa"
         // rpmdb still has the package, so the re-probe yields Adoptable.
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
             ..Default::default()
         };
@@ -6243,8 +6248,8 @@ scope = "@anolisa"
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
             origin_fails: true,
             ..Default::default()
@@ -6275,8 +6280,8 @@ scope = "@anolisa"
     fn delegated_install_writes_rpm_managed_state() {
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
         let fake = FakeInstaller::new(
-            "anolisa-copilot-shell",
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
         )
         .with_origin("anolisa");
         let exec = RpmExec {
@@ -6304,7 +6309,7 @@ scope = "@anolisa"
         assert!(obj.files.is_empty(), "dnf-owned files stay out of state");
         assert_eq!(obj.version, "2.3.0-1.al8");
         let meta = obj.rpm_metadata.as_ref().expect("rpm metadata");
-        assert_eq!(meta.package_name, "anolisa-copilot-shell");
+        assert_eq!(meta.package_name, "copilot-shell");
         assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
         assert_eq!(meta.arch.as_deref(), Some("x86_64"));
         assert_eq!(meta.source_repo.as_deref(), Some("anolisa"));
@@ -6317,8 +6322,8 @@ scope = "@anolisa"
     fn delegated_install_non_root_is_refused() {
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
         let fake = FakeInstaller::new(
-            "anolisa-copilot-shell",
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
         );
         let exec = RpmExec {
             query: &fake,
@@ -6351,8 +6356,8 @@ scope = "@anolisa"
     fn delegated_install_dry_run_previews_without_txn_or_state() {
         let (_tmp, ctx) = system_ctx_with_raw_repo(true);
         let fake = FakeInstaller::new(
-            "anolisa-copilot-shell",
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
         );
         let exec = RpmExec {
             query: &fake,
@@ -6379,8 +6384,8 @@ scope = "@anolisa"
     fn delegated_install_dnf_failure_surfaces() {
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
         let fake = FakeInstaller::new(
-            "anolisa-copilot-shell",
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
         )
         .failing_install();
         let exec = RpmExec {
@@ -6560,8 +6565,8 @@ scope = "@anolisa"
 
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
             ..Default::default()
         };
@@ -6601,10 +6606,10 @@ scope = "@anolisa"
 
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
         let outcome =
@@ -6631,10 +6636,10 @@ scope = "@anolisa"
 
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
         let outcome =
@@ -6659,8 +6664,8 @@ scope = "@anolisa"
         seed_datadir_contract(&layout, "copilot-shell", &contract);
 
         let fake = FakeInstaller::new(
-            "anolisa-copilot-shell",
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
         )
         .with_origin("anolisa");
         let exec = RpmExec {
@@ -6693,8 +6698,8 @@ scope = "@anolisa"
         // No datadir contract seeded.
 
         let fake = FakeInstaller::new(
-            "anolisa-copilot-shell",
-            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
         )
         .with_origin("anolisa");
         let exec = RpmExec {
@@ -6738,10 +6743,10 @@ scope = "@anolisa"
 
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
         let outcome =
@@ -6788,10 +6793,10 @@ scope = "@anolisa"
 
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
         let outcome =

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -291,7 +291,7 @@ mod tests {
                     "status": "available",
                     "backends": [
                         {"type": "oss", "url": "https://example.com/agentsight.tar.gz", "sha256": "abc"},
-                        {"type": "rpm", "repo_url": "https://repo.example.com", "package": "anolisa-agentsight"}
+                        {"type": "rpm", "repo_url": "https://repo.example.com", "package": "agentsight"}
                     ],
                     "platforms": [{"os": "linux", "arch": "x86_64", "distros": ["alinux3"]}],
                     "tags": ["agent", "trace"]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -701,7 +701,7 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
@@ -709,13 +709,8 @@ mod tests {
         );
         // rpmdb has moved on to 2.3.0 via a manual dnf update.
         let rpm = FakeQuery::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.3.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
         )
         .with_origin("alinux-updates");
 
@@ -750,20 +745,15 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmManaged,
                 ObjectStatus::Installed,
             ),
         );
         let rpm = FakeQuery::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.3.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
         );
         repair_with_query("copilot-shell", &c, &rpm).expect("repair ok");
 
@@ -790,7 +780,7 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
@@ -798,13 +788,8 @@ mod tests {
         );
         // No origin configured on the fake -> installed_origin yields None.
         let rpm = FakeQuery::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.3.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
         );
         repair_with_query("copilot-shell", &c, &rpm).expect("repair ok");
         let obj = load_state(&c)
@@ -827,13 +812,13 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
-        let rpm = FakeQuery::new("anolisa-copilot-shell", None);
+        let rpm = FakeQuery::new("copilot-shell", None);
         let err =
             repair_with_query("copilot-shell", &c, &rpm).expect_err("removed package must error");
         assert_eq!(err.code(), "EXECUTION_FAILED");
@@ -861,20 +846,15 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmManaged,
                 ObjectStatus::Installed,
             ),
         );
         let rpm = FakeQuery::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         )
         .multi_version();
         let err =
@@ -893,13 +873,13 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
-        let rpm = FakeQuery::new("anolisa-copilot-shell", None).command_missing();
+        let rpm = FakeQuery::new("copilot-shell", None).command_missing();
         let err =
             repair_with_query("copilot-shell", &c, &rpm).expect_err("missing tooling must error");
         assert_eq!(err.code(), "EXECUTION_FAILED");
@@ -914,7 +894,7 @@ mod tests {
         // this test uses system mode to keep the seeded state under `tmp`.
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         seed(&c, raw_object("copilot-shell", "9.9.9"));
-        let rpm = FakeQuery::new("anolisa-copilot-shell", None);
+        let rpm = FakeQuery::new("copilot-shell", None);
         let err = repair_with_query("copilot-shell", &c, &rpm)
             .expect_err("raw repair is not implemented");
         assert_eq!(err.code(), "NOT_IMPLEMENTED");
@@ -925,7 +905,7 @@ mod tests {
     fn repair_unknown_component_routes_to_invalid_argument() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
-        let rpm = FakeQuery::new("anolisa-copilot-shell", None);
+        let rpm = FakeQuery::new("copilot-shell", None);
         let err =
             repair_with_query("copilot-shell", &c, &rpm).expect_err("absent component must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
@@ -942,20 +922,15 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeQuery::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.3.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
         );
         repair_with_query("copilot-shell", &c, &rpm).expect("dry-run ok");
         assert_eq!(
@@ -978,20 +953,15 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.3.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeQuery::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.3.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
         );
         repair_with_query("copilot-shell", &c, &rpm).expect("repair ok");
         let obj = load_state(&c)
@@ -1018,15 +988,11 @@ mod tests {
         );
         obj.rpm_metadata = None;
         seed(&c, obj);
-        // Candidate chain falls through to the default `anolisa-<component>`.
+        // No recorded package_name, so the candidate chain falls through to the
+        // bare component name `<component>`.
         let rpm = FakeQuery::new(
-            "anolisa-legacy-rpm",
-            Some(pkg_info(
-                "anolisa-legacy-rpm",
-                "1.0.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "legacy-rpm",
+            Some(pkg_info("legacy-rpm", "1.0.0", Some("1.al8"), "x86_64")),
         )
         .with_origin("@System");
         repair_with_query("legacy-rpm", &c, &rpm).expect("repair ok");
@@ -1035,7 +1001,7 @@ mod tests {
             .cloned()
             .expect("present");
         let meta = obj.rpm_metadata.expect("metadata backfilled");
-        assert_eq!(meta.package_name, "anolisa-legacy-rpm");
+        assert_eq!(meta.package_name, "legacy-rpm");
         assert_eq!(meta.evr.as_deref(), Some("1.0.0-1.al8"));
         assert_eq!(obj.version, "1.0.0-1.al8");
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -2409,7 +2409,7 @@ mod tests {
         let mut obs_state = InstalledState::default();
         obs_state.upsert_object(rpm_observed_object(
             "copilot-shell",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             "2.3.0-1.al8",
         ));
         let obs = select_components(
@@ -2421,7 +2421,7 @@ mod tests {
             None,
         );
         assert_eq!(obs[0].status, "adopted", "rpm-observed must not escalate");
-        assert_eq!(obs[0].rpm_package.as_deref(), Some("anolisa-copilot-shell"));
+        assert_eq!(obs[0].rpm_package.as_deref(), Some("copilot-shell"));
         assert_eq!(obs[0].rpm_evr.as_deref(), Some("2.3.0-1.al8"));
         assert_eq!(obs[0].rpm_source_repo.as_deref(), Some("@System"));
     }
@@ -2470,14 +2470,14 @@ mod tests {
     fn observed_record_reports_installed_default_name() {
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", "1.al8"),
             )],
-            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            origins: vec![("copilot-shell".to_string(), "@System".to_string())],
         };
         let rec = observed_record("copilot-shell", None, None, &q).expect("observed");
         assert_eq!(rec.status, "observed");
-        assert_eq!(rec.rpm_package.as_deref(), Some("anolisa-copilot-shell"));
+        assert_eq!(rec.rpm_package.as_deref(), Some("copilot-shell"));
         assert_eq!(rec.rpm_evr.as_deref(), Some("2.3.0-1.al8"));
         assert_eq!(rec.rpm_source_repo.as_deref(), Some("@System"));
         assert_eq!(rec.version.as_deref(), Some("2.3.0-1.al8"));
@@ -2547,11 +2547,11 @@ mod tests {
     /// rpmdb EVR matching the recorded one is not drift.
     #[test]
     fn probe_rpm_drift_none_when_evr_matches() {
-        let meta = rpm_meta("anolisa-copilot-shell", "2.3.0-1.al8");
+        let meta = rpm_meta("copilot-shell", "2.3.0-1.al8");
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", "1.al8"),
             )],
             origins: Vec::new(),
         };
@@ -2561,11 +2561,11 @@ mod tests {
     /// A newer rpmdb EVR than recorded (manual `dnf update`) is drift.
     #[test]
     fn probe_rpm_drift_detects_evr_mismatch() {
-        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let meta = rpm_meta("copilot-shell", "2.2.0-1.al8");
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", "1.al8"),
             )],
             origins: Vec::new(),
         };
@@ -2578,7 +2578,7 @@ mod tests {
     /// The package gone from rpmdb (manual `rpm -e`) is Missing.
     #[test]
     fn probe_rpm_drift_detects_missing() {
-        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let meta = rpm_meta("copilot-shell", "2.2.0-1.al8");
         let q = FakeQuery::default();
         assert!(matches!(
             probe_rpm_drift(&meta, &q),
@@ -2589,7 +2589,7 @@ mod tests {
     /// A same-name multi-version rpmdb is surfaced as drift, not a silent pass.
     #[test]
     fn probe_rpm_drift_multi_version_is_drifted() {
-        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let meta = rpm_meta("copilot-shell", "2.2.0-1.al8");
         let q = ErrQuery(PackageQueryError::UnexpectedOutput {
             command: "rpm".to_string(),
             detail: "2 installed versions".to_string(),
@@ -2603,7 +2603,7 @@ mod tests {
     /// Missing rpm/dnf tooling cannot prove drift; the recorded status stands.
     #[test]
     fn probe_rpm_drift_tooling_missing_keeps_status() {
-        let meta = rpm_meta("anolisa-copilot-shell", "2.2.0-1.al8");
+        let meta = rpm_meta("copilot-shell", "2.2.0-1.al8");
         let q = ErrQuery(PackageQueryError::CommandMissing {
             command: "rpm".to_string(),
         });
@@ -2617,7 +2617,7 @@ mod tests {
         let mut state = InstalledState::default();
         state.upsert_object(rpm_observed_object(
             "copilot-shell",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             "2.2.0-1.al8",
         ));
         let mut records = select_components(
@@ -2632,8 +2632,8 @@ mod tests {
 
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", "1.al8"),
             )],
             origins: Vec::new(),
         };
@@ -2655,7 +2655,7 @@ mod tests {
         let mut state = InstalledState::default();
         state.upsert_object(rpm_observed_object(
             "copilot-shell",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             "2.2.0-1.al8",
         ));
         let mut records = select_components(
@@ -2712,7 +2712,7 @@ mod tests {
         let mut state = InstalledState::default();
         state.upsert_object(rpm_observed_object(
             "copilot-shell",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             "2.2.0-1.al8",
         ));
         // A record whose live projection already escalated past `installed`.
@@ -2732,8 +2732,8 @@ mod tests {
         // rpmdb has drifted, but the failed status must survive untouched.
         let q = FakeQuery {
             installed: vec![(
-                "anolisa-copilot-shell".to_string(),
-                pkg_info("anolisa-copilot-shell", "2.3.0", "1.al8"),
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", "1.al8"),
             )],
             origins: Vec::new(),
         };

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1755,13 +1755,13 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
         let snapshot_dir = seed_manifest_snapshot(&c, "copilot-shell");
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         run(args("copilot-shell", false), &c, &rpm, true).expect("uninstall ok");
 
         assert_eq!(
@@ -1804,12 +1804,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         run(args_rm("copilot-shell"), &c, &rpm, true).expect("uninstall ok");
 
         assert_eq!(
@@ -1844,12 +1844,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         let err = run(args_rm("copilot-shell"), &c, &rpm, false).expect_err("must refuse");
 
         assert_eq!(err.code(), "EXECUTION_FAILED");
@@ -1882,12 +1882,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmManaged,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         run(args("copilot-shell", false), &c, &rpm, true).expect("uninstall ok");
 
         assert_eq!(
@@ -1967,13 +1967,13 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
         let snapshot_dir = seed_manifest_snapshot(&c, "copilot-shell");
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         run(args_rm("copilot-shell"), &c, &rpm, true).expect("dry-run ok");
 
         assert_eq!(rpm.remove_calls.get(), 0, "dry-run must not run dnf");
@@ -2004,12 +2004,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::absent("anolisa-copilot-shell");
+        let rpm = FakeRpm::absent("copilot-shell");
         run(args_rm("copilot-shell"), &c, &rpm, true).expect("uninstall ok");
 
         assert_eq!(
@@ -2040,12 +2040,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell").failing();
+        let rpm = FakeRpm::present("copilot-shell").failing();
         let err =
             run(args_rm("copilot-shell"), &c, &rpm, true).expect_err("dnf failure must surface");
 
@@ -2080,12 +2080,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmManaged,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell").tooling_missing();
+        let rpm = FakeRpm::present("copilot-shell").tooling_missing();
         let err = run(args_rm("copilot-shell"), &c, &rpm, true)
             .expect_err("missing rpm tooling must surface");
 
@@ -2124,12 +2124,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell").tooling_missing();
+        let rpm = FakeRpm::present("copilot-shell").tooling_missing();
         let err = run(args_rm("copilot-shell"), &c, &rpm, true)
             .expect_err("missing rpm tooling must surface");
 
@@ -2159,12 +2159,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmManaged,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell").remove_tooling_missing();
+        let rpm = FakeRpm::present("copilot-shell").remove_tooling_missing();
         let err = run(args("copilot-shell", false), &c, &rpm, true)
             .expect_err("missing dnf must surface");
 
@@ -2273,12 +2273,12 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             vec![sample_claim("copilot-shell", "openclaw")],
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         let err = run(args_rm("copilot-shell"), &c, &rpm, true).expect_err("adapter must block");
 
         assert_eq!(err.code(), "INVALID_ARGUMENT");
@@ -2316,15 +2316,15 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             vec![sample_claim("copilot-shell", "openclaw")],
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         let err = uninstall_rpm_component(
             "copilot-shell",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             Ownership::RpmObserved,
             true,
             &c,
@@ -2367,15 +2367,15 @@ mod tests {
             &c,
             vec![rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 Ownership::RpmObserved,
             )],
             Vec::new(),
         );
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         uninstall_rpm_component(
             "copilot-shell",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             Ownership::RpmManaged, // stale pre-lock read; the on-disk state is observed
             false,                 // no --remove-system-package
             &c,
@@ -2410,14 +2410,10 @@ mod tests {
             InstallMode::System,
             Some(tmp.path().to_path_buf()),
         );
-        let mut obj = rpm_object(
-            "copilot-shell",
-            "anolisa-copilot-shell",
-            Ownership::RpmObserved,
-        );
+        let mut obj = rpm_object("copilot-shell", "copilot-shell", Ownership::RpmObserved);
         obj.rpm_metadata = None;
         seed(&c, vec![obj], Vec::new());
-        let rpm = FakeRpm::present("anolisa-copilot-shell");
+        let rpm = FakeRpm::present("copilot-shell");
         let err = run(args("copilot-shell", false), &c, &rpm, true).expect_err("must refuse");
 
         assert_eq!(err.code(), "EXECUTION_FAILED");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -2071,27 +2071,17 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         )
-        .upgrading_to(pkg_info(
-            "anolisa-copilot-shell",
-            "2.3.0",
-            Some("1.al8"),
-            "x86_64",
-        ));
+        .upgrading_to(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"));
 
         update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true).expect("update ok");
         assert_eq!(rpm.update_calls.get(), 1, "dnf update must run once");
@@ -2126,27 +2116,17 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "1.0.0-1.al8",
                 Ownership::RpmManaged,
                 ObjectStatus::Installed,
             ),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "1.0.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "1.0.0", Some("1.al8"), "x86_64")),
         )
-        .upgrading_to(pkg_info(
-            "anolisa-copilot-shell",
-            "1.1.0",
-            Some("1.al8"),
-            "x86_64",
-        ));
+        .upgrading_to(pkg_info("copilot-shell", "1.1.0", Some("1.al8"), "x86_64"));
 
         update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true).expect("update ok");
 
@@ -2169,20 +2149,15 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         );
 
         let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, false)
@@ -2214,23 +2189,18 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         )
         .with_available(vec![pkg_info(
-            "anolisa-copilot-shell",
+            "copilot-shell",
             "2.3.0",
             Some("1.al8"),
             "x86_64",
@@ -2254,7 +2224,7 @@ mod tests {
     fn unknown_component_routes_to_invalid_argument() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
-        let rpm = FakeRpm::new("anolisa-copilot-shell", None);
+        let rpm = FakeRpm::new("copilot-shell", None);
         let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
             .expect_err("absent component must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
@@ -2307,14 +2277,14 @@ mod tests {
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         // rpmdb reports nothing installed for the package.
-        let rpm = FakeRpm::new("anolisa-copilot-shell", None);
+        let rpm = FakeRpm::new("copilot-shell", None);
         let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
             .expect_err("drift must error");
         assert_eq!(err.code(), "EXECUTION_FAILED");
@@ -2973,13 +2943,8 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
             &raw_artifact("copilot-shell", "0.2.0", b"new\n"),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         );
 
         update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
@@ -3010,20 +2975,15 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         )
         .failing_update();
 
@@ -3050,20 +3010,15 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         )
         .multi_version();
         let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
@@ -3083,7 +3038,7 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.3.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
@@ -3091,13 +3046,8 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
         );
         // upgrade_to is None => update() is a no-op; EVR stays the same.
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.3.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
         );
         update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true).expect("update ok");
         assert_eq!(rpm.update_calls.get(), 1);
@@ -3121,20 +3071,15 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
             &c,
             rpm_object(
                 "copilot-shell",
-                "anolisa-copilot-shell",
+                "copilot-shell",
                 "2.2.0-1.al8",
                 Ownership::RpmObserved,
                 ObjectStatus::Adopted,
             ),
         );
         let rpm = FakeRpm::new(
-            "anolisa-copilot-shell",
-            Some(pkg_info(
-                "anolisa-copilot-shell",
-                "2.2.0",
-                Some("1.al8"),
-                "x86_64",
-            )),
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
         )
         .post_update_missing();
 

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -113,7 +113,7 @@ pub struct DistributionSelector {
 /// format a distribution uses*): this says *what the component is named under a
 /// given backend*. Only populated where a backend needs an explicit name; an
 /// absent table leaves package-name resolution to the lower mapping tiers
-/// (repo.toml `package_map` / RPM provides / default `anolisa-<component>`).
+/// (repo.toml `package_map` / RPM provides / the bare component name).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ManifestBackends {
     /// RPM backend packaging info; `None` falls through to the lower tiers.
@@ -132,7 +132,7 @@ impl ManifestBackends {
 /// `[backends.rpm]` — RPM-backend packaging info for a component.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpmBackendSpec {
-    /// RPM package name for this component (e.g. `anolisa-copilot-shell`),
+    /// RPM package name for this component (e.g. `copilot-shell`),
     /// the highest-precedence package-name source after a CLI `--package`
     /// override.
     pub package: String,
@@ -1720,11 +1720,11 @@ mod tests {
             layer = "runtime"
 
             [backends.rpm]
-            package = "anolisa-copilot-shell"
+            package = "copilot-shell"
         "#;
         let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
         assert!(!m.backends.is_empty());
-        assert_eq!(m.rpm_package(), Some("anolisa-copilot-shell"));
+        assert_eq!(m.rpm_package(), Some("copilot-shell"));
     }
 
     #[test]
@@ -1740,13 +1740,13 @@ mod tests {
             layer = "runtime"
 
             [backends.rpm]
-            package = "anolisa-copilot-shell"
+            package = "copilot-shell"
         "#,
         )
         .expect("parse");
         let dumped = toml::to_string(&with_rpm).expect("serialize");
         assert!(
-            dumped.contains("anolisa-copilot-shell"),
+            dumped.contains("copilot-shell"),
             "rpm package must round-trip: {dumped}"
         );
 

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -161,7 +161,7 @@ impl Ownership {
 /// time; refreshed on `repair` and `update`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RpmMetadata {
-    /// RPM package name (e.g. `anolisa-copilot-shell`).
+    /// RPM package name (e.g. `copilot-shell`).
     pub package_name: String,
     /// Full EVR (epoch:version-release) string from rpmdb.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1242,7 +1242,7 @@ mod tests {
         obj.adopted = true;
         obj.install_backend = Some("rpm".to_string());
         obj.rpm_metadata = Some(RpmMetadata {
-            package_name: "anolisa-copilot-shell".to_string(),
+            package_name: "copilot-shell".to_string(),
             evr: Some("0:1.2.3-1.al8".to_string()),
             arch: Some("x86_64".to_string()),
             source_repo: Some("@System".to_string()),
@@ -1261,7 +1261,7 @@ mod tests {
         assert!(!comp.owns_removal());
 
         let rpm = comp.rpm_metadata.as_ref().expect("rpm_metadata present");
-        assert_eq!(rpm.package_name, "anolisa-copilot-shell");
+        assert_eq!(rpm.package_name, "copilot-shell");
         assert_eq!(rpm.evr.as_deref(), Some("0:1.2.3-1.al8"));
         assert_eq!(rpm.arch.as_deref(), Some("x86_64"));
         assert_eq!(rpm.source_repo.as_deref(), Some("@System"));
@@ -1277,7 +1277,7 @@ mod tests {
         obj.ownership = Some(Ownership::RpmManaged);
         obj.install_backend = Some("rpm".to_string());
         obj.rpm_metadata = Some(RpmMetadata {
-            package_name: "anolisa-copilot-shell".to_string(),
+            package_name: "copilot-shell".to_string(),
             evr: Some("0:1.2.3-1.al8".to_string()),
             arch: Some("x86_64".to_string()),
             source_repo: Some("anolisa-release".to_string()),

--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -512,31 +512,31 @@ mod tests {
     #[test]
     fn installed_returns_info() {
         let q = query_with_rpm(
-            "anolisa-tokenless",
-            ok_out(Some(0), "anolisa-tokenless|(none)|2.0.1|1.al8|x86_64", ""),
+            "tokenless",
+            ok_out(Some(0), "tokenless|(none)|2.0.1|1.al8|x86_64", ""),
         );
         let info = q
-            .query_installed("anolisa-tokenless")
+            .query_installed("tokenless")
             .unwrap()
             .expect("installed package should yield Some");
-        assert_eq!(info.name, "anolisa-tokenless");
+        assert_eq!(info.name, "tokenless");
         assert_eq!(info.version.epoch, None);
         assert_eq!(info.version.version, "2.0.1");
         assert_eq!(info.version.release.as_deref(), Some("1.al8"));
         assert_eq!(info.arch, "x86_64");
         assert_eq!(info.origin, None);
         assert_eq!(info.version.to_string(), "2.0.1-1.al8");
-        assert!(q.is_installed("anolisa-tokenless").unwrap());
+        assert!(q.is_installed("tokenless").unwrap());
     }
 
     #[test]
     fn not_installed_returns_none() {
         let q = query_with_rpm(
-            "anolisa-tokenless",
-            ok_out(Some(1), "package anolisa-tokenless is not installed", ""),
+            "tokenless",
+            ok_out(Some(1), "package tokenless is not installed", ""),
         );
-        assert_eq!(q.query_installed("anolisa-tokenless").unwrap(), None);
-        assert!(!q.is_installed("anolisa-tokenless").unwrap());
+        assert_eq!(q.query_installed("tokenless").unwrap(), None);
+        assert!(!q.is_installed("tokenless").unwrap());
     }
 
     #[test]
@@ -580,20 +580,17 @@ mod tests {
 
     #[test]
     fn unexpected_field_count_maps_to_error() {
-        let q = query_with_rpm(
-            "anolisa-tokenless",
-            ok_out(Some(0), "anolisa-tokenless|2.0.1", ""),
-        );
-        let err = q.query_installed("anolisa-tokenless").unwrap_err();
+        let q = query_with_rpm("tokenless", ok_out(Some(0), "tokenless|2.0.1", ""));
+        let err = q.query_installed("tokenless").unwrap_err();
         assert!(matches!(err, PackageQueryError::UnexpectedOutput { .. }));
     }
 
     #[test]
     fn multiple_installed_is_unexpected() {
-        let two = "anolisa-tokenless|(none)|2.0.1|1.al8|x86_64\n\
-                   anolisa-tokenless|(none)|2.0.2|1.al8|x86_64\n";
-        let q = query_with_rpm("anolisa-tokenless", ok_out(Some(0), two, ""));
-        let err = q.query_installed("anolisa-tokenless").unwrap_err();
+        let two = "tokenless|(none)|2.0.1|1.al8|x86_64\n\
+                   tokenless|(none)|2.0.2|1.al8|x86_64\n";
+        let q = query_with_rpm("tokenless", ok_out(Some(0), two, ""));
+        let err = q.query_installed("tokenless").unwrap_err();
         match err {
             PackageQueryError::UnexpectedOutput { detail, .. } => {
                 assert!(
@@ -634,10 +631,10 @@ mod tests {
 
     #[test]
     fn available_returns_candidates() {
-        let out = "anolisa-tokenless|(none)|2.0.1|1.al8|x86_64|anolisa\n\
-                   anolisa-tokenless|(none)|2.0.1|1.al8|aarch64|baseos\n";
-        let q = query_with_dnf("anolisa-tokenless", ok_out(Some(0), out, ""));
-        let candidates = q.query_available("anolisa-tokenless").unwrap();
+        let out = "tokenless|(none)|2.0.1|1.al8|x86_64|anolisa\n\
+                   tokenless|(none)|2.0.1|1.al8|aarch64|baseos\n";
+        let q = query_with_dnf("tokenless", ok_out(Some(0), out, ""));
+        let candidates = q.query_available("tokenless").unwrap();
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].origin.as_deref(), Some("anolisa"));
         assert_eq!(candidates[0].arch, "x86_64");
@@ -683,9 +680,9 @@ mod tests {
 
     #[test]
     fn installed_origin_returns_reponame() {
-        let q = query_with_dnf("anolisa-tokenless", ok_out(Some(0), "@System\n", ""));
+        let q = query_with_dnf("tokenless", ok_out(Some(0), "@System\n", ""));
         assert_eq!(
-            q.installed_origin("anolisa-tokenless").unwrap().as_deref(),
+            q.installed_origin("tokenless").unwrap().as_deref(),
             Some("@System")
         );
     }
@@ -694,8 +691,8 @@ mod tests {
     fn installed_origin_empty_is_none() {
         // A package with no reported reponame yields an empty repoquery result;
         // origin is supplementary, so absence is a non-fatal `None`.
-        let q = query_with_dnf("anolisa-tokenless", ok_out(Some(0), "", ""));
-        assert_eq!(q.installed_origin("anolisa-tokenless").unwrap(), None);
+        let q = query_with_dnf("tokenless", ok_out(Some(0), "", ""));
+        assert_eq!(q.installed_origin("tokenless").unwrap(), None);
     }
 
     #[test]
@@ -722,12 +719,12 @@ mod tests {
     fn what_provides_returns_single_name() {
         let q = query_with_rpm(
             "anolisa-component(tokenless)",
-            ok_out(Some(0), "anolisa-tokenless\n", ""),
+            ok_out(Some(0), "tokenless\n", ""),
         );
         let names = q
             .what_provides_installed("anolisa-component(tokenless)")
             .unwrap();
-        assert_eq!(names, vec!["anolisa-tokenless".to_string()]);
+        assert_eq!(names, vec!["tokenless".to_string()]);
     }
 
     #[test]
@@ -736,12 +733,12 @@ mod tests {
         // the same name must collapse to a single entry.
         let q = query_with_rpm(
             "anolisa-component(tokenless)",
-            ok_out(Some(0), "anolisa-tokenless\nanolisa-tokenless\n", ""),
+            ok_out(Some(0), "tokenless\ntokenless\n", ""),
         );
         let names = q
             .what_provides_installed("anolisa-component(tokenless)")
             .unwrap();
-        assert_eq!(names, vec!["anolisa-tokenless".to_string()]);
+        assert_eq!(names, vec!["tokenless".to_string()]);
     }
 
     #[test]
@@ -750,17 +747,14 @@ mod tests {
         // case callers must detect; both names are preserved in order.
         let q = query_with_rpm(
             "anolisa-component(tokenless)",
-            ok_out(Some(0), "anolisa-tokenless\nvendor-tokenless\n", ""),
+            ok_out(Some(0), "tokenless\nvendor-tokenless\n", ""),
         );
         let names = q
             .what_provides_installed("anolisa-component(tokenless)")
             .unwrap();
         assert_eq!(
             names,
-            vec![
-                "anolisa-tokenless".to_string(),
-                "vendor-tokenless".to_string()
-            ]
+            vec!["tokenless".to_string(), "vendor-tokenless".to_string()]
         );
     }
 

--- a/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
@@ -179,30 +179,30 @@ mod tests {
     fn update_success_returns_ok() {
         let t = txn(
             "update",
-            "anolisa-copilot-shell",
-            ok_out(Some(0), "Upgraded:\n  anolisa-copilot-shell\n", ""),
+            "copilot-shell",
+            ok_out(Some(0), "Upgraded:\n  copilot-shell\n", ""),
         );
-        t.update("anolisa-copilot-shell").expect("update ok");
+        t.update("copilot-shell").expect("update ok");
     }
 
     #[test]
     fn install_success_returns_ok() {
         let t = txn(
             "install",
-            "anolisa-copilot-shell",
-            ok_out(Some(0), "Installed:\n  anolisa-copilot-shell\n", ""),
+            "copilot-shell",
+            ok_out(Some(0), "Installed:\n  copilot-shell\n", ""),
         );
-        t.install("anolisa-copilot-shell").expect("install ok");
+        t.install("copilot-shell").expect("install ok");
     }
 
     #[test]
     fn remove_success_returns_ok() {
         let t = txn(
             "remove",
-            "anolisa-copilot-shell",
-            ok_out(Some(0), "Removed:\n  anolisa-copilot-shell\n", ""),
+            "copilot-shell",
+            ok_out(Some(0), "Removed:\n  copilot-shell\n", ""),
         );
-        t.remove("anolisa-copilot-shell").expect("remove ok");
+        t.remove("copilot-shell").expect("remove ok");
     }
 
     #[test]
@@ -211,14 +211,10 @@ mod tests {
         // remove failure apart from an install/update failure.
         let t = txn(
             "remove",
-            "anolisa-copilot-shell",
-            ok_out(
-                Some(1),
-                "",
-                "Error: No match for argument: anolisa-copilot-shell",
-            ),
+            "copilot-shell",
+            ok_out(Some(1), "", "Error: No match for argument: copilot-shell"),
         );
-        let err = t.remove("anolisa-copilot-shell").unwrap_err();
+        let err = t.remove("copilot-shell").unwrap_err();
         match err {
             PackageTransactionError::TransactionFailed {
                 operation, stderr, ..
@@ -234,10 +230,10 @@ mod tests {
     fn update_nonzero_exit_maps_to_transaction_failed() {
         let t = txn(
             "update",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             ok_out(Some(1), "", "Error: nothing to do, repo unreachable"),
         );
-        let err = t.update("anolisa-copilot-shell").unwrap_err();
+        let err = t.update("copilot-shell").unwrap_err();
         match err {
             PackageTransactionError::TransactionFailed {
                 command,
@@ -260,10 +256,10 @@ mod tests {
         // an install failure apart from an update failure.
         let t = txn(
             "install",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             ok_out(Some(1), "", "Error: No match for argument"),
         );
-        let err = t.install("anolisa-copilot-shell").unwrap_err();
+        let err = t.install("copilot-shell").unwrap_err();
         match err {
             PackageTransactionError::TransactionFailed {
                 operation, stderr, ..
@@ -281,14 +277,14 @@ mod tests {
         // an empty diagnostic.
         let t = txn(
             "update",
-            "anolisa-copilot-shell",
+            "copilot-shell",
             ok_out(
                 Some(1),
                 "Error: This command has to be run with superuser privileges",
                 "",
             ),
         );
-        let err = t.update("anolisa-copilot-shell").unwrap_err();
+        let err = t.update("copilot-shell").unwrap_err();
         match err {
             PackageTransactionError::TransactionFailed { stderr, .. } => {
                 assert!(stderr.contains("superuser privileges"), "got: {stderr}");

--- a/src/anolisa/templates/installed-state.toml
+++ b/src/anolisa/templates/installed-state.toml
@@ -62,7 +62,7 @@ adopted = true
 subscription_scope = "none"
 
 [objects.rpm_metadata]
-package_name = "anolisa-copilot-shell"
+package_name = "copilot-shell"
 evr = "0:1.2.3-1.al8"
 arch = "x86_64"
 source_repo = "@System"


### PR DESCRIPTION
## Description

Installing a component through the **rpm backend** delegated a `dnf install` whose package name was hardcoded with an `anolisa-` prefix (e.g. `anolisa-tokenless`). The real RPM package name carries no such prefix — every component spec's `Name:` is the bare component name (`tokenless`, `copilot-shell`, ...) — so the delegated install targeted a non-existent package.

The rpm package-name resolution chain is `--package` > manifest `[backends.rpm].package` > `package_map` > virtual-provides reverse lookup > default. Only the final default was wrong: it produced `anolisa-<component>` instead of the bare `<component>`. This fixes the default in both `rpm_package_candidates` and the `probe_rpm_situation` fallback.

## Design Note

- **Align with the raw backend and the real spec names.** The raw backend's `RepoConfig::package_name` already defaults to the bare component name; the rpm path now matches it, and both match the published spec `Name:` fields.
- **Virtual-provides contract untouched.** The `anolisa-component(<name>)` capability namespace is unrelated to the package name and is preserved, so a future packaging-side `Provides:` still short-circuits the default.
- **Test fixtures de-prefixed.** RPM package-name fixtures across the suite used the misleading `anolisa-<component>` form; they now use the bare name so test data matches reality. Repo names (`anolisa-release`) and the virtual-provides capability are left intact.

## Test

- **Full gate green:** `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- **Focused:** `cargo test -p anolisa-cli commands::tier1::install` — delegated install / adopt / probe now resolve the bare `<component>` name.
- **Not run:** real-host `dnf install` verification against a live rpmdb.

close #1150
