### PR TITLE
fix(ckpt): rollback offset removal, cron absolute path, and misc fixes

### DIFF
--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -2329,7 +2329,8 @@ mod tests {
 
     #[test]
     fn load_config_file_nonexistent_returns_default() {
-        let fc = load_config_file(Path::new("/nonexistent/config.toml")).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let fc = load_config_file(&dir.path().join("config.toml")).unwrap();
         assert_eq!(fc, FileConfig::default());
     }
 

--- a/src/ws-ckpt/src/plugins/hermes/__init__.py
+++ b/src/ws-ckpt/src/plugins/hermes/__init__.py
@@ -125,6 +125,10 @@ def _on_session_end(
     """Handle on_session_end — create a checkpoint after the turn."""
     manager = get_manager()
 
+    if manager.skip_next_auto_checkpoint:
+        manager.skip_next_auto_checkpoint = False
+        return
+
     if not manager.config.auto_checkpoint:
         return
 

--- a/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
+++ b/src/ws-ckpt/src/plugins/hermes/checkpoint_manager.py
@@ -99,6 +99,7 @@ class CheckpointManager:
     def __init__(self, config: HermesPluginConfig) -> None:
         self._config = config
         self._turn_count: int = 0
+        self.skip_next_auto_checkpoint: bool = False
 
     @property
     def config(self) -> HermesPluginConfig:

--- a/src/ws-ckpt/src/plugins/hermes/cron.py
+++ b/src/ws-ckpt/src/plugins/hermes/cron.py
@@ -20,7 +20,7 @@ _MARKER_RE_UNQUOTED = re.compile(r"ws-ckpt\s+checkpoint\s+.*-w\s+(\S+)")
 def _build_cron_line(workspace: str, schedule: str) -> str:
     quoted_ws = "'" + workspace.replace("'", "'\\''") + "'"
     return (
-        f"{schedule} ws-ckpt checkpoint -w {quoted_ws}"
+        f"{schedule} /usr/local/bin/ws-ckpt checkpoint -w {quoted_ws}"
         f' -s "cron-$(date +\\%s)"'
         f' -m "scheduled snapshot"'
         f" --metadata '{{\"auto\":true,\"type\":\"cron\"}}'"

--- a/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_init.py
+++ b/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_init.py
@@ -72,6 +72,7 @@ class TestOnSessionEnd:
         cfg = HermesPluginConfig(workspace="/ws", auto_checkpoint=False)
         mgr = MagicMock(spec=CheckpointManager)
         type(mgr).config = PropertyMock(return_value=cfg)
+        mgr.skip_next_auto_checkpoint = False
         mock_get_mgr.return_value = mgr
         import hermes as h
         h._on_session_end()
@@ -82,6 +83,7 @@ class TestOnSessionEnd:
         cfg = HermesPluginConfig(workspace="/ws", auto_checkpoint=True)
         mgr = MagicMock(spec=CheckpointManager)
         type(mgr).config = PropertyMock(return_value=cfg)
+        mgr.skip_next_auto_checkpoint = False
         mgr.advance_turn.return_value = 1
         mgr.create_checkpoint.return_value = CheckpointResult(
             success=True, message="ok", snapshot="s1"
@@ -102,6 +104,7 @@ class TestOnSessionEnd:
         cfg = HermesPluginConfig(workspace="/ws", auto_checkpoint=True)
         mgr = MagicMock(spec=CheckpointManager)
         type(mgr).config = PropertyMock(return_value=cfg)
+        mgr.skip_next_auto_checkpoint = False
         mgr.advance_turn.return_value = 1
         mgr.create_checkpoint.return_value = CheckpointResult(
             success=True, message="ok", snapshot="s1"

--- a/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_tools.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hermes.checkpoint_manager import get_manager
 from hermes.tools import (
     _parse_workspace_policy_json,
     _render_workspace_policy,
@@ -313,6 +314,33 @@ class TestHandlers:
         cmd_args = mock_cmd.call_args[0][0]
         assert "-n" in cmd_args
         assert "2" in cmd_args
+
+    @patch("hermes.tools._run_ws_ckpt_cmd", return_value=(True, "rolled back"))
+    @patch("hermes.tools._reject_if_cwd_inside_workspace", return_value=None)
+    @patch("hermes.tools._resolve_workspace", return_value=("/ws", None))
+    def test_rollback_sets_skip_flag(self, _ws, _cwd, _cmd):
+        mgr = get_manager()
+        mgr.skip_next_auto_checkpoint = False
+        handle_ws_ckpt_rollback({"target": "snap1"})
+        assert mgr.skip_next_auto_checkpoint is True
+
+    @patch("hermes.tools._run_ws_ckpt_cmd", return_value=(True, "preview"))
+    @patch("hermes.tools._reject_if_cwd_inside_workspace")
+    @patch("hermes.tools._resolve_workspace", return_value=("/ws", None))
+    def test_rollback_preview_does_not_set_skip_flag(self, _ws, _cwd, _cmd):
+        mgr = get_manager()
+        mgr.skip_next_auto_checkpoint = False
+        handle_ws_ckpt_rollback({"target": "snap1", "preview": True})
+        assert mgr.skip_next_auto_checkpoint is False
+
+    @patch("hermes.tools._run_ws_ckpt_cmd", return_value=(False, "failed"))
+    @patch("hermes.tools._reject_if_cwd_inside_workspace", return_value=None)
+    @patch("hermes.tools._resolve_workspace", return_value=("/ws", None))
+    def test_rollback_failure_does_not_set_skip_flag(self, _ws, _cwd, _cmd):
+        mgr = get_manager()
+        mgr.skip_next_auto_checkpoint = False
+        handle_ws_ckpt_rollback({"target": "snap1"})
+        assert mgr.skip_next_auto_checkpoint is False
 
     @patch("hermes.tools._run_ws_ckpt_cmd", return_value=(True, "Rollback preview\nM  file.txt"))
     @patch("hermes.tools._reject_if_cwd_inside_workspace")

--- a/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tests/test_hermes_tools.py
@@ -312,7 +312,7 @@ class TestHandlers:
         assert result["success"] is True
         cmd_args = mock_cmd.call_args[0][0]
         assert "-n" in cmd_args
-        assert "3" in cmd_args  # 2 + 1 offset
+        assert "2" in cmd_args
 
     @patch("hermes.tools._run_ws_ckpt_cmd", return_value=(True, "Rollback preview\nM  file.txt"))
     @patch("hermes.tools._reject_if_cwd_inside_workspace")

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -692,6 +692,8 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
     if preview:
         cmd.append("--preview")
     success, output = _run_ws_ckpt_cmd(cmd)
+    if success and not preview:
+        get_manager().skip_next_auto_checkpoint = True
     return _ok(output) if success else _err(output)
 
 

--- a/src/ws-ckpt/src/plugins/hermes/tools.py
+++ b/src/ws-ckpt/src/plugins/hermes/tools.py
@@ -686,9 +686,7 @@ def handle_ws_ckpt_rollback(args: Dict[str, Any], **_kwargs) -> str:
             return rejection
 
     if num_ancestors is not None:
-        # Plugin snapshots after each response, so head == current state;
-        # +1 so user's "go back 1 step" skips the head snapshot.
-        cmd = ["ws-ckpt", "rollback", "-w", workspace, "-n", str(int(num_ancestors) + 1)]
+        cmd = ["ws-ckpt", "rollback", "-w", workspace, "-n", str(num_ancestors)]
     else:
         cmd = ["ws-ckpt", "rollback", "-w", workspace, "-s", target]
     if preview:

--- a/src/ws-ckpt/src/plugins/openclaw/src/__tests__/commands.test.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/__tests__/commands.test.ts
@@ -234,14 +234,14 @@ describe("CommandExecutor", () => {
   });
 
   describe("rollback — numAncestors", () => {
-    it("passes numAncestors+1 to CLI", async () => {
+    it("passes numAncestors as-is when autoCheckpoint is not enabled", async () => {
       mockSuccess("rolled back");
       const exec = new CommandExecutor();
       const r = await exec.rollback("/ws", undefined, 2);
       expect(r.exitCode).toBe(0);
       const args = promisifiedMock.mock.calls[0][1];
       expect(args).toContain("--num-ancestors");
-      expect(args).toContain("3");
+      expect(args).toContain("2");
     });
 
     it("throws when neither target nor numAncestors", async () => {

--- a/src/ws-ckpt/src/plugins/openclaw/src/__tests__/handlers.test.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/__tests__/handlers.test.ts
@@ -150,6 +150,7 @@ describe("handlers — validation", () => {
     pluginState.manager = origManager;
     pluginState.environmentReady = origReady;
     pluginState.resolvedConfig = origConfig;
+    pluginState.skipNextAutoCheckpoint = false;
   });
 
   it("handleCheckpoint requires id", async () => {
@@ -196,6 +197,38 @@ describe("handlers — validation", () => {
     const r = await handleRollback("snap1");
     expect(r.isError).toBe(false);
     expect(r.text).toContain("snap1");
+  });
+
+  it("handleRollback sets skipNextAutoCheckpoint on success", async () => {
+    mockManager.rollback.mockResolvedValue({
+      success: true,
+      target: "snap1",
+      message: "Rolled back to snap1",
+    });
+    pluginState.skipNextAutoCheckpoint = false;
+    await handleRollback("snap1");
+    expect(pluginState.skipNextAutoCheckpoint).toBe(true);
+  });
+
+  it("handleRollback does not set skipNextAutoCheckpoint on preview", async () => {
+    mockManager.rollback.mockResolvedValue({
+      success: true,
+      target: "snap1",
+      message: "Preview",
+    });
+    pluginState.skipNextAutoCheckpoint = false;
+    await handleRollback("snap1", undefined, undefined, true);
+    expect(pluginState.skipNextAutoCheckpoint).toBe(false);
+  });
+
+  it("handleRollback does not set skipNextAutoCheckpoint on failure", async () => {
+    mockManager.rollback.mockResolvedValue({
+      success: false,
+      message: "failed",
+    });
+    pluginState.skipNextAutoCheckpoint = false;
+    await handleRollback("snap1");
+    expect(pluginState.skipNextAutoCheckpoint).toBe(false);
   });
 
   it("handleListCheckpoints empty", async () => {

--- a/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/commands.ts
@@ -108,9 +108,7 @@ export class CommandExecutor {
     }
     const args = ["rollback", "--workspace", workspace];
     if (numAncestors !== undefined) {
-      // Plugin snapshots after each response, so head == current state;
-      // +1 so user's "go back 1 step" skips the head snapshot.
-      args.push("--num-ancestors", String(numAncestors + 1));
+      args.push("--num-ancestors", String(numAncestors));
     } else if (target) {
       args.push("--snapshot", target);
     }

--- a/src/ws-ckpt/src/plugins/openclaw/src/cron.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/cron.ts
@@ -20,7 +20,7 @@ function shellQuote(s: string): string {
 
 function buildCronLine(workspace: string, schedule: string): string {
   return (
-    `${schedule} ws-ckpt checkpoint -w ${shellQuote(workspace)}` +
+    `${schedule} /usr/local/bin/ws-ckpt checkpoint -w ${shellQuote(workspace)}` +
     ` -s "cron-$(date +\\%s)"` +
     ` -m "scheduled snapshot"` +
     ` --metadata '{"auto":true,"type":"cron"}'` +

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -125,10 +125,17 @@ export async function handleRollback(
   }
 
   if (workspace?.trim()) {
-    return runRollbackViaExecutor(resolvedWs, trimmed || undefined, numAncestors, preview);
+    const execResult = await runRollbackViaExecutor(resolvedWs, trimmed || undefined, numAncestors, preview);
+    if (!execResult.isError && !preview) {
+      pluginState.skipNextAutoCheckpoint = true;
+    }
+    return execResult;
   }
 
   const result = await pluginState.manager.rollback(trimmed || undefined, numAncestors, preview);
+  if (result.success && !preview) {
+    pluginState.skipNextAutoCheckpoint = true;
+  }
   return { text: result.message, isError: !result.success };
 }
 

--- a/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/handlers.ts
@@ -434,6 +434,10 @@ export async function handleConfig(
       const schedules = pluginState.resolvedConfig.cronSchedules ?? [];
       const warnings = await CrontabManager.migrate(oldWs, value, schedules);
       const persistErr = persistConfig({ workspace: value });
+      // Re-initialize manager with new workspace so subsequent commands use it
+      if (pluginState.manager) {
+        await pluginState.manager.ensureWorkspace(value);
+      }
       let msg = `Config updated: workspace = ${value}`;
       if (persistErr) msg += `\n\nWARNING: Failed to persist config: ${persistErr}. Change is in-memory only.`;
       if (warnings.length > 0) msg += "\n\n" + warnings.join("\n");

--- a/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
@@ -104,7 +104,10 @@ export function registerHooks(api: OpenClawPluginApi, config: PluginConfig): voi
           console.warn("[ws-ckpt] Cron sync error:", err instanceof Error ? err.message : String(err));
         }
       }
+    }
+
     if (!config.autoCheckpoint) return;
+    const workspace = pluginState.resolvedConfig?.workspace;
     if (!pluginState.manager || !pluginState.environmentReady || !workspace) return;
 
     const cwdCheckStart = cwdInsideWorkspace(workspace);

--- a/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/hooks.ts
@@ -52,6 +52,10 @@ export function registerHooks(api: OpenClawPluginApi, config: PluginConfig): voi
 
   // Hook: agent_end — create end-of-turn checkpoint
   api.on("agent_end", async (_event: unknown) => {
+    if (pluginState.skipNextAutoCheckpoint) {
+      pluginState.skipNextAutoCheckpoint = false;
+      return;
+    }
     if (!config.autoCheckpoint) return;
     if (!pluginState.manager || !pluginState.environmentReady) return;
 
@@ -100,10 +104,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PluginConfig): voi
           console.warn("[ws-ckpt] Cron sync error:", err instanceof Error ? err.message : String(err));
         }
       }
-    }
-
     if (!config.autoCheckpoint) return;
-    const workspace = pluginState.resolvedConfig?.workspace;
     if (!pluginState.manager || !pluginState.environmentReady || !workspace) return;
 
     const cwdCheckStart = cwdInsideWorkspace(workspace);

--- a/src/ws-ckpt/src/plugins/openclaw/src/state.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/src/state.ts
@@ -27,6 +27,9 @@ export const pluginState = {
 
   /** Resolved plugin config for inspection via ws-ckpt-config tool. */
   resolvedConfig: null as PluginConfig | null,
+
+  /** One-shot flag: skip the next turn-end auto-checkpoint (set after rollback). */
+  skipNextAutoCheckpoint: false,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/ws-ckpt/src/plugins/openclaw/vitest.config.ts
+++ b/src/ws-ckpt/src/plugins/openclaw/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    pool: "threads",
     coverage: {
       provider: "v8",
       thresholds: {


### PR DESCRIPTION
## Description

- 移除 rollback numAncestors 的 +1 偏移，直接按用户指定值传递给 CLI
- crontab 入口使用 /usr/local/bin/ws-ckpt 绝对路径
- workspace config 更新后调用 ensureWorkspace() 同步状态
- vitest 配置添加 pool: "threads"
- load_config_file 测试使用 tempdir 替代硬编码 /nonexistent/ 路径

### rollback -n offset 移除

hermes（tools.py）和 openclaw（commands.ts）的 rollback 此前在 autoCheckpoint 启用时会对 numAncestors +1 以跳过 head snapshot。现在统一去掉这个偏移，让用户直接控制回退步数。同步更新了两端的测试。

### cron 绝对路径

cron.py 和 cron.ts 写入 crontab 的命令从 bare `ws-ckpt` 改为 `/usr/local/bin/ws-ckpt`，避免 cron 环境下 PATH 找不到二进制。

## Related Issue

no-issue: 自主发现 bug 修复

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

## Additional Notes