### PR TITLE
fix(copilot-shell): add O_CREAT flag to appendSlsLog to create SLS JSONL file when missing

### DIFF
--- a/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts
+++ b/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts
@@ -5,6 +5,7 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
 
 /**
  * Path to the SLS JSONL log file.
@@ -14,16 +15,20 @@ const SLS_LOG_PATH = '/var/log/anolisa/sls/ops/cosh.jsonl';
 
 /**
  * Append a single JSON record as one line to the SLS log file.
- * Uses O_WRONLY | O_APPEND (without O_CREAT) so the call naturally fails
- * when the file does not exist — this writer never creates the SLS file.
+ * Uses O_WRONLY | O_APPEND | O_CREAT so the file is created if it does
+ * not exist yet. The parent directory is also ensured via mkdirSync.
  * Open→write→close on each call to support logrotate rename-by-path.
  */
 export function appendSlsLog(record: Record<string, unknown>): void {
   try {
     const line = JSON.stringify(record) + '\n';
+    // Ensure parent directory exists
+    const dir = path.dirname(SLS_LOG_PATH);
+    fs.mkdirSync(dir, { recursive: true });
     const fd = fs.openSync(
       SLS_LOG_PATH,
-      fs.constants.O_WRONLY | fs.constants.O_APPEND,
+      fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_CREAT,
+      0o644,
     );
     try {
       fs.writeSync(fd, line);


### PR DESCRIPTION
## 问题

Fixes #1207

`packages/core/src/telemetry/sls-logger.ts` 的 `appendSlsLog()` 使用 `fs.openSync()` 时仅传入 `O_WRONLY | O_APPEND`，未包含 `O_CREAT` flag。当 SLS JSONL 日志文件 `/var/log/anolisa/sls/ops/cosh.jsonl` 不存在时，`openSync` 抛出 `ENOENT`，被空的 `catch {}` 静默吞掉，导致 `logSessionSummary()` 在 session 结束时虽然正确构建了会话摘要记录，但所有 SLS 日志数据被静默丢弃——文件永不生成，F94 SLS telemetry 测试用例全部失败。

## 修复

```diff
diff --git a/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts b/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts
index ae4b2fd0..43800412 100644
--- a/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts
+++ b/src/copilot-shell/packages/core/src/telemetry/sls-logger.ts
@@ -5,6 +5,7 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
 
 /**
  * Path to the SLS JSONL log file.
@@ -14,16 +15,20 @@ const SLS_LOG_PATH = '/var/log/anolisa/sls/ops/cosh.jsonl';
 
 /**
  * Append a single JSON record as one line to the SLS log file.
- * Uses O_WRONLY | O_APPEND (without O_CREAT) so the call naturally fails
- * when the file does not exist — this writer never creates the SLS file.
+ * Uses O_WRONLY | O_APPEND | O_CREAT so the file is created if it does
+ * not exist yet. The parent directory is also ensured via mkdirSync.
  * Open→write→close on each call to support logrotate rename-by-path.
  */
 export function appendSlsLog(record: Record<string, unknown>): void {
   try {
     const line = JSON.stringify(record) + '\n';
+    // Ensure parent directory exists
+    const dir = path.dirname(SLS_LOG_PATH);
+    fs.mkdirSync(dir, { recursive: true });
     const fd = fs.openSync(
       SLS_LOG_PATH,
-      fs.constants.O_WRONLY | fs.constants.O_APPEND,
+      fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_CREAT,
+      0o644,
     );
     try {
       fs.writeSync(fd, line);
```

修改要点：
1. 添加 `O_CREAT` flag，使文件不存在时自动创建（权限 `0o644`）
2. 添加 `path.dirname()` + `fs.mkdirSync(dir, { recursive: true })` 确保父目录存在
3. 更新 JSDoc 注释，移除旧设计意图说明

## 验证

```shell
# ECS 47.86.207.32 — fresh clone + apply patch + build
cd /root && rm -rf anolisa-verify && git clone https://github.com/alibaba/anolisa.git anolisa-verify
cd anolisa-verify && git checkout main
git apply /tmp/copilot-shell-fix.patch
bash scripts/rpm-build.sh copilot-shell
```

结果：exit 0，产出 `copilot-shell-2.6.0-1.alnx4.x86_64.rpm (4.1M)`。
