### PR TITLE
feat(skillfs): add managed mount recovery

### DIFF
--- a/src/skillfs/Cargo.lock
+++ b/src/skillfs/Cargo.lock
@@ -738,7 +738,9 @@ name = "skillfs"
 version = "0.3.0"
 dependencies = [
  "clap",
+ "libc",
  "parking_lot",
+ "serde",
  "serde_json",
  "skillfs-core",
  "skillfs-fuse",

--- a/src/skillfs/Cargo.toml
+++ b/src/skillfs/Cargo.toml
@@ -28,3 +28,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "local-time"] 
 thiserror = "2"
 parking_lot = "0.12"
 tempfile = "3"
+libc = "0.2"

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -132,7 +132,34 @@ cargo run -p skillfs -- classify /path/to/skills
 
 # 挂载 FUSE 文件系统
 cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint
+
+# Managed 挂载（opt-in）：托管监督器保持挂载存活，网关重启不会丢失挂载
+cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint --managed
+
+# 停止 managed 挂载：清除 desired state、终止监督器/worker 并卸载
+cargo run -p skillfs -- stop /path/to/mountpoint
 ```
+
+### Managed 挂载模式
+
+默认 `mount`（含 `--foreground`）与原来完全一致：进程在前台阻塞，`SIGTERM`
+/ `Ctrl+C` 会干净卸载。当启动 SkillFS 的进程（如 OpenClaw 网关）重启时，其
+子进程会被终止，挂载随之消失。
+
+`--managed` 是一个 opt-in 选项，用于跨网关重启保持挂载：
+
+- 客户端写入托管状态后，用 `setsid` 启动一个脱离调用者进程组/会话的
+  **监督器**，等待挂载 ready 后返回。
+- 监督器以相同的 source、mountpoint、config、security、audit、activation、
+  trusted-writer 和 logging 选项启动前台 FUSE **worker**。
+- 若 worker 在 desired state 仍为 mounted 时意外退出，监督器会在有界退避后
+  自动重挂。
+- **只有显式执行 `skillfs stop <MOUNTPOINT>`（或 unmount）才会清除 desired
+  mounted 状态**，终止监督器/worker 并干净卸载。`stop` 是幂等的，可安全地对
+  已卸载的挂载重复执行。
+
+托管状态存放在 `$XDG_RUNTIME_DIR/skillfs/`（否则 `/run/user/<uid>/skillfs/`，
+再回退到 `/tmp/skillfs-<uid>/`），instance id 由规范化后的 mountpoint 派生。
 
 ### `skillfs-views.toml`
 

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -157,6 +157,9 @@ cargo run -p skillfs -- stop /path/to/mountpoint
 - **只有显式执行 `skillfs stop <MOUNTPOINT>`（或 unmount）才会清除 desired
   mounted 状态**，终止监督器/worker 并干净卸载。`stop` 是幂等的，可安全地对
   已卸载的挂载重复执行。
+- 如果监督器被 `kill -9` 等方式强制终止，可能留下仍在服务但无人监控的孤儿
+  worker。此时执行 `skillfs stop <MOUNTPOINT>` 可清理残留状态、进程和挂载，
+  再重新执行 `mount --managed` 即可恢复托管。
 
 托管状态存放在 `$XDG_RUNTIME_DIR/skillfs/`（否则 `/run/user/<uid>/skillfs/`，
 再回退到 `/tmp/skillfs-<uid>/`），instance id 由规范化后的 mountpoint 派生。

--- a/src/skillfs/crates/skillfs-cli/Cargo.toml
+++ b/src/skillfs/crates/skillfs-cli/Cargo.toml
@@ -20,7 +20,9 @@ clap = { version = "4", features = ["derive"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 parking_lot = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src/skillfs/crates/skillfs-cli/Cargo.toml
+++ b/src/skillfs/crates/skillfs-cli/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-libc = "0.2"
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src/skillfs/crates/skillfs-cli/src/help_text.rs
+++ b/src/skillfs/crates/skillfs-cli/src/help_text.rs
@@ -43,6 +43,11 @@ pub const MOUNT_AFTER_HELP: &str = r#"Examples:
   skillfs mount ./skills /mnt/skillfs --foreground
       Development mount. Browse skills at /mnt/skillfs/skills.
 
+  skillfs mount ./skills /mnt/skillfs --managed
+      Opt-in managed mount. A detached supervisor keeps the mount alive and
+      remounts it if the FUSE worker exits, so a gateway restart does not drop
+      the mount. Clear the desired state with 'skillfs stop /mnt/skillfs'.
+
   skillfs mount ./skills ./skills --security-mode --audit-log /var/log/skillfs/audit.jsonl
       In-place mount with audit events and .skill-meta protection.
 
@@ -64,6 +69,14 @@ Security notes:
   hidden from the ordinary view.
   Same-skill relative symlinks and same-skill hardlinks are allowed; cross-skill
   and absolute symlink targets are rejected by policy."#;
+
+pub const STOP_AFTER_HELP: &str = r#"Example:
+  skillfs stop /mnt/skillfs
+      Clear the managed desired state, terminate the supervisor and worker,
+      and unmount. Idempotent: safe to run when nothing is mounted.
+
+Only managed mounts (started with 'skillfs mount --managed') are tracked. A
+non-managed foreground mount is stopped with SIGTERM / Ctrl+C or fusermount3 -u."#;
 
 pub const CLASSIFY_AFTER_HELP: &str = r#"Example:
   skillfs classify ./skills --primary-count 6

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -35,6 +35,7 @@ use tokio::signal;
 use tracing::{error, info, warn};
 
 mod help_text;
+mod managed;
 
 // ---------------------------------------------------------------------------
 // CLI Arguments
@@ -84,6 +85,16 @@ enum Commands {
         /// Keep SkillFS in the foreground; useful for tests and systemd.
         #[arg(long, help_heading = help_text::HEADING_PROCESS)]
         foreground: bool,
+
+        /// Opt in to managed mode: keep the mount alive across gateway
+        /// restarts.
+        ///
+        /// Starts a detached supervisor (in its own session) that holds the
+        /// desired state as "mounted" and remounts the FUSE worker if it
+        /// exits unexpectedly. The command returns once the mount is ready.
+        /// Clear the desired state with `skillfs stop <MOUNTPOINT>`.
+        #[arg(long, help_heading = help_text::HEADING_PROCESS)]
+        managed: bool,
 
         /// Write the SkillFS process PID after the mount starts.
         ///
@@ -274,6 +285,22 @@ enum Commands {
         #[arg(long)]
         enabled_only: bool,
     },
+
+    /// Stop a managed mount and clear its desired state
+    #[command(after_help = help_text::STOP_AFTER_HELP)]
+    Stop {
+        /// Mountpoint of the managed mount to stop.
+        #[arg(value_name = "MOUNTPOINT")]
+        mountpoint: PathBuf,
+    },
+
+    /// Internal: run the managed mount supervisor (spawned by `mount --managed`).
+    #[command(hide = true)]
+    Supervise {
+        /// Managed instance identifier.
+        #[arg(long, value_name = "ID")]
+        instance: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
@@ -288,6 +315,10 @@ enum OutputFormat {
 
 #[tokio::main]
 async fn main() {
+    // Capture the raw arguments (excluding the program name) before clap
+    // consumes them. Managed mode reconstructs the foreground worker
+    // invocation from these so every mount flag is preserved verbatim.
+    let raw_args: Vec<String> = std::env::args().skip(1).collect();
     let cli = Cli::parse();
 
     let pid = std::process::id();
@@ -347,19 +378,20 @@ async fn main() {
 
     info!(pid, "starting skillfs CLI");
 
-    if let Err(e) = run(cli).await {
+    if let Err(e) = run(cli, raw_args).await {
         error!(error = %e, "command failed");
         std::process::exit(1);
     }
 }
 
-async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Mount {
             source,
             mountpoint,
             allow_other,
             foreground,
+            managed,
             pid_file,
             audit_log,
             audit_queue_capacity,
@@ -380,6 +412,12 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             trusted_peer_uid,
             trusted_peer_gid,
         } => {
+            if managed {
+                // Managed mode: spawn a detached supervisor and return once
+                // the mount is ready. The supervisor re-invokes this binary
+                // as a foreground worker using the preserved raw arguments.
+                return managed::run_client(&raw_args, &source, &mountpoint);
+            }
             cmd_mount(
                 source,
                 mountpoint,
@@ -417,6 +455,8 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             source,
             enabled_only,
         } => cmd_list(source, enabled_only).await,
+        Commands::Stop { mountpoint } => managed::run_stop(&mountpoint),
+        Commands::Supervise { instance } => managed::run_supervisor(&instance),
     }
 }
 

--- a/src/skillfs/crates/skillfs-cli/src/managed.rs
+++ b/src/skillfs/crates/skillfs-cli/src/managed.rs
@@ -12,7 +12,9 @@
 //!   the mount to become ready, then returns.
 //! * **supervisor** — `skillfs supervise --instance <id>` (hidden): runs the
 //!   foreground FUSE worker and remounts it after a bounded backoff whenever
-//!   it exits while the desired state is still "mounted".
+//!   it exits while the desired state is still "mounted". A `kill -9`ed worker
+//!   leaves a dead FUSE endpoint (mounted but `ENOTCONN`); the supervisor
+//!   detects and unmounts that stale endpoint before starting a replacement.
 //! * **worker** — `skillfs mount --foreground ...`: the ordinary foreground
 //!   mount path, unchanged.
 //!
@@ -285,6 +287,24 @@ fn write_pid(path: &Path, pid: u32) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Observed state of a managed mountpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MountState {
+    /// Present in `/proc/mounts` and a minimal access succeeds.
+    Ready,
+    /// Not present in `/proc/mounts`.
+    NotMounted,
+    /// Present in `/proc/mounts` but access fails with `ENOTCONN`
+    /// ("Transport endpoint is not connected") — a dead FUSE endpoint, e.g.
+    /// after the worker was `kill -9`ed.
+    Stale,
+    /// Present in `/proc/mounts` but access fails for some other reason.
+    UnknownError,
+}
+
+/// How long to keep retrying unmount of a stale endpoint before giving up.
+const UNMOUNT_TIMEOUT_MS: u64 = 3_000;
+
 /// Whether the mountpoint currently appears in `/proc/mounts`.
 pub fn is_mounted(mountpoint: &Path) -> bool {
     let target = mountpoint.to_string_lossy();
@@ -296,15 +316,62 @@ pub fn is_mounted(mountpoint: &Path) -> bool {
     }
 }
 
-/// Readiness = present in `/proc/mounts` and a minimal readdir succeeds.
-fn is_mount_ready(mountpoint: &Path) -> bool {
-    is_mounted(mountpoint) && std::fs::read_dir(mountpoint).is_ok()
+/// Classify the mountpoint: distinguish a healthy mount from a dead FUSE
+/// endpoint so recovery can unmount stale mounts before remounting.
+pub fn classify_mount(mountpoint: &Path) -> MountState {
+    if !is_mounted(mountpoint) {
+        return MountState::NotMounted;
+    }
+    // Minimal access. A dead FUSE endpoint fails opendir with ENOTCONN.
+    match std::fs::read_dir(mountpoint) {
+        Ok(_) => MountState::Ready,
+        Err(e) if e.raw_os_error() == Some(libc::ENOTCONN) => MountState::Stale,
+        Err(_) => MountState::UnknownError,
+    }
 }
 
-fn force_unmount(mountpoint: &Path) {
+/// Readiness = mounted and a minimal readdir succeeds.
+fn is_mount_ready(mountpoint: &Path) -> bool {
+    classify_mount(mountpoint) == MountState::Ready
+}
+
+/// Attempt a single unmount pass: `fusermount3 -u`, then `umount` as a
+/// fallback. Returns `true` if the mountpoint is gone afterward.
+fn unmount_once(mountpoint: &Path) -> bool {
     let _ = std::process::Command::new("fusermount3")
         .args(["-u", &mountpoint.to_string_lossy()])
         .output();
+    if !is_mounted(mountpoint) {
+        return true;
+    }
+    let _ = std::process::Command::new("umount")
+        .arg(mountpoint.as_os_str())
+        .output();
+    !is_mounted(mountpoint)
+}
+
+/// Unmount a (possibly stale/dead) FUSE endpoint, retrying within a bounded
+/// window. Succeeds immediately if nothing is mounted. Errors only if the
+/// endpoint is still present after both `fusermount3 -u` and `umount` over the
+/// retry window.
+fn clear_mount(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
+    let deadline = Instant::now() + Duration::from_millis(UNMOUNT_TIMEOUT_MS);
+    loop {
+        if !is_mounted(mountpoint) {
+            return Ok(());
+        }
+        if unmount_once(mountpoint) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "failed to unmount '{}' via fusermount3 and umount",
+                mountpoint.display()
+            )
+            .into());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -602,6 +669,27 @@ pub fn run_supervisor(instance_id: &str) -> Result<(), Box<dyn Error>> {
             break;
         }
 
+        // A `kill -9`ed worker leaves a dead FUSE endpoint behind: the
+        // mountpoint is still listed in /proc/mounts but every access returns
+        // ENOTCONN ("Transport endpoint is not connected"). The replacement
+        // worker cannot mount over it, so unmount the stale endpoint before
+        // remounting.
+        match classify_mount(&mountpoint) {
+            MountState::Stale | MountState::UnknownError => {
+                warn!(
+                    mountpoint = %mountpoint.display(),
+                    "detected stale FUSE mount after worker exit; clearing before remount"
+                );
+                if let Err(e) = clear_mount(&mountpoint) {
+                    warn!(
+                        error = %e,
+                        "failed to clear stale mount; remount may fail this cycle"
+                    );
+                }
+            }
+            MountState::Ready | MountState::NotMounted => {}
+        }
+
         if start.elapsed() >= Duration::from_secs(STABLE_RUN_SECS) {
             backoff_ms = INITIAL_BACKOFF_MS;
         }
@@ -652,7 +740,9 @@ fn wait_child_timeout(child: &mut std::process::Child, timeout: Duration) -> std
 /// Final cleanup: ensure the mount is gone and remove instance state.
 fn finish(paths: &ManagedPaths, mountpoint: &Path) {
     if is_mounted(mountpoint) {
-        force_unmount(mountpoint);
+        if let Err(e) = clear_mount(mountpoint) {
+            warn!(error = %e, "failed to unmount during supervisor cleanup");
+        }
     }
     let _ = std::fs::remove_file(&paths.worker_pid);
     let _ = std::fs::remove_file(&paths.supervisor_pid);
@@ -682,14 +772,19 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
     if !had_state {
         let _ = std::fs::remove_file(&paths.worker_pid);
         let _ = std::fs::remove_file(&paths.supervisor_pid);
-        if is_mounted(&normalized) {
-            force_unmount(&normalized);
-            println!("skillfs: unmounted {}", normalized.display());
-        } else {
-            println!(
-                "skillfs: no managed mount at {} (already stopped)",
-                normalized.display()
-            );
+        match classify_mount(&normalized) {
+            MountState::NotMounted => {
+                println!(
+                    "skillfs: no managed mount at {} (already stopped)",
+                    normalized.display()
+                );
+            }
+            // Present (ready or a stale/dead endpoint): unmount it, surfacing
+            // an error if cleanup cannot complete.
+            _ => {
+                clear_mount(&normalized)?;
+                println!("skillfs: unmounted {}", normalized.display());
+            }
         }
         return Ok(());
     }
@@ -721,13 +816,14 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    // Wait for processes to exit and the mount to disappear.
+    // Wait for the managed processes to exit. The supervisor unmounts cleanly
+    // on SIGTERM, so once it is gone the mount is normally already down; any
+    // remaining endpoint is cleared explicitly below.
     let deadline = Instant::now() + Duration::from_millis(STOP_TIMEOUT_MS);
     loop {
         let sup_gone = sup_pid.is_none_or(|p| !pid_alive(p));
         let worker_gone = worker_pid.is_none_or(|p| !pid_alive(p));
-        let unmounted = !is_mounted(&normalized);
-        if sup_gone && worker_gone && unmounted {
+        if sup_gone && worker_gone {
             break;
         }
         if Instant::now() >= deadline {
@@ -742,19 +838,25 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
                     send_signal(p, libc::SIGKILL);
                 }
             }
-            if is_mounted(&normalized) {
-                force_unmount(&normalized);
-            }
             break;
         }
         std::thread::sleep(Duration::from_millis(100));
     }
+
+    // Ensure the mount is gone, clearing any stale/dead endpoint a killed
+    // worker left behind. Errors are surfaced after state cleanup.
+    let unmount_result = if is_mounted(&normalized) {
+        clear_mount(&normalized)
+    } else {
+        Ok(())
+    };
 
     // Best-effort final cleanup of any residual state files.
     let _ = std::fs::remove_file(&paths.worker_pid);
     let _ = std::fs::remove_file(&paths.supervisor_pid);
     let _ = std::fs::remove_file(&paths.state);
 
+    unmount_result?;
     println!("skillfs: stopped managed mount at {}", normalized.display());
     Ok(())
 }
@@ -867,6 +969,35 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("nope.json");
         assert_eq!(current_desired_state(&missing), DesiredState::Stopped);
+    }
+
+    #[test]
+    fn classify_mount_absent_path_is_not_mounted() {
+        let dir = tempfile::tempdir().unwrap();
+        let never_mounted = dir.path().join("not-a-mount");
+        assert_eq!(classify_mount(&never_mounted), MountState::NotMounted);
+    }
+
+    #[test]
+    fn classify_mount_plain_dir_is_not_mounted() {
+        // A real, accessible directory that is not a mountpoint classifies as
+        // NotMounted (it is not present in /proc/mounts), never Ready.
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(classify_mount(dir.path()), MountState::NotMounted);
+    }
+
+    #[test]
+    fn is_mount_ready_false_for_plain_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_mount_ready(dir.path()));
+    }
+
+    #[test]
+    fn clear_mount_is_ok_when_nothing_mounted() {
+        let dir = tempfile::tempdir().unwrap();
+        // Not a mountpoint, so clear_mount must succeed immediately without
+        // invoking any unmount tooling.
+        clear_mount(dir.path()).unwrap();
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-cli/src/managed.rs
+++ b/src/skillfs/crates/skillfs-cli/src/managed.rs
@@ -1,0 +1,787 @@
+//! Managed mount supervisor for SkillFS.
+//!
+//! `skillfs mount --managed <SOURCE> <MOUNTPOINT>` keeps the mount desired
+//! state as "mounted" until an explicit `skillfs stop <MOUNTPOINT>` clears
+//! it. This survives the caller's process group being torn down (for
+//! example when the OpenClaw gateway that launched SkillFS restarts).
+//!
+//! Three roles share the `skillfs` binary:
+//!
+//! * **client** — `skillfs mount --managed ...`: writes managed state,
+//!   spawns a detached supervisor in its own session (`setsid`), waits for
+//!   the mount to become ready, then returns.
+//! * **supervisor** — `skillfs supervise --instance <id>` (hidden): runs the
+//!   foreground FUSE worker and remounts it after a bounded backoff whenever
+//!   it exits while the desired state is still "mounted".
+//! * **worker** — `skillfs mount --foreground ...`: the ordinary foreground
+//!   mount path, unchanged.
+//!
+//! State lives under `$XDG_RUNTIME_DIR/skillfs/` (or `/run/user/<uid>/skillfs/`,
+//! falling back to `/tmp/skillfs-<uid>/`). The instance id is derived from the
+//! canonical mountpoint so `mount` and `stop` agree on the same instance.
+
+use std::collections::hash_map::DefaultHasher;
+use std::error::Error;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+/// Schema version for the on-disk managed state file.
+pub const STATE_SCHEMA_VERSION: u32 = 1;
+
+/// Initial remount backoff after an unexpected worker exit.
+const INITIAL_BACKOFF_MS: u64 = 200;
+/// Upper bound on the remount backoff.
+const MAX_BACKOFF_MS: u64 = 5_000;
+/// A worker that ran at least this long is treated as a healthy mount whose
+/// later exit is not part of a crash loop, so the backoff resets.
+const STABLE_RUN_SECS: u64 = 10;
+/// Poll interval while waiting on the worker child.
+const WORKER_POLL_MS: u64 = 200;
+/// How long the client waits for the mount to become ready before failing.
+const READY_TIMEOUT_MS: u64 = 10_000;
+/// How long `stop` waits for processes to exit / the mount to disappear.
+const STOP_TIMEOUT_MS: u64 = 10_000;
+
+/// Desired lifecycle state for a managed mount.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DesiredState {
+    /// The supervisor should keep the mount alive, remounting on exit.
+    Mounted,
+    /// An explicit stop cleared the desired state; do not remount.
+    Stopped,
+}
+
+/// On-disk record describing a managed mount instance.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ManagedState {
+    pub schema_version: u32,
+    pub instance_id: String,
+    pub mountpoint: String,
+    pub source: String,
+    pub worker_program: String,
+    pub worker_args: Vec<String>,
+    pub desired_state: DesiredState,
+}
+
+impl ManagedState {
+    fn load(path: &Path) -> Result<Self, Box<dyn Error>> {
+        let raw = std::fs::read_to_string(path)?;
+        let state: ManagedState = serde_json::from_str(&raw)?;
+        Ok(state)
+    }
+
+    fn save(&self, path: &Path) -> Result<(), Box<dyn Error>> {
+        let raw = serde_json::to_string_pretty(self)?;
+        // Write-and-rename for atomicity so a concurrent reader never sees a
+        // half-written file.
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, raw)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+}
+
+/// Filesystem paths for a managed mount instance.
+pub struct ManagedPaths {
+    pub dir: PathBuf,
+    pub state: PathBuf,
+    pub supervisor_pid: PathBuf,
+    pub worker_pid: PathBuf,
+    pub supervisor_log: PathBuf,
+    pub worker_log: PathBuf,
+}
+
+impl ManagedPaths {
+    fn new(instance_id: &str) -> Self {
+        let dir = runtime_dir();
+        ManagedPaths {
+            state: dir.join(format!("{instance_id}.state.json")),
+            supervisor_pid: dir.join(format!("{instance_id}.supervisor.pid")),
+            worker_pid: dir.join(format!("{instance_id}.worker.pid")),
+            supervisor_log: dir.join(format!("{instance_id}.supervisor.log")),
+            worker_log: dir.join(format!("{instance_id}.worker.log")),
+            dir,
+        }
+    }
+}
+
+/// Resolve the managed-state runtime directory.
+///
+/// Prefers `$XDG_RUNTIME_DIR/skillfs`, then `/run/user/<uid>/skillfs`, and
+/// falls back to `/tmp/skillfs-<uid>` only if neither is usable.
+pub fn runtime_dir() -> PathBuf {
+    let uid = unsafe { libc::getuid() };
+    if let Some(base) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let base = PathBuf::from(base);
+        if !base.as_os_str().is_empty() {
+            return base.join("skillfs");
+        }
+    }
+    let run_user = PathBuf::from(format!("/run/user/{uid}"));
+    if run_user.is_dir() {
+        return run_user.join("skillfs");
+    }
+    PathBuf::from(format!("/tmp/skillfs-{uid}"))
+}
+
+/// Normalize a mountpoint path for identity purposes: canonicalize if it
+/// exists, otherwise fall back to an absolute (lexical) path so `mount` and
+/// `stop` derive the same instance id before/after the directory exists.
+pub fn normalize_mountpoint(mountpoint: &Path) -> PathBuf {
+    if let Ok(canon) = mountpoint.canonicalize() {
+        return canon;
+    }
+    std::path::absolute(mountpoint).unwrap_or_else(|_| mountpoint.to_path_buf())
+}
+
+/// Stable, collision-resistant instance id derived from a normalized path.
+///
+/// Combines a sanitized basename (for human readability) with a hash of the
+/// full path (for uniqueness).
+pub fn instance_id_for(normalized: &Path) -> String {
+    let mut hasher = DefaultHasher::new();
+    normalized.as_os_str().hash(&mut hasher);
+    let hash = hasher.finish();
+
+    let base: String = normalized
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "root".to_string())
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .take(24)
+        .collect();
+    let base = if base.is_empty() {
+        "root".to_string()
+    } else {
+        base
+    };
+    format!("{base}-{hash:016x}")
+}
+
+/// Build the worker argument vector from the client's raw arguments.
+///
+/// The worker runs the ordinary foreground mount path, so we drop `--managed`
+/// and ensure `--foreground` is present. `raw_args` excludes the program name.
+pub fn build_worker_args(raw_args: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = raw_args
+        .iter()
+        .filter(|a| a.as_str() != "--managed")
+        .cloned()
+        .collect();
+    if !out.iter().any(|a| a == "--foreground") {
+        // Insert right after the `mount` subcommand token so it lands in the
+        // subcommand's argument list rather than being read as a global.
+        if let Some(pos) = out.iter().position(|a| a == "mount") {
+            out.insert(pos + 1, "--foreground".to_string());
+        } else {
+            out.insert(0, "--foreground".to_string());
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Process / mount helpers
+// ---------------------------------------------------------------------------
+
+fn pid_alive(pid: i32) -> bool {
+    pid > 0 && unsafe { libc::kill(pid, 0) } == 0
+}
+
+fn send_signal(pid: i32, sig: i32) {
+    if pid > 0 {
+        unsafe {
+            libc::kill(pid, sig);
+        }
+    }
+}
+
+fn read_pid(path: &Path) -> Option<i32> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+}
+
+fn write_pid(path: &Path, pid: u32) -> Result<(), Box<dyn Error>> {
+    std::fs::write(path, format!("{pid}\n"))?;
+    Ok(())
+}
+
+/// Whether the mountpoint currently appears in `/proc/mounts`.
+pub fn is_mounted(mountpoint: &Path) -> bool {
+    let target = mountpoint.to_string_lossy();
+    match std::fs::read_to_string("/proc/mounts") {
+        Ok(info) => info
+            .lines()
+            .any(|line| line.split_whitespace().nth(1) == Some(&*target)),
+        Err(_) => false,
+    }
+}
+
+/// Readiness = present in `/proc/mounts` and a minimal readdir succeeds.
+fn is_mount_ready(mountpoint: &Path) -> bool {
+    is_mounted(mountpoint) && std::fs::read_dir(mountpoint).is_ok()
+}
+
+fn force_unmount(mountpoint: &Path) {
+    let _ = std::process::Command::new("fusermount3")
+        .args(["-u", &mountpoint.to_string_lossy()])
+        .output();
+}
+
+// ---------------------------------------------------------------------------
+// Client: `skillfs mount --managed ...`
+// ---------------------------------------------------------------------------
+
+/// Entry point for a managed mount request. Validates the source, writes the
+/// managed state, spawns a detached supervisor, and waits for readiness.
+pub fn run_client(
+    raw_args: &[String],
+    source: &Path,
+    mountpoint: &Path,
+) -> Result<(), Box<dyn Error>> {
+    // Fast, client-side validation so operators get an immediate error
+    // instead of a readiness timeout when the source is wrong. Deeper
+    // validation still happens in the worker.
+    if !source.exists() {
+        return Err(format!("Source directory does not exist: {}", source.display()).into());
+    }
+    if !source.is_dir() {
+        return Err(format!("Source is not a directory: {}", source.display()).into());
+    }
+
+    // Create the mountpoint up front (mirrors the compat-mode mount UX) so it
+    // can be canonicalized into a stable instance id.
+    if !mountpoint.exists() {
+        std::fs::create_dir_all(mountpoint).map_err(|e| {
+            format!(
+                "failed to create mount point '{}': {e}",
+                mountpoint.display()
+            )
+        })?;
+    }
+
+    let normalized = normalize_mountpoint(mountpoint);
+    let source_norm = normalize_mountpoint(source);
+    let instance_id = instance_id_for(&normalized);
+    let paths = ManagedPaths::new(&instance_id);
+
+    // If a live supervisor already owns this mountpoint, do not start a
+    // second one.
+    if let Some(pid) = read_pid(&paths.supervisor_pid) {
+        if pid_alive(pid) && is_mounted(&normalized) {
+            info!(
+                mountpoint = %normalized.display(),
+                supervisor_pid = pid,
+                "managed mount already active; nothing to do"
+            );
+            println!(
+                "skillfs: managed mount already active at {}",
+                normalized.display()
+            );
+            return Ok(());
+        }
+    }
+
+    std::fs::create_dir_all(&paths.dir).map_err(|e| {
+        format!(
+            "failed to create runtime dir '{}': {e}",
+            paths.dir.display()
+        )
+    })?;
+
+    let worker_program = std::env::current_exe()
+        .map_err(|e| format!("failed to resolve current executable: {e}"))?;
+    let worker_args = build_worker_args(raw_args);
+
+    let state = ManagedState {
+        schema_version: STATE_SCHEMA_VERSION,
+        instance_id: instance_id.clone(),
+        mountpoint: normalized.to_string_lossy().to_string(),
+        source: source_norm.to_string_lossy().to_string(),
+        worker_program: worker_program.to_string_lossy().to_string(),
+        worker_args,
+        desired_state: DesiredState::Mounted,
+    };
+    state.save(&paths.state)?;
+
+    spawn_supervisor(&worker_program, &instance_id, &paths)?;
+
+    // Wait for readiness.
+    let deadline = Instant::now() + Duration::from_millis(READY_TIMEOUT_MS);
+    loop {
+        if is_mount_ready(&normalized) {
+            info!(
+                mountpoint = %normalized.display(),
+                instance = %instance_id,
+                "managed mount ready"
+            );
+            println!(
+                "skillfs: managed mount ready at {} (stop with: skillfs stop {})",
+                normalized.display(),
+                normalized.display()
+            );
+            return Ok(());
+        }
+        // If the supervisor died before the mount came up, surface the
+        // worker log so the failure is diagnosable.
+        if let Some(pid) = read_pid(&paths.supervisor_pid) {
+            if !pid_alive(pid) {
+                break;
+            }
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let worker_log = std::fs::read_to_string(&paths.worker_log).unwrap_or_default();
+    let mut tail_lines: Vec<&str> = worker_log.lines().rev().take(20).collect();
+    tail_lines.reverse();
+    let tail = tail_lines.join("\n");
+    Err(format!(
+        "managed mount did not become ready within {}ms.\n--- worker log tail ---\n{}",
+        READY_TIMEOUT_MS, tail
+    )
+    .into())
+}
+
+/// Spawn the supervisor detached in its own session so a restart of the
+/// caller's process group does not tear it down.
+fn spawn_supervisor(
+    program: &Path,
+    instance_id: &str,
+    paths: &ManagedPaths,
+) -> Result<(), Box<dyn Error>> {
+    use std::os::unix::process::CommandExt;
+
+    let sup_log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&paths.supervisor_log)
+        .map_err(|e| {
+            format!(
+                "failed to open supervisor log '{}': {e}",
+                paths.supervisor_log.display()
+            )
+        })?;
+    let sup_log_err = sup_log.try_clone()?;
+
+    let mut cmd = std::process::Command::new(program);
+    cmd.arg("supervise")
+        .arg("--instance")
+        .arg(instance_id)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(sup_log))
+        .stderr(std::process::Stdio::from(sup_log_err));
+
+    // Detach: new session + new process group, no controlling terminal.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("failed to spawn supervisor: {e}"))?;
+    info!(
+        supervisor_pid = child.id(),
+        instance = %instance_id,
+        "spawned detached managed supervisor"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Supervisor: `skillfs supervise --instance <id>`
+// ---------------------------------------------------------------------------
+
+static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn handle_term(_sig: i32) {
+    SHUTDOWN.store(true, Ordering::SeqCst);
+}
+
+fn install_term_handler() {
+    let handler = handle_term as extern "C" fn(i32) as *const () as libc::sighandler_t;
+    unsafe {
+        libc::signal(libc::SIGTERM, handler);
+        libc::signal(libc::SIGINT, handler);
+    }
+}
+
+/// Entry point for the detached supervisor process.
+pub fn run_supervisor(instance_id: &str) -> Result<(), Box<dyn Error>> {
+    let paths = ManagedPaths::new(instance_id);
+    let state = ManagedState::load(&paths.state)
+        .map_err(|e| format!("failed to load managed state for '{instance_id}': {e}"))?;
+    let mountpoint = PathBuf::from(&state.mountpoint);
+
+    write_pid(&paths.supervisor_pid, std::process::id())?;
+    install_term_handler();
+    info!(
+        instance = %instance_id,
+        mountpoint = %mountpoint.display(),
+        "managed supervisor started"
+    );
+
+    let mut backoff_ms = INITIAL_BACKOFF_MS;
+
+    loop {
+        if SHUTDOWN.load(Ordering::SeqCst) {
+            break;
+        }
+        if current_desired_state(&paths.state) == DesiredState::Stopped {
+            break;
+        }
+
+        let worker_out = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&paths.worker_log)
+            .map_err(|e| format!("failed to open worker log: {e}"))?;
+        let worker_err = worker_out.try_clone()?;
+
+        let start = Instant::now();
+        let mut child = std::process::Command::new(&state.worker_program)
+            .args(&state.worker_args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::from(worker_out))
+            .stderr(std::process::Stdio::from(worker_err))
+            .spawn()
+            .map_err(|e| format!("failed to spawn worker: {e}"))?;
+        let worker_pid = child.id();
+        let _ = write_pid(&paths.worker_pid, worker_pid);
+        info!(worker_pid, "managed worker started");
+
+        // Wait for the worker, watching for shutdown.
+        loop {
+            if SHUTDOWN.load(Ordering::SeqCst)
+                || current_desired_state(&paths.state) == DesiredState::Stopped
+            {
+                info!(
+                    worker_pid,
+                    "stopping managed worker (desired state cleared)"
+                );
+                send_signal(worker_pid as i32, libc::SIGTERM);
+                let _ = wait_child_timeout(&mut child, Duration::from_millis(STOP_TIMEOUT_MS));
+                let _ = std::fs::remove_file(&paths.worker_pid);
+                finish(&paths, &mountpoint);
+                return Ok(());
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    warn!(worker_pid, ?status, "managed worker exited");
+                    break;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(WORKER_POLL_MS)),
+                Err(e) => {
+                    warn!(error = %e, "error waiting on managed worker");
+                    break;
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&paths.worker_pid);
+
+        // Worker exited on its own. Decide whether to remount.
+        if SHUTDOWN.load(Ordering::SeqCst)
+            || current_desired_state(&paths.state) == DesiredState::Stopped
+        {
+            break;
+        }
+
+        if start.elapsed() >= Duration::from_secs(STABLE_RUN_SECS) {
+            backoff_ms = INITIAL_BACKOFF_MS;
+        }
+        info!(
+            backoff_ms,
+            "managed worker exited unexpectedly; remounting after backoff"
+        );
+        // Sleep in small slices so shutdown is responsive during backoff.
+        let backoff_deadline = Instant::now() + Duration::from_millis(backoff_ms);
+        while Instant::now() < backoff_deadline {
+            if SHUTDOWN.load(Ordering::SeqCst) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        backoff_ms = (backoff_ms.saturating_mul(2)).min(MAX_BACKOFF_MS);
+    }
+
+    finish(&paths, &mountpoint);
+    Ok(())
+}
+
+fn current_desired_state(state_path: &Path) -> DesiredState {
+    // A missing/unreadable state file means the instance was torn down; treat
+    // it as stopped so the supervisor exits rather than remounting forever.
+    ManagedState::load(state_path)
+        .map(|s| s.desired_state)
+        .unwrap_or(DesiredState::Stopped)
+}
+
+fn wait_child_timeout(child: &mut std::process::Child, timeout: Duration) -> std::io::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait()? {
+            Some(_) => return Ok(()),
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Ok(());
+                }
+                std::thread::sleep(Duration::from_millis(WORKER_POLL_MS));
+            }
+        }
+    }
+}
+
+/// Final cleanup: ensure the mount is gone and remove instance state.
+fn finish(paths: &ManagedPaths, mountpoint: &Path) {
+    if is_mounted(mountpoint) {
+        force_unmount(mountpoint);
+    }
+    let _ = std::fs::remove_file(&paths.worker_pid);
+    let _ = std::fs::remove_file(&paths.supervisor_pid);
+    let _ = std::fs::remove_file(&paths.state);
+    info!(mountpoint = %mountpoint.display(), "managed supervisor exiting");
+}
+
+// ---------------------------------------------------------------------------
+// Stop: `skillfs stop <MOUNTPOINT>`
+// ---------------------------------------------------------------------------
+
+/// Entry point for `skillfs stop`. Clears the desired state, terminates the
+/// managed supervisor/worker, and unmounts. Idempotent: tolerates an
+/// already-unmounted mount and a missing managed instance.
+pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
+    let normalized = normalize_mountpoint(mountpoint);
+    let instance_id = instance_id_for(&normalized);
+    let paths = ManagedPaths::new(&instance_id);
+
+    let had_state = paths.state.exists();
+
+    // Clear desired state first so the supervisor will not remount even if a
+    // remount races with our signal.
+    if had_state {
+        if let Ok(mut state) = ManagedState::load(&paths.state) {
+            state.desired_state = DesiredState::Stopped;
+            let _ = state.save(&paths.state);
+        }
+    }
+
+    // Prefer signaling the supervisor: it owns the worker and unmounts it
+    // cleanly. Fall back to signaling the worker directly.
+    let sup_pid = read_pid(&paths.supervisor_pid);
+    let worker_pid = read_pid(&paths.worker_pid);
+
+    if let Some(pid) = sup_pid {
+        if pid_alive(pid) {
+            info!(supervisor_pid = pid, "stopping managed supervisor");
+            send_signal(pid, libc::SIGTERM);
+        }
+    }
+    if sup_pid.is_none_or(|p| !pid_alive(p)) {
+        if let Some(pid) = worker_pid {
+            if pid_alive(pid) {
+                info!(worker_pid = pid, "stopping managed worker directly");
+                send_signal(pid, libc::SIGTERM);
+            }
+        }
+    }
+
+    // Wait for processes to exit and the mount to disappear.
+    let deadline = Instant::now() + Duration::from_millis(STOP_TIMEOUT_MS);
+    loop {
+        let sup_gone = sup_pid.is_none_or(|p| !pid_alive(p));
+        let worker_gone = worker_pid.is_none_or(|p| !pid_alive(p));
+        let unmounted = !is_mounted(&normalized);
+        if sup_gone && worker_gone && unmounted {
+            break;
+        }
+        if Instant::now() >= deadline {
+            warn!("stop timed out waiting for clean shutdown; forcing");
+            if let Some(p) = sup_pid {
+                if pid_alive(p) {
+                    send_signal(p, libc::SIGKILL);
+                }
+            }
+            if let Some(p) = worker_pid {
+                if pid_alive(p) {
+                    send_signal(p, libc::SIGKILL);
+                }
+            }
+            if is_mounted(&normalized) {
+                force_unmount(&normalized);
+            }
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    // Best-effort final cleanup of any residual state files.
+    let _ = std::fs::remove_file(&paths.worker_pid);
+    let _ = std::fs::remove_file(&paths.supervisor_pid);
+    let _ = std::fs::remove_file(&paths.state);
+
+    if had_state {
+        println!("skillfs: stopped managed mount at {}", normalized.display());
+    } else if is_mounted(&normalized) {
+        // No managed instance recorded, but something is mounted here — still
+        // best-effort unmount so `stop` is a reliable teardown.
+        force_unmount(&normalized);
+        println!("skillfs: unmounted {}", normalized.display());
+    } else {
+        println!(
+            "skillfs: no managed mount at {} (already stopped)",
+            normalized.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instance_id_is_stable_for_same_path() {
+        let p = Path::new("/tmp/skillfs-test-mount");
+        let a = instance_id_for(p);
+        let b = instance_id_for(p);
+        assert_eq!(a, b, "instance id must be deterministic");
+    }
+
+    #[test]
+    fn instance_id_differs_for_different_paths() {
+        let a = instance_id_for(Path::new("/tmp/mount-a"));
+        let b = instance_id_for(Path::new("/tmp/mount-b"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn instance_id_includes_sanitized_basename() {
+        let id = instance_id_for(Path::new("/var/run/my.mount point"));
+        // Non-alphanumerics in the basename become dashes.
+        assert!(id.starts_with("my-mount-point-"), "got: {id}");
+    }
+
+    #[test]
+    fn build_worker_args_drops_managed_and_adds_foreground() {
+        let raw = vec![
+            "mount".to_string(),
+            "/src".to_string(),
+            "/mnt".to_string(),
+            "--managed".to_string(),
+        ];
+        let out = build_worker_args(&raw);
+        assert!(!out.iter().any(|a| a == "--managed"));
+        assert_eq!(out, vec!["mount", "--foreground", "/src", "/mnt"]);
+    }
+
+    #[test]
+    fn build_worker_args_keeps_existing_foreground_without_duplicating() {
+        let raw = vec![
+            "mount".to_string(),
+            "--foreground".to_string(),
+            "/src".to_string(),
+            "/mnt".to_string(),
+            "--managed".to_string(),
+        ];
+        let out = build_worker_args(&raw);
+        assert_eq!(out.iter().filter(|a| *a == "--foreground").count(), 1);
+        assert!(!out.iter().any(|a| a == "--managed"));
+    }
+
+    #[test]
+    fn build_worker_args_preserves_other_flags() {
+        let raw = vec![
+            "mount".to_string(),
+            "/src".to_string(),
+            "/mnt".to_string(),
+            "--managed".to_string(),
+            "--security-mode".to_string(),
+            "--audit-log".to_string(),
+            "/var/log/a.jsonl".to_string(),
+        ];
+        let out = build_worker_args(&raw);
+        assert!(out.iter().any(|a| a == "--security-mode"));
+        assert!(out.iter().any(|a| a == "--audit-log"));
+        assert!(out.iter().any(|a| a == "/var/log/a.jsonl"));
+    }
+
+    #[test]
+    fn state_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let state = ManagedState {
+            schema_version: STATE_SCHEMA_VERSION,
+            instance_id: "mnt-000000000000dead".to_string(),
+            mountpoint: "/mnt/skillfs".to_string(),
+            source: "/srv/skills".to_string(),
+            worker_program: "/usr/bin/skillfs".to_string(),
+            worker_args: vec![
+                "mount".to_string(),
+                "--foreground".to_string(),
+                "/srv/skills".to_string(),
+                "/mnt/skillfs".to_string(),
+            ],
+            desired_state: DesiredState::Mounted,
+        };
+        state.save(&path).unwrap();
+        let loaded = ManagedState::load(&path).unwrap();
+        assert_eq!(loaded.instance_id, state.instance_id);
+        assert_eq!(loaded.desired_state, DesiredState::Mounted);
+        assert_eq!(loaded.worker_args, state.worker_args);
+    }
+
+    #[test]
+    fn desired_state_serializes_lowercase() {
+        let json = serde_json::to_string(&DesiredState::Stopped).unwrap();
+        assert_eq!(json, "\"stopped\"");
+        let parsed: DesiredState = serde_json::from_str("\"mounted\"").unwrap();
+        assert_eq!(parsed, DesiredState::Mounted);
+    }
+
+    #[test]
+    fn current_desired_state_missing_file_is_stopped() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.json");
+        assert_eq!(current_desired_state(&missing), DesiredState::Stopped);
+    }
+
+    #[test]
+    fn runtime_dir_prefers_xdg_runtime_dir() {
+        // Safe: single-threaded unit test process; we restore afterward.
+        let prev = std::env::var_os("XDG_RUNTIME_DIR");
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", "/run/user/12345");
+        }
+        assert_eq!(runtime_dir(), PathBuf::from("/run/user/12345/skillfs"));
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+    }
+}

--- a/src/skillfs/crates/skillfs-cli/src/managed.rs
+++ b/src/skillfs/crates/skillfs-cli/src/managed.rs
@@ -89,7 +89,6 @@ impl ManagedState {
 
 /// Filesystem paths for a managed mount instance.
 pub struct ManagedPaths {
-    pub dir: PathBuf,
     pub state: PathBuf,
     pub supervisor_pid: PathBuf,
     pub worker_pid: PathBuf,
@@ -106,7 +105,6 @@ impl ManagedPaths {
             worker_pid: dir.join(format!("{instance_id}.worker.pid")),
             supervisor_log: dir.join(format!("{instance_id}.supervisor.log")),
             worker_log: dir.join(format!("{instance_id}.worker.log")),
-            dir,
         }
     }
 }
@@ -128,6 +126,73 @@ pub fn runtime_dir() -> PathBuf {
         return run_user.join("skillfs");
     }
     PathBuf::from(format!("/tmp/skillfs-{uid}"))
+}
+
+/// Resolve and secure the managed-state runtime directory.
+///
+/// The state and pid files under this directory drive process signaling and
+/// remount behavior, so the directory must be private to the current user.
+/// The directory is created `0700` if missing; if it already exists it must be
+/// a real directory (not a symlink) owned by the current uid, and any
+/// group/other permission bits are stripped. This matters most for the
+/// `/tmp/skillfs-<uid>` fallback, where a hostile actor could pre-create the
+/// path.
+pub fn secure_runtime_dir() -> Result<PathBuf, Box<dyn Error>> {
+    let dir = runtime_dir();
+    secure_dir(&dir)?;
+    Ok(dir)
+}
+
+/// Create `dir` `0700` if missing, or validate + tighten it if it exists.
+fn secure_dir(dir: &Path) -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+    let uid = unsafe { libc::getuid() };
+
+    match std::fs::symlink_metadata(dir) {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                return Err(format!(
+                    "refusing to use runtime dir '{}': it is a symlink",
+                    dir.display()
+                )
+                .into());
+            }
+            if !meta.is_dir() {
+                return Err(format!(
+                    "runtime path '{}' exists but is not a directory",
+                    dir.display()
+                )
+                .into());
+            }
+            if meta.uid() != uid {
+                return Err(format!(
+                    "refusing to use runtime dir '{}': owned by uid {}, expected {}",
+                    dir.display(),
+                    meta.uid(),
+                    uid
+                )
+                .into());
+            }
+            // Strip any group/other access bits so pid/state files stay private.
+            if meta.mode() & 0o077 != 0 {
+                std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(
+                    |e| format!("failed to tighten runtime dir '{}': {e}", dir.display()),
+                )?;
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(dir)
+                .map_err(|e| format!("failed to create runtime dir '{}': {e}", dir.display()))?;
+        }
+        Err(e) => {
+            return Err(format!("failed to inspect runtime dir '{}': {e}", dir.display()).into());
+        }
+    }
+    Ok(())
 }
 
 /// Normalize a mountpoint path for identity purposes: canonicalize if it
@@ -279,29 +344,57 @@ pub fn run_client(
     let instance_id = instance_id_for(&normalized);
     let paths = ManagedPaths::new(&instance_id);
 
-    // If a live supervisor already owns this mountpoint, do not start a
-    // second one.
+    // Create/validate the private runtime dir before reading or writing any
+    // pid/state files it holds.
+    secure_runtime_dir()?;
+
+    // A live supervisor PID owns this instance, even if the mount is
+    // momentarily down during remount/backoff recovery. Never spawn a second
+    // supervisor for the same instance: it would overwrite state and race the
+    // incumbent over the mountpoint.
     if let Some(pid) = read_pid(&paths.supervisor_pid) {
-        if pid_alive(pid) && is_mounted(&normalized) {
-            info!(
-                mountpoint = %normalized.display(),
-                supervisor_pid = pid,
-                "managed mount already active; nothing to do"
-            );
-            println!(
-                "skillfs: managed mount already active at {}",
-                normalized.display()
-            );
-            return Ok(());
+        if pid_alive(pid) {
+            if is_mount_ready(&normalized) {
+                info!(
+                    mountpoint = %normalized.display(),
+                    supervisor_pid = pid,
+                    "managed mount already active; nothing to do"
+                );
+                println!(
+                    "skillfs: managed mount already active at {}",
+                    normalized.display()
+                );
+                return Ok(());
+            }
+            // Supervisor alive but mount not ready yet — wait for it to
+            // converge rather than starting a competing supervisor.
+            let deadline = Instant::now() + Duration::from_millis(READY_TIMEOUT_MS);
+            while Instant::now() < deadline {
+                if !pid_alive(pid) {
+                    break; // incumbent died; fall through to (re)start below
+                }
+                if is_mount_ready(&normalized) {
+                    println!(
+                        "skillfs: managed mount ready at {} (stop with: skillfs stop {})",
+                        normalized.display(),
+                        normalized.display()
+                    );
+                    return Ok(());
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            if pid_alive(pid) {
+                return Err(format!(
+                    "managed supervisor (pid {pid}) is active for {} but the mount is not ready; \
+                     run 'skillfs stop {}' to recover before remounting",
+                    normalized.display(),
+                    normalized.display()
+                )
+                .into());
+            }
+            // Incumbent supervisor exited while we waited — safe to start fresh.
         }
     }
-
-    std::fs::create_dir_all(&paths.dir).map_err(|e| {
-        format!(
-            "failed to create runtime dir '{}': {e}",
-            paths.dir.display()
-        )
-    })?;
 
     let worker_program = std::env::current_exe()
         .map_err(|e| format!("failed to resolve current executable: {e}"))?;
@@ -431,6 +524,7 @@ fn install_term_handler() {
 /// Entry point for the detached supervisor process.
 pub fn run_supervisor(instance_id: &str) -> Result<(), Box<dyn Error>> {
     let paths = ManagedPaths::new(instance_id);
+    secure_runtime_dir()?;
     let state = ManagedState::load(&paths.state)
         .map_err(|e| format!("failed to load managed state for '{instance_id}': {e}"))?;
     let mountpoint = PathBuf::from(&state.mountpoint);
@@ -577,16 +671,34 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
     let normalized = normalize_mountpoint(mountpoint);
     let instance_id = instance_id_for(&normalized);
     let paths = ManagedPaths::new(&instance_id);
+    secure_runtime_dir()?;
 
     let had_state = paths.state.exists();
 
+    // No managed instance recorded for this mountpoint. `stop` is still a
+    // reliable teardown, so unmount immediately instead of waiting the full
+    // stop timeout on processes that do not exist (handles stale or
+    // non-managed dead mounts).
+    if !had_state {
+        let _ = std::fs::remove_file(&paths.worker_pid);
+        let _ = std::fs::remove_file(&paths.supervisor_pid);
+        if is_mounted(&normalized) {
+            force_unmount(&normalized);
+            println!("skillfs: unmounted {}", normalized.display());
+        } else {
+            println!(
+                "skillfs: no managed mount at {} (already stopped)",
+                normalized.display()
+            );
+        }
+        return Ok(());
+    }
+
     // Clear desired state first so the supervisor will not remount even if a
     // remount races with our signal.
-    if had_state {
-        if let Ok(mut state) = ManagedState::load(&paths.state) {
-            state.desired_state = DesiredState::Stopped;
-            let _ = state.save(&paths.state);
-        }
+    if let Ok(mut state) = ManagedState::load(&paths.state) {
+        state.desired_state = DesiredState::Stopped;
+        let _ = state.save(&paths.state);
     }
 
     // Prefer signaling the supervisor: it owns the worker and unmounts it
@@ -643,19 +755,7 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
     let _ = std::fs::remove_file(&paths.supervisor_pid);
     let _ = std::fs::remove_file(&paths.state);
 
-    if had_state {
-        println!("skillfs: stopped managed mount at {}", normalized.display());
-    } else if is_mounted(&normalized) {
-        // No managed instance recorded, but something is mounted here — still
-        // best-effort unmount so `stop` is a reliable teardown.
-        force_unmount(&normalized);
-        println!("skillfs: unmounted {}", normalized.display());
-    } else {
-        println!(
-            "skillfs: no managed mount at {} (already stopped)",
-            normalized.display()
-        );
-    }
+    println!("skillfs: stopped managed mount at {}", normalized.display());
     Ok(())
 }
 
@@ -767,6 +867,46 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("nope.json");
         assert_eq!(current_desired_state(&missing), DesiredState::Stopped);
+    }
+
+    #[test]
+    fn secure_dir_creates_private_directory() {
+        use std::os::unix::fs::PermissionsExt;
+        let parent = tempfile::tempdir().unwrap();
+        let dir = parent.path().join("skillfs");
+        secure_dir(&dir).unwrap();
+        assert!(dir.is_dir());
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "runtime dir must be created 0700, got {mode:o}"
+        );
+    }
+
+    #[test]
+    fn secure_dir_tightens_loose_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let parent = tempfile::tempdir().unwrap();
+        let dir = parent.path().join("skillfs");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        secure_dir(&dir).unwrap();
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode & 0o077, 0, "group/other bits must be stripped");
+    }
+
+    #[test]
+    fn secure_dir_rejects_symlink() {
+        let parent = tempfile::tempdir().unwrap();
+        let target = parent.path().join("real");
+        std::fs::create_dir(&target).unwrap();
+        let link = parent.path().join("skillfs");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let err = secure_dir(&link).unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected symlink rejection, got: {err}"
+        );
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-cli/src/managed.rs
+++ b/src/skillfs/crates/skillfs-cli/src/managed.rs
@@ -42,6 +42,10 @@ const MAX_BACKOFF_MS: u64 = 5_000;
 /// A worker that ran at least this long is treated as a healthy mount whose
 /// later exit is not part of a crash loop, so the backoff resets.
 const STABLE_RUN_SECS: u64 = 10;
+/// Maximum consecutive sub-`STABLE_RUN_SECS` worker failures before the
+/// supervisor gives up remounting. Bounds a crash loop caused by a persistently
+/// failing worker (bad config, FUSE unavailable, EBUSY, ...).
+const MAX_FAST_FAILURES: u32 = 5;
 /// Poll interval while waiting on the worker child.
 const WORKER_POLL_MS: u64 = 200;
 /// How long the client waits for the mount to become ready before failing.
@@ -463,6 +467,32 @@ pub fn run_client(
         }
     }
 
+    // A killed supervisor can leave behind an orphan worker that still serves
+    // the mount. Do not start a competing worker over it: terminate the orphan
+    // and clear the mountpoint, then create a fresh supervised pair below.
+    if let Some(pid) = read_pid(&paths.worker_pid) {
+        if pid_alive(pid) {
+            warn!(
+                worker_pid = pid,
+                mountpoint = %normalized.display(),
+                "found orphan managed worker without a live supervisor; replacing it"
+            );
+            send_signal(pid, libc::SIGTERM);
+            let deadline = Instant::now() + Duration::from_millis(STOP_TIMEOUT_MS);
+            while pid_alive(pid) && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            if pid_alive(pid) {
+                send_signal(pid, libc::SIGKILL);
+            }
+        }
+        let _ = std::fs::remove_file(&paths.worker_pid);
+    }
+    if is_mounted(&normalized) {
+        clear_mount(&normalized)?;
+    }
+    let _ = std::fs::remove_file(&paths.supervisor_pid);
+
     let worker_program = std::env::current_exe()
         .map_err(|e| format!("failed to resolve current executable: {e}"))?;
     let worker_args = build_worker_args(raw_args);
@@ -509,12 +539,22 @@ pub fn run_client(
         std::thread::sleep(Duration::from_millis(100));
     }
 
+    // Readiness failed (timeout, or the supervisor died before the mount came
+    // up). Capture the worker log before cleanup, then tear down the supervisor
+    // we just spawned so it does not keep retrying in the background after we
+    // return an error.
     let worker_log = std::fs::read_to_string(&paths.worker_log).unwrap_or_default();
     let mut tail_lines: Vec<&str> = worker_log.lines().rev().take(20).collect();
     tail_lines.reverse();
     let tail = tail_lines.join("\n");
+
+    if let Err(e) = teardown_instance(&paths, &normalized) {
+        warn!(error = %e, "failed to clean up after managed mount startup failure");
+    }
+
     Err(format!(
-        "managed mount did not become ready within {}ms.\n--- worker log tail ---\n{}",
+        "managed mount did not become ready within {}ms; supervisor stopped.\n\
+         --- worker log tail ---\n{}",
         READY_TIMEOUT_MS, tail
     )
     .into())
@@ -605,6 +645,7 @@ pub fn run_supervisor(instance_id: &str) -> Result<(), Box<dyn Error>> {
     );
 
     let mut backoff_ms = INITIAL_BACKOFF_MS;
+    let mut fast_failures: u32 = 0;
 
     loop {
         if SHUTDOWN.load(Ordering::SeqCst) {
@@ -691,11 +732,31 @@ pub fn run_supervisor(instance_id: &str) -> Result<(), Box<dyn Error>> {
         }
 
         if start.elapsed() >= Duration::from_secs(STABLE_RUN_SECS) {
+            // The worker ran long enough to be a healthy mount; this exit is not
+            // part of a crash loop, so reset both the backoff and the counter.
             backoff_ms = INITIAL_BACKOFF_MS;
+            fast_failures = 0;
+        } else {
+            fast_failures += 1;
+            if fast_failures >= MAX_FAST_FAILURES {
+                warn!(
+                    fast_failures,
+                    stable_run_secs = STABLE_RUN_SECS,
+                    mountpoint = %mountpoint.display(),
+                    "managed worker keeps failing fast; giving up crash-loop remount"
+                );
+                // Mark the instance stopped so nothing resurrects it, then fall
+                // through to finish(): unmount and clear residual state.
+                if let Ok(mut state) = ManagedState::load(&paths.state) {
+                    state.desired_state = DesiredState::Stopped;
+                    let _ = state.save(&paths.state);
+                }
+                break;
+            }
         }
         info!(
             backoff_ms,
-            "managed worker exited unexpectedly; remounting after backoff"
+            fast_failures, "managed worker exited unexpectedly; remounting after backoff"
         );
         // Sleep in small slices so shutdown is responsive during backoff.
         let backoff_deadline = Instant::now() + Duration::from_millis(backoff_ms);
@@ -754,41 +815,14 @@ fn finish(paths: &ManagedPaths, mountpoint: &Path) {
 // Stop: `skillfs stop <MOUNTPOINT>`
 // ---------------------------------------------------------------------------
 
-/// Entry point for `skillfs stop`. Clears the desired state, terminates the
-/// managed supervisor/worker, and unmounts. Idempotent: tolerates an
-/// already-unmounted mount and a missing managed instance.
-pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
-    let normalized = normalize_mountpoint(mountpoint);
-    let instance_id = instance_id_for(&normalized);
-    let paths = ManagedPaths::new(&instance_id);
-    secure_runtime_dir()?;
-
-    let had_state = paths.state.exists();
-
-    // No managed instance recorded for this mountpoint. `stop` is still a
-    // reliable teardown, so unmount immediately instead of waiting the full
-    // stop timeout on processes that do not exist (handles stale or
-    // non-managed dead mounts).
-    if !had_state {
-        let _ = std::fs::remove_file(&paths.worker_pid);
-        let _ = std::fs::remove_file(&paths.supervisor_pid);
-        match classify_mount(&normalized) {
-            MountState::NotMounted => {
-                println!(
-                    "skillfs: no managed mount at {} (already stopped)",
-                    normalized.display()
-                );
-            }
-            // Present (ready or a stale/dead endpoint): unmount it, surfacing
-            // an error if cleanup cannot complete.
-            _ => {
-                clear_mount(&normalized)?;
-                println!("skillfs: unmounted {}", normalized.display());
-            }
-        }
-        return Ok(());
-    }
-
+/// Tear down a managed instance: mark it stopped, signal the supervisor
+/// (falling back to the worker), wait for exit, unmount, and remove residual
+/// pid/state files. Returns the unmount result so callers can surface a cleanup
+/// failure; every other step is best-effort.
+///
+/// Shared by `stop` and by the client's startup-abort path so neither has to
+/// duplicate the signal/wait/unmount sequence.
+fn teardown_instance(paths: &ManagedPaths, mountpoint: &Path) -> Result<(), Box<dyn Error>> {
     // Clear desired state first so the supervisor will not remount even if a
     // remount races with our signal.
     if let Ok(mut state) = ManagedState::load(&paths.state) {
@@ -827,7 +861,7 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
             break;
         }
         if Instant::now() >= deadline {
-            warn!("stop timed out waiting for clean shutdown; forcing");
+            warn!("teardown timed out waiting for clean shutdown; forcing");
             if let Some(p) = sup_pid {
                 if pid_alive(p) {
                     send_signal(p, libc::SIGKILL);
@@ -844,9 +878,9 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
     }
 
     // Ensure the mount is gone, clearing any stale/dead endpoint a killed
-    // worker left behind. Errors are surfaced after state cleanup.
-    let unmount_result = if is_mounted(&normalized) {
-        clear_mount(&normalized)
+    // worker left behind. The error is surfaced after state cleanup.
+    let unmount_result = if is_mounted(mountpoint) {
+        clear_mount(mountpoint)
     } else {
         Ok(())
     };
@@ -856,7 +890,45 @@ pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
     let _ = std::fs::remove_file(&paths.supervisor_pid);
     let _ = std::fs::remove_file(&paths.state);
 
-    unmount_result?;
+    unmount_result
+}
+
+/// Entry point for `skillfs stop`. Clears the desired state, terminates the
+/// managed supervisor/worker, and unmounts. Idempotent: tolerates an
+/// already-unmounted mount and a missing managed instance.
+pub fn run_stop(mountpoint: &Path) -> Result<(), Box<dyn Error>> {
+    let normalized = normalize_mountpoint(mountpoint);
+    let instance_id = instance_id_for(&normalized);
+    let paths = ManagedPaths::new(&instance_id);
+    secure_runtime_dir()?;
+
+    let had_state = paths.state.exists();
+
+    // No managed instance recorded for this mountpoint. `stop` is still a
+    // reliable teardown, so unmount immediately instead of waiting the full
+    // stop timeout on processes that do not exist (handles stale or
+    // non-managed dead mounts).
+    if !had_state {
+        let _ = std::fs::remove_file(&paths.worker_pid);
+        let _ = std::fs::remove_file(&paths.supervisor_pid);
+        match classify_mount(&normalized) {
+            MountState::NotMounted => {
+                println!(
+                    "skillfs: no managed mount at {} (already stopped)",
+                    normalized.display()
+                );
+            }
+            // Present (ready or a stale/dead endpoint): unmount it, surfacing
+            // an error if cleanup cannot complete.
+            _ => {
+                clear_mount(&normalized)?;
+                println!("skillfs: unmounted {}", normalized.display());
+            }
+        }
+        return Ok(());
+    }
+
+    teardown_instance(&paths, &normalized)?;
     println!("skillfs: stopped managed mount at {}", normalized.display());
     Ok(())
 }

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -1104,6 +1104,85 @@ fn control_socket_with_decision_command_fails_startup() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Managed mount / stop startup gates
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn managed_mount_parses_and_rejects_missing_source() {
+    // `--managed` must parse, and the managed client must fail fast with a
+    // clear source error before detaching a supervisor — proving the flag is
+    // wired without needing FUSE.
+    let parent = tempfile::tempdir().expect("parent tempdir");
+    let missing_source = parent.path().join("does-not-exist");
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            missing_source.to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--managed",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("Source directory does not exist"),
+        "expected missing-source error, got: {combined}"
+    );
+}
+
+#[test]
+fn stop_is_idempotent_when_nothing_mounted() {
+    // `stop` on a path with no managed instance and nothing mounted must
+    // succeed (idempotent teardown).
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args(["stop", mount.path().to_str().unwrap()])
+        .output()
+        .expect("invoke skillfs");
+    assert!(
+        out.status.success(),
+        "expected success (idempotent stop), stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("no managed mount") || combined.contains("already stopped"),
+        "expected idempotent no-op message, got: {combined}"
+    );
+}
+
+#[test]
+fn supervise_missing_instance_fails() {
+    // The hidden supervise subcommand must fail cleanly when the instance
+    // state file is absent, rather than spinning.
+    let out = Command::new(bin_path())
+        .args(["supervise", "--instance", "nonexistent-0000000000000000"])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("failed to load managed state"),
+        "expected managed-state load error, got: {combined}"
+    );
+}
+
 #[test]
 fn control_socket_created_and_accepts_ping() {
     let source = empty_source();

--- a/src/skillfs/crates/skillfs-fuse/Cargo.toml
+++ b/src/skillfs/crates/skillfs-fuse/Cargo.toml
@@ -18,7 +18,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = "0.8"
-libc = "0.2"
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src/skillfs/scripts/test.sh
+++ b/src/skillfs/scripts/test.sh
@@ -25,6 +25,7 @@ MOUNT_DIR="$TMP_ROOT/mount"
 PID_FILE="$TMP_ROOT/skillfs.pid"
 LOG_FILE="$TMP_ROOT/skillfs.log"
 MOUNT_PID=""
+MANAGED_MOUNT_DIR=""
 
 info() {
 	echo "[skillfs-e2e] $1"
@@ -51,6 +52,12 @@ cleanup() {
 	if [[ -n "$MOUNT_PID" ]] && kill -0 "$MOUNT_PID" 2>/dev/null; then
 		kill "$MOUNT_PID" 2>/dev/null || true
 		wait "$MOUNT_PID" 2>/dev/null || true
+	fi
+	if [[ -n "$MANAGED_MOUNT_DIR" ]]; then
+		"$BIN" stop "$MANAGED_MOUNT_DIR" >/dev/null 2>&1 || true
+		if grep -Fq " $MANAGED_MOUNT_DIR " /proc/mounts 2>/dev/null; then
+			fusermount3 -u "$MANAGED_MOUNT_DIR" >/dev/null 2>&1 || true
+		fi
 	fi
 	rm -rf "$TMP_ROOT"
 }
@@ -225,5 +232,84 @@ if ! wait_for_mount_state unmounted; then
 	fail "卸载超时"
 fi
 pass "FUSE 已正确卸载"
+
+# ---------------------------------------------------------------------------
+# Managed mount supervisor smoke test
+# ---------------------------------------------------------------------------
+
+info "测试 managed mount 监督器"
+
+# Isolate managed runtime state in a dedicated XDG_RUNTIME_DIR so the pid /
+# state files for this run are the only ones present.
+export XDG_RUNTIME_DIR="$TMP_ROOT/xdg"
+mkdir -p "$XDG_RUNTIME_DIR"
+RUNTIME_STATE_DIR="$XDG_RUNTIME_DIR/skillfs"
+MANAGED_MOUNT_DIR="$TMP_ROOT/managed-mount"
+mkdir -p "$MANAGED_MOUNT_DIR"
+
+if ! "$BIN" mount "$SOURCE_DIR" "$MANAGED_MOUNT_DIR" --managed \
+	--log-file "$TMP_ROOT/managed-client.log" >/dev/null 2>&1; then
+	fail "managed mount 客户端返回非零"
+fi
+
+managed_ready=false
+for _ in $(seq 1 50); do
+	if grep -Fq " $MANAGED_MOUNT_DIR " /proc/mounts 2>/dev/null; then
+		managed_ready=true
+		break
+	fi
+	sleep 0.1
+done
+[[ "$managed_ready" == true ]] || fail "managed 挂载超时"
+pass "managed 挂载成功"
+
+WORKER_PID_FILE="$(ls "$RUNTIME_STATE_DIR"/*.worker.pid 2>/dev/null | head -n1)"
+SUP_PID_FILE="$(ls "$RUNTIME_STATE_DIR"/*.supervisor.pid 2>/dev/null | head -n1)"
+[[ -n "$WORKER_PID_FILE" ]] || fail "找不到 worker pid 文件"
+[[ -n "$SUP_PID_FILE" ]] || fail "找不到 supervisor pid 文件"
+OLD_WORKER_PID="$(cat "$WORKER_PID_FILE")"
+SUP_PID="$(cat "$SUP_PID_FILE")"
+
+info "强杀 worker (pid=$OLD_WORKER_PID)，保留 supervisor (pid=$SUP_PID)"
+kill -KILL "$OLD_WORKER_PID" 2>/dev/null || true
+
+restored=false
+for _ in $(seq 1 150); do
+	if grep -Fq " $MANAGED_MOUNT_DIR " /proc/mounts 2>/dev/null; then
+		NEW_WORKER_PID="$(cat "$WORKER_PID_FILE" 2>/dev/null || echo)"
+		if [[ -n "$NEW_WORKER_PID" && "$NEW_WORKER_PID" != "$OLD_WORKER_PID" ]] \
+			&& kill -0 "$NEW_WORKER_PID" 2>/dev/null; then
+			restored=true
+			break
+		fi
+	fi
+	sleep 0.1
+done
+[[ "$restored" == true ]] || fail "worker 被杀后未在超时内恢复挂载"
+pass "worker 崩溃后 supervisor 自动重挂"
+
+info "执行 skillfs stop"
+if ! "$BIN" stop "$MANAGED_MOUNT_DIR" >/dev/null 2>&1; then
+	fail "stop 返回非零"
+fi
+
+managed_stopped=false
+for _ in $(seq 1 50); do
+	if ! grep -Fq " $MANAGED_MOUNT_DIR " /proc/mounts 2>/dev/null; then
+		managed_stopped=true
+		break
+	fi
+	sleep 0.1
+done
+[[ "$managed_stopped" == true ]] || fail "stop 后未卸载"
+
+if kill -0 "$SUP_PID" 2>/dev/null; then
+	fail "stop 后 supervisor 仍在运行"
+fi
+if [[ -f "$WORKER_PID_FILE" || -f "$SUP_PID_FILE" ]]; then
+	fail "stop 后仍残留 pid 状态文件"
+fi
+pass "stop 清理 managed 挂载与进程"
+MANAGED_MOUNT_DIR=""
 
 info "端到端测试完成"

--- a/src/skillfs/scripts/test.sh
+++ b/src/skillfs/scripts/test.sh
@@ -273,12 +273,29 @@ SUP_PID="$(cat "$SUP_PID_FILE")"
 info "强杀 worker (pid=$OLD_WORKER_PID)，保留 supervisor (pid=$SUP_PID)"
 kill -KILL "$OLD_WORKER_PID" 2>/dev/null || true
 
+# After SIGKILL the endpoint is dead: still in /proc/mounts but access returns
+# ENOTCONN ("Transport endpoint is not connected"), or the worker has exited.
+# Best-effort observation of that transient state (may race with fast recovery).
+for _ in $(seq 1 30); do
+	if ! kill -0 "$OLD_WORKER_PID" 2>/dev/null; then
+		break
+	fi
+	if ! ls "$MANAGED_MOUNT_DIR" >/dev/null 2>&1; then
+		info "检测到 dead FUSE endpoint (预期)"
+		break
+	fi
+	sleep 0.1
+done
+
+# Recovery must: clear the stale endpoint, start a new worker, and leave the
+# mountpoint actually readable again (ls succeeds => ENOTCONN is gone).
 restored=false
 for _ in $(seq 1 150); do
 	if grep -Fq " $MANAGED_MOUNT_DIR " /proc/mounts 2>/dev/null; then
 		NEW_WORKER_PID="$(cat "$WORKER_PID_FILE" 2>/dev/null || echo)"
 		if [[ -n "$NEW_WORKER_PID" && "$NEW_WORKER_PID" != "$OLD_WORKER_PID" ]] \
-			&& kill -0 "$NEW_WORKER_PID" 2>/dev/null; then
+			&& kill -0 "$NEW_WORKER_PID" 2>/dev/null \
+			&& ls "$MANAGED_MOUNT_DIR" >/dev/null 2>&1; then
 			restored=true
 			break
 		fi
@@ -286,7 +303,13 @@ for _ in $(seq 1 150); do
 	sleep 0.1
 done
 [[ "$restored" == true ]] || fail "worker 被杀后未在超时内恢复挂载"
-pass "worker 崩溃后 supervisor 自动重挂"
+pass "worker 崩溃后 supervisor 清理 dead endpoint 并重挂"
+
+# Confirm the recovered mount serves content, not a stale endpoint.
+if ! ls "$MANAGED_MOUNT_DIR/skills" >/dev/null 2>&1; then
+	fail "恢复后 mountpoint 仍不可访问"
+fi
+pass "恢复后 ls <mountpoint>/skills 成功"
 
 info "执行 skillfs stop"
 if ! "$BIN" stop "$MANAGED_MOUNT_DIR" >/dev/null 2>&1; then

--- a/src/skillfs/scripts/test.sh
+++ b/src/skillfs/scripts/test.sh
@@ -311,6 +311,118 @@ if ! ls "$MANAGED_MOUNT_DIR/skills" >/dev/null 2>&1; then
 fi
 pass "恢复后 ls <mountpoint>/skills 成功"
 
+ORPHAN_WORKER_PID="$(cat "$WORKER_PID_FILE")"
+info "强杀 supervisor (pid=$SUP_PID)，保留孤儿 worker (pid=$ORPHAN_WORKER_PID)"
+kill -KILL "$SUP_PID" 2>/dev/null || true
+for _ in $(seq 1 50); do
+	if ! kill -0 "$SUP_PID" 2>/dev/null; then
+		break
+	fi
+	sleep 0.1
+done
+if kill -0 "$SUP_PID" 2>/dev/null; then
+	fail "supervisor 被 kill -9 后仍在运行"
+fi
+if ! kill -0 "$ORPHAN_WORKER_PID" 2>/dev/null; then
+	fail "supervisor 被 kill -9 后 worker 未保持孤儿运行"
+fi
+
+if ! "$BIN" mount "$SOURCE_DIR" "$MANAGED_MOUNT_DIR" --managed \
+	--log-file "$TMP_ROOT/managed-client-recover.log" >/dev/null 2>&1; then
+	fail "孤儿 worker 场景下重新执行 managed mount 失败"
+fi
+
+SUP_PID_FILE="$(ls "$RUNTIME_STATE_DIR"/*.supervisor.pid 2>/dev/null | head -n1)"
+WORKER_PID_FILE="$(ls "$RUNTIME_STATE_DIR"/*.worker.pid 2>/dev/null | head -n1)"
+[[ -n "$SUP_PID_FILE" ]] || fail "恢复后找不到 supervisor pid 文件"
+[[ -n "$WORKER_PID_FILE" ]] || fail "恢复后找不到 worker pid 文件"
+SUP_PID="$(cat "$SUP_PID_FILE")"
+NEW_WORKER_PID="$(cat "$WORKER_PID_FILE")"
+if [[ "$NEW_WORKER_PID" == "$ORPHAN_WORKER_PID" ]]; then
+	fail "重新 managed mount 后仍复用孤儿 worker"
+fi
+if kill -0 "$ORPHAN_WORKER_PID" 2>/dev/null; then
+	fail "重新 managed mount 后孤儿 worker 仍在运行"
+fi
+if ! kill -0 "$SUP_PID" 2>/dev/null || ! kill -0 "$NEW_WORKER_PID" 2>/dev/null; then
+	fail "重新 managed mount 后 supervisor/worker 未运行"
+fi
+if ! ls "$MANAGED_MOUNT_DIR/skills" >/dev/null 2>&1; then
+	fail "清理孤儿 worker 后 mountpoint 不可访问"
+fi
+pass "supervisor 被杀后的孤儿 worker 可由下一次 managed mount 清理并重建"
+
+# ---------------------------------------------------------------------------
+# Fast-failure / ready-timeout crash-loop circuit breaker
+# ---------------------------------------------------------------------------
+
+info "测试 managed mount 快速失败熔断"
+
+# Isolate this instance's runtime state in its own XDG_RUNTIME_DIR so its pid /
+# state / log files are the only ones present, independent of the still-active
+# managed mount above.
+FAIL_XDG="$TMP_ROOT/xdg-fail"
+mkdir -p "$FAIL_XDG"
+FAIL_STATE_DIR="$FAIL_XDG/skillfs"
+FAIL_MOUNT_DIR="$TMP_ROOT/managed-fail-mount"
+mkdir -p "$FAIL_MOUNT_DIR"
+FAIL_CLIENT_LOG="$TMP_ROOT/managed-fail-client.log"
+
+# `--activation-mode bogus` passes client-side source validation but makes every
+# foreground worker exit immediately, so the supervisor faces a permanent crash
+# loop. The client must fail (not falsely report success) and the supervisor
+# must give up rather than retry forever.
+if XDG_RUNTIME_DIR="$FAIL_XDG" "$BIN" mount "$SOURCE_DIR" "$FAIL_MOUNT_DIR" \
+	--managed --activation-mode bogus \
+	--log-file "$FAIL_CLIENT_LOG" >/dev/null 2>&1; then
+	fail "快速失败场景下 managed mount 客户端应返回非零"
+fi
+pass "快速失败场景 managed mount 客户端返回错误"
+
+# No live supervisor or worker may remain after the client returns.
+fail_daemon_gone=false
+for _ in $(seq 1 100); do
+	live=false
+	for pf in "$FAIL_STATE_DIR"/*.supervisor.pid "$FAIL_STATE_DIR"/*.worker.pid; do
+		[[ -e "$pf" ]] || continue
+		p="$(cat "$pf" 2>/dev/null || echo)"
+		if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
+			live=true
+		fi
+	done
+	if [[ "$live" == false ]]; then
+		fail_daemon_gone=true
+		break
+	fi
+	sleep 0.1
+done
+[[ "$fail_daemon_gone" == true ]] || fail "快速失败后仍有存活的 supervisor/worker"
+pass "快速失败后无存活 supervisor/worker"
+
+# The mountpoint must not stay mounted, and the desired state must not remain
+# "mounted" (crash-loop give up marks it stopped and clears the state file).
+if grep -Fq " $FAIL_MOUNT_DIR " /proc/mounts 2>/dev/null; then
+	fail "快速失败后 mountpoint 仍处于挂载状态"
+fi
+FAIL_STATE_FILE="$(ls "$FAIL_STATE_DIR"/*.state.json 2>/dev/null | head -n1 || true)"
+if [[ -n "$FAIL_STATE_FILE" ]] && grep -Fq '"mounted"' "$FAIL_STATE_FILE" 2>/dev/null; then
+	fail "快速失败后 desired state 仍为 mounted"
+fi
+pass "快速失败后 state 未保持 mounted 且未残留挂载"
+
+# The crash loop must be bounded: once the supervisor gives up (and exits), its
+# log stops growing. With no live daemon, two samples must be identical.
+FAIL_SUP_LOG="$(ls "$FAIL_STATE_DIR"/*.supervisor.log 2>/dev/null | head -n1 || true)"
+if [[ -n "$FAIL_SUP_LOG" ]]; then
+	fail_size1="$(wc -c <"$FAIL_SUP_LOG")"
+	sleep 1
+	fail_size2="$(wc -c <"$FAIL_SUP_LOG")"
+	assert_equals "$fail_size2" "$fail_size1" "快速失败后 supervisor 日志不再增长"
+fi
+
+# Best-effort cleanup of the failed instance (mountpoint should already be gone).
+XDG_RUNTIME_DIR="$FAIL_XDG" "$BIN" stop "$FAIL_MOUNT_DIR" >/dev/null 2>&1 || true
+
 info "执行 skillfs stop"
 if ! "$BIN" stop "$MANAGED_MOUNT_DIR" >/dev/null 2>&1; then
 	fail "stop 返回非零"


### PR DESCRIPTION
## Summary

Adds opt-in managed mount mode for SkillFS. `skillfs mount --managed` starts a detached supervisor that keeps the mount desired state as mounted until `skillfs stop <MOUNTPOINT>` is called.

This fixes the OpenClaw gateway restart experience and dead FUSE recovery path. It can close #1265 and #1268.

Closes #1265
Closes #1268

## What Changed

- Added `skillfs mount --managed` for restart-resistant managed mounts.
- Added `skillfs stop <MOUNTPOINT>` to clear desired mounted state and unmount cleanly.
- Added a hidden supervisor role that restarts the foreground FUSE worker when it exits unexpectedly.
- Detects stale/dead FUSE endpoints after worker `SIGKILL`, clears them, and remounts.
- Hardened managed runtime state directory ownership and permissions.
- Preserved existing default `skillfs mount`, `--foreground`, and SIGTERM clean-unmount behavior.

## Behavior / Compatibility

Managed mode is opt-in. Existing mount behavior is unchanged unless `--managed` is used.

For OpenClaw usage, `skillfs mount --managed` keeps the SkillFS mount usable across gateway restart. Explicit `skillfs stop <MOUNTPOINT>` remains the supported way to stop the managed mount.

## Validation

Validated with OpenClaw 2026.6.10 and FUSE available.

Commands run:

```sh
cd /home/ecs-user/anolisa/src/skillfs
cargo build --bin skillfs
cargo test -p skillfs --test cli_startup_tests
scripts/test.sh