### PR TITLE
fix(rpm-build): narrow agent-memory tarball --exclude=dist to top-level only

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -572,7 +572,7 @@ build_agent_memory() {
     # captures it via the default include.
     tar -cf - -C "$MEM_DIR" \
         --exclude='target' \
-        --exclude='dist' \
+        --exclude='./dist' \
         --exclude='.git' \
         --exclude='vendor' \
         --exclude='.cargo' \


### PR DESCRIPTION
## Summary

`build_agent_memory()` 的 `--exclude='dist'` 会匹配所有层级的 `dist/` 目录,误删了 `adapters/agent-memory/openclaw/dist/index.js`(Step 1 构建的 OpenClaw 插件)。spec `%build` 的 `test -f` 检查会失败。

改为 `--exclude='./dist'` 只排除顶层 `dist/`,保留嵌套的。

## Verification

```
# --exclude='dist' (旧): 嵌套 dist/ 被删
tar --exclude='dist' ... | grep dist  → (nothing)

# --exclude='./dist' (新): 只删顶层,嵌套保留
tar --exclude='./dist' ... | grep dist  → adapters/.../openclaw/dist/index.js ✓
```

agentsight/os-skills 的 component.toml + adapters 漏拷问题由 #1192 修复(同 #1189 根因)。
