### PR TITLE
fix(memory): unblock vector/hybrid search + reserved-path/doc fixes

### DIFF
--- a/src/agent-memory/docs/user_manual.md
+++ b/src/agent-memory/docs/user_manual.md
@@ -155,7 +155,7 @@ All tools are invoked via MCP `tools/call` with JSON object arguments. Errors re
 | `memory_observe` | `content` | `hint`, `type` | `observed at notes/observed/<ulid>.md` |
 | `memory_get_context` | — | `max_tokens` (default 2048) | markdown preview of recently modified files; each entry has `suspicious` |
 | `memory_sessions` | — | `limit` (default 10) | historical session list |
-| `memory_timeline` | — | — | cross-session timeline |
+| `memory_timeline` | `session_id` | `limit` (default 50) | tool-call timeline for a specific session |
 | `mem_index_refresh` | — | — | force-rebuild the FTS5 index |
 
 ### Tier C — governance & versioning (7)
@@ -172,21 +172,21 @@ All tools are invoked via MCP `tools/call` with JSON object arguments. Errors re
 
 ### Sovereignty & import/export (13)
 
-| Tool | Description |
-|------|------|
-| `memory_about` | memory store metadata |
-| `memory_auto_created` | query auto-extracted facts |
-| `memory_consent` | grant/revoke memory operations |
-| `memory_forget` | delete specific memory entries |
-| `mem_export` | export the memory store to an archive |
-| `mem_import` | import memory from an archive |
-| `memory_task_save` | save task context |
-| `memory_task_list` | list saved tasks |
-| `memory_task_resume` | resume task context |
-| `memory_task_close` | close a task |
-| `memory_summary` | memory store statistics overview |
-| `memory_session_context` | session-start context injection |
-| `mem_dream` | user profile synthesis |
+| Tool | Required | Optional | Returns / notes |
+|------|------|------|------|
+| `memory_about` | `topic` | `limit` (default 10) | matching memory paths and snippets for a topic |
+| `memory_auto_created` | — | `limit` (default 20) | JSON array of auto-extracted facts |
+| `memory_consent` | — | `action` (query/allow/deny), `scope` (all/consolidation/capture) | grant/revoke memory operations |
+| `memory_forget` | `topic` | `confirm` (default `false`=preview, `true`=delete) | delete memory entries about a topic |
+| `mem_export` | — | `category`, `source` | export the store as an AMA JSON string (does not write a file) |
+| `mem_import` | `json_data` | `strategy` (skip-existing/overwrite, default skip-existing), `dry_run` (default false) | import memory from an AMA JSON string |
+| `memory_task_save` | `title` | `status`, `progress`, `next_steps`, `blockers`, `files_modified`, `decisions`, `context`, `id` | save/update a task; returns the task id (pass `id` to update an existing task) |
+| `memory_task_list` | — | `status` (in-progress/blocked/done/cancelled) | JSON array of task summaries |
+| `memory_task_resume` | `id` | — | resume task context (formatted for continuing in a new session) |
+| `memory_task_close` | `id` | `reason` | close a task (mark done) |
+| `memory_summary` | — | `recent_limit` (default 10) | memory store statistics overview JSON |
+| `memory_session_context` | — | `limit` | session-start context injection |
+| `mem_dream` | — | — | user profile synthesis JSON |
 
 ### Error code semantics
 

--- a/src/agent-memory/docs/user_manual.zh.md
+++ b/src/agent-memory/docs/user_manual.zh.md
@@ -155,7 +155,7 @@ anolisa adapter status agent-memory
 | `memory_observe` | `content` | `hint`、`type` | `observed at notes/observed/<ulid>.md` |
 | `memory_get_context` | — | `max_tokens`（默认 2048） | 最近修改文件的 markdown 预览，每条含 `suspicious` |
 | `memory_sessions` | — | `limit`（默认 10） | 历史会话列表 |
-| `memory_timeline` | — | — | 跨会话时间线 |
+| `memory_timeline` | `session_id` | `limit`（默认 50） | 指定会话的工具调用时间线 |
 | `mem_index_refresh` | — | — | 强制重建 FTS5 索引 |
 
 ### Tier C — 治理与版本（7 个）
@@ -172,21 +172,21 @@ anolisa adapter status agent-memory
 
 ### 主权与导入导出（13 个）
 
-| 工具 | 说明 |
-|------|------|
-| `memory_about` | 记忆仓元信息 |
-| `memory_auto_created` | 查询自动提取的事实 |
-| `memory_consent` | 同意/撤回记忆操作 |
-| `memory_forget` | 删除指定记忆条目 |
-| `mem_export` | 导出记忆仓到归档 |
-| `mem_import` | 从归档导入记忆 |
-| `memory_task_save` | 保存任务上下文 |
-| `memory_task_list` | 列出已保存任务 |
-| `memory_task_resume` | 恢复任务上下文 |
-| `memory_task_close` | 关闭任务 |
-| `memory_summary` | 记忆仓统计概览 |
-| `memory_session_context` | 会话启动上下文注入 |
-| `mem_dream` | 用户画像合成 |
+| 工具 | 必填 | 可选 | 返回/说明 |
+|------|------|------|------|
+| `memory_about` | `topic` | `limit`（默认 10） | 按 topic 检索匹配记忆路径与 snippet |
+| `memory_auto_created` | — | `limit`（默认 20） | 自动提取事实列表（JSON 数组） |
+| `memory_consent` | — | `action`（query/allow/deny）、`scope`（all/consolidation/capture） | 同意/撤回记忆操作 |
+| `memory_forget` | `topic` | `confirm`（默认 `false`=预览，`true`=删除） | 删除指定 topic 的记忆条目 |
+| `mem_export` | — | `category`、`source` | 导出记忆仓为 AMA JSON 字符串（不写文件） |
+| `mem_import` | `json_data` | `strategy`（skip-existing/overwrite，默认 skip-existing）、`dry_run`（默认 false） | 从 AMA JSON 字符串导入记忆 |
+| `memory_task_save` | `title` | `status`、`progress`、`next_steps`、`blockers`、`files_modified`、`decisions`、`context`、`id` | 保存/更新任务，返回 task id（传 `id` 更新已有任务） |
+| `memory_task_list` | — | `status`（in-progress/blocked/done/cancelled） | 任务摘要 JSON 数组 |
+| `memory_task_resume` | `id` | — | 恢复任务上下文（格式化为新会话续作用） |
+| `memory_task_close` | `id` | `reason` | 关闭任务（标记 done） |
+| `memory_summary` | — | `recent_limit`（默认 10） | 记忆仓统计概览 JSON |
+| `memory_session_context` | — | `limit` | 会话启动上下文注入 |
+| `mem_dream` | — | — | 用户画像合成 JSON |
 
 ### 错误码语义
 

--- a/src/agent-memory/src/embedding/mod.rs
+++ b/src/agent-memory/src/embedding/mod.rs
@@ -98,7 +98,7 @@ pub fn build_provider(config: &EmbeddingConfig) -> Result<Option<Arc<dyn Embeddi
             }
             let provider = openai::OpenAiEmbedding::new(&key, model, base_url.as_deref())?;
             tracing::info!(
-                "OpenAI embedding provider ready (model={}, dims={})",
+                "OpenAI embedding provider ready (model={}, dims={} estimated; resolves on first embed)",
                 model,
                 provider.dimensions()
             );

--- a/src/agent-memory/src/embedding/openai.rs
+++ b/src/agent-memory/src/embedding/openai.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -12,7 +14,13 @@ pub struct OpenAiEmbedding {
     base_url: String,
     api_key: String,
     model: String,
-    dimensions: usize,
+    /// Best-effort dimensionality. Seeded from a small model→dim table at
+    /// construction (an estimate for unknown models, e.g. DashScope
+    /// text-embedding-v3 is 1024, not the 1536 fallback) and overwritten
+    /// with the true value observed on the first successful embed. Uses
+    /// atomic storage so the shared provider can be updated from the
+    /// worker thread without a lock.
+    dimensions: AtomicUsize,
 }
 
 impl OpenAiEmbedding {
@@ -23,14 +31,15 @@ impl OpenAiEmbedding {
             .trim_end_matches('/')
             .to_string();
 
-        let dimensions = match model {
+        let estimate = match model {
             "text-embedding-3-small" => 1536,
             "text-embedding-3-large" => 3072,
             "text-embedding-ada-002" => 1536,
             _ => {
-                // Unknown model — guess from common dimensionalities.
-                // The first embed call will tell us the real value; this
-                // is just a pre-flight estimate.
+                // Unknown model — 1536 is just a pre-flight estimate used
+                // only for the startup log and the empty-input zero vector.
+                // The first real embed response carries the true length and
+                // overwrites this value.
                 1536
             }
         };
@@ -43,8 +52,16 @@ impl OpenAiEmbedding {
             base_url,
             api_key: api_key.to_string(),
             model: model.to_string(),
-            dimensions,
+            dimensions: AtomicUsize::new(estimate),
         })
+    }
+
+    /// Record the true dimensionality observed in a response so subsequent
+    /// empty-input zero vectors and the dimensions() accessor are accurate.
+    fn observe_dim(&self, len: usize) {
+        if len != 0 {
+            self.dimensions.store(len, Ordering::Relaxed);
+        }
     }
 }
 
@@ -64,7 +81,7 @@ impl EmbeddingProvider for OpenAiEmbedding {
         let trimmed = text.trim();
         if trimmed.is_empty() {
             return Ok(Embedding {
-                vector: vec![0.0_f32; self.dimensions],
+                vector: vec![0.0_f32; self.dimensions.load(Ordering::Relaxed)],
             });
         }
 
@@ -104,12 +121,17 @@ impl EmbeddingProvider for OpenAiEmbedding {
             .into_iter()
             .next()
             .map(|d| d.embedding)
-            .unwrap_or_else(|| vec![0.0_f32; self.dimensions]);
+            .unwrap_or_else(|| vec![0.0_f32; self.dimensions.load(Ordering::Relaxed)]);
+
+        // Lock in the true dimensionality from the response so the
+        // startup estimate doesn't mislabel the provider (e.g. DashScope
+        // text-embedding-v3 = 1024, not the 1536 fallback).
+        self.observe_dim(vector.len());
 
         Ok(Embedding { vector })
     }
 
     fn dimensions(&self) -> usize {
-        self.dimensions
+        self.dimensions.load(Ordering::Relaxed)
     }
 }

--- a/src/agent-memory/src/index/store.rs
+++ b/src/agent-memory/src/index/store.rs
@@ -752,6 +752,22 @@ impl BM25Store {
         Ok(out)
     }
 
+    /// Paths present in the `files` (BM25) table that have no matching row
+    /// in `files_vec`. Used by full_scan's backfill pass to compute vectors
+    /// for files that exist on disk and are BM25-indexed but were never
+    /// embedded — e.g. written before an embedding provider was configured,
+    /// or recovered after an inotify overflow.
+    pub fn paths_without_vec(&self) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT f.path FROM files f \
+             LEFT JOIN files_vec v ON v.path = f.path \
+             WHERE v.path IS NULL",
+        )?;
+        let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+        let out: Vec<String> = rows.flatten().collect();
+        Ok(out)
+    }
+
     pub fn mtime_for(&self, rel_path: &str) -> Option<i64> {
         self.conn
             .query_row(

--- a/src/agent-memory/src/index/worker.rs
+++ b/src/agent-memory/src/index/worker.rs
@@ -35,6 +35,15 @@ impl IndexWorker {
         store: Arc<Mutex<BM25Store>>,
         embedding: Option<Arc<dyn EmbeddingProvider>>,
     ) -> Result<Self> {
+        // Capture the tokio runtime handle from the spawning thread (which
+        // runs inside the server's runtime) so the worker's dedicated
+        // std::thread can drive async embedding calls via `handle.block_on`.
+        // `Handle::try_current()` returns None on a plain std::thread with no
+        // runtime context — which is exactly why the worker previously never
+        // produced any vectors. Capturing here (on the runtime thread) is the
+        // fix; the worker thread itself has no current runtime.
+        let rt_handle = tokio::runtime::Handle::try_current().ok();
+
         // 1. Sync full scan so the caller can safely read svc.index.count()
         full_scan(&mount, &store)?;
 
@@ -45,13 +54,19 @@ impl IndexWorker {
         let mount_clone = mount.clone();
         let store_clone = Arc::clone(&store);
         let emb_clone = embedding.clone();
+        let rt_clone = rt_handle.clone();
 
         let handle = thread::Builder::new()
             .name("agentmem-index".into())
             .spawn(move || {
-                if let Err(e) =
-                    run_watcher(mount_clone, store_clone, emb_clone, cancel_rx, ready_tx)
-                {
+                if let Err(e) = run_watcher(
+                    mount_clone,
+                    store_clone,
+                    emb_clone,
+                    rt_clone,
+                    cancel_rx,
+                    ready_tx,
+                ) {
                     tracing::warn!("index watcher exited: {e}");
                 }
             })
@@ -117,6 +132,7 @@ fn run_watcher(
     mount: MountPointLite,
     store: Arc<Mutex<BM25Store>>,
     embedding: Option<Arc<dyn EmbeddingProvider>>,
+    rt_handle: Option<tokio::runtime::Handle>,
     cancel_rx: stdmpsc::Receiver<()>,
     ready_tx: stdmpsc::SyncSender<Result<()>>,
 ) -> Result<()> {
@@ -188,6 +204,7 @@ fn run_watcher(
                 &mount,
                 &store,
                 embedding.as_deref(),
+                rt_handle.as_ref(),
                 &mut pending_modify,
                 &mut pending_remove,
             )?;
@@ -225,6 +242,7 @@ fn flush(
     mount: &MountPointLite,
     store: &Arc<Mutex<BM25Store>>,
     embedding: Option<&dyn EmbeddingProvider>,
+    rt_handle: Option<&tokio::runtime::Handle>,
     pending_modify: &mut HashSet<PathBuf>,
     pending_remove: &mut HashSet<PathBuf>,
 ) -> Result<()> {
@@ -264,10 +282,13 @@ fn flush(
     let mut to_upsert: Vec<(String, i64, u64, String)> = Vec::new();
     let mut to_upsert_vec: Vec<(String, Vec<f32>)> = Vec::new();
 
-    // If we have an embedding provider, grab the tokio handle so
-    // we can block_on from this dedicated std::thread. If there
-    // is no tokio runtime (unit tests), embedding is skipped.
-    let rt_handle = embedding.and_then(|_| tokio::runtime::Handle::try_current().ok());
+    // If we have an embedding provider, use the tokio handle captured at
+    // spawn time (the worker runs on a dedicated std::thread that has no
+    // current runtime of its own). `handle.block_on` from a non-runtime
+    // thread is the supported way to drive async work from sync context.
+    // When no handle is available (e.g. tests without a runtime), embedding
+    // is skipped — vector search then degrades to BM25, matching the
+    // no-provider fallback.
 
     for path in pending_modify.drain() {
         let rel = match relative(mount, &path) {
@@ -297,7 +318,7 @@ fn flush(
         to_upsert.push((rel.clone(), mtime, meta.len(), body.clone()));
 
         // Compute embedding for this file if provider is available.
-        if let (Some(emb), Some(rt)) = (embedding, rt_handle.as_ref()) {
+        if let (Some(emb), Some(rt)) = (embedding, rt_handle) {
             if let Ok(embedding_vec) = rt.block_on(emb.embed(&body)) {
                 to_upsert_vec.push((rel, embedding_vec.vector));
             }

--- a/src/agent-memory/src/index/worker.rs
+++ b/src/agent-memory/src/index/worker.rs
@@ -45,7 +45,7 @@ impl IndexWorker {
         let rt_handle = tokio::runtime::Handle::try_current().ok();
 
         // 1. Sync full scan so the caller can safely read svc.index.count()
-        full_scan(&mount, &store)?;
+        full_scan(&mount, &store, embedding.as_deref(), rt_handle.as_ref())?;
 
         // 2. Spawn watcher thread. Use a oneshot mpsc to know when the
         //    watcher has been wired up.
@@ -182,7 +182,7 @@ fn run_watcher(
                 Ok(Err(e)) => {
                     if is_overflow(&e) {
                         tracing::warn!("inotify overflow detected; triggering full rescan");
-                        full_scan(&mount, &store)?;
+                        full_scan(&mount, &store, embedding.as_deref(), rt_handle.as_ref())?;
                         pending_modify.clear();
                         pending_remove.clear();
                     } else {
@@ -318,10 +318,8 @@ fn flush(
         to_upsert.push((rel.clone(), mtime, meta.len(), body.clone()));
 
         // Compute embedding for this file if provider is available.
-        if let (Some(emb), Some(rt)) = (embedding, rt_handle) {
-            if let Ok(embedding_vec) = rt.block_on(emb.embed(&body)) {
-                to_upsert_vec.push((rel, embedding_vec.vector));
-            }
+        if let Some(v) = embed_sync(embedding, rt_handle, &body) {
+            to_upsert_vec.push((rel, v));
         }
     }
 
@@ -350,70 +348,161 @@ fn flush(
     Ok(())
 }
 
-fn full_scan(mount: &MountPointLite, store: &Arc<Mutex<BM25Store>>) -> Result<()> {
+fn full_scan(
+    mount: &MountPointLite,
+    store: &Arc<Mutex<BM25Store>>,
+    embedding: Option<&dyn EmbeddingProvider>,
+    rt_handle: Option<&tokio::runtime::Handle>,
+) -> Result<()> {
     use walkdir::WalkDir;
 
-    let mut store = store.lock().expect("index store poisoned");
-    let mut seen: HashSet<String> = HashSet::new();
-    let agent_id = std::env::var("MCP_CLIENT_NAME").ok();
-
-    for entry in WalkDir::new(&mount.root)
-        .follow_links(false)
-        .into_iter()
-        .filter_entry(|e| !is_under_meta(mount, e.path()))
     {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        if !entry.file_type().is_file() {
-            continue;
+        let mut store = store.lock().expect("index store poisoned");
+        let mut seen: HashSet<String> = HashSet::new();
+        let agent_id = std::env::var("MCP_CLIENT_NAME").ok();
+
+        for entry in WalkDir::new(&mount.root)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(|e| !is_under_meta(mount, e.path()))
+        {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.path();
+            let rel = match relative(mount, path) {
+                Some(r) => r,
+                None => continue,
+            };
+            let rel_path = Path::new(&rel);
+            let meta = match crate::safe_fs::metadata(mount.root_fd.as_fd(), rel_path) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if !meta.is_file() {
+                continue;
+            }
+            if !is_indexable(rel_path, meta.len()) {
+                continue;
+            }
+            let body = match extract_text(mount.root_fd.as_fd(), rel_path) {
+                Some(b) => b,
+                None => continue,
+            };
+            let mtime = super::store::mtime_ms_of(&meta);
+            // Skip if already indexed with same mtime
+            if let Some(known) = store.mtime_for(&rel) {
+                if known == mtime {
+                    seen.insert(rel.clone());
+                    continue;
+                }
+            }
+            if let Err(e) = store.upsert(&rel, mtime, meta.len(), &body, agent_id.as_deref()) {
+                tracing::warn!("index full-scan upsert failed for {rel}: {e}");
+            }
+            seen.insert(rel);
         }
-        let path = entry.path();
-        let rel = match relative(mount, path) {
-            Some(r) => r,
-            None => continue,
-        };
+
+        // Remove entries no longer on disk
+        let known = store.known_paths()?;
+        for p in known {
+            if !seen.contains(&p) {
+                if let Err(e) = store.remove(&p) {
+                    tracing::warn!("index full-scan remove failed for {p}: {e}");
+                }
+            }
+        }
+    } // store lock released before the (potentially slow) embedding backfill
+
+    // Backfill dense embeddings for files that are BM25-indexed but have no
+    // vector — e.g. pre-existing files at startup, or files recovered after
+    // an inotify overflow. Without this, vector/hybrid search would miss any
+    // file that never received a modify event after the provider was enabled.
+    backfill_vectors(mount, store, embedding, rt_handle)?;
+
+    Ok(())
+}
+
+/// Compute and store embeddings for every indexed file that lacks one.
+/// The embedding HTTP call happens outside the store mutex so concurrent
+/// searches are not blocked; only the brief path-query and final vec-write
+/// hold the lock. No-op when no provider is configured.
+fn backfill_vectors(
+    mount: &MountPointLite,
+    store: &Arc<Mutex<BM25Store>>,
+    embedding: Option<&dyn EmbeddingProvider>,
+    rt_handle: Option<&tokio::runtime::Handle>,
+) -> Result<()> {
+    if embedding.is_none() {
+        return Ok(());
+    }
+    // Phase 1 (locked, brief): which indexed paths lack a vector?
+    let missing: Vec<String> = {
+        let store = store.lock().expect("index store poisoned");
+        store.paths_without_vec()?
+    };
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    // Phase 2 (lock-free): read body + embed. Holding the mutex across an
+    // embedding HTTP call would block every concurrent search.
+    let mut to_upsert: Vec<(String, Vec<f32>)> = Vec::new();
+    for rel in missing {
         let rel_path = Path::new(&rel);
-        let meta = match crate::safe_fs::metadata(mount.root_fd.as_fd(), rel_path) {
-            Ok(m) => m,
-            Err(_) => continue,
-        };
-        if !meta.is_file() {
-            continue;
-        }
-        if !is_indexable(rel_path, meta.len()) {
-            continue;
-        }
         let body = match extract_text(mount.root_fd.as_fd(), rel_path) {
             Some(b) => b,
             None => continue,
         };
-        let mtime = super::store::mtime_ms_of(&meta);
-        // Skip if already indexed with same mtime
-        if let Some(known) = store.mtime_for(&rel) {
-            if known == mtime {
-                seen.insert(rel.clone());
-                continue;
-            }
-        }
-        if let Err(e) = store.upsert(&rel, mtime, meta.len(), &body, agent_id.as_deref()) {
-            tracing::warn!("index full-scan upsert failed for {rel}: {e}");
-        }
-        seen.insert(rel);
-    }
-
-    // Remove entries no longer on disk
-    let known = store.known_paths()?;
-    for p in known {
-        if !seen.contains(&p) {
-            if let Err(e) = store.remove(&p) {
-                tracing::warn!("index full-scan remove failed for {p}: {e}");
-            }
+        if let Some(v) = embed_sync(embedding, rt_handle, &body) {
+            to_upsert.push((rel, v));
         }
     }
 
+    // Phase 3 (locked): write vectors.
+    if !to_upsert.is_empty() {
+        let mut store = store.lock().expect("index store poisoned");
+        for (rel, v) in to_upsert {
+            if let Err(e) = store.upsert_vec(&rel, &v) {
+                tracing::warn!("index full-scan vec upsert failed for {rel}: {e}");
+            }
+        }
+    }
     Ok(())
+}
+
+/// Drive an async embedding call from sync context, picking the blocking
+/// strategy for the current thread.
+///
+/// On a tokio runtime thread (the startup full_scan, called from within
+/// the server's `block_on`), `block_in_place` makes a nested
+/// `Handle::current().block_on` legal instead of panicking with
+/// "Cannot start a runtime from within a runtime". On the index worker's
+/// plain std::thread, drive via the runtime handle captured at spawn time
+/// (`block_on` from a non-runtime thread).
+///
+/// Returns `None` when no provider is configured or no runtime is available
+/// (tests outside a runtime); vector search then degrades to BM25, matching
+/// the no-provider fallback.
+fn embed_sync(
+    embedding: Option<&dyn EmbeddingProvider>,
+    rt_handle: Option<&tokio::runtime::Handle>,
+    text: &str,
+) -> Option<Vec<f32>> {
+    let emb = embedding?;
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(|| handle.block_on(emb.embed(text)))
+            .ok()
+            .map(|e| e.vector)
+    } else if let Some(handle) = rt_handle {
+        handle.block_on(emb.embed(text)).ok().map(|e| e.vector)
+    } else {
+        None
+    }
 }
 
 fn is_under_meta(mount: &MountPointLite, path: &Path) -> bool {

--- a/src/agent-memory/src/index/worker.rs
+++ b/src/agent-memory/src/index/worker.rs
@@ -422,18 +422,7 @@ fn is_under_meta(mount: &MountPointLite, path: &Path) -> bool {
     // Canonicalize before comparing so .anolisa/ events don't leak into
     // the index just because of a path-form mismatch.
     let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    canon.starts_with(&mount.meta_dir) || is_under_git(&canon, &mount.root)
-}
-
-/// Reject paths under .git/ — git internal files (HEAD, refs, COMMIT_EDITMSG)
-/// are not user memory content and pollute the FTS index when auto_commit
-/// triggers hundreds of inotify events per commit.
-fn is_under_git(path: &Path, root: &Path) -> bool {
-    path.strip_prefix(root)
-        .ok()
-        .and_then(|rel| rel.components().next())
-        .map(|c| c.as_os_str() == ".git")
-        .unwrap_or(false)
+    canon.starts_with(&mount.meta_dir) || crate::safe_fs::is_under_git(&canon, &mount.root)
 }
 
 fn relative(mount: &MountPointLite, path: &Path) -> Option<String> {

--- a/src/agent-memory/src/safe_fs/mod.rs
+++ b/src/agent-memory/src/safe_fs/mod.rs
@@ -150,6 +150,19 @@ pub fn exists(root: BorrowedFd<'_>, rel: &Path) -> bool {
     metadata(root, rel).is_ok()
 }
 
+/// Reject paths under a `.git/` directory at the mount root. Git internal
+/// files (HEAD, refs, COMMIT_EDITMSG, logs/) are OS-managed, not user
+/// memory, and must be excluded from indexing and context assembly just
+/// like the `.anolisa/` meta dir. Shared by the index worker and
+/// `memory_get_context` so the reserved-path set stays consistent.
+pub fn is_under_git(path: &Path, root: &Path) -> bool {
+    path.strip_prefix(root)
+        .ok()
+        .and_then(|rel| rel.components().next())
+        .map(|c| c.as_os_str() == ".git")
+        .unwrap_or(false)
+}
+
 /// Probe a path to confirm no symlink lies anywhere on the resolution
 /// path. Used by `mkdir` / `remove` (which still go through `std::fs`
 /// because openat2 has no recursive-rm primitive) to short-circuit

--- a/src/agent-memory/src/tools/memory_get_context.rs
+++ b/src/agent-memory/src/tools/memory_get_context.rs
@@ -30,10 +30,18 @@ pub fn memory_get_context(svc: &MemoryService, max_tokens: usize) -> Result<Stri
     // closing the symlink-swap TOCTOU window that std::fs::read_to_string
     // would leave open.
     let mut entries: Vec<(std::time::SystemTime, String, u64)> = Vec::new();
+    let root = svc.mount.root.clone();
     for entry in WalkDir::new(&svc.mount.root)
         .follow_links(false)
         .into_iter()
-        .filter_entry(|e| !e.path().starts_with(&meta_dir))
+        // Skip the OS-managed meta dir (.anolisa/) and the git mirror
+        // (.git/) — neither is user memory. `.git/` was previously
+        // leaked here (only the index worker excluded it), surfacing
+        // git internals like `.git/logs/HEAD` as context. Share the
+        // predicate with the worker via safe_fs::is_under_git.
+        .filter_entry(|e| {
+            !e.path().starts_with(&meta_dir) && !crate::safe_fs::is_under_git(e.path(), &root)
+        })
     {
         let entry = match entry {
             Ok(e) => e,

--- a/src/agent-memory/src/tools/memory_search.rs
+++ b/src/agent-memory/src/tools/memory_search.rs
@@ -126,20 +126,25 @@ pub fn memory_search(
                 }
             };
 
-            // FIXME: this blocks the tokio worker. In production the
-            // embedding call should be spawned on a dedicated blocking
-            // thread or use a channel-based async bridge. For now, the
-            // MCP server is single-client stdio so the block_on cost is
-            // bounded by the embedding provider's HTTP timeout.
-            //
-            // Use try_current() so tests (which run outside a tokio
-            // runtime) get a clean error instead of a panic.
-            let rt = tokio::runtime::Handle::try_current().map_err(|_| {
-                MemoryError::NotImplemented(
-                    "embedding requires a tokio runtime; tests should use #[tokio::test]",
-                )
-            })?;
-            let embedding = rt.block_on(emb.embed(query)).map_err(|e| {
+            // Drive the async embedding call from this sync tool handler.
+            // We are on a tokio worker thread (the MCP handler is async),
+            // so `Handle::block_on` on the *current* runtime would panic
+            // ("Cannot start a runtime from within a runtime").
+            // `block_in_place` moves this thread out of the scheduler,
+            // making a nested `Handle::current().block_on` legal. Requires
+            // a multi-thread runtime (the server uses one; tests covering
+            // this path must use `#[tokio::test(flavor = "multi_thread")]`).
+            // Outside any runtime, fall back to a clean NotImplemented.
+            let embedding = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::try_current()
+                    .map_err(|_| {
+                        MemoryError::NotImplemented(
+                            "embedding requires a tokio runtime; tests should use #[tokio::test]",
+                        )
+                    })?
+                    .block_on(emb.embed(query))
+            })
+            .map_err(|e| {
                 svc.audit_log(
                     AuditEntry::new(TOOL)
                         .path(format!("embed:{:.120}", query))

--- a/src/agent-memory/tests/tier_b_test.rs
+++ b/src/agent-memory/tests/tier_b_test.rs
@@ -3,12 +3,16 @@
 //! These tests need the inotify/FSEvents watcher; they sleep briefly to give
 //! events time to land. Time budgets are conservative (≤ 2s per case).
 
+use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use tempfile::tempdir;
 
 use agent_memory::config::AppConfig;
+use agent_memory::embedding::{Embedding, EmbeddingProvider};
 use agent_memory::error::MemoryError;
+use agent_memory::index::IndexHandle;
 use agent_memory::service::MemoryService;
 
 fn setup() -> (tempfile::TempDir, MemoryService) {
@@ -407,4 +411,83 @@ fn search_category_filter_works() {
         .memory_search("rust", 10, None, Some("nonexistent"), None)
         .unwrap();
     assert!(hits.is_empty(), "expected no hits for unknown category");
+}
+
+// ---------- vector / hybrid search with an embedding provider ----------
+//
+// Regression for the "Cannot start a runtime from within a runtime" panic
+// (memory_search.rs) and the silent files_vec skip (worker.rs). Before the
+// fix, `mode=vector|hybrid` panicked because the sync tool handler called
+// `Handle::block_on` from a tokio worker, and the index worker never wrote
+// any vectors because `Handle::try_current()` is None on its dedicated
+// std::thread. This test configures a mock provider and asserts both that
+// vectors land in the store and that search returns hits without panicking.
+
+/// Deterministic embedding: maps a keyword to a basis vector so cosine
+/// similarity cleanly separates "rust" docs from "python" docs.
+struct KeywordEmbedding {
+    dim: usize,
+}
+
+#[async_trait]
+impl EmbeddingProvider for KeywordEmbedding {
+    async fn embed(&self, text: &str) -> agent_memory::Result<Embedding> {
+        let mut v = vec![0.0_f32; self.dim];
+        let t = text.to_lowercase();
+        if t.contains("rust") {
+            v[0] = 1.0;
+        } else if t.contains("python") {
+            v[1] = 1.0;
+        } else {
+            v[2] = 1.0;
+        }
+        Ok(Embedding { vector: v })
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn vector_and_hybrid_search_with_provider_hit_without_panic() {
+    let tmp = tempdir().unwrap();
+    let mut cfg = AppConfig::default();
+    cfg.global.user_id = "tester".into();
+    cfg.memory.paths.base_dir = tmp.path().to_string_lossy().into();
+    cfg.memory.session.base_dir = tmp.path().join("__sessions__").to_string_lossy().into();
+    cfg.memory.mount.strategy = agent_memory::mount::MountStrategyKind::Userland;
+    let mut svc = MemoryService::new(cfg).unwrap();
+
+    // Inject the mock provider into the service and rebuild the index so
+    // the worker holds both the provider and a runtime handle captured on
+    // this thread (we are inside a multi-thread tokio runtime here).
+    let mock = Arc::new(KeywordEmbedding { dim: 8 });
+    svc.embedding = Some(mock.clone());
+    let new_index = IndexHandle::open(&svc.mount, Some(mock), 0.01, 0.3, true).unwrap();
+    svc.index = Some(Arc::new(new_index));
+
+    svc.write("notes/a.md", "rust ownership system", false)
+        .unwrap();
+    svc.write("notes/b.md", "python garbage collector", false)
+        .unwrap();
+
+    // README + 2 notes = 3 BM25 rows; then give the worker a debounce
+    // window to compute and flush embeddings.
+    assert!(wait_for_index(&svc, 3), "BM25 index did not reach 3 rows");
+    std::thread::sleep(Duration::from_millis(800));
+
+    // vector: must not panic; the "rust" query vector aligns with a.md.
+    let hits = svc
+        .memory_search("rust", 5, Some("vector"), None, None)
+        .unwrap();
+    assert!(!hits.is_empty(), "vector search returned no hits");
+    assert_eq!(hits[0].path, "notes/a.md");
+
+    // hybrid: must not panic either.
+    let hits = svc
+        .memory_search("rust", 5, Some("hybrid"), None, None)
+        .unwrap();
+    assert!(!hits.is_empty(), "hybrid search returned no hits");
+    assert_eq!(hits[0].path, "notes/a.md");
 }

--- a/src/agent-memory/tests/tier_b_test.rs
+++ b/src/agent-memory/tests/tier_b_test.rs
@@ -523,3 +523,48 @@ fn get_context_skips_git_dir() {
         "real note missing from context:\n{ctx}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn full_scan_backfills_vectors_for_preexisting_files() {
+    // Regression for the full_scan vector gap: files that exist on disk and
+    // are BM25-indexed but were never embedded (e.g. written before an
+    // embedding provider was configured) must get vectors on the next
+    // full_scan — otherwise vector/hybrid search silently misses them.
+    let tmp = tempdir().unwrap();
+    let mut cfg = AppConfig::default();
+    cfg.global.user_id = "tester".into();
+    cfg.memory.paths.base_dir = tmp.path().to_string_lossy().into();
+    cfg.memory.session.base_dir = tmp.path().join("__sessions__").to_string_lossy().into();
+    cfg.memory.mount.strategy = agent_memory::mount::MountStrategyKind::Userland;
+
+    // Phase 1: write two files with NO embedding provider → BM25 only.
+    {
+        let svc = MemoryService::new(cfg.clone()).unwrap();
+        svc.write("notes/a.md", "rust ownership system", false)
+            .unwrap();
+        svc.write("notes/b.md", "python garbage collector", false)
+            .unwrap();
+        assert!(wait_for_index(&svc, 3), "BM25 index did not reach 3 rows");
+    } // drop → worker joined, bm25.db persists on disk
+
+    // Phase 2: reopen on the same base_dir and inject a mock provider.
+    // IndexHandle::open's startup full_scan must backfill vectors for the
+    // pre-existing files without any new modify events.
+    let mut svc = MemoryService::new(cfg).unwrap();
+    let mock = Arc::new(KeywordEmbedding { dim: 8 });
+    svc.embedding = Some(mock.clone());
+    let new_index = IndexHandle::open(&svc.mount, Some(mock), 0.01, 0.3, true).unwrap();
+    svc.index = Some(Arc::new(new_index));
+
+    // full_scan ran synchronously inside open(); give the BM25 side a beat
+    // to settle, then vector search must find a.md (no new write happened).
+    std::thread::sleep(Duration::from_millis(300));
+    let hits = svc
+        .memory_search("rust", 5, Some("vector"), None, None)
+        .unwrap();
+    assert!(
+        !hits.is_empty(),
+        "vector search found no hits after backfill"
+    );
+    assert_eq!(hits[0].path, "notes/a.md");
+}

--- a/src/agent-memory/tests/tier_b_test.rs
+++ b/src/agent-memory/tests/tier_b_test.rs
@@ -491,3 +491,35 @@ async fn vector_and_hybrid_search_with_provider_hit_without_panic() {
     assert!(!hits.is_empty(), "hybrid search returned no hits");
     assert_eq!(hits[0].path, "notes/a.md");
 }
+
+#[test]
+fn get_context_skips_git_dir() {
+    // Regression: memory_get_context used to only filter .anolisa/ and
+    // leaked .git/logs/HEAD (and other git internals) into the agent's
+    // context when git versioning was enabled. It must now exclude .git/
+    // the same way the index worker does, while still surfacing real notes.
+    let tmp = tempdir().unwrap();
+    let mut cfg = AppConfig::default();
+    cfg.global.user_id = "tester".into();
+    cfg.memory.paths.base_dir = tmp.path().to_string_lossy().into();
+    cfg.memory.session.base_dir = tmp.path().join("__sessions__").to_string_lossy().into();
+    cfg.memory.mount.strategy = agent_memory::mount::MountStrategyKind::Userland;
+    cfg.memory.git.enabled = true;
+    cfg.memory.git.auto_commit = true;
+    let svc = MemoryService::new(cfg).unwrap();
+
+    svc.write("note.md", "real note body", false).unwrap();
+    // Let git auto-commit land so .git/logs/HEAD exists on disk.
+    std::thread::sleep(Duration::from_millis(400));
+
+    let ctx = svc.memory_get_context(4096).unwrap();
+    assert!(
+        !ctx.contains("## .git/"),
+        "context leaks git internals:\n{ctx}"
+    );
+    assert!(!ctx.contains("logs/HEAD"), "context leaks git log:\n{ctx}");
+    assert!(
+        ctx.contains("note.md"),
+        "real note missing from context:\n{ctx}"
+    );
+}


### PR DESCRIPTION
## Description

Fixes the vector/hybrid search path in `agent-memory` 0.2.0, which was completely non-functional whenever an embedding provider was configured, plus three related issues found during full functional verification against a real DashScope (OpenAI-compatible) embedding endpoint.

**Root cause of the primary bug (double failure):**
1. The index worker runs on a dedicated `std::thread` where `Handle::try_current()` returns `None`, so the embedding branch was skipped and `files_vec` stayed empty — no vectors were ever indexed.
2. `memory_search mode=vector|hybrid` called `Handle::block_on` from a tokio worker thread, panicking with `Cannot start a runtime from within a runtime`.

Existing CI only covered the no-provider BM25 fallback, so the runtime path escaped detection.

**Commits in this PR:**
- `fix(memory): unblock vector/hybrid search on tokio runtime` — capture the runtime handle at spawn time and thread it through to the worker; use `block_in_place` in the search path. Adds a regression test with a mock `EmbeddingProvider`.
- `fix(memory): stop leaking .git internals via memory_get_context` — `memory_get_context` only filtered `.anolisa/`, surfacing `.git/logs/HEAD` as agent context. Extract `is_under_git` to `safe_fs` as the single shared predicate.
- `docs(memory): align tool parameter tables with actual signatures` — `memory_timeline` was missing required `session_id`; the sovereignty/import-export table had no parameter columns. Rewritten against `mcp_server/tools.rs` (zh + en).
- `refactor(memory): resolve embedding dimensions from first response` — `OpenAiEmbedding` hardcoded 1536 for unknown models (DashScope `text-embedding-v3` is 1024). Store dimensionality in an `AtomicUsize` seeded with the estimate, overwrite from the first real response.
- `fix(memory): backfill vectors for preexisting files in full_scan` — `full_scan` (startup + inotify-overflow recovery) only built BM25, never vectors, so pre-existing files were invisible to vector search until modified. Adds a `paths_without_vec` query + a backfill pass; centralises the `block_on` strategy in an `embed_sync` helper used by both `flush` and `full_scan`.

## Related Issue

no-issue: vector/hybrid search was non-functional when an embedding provider was configured; the defects were discovered and root-caused during full functional verification of the installed 0.2.0 build, and no tracking issue exists yet.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [x] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Branch rebased onto latest `alibaba/main`; pre-push CI all green:

- `cargo fmt --check` — pass
- `cargo clippy --all-targets -- -D warnings` — 0 warnings
- `cargo test` — 161 unit + all integration suites pass (tier_b now 23, +2 new regression tests)

End-to-end verification against a real DashScope `text-embedding-v3` (1024-dim) endpoint via a stdio JSON-RPC driver:

- `memory_search mode=vector` returns the semantic match (`decisions/2026-06/db-pick.md`, score 0.805) for a Chinese query with no keyword overlap — previously panicked.
- `memory_search mode=hybrid` returns the same hit (RRF score 0.33) — previously panicked.
- 46/46 functional cases pass, 0 panics.
- `memory_get_context` output no longer contains `.git/` entries (was leaking `.git/logs/HEAD`).
- Startup log now reads `dims=… estimated; resolves on first embed`; true 1024-dim is locked in after the first embed.

New regression tests in `tests/tier_b_test.rs`:
- `vector_and_hybrid_search_with_provider_hit_without_panic` — mock provider + multi-thread runtime; asserts vectors land in the store and search returns hits without panicking.
- `get_context_skips_git_dir` — enables git, asserts `.git/` is absent from context while real notes are present.
- `full_scan_backfills_vectors_for_preexisting_files` — writes files with no provider, reopens with a mock provider, asserts vector search finds the preexisting files with no new modify events.

## Additional Notes

- No LLM is required for vector search; only an embedding model (`/v1/embeddings` endpoint). agent-memory itself makes zero LLM calls.
- The startup `full_scan` now computes embeddings for pre-existing files synchronously, which adds HTTP latency proportional to file count at startup. This is bounded by the embedding provider's timeout and is the intended trade-off for correctness (vector search must see pre-existing memory). Files already embedding-persisted in `files_vec` are skipped via the `paths_without_vec` query.
- Commits are `Signed-off-by: Shile Zhang <shile.zhang@linux.alibaba.com>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
