### PR TITLE
fix(sight): exit non-zero on CLI query failures

### DIFF
--- a/src/agentsight/src/bin/cli/audit.rs
+++ b/src/agentsight/src/bin/cli/audit.rs
@@ -78,14 +78,20 @@ impl AuditCommand {
 
         match store.query_since(since_ns, event_type) {
             Ok(records) => self.output_records(&records, &format!("Last {hours} hours")),
-            Err(e) => eprintln!("Query failed: {e}"),
+            Err(e) => {
+                eprintln!("Query failed: {e}");
+                std::process::exit(1);
+            }
         }
     }
 
     fn query_by_pid(&self, store: &AuditStore, pid: u32, event_type: Option<AuditEventType>) {
         match store.query_by_pid(pid, event_type) {
             Ok(records) => self.output_records(&records, &format!("PID {pid}")),
-            Err(e) => eprintln!("Query failed: {e}"),
+            Err(e) => {
+                eprintln!("Query failed: {e}");
+                std::process::exit(1);
+            }
         }
     }
 
@@ -198,7 +204,10 @@ impl AuditCommand {
                     }
                 }
             }
-            Err(e) => eprintln!("Summary query failed: {e}"),
+            Err(e) => {
+                eprintln!("Summary query failed: {e}");
+                std::process::exit(1);
+            }
         }
     }
 }

--- a/src/agentsight/src/bin/cli/token.rs
+++ b/src/agentsight/src/bin/cli/token.rs
@@ -44,7 +44,10 @@ impl TokenCommand {
     }
 
     fn execute_summary(&self, data_path: &std::path::Path) {
-        // Open token store
+        if self.data_file.is_some() && !data_path.exists() {
+            eprintln!("Database not found: {}", data_path.display());
+            std::process::exit(1);
+        }
         let store = TokenStore::new(data_path);
         let query = agentsight::TokenQuery::new(&store);
 


### PR DESCRIPTION
## Summary

audit/token CLI 查询失败时 exit 0,调用方无法从退出码判断成功/失败。

## Fix

- audit: query_by_time, query_by_pid, print_summary 失败后 process::exit(1)
- token: --data-file 指向不存在的路径时 exit 1(不再静默创建空 DB 返回全零)

## What is NOT changed

- summary 子命令仍然 exit 0(设计如此,degraded sources 不算失败)
- 默认路径(无 --data-file)行为不变