### PR TITLE
feat(memory): add anolisa-cli adapter contract via component.toml

### DIFF
--- a/src/agent-memory/.anolisa/component.toml
+++ b/src/agent-memory/.anolisa/component.toml
@@ -1,0 +1,23 @@
+# Agent-memory RPM component contract (source template).
+# The version field below is substituted from Cargo.toml by `make` (sed).
+# This is publishing/plugin metadata only — framework execution (config
+# writes, skill delivery, CLI argv, scripts) belongs to built-in framework
+# drivers, not generic manifest keys.
+# Installed to: %{_datadir}/anolisa/components/agent-memory/component.toml
+[component]
+name = "agent-memory"
+version = "0.2.0"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "memory-anolisa"
+source = "adapters/openclaw"
+dest = "{datadir}/adapters/{component}/openclaw/"
+
+[adapters.bundle]
+# Entry-point manifest inside the bundle directory (the file the OpenClaw
+# driver reads to identify the plugin). Declared explicitly rather than
+# relying on the driver's "openclaw.plugin.json" default, so the contract is
+# self-describing and survives driver default changes.
+entry = "openclaw.plugin.json"

--- a/src/agent-memory/.anolisa/component.toml.in
+++ b/src/agent-memory/.anolisa/component.toml.in
@@ -1,0 +1,23 @@
+# Agent-memory RPM component contract (source template).
+# The version field below is substituted from Cargo.toml by `make` (sed).
+# This is publishing/plugin metadata only — framework execution (config
+# writes, skill delivery, CLI argv, scripts) belongs to built-in framework
+# drivers, not generic manifest keys.
+# Installed to: %{_datadir}/anolisa/components/agent-memory/component.toml
+[component]
+name = "agent-memory"
+version = "@VERSION@"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "memory-anolisa"
+source = "adapters/openclaw"
+dest = "{datadir}/adapters/{component}/openclaw/"
+
+[adapters.bundle]
+# Entry-point manifest inside the bundle directory (the file the OpenClaw
+# driver reads to identify the plugin). Declared explicitly rather than
+# relying on the driver's "openclaw.plugin.json" default, so the contract is
+# self-describing and survives driver default changes.
+entry = "openclaw.plugin.json"

--- a/src/agent-memory/Makefile
+++ b/src/agent-memory/Makefile
@@ -25,6 +25,10 @@ SHARE_DIR ?= $(DATADIR)/adapters/agent-memory
 # Adapter directories
 ADAPTER_SRC_DIR := adapters/agent-memory
 OPENCLAW_PLUGIN_SRC_DIR := $(ADAPTER_SRC_DIR)/openclaw
+# Component contract (publishing/plugin metadata) — kept separate from the
+# adapter payload tree so the contract is not mixed with adapter resources.
+# Shipped to %{_datadir}/anolisa/components/agent-memory/component.toml.
+COMPONENT_CONTRACT := .anolisa/component.toml
 
 # RPM build paths
 RPMBUILD_DIR ?= $(HOME)/rpmbuild
@@ -87,7 +91,11 @@ sync-versions: ## Sync $(VERSION) (from Cargo.toml) into all derived JSON files
 		echo "==> Synced derived files to $(VERSION)"; \
 	fi
 
-build-openclaw-plugin: sync-versions ## Build openclaw TS plugin (dist/index.js)
+$(COMPONENT_CONTRACT): $(COMPONENT_CONTRACT).in Cargo.toml
+	@echo "==> Generating component contract (version=$(VERSION))..."
+	@sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+build-openclaw-plugin: sync-versions $(COMPONENT_CONTRACT) ## Build openclaw TS plugin (dist/index.js)
 	@echo "==> Building $(NAME) OpenClaw plugin..."
 	# --legacy-peer-deps: the plugin declares `openclaw: "*"` as a peer
 	# but the dev openclaw resolves to CalVer 2026.5.7, which npm 7+'s
@@ -207,7 +215,7 @@ dist: clean build-openclaw-plugin ## Create source + vendor tarballs for RPM bui
 	@rm -rf dist/$(NAME)-$(VERSION) && mkdir -p dist/$(NAME)-$(VERSION)
 	@cp -R Cargo.toml Cargo.lock src config tests docs \
 		Makefile agent-memory.spec.in CHANGELOG.md LICENSE \
-		.gitignore dist/$(NAME)-$(VERSION)/
+		.gitignore .anolisa dist/$(NAME)-$(VERSION)/
 	@mkdir -p dist/$(NAME)-$(VERSION)/.cargo
 	@cp .cargo/config.toml dist/$(NAME)-$(VERSION)/.cargo/config.toml
 	# Adapter: include source + pre-built dist/index.js, exclude
@@ -261,7 +269,7 @@ clean: ## Clean build artifacts
 	cargo clean
 	rm -rf dist/ vendor/ .cargo/
 	rm -rf $(OPENCLAW_PLUGIN_SRC_DIR)/dist/ $(OPENCLAW_PLUGIN_SRC_DIR)/node_modules/
-	rm -f $(SPEC_FILE)
+	rm -f $(SPEC_FILE) $(COMPONENT_CONTRACT)
 	rm -rf $(OPENCLAW_PLUGIN_SRC_DIR)/dist $(OPENCLAW_PLUGIN_SRC_DIR)/node_modules
 
 version: ## Show current version

--- a/src/agent-memory/agent-memory.spec.in
+++ b/src/agent-memory/agent-memory.spec.in
@@ -135,6 +135,12 @@ mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/agent-memory/openclaw/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/agent-memory/openclaw/dist
 
 install -m 0644 adapters/agent-memory/manifest.json %{buildroot}%{_datadir}/anolisa/adapters/agent-memory/
+# Install the agent-memory RPM component contract (publishing/plugin
+# metadata) at the component-level path declared by the ANOLISA
+# component-contract model:
+# %{_datadir}/anolisa/components/<component>/component.toml.
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/components/agent-memory
+install -m 0644 .anolisa/component.toml %{buildroot}%{_datadir}/anolisa/components/agent-memory/
 install -m 0755 adapters/agent-memory/openclaw/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/agent-memory/openclaw/scripts/
 install -m 0755 adapters/agent-memory/openclaw/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/agent-memory/openclaw/scripts/
 install -m 0755 adapters/agent-memory/openclaw/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/agent-memory/openclaw/scripts/
@@ -151,6 +157,9 @@ install -m 0644 adapters/agent-memory/openclaw/dist/index.js %{buildroot}%{_data
 %dir %{_datadir}/anolisa
 %dir %{_datadir}/anolisa/agent-memory
 %attr(0644,root,root) %{_datadir}/anolisa/agent-memory/default.toml
+%dir %{_datadir}/anolisa/components
+%dir %{_datadir}/anolisa/components/agent-memory
+%attr(0644,root,root) %{_datadir}/anolisa/components/agent-memory/component.toml
 %dir %{_datadir}/anolisa/mcp-servers
 %attr(0644,root,root) %{_datadir}/anolisa/mcp-servers/agent-memory.json
 %{_userunitdir}/anolisa-memory@.service


### PR DESCRIPTION
## Description

Mirror tokenless's `component-contract` pattern so the anolisa CLI adapter manager can discover the OpenClaw plugin bundle through the new `[[adapters]]` TOML schema instead of the legacy `manifest.json`.

- `.anolisa/component.toml.in`: template with `@VERSION@` placeholder, declares the openclaw adapter (`plugin_id=memory-anolisa`, `bundle.entry=openclaw.plugin.json`, `dest={datadir}/adapters/{component}/openclaw/`).
- `Makefile`: `sed` rule generates `.anolisa/component.toml` from `.in`, wired into `build-openclaw-plugin` deps; `dist` tarball now packs `.anolisa/`.
- `agent-memory.spec.in`: install `component.toml` to `%{_datadir}/anolisa/components/agent-memory/` and declare in `%files`.

The legacy `adapters/agent-memory/manifest.json` is kept (transitional, aligns with tokenless which ships both). anolisa-core already parses the `[[adapters]]` schema (`AdapterSpec`/`AdapterBundleSpec` in `anolisa-core/src/manifest.rs`), so no Rust changes are needed.

## Related Issue

no-issue: aligns with tokenless's existing component-contract pattern; a contract-completion change with no dedicated issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `memory` (agent-memory)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `make .anolisa/component.toml` — generates correctly, `version = "0.2.0"` substituted from `Cargo.toml`.
- `cargo fmt --check` — passes.
- Verified the `dest` template expands to the spec install path: `{datadir}/adapters/{component}/openclaw/` → `adapters/agent-memory/openclaw/`, matching `agent-memory.spec.in` `%install`.
- Verified the schema mirrors tokenless's openclaw `[[adapters]]` entry verbatim (only `name`/`version`/`plugin_id` differ).
- Verified `anolisa-core` parses `[[adapters]]` via `AdapterSpec`/`AdapterBundleSpec` (`crates/anolisa-core/src/manifest.rs`).

> Note: `cargo clippy`/`cargo test` were **not** run locally — the local `vendor/` dir is incomplete (missing `reqwest`), an environment artifact since `vendor/` is gitignored and not part of this PR. This PR contains no Rust source changes; CI will run the full `clippy`/`test` gate via `make dist` re-vendoring.

## Additional Notes

The generated `.anolisa/component.toml` is committed (version already substituted), matching tokenless's existing convention. `%dir %{_datadir}/anolisa/components` ownership matches `os-skills`/`tokenless` specs (shared dir owned by multiple packages — standard RPM practice, not a conflict).