### PR TITLE
(bugfix): return error

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/sandbox_manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/sandbox_manifest.rs
@@ -94,18 +94,37 @@ impl SandboxManifest {
     }
 
     /// Load from explicit search paths (for testing / custom prefix).
+    ///
+    /// If a system-deployed manifest is found but has a lower
+    /// `manifest_version` than the built-in one, the built-in takes
+    /// precedence — this prevents stale `/etc/anolisa/sandbox.toml`
+    /// (from an older `system setup`) from overriding newer scenario
+    /// definitions compiled into the binary.
     pub fn load_with_search_paths(paths: &[PathBuf]) -> Result<Self, ManifestError> {
+        let builtin = Self::parse(BUILTIN_MANIFEST)?;
+
         for path in paths {
             if path.is_file() {
                 let content = std::fs::read_to_string(path).map_err(|e| ManifestError::Io {
                     path: path.clone(),
                     source: e,
                 })?;
-                return Self::parse(&content);
+                let disk = Self::parse(&content)?;
+                if disk.manifest_version >= builtin.manifest_version {
+                    return Ok(disk);
+                }
+                // Stale manifest on disk — prefer built-in.
+                eprintln!(
+                    "[osbase] warning: {} has manifest_version={} \
+                     but built-in is {}; using built-in",
+                    path.display(),
+                    disk.manifest_version,
+                    builtin.manifest_version,
+                );
+                return Ok(builtin);
             }
         }
-        // Fallback to built-in
-        Self::parse(BUILTIN_MANIFEST)
+        Ok(builtin)
     }
 
     /// Parse from TOML string.
@@ -205,7 +224,7 @@ mod tests {
     #[test]
     fn parse_builtin_manifest() {
         let m = SandboxManifest::parse(BUILTIN_MANIFEST).expect("builtin must parse");
-        assert_eq!(m.manifest_version, 2);
+        assert_eq!(m.manifest_version, 3);
         assert_eq!(m.scenarios.len(), 5);
         assert!(m.find_scenario("gvisor").is_some());
         assert!(m.find_scenario("firecracker").is_some());

--- a/src/anolisa/manifests/sandbox.toml
+++ b/src/anolisa/manifests/sandbox.toml
@@ -1,7 +1,7 @@
 # sandbox.toml — osbase sandbox scenario registry
 # 用户可编辑：添加/删除 scenario、修改包名、调整内核要求
 
-manifest_version = 2
+manifest_version = 3
 
 [[scenario]]
 name = "runc"


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

Fix `osbase sandbox install gvisor/firecracker` verify phase incorrectly falling back to `systemctl is-active containerd` instead of using the scenario's `verify_commands`.

When a stale `/etc/anolisa/sandbox.toml` (deployed by an older `system setup`) has a lower `manifest_version` than the binary's built-in manifest, the loader now discards the disk file and uses the built-in definitions, ensuring `verify_commands` fields for gVisor/Firecracker take effect.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->
1. **Unit tests**: `cargo test --locked` — 588 passed (including `parse_builtin_manifest` asserting manifest_version=3)
2. **Remote integration** (Alinux 3, kernel 6.6.102):
   - Disk `/etc/anolisa/sandbox.toml` at manifest_version=2 (missing `verify_commands`)
   - `anolisa osbase sandbox install gvisor` → `verify: ✓ all checks passed: runsc --version`
   - `anolisa osbase sandbox install firecracker` → `verify: ✓ all checks passed: firecracker --version, jailer --version`
3. **Version protection path**: daemon manifest load triggers `disk(v2) < builtin(v3)` branch, emits warning, and uses built-in definitions

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
- The system-helper daemon binary must also be updated (`systemctl restart anolisa-system-helper`); otherwise the CLI forwards requests via socket to the old daemon which still loads the stale manifest
- Bumping `manifest_version` from 2 to 3 is a one-time operation; future additions of scenario fields should increment the version accordingly
