### PR TITLE
feat(tokenless): integrate stash into response compression + retrieve CLI

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde_json",
+ "tokenless-ccr",
  "tokenless-schema",
  "tokenless-stats",
  "toon-format",
@@ -760,6 +761,7 @@ version = "0.6.0"
 dependencies = [
  "regex",
  "serde_json",
+ "tokenless-ccr",
 ]
 
 [[package]]

--- a/src/tokenless/crates/tokenless-ccr/src/lib.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/lib.rs
@@ -28,5 +28,7 @@ pub use backends::in_memory::InMemoryStore;
 #[cfg(feature = "sqlite")]
 pub use backends::sqlite::SqliteStore;
 pub use key::compute_key;
-pub use marker::{MARKER_PREFIX, MARKER_SUFFIX, extract_hash, marker_for, parse_marker};
+pub use marker::{
+    MARKER_PREFIX, MARKER_SUFFIX, extract_hash, is_valid_hash, marker_for, parse_marker,
+};
 pub use store::{StashError, StashStore};

--- a/src/tokenless/crates/tokenless-ccr/src/marker.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/marker.rs
@@ -38,13 +38,17 @@ pub fn extract_hash(text: &str) -> Option<&str> {
     Some(hash)
 }
 
-/// A valid stash key is exactly 24 lowercase hex characters.
+/// Whether `hash` is a valid stash key: exactly 24 ASCII hex characters
+/// (case-insensitive — keys are stored lowercase, lookups normalize). Public
+/// so callers can validate a bare hash before a DB round-trip and surface a
+/// clear format error to the user.
+pub fn is_valid_hash(hash: &str) -> bool {
+    hash.len() == 24 && hash.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// A valid stash key is exactly 24 ASCII hex characters.
 fn validate_hash(hash: &str) -> Option<()> {
-    if hash.len() == 24 && hash.bytes().all(|b| b.is_ascii_hexdigit()) {
-        Some(())
-    } else {
-        None
-    }
+    if is_valid_hash(hash) { Some(()) } else { None }
 }
 
 #[cfg(test)]
@@ -57,6 +61,21 @@ mod tests {
         let marker = marker_for(hash);
         assert_eq!(marker, "<<tokenless:0123456789abcdef01234567>>");
         assert_eq!(parse_marker(&marker), Some(hash));
+    }
+
+    #[test]
+    fn is_valid_hash_accepts_24_hex_case_insensitive() {
+        assert!(is_valid_hash("0123456789abcdef01234567"));
+        assert!(is_valid_hash("ABCDEF0123456789ABCDEF01")); // uppercase ok
+    }
+
+    #[test]
+    fn is_valid_hash_rejects_malformed() {
+        assert!(!is_valid_hash("0123456789abcdef0123456")); // 23 chars
+        assert!(!is_valid_hash("0123456789abcdef0123456789")); // 26 chars
+        assert!(!is_valid_hash("ZZZZZZZZZZZZZZZZZZZZZZZZ")); // non-hex
+        assert!(!is_valid_hash(""));
+        assert!(!is_valid_hash("/some/path"));
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-cli/Cargo.toml
+++ b/src/tokenless/crates/tokenless-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 tokenless-schema = { path = "../tokenless-schema" }
 tokenless-stats = { path = "../tokenless-stats" }
+tokenless-ccr = { path = "../tokenless-ccr" }
 dirs.workspace = true
 clap.workspace = true
 serde_json.workspace = true

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -5,6 +5,8 @@ use clap::{Parser, Subcommand};
 use std::fs;
 use std::io::{self, Read};
 use std::process;
+use std::sync::Arc;
+use tokenless_ccr::{SqliteStore, StashStore, extract_hash, is_valid_hash};
 use tokenless_schema::{ResponseCompressor, SchemaCompressor};
 use tokenless_stats::{
     CompressionMode, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
@@ -66,6 +68,25 @@ enum Commands {
         /// Max nesting depth before truncation
         #[arg(long)]
         max_depth: Option<usize>,
+        /// Disable reversible stash. By default, dropped array items are
+        /// stashed so they can be retrieved via `tokenless retrieve`; this
+        /// flag makes truncation lossy (the pre-stash behavior).
+        #[arg(long)]
+        no_stash: bool,
+        /// Override the stash database path (default ~/.tokenless/stash.db).
+        /// Resolved under the trusted home directory; rejected if outside.
+        #[arg(long)]
+        stash_db: Option<String>,
+    },
+    /// Retrieve a stashed payload by its hash key. Accepts a bare 24-hex hash
+    /// or any text containing a `<<tokenless:HASH>>` marker (the marker is
+    /// extracted automatically).
+    Retrieve {
+        /// The stash hash, or a line containing a `<<tokenless:HASH>>` marker.
+        hash: String,
+        /// Override the stash database path (default ~/.tokenless/stash.db).
+        #[arg(long)]
+        stash_db: Option<String>,
     },
     /// View and export statistics
     #[command(subcommand)]
@@ -292,6 +313,70 @@ fn open_recorder() -> Result<StatsRecorder, (String, i32)> {
     StatsRecorder::new(get_db_path()).map_err(|e| (format!("Failed to open database: {}", e), 1))
 }
 
+/// Resolve the stash database path under the trusted home directory.
+///
+/// Mirrors `get_db_path`'s trust model (passwd-rooted home, validated env
+/// override) so an attacker cannot redirect the stash to a system-critical
+/// location by setting `TOKENLESS_STASH_DB` or passing `--stash-db`. Returns
+/// `None` when no trusted home anchor exists or an override is rejected —
+/// callers fail open (no stash, lossy truncation) rather than writing state
+/// to an untrusted location.
+fn get_stash_db_path(override_path: Option<&str>) -> Option<String> {
+    let home = get_home_dir();
+    if home.is_empty() {
+        eprintln!("[tokenless] no home directory available — stash disabled");
+        return None;
+    }
+    // An explicit --stash-db override is validated the same way as the
+    // TOKENLESS_STASH_DB env var: on rejection we warn AND fall back to the
+    // default under the trusted home (rather than silently disabling the
+    // stash), so a typo doesn't quietly drop reversibility.
+    if let Some(p) = override_path.filter(|s| !s.is_empty()) {
+        match validate_db_path(p, &home) {
+            Ok(valid) => return Some(valid),
+            Err(reason) => eprintln!("[tokenless] rejecting --stash-db {}: {}", p, reason),
+        }
+    }
+    match std::env::var("TOKENLESS_STASH_DB") {
+        Ok(env_path) if !env_path.is_empty() => match validate_db_path(&env_path, &home) {
+            Ok(path) => Some(path),
+            Err(reason) => {
+                eprintln!("[tokenless] ignoring TOKENLESS_STASH_DB: {}", reason);
+                Some(format!("{}/.tokenless/stash.db", home))
+            }
+        },
+        _ => Some(format!("{}/.tokenless/stash.db", home)),
+    }
+}
+
+/// Open a stash store, returning the specific failure cause. Used by
+/// user-initiated paths (`retrieve`) where a generic "unavailable" message
+/// would hide the real reason (no home, path rejected, corrupt DB, …).
+fn open_stash_store_or_err(override_path: Option<&str>) -> Result<Arc<dyn StashStore>, String> {
+    let path = get_stash_db_path(override_path)
+        .ok_or_else(|| "no trusted home directory available for stash db".to_string())?;
+    if let Some(parent) = std::path::Path::new(&path).parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("cannot create stash directory {}: {}", parent.display(), e))?;
+    }
+    SqliteStore::new(&path)
+        .map_err(|e| format!("cannot open stash db at {}: {}", path, e))
+        .map(|s| Arc::new(s) as Arc<dyn StashStore>)
+}
+
+/// Open a stash store, failing open to `None` on any error. Compression
+/// proceeds without stash (lossy truncation) when the home anchor is missing,
+/// the parent directory cannot be created, or the database cannot be opened.
+fn open_stash_store(override_path: Option<&str>) -> Option<Arc<dyn StashStore>> {
+    match open_stash_store_or_err(override_path) {
+        Ok(store) => Some(store),
+        Err(e) => {
+            eprintln!("[tokenless] stash disabled: {}", e);
+            None
+        }
+    }
+}
+
 fn run() -> Result<(), (String, i32)> {
     let cli = Cli::parse();
 
@@ -362,6 +447,8 @@ fn run() -> Result<(), (String, i32)> {
             truncate_strings_at,
             truncate_arrays_at,
             max_depth,
+            no_stash,
+            stash_db,
         } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
             let value: serde_json::Value = serde_json::from_str(&input)
@@ -377,6 +464,21 @@ fn run() -> Result<(), (String, i32)> {
             if let Some(v) = max_depth {
                 compressor = compressor.with_max_depth(v);
             }
+            // Load config before deciding on the stash so we can skip it
+            // entirely when compression is disabled (dry-run). Attaching the
+            // stash in dry-run would write entries whose `<<tokenless:KEY>>`
+            // markers never reach the LLM (the original input is emitted),
+            // orphaning them.
+            let config = TokenlessConfig::load();
+            let compression_on = config.is_compression_enabled();
+            let stash = if no_stash || !compression_on {
+                None
+            } else {
+                open_stash_store(stash_db.as_deref())
+            };
+            if let Some(ref store) = stash {
+                compressor = compressor.with_stash_store(store.clone());
+            }
             let result = compressor.compress(&value);
             let after_compact = serde_json::to_string(&result).unwrap_or_else(|_| String::new());
 
@@ -387,13 +489,16 @@ fn run() -> Result<(), (String, i32)> {
                     "tokenless: response compression did not reduce size ({} -> {} est. tokens), outputting original",
                     before_tokens, after_tokens
                 );
+                // No-savings discard edge: if a stash was attached and an
+                // array was truncated, those writes orphan (markers live in
+                // `after_compact`, which is discarded). Truncation almost
+                // always yields savings, so this is rare; orphaned entries
+                // are TTL-cleaned.
                 input.clone()
             } else {
                 after_compact.clone()
             };
 
-            let config = TokenlessConfig::load();
-            let compression_on = config.is_compression_enabled();
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             let emit_text = if compression_on {
                 output_text.clone()
@@ -412,6 +517,43 @@ fn run() -> Result<(), (String, i32)> {
                 output_text,
                 mode,
             );
+        }
+        Commands::Retrieve { hash, stash_db } => {
+            let store = match open_stash_store_or_err(stash_db.as_deref()) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Err((format!("stash unavailable: {}", e), 1));
+                }
+            };
+            // Accept either a bare 24-hex hash or text containing a marker;
+            // extract_hash validates the embedded hash. When no marker is
+            // found, validate the bare hash format before the DB round-trip
+            // so a mistaken non-hash argument (e.g. a file path) gets a clear
+            // format error instead of a misleading "no stashed payload".
+            let key = match extract_hash(&hash) {
+                Some(h) => h.to_string(),
+                None if is_valid_hash(&hash) => hash.to_string(),
+                None => {
+                    return Err((
+                        format!(
+                            "invalid stash hash: {:?} (expected 24 hex chars or a <<tokenless:HASH>> marker)",
+                            hash
+                        ),
+                        1,
+                    ));
+                }
+            };
+            match store.retrieve(&key) {
+                Ok(Some(payload)) => {
+                    println!("{}", payload);
+                }
+                Ok(None) => {
+                    return Err((format!("no stashed payload for hash: {}", key), 1));
+                }
+                Err(e) => {
+                    return Err((format!("stash retrieve failed: {}", e), 1));
+                }
+            }
         }
         Commands::Stats(stats_cmd) => {
             let recorder = open_recorder()?;

--- a/src/tokenless/crates/tokenless-schema/Cargo.toml
+++ b/src/tokenless/crates/tokenless-schema/Cargo.toml
@@ -8,3 +8,6 @@ description = "Schema and response compression for LLM token optimization"
 [dependencies]
 serde_json.workspace = true
 regex.workspace = true
+# Stash trait + key + marker only — no SQLite backend here. The CLI supplies
+# the concrete backend, so the schema crate stays free of rusqlite.
+tokenless-ccr = { path = "../tokenless-ccr", default-features = false }

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -1,5 +1,7 @@
 use serde_json::{Map, Value};
 use std::collections::HashSet;
+use std::sync::Arc;
+use tokenless_ccr::{StashStore, marker_for};
 
 /// ResponseCompressor compresses API responses by truncating strings,
 /// limiting array sizes, removing null values, and dropping debug fields.
@@ -11,6 +13,13 @@ pub struct ResponseCompressor {
     drop_empty_fields: bool,
     max_depth: usize,
     add_truncation_marker: bool,
+    /// Optional reversible stash. When present, array items dropped by
+    /// truncation are stashed under a BLAKE3 key and a `<<tokenless:KEY>>`
+    /// marker is embedded in the output so the LLM can retrieve the originals.
+    /// When `None`, truncation is lossy and non-retrievable — the original
+    /// pre-stash behavior. Keeping this optional means the stash stays off
+    /// the core compression path unless a caller explicitly enables it.
+    stash_store: Option<Arc<dyn StashStore>>,
 }
 
 impl Default for ResponseCompressor {
@@ -39,6 +48,7 @@ impl Default for ResponseCompressor {
             // `SchemaCompressor::default()`.
             max_depth: 8,
             add_truncation_marker: true,
+            stash_store: None,
         }
     }
 }
@@ -82,6 +92,14 @@ impl ResponseCompressor {
     /// Set whether to add truncation markers
     pub fn with_add_truncation_marker(mut self, add: bool) -> Self {
         self.add_truncation_marker = add;
+        self
+    }
+
+    /// Attach a reversible stash store. When set, dropped array items are
+    /// stashed and a retrievable marker is embedded in the output; when
+    /// unset (the default), truncation stays lossy.
+    pub fn with_stash_store(mut self, store: Arc<dyn StashStore>) -> Self {
+        self.stash_store = Some(store);
         self
     }
 
@@ -201,13 +219,44 @@ impl ResponseCompressor {
         // Add truncation marker if array was truncated
         if truncate && self.add_truncation_marker {
             let remaining = arr.len() - self.truncate_arrays_at;
-            result.push(Value::String(format!(
-                "<... {} more items truncated>",
-                remaining
-            )));
+            // NOTE: the dropped slice is captured BEFORE compress_value runs,
+            // so stashed items preserve fields the compressor would otherwise
+            // strip (drop_fields like `debug`/`stacktrace`, nulls, depth
+            // limits). This is intentional — retrieval must yield the
+            // original content verbatim — but it means drop_fields serves no
+            // data-hygiene purpose for stashed content; if a field must not
+            // survive in the stash DB, strip it upstream of the compressor.
+            let dropped = &arr[self.truncate_arrays_at..];
+            let marker = match self.stash_dropped(dropped) {
+                Some(key) => format!(
+                    "<... {} items truncated, retrieve with {}>",
+                    remaining,
+                    marker_for(&key)
+                ),
+                None => format!("<... {} more items truncated>", remaining),
+            };
+            result.push(Value::String(marker));
         }
 
         Value::Array(result)
+    }
+
+    /// Stash the dropped tail of a truncated array, returning the stash key.
+    /// Returns `None` when no store is attached, when the dropped slice is
+    /// empty, or when stashing fails — in all these cases the caller falls
+    /// back to the plain (lossy) truncation marker. Stashing the raw dropped
+    /// items (not their compressed forms) means retrieval yields the original
+    /// content verbatim.
+    fn stash_dropped(&self, dropped: &[Value]) -> Option<String> {
+        let stash = self.stash_store.as_ref()?;
+        if dropped.is_empty() {
+            return None;
+        }
+        let payload = serde_json::to_string(dropped).ok()?;
+        if payload.is_empty() {
+            return None;
+        }
+        stash.stash(&payload).ok()
     }
 
     /// Compress an object, removing drop_fields and recursing
@@ -499,5 +548,75 @@ mod tests {
         // Should not panic and should be valid UTF-8
         let s = result.as_str().unwrap();
         assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn test_array_truncation_without_stash_is_lossy() {
+        // No stash attached: original lossy marker, no retrievable hash.
+        let compressor = ResponseCompressor::new().with_truncate_arrays_at(3);
+        let arr: Vec<i32> = (1..=10).collect();
+        let result = compressor.compress(&json!(arr));
+        let marker = result.as_array().unwrap().last().unwrap();
+        let s = marker.as_str().unwrap();
+        assert!(s.contains("more items truncated"));
+        assert!(!s.contains("tokenless:"));
+    }
+
+    #[test]
+    fn test_array_truncation_with_stash_round_trip() {
+        use std::sync::Arc;
+        use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+        let store = Arc::new(InMemoryStore::new());
+        let compressor = ResponseCompressor::new()
+            .with_truncate_arrays_at(3)
+            .with_stash_store(store.clone());
+        let arr: Vec<i32> = (1..=10).collect();
+        let result = compressor.compress(&json!(arr));
+        let arr_result = result.as_array().unwrap();
+        // 3 kept items + 1 marker
+        assert_eq!(arr_result.len(), 4);
+        let marker = arr_result[3].as_str().unwrap();
+        assert!(marker.contains("retrieve with"));
+        let hash = extract_hash(marker).expect("marker should embed a hash");
+
+        // Retrieved payload is the JSON array of the dropped items [4..=10].
+        let retrieved = store.retrieve(hash).unwrap().expect("must be retrievable");
+        let recovered: Vec<i32> = serde_json::from_str(&retrieved).unwrap();
+        assert_eq!(recovered, (4..=10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_array_truncation_with_failing_stash_falls_back_to_lossy() {
+        // A stash that always errors must not break compression: the marker
+        // degrades to the plain lossy form.
+        use std::sync::Arc;
+        use tokenless_ccr::{StashError, StashStore};
+
+        struct AlwaysFail;
+        impl StashStore for AlwaysFail {
+            fn stash(&self, _payload: &str) -> Result<String, StashError> {
+                Err(StashError::Backend("simulated".to_string()))
+            }
+            fn retrieve(&self, _hash: &str) -> Result<Option<String>, StashError> {
+                Ok(None)
+            }
+            fn len(&self) -> usize {
+                0
+            }
+            fn evict_expired(&self) -> Result<usize, StashError> {
+                Ok(0)
+            }
+        }
+
+        let compressor = ResponseCompressor::new()
+            .with_truncate_arrays_at(3)
+            .with_stash_store(Arc::new(AlwaysFail));
+        let arr: Vec<i32> = (1..=10).collect();
+        let result = compressor.compress(&json!(arr));
+        let marker = result.as_array().unwrap().last().unwrap();
+        let s = marker.as_str().unwrap();
+        assert!(s.contains("more items truncated"));
+        assert!(!s.contains("tokenless:"));
     }
 }


### PR DESCRIPTION
## Description

Wires the reversible stash from `tokenless-ccr` (merged in #1255) into the response compression path so dropped array items become retrievable instead of permanently lost. This is part 2 of the stash feature (part 1 = the crate; part 3 = tests + docs, opened as a stacked PR on top of this one).

**ResponseCompressor (`crates/tokenless-schema`):**
- Add `stash_store: Option<Arc<dyn StashStore>>`. `None` (the default) preserves the original lossy truncation path — zero core-path impact.
- `with_stash_store()` builder; `compress_array` stashes the raw dropped tail and embeds a `<<tokenless:KEY>>` marker. On stash absence/failure the marker degrades to the plain `<... N more items truncated>` form (fail-open).
- Schema crate depends on `tokenless-ccr` with `default-features = false` — pulls only the trait + key + marker, no `rusqlite` (the CLI supplies the concrete backend).

**CLI (`crates/tokenless-cli`):**
- `compress-response` gains `--no-stash` (opt out) and `--stash-db` (override path). By default a `SqliteStore` is opened at `~/.tokenless/stash.db` and injected; `open_stash_store` fails open to `None` on any error so compression proceeds without stash.
- New `Retrieve` subcommand: reads the stash db, accepts either a bare 24-hex hash or a line containing a `<<tokenless:HASH>>` marker (extracted via `tokenless_ccr::extract_hash`). Retrieve is user-initiated, so failures surface as errors rather than fail-open.
- Stash db path resolution mirrors the stats db trust model: passwd-rooted home (not `$HOME`), `TOKENLESS_STASH_DB` / `--stash-db` validated via the existing `validate_db_path` (canonicalize + `starts_with` home) so an attacker cannot redirect the stash to a system-critical location. Reused `validate_db_path` rather than duplicating.

**Scope decision:** `SchemaCompressor`'s description truncation is intentionally left lossy — a stash marker (~65 chars) against 256/160-char description limits would be 25–40% overhead. Array truncation is the high-value case and is covered here.

## Related Issue

no-issue: internal tokenless stash feature, part 2 of 3 (part 1 merged in #1255).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `tokenless`: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace   # 8 suites green
```

End-to-end (shipped binary, separate processes — proves the cross-process SQLite model for the fork+exec hook path):

```bash
echo '[1,...,200]' | tokenless compress-response --truncate-arrays-at 5
# -> [1,2,3,4,5,"<... 195 items truncated, retrieve with <<tokenless:c30c…>>"]
tokenless retrieve c30ccf5ed1125e0ed871ba8e   # separate process, same stash db
# -> [6,7,8,…,200]
tokenless compress-response --no-stash ...    # lossy path (pre-stash behavior)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
