### PR TITLE
fix(sec-core): tame ledger reconcile noise

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/skill_ledger_activation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/skill_ledger_activation.py
@@ -16,6 +16,7 @@ from agent_sec_cli.daemon.jobs.base import BackgroundJob, JobStatus, utc_now
 from agent_sec_cli.daemon.protocol import DaemonRequest
 from agent_sec_cli.daemon.registry import HandlerResult, MethodSpec
 from agent_sec_cli.daemon.runtime import DaemonRuntime
+from agent_sec_cli.skill_ledger.errors import SkillLedgerError
 
 METHOD_SKILLFS_NOTIFY_CHANGE = "skill_ledger.skillfs_notify_change"
 SCHEMA_VERSION = 1
@@ -37,6 +38,7 @@ _ALLOWED_EVENT_KINDS = frozenset(
         "reconcile",
     }
 )
+_UNRESOLVED_LIVE_ROOT_PREFIX = "cannot resolve live skill root for "
 
 
 @dataclass
@@ -273,9 +275,16 @@ def process_skill_change(change: SkillFsChange) -> dict[str, Any]:
     try:
         scan_result = _scan_skill(str(change.skill_dir), backend)
     except Exception as exc:
+        if _is_unresolved_live_root_error(exc):
+            return _skipped_unmanaged_result(change, str(exc))
         scan_error = str(exc)
 
-    activation_result = _resolve_activation(str(change.skill_dir), backend, policy)
+    try:
+        activation_result = _resolve_activation(str(change.skill_dir), backend, policy)
+    except Exception as exc:
+        if scan_error is None and _is_unresolved_live_root_error(exc):
+            return _skipped_unmanaged_result(change, str(exc))
+        raise
     result: dict[str, Any] = {
         "status": "processed" if scan_error is None else "error",
         "skill": change.to_dict(),
@@ -285,6 +294,23 @@ def process_skill_change(change: SkillFsChange) -> dict[str, Any]:
     if scan_error is not None:
         result["error"] = scan_error
     return result
+
+
+def _is_unresolved_live_root_error(exc: Exception) -> bool:
+    return isinstance(exc, SkillLedgerError) and str(exc).startswith(
+        _UNRESOLVED_LIVE_ROOT_PREFIX
+    )
+
+
+def _skipped_unmanaged_result(change: SkillFsChange, message: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "reasonCode": "unmanaged_skill_root",
+        "message": message,
+        "skill": change.to_dict(),
+        "scan": None,
+        "activation": None,
+    }
 
 
 def _validate_skill_dir(value: Any) -> Path:
@@ -361,7 +387,7 @@ def _resolve_activation_policy() -> str:
 
 def _resolve_managed_skill_dirs() -> list[Path]:
     from agent_sec_cli.skill_ledger.config import (  # noqa: PLC0415
-        resolve_skill_dirs,
+        resolve_managed_skill_dirs,
     )
 
-    return resolve_skill_dirs()
+    return resolve_managed_skill_dirs()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/skill_ledger_activation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/skill_ledger_activation.py
@@ -16,7 +16,7 @@ from agent_sec_cli.daemon.jobs.base import BackgroundJob, JobStatus, utc_now
 from agent_sec_cli.daemon.protocol import DaemonRequest
 from agent_sec_cli.daemon.registry import HandlerResult, MethodSpec
 from agent_sec_cli.daemon.runtime import DaemonRuntime
-from agent_sec_cli.skill_ledger.errors import SkillLedgerError
+from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 METHOD_SKILLFS_NOTIFY_CHANGE = "skill_ledger.skillfs_notify_change"
 SCHEMA_VERSION = 1
@@ -38,7 +38,6 @@ _ALLOWED_EVENT_KINDS = frozenset(
         "reconcile",
     }
 )
-_UNRESOLVED_LIVE_ROOT_PREFIX = "cannot resolve live skill root for "
 
 
 @dataclass
@@ -272,18 +271,26 @@ def process_skill_change(change: SkillFsChange) -> dict[str, Any]:
     policy = _resolve_activation_policy()
     scan_result: dict[str, Any] | None = None
     scan_error: str | None = None
+    scan_exception: Exception | None = None
     try:
         scan_result = _scan_skill(str(change.skill_dir), backend)
     except Exception as exc:
         if _is_unresolved_live_root_error(exc):
             return _skipped_unmanaged_result(change, str(exc))
         scan_error = str(exc)
+        scan_exception = exc
 
     try:
         activation_result = _resolve_activation(str(change.skill_dir), backend, policy)
     except Exception as exc:
-        if scan_error is None and _is_unresolved_live_root_error(exc):
-            return _skipped_unmanaged_result(change, str(exc))
+        if _is_unresolved_live_root_error(exc):
+            if scan_exception is None:
+                return _skipped_unmanaged_result(change, str(exc))
+            # A prior scanner failure is the health signal; keep it attached
+            # instead of downgrading the later live-root failure to skipped.
+            raise exc from scan_exception
+        if scan_exception is not None:
+            raise exc from scan_exception
         raise
     result: dict[str, Any] = {
         "status": "processed" if scan_error is None else "error",
@@ -297,9 +304,7 @@ def process_skill_change(change: SkillFsChange) -> dict[str, Any]:
 
 
 def _is_unresolved_live_root_error(exc: Exception) -> bool:
-    return isinstance(exc, SkillLedgerError) and str(exc).startswith(
-        _UNRESOLVED_LIVE_ROOT_PREFIX
-    )
+    return isinstance(exc, UnresolvedLiveRootError)
 
 
 def _skipped_unmanaged_result(change: SkillFsChange, message: str) -> dict[str, Any]:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/live_root.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/live_root.py
@@ -19,7 +19,10 @@ from agent_sec_cli.skill_ledger.core.manifest_integrity import (
     verify_manifest_integrity,
 )
 from agent_sec_cli.skill_ledger.core.version_chain import snapshot_dir_path
-from agent_sec_cli.skill_ledger.errors import SkillLedgerError
+from agent_sec_cli.skill_ledger.errors import (
+    SkillLedgerError,
+    UnresolvedLiveRootError,
+)
 from agent_sec_cli.skill_ledger.models.manifest import SignedManifest
 from agent_sec_cli.skill_ledger.signing.base import SigningBackend
 from agent_sec_cli.skill_ledger.utils import validate_skill_dir
@@ -128,12 +131,7 @@ def require_live_skill_dir(
     resolution = resolve_live_skill_dir(skill_dir, backend)
     if resolution.skill_dir is not None:
         return resolution.skill_dir
-    raise SkillLedgerError(
-        f"cannot resolve live skill root for {Path(skill_dir)}; the path may be "
-        "a SkillFS runtime view. Run the command against a Skill Ledger managed "
-        "source/backing skill path or ensure managedSkillDirs points to "
-        "source/backing roots."
-    )
+    raise UnresolvedLiveRootError(Path(skill_dir))
 
 
 def live_skill_dir_manageability(

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/errors.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/errors.py
@@ -1,5 +1,7 @@
 """Custom exception hierarchy for skill-ledger."""
 
+from pathlib import Path
+
 
 class SkillLedgerError(Exception):
     """Base exception for all skill-ledger errors."""
@@ -60,6 +62,24 @@ class ConfigError(SkillLedgerError):
     def __init__(self, reason: str) -> None:
         super().__init__(f"Configuration error: {reason}")
         self.reason = reason
+
+
+# ---------------------------------------------------------------------------
+# Live root resolution
+# ---------------------------------------------------------------------------
+
+
+class UnresolvedLiveRootError(SkillLedgerError):
+    """A user-visible skill path cannot be resolved to a live source root."""
+
+    def __init__(self, skill_dir: str | Path) -> None:
+        self.skill_dir = Path(skill_dir)
+        super().__init__(
+            f"cannot resolve live skill root for {self.skill_dir}; the path may be "
+            "a SkillFS runtime view. Run the command against a Skill Ledger managed "
+            "source/backing skill path or ensure managedSkillDirs points to "
+            "source/backing roots."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
+++ b/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
@@ -170,7 +170,8 @@ class TestVerifySkillsDir(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_nonexistent_dir(self):
-        results = verify_skills_dir("/nonexistent/path", [])
+        missing_dir = os.path.join(self.tmpdir, "missing_skills")
+        results = verify_skills_dir(missing_dir, [])
         self.assertEqual(results["passed"], [])
         self.assertEqual(results["failed"], [])
 
@@ -192,8 +193,9 @@ class TestLoadConfig(unittest.TestCase):
     def test_missing_config(self):
         from pathlib import Path
 
+        missing_config = Path(self.tmpdir) / "missing.conf"
         with self.assertRaises(ErrConfigMissing):
-            load_config(Path("/nonexistent/config.conf"))
+            load_config(missing_config)
 
     def test_single_skills_dir(self):
         from pathlib import Path
@@ -229,8 +231,9 @@ class TestLoadTrustedKeys(unittest.TestCase):
     def test_nonexistent_dir(self):
         from pathlib import Path
 
+        missing_dir = Path(self.tmpdir) / "missing_keys"
         with self.assertRaises(ErrNoTrustedKeys):
-            load_trusted_keys(Path("/nonexistent/keys"))
+            load_trusted_keys(missing_dir)
 
     def test_empty_keys_dir(self):
         from pathlib import Path

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -12,7 +12,7 @@ from agent_sec_cli.daemon.skill_ledger_activation import (
     METHOD_SKILLFS_NOTIFY_CHANGE,
 )
 from agent_sec_cli.skill_ledger import config as config_module
-from agent_sec_cli.skill_ledger.errors import SkillLedgerError
+from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 PENDING_DECISION_TARGET = ".skill-meta/versions/__pending_decision__.snapshot"
 
@@ -764,17 +764,12 @@ def test_daemon_unresolved_live_root_keeps_job_running(monkeypatch, tmp_path: Pa
     write_isolated_config(tmp_path)
     skill_dir = make_skill(tmp_path / "skills", "weather", {"run.sh": "echo ok\n"})
     socket_path = daemon_socket_path(tmp_path)
-    message = (
-        f"cannot resolve live skill root for {skill_dir.resolve()}; the path may be "
-        "a SkillFS runtime view. Run the command against a Skill Ledger managed "
-        "source/backing skill path or ensure managedSkillDirs points to "
-        "source/backing roots."
-    )
+    live_root_error = UnresolvedLiveRootError(skill_dir.resolve())
     scan_calls = {"count": 0}
 
     def fail_live_root(_skill_path: str, _backend: Any) -> dict[str, Any]:
         scan_calls["count"] += 1
-        raise SkillLedgerError(message)
+        raise live_root_error
 
     monkeypatch.setattr(
         "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -5,11 +5,14 @@ import json
 from pathlib import Path
 from typing import Any
 
+from agent_sec_cli.daemon import skill_ledger_activation
 from agent_sec_cli.daemon.client import DaemonClient
 from agent_sec_cli.daemon.server import DaemonServer
 from agent_sec_cli.daemon.skill_ledger_activation import (
     METHOD_SKILLFS_NOTIFY_CHANGE,
 )
+from agent_sec_cli.skill_ledger import config as config_module
+from agent_sec_cli.skill_ledger.errors import SkillLedgerError
 
 PENDING_DECISION_TARGET = ".skill-meta/versions/__pending_decision__.snapshot"
 
@@ -209,8 +212,6 @@ def test_daemon_reconcile_existing_clean_skill_keeps_existing_version(
     skill_dir = make_skill(tmp_path / "skills", "weather", {"run.sh": "echo ok\n"})
     socket_path = daemon_socket_path(tmp_path)
     scan_calls = {"count": 0}
-
-    from agent_sec_cli.daemon import skill_ledger_activation
 
     real_scan = skill_ledger_activation._scan_skill
 
@@ -692,6 +693,126 @@ def test_daemon_invalid_activation_policy_sets_job_error(monkeypatch, tmp_path: 
     assert activation_job["state"] == "error"
     assert "activationPolicy" in activation_job["last_error"]
     assert not (skill_dir / ".skill-meta" / "activation.json").exists()
+
+
+def test_daemon_startup_reconcile_ignores_default_discovery_dirs(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg_data"))
+    managed_skill = make_skill(
+        tmp_path / "managed-skills",
+        "managed-weather",
+        {"run.sh": "echo ok\n"},
+    )
+    default_skill = make_skill(
+        tmp_path / "default-skills",
+        "default-weather",
+        {"run.sh": "echo ok\n"},
+    )
+    monkeypatch.setattr(
+        config_module,
+        "DEFAULT_SKILL_DIRS",
+        [str(default_skill.parent / "*")],
+    )
+    write_isolated_config(
+        tmp_path,
+        {
+            "enableDefaultSkillDirs": True,
+            "managedSkillDirs": [str(managed_skill)],
+        },
+    )
+    socket_path = daemon_socket_path(tmp_path)
+    scanned: list[str] = []
+
+    real_scan = skill_ledger_activation._scan_skill
+
+    def spy_scan(skill_path: str, backend: Any) -> dict[str, Any]:
+        scanned.append(skill_path)
+        return real_scan(skill_path, backend)
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        spy_scan,
+    )
+
+    async def scenario():
+        server = DaemonServer(socket_path=socket_path)
+        await server.start()
+        try:
+            activation = await wait_for(
+                lambda: (
+                    read_activation(managed_skill)
+                    if (managed_skill / ".skill-meta" / "activation.json").is_file()
+                    else None
+                )
+            )
+        finally:
+            await server.stop()
+        return activation
+
+    activation = asyncio.run(scenario())
+
+    assert activation["target"] == ".skill-meta/versions/v000001.snapshot"
+    assert scanned == [str(managed_skill.resolve())]
+    assert not (default_skill / ".skill-meta" / "activation.json").exists()
+
+
+def test_daemon_unresolved_live_root_keeps_job_running(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg_data"))
+    write_isolated_config(tmp_path)
+    skill_dir = make_skill(tmp_path / "skills", "weather", {"run.sh": "echo ok\n"})
+    socket_path = daemon_socket_path(tmp_path)
+    message = (
+        f"cannot resolve live skill root for {skill_dir.resolve()}; the path may be "
+        "a SkillFS runtime view. Run the command against a Skill Ledger managed "
+        "source/backing skill path or ensure managedSkillDirs points to "
+        "source/backing roots."
+    )
+    scan_calls = {"count": 0}
+
+    def fail_live_root(_skill_path: str, _backend: Any) -> dict[str, Any]:
+        scan_calls["count"] += 1
+        raise SkillLedgerError(message)
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        fail_live_root,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation",
+        lambda _skill_path, _backend, _policy: {"target": None},
+    )
+
+    async def scenario():
+        server = DaemonServer(socket_path=socket_path)
+        await server.start()
+        try:
+            client = DaemonClient(socket_path=socket_path, timeout_ms=3000)
+            response = await asyncio.to_thread(
+                client.call,
+                METHOD_SKILLFS_NOTIFY_CHANGE,
+                notify_payload(skill_dir),
+                trace_context={},
+            )
+            await wait_for(lambda: scan_calls["count"] == 1)
+            health = await asyncio.to_thread(
+                client.call,
+                "daemon.health",
+                trace_context={},
+            )
+        finally:
+            await server.stop()
+        return response, health
+
+    response, health = asyncio.run(scenario())
+
+    assert response.ok is True
+    jobs = {job["name"]: job for job in health.data["jobs"]}
+    activation_job = jobs["skill-ledger-activation"]
+    assert activation_job["state"] == "running"
+    assert activation_job["last_error"] is None
 
 
 def test_daemon_startup_reconciles_managed_skill(monkeypatch, tmp_path: Path):

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -19,7 +19,7 @@ from agent_sec_cli.daemon.skill_ledger_activation import (
     process_skill_change,
     skillfs_notify_change_handler,
 )
-from agent_sec_cli.skill_ledger.errors import SkillLedgerError
+from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 
 def make_skill(tmp_path: Path, name: str = "demo-skill") -> Path:
@@ -393,12 +393,7 @@ def test_process_skill_change_skips_unresolved_live_root_from_scan(
 ):
     skill_dir = make_skill(tmp_path, "weather")
     backend = object()
-    message = (
-        f"cannot resolve live skill root for {skill_dir.resolve()}; the path may be "
-        "a SkillFS runtime view. Run the command against a Skill Ledger managed "
-        "source/backing skill path or ensure managedSkillDirs points to "
-        "source/backing roots."
-    )
+    live_root_error = UnresolvedLiveRootError(skill_dir.resolve())
 
     def fake_backend() -> object:
         return backend
@@ -406,7 +401,7 @@ def test_process_skill_change_skips_unresolved_live_root_from_scan(
     def fail_scan(path: str, received_backend: object) -> dict[str, Any]:
         assert path == str(skill_dir.resolve())
         assert received_backend is backend
-        raise SkillLedgerError(message)
+        raise live_root_error
 
     monkeypatch.setattr(
         "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
@@ -428,7 +423,7 @@ def test_process_skill_change_skips_unresolved_live_root_from_scan(
 
     assert result["status"] == "skipped"
     assert result["reasonCode"] == "unmanaged_skill_root"
-    assert result["message"] == message
+    assert result["message"] == str(live_root_error)
     assert result["skill"]["skillName"] == "weather"
     assert result["scan"] is None
     assert result["activation"] is None
@@ -441,12 +436,7 @@ def test_process_skill_change_skips_unresolved_live_root_from_activation(
 ):
     skill_dir = make_skill(tmp_path, "weather")
     backend = object()
-    message = (
-        f"cannot resolve live skill root for {skill_dir.resolve()}; the path may be "
-        "a SkillFS runtime view. Run the command against a Skill Ledger managed "
-        "source/backing skill path or ensure managedSkillDirs points to "
-        "source/backing roots."
-    )
+    live_root_error = UnresolvedLiveRootError(skill_dir.resolve())
 
     def fake_backend() -> object:
         return backend
@@ -462,7 +452,7 @@ def test_process_skill_change_skips_unresolved_live_root_from_activation(
         assert path == str(skill_dir.resolve())
         assert received_backend is backend
         assert policy == "pass_only"
-        raise SkillLedgerError(message)
+        raise live_root_error
 
     monkeypatch.setattr(
         "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
@@ -492,11 +482,67 @@ def test_process_skill_change_skips_unresolved_live_root_from_activation(
 
     assert result["status"] == "skipped"
     assert result["reasonCode"] == "unmanaged_skill_root"
-    assert result["message"] == message
+    assert result["message"] == str(live_root_error)
     assert result["skill"]["skillName"] == "weather"
     assert result["scan"] is None
     assert result["activation"] is None
     assert "error" not in result
+
+
+def test_process_skill_change_does_not_skip_live_root_after_scan_error(
+    monkeypatch,
+    tmp_path: Path,
+):
+    skill_dir = make_skill(tmp_path, "weather")
+    backend = object()
+    scan_failure = RuntimeError("scanner failed")
+    live_root_error = UnresolvedLiveRootError(skill_dir.resolve())
+
+    def fake_backend() -> object:
+        return backend
+
+    def fail_scan(path: str, received_backend: object) -> dict[str, Any]:
+        assert path == str(skill_dir.resolve())
+        assert received_backend is backend
+        raise scan_failure
+
+    def fail_resolve(
+        path: str, received_backend: object, policy: str
+    ) -> dict[str, Any]:
+        assert path == str(skill_dir.resolve())
+        assert received_backend is backend
+        assert policy == "pass_only"
+        raise live_root_error
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
+        fake_backend,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        fail_scan,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation",
+        fail_resolve,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation_policy",
+        lambda: "pass_only",
+    )
+
+    with pytest.raises(UnresolvedLiveRootError) as exc_info:
+        process_skill_change(
+            SkillFsChange(
+                skill_dir=skill_dir.resolve(),
+                skill_name=skill_dir.name,
+                event_kinds={"write"},
+                paths={"SKILL.md"},
+            )
+        )
+
+    assert exc_info.value is live_root_error
+    assert exc_info.value.__cause__ is scan_failure
 
 
 def test_default_job_name_is_stable():

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -19,6 +19,7 @@ from agent_sec_cli.daemon.skill_ledger_activation import (
     process_skill_change,
     skillfs_notify_change_handler,
 )
+from agent_sec_cli.skill_ledger.errors import SkillLedgerError
 
 
 def make_skill(tmp_path: Path, name: str = "demo-skill") -> Path:
@@ -384,6 +385,118 @@ def test_process_skill_change_resolves_activation_after_scan_error(
         ("scan", str(skill_dir.resolve()), backend),
         ("resolve", str(skill_dir.resolve()), backend, "pass_only"),
     ]
+
+
+def test_process_skill_change_skips_unresolved_live_root_from_scan(
+    monkeypatch,
+    tmp_path: Path,
+):
+    skill_dir = make_skill(tmp_path, "weather")
+    backend = object()
+    message = (
+        f"cannot resolve live skill root for {skill_dir.resolve()}; the path may be "
+        "a SkillFS runtime view. Run the command against a Skill Ledger managed "
+        "source/backing skill path or ensure managedSkillDirs points to "
+        "source/backing roots."
+    )
+
+    def fake_backend() -> object:
+        return backend
+
+    def fail_scan(path: str, received_backend: object) -> dict[str, Any]:
+        assert path == str(skill_dir.resolve())
+        assert received_backend is backend
+        raise SkillLedgerError(message)
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
+        fake_backend,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        fail_scan,
+    )
+
+    result = process_skill_change(
+        SkillFsChange(
+            skill_dir=skill_dir.resolve(),
+            skill_name=skill_dir.name,
+            event_kinds={"write"},
+            paths={"SKILL.md"},
+        )
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reasonCode"] == "unmanaged_skill_root"
+    assert result["message"] == message
+    assert result["skill"]["skillName"] == "weather"
+    assert result["scan"] is None
+    assert result["activation"] is None
+    assert "error" not in result
+
+
+def test_process_skill_change_skips_unresolved_live_root_from_activation(
+    monkeypatch,
+    tmp_path: Path,
+):
+    skill_dir = make_skill(tmp_path, "weather")
+    backend = object()
+    message = (
+        f"cannot resolve live skill root for {skill_dir.resolve()}; the path may be "
+        "a SkillFS runtime view. Run the command against a Skill Ledger managed "
+        "source/backing skill path or ensure managedSkillDirs points to "
+        "source/backing roots."
+    )
+
+    def fake_backend() -> object:
+        return backend
+
+    def fake_scan(path: str, received_backend: object) -> dict[str, Any]:
+        assert path == str(skill_dir.resolve())
+        assert received_backend is backend
+        return {"status": "noop"}
+
+    def fail_resolve(
+        path: str, received_backend: object, policy: str
+    ) -> dict[str, Any]:
+        assert path == str(skill_dir.resolve())
+        assert received_backend is backend
+        assert policy == "pass_only"
+        raise SkillLedgerError(message)
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
+        fake_backend,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        fake_scan,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation",
+        fail_resolve,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation_policy",
+        lambda: "pass_only",
+    )
+
+    result = process_skill_change(
+        SkillFsChange(
+            skill_dir=skill_dir.resolve(),
+            skill_name=skill_dir.name,
+            event_kinds={"write"},
+            paths={"SKILL.md"},
+        )
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reasonCode"] == "unmanaged_skill_root"
+    assert result["message"] == message
+    assert result["skill"]["skillName"] == "weather"
+    assert result["scan"] is None
+    assert result["activation"] is None
+    assert "error" not in result
 
 
 def test_default_job_name_is_stable():

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_rule_loader.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_rule_loader.py
@@ -76,8 +76,10 @@ rules:
         self.assertEqual(rules[0].patterns, ["(?i)test\\s+pattern"])
 
     def test_load_file_not_found(self):
-        with self.assertRaises(FileNotFoundError):
-            load_rules_from_yaml(Path("/nonexistent/rules.yaml"))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_path = Path(tmpdir) / "missing_rules.yaml"
+            with self.assertRaises(FileNotFoundError):
+                load_rules_from_yaml(missing_path)
 
     def test_load_invalid_yaml_syntax(self):
         with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
## Description

Restricts the Skill Ledger activation daemon startup reconcile to explicitly managed skill directories. Unresolved live-root errors for unmanaged SkillFS/runtime paths are now reported as per-skill skipped diagnostics instead of setting the whole activation job to unhealthy, while scanner failures, bad policies, ambiguous roots, and unexpected errors still surface as job errors.

## Related Issue

no-issue: requested Skill Ledger daemon reconcile bug fix

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `uv run --project agent-sec-cli pytest tests/unit-test/daemon/test_skill_ledger_activation.py tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py -v`
- `uv run --project agent-sec-cli pytest tests/unit-test/skill_ledger/test_live_root.py tests/integration-test/skill-ledger/test_skill_ledger_integration.py::test_show_unmanaged_skill_root_returns_diagnostic tests/integration-test/skill-ledger/test_skill_ledger_integration.py::test_decide_does_not_trust_fuse_view_from_default_skill_dirs -v`
- `uv run --project agent-sec-cli ruff check --config agent-sec-cli/pyproject.toml agent-sec-cli/src/agent_sec_cli/daemon/skill_ledger_activation.py tests/unit-test/daemon/test_skill_ledger_activation.py tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py`
- `git diff --check HEAD`

## Additional Notes

Local `make python-lint-ci` could not run its incremental lint step because `diff-quality` is not installed in this environment; changed-file Ruff checks passed directly.
