### PR TITLE
fix(skillfs): reject PrivateTmp backing roots

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/help_text.rs
+++ b/src/skillfs/crates/skillfs-cli/src/help_text.rs
@@ -53,10 +53,13 @@ pub const MOUNT_AFTER_HELP: &str = r#"Examples:
 
   skillfs mount ./skills ./skills --security-mode --security --activation-mode file \
     --notify-socket /run/skill-ledger.sock \
-    --ledger-backing-root /run/skillfs/source \
+    --ledger-backing-root /run/user/$UID/skillfs-ledger/source \
     --trusted-writer-exe /usr/bin/skill-ledger
       Ledger-driven activation flow. The daemon writes activation state;
-      SkillFS exposes current, fallback, or hidden skill views.
+      SkillFS exposes current, fallback, or hidden skill views. Put the
+      daemon-facing source/backing root under /run/user/$UID/... or /run/...:
+      agent-sec-core.service runs with PrivateTmp=true, so /tmp and /var/tmp
+      are invisible to the daemon and are rejected at startup.
 
 Important paths:
   SOURCE      Directory that stores real skill folders and skillfs-views.toml.

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -1,6 +1,6 @@
 //! SkillFS CLI — AI agent skill management via virtual filesystem.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 fn cleanup_pid_file(pid_file: &Option<PathBuf>) {
@@ -216,6 +216,11 @@ enum Commands {
         /// validates the path and fails closed if ownership, permissions, or
         /// mount layout are unsafe. Requires `--security --activation-mode
         /// file` and is mutually exclusive with `--decision-command`.
+        ///
+        /// Recommended location: `/run/user/$UID/skillfs-ledger/...` or
+        /// `/run/skillfs-ledger/...`. Do NOT use `/tmp` or `/var/tmp`:
+        /// agent-sec-core.service runs with PrivateTmp=true, so a daemon-facing
+        /// path there is invisible to the daemon and startup is rejected.
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_LEDGER)]
         ledger_backing_root: Option<PathBuf>,
 
@@ -471,6 +476,69 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
 /// window keeps audit volume reasonable without losing the signal that an
 /// out-of-band change happened.
 const DRIFT_DEBOUNCE_MS: u64 = 200;
+
+/// Compute the expected canonical path a daemon-facing directory will
+/// resolve to, without requiring the leaf to exist.
+///
+/// Mirrors the parent-canonicalize + leaf-join shape used by
+/// `LedgerBackingRoot::setup`: the parent must resolve, but the final
+/// component may be created later. Falls back to the input path when the
+/// parent cannot be canonicalized so the caller still gets a best-effort
+/// answer instead of silently skipping the check.
+fn expected_daemon_facing_path(p: &Path) -> PathBuf {
+    let parent = p
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    match parent.canonicalize() {
+        Ok(parent_canon) => match p.file_name() {
+            Some(leaf) => parent_canon.join(leaf),
+            None => parent_canon,
+        },
+        Err(_) => p.to_path_buf(),
+    }
+}
+
+/// Return `true` when a daemon-facing path resolves under a private-tmp
+/// root (`/tmp` or `/var/tmp`).
+///
+/// `agent-sec-core.service` runs with `PrivateTmp=true`, so the daemon
+/// gets a private mount namespace where the host `/tmp` and `/var/tmp`
+/// are invisible. A daemon-facing source/backing root under those roots
+/// would make the daemon reject notifications and time out activation.
+/// Both the literal and canonical forms of the tmp roots are checked so
+/// a symlinked `/tmp` (e.g. `/tmp -> /private/tmp`) is still caught.
+fn daemon_facing_path_under_private_tmp(candidate: &Path) -> bool {
+    for root in ["/tmp", "/var/tmp"] {
+        let root_path = Path::new(root);
+        if candidate.starts_with(root_path) {
+            return true;
+        }
+        if let Ok(canon_root) = root_path.canonicalize() {
+            if candidate.starts_with(&canon_root) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Return `true` when an operator-supplied daemon-facing argument resolves
+/// under a private-tmp root.
+///
+/// Checks both the parent-canonicalize + leaf shape (so a not-yet-created
+/// leaf is still evaluated) and, when the path already exists, its fully
+/// canonicalized form. The latter closes a symlink bypass such as
+/// `/run/.../x -> /tmp/real`, which passes the shape check but is resolved
+/// to a PrivateTmp-invisible path once the daemon follows it.
+fn daemon_facing_arg_under_private_tmp(path: &Path) -> bool {
+    daemon_facing_path_under_private_tmp(&expected_daemon_facing_path(path))
+        || path
+            .canonicalize()
+            .ok()
+            .as_deref()
+            .is_some_and(daemon_facing_path_under_private_tmp)
+}
 
 #[allow(clippy::too_many_arguments)]
 async fn cmd_mount(
@@ -907,6 +975,86 @@ async fn cmd_mount(
         skillfs_fuse::security::validate_protocol_events_path_outside_source(p, &source_canon)
             .map_err(|e| format!("{}", e))?;
     }
+
+    // #1262 PrivateTmp gate. When daemon-driven activation is enabled,
+    // agent-sec-core.service runs with PrivateTmp=true and therefore
+    // cannot see the host /tmp or /var/tmp. Any daemon-facing path under
+    // those roots makes the daemon reject notify, fail to tail the events
+    // log, or time out the activation reload, which hides the affected
+    // skills. Fail fast here — before the audit sink is opened, the
+    // mountpoint is auto-created, or any backing root bind mount runs — so
+    // a rejected config leaves no side effects behind. The pure
+    // inside-source guards above keep their own error ordering; this only
+    // adds a check, never a side effect.
+    //
+    // Guarded paths (all daemon-facing):
+    //   * backing root, or the source fallback (the daemon's scan target);
+    //   * --activation-events-log (the daemon tails this JSONL file);
+    //   * --notify-socket (the daemon owns this Unix socket).
+    // A plain agent-visible mountpoint under /tmp is NOT guarded.
+    let daemon_driven_activation = security
+        && activation_mode == ActivationMode::File
+        && (notify_socket.is_some() || activation_events_log.is_some());
+    if daemon_driven_activation {
+        // Daemon-facing root: the backing root when set, otherwise the
+        // source is what the daemon scans directly.
+        if let Some(ref br_path) = ledger_backing_root {
+            if daemon_facing_arg_under_private_tmp(br_path) {
+                return Err(format!(
+                    "--ledger-backing-root {} resolves under /tmp or /var/tmp, which the \
+                     agent-sec-core.service daemon cannot see because it runs with \
+                     PrivateTmp=true. Daemon-driven activation would be rejected and the \
+                     affected skills hidden. Use a daemon-visible backing root such as \
+                     /run/user/$UID/skillfs-ledger/... or /run/skillfs-ledger/... instead.",
+                    br_path.display()
+                )
+                .into());
+            }
+        } else if daemon_facing_path_under_private_tmp(&source_canon) {
+            return Err(format!(
+                "the daemon-facing source root {} resolves under /tmp or /var/tmp, which the \
+                 agent-sec-core.service daemon cannot see because it runs with PrivateTmp=true. \
+                 Daemon-driven activation would be rejected and the affected skills hidden. \
+                 Set --ledger-backing-root to a daemon-visible path such as \
+                 /run/user/$UID/skillfs-ledger/... or /run/skillfs-ledger/... instead.",
+                source_canon.display()
+            )
+            .into());
+        }
+
+        // Daemon-facing transport paths. These are independent of the
+        // backing root: the daemon must reach them regardless of where the
+        // scan target lives.
+        if let Some(ref p) = activation_events_log {
+            if daemon_facing_arg_under_private_tmp(p) {
+                return Err(format!(
+                    "--activation-events-log {} resolves under /tmp or /var/tmp, which the \
+                     agent-sec-core.service daemon cannot see because it runs with \
+                     PrivateTmp=true. The daemon tails this JSONL file, so daemon-driven \
+                     activation would break and the affected skills be hidden. Use a \
+                     daemon-visible path such as /run/user/$UID/skillfs-ledger/... or \
+                     /run/skillfs-ledger/... instead.",
+                    p.display()
+                )
+                .into());
+            }
+        }
+        if let Some(ref p) = notify_socket {
+            if daemon_facing_arg_under_private_tmp(p) {
+                return Err(format!(
+                    "--notify-socket {} resolves under /tmp or /var/tmp, which the \
+                     agent-sec-core.service daemon cannot see because it runs with \
+                     PrivateTmp=true. The daemon owns this socket, so daemon-driven \
+                     activation would break and the affected skills be hidden. Use a \
+                     daemon-visible path such as /run/user/$UID/skillfs-ledger/... or \
+                     /run/skillfs-ledger/... instead.",
+                    p.display()
+                )
+                .into());
+            }
+        }
+    }
+
     let audit_sink = audit_runtime.build_sink().map_err(|e| {
         format!(
             "failed to open audit log '{}': {}",

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -666,6 +666,445 @@ fn ledger_backing_root_inside_source_fails_before_mount() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #1262: PrivateTmp daemon-facing backing root / source gates
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// agent-sec-core.service runs with PrivateTmp=true, so a daemon-facing
+// source or backing root under /tmp or /var/tmp is invisible to the
+// daemon. SkillFS must fail fast at startup (before any mount / bind
+// mount) rather than letting notify be rejected and activation time out.
+
+/// A directory that is NOT under /tmp (tempfile defaults to /tmp). Rooted
+/// at the crate's target dir so daemon-facing paths can be exercised with
+/// a genuinely non-tmp canonical location.
+fn non_tmp_dir() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("skillfs-nontmp-")
+        .tempdir_in(env!("CARGO_TARGET_TMPDIR"))
+        .expect("non-tmp tempdir")
+}
+
+/// A collision-resistant leaf name (pid + nanosecond timestamp) so tests
+/// that use a fixed parent directory (e.g. /tmp) never trip over a stale
+/// path left behind by a previous manual run.
+fn unique_leaf(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{prefix}-{}-{}", std::process::id(), nanos)
+}
+
+/// Spawn the binary, let startup run briefly, then kill it and return the
+/// combined stdout+stderr. Used for configs that pass the new gate and
+/// would otherwise block on the FUSE mount.
+fn run_briefly(args: &[&str]) -> String {
+    let mut child = Command::new(bin_path())
+        .args(args)
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    let _ = child.kill();
+    let out = child.wait_with_output().expect("wait for child");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    )
+}
+
+#[test]
+fn backing_root_under_tmp_fails_before_setup() {
+    // --ledger-backing-root under /tmp with daemon-driven activation
+    // (--notify-socket) must be rejected before any mount / bind mount.
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    // Leaf need not exist; parent (/tmp) canonicalizes. Nothing is created.
+    // Use a unique leaf so a stale dir from a prior run cannot skew the
+    // "dir not created" assertion below.
+    let backing = format!("/tmp/{}", unique_leaf("skillfs-privtmp-test-backing"));
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            "/run/skillfs-privtmp-test.sock",
+            "--ledger-backing-root",
+            &backing,
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--ledger-backing-root")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true")
+            && combined.contains("/run/user/$UID/")
+            && combined.contains("/run/"),
+        "expected PrivateTmp backing-root rejection, got: {combined}"
+    );
+    assert!(
+        !Path::new(&backing).exists(),
+        "backing root dir must not be created when the gate rejects it"
+    );
+}
+
+#[test]
+fn backing_root_under_var_tmp_fails_before_setup() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let backing = format!("/var/tmp/{}", unique_leaf("skillfs-privtmp-test-backing"));
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--activation-events-log",
+            "/run/skillfs-privtmp-test-events.jsonl",
+            "--ledger-backing-root",
+            &backing,
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--ledger-backing-root")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true"),
+        "expected PrivateTmp backing-root rejection for /var/tmp, got: {combined}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn backing_root_symlink_to_tmp_fails_before_setup() {
+    // A backing root whose path shape is non-tmp but which symlinks to a
+    // real /tmp directory must still be rejected. Without canonicalizing
+    // the backing root itself, the parent-canonicalize + leaf shape check
+    // would pass while LedgerBackingRoot::setup resolves the symlink and
+    // hands the daemon a /tmp path it cannot see.
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    // Real target directory under /tmp (must exist for canonicalize to
+    // resolve the symlink through to it).
+    let tmp_target = tempfile::tempdir().expect("tmp target");
+    // Symlink lives under a non-tmp parent so the shape check alone passes.
+    let parent = non_tmp_dir();
+    let link = parent.path().join("backing-link");
+    std::os::unix::fs::symlink(tmp_target.path(), &link).expect("create symlink");
+
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            "/run/skillfs-privtmp-test.sock",
+            "--ledger-backing-root",
+            link.to_str().unwrap(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--ledger-backing-root")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true"),
+        "expected PrivateTmp rejection for symlinked backing root, got: {combined}"
+    );
+}
+
+#[test]
+fn fallback_source_under_tmp_fails_before_mount() {
+    // Non-in-place mount, no backing root: the daemon-facing root falls
+    // back to the source. A source under /tmp with a notify trigger must
+    // be rejected with a message that points at --ledger-backing-root.
+    let source = empty_source(); // tempfile => under /tmp
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            "/run/skillfs-privtmp-test.sock",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("source")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true")
+            && combined.contains("--ledger-backing-root")
+            && combined.contains("/run/"),
+        "expected PrivateTmp source-fallback rejection, got: {combined}"
+    );
+}
+
+#[test]
+fn mountpoint_under_tmp_not_rejected_when_source_is_non_tmp() {
+    // Only the daemon-facing path (source/backing root) is guarded. A
+    // plain agent-visible mountpoint under /tmp must NOT trip the new
+    // PrivateTmp gate when the source is non-tmp. The mount may still fail
+    // later for ordinary environment reasons, but the PrivateTmp error
+    // must not fire.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir"); // under /tmp
+    let combined = run_briefly(&[
+        "mount",
+        source.path().to_str().unwrap(),
+        mount.path().to_str().unwrap(),
+        "--security",
+        "--activation-mode",
+        "file",
+        "--notify-socket",
+        "/run/skillfs-privtmp-test.sock",
+    ]);
+    assert!(
+        !combined.contains("PrivateTmp=true"),
+        "PrivateTmp gate must not fire for an agent-visible /tmp mountpoint \
+         with a non-tmp source, got: {combined}"
+    );
+}
+
+#[test]
+fn non_tmp_daemon_facing_root_passes_gate() {
+    // A non-tmp daemon-facing backing root keeps existing behavior: the
+    // new gate does not fire. Using backing_root == source (a non-in-place
+    // convenience that needs no bind mount) exercises the backing-root
+    // branch without requiring CAP_SYS_ADMIN.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let combined = run_briefly(&[
+        "mount",
+        source.path().to_str().unwrap(),
+        mount.path().to_str().unwrap(),
+        "--security",
+        "--activation-mode",
+        "file",
+        "--notify-socket",
+        "/run/skillfs-privtmp-test.sock",
+        "--ledger-backing-root",
+        source.path().to_str().unwrap(),
+    ]);
+    assert!(
+        !combined.contains("PrivateTmp=true") && !combined.contains("resolves under /tmp"),
+        "PrivateTmp gate must not fire for a non-tmp backing root, got: {combined}"
+    );
+}
+
+#[test]
+fn activation_events_log_under_tmp_fails_before_mount() {
+    // The daemon tails the activation events log, so it is a daemon-facing
+    // transport path. A non-tmp source/mount with the events log under /tmp
+    // must still be rejected, naming --activation-events-log.
+    let source = non_tmp_dir();
+    let mount = non_tmp_dir();
+    let events_log = format!("/tmp/{}", unique_leaf("skillfs-privtmp-test-events.jsonl"));
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--activation-events-log",
+            &events_log,
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--activation-events-log")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("agent-sec-core.service")
+            && combined.contains("PrivateTmp=true")
+            && combined.contains("/run/"),
+        "expected PrivateTmp events-log rejection, got: {combined}"
+    );
+}
+
+#[test]
+fn activation_events_log_under_var_tmp_fails_before_mount() {
+    let source = non_tmp_dir();
+    let mount = non_tmp_dir();
+    let events_log = format!(
+        "/var/tmp/{}",
+        unique_leaf("skillfs-privtmp-test-events.jsonl")
+    );
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--activation-events-log",
+            &events_log,
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--activation-events-log")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true"),
+        "expected PrivateTmp events-log rejection for /var/tmp, got: {combined}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn activation_events_log_symlink_to_tmp_fails_before_mount() {
+    // A non-tmp events-log path that symlinks to a real /tmp file resolves
+    // (via canonicalize) to a PrivateTmp-invisible path and must be
+    // rejected, mirroring the backing-root symlink handling.
+    let source = non_tmp_dir();
+    let mount = non_tmp_dir();
+    let tmp_target = tempfile::NamedTempFile::new().expect("tmp target file"); // /tmp
+    let parent = non_tmp_dir();
+    let link = parent.path().join("events-link.jsonl");
+    std::os::unix::fs::symlink(tmp_target.path(), &link).expect("create symlink");
+
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--activation-events-log",
+            link.to_str().unwrap(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--activation-events-log")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true"),
+        "expected PrivateTmp rejection for symlinked events log, got: {combined}"
+    );
+}
+
+#[test]
+fn notify_socket_under_tmp_fails_before_mount() {
+    // The daemon owns the notify socket, so it is daemon-facing. A non-tmp
+    // source/mount with the notify socket under /tmp must be rejected,
+    // naming --notify-socket.
+    let source = non_tmp_dir();
+    let mount = non_tmp_dir();
+    let socket = format!("/tmp/{}", unique_leaf("skillfs-privtmp-test.sock"));
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            &socket,
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--notify-socket")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("agent-sec-core.service")
+            && combined.contains("PrivateTmp=true")
+            && combined.contains("/run/"),
+        "expected PrivateTmp notify-socket rejection, got: {combined}"
+    );
+}
+
+#[test]
+fn non_tmp_transport_paths_pass_gate() {
+    // Non-tmp events log AND non-tmp notify socket keep existing behavior:
+    // the PrivateTmp gate does not fire.
+    let source = non_tmp_dir();
+    let mount = non_tmp_dir();
+    let events_dir = non_tmp_dir();
+    let events_log = events_dir.path().join("events.jsonl");
+    let combined = run_briefly(&[
+        "mount",
+        source.path().to_str().unwrap(),
+        mount.path().to_str().unwrap(),
+        "--security",
+        "--activation-mode",
+        "file",
+        "--activation-events-log",
+        events_log.to_str().unwrap(),
+        "--notify-socket",
+        "/run/skillfs-privtmp-test.sock",
+    ]);
+    assert!(
+        !combined.contains("PrivateTmp=true") && !combined.contains("resolves under /tmp"),
+        "PrivateTmp gate must not fire for non-tmp transport paths, got: {combined}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // PID file cleanup tests
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -800,11 +1239,15 @@ staging_patterns = [".openclaw-install-stage-*"]
 
 #[test]
 fn staging_patterns_with_activation_events_log_passes_gate() {
-    let source = empty_source();
+    // Source and events log must be non-tmp: with the PrivateTmp gate a
+    // /tmp events log or source would abort startup, making the "staging
+    // gate did not fire" assertion pass for the wrong reason.
+    let source = non_tmp_dir();
     let mount = tempfile::tempdir().expect("mount tempdir");
     let config_dir = tempfile::tempdir().expect("config dir");
     let config_path = config_dir.path().join("security.toml");
-    let events_log = tempfile::NamedTempFile::new().expect("events log");
+    let events_dir = non_tmp_dir();
+    let events_log = events_dir.path().join("events.jsonl");
     std::fs::write(
         &config_path,
         r#"
@@ -826,7 +1269,7 @@ staging_patterns = [".openclaw-install-stage-*"]
             "--config",
             config_path.to_str().unwrap(),
             "--activation-events-log",
-            events_log.path().to_str().unwrap(),
+            events_log.to_str().unwrap(),
         ])
         .stderr(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -845,11 +1288,17 @@ staging_patterns = [".openclaw-install-stage-*"]
         !combined.contains("install.staging_patterns requires"),
         "staging gate must not fire when --activation-events-log is set, got: {combined}"
     );
+    assert!(
+        !combined.contains("PrivateTmp=true"),
+        "PrivateTmp gate must not fire for a non-tmp source + events log, got: {combined}"
+    );
 }
 
 #[test]
 fn staging_patterns_with_notify_socket_passes_gate() {
-    let source = empty_source();
+    // Source and notify socket must be non-tmp for the same reason as
+    // above: otherwise the PrivateTmp gate would mask the staging check.
+    let source = non_tmp_dir();
     let mount = tempfile::tempdir().expect("mount tempdir");
     let config_dir = tempfile::tempdir().expect("config dir");
     let config_path = config_dir.path().join("security.toml");
@@ -874,7 +1323,7 @@ staging_patterns = [".openclaw-install-stage-*"]
             "--config",
             config_path.to_str().unwrap(),
             "--notify-socket",
-            "/tmp/nonexistent-daemon.sock",
+            "/run/skillfs-staging-test.sock",
         ])
         .stderr(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -892,6 +1341,10 @@ staging_patterns = [".openclaw-install-stage-*"]
     assert!(
         !combined.contains("install.staging_patterns requires"),
         "staging gate must not fire when --notify-socket is set, got: {combined}"
+    );
+    assert!(
+        !combined.contains("PrivateTmp=true"),
+        "PrivateTmp gate must not fire for a non-tmp source + notify socket, got: {combined}"
     );
 }
 


### PR DESCRIPTION
## Summary

SkillFS now fails fast when daemon-driven activation would pass an
agent-sec-core daemon a source or backing-root path under `/tmp` or
`/var/tmp`.

This avoids the silent failure from #1262 where `agent-sec-core.service`
runs with `PrivateTmp=true`, cannot resolve the host tmp path, rejects
`skillfs_notify_change`, and SkillFS later hides the skill after activation
reload times out.

closes #1262

## What Changed

- Added a startup gate for `--security --activation-mode file` when
  `--notify-socket` or `--activation-events-log` is enabled.
- Rejects daemon-facing `--ledger-backing-root` paths under `/tmp` or
  `/var/tmp` before backing-root setup.
- Rejects fallback daemon-facing `source` paths under `/tmp` or `/var/tmp`
  when no backing root is configured.
- Checks existing backing-root symlinks by canonicalizing the path before
  setup, so non-tmp symlinks pointing into `/tmp` are rejected.
- Updated CLI help text to recommend `/run/user/$UID/...` or `/run/...`
  for daemon-visible backing roots.

## Behavior / Compatibility

- Agent-visible mountpoints under `/tmp` are not blanket rejected.
- Existing valid `/run` or `/run/user/$UID` daemon-facing roots continue to
  work.
- Incompatible configs now fail during startup with a clear PrivateTmp error
  instead of timing out and hiding skills later.
- README files are intentionally unchanged; broader documentation cleanup will
  be handled separately.

## Validation

- `cargo +1.86.0 test -p skillfs --test cli_startup_tests`
- `cargo +1.86.0 test -p skillfs-fuse backing_root`
- `cargo +1.86.0 fmt --all --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`