### PR TITLE
fix(copilot-shell): make system-profile BINDIR follow PREFIX

### DIFF
--- a/src/copilot-shell/Makefile
+++ b/src/copilot-shell/Makefile
@@ -11,7 +11,7 @@ PREFIX   ?= $(HOME)/.local
 BINDIR   ?= $(PREFIX)/bin
 else
 PREFIX   ?= /usr
-BINDIR   ?= /usr/local/bin
+BINDIR   ?= $(PREFIX)/bin
 endif
 LIBDIR    = $(PREFIX)/lib/copilot-shell
 DATADIR   = $(PREFIX)/share/copilot-shell


### PR DESCRIPTION
## 问题

Fixes #1176

Makefile 的 system 安装 profile 硬编码 `BINDIR ?= /usr/local/bin`，不随 `PREFIX` 变化。RPM spec 的 `%install` 执行 `make install DESTDIR=%{buildroot} PREFIX=%{_prefix}` 时未显式传 `BINDIR`，导致 cosh/co/copilot 被装到 `/usr/local/bin`，而 spec `%files` 与 2.6.0 新增的 cosh-switch `%install` 步骤都期望 `%{_bindir}`(/usr/bin)。rpmbuild 因此失败：

- `%install`：`cat > %{buildroot}%{_bindir}/cosh-switch` 因 `make install` 未创建 `/usr/bin` 而失败（2.6.0 cosh-switch 症状，掩盖了后续 %files 报错）；
- `%files`：`File not found: .../usr/bin/{co,copilot,cosh}`。

由 AgenticOS Nightly 自 2026-06-05 起每 nightly 如实上报 BUILD_FAILED 后定位（详见 #1176）。

## 修复

system profile 与 user profile 对齐：`BINDIR ?= $(PREFIX)/bin`，使 `PREFIX=/usr` → `/usr/bin`，与 spec 一致。

```diff
 ifeq ($(INSTALL_PROFILE),user)
 PREFIX   ?= $(HOME)/.local
 BINDIR   ?= $(PREFIX)/bin
 else
 PREFIX   ?= /usr
-BINDIR   ?= /usr/local/bin
+BINDIR   ?= $(PREFIX)/bin
 endif
```

## 验证

```shell
cd src/copilot-shell
make install INSTALL_PROFILE=system PREFIX=/usr DESTDIR=/tmp/cs_test
find /tmp/cs_test -name cosh
# 修复前：/tmp/cs_test/usr/local/bin/cosh
# 修复后：/tmp/cs_test/usr/bin/cosh  ✓
```

实测 `Installed: /tmp/cs_test/usr/bin/{cosh,co,copilot}`，二进制落在 `/usr/bin`。同时 `make install` 的 `install -d "$(DESTDIR)$(BINDIR)"` 现在会创建 `/usr/bin` 目录，使 spec `%install` 的 cosh-switch `cat > .../usr/bin/cosh-switch` 步骤也能成功（cosh-switch 症状一并消失，无需单独处理）。

> 未在本机跑完整 `rpmbuild`（需 npm bundle，且本机构建环境与 ECS 不同）；BINDIR 根因已由 `make install` 实证，spec `%files`/cosh-switch 依赖的 `/usr/bin` 路径已对齐。

Co-Authored-By: Claude <noreply@anthropic.com>
