### PR TITLE
feat(tokenless): record stash writes/size in stats

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -437,6 +437,9 @@ fn run() -> Result<(), (String, i32)> {
                 input,
                 output_text,
                 mode,
+                None,
+                None,
+                None,
             );
         }
         Commands::CompressResponse {
@@ -480,6 +483,25 @@ fn run() -> Result<(), (String, i32)> {
                 compressor = compressor.with_stash_store(store.clone());
             }
             let result = compressor.compress(&value);
+            // Stash observability: capture write/error counts + live entry
+            // count for stats. All three are None when no stash store is
+            // attached (vs Some(0) when a stash is attached but nothing was
+            // truncated) so stats queries can distinguish "no stash" runs
+            // from "stash, zero writes" runs. Counts are read AFTER compress
+            // so they reflect this call; stash_size reflects entries added.
+            let stash_writes = stash.as_ref().map(|_| compressor.stash_writes());
+            let stash_errors = stash.as_ref().map(|_| compressor.stash_errors());
+            let stash_size = stash.as_ref().map(|s| s.len());
+            // Surface persistent stash backend failures (disk full, locked DB,
+            // I/O) so they aren't invisible — compression degrades to the
+            // lossy marker per entry, but a non-zero count means the stash
+            // path is broken and retrievals will miss.
+            if matches!(stash_errors, Some(e) if e > 0) {
+                eprintln!(
+                    "[tokenless] stash: {} write(s) failed during compression; truncated entries are not retrievable (check stash db health)",
+                    stash_errors.expect("checked Some above")
+                );
+            }
             let after_compact = serde_json::to_string(&result).unwrap_or_else(|_| String::new());
 
             let before_tokens = estimate_tokens(&input);
@@ -516,6 +538,9 @@ fn run() -> Result<(), (String, i32)> {
                 input,
                 output_text,
                 mode,
+                stash_writes,
+                stash_errors,
+                stash_size,
             );
         }
         Commands::Retrieve { hash, stash_db } => {
@@ -734,6 +759,9 @@ fn run() -> Result<(), (String, i32)> {
                 input,
                 record_after,
                 mode,
+                None,
+                None,
+                None,
             );
         }
         Commands::DecompressToon { file } => {
@@ -816,6 +844,9 @@ fn record_compression_stats(
     before_text: String,
     after_text: String,
     mode: CompressionMode,
+    stash_writes: Option<usize>,
+    stash_errors: Option<usize>,
+    stash_size: Option<usize>,
 ) {
     // Short-circuit only if both stats and SLS are disabled.
     if !config.is_stats_enabled() && !config.is_sls_enabled() {
@@ -853,7 +884,10 @@ fn record_compression_stats(
     if let Some(tuid) = tool_use_id {
         record = record.with_tool_use_id(tuid);
     }
-    record = record.with_source_pid(pid as i64).with_mode(mode);
+    record = record
+        .with_source_pid(pid as i64)
+        .with_mode(mode)
+        .with_stash(stash_writes, stash_errors, stash_size);
 
     // SQLite stats recording — gated by stats_enabled
     if config.is_stats_enabled()

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -1,4 +1,5 @@
 use serde_json::{Map, Value};
+use std::cell::Cell;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokenless_ccr::{StashStore, marker_for};
@@ -20,6 +21,15 @@ pub struct ResponseCompressor {
     /// pre-stash behavior. Keeping this optional means the stash stays off
     /// the core compression path unless a caller explicitly enables it.
     stash_store: Option<Arc<dyn StashStore>>,
+    /// Number of stash writes performed during the last `compress()` call.
+    /// Exposed for stats recording so callers can observe stash usage without
+    /// the schema crate depending on the stats crate.
+    stash_writes: Cell<usize>,
+    /// Number of stash writes that **failed** during the last `compress()`
+    /// call (backend error — disk full, locked DB, I/O). Exposed so the CLI
+    /// can surface persistent backend failures instead of silently degrading
+    /// to the lossy marker.
+    stash_errors: Cell<usize>,
 }
 
 impl Default for ResponseCompressor {
@@ -49,6 +59,8 @@ impl Default for ResponseCompressor {
             max_depth: 8,
             add_truncation_marker: true,
             stash_store: None,
+            stash_writes: Cell::new(0),
+            stash_errors: Cell::new(0),
         }
     }
 }
@@ -110,6 +122,13 @@ impl ResponseCompressor {
 
     /// Compress a JSON response value
     pub fn compress(&self, response: &Value) -> Value {
+        // Reset the stash counters so they reflect this call only. Cell (not
+        // AtomicUsize) is the right primitive: ResponseCompressor is
+        // stack-allocated per compress call and never shared across threads,
+        // and Cell makes the struct !Sync — preventing the false thread-safety
+        // impression that a reset-then-increment AtomicUsize pattern would give.
+        self.stash_writes.set(0);
+        self.stash_errors.set(0);
         let original_text = serde_json::to_string(response).unwrap_or_default();
         let result = self.compress_value(response, 0);
 
@@ -120,6 +139,19 @@ impl ResponseCompressor {
         }
 
         result
+    }
+
+    /// Number of stash writes performed during the last `compress()` call.
+    /// Zero when no stash store is attached or no arrays were truncated.
+    pub fn stash_writes(&self) -> usize {
+        self.stash_writes.get()
+    }
+
+    /// Number of stash writes that failed during the last `compress()` call.
+    /// Non-zero signals a persistent backend problem (disk full, locked DB,
+    /// I/O) — the caller should log it so the failure isn't invisible.
+    pub fn stash_errors(&self) -> usize {
+        self.stash_errors.get()
     }
 
     /// Recursively compress a JSON value
@@ -256,7 +288,19 @@ impl ResponseCompressor {
         if payload.is_empty() {
             return None;
         }
-        stash.stash(&payload).ok()
+        let key = match stash.stash(&payload) {
+            Ok(k) => {
+                self.stash_writes.set(self.stash_writes.get() + 1);
+                k
+            }
+            Err(_) => {
+                // Surface the backend failure via the counter so the CLI can
+                // log it; degrade to the lossy marker for this entry.
+                self.stash_errors.set(self.stash_errors.get() + 1);
+                return None;
+            }
+        };
+        Some(key)
     }
 
     /// Compress an object, removing drop_fields and recursing
@@ -584,6 +628,38 @@ mod tests {
         let retrieved = store.retrieve(hash).unwrap().expect("must be retrievable");
         let recovered: Vec<i32> = serde_json::from_str(&retrieved).unwrap();
         assert_eq!(recovered, (4..=10).collect::<Vec<_>>());
+        // One truncated array → one stash write.
+        assert_eq!(compressor.stash_writes(), 1);
+    }
+
+    #[test]
+    fn test_stash_writes_counter_zero_without_store() {
+        // No stash store attached → counter stays zero even when arrays are
+        // truncated (lossy path).
+        let compressor = ResponseCompressor::new().with_truncate_arrays_at(3);
+        let arr: Vec<i32> = (1..=10).collect();
+        compressor.compress(&json!(arr));
+        assert_eq!(compressor.stash_writes(), 0);
+    }
+
+    #[test]
+    fn test_stash_writes_counter_resets_per_compress() {
+        use std::sync::Arc;
+        use tokenless_ccr::InMemoryStore;
+
+        let store = Arc::new(InMemoryStore::new());
+        let compressor = ResponseCompressor::new()
+            .with_truncate_arrays_at(3)
+            .with_stash_store(store);
+        let arr: Vec<i32> = (1..=10).collect();
+        compressor.compress(&json!(arr));
+        assert_eq!(compressor.stash_writes(), 1);
+        // Second call resets, then writes again — still 1, not 2.
+        compressor.compress(&json!(arr));
+        assert_eq!(compressor.stash_writes(), 1);
+        // A call that doesn't truncate (within limit) resets to 0.
+        compressor.compress(&json!([1, 2, 3]));
+        assert_eq!(compressor.stash_writes(), 0);
     }
 
     #[test]
@@ -618,5 +694,9 @@ mod tests {
         let s = marker.as_str().unwrap();
         assert!(s.contains("more items truncated"));
         assert!(!s.contains("tokenless:"));
+        // The failed write is surfaced via the error counter so a persistent
+        // backend failure isn't invisible.
+        assert_eq!(compressor.stash_errors(), 1);
+        assert_eq!(compressor.stash_writes(), 0);
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/record.rs
+++ b/src/tokenless/crates/tokenless-stats/src/record.rs
@@ -116,6 +116,17 @@ pub struct StatsRecord {
     pub after_output: Option<String>,
     /// Whether compression was applied (Active) or only predicted (DryRun)
     pub mode: CompressionMode,
+    /// Number of stash writes triggered by this compression (reversible stash
+    /// feature). `None` for records written by older versions (pre-stash) or
+    /// for operations that don't involve the stash.
+    pub stash_writes: Option<i64>,
+    /// Number of stash writes that failed during this compression (backend
+    /// error — disk full, locked DB, I/O). `None` for pre-stash records or
+    /// operations without a stash store attached.
+    pub stash_errors: Option<i64>,
+    /// Stash entry count at record time (a gauge of stash growth). `None` for
+    /// pre-stash records or operations without a stash store attached.
+    pub stash_size: Option<i64>,
 }
 
 impl StatsRecord {
@@ -145,6 +156,9 @@ impl StatsRecord {
             before_output: None,
             after_output: None,
             mode: CompressionMode::default(),
+            stash_writes: None,
+            stash_errors: None,
+            stash_size: None,
         }
     }
 
@@ -195,6 +209,22 @@ impl StatsRecord {
     pub fn with_output(mut self, before: String, after: String) -> Self {
         self.before_output = Some(before);
         self.after_output = Some(after);
+        self
+    }
+
+    /// Set stash write/error counts and stash size for this record (reversible
+    /// stash observability). All `Option`; pass `None` when the operation had
+    /// no stash store attached — this distinguishes "no stash" from "stash,
+    /// zero writes" in stats queries.
+    pub fn with_stash(
+        mut self,
+        writes: Option<usize>,
+        errors: Option<usize>,
+        size: Option<usize>,
+    ) -> Self {
+        self.stash_writes = writes.map(|w| w as i64);
+        self.stash_errors = errors.map(|e| e as i64);
+        self.stash_size = size.map(|s| s as i64);
         self
     }
 

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -64,7 +64,10 @@ impl StatsRecorder {
                 after_text TEXT,
                 before_output TEXT,
                 after_output TEXT,
-                mode TEXT
+                mode TEXT,
+                stash_writes INTEGER,
+                stash_errors INTEGER,
+                stash_size INTEGER
             )",
             [],
         )?;
@@ -86,11 +89,18 @@ impl StatsRecorder {
             [],
         )?;
 
-        // Schema migration: add columns introduced in v0.3.0 if missing.
-        // Use PRAGMA table_info to check column existence before ALTER TABLE
-        // instead of relying on error-message string matching, which is
-        // fragile across SQLite versions and locales.
-        for col in &["before_output", "after_output", "mode"] {
+        // Schema migration: add columns introduced after the initial schema if
+        // missing. Use PRAGMA table_info to check column existence before
+        // ALTER TABLE instead of relying on error-message string matching,
+        // which is fragile across SQLite versions and locales.
+        for (col, col_type) in &[
+            ("before_output", "TEXT"),
+            ("after_output", "TEXT"),
+            ("mode", "TEXT"),
+            ("stash_writes", "INTEGER"),
+            ("stash_errors", "INTEGER"),
+            ("stash_size", "INTEGER"),
+        ] {
             let exists: bool = conn
                 .query_row(
                     "SELECT COUNT(*) FROM pragma_table_info('stats') WHERE name = ?",
@@ -100,7 +110,10 @@ impl StatsRecorder {
                 .map(|c| c > 0)
                 .unwrap_or(false);
             if !exists {
-                conn.execute(&format!("ALTER TABLE stats ADD COLUMN {} TEXT", col), [])?;
+                conn.execute(
+                    &format!("ALTER TABLE stats ADD COLUMN {} {}", col, col_type),
+                    [],
+                )?;
             }
         }
 
@@ -137,8 +150,9 @@ impl StatsRecorder {
                 timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
                 before_chars, before_tokens, after_chars, after_tokens,
                 before_text, after_text,
-                before_output, after_output, mode
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                before_output, after_output, mode,
+                stash_writes, stash_errors, stash_size
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             rusqlite::params![
                 record.timestamp.to_rfc3339(),
                 record.operation.as_str(),
@@ -155,6 +169,9 @@ impl StatsRecorder {
                 record.before_output,
                 record.after_output,
                 record.mode.as_str(),
+                record.stash_writes,
+                record.stash_errors,
+                record.stash_size,
             ],
         )?;
 
@@ -165,19 +182,27 @@ impl StatsRecorder {
     /// from unbounded loads while remaining generous for practical use.
     const DEFAULT_LIMIT: usize = 10_000;
 
+    /// Canonical column list for `stats` SELECTs. Defined once at impl level
+    /// so `row_to_record`'s positional `row.get(N)` indices stay in sync with
+    /// the SELECT order — adding a column here is the only place to update.
+    /// `concat!` keeps the source multi-line (one group per row_to_record
+    /// index span) without leaking indentation padding into the SQL string.
+    const SELECT_COLS: &str = concat!(
+        "id, timestamp, operation, agent_id, source_pid, ",
+        "session_id, tool_use_id, before_chars, before_tokens, ",
+        "after_chars, after_tokens, before_text, after_text, ",
+        "before_output, after_output, mode, stash_writes, ",
+        "stash_errors, stash_size"
+    );
+
     /// Query all records, newest first, with optional limit
     pub fn all_records(&self, limit: Option<usize>) -> StatsResult<Vec<StatsRecord>> {
         let conn = self.lock_conn();
 
-        const SELECT_COLS: &str =
-            "id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
-                        before_chars, before_tokens, after_chars, after_tokens,
-                        before_text, after_text, before_output, after_output, mode";
-
         let n = limit.unwrap_or(Self::DEFAULT_LIMIT);
         let mut stmt = conn.prepare(&format!(
             "SELECT {} FROM stats ORDER BY timestamp DESC LIMIT ?",
-            SELECT_COLS
+            Self::SELECT_COLS
         ))?;
         let rows = stmt.query_map([n as i64], Self::row_to_record)?;
         let records: Vec<_> = rows
@@ -204,12 +229,10 @@ impl StatsRecorder {
     pub fn record_by_id(&self, id: i64) -> StatsResult<Option<StatsRecord>> {
         let conn = self.lock_conn();
 
-        let mut stmt = conn.prepare(
-            "SELECT id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
-                    before_chars, before_tokens, after_chars, after_tokens,
-                    before_text, after_text, before_output, after_output, mode
-             FROM stats WHERE id = ?",
-        )?;
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {} FROM stats WHERE id = ?",
+            Self::SELECT_COLS
+        ))?;
 
         let mut rows = stmt.query_map([id], Self::row_to_record)?;
 
@@ -228,15 +251,10 @@ impl StatsRecorder {
     ) -> StatsResult<Vec<StatsRecord>> {
         let conn = self.lock_conn();
 
-        const SELECT_COLS: &str =
-            "id, timestamp, operation, agent_id, source_pid, session_id, tool_use_id,
-                        before_chars, before_tokens, after_chars, after_tokens,
-                        before_text, after_text, before_output, after_output, mode";
-
         let n = limit.unwrap_or(Self::DEFAULT_LIMIT);
         let mut stmt = conn.prepare(&format!(
             "SELECT {} FROM stats WHERE session_id = ? ORDER BY timestamp DESC LIMIT ?",
-            SELECT_COLS
+            Self::SELECT_COLS
         ))?;
         let rows = stmt.query_map(rusqlite::params![session_id, n as i64], Self::row_to_record)?;
         Ok(rows.filter_map(|r| r.ok()).collect())
@@ -295,6 +313,9 @@ impl StatsRecorder {
             before_output: row.get(13)?,
             after_output: row.get(14)?,
             mode: CompressionMode::from_db(&row.get::<_, Option<String>>(15)?.unwrap_or_default()),
+            stash_writes: row.get(16)?,
+            stash_errors: row.get(17)?,
+            stash_size: row.get(18)?,
         })
     }
 }
@@ -390,6 +411,38 @@ mod tests {
         let got = rec.record_by_id(id).unwrap().unwrap();
         assert_eq!(got.mode, CompressionMode::DryRun);
         assert_eq!(got.session_id.as_deref(), Some("s1"));
+    }
+
+    #[test]
+    fn records_and_reads_stash_fields() {
+        let (rec, _dir) = new_recorder();
+        let rec_in = sample(
+            OperationType::CompressResponse,
+            CompressionMode::Active,
+            "stash-ses",
+        )
+        .with_stash(Some(3), Some(0), Some(42));
+        let id = rec.record(&rec_in).unwrap();
+        let got = rec.record_by_id(id).unwrap().unwrap();
+        assert_eq!(got.stash_writes, Some(3));
+        assert_eq!(got.stash_errors, Some(0));
+        assert_eq!(got.stash_size, Some(42));
+    }
+
+    #[test]
+    fn stash_fields_default_none_when_unstashed() {
+        let (rec, _dir) = new_recorder();
+        let id = rec
+            .record(&sample(
+                OperationType::CompressResponse,
+                CompressionMode::Active,
+                "no-stash",
+            ))
+            .unwrap();
+        let got = rec.record_by_id(id).unwrap().unwrap();
+        assert_eq!(got.stash_writes, None);
+        assert_eq!(got.stash_errors, None);
+        assert_eq!(got.stash_size, None);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Add stash observability so compression stats carry how many stash writes each compress triggered and the live stash entry count — the gauge for tuning stash TTL/capacity and verifying the reversible path is exercised in production. This is priority item #2 from the stash-feature completion list (part 1 = crate #1255 merged; part 2 = #1270 integration; part 3 = #1271 tests+docs; MCP retrieve = #1285; this PR = stash stats).

**ResponseCompressor (`tokenless-schema`):**
- `Cell<usize>` stash-write and stash-error counters, reset at the start of each `compress()`, incremented on every `stash_dropped()` (writes on success, errors on failure). `Cell` (not `AtomicUsize`) is the right primitive: `ResponseCompressor` is single-threaded and `Cell` makes the struct `!Sync`, avoiding the false thread-safety impression a reset-then-increment `AtomicUsize` would give. Exposed via `stash_writes()` / `stash_errors()` so the CLI reads them without the schema crate depending on the stats crate — no new cross-crate coupling.

**StatsRecord (`tokenless-stats`):**
- Nullable `stash_writes` / `stash_errors` / `stash_size` columns (`Option<i64>`) + `with_stash(writes, errors, size)` builder.
- Migration extends the existing `pragma_table_info` + `ALTER TABLE` pattern (now `(col, type)` tuples so INTEGER columns are supported) — old DBs gain the columns at first open; pre-stash records read back as `None`. INSERT / SELECT / `row_to_record` updated.

**CLI:**
- `compress-response` reads `compressor.stash_writes()` + `compressor.stash_errors()` + `stash.len()` after compress and records them. `compress-schema` / `compress-toon` pass `None` (no stash path). `record_compression_stats` gains the three stash params.

**Scope decision:** retrieve-side `hits`/`misses` are intentionally not added — retrieve is not a compression operation and would need a new `OperationType` + schema change; deferred until there's a retrieve-stats use case. This PR covers the compress-side observability (write count + stash growth), which is the high-value tuning signal.

## Related Issue

no-issue: internal tokenless stash feature completion (stash stats).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `tokenless`: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` pass
- [x] Lock files are up to date

## Testing

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace   # schema 27→29, stats 67→69; all green
```

New tests: counter zero-without-store / resets-per-compress / round-trip (schema); stash-fields round-trip / default-None (stats).

## Additional Notes

⚠️ **Stacked on #1270** — reuses that PR's stash integration in ResponseCompressor + the CLI compress-response handler. Merge #1270 first, then I rebase this to a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

