### PR TITLE
chore(memory): bump to v0.2.0

### DIFF
--- a/src/agent-memory/CHANGELOG.md
+++ b/src/agent-memory/CHANGELOG.md
@@ -1,118 +1,64 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## Unreleased
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## 0.2.0
 
-## [Unreleased]
+- add prompt-injection safety module (looksLikePromptInjection + escapeMemoryForPrompt) mirrored between Rust core and TS adapter
+- add secret detection and PII redaction to the safety module
+- add auto-recall before_prompt_build hook injecting relevant memories each turn
+- add auto-capture agent_end hook with trigger filtering, SHA256 dedup and injection rejection
+- add dense-vector semantic search via pluggable EmbeddingProvider (OpenAI /v1/embeddings, Ollama /api/embed)
+- add files_vec table (schema v2) for per-file dense embeddings alongside FTS5 BM25
+- add hybrid search with reciprocal rank fusion (RRF, k=60) of BM25 + vector scores
+- add memory_search mode parameter (bm25/vector/hybrid) with graceful fallback to BM25
+- add per-agent memory isolation via [memory].agent_scope (shared/isolated/filter), schema v5
+- add memory sovereignty tools (memory_about/forget/auto_created/consent) with consent.toml preferences
+- add 4-type closed memory classification (user/feedback/project/reference) to memory_observe
+- add mem_export and mem_import for cross-agent memory migration (AMA archive format)
+- add memory_summary tool for memory overview and source tracking
+- add memory_session_context tool
+- add memory_sessions and memory_timeline session history query tools
+- add MEMORY.md index file and mem_index_refresh tool
+- add user profile synthesis (Dreaming V3 mem_dream)
+- add memory consolidation: auto-extract L1 atomic facts from session audit logs on shutdown
+- add episodic memory extraction from coherent tool-call chains
+- add cross-session task persistence and incremental consolidation
+- add consolidation quality filters (mutual exclusion, non-derivable, date normalization)
+- add time-decay ranking (exp(-λ×age_days)) applied to BM25/vector/hybrid scores
+- add cold archival of old never-accessed files with mem_compact tool
+- add conflict detection via BM25 similarity before writing new facts
+- add category subdirectories (facts/<category>/) with memory_search category filter
+- add token tracking (tokens field in AuditEntry)
+- add mem_consolidate tool for manual consolidation trigger
+- add corpus supplement registration for memory_search corpus=all
+- add EmbeddingConfig (None/OpenAI/Ollama) with TOML parsing and env overrides
+- extend memory_search signature with optional mode and category parameters
+- cap memory_search query at 1024 characters to prevent FTS5 resource exhaustion
+- truncate embedding error response bodies to 200 chars to prevent API key leakage
+- distinguish CJK vs ASCII token estimation in ConsolidatedFact
+- hold FactWriter JSONL file handle under mutex to prevent line interleaving
+- derive BM25Store mount root from db path with canonicalize + starts_with traversal guard
+- compute Episode duration from entry timestamps instead of chain length
+- propagate session_id to extracted episodic facts
+- return fact count from consolidate() for mem_consolidate reporting
+- fix effectiveMode in search response to reflect actual mode used
+- fix embedding API empty-response handling to return zero vector of correct dimensionality
 
-### Added
+## 0.1.0
 
-- Prompt-injection safety module (`looksLikePromptInjection` + `escapeMemoryForPrompt`)
-  with 8 heuristics mirrored between Rust core and TypeScript adapter.
-- `SearchHit.suspicious` field automatically populated from full-body injection check.
-- `<relevant-memories>` safety wrapper for all memory content injected into LLM prompts.
-- Auto-recall: `before_prompt_build` hook injects relevant memories each turn.
-- Auto-capture: `agent_end` hook with trigger-based filtering, SHA256 dedup, and
-  injection rejection before persisting observations.
-- Dense-vector semantic search via pluggable `EmbeddingProvider` trait:
-  OpenAI (`/v1/embeddings`) and Ollama (`/api/embed`) backends.
-- `files_vec` table (schema v2) for per-file dense embeddings alongside FTS5 BM25.
-- Hybrid search with reciprocal rank fusion (RRF, k=60) of BM25 + vector scores.
-- `memory_search` `mode` parameter: `bm25` (default), `vector`, `hybrid`.
-- Graceful fallback from vector/hybrid to BM25 when no embedding provider is configured.
-- Embedding computed automatically during index worker flush (phase 2).
-- System prompt integration (`promptBuilder`) with tool usage guidelines.
-- Corpus supplement registration for `memory_search corpus=all` integration.
-- `EmbeddingConfig` (None|OpenAI|Ollama) with TOML parsing and environment variable overrides.
-- 30-second HTTP timeout on embedding API clients.
-- Per-agent memory isolation via `[memory].agent_scope` (`shared` | `isolated` |
-  `filter`). Agent identity is sourced from the `MCP_CLIENT_NAME` environment
-  variable, persisted on `upsert`, and enforced at `search_scoped` time using a
-  parameterised SQL binding. Schema bumped to v5
-  (`ALTER TABLE files ADD COLUMN agent_id TEXT DEFAULT NULL`). `memory_search`
-  gains an optional `agent_scope` parameter overriding the config per call.
-  Vector/hybrid modes degrade to scoped BM25 when an agent scope is active so
-  the isolation boundary is never silently widened.
-
-- Memory consolidation: auto-extract L1 atomic facts from session audit logs
-  on shutdown via heuristic rules (working context, interest, change, lesson,
-  promoted, summary). Zero LLM calls, pure pattern matching. Configurable via
-  `[memory.consolidation]` with env overrides.
-- Episodic memory extraction: identify coherent tool-call chains (edit-verify
-  cycles, promote chains, error recovery, multi-step task sequences) from
-  session logs and store as episodic facts with chain steps, outcome, and
-  real duration.
-- Time-decay ranking: exponential decay (`exp(-λ×age_days)`) applied to BM25,
-  vector, and hybrid search scores. Configurable via `[memory.index]` with
-  env overrides `MEMORY_INDEX_TIME_DECAY_LAMBDA` / `MEMORY_INDEX_TIME_DECAY_ALPHA`.
-- Cold archival: automatic marking of old, never-accessed files as "cold" excluded
-  from normal search but still queryable via deep search. `mem_compact` MCP tool
-  for manual triggering. Config: `cold_after_days`, `exclude_cold_on_search`.
-- Conflict detection: BM25-based similarity search before writing new facts.
-  Conflicting facts are marked as superseded in the DB and excluded from normal
-  search. Configurable threshold via `conflict_bm25_threshold`.
-- Category subdirectories: consolidated facts organized under `facts/<category>/`
-  for structured browsing. `memory_search` gains optional `category` parameter
-  to filter results to a specific fact category.
-- Token tracking: `tokens` field in `AuditEntry` for estimating token consumption
-  of search and retrieval operations in the audit log.
-- `mem_consolidate` MCP tool for manual consolidation trigger.
-- `mem_compact` MCP tool for manual cold archival trigger.
-- `ConsolidationConfig` and `IndexConfig` expanded with env var overrides for
-  all new parameters.
-
-### Changed
-
-- `memory_search` signature extended with optional `mode` and `category` parameters.
-- `memory_search` query capped at 1024 characters to prevent FTS5 resource exhaustion.
-- Embedding error response bodies truncated to 200 chars to prevent API key leakage.
-- `ConsolidatedFact` token estimation distinguishes CJK (~1 token/char) from ASCII
-  (~4 chars/token) for more accurate context budget control.
-- `FactWriter` JSONL writes use a held file handle under a mutex to prevent line
-  interleaving from concurrent consolidation calls.
-- `BM25Store` derives mount root from db path instead of trusting `_MEMORY_MOUNT_ROOT`
-  env var, with `canonicalize()` + `starts_with()` path traversal guard.
-- `Episode::new` accepts real `duration_secs` computed from entry timestamps instead
-  of using `chain.len()` as a placeholder.
-- `episode::extract_episodes` accepts `session_id` to propagate correct ownership
-  to extracted facts. (was using entry `ts` timestamp as session_id placeholder).
-- `consolidate()` returns `usize` (fact count) instead of `()`, enabling
-  `mem_consolidate` to report the actual number of facts written.
-
-### Changed
-
-- `memory_search` signature extended with optional `mode` parameter (backward-compatible).
-- Index handle (`IndexHandle`) now carries an optional embedding provider reference.
-- `reqwest` dependency added with `rustls-tls` and `json` features.
-
-### Fixed
-
-- `effectiveMode` in search tool response now reflects the actual mode used.
-- Embedding API empty-response handling: returns zero vector of correct dimensionality
-  instead of dimension-0 vector.
-
-## [0.1.0] - 2026-05-27
-
-### Added
-
-- Initial release: filesystem memory MCP server for AI agents (Linux only).
-- 21 MCP tools over stdio JSON-RPC 2.0 in three tiers:
-  - Tier A file ops: `mem_read` / `mem_write` / `mem_append` / `mem_edit` / `mem_list` / `mem_grep` / `mem_diff` / `mem_mkdir` / `mem_remove` / `mem_promote` / `mem_session_log`.
-  - Tier B structured search: `memory_search` (BM25) / `memory_observe` / `memory_get_context`.
-  - Tier C governance: `mem_snapshot` / `mem_snapshot_list` / `mem_snapshot_restore` / `mem_log` / `mem_revert`.
-- Per-namespace mount under `~/.anolisa/memory/<ns>/` with optional Linux user-namespace + private tmpfs isolation; pluggable `auto` / `userland` / `userns` strategies.
-- Path sandbox via `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` on every Tier A file open; `fdopendir` + `fstatat` + `unlinkat` for recursive removal so symlink swaps cannot race.
-- SQLite FTS5 BM25 background index with transactional upsert, schema-versioned migrations, trigram tokenizer for CJK, inotify-driven debounced flush, and full rescan on overflow.
-- Optional git versioning with auto-commit serialized under a per-handle mutex; commits offloaded via `tokio::task::spawn_blocking`; empty trees skipped.
-- tar.gz snapshots with strict id whitelist, atomic per-entry rename swap on restore, and rollback entries preserved under `.anolisa/trash/` instead of deleted.
-- Optional cgroup v2 `memory.max` self-limit applied before the tokio runtime starts.
-- JSONL audit log opened with `O_NOFOLLOW | O_CLOEXEC` and held as `Mutex<File>`; optional systemd-journald fan-out.
-- Profile gating (`basic` / `advanced` / `expert`) enforced at both `tools/list` and `tools/call`; `deny_unknown_fields` on every config struct so misspelt keys hard-fail at load.
-- Per-session scratch and log under `/run/anolisa/sessions/<sid>/` with `0700` permissions; tmpfiles.d snippet ships the directory.
-- systemd user template `anolisa-memory@.service` with hardening (`ProtectKernelTunables/Modules/Logs`, `SystemCallFilter=@system-service`, `MemoryDenyWriteExecute`, `RestrictNamespaces` allowlist `user mnt`, `RestrictAddressFamilies=AF_UNIX`).
-- RPM packaging with offline vendor tarball (`Source1`); single statically-linked binary (bundled SQLite + vendored libgit2).
-- OpenClaw plugin `memory-anolisa` bundled under `/usr/share/anolisa/adapters/agent-memory/openclaw/`: 4 OpenClaw memory contract tools (`memory_search` / `memory_get` / `memory_observe` / `memory_get_context`) routed to the agent-memory MCP server as a stdio child with lazy start, bounded respawn (3 attempts), per-method timeouts, env allowlist, and a bounded stderr ring buffer. `install.sh` / `uninstall.sh` register/clean via the OpenClaw CLI; RPM `%preun` auto-cleans `plugins.{allow,entries,slots}` from `openclaw.json`.
-- Single-source version sync: `Cargo.toml` is the authority, Makefile `sync-versions` propagates the value (via `jq`, idempotent) into `manifest.json` / `package.json` / `package-lock.json` / `openclaw.plugin.json` / `mcp-server.json`, and esbuild `--define` injects the same constant into the bundle's `PLUGIN_VERSION` — so the RPM header, binary, plugin manifest, and MCP `initialize.clientInfo.version` always agree.
-- Interactive `mcp-harness` example for manual tool-call verification; 140 automated Rust tests across 12 integration suites plus lib/main unit tests covering all 19 tools, plus TypeScript unit tests for the OpenClaw plugin's config validation and tool-name mapping.
+- introduce filesystem memory MCP server for AI agents (Linux only) with 21 tools over stdio JSON-RPC 2.0 in three tiers (Tier A file ops, Tier B BM25 search, Tier C governance)
+- add per-namespace mount under ~/.anolisa/memory/<ns>/ with optional user-namespace + private tmpfs isolation (auto/userland/userns strategies)
+- enforce path sandbox via openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS) on every Tier A file open
+- add SQLite FTS5 BM25 background index with transactional upsert, schema migrations, trigram CJK tokenizer and inotify-driven debounced flush
+- add optional git versioning with auto-commit serialized under a per-handle mutex
+- add tar.gz snapshots with strict id whitelist, atomic rename swap on restore and rollback entries under .anolisa/trash/
+- add optional cgroup v2 memory.max self-limit applied before the tokio runtime starts
+- add JSONL audit log (O_NOFOLLOW | O_CLOEXEC, Mutex<File>) with optional systemd-journald fan-out
+- enforce profile gating (basic/advanced/expert) at both tools/list and tools/call with deny_unknown_fields on config structs
+- add per-session scratch and log under /run/anolisa/sessions/<sid>/ (0700) with tmpfiles.d snippet
+- add systemd user template anolisa-memory@.service with hardening (ProtectKernelTunables/Modules/Logs, SystemCallFilter, MemoryDenyWriteExecute, RestrictNamespaces, RestrictAddressFamilies=AF_UNIX)
+- add RPM packaging with offline vendor tarball and single statically-linked binary (bundled SQLite + vendored libgit2)
+- add OpenClaw plugin memory-anolisa with install/detect/uninstall lifecycle and 4 memory contract tools routed to the MCP server as a stdio child
+- add single-source version sync from Cargo.toml into manifest/package/openclaw/mcp JSON and the bundle
+- add mcp-harness example and 140 automated tests across 12 integration suites

--- a/src/agent-memory/Cargo.lock
+++ b/src/agent-memory/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-memory"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/agent-memory/Cargo.toml
+++ b/src/agent-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-memory"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 # edition 2024 stabilised in rustc 1.85; let-chains land in 1.88 so we
 # avoid them. Anolis ships 1.86, which is fine for build but won't take

--- a/src/agent-memory/adapters/agent-memory/manifest.json
+++ b/src/agent-memory/adapters/agent-memory/manifest.json
@@ -1,6 +1,6 @@
 {
   "component": "agent-memory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "targets": {
     "openclaw": {
       "compatibleVersions": ">=5.0.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memory-anolisa",
   "name": "Anolisa Memory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Persistent memory backed by the agent-memory MCP server with namespace isolation and openat2 sandbox. Provides BM25 search, file read/write, observe, and context assembly tools.",
   "activation": {
     "onStartup": false

--- a/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memory-anolisa-openclaw-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/package.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-memory/agent-memory.spec.in
+++ b/src/agent-memory/agent-memory.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 3
+%define anolis_release 1
 %global debug_package %{nil}
 
 Name:           agent-memory
@@ -196,6 +196,25 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Mon Jun 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-1
+- Add semantic search (BM25/vector/hybrid via RRF) with OpenAI and Ollama
+  embedding providers; graceful fallback to BM25 when unconfigured
+- Add memory safety module: prompt-injection detection, secret detection
+  and PII redaction, with relevant-memories safety wrapper
+- Add auto-recall (before_prompt_build) and auto-capture (agent_end) hooks
+- Add memory sovereignty tools (memory_about/forget/auto_created/consent)
+  with consent.toml preferences
+- Add mem_export/mem_import (AMA archive) for cross-agent memory migration
+- Add memory_summary, memory_session_context, memory_sessions and
+  memory_timeline tools; MEMORY.md index with mem_index_refresh
+- Add 4-type closed memory classification (user/feedback/project/reference)
+- Add per-agent memory isolation via [memory].agent_scope (schema v5)
+- Add memory consolidation (L1 atomic facts, episodic extraction,
+  cross-session persistence, quality filters) with mem_consolidate tool
+- Add time-decay ranking, cold archival (mem_compact), conflict detection
+  and category subdirectories with memory_search category filter
+- Add user profile synthesis (Dreaming V3 mem_dream)
+
 * Thu May 28 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.1.0-3
 - Fix OPENCLAW_HOME double-nesting; normalize OPENCLAW_STATE_DIR across
   lifecycle scripts (env -u OPENCLAW_HOME, trailing slash, state paths)

--- a/src/agent-memory/config/mcp-server.json
+++ b/src/agent-memory/config/mcp-server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-memory",
   "description": "Agent memory — filesystem memory MCP server. 31 tools across three tiers: Tier A file ops (read/write/append/edit/list/grep/diff/mkdir/remove/promote + mem_session_log), Tier B structured (memory_search, memory_observe, memory_get_context, memory_task_save/resume/list/close, memory_forget, memory_consent, mem_export, mem_import), Tier C governance (mem_snapshot/mem_snapshot_list/mem_snapshot_restore/mem_log/mem_revert/mem_consolidate/mem_compact, memory_about, memory_auto_created). Optional Linux user-namespace isolation, SQLite FTS5 BM25 + vector hybrid background index, time-decay ranking, cold archival, episodic memory extraction, conflict detection, git versioning, tar.gz snapshots, cgroup v2 memory.max, and journald audit fan-out.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "command": "/usr/bin/agent-memory",
   "args": [],
   "env": {},

--- a/src/agent-memory/docs/user_manual.md
+++ b/src/agent-memory/docs/user_manual.md
@@ -582,5 +582,5 @@ For deeper investigation: start with `RUST_LOG=agent_memory=debug` and inspect b
 ---
 
 **License**: Apache-2.0
-**Version**: 0.1.0
+**Version**: 0.2.0
 **Document version**: 2.0 (aligned with ANOLISA-design user-guide structure)

--- a/src/agent-memory/docs/user_manual.zh.md
+++ b/src/agent-memory/docs/user_manual.zh.md
@@ -582,5 +582,5 @@ RUST_LOG=agent_memory=debug agent-memory
 ---
 
 **许可证**：Apache-2.0
-**版本**：0.1.0
+**版本**：0.2.0
 **文档版本**：2.0（对齐 ANOLISA-design user-guide 结构）

--- a/src/anolisa/manifests/runtime/agent-memory.toml
+++ b/src/anolisa/manifests/runtime/agent-memory.toml
@@ -1,6 +1,6 @@
 [component]
 name = "agent-memory"
-version = "0.1.0"
+version = "0.2.0"
 layer = "runtime"
 domain = "state"
 description = "Agent persistent memory and context"


### PR DESCRIPTION
## Description

Release agent-memory v0.2.0 — a MINOR version bump.

Consolidates 16 commits since `memory/v0.1.0` into the first minor release: semantic search (BM25/vector/hybrid via reciprocal rank fusion), the memory safety module (prompt-injection detection, secret detection, PII redaction), auto-recall / auto-capture hooks, memory sovereignty tools, mem_export / mem_import, session / timeline / summary tools, consolidation + episodic memory, time-decay ranking, cold archival, conflict detection, and Dreaming V3 user-profile synthesis.

This PR is the version-bump commit only — Cargo.toml/Cargo.lock, all derived JSON (adapter manifest, mcp-server, openclaw plugin/package/lock), the anolisa runtime manifest, user manuals, the RPM spec (`anolis_release` reset to 1 + 0.2.0-1 changelog), and the CHANGELOG refactored to the flat `tokenless` format. No Rust source changes.

## Related Issue

no-issue: version release bump for agent-memory v0.2.0 (no code-level issue to track)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [x] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

> Note: this PR is a pure version-bump commit (no Rust source touched); the "added tests" box is unchecked accordingly. Underlying features shipped in prior commits each carried their own tests.

## Testing

Verified locally on Linux (rustc 1.95.0), branch `release/memory/v0.2.y` (single commit on top of `alibaba/main`):

- `cargo fmt --check` — pass
- `cargo clippy --all-targets --locked -- -D warnings` — pass, 0 warnings
- `cargo build --release --locked` — pass, binary reports `agent-memory 0.2.0`
- `cargo test --locked` — full suite pass (all integration suites green, 0 failures)
- `make sync-versions` re-run — no-op (all derived files already at 0.2.0)
- RPM rebuild: cleaned stale artifacts + `cargo clean`, then `make rpm` → `agent-memory-0.2.0-1.alnx4.x86_64.rpm` (4.6 M); `rpm -qip` confirms Version 0.2.0 / Release 1.alnx4 and the 0.2.0-1 changelog entry.

## Additional Notes

- Single commit on top of current `alibaba/main` (`152c4e23`); `alibaba/main..HEAD` shows only `chore(memory): bump to v0.2.0`.
- After merge to `main`, the annotated tag `memory/v0.2.0` should be created (`git tag -a memory/v0.2.0`).
- CHANGELOG refactored to the flat `src/tokenless/CHANGELOG.md` style (`## Unreleased` / `## 0.2.0` / `## 0.1.0`, no per-section grouping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
