### PR TITLE
fix(sight): show all verdicts in the summary

### DIFF
--- a/src/agentsight/dashboard/src/pages/SecurityObservabilityPage.tsx
+++ b/src/agentsight/dashboard/src/pages/SecurityObservabilityPage.tsx
@@ -449,6 +449,7 @@ export const SecurityObservabilityPage: React.FC = () => {
               categoryItems={categoryItems}
               eventTypeItems={eventTypeItems}
               resultItems={resultItems}
+              verdictItems={verdictItems}
               latestEvents={latestEvents}
               onSelectEvent={setSelectedEventId}
               onViewVerdict={(verdict) => {

--- a/src/agentsight/dashboard/src/pages/security/OverviewRiskSummary.tsx
+++ b/src/agentsight/dashboard/src/pages/security/OverviewRiskSummary.tsx
@@ -11,10 +11,8 @@ import {
   fmtNumber,
   fmtPercent,
   isPassVerdict,
-  securityEventVerdict,
   verdictBadgeClasses,
   verdictBarClasses,
-  verdictCountItems,
   verdictTone,
 } from './utils';
 
@@ -23,24 +21,26 @@ export const OverviewRiskSummary: React.FC<{
   eventsResponse: SecurityApiResponse<SecurityPaginated<SecurityEventRecord>> | null;
   categoryItems: SecurityCountItem[];
   resultItems: SecurityCountItem[];
+  verdictItems: SecurityCountItem[];
   onViewVerdict?: (verdict: string) => void;
-}> = ({ summary, eventsResponse, categoryItems, resultItems, onViewVerdict }) => {
-  const events = eventsResponse?.data.items ?? [];
+}> = ({ summary, eventsResponse, categoryItems, resultItems, verdictItems, onViewVerdict }) => {
   const totalEvents = eventsResponse?.data.total ?? summary?.total ?? 0;
-  const loadedEvents = events.length;
-  const verdictItems = verdictCountItems(events);
   const verdictTotal = verdictItems.reduce((sum, item) => sum + item.count, 0);
   const maxVerdictCount = Math.max(1, ...verdictItems.map((item) => item.count));
-  const nonPassCount = events.filter((event) => {
-    const verdict = securityEventVerdict(event);
-    return verdict !== '-' && !isPassVerdict(verdict);
-  }).length;
-  const riskCount = events.filter((event) => verdictTone(securityEventVerdict(event)) === 'risk').length;
-  const warningCount = events.filter((event) => verdictTone(securityEventVerdict(event)) === 'warning').length;
+  const nonPassCount = verdictItems
+    .filter((item) => {
+      const verdict = String(item.value);
+      return verdict !== '-' && !isPassVerdict(verdict);
+    })
+    .reduce((sum, item) => sum + item.count, 0);
+  const riskCount = verdictItems
+    .filter((item) => verdictTone(String(item.value)) === 'risk')
+    .reduce((sum, item) => sum + item.count, 0);
+  const warningCount = verdictItems
+    .filter((item) => verdictTone(String(item.value)) === 'warning')
+    .reduce((sum, item) => sum + item.count, 0);
   const nonPassRatio = fmtPercent(nonPassCount, verdictTotal);
-  const coverageText = loadedEvents < totalEvents
-    ? `基于最近 ${fmtNumber(loadedEvents)} / ${fmtNumber(totalEvents)} 条含详情事件统计 verdict`
-    : `基于当前时间范围内 ${fmtNumber(loadedEvents)} 条含详情事件统计 verdict`;
+  const coverageText = `基于当前时间范围内 ${fmtNumber(verdictTotal)} 条含 verdict 事件统计`;
 
   let statusLabel = '暂无 verdict';
   let statusClasses = 'bg-gray-100 text-gray-700';

--- a/src/agentsight/dashboard/src/pages/security/OverviewTab.tsx
+++ b/src/agentsight/dashboard/src/pages/security/OverviewTab.tsx
@@ -19,6 +19,7 @@ export const OverviewTab: React.FC<{
   categoryItems: SecurityCountItem[];
   eventTypeItems: SecurityCountItem[];
   resultItems: SecurityCountItem[];
+  verdictItems: SecurityCountItem[];
   latestEvents: SecurityEventRecord[];
   onSelectEvent: (eventId: string) => void;
   onViewVerdict: (verdict: string) => void;
@@ -31,6 +32,7 @@ export const OverviewTab: React.FC<{
   categoryItems,
   eventTypeItems,
   resultItems,
+  verdictItems,
   latestEvents,
   onSelectEvent,
   onViewVerdict,
@@ -56,6 +58,7 @@ export const OverviewTab: React.FC<{
       eventsResponse={recentEvents}
       categoryItems={categoryItems}
       resultItems={resultItems}
+      verdictItems={verdictItems}
       onViewVerdict={onViewVerdict}
     />
     {summary?.state === 'empty' && (

--- a/src/agentsight/dashboard/src/test/SecurityObservabilityPage.test.tsx
+++ b/src/agentsight/dashboard/src/test/SecurityObservabilityPage.test.tsx
@@ -66,6 +66,13 @@ const warningEvent = {
   },
 };
 
+const defaultSecurityCountItems = (groupBy: string) => {
+  if (groupBy === 'category') return [{ value: 'tool_output', count: 8 }];
+  if (groupBy === 'result') return [{ value: 'succeeded', count: 12 }];
+  if (groupBy === 'verdict') return [{ value: 'deny', count: 1 }, { value: 'warning', count: 1 }];
+  return [{ value: 'tool_output_leak', count: 8 }];
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockFetchSecurityStatus.mockResolvedValue({
@@ -94,11 +101,7 @@ beforeEach(() => {
     state: 'ok',
     data: {
       group_by: groupBy,
-      items: groupBy === 'category'
-        ? [{ value: 'tool_output', count: 8 }]
-        : groupBy === 'result'
-          ? [{ value: 'succeeded', count: 12 }]
-          : [{ value: 'tool_output_leak', count: 8 }],
+      items: defaultSecurityCountItems(groupBy),
     },
   }));
   mockFetchSecurityEvents.mockResolvedValue({
@@ -215,6 +218,28 @@ describe('SecurityObservabilityPage', () => {
     expect(screen.queryByText('latest events')).not.toBeInTheDocument();
   });
 
+  it('uses exact verdict counts instead of the overview event sample', async () => {
+    mockFetchSecurityCountBy.mockImplementation((groupBy: string) => Promise.resolve({
+      state: 'ok',
+      data: {
+        group_by: groupBy,
+        items: groupBy === 'verdict'
+          ? [{ value: 'deny', count: 58 }, { value: 'pass', count: 120 }]
+          : defaultSecurityCountItems(groupBy),
+      },
+    }));
+    mockFetchSecurityEvents.mockResolvedValueOnce({
+      state: 'ok',
+      data: { items: [event], total: 500, limit: 500, offset: 0, next_offset: null },
+    });
+
+    render(<SecurityObservabilityPage />);
+
+    expect(await screen.findByText('58 / 178 个 verdict 非 pass')).toBeInTheDocument();
+    expect(screen.getByText('存在 58 个风险 verdict')).toBeInTheDocument();
+    expect(screen.getByText('基于当前时间范围内 178 条含 verdict 事件统计')).toBeInTheDocument();
+  });
+
   it('opens event detail drawer from the events tab', async () => {
     render(<SecurityObservabilityPage />);
 
@@ -228,10 +253,13 @@ describe('SecurityObservabilityPage', () => {
     expect(screen.getAllByText('Verdict').length).toBeGreaterThanOrEqual(2);
     expect(screen.queryByText('Event Type')).not.toBeInTheDocument();
     expect(screen.queryByText('PID')).not.toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'tool_output_leak' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'deny' })).toBeInTheDocument();
     expect(screen.getAllByText('succeeded').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('deny').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('warning')).toHaveClass('bg-amber-100');
+    const warningBadge = screen.getAllByText('warning')
+      .find((element) => element.tagName.toLowerCase() === 'span');
+    expect(warningBadge).toBeDefined();
+    expect(warningBadge!).toHaveClass('bg-amber-100');
 
     fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'tool_output' } });
     fireEvent.change(screen.getByLabelText('Result'), { target: { value: 'succeeded' } });


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
OverviewRiskSummary previously computed verdict statistics by iterating over the client-side event sample (capped at 500 items), so the summary only reflected a subset of the actual verdicts when the time range contained more events.

Thread verdictItems from fetchSecurityCountBy('verdict') through SecurityObservabilityPage → OverviewTab → OverviewRiskSummary so the risk summary always shows authoritative server-aggregated counts. Remove the local verdictCountItems call and the conditional "partial sample" disclaimer that is no longer needed.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #1230 


  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #1230 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
