### PR TITLE
fix(sight): improve severity labels and agent sidebar UX

### DIFF
--- a/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
+++ b/src/agentsight/dashboard/src/components/AgentHealthSidebar.tsx
@@ -19,7 +19,7 @@ const STATUS_LABELS: Record<string, string> = {
   hung: '响应卡住',
   unknown: '待检测',
   no_port: '客户端进程',
-  offline: '已退出',
+  offline: '异常退出',
 };
 
 /** Status tooltip / 描述，帮助用户理解状态含义 */
@@ -29,7 +29,7 @@ const STATUS_TOOLTIPS: Record<string, string> = {
   hung: '端口可连但 HTTP 探活超时，进程可能卡死',
   unknown: '首轮健康检查未完成',
   no_port: 'TUI / 子进程，本身不提供服务端口（正常）',
-  offline: '进程已退出，5 分钟后从列表自动移除',
+  offline: '进程异常退出，影响了进行中的 LLM 对话，5 分钟后自动移除',
 };
 
 /** Format relative time in Chinese */
@@ -239,15 +239,15 @@ export const AgentHealthSidebar: React.FC = () => {
       // 一次拉全部（包含 client/worker），后续按 agent_name 分组挂到各自主卡下面
       const data = await fetchAgentHealth({ includeClients: true });
 
-      // 检测新增离线和卡顿 agent
+      // 检测新增异常退出（仅 has_crash=true 的才通知）和卡顿 agent
       data.agents.forEach(a => {
-        if (a.status === 'offline' && !notifiedOfflineRef.current.has(a.pid)) {
+        if (a.status === 'offline' && a.has_crash && !notifiedOfflineRef.current.has(a.pid)) {
           notifiedOfflineRef.current.add(a.pid);
-          addToast(`\u26a0\ufe0f Agent "${a.agent_name}" (PID ${a.pid}) \u5df2\u9000\u51fa`);
+          addToast(`⚠️ Agent "${a.agent_name}" (PID ${a.pid}) 异常退出，影响了进行中的对话`);
         }
         if (a.status === 'hung' && !notifiedOfflineRef.current.has(-a.pid)) {
           notifiedOfflineRef.current.add(-a.pid); // 用负数区分 hung 通知
-          addToast(`\u23f3 Agent "${a.agent_name}" (PID ${a.pid}) \u54cd\u5e94\u8d85\u65f6\uff0c\u53ef\u80fd\u5361\u987f`);
+          addToast(`⏳ Agent "${a.agent_name}" (PID ${a.pid}) 响应超时，可能卡顿`);
         }
       });
       // 清理不再存在的 PID
@@ -340,11 +340,16 @@ export const AgentHealthSidebar: React.FC = () => {
              style={{ height: 'calc(100vh - 56px)' }}>
         {/* Header */}
         <div className="px-3 py-3 border-b border-gray-200 flex items-center justify-between">
-          <span className="text-sm font-semibold text-gray-800">Agent 状态</span>
+          <span
+            className="text-sm font-semibold text-gray-800 cursor-help border-b border-dashed border-gray-300"
+            title="监控本机 AI Agent 进程健康状态。仅当进程异常退出并影响了进行中的 LLM 对话时，才会展示崩溃记录。正常退出的进程不会显示。"
+          >
+            Agent 状态
+          </span>
           <div className="flex items-center gap-1">
             {offlineCount > 0 && (
               <span className="text-xs px-1.5 py-0.5 rounded-full bg-red-100 text-red-600 font-semibold">
-                {offlineCount} 下线
+                {offlineCount} 崩溃
               </span>
             )}
             {hungCount > 0 && (

--- a/src/agentsight/dashboard/src/components/InterruptionBadge.tsx
+++ b/src/agentsight/dashboard/src/components/InterruptionBadge.tsx
@@ -21,9 +21,9 @@ const SEVERITY_STYLES: Record<InterruptionSeverity, string> = {
 
 const SEVERITY_LABEL: Record<InterruptionSeverity, string> = {
   critical: '严重',
-  high:     '高危',
-  medium:   '中危',
-  low:      '低危',
+  high:     '重要',
+  medium:   '中等',
+  low:      '轻微',
 };
 
 const SEVERITY_ORDER: InterruptionSeverity[] = ['critical', 'high', 'medium', 'low'];

--- a/src/agentsight/dashboard/src/pages/ConversationList.tsx
+++ b/src/agentsight/dashboard/src/pages/ConversationList.tsx
@@ -1067,9 +1067,9 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
                         {(
                           [
                             { key: 'critical', label: '严重', bg: 'bg-red-100 text-red-700 border border-red-300' },
-                            { key: 'high',     label: '高危', bg: 'bg-orange-100 text-orange-700 border border-orange-300' },
-                            { key: 'medium',   label: '中危', bg: 'bg-yellow-100 text-yellow-700 border border-yellow-300' },
-                            { key: 'low',      label: '低危', bg: 'bg-blue-100 text-blue-700 border border-blue-300' },
+                            { key: 'high',     label: '重要', bg: 'bg-orange-100 text-orange-700 border border-orange-300' },
+                            { key: 'medium',   label: '中等', bg: 'bg-yellow-100 text-yellow-700 border border-yellow-300' },
+                            { key: 'low',      label: '轻微', bg: 'bg-blue-100 text-blue-700 border border-blue-300' },
                           ] as const
                         ).map(({ key, label, bg }) => {
                           const cnt = interruptionCount.by_severity[key];

--- a/src/agentsight/dashboard/src/test/InterruptionBadge.test.tsx
+++ b/src/agentsight/dashboard/src/test/InterruptionBadge.test.tsx
@@ -17,7 +17,7 @@ describe('InterruptionBadge', () => {
 
     it('should render count and severity label', () => {
       render(<InterruptionBadge count={3} severity="high" />);
-      expect(screen.getAllByText('3 高危').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('3 重要').length).toBeGreaterThan(0);
     });
 
     it('should render critical severity', () => {
@@ -27,12 +27,12 @@ describe('InterruptionBadge', () => {
 
     it('should render medium severity by default', () => {
       render(<InterruptionBadge count={2} />);
-      expect(screen.getAllByText('2 中危').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('2 中等').length).toBeGreaterThan(0);
     });
 
     it('should render low severity', () => {
       render(<InterruptionBadge count={5} severity="low" />);
-      expect(screen.getAllByText('5 低危').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('5 轻微').length).toBeGreaterThan(0);
     });
 
     it('should call onClick when clicked', () => {
@@ -52,7 +52,7 @@ describe('InterruptionBadge', () => {
         />
       );
       expect(screen.getAllByText('1 严重').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('2 高危').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('2 重要').length).toBeGreaterThan(0);
     });
 
     it('should return null when all severities are zero', () => {
@@ -74,7 +74,7 @@ describe('InterruptionBadge', () => {
           ]}
         />
       );
-      expect(screen.getAllByText('3 高危').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('3 重要').length).toBeGreaterThan(0);
     });
 
     it('should call onClick on detailed badges', () => {

--- a/src/agentsight/dashboard/src/types/index.ts
+++ b/src/agentsight/dashboard/src/types/index.ts
@@ -184,6 +184,8 @@ export interface AgentHealthStatus {
   role: 'gateway' | 'client' | 'worker';
   /** 父进程 PID */
   parent_pid?: number;
+  /** 进程退出时是否关联了 agent_crash 事件（有未完成的 LLM 调用被中断） */
+  has_crash?: boolean;
 }
 
 export interface AgentHealthResponse {

--- a/src/agentsight/docs/agent-diagnostics-guide.md
+++ b/src/agentsight/docs/agent-diagnostics-guide.md
@@ -1,0 +1,478 @@
+# AgentSight Agent 诊断功能指南
+
+## 概述
+
+AgentSight 是一款基于 eBPF 的 AI Agent 可观测性工具，提供零侵入式的 Agent 运行时诊断能力。无需修改 Agent 代码或配置，即可实现对 LLM API 调用、进程行为、异常中断的全方位监控和诊断。
+
+**核心价值：**
+
+- **零侵入** — 基于 eBPF 内核探针采集，Agent 无感知
+- **实时诊断** — 毫秒级检测异常中断、进程崩溃、死循环等问题
+- **智能归因** — 自动分类中断类型并给出严重级别
+- **可视化** — 内置 Dashboard 提供实时健康视图和历史回溯
+
+---
+
+## 功能一览
+
+| 诊断能力 | 说明 |
+|----------|------|
+| Agent 自动发现 | 扫描 /proc 和监控 execve 事件，自动识别运行中的 AI Agent |
+| 进程健康监控 | 周期性探测 Agent 存活状态与响应延迟 |
+| 中断事件检测 | 12 种中断类型的实时检测与自动分类 |
+| 死循环检测 | 跨调用分析识别 Agent 陷入逻辑循环 |
+| OOM 崩溃归因 | 通过 dmesg 分析确认进程是否因内存不足被杀 |
+
+
+---
+
+## 1. Agent 自动发现
+
+AgentSight 支持两种 Agent 发现机制：
+
+### 1.1 命令行规则匹配
+
+通过配置文件中的 `cmdline.allow` 规则，基于进程命令行 Glob 模式匹配 Agent：
+
+```json
+{
+  "cmdline": {
+    "allow": [
+      {"rule": ["hermes*"], "agent_name": "Hermes"},
+      {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
+      {"rule": ["*node*", "*cosh*"], "agent_name": "Cosh"},
+      {"rule": ["claude*"], "agent_name": "Claude"}
+    ]
+  }
+}
+```
+
+- 支持 `*`（任意字符串）和 `?`（单字符）通配符
+- `rule` 数组中的多个模式按顺序匹配命令行参数
+- `agent_name` 为该 Agent 在系统中的显示名称
+
+### 1.2 DNS 域名规则匹配
+
+通过 HTTPS 域名规则发现正在调用 LLM API 的进程：
+
+```json
+{
+  "https": [
+    {"rule": ["*.openai.com"]},
+    {"rule": ["*.anthropic.com"]},
+    {"rule": ["dashscope.aliyuncs.com"]}
+  ]
+}
+```
+
+当检测到进程发起对匹配域名的 DNS 请求或已建立 TCP 连接时，自动附着 SSL 探针进行流量采集。
+
+### 1.3 内置支持的 Agent
+
+| Agent 名称 | 识别方式 |
+|------------|----------|
+| Hermes | 进程命令行包含 `hermes` |
+| Cosh (Copilot Shell) | Node.js 进程，命令行包含 `cosh` / `copilot-shell` |
+| OpenClaw | 进程名包含 `openclaw-gatewa` |
+| Claude Code | 进程名以 `claude` 开头 |
+| 自定义 Agent | 通过 `cmdline.allow` 配置自定义规则 |
+
+---
+
+## 2. 进程健康监控
+
+AgentSight 后台 HealthChecker 线程周期性执行健康检查：
+
+### 2.1 监控机制
+
+AgentSight 对所有发现的 Agent 进程提供**两层监控**：
+
+| 层级 | 能力 | 端口要求 |
+|------|------|----------|
+| **进程存活性监控** | 周期性扫描进程是否存在，消失即触发 `agent_crash` 崩溃检测 | 无需端口 |
+| **HTTP 健康探测** | 对监听端口发起 HTTP 请求，判断响应延迟和进程挂死 | 需要端口 |
+
+即使 Agent 没有监听任何 TCP 端口（如 Cosh），AgentSight 依然能检测其崩溃退出并生成中断事件。
+
+### 2.2 检查流程
+
+1. 扫描系统中所有匹配的 Agent 进程
+2. 将消失的进程标记为 Offline 并触发崩溃检测
+3. 对存活进程检测其监听的 TCP 端口
+4. 有端口时发起 HTTP 探测，判断响应状态
+
+### 2.3 健康状态
+
+| 状态 | 含义 |
+|------|------|
+| `Healthy` | HTTP 探测收到响应（任何状态码） |
+| `Unhealthy` | 连接被拒绝或无法到达 |
+| `Hung` | 连接成功但响应超时（进程可能挂死） |
+| `NoPort` | 进程存活但无监听端口（仍可检测崩溃） |
+| `Offline` | 进程异常退出（仅关联了 crash 事件时保留） |
+
+### 2.4 Dashboard 侧边栏展示规则
+
+Dashboard 右侧「Agent 状态」侧边栏实时展示已发现的 Agent 进程健康状态，展示规则如下：
+
+- **正常退出**（无未完成的 LLM 调用）：静默移除，不在侧边栏展示，不生成中断事件
+- **异常退出**（存在 pending LLM 调用被中断）：生成 `agent_crash` 中断事件，侧边栏展示崩溃记录，保留 5 分钟后自动清理
+- **卡顿（Hung）**：始终展示，提供一键重启按钮
+
+这意味着 Agent 正常重启（如 OpenClaw 自动重启）不会在侧边栏产生噪音，只有真正影响用户对话的崩溃才会被展示。
+
+### 2.5 API 查询
+
+```bash
+# 查询所有 Agent 健康状态
+curl http://127.0.0.1:7396/api/agent-health
+```
+
+响应示例：
+
+```json
+{
+  "agents": [
+    {
+      "pid": 12345,
+      "agent_name": "OpenClaw",
+      "status": "healthy",
+      "ports": [8080],
+      "latency_ms": 12,
+      "last_check_time": 1717830000000
+    }
+  ],
+  "last_scan_time": 1717830000000
+}
+```
+
+---
+
+## 3. 中断事件检测
+
+AgentSight 实时分析每次 LLM API 调用，自动检测并分类 12 种中断类型。
+
+### 3.1 中断类型
+
+| 类型 | 触发条件 | 严重级别 | 验证状态 |
+|------|----------|----------|----------|
+| `agent_crash` | Agent 进程中途消失（有未完成的 LLM 调用） | Critical | 已验证 |
+| `dead_loop` | Agent 陷入逻辑循环（重复工具调用序列/相似输出） | Critical | 已验证 |
+| `retry_storm` | 同一错误类型在会话内重复超过阈值 | Critical | 已验证 |
+| `auth_error` | HTTP 401/403 或错误含 `invalid_api_key` | High | 已验证 |
+| `network_timeout` | HTTP 408/504 或错误含 `timeout` | High | 已编码 |
+| `service_unavailable` | HTTP 502/503 或错误含 `overloaded` | High | 已编码 |
+| `context_overflow` | 上下文长度超限（`context_length_exceeded` 等） | High | 已编码 |
+| `sse_truncated` | SSE 流未正常结束 | High | 已编码 |
+| `llm_error` | HTTP >= 400 通用兜底（优先级最低） | High | 已编码 |
+| `rate_limit` | HTTP 429 或错误含 `rate_limit` | Medium | 已编码 |
+| `safety_filter` | finish_reason == `content_filter` | Medium | 已编码 |
+| `token_limit` | finish_reason == `length` 且输出达到上限 | Medium | 已编码 |
+
+> **验证状态说明**：「已验证」表示已通过端到端集成测试确认功能正确；「已编码」表示检测逻辑已实现，将在后续版本补充端到端验证。
+
+### 3.2 严重级别
+
+| 级别 | 权重 | 说明 |
+|------|------|------|
+| Critical | 4 | 需要立即处理，Agent 已不可用 |
+| High | 3 | 严重影响功能，需尽快排查 |
+| Medium | 2 | 对用户有影响，建议关注 |
+| Low | 1 | 轻微影响，可观察 |
+
+### 3.3 检测优先级
+
+当一次 LLM 调用同时命中多条规则时，按以下优先级取最高优先级的类型：
+
+1. AuthError（401/403）
+2. RateLimit（429）
+3. NetworkTimeout（408/504）
+4. ServiceUnavailable（502/503）
+5. ContextOverflow
+6. SafetyFilter
+7. LlmError（通用 HTTP 错误兜底）
+8. SseTruncated
+9. TokenLimit
+
+### 3.4 API 接口
+
+```bash
+# 查询中断事件列表
+curl "http://127.0.0.1:7396/api/interruptions?start_ns=&end_ns=&agent_name=&interruption_type=&severity="
+
+# 按严重级别统计
+curl "http://127.0.0.1:7396/api/interruptions/count"
+
+# 按类型统计
+curl "http://127.0.0.1:7396/api/interruptions/stats"
+
+# 按 Session 维度聚合
+curl "http://127.0.0.1:7396/api/interruptions/session-counts"
+
+# 按 Conversation 维度聚合
+curl "http://127.0.0.1:7396/api/interruptions/conversation-counts"
+
+# 查询指定 Session 的中断
+curl "http://127.0.0.1:7396/api/sessions/{session_id}/interruptions"
+
+# 查询指定 Conversation 的中断
+curl "http://127.0.0.1:7396/api/conversations/{conversation_id}/interruptions"
+```
+
+---
+
+## 4. 死循环检测（DeadLoop）
+
+当 Agent 未触发任何错误，但陷入逻辑循环（重复相同的工具调用或生成相似输出）时，AgentSight 通过跨调用分析识别此类问题。
+
+### 4.1 检测规则
+
+| 规则 | 说明 | 默认阈值 |
+|------|------|----------|
+| 工具序列重复 | 连续 N 次调用使用相同的工具名序列 | 3 次 |
+| 输出相似度循环 | 连续 N 次输出的 Jaccard 相似度 > 阈值 | 3 次，相似度 0.85 |
+| Token 空耗 | 输入 Token 持续增长但输出不变 | — |
+
+### 4.2 配置
+
+```json
+{
+  "deadloop": {
+    "enabled": true,
+    "kill_after_count": 3
+  }
+}
+```
+
+- `enabled` — 是否启用死循环检测（默认关闭）
+- `kill_after_count` — 连续检测到 N 次循环后自动终止 Agent 进程（设为 0 表示仅告警不终止）
+
+### 4.3 检测窗口
+
+- 滑动窗口大小：最近 10 次 LLM 调用
+- 仅分析同一 conversation 内的调用序列
+
+---
+
+## 5. OOM 崩溃归因
+
+当 Agent 进程因内存不足 (OOM) 被内核杀掉时，AgentSight 能自动归因。
+
+### 5.1 检测路径
+
+| 路径 | 触发时机 | 延迟 |
+|------|----------|------|
+| 实时路径 | HealthChecker 检测到进程消失后查询 dmesg | ~30s |
+| 启动恢复 | AgentSight 自身被 OOM 后重启，扫描 dmesg 历史 | 启动时 |
+
+### 5.2 事件标记
+
+OOM 崩溃事件在 `detail` 字段中额外包含：
+
+```json
+{
+  "oom": true,
+  "source": "healthchecker+dmesg",
+  "pid": 12345,
+  "agent_name": "OpenClaw"
+}
+```
+
+---
+
+## 6. 健康分计算
+
+AgentSight 基于中断事件计算 Agent 运行健康分（0~100）。
+
+### 6.1 计算公式
+
+```
+health_score = 100 - min(100, capped_penalty / total_conversations * 100)
+```
+
+### 6.2 计算规则
+
+- **惩罚权重**：Critical=10, High=5, Medium=2, Low=1
+- **同 Session 惩罚上限**：单个 Session 内累计惩罚最高 10 分（防止重试风暴放大惩罚）
+- **分母为 Conversation 数**：避免长生命周期 Agent 被单次错误过度惩罚
+
+### 6.3 示例
+
+| 场景 | 正常对话数 | 中断情况 | 健康分 |
+|------|-----------|----------|--------|
+| 完全健康 | 10 | 无 | 100 |
+| 偶发错误 | 10 | 1 个 auth_error (high=5) | 95 |
+| 进程崩溃 | 10 | 1 个 agent_crash (critical=10) | 90 |
+| 严重异常 | 5 | 3 个 auth_error (capped=10) | 60 |
+
+---
+
+## 7. Prometheus 指标导出
+
+AgentSight 提供标准 Prometheus 格式的 `/metrics` 端点：
+
+```bash
+curl http://127.0.0.1:7396/metrics
+```
+
+导出指标包括：
+
+| 指标名 | 类型 | 说明 |
+|--------|------|------|
+| `agentsight_llm_requests_total` | counter | 各 Agent 的 LLM 请求总数 |
+| `agentsight_interruptions_total` | counter | 各中断类型的事件总数 |
+
+---
+
+## 8. Dashboard 可视化
+
+AgentSight 内置 Web Dashboard，通过 `agentsight serve` 启动：
+
+```bash
+# 启动（默认 127.0.0.1:7396）
+agentsight serve
+
+# 绑定到所有接口
+agentsight serve --host 0.0.0.0 --port 7396
+```
+
+打开 `http://<server-ip>:7396` 即可查看：
+
+- **会话列表** — 所有被追踪的 Agent 会话及其 Token 统计
+- **对话详情** — 每轮 LLM 调用的输入输出、工具调用、Token 消耗
+- **中断事件** — 按严重级别标注的中断事件时间线
+- **Agent 健康** — 实时进程健康状态面板
+- **Token 趋势** — 分 Agent / 分模型的 Token 时序图
+
+---
+
+## 9. 快速开始
+
+### 9.1 环境要求
+
+| 组件 | 版本要求 |
+|------|----------|
+| Linux 内核 | >= 5.8（需 BTF 支持） |
+| 运行权限 | root（eBPF 和 dmesg 需要） |
+
+### 9.2 安装
+
+```bash
+sudo yum install agentsight
+```
+
+### 9.3 启动追踪
+
+```bash
+# 前台模式（开发调试）
+sudo agentsight trace
+
+# 后台 Daemon 模式
+sudo agentsight trace --daemon
+```
+
+### 9.4 配置文件
+
+配置文件路径：`/etc/agentsight/config.json`（若不存在则使用内置默认规则）
+
+完整配置示例：
+
+```json
+{
+  "https": [
+    {"rule": ["*.openai.com"]},
+    {"rule": ["*.anthropic.com"]},
+    {"rule": ["dashscope.aliyuncs.com"]}
+  ],
+  "cmdline": {
+    "allow": [
+      {"rule": ["hermes*"], "agent_name": "Hermes"},
+      {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
+      {"rule": ["*node*", "*cosh*"], "agent_name": "Cosh"},
+      {"rule": ["claude*"], "agent_name": "Claude"},
+      {"rule": ["*python3*", "*my-agent*"], "agent_name": "MyAgent"}
+    ]
+  },
+  "deadloop": {
+    "enabled": false,
+    "kill_after_count": 3
+  }
+}
+```
+
+修改配置后重启服务生效：
+
+```bash
+systemctl restart agentsight
+```
+
+---
+
+## 10. 数据存储与导出
+
+### 10.1 本地存储
+
+所有诊断数据存储在 SQLite 数据库中：
+
+- 默认路径：`/var/log/sysak/.agentsight/agentsight.db`
+- 数据保留：默认 30 天自动清理
+
+### 10.2 云端导出
+
+支持将诊断数据导出到阿里云 SLS（日志服务）进行集中分析：
+
+```bash
+# 通过环境变量配置 Logtail 导出路径
+Environment=SLS_LOGTAIL_FILE=/var/sysom/ilog/agentsight
+```
+
+### 10.3 ATIF 标准格式导出
+
+支持将 Agent 对话轨迹以 ATIF（Agent Trajectory Interchange Format）v1.6 标准格式导出：
+
+```bash
+# 按 trace 导出
+curl http://127.0.0.1:7396/api/export/atif/trace/{trace_id}
+
+# 按 session 导出
+curl http://127.0.0.1:7396/api/export/atif/session/{session_id}
+
+# 按 conversation 导出
+curl http://127.0.0.1:7396/api/export/atif/conversation/{conversation_id}
+```
+
+---
+
+## 11. 支持的 LLM 提供商
+
+AgentSight 自动识别并解析以下 LLM API 格式：
+
+| 提供商 | API 格式 | Token 解析 |
+|--------|----------|-----------|
+| OpenAI / 兼容 API | OpenAI Chat Completions | 完整 |
+| Anthropic (Claude) | Messages API（含 cache token） | 完整 |
+| Google Gemini | GenerateContent API | 完整 |
+| 通义千问 (Qwen) | DashScope API | 完整 |
+
+---
+
+## 附录：完整 API 列表
+
+| 端点 | 方法 | 说明 |
+|------|------|------|
+| `/health` | GET | 服务健康检查 |
+| `/metrics` | GET | Prometheus 指标 |
+| `/api/sessions` | GET | 会话列表 |
+| `/api/sessions/{id}/traces` | GET | 会话下的对话列表 |
+| `/api/traces/{id}` | GET | Trace 详情 |
+| `/api/conversations/{id}` | GET | 对话详情 |
+| `/api/agent-names` | GET | Agent 名称列表 |
+| `/api/agent-health` | GET | Agent 健康状态 |
+| `/api/interruptions` | GET | 中断事件列表 |
+| `/api/interruptions/count` | GET | 中断统计（按严重级别） |
+| `/api/interruptions/stats` | GET | 中断统计（按类型） |
+| `/api/interruptions/session-counts` | GET | 各 Session 的中断聚合 |
+| `/api/interruptions/conversation-counts` | GET | 各 Conversation 的中断聚合 |
+| `/api/sessions/{id}/interruptions` | GET | 指定 Session 的中断 |
+| `/api/conversations/{id}/interruptions` | GET | 指定 Conversation 的中断 |
+| `/api/export/atif/trace/{id}` | GET | ATIF 格式导出 |

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -170,6 +170,9 @@ impl HealthChecker {
                 let mut seen_conv: HashSet<(String, Option<String>, Option<String>)> =
                     HashSet::new();
 
+                // Track PIDs that had crash events (for sidebar display filtering)
+                let mut crash_pids: Vec<u32> = Vec::new();
+
                 for (agent_name, group) in &by_agent {
                     let pids: Vec<i32> = group.iter().map(|o| o.pid as i32).collect();
                     // Use the representative offline entry for metadata (pid shown in detail).
@@ -263,10 +266,26 @@ impl HealthChecker {
                         for o in group {
                             self.mark_pending_interrupted(o.pid, "agent_crash");
                         }
+                        // Mark all PIDs in this group as having a crash event
+                        crash_pids.extend(group.iter().map(|o| o.pid));
                     } else {
                         // No pending calls — treat as normal/graceful shutdown.
                         log::debug!(
                             "Agent {agent_name} (pids={pids:?}) exited with no pending calls — treating as normal shutdown"
+                        );
+                    }
+                }
+
+                // Update store: mark crash PIDs, then remove normal exits
+                if let Ok(mut store) = self.store.write() {
+                    for pid in &crash_pids {
+                        store.mark_has_crash(*pid);
+                    }
+                    let removed = store.remove_normal_exits();
+                    if removed > 0 {
+                        log::debug!(
+                            "Removed {} normal-exit entries from health store (no crash event)",
+                            removed
                         );
                     }
                 }
@@ -317,6 +336,7 @@ impl HealthChecker {
                     offline_since: None,
                     role,
                     parent_pid: ppid,
+                    has_crash: false,
                 }
             } else {
                 self.probe_agent(agent, &ports, restart_cmd, role, ppid)
@@ -375,6 +395,7 @@ impl HealthChecker {
                         offline_since: None,
                         role: role.clone(),
                         parent_pid,
+                        has_crash: false,
                     };
                 }
                 Err(ureq::Error::Status(_code, _resp)) => {
@@ -393,6 +414,7 @@ impl HealthChecker {
                         offline_since: None,
                         role: role.clone(),
                         parent_pid,
+                        has_crash: false,
                     };
                 }
                 Err(ureq::Error::Transport(e)) => {
@@ -436,6 +458,7 @@ impl HealthChecker {
             offline_since: None,
             role,
             parent_pid,
+            has_crash: false,
         }
     }
 

--- a/src/agentsight/src/health/store.rs
+++ b/src/agentsight/src/health/store.rs
@@ -66,6 +66,10 @@ pub struct AgentHealthStatus {
     /// 父进程 PID（用于折叠展示）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_pid: Option<u32>,
+    /// 进程退出时是否关联了 agent_crash 中断事件（有未完成的 LLM 调用）。
+    /// 仅 Offline 状态有意义：true = 异常退出（影响了进行中的对话），false = 正常退出。
+    #[serde(default)]
+    pub has_crash: bool,
 }
 
 /// Stores the latest health check results for all tracked agents
@@ -105,10 +109,27 @@ impl HealthStore {
                 entry.latency_ms = None;
                 entry.error_message = Some("进程已退出".to_string());
                 entry.offline_since = Some(now_ms());
+                entry.has_crash = false;
                 newly_offline.push(entry.clone());
             }
         }
         newly_offline
+    }
+
+    /// 标记指定 PID 的 offline 条目为关联了 crash 事件（异常退出）。
+    pub fn mark_has_crash(&mut self, pid: u32) {
+        if let Some(entry) = self.agents.get_mut(&pid) {
+            entry.has_crash = true;
+        }
+    }
+
+    /// 移除所有无 crash 关联的 offline 条目（正常退出不需要展示）。
+    /// 返回被移除的 PID 数量。
+    pub fn remove_normal_exits(&mut self) -> usize {
+        let before = self.agents.len();
+        self.agents
+            .retain(|_, entry| entry.status != AgentHealthState::Offline || entry.has_crash);
+        before - self.agents.len()
     }
 
     /// 自动清理超过 TTL 的 Offline 条目（避免历史进程长期残留 UI）。
@@ -146,4 +167,172 @@ pub fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(pid: u32, status: AgentHealthState, has_crash: bool) -> AgentHealthStatus {
+        AgentHealthStatus {
+            pid,
+            agent_name: format!("agent-{pid}"),
+            category: "test".to_string(),
+            exe_path: "/usr/bin/test".to_string(),
+            ports: vec![],
+            status,
+            last_check_time: now_ms(),
+            latency_ms: None,
+            error_message: None,
+            restart_cmd: None,
+            offline_since: None,
+            role: AgentRole::Gateway,
+            parent_pid: None,
+            has_crash,
+        }
+    }
+
+    #[test]
+    fn test_new_store_is_empty() {
+        let store = HealthStore::new();
+        assert_eq!(store.all_agents().len(), 0);
+        assert_eq!(store.last_scan_time, 0);
+    }
+
+    #[test]
+    fn test_update_and_retrieve() {
+        let mut store = HealthStore::new();
+        let agent = make_agent(100, AgentHealthState::Healthy, false);
+        store.update(100, agent.clone());
+        let all = store.all_agents();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].pid, 100);
+    }
+
+    #[test]
+    fn test_mark_stale_offline() {
+        let mut store = HealthStore::new();
+        store.update(1, make_agent(1, AgentHealthState::Healthy, false));
+        store.update(2, make_agent(2, AgentHealthState::Healthy, false));
+
+        // PID 1 is still active, PID 2 is gone
+        let active: HashSet<u32> = [1].into_iter().collect();
+        let newly_offline = store.mark_stale_offline(&active);
+
+        assert_eq!(newly_offline.len(), 1);
+        assert_eq!(newly_offline[0].pid, 2);
+        assert_eq!(newly_offline[0].status, AgentHealthState::Offline);
+        assert!(!newly_offline[0].has_crash);
+        assert!(newly_offline[0].offline_since.is_some());
+    }
+
+    #[test]
+    fn test_mark_stale_offline_idempotent() {
+        let mut store = HealthStore::new();
+        store.update(1, make_agent(1, AgentHealthState::Healthy, false));
+
+        let active: HashSet<u32> = HashSet::new();
+        let first = store.mark_stale_offline(&active);
+        assert_eq!(first.len(), 1);
+
+        // Second call should not re-mark already-offline entries
+        let second = store.mark_stale_offline(&active);
+        assert_eq!(second.len(), 0);
+    }
+
+    #[test]
+    fn test_mark_has_crash() {
+        let mut store = HealthStore::new();
+        let mut agent = make_agent(10, AgentHealthState::Offline, false);
+        agent.offline_since = Some(now_ms());
+        store.update(10, agent);
+
+        assert!(!store.all_agents()[0].has_crash);
+
+        store.mark_has_crash(10);
+        assert!(store.all_agents()[0].has_crash);
+    }
+
+    #[test]
+    fn test_mark_has_crash_nonexistent_pid() {
+        let mut store = HealthStore::new();
+        // Should not panic on missing PID
+        store.mark_has_crash(999);
+        assert_eq!(store.all_agents().len(), 0);
+    }
+
+    #[test]
+    fn test_remove_normal_exits() {
+        let mut store = HealthStore::new();
+        // Crash exit (should be kept)
+        store.update(1, make_agent(1, AgentHealthState::Offline, true));
+        // Normal exit (should be removed)
+        store.update(2, make_agent(2, AgentHealthState::Offline, false));
+        // Still alive (should be kept)
+        store.update(3, make_agent(3, AgentHealthState::Healthy, false));
+
+        let removed = store.remove_normal_exits();
+        assert_eq!(removed, 1);
+
+        let remaining = store.all_agents();
+        assert_eq!(remaining.len(), 2);
+        let pids: HashSet<u32> = remaining.iter().map(|a| a.pid).collect();
+        assert!(pids.contains(&1)); // crash kept
+        assert!(pids.contains(&3)); // alive kept
+        assert!(!pids.contains(&2)); // normal exit removed
+    }
+
+    #[test]
+    fn test_remove_normal_exits_no_offline() {
+        let mut store = HealthStore::new();
+        store.update(1, make_agent(1, AgentHealthState::Healthy, false));
+        store.update(2, make_agent(2, AgentHealthState::Hung, false));
+
+        let removed = store.remove_normal_exits();
+        assert_eq!(removed, 0);
+        assert_eq!(store.all_agents().len(), 2);
+    }
+
+    #[test]
+    fn test_cleanup_stale_offline() {
+        let mut store = HealthStore::new();
+        let mut agent = make_agent(1, AgentHealthState::Offline, true);
+        // Set offline_since to 10 minutes ago
+        agent.offline_since = Some(now_ms().saturating_sub(10 * 60 * 1000));
+        store.update(1, agent);
+
+        // TTL = 5 minutes -> should be cleaned
+        let removed = store.cleanup_stale_offline(5 * 60 * 1000);
+        assert_eq!(removed, 1);
+        assert_eq!(store.all_agents().len(), 0);
+    }
+
+    #[test]
+    fn test_cleanup_stale_offline_within_ttl() {
+        let mut store = HealthStore::new();
+        let mut agent = make_agent(1, AgentHealthState::Offline, true);
+        agent.offline_since = Some(now_ms()); // just now
+        store.update(1, agent);
+
+        let removed = store.cleanup_stale_offline(5 * 60 * 1000);
+        assert_eq!(removed, 0);
+        assert_eq!(store.all_agents().len(), 1);
+    }
+
+    #[test]
+    fn test_remove_by_pid() {
+        let mut store = HealthStore::new();
+        store.update(5, make_agent(5, AgentHealthState::Healthy, false));
+
+        assert!(store.remove_by_pid(5));
+        assert!(!store.remove_by_pid(5)); // already removed
+        assert_eq!(store.all_agents().len(), 0);
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let store = HealthStore::default();
+        assert_eq!(store.all_agents().len(), 0);
+        assert_eq!(store.last_scan_time, 0);
+    }
 }


### PR DESCRIPTION
## Description

Two UX improvements for the AgentSight dashboard:

1. **Severity label wording**: Replace '高危/中危/低危' (sounds like security vulnerability severity) with '重要/中等/轻微' (appropriate for observability context)

2. **Agent sidebar crash-only display**: Previously all exited processes were shown in the sidebar for 5 minutes regardless of exit reason. Now only processes that crashed with pending LLM calls are displayed, reducing noise for normal exits (e.g. OpenClaw graceful restarts). Added a description text explaining the sidebar behavior.

## Related Issue

closes #1252

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo check` passes successfully
- Severity labels verified in InterruptionBadge.test.tsx (updated assertions)

## Additional Notes

Backend change is purely in-memory (HealthStore), no database schema changes required.