### PR TITLE
fix(agent-sec-core): override loongshield exit 0 on error + actionable ErrManifestMissing

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
@@ -21,7 +21,10 @@ class ErrManifestMissing(SkillVerifyError):
 
     def __init__(self, skill_name: str) -> None:
         super().__init__(
-            f"ERR_MANIFEST_MISSING: Missing .skill-meta/Manifest.json in '{skill_name}'"
+            f"ERR_MANIFEST_MISSING: Missing .skill-meta/Manifest.json in '{skill_name}'.\n"
+            f"  Cause: the skill directory has not been signed, or the manifest was deleted.\n"
+            f"  Please run `agent-sec-cli sign-skill --skill {skill_name}` to create it,\n"
+            f"  or use `agent-sec-cli verify --help` for usage details."
         )
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/hardening.py
@@ -165,10 +165,23 @@ class HardeningBackend(BaseBackend):
         data["returncode"] = proc.returncode
         self._parse_output(clean_output, data)
 
+        # loongshield may return exit 0 even when it encounters errors
+        # (e.g. missing config file, ENFORCE-ERROR on reinforce without root).
+        # Detect such conditions in the parsed output and override the exit
+        # code so the CLI surface reports failure to callers.
+        has_output_errors = bool(data.get("failures")) or bool(
+            data.get("fixed_items")
+        )
+        has_error_lines = bool(re.search(r"\[ERROR", clean_output))
+
+        effective_exit = proc.returncode
+        if effective_exit == 0 and (has_output_errors or has_error_lines):
+            effective_exit = 1
+
         return ActionResult(
-            success=(proc.returncode == 0),
+            success=(effective_exit == 0),
             stdout=clean_output,
-            exit_code=proc.returncode,
+            exit_code=effective_exit,
             data=data,
         )
 


### PR DESCRIPTION
## 问题

Fixes #1280
Fixes #1281

`agent-sec-cli harden` 命令在调用 `loongshield` 后端时，`HardeningBackend` 直接透传 `loongshield` 的 exit code。但 `loongshield` 在遇到配置文件缺失或非 root 用户执行 reinforce 时仍返回 exit 0，导致 CLI 误报成功。同时 `verify` 命令的 `ErrManifestMissing` 错误信息缺乏可操作性提示。

## 修复

```diff
# hardening.py: 检测 [ERROR/ENFORCE-ERROR 输出并覆盖 exit code
+has_output_errors = bool(data.get("failures")) or bool(data.get("fixed_items"))
+has_error_lines = bool(re.search(r"\[ERROR", clean_output))
+effective_exit = proc.returncode
+if effective_exit == 0 and (has_output_errors or has_error_lines):
+    effective_exit = 1

# errors.py: ErrManifestMissing 增加可操作性提示
+f"  Cause: the skill directory has not been signed, or the manifest was deleted.\n"
+f"  Please run `agent-sec-cli sign-skill --skill {skill_name}` to create it,\n"
+f"  or use `agent-sec-cli verify --help` for usage details."
```

## 验证

```shell
# ECS fresh clone + apply patch + build
source /root/.cargo/env
git clone https://github.com/alibaba/anolisa.git && cd anolisa
git apply fix.patch
bash scripts/rpm-build.sh agent-sec-core
# → VERIFY_EXIT=0, 7 RPMs produced (agent-sec-cli-0.7.0-1.alnx4.x86_64.rpm 207M)

# Tests
cd /root/agentic-os-tests/agent-sec-core
python3 -m pytest tests/test_cli_harden.py tests/test_cli_verify.py -xvs
# → 9 passed, 0 failed
```

Co-Authored-By: Claude <noreply@anthropic.com>