### PR TITLE
docs(skillfs): refresh README language and security notes

### DIFF
--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -1,85 +1,70 @@
 # SkillFS
 
-基于 FUSE 的本地技能文件系统，负责解析 `SKILL.md`、按 view 组织技能，并把编译后的 `SKILL.md` 通过 FUSE 文件系统暴露出来。
+**English** | [中文](README_zh.md)
+
+SkillFS is a local FUSE filesystem for agent skills. It parses `SKILL.md`,
+organizes skills with views, and exposes compiled `SKILL.md` content through a
+mounted filesystem while ordinary skill files remain backed by the source tree.
 
 [![Rust](https://img.shields.io/badge/Rust-1.86+-orange.svg)](https://www.rust-lang.org/)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-## 能力
+## Capabilities
 
-- 解析标准的 `SKILL.md`。
-- 支持平铺目录和分类目录加载。
-- 通过 `skillfs-views.toml` 管理默认视图和 secondary views。
-- FUSE 目录中显示 primary view 技能。
-- 始终暴露 `skill-discover`，用于列出 secondary views 中的技能及其源文件路径。
-- 读取 `SKILL.md` 时执行条件编译和命令归一化。
-- 透传 skill 目录内的物理文件和子目录。
-- 支持 normal mount 与 in-place mount。
-- 支持挂载后的物理写入透传，并把 `SKILL.md` 变化同步回 store。
-- 支持主流 POSIX/FUSE 读写语义：fd-backed I/O、metadata、目录流、
-  rename、PATH_MAX fallback、open-after-unlink、safe symlink/link、FIFO、
-  `user.*` xattr。
-- 提供安全集成基础设施：`.skill-meta` 保护、audit JSONL、security mount
-  mode、install inbox、trusted writer (exe identity)、activation file/xattr、notify、
-  protocol event log、runtime reload 和 startup reconcile。
+- Parses standard `SKILL.md` files.
+- Loads both flat skill directories and categorized directory layouts.
+- Uses `skillfs-views.toml` to choose the default view and secondary views.
+- Shows default-view skills directly in the mounted agent view.
+- Always exposes the virtual `skill-discover` skill so agents can discover
+  skills from secondary views and their source paths.
+- Compiles `SKILL.md` on read, including conditional blocks and command
+  normalization.
+- Passes ordinary files and subdirectories through to the physical source tree.
+- Supports normal mounts and in-place mounts.
+- Supports physical write passthrough while mounted; `SKILL.md` changes reparse
+  and update the in-memory store.
+- Provides a Linux POSIX compatibility baseline for ordinary passthrough paths:
+  fd-backed I/O, create/mkdir mode handling, long-path fallback,
+  open-after-unlink handles, restricted symlink/hardlink policy, FIFO creation,
+  and conservative `user.*` xattr passthrough.
+- Provides optional external security integration surfaces: decision-command
+  activation, activation file/xattr consumption, notify socket events, protocol
+  JSONL events, active-mapping reload, startup reconcile, trusted writer
+  identity checks, trusted control socket writes, and managed mount recovery.
 
-## 功能矩阵
+## Behavior Matrix
 
-| 操作 | normal mount | in-place mount | 说明 |
-|------|--------------|----------------|------|
-| `readdir` | 虚拟视图 | 虚拟视图 | 由 views + store 决定可见 skill |
-| 读 `SKILL.md` | 编译后返回 | 编译后返回 | 走 `compiler::compile` |
-| 读其他文件 | 透传 | 透传 | 直接读取物理文件 |
-| 写 `SKILL.md` | 透传 + store reparse | 透传 + store reparse | 目录名是 store 权威 key |
-| `create` 普通文件 | 透传 | 透传 | 不触发 store 更新 |
-| `mkdir` skill 目录 | 立即可见 | 立即可见 | 先插入 degraded placeholder |
-| `rename` skill 目录 | 立即切换可见性 | 立即切换可见性 | 无空窗，旧名立即移除 |
-| `unlink` `SKILL.md` | 从 store 移除 | 从 store 移除 | skill 从虚拟视图消失 |
-| `rmdir` skill 目录 | 从 store 移除 | 从 store 移除 | 递归清理 inode 映射 |
-| `setattr(size)` | 支持 truncate | 支持 truncate | 其他控制属性不作为主要能力 |
-| `symlink` | 策略允许 | 策略允许 | 允许相对 same-skill；拒绝绝对、跨 skill、`.skill-meta`、lifecycle |
-| `link` | 策略允许 | 策略允许 | 允许 same-skill regular file；拒绝跨 skill 和特殊文件 |
-| `mknod` | FIFO only | FIFO only | block/char/socket/device node 仍拒绝 |
-| xattr | `user.*` | `user.*` | no-follow passthrough；非 user namespace 拒绝 |
+| Operation | Normal mount | In-place mount | Notes |
+| --- | --- | --- | --- |
+| `readdir` | Virtual view | Virtual view | Visibility comes from views plus the store. |
+| Read `SKILL.md` | Compiled output | Compiled output | Uses `compiler::compile`. |
+| Read other files | Passthrough | Passthrough | Reads the physical source file. |
+| Write `SKILL.md` | Passthrough + store reparse | Passthrough + store reparse | Directory name is the authoritative store key. |
+| `create` ordinary file | Passthrough | Passthrough | Does not update the store. |
+| `mkdir` skill directory | Immediately visible | Immediately visible | Inserts a degraded placeholder before async reparse. |
+| `rename` skill directory | Visibility switches immediately | Visibility switches immediately | Old name is removed without a visibility gap. |
+| `unlink` `SKILL.md` | Removes from store | Removes from store | Skill disappears from the virtual view. |
+| `rmdir` skill directory | Removes from store | Removes from store | Also clears inode mappings. |
+| `setattr(size)` | Truncate supported | Truncate supported | Other metadata operations are conservative passthrough where allowed. |
+| `symlink` | Restricted passthrough | Restricted passthrough | Allows relative same-skill targets only. |
+| `link` | Restricted passthrough | Restricted passthrough | Allows same-skill regular files only. |
+| `mkfifo` | Passthrough | Passthrough | FIFO only; device/socket nodes are rejected. |
+| `xattr user.*` | Passthrough | Passthrough | Ordinary passthrough paths only. |
 
-## 安全集成能力
+## Scope
 
-SkillFS 不直接实现扫描、签名校验或风险判断。它提供文件系统层能力，让外部
-安全组件决定一个 skill 应该暴露为 current、fallback snapshot，还是 hidden。
+- Public CLI commands are `mount`, `stop`, `classify`, `validate`, and `list`.
+- Skill visibility is controlled by `skillfs-views.toml`.
+- FUSE write passthrough is supported while mounted, but only `SKILL.md`
+  changes trigger store synchronization.
+- The authoritative skill key is the directory name, not a stale frontmatter
+  `name:` after rename.
+- In-place mounting over-mounts the source directory. Controlled skill writes
+  through SkillFS are supported, but tools that rename or replace the mounted
+  directory itself, such as workspace checkpoint/init/rollback tools, must run
+  before mounting or after unmounting.
 
-当前已支持：
-
-- `.skill-meta/**` 默认 mutation-protected，普通 mount-path 写入返回
-  deterministic permission error。
-- `--audit-log <PATH>` 输出稳定 JSONL audit stream。
-- `--security-mode` 要求 source 和 mountpoint 指向同一目录，用于更强的
-  in-place enforcement。
-- `/.skillfs-inbox/<skill>/...` 作为安装候选入口；写入落到 source，完成信号
-  触发后续安全流程。
-- `--decision-command <COMMAND>` 兼容路径：变更后 debounce，执行
-  `<COMMAND> scan <skill_dir> --json`，再执行
-  `<COMMAND> resolve <skill_dir> --json`，刷新 active mapping。
-- `--activation-mode file` 生产路径：从
-  `.skill-meta/activation.json` 或
-  `user.agent_sec.skill_ledger.activation` xattr 读取 activation。
-- `--notify-socket <PATH>` 发送 skill 变更通知给外部 daemon。
-- `--activation-events-log <PATH>` 写入 activation protocol event JSONL。
-- `--activation-reload-mode poll` 在 notify 后轮询 activation 并刷新 resolver。
-- startup reconcile 会在挂载后对已知 skill 发出 best-effort reconcile 通知。
-- `--trusted-writer-exe <PATH>`（推荐）生产级可信写门禁，按
-  `/proc/<tgid>/exe` readlink + 文件身份 `(dev, ino)` 匹配，结合 starttime
-  做 PID reuse 防护，抗 `prctl PR_SET_NAME` 伪造。
-- `--trusted-writer <NAME>`（deprecated / 兼容性）按 Linux TGID `comm` 匹配；
-  进程 `comm` 可被伪造，不应用于生产。两者同时配置时 exe 为授权依据。
-
-## 范围
-
-- 运行入口是 `mount`、`classify`、`validate`、`list`。
-- 技能可见性由 `skillfs-views.toml` 决定。
-- FUSE 当前已经支持挂载后的写 passthrough，但只有 `SKILL.md` 会触发 store 同步。
-- store 的权威 key 是目录名，不再信任重命名后可能滞后的 frontmatter `name:`。
-
-## 架构
+## Architecture
 
 ```text
 physical skills dir
@@ -99,74 +84,95 @@ physical skills dir
      mounted /skills view
 ```
 
-    ## 写路径与一致性
+## Write Path And Consistency
 
-    SkillFS 现在不是纯只读文件系统，而是“虚拟目录视图 + 物理写透传”的混合模型：
+SkillFS is a hybrid filesystem: a virtual directory view plus physical
+passthrough writes.
 
-    - `readdir` 仍由虚拟视图控制。
-    - `SKILL.md` 读取仍返回编译后的内容，而不是原始文件。
-    - 其他文件读写直接落到底层文件系统。
-    - `SKILL.md` 的写入、创建、rename 后写入会通过后台 sync worker 重新解析并更新 `SharedSkillStore`。
-    - `mkdir` / `rename` skill 目录走立即一致路径，先同步更新 store，再由异步 reparse 覆盖为真实条目。
-    - in-place mount 通过 `/proc/self/fd/{n}` 访问底层 source，避免 over-mount 自回环。
+- `readdir` is still controlled by the virtual view.
+- Reading `SKILL.md` returns compiled content, not the raw source file.
+- Other files read and write directly against the underlying filesystem.
+- Writing, creating, or writing after renaming `SKILL.md` reparses the file and
+  updates `SharedSkillStore`.
+- `mkdir` and skill-directory `rename` take an immediate-consistency path by
+  synchronously updating the store, with async reparse later replacing the
+  placeholder with the real entry.
+- In-place mounts use `/proc/self/fd/{n}` to reach the underlying source and
+  avoid recursively entering the FUSE over-mount.
 
-## 快速开始
+## Quick Start
 
-### 构建
+### Build
 
 ```bash
 cargo build --release
 ```
 
-### 常用命令
+### Common Commands
 
 ```bash
-# 验证 skills
+# Validate skills.
 cargo run -p skillfs -- validate /path/to/skills
 
-# 列出 skills
+# List skills.
 cargo run -p skillfs -- list /path/to/skills
 
-# 生成或查看 skillfs-views.toml
+# Generate or inspect skillfs-views.toml.
 cargo run -p skillfs -- classify /path/to/skills
 
-# 挂载 FUSE 文件系统
+# Mount the FUSE filesystem.
 cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint
 
-# Managed 挂载（opt-in）：托管监督器保持挂载存活，网关重启不会丢失挂载
+# Opt-in managed mount: a detached supervisor keeps the mount alive.
 cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint --managed
 
-# 停止 managed 挂载：清除 desired state、终止监督器/worker 并卸载
+# Stop a managed mount and clear desired mounted state.
 cargo run -p skillfs -- stop /path/to/mountpoint
 ```
 
-### Managed 挂载模式
+### Managed Mount Mode
 
-默认 `mount`（含 `--foreground`）与原来完全一致：进程在前台阻塞，`SIGTERM`
-/ `Ctrl+C` 会干净卸载。当启动 SkillFS 的进程（如 OpenClaw 网关）重启时，其
-子进程会被终止，挂载随之消失。
+Default `mount`, including `--foreground`, keeps the original foreground
+behavior: the process blocks, and `SIGTERM` or `Ctrl+C` cleanly unmounts. If the
+launcher process, such as a gateway, restarts and terminates its child
+processes, the mount disappears with it.
 
-`--managed` 是一个 opt-in 选项，用于跨网关重启保持挂载：
+`--managed` is opt-in and is intended for mounts that should survive gateway
+restarts:
 
-- 客户端写入托管状态后，用 `setsid` 启动一个脱离调用者进程组/会话的
-  **监督器**，等待挂载 ready 后返回。
-- 监督器以相同的 source、mountpoint、config、security、audit、activation、
-  trusted-writer 和 logging 选项启动前台 FUSE **worker**。
-- 若 worker 在 desired state 仍为 mounted 时意外退出，监督器会在有界退避后
-  自动重挂。
-- **只有显式执行 `skillfs stop <MOUNTPOINT>`（或 unmount）才会清除 desired
-  mounted 状态**，终止监督器/worker 并干净卸载。`stop` 是幂等的，可安全地对
-  已卸载的挂载重复执行。
-- 如果监督器被 `kill -9` 等方式强制终止，可能留下仍在服务但无人监控的孤儿
-  worker。此时执行 `skillfs stop <MOUNTPOINT>` 可清理残留状态、进程和挂载，
-  再重新执行 `mount --managed` 即可恢复托管。
+- The client writes managed state, starts a detached supervisor in its own
+  session with `setsid`, waits for readiness, and then returns.
+- The supervisor starts a foreground FUSE worker with the same source,
+  mountpoint, config, security, audit, activation, trusted-writer, control
+  socket, and logging options.
+- If the worker exits unexpectedly while desired state remains `mounted`, the
+  supervisor remounts after bounded backoff.
+- Only `skillfs stop <MOUNTPOINT>` clears desired mounted state, terminates the
+  supervisor/worker, and unmounts. `stop` is idempotent and can be run safely on
+  an already-unmounted path.
+- If the supervisor is killed with `kill -9`, an orphan worker may continue to
+  serve the mount without monitoring. Run `skillfs stop <MOUNTPOINT>` to clean
+  residual state, processes, and mounts before starting `mount --managed` again.
 
-托管状态存放在 `$XDG_RUNTIME_DIR/skillfs/`（否则 `/run/user/<uid>/skillfs/`，
-再回退到 `/tmp/skillfs-<uid>/`），instance id 由规范化后的 mountpoint 派生。
+Managed state is stored in a user-isolated runtime directory: first
+`$XDG_RUNTIME_DIR/skillfs/`, then `/run/user/<uid>/skillfs/`, and when neither
+is available it falls back to `/tmp/skillfs-<uid>/`. The instance id is derived
+from the normalized mountpoint, so `mount` and `stop` always resolve the same
+mountpoint to the same instance.
 
-### `skillfs-views.toml`
+### In-place Mount And Workspace Snapshots
 
-技能选择依赖 `skillfs-views.toml`：
+When SkillFS is mounted in-place, tools that replace the mountpoint directory
+itself must run before mounting or after unmounting. For example,
+`ws-ckpt checkpoint -w <MOUNTPOINT>` may fail with `Device or resource busy` if
+`<MOUNTPOINT>` is an active SkillFS mount.
+
+Writes through SkillFS, including skill install/update/remove, remain supported
+while mounted.
+
+## `skillfs-views.toml`
+
+Skill selection is controlled by `skillfs-views.toml`:
 
 ```toml
 [[view]]
@@ -182,12 +188,13 @@ description = "Skills exposed via skill-discover"
 skills = ["apple-notes", "blogwatcher"]
 ```
 
-挂载后：
+After mounting:
 
-- `/skills` 中显示默认 view 技能。
-- `skill-discover/SKILL.md` 中列出 secondary views 的技能和 `source_path`。
+- `/skills` shows skills from the default view.
+- `skill-discover/SKILL.md` lists skills from secondary views and their
+  `source_path`.
 
-## `SKILL.md` 格式
+## `SKILL.md` Format
 
 ```markdown
 ---
@@ -212,87 +219,190 @@ Detailed instructions.
 - `result` (string, required): Result value
 ```
 
-## 条件编译
+## Conditional Compilation
 
-FUSE 读取 `SKILL.md` 时会执行 `compiler::compile`，支持：
+When FUSE reads `SKILL.md`, SkillFS runs `compiler::compile` and supports:
 
 - `<!-- @if os == darwin -->`
 - `<!-- @if has_command("uv") -->`
 - `<!-- @else -->`
 - `<!-- @endif -->`
 
-没有条件块时，也会做少量启发式命令归一化，例如：
+When there are no conditional blocks, SkillFS also applies a small set of
+heuristic command normalizations, for example:
 
 - `pip install` -> `uv pip install`
 - `python -m venv` -> `uv venv`
 - `npm install` -> `pnpm install` / `yarn install`
 
-## 项目结构
+## Project Layout
 
 ```text
 crates/
   skillfs-core/   parser, store, views, compiler, env, watcher
-  skillfs-fuse/   FUSE 文件系统
-  skillfs-cli/    mount / classify / validate / list
-docs/specs/       实现说明
-scripts/          保留 build.sh 与 test.sh
+  skillfs-fuse/   FUSE filesystem and POSIX passthrough layer
+  skillfs-cli/    mount / stop / classify / validate / list
+docs/specs/       implementation specifications
+docs/security/    external decision and runtime activation docs
+docs/testing/     POSIX acceptance and external harness docs
+docs/skills/      bundled agent-facing SkillFS skill
+scripts/          build.sh, test.sh, and optional POSIX harness
 ```
 
-## 测试脚本
+## Test Scripts
 
 - [scripts/build.sh](scripts/build.sh)
-  - 统一执行 workspace 构建。
+  - Runs the workspace build.
 - [scripts/test.sh](scripts/test.sh)
-  - 创建临时 skill 源目录和 `skillfs-views.toml`。
-  - 验证 FUSE 挂载成功。
-  - 验证 `/skills` 暴露 default view 技能。
-  - 验证 `skill-discover` 正确列出 secondary view 与 `source_path`。
-  - 验证 skill 目录中的物理文件透传。
-  - 验证通过 `SIGTERM` 可以正确卸载。
+  - Creates a temporary skill source directory and `skillfs-views.toml`.
+  - Verifies that the FUSE mount starts.
+  - Verifies that `/skills` exposes default-view skills.
+  - Verifies that `skill-discover` lists secondary views and `source_path`.
+  - Verifies passthrough reads for physical files inside a skill directory.
+  - Verifies clean unmount through `SIGTERM`.
+- [scripts/posix/run_pjdfstest.sh](scripts/posix/run_pjdfstest.sh)
+  - Optional external POSIX harness; normal `cargo test` does not depend on it.
 
-## 测试覆盖
+## Test Coverage
 
-`crates/skillfs-fuse/tests/` 当前覆盖：
+`crates/skillfs-fuse/tests/` covers:
 
-- normal / in-place mount 的 `SKILL.md` 编译读、写透传、store reparse、
-  mkdir/rename/unlink/rmdir 可见性和 stale frontmatter 防回归。
-- POSIX open/create、metadata、目录流、PATH_MAX fallback、open-after-unlink、
-  safe symlink/link/FIFO、`user.*` xattr。
-- `.skill-meta`、lifecycle、security mode、audit runtime、source drift、
-  install inbox、trusted writer、activation consumer、notify、runtime reload、
-  startup reconcile。
-- 外部 pjdfstest harness 可选运行，正常 `cargo test` 不依赖 pjdfstest。
+- compiled `SKILL.md` reads, write passthrough, store reparse,
+  mkdir/rename/unlink/rmdir visibility, and stale-frontmatter regressions for
+  normal and in-place mounts;
+- POSIX open/create, metadata, directory streams, long-path fallback,
+  open-after-unlink, safe symlink/link/FIFO, and `user.*` xattrs;
+- `.skill-meta`, lifecycle namespaces, security mode, audit runtime, source
+  drift, install inbox, staging/direct install flows, trusted writer, trusted
+  metadata view, activation consumer, control socket server behavior, notify,
+  runtime reload, startup reconcile, and post-publish grace paths.
 
-`skillfs-core` 当前覆盖：
+`crates/skillfs-cli/tests/` covers CLI parsing and startup gates, including
+managed mount supervision, activation/notify option compatibility, backing-root
+requirements, trusted writer executable validation, and control-socket trusted
+peer configuration.
 
-- parser、store、watcher 的单元与集成测试。
+`skillfs-core` covers parser, store, compiler, and watcher behavior with unit
+and integration tests.
 
-## 功能亮点
+## Highlights
 
-- 虚拟视图与物理文件系统解耦：目录展示由 views 控制，文件内容仍来自真实 source。
-- `SKILL.md` 读写分离：读取给 agent 编译结果，写入落到原始文件。
-- rename 后目录名是统一权威 key，避免 stale frontmatter 把旧 skill 名重新注入 store。
-- in-place mount 通过 dir fd 绕过 FUSE 自身，避免写回进入自循环。
-- active mapping 支持把 `/skills/<name>` 映射到当前 source、可信 snapshot 或
-  hidden，已打开 fd 保持 open-time target pinning。
+- Virtual views are decoupled from the physical filesystem: directory
+  visibility is view-controlled while file content still comes from the real
+  source tree.
+- `SKILL.md` reads and writes are intentionally split: agents read compiled
+  content, while writes update the raw source file.
+- Directory name is the unified authoritative skill key after rename, avoiding
+  stale frontmatter reinjection under the old skill name.
+- In-place mounts use a pre-opened source dir fd so SkillFS can write through
+  without recursively entering its own FUSE mount.
+- Active mapping can expose `/skills/<name>` as current source, trusted
+  snapshot, or hidden, and open file handles keep their open-time target pinned.
 
-## 文档
+## Security Integration
 
-- [HANDOFF.md](HANDOFF.md) - 代码状态与后续建议
-- [docs/specs/skillfs-v1-spec.md](docs/specs/skillfs-v1-spec.md) - 整体架构说明
-- [docs/specs/core-spec.md](docs/specs/core-spec.md) - `skillfs-core` 实现
-- [docs/specs/fuse-spec.md](docs/specs/fuse-spec.md) - `skillfs-fuse` 实现
-- [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md) - 文件系统能力、POSIX 兼容、安全集成与演进记录
-- [docs/specs/posix-phase1-spec.md](docs/specs/posix-phase1-spec.md) - POSIX Phase 1 行为规格
-- [docs/testing/posix-external-harness.md](docs/testing/posix-external-harness.md) - 外部 POSIX harness 使用说明
-- [docs/testing/posix-phase1-acceptance.md](docs/testing/posix-phase1-acceptance.md) - Phase 1 验收条件
-- [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX 文件系统测试矩阵
-- [POSIX_FS_REFERENCES.md](POSIX_FS_REFERENCES.md) - POSIX / FUSE / 本仓库参考资料
+SkillFS does not perform scanning, signing, or risk decisions inside the
+filesystem core. An external provider decides whether a skill is exposed as:
 
-## 验证
+- `current`: serve the live source tree;
+- `fallback`: serve a trusted `.skill-meta/versions/*.snapshot`;
+- `hidden`: hide the skill from the agent-facing view.
+
+Two integration paths are supported:
+
+- Legacy decision-command mode:
+  `--security --decision-command <COMMAND>` runs
+  `<COMMAND> scan <skill_dir> --json` and then
+  `<COMMAND> resolve <skill_dir> --json`.
+- Activation-file mode:
+  `--security --activation-mode file` consumes
+  `.skill-meta/activation.json` or
+  `user.agent_sec.skill_ledger.activation`, sends notify events to an external
+  daemon when configured, and reloads active mappings when activation changes.
+
+Related security surfaces:
+
+- `.skill-meta/**` is hidden from untrusted lookup/list/read paths and ordinary
+  mutation attempts are rejected. Trusted exact-path access can route to the
+  live source for metadata operations.
+- `--audit-log <PATH>` writes stable JSONL audit events.
+- `--security-mode` requires `SOURCE` and `MOUNTPOINT` to resolve to the same
+  directory so normal userspace access goes through FUSE policy and audit.
+- `/.skillfs-inbox/<skill>/...` is an install/repair entry point for hidden or
+  new skills; writes land in the source tree and completion can trigger the
+  external security flow.
+- `--notify-socket <PATH>` sends debounced skill mutation notifications to an
+  external daemon.
+- `--activation-events-log <PATH>` writes activation protocol events as JSONL.
+- `--activation-reload-mode poll` re-reads activation state after notify events
+  and updates the resolver without a remount.
+- Startup reconcile sends best-effort notifications for known skills after
+  mount startup.
+- `--ledger-backing-root <PATH>` provides a daemon-visible source view for
+  in-place activation/notify mounts, because the public source path is a FUSE
+  over-mount. Use `/run/user/$UID/skillfs-ledger/...` or
+  `/run/skillfs-ledger/...` for daemon-facing roots. Do not use `/tmp` or
+  `/var/tmp`: packaged `agent-sec-core.service` runs with `PrivateTmp=true`,
+  so host tmp paths are invisible to the daemon and are rejected at startup.
+- `--trusted-writer-exe <PATH>` is the recommended mount-path trusted writer
+  gate. It verifies `/proc/<tgid>/exe`, `(dev, ino)`, and process start time to
+  reduce PID-reuse and process-name spoofing risk.
+- `--trusted-writer <NAME>` is a deprecated compatibility gate based on Linux
+  TGID `comm`; process names can be spoofed and this should not be used for
+  production trust.
+- `--control-socket <PATH>` with `--trusted-peer-exe <PATH>` starts a trusted
+  Unix socket control plane. Trusted peers can write activation JSON or xattr
+  through methods such as `meta.writeActivation` and
+  `meta.setActivationXattr`.
+
+## Documentation
+
+- [docs/specs/skillfs-spec.md](docs/specs/skillfs-spec.md) - Architecture,
+  runtime consistency boundaries, and deployment scenarios.
+- [docs/specs/core-spec.md](docs/specs/core-spec.md) - `skillfs-core`
+  implementation.
+- [docs/specs/fuse-spec.md](docs/specs/fuse-spec.md) - `skillfs-fuse`
+  implementation.
+- [docs/specs/posix-phase1-spec.md](docs/specs/posix-phase1-spec.md) - POSIX
+  passthrough baseline.
+- [docs/testing/posix-phase1-acceptance.md](docs/testing/posix-phase1-acceptance.md)
+  - POSIX acceptance checklist.
+- [docs/testing/posix-external-harness.md](docs/testing/posix-external-harness.md)
+  - External POSIX harness usage.
+- [docs/security/external-decision-protocol.md](docs/security/external-decision-protocol.md)
+  - Decision-command JSON protocol.
+- [docs/security/runtime-activation-implementation-plan.md](docs/security/runtime-activation-implementation-plan.md)
+  - Activation, notify, reload, and backing-root integration.
+- [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md)
+  - Long-lived filesystem capability record.
+- [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX test matrix and
+  current coverage.
+- [POSIX_FS_REFERENCES.md](POSIX_FS_REFERENCES.md) - POSIX, FUSE, and project
+  references.
+
+## Validation
+
+These commands are CI-equivalent checks. Run them before PR submission when
+touching SkillFS code.
 
 ```bash
-cargo test -p skillfs-core
-cargo test -p skillfs-fuse
-cargo check -p skillfs -p skillfs-fuse
+# 1. Formatting: must produce no diff.
+cargo fmt --all --check
+
+# 2. Clippy: must be warning-free under -D warnings.
+cargo clippy --workspace --all-targets -- -D warnings
+
+# 3. Unit and integration tests in the workspace.
+cargo test --workspace
+
+# 4. End-to-end FUSE mount test. Requires fuse3 and /dev/fuse; skips itself
+#    on macOS or containers without /dev/fuse.
+scripts/test.sh
+
+# 5. Rustdoc. Required when changing public API or doc comments; useful for
+#    catching broken intra-doc links early.
+cargo doc --workspace --no-deps
 ```
+
+Contributor conventions for comments, module layout, dependencies, error
+handling, and commits are documented in [AGENTS.md](AGENTS.md).

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -2,81 +2,61 @@
 
 [English](README.md) | **中文**
 
-基于 FUSE 的本地技能文件系统，负责解析 `SKILL.md`、按 view 组织技能，并把编译后的 `SKILL.md` 通过 FUSE 文件系统暴露出来。
+SkillFS 是面向 agent skill 的本地 FUSE 文件系统。它解析 `SKILL.md`，按 view
+组织技能，并通过挂载后的文件系统暴露编译后的 `SKILL.md`，同时让普通 skill
+文件继续由真实 source 树承载。
 
 [![Rust](https://img.shields.io/badge/Rust-1.86+-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 ## 能力
 
-- 解析标准的 `SKILL.md`。
-- 支持平铺目录和分类目录加载。
-- 通过 `skillfs-views.toml` 管理默认视图和 secondary views。
-- FUSE 目录中显示 primary view 技能。
-- 始终暴露 `skill-discover`，用于列出 secondary views 中的技能及其源文件路径。
-- 读取 `SKILL.md` 时执行条件编译和命令归一化。
-- 透传 skill 目录内的物理文件和子目录。
-- 支持 normal mount 与 in-place mount。
-- 支持挂载后的物理写入透传，并把 `SKILL.md` 变化同步回 store。
-- 为普通 passthrough 路径提供 Linux POSIX 兼容基线，包括
-  fd-backed I/O、create/mkdir mode 处理、长路径 fallback、
-  open-after-unlink 句柄、受限 symlink/hardlink 策略、FIFO 创建、
-  以及保守的 `user.*` xattr 透传。
-- 提供可选的外部安全集成面：decision-command activation、
-  activation 文件/xattr 消费、notify socket 事件、protocol JSONL
-  事件、active mapping reload、startup reconcile，以及可信写进程
-  身份校验。
+- 解析标准 `SKILL.md` 文件。
+- 支持平铺 skill 目录和分类目录布局。
+- 通过 `skillfs-views.toml` 选择默认 view 和 secondary views。
+- 在挂载后的 agent 视图中直接显示默认 view 的 skills。
+- 始终暴露虚拟 `skill-discover` skill，让 agent 能发现 secondary views 中的
+  skills 及其 source paths。
+- 读取 `SKILL.md` 时执行条件块编译和命令归一化。
+- 将普通文件和子目录透传到底层物理 source 树。
+- 支持 normal mount 和 in-place mount。
+- 支持挂载期间的物理写透传；`SKILL.md` 变化会重新解析并更新内存 store。
+- 为普通 passthrough 路径提供 Linux POSIX 兼容基线：fd-backed I/O、
+  create/mkdir mode 处理、长路径 fallback、open-after-unlink 句柄、受限
+  symlink/hardlink 策略、FIFO 创建，以及保守的 `user.*` xattr 透传。
+- 提供可选外部安全集成面：decision-command activation、activation 文件/xattr
+  消费、notify socket 事件、protocol JSONL 事件、active mapping reload、
+  startup reconcile、可信写进程身份校验、可信 control socket 写入，以及
+  managed mount recovery。
 
-## 功能矩阵
+## 行为矩阵
 
 | 操作 | normal mount | in-place mount | 说明 |
-|------|--------------|----------------|------|
-| `readdir` | 虚拟视图 | 虚拟视图 | 由 views + store 决定可见 skill |
-| 读 `SKILL.md` | 编译后返回 | 编译后返回 | 走 `compiler::compile` |
-| 读其他文件 | 透传 | 透传 | 直接读取物理文件 |
-| 写 `SKILL.md` | 透传 + store reparse | 透传 + store reparse | 目录名是 store 权威 key |
-| `create` 普通文件 | 透传 | 透传 | 不触发 store 更新 |
-| `mkdir` skill 目录 | 立即可见 | 立即可见 | 先插入 degraded placeholder |
-| `rename` skill 目录 | 立即切换可见性 | 立即切换可见性 | 无空窗，旧名立即移除 |
-| `unlink` `SKILL.md` | 从 store 移除 | 从 store 移除 | skill 从虚拟视图消失 |
-| `rmdir` skill 目录 | 从 store 移除 | 从 store 移除 | 递归清理 inode 映射 |
-| `setattr(size)` | 支持 truncate | 支持 truncate | 其他控制属性不作为主要能力 |
-| `symlink` | 受限透传 | 受限透传 | 仅允许同 skill 内的相对目标 |
-| `link` | 受限透传 | 受限透传 | 仅允许同 skill 内普通文件 |
-| `mkfifo` | 透传 | 透传 | 仅 FIFO；device node 仍拒绝 |
-| `xattr user.*` | 透传 | 透传 | 仅普通 passthrough 路径 |
-
-## 安全集成
-
-SkillFS 不在文件系统核心中实现安全判断。外部 provider 负责扫描、
-认证和策略判断，然后告诉 SkillFS 应该暴露哪个运行视图：
-
-- `current`：暴露当前 source；
-- `fallback`：暴露可信 `.skill-meta/versions/*.snapshot`；
-- `hidden`：不在 `/skills` 中暴露该 skill。
-
-当前支持两条集成路径：
-
-- 兼容模式：通过 `--security --decision-command`，SkillFS 依次执行
-  `<decision-command> scan <skill_dir> --json` 和
-  `<decision-command> resolve <skill_dir> --json`；
-- activation 模式：通过 `--activation-mode file`，SkillFS 消费
-  `.skill-meta/activation.json` 或
-  `user.agent_sec.skill_ledger.activation`，向外部 daemon 发送 notify
-  事件，并在 activation 变化后刷新 active mapping。
-
-对于 in-place security mount，`--ledger-backing-root` 提供 daemon
-可读写的 source 视图，避免 daemon 读取 agent 可见的 FUSE 视图。
-`--trusted-writer-exe` 可以通过可信进程的 executable 路径和
-`(dev, ino)` 身份授权部分 `.skill-meta/**` 写入；进程名匹配仅保留为
-兼容 fallback。
+| --- | --- | --- | --- |
+| `readdir` | 虚拟视图 | 虚拟视图 | 可见性由 views 和 store 决定。 |
+| 读 `SKILL.md` | 编译后内容 | 编译后内容 | 使用 `compiler::compile`。 |
+| 读其他文件 | 透传 | 透传 | 读取物理 source 文件。 |
+| 写 `SKILL.md` | 透传 + store reparse | 透传 + store reparse | 目录名是 store 权威 key。 |
+| `create` 普通文件 | 透传 | 透传 | 不更新 store。 |
+| `mkdir` skill 目录 | 立即可见 | 立即可见 | 异步 reparse 前先插入 degraded placeholder。 |
+| `rename` skill 目录 | 可见性立即切换 | 可见性立即切换 | 旧名无空窗移除。 |
+| `unlink` `SKILL.md` | 从 store 移除 | 从 store 移除 | skill 从虚拟视图消失。 |
+| `rmdir` skill 目录 | 从 store 移除 | 从 store 移除 | 同时清理 inode 映射。 |
+| `setattr(size)` | 支持 truncate | 支持 truncate | 其他 metadata 操作在允许时保守透传。 |
+| `symlink` | 受限透传 | 受限透传 | 仅允许同 skill 内相对目标。 |
+| `link` | 受限透传 | 受限透传 | 仅允许同 skill 内普通文件。 |
+| `mkfifo` | 透传 | 透传 | 仅 FIFO；device/socket node 拒绝。 |
+| `xattr user.*` | 透传 | 透传 | 仅普通 passthrough 路径。 |
 
 ## 范围
 
-- 运行入口是 `mount`、`classify`、`validate`、`list`。
-- 技能可见性由 `skillfs-views.toml` 决定。
-- FUSE 当前已经支持挂载后的写 passthrough，但只有 `SKILL.md` 会触发 store 同步。
-- store 的权威 key 是目录名，不再信任重命名后可能滞后的 frontmatter `name:`。
+- 公开 CLI 命令是 `mount`、`stop`、`classify`、`validate` 和 `list`。
+- skill 可见性由 `skillfs-views.toml` 控制。
+- FUSE 支持挂载期间写透传，但只有 `SKILL.md` 变化会触发 store 同步。
+- 权威 skill key 是目录名，不是 rename 后可能滞后的 frontmatter `name:`。
+- in-place mount 会 over-mount source 目录。受控的 skill 写入可以通过
+  SkillFS 执行，但会 rename 或替换挂载目录本身的工具，例如 workspace
+  checkpoint/init/rollback 工具，必须在 mount 前或 unmount 后执行。
 
 ## 架构
 
@@ -100,14 +80,17 @@ physical skills dir
 
 ## 写路径与一致性
 
-SkillFS 现在不是纯只读文件系统，而是"虚拟目录视图 + 物理写透传"的混合模型：
+SkillFS 是一个混合文件系统：虚拟目录视图 + 物理写透传。
 
-- `readdir` 仍由虚拟视图控制。
-- `SKILL.md` 读取仍返回编译后的内容，而不是原始文件。
-- 其他文件读写直接落到底层文件系统。
-- `SKILL.md` 的写入、创建、rename 后写入会通过后台 sync worker 重新解析并更新 `SharedSkillStore`。
-- `mkdir` / `rename` skill 目录走立即一致路径，先同步更新 store，再由异步 reparse 覆盖为真实条目。
-- in-place mount 通过 `/proc/self/fd/{n}` 访问底层 source，避免 over-mount 自回环。
+- `readdir` 仍由虚拟 view 控制。
+- 读取 `SKILL.md` 返回编译后内容，而不是原始 source 文件。
+- 其他文件直接读写底层文件系统。
+- 写入、创建或 rename 后写入 `SKILL.md` 会重新解析文件并更新
+  `SharedSkillStore`。
+- `mkdir` 和 skill 目录 `rename` 走立即一致路径，先同步更新 store，之后由
+  异步 reparse 用真实条目替换 placeholder。
+- in-place mount 使用 `/proc/self/fd/{n}` 访问底层 source，避免递归进入
+  自己的 FUSE over-mount。
 
 ## 快速开始
 
@@ -131,11 +114,51 @@ cargo run -p skillfs -- classify /path/to/skills
 
 # 挂载 FUSE 文件系统
 cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint
+
+# opt-in managed mount：由脱离调用方的 supervisor 保持挂载存活
+cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint --managed
+
+# 停止 managed mount 并清除 desired mounted state
+cargo run -p skillfs -- stop /path/to/mountpoint
 ```
 
-### `skillfs-views.toml`
+### Managed Mount 模式
 
-技能选择依赖 `skillfs-views.toml`：
+默认 `mount`（包括 `--foreground`）保持原有前台行为：进程阻塞，
+`SIGTERM` 或 `Ctrl+C` 会干净卸载。如果启动它的进程（例如 gateway）重启并终止
+子进程，挂载也会随之消失。
+
+`--managed` 是 opt-in，用于需要跨 gateway restart 保持挂载的场景：
+
+- client 写入 managed state，使用 `setsid` 在独立 session 中启动 detached
+  supervisor，等待挂载 ready 后返回。
+- supervisor 用相同的 source、mountpoint、config、security、audit、
+  activation、trusted-writer、control socket 和 logging 选项启动前台 FUSE
+  worker。
+- 如果 worker 在 desired state 仍为 `mounted` 时意外退出，supervisor 会在有界
+  backoff 后重新挂载。
+- 只有 `skillfs stop <MOUNTPOINT>` 会清除 desired mounted state，终止
+  supervisor/worker 并卸载。`stop` 是幂等的，对已经卸载的路径重复执行也是安全的。
+- 如果 supervisor 被 `kill -9` 强制终止，可能留下仍在服务但无人监控的 orphan
+  worker。重新启动 `mount --managed` 前，先执行 `skillfs stop <MOUNTPOINT>` 清理
+  残留 state、process 和 mount。
+
+managed state 存放在按用户隔离的运行时目录下：优先
+`$XDG_RUNTIME_DIR/skillfs/`，其次 `/run/user/<uid>/skillfs/`，两者都不可用时
+回退到 `/tmp/skillfs-<uid>/`。实例 id 从规范化后的 mountpoint 派生，因此
+`mount` 与 `stop` 对同一挂载点始终指向同一实例。
+
+### In-place Mount 与 Workspace Snapshot
+
+SkillFS 使用 in-place mount 时，会替换挂载目录本身的工具需要在 mount 前或
+unmount 后执行。例如，`ws-ckpt checkpoint -w <MOUNTPOINT>` 如果作用在活跃的
+SkillFS mountpoint 上，可能会因为 `Device or resource busy` 失败。
+
+通过 SkillFS 进行的写入，包括 install/update/remove skills，挂载期间仍然支持。
+
+## `skillfs-views.toml`
+
+skill 选择由 `skillfs-views.toml` 控制：
 
 ```toml
 [[view]]
@@ -153,8 +176,9 @@ skills = ["apple-notes", "blogwatcher"]
 
 挂载后：
 
-- `/skills` 中显示默认 view 技能。
-- `skill-discover/SKILL.md` 中列出 secondary views 的技能和 `source_path`。
+- `/skills` 显示 default view 中的 skills。
+- `skill-discover/SKILL.md` 列出 secondary views 中的 skills 及其
+  `source_path`。
 
 ## `SKILL.md` 格式
 
@@ -183,14 +207,14 @@ Detailed instructions.
 
 ## 条件编译
 
-FUSE 读取 `SKILL.md` 时会执行 `compiler::compile`，支持：
+FUSE 读取 `SKILL.md` 时，SkillFS 会执行 `compiler::compile`，支持：
 
 - `<!-- @if os == darwin -->`
 - `<!-- @if has_command("uv") -->`
 - `<!-- @else -->`
 - `<!-- @endif -->`
 
-没有条件块时，也会做少量启发式命令归一化，例如：
+没有条件块时，SkillFS 也会执行少量启发式命令归一化，例如：
 
 - `pip install` -> `uv pip install`
 - `python -m venv` -> `uv venv`
@@ -202,93 +226,142 @@ FUSE 读取 `SKILL.md` 时会执行 `compiler::compile`，支持：
 crates/
   skillfs-core/   parser, store, views, compiler, env, watcher
   skillfs-fuse/   FUSE 文件系统与 POSIX passthrough 层
-  skillfs-cli/    mount / classify / validate / list
-docs/specs/       实现说明
-docs/testing/     POSIX 验收与外部 harness 文档
+  skillfs-cli/    mount / stop / classify / validate / list
+docs/specs/       实现规格
+docs/security/    external decision 与 runtime activation 文档
+docs/testing/     POSIX 验收与 external harness 文档
+docs/skills/      随仓库分发的 agent-facing SkillFS skill
 scripts/          build.sh、test.sh 与可选 POSIX harness
 ```
 
 ## 测试脚本
 
 - [scripts/build.sh](scripts/build.sh)
-  - 统一执行 workspace 构建。
+  - 执行 workspace build。
 - [scripts/test.sh](scripts/test.sh)
-  - 创建临时 skill 源目录和 `skillfs-views.toml`。
-  - 验证 FUSE 挂载成功。
-  - 验证 `/skills` 暴露 default view 技能。
-  - 验证 `skill-discover` 正确列出 secondary view 与 `source_path`。
-  - 验证 skill 目录中的物理文件透传。
-  - 验证通过 `SIGTERM` 可以正确卸载。
+  - 创建临时 skill source 目录和 `skillfs-views.toml`。
+  - 验证 FUSE mount 启动成功。
+  - 验证 `/skills` 暴露 default-view skills。
+  - 验证 `skill-discover` 列出 secondary views 和 `source_path`。
+  - 验证 skill 目录中物理文件的 passthrough read。
+  - 验证通过 `SIGTERM` 干净卸载。
+- [scripts/posix/run_pjdfstest.sh](scripts/posix/run_pjdfstest.sh)
+  - 可选 external POSIX harness；普通 `cargo test` 不依赖它。
 
 ## 测试覆盖
 
-`crates/skillfs-fuse/tests/write_guard_tests.rs` 当前覆盖：
+`crates/skillfs-fuse/tests/` 覆盖：
 
-- normal mount：读 `SKILL.md`、写透传、`mkdir` 立即可见、`rename` 无空窗、post-rename stale frontmatter 不复活旧名。
-- in-place mount：`mkdir` 立即可见、`rename` 无空窗、post-rename stale frontmatter 不复活旧名。
-- `.skill-meta/**` 与虚拟路径的元数据保护边界。
+- normal 和 in-place mount 下的 compiled `SKILL.md` read、write passthrough、
+  store reparse、mkdir/rename/unlink/rmdir 可见性，以及 stale frontmatter 防回归；
+- POSIX open/create、metadata、目录流、长路径 fallback、open-after-unlink、
+  safe symlink/link/FIFO 和 `user.*` xattr；
+- `.skill-meta`、lifecycle namespaces、security mode、audit runtime、source
+  drift、install inbox、staging/direct install flows、trusted writer、trusted
+  metadata view、activation consumer、control socket server behavior、notify、
+  runtime reload、startup reconcile 和 post-publish grace paths。
 
-额外 FUSE integration suites 覆盖 POSIX passthrough 行为：
+`crates/skillfs-cli/tests/` 覆盖 CLI parsing 和 startup gates，包括 managed
+mount supervision、activation/notify option compatibility、backing-root
+requirements、trusted writer executable validation，以及 control-socket
+trusted peer configuration。
 
-- open/read/write flag 处理与 fd-backed I/O；
-- create/mkdir mode 与 umask 行为；
-- PATH_MAX fallback 与 open-after-unlink 句柄；
-- 同 skill 内 symlink / hardlink 策略；
-- FIFO 创建与 device node 拒绝；
-- `user.*` xattr get/list/set/remove 行为。
-
-可选 pjdfstest harness 位于
-[scripts/posix/run_pjdfstest.sh](scripts/posix/run_pjdfstest.sh)，
-操作说明见
-[docs/testing/posix-external-harness.md](docs/testing/posix-external-harness.md)。
-
-`skillfs-core` 当前覆盖：
-
-- parser、store、watcher 的单元与集成测试。
+`skillfs-core` 通过单元和集成测试覆盖 parser、store、compiler 与 watcher 行为。
 
 ## 功能亮点
 
-- 虚拟视图与物理文件系统解耦：目录展示由 views 控制，文件内容仍来自真实 source。
-- `SKILL.md` 读写分离：读取给 agent 编译结果，写入落到原始文件。
-- rename 后目录名是统一权威 key，避免 stale frontmatter 把旧 skill 名重新注入 store。
-- in-place mount 通过 dir fd 绕过 FUSE 自身，避免写回进入自循环。
+- 虚拟 views 与物理文件系统解耦：目录可见性由 view 控制，文件内容仍来自真实
+  source 树。
+- `SKILL.md` 读写刻意分离：agent 读取编译后内容，写入更新原始 source 文件。
+- rename 后目录名是统一权威 skill key，避免 stale frontmatter 把旧 skill 名重新注入。
+- in-place mount 使用预打开 source dir fd，让 SkillFS 写透传时不会递归进入自己的
+  FUSE mount。
+- active mapping 可以把 `/skills/<name>` 暴露为 current source、trusted
+  snapshot 或 hidden，已打开 fd 保持 open-time target pinning。
+
+## 安全集成
+
+SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。外部 provider 决定
+一个 skill 应暴露为：
+
+- `current`：服务 live source；
+- `fallback`：服务可信 `.skill-meta/versions/*.snapshot`；
+- `hidden`：从 agent-facing 视图隐藏该 skill。
+
+当前支持两条集成路径：
+
+- 兼容 decision-command 模式：
+  `--security --decision-command <COMMAND>` 会执行
+  `<COMMAND> scan <skill_dir> --json`，再执行
+  `<COMMAND> resolve <skill_dir> --json`。
+- activation-file 模式：
+  `--security --activation-mode file` 消费
+  `.skill-meta/activation.json` 或
+  `user.agent_sec.skill_ledger.activation`；配置后会向外部 daemon 发送 notify
+  事件，并在 activation 变化后重新加载 active mapping。
+
+相关安全能力：
+
+- `.skill-meta/**` 对不可信 lookup/list/read 路径隐藏，普通 mutation 会被拒绝。
+  可信 exact-path access 可把 metadata 操作路由到 live source。
+- `--audit-log <PATH>` 写稳定 JSONL audit events。
+- `--security-mode` 要求 `SOURCE` 和 `MOUNTPOINT` 指向同一目录，使普通
+  userspace 访问都经过 FUSE policy 和 audit。
+- `/.skillfs-inbox/<skill>/...` 是 hidden 或 new skill 的安装/修复入口；
+  写入落到 source，完成信号可触发外部安全流程。
+- `--notify-socket <PATH>` 将 debounce 后的 skill mutation 通知发给外部 daemon。
+- `--activation-events-log <PATH>` 将 activation protocol events 写成 JSONL。
+- `--activation-reload-mode poll` 在 notify events 后重读 activation state，
+  无需 remount 即可更新 resolver。
+- startup reconcile 会在挂载启动后对已知 skills 发送 best-effort 通知。
+- `--ledger-backing-root <PATH>` 为 in-place activation/notify mount 提供
+  daemon 可见的 source 视图，因为公开 source path 已经是 FUSE over-mount。
+  推荐使用 `/run/user/$UID/skillfs-ledger/...` 或
+  `/run/skillfs-ledger/...` 作为 daemon-facing root。不要使用 `/tmp` 或
+  `/var/tmp`：packaged `agent-sec-core.service` 以 `PrivateTmp=true` 运行，
+  宿主 tmp 路径对 daemon 不可见，因此会在启动阶段被拒绝。
+- `--trusted-writer-exe <PATH>` 是推荐的 mount-path 可信写门禁。它验证
+  `/proc/<tgid>/exe`、`(dev, ino)` 和进程 start time，以降低 PID reuse 和
+  process-name spoofing 风险。
+- `--trusted-writer <NAME>` 是已废弃的兼容门禁，基于 Linux TGID `comm`；
+  进程名可伪造，不应用作生产可信依据。
+- `--control-socket <PATH>` 配合 `--trusted-peer-exe <PATH>` 启动可信 Unix
+  socket control plane。可信 peer 可通过 `meta.writeActivation`、
+  `meta.setActivationXattr` 等方法写 activation JSON 或 xattr。
 
 ## 文档
 
-- [docs/specs/skillfs-spec.md](docs/specs/skillfs-spec.md) - 整体架构、运行时一致性边界、场景对比
-- [docs/specs/core-spec.md](docs/specs/core-spec.md) - `skillfs-core` 实现
-- [docs/specs/fuse-spec.md](docs/specs/fuse-spec.md) - `skillfs-fuse` 实现
-- [docs/specs/posix-phase1-spec.md](docs/specs/posix-phase1-spec.md) - POSIX passthrough 基线
-- [docs/testing/posix-phase1-acceptance.md](docs/testing/posix-phase1-acceptance.md) - POSIX 验收清单
-- [docs/security/external-decision-protocol.md](docs/security/external-decision-protocol.md) - decision-command JSON 协议
-- [docs/security/runtime-activation-implementation-plan.md](docs/security/runtime-activation-implementation-plan.md) - activation / notify / reload / backing-root 集成说明
-- [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md) - 长期维护的能力记录
-- [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX 测试矩阵与当前覆盖
+- [docs/specs/skillfs-spec.md](docs/specs/skillfs-spec.md) - 架构、运行时一致性边界和部署场景。
+- [docs/specs/core-spec.md](docs/specs/core-spec.md) - `skillfs-core` 实现。
+- [docs/specs/fuse-spec.md](docs/specs/fuse-spec.md) - `skillfs-fuse` 实现。
+- [docs/specs/posix-phase1-spec.md](docs/specs/posix-phase1-spec.md) - POSIX passthrough 基线。
+- [docs/testing/posix-phase1-acceptance.md](docs/testing/posix-phase1-acceptance.md) - POSIX 验收清单。
+- [docs/testing/posix-external-harness.md](docs/testing/posix-external-harness.md) - external POSIX harness 用法。
+- [docs/security/external-decision-protocol.md](docs/security/external-decision-protocol.md) - decision-command JSON 协议。
+- [docs/security/runtime-activation-implementation-plan.md](docs/security/runtime-activation-implementation-plan.md) - activation、notify、reload 与 backing-root 集成。
+- [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md) - 长期维护的 filesystem capability record。
+- [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX 测试矩阵与当前覆盖。
+- [POSIX_FS_REFERENCES.md](POSIX_FS_REFERENCES.md) - POSIX、FUSE 和项目参考资料。
 
 ## 验证
 
-下列命令是 CI 等价检查；本地在提交 PR 前跑一遍可以缩短反馈环。
-任何一条不通过的改动都不应被合入。SkillFS 代码改动提交前必须
-先通过格式检查和 clippy。
+这些命令等价于 CI 检查。修改 SkillFS 代码并提交 PR 前应执行。
 
 ```bash
-# 1. 格式化 — 必须无 diff。
+# 1. 格式化：必须无 diff
 cargo fmt --all --check
 
-# 2. Clippy — 在 -D warnings 下必须零 warning。
+# 2. Clippy：在 -D warnings 下必须零 warning
 cargo clippy --workspace --all-targets -- -D warnings
 
-# 3. workspace 内的单元与集成测试。
+# 3. workspace 内单元与集成测试
 cargo test --workspace
 
-# 4. 端到端 FUSE 挂载测试（需要 fuse3 + /dev/fuse；
-#    在 macOS 或无 /dev/fuse 的容器中脚本会自动跳过）。
+# 4. 端到端 FUSE mount 测试：需要 fuse3 和 /dev/fuse；在 macOS 或无 /dev/fuse 的容器中会自动跳过
 scripts/test.sh
 
-# 5. Rustdoc — 修改公共 API 或 doc 注释时必跑，其余情况建议跑；
-#    可在第一时间发现 intra-doc link 失效。
+# 5. Rustdoc：修改公共 API 或 doc comments 时必须执行；也有助于尽早发现 intra-doc link 失效
 cargo doc --workspace --no-deps
 ```
 
-完整贡献者约定（注释风格、模块布局、依赖策略、错误处理、commit 规范）
-见 [AGENTS.md](AGENTS.md)。
+注释风格、模块布局、依赖策略、错误处理和 commit 规范见 [AGENTS.md](AGENTS.md)。


### PR DESCRIPTION
## Summary

Refresh the SkillFS README files so `README.md` is the English entry point and
`README_zh.md` is the Chinese entry point.

This also documents the daemon-facing backing-root path guidance introduced by
#1283: use `/run/user/$UID/skillfs-ledger/...` or `/run/skillfs-ledger/...`,
not `/tmp` or `/var/tmp`, when SkillFS is integrated with the packaged
`agent-sec-core.service` running with `PrivateTmp=true`.

## What Changed

- Reworked `src/skillfs/README.md` as the English README.
- Reworked `src/skillfs/README_zh.md` as the Chinese README.
- Added language switch links between the two README files.
- Documented the `--ledger-backing-root` PrivateTmp constraint in the security
  integration section.

## Behavior / Compatibility

- Documentation-only change.
- No CLI, runtime, FUSE, or security behavior changes.
- Complements #1283 by documenting the safe backing-root path guidance.

## Validation

- `git diff --check -- src/skillfs/README.md src/skillfs/README_zh.md`

## Related

- Follow-up documentation for #1283
