### PR TITLE
ci(agentsight): use uv tool install for diff-cover

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -575,6 +575,11 @@ jobs:
         with:
           workspaces: src/agentsight
 
+      - name: astral-sh/setup-uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: '3.11.6'
+
       - name: Install eBPF build dependencies
         run: |
           sudo apt-get update
@@ -633,7 +638,7 @@ jobs:
 
       - name: Install diff-cover
         if: github.event_name == 'pull_request'
-        run: pip install --break-system-packages diff-cover
+        run: uv tool install --force diff-cover
 
       - name: Incremental coverage gate (PR only)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

Migrate the agentsight CI job's diff-cover installation from `pip install --break-system-packages diff-cover` to `uv tool install --force diff-cover`, matching the existing stable pattern in the agent-sec-core job.

## Problem

The agentsight `Incremental coverage gate` step intermittently fails with:

```
/home/github-runner/.../xx.sh: line 5: diff-cover: command not found
Error: Incremental coverage gate failed: new code coverage < 80%
```

Root cause: `pip install --break-system-packages diff-cover` installs the package into the user site-packages, but the `diff-cover` executable wrapper lands in `~/.local/bin`, which is **not reliably on PATH** on the self-hosted runner. The `|| GATE_FAILED=true` fallback then reports a false-negative coverage failure — the gate fails not because coverage is below 80%, but because the tool cannot be found. This blocked #661 twice.

## Fix

Align with the agent-sec-core job (ci.yaml lines 300-315), which has used this pattern stably:
1. Add `astral-sh/setup-uv@v8.0.0` step (with `python-version: 3.11.6`) — setup-uv ensures the uv-managed bin directory is on PATH.
2. Change install to `uv tool install --force diff-cover` — uv installs into an isolated venv and places the wrapper in a PATH-guaranteed bin dir.

## Verification

| Check | Status |
|-------|--------|
| YAML syntax | pass |
| Local repro: `uv tool install --force diff-cover` + bare `diff-cover --version` | pass (10.3.0, found at `~/.local/bin/diff-cover`) |
| Parity with sec-core job (same action version, same python-version, same install cmd) | verified — lines 300-315 use identical pattern and run stably |
| `python3 scripts/check-arch-boundaries.py` unaffected by setup-uv | verified — sec-core job calls `python3` after setup-uv without issue; setup-uv does not override system `python3` |

## What is NOT changed

- The `if: github.event_name == pull_request` guard on the install step is preserved (sec-core installs unconditionally; agentsight only needs it on PRs — slightly more efficient, no behavior change for the gate).
- No change to the coverage threshold (80%), the `--ignore-filename-regex`, or the gate logic itself.
- No change to any other job.

## Test plan

- [ ] CI on this PR passes `Incremental coverage gate` step (the very step this fixes)
- [ ] After merge, re-run #661 CI — the `diff-cover: command not found` flake should be gone
