### PR TITLE
docs(docs): add cosh-ng user and developer documentation

### DIFF
--- a/docs/cosh-ng/en/developers/adding-commands.md
+++ b/docs/cosh-ng/en/developers/adding-commands.md
@@ -1,0 +1,133 @@
+# Adding CLI Commands
+
+## Overview
+
+cosh-cli uses clap to build its command tree, with each subsystem corresponding to a `cmd/<subsystem>.rs` module. Adding a new command requires modifications across three layers: type definitions (cosh-types) → platform implementation (cosh-platform) → CLI entry (cosh-cli).
+
+## Steps
+
+### 1. Define Response Types (cosh-types)
+
+Add or extend data types in `crates/cosh-types/src/`:
+
+```rust
+// crates/cosh-types/src/my_subsystem.rs
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct MyResult {
+    pub field: String,
+    pub success: bool,
+}
+```
+
+Export in `lib.rs`.
+
+### 2. Implement Platform Logic (cosh-platform)
+
+Implement the actual operation in `crates/cosh-platform/src/`:
+
+```rust
+// crates/cosh-platform/src/my_subsystem.rs
+use cosh_types::error::CoshError;
+use cosh_types::my_subsystem::MyResult;
+
+use crate::detect::Distro;
+
+pub fn my_action(distro: &Distro, param: &str, dry_run: bool) -> Result<MyResult, CoshError> {
+    if dry_run {
+        return Ok(MyResult { field: param.to_string(), success: true });
+    }
+    // Actual execution logic...
+    Ok(MyResult { field: param.to_string(), success: true })
+}
+```
+
+### 3. Register CLI Command (cosh-cli)
+
+Create `crates/cosh-cli/src/cmd/my_subsystem.rs`:
+
+```rust
+use std::time::Instant;
+
+use clap::Subcommand;
+use cosh_platform::detect::Distro;
+use cosh_platform::my_subsystem;
+
+use crate::{build_meta, print_failure, print_success};
+
+#[derive(Subcommand)]
+pub enum MyCommands {
+    /// Do something
+    DoSomething {
+        /// Target parameter
+        target: String,
+        /// Preview without executing
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+pub fn run(action: MyCommands, distro: &Distro, start: Instant) -> i32 {
+    match action {
+        MyCommands::DoSomething { target, dry_run } => {
+            match my_subsystem::my_action(distro, &target, dry_run) {
+                Ok(result) => print_success(result, build_meta("my", distro, start, dry_run)),
+                Err(e) => print_failure(e, build_meta("my", distro, start, dry_run)),
+            }
+        }
+    }
+}
+```
+
+Register in `cmd/mod.rs`:
+
+```rust
+pub mod my_subsystem;
+```
+
+Add the subcommand in `main.rs`:
+
+```rust
+#[derive(Subcommand)]
+enum Commands {
+    // ...existing...
+    /// My new subsystem
+    My {
+        #[command(subcommand)]
+        action: cmd::my_subsystem::MyCommands,
+    },
+}
+```
+
+And add the branch in `match cli.command`:
+
+```rust
+Commands::My { action } => cmd::my_subsystem::run(action, &distro, start),
+```
+
+### 4. Add Integration Tests
+
+Add tests in `crates/cosh-cli/tests/cli_integration.rs`:
+
+```rust
+#[test]
+fn test_my_command_json_envelope() {
+    let output = run_cli(&["my", "do-something", "target", "--dry-run"]);
+    let resp: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(resp["ok"], true);
+    assert_eq!(resp["meta"]["subsystem"], "my");
+    assert_eq!(resp["meta"]["dry_run"], true);
+}
+```
+
+## Design Constraints
+
+| Rule | Description |
+|------|-------------|
+| JSON output | Always use `CoshResponse<T>` envelope |
+| Exit codes | Success = 0, Failure = 1 |
+| `--dry-run` | All write operations must support |
+| Input validation | Use `validate_*` to check parameters before execution |
+| subsystem field | `meta.subsystem` must match the command name |
+| Distribution routing | Logic that needs to distinguish distributions goes in `cosh-platform` |

--- a/docs/cosh-ng/en/developers/adding-distros.md
+++ b/docs/cosh-ng/en/developers/adding-distros.md
@@ -1,0 +1,140 @@
+# Adding Distribution Support
+
+## Overview
+
+cosh-ng abstracts OS differences through the `Distro` enum. Adding support for a new distribution requires modifications at two layers: the detection layer (`cosh-platform/src/detect.rs`) and the backend routing layer (`cosh-platform/src/pkg.rs`, etc.).
+
+## Steps
+
+### 1. Add Distro Enum Variant
+
+Add a variant in `crates/cosh-platform/src/detect.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Distro {
+    // ...existing...
+    MyDistro { version: String },   // New
+}
+```
+
+### 2. Implement Detection Logic
+
+Add ID mapping in the `detect_from_content()` match branch:
+
+```rust
+match id.as_deref() {
+    // ...existing...
+    Some("mydistro") => Distro::MyDistro { version },
+    // ...
+}
+```
+
+Linux systems identify distributions by parsing the `ID` field from `/etc/os-release`. Values must match in lowercase.
+
+### 3. Implement Helper Methods
+
+```rust
+impl Distro {
+    pub fn id_str(&self) -> &str {
+        match self {
+            // ...existing...
+            Distro::MyDistro { .. } => "mydistro",
+        }
+    }
+
+    pub fn display_name(&self) -> String {
+        match self {
+            // ...existing...
+            Distro::MyDistro { version } => format!("MyDistro {}", version),
+        }
+    }
+
+    pub fn pkg_manager(&self) -> PkgManager {
+        match self {
+            // ...existing...
+            Distro::MyDistro { .. } => PkgManager::Dnf, // Choose based on actual situation
+        }
+    }
+}
+```
+
+If the new distribution uses a package manager not in the existing `PkgManager` enum, extend that enum first.
+
+### 4. Add Package Manager Backend (if needed)
+
+If a new `PkgManager` variant is needed, add the corresponding command builder in `crates/cosh-platform/src/pkg.rs`:
+
+```rust
+// New PkgManager variant
+pub enum PkgManager {
+    // ...existing...
+    Pacman,
+}
+
+// Add routing branch in pkg_install / pkg_remove / pkg_search / pkg_list
+PkgManager::Pacman => ("pacman", vec!["-S", "--noconfirm", package]),
+```
+
+### 5. Add Unit Tests
+
+Add in the `#[cfg(test)]` module of `detect.rs`:
+
+```rust
+#[test]
+fn test_detect_mydistro() {
+    let content = "NAME=\"My Distro\"\nVERSION_ID=\"1.0\"\nID=mydistro\n";
+    let distro = Distro::detect_from_content(content);
+    assert_eq!(distro, Distro::MyDistro { version: "1.0".into() });
+    assert_eq!(distro.pkg_manager(), PkgManager::Dnf);
+}
+```
+
+### 6. Run Tests to Verify
+
+```bash
+cd src/cosh-ng
+
+# Run detection-related tests
+cargo test --locked -p cosh-platform test_detect
+
+# Run full test suite
+cargo test --locked -p cosh-platform
+
+# Run CLI integration tests (ensure new routing doesn't break JSON envelope)
+cargo test --locked -p cosh-cli
+```
+
+## Current Support Matrix
+
+| Distribution ID | Distro Variant | PkgManager | Notes |
+|----------------|---------------|------------|-------|
+| `alinux` | `Alinux` | Dnf | Alibaba Cloud native Linux |
+| `centos` | `CentOS` | Dnf | |
+| `fedora` | `Fedora` | Dnf | |
+| `ubuntu` | `Ubuntu` | Apt | |
+| `debian` | `Debian` | Apt | |
+| `opensuse-leap` / `opensuse-tumbleweed` / `sles` | `OpenSUSE` | Zypper | Three IDs map to same variant |
+| macOS (compile target) | `MacOS` | Brew | Detected via `sw_vers` |
+
+## Design Constraints
+
+| Rule | Description |
+|------|-------------|
+| Lowercase ID | `detect_from_content()` does `to_lowercase()` on ID |
+| Unknown fallback | Unrecognized IDs fall into `Unknown(String)`, subsequent operations return `UnsupportedDistro` |
+| Multi-ID merge | Multiple IDs can map to the same Distro variant (e.g., opensuse family) |
+| Package manager decoupling | `PkgManager` and `Distro` are separate enums, mapped via `pkg_manager()` |
+| No config merging | Detection logic only takes the first matching `ID` and `VERSION_ID` |
+
+## Complete Checklist
+
+- [ ] Add new variant to `Distro` enum
+- [ ] Add match branch in `detect_from_content()`
+- [ ] `id_str()` returns correct string identifier
+- [ ] `display_name()` returns readable name
+- [ ] `pkg_manager()` maps to correct package manager
+- [ ] `Display` trait (via `display_name()`) formats correctly
+- [ ] Unit tests cover normal parsing and edge cases
+- [ ] If new PkgManager needed, add routing in `pkg.rs` functions
+- [ ] Update user documentation `users/supported-distros.md`

--- a/docs/cosh-ng/en/developers/architecture.md
+++ b/docs/cosh-ng/en/developers/architecture.md
@@ -1,0 +1,92 @@
+# Architecture
+
+cosh-ng uses a 5-crate Rust workspace architecture, version 0.11.0, requiring Rust 1.74+.
+
+## Crate Dependency Graph
+
+```
+cosh-types          cosh-platform          cosh-cli / cosh-core
+  (pure types)    ← (distro detection +  ← (CLI entry / Agent core)
+  zero side effects   backend routing)
+
+cosh-shell
+  (independent crate, no internal dependencies)
+
+Dependency direction: cosh-cli / cosh-core → cosh-platform → cosh-types
+                     cosh-shell is independent (communicates with cosh-core process via stdin/stdout)
+```
+
+## Crate Responsibilities
+
+| Crate | Binary | Responsibility |
+|-------|--------|---------------|
+| `cosh-types` | — | Pure data types, zero side effects. Defines CoshResponse envelope, CoshError, ws-ckpt IPC types |
+| `cosh-platform` | — | Platform abstraction layer. Distro detection, package manager routing, systemd adapter, ws-ckpt IPC client, audit system |
+| `cosh-cli` | `cosh-cli` | CLI entry. 4 command domains (pkg/svc/checkpoint/audit), JSON output |
+| `cosh-core` | `cosh-core` | Agent core. Headless JSONL backend, LLM integration, hooks, tools, skills, extensions, sessions |
+| `cosh-shell` | `cosh-shell` | Interactive terminal. PTY host, OSC markers, AI adapters, approval control, TUI rendering |
+
+## Directory Layout
+
+```
+cosh-ng/
+├── crates/
+│   ├── cosh-types/       # Pure type definitions
+│   │   └── src/          # audit.rs, checkpoint.rs, config.rs, error.rs, output.rs, pkg.rs, svc.rs
+│   ├── cosh-platform/    # Platform abstraction
+│   │   └── src/          # audit/, checkpoint.rs, detect.rs, pkg.rs, svc.rs, validate.rs
+│   ├── cosh-cli/         # CLI binary
+│   │   ├── src/          # main.rs, cmd/{pkg,svc,checkpoint,audit}.rs
+│   │   └── tests/        # Integration tests
+│   ├── cosh-core/        # Agent core binary
+│   │   └── src/          # main.rs, core.rs, headless.rs, hook.rs, provider/, tool/, skill/, extension/
+│   └── cosh-shell/       # Interactive terminal binary
+│       ├── src/          # main.rs, adapter/, agent/, approval/, hooks/, shell_host/, tools/, ui/
+│       └── tests/        # Layered tests
+├── Cargo.toml            # Workspace configuration
+└── rust-toolchain.toml
+```
+
+## Data Flow
+
+### cosh-cli Execution Flow
+
+```
+User command → clap parsing → cmd module routing → cosh-platform backend execution → CoshResponse<T> JSON output
+```
+
+### cosh-core Headless Flow
+
+```
+stdin JSONL → message parsing → UserPromptSubmit hook → LLM generation → tool calls → approval protocol → stdout JSONL
+```
+
+### cosh-shell Interactive Flow
+
+```
+User input → PTY host → OSC boundary detection → AI adapter (launches cosh-core subprocess)
+           → streaming response → approval card rendering → tool execution result display
+```
+
+## Key Design Constraints
+
+- **ws-ckpt IPC wire format** — bincode + 4-byte little-endian length prefix. Enum variant order is the binary contract, cannot be reordered
+- **Unified JSON envelope** — All cosh-cli commands return `CoshResponse<T>` (ok + data/error + meta)
+- **Cross-distro routing** — `Distro::detect()` reads `/etc/os-release` to route to correct backend
+- **Tool classification** — ReadOnly / FileEdit / ShellExec / ShellEvidence, approval mode decides based on this
+- **Hook aliasing** — cosh-ng internal tool names map bidirectionally with copilot-shell standard names
+
+## Dependency Management
+
+All third-party dependencies declare versions in `[workspace.dependencies]`, sub-crates reference via `dep = { workspace = true }`. Key dependencies:
+
+| Dependency | Purpose |
+|-----------|---------|
+| `serde` / `serde_json` | Serialization |
+| `clap` | CLI argument parsing |
+| `tokio` | Async runtime (cosh-core) |
+| `reqwest` | HTTP client (LLM API) |
+| `tracing` | Structured logging |
+| `ratatui` | TUI rendering (cosh-shell) |
+| `nix` | Unix system calls |
+| `bincode` | ws-ckpt IPC serialization |

--- a/docs/cosh-ng/en/developers/contributing.md
+++ b/docs/cosh-ng/en/developers/contributing.md
@@ -1,0 +1,130 @@
+# Contributing Guide
+
+## Development Environment
+
+| Requirement | Version |
+|-------------|---------|
+| Rust toolchain | stable (managed by `rust-toolchain.toml`) |
+| Minimum Rust version | 1.74 |
+| Components | rustfmt + clippy |
+
+```bash
+cd src/cosh-ng
+rustup show   # Confirm toolchain is ready
+```
+
+## Build
+
+```bash
+# Full build (all 5 crates)
+cargo build --workspace
+
+# Release build
+cargo build --workspace --release
+
+# Build a specific binary
+cargo build --bin cosh-cli
+cargo build --bin cosh-core
+cargo build --bin cosh-shell
+```
+
+## Code Quality Checks
+
+All of the following checks must pass before committing:
+
+```bash
+# Format check
+cargo fmt --all -- --check
+
+# Clippy (warnings treated as errors)
+cargo clippy --all-targets --locked -- -D warnings
+
+# Tests
+cargo test --locked
+
+# Documentation build (when modifying pub API)
+cargo doc --workspace --no-deps
+```
+
+## Workspace Structure
+
+```
+cosh-ng/
+├── Cargo.toml              # workspace configuration
+├── rust-toolchain.toml     # stable + rustfmt + clippy
+└── crates/
+    ├── cosh-types/         # Pure types, zero side effects
+    ├── cosh-platform/      # Platform abstraction (distro detection, backend routing)
+    ├── cosh-cli/           # CLI entry
+    ├── cosh-core/          # Agent core
+    └── cosh-shell/         # Interactive terminal
+```
+
+## Dependency Management
+
+- All dependency versions are declared in `[workspace.dependencies]`
+- Sub-crates reference via `dep = { workspace = true }`
+- Check for existing equivalent crates before adding new dependencies
+- Major version upgrades are not allowed without discussion
+
+## Code Standards
+
+### Module Organization
+
+Use Rust 2018+ recommended file layout, **do not use `mod.rs`**:
+
+```
+# Correct
+src/extension.rs        # Parent module
+src/extension/          # Child module directory
+    config.rs
+    manager.rs
+
+# Wrong — do not use
+src/extension/mod.rs
+```
+
+### Error Handling
+
+| Scenario | Approach |
+|----------|----------|
+| Library crate | `thiserror` enum |
+| Binary | `anyhow::Result` |
+| Unreachable path | `unreachable!()` + comment |
+| Prohibited | `unwrap()` / `expect()` / `panic!()` |
+
+### Comments
+
+- `///` for all pub items
+- `//` only explains *why*, does not repeat type signatures
+- First line is a standalone summary, imperative or noun phrase
+- No `TODO` without owner, no commented-out old code
+
+### Clippy
+
+- Default deny all warnings
+- When genuinely needed, use narrowest scope `#[allow(clippy::xxx)]` + comment explaining why
+
+## Commit Standards
+
+Format: `type(scope): imperative description`
+
+- Types: feat / fix / refactor / docs / test / ci / chore
+- Scope: `cosh-ng` maps to `cosh` (when changes span multiple crates)
+- Within 50 characters, English, imperative mood, lowercase first letter, no period
+- Requires `Signed-off-by` trailer
+
+```bash
+git commit \
+  --trailer "Assisted-by: Qoder:1.7.0" \
+  --trailer "Signed-off-by: $(git config user.name) <$(git config user.email)>" \
+  -m 'feat(cosh): add registry list action for hooks'
+```
+
+## PR Process
+
+1. Branch from latest main
+2. Follow branch naming: `feature/cosh/<short-desc>`
+3. Ensure all checks pass before pushing
+4. PR title follows commit message format
+5. Fill in PR template (Description / Testing / Related Issue)

--- a/docs/cosh-ng/en/developers/ipc-protocol.md
+++ b/docs/cosh-ng/en/developers/ipc-protocol.md
@@ -1,0 +1,140 @@
+# ws-ckpt IPC Protocol
+
+## Overview
+
+cosh-ng communicates with the ws-ckpt daemon via Unix Domain Socket to manage workspace snapshots.
+Communication uses a frame format of **bincode serialization + 4-byte little-endian length prefix**.
+
+## Architecture
+
+```
+cosh-cli / cosh-core          ws-ckpt daemon
+     │                              │
+     │  Unix socket                 │
+     │  /run/ws-ckpt/ws-ckpt.sock   │
+     │─────────────────────────────→│
+     │  [4B LE len][bincode req]    │
+     │                              │
+     │←─────────────────────────────│
+     │  [4B LE len][bincode resp]   │
+```
+
+The client implementation is in `crates/cosh-platform/src/checkpoint.rs` (`CkptClient`),
+and type definitions are in `crates/cosh-types/src/checkpoint.rs`.
+
+## Frame Format
+
+Each message consists of two parts:
+
+```
+┌──────────────────┬───────────────────────────────┐
+│ 4-byte LE u32    │ bincode-encoded enum payload   │
+│ (payload length) │ (WsCkptRequest / Response)     │
+└──────────────────┴───────────────────────────────┘
+```
+
+- Length prefix: little-endian unsigned 32-bit integer representing the byte count of the subsequent bincode payload
+- Maximum response limit: 64 MiB (prevents OOM)
+- Default timeout: 5000ms (configurable via `CkptClient::with_timeout()`)
+
+## Request Types (WsCkptRequest)
+
+bincode serializes enums by variant index (first variant = index 0). **Variant order is the binary contract and must not be reordered.**
+
+| Index | Variant | Description |
+|-------|---------|-------------|
+| 0 | `Init { workspace }` | Initialize a workspace |
+| 1 | `Checkpoint { workspace, id, message, metadata, pin }` | Create a snapshot |
+| 2 | `Rollback { workspace, to }` | Rollback to a specified snapshot |
+| 3 | `Delete { workspace, snapshot, force }` | Delete a snapshot |
+| 4 | `List { workspace, format }` | List snapshots |
+| 5 | `Diff { workspace, from, to }` | Diff between two snapshots |
+| 6 | `Status { workspace }` | Query status |
+| 7 | `Cleanup { workspace, keep }` | Clean up old snapshots |
+| 8 | `Config` | Get daemon configuration |
+| 9 | `ReloadConfig` | Reload configuration |
+| 10 | `Recover { workspace }` | Recover a workspace |
+| 11 | `HealthAdvisory` | Health check |
+
+## Response Types (WsCkptResponse)
+
+| Variant | Corresponding Request | Key Fields |
+|---------|----------------------|------------|
+| `InitOk { ws_id }` | Init | Workspace ID |
+| `CheckpointOk { snapshot_id }` | Checkpoint | Snapshot ID |
+| `RollbackOk { from, to }` | Rollback | Rollback source and target |
+| `DeleteOk { target }` | Delete | Deleted snapshot identifier |
+| `Error { code, message }` | Any | Error code + human-readable description |
+| `ListOk { snapshots }` | List | `Vec<SnapshotEntry>` |
+| `DiffOk { changes }` | Diff | `Vec<DiffEntry>` |
+| `StatusOk { report }` | Status | `StatusReport` |
+| `CleanupOk { removed }` | Cleanup | List of removed snapshot IDs |
+| `ConfigOk { config }` | Config | `ConfigReport` |
+| `ReloadConfigOk` | ReloadConfig | No payload |
+| `CheckpointSkipped { reason }` | Checkpoint | Skip reason (e.g., no changes) |
+| `RecoverOk { workspace }` | Recover | Recovered workspace path |
+| `HealthAdvisoryOk { ... }` | HealthAdvisory | Over-limit workspace count, disk usage |
+
+## Error Codes (WsCkptErrorCode)
+
+| Index | Variant | Description |
+|-------|---------|-------------|
+| 0 | `WorkspaceNotFound` | Workspace does not exist |
+| 1 | `SnapshotNotFound` | Snapshot does not exist |
+| 2 | `AlreadyInitialized` | Workspace already initialized |
+| 3 | `BtrfsError` | Btrfs operation error |
+| 4 | `IoError` | I/O error |
+| 5 | `InvalidPath` | Invalid path |
+| 6 | `ConfirmationRequired` | Confirmation needed (e.g., deleting a pinned snapshot) |
+| 7 | `InternalError` | Internal error |
+| 8 | `SnapshotAlreadyExists` | Snapshot ID conflict |
+| 9 | `WriteLockConflict` | Write lock conflict |
+| 10 | `DiskSpaceInsufficient` | Insufficient disk space |
+
+## Client Usage
+
+```rust
+use cosh_platform::checkpoint::CkptClient;
+
+// Default path /run/ws-ckpt/ws-ckpt.sock
+let client = CkptClient::default_path();
+
+// Or specify path and timeout
+let client = CkptClient::with_timeout("/custom/path.sock", 10000);
+
+// Health check
+if !client.is_available() {
+    eprintln!("ws-ckpt daemon not running");
+}
+
+// Operation examples
+let result = client.create("/home/user/project", "snap-001", Some("initial"), None, false)?;
+let list = client.list(Some("/home/user/project"))?;
+let restored = client.restore("/home/user/project", "snap-001")?;
+```
+
+## Key Constraints
+
+| Constraint | Description |
+|------------|-------------|
+| Variant order is immutable | bincode serializes enums by index; reordering breaks the wire format |
+| New additions append only | New Request/Response variants can only be added at the end |
+| Types must stay in sync | Definitions in `cosh-types` must exactly match `ws-ckpt-common` |
+| Timeout handling | Client sets read/write timeouts to avoid blocking when daemon is unresponsive |
+| Length limit | Responses exceeding 64 MiB are treated as anomalous; connection is dropped immediately |
+| Socket path | Default `/run/ws-ckpt/ws-ckpt.sock`; overridable via environment variable or CLI argument |
+
+## Test Verification
+
+```bash
+cd src/cosh-ng
+
+# bincode round-trip serialization tests
+cargo test --locked -p cosh-types -- checkpoint
+
+# Variant index contract tests
+cargo test --locked -p cosh-types test_request_bincode_variant_index
+
+# CkptClient unit tests (no running daemon required)
+cargo test --locked -p cosh-platform -- checkpoint
+```

--- a/docs/cosh-ng/en/developers/security-heuristics.md
+++ b/docs/cosh-ng/en/developers/security-heuristics.md
@@ -1,0 +1,207 @@
+# Security Heuristics
+
+## Overview
+
+The cosh-ng audit subsystem implements a PEP→PDP→Log three-stage security decision pipeline. Each command undergoes structured parsing, policy matching, and logging before execution, resulting in one of three dispositions: Allow / Deny / RequireApproval.
+
+## Architecture
+
+```
+Raw command string
+     │
+     ▼
+┌─────────────────┐
+│ action parser   │  Rejects shell metacharacters, control bytes
+│ (PEP boundary)  │  Structures into Action{subsystem,operation,target,args}
+└────────┬────────┘
+         │ Parse failure → immediate Deny
+         ▼
+┌─────────────────┐
+│ evaluate (PDP)  │  Iterates policy.rules[], first match wins
+│                 │  No match → policy.default
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ audit log       │  Redacts then writes to JSONL log
+│ (redact + log)  │  CallerInfo: session/user/uid/pid
+└─────────────────┘
+```
+
+Code located in `crates/cosh-platform/src/audit/`.
+
+## Command Parsing (action parser)
+
+Source file: `audit/action.rs`
+
+The parser rejects dangerous input before PDP:
+
+| Check | Rejection Condition | Reason |
+|-------|-------------------|--------|
+| Empty string | Empty after `trim()` | No valid operation |
+| Control bytes | Contains `\n` or `\r` | Prevents command injection |
+| Shell metacharacters | Contains any of `;|&><$\`(){}` | Prevents command chaining/redirection/subshell |
+
+On parse failure, callers should map to `Outcome::Deny` (never auto-allow).
+
+After successful parsing, structure is determined by the first token:
+- `pkg` / `svc` / `checkpoint` / `cosh` → Structured subsystem (operation=tokens[1], target=tokens[2])
+- Others → Shell subsystem (operation=first token, target=second token, args=tokens[1..])
+
+## Policy System
+
+Source files: `audit/policy.rs`, `audit/builtin.rs`
+
+### Policy Loading Priority
+
+1. File specified by `$COSH_AUDIT_POLICY` environment variable
+2. `~/.copilot-shell/cosh/audit.toml` (user-level)
+3. `/etc/cosh/audit.toml` (system-level)
+4. Built-in `balanced` preset (factory default)
+
+Only the first existing source is used; no cross-file merging.
+
+### Built-in Presets
+
+| Preset | Default Outcome | Use Case |
+|--------|----------------|----------|
+| `permissive` | Allow | Sandbox / CI environments |
+| `balanced` | RequireApproval | Daily development (default) |
+| `strict` | Deny | Production / untrusted agents |
+
+### Policy File Format (TOML)
+
+```toml
+version = "v1"
+default = "RequireApproval"   # Allow / Deny / RequireApproval
+
+[[rules]]
+name = "allow-readonly"
+matches.subsystem = "shell"
+matches.operation = { one_of = ["ls", "cat", "ps", "df", "echo", "uptime"] }
+outcome = "Allow"
+
+[[rules]]
+name = "deny-destructive"
+matches.subsystem = "shell"
+matches.operation = { one_of = ["rm", "sudo", "shutdown", "dd", "mkfs", "tee"] }
+outcome = "Deny"
+reason = "destructive command blocked by policy"
+```
+
+### Match Syntax (StringMatch)
+
+| Form | Example | Description |
+|------|---------|-------------|
+| Exact match | `"install"` | String equality |
+| Enum match | `{ one_of = ["start", "restart", "stop"] }` | Any one matches |
+| Glob match | `{ glob = "-i*" }` | Supports `*` and `?` |
+
+Match block supports fields: `subsystem`, `operation`, `target`, `arg[].key`, `arg[].value`
+
+## Decision Engine (evaluate)
+
+Source file: `audit/evaluate.rs`
+
+- Iterates `policy.rules[]`; the first matching rule determines the outcome
+- Falls back to `policy.default` when no rules match
+- Returns `Decision { outcome, reason, matched_rule, policy_version }`
+- `policy_version` includes source identifier + SHA256 hash for audit traceability
+
+## Balanced Preset Core Rules
+
+### Allow
+
+| Category | Example Commands |
+|----------|-----------------|
+| Read-only atomic commands | `uptime`, `ls -la`, `cat`, `ps aux`, `df -h`, `echo` |
+| Git read-only | `git status`, `git log`, `git diff`, `git show`, `git blame` |
+| Git branch viewing | `git branch`, `git branch -v` |
+| Git stash viewing | `git stash`, `git stash list`, `git stash show` |
+| Safe tool pairs | `systemctl status`, `apt list`, `dnf list`, `docker ps` |
+| pkg/svc read-only | `pkg search`, `pkg list`, `svc status`, `svc list` |
+| checkpoint read-only | `checkpoint list`, `checkpoint status` |
+
+### Deny
+
+| Category | Example Commands |
+|----------|-----------------|
+| Destructive commands | `rm -rf /`, `sudo`, `shutdown`, `dd`, `mkfs`, `tee` |
+| Git mutations | `git push`, `git reset --hard`, `git clean`, `git rebase` |
+| Git branch mutations | `git branch -D`, `git branch -m`, `git branch --delete` |
+| Git stash mutations | `git stash drop`, `git stash clear`, `git stash pop/apply` |
+| sed in-place edits | `sed -i`, `sed --in-place` |
+| find destructive | `find . -delete`, `find . -fprint` |
+
+### RequireApproval
+
+| Category | Example Commands |
+|----------|-----------------|
+| Package management writes | `pkg install`, `pkg remove` |
+| Service management writes | `svc start`, `svc restart` |
+| Checkpoint writes | `checkpoint create`, `checkpoint restore` |
+| Unknown commands | Commands not matching any allow/deny rule |
+
+## Logging and Redaction
+
+Source files: `audit/log.rs`, `audit/redact.rs`
+
+### Redaction Rules
+
+Automatic redaction before writing to log:
+
+| Detection Method | Trigger Condition | Replacement |
+|-----------------|-------------------|-------------|
+| Sensitive key | args key contains `password/secret/token/api_key/apikey` | `<redacted>` |
+| PEM content | raw field contains PEM header like `BEGIN PRIVATE KEY` | `<redacted-pem>` |
+
+Redaction occurs at log-write time (not during PDP), ensuring PDP can make decisions based on original values.
+
+### Log Entry Fields
+
+```json
+{
+  "timestamp": "2025-01-01T00:00:00Z",
+  "session_id": "p1234-t1704067200",
+  "user": "admin",
+  "uid": 1000,
+  "euid": 1000,
+  "sudo_user": null,
+  "pid": 1234,
+  "action": { "subsystem": "pkg", "operation": "install", ... },
+  "decision": { "outcome": "RequireApproval", "reason": "...", ... },
+  "source": "Cli",
+  "redacted": false
+}
+```
+
+Log path is overridable via `$COSH_AUDIT_LOG` environment variable (for testing).
+
+## Public API
+
+| Function | Purpose |
+|----------|---------|
+| `audit::check(action, source, &loaded)` | Full PEP→PDP→Log pipeline |
+| `audit::classify(action, &loaded)` | PDP only, no logging (for TUI real-time classification) |
+| `audit::record_decision(action, &decision, source)` | Record an already-made decision (e.g., Deny from parse failure) |
+| `audit::evaluate(action, &loaded)` | Pure PDP function |
+| `parse_action_string(raw)` | Raw string → Action |
+| `LoadedPolicy::load()` | Load the active policy |
+
+## Test Verification
+
+```bash
+cd src/cosh-ng
+
+# Audit policy matching tests (balanced preset allow/deny/approve coverage)
+cargo test --locked -p cosh-platform -- audit
+
+# Action parser tests
+cargo test --locked -p cosh-platform -- action
+
+# Policy loading and validation tests
+cargo test --locked -p cosh-platform -- policy
+
+# Redaction tests
+cargo test --locked -p cosh-platform -- redact
+```

--- a/docs/cosh-ng/en/developers/testing.md
+++ b/docs/cosh-ng/en/developers/testing.md
@@ -1,0 +1,117 @@
+# Testing
+
+## Running Tests
+
+```bash
+cd src/cosh-ng
+
+# All tests
+cargo test --locked
+
+# By crate
+cargo test --locked -p cosh-types      # Pure types, no tests
+cargo test --locked -p cosh-platform   # 174 unit tests
+cargo test --locked -p cosh-cli        # 55 integration tests
+cargo test --locked -p cosh-core       # Unit + integration tests
+cargo test --locked -p cosh-shell      # Unit + integration (includes PTY tests, slower)
+
+# Run a single test
+cargo test --locked -p cosh-platform test_detect_alinux
+
+# Run a specific test file
+cargo test --locked -p cosh-cli --test cli_integration
+```
+
+## Test Layers
+
+### cosh-types
+
+Pure type definitions, typically no tests. Serialization/deserialization correctness is covered by upper-layer crate tests.
+
+### cosh-platform
+
+Unit tests cover:
+- Distribution detection (mocking `/etc/os-release`)
+- Package manager command generation
+- Audit policy rule matching
+- ws-ckpt IPC protocol encoding/decoding
+
+```bash
+cargo test --locked -p cosh-platform
+# ~174 tests, < 1s
+```
+
+### cosh-cli
+
+Integration tests (`crates/cosh-cli/tests/cli_integration.rs`):
+- JSON output envelope format validation
+- `--dry-run` behavior
+- Argument parsing for each subcommand
+- Error code mapping
+
+```bash
+cargo test --locked -p cosh-cli
+# ~55 tests, ~4s
+```
+
+### cosh-core
+
+| Test File | Coverage |
+|-----------|----------|
+| `tests/jsonl_protocol.rs` | JSONL message serialization/deserialization |
+| `tests/registry_protocol.rs` | Registry mode request-response |
+| `tests/tool_approval.rs` | Tool approval protocol |
+| `tests/sls_integration.rs` | SLS logging integration |
+
+Unit tests distributed across modules:
+- `extension/` — Configuration parsing, variable substitution, extension loading
+- `state.rs` — State file read/write
+- `hook.rs` — Hook protocol
+
+```bash
+cargo test --locked -p cosh-core
+```
+
+### cosh-shell
+
+Most complex test structure, divided into three layers:
+
+**Integration tests** (`crates/cosh-shell/tests/`):
+
+| Directory | Coverage |
+|-----------|----------|
+| `logic/` | Command classification, failure analysis, agent event handling |
+| `protocol/` | Adapter protocol, control messages |
+| `raw_cli/` | Raw mode CLI behavior |
+| `shell_host/` | PTY sessions, OSC marker parsing |
+
+**Inline unit tests** (`#[cfg(test)]` modules in `src/`):
+
+| Module | Coverage |
+|--------|----------|
+| `approval/tests.rs` | Approval decision logic |
+| `hooks/` | Hook engine, runtime behavior |
+| `runtime/` | State machine, evidence requests |
+| `shell_host/osc_tests.rs` | OSC escape sequence parsing |
+| `tools/` | Tool risk analysis, display |
+
+```bash
+cargo test --locked -p cosh-shell
+# Slower (PTY tests require fork + terminal interaction)
+```
+
+## Test Utilities
+
+| Utility | Purpose |
+|---------|---------|
+| `tempfile` | Create temporary directories for isolated tests |
+| `COSH_STATES_DIR` | Environment variable to override state directory |
+| `ExtensionManager::new_isolated()` | Test-specific constructor |
+
+## Writing Tests Guide
+
+1. Integration tests go in `tests/` directory, unit tests inline in modules
+2. Test function naming: `test_<behavior_under_test>_<scenario>`
+3. Use `tempfile::tempdir()` to isolate filesystem side effects
+4. Do not depend on network (LLM API tests use mocks)
+5. PTY tests annotated with `#[ignore]` (if they require a real terminal environment)

--- a/docs/cosh-ng/en/users/cli/audit.md
+++ b/docs/cosh-ng/en/users/cli/audit.md
@@ -1,0 +1,115 @@
+# Security Audit
+
+The `cosh-cli audit` subsystem implements a PEP/PDP architecture for security policy evaluation. Before executing dangerous operations, Agents can first check whether an operation is allowed through the audit subsystem.
+
+## Core Concepts
+
+- **PEP** (Policy Enforcement Point) — Executes the complete evaluation + logging flow
+- **PDP** (Policy Decision Point) — Pure decision logic, returns decisions based on policy rules
+- **Decision** — Evaluation result: Allow / Deny / RequireApproval
+- **Policy** — Policy rule set, divided into built-in presets and custom policies
+
+## Command List
+
+| Command | Description |
+|---------|-------------|
+| `cosh-cli audit check --action <cmd>` | Evaluate command safety |
+| `cosh-cli audit log` | View audit log |
+| `cosh-cli audit policy show` | Display current policy |
+
+## check
+
+Evaluates whether a shell command is allowed by policy.
+
+```bash
+cosh-cli audit check --action "rm -rf /var/log"
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "outcome": "Deny",
+    "matched_rule": "shell-deny-destructive",
+    "reason": "destructive command matches deny pattern"
+  },
+  "meta": { "subsystem": "audit", "duration_ms": 2, "distro": "alinux", "dry_run": false }
+}
+```
+
+Safe command example:
+
+```bash
+cosh-cli audit check --action "cat /etc/os-release"
+```
+
+```json
+{
+  "ok": true,
+  "data": {
+    "outcome": "Allow",
+    "matched_rule": null,
+    "reason": "no deny rules matched"
+  },
+  "meta": { "subsystem": "audit", "duration_ms": 1, "distro": "alinux", "dry_run": false }
+}
+```
+
+## log
+
+View audit log entries.
+
+```bash
+cosh-cli audit log --session abc123
+```
+
+Audit logs are written to the path specified by `$COSH_AUDIT_LOG`. If not set, defaults to `~/.copilot-shell/audit.log`.
+
+## policy show
+
+Display the currently effective audit policy.
+
+```bash
+cosh-cli audit policy show
+```
+
+## Built-in Policy Presets
+
+| Preset | Description |
+|--------|-------------|
+| `permissive` | Permissive mode, most operations Allow |
+| `balanced` | Balanced mode (default), write operations require approval |
+| `strict` | Strict mode, almost all non-read-only operations Deny |
+
+## Policy Loading Priority
+
+1. Policy file specified by `COSH_AUDIT_POLICY` environment variable
+2. `~/.copilot-shell/cosh/audit.toml` (user-level)
+3. `/etc/cosh/audit.toml` (system-level)
+4. Built-in `balanced` preset
+
+## Action Parsing
+
+`parse_action_string()` parses raw shell strings into structured `Action`:
+
+- Tokenizes by whitespace (spaces, tabs, newlines)
+- Detects shell metacharacters (`;` `|` `&` `>` `<` `$` `` ` `` `(` `)` `{` `}`)
+- Commands containing metacharacters are directly rejected (cannot be safely analyzed)
+
+## Log Redaction
+
+Audit logs are automatically redacted for sensitive fields before writing:
+
+- Password arguments (`--password`, `-p` followed values)
+- API keys and tokens
+- Secret values in environment variables
+
+## Decision Enum
+
+| Decision | Meaning | Agent Behavior |
+|----------|---------|---------------|
+| `Allow` | Policy allows | Execute directly |
+| `Deny` | Policy denies | Abort, do not execute |
+| `RequireApproval` | Requires human confirmation | Pause, wait for user approval |

--- a/docs/cosh-ng/en/users/cli/checkpoint.md
+++ b/docs/cosh-ng/en/users/cli/checkpoint.md
@@ -1,0 +1,102 @@
+# Workspace Checkpoints
+
+The `cosh-cli checkpoint` subsystem manages workspace snapshots by communicating with the ws-ckpt daemon via Unix socket. Snapshots enable Agents to save state before executing high-risk operations and quickly rollback on failure.
+
+## Prerequisites
+
+Checkpoint commands require a running ws-ckpt daemon. If not running, commands return `CheckpointDaemonUnavailable` error.
+
+## Command List
+
+| Command | Description |
+|---------|-------------|
+| `cosh-cli checkpoint create` | Create snapshot |
+| `cosh-cli checkpoint restore <id>` | Restore to specified snapshot |
+| `cosh-cli checkpoint list` | List all snapshots |
+| `cosh-cli checkpoint status` | Check daemon status |
+| `cosh-cli checkpoint init` | Initialize workspace |
+| `cosh-cli checkpoint delete` | Delete snapshot |
+| `cosh-cli checkpoint diff` | Compare two snapshots |
+
+## create
+
+Create a snapshot with an identifier and description.
+
+```bash
+cosh-cli checkpoint create --workspace /home/agent/project --id step-042 -m "before refactor"
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "checkpoint_id": "step-042",
+    "step": 42
+  },
+  "meta": { "subsystem": "checkpoint", "duration_ms": 150, "distro": "alinux", "dry_run": false }
+}
+```
+
+## restore
+
+Restore workspace to a specified snapshot state.
+
+```bash
+cosh-cli checkpoint restore step-040 --workspace /home/agent/project
+```
+
+## list
+
+List all snapshots in the workspace.
+
+```bash
+cosh-cli checkpoint list --workspace /home/agent/project
+```
+
+## diff
+
+Compare differences between two snapshots.
+
+```bash
+cosh-cli checkpoint diff --workspace /home/agent/project --from step-040 --to step-042
+```
+
+## init
+
+Initialize checkpoint management for a workspace.
+
+```bash
+cosh-cli checkpoint init --workspace /home/agent/project
+```
+
+## delete
+
+Delete a specified snapshot.
+
+```bash
+cosh-cli checkpoint delete --snapshot step-042
+```
+
+## status
+
+Check ws-ckpt daemon connection status.
+
+```bash
+cosh-cli checkpoint status
+```
+
+## IPC Protocol
+
+Checkpoint commands communicate with the ws-ckpt daemon via Unix socket, using bincode serialization + 4-byte little-endian length prefix frame format. See developer documentation [IPC Protocol](../../developers/ipc-protocol.md).
+
+## Typical Agent Workflow
+
+```
+1. cosh-cli checkpoint create --id pre-action -m "safe point"
+2. Execute high-risk operation (file modifications, service restarts, etc.)
+3. Verify operation results
+4. If failed → cosh-cli checkpoint restore pre-action
+5. If successful → proceed to next step
+```

--- a/docs/cosh-ng/en/users/cli/overview.md
+++ b/docs/cosh-ng/en/users/cli/overview.md
@@ -1,0 +1,57 @@
+# cosh-cli Overview
+
+cosh-cli is the structured command-line tool of cosh-ng, providing AI Agents with a zero-learning-cost cross-distribution system operation interface. All commands output JSON-formatted `CoshResponse<T>` envelopes.
+
+## Design Philosophy
+
+1. **Zero Learning** — Agents don't need to distinguish between dnf / apt / zypper
+2. **Structured Output** — Pure JSON, no regex parsing of text needed
+3. **Reversible** — checkpoint create → execute → rollback on failure
+4. **Classified Errors** — `recoverable` field tells Agents whether retry is worthwhile
+5. **Dry-run** — All write operations support `--dry-run` preview
+
+## Command Subsystems
+
+| Subsystem | Description | Documentation |
+|-----------|-------------|---------------|
+| `pkg` | Cross-distribution package management | [package-management.md](package-management.md) |
+| `svc` | systemd service management | [service-management.md](service-management.md) |
+| `checkpoint` | Workspace snapshots (ws-ckpt) | [checkpoint.md](checkpoint.md) |
+| `audit` | Security policy auditing | [audit.md](audit.md) |
+
+## Common Options
+
+```
+cosh-cli <SUBCOMMAND> [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--help` / `-h` | Display help information |
+| `--version` / `-V` | Display version number |
+| `--dry-run` | Preview mode, no actual execution (supported by each write subcommand) |
+
+## Quick Examples
+
+```bash
+# Package management
+cosh-cli pkg install nginx
+cosh-cli pkg search "web server"
+cosh-cli pkg list --installed
+cosh-cli pkg remove nginx --dry-run
+
+# Service management
+cosh-cli svc status nginx
+cosh-cli svc restart nginx --dry-run
+cosh-cli svc list --state running
+
+# Workspace snapshots
+cosh-cli checkpoint create --workspace /home/agent/project --id step-042 -m "before refactor"
+cosh-cli checkpoint restore step-040 --workspace /home/agent/project
+cosh-cli checkpoint list --workspace /home/agent/project
+
+# Security audit
+cosh-cli audit check --action "rm -rf /var/log"
+cosh-cli audit log --session abc123
+cosh-cli audit policy show
+```

--- a/docs/cosh-ng/en/users/cli/package-management.md
+++ b/docs/cosh-ng/en/users/cli/package-management.md
@@ -1,0 +1,124 @@
+# Package Management
+
+The `cosh-cli pkg` subsystem provides cross-distribution package management operations. It automatically detects the current distribution and routes to the corresponding package manager backend (dnf / apt-get / zypper / brew).
+
+## Command List
+
+| Command | Description |
+|---------|-------------|
+| `cosh-cli pkg install <name>` | Install package |
+| `cosh-cli pkg remove <name>` | Remove package |
+| `cosh-cli pkg search <query>` | Search packages |
+| `cosh-cli pkg list --installed` | List installed packages |
+
+## install
+
+Install a specified package.
+
+```bash
+cosh-cli pkg install nginx
+cosh-cli pkg install nginx --dry-run
+```
+
+Success output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "package": "nginx",
+    "version": "1.24.0",
+    "already_installed": false,
+    "dependencies_installed": []
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 5200, "distro": "alinux", "dry_run": false }
+}
+```
+
+If the package is already installed, `already_installed` is `true` and the command still returns success.
+
+## remove
+
+Remove a specified package.
+
+```bash
+cosh-cli pkg remove nginx
+cosh-cli pkg remove nginx --dry-run
+```
+
+Success output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "package": "nginx",
+    "version_removed": "1.24.0",
+    "dependencies_removed": []
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 2100, "distro": "ubuntu", "dry_run": false }
+}
+```
+
+## search
+
+Search available packages. Results include installation status.
+
+```bash
+cosh-cli pkg search "web server"
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "packages": [
+      { "name": "nginx", "version": "1.24.0", "description": "...", "installed": true },
+      { "name": "apache2", "version": "2.4.58", "description": "...", "installed": false }
+    ],
+    "total": 2
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 800, "distro": "ubuntu", "dry_run": false }
+}
+```
+
+## list
+
+List installed packages.
+
+```bash
+cosh-cli pkg list --installed
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "packages": [
+      { "name": "nginx", "version": "1.24.0" },
+      { "name": "curl", "version": "8.5.0" }
+    ],
+    "total": 2
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 300, "distro": "centos", "dry_run": false }
+}
+```
+
+## Backend Mapping
+
+| Operation | dnf | apt-get | zypper | brew |
+|-----------|-----|---------|--------|------|
+| install | `dnf install -y` | `apt-get install -y` | `zypper install -y` | `brew install` |
+| remove | `dnf remove -y` | `apt-get remove -y` | `zypper remove -y` | `brew uninstall` |
+| search | `dnf search -q` | `apt-cache search` | `zypper search` | `brew search` |
+| list | `dnf list installed -q` | `dpkg-query -W` | `zypper se --installed-only` | `brew list --versions` |
+
+## Error Handling
+
+- Package not found returns `PkgNotFound`, `hint` suggests searching
+- Package manager execution failure returns `PkgBackendError`, `recoverable: true`
+- Unsupported distribution returns `UnsupportedDistro`

--- a/docs/cosh-ng/en/users/cli/service-management.md
+++ b/docs/cosh-ng/en/users/cli/service-management.md
@@ -1,0 +1,120 @@
+# Service Management
+
+The `cosh-cli svc` subsystem manages system services via systemd. All Linux distributions use the unified `systemctl` interface. macOS does not support this subsystem.
+
+## Command List
+
+| Command | Description |
+|---------|-------------|
+| `cosh-cli svc status <name>` | View service status |
+| `cosh-cli svc start <name>` | Start service |
+| `cosh-cli svc stop <name>` | Stop service |
+| `cosh-cli svc restart <name>` | Restart service |
+| `cosh-cli svc enable <name>` | Enable auto-start on boot |
+| `cosh-cli svc disable <name>` | Disable auto-start on boot |
+| `cosh-cli svc list` | List services |
+
+## status
+
+View detailed service status including running state, PID, memory usage, and recent logs.
+
+```bash
+cosh-cli svc status nginx
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "name": "nginx",
+    "active": true,
+    "enabled": true,
+    "state": "Running",
+    "pid": 1234,
+    "memory": "12.5M",
+    "uptime_seconds": 86400,
+    "recent_logs": [
+      "2026-06-30 10:00:01 [notice] worker process started",
+      "2026-06-30 10:00:01 [notice] signal process started"
+    ]
+  },
+  "meta": { "subsystem": "svc", "duration_ms": 50, "distro": "alinux", "dry_run": false }
+}
+```
+
+## start / stop / restart
+
+Control service running state. Supports `--dry-run` preview.
+
+```bash
+cosh-cli svc restart nginx
+cosh-cli svc restart nginx --dry-run
+```
+
+Success output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "name": "nginx",
+    "action": "restart",
+    "success": true
+  },
+  "meta": { "subsystem": "svc", "duration_ms": 1200, "distro": "ubuntu", "dry_run": false }
+}
+```
+
+## enable / disable
+
+Control service auto-start on boot.
+
+```bash
+cosh-cli svc enable nginx
+cosh-cli svc disable nginx
+```
+
+## list
+
+List system services with optional state filtering.
+
+```bash
+cosh-cli svc list
+cosh-cli svc list --state running
+cosh-cli svc list --state failed
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "services": [
+      { "name": "nginx", "active": true, "enabled": true, "state": "Running" },
+      { "name": "sshd", "active": true, "enabled": true, "state": "Running" }
+    ],
+    "total": 2
+  },
+  "meta": { "subsystem": "svc", "duration_ms": 200, "distro": "centos", "dry_run": false }
+}
+```
+
+## Service State Enum
+
+| State | Description |
+|-------|-------------|
+| `Running` | Currently running |
+| `Stopped` | Stopped |
+| `Failed` | Execution failed |
+| `Activating` | Starting up |
+| `Deactivating` | Shutting down |
+| `Unknown` | State unknown |
+
+## Error Handling
+
+- Service not found returns `SvcNotFound`
+- Start failure returns `SvcStartFailed`, stop failure returns `SvcStopFailed`
+- Root privileges required returns `PermissionDenied`

--- a/docs/cosh-ng/en/users/configuration.md
+++ b/docs/cosh-ng/en/users/configuration.md
@@ -1,0 +1,117 @@
+# Configuration
+
+The three cosh-ng binaries share the configuration file `~/.copilot-shell/config.toml`. Environment variable overrides and CLI parameter precedence are supported.
+
+## Configuration File Locations
+
+Configuration is loaded in the following priority order (highest to lowest):
+
+1. `.copilot-shell/config.toml` (project-level, current directory)
+2. `~/.copilot-shell/config.toml` (user-level)
+3. `/etc/copilot-shell/config.toml` (system-level)
+
+## cosh-core Configuration
+
+```toml
+[ai]
+# Active model identifier
+active_model = "qwen-plus"
+# Output language (optional)
+output_language = "zh"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = ""        # Or via ALIBABA_CLOUD_ACCESS_KEY_ID
+access_key_secret = ""    # Or via ALIBABA_CLOUD_ACCESS_KEY_SECRET
+model = "qwen-plus"
+
+[ai.providers.dashscope]
+type = "dashscope"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = ""              # Or via DASHSCOPE_API_KEY
+model = "qwen-plus"
+
+[agent]
+# Approval mode: trust | auto | balanced | suggest | strict
+approval_mode = "balanced"
+# Maximum conversation turns
+max_turns = 20
+
+[hooks]
+enabled = true
+
+[skills]
+# Custom skill search paths
+custom_paths = []
+
+[session]
+# Session persistence directory (relative to ~/.copilot-shell/)
+persist_dir = "sessions"
+auto_persist = true
+
+[logging]
+level = "warn"
+```
+
+## cosh-shell Configuration
+
+```toml
+[ui]
+# Log level
+log_level = "warn"
+
+[shell]
+# Default shell (auto = auto-detect)
+default = "auto"
+# Default AI adapter
+adapter_default = "cosh-core"
+# Analysis mode (smart | auto | manual)
+analysis_mode = "smart"
+# Approval mode (recommend | auto | trust)
+approval_mode = "auto"
+```
+
+## Environment Variable Overrides
+
+| Environment Variable | Purpose | Mapped Configuration |
+|---------------------|---------|---------------------|
+| `COSH_MODEL` | Override active model | `ai.active_model` |
+| `COSH_APPROVAL_MODE` | Override approval mode | `agent.approval_mode` |
+| `COSH_AI_PROVIDER` | Override active provider | `ai.active_provider` |
+| `COSH_OUTPUT_LANGUAGE` | Output language | `ai.output_language` |
+| `COSH_MAX_TURNS` | Maximum turns | `agent.max_turns` |
+| `COSH_LOG` | Log level (global) | `logging.level` |
+| `RUST_LOG` | Rust log filter | — |
+| `COSH_SHELL_ADAPTER` | Shell adapter | `shell.adapter_default` |
+| `COSH_SHELL_DEBUG` | Maps to debug level | `ui.log_level` |
+| `COSH_SHELL_LANG` | Shell language | — |
+| `ALIBABA_CLOUD_ACCESS_KEY_ID` | Alibaba Cloud AK | `ai.providers.aliyun.access_key_id` |
+| `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | Alibaba Cloud SK | `ai.providers.aliyun.access_key_secret` |
+| `DASHSCOPE_API_KEY` | DashScope API Key | Provider resolution chain |
+
+## Log Level Priority
+
+```
+COSH_LOG > RUST_LOG > --verbose > config file > default (warn)
+```
+
+Valid values: `error`, `warn`, `info`, `debug`, `trace`
+
+## Log Files
+
+```
+~/.copilot-shell/logs/
+├── cosh-shell.log.2026-06-26    # Daily rotation
+├── cosh-core.log.2026-06-26
+└── ...
+```
+
+## Approval Mode Reference
+
+| Mode | ReadOnly Tools | FileEdit Tools | ShellExec Tools |
+|------|----------------|----------------|-----------------|
+| `trust` | Auto-execute | Auto-execute | Auto-execute |
+| `auto` | Auto-execute | Auto-execute | Require approval |
+| `balanced` | Auto-execute | Require approval | Require approval |
+| `suggest` | Auto-execute | Require approval | Require approval |
+| `strict` | Auto-execute | Require approval | Require approval |

--- a/docs/cosh-ng/en/users/core/extensions.md
+++ b/docs/cosh-ng/en/users/core/extensions.md
@@ -1,0 +1,151 @@
+# Extension System
+
+The cosh-core extension system registers skill directories and hooks via `cosh-extension.json` configuration files. An extension is a directory containing a configuration file, which can come from system-level or user-level installations.
+
+## Extension Directories
+
+| Level | Path | Description |
+|-------|------|-------------|
+| User-level | `~/.copilot-shell/extensions/<name>/` | Higher priority, overrides same-name system extensions |
+| System-level | `/usr/share/anolisa/extensions/<name>/` | RPM/package manager installed |
+
+When user-level and system-level extensions share the same name, user-level overrides system-level.
+
+## Configuration File
+
+Each extension directory must contain `cosh-extension.json`:
+
+```json
+{
+  "name": "agent-sec-core",
+  "version": "0.7.0",
+  "skills": "skills",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(run_shell_command|shell)$",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "code-scanner",
+            "command": "python3 ${extensionPath}/hooks/code_scanner_hook.py",
+            "description": "Scans tool code for security vulnerabilities",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "context-loader",
+            "command": "${extensionPath}/hooks/load-context.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Extension unique identifier |
+| `version` | string | No | Version number (default "0.0.0") |
+| `skills` | string \| string[] | No | Skill directory (default "skills"), relative to extension root |
+| `hooks` | object | No | Hook definitions grouped by event |
+
+### Hook Group Structure
+
+```json
+{
+  "matcher": "^shell$",
+  "sequential": true,
+  "hooks": [
+    {
+      "type": "command",
+      "name": "hook-name",
+      "command": "execution command",
+      "description": "description",
+      "timeout": 5000
+    }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `matcher` | Regex matching tool names (only effective for PreToolUse/PostToolUse) |
+| `sequential` | Whether hooks in the group execute sequentially |
+| `hooks[].command` | Shell command the hook executes |
+| `hooks[].timeout` | Timeout in milliseconds |
+
+## Variable Substitution
+
+String fields in configuration support variable substitution:
+
+| Variable | Replaced With |
+|----------|--------------|
+| `${extensionPath}` | Extension directory absolute path |
+| `${workspacePath}` | Current workspace directory |
+| `${/}` | Path separator (always `/` on Linux) |
+
+Example: `"command": "python3 ${extensionPath}/hooks/check.py --dir=${workspacePath}"`
+
+## Installation Metadata
+
+Optional file `cosh-extension-install.json` records the installation source:
+
+```json
+{
+  "source": "/path/to/local/extension",
+  "type": "link",
+  "installed_at": "2026-07-01T10:00:00Z"
+}
+```
+
+`type` options: `"local"` (copy install) or `"link"` (symbolic link).
+
+## Enable/Disable
+
+Manage extension state via the Registry protocol:
+
+```bash
+# List extensions
+echo '{"type":"registry_request","request_id":"r1","domain":"extensions","action":"list","params":{}}' \
+  | cosh-core --registry
+
+# View details
+echo '{"type":"registry_request","request_id":"r2","domain":"extensions","action":"detail","params":{"name":"agent-sec-core"}}' \
+  | cosh-core --registry
+
+# Disable extension
+echo '{"type":"registry_request","request_id":"r3","domain":"extensions","action":"disable","params":{"name":"hook-test"}}' \
+  | cosh-core --registry
+
+# Enable extension
+echo '{"type":"registry_request","request_id":"r4","domain":"extensions","action":"enable","params":{"name":"hook-test"}}' \
+  | cosh-core --registry
+```
+
+Disabled state is persisted in `~/.copilot-shell/states/extensions.json`:
+
+```json
+{ "disabled": ["hook-test"] }
+```
+
+After disabling an extension, its hooks and skills are no longer effective. Enabling automatically clears the disabled state of hooks related to that extension.
+
+## Loading Flow
+
+1. Scan system-level directory (lower priority)
+2. Scan user-level directory (higher priority, overrides same names)
+3. Read `cosh-extension.json` and parse
+4. Perform variable substitution (`${extensionPath}`, etc.)
+5. Load `cosh-extension-install.json` (if present)
+6. Apply disabled state (read from `extensions.json`)
+7. Sort by extension name alphabetically

--- a/docs/cosh-ng/en/users/core/headless-mode.md
+++ b/docs/cosh-ng/en/users/core/headless-mode.md
@@ -1,0 +1,165 @@
+# Headless Mode
+
+cosh-core's headless mode provides a JSONL protocol interface via stdin/stdout. It is the standard communication method between cosh-shell and cosh-core, and can also be integrated by any client.
+
+## Startup
+
+```bash
+# Long-running mode (continuously receives JSONL)
+cosh-core --headless
+
+# Single prompt (auto-exits after execution)
+cosh-core --headless "Check disk usage"
+
+# With parameters
+cosh-core --headless --model qwen-max --approval-mode trust
+```
+
+## Input Messages (Shell → Core)
+
+All input is sent line by line via stdin, with each line being a JSON object distinguished by the `type` field.
+
+### user — User Message
+
+```json
+{
+  "type": "user",
+  "message": { "role": "user", "content": "List files in current directory" },
+  "session_id": "optional-session-id",
+  "shell_context": { "cwd": "/home/user/project", "env": {}, "last_exit_code": 0 }
+}
+```
+
+### control_request — Control Request
+
+```json
+{
+  "type": "control_request",
+  "request_id": "req-001",
+  "request": { "subtype": "initialize" }
+}
+```
+
+Supported `subtype` values:
+
+| subtype | Description |
+|---------|-------------|
+| `initialize` | Initialize session (returns capability declaration + system init message) |
+| `interrupt` | Interrupt current generation |
+| `shutdown` | Shut down process |
+| `switch_model` | Switch model (requires `model` field) |
+| `reload_config` | Reload config.toml |
+| `config_override` | Runtime config override (`approval_mode`, `allowed_tools`) |
+
+### control_response — Control Response (replying to Core's request)
+
+```json
+{
+  "type": "control_response",
+  "response": {
+    "subtype": "tool_approval",
+    "request_id": "req-002",
+    "response": { "behavior": "allow" }
+  }
+}
+```
+
+### registry_request — Registry Request
+
+```json
+{
+  "type": "registry_request",
+  "request_id": "reg-001",
+  "domain": "tools",
+  "action": "list",
+  "params": {}
+}
+```
+
+## Output Messages (Core → Shell)
+
+All output is written to stdout, also line-by-line JSON.
+
+### system — System Message
+
+```json
+{"type":"system","subtype":"init","session_id":"...","model":"qwen3.7-plus","tools":["ask_user_question","edit","grep","read_file","shell","skill","todo","write_file"]}
+```
+
+Common `subtype` values: `init`, `auth_required`, `auth_ok`, `model_switched`, `config_reloaded`.
+
+### stream_event — Streaming Event
+
+Token-by-token output during LLM generation:
+
+```json
+{"type":"stream_event","event":{"subtype":"text_delta","content":"Hello"}}
+{"type":"stream_event","event":{"subtype":"thinking_delta","content":"Let me analyze..."}}
+{"type":"stream_event","event":{"subtype":"tool_use_begin","tool_name":"shell","tool_use_id":"tu-1"}}
+{"type":"stream_event","event":{"subtype":"tool_use_delta","content":"{\"command\":\"df -h\"}"}}
+{"type":"stream_event","event":{"subtype":"tool_use_end"}}
+```
+
+### control_request — Core-initiated Request
+
+When Core needs Shell cooperation (e.g., tool approval, user question):
+
+```json
+{
+  "type": "control_request",
+  "request_id": "cr-001",
+  "request": { "subtype": "can_use_tool", "tool_name": "shell", "tool_input": {"command": "rm -rf /tmp/old"} }
+}
+```
+
+### result — Turn End
+
+```json
+{"type":"result","subtype":"success","is_error":false,"result":"completed","session_id":"...","duration_ms":1234}
+```
+
+## Initialization Handshake
+
+Standard startup sequence:
+
+```
+Shell → Core:  {"type":"control_request","request_id":"init-1","request":{"subtype":"initialize"}}
+Core → Shell:  {"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{...}}}}
+Core → Shell:  {"type":"system","subtype":"init","session_id":"...","model":"...","tools":[...]}
+```
+
+`capabilities` declares the protocol capabilities Core supports:
+
+| Capability | Description |
+|-----------|-------------|
+| `can_handle_can_use_tool` | Supports tool approval protocol |
+| `can_handle_host_executed_shell_tool_result` | Supports Shell-side execution result callback |
+| `can_handle_shell_evidence_tool` | Supports terminal evidence tool |
+
+## Authentication Flow
+
+If no API key is configured, Core sends an authentication request during initialization:
+
+```
+Core → Shell:  {"type":"control_request","request_id":"auth-init","request":{"subtype":"auth_required","reason":"not_configured","providers":[...]}}
+Shell → Core:  {"type":"control_response","response":{"subtype":"auth_response","request_id":"auth-init","response":{"provider_id":"dashscope","values":{"api_key":"sk-xxx"},"persist":true}}}
+Core → Shell:  {"type":"system","subtype":"auth_ok"}
+```
+
+## Session Resume
+
+```bash
+cosh-core --headless --resume <session-id>
+```
+
+Core loads history messages from `~/.copilot-shell/sessions/<session-id>.json` and restores the conversation context.
+
+## Error Handling
+
+Protocol-level errors are delivered via `result` messages:
+
+```json
+{"type":"result","is_error":true,"errors":["provider returned HTTP 429: rate limit exceeded"],"session_id":"..."}
+```
+
+Input lines with JSON parse failures are silently ignored (debug log only) and do not terminate the process.

--- a/docs/cosh-ng/en/users/core/hooks.md
+++ b/docs/cosh-ng/en/users/core/hooks.md
@@ -1,0 +1,106 @@
+# Hook System
+
+The cosh-core hook system allows injecting external logic at key points in the Agent execution flow. Hooks are implemented by executing external commands and support interception, auditing, and context injection.
+
+## Event Points
+
+| Event | Trigger Timing | Interceptable |
+|-------|---------------|---------------|
+| `PreToolUse` | Before tool execution | Yes (block/allow/ask) |
+| `PostToolUse` | After tool execution | Yes (block/allow) |
+| `PostToolUseFailure` | After tool execution failure | No |
+| `UserPromptSubmit` | When user message is submitted | Yes (block/allow) |
+| `SessionStart` | After session initialization | No |
+| `Stop` | When Agent decides to stop | Yes (block/allow) |
+| `BeforeModel` | Before LLM request is sent | No |
+| `AfterModel` | After LLM response is received | No |
+
+## Configuration
+
+Define hooks in `~/.copilot-shell/config.toml`:
+
+```toml
+[hooks]
+enabled = true
+
+[[hooks.PreToolUse]]
+name = "security-check"
+command = "/usr/local/bin/my-security-hook"
+timeout = 5000
+
+[[hooks.SessionStart]]
+name = "context-loader"
+command = "/usr/local/bin/load-context"
+timeout = 3000
+```
+
+Hooks can also be registered via an extension's `cosh-extension.json`.
+
+## Protocol
+
+### Input (stdin → hook process)
+
+Core writes event data in JSON format to the hook process stdin:
+
+```json
+{
+  "session_id": "abc-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "timestamp": "2026-07-01T10:00:00Z",
+  "transcript_path": "/home/user/.copilot-shell/sessions/abc-123",
+  "tool_name": "shell",
+  "tool_input": { "command": "rm -rf /tmp/old" }
+}
+```
+
+### Output (hook process → stdout)
+
+Hooks return decisions in JSON format:
+
+```json
+{
+  "decision": "block",
+  "reason": "Dangerous rm -rf command",
+  "systemMessage": "Command blocked by security policy"
+}
+```
+
+### Decision Values
+
+| decision | Meaning |
+|----------|---------|
+| `allow` | Allow to proceed |
+| `block` / `deny` | Intercept, abort the operation |
+| `ask` | Require user confirmation |
+| None / empty | Pass-through (no intervention) |
+
+### Additional Fields
+
+| Field | Description |
+|-------|-------------|
+| `reason` | Decision reason (embedded in block/deny decisions, also serves as notification message fallback) |
+| `systemMessage` | Notification message (displayed to user with priority over reason) |
+| `hookSpecificOutput` | Custom JSON data (`additional_context` within it is injected into conversation context) |
+
+## Execution Model
+
+1. Multiple hooks can be registered for the same event point, executed sequentially in configuration order
+2. If any hook returns `block`, the final decision is block (short-circuit)
+3. Hook timeout (default 5000ms) is treated as pass-through
+4. Non-zero exit code from hook process is treated as error, does not affect main flow
+5. Hook definitions without a `name` field are skipped
+
+## Notifications
+
+Notifications generated after hook execution are delivered to Shell via JSONL output:
+
+```json
+{"type":"stream_event","event":{"subtype":"hook_notification","hook_name":"security-check","message":"Command blocked by security policy","decision":"block"}}
+```
+
+Shell is responsible for rendering notification cards.
+
+## Extension Hooks
+
+Hooks registered via `cosh-extension.json` are merged with configuration file hooks and use the same execution protocol. See [extensions.md](extensions.md).

--- a/docs/cosh-ng/en/users/core/overview.md
+++ b/docs/cosh-ng/en/users/core/overview.md
@@ -1,0 +1,85 @@
+# cosh-core Overview
+
+cosh-core is the AI Agent runtime core of cosh-ng. It provides a headless JSONL backend integrating LLM providers, hook system, tool execution, skill management, and session persistence.
+
+## Positioning
+
+cosh-core serves as the backend engine for cosh-shell. cosh-shell communicates with the cosh-core process via stdin/stdout (JSONL protocol). cosh-core can also be used independently:
+
+- **Single prompt mode** — Pass in a prompt directly, exit after execution
+- **Headless mode** — Long-running process, continuously receiving JSONL messages
+- **Registry mode** — Process registry requests only, then exit
+
+## Run Modes
+
+```bash
+# Single prompt (requires explicit --headless)
+cosh-core --headless "Check system load"
+
+# Long-running headless mode (receives JSONL via stdin)
+cosh-core --headless
+
+# Registry mode
+cosh-core --registry
+
+# Override model
+cosh-core --headless --model qwen-max "Analyze this code"
+
+# Override approval mode
+cosh-core --headless --approval-mode trust "Install nginx"
+
+# Resume session
+cosh-core --headless --resume <session-id>
+```
+
+## CLI Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--headless` | Force headless JSONL mode |
+| `--model <name>` | Override configured model |
+| `--approval-mode <mode>` | Override approval mode (trust/auto/balanced/strict) |
+| `--allowed-tools <tools>` | Comma-separated list of auto-approved tools |
+| `--resume <session-id>` | Resume an existing session |
+| `--verbose` | Increase log verbosity |
+| `--registry` | Registry mode |
+| `--enable-shell-evidence-tool` | Enable terminal output evidence tool |
+
+## Core Capabilities
+
+| Capability | Description | Documentation |
+|-----------|-------------|---------------|
+| LLM Providers | OpenAI compatible / Aliyun SysOM | [providers.md](providers.md) |
+| Hook System | 8 event points, extensible | [hooks.md](hooks.md) |
+| Tool Execution | Built-in tools + custom tools | [tools.md](tools.md) |
+| Skill Management | Markdown skill definitions | [skills.md](skills.md) |
+| Extension Loading | cosh-extension.json | [extensions.md](extensions.md) |
+| Session Persistence | JSON format session storage | — |
+
+## Architecture Overview
+
+```
+stdin (JSONL)                stdout (JSONL)
+     │                            ▲
+     ▼                            │
+┌────────────────────────────────────────┐
+│              cosh-core                 │
+│  ┌──────┐  ┌──────────┐  ┌──────────┐  │
+│  │ Auth │  │ Provider │  │  Tools   │  │
+│  └──────┘  └──────────┘  └──────────┘  │
+│  ┌──────┐  ┌──────────┐  ┌──────────┐  │
+│  │Hooks │  │ Session  │  │  Skills  │  │
+│  └──────┘  └──────────┘  └──────────┘  │
+└────────────────────────────────────────┘
+```
+
+## Authentication Flow
+
+If no API key is configured, cosh-core sends an `auth_required` control request on startup:
+
+1. Core sends `AuthRequired`, listing available authentication providers
+2. Shell (or external client) displays authentication UI
+3. User selects a provider and fills in credentials
+4. Shell sends back `ControlResponse` containing credentials
+5. Core applies credentials, optionally persists to config.toml
+6. Core sends `auth_ok` status, begins normal operation

--- a/docs/cosh-ng/en/users/core/providers.md
+++ b/docs/cosh-ng/en/users/core/providers.md
@@ -1,0 +1,95 @@
+# LLM Providers
+
+cosh-core connects to multiple LLM providers via the OpenAI-compatible API protocol. All providers use streaming SSE output and support function calling.
+
+## Supported Providers
+
+| Provider Type | Profile | Description |
+|--------------|---------|-------------|
+| `dashscope` | DashScope | Alibaba Cloud Bailian (Qwen series), supports thinking |
+| `aliyun` | SysOM | Alibaba Cloud AK/SK signature authentication (ROA style) |
+| `openai` | OpenAI | OpenAI official API, uses `max_completion_tokens` |
+| `deepseek` | DeepSeek | DeepSeek API, supports thinking |
+| Other | Generic | Any OpenAI-compatible endpoint |
+
+## Configuration
+
+Configure providers in `~/.copilot-shell/config.toml`:
+
+```toml
+[ai]
+active_model = "qwen-plus"
+
+[ai.providers.dashscope]
+type = "dashscope"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = ""    # Or via DASHSCOPE_API_KEY environment variable
+model = "qwen-plus"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = ""      # Or ALIBABA_CLOUD_ACCESS_KEY_ID
+access_key_secret = ""  # Or ALIBABA_CLOUD_ACCESS_KEY_SECRET
+model = "qwen-plus"
+
+[ai.providers.openai]
+type = "openai"
+base_url = "https://api.openai.com/v1"
+api_key = ""    # Or OPENAI_API_KEY
+model = "gpt-4o"
+
+[ai.providers.deepseek]
+type = "deepseek"
+base_url = "https://api.deepseek.com/v1"
+api_key = ""
+model = "deepseek-chat"
+```
+
+## Provider Profile Differences
+
+Behavioral differences across profiles in API requests:
+
+| Profile | max_tokens Field | Thinking Field | Authentication |
+|---------|-----------------|----------------|----------------|
+| Generic | `max_tokens` | — | Bearer token |
+| DashScope | `max_tokens` | `reasoning_content` | Bearer token |
+| OpenAI | `max_completion_tokens` | — | Bearer token |
+| DeepSeek | `max_tokens` | `reasoning_content` | Bearer token |
+| SysOM (aliyun) | — | — | AK/SK signature |
+
+## Runtime Switching
+
+Dynamically switch models via JSONL control protocol:
+
+```json
+{"type":"control_request","request_id":"sw-1","request":{"subtype":"switch_model","model":"qwen-max"}}
+```
+
+Or override via CLI arguments:
+
+```bash
+cosh-core --headless --model qwen-max
+```
+
+Environment variable override:
+
+```bash
+COSH_MODEL=qwen-max cosh-core --headless
+```
+
+## Authentication Priority
+
+1. CLI `--model` argument → selects corresponding provider config
+2. Environment variables (`DASHSCOPE_API_KEY`, `ALIBABA_CLOUD_ACCESS_KEY_*`)
+3. Values in config.toml `[ai.providers.<name>]`
+4. All empty → triggers interactive authentication flow (sends `auth_required` to Shell)
+
+## Generation Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_tokens` | 4096 | Maximum generated tokens |
+| `temperature` | — | Sampling temperature (uses provider default if not set) |
+| `stream` | true | Always stream output |
+
+Custom parameters can be passed via `extra_params` in the `[ai.providers.<name>]` section of config.toml.

--- a/docs/cosh-ng/en/users/core/skills.md
+++ b/docs/cosh-ng/en/users/core/skills.md
@@ -1,0 +1,63 @@
+# Skill System
+
+The cosh-core skill system allows defining reusable Agent skills via Markdown files. LLM can proactively discover and invoke registered skills during conversations.
+
+## Skill Search Paths
+
+Skills are searched in the following directories by priority (highest to lowest):
+
+| Level | Path | Description |
+|-------|------|-------------|
+| Project | `<project>/.copilot-shell/skills/` | Project-level skills |
+| Custom | config.toml `skills.custom_paths` | Custom paths |
+| User | `~/.copilot-shell/skills/` | User-level skills |
+| Extension | Extension `skill_dirs` declaration | Registered via extensions |
+| System | `/usr/share/anolisa/skills/` | System-level (RPM installed) |
+
+Skills with the same name are overridden by priority (Project > Custom > User > Extension > System).
+
+## Skill File Format
+
+A skill is a Markdown file (`.md`) containing YAML frontmatter and body:
+
+```markdown
+---
+name: check-disk
+description: Check disk usage and provide recommendations
+---
+
+# Check Disk Usage
+
+1. Run `df -h` to get mount point utilization
+2. Issue warnings for partitions with usage above 80%
+3. Run `du -sh /var/log` to check log directory size
+```
+
+## Configuration
+
+```toml
+[skills]
+custom_paths = ["~/my-skills", "/opt/team-skills"]
+```
+
+## Runtime Behavior
+
+1. On startup, `SkillManager` scans all paths and builds a skill cache
+2. The skill list is injected into the system prompt's `# Available Skills` section
+3. LLM invokes skills via the `skill` tool (passing the skill name)
+4. Skill content is injected into the conversation context as a system message
+5. File system watcher automatically detects new/modified skill files (hot reload)
+
+## Disabling Skills
+
+Managed via the state file `~/.copilot-shell/states/skills.json`:
+
+```json
+{ "disabled": ["dangerous-skill"] }
+```
+
+Disabled skills do not appear in the LLM's visible list.
+
+## Difference from copilot-shell
+
+The cosh-core skill system mirrors copilot-shell's skill discovery logic but is implemented in pure Rust. The same skill files can be loaded by both simultaneously.

--- a/docs/cosh-ng/en/users/core/tools.md
+++ b/docs/cosh-ng/en/users/core/tools.md
@@ -1,0 +1,92 @@
+# Tool System
+
+cosh-core includes a set of built-in tools for LLM to invoke during conversations. Tools are classified by security level, which determines the approval strategy.
+
+## Built-in Tool List
+
+| Tool Name | Classification | Description |
+|-----------|---------------|-------------|
+| `read_file` | ReadOnly | Read file contents (supports line ranges) |
+| `grep` | ReadOnly | Regex search file contents |
+| `edit` | FileEdit | Precise file editing via search-and-replace |
+| `write_file` | FileEdit | Create or overwrite files |
+| `shell` | ShellExec | Execute shell commands |
+| `skill` | Other | Invoke registered skills |
+| `todo` | Other | Manage task lists |
+| `ask_user_question` | Other | Ask user a question and wait for response |
+| `cosh_shell_evidence` | ShellEvidence | Get terminal output as evidence (requires `--enable-shell-evidence-tool`) |
+
+## Tool Classification
+
+```rust
+pub enum ToolKind {
+    ReadOnly,       // Pure read, does not modify system state
+    FileEdit,       // Modifies file contents
+    ShellExec,      // Executes arbitrary shell commands
+    ShellEvidence,  // Reads terminal output history
+    Other,          // Side-effect-free auxiliary operations
+}
+```
+
+Classification determines the default behavior under approval modes:
+
+| Approval Mode | ReadOnly | FileEdit | ShellExec | ShellEvidence | Other |
+|--------------|----------|----------|-----------|---------------|-------|
+| `trust` | Auto | Auto | Auto | Auto | Auto |
+| `auto` | Auto | Auto | Approval | Auto | Auto |
+| `balanced` | Auto | Approval | Approval | Auto | Approval |
+| `suggest` | Auto | Approval | Approval | Auto | Approval |
+| `strict` | Auto | Approval | Approval | Auto | Approval |
+
+> **Note**: `ask_user_question` and `cosh_shell_evidence` tools always bypass the approval flow and auto-execute regardless of mode.
+
+## Tool Call Protocol
+
+When LLM decides to call a tool, Core notifies via streaming events:
+
+```json
+{"type":"stream_event","event":{"subtype":"tool_use_begin","tool_name":"shell","tool_use_id":"tu-1"}}
+{"type":"stream_event","event":{"subtype":"tool_use_delta","content":"{\"command\":\"df -h\"}"}}
+{"type":"stream_event","event":{"subtype":"tool_use_end"}}
+```
+
+If approval is required, Core sends a `can_use_tool` request:
+
+```json
+{"type":"control_request","request_id":"apr-1","request":{"subtype":"can_use_tool","tool_name":"shell","tool_input":{"command":"df -h"}}}
+```
+
+Shell replies with the approval result:
+
+```json
+{"type":"control_response","response":{"subtype":"tool_approval","request_id":"apr-1","response":{"behavior":"allow"}}}
+```
+
+`behavior` options: `allow`, `deny`, `ask`.
+
+## Tool Results
+
+After tool execution completes, results are injected into the conversation context for LLM to continue reasoning. Each tool returns:
+
+```rust
+pub struct ToolResult {
+    pub output: String,   // Tool output content
+    pub is_error: bool,   // Whether this is an error result
+}
+```
+
+## Auto-approved Tools
+
+Specify tools that are always auto-approved via the `--allowed-tools` argument:
+
+```bash
+cosh-core --headless --allowed-tools shell,edit
+```
+
+With this, `shell` and `edit` tools auto-execute under any approval mode without user confirmation.
+
+## Tool Registration
+
+Tools are managed uniformly via `ToolRegistry`. The default tool set is created via `ToolRegistry::with_defaults()`. `--enable-shell-evidence-tool` additionally registers the `cosh_shell_evidence` tool.
+
+Custom tools can be injected via the extension system. See [extensions.md](extensions.md).

--- a/docs/cosh-ng/en/users/output-format.md
+++ b/docs/cosh-ng/en/users/output-format.md
@@ -1,0 +1,83 @@
+# Output Format
+
+All cosh-cli commands output a unified JSON envelope `CoshResponse<T>`, making it easy for AI Agents to parse.
+
+## Success Response
+
+```json
+{
+  "ok": true,
+  "data": { ... },
+  "meta": {
+    "subsystem": "pkg",
+    "duration_ms": 342,
+    "distro": "alinux",
+    "dry_run": false
+  }
+}
+```
+
+## Error Response
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "PkgNotFound",
+    "message": "package 'nginx-extra' not found",
+    "recoverable": true,
+    "hint": "try 'cosh-cli pkg search nginx'",
+    "subsystem": "pkg"
+  },
+  "meta": {
+    "subsystem": "pkg",
+    "duration_ms": 120,
+    "distro": "ubuntu",
+    "dry_run": false
+  }
+}
+```
+
+## Key Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ok` | bool | Whether the operation succeeded |
+| `data` | object | Business data carried on success |
+| `error.code` | string | Error code enum (see below) |
+| `error.recoverable` | bool | Whether the Agent should retry |
+| `error.hint` | string | Suggested next action |
+| `meta.subsystem` | string | Source subsystem (pkg/svc/checkpoint/audit) |
+| `meta.duration_ms` | u64 | Operation duration (milliseconds) |
+| `meta.distro` | string | Detected distribution |
+| `meta.dry_run` | bool | Whether this was a preview |
+
+## Error Codes
+
+| Error Code | Subsystem | Meaning |
+|-----------|-----------|---------|
+| `PkgNotFound` | pkg | Package does not exist |
+| `PkgBackendError` | pkg | Package manager execution failed |
+| `UnsupportedDistro` | pkg/svc | Unsupported distribution |
+| `SvcNotFound` | svc | Service does not exist |
+| `SvcStartFailed` | svc | Service start failed |
+| `SvcStopFailed` | svc | Service stop failed |
+| `CheckpointDaemonUnavailable` | checkpoint | ws-ckpt daemon not running |
+| `CheckpointNotFound` | checkpoint | Snapshot does not exist |
+| `AuditDenied` | audit | Policy denied |
+| `Timeout` | * | Command execution timed out |
+| `PermissionDenied` | * | Insufficient permissions |
+
+## Exit Codes
+
+- `0` — Operation successful (`ok: true`)
+- `1` — Operation failed (`ok: false`)
+
+## Agent Integration Pattern
+
+For AI Agents consuming cosh-cli output, the recommended pattern is:
+
+1. Parse JSON, check the `ok` field
+2. If `ok: false`, read `error.recoverable` to decide whether to retry
+3. If not recoverable, display `error.hint` to the user or execute the suggested command
+4. When `meta.dry_run` is `true`, this is a preview result and the actual operation has not been executed

--- a/docs/cosh-ng/en/users/quickstart.md
+++ b/docs/cosh-ng/en/users/quickstart.md
@@ -1,0 +1,76 @@
+# Quick Start
+
+cosh-ng (Computable Operating System Harness) provides deterministic cross-distribution system operation interfaces for AI Agents. It consists of three binaries:
+
+- **cosh-cli** — Structured JSON CLI covering package management, service management, workspace checkpoints, and security auditing
+- **cosh-core** — Headless JSONL backend integrating LLM providers, hooks, tools, and skills
+- **cosh-shell** — AI-enhanced interactive terminal with PTY host, streaming analysis, and tool approval
+
+## Prerequisites
+
+- Linux (Alinux / CentOS / Ubuntu / Debian / Fedora / openSUSE) or macOS (limited functionality)
+- Rust 1.74+
+- pkg/svc commands require root or sudo privileges
+- checkpoint commands require a running ws-ckpt daemon
+
+## Build
+
+```bash
+cd src/cosh-ng
+cargo build --workspace
+```
+
+Build artifacts are located under `target/debug/`: `cosh-cli`, `cosh-core`, `cosh-shell`.
+
+Release build:
+
+```bash
+cargo build --workspace --release
+```
+
+## First Run
+
+### cosh-cli: Structured System Operations
+
+```bash
+# Install a package (JSON output)
+cosh-cli pkg install nginx
+# → {"ok":true,"data":{"package":"nginx","version":"1.24.0","already_installed":false},...}
+
+# Preview mode (no actual execution)
+cosh-cli pkg install nginx --dry-run
+
+# Check service status
+cosh-cli svc status nginx
+# → {"ok":true,"data":{"name":"nginx","active":true,"enabled":true,"recent_logs":[...]},...}
+```
+
+### cosh-core: AI Agent Backend
+
+```bash
+# Single prompt execution
+cosh-core --headless "Check disk usage"
+
+# Or pipe into headless mode
+echo '{"type":"user","message":{"role":"user","content":"List files in current directory"}}' | cosh-core --headless
+```
+
+### cosh-shell: Interactive Terminal
+
+```bash
+# Start interactive AI Shell
+cosh-shell
+```
+
+## Configuration
+
+Configuration file is located at `~/.copilot-shell/config.toml`. A default configuration is automatically created on first run.
+
+See [Configuration](configuration.md) for details.
+
+## Next Steps
+
+- [cosh-cli Overview](cli/overview.md) — Learn about the CLI subsystems
+- [cosh-core Overview](core/overview.md) — Learn about headless mode and LLM integration
+- [cosh-shell Overview](shell/overview.md) — Learn about the interactive terminal
+- [Output Format](output-format.md) — Understand the JSON envelope and error codes

--- a/docs/cosh-ng/en/users/shell/ai-analysis.md
+++ b/docs/cosh-ng/en/users/shell/ai-analysis.md
@@ -1,0 +1,90 @@
+# AI Analysis
+
+cosh-shell can automatically or on-demand invoke the AI adapter to analyze failure causes and provide suggestions when a command failure is detected.
+
+## Analysis Modes
+
+Switch via `/mode analysis <mode>` or configure `shell.analysis_mode`:
+
+| Mode | Description |
+|------|-------------|
+| `smart` | Smart mode: severe errors show action cards, general errors show hints |
+| `auto` | Auto mode: immediately auto-analyze on detected failure |
+| `manual` | Manual mode: show action cards, wait for user confirmation before analysis |
+
+## Failure Classification
+
+cosh-shell performs semantic analysis on command exit codes and output, classifying failures:
+
+| Classification | Example | Description |
+|---------------|---------|-------------|
+| `CommandNotFound` | `command not found` | Command does not exist |
+| `PermissionDenied` | `Permission denied` | Insufficient permissions |
+| `BuildOrTestFailure` | `error[E0308]` | Compilation/test error |
+| `AbnormalSignal` | SIGSEGV | Abnormal signal termination |
+| `GenericRuntimeFailure` | Non-zero exit code | General runtime error |
+| `UsageOrHelp` | `Usage:` output | Usage error |
+| `UnknownFailure` | Other | Unclassified failure |
+
+The following classifications are considered "not real failures" and do not trigger analysis:
+- `Success` — Actually succeeded
+- `InteractiveCancel` — User actively cancelled
+- `UserInterrupt` — Ctrl+C
+- `PipelineNormal` — Normal pipeline exit code
+- `ProviderOrInternalArtifact` — Exit code from internal tools
+
+## Analysis Disposition Matrix
+
+| Failure Classification | Auto Mode | Smart Mode | Manual Mode |
+|-----------------------|-----------|------------|-------------|
+| CommandNotFound / PermissionDenied / AbnormalSignal / BuildOrTestFailure | Auto-analyze | Action card | Action card |
+| GenericRuntimeFailure | Auto-analyze | Hint | Action card |
+| UnknownFailure | Action card | Hint | Hint |
+| UsageOrHelp | Hint | Silent | Silent |
+
+Disposition type descriptions:
+- **Auto-analyze** — Immediately invoke AI adapter for analysis
+- **Action card** — Render interactive card, user can choose "Analyze" or "Skip"
+- **Hint** — Display brief hint, user can trigger analysis via slash command
+- **Silent** — Log only, do not disturb user
+
+## Analysis Flow
+
+```
+Command execution failed (exit code ≠ 0)
+       │
+       ▼
+  Failure semantic classification
+       │
+       ▼
+  Disposition decision (based on analysis mode)
+       │
+       ├── AutoAnalyze → Directly start Agent analysis
+       ├── ActionCard  → Render action card → Wait for user confirmation
+       ├── Hint        → Display brief hint
+       └── SilentRecord → Silent log
+```
+
+## Agent Analysis Process
+
+1. Collect failure context: command text, exit code, output excerpt (up to 8KB)
+2. Construct prompt and send to AI adapter (cosh-core)
+3. Adapter streams back analysis results
+4. cosh-shell renders analysis content in Markdown format
+5. User can Ctrl+C to cancel during analysis
+
+## Configuration
+
+```toml
+[shell]
+# Analysis mode: smart | auto | manual
+analysis_mode = "smart"
+```
+
+Runtime switching:
+
+```
+/mode analysis smart
+/mode analysis auto
+/mode analysis manual
+```

--- a/docs/cosh-ng/en/users/shell/approval.md
+++ b/docs/cosh-ng/en/users/shell/approval.md
@@ -1,0 +1,118 @@
+# Tool Approval
+
+cosh-shell's tool approval system presents operation details as visual cards when an AI adapter requests tool execution, letting the user decide whether to allow it.
+
+## Approval Modes
+
+Switch via `/mode approval <mode>` or configure `shell.approval_mode`:
+
+| Mode | Meaning | Mapping to cosh-core |
+|------|---------|---------------------|
+| `recommend` | Recommend mode: all tool calls require approval | `strict` |
+| `auto` | Auto mode (default): only shell commands require approval | `auto` |
+| `trust` | Trust mode: all tools auto-execute (requires `confirm`) | `trust` |
+
+Switching to trust mode requires secondary confirmation:
+
+```
+/mode approval trust confirm
+```
+
+## Approval Cards
+
+When a tool requires approval, cosh-shell renders an inline approval panel:
+
+```
+┌─────────────────────────────────────────┐
+│ 🔧 Tool: shell                    [1/3] │
+│ Risk: medium                            │
+│─────────────────────────────────────────│
+│ Command:                                │
+│   rm -rf /tmp/old-build                 │
+│─────────────────────────────────────────│
+│ ⚠ Hook: sandbox-guard                   │
+│   "Command matches risk pattern"         │
+│─────────────────────────────────────────│
+│ [✓ Approve]  [ Deny ]  [ Details ]      │
+└─────────────────────────────────────────┘
+```
+
+### Card Elements
+
+| Element | Description |
+|---------|-------------|
+| Tool | Tool name |
+| Risk | Risk level (assessed by hooks) |
+| Queue | Queue position (when multiple requests are queued) |
+| Command/Input | Tool input preview |
+| Hook warnings | Warning messages from hooks |
+| Actions | Available action buttons |
+
+### User Actions
+
+| Action | Description |
+|--------|-------------|
+| Approve | Allow execution |
+| Deny | Reject execution |
+| Details | Expand full input content |
+
+## Shell Command Handoff
+
+When the approved tool is of `shell` type and the user approves, the command is "handed off" to the foreground PTY for execution (rather than being executed by cosh-core in the background):
+
+```
+User approves shell command
+       │
+       ▼
+cosh-shell injects command into PTY
+       │
+       ▼
+bash/zsh executes in foreground (user can interact)
+       │
+       ▼
+Execution result returned via OSC markers
+```
+
+This means:
+- Command output is displayed directly in the terminal
+- User can interact in real-time (e.g., confirmation prompts)
+- Ctrl+C can interrupt execution
+
+## Approval Journal
+
+All approval decisions are recorded in an in-memory journal:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Approval request unique identifier |
+| `run_id` | Associated Agent run ID |
+| `kind` | Request type (Tool / ShellCommand) |
+| `risk` | Risk level |
+| `decision` | Final decision (Allow / Deny / Cancel) |
+| `subject` | Tool name |
+| `preview` | Operation preview |
+
+## Relationship with cosh-core Approval Protocol
+
+cosh-shell's approval system is the frontend implementation of the `can_use_tool` control request in the cosh-core JSONL protocol:
+
+```
+Core → Shell:  {"type":"control_request","request_id":"apr-1","request":{"subtype":"can_use_tool",...}}
+                       │
+                       ▼
+              cosh-shell renders approval card
+                       │
+                       ▼ (user decision)
+Shell → Core:  {"type":"control_response","response":{"subtype":"tool_approval","request_id":"apr-1","response":{"behavior":"allow"}}}
+```
+
+## Configuration
+
+```toml
+[shell]
+# Approval mode: recommend | auto | trust
+approval_mode = "auto"
+
+# Trusted command list (always auto-approved)
+trusted_commands = ["ls", "cat", "echo"]
+```

--- a/docs/cosh-ng/en/users/shell/interactive-mode.md
+++ b/docs/cosh-ng/en/users/shell/interactive-mode.md
@@ -1,0 +1,128 @@
+# Interactive Mode
+
+cosh-shell runs bash/zsh on top of a native PTY and marks command boundaries using OSC escape sequences, enabling seamless integration of AI analysis and tool approval.
+
+## PTY Host
+
+cosh-shell creates a pseudo-terminal pair via `openpty()` and starts a bash or zsh subprocess on the slave end:
+
+```
+┌──────────────────────┐
+│    cosh-shell        │
+│  ┌────────────────┐  │       ┌──────────────┐
+│  │  PTY master    │──────────│  bash/zsh    │
+│  └────────────────┘  │       │  (PTY slave) │
+│  ┌────────────────┐  │       └──────────────┘
+│  │  OSC Parser    │  │
+│  └────────────────┘  │
+└──────────────────────┘
+```
+
+### Shell Selection
+
+```bash
+cosh-shell                    # Default: auto (auto-detect)
+cosh-shell --shell zsh        # Use zsh
+cosh-shell raw qwen --shell zsh
+```
+
+Shell selection priority:
+1. `--shell` argument
+2. `COSH_SHELL_RAW_SHELL` environment variable
+3. Configuration file `shell.default`
+4. Auto-detect (default bash)
+
+### Run Modes
+
+| Mode | Description |
+|------|-------------|
+| Default (no subcommand) | Start interactive shell with configured adapter |
+| `raw [adapter]` | Explicitly specify adapter |
+| `-c <command>` | Execute command then exit (pass-through to underlying shell) |
+| `-- <command>` | Execute command directly then exit |
+| `--isolated` | Isolated mode, do not load user rcfile |
+| `--login` / `-l` | Start as login shell |
+
+## OSC Marking System
+
+cosh-shell injects a custom rcfile (bashrc/zshrc) into the child shell, marking command lifecycle via OSC 1337 escape sequences:
+
+```
+ESC]1337;COSH;<payload>BEL
+```
+
+Marked events include:
+- Shell ready (prompt displayed)
+- Command execution start (preexec)
+- Command execution end (precmd, carries exit code)
+- Working directory change
+
+These markers enable cosh-shell to precisely identify:
+1. When the user enters a command
+2. When a command starts/ends
+3. The command's exit code
+4. Current working directory
+
+## Input Classification
+
+User input in the shell is classified into the following types:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| Shell Command | Normal shell command | `ls -la`, `git status` |
+| Slash Command | Built-in control command starting with `/` | `/help`, `/mode` |
+| Natural Language | Natural language question | Handled by AI adapter |
+| Agent Marker | Agent execution marker | Internal use |
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Display help information |
+| `/mode [approval\|analysis] [value]` | View or switch mode |
+| `/config [key] [value]` | View or modify runtime configuration |
+| `/hooks [list\|enable\|disable] [name]` | Manage hooks |
+| `/extensions [list\|enable\|disable] [name]` | Manage extensions |
+| `/skills [list\|enable\|disable] [name]` | Manage skills |
+| `/debug [state\|events\|adapter]` | Debug information |
+| `/auth` | Trigger authentication flow |
+
+## Startup Flow
+
+1. Parse command-line arguments (shell type, adapter, mode)
+2. Install terminal restore handler (restore termios on SIGTERM/SIGHUP/panic)
+3. Load configuration (`~/.copilot-shell/config.toml`)
+4. Initialize logging (file output to `~/.copilot-shell/logs/`)
+5. Create PTY session, start bash/zsh subprocess
+6. Inject OSC marking script
+7. Start AI adapter connection
+8. Render startup banner (COSH logo + adapter/shell/approval mode info)
+9. Enter main event loop
+
+## Terminal Restore
+
+cosh-shell automatically restores terminal state (termios) in the following scenarios:
+
+- Process receives SIGTERM / SIGHUP / SIGQUIT
+- Panic triggered
+- Normal exit
+
+Ensures terminal is not left in raw mode after abnormal exit.
+
+## Native Mode vs Isolated Mode
+
+| Feature | Native Mode (default) | Isolated Mode (`--isolated`) |
+|---------|----------------------|------------------------------|
+| User rcfile | Loaded (~/.bashrc etc.) | Skipped |
+| PS1 prompt | Preserves user settings | Uses `cosh-osc$ ` |
+| History | Loads $HISTFILE | Not loaded |
+| Environment variables | Inherited | Minimized |
+
+## Session Working Directory
+
+cosh-shell creates a working directory for each session under `~/.copilot-shell/`, storing:
+
+- OSC marking scripts
+- Command output references (auto-cleaned after 24 hours)
+- Terminal restore request files
+- Shell handoff request files

--- a/docs/cosh-ng/en/users/shell/overview.md
+++ b/docs/cosh-ng/en/users/shell/overview.md
@@ -1,0 +1,98 @@
+# cosh-shell Overview
+
+cosh-shell is the AI-enhanced interactive terminal of cosh-ng. It layers AI analysis capabilities, tool approval controls, and inline card rendering on top of a native bash/zsh PTY, providing users with a secure and observable Agent interaction experience.
+
+## Positioning
+
+cosh-shell is the user-facing frontend layer:
+
+- Manages the PTY host (bash/zsh subprocess)
+- Connects to backends via AI adapters (default: cosh-core)
+- Renders approval cards and AI analysis results
+- Implements tool approval control protocol
+
+## Run Modes
+
+```bash
+# Default startup (uses configured adapter and shell)
+cosh-shell
+
+# Explicitly specify adapter (positional argument)
+cosh-shell raw cosh-core
+cosh-shell raw claude
+cosh-shell raw qwen
+
+# Specify underlying shell
+cosh-shell --shell zsh
+cosh-shell raw co --shell bash
+
+# Pass-through mode: execute single command then exit
+cosh-shell -c 'ls -la'
+cosh-shell -- git status
+
+# Login shell mode
+cosh-shell --login
+cosh-shell -l
+
+# Isolated mode (skip user rcfile)
+cosh-shell --isolated
+```
+
+## Supported AI Adapters
+
+| Adapter | Backend | Description |
+|---------|---------|-------------|
+| `cosh-core` | cosh-core process | Default adapter, full control protocol |
+| `claude` | Claude Code CLI | Claude adapter |
+| `qwen` | Qwen Code CLI | Qwen adapter |
+| `fake` | Mock | For development testing, no backend required |
+
+## Adapter Capabilities
+
+| Capability | Description |
+|-----------|-------------|
+| `text_stream` | Text streaming output |
+| `thinking_stream` | Thinking process streaming output |
+| `session_resume` | Session resume |
+| `tool_intent` | Tool call intent awareness |
+| `user_question` | Ask user questions |
+| `cancellable` | Supports cancelling running requests |
+| `control_protocol` | Full control protocol support |
+
+## Core Features
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| PTY Interaction | Native bash/zsh terminal | [interactive-mode.md](interactive-mode.md) |
+| AI Analysis | Streaming command analysis | [ai-analysis.md](ai-analysis.md) |
+| Tool Approval | Visual approval cards | [approval.md](approval.md) |
+
+## Architecture Overview
+
+```
+┌────────────────────────────────────────────┐
+│                 cosh-shell                 │
+│  ┌───────────┐  ┌──────────┐  ┌─────────┐  │
+│  │ PTY Host  │  │ Adapter  │  │   UI    │  │
+│  │ (bash/zsh)│  │(cosh-core│  │(ratatui)│  │
+│  └───────────┘  │/claude..)│  └─────────┘  │
+│  ┌───────────┐  └──────────┘  ┌─────────┐  │
+│  │  Hooks    │  ┌──────────┐  │Approval │  │
+│  │  Engine   │  │  Tools   │  │ Broker  │  │
+│  └───────────┘  └──────────┘  └─────────┘  │
+└────────────────────────────────────────────┘
+         │                │
+         ▼                ▼
+    bash/zsh PTY     cosh-core process
+```
+
+## Configuration
+
+cosh-shell specific configuration is in the `[ui]` and `[shell]` sections of `~/.copilot-shell/config.toml`. See [Configuration](../configuration.md) for details.
+
+## Project Trust
+
+cosh-shell maintains project-level trust storage. On first launch in a new project directory, it prompts the user to confirm whether to trust the project. Trust status determines:
+
+- Whether to load `.cosh/hooks` from the project directory
+- Whether to apply project-level configuration overrides

--- a/docs/cosh-ng/en/users/supported-distros.md
+++ b/docs/cosh-ng/en/users/supported-distros.md
@@ -1,0 +1,42 @@
+# Supported Distributions
+
+cosh-ng automatically detects the current operating system by reading `/etc/os-release` (Linux) or calling `sw_vers` (macOS), and routes to the corresponding package manager and service manager backend.
+
+## Support Matrix
+
+| Distribution | Package Manager | Service Manager | Notes |
+|-------------|----------------|-----------------|-------|
+| Alinux (2/3/4) | dnf | systemd | Alibaba Cloud native Linux |
+| CentOS 7/8/9 | dnf | systemd | |
+| Fedora | dnf | systemd | |
+| Ubuntu | apt-get | systemd | |
+| Debian | apt-get | systemd | |
+| openSUSE Leap/Tumbleweed | zypper | systemd | |
+| macOS | brew | — | Only pkg subsystem available |
+
+## Detection Logic
+
+Distribution detection is implemented via `Distro::detect()`:
+
+1. When the compile target is macOS, calls `sw_vers -productVersion` to get the version
+2. On Linux, reads `/etc/os-release` and parses the `ID` and `VERSION_ID` fields
+3. Maps `ID` to a known distribution variant
+4. Unrecognized `ID` values fall into `Unknown`, and most operations return `UnsupportedDistro` error
+
+## Package Manager Mapping
+
+| Distribution ID | Package Manager | Install Command | Search Command |
+|----------------|----------------|-----------------|----------------|
+| alinux / centos / fedora | Dnf | `dnf install -y` | `dnf search -q` |
+| ubuntu / debian | Apt | `apt-get install -y` | `apt-cache search` |
+| opensuse-leap / opensuse-tumbleweed / sles | Zypper | `zypper install -y` | `zypper search` |
+| macOS | Brew | `brew install` | `brew search` |
+
+## Service Manager
+
+All Linux distributions use systemd (`systemctl`) uniformly. macOS does not support the svc subsystem.
+
+## Adding New Distribution Support
+
+To add support for a new distribution, see the developer documentation
+[Adding Distribution Support Guide](../developers/adding-distros.md).

--- a/docs/cosh-ng/zh/developers/adding-commands.md
+++ b/docs/cosh-ng/zh/developers/adding-commands.md
@@ -1,0 +1,133 @@
+# 新增 CLI 命令
+
+## 概述
+
+cosh-cli 使用 clap 构建命令树，每个子系统对应一个 `cmd/<subsystem>.rs` 模块。新增命令需要修改三层：类型定义（cosh-types）→ 平台实现（cosh-platform）→ CLI 入口（cosh-cli）。
+
+## 步骤
+
+### 1. 定义响应类型（cosh-types）
+
+在 `crates/cosh-types/src/` 中新增或扩展数据类型：
+
+```rust
+// crates/cosh-types/src/my_subsystem.rs
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct MyResult {
+    pub field: String,
+    pub success: bool,
+}
+```
+
+在 `lib.rs` 中导出。
+
+### 2. 实现平台逻辑（cosh-platform）
+
+在 `crates/cosh-platform/src/` 中实现实际操作：
+
+```rust
+// crates/cosh-platform/src/my_subsystem.rs
+use cosh_types::error::CoshError;
+use cosh_types::my_subsystem::MyResult;
+
+use crate::detect::Distro;
+
+pub fn my_action(distro: &Distro, param: &str, dry_run: bool) -> Result<MyResult, CoshError> {
+    if dry_run {
+        return Ok(MyResult { field: param.to_string(), success: true });
+    }
+    // 实际执行逻辑...
+    Ok(MyResult { field: param.to_string(), success: true })
+}
+```
+
+### 3. 注册 CLI 命令（cosh-cli）
+
+创建 `crates/cosh-cli/src/cmd/my_subsystem.rs`：
+
+```rust
+use std::time::Instant;
+
+use clap::Subcommand;
+use cosh_platform::detect::Distro;
+use cosh_platform::my_subsystem;
+
+use crate::{build_meta, print_failure, print_success};
+
+#[derive(Subcommand)]
+pub enum MyCommands {
+    /// Do something
+    DoSomething {
+        /// Target parameter
+        target: String,
+        /// Preview without executing
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+pub fn run(action: MyCommands, distro: &Distro, start: Instant) -> i32 {
+    match action {
+        MyCommands::DoSomething { target, dry_run } => {
+            match my_subsystem::my_action(distro, &target, dry_run) {
+                Ok(result) => print_success(result, build_meta("my", distro, start, dry_run)),
+                Err(e) => print_failure(e, build_meta("my", distro, start, dry_run)),
+            }
+        }
+    }
+}
+```
+
+在 `cmd/mod.rs` 中注册：
+
+```rust
+pub mod my_subsystem;
+```
+
+在 `main.rs` 中添加子命令：
+
+```rust
+#[derive(Subcommand)]
+enum Commands {
+    // ...existing...
+    /// My new subsystem
+    My {
+        #[command(subcommand)]
+        action: cmd::my_subsystem::MyCommands,
+    },
+}
+```
+
+并在 `match cli.command` 中添加分支：
+
+```rust
+Commands::My { action } => cmd::my_subsystem::run(action, &distro, start),
+```
+
+### 4. 添加集成测试
+
+在 `crates/cosh-cli/tests/cli_integration.rs` 中添加测试：
+
+```rust
+#[test]
+fn test_my_command_json_envelope() {
+    let output = run_cli(&["my", "do-something", "target", "--dry-run"]);
+    let resp: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(resp["ok"], true);
+    assert_eq!(resp["meta"]["subsystem"], "my");
+    assert_eq!(resp["meta"]["dry_run"], true);
+}
+```
+
+## 设计约束
+
+| 规则 | 说明 |
+|------|------|
+| JSON 输出 | 始终使用 `CoshResponse<T>` 信封 |
+| 退出码 | 成功 = 0，失败 = 1 |
+| `--dry-run` | 所有写操作必须支持 |
+| 输入验证 | 在执行前使用 `validate_*` 检查参数 |
+| subsystem 字段 | `meta.subsystem` 必须与命令名一致 |
+| 发行版路由 | 需要区分发行版的逻辑放在 `cosh-platform` |

--- a/docs/cosh-ng/zh/developers/adding-distros.md
+++ b/docs/cosh-ng/zh/developers/adding-distros.md
@@ -1,0 +1,141 @@
+# 新增发行版适配
+
+## 概述
+
+cosh-ng 通过 `Distro` 枚举抽象操作系统差异，新增发行版支持需要修改两层：
+检测层（`cosh-platform/src/detect.rs`）和后端路由层（`cosh-platform/src/pkg.rs` 等）。
+
+## 步骤
+
+### 1. 添加 Distro 枚举变体
+
+在 `crates/cosh-platform/src/detect.rs` 中添加变体：
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Distro {
+    // ...existing...
+    MyDistro { version: String },   // 新增
+}
+```
+
+### 2. 实现检测逻辑
+
+在 `detect_from_content()` 的 match 分支中添加 ID 映射：
+
+```rust
+match id.as_deref() {
+    // ...existing...
+    Some("mydistro") => Distro::MyDistro { version },
+    // ...
+}
+```
+
+Linux 系统通过解析 `/etc/os-release` 的 `ID` 字段识别发行版，值需小写匹配。
+
+### 3. 实现辅助方法
+
+```rust
+impl Distro {
+    pub fn id_str(&self) -> &str {
+        match self {
+            // ...existing...
+            Distro::MyDistro { .. } => "mydistro",
+        }
+    }
+
+    pub fn display_name(&self) -> String {
+        match self {
+            // ...existing...
+            Distro::MyDistro { version } => format!("MyDistro {}", version),
+        }
+    }
+
+    pub fn pkg_manager(&self) -> PkgManager {
+        match self {
+            // ...existing...
+            Distro::MyDistro { .. } => PkgManager::Dnf, // 根据实际情况选择
+        }
+    }
+}
+```
+
+如果新发行版使用的包管理器不在现有 `PkgManager` 枚举中，需先扩展该枚举。
+
+### 4. 添加包管理器后端（如需新增）
+
+如果需要新的 `PkgManager` 变体，在 `crates/cosh-platform/src/pkg.rs` 中添加对应的命令构建函数：
+
+```rust
+// 新增 PkgManager 变体
+pub enum PkgManager {
+    // ...existing...
+    Pacman,
+}
+
+// 在 pkg_install / pkg_remove / pkg_search / pkg_list 中添加路由分支
+PkgManager::Pacman => ("pacman", vec!["-S", "--noconfirm", package]),
+```
+
+### 5. 添加单元测试
+
+在 `detect.rs` 的 `#[cfg(test)]` 模块中添加：
+
+```rust
+#[test]
+fn test_detect_mydistro() {
+    let content = "NAME=\"My Distro\"\nVERSION_ID=\"1.0\"\nID=mydistro\n";
+    let distro = Distro::detect_from_content(content);
+    assert_eq!(distro, Distro::MyDistro { version: "1.0".into() });
+    assert_eq!(distro.pkg_manager(), PkgManager::Dnf);
+}
+```
+
+### 6. 运行测试验证
+
+```bash
+cd src/cosh-ng
+
+# 运行检测相关测试
+cargo test --locked -p cosh-platform test_detect
+
+# 运行完整测试套件
+cargo test --locked -p cosh-platform
+
+# 运行 CLI 集成测试（确保新路由不破坏 JSON 信封）
+cargo test --locked -p cosh-cli
+```
+
+## 当前支持矩阵
+
+| 发行版 ID | Distro 变体 | PkgManager | 备注 |
+|-----------|-------------|------------|------|
+| `alinux` | `Alinux` | Dnf | 阿里云原生 Linux |
+| `centos` | `CentOS` | Dnf | |
+| `fedora` | `Fedora` | Dnf | |
+| `ubuntu` | `Ubuntu` | Apt | |
+| `debian` | `Debian` | Apt | |
+| `opensuse-leap` / `opensuse-tumbleweed` / `sles` | `OpenSUSE` | Zypper | 三个 ID 映射到同一变体 |
+| macOS (编译目标) | `MacOS` | Brew | 通过 `sw_vers` 检测 |
+
+## 设计约束
+
+| 规则 | 说明 |
+|------|------|
+| ID 小写 | `detect_from_content()` 对 ID 做 `to_lowercase()` |
+| Unknown 兜底 | 未识别的 ID 归入 `Unknown(String)`，后续操作返回 `UnsupportedDistro` |
+| 多 ID 合并 | 多个 ID 可映射同一 Distro 变体（如 opensuse 系列） |
+| 包管理器解耦 | `PkgManager` 与 `Distro` 是独立枚举，通过 `pkg_manager()` 映射 |
+| 不合并配置 | 检测逻辑只取第一个匹配的 `ID` 和 `VERSION_ID` |
+
+## 完整检查清单
+
+- [ ] `Distro` 枚举添加新变体
+- [ ] `detect_from_content()` 添加 match 分支
+- [ ] `id_str()` 返回正确的字符串标识
+- [ ] `display_name()` 返回可读名称
+- [ ] `pkg_manager()` 映射到正确的包管理器
+- [ ] `Display` trait（通过 `display_name()`）正确格式化
+- [ ] 单元测试覆盖正常解析和边界情况
+- [ ] 如需新 PkgManager，在 `pkg.rs` 各函数中添加路由
+- [ ] 更新用户文档 `users/supported-distros.md`

--- a/docs/cosh-ng/zh/developers/architecture.md
+++ b/docs/cosh-ng/zh/developers/architecture.md
@@ -1,0 +1,93 @@
+# 架构
+
+cosh-ng 采用 5-crate Rust 工作空间架构，版本号 0.11.0，Rust 版本要求 1.74+。
+
+## Crate 依赖图
+
+```
+cosh-types          cosh-platform          cosh-cli / cosh-core
+  (纯类型)       ← (发行版检测 +        ← (CLI 入口 / Agent 核心)
+  零副作用          后端路由)
+
+cosh-shell
+  (独立 crate，无内部依赖)
+
+依赖方向: cosh-cli / cosh-core → cosh-platform → cosh-types
+         cosh-shell 独立（通过 stdin/stdout 与 cosh-core 进程通信）
+```
+
+## Crate 职责
+
+| Crate | 二进制 | 职责 |
+|-------|--------|------|
+| `cosh-types` | — | 纯数据类型，零副作用。定义 CoshResponse 信封、CoshError、ws-ckpt IPC 类型 |
+| `cosh-platform` | — | 平台抽象层。发行版检测、包管理器路由、systemd 适配、ws-ckpt IPC 客户端、审计系统 |
+| `cosh-cli` | `cosh-cli` | CLI 入口。4 个命令域（pkg/svc/checkpoint/audit），JSON 输出 |
+| `cosh-core` | `cosh-core` | Agent 核心。Headless JSONL 后端、LLM 集成、钩子、工具、技能、扩展、会话 |
+| `cosh-shell` | `cosh-shell` | 交互终端。PTY 主机、OSC 标记、AI 适配器、审批控制、TUI 渲染 |
+
+## 目录布局
+
+```
+cosh-ng/
+├── crates/
+│   ├── cosh-types/       # 纯类型定义
+│   │   └── src/          # audit.rs, checkpoint.rs, config.rs, error.rs, output.rs, pkg.rs, svc.rs
+│   ├── cosh-platform/    # 平台抽象
+│   │   └── src/          # audit/, checkpoint.rs, detect.rs, pkg.rs, svc.rs, validate.rs
+│   ├── cosh-cli/         # CLI 二进制
+│   │   ├── src/          # main.rs, cmd/{pkg,svc,checkpoint,audit}.rs
+│   │   └── tests/        # 集成测试
+│   ├── cosh-core/        # Agent 核心二进制
+│   │   └── src/          # main.rs, core.rs, headless.rs, hook.rs, provider/, tool/, skill/, extension/
+│   └── cosh-shell/       # 交互终端二进制
+│       ├── src/          # main.rs, adapter/, agent/, approval/, hooks/, shell_host/, tools/, ui/
+│       └── tests/        # 分层测试
+├── Cargo.toml            # 工作空间配置
+└── rust-toolchain.toml
+```
+
+## 数据流
+
+### cosh-cli 执行流程
+
+```
+用户命令 → clap 解析 → cmd 模块路由 → cosh-platform 后端执行 → CoshResponse<T> JSON 输出
+```
+
+### cosh-core headless 流程
+
+```
+stdin JSONL → 消息解析 → UserPromptSubmit 钩子 → LLM 生成 → 工具调用 → 审批协议 → stdout JSONL
+```
+
+### cosh-shell 交互流程
+
+```
+用户键入 → PTY 主机 → OSC 边界检测 → AI 适配器（启动 cosh-core 子进程）
+         → 流式响应 → 审批卡片渲染 → 工具执行结果回显
+```
+
+## 关键设计约束
+
+- **ws-ckpt IPC 线格式** — bincode + 4 字节小端长度前缀。枚举变体顺序即二进制契约，不可重排
+- **统一 JSON 信封** — cosh-cli 所有命令返回 `CoshResponse<T>`（ok + data/error + meta）
+- **跨发行版路由** — `Distro::detect()` 读取 `/etc/os-release` 路由到正确后端
+- **工具分类** — ReadOnly / FileEdit / ShellExec / ShellEvidence，审批模式据此决策
+- **钩子别名** — cosh-ng 内部工具名与 copilot-shell 标准名双向映射
+
+## 依赖管理
+
+所有第三方依赖在 `[workspace.dependencies]` 声明版本，子 crate 通过
+`dep = { workspace = true }` 引用。主要依赖：
+
+| 依赖 | 用途 |
+|------|------|
+| `serde` / `serde_json` | 序列化 |
+| `clap` | CLI 参数解析 |
+| `tokio` | 异步运行时（cosh-core） |
+| `reqwest` | HTTP 客户端（LLM API） |
+| `tracing` | 结构化日志 |
+| `ratatui` | TUI 渲染（cosh-shell） |
+| `nix` | Unix 系统调用 |
+| `bincode` | ws-ckpt IPC 序列化 |

--- a/docs/cosh-ng/zh/developers/contributing.md
+++ b/docs/cosh-ng/zh/developers/contributing.md
@@ -1,0 +1,130 @@
+# 贡献指南
+
+## 开发环境
+
+| 要求 | 版本 |
+|------|------|
+| Rust toolchain | stable（`rust-toolchain.toml` 管理） |
+| Rust 最低版本 | 1.74 |
+| 组件 | rustfmt + clippy |
+
+```bash
+cd src/cosh-ng
+rustup show   # 确认 toolchain 已就绪
+```
+
+## 构建
+
+```bash
+# 完整构建（所有 5 个 crate）
+cargo build --workspace
+
+# 发布构建
+cargo build --workspace --release
+
+# 单独构建某个二进制
+cargo build --bin cosh-cli
+cargo build --bin cosh-core
+cargo build --bin cosh-shell
+```
+
+## 代码质量检查
+
+提交前必须通过以下全部检查：
+
+```bash
+# 格式检查
+cargo fmt --all -- --check
+
+# Clippy（warnings 视为错误）
+cargo clippy --all-targets --locked -- -D warnings
+
+# 测试
+cargo test --locked
+
+# 文档构建（修改 pub API 时）
+cargo doc --workspace --no-deps
+```
+
+## 工作空间结构
+
+```
+cosh-ng/
+├── Cargo.toml              # workspace 配置
+├── rust-toolchain.toml     # stable + rustfmt + clippy
+└── crates/
+    ├── cosh-types/         # 纯类型，零副作用
+    ├── cosh-platform/      # 平台抽象（发行版检测、后端路由）
+    ├── cosh-cli/           # CLI 入口
+    ├── cosh-core/          # Agent 核心
+    └── cosh-shell/         # 交互终端
+```
+
+## 依赖管理
+
+- 所有依赖版本在 `[workspace.dependencies]` 统一声明
+- 子 crate 通过 `dep = { workspace = true }` 引用
+- 添加新依赖前检查是否已存在等价 crate
+- 不允许未经讨论升级主版本号
+
+## 代码规范
+
+### 模块组织
+
+使用 Rust 2018+ 推荐的文件布局，**不使用 `mod.rs`**：
+
+```
+# 正确
+src/extension.rs        # 父模块
+src/extension/          # 子模块目录
+    config.rs
+    manager.rs
+
+# 错误 — 不使用
+src/extension/mod.rs
+```
+
+### 错误处理
+
+| 场景 | 方式 |
+|------|------|
+| 库 crate | `thiserror` 枚举 |
+| 二进制 | `anyhow::Result` |
+| 不可达路径 | `unreachable!()` + 注释 |
+| 禁止 | `unwrap()` / `expect()` / `panic!()` |
+
+### 注释
+
+- `///` 用于所有 pub 项
+- `//` 仅解释 *为什么*，不重复类型签名
+- 首行为独立摘要，祈使句或名词短语
+- 不允许 `TODO` 无 owner、注释掉的旧代码
+
+### Clippy
+
+- 默认 deny 所有 warnings
+- 确需忽略时使用最窄范围的 `#[allow(clippy::xxx)]` + 注释说明
+
+## 提交规范
+
+格式：`type(scope): imperative description`
+
+- 类型：feat / fix / refactor / docs / test / ci / chore
+- scope：`cosh-ng` 对应 `cosh`（如改动跨多个 crate）
+- 50 字符内，英文，祈使语气，首字母小写，无句号
+- 需要 `Signed-off-by` trailer
+
+```bash
+git commit \
+  --trailer "Assisted-by: Qoder:1.7.0" \
+  --trailer "Signed-off-by: $(git config user.name) <$(git config user.email)>" \
+  -m 'feat(cosh): add registry list action for hooks'
+```
+
+## PR 流程
+
+1. 从最新 main 分支切出特性分支
+2. 遵循分支命名：`feature/cosh/<short-desc>`
+3. 确保所有检查通过后推送
+4. PR 标题遵循 commit message 格式
+5. 填写 PR 模板（Description / Testing / Related Issue）

--- a/docs/cosh-ng/zh/developers/ipc-protocol.md
+++ b/docs/cosh-ng/zh/developers/ipc-protocol.md
@@ -1,0 +1,140 @@
+# ws-ckpt IPC 协议
+
+## 概述
+
+cosh-ng 通过 Unix Domain Socket 与 ws-ckpt 守护进程通信，实现工作空间快照管理。
+通信使用 **bincode 序列化 + 4 字节小端长度前缀** 的帧格式。
+
+## 架构
+
+```
+cosh-cli / cosh-core          ws-ckpt daemon
+     │                              │
+     │  Unix socket                 │
+     │  /run/ws-ckpt/ws-ckpt.sock   │
+     │─────────────────────────────→│
+     │  [4B LE len][bincode req]    │
+     │                              │
+     │←─────────────────────────────│
+     │  [4B LE len][bincode resp]   │
+```
+
+客户端实现位于 `crates/cosh-platform/src/checkpoint.rs`（`CkptClient`），
+类型定义位于 `crates/cosh-types/src/checkpoint.rs`。
+
+## 帧格式
+
+每个消息由两部分组成：
+
+```
+┌──────────────────┬───────────────────────────────┐
+│ 4 字节 LE u32    │ bincode 编码的枚举载荷        │
+│ (payload 长度)   │ (WsCkptRequest / Response)    │
+└──────────────────┴───────────────────────────────┘
+```
+
+- 长度前缀：小端序无符号 32 位整数，表示后续 bincode 载荷的字节数
+- 最大响应限制：64 MiB（防止 OOM）
+- 默认超时：5000ms（可通过 `CkptClient::with_timeout()` 配置）
+
+## 请求类型（WsCkptRequest）
+
+bincode 按枚举变体索引序列化（第一个变体 = index 0）。**变体顺序即二进制契约，不可重排。**
+
+| 索引 | 变体 | 说明 |
+|------|------|------|
+| 0 | `Init { workspace }` | 初始化工作空间 |
+| 1 | `Checkpoint { workspace, id, message, metadata, pin }` | 创建快照 |
+| 2 | `Rollback { workspace, to }` | 回滚到指定快照 |
+| 3 | `Delete { workspace, snapshot, force }` | 删除快照 |
+| 4 | `List { workspace, format }` | 列出快照 |
+| 5 | `Diff { workspace, from, to }` | 两个快照间的差异 |
+| 6 | `Status { workspace }` | 查询状态 |
+| 7 | `Cleanup { workspace, keep }` | 清理旧快照 |
+| 8 | `Config` | 获取守护进程配置 |
+| 9 | `ReloadConfig` | 重新加载配置 |
+| 10 | `Recover { workspace }` | 恢复工作空间 |
+| 11 | `HealthAdvisory` | 健康检查 |
+
+## 响应类型（WsCkptResponse）
+
+| 变体 | 对应请求 | 关键字段 |
+|------|----------|----------|
+| `InitOk { ws_id }` | Init | 工作空间 ID |
+| `CheckpointOk { snapshot_id }` | Checkpoint | 快照 ID |
+| `RollbackOk { from, to }` | Rollback | 回滚源和目标 |
+| `DeleteOk { target }` | Delete | 被删除的快照标识 |
+| `Error { code, message }` | 任意 | 错误码 + 人类可读描述 |
+| `ListOk { snapshots }` | List | `Vec<SnapshotEntry>` |
+| `DiffOk { changes }` | Diff | `Vec<DiffEntry>` |
+| `StatusOk { report }` | Status | `StatusReport` |
+| `CleanupOk { removed }` | Cleanup | 被移除的快照 ID 列表 |
+| `ConfigOk { config }` | Config | `ConfigReport` |
+| `ReloadConfigOk` | ReloadConfig | 无载荷 |
+| `CheckpointSkipped { reason }` | Checkpoint | 跳过原因（如无变更） |
+| `RecoverOk { workspace }` | Recover | 恢复的工作空间路径 |
+| `HealthAdvisoryOk { ... }` | HealthAdvisory | 超限工作空间数、磁盘用量 |
+
+## 错误码（WsCkptErrorCode）
+
+| 索引 | 变体 | 说明 |
+|------|------|------|
+| 0 | `WorkspaceNotFound` | 工作空间不存在 |
+| 1 | `SnapshotNotFound` | 快照不存在 |
+| 2 | `AlreadyInitialized` | 工作空间已初始化 |
+| 3 | `BtrfsError` | Btrfs 操作错误 |
+| 4 | `IoError` | I/O 错误 |
+| 5 | `InvalidPath` | 非法路径 |
+| 6 | `ConfirmationRequired` | 需要确认（如删除 pinned 快照） |
+| 7 | `InternalError` | 内部错误 |
+| 8 | `SnapshotAlreadyExists` | 快照 ID 冲突 |
+| 9 | `WriteLockConflict` | 写锁冲突 |
+| 10 | `DiskSpaceInsufficient` | 磁盘空间不足 |
+
+## 客户端使用
+
+```rust
+use cosh_platform::checkpoint::CkptClient;
+
+// 默认路径 /run/ws-ckpt/ws-ckpt.sock
+let client = CkptClient::default_path();
+
+// 或指定路径和超时
+let client = CkptClient::with_timeout("/custom/path.sock", 10000);
+
+// 健康检查
+if !client.is_available() {
+    eprintln!("ws-ckpt daemon not running");
+}
+
+// 操作示例
+let result = client.create("/home/user/project", "snap-001", Some("initial"), None, false)?;
+let list = client.list(Some("/home/user/project"))?;
+let restored = client.restore("/home/user/project", "snap-001")?;
+```
+
+## 关键约束
+
+| 约束 | 说明 |
+|------|------|
+| 变体顺序不可变 | bincode 使用索引序列化枚举，重排即破坏线格式 |
+| 新增只能追加 | 新的 Request/Response 变体只能在末尾添加 |
+| 类型必须同步 | `cosh-types` 中的定义必须与 `ws-ckpt-common` 完全一致 |
+| 超时处理 | 客户端对 read/write 设置超时，避免守护进程无响应时阻塞 |
+| 长度限制 | 响应超过 64 MiB 视为异常，立即断开 |
+| socket 路径 | 默认 `/run/ws-ckpt/ws-ckpt.sock`，可通过环境变量或 CLI 参数覆盖 |
+
+## 测试验证
+
+```bash
+cd src/cosh-ng
+
+# bincode 往返序列化测试
+cargo test --locked -p cosh-types -- checkpoint
+
+# 变体索引契约测试
+cargo test --locked -p cosh-types test_request_bincode_variant_index
+
+# CkptClient 单元测试（不需要运行的守护进程）
+cargo test --locked -p cosh-platform -- checkpoint
+```

--- a/docs/cosh-ng/zh/developers/security-heuristics.md
+++ b/docs/cosh-ng/zh/developers/security-heuristics.md
@@ -1,0 +1,208 @@
+# 安全启发规则
+
+## 概述
+
+cosh-ng 审计子系统实现了 PEP→PDP→Log 三阶段安全决策流水线。每条命令在执行前经过
+结构化解析、策略匹配和日志记录，决定 Allow / Deny / RequireApproval 三种处置结果。
+
+## 架构
+
+```
+原始命令字符串
+     │
+     ▼
+┌─────────────────┐
+│ action parser   │  拒绝 shell 元字符、控制字节
+│ (PEP 边界)       │  结构化为 Action{subsystem,operation,target,args}
+└────────┬────────┘
+         │ 解析失败 → 直接 Deny
+         ▼
+┌─────────────────┐
+│ evaluate (PDP)  │  遍历 policy.rules[]，首条匹配胜出
+│                 │  无匹配 → policy.default
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ audit log       │  脱敏后写入 JSONL 日志
+│ (redact + log)  │  CallerInfo: session/user/uid/pid
+└─────────────────┘
+```
+
+代码位于 `crates/cosh-platform/src/audit/`。
+
+## 命令解析（action parser）
+
+源文件：`audit/action.rs`
+
+解析器在 PDP 之前拒绝危险输入：
+
+| 检查 | 拒绝条件 | 理由 |
+|------|----------|------|
+| 空字符串 | `trim()` 后为空 | 无有效操作 |
+| 控制字节 | 包含 `\n` 或 `\r` | 防止命令注入 |
+| Shell 元字符 | 包含 `;|&><$\`(){}` 中任意字符 | 防止命令链接/重定向/子 shell |
+
+解析失败时，调用方应映射为 `Outcome::Deny`（永不自动放行）。
+
+解析成功后，按首 token 决定结构：
+- `pkg` / `svc` / `checkpoint` / `cosh` → 结构化子系统（operation=tokens[1]，target=tokens[2]）
+- 其它 → Shell 子系统（operation=首 token，target=第二 token，args=tokens[1..]）
+
+## 策略系统
+
+源文件：`audit/policy.rs`、`audit/builtin.rs`
+
+### 策略加载优先级
+
+1. `$COSH_AUDIT_POLICY` 环境变量指定的文件
+2. `~/.copilot-shell/cosh/audit.toml`（用户级）
+3. `/etc/cosh/audit.toml`（系统级）
+4. 内置 `balanced` 预设（出厂默认）
+
+只使用第一个存在的来源，不跨文件合并。
+
+### 内置预设
+
+| 预设 | 默认结果 | 适用场景 |
+|------|----------|----------|
+| `permissive` | Allow | 沙箱 / CI 环境 |
+| `balanced` | RequireApproval | 日常开发（默认） |
+| `strict` | Deny | 生产 / 不可信 Agent |
+
+### 策略文件格式（TOML）
+
+```toml
+version = "v1"
+default = "RequireApproval"   # Allow / Deny / RequireApproval
+
+[[rules]]
+name = "allow-readonly"
+matches.subsystem = "shell"
+matches.operation = { one_of = ["ls", "cat", "ps", "df", "echo", "uptime"] }
+outcome = "Allow"
+
+[[rules]]
+name = "deny-destructive"
+matches.subsystem = "shell"
+matches.operation = { one_of = ["rm", "sudo", "shutdown", "dd", "mkfs", "tee"] }
+outcome = "Deny"
+reason = "destructive command blocked by policy"
+```
+
+### 匹配语法（StringMatch）
+
+| 形式 | 示例 | 说明 |
+|------|------|------|
+| 精确匹配 | `"install"` | 字符串相等 |
+| 枚举匹配 | `{ one_of = ["start", "restart", "stop"] }` | 任一匹配即可 |
+| Glob 匹配 | `{ glob = "-i*" }` | 支持 `*` 和 `?` |
+
+match 块支持字段：`subsystem`、`operation`、`target`、`arg[].key`、`arg[].value`
+
+## 决策引擎（evaluate）
+
+源文件：`audit/evaluate.rs`
+
+- 遍历 `policy.rules[]`，第一条匹配的规则决定结果
+- 未匹配任何规则时使用 `policy.default`
+- 返回 `Decision { outcome, reason, matched_rule, policy_version }`
+- `policy_version` 包含来源标识 + SHA256 哈希，确保审计可追溯
+
+## balanced 预设核心规则
+
+### 允许（Allow）
+
+| 类别 | 命令示例 |
+|------|----------|
+| 只读单体命令 | `uptime`, `ls -la`, `cat`, `ps aux`, `df -h`, `echo` |
+| Git 只读 | `git status`, `git log`, `git diff`, `git show`, `git blame` |
+| Git 分支查看 | `git branch`, `git branch -v` |
+| Git stash 查看 | `git stash`, `git stash list`, `git stash show` |
+| 安全工具对 | `systemctl status`, `apt list`, `dnf list`, `docker ps` |
+| pkg/svc 只读 | `pkg search`, `pkg list`, `svc status`, `svc list` |
+| checkpoint 只读 | `checkpoint list`, `checkpoint status` |
+
+### 拒绝（Deny）
+
+| 类别 | 命令示例 |
+|------|----------|
+| 破坏性命令 | `rm -rf /`, `sudo`, `shutdown`, `dd`, `mkfs`, `tee` |
+| Git 变更 | `git push`, `git reset --hard`, `git clean`, `git rebase` |
+| Git 分支变更 | `git branch -D`, `git branch -m`, `git branch --delete` |
+| Git stash 变更 | `git stash drop`, `git stash clear`, `git stash pop/apply` |
+| sed 就地编辑 | `sed -i`, `sed --in-place` |
+| find 破坏 | `find . -delete`, `find . -fprint` |
+
+### 需要审批（RequireApproval）
+
+| 类别 | 命令示例 |
+|------|----------|
+| 包管理写操作 | `pkg install`, `pkg remove` |
+| 服务管理写操作 | `svc start`, `svc restart` |
+| 快照写操作 | `checkpoint create`, `checkpoint restore` |
+| 未知命令 | 不匹配任何 allow/deny 规则的命令 |
+
+## 日志与脱敏
+
+源文件：`audit/log.rs`、`audit/redact.rs`
+
+### 脱敏规则
+
+在写入日志前自动脱敏：
+
+| 检测方式 | 触发条件 | 替换值 |
+|----------|----------|--------|
+| 敏感 key | args 中 key 包含 `password/secret/token/api_key/apikey` | `<redacted>` |
+| PEM 内容 | raw 字段包含 `BEGIN PRIVATE KEY` 等 PEM 头 | `<redacted-pem>` |
+
+脱敏在 log-write 时执行（非 PDP 阶段），确保 PDP 可以基于原始值决策。
+
+### 日志条目字段
+
+```json
+{
+  "timestamp": "2025-01-01T00:00:00Z",
+  "session_id": "p1234-t1704067200",
+  "user": "admin",
+  "uid": 1000,
+  "euid": 1000,
+  "sudo_user": null,
+  "pid": 1234,
+  "action": { "subsystem": "pkg", "operation": "install", ... },
+  "decision": { "outcome": "RequireApproval", "reason": "...", ... },
+  "source": "Cli",
+  "redacted": false
+}
+```
+
+日志路径通过 `$COSH_AUDIT_LOG` 环境变量覆盖（测试用）。
+
+## 公开 API
+
+| 函数 | 用途 |
+|------|------|
+| `audit::check(action, source, &loaded)` | 完整 PEP→PDP→Log 流程 |
+| `audit::classify(action, &loaded)` | 仅 PDP，不写日志（TUI 实时分类用） |
+| `audit::record_decision(action, &decision, source)` | 记录已决策结果（如解析失败的 Deny） |
+| `audit::evaluate(action, &loaded)` | 纯 PDP 函数 |
+| `parse_action_string(raw)` | 原始字符串 → Action |
+| `LoadedPolicy::load()` | 加载活跃策略 |
+
+## 测试验证
+
+```bash
+cd src/cosh-ng
+
+# 审计策略匹配测试（balanced 预设的 allow/deny/approve 覆盖）
+cargo test --locked -p cosh-platform -- audit
+
+# action parser 测试
+cargo test --locked -p cosh-platform -- action
+
+# 策略加载和验证测试
+cargo test --locked -p cosh-platform -- policy
+
+# 脱敏测试
+cargo test --locked -p cosh-platform -- redact
+```

--- a/docs/cosh-ng/zh/developers/testing.md
+++ b/docs/cosh-ng/zh/developers/testing.md
@@ -1,0 +1,117 @@
+# 测试
+
+## 运行测试
+
+```bash
+cd src/cosh-ng
+
+# 全部测试
+cargo test --locked
+
+# 按 crate 运行
+cargo test --locked -p cosh-types      # 纯类型，无测试
+cargo test --locked -p cosh-platform   # 174 个单元测试
+cargo test --locked -p cosh-cli        # 55 个集成测试
+cargo test --locked -p cosh-core       # 单元 + 集成测试
+cargo test --locked -p cosh-shell      # 单元 + 集成（含 PTY 测试，耗时较长）
+
+# 运行单个测试
+cargo test --locked -p cosh-platform test_detect_alinux
+
+# 运行某个测试文件
+cargo test --locked -p cosh-cli --test cli_integration
+```
+
+## 测试分层
+
+### cosh-types
+
+纯类型定义，通常无测试。序列化/反序列化正确性由上层 crate 测试覆盖。
+
+### cosh-platform
+
+单元测试覆盖：
+- 发行版检测（模拟 `/etc/os-release`）
+- 包管理器命令生成
+- 审计策略规则匹配
+- ws-ckpt IPC 协议编解码
+
+```bash
+cargo test --locked -p cosh-platform
+# 约 174 个测试，< 1s
+```
+
+### cosh-cli
+
+集成测试（`crates/cosh-cli/tests/cli_integration.rs`）：
+- JSON 输出信封格式验证
+- `--dry-run` 行为
+- 各子命令参数解析
+- 错误码映射
+
+```bash
+cargo test --locked -p cosh-cli
+# 约 55 个测试，~ 4s
+```
+
+### cosh-core
+
+| 测试文件 | 覆盖范围 |
+|----------|----------|
+| `tests/jsonl_protocol.rs` | JSONL 消息序列化/反序列化 |
+| `tests/registry_protocol.rs` | Registry 模式请求响应 |
+| `tests/tool_approval.rs` | 工具审批协议 |
+| `tests/sls_integration.rs` | SLS 日志集成 |
+
+单元测试分布在各模块中：
+- `extension/` — 配置解析、变量替换、扩展加载
+- `state.rs` — 状态文件读写
+- `hook.rs` — 钩子协议
+
+```bash
+cargo test --locked -p cosh-core
+```
+
+### cosh-shell
+
+测试结构最复杂，分为三层：
+
+**集成测试**（`crates/cosh-shell/tests/`）：
+
+| 目录 | 覆盖范围 |
+|------|----------|
+| `logic/` | 命令分类、失败分析、agent 事件处理 |
+| `protocol/` | 适配器协议、控制消息 |
+| `raw_cli/` | Raw 模式 CLI 行为 |
+| `shell_host/` | PTY 会话、OSC 标记解析 |
+
+**内联单元测试**（`src/` 内 `#[cfg(test)]` 模块）：
+
+| 模块 | 覆盖范围 |
+|------|----------|
+| `approval/tests.rs` | 审批决策逻辑 |
+| `hooks/` | 钩子引擎、运行时行为 |
+| `runtime/` | 状态机、evidence 请求 |
+| `shell_host/osc_tests.rs` | OSC 转义序列解析 |
+| `tools/` | 工具风险分析、展示 |
+
+```bash
+cargo test --locked -p cosh-shell
+# 耗时较长（PTY 测试需要 fork + 终端交互）
+```
+
+## 测试工具
+
+| 工具 | 用途 |
+|------|------|
+| `tempfile` | 创建临时目录用于隔离测试 |
+| `COSH_STATES_DIR` | 环境变量覆盖状态目录 |
+| `ExtensionManager::new_isolated()` | 测试专用构造函数 |
+
+## 编写测试指南
+
+1. 集成测试放在 `tests/` 目录，单元测试内联在模块中
+2. 测试函数命名：`test_<被测行为>_<场景>`
+3. 使用 `tempfile::tempdir()` 隔离文件系统副作用
+4. 不依赖网络（LLM API 测试用 mock）
+5. PTY 测试标注 `#[ignore]`（如需要真实终端环境）

--- a/docs/cosh-ng/zh/users/cli/audit.md
+++ b/docs/cosh-ng/zh/users/cli/audit.md
@@ -1,0 +1,117 @@
+# 安全审计
+
+`cosh-cli audit` 子系统实现 PEP/PDP 架构的安全策略评估。在执行危险操作前，
+Agent 可以先通过 audit 子系统检查操作是否被允许。
+
+## 核心概念
+
+- **PEP**（策略执行点）— 执行完整的评估 + 日志记录流程
+- **PDP**（策略决策点）— 纯决策逻辑，根据策略规则返回决定
+- **Decision** — 评估结果：Allow / Deny / RequireApproval
+- **Policy** — 策略规则集，分为内置预设和自定义策略
+
+## 命令列表
+
+| 命令 | 说明 |
+|------|------|
+| `cosh-cli audit check --action <cmd>` | 评估命令安全性 |
+| `cosh-cli audit log` | 查看审计日志 |
+| `cosh-cli audit policy show` | 显示当前策略 |
+
+## check
+
+评估一条 shell 命令是否被策略允许。
+
+```bash
+cosh-cli audit check --action "rm -rf /var/log"
+```
+
+输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "outcome": "Deny",
+    "matched_rule": "shell-deny-destructive",
+    "reason": "destructive command matches deny pattern"
+  },
+  "meta": { "subsystem": "audit", "duration_ms": 2, "distro": "alinux", "dry_run": false }
+}
+```
+
+安全命令示例：
+
+```bash
+cosh-cli audit check --action "cat /etc/os-release"
+```
+
+```json
+{
+  "ok": true,
+  "data": {
+    "outcome": "Allow",
+    "matched_rule": null,
+    "reason": "no deny rules matched"
+  },
+  "meta": { "subsystem": "audit", "duration_ms": 1, "distro": "alinux", "dry_run": false }
+}
+```
+
+## log
+
+查看审计日志条目。
+
+```bash
+cosh-cli audit log --session abc123
+```
+
+审计日志默认写入 `$COSH_AUDIT_LOG` 指定路径，未设置时使用
+`~/.copilot-shell/audit.log`。
+
+## policy show
+
+显示当前生效的审计策略。
+
+```bash
+cosh-cli audit policy show
+```
+
+## 内置策略预设
+
+| 预设 | 说明 |
+|------|------|
+| `permissive` | 宽松模式，大多数操作 Allow |
+| `balanced` | 平衡模式（默认），写操作需要审批 |
+| `strict` | 严格模式，几乎所有非只读操作 Deny |
+
+## 策略加载优先级
+
+1. 环境变量 `COSH_AUDIT_POLICY` 指定的策略文件
+2. `~/.copilot-shell/cosh/audit.toml`（用户级）
+3. `/etc/cosh/audit.toml`（系统级）
+4. 内置 `balanced` 预设
+
+## 动作解析
+
+`parse_action_string()` 将原始 shell 字符串解析为结构化 `Action`：
+
+- 按空白字符（空格、Tab、换行）分词
+- 检测 shell 元字符（`;` `|` `&` `>` `<` `$` `` ` `` `(` `)` `{` `}`）
+- 含元字符的命令直接拒绝（无法安全分析）
+
+## 日志脱敏
+
+审计日志写入前自动对敏感字段脱敏：
+
+- 密码参数（`--password`、`-p` 后的值）
+- API 密钥和 token
+- 环境变量中的 secret 值
+
+## Decision 枚举
+
+| 决定 | 含义 | Agent 行为 |
+|------|------|-----------|
+| `Allow` | 策略允许 | 直接执行 |
+| `Deny` | 策略拒绝 | 中止，不执行 |
+| `RequireApproval` | 需要人工确认 | 暂停，等待用户审批 |

--- a/docs/cosh-ng/zh/users/cli/checkpoint.md
+++ b/docs/cosh-ng/zh/users/cli/checkpoint.md
@@ -1,0 +1,105 @@
+# 工作区快照
+
+`cosh-cli checkpoint` 子系统管理工作区快照，通过 Unix socket 与 ws-ckpt 守护
+进程通信。快照使 Agent 可以在执行高风险操作前保存状态，失败时快速回滚。
+
+## 前置条件
+
+checkpoint 命令需要运行中的 ws-ckpt 守护进程。如未运行，命令返回
+`CheckpointDaemonUnavailable` 错误。
+
+## 命令列表
+
+| 命令 | 说明 |
+|------|------|
+| `cosh-cli checkpoint create` | 创建快照 |
+| `cosh-cli checkpoint restore <id>` | 恢复到指定快照 |
+| `cosh-cli checkpoint list` | 列出所有快照 |
+| `cosh-cli checkpoint status` | 查看守护进程状态 |
+| `cosh-cli checkpoint init` | 初始化工作区 |
+| `cosh-cli checkpoint delete` | 删除快照 |
+| `cosh-cli checkpoint diff` | 对比两个快照 |
+
+## create
+
+创建一个带有标识和说明的快照。
+
+```bash
+cosh-cli checkpoint create --workspace /home/agent/project --id step-042 -m "before refactor"
+```
+
+输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "checkpoint_id": "step-042",
+    "step": 42
+  },
+  "meta": { "subsystem": "checkpoint", "duration_ms": 150, "distro": "alinux", "dry_run": false }
+}
+```
+
+## restore
+
+恢复工作区到指定快照状态。
+
+```bash
+cosh-cli checkpoint restore step-040 --workspace /home/agent/project
+```
+
+## list
+
+列出工作区中的所有快照。
+
+```bash
+cosh-cli checkpoint list --workspace /home/agent/project
+```
+
+## diff
+
+对比两个快照之间的差异。
+
+```bash
+cosh-cli checkpoint diff --workspace /home/agent/project --from step-040 --to step-042
+```
+
+## init
+
+初始化工作区的快照管理。
+
+```bash
+cosh-cli checkpoint init --workspace /home/agent/project
+```
+
+## delete
+
+删除指定快照。
+
+```bash
+cosh-cli checkpoint delete --snapshot step-042
+```
+
+## status
+
+查看 ws-ckpt 守护进程连接状态。
+
+```bash
+cosh-cli checkpoint status
+```
+
+## IPC 协议
+
+checkpoint 命令通过 Unix socket 与 ws-ckpt 守护进程通信，使用 bincode 序列化 +
+4 字节小端长度前缀帧格式。详见开发者文档 [IPC 协议](../../developers/ipc-protocol.md)。
+
+## 典型 Agent 工作流
+
+```
+1. cosh-cli checkpoint create --id pre-action -m "safe point"
+2. 执行高风险操作（文件修改、服务重启等）
+3. 验证操作结果
+4. 若失败 → cosh-cli checkpoint restore pre-action
+5. 若成功 → 继续下一步
+```

--- a/docs/cosh-ng/zh/users/cli/overview.md
+++ b/docs/cosh-ng/zh/users/cli/overview.md
@@ -1,0 +1,58 @@
+# cosh-cli 总览
+
+cosh-cli 是 cosh-ng 的结构化命令行工具，为 AI Agent 提供零学习成本的跨发行版
+系统操作接口。所有命令输出 JSON 格式的 `CoshResponse<T>` 信封。
+
+## 设计理念
+
+1. **零学习** — Agent 无需区分 dnf / apt / zypper
+2. **结构化输出** — 纯 JSON，无需正则解析文本
+3. **可逆** — checkpoint 创建 → 执行 → 失败时回滚
+4. **分类错误** — `recoverable` 字段告知 Agent 是否值得重试
+5. **Dry-run** — 所有写操作支持 `--dry-run` 预览
+
+## 命令子系统
+
+| 子系统 | 说明 | 详细文档 |
+|--------|------|----------|
+| `pkg` | 跨发行版包管理 | [package-management.md](package-management.md) |
+| `svc` | systemd 服务管理 | [service-management.md](service-management.md) |
+| `checkpoint` | 工作区快照（ws-ckpt） | [checkpoint.md](checkpoint.md) |
+| `audit` | 安全策略审计 | [audit.md](audit.md) |
+
+## 通用选项
+
+```
+cosh-cli <SUBCOMMAND> [OPTIONS]
+```
+
+| 选项 | 说明 |
+|------|------|
+| `--help` / `-h` | 显示帮助信息 |
+| `--version` / `-V` | 显示版本号 |
+| `--dry-run` | 预览模式，不实际执行（各写操作子命令各自支持） |
+
+## 快速示例
+
+```bash
+# 包管理
+cosh-cli pkg install nginx
+cosh-cli pkg search "web server"
+cosh-cli pkg list --installed
+cosh-cli pkg remove nginx --dry-run
+
+# 服务管理
+cosh-cli svc status nginx
+cosh-cli svc restart nginx --dry-run
+cosh-cli svc list --state running
+
+# 工作区快照
+cosh-cli checkpoint create --workspace /home/agent/project --id step-042 -m "before refactor"
+cosh-cli checkpoint restore step-040 --workspace /home/agent/project
+cosh-cli checkpoint list --workspace /home/agent/project
+
+# 安全审计
+cosh-cli audit check --action "rm -rf /var/log"
+cosh-cli audit log --session abc123
+cosh-cli audit policy show
+```

--- a/docs/cosh-ng/zh/users/cli/package-management.md
+++ b/docs/cosh-ng/zh/users/cli/package-management.md
@@ -1,0 +1,125 @@
+# 包管理
+
+`cosh-cli pkg` 子系统提供跨发行版的包管理操作。自动检测当前发行版并路由到
+对应的包管理器后端（dnf / apt-get / zypper / brew）。
+
+## 命令列表
+
+| 命令 | 说明 |
+|------|------|
+| `cosh-cli pkg install <name>` | 安装软件包 |
+| `cosh-cli pkg remove <name>` | 卸载软件包 |
+| `cosh-cli pkg search <query>` | 搜索软件包 |
+| `cosh-cli pkg list --installed` | 列出已安装包 |
+
+## install
+
+安装指定的软件包。
+
+```bash
+cosh-cli pkg install nginx
+cosh-cli pkg install nginx --dry-run
+```
+
+成功输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "package": "nginx",
+    "version": "1.24.0",
+    "already_installed": false,
+    "dependencies_installed": []
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 5200, "distro": "alinux", "dry_run": false }
+}
+```
+
+若包已安装，`already_installed` 为 `true`，命令仍返回成功。
+
+## remove
+
+卸载指定的软件包。
+
+```bash
+cosh-cli pkg remove nginx
+cosh-cli pkg remove nginx --dry-run
+```
+
+成功输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "package": "nginx",
+    "version_removed": "1.24.0",
+    "dependencies_removed": []
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 2100, "distro": "ubuntu", "dry_run": false }
+}
+```
+
+## search
+
+搜索可用包。返回结果包含安装状态。
+
+```bash
+cosh-cli pkg search "web server"
+```
+
+输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "packages": [
+      { "name": "nginx", "version": "1.24.0", "description": "...", "installed": true },
+      { "name": "apache2", "version": "2.4.58", "description": "...", "installed": false }
+    ],
+    "total": 2
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 800, "distro": "ubuntu", "dry_run": false }
+}
+```
+
+## list
+
+列出已安装的软件包。
+
+```bash
+cosh-cli pkg list --installed
+```
+
+输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "packages": [
+      { "name": "nginx", "version": "1.24.0" },
+      { "name": "curl", "version": "8.5.0" }
+    ],
+    "total": 2
+  },
+  "meta": { "subsystem": "pkg", "duration_ms": 300, "distro": "centos", "dry_run": false }
+}
+```
+
+## 后端映射
+
+| 操作 | dnf | apt-get | zypper | brew |
+|------|-----|---------|--------|------|
+| install | `dnf install -y` | `apt-get install -y` | `zypper install -y` | `brew install` |
+| remove | `dnf remove -y` | `apt-get remove -y` | `zypper remove -y` | `brew uninstall` |
+| search | `dnf search -q` | `apt-cache search` | `zypper search` | `brew search` |
+| list | `dnf list installed -q` | `dpkg-query -W` | `zypper se --installed-only` | `brew list --versions` |
+
+## 错误处理
+
+- 包不存在时返回 `PkgNotFound`，`hint` 建议搜索
+- 包管理器执行失败返回 `PkgBackendError`，`recoverable: true`
+- 未支持的发行版返回 `UnsupportedDistro`

--- a/docs/cosh-ng/zh/users/cli/service-management.md
+++ b/docs/cosh-ng/zh/users/cli/service-management.md
@@ -1,0 +1,121 @@
+# 服务管理
+
+`cosh-cli svc` 子系统通过 systemd 管理系统服务。所有 Linux 发行版使用统一的
+`systemctl` 接口，macOS 不支持此子系统。
+
+## 命令列表
+
+| 命令 | 说明 |
+|------|------|
+| `cosh-cli svc status <name>` | 查看服务状态 |
+| `cosh-cli svc start <name>` | 启动服务 |
+| `cosh-cli svc stop <name>` | 停止服务 |
+| `cosh-cli svc restart <name>` | 重启服务 |
+| `cosh-cli svc enable <name>` | 启用开机自启 |
+| `cosh-cli svc disable <name>` | 禁用开机自启 |
+| `cosh-cli svc list` | 列出服务 |
+
+## status
+
+查看服务的详细状态，包括运行状态、PID、内存占用和最近日志。
+
+```bash
+cosh-cli svc status nginx
+```
+
+输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "name": "nginx",
+    "active": true,
+    "enabled": true,
+    "state": "Running",
+    "pid": 1234,
+    "memory": "12.5M",
+    "uptime_seconds": 86400,
+    "recent_logs": [
+      "2026-06-30 10:00:01 [notice] worker process started",
+      "2026-06-30 10:00:01 [notice] signal process started"
+    ]
+  },
+  "meta": { "subsystem": "svc", "duration_ms": 50, "distro": "alinux", "dry_run": false }
+}
+```
+
+## start / stop / restart
+
+控制服务运行状态。支持 `--dry-run` 预览。
+
+```bash
+cosh-cli svc restart nginx
+cosh-cli svc restart nginx --dry-run
+```
+
+成功输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "name": "nginx",
+    "action": "restart",
+    "success": true
+  },
+  "meta": { "subsystem": "svc", "duration_ms": 1200, "distro": "ubuntu", "dry_run": false }
+}
+```
+
+## enable / disable
+
+控制服务的开机自启状态。
+
+```bash
+cosh-cli svc enable nginx
+cosh-cli svc disable nginx
+```
+
+## list
+
+列出系统服务，支持按状态过滤。
+
+```bash
+cosh-cli svc list
+cosh-cli svc list --state running
+cosh-cli svc list --state failed
+```
+
+输出：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "services": [
+      { "name": "nginx", "active": true, "enabled": true, "state": "Running" },
+      { "name": "sshd", "active": true, "enabled": true, "state": "Running" }
+    ],
+    "total": 2
+  },
+  "meta": { "subsystem": "svc", "duration_ms": 200, "distro": "centos", "dry_run": false }
+}
+```
+
+## 服务状态枚举
+
+| 状态 | 说明 |
+|------|------|
+| `Running` | 正在运行 |
+| `Stopped` | 已停止 |
+| `Failed` | 运行失败 |
+| `Activating` | 正在启动 |
+| `Deactivating` | 正在停止 |
+| `Unknown` | 状态未知 |
+
+## 错误处理
+
+- 服务不存在返回 `SvcNotFound`
+- 启动失败返回 `SvcStartFailed`，停止失败返回 `SvcStopFailed`
+- 需要 root 权限时返回 `PermissionDenied`

--- a/docs/cosh-ng/zh/users/configuration.md
+++ b/docs/cosh-ng/zh/users/configuration.md
@@ -1,0 +1,118 @@
+# 配置
+
+cosh-ng 的三个二进制共享配置文件 `~/.copilot-shell/config.toml`。支持环境变量
+覆盖和 CLI 参数优先。
+
+## 配置文件位置
+
+配置按以下优先级加载（从高到低）：
+
+1. `.copilot-shell/config.toml`（项目级，当前目录）
+2. `~/.copilot-shell/config.toml`（用户级）
+3. `/etc/copilot-shell/config.toml`（系统级）
+
+## cosh-core 配置
+
+```toml
+[ai]
+# 活跃的模型标识
+active_model = "qwen-plus"
+# 输出语言（可选）
+output_language = "zh"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = ""        # 或通过 ALIBABA_CLOUD_ACCESS_KEY_ID
+access_key_secret = ""    # 或通过 ALIBABA_CLOUD_ACCESS_KEY_SECRET
+model = "qwen-plus"
+
+[ai.providers.dashscope]
+type = "dashscope"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = ""              # 或通过 DASHSCOPE_API_KEY
+model = "qwen-plus"
+
+[agent]
+# 审批模式：trust | auto | balanced | suggest | strict
+approval_mode = "balanced"
+# 最大对话轮次
+max_turns = 20
+
+[hooks]
+enabled = true
+
+[skills]
+# 自定义技能搜索路径
+custom_paths = []
+
+[session]
+# 会话持久化目录（相对于 ~/.copilot-shell/）
+persist_dir = "sessions"
+auto_persist = true
+
+[logging]
+level = "warn"
+```
+
+## cosh-shell 配置
+
+```toml
+[ui]
+# 日志级别
+log_level = "warn"
+
+[shell]
+# 默认 shell（auto = 自动检测）
+default = "auto"
+# 默认 AI 适配器
+adapter_default = "cosh-core"
+# 分析模式（smart | auto | manual）
+analysis_mode = "smart"
+# 审批模式（recommend | auto | trust）
+approval_mode = "auto"
+```
+
+## 环境变量覆盖
+
+| 环境变量 | 作用 | 对应配置 |
+|----------|------|----------|
+| `COSH_MODEL` | 覆盖活跃模型 | `ai.active_model` |
+| `COSH_APPROVAL_MODE` | 覆盖审批模式 | `agent.approval_mode` |
+| `COSH_AI_PROVIDER` | 覆盖活跃提供商 | `ai.active_provider` |
+| `COSH_OUTPUT_LANGUAGE` | 输出语言 | `ai.output_language` |
+| `COSH_MAX_TURNS` | 最大轮次 | `agent.max_turns` |
+| `COSH_LOG` | 日志级别（全局） | `logging.level` |
+| `RUST_LOG` | Rust 日志过滤 | — |
+| `COSH_SHELL_ADAPTER` | Shell 适配器 | `shell.adapter_default` |
+| `COSH_SHELL_DEBUG` | 映射为 debug 级别 | `ui.log_level` |
+| `COSH_SHELL_LANG` | Shell 语言 | — |
+| `ALIBABA_CLOUD_ACCESS_KEY_ID` | 阿里云 AK | `ai.providers.aliyun.access_key_id` |
+| `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | 阿里云 SK | `ai.providers.aliyun.access_key_secret` |
+| `DASHSCOPE_API_KEY` | DashScope API Key | provider 解析链 |
+
+## 日志级别优先级
+
+```
+COSH_LOG > RUST_LOG > --verbose > config file > default (warn)
+```
+
+合法值：`error`、`warn`、`info`、`debug`、`trace`
+
+## 日志文件
+
+```
+~/.copilot-shell/logs/
+├── cosh-shell.log.2026-06-26    # 按天轮转
+├── cosh-core.log.2026-06-26
+└── ...
+```
+
+## 审批模式说明
+
+| 模式 | ReadOnly 工具 | FileEdit 工具 | ShellExec 工具 |
+|------|---------------|---------------|----------------|
+| `trust` | 自动执行 | 自动执行 | 自动执行 |
+| `auto` | 自动执行 | 自动执行 | 需要审批 |
+| `balanced` | 自动执行 | 需要审批 | 需要审批 |
+| `suggest` | 自动执行 | 需要审批 | 需要审批 |
+| `strict` | 自动执行 | 需要审批 | 需要审批 |

--- a/docs/cosh-ng/zh/users/core/extensions.md
+++ b/docs/cosh-ng/zh/users/core/extensions.md
@@ -1,0 +1,151 @@
+# 扩展系统
+
+cosh-core 的扩展系统通过 `cosh-extension.json` 配置文件注册技能目录和钩子。扩展是一个包含配置文件的目录，可来自系统级安装或用户级安装。
+
+## 扩展目录
+
+| 层级 | 路径 | 说明 |
+|------|------|------|
+| 用户级 | `~/.copilot-shell/extensions/<name>/` | 优先级高，覆盖同名系统扩展 |
+| 系统级 | `/usr/share/anolisa/extensions/<name>/` | RPM/包管理器安装 |
+
+用户级扩展与系统级扩展同名时，用户级覆盖系统级。
+
+## 配置文件
+
+每个扩展目录下必须包含 `cosh-extension.json`：
+
+```json
+{
+  "name": "agent-sec-core",
+  "version": "0.7.0",
+  "skills": "skills",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(run_shell_command|shell)$",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "code-scanner",
+            "command": "python3 ${extensionPath}/hooks/code_scanner_hook.py",
+            "description": "Scans tool code for security vulnerabilities",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "context-loader",
+            "command": "${extensionPath}/hooks/load-context.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 字段说明
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | 是 | 扩展唯一标识 |
+| `version` | string | 否 | 版本号（默认 "0.0.0"） |
+| `skills` | string \| string[] | 否 | 技能目录（默认 "skills"），相对于扩展根目录 |
+| `hooks` | object | 否 | 按事件分组的钩子定义 |
+
+### 钩子组结构
+
+```json
+{
+  "matcher": "^shell$",
+  "sequential": true,
+  "hooks": [
+    {
+      "type": "command",
+      "name": "hook-name",
+      "command": "执行命令",
+      "description": "说明",
+      "timeout": 5000
+    }
+  ]
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `matcher` | 正则匹配工具名（仅 PreToolUse/PostToolUse 有效） |
+| `sequential` | 组内钩子是否顺序执行 |
+| `hooks[].command` | 钩子执行的 shell 命令 |
+| `hooks[].timeout` | 超时时间（毫秒） |
+
+## 变量替换
+
+配置中的字符串字段支持变量替换：
+
+| 变量 | 替换为 |
+|------|--------|
+| `${extensionPath}` | 扩展目录绝对路径 |
+| `${workspacePath}` | 当前工作区目录 |
+| `${/}` | 路径分隔符（Linux 始终为 `/`） |
+
+示例：`"command": "python3 ${extensionPath}/hooks/check.py --dir=${workspacePath}"`
+
+## 安装元数据
+
+可选文件 `cosh-extension-install.json` 记录安装来源：
+
+```json
+{
+  "source": "/path/to/local/extension",
+  "type": "link",
+  "installed_at": "2026-07-01T10:00:00Z"
+}
+```
+
+`type` 可选值：`"local"`（复制安装）或 `"link"`（符号链接）。
+
+## 启用/禁用
+
+通过 Registry 协议管理扩展状态：
+
+```bash
+# 列出扩展
+echo '{"type":"registry_request","request_id":"r1","domain":"extensions","action":"list","params":{}}' \
+  | cosh-core --registry
+
+# 查看详情
+echo '{"type":"registry_request","request_id":"r2","domain":"extensions","action":"detail","params":{"name":"agent-sec-core"}}' \
+  | cosh-core --registry
+
+# 禁用扩展
+echo '{"type":"registry_request","request_id":"r3","domain":"extensions","action":"disable","params":{"name":"hook-test"}}' \
+  | cosh-core --registry
+
+# 启用扩展
+echo '{"type":"registry_request","request_id":"r4","domain":"extensions","action":"enable","params":{"name":"hook-test"}}' \
+  | cosh-core --registry
+```
+
+禁用状态持久化在 `~/.copilot-shell/states/extensions.json`：
+
+```json
+{ "disabled": ["hook-test"] }
+```
+
+禁用扩展后，其钩子和技能均不生效。启用时自动清除该扩展相关钩子的禁用状态。
+
+## 加载流程
+
+1. 扫描系统级目录（低优先级）
+2. 扫描用户级目录（高优先级，同名覆盖）
+3. 读取 `cosh-extension.json` 并解析
+4. 执行变量替换（`${extensionPath}` 等）
+5. 加载 `cosh-extension-install.json`（如存在）
+6. 应用禁用状态（从 `extensions.json` 读取）
+7. 按扩展名字母排序

--- a/docs/cosh-ng/zh/users/core/headless-mode.md
+++ b/docs/cosh-ng/zh/users/core/headless-mode.md
@@ -1,0 +1,165 @@
+# Headless 模式
+
+cosh-core 的 headless 模式通过 stdin/stdout 提供 JSONL 协议接口，是 cosh-shell 与 cosh-core 之间的标准通信方式，也可供任意客户端集成。
+
+## 启动
+
+```bash
+# 长驻模式（持续接收 JSONL）
+cosh-core --headless
+
+# 单条提示（执行完自动退出）
+cosh-core --headless "帮我查看磁盘使用情况"
+
+# 配合参数
+cosh-core --headless --model qwen-max --approval-mode trust
+```
+
+## 输入消息（Shell → Core）
+
+所有输入通过 stdin 逐行发送，每行一个 JSON 对象，以 `type` 字段区分消息类型。
+
+### user — 用户消息
+
+```json
+{
+  "type": "user",
+  "message": { "role": "user", "content": "列出当前目录文件" },
+  "session_id": "optional-session-id",
+  "shell_context": { "cwd": "/home/user/project", "env": {}, "last_exit_code": 0 }
+}
+```
+
+### control_request — 控制请求
+
+```json
+{
+  "type": "control_request",
+  "request_id": "req-001",
+  "request": { "subtype": "initialize" }
+}
+```
+
+支持的 `subtype`：
+
+| subtype | 说明 |
+|---------|------|
+| `initialize` | 初始化会话（返回能力声明 + 系统 init 消息） |
+| `interrupt` | 中断当前生成 |
+| `shutdown` | 关闭进程 |
+| `switch_model` | 切换模型（需 `model` 字段） |
+| `reload_config` | 重新加载 config.toml |
+| `config_override` | 运行时覆盖配置（`approval_mode`、`allowed_tools`） |
+
+### control_response — 控制响应（回复 Core 的请求）
+
+```json
+{
+  "type": "control_response",
+  "response": {
+    "subtype": "tool_approval",
+    "request_id": "req-002",
+    "response": { "behavior": "allow" }
+  }
+}
+```
+
+### registry_request — 注册表请求
+
+```json
+{
+  "type": "registry_request",
+  "request_id": "reg-001",
+  "domain": "tools",
+  "action": "list",
+  "params": {}
+}
+```
+
+## 输出消息（Core → Shell）
+
+所有输出写入 stdout，同样逐行 JSON。
+
+### system — 系统消息
+
+```json
+{"type":"system","subtype":"init","session_id":"...","model":"qwen3.7-plus","tools":["ask_user_question","edit","grep","read_file","shell","skill","todo","write_file"]}
+```
+
+常见 `subtype`：`init`、`auth_required`、`auth_ok`、`model_switched`、`config_reloaded`。
+
+### stream_event — 流式事件
+
+LLM 生成过程中逐 token 输出：
+
+```json
+{"type":"stream_event","event":{"subtype":"text_delta","content":"你好"}}
+{"type":"stream_event","event":{"subtype":"thinking_delta","content":"让我分析..."}}
+{"type":"stream_event","event":{"subtype":"tool_use_begin","tool_name":"shell","tool_use_id":"tu-1"}}
+{"type":"stream_event","event":{"subtype":"tool_use_delta","content":"{\"command\":\"df -h\"}"}}
+{"type":"stream_event","event":{"subtype":"tool_use_end"}}
+```
+
+### control_request — Core 发起的请求
+
+Core 需要 Shell 协作时（如工具审批、用户提问）：
+
+```json
+{
+  "type": "control_request",
+  "request_id": "cr-001",
+  "request": { "subtype": "can_use_tool", "tool_name": "shell", "tool_input": {"command": "rm -rf /tmp/old"} }
+}
+```
+
+### result — 轮次结束
+
+```json
+{"type":"result","subtype":"success","is_error":false,"result":"completed","session_id":"...","duration_ms":1234}
+```
+
+## 初始化握手
+
+标准启动序列：
+
+```
+Shell → Core:  {"type":"control_request","request_id":"init-1","request":{"subtype":"initialize"}}
+Core → Shell:  {"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{...}}}}
+Core → Shell:  {"type":"system","subtype":"init","session_id":"...","model":"...","tools":[...]}
+```
+
+`capabilities` 声明 Core 支持的协议能力：
+
+| 能力 | 说明 |
+|------|------|
+| `can_handle_can_use_tool` | 支持工具审批协议 |
+| `can_handle_host_executed_shell_tool_result` | 支持 Shell 端执行结果回传 |
+| `can_handle_shell_evidence_tool` | 支持终端证据工具 |
+
+## 认证流程
+
+若未配置 API 密钥，Core 在初始化时发送认证请求：
+
+```
+Core → Shell:  {"type":"control_request","request_id":"auth-init","request":{"subtype":"auth_required","reason":"not_configured","providers":[...]}}
+Shell → Core:  {"type":"control_response","response":{"subtype":"auth_response","request_id":"auth-init","response":{"provider_id":"dashscope","values":{"api_key":"sk-xxx"},"persist":true}}}
+Core → Shell:  {"type":"system","subtype":"auth_ok"}
+```
+
+## 会话恢复
+
+```bash
+cosh-core --headless --resume <session-id>
+```
+
+Core 从 `~/.copilot-shell/sessions/<session-id>.json` 加载历史消息，恢复对话上下文。
+
+## 错误处理
+
+协议级错误通过 `result` 消息传递：
+
+```json
+{"type":"result","is_error":true,"errors":["provider returned HTTP 429: rate limit exceeded"],"session_id":"..."}
+```
+
+输入行 JSON 解析失败时静默忽略（仅 debug 日志），不会终止进程。

--- a/docs/cosh-ng/zh/users/core/hooks.md
+++ b/docs/cosh-ng/zh/users/core/hooks.md
@@ -1,0 +1,106 @@
+# 钩子系统
+
+cosh-core 的钩子系统允许在 Agent 执行流程的关键节点注入外部逻辑。钩子通过执行外部命令实现，支持拦截、审计和上下文注入。
+
+## 事件点
+
+| 事件 | 触发时机 | 可拦截 |
+|------|----------|--------|
+| `PreToolUse` | 工具执行前 | 是（block/allow/ask） |
+| `PostToolUse` | 工具执行后 | 是（block/allow） |
+| `PostToolUseFailure` | 工具执行失败后 | 否 |
+| `UserPromptSubmit` | 用户消息提交时 | 是（block/allow） |
+| `SessionStart` | 会话初始化完成后 | 否 |
+| `Stop` | Agent 决定停止时 | 是（block/allow） |
+| `BeforeModel` | LLM 请求发送前 | 否 |
+| `AfterModel` | LLM 响应接收后 | 否 |
+
+## 配置
+
+在 `~/.copilot-shell/config.toml` 中定义：
+
+```toml
+[hooks]
+enabled = true
+
+[[hooks.PreToolUse]]
+name = "security-check"
+command = "/usr/local/bin/my-security-hook"
+timeout = 5000
+
+[[hooks.SessionStart]]
+name = "context-loader"
+command = "/usr/local/bin/load-context"
+timeout = 3000
+```
+
+钩子也可通过扩展的 `cosh-extension.json` 注册。
+
+## 协议
+
+### 输入（stdin → 钩子进程）
+
+Core 以 JSON 格式将事件数据写入钩子进程的 stdin：
+
+```json
+{
+  "session_id": "abc-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "timestamp": "2026-07-01T10:00:00Z",
+  "transcript_path": "/home/user/.copilot-shell/sessions/abc-123",
+  "tool_name": "shell",
+  "tool_input": { "command": "rm -rf /tmp/old" }
+}
+```
+
+### 输出（钩子进程 → stdout）
+
+钩子以 JSON 格式返回决策：
+
+```json
+{
+  "decision": "block",
+  "reason": "危险的 rm -rf 命令",
+  "systemMessage": "该命令被安全策略拦截"
+}
+```
+
+### 决策值
+
+| decision | 含义 |
+|----------|------|
+| `allow` | 允许继续 |
+| `block` / `deny` | 拦截，终止该操作 |
+| `ask` | 需要用户确认 |
+| 无 / 空 | 透传（不干预） |
+
+### 附加字段
+
+| 字段 | 说明 |
+|------|------|
+| `reason` | 决策原因（block/deny 时嵌入决策，同时作为通知消息后备） |
+| `systemMessage` | 通知消息（优先于 reason 展示给用户） |
+| `hookSpecificOutput` | 自定义 JSON 数据（其中 `additional_context` 会注入对话上下文） |
+
+## 执行模型
+
+1. 同一事件点可注册多个钩子，按配置顺序依次执行
+2. 任一钩子返回 `block`，则最终决策为 block（短路）
+3. 钩子超时（默认 5000ms）视为透传
+4. 钩子进程退出码非零视为错误，不影响主流程
+5. 无 `name` 字段的钩子定义会被跳过
+
+## 通知
+
+钩子执行后产生的通知通过 JSONL 输出传递给 Shell：
+
+```json
+{"type":"stream_event","event":{"subtype":"hook_notification","hook_name":"security-check","message":"该命令被安全策略拦截","decision":"block"}}
+```
+
+Shell 端负责渲染通知卡片。
+
+## 扩展钩子
+
+通过 `cosh-extension.json` 注册的钩子与配置文件中的钩子合并，使用相同的执行协议。参见 [extensions.md](extensions.md)。

--- a/docs/cosh-ng/zh/users/core/overview.md
+++ b/docs/cosh-ng/zh/users/core/overview.md
@@ -1,0 +1,85 @@
+# cosh-core 总览
+
+cosh-core 是 cosh-ng 的 AI Agent 运行时核心。它提供无头 JSONL 后端，集成 LLM 提供商、钩子系统、工具执行、技能管理和会话持久化。
+
+## 定位
+
+cosh-core 是 cosh-shell 的后端引擎。cosh-shell 通过 stdin/stdout 与 cosh-core 进程通信（JSONL 协议）。cosh-core 也可以独立使用：
+
+- **单条提示模式** — 直接传入 prompt，执行完退出
+- **Headless 模式** — 长驻进程，持续接收 JSONL 消息
+- **Registry 模式** — 仅处理注册表请求后退出
+
+## 运行模式
+
+```bash
+# 单条提示（需显式 --headless）
+cosh-core --headless "帮我查看系统负载"
+
+# 长驻 headless 模式（通过 stdin 接收 JSONL）
+cosh-core --headless
+
+# Registry 模式
+cosh-core --registry
+
+# 覆盖模型
+cosh-core --headless --model qwen-max "分析这段代码"
+
+# 覆盖审批模式
+cosh-core --headless --approval-mode trust "安装 nginx"
+
+# 恢复会话
+cosh-core --headless --resume <session-id>
+```
+
+## CLI 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--headless` | 强制 headless JSONL 模式 |
+| `--model <name>` | 覆盖配置中的模型 |
+| `--approval-mode <mode>` | 覆盖审批模式（trust/auto/balanced/strict） |
+| `--allowed-tools <tools>` | 逗号分隔的自动审批工具列表 |
+| `--resume <session-id>` | 恢复已有会话 |
+| `--verbose` | 增加日志详细程度 |
+| `--registry` | Registry 模式 |
+| `--enable-shell-evidence-tool` | 启用终端输出证据工具 |
+
+## 核心能力
+
+| 能力 | 说明 | 详细文档 |
+|------|------|----------|
+| LLM 提供商 | OpenAI 兼容 / Aliyun SysOM | [providers.md](providers.md) |
+| 钩子系统 | 8 个事件点，可扩展 | [hooks.md](hooks.md) |
+| 工具执行 | 内置工具 + 自定义工具 | [tools.md](tools.md) |
+| 技能管理 | Markdown 技能定义 | [skills.md](skills.md) |
+| 扩展加载 | cosh-extension.json | [extensions.md](extensions.md) |
+| 会话持久化 | JSON 格式会话存储 | — |
+
+## 架构概览
+
+```
+stdin (JSONL)                stdout (JSONL)
+     │                            ▲
+     ▼                            │
+┌────────────────────────────────────────┐
+│              cosh-core                 │
+│  ┌──────┐  ┌──────────┐  ┌──────────┐  │
+│  │ Auth │  │ Provider │  │  Tools   │  │
+│  └──────┘  └──────────┘  └──────────┘  │
+│  ┌──────┐  ┌──────────┐  ┌──────────┐  │
+│  │Hooks │  │ Session  │  │  Skills  │  │
+│  └──────┘  └──────────┘  └──────────┘  │
+└────────────────────────────────────────┘
+```
+
+## 认证流程
+
+若未配置 API 密钥，cosh-core 在启动时发送 `auth_required` 控制请求：
+
+1. Core 发送 `AuthRequired`，列出可用认证提供商
+2. Shell（或外部客户端）展示认证 UI
+3. 用户选择提供商并填写凭证
+4. Shell 回送 `ControlResponse` 包含凭证
+5. Core 应用凭证，可选持久化到 config.toml
+6. Core 发送 `auth_ok` 状态，开始正常工作

--- a/docs/cosh-ng/zh/users/core/providers.md
+++ b/docs/cosh-ng/zh/users/core/providers.md
@@ -1,0 +1,87 @@
+# LLM 提供商
+
+cosh-core 通过 OpenAI 兼容 API 协议对接多家 LLM 提供商。所有提供商均使用流式 SSE 输出，支持 function calling。
+
+## 支持的提供商
+
+| 提供商类型 | Profile | 说明 |
+|------------|---------|------|
+| `dashscope` | DashScope | 阿里云百炼（通义千问系列），支持 thinking |
+| `aliyun` | SysOM | 阿里云 AK/SK 签名认证（ROA 风格） |
+| `openai` | OpenAI | OpenAI 官方 API，使用 `max_completion_tokens` |
+| 其他 | Generic | 任意 OpenAI 兼容端点 |
+
+## 配置
+
+在 `~/.copilot-shell/config.toml` 中配置提供商：
+
+```toml
+[ai]
+active_model = "qwen-plus"
+
+[ai.providers.dashscope]
+type = "dashscope"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = ""    # 或通过 DASHSCOPE_API_KEY 环境变量
+model = "qwen-plus"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = ""      # 或 ALIBABA_CLOUD_ACCESS_KEY_ID
+access_key_secret = ""  # 或 ALIBABA_CLOUD_ACCESS_KEY_SECRET
+model = "qwen-plus"
+
+[ai.providers.openai]
+type = "openai"
+base_url = "https://api.openai.com/v1"
+api_key = ""    # 或 OPENAI_API_KEY
+model = "gpt-4o"
+```
+
+## Provider Profile 差异
+
+不同 Profile 在 API 请求中的行为差异：
+
+| Profile | max_tokens 字段 | thinking 字段 | 认证方式 |
+|---------|----------------|---------------|----------|
+| Generic | `max_tokens` | — | Bearer token |
+| DashScope | `max_tokens` | `reasoning_content` | Bearer token |
+| OpenAI | `max_completion_tokens` | — | Bearer token |
+| SysOM (aliyun) | — | — | AK/SK 签名 |
+
+## 运行时切换
+
+通过 JSONL 控制协议动态切换模型：
+
+```json
+{"type":"control_request","request_id":"sw-1","request":{"subtype":"switch_model","model":"qwen-max"}}
+```
+
+或通过 CLI 参数覆盖：
+
+```bash
+cosh-core --headless --model qwen-max
+```
+
+环境变量覆盖：
+
+```bash
+COSH_MODEL=qwen-max cosh-core --headless
+```
+
+## 认证优先级
+
+1. CLI `--model` 参数 → 选择对应的 provider 配置
+2. 环境变量（`DASHSCOPE_API_KEY`、`ALIBABA_CLOUD_ACCESS_KEY_*`）
+3. config.toml 中 `[ai.providers.<name>]` 的配置值
+4. 均为空时 → 触发交互式认证流程（向 Shell 发送 `auth_required`）
+
+## 生成参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `max_tokens` | 4096 | 最大生成 token 数 |
+| `temperature` | — | 采样温度（不设置则使用提供商默认） |
+| `stream` | true | 始终流式输出 |
+
+可通过 config.toml 的 `[ai.providers.<name>]` 段添加 `extra_params` 传递自定义参数。

--- a/docs/cosh-ng/zh/users/core/skills.md
+++ b/docs/cosh-ng/zh/users/core/skills.md
@@ -1,0 +1,63 @@
+# 技能系统
+
+cosh-core 的技能系统允许通过 Markdown 文件定义可复用的 Agent 技能。LLM 可在对话中主动发现和调用已注册的技能。
+
+## 技能搜索路径
+
+技能按优先级从高到低在以下目录中搜索：
+
+| 层级 | 路径 | 说明 |
+|------|------|------|
+| Project | `<project>/.copilot-shell/skills/` | 项目级技能 |
+| Custom | config.toml `skills.custom_paths` | 自定义路径 |
+| User | `~/.copilot-shell/skills/` | 用户级技能 |
+| Extension | 扩展 `skill_dirs` 声明 | 通过扩展注册 |
+| System | `/usr/share/anolisa/skills/` | 系统级（RPM 安装） |
+
+同名技能按优先级覆盖（Project > Custom > User > Extension > System）。
+
+## 技能文件格式
+
+技能是一个 Markdown 文件（`.md`），包含 YAML frontmatter 和正文：
+
+```markdown
+---
+name: check-disk
+description: 检查磁盘使用情况并给出建议
+---
+
+# 检查磁盘使用情况
+
+1. 执行 `df -h` 获取挂载点使用率
+2. 对使用率超过 80% 的分区发出警告
+3. 执行 `du -sh /var/log` 检查日志目录大小
+```
+
+## 配置
+
+```toml
+[skills]
+custom_paths = ["~/my-skills", "/opt/team-skills"]
+```
+
+## 运行时行为
+
+1. 启动时 `SkillManager` 扫描所有路径，构建技能缓存
+2. 技能列表注入系统提示词的 `# Available Skills` 段
+3. LLM 通过 `skill` 工具调用技能（传入技能名称）
+4. 技能内容以 system message 形式注入对话上下文
+5. 文件系统监听器自动检测新增/修改的技能文件（热加载）
+
+## 禁用技能
+
+通过状态文件 `~/.copilot-shell/states/skills.json` 管理：
+
+```json
+{ "disabled": ["dangerous-skill"] }
+```
+
+被禁用的技能不会出现在 LLM 的可见列表中。
+
+## 与 copilot-shell 的区别
+
+cosh-core 的技能系统镜像了 copilot-shell 的技能发现逻辑，但实现为纯 Rust。同一套技能文件可同时被两者加载。

--- a/docs/cosh-ng/zh/users/core/tools.md
+++ b/docs/cosh-ng/zh/users/core/tools.md
@@ -1,0 +1,92 @@
+# 工具系统
+
+cosh-core 内置一组工具供 LLM 在对话过程中调用。工具按安全等级分类，决定审批策略。
+
+## 内置工具列表
+
+| 工具名 | 分类 | 说明 |
+|--------|------|------|
+| `read_file` | ReadOnly | 读取文件内容（支持行范围） |
+| `grep` | ReadOnly | 正则搜索文件内容 |
+| `edit` | FileEdit | 基于搜索替换的精确文件编辑 |
+| `write_file` | FileEdit | 创建或覆盖文件 |
+| `shell` | ShellExec | 执行 shell 命令 |
+| `skill` | Other | 调用已注册的技能 |
+| `todo` | Other | 管理任务清单 |
+| `ask_user_question` | Other | 向用户提问并等待回答 |
+| `cosh_shell_evidence` | ShellEvidence | 获取终端输出作为证据（需 `--enable-shell-evidence-tool`） |
+
+## 工具分类
+
+```rust
+pub enum ToolKind {
+    ReadOnly,       // 纯读取，不修改系统状态
+    FileEdit,       // 修改文件内容
+    ShellExec,      // 执行任意 shell 命令
+    ShellEvidence,  // 读取终端输出历史
+    Other,          // 无副作用的辅助操作
+}
+```
+
+分类决定了审批模式下的默认行为：
+
+| 审批模式 | ReadOnly | FileEdit | ShellExec | ShellEvidence | Other |
+|----------|----------|----------|-----------|---------------|-------|
+| `trust` | 自动 | 自动 | 自动 | 自动 | 自动 |
+| `auto` | 自动 | 自动 | 审批 | 自动 | 自动 |
+| `balanced` | 自动 | 审批 | 审批 | 自动 | 审批 |
+| `suggest` | 自动 | 审批 | 审批 | 自动 | 审批 |
+| `strict` | 自动 | 审批 | 审批 | 自动 | 审批 |
+
+> **注意**：`ask_user_question` 和 `cosh_shell_evidence` 工具始终绕过审批流程，无论何种模式均自动执行。
+
+## 工具调用协议
+
+LLM 决定调用工具时，Core 通过流式事件通知：
+
+```json
+{"type":"stream_event","event":{"subtype":"tool_use_begin","tool_name":"shell","tool_use_id":"tu-1"}}
+{"type":"stream_event","event":{"subtype":"tool_use_delta","content":"{\"command\":\"df -h\"}"}}
+{"type":"stream_event","event":{"subtype":"tool_use_end"}}
+```
+
+如果需要审批，Core 发送 `can_use_tool` 请求：
+
+```json
+{"type":"control_request","request_id":"apr-1","request":{"subtype":"can_use_tool","tool_name":"shell","tool_input":{"command":"df -h"}}}
+```
+
+Shell 回复审批结果：
+
+```json
+{"type":"control_response","response":{"subtype":"tool_approval","request_id":"apr-1","response":{"behavior":"allow"}}}
+```
+
+`behavior` 可选值：`allow`、`deny`、`ask`。
+
+## 工具结果
+
+工具执行完成后，结果注入对话上下文供 LLM 继续推理。每个工具返回：
+
+```rust
+pub struct ToolResult {
+    pub output: String,   // 工具输出内容
+    pub is_error: bool,   // 是否为错误结果
+}
+```
+
+## 自动审批工具
+
+通过 `--allowed-tools` 参数指定始终自动审批的工具列表：
+
+```bash
+cosh-core --headless --allowed-tools shell,edit
+```
+
+此时 `shell` 和 `edit` 工具在任何审批模式下都自动执行，无需用户确认。
+
+## 工具注册
+
+工具通过 `ToolRegistry` 统一管理。默认注册的工具集合通过 `ToolRegistry::with_defaults()` 创建。`--enable-shell-evidence-tool` 额外注册 `cosh_shell_evidence` 工具。
+
+自定义工具可通过扩展系统注入，参见 [extensions.md](extensions.md)。

--- a/docs/cosh-ng/zh/users/output-format.md
+++ b/docs/cosh-ng/zh/users/output-format.md
@@ -1,0 +1,83 @@
+# 输出格式
+
+cosh-cli 的所有命令输出统一的 JSON 信封 `CoshResponse<T>`，方便 AI Agent 解析。
+
+## 成功响应
+
+```json
+{
+  "ok": true,
+  "data": { ... },
+  "meta": {
+    "subsystem": "pkg",
+    "duration_ms": 342,
+    "distro": "alinux",
+    "dry_run": false
+  }
+}
+```
+
+## 错误响应
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "PkgNotFound",
+    "message": "package 'nginx-extra' not found",
+    "recoverable": true,
+    "hint": "try 'cosh-cli pkg search nginx'",
+    "subsystem": "pkg"
+  },
+  "meta": {
+    "subsystem": "pkg",
+    "duration_ms": 120,
+    "distro": "ubuntu",
+    "dry_run": false
+  }
+}
+```
+
+## 关键字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `ok` | bool | 操作是否成功 |
+| `data` | object | 成功时携带的业务数据 |
+| `error.code` | string | 错误码枚举（详见下方） |
+| `error.recoverable` | bool | Agent 是否值得重试 |
+| `error.hint` | string | 建议的下一步操作 |
+| `meta.subsystem` | string | 来源子系统（pkg/svc/checkpoint/audit） |
+| `meta.duration_ms` | u64 | 操作耗时（毫秒） |
+| `meta.distro` | string | 当前检测到的发行版 |
+| `meta.dry_run` | bool | 是否为预览模式 |
+
+## 错误码
+
+| 错误码 | 子系统 | 含义 |
+|--------|--------|------|
+| `PkgNotFound` | pkg | 包不存在 |
+| `PkgBackendError` | pkg | 包管理器执行失败 |
+| `UnsupportedDistro` | pkg/svc | 不支持的发行版 |
+| `SvcNotFound` | svc | 服务不存在 |
+| `SvcStartFailed` | svc | 服务启动失败 |
+| `SvcStopFailed` | svc | 服务停止失败 |
+| `CheckpointDaemonUnavailable` | checkpoint | ws-ckpt 守护进程未运行 |
+| `CheckpointNotFound` | checkpoint | 快照不存在 |
+| `AuditDenied` | audit | 策略拒绝 |
+| `Timeout` | * | 命令执行超时 |
+| `PermissionDenied` | * | 权限不足 |
+
+## 退出码
+
+- `0` — 操作成功（`ok: true`）
+- `1` — 操作失败（`ok: false`）
+
+## Agent 对接模式
+
+对于 AI Agent 消费 cosh-cli 输出，推荐以下模式：
+
+1. 解析 JSON，检查 `ok` 字段
+2. 若 `ok: false`，读取 `error.recoverable` 决定是否重试
+3. 若不可恢复，展示 `error.hint` 给用户或执行 hint 中的建议命令
+4. `meta.dry_run` 为 `true` 时，表示这是预览结果，实际操作尚未执行

--- a/docs/cosh-ng/zh/users/quickstart.md
+++ b/docs/cosh-ng/zh/users/quickstart.md
@@ -1,0 +1,76 @@
+# 快速开始
+
+cosh-ng（Computable Operating System Harness）为 AI Agent 提供确定性的跨发行版系统操作接口。它由三个二进制组成：
+
+- **cosh-cli** — 结构化 JSON CLI，覆盖包管理、服务管理、工作区快照和安全审计
+- **cosh-core** — 无头 JSONL 后端，集成 LLM 提供商、钩子、工具和技能
+- **cosh-shell** — AI 增强的交互式终端，提供 PTY 主机、流式分析和工具审批
+
+## 前置条件
+
+- Linux（Alinux / CentOS / Ubuntu / Debian / Fedora / openSUSE）或 macOS（有限功能）
+- Rust 1.74+
+- pkg/svc 命令需要 root 或 sudo 权限
+- checkpoint 命令需要运行中的 ws-ckpt 守护进程
+
+## 构建
+
+```bash
+cd src/cosh-ng
+cargo build --workspace
+```
+
+构建产物位于 `target/debug/` 下：`cosh-cli`、`cosh-core`、`cosh-shell`。
+
+发布构建：
+
+```bash
+cargo build --workspace --release
+```
+
+## 第一次运行
+
+### cosh-cli：结构化系统操作
+
+```bash
+# 安装一个包（JSON 输出）
+cosh-cli pkg install nginx
+# → {"ok":true,"data":{"package":"nginx","version":"1.24.0","already_installed":false},...}
+
+# 预览模式（不实际执行）
+cosh-cli pkg install nginx --dry-run
+
+# 查看服务状态
+cosh-cli svc status nginx
+# → {"ok":true,"data":{"name":"nginx","active":true,"enabled":true,"recent_logs":[...]},...}
+```
+
+### cosh-core：AI Agent 后端
+
+```bash
+# 单条提示执行
+cosh-core --headless "帮我查看磁盘使用情况"
+
+# 或通过管道进入 headless 模式
+echo '{"type":"user","message":{"role":"user","content":"列出当前目录文件"}}' | cosh-core --headless
+```
+
+### cosh-shell：交互式终端
+
+```bash
+# 启动交互式 AI Shell
+cosh-shell
+```
+
+## 配置
+
+配置文件位于 `~/.copilot-shell/config.toml`。首次运行时自动创建默认配置。
+
+详见 [配置文档](configuration.md)。
+
+## 下一步
+
+- [cosh-cli 总览](cli/overview.md) — 了解 CLI 子系统
+- [cosh-core 总览](core/overview.md) — 了解无头模式与 LLM 集成
+- [cosh-shell 总览](shell/overview.md) — 了解交互式终端
+- [输出格式](output-format.md) — 理解 JSON 信封与错误码

--- a/docs/cosh-ng/zh/users/shell/ai-analysis.md
+++ b/docs/cosh-ng/zh/users/shell/ai-analysis.md
@@ -1,0 +1,90 @@
+# AI 分析
+
+cosh-shell 在检测到命令失败时，可自动或按需调用 AI 适配器分析失败原因并给出建议。
+
+## 分析模式
+
+通过 `/mode analysis <mode>` 或配置 `shell.analysis_mode` 切换：
+
+| 模式 | 说明 |
+|------|------|
+| `smart` | 智能模式：严重错误显示操作卡片，一般错误提示可分析 |
+| `auto` | 自动模式：检测到失败立即自动分析 |
+| `manual` | 手动模式：显示操作卡片，等待用户确认后分析 |
+
+## 失败分类
+
+cosh-shell 对命令退出码和输出进行语义分析，将失败归类：
+
+| 分类 | 示例 | 说明 |
+|------|------|------|
+| `CommandNotFound` | `command not found` | 命令不存在 |
+| `PermissionDenied` | `Permission denied` | 权限不足 |
+| `BuildOrTestFailure` | `error[E0308]` | 编译/测试错误 |
+| `AbnormalSignal` | SIGSEGV | 异常信号终止 |
+| `GenericRuntimeFailure` | 非零退出码 | 一般运行时错误 |
+| `UsageOrHelp` | `Usage:` 输出 | 用法错误 |
+| `UnknownFailure` | 其他 | 未分类失败 |
+
+以下分类视为"非真正失败"，不触发分析：
+- `Success` — 实际成功
+- `InteractiveCancel` — 用户主动中断
+- `UserInterrupt` — Ctrl+C
+- `PipelineNormal` — 管道正常退出码
+- `ProviderOrInternalArtifact` — 内部工具产生的退出码
+
+## 分析处置矩阵
+
+| 失败分类 | Auto 模式 | Smart 模式 | Manual 模式 |
+|----------|-----------|------------|-------------|
+| CommandNotFound / PermissionDenied / AbnormalSignal / BuildOrTestFailure | 自动分析 | 操作卡片 | 操作卡片 |
+| GenericRuntimeFailure | 自动分析 | 提示 | 操作卡片 |
+| UnknownFailure | 操作卡片 | 提示 | 提示 |
+| UsageOrHelp | 提示 | 静默 | 静默 |
+
+处置类型说明：
+- **自动分析** — 立即调用 AI 适配器分析
+- **操作卡片** — 渲染交互卡片，用户可选择"分析"或"跳过"
+- **提示** — 显示简短提示，用户可输入 slash 命令触发分析
+- **静默** — 仅记录，不干扰用户
+
+## 分析流程
+
+```
+命令执行失败（exit code ≠ 0）
+       │
+       ▼
+  失败语义分类
+       │
+       ▼
+  处置决策（按分析模式）
+       │
+       ├── AutoAnalyze → 直接启动 Agent 分析
+       ├── ActionCard  → 渲染操作卡片 → 等待用户确认
+       ├── Hint        → 显示简短提示
+       └── SilentRecord → 静默记录
+```
+
+## Agent 分析过程
+
+1. 收集失败上下文：命令文本、退出码、输出摘录（最多 8KB）
+2. 构造 prompt 发送到 AI 适配器（cosh-core）
+3. 适配器流式返回分析结果
+4. cosh-shell 以 Markdown 格式渲染分析内容
+5. 用户可在分析过程中 Ctrl+C 取消
+
+## 配置
+
+```toml
+[shell]
+# 分析模式：smart | auto | manual
+analysis_mode = "smart"
+```
+
+运行时切换：
+
+```
+/mode analysis smart
+/mode analysis auto
+/mode analysis manual
+```

--- a/docs/cosh-ng/zh/users/shell/approval.md
+++ b/docs/cosh-ng/zh/users/shell/approval.md
@@ -1,0 +1,118 @@
+# 工具审批
+
+cosh-shell 的工具审批系统在 AI 适配器请求执行工具时，以可视化卡片呈现操作详情，让用户决定是否允许。
+
+## 审批模式
+
+通过 `/mode approval <mode>` 或配置 `shell.approval_mode` 切换：
+
+| 模式 | 含义 | 对 cosh-core 的映射 |
+|------|------|---------------------|
+| `recommend` | 推荐模式：所有工具调用需审批 | `strict` |
+| `auto` | 自动模式（默认）：仅 shell 命令需审批 | `auto` |
+| `trust` | 信任模式：所有工具自动执行（需 `confirm` 确认） | `trust` |
+
+切换到 trust 模式需要二次确认：
+
+```
+/mode approval trust confirm
+```
+
+## 审批卡片
+
+当工具需要审批时，cosh-shell 渲染内联审批面板：
+
+```
+┌─────────────────────────────────────────┐
+│ 🔧 Tool: shell                    [1/3] │
+│ Risk: medium                            │
+│─────────────────────────────────────────│
+│ Command:                                │
+│   rm -rf /tmp/old-build                 │
+│─────────────────────────────────────────│
+│ ⚠ Hook: sandbox-guard                   │
+│   "命令匹配风险模式"                       │
+│─────────────────────────────────────────│
+│ [✓ Approve]  [ Deny ]  [ Details ]      │
+└─────────────────────────────────────────┘
+```
+
+### 卡片元素
+
+| 元素 | 说明 |
+|------|------|
+| Tool | 工具名称 |
+| Risk | 风险等级（由钩子评估） |
+| Queue | 队列位置（当多个请求排队时） |
+| Command/Input | 工具输入预览 |
+| Hook warnings | 钩子产生的警告信息 |
+| Actions | 可选操作按钮 |
+
+### 用户操作
+
+| 操作 | 说明 |
+|------|------|
+| Approve | 允许执行 |
+| Deny | 拒绝执行 |
+| Details | 展开完整输入内容 |
+
+## Shell 命令 Handoff
+
+当审批的工具是 `shell` 类型且用户批准时，命令会"移交"到前台 PTY 执行（而非由 cosh-core 在后台执行）：
+
+```
+用户批准 shell 命令
+       │
+       ▼
+cosh-shell 将命令注入 PTY
+       │
+       ▼
+bash/zsh 在前台执行（用户可交互）
+       │
+       ▼
+执行结果通过 OSC 标记回传
+```
+
+这意味着：
+- 命令输出直接显示在终端
+- 用户可以实时交互（如确认提示）
+- Ctrl+C 可中断执行
+
+## 审批日志
+
+所有审批决策记录在内存中的 journal：
+
+| 字段 | 说明 |
+|------|------|
+| `id` | 审批请求唯一标识 |
+| `run_id` | 所属 Agent 运行 ID |
+| `kind` | 请求类型（Tool / ShellCommand） |
+| `risk` | 风险等级 |
+| `decision` | 最终决策（Allow / Deny / Cancel） |
+| `subject` | 工具名称 |
+| `preview` | 操作预览 |
+
+## 与 cosh-core 审批协议的关系
+
+cosh-shell 的审批系统是 cosh-core JSONL 协议中 `can_use_tool` 控制请求的前端实现：
+
+```
+Core → Shell:  {"type":"control_request","request_id":"apr-1","request":{"subtype":"can_use_tool",...}}
+                       │
+                       ▼
+              cosh-shell 渲染审批卡片
+                       │
+                       ▼ (用户决策)
+Shell → Core:  {"type":"control_response","response":{"subtype":"tool_approval","request_id":"apr-1","response":{"behavior":"allow"}}}
+```
+
+## 配置
+
+```toml
+[shell]
+# 审批模式：recommend | auto | trust
+approval_mode = "auto"
+
+# 信任的命令列表（始终自动审批）
+trusted_commands = ["ls", "cat", "echo"]
+```

--- a/docs/cosh-ng/zh/users/shell/interactive-mode.md
+++ b/docs/cosh-ng/zh/users/shell/interactive-mode.md
@@ -1,0 +1,128 @@
+# 交互模式
+
+cosh-shell 在原生 PTY 之上运行 bash/zsh，通过 OSC 转义序列标记命令边界，实现 AI 分析与工具审批的无缝集成。
+
+## PTY 主机
+
+cosh-shell 通过 `openpty()` 创建伪终端对，在 slave 端启动 bash 或 zsh 子进程：
+
+```
+┌──────────────────────┐
+│    cosh-shell        │
+│  ┌────────────────┐  │       ┌──────────────┐
+│  │  PTY master    │──────────│  bash/zsh    │
+│  └────────────────┘  │       │  (PTY slave) │
+│  ┌────────────────┐  │       └──────────────┘
+│  │  OSC Parser    │  │
+│  └────────────────┘  │
+└──────────────────────┘
+```
+
+### Shell 选择
+
+```bash
+cosh-shell                    # 默认使用 auto（自动检测）
+cosh-shell --shell zsh        # 使用 zsh
+cosh-shell raw qwen --shell zsh
+```
+
+Shell 选择优先级：
+1. `--shell` 参数
+2. `COSH_SHELL_RAW_SHELL` 环境变量
+3. 配置文件 `shell.default`
+4. 自动检测（默认 bash）
+
+### 运行模式
+
+| 模式 | 说明 |
+|------|------|
+| 默认（无子命令） | 使用配置的适配器启动交互式 shell |
+| `raw [adapter]` | 显式指定适配器 |
+| `-c <command>` | 执行命令后退出（直通底层 shell） |
+| `-- <command>` | 直接执行命令后退出 |
+| `--isolated` | 隔离模式，不加载用户 rcfile |
+| `--login` / `-l` | 作为登录 shell 启动 |
+
+## OSC 标记系统
+
+cosh-shell 注入自定义 rcfile（bashrc/zshrc）到子 shell，通过 OSC 1337 转义序列标记命令生命周期：
+
+```
+ESC]1337;COSH;<payload>BEL
+```
+
+标记的事件包括：
+- Shell 就绪（prompt 显示）
+- 命令开始执行（preexec）
+- 命令执行结束（precmd，携带退出码）
+- 工作目录变更
+
+这些标记使 cosh-shell 精确识别：
+1. 用户何时输入命令
+2. 命令何时开始/结束
+3. 命令的退出码
+4. 当前工作目录
+
+## 输入分类
+
+用户在 shell 中的输入被分类为以下类型：
+
+| 类型 | 说明 | 示例 |
+|------|------|------|
+| Shell 命令 | 普通 shell 命令 | `ls -la`、`git status` |
+| Slash 命令 | `/` 开头的内置控制命令 | `/help`、`/mode` |
+| Natural Language | 自然语言提问 | 由 AI 适配器处理 |
+| Agent Marker | Agent 执行标记 | 内部使用 |
+
+## Slash 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/help` | 显示帮助信息 |
+| `/mode [approval\|analysis] [value]` | 查看或切换模式 |
+| `/config [key] [value]` | 查看或修改运行时配置 |
+| `/hooks [list\|enable\|disable] [name]` | 管理钩子 |
+| `/extensions [list\|enable\|disable] [name]` | 管理扩展 |
+| `/skills [list\|enable\|disable] [name]` | 管理技能 |
+| `/debug [state\|events\|adapter]` | 调试信息 |
+| `/auth` | 触发认证流程 |
+
+## 启动流程
+
+1. 解析命令行参数（shell 类型、适配器、模式）
+2. 安装终端恢复处理（SIGTERM/SIGHUP/panic 时恢复 termios）
+3. 加载配置（`~/.copilot-shell/config.toml`）
+4. 初始化日志（文件输出到 `~/.copilot-shell/logs/`）
+5. 创建 PTY 会话，启动 bash/zsh 子进程
+6. 注入 OSC 标记脚本
+7. 启动 AI 适配器连接
+8. 渲染启动横幅（COSH logo + 适配器/shell/审批模式信息）
+9. 进入主事件循环
+
+## 终端恢复
+
+cosh-shell 在以下场景自动恢复终端状态（termios）：
+
+- 进程收到 SIGTERM / SIGHUP / SIGQUIT
+- panic 触发
+- 正常退出
+
+确保异常退出时终端不会留在 raw mode。
+
+## Native 模式 vs 隔离模式
+
+| 特性 | Native 模式（默认） | 隔离模式（`--isolated`） |
+|------|---------------------|--------------------------|
+| 用户 rcfile | 加载（~/.bashrc 等） | 跳过 |
+| PS1 提示符 | 保留用户设置 | 使用 `cosh-osc$ ` |
+| 历史记录 | 加载 $HISTFILE | 不加载 |
+| 环境变量 | 继承 | 最小化 |
+
+## 会话工作目录
+
+cosh-shell 在 `~/.copilot-shell/` 下为每个会话创建工作目录，存储：
+
+- OSC 标记脚本
+- 命令输出引用（24 小时自动清理）
+- 终端恢复请求文件
+- Shell handoff 请求文件

--- a/docs/cosh-ng/zh/users/shell/overview.md
+++ b/docs/cosh-ng/zh/users/shell/overview.md
@@ -1,0 +1,101 @@
+# cosh-shell 总览
+
+cosh-shell 是 cosh-ng 的 AI 增强交互式终端。它在原生 bash/zsh PTY 之上叠加
+AI 分析能力、工具审批控制和内联卡片渲染，为用户提供安全、可观测的 Agent
+交互体验。
+
+## 定位
+
+cosh-shell 是面向终端用户的前端层：
+
+- 管理 PTY 主机（bash/zsh 子进程）
+- 通过 AI 适配器连接后端（默认 cosh-core）
+- 渲染审批卡片和 AI 分析结果
+- 实施工具审批控制协议
+
+## 运行模式
+
+```bash
+# 默认启动（使用配置中的适配器和 shell）
+cosh-shell
+
+# 显式指定适配器（位置参数）
+cosh-shell raw cosh-core
+cosh-shell raw claude
+cosh-shell raw qwen
+
+# 指定底层 shell
+cosh-shell --shell zsh
+cosh-shell raw co --shell bash
+
+# 直通模式：执行单条命令后退出
+cosh-shell -c 'ls -la'
+cosh-shell -- git status
+
+# 登录 shell 模式
+cosh-shell --login
+cosh-shell -l
+
+# 隔离模式（跳过用户 rcfile）
+cosh-shell --isolated
+```
+
+## 支持的 AI 适配器
+
+| 适配器 | 后端 | 说明 |
+|--------|------|------|
+| `cosh-core` | cosh-core 进程 | 默认适配器，完整控制协议 |
+| `claude` | Claude Code CLI | Claude 适配器 |
+| `qwen` | Qwen Code CLI | 通义千问适配器 |
+| `fake` | 模拟 | 开发测试用，无需后端 |
+
+## 适配器能力
+
+| 能力 | 说明 |
+|------|------|
+| `text_stream` | 文本流式输出 |
+| `thinking_stream` | 思考过程流式输出 |
+| `session_resume` | 会话恢复 |
+| `tool_intent` | 工具调用意图感知 |
+| `user_question` | 向用户提问 |
+| `cancellable` | 支持取消运行中的请求 |
+| `control_protocol` | 完整控制协议支持 |
+
+## 核心功能
+
+| 功能 | 说明 | 详细文档 |
+|------|------|----------|
+| PTY 交互 | bash/zsh 原生终端 | [interactive-mode.md](interactive-mode.md) |
+| AI 分析 | 流式命令分析 | [ai-analysis.md](ai-analysis.md) |
+| 工具审批 | 可视化审批卡片 | [approval.md](approval.md) |
+
+## 架构概览
+
+```
+┌────────────────────────────────────────────┐
+│                 cosh-shell                 │
+│  ┌───────────┐  ┌──────────┐  ┌─────────┐  │
+│  │ PTY Host  │  │ Adapter  │  │   UI    │  │
+│  │ (bash/zsh)│  │(cosh-core│  │(ratatui)│  │
+│  └───────────┘  │/claude..)│  └─────────┘  │
+│  ┌───────────┐  └──────────┘  ┌─────────┐  │
+│  │  Hooks    │  ┌──────────┐  │Approval │  │
+│  │  Engine   │  │  Tools   │  │ Broker  │  │
+│  └───────────┘  └──────────┘  └─────────┘  │
+└────────────────────────────────────────────┘
+         │                │
+         ▼                ▼
+    bash/zsh PTY     cosh-core 进程
+```
+
+## 配置
+
+cosh-shell 特有配置位于 `~/.copilot-shell/config.toml` 的 `[ui]` 和 `[shell]`
+段。详见 [配置文档](../configuration.md)。
+
+## 项目信任
+
+cosh-shell 维护项目级信任存储。首次在新项目目录启动时，提示用户确认是否信任该项目。信任状态决定：
+
+- 是否加载项目目录下的 `.cosh/hooks`
+- 是否应用项目级配置覆盖

--- a/docs/cosh-ng/zh/users/supported-distros.md
+++ b/docs/cosh-ng/zh/users/supported-distros.md
@@ -1,0 +1,43 @@
+# 支持的发行版
+
+cosh-ng 通过读取 `/etc/os-release`（Linux）或调用 `sw_vers`（macOS）自动检测
+当前操作系统，并路由到对应的包管理器和服务管理器后端。
+
+## 支持矩阵
+
+| 发行版 | 包管理器 | 服务管理器 | 备注 |
+|--------|----------|------------|------|
+| Alinux (2/3/4) | dnf | systemd | 阿里云原生 Linux |
+| CentOS 7/8/9 | dnf | systemd | |
+| Fedora | dnf | systemd | |
+| Ubuntu | apt-get | systemd | |
+| Debian | apt-get | systemd | |
+| openSUSE Leap/Tumbleweed | zypper | systemd | |
+| macOS | brew | — | 仅 pkg 子系统可用 |
+
+## 检测逻辑
+
+发行版检测通过 `Distro::detect()` 实现：
+
+1. 编译目标为 macOS 时，调用 `sw_vers -productVersion` 获取版本
+2. Linux 系统读取 `/etc/os-release`，解析 `ID` 和 `VERSION_ID` 字段
+3. 根据 `ID` 映射到已知发行版变体
+4. 未识别的 `ID` 归入 `Unknown`，大多数操作返回 `UnsupportedDistro` 错误
+
+## 包管理器映射
+
+| 发行版 ID | 包管理器 | 安装命令 | 搜索命令 |
+|-----------|----------|----------|----------|
+| alinux / centos / fedora | Dnf | `dnf install -y` | `dnf search -q` |
+| ubuntu / debian | Apt | `apt-get install -y` | `apt-cache search` |
+| opensuse-leap / opensuse-tumbleweed / sles | Zypper | `zypper install -y` | `zypper search` |
+| macOS | Brew | `brew install` | `brew search` |
+
+## 服务管理器
+
+所有 Linux 发行版统一使用 systemd（`systemctl`）。macOS 不支持 svc 子系统。
+
+## 添加新发行版支持
+
+如需支持新的发行版，参见开发者文档
+[新增发行版适配指南](../developers/adding-distros.md)。

--- a/src/cosh-ng/docs
+++ b/src/cosh-ng/docs
@@ -1,0 +1,1 @@
+../../docs/cosh-ng


### PR DESCRIPTION
## Description

Add comprehensive user and developer documentation for the cosh-ng component. The documentation covers quickstart, configuration, CLI commands, shell interaction, core modules (providers, hooks, tools, skills, extensions, headless mode), and developer guides (architecture, testing, contributing, adding commands/distros, IPC protocol, security heuristics). Both Chinese (zh) and English (en) versions are provided with identical structure.

## Related Issue

no-issue: Initial documentation creation for cosh-ng component

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `docs`

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Documentation-only change, no code tests required. Verified all 54 markdown files render correctly with consistent structure between zh and en.

## Additional Notes

Directory structure:
- `docs/cosh-ng/zh/` — 27 Chinese documentation files
- `docs/cosh-ng/en/` — 27 English documentation files (1:1 translation)

Categories:
- `users/` — Quickstart, configuration, supported distros, output format, core modules, CLI commands, shell interaction
- `developers/` — Architecture, testing, contributing, adding commands, adding distros, IPC protocol, security heuristics
