### PR TITLE
fix(rpm-build): include component.toml & adapters in agentsight/os-skills tarballs

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -329,6 +329,11 @@ build_agentic_os_skills() {
         cp "${ROOT_DIR}/LICENSE" "$pkg_dir/"
     fi
 
+    # component.toml — spec %install installs it to %{_datadir}/anolisa/components/os-skills/
+    [ -f "${SKILLS_DIR}/component.toml" ] && cp "${SKILLS_DIR}/component.toml" "$pkg_dir/"
+    # adapters/ — spec %install installs adapter-manifest.json + openclaw/hermes scripts
+    [ -d "${SKILLS_DIR}/adapters" ] && cp -rp "${SKILLS_DIR}/adapters" "$pkg_dir/"
+
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
     rm -rf "$tmp_dir"
 
@@ -409,6 +414,9 @@ build_agentsight() {
     [ -f "${SIGHT_DIR}/README.md" ] && cp "${SIGHT_DIR}/README.md" "$pkg_dir/"
     [ -f "${SIGHT_DIR}/README_CN.md" ] && cp "${SIGHT_DIR}/README_CN.md" "$pkg_dir/"
     [ -f "${SIGHT_DIR}/LICENSE" ] && cp "${SIGHT_DIR}/LICENSE" "$pkg_dir/"
+
+    # component.toml — spec %install installs it to %{_datadir}/anolisa/components/agentsight/
+    [ -f "${SIGHT_DIR}/component.toml" ] && cp "${SIGHT_DIR}/component.toml" "$pkg_dir/"
 
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
     rm -rf "$tmp_dir"


### PR DESCRIPTION
## 问题

Closes #1189

`scripts/rpm-build.sh` 的 `build_agentsight()` 与 `build_agentic_os_skills()` 按 fixed file list 拼 source tarball 时漏拷 `component.toml`（os-skills 还漏 `adapters/`），各自 spec 的 `%install` 段 `install -p component.toml ...`（os-skills 还装 `adapters/adapter-manifest.json` + openclaw/hermes 脚本）因 `install: cannot stat 'component.toml'` 失败，RPM 构建中断。

由 AgenticOS Nightly（2026-06-29，anolisa `152c4e23`）如实上报 BUILD_FAILED 后定位。

## 修复

tarball 拼装段补上缺失文件：

```diff
build_agentic_os_skills():
+    [ -f "${SKILLS_DIR}/component.toml" ] && cp "${SKILLS_DIR}/component.toml" "$pkg_dir/"
+    [ -d "${SKILLS_DIR}/adapters" ] && cp -rp "${SKILLS_DIR}/adapters" "$pkg_dir/"

build_agentsight():
+    [ -f "${SIGHT_DIR}/component.toml" ] && cp "${SIGHT_DIR}/component.toml" "$pkg_dir/"
```

## 验证

- **os-skills**：本地完整 `bash scripts/rpm-build.sh os-skills` → 成功，产出 `os-skills-0.0.1-1.al8.noarch.rpm`，payload 含 `component.toml` + `adapters/.../manifest.json` + 全部 `.sh`。
- **agentsight**：复现 tarball 打包 + `rpmbuild -ba`（stub 二进制，本机 rustc 1.75 无法跑 edition 2024 的 cargo 构建）→ 成功，`%install` 不再报 `cannot stat component.toml`，payload 含 `component.toml`。cargo/二进制部分在 Nightly ECS（rustup 1.95）上已证明正常。

Co-Authored-By: Claude <noreply@anthropic.com>