### PR TITLE
fix(sec-core): correct codex-plugin paths in makefile and ci

### DIFF
--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -97,9 +97,10 @@ jobs:
           ls /usr/bin/agent-sec-daemon
           echo "=== Verify codex plugin ==="
           ls /opt/agent-sec/codex-plugin/
-          ls /opt/agent-sec/codex-plugin/hooks/
-          ls /opt/agent-sec/codex-plugin/hooks/code_scanner_hook.py
-          ls /opt/agent-sec/codex-plugin/hooks/skill_ledger_hook.py
+          ls /opt/agent-sec/codex-plugin/hooks-plugin/hooks/
+          ls /opt/agent-sec/codex-plugin/hooks-plugin/hooks/code_scanner_hook.py
+          ls /opt/agent-sec/codex-plugin/hooks-plugin/hooks/skill_ledger_hook.py
+          ls /opt/agent-sec/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
           ls /opt/agent-sec/codex-plugin/install.sh
           ls /opt/agent-sec/codex-plugin/.agents/plugins/marketplace.json
           echo "=== Verify skills ==="

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -198,7 +198,7 @@ build-hermes-plugin: ## Stage hermes-plugin Python sources to BUILD_DIR
 .PHONY: stage-codex-plugin
 stage-codex-plugin: ## Stage codex-plugin hooks and install script to BUILD_DIR
 	install -d -m 0755 $(BUILD_DIR)/codex-plugin
-	cp -rp codex-plugin/hooks-plugin/. $(BUILD_DIR)/codex-plugin/
+	cp -rp codex-plugin/hooks-plugin $(BUILD_DIR)/codex-plugin/
 	cp -p codex-plugin/install.sh $(BUILD_DIR)/codex-plugin/
 	cp -rp codex-plugin/.agents $(BUILD_DIR)/codex-plugin/
 


### PR DESCRIPTION
## Summary
Fixes incorrect codex-plugin paths introduced in #1138 that caused RPM build/install verification to fail.

## Changes
- `src/agent-sec-core/Makefile`: correct the source/destination paths for codex-plugin staging and install targets.
- `.github/workflows/sec-core-rpmbuild.yaml`: align verification commands with the corrected install paths.

## Related
- Follow-up to #1138 (codex-plugin RPM packaging).

## Test
- Triggered `sec-core-rpmbuild` workflow on fork; RPM builds successfully.
- Installed the RPM in a clean container and verified codex-plugin files land at the expected paths.