### PR TITLE
fix(tokenless): bundle tool_categories.json into dist for npm installs

### DIFF
--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -292,6 +292,7 @@ function loadToolCategories(): ToolCategories {
   try {
     // Try multiple possible locations for tool_categories.json
     const possiblePaths = [
+      join(import.meta.dirname, "tool_categories.json"),
       join(import.meta.dirname, "..", "..", "common", "hooks", "tool_categories.json"),
       join(import.meta.dirname, "common", "hooks", "tool_categories.json"),
       "/usr/share/anolisa/adapters/tokenless/common/hooks/tool_categories.json",

--- a/src/tokenless/adapters/tokenless/openclaw/package.json.in
+++ b/src/tokenless/adapters/tokenless/openclaw/package.json.in
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
-    "build": "npm run clean && tsc --project tsconfig.json"
+    "build": "npm run clean && tsc --project tsconfig.json && cp ../common/hooks/tool_categories.json dist/"
   },
   "peerDependencies": {
     "rtk": ">=0.35.0",


### PR DESCRIPTION
## Description

The openclaw plugin `loadToolCategories()` resolves `tool_categories.json` via relative paths that only work with RPM/DEB installs (`make install` copies the entire `adapters/tokenless/` tree). npm/`openclaw plugins install` only deploys the `openclaw/` directory, so the JSON file is never found and the plugin always falls back to hardcoded tool categories.

This PR:
- Copies `tool_categories.json` into `dist/` during `npm run build`
- Adds `dist/`-local path as the first lookup in `loadToolCategories()`

This ensures consistent tool categorization across both install paths and eliminates the `[tokenless] Could not find tool_categories.json` warning for npm users.

## Related Issue

no-issue: packaging improvement for npm install path, no functional change (fallback values match JSON exactly)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅  
- `cargo test --workspace` ✅ (151 tests passed, 0 failed)
- `npm run build` (openclaw plugin) ✅ — `dist/tool_categories.json` produced
- Verified `dist/index.js` contains `join(import.meta.dirname, "tool_categories.json")` as the first path

🤖 Generated with [Claude Code](https://claude.com/claude-code)