### PR TITLE
fix(anolisa): keep system repos enabled in RPM transactions

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/provisioner.rs
+++ b/src/anolisa/crates/anolisa-core/src/provisioner.rs
@@ -1,6 +1,6 @@
 //! Dependency provisioner: install missing system packages after resolver preflight.
 //!
-//! This module bridges the gap between the read-only [`DependencyResolver`] and
+//! This module bridges the gap between the read-only [`DependencyResolver`](crate::resolver::DependencyResolver) and
 //! the install executor. It consumes a [`ResolutionPlan`], classifies each
 //! unsatisfied dependency by provisionability, and either auto-installs (system
 //! mode) or reports remediation (user mode).

--- a/src/anolisa/crates/anolisa-platform/src/rpm_repo.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_repo.rs
@@ -37,8 +37,34 @@ impl DnfRepoSource {
         self.gpgcheck
     }
 
+    /// DNF options for **read-only queries** (e.g. `repoquery`).
+    ///
+    /// Disables all host repos (`--disablerepo=*`) so availability probes only
+    /// report packages from the ANOLISA-configured repo, never silently falling
+    /// back to a system repo that happens to carry a same-named package.
     pub(crate) fn append_dnf_options(&self, args: &mut Vec<String>) {
         args.push("--disablerepo=*".to_string());
+        args.push(format!("--repofrompath={},{}", self.id, self.base_url));
+        args.push(format!("--enablerepo={}", self.id));
+        if let Some(gpgcheck) = self.gpgcheck {
+            args.push(format!(
+                "--setopt={}.gpgcheck={}",
+                self.id,
+                if gpgcheck { "1" } else { "0" }
+            ));
+        }
+    }
+
+    /// DNF options for **write transactions** (`install`/`update`/`remove`).
+    ///
+    /// Unlike [`append_dnf_options`](Self::append_dnf_options), this does **not**
+    /// emit `--disablerepo=*`. RPM packages declare their own `Requires:` and dnf
+    /// resolves the entire dependency graph in one transaction. If all system
+    /// repos are disabled, dnf cannot satisfy cross-repo dependencies that live
+    /// outside the ANOLISA repo (e.g. `bubblewrap` in EPEL). Keeping system repos
+    /// enabled lets dnf pull ANOLISA components from the configured repo while
+    /// still resolving system-level `Requires` from the host's enabled repos.
+    pub(crate) fn append_dnf_txn_options(&self, args: &mut Vec<String>) {
         args.push(format!("--repofrompath={},{}", self.id, self.base_url));
         args.push(format!("--enablerepo={}", self.id));
         if let Some(gpgcheck) = self.gpgcheck {

--- a/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
@@ -96,8 +96,30 @@ impl<R: CommandRunner> RpmTransaction<R> {
         };
 
         let mut args = vec!["-y".to_string()];
-        repo.append_dnf_options(&mut args);
-        args.push(verb.to_string());
+        repo.append_dnf_txn_options(&mut args);
+
+        // For install/upgrade, use `repository-packages <repo-id>` to constrain
+        // the primary target to the configured repo. System repos stay enabled
+        // for dependency resolution, but dnf will only pull the requested
+        // package from the ANOLISA-configured repo — not a higher-EVR build
+        // from a host-enabled system repo. For remove, use the plain verb
+        // since the package should be removed regardless of its source repo.
+        match verb {
+            "install" => {
+                args.push("repository-packages".to_string());
+                args.push(repo.id().to_string());
+                args.push("install".to_string());
+            }
+            "update" => {
+                // `dnf repository-packages` uses `upgrade`, not `update`.
+                args.push("repository-packages".to_string());
+                args.push(repo.id().to_string());
+                args.push("upgrade".to_string());
+            }
+            _ => {
+                args.push(verb.to_string());
+            }
+        }
         args.push(package.to_string());
         args
     }
@@ -259,22 +281,70 @@ mod tests {
     }
 
     #[test]
-    fn install_with_repo_uses_configured_repo_only() {
+    fn install_with_repo_uses_repository_packages() {
+        // Transactions keep system repos enabled (no --disablerepo=*) so dnf
+        // can resolve cross-repo Requires (e.g. bubblewrap in EPEL). The
+        // primary target is constrained to the configured repo via
+        // `repository-packages`, preventing dnf from pulling a higher-EVR
+        // build from a host-enabled system repo.
         let t = txn_with_repo(
             "install",
             "copilot-shell",
             &[
                 "-y",
-                "--disablerepo=*",
                 "--repofrompath=anolisa-configured,http://repo.example/alinux/4/agentic-os/x86_64/os",
                 "--enablerepo=anolisa-configured",
                 "--setopt=anolisa-configured.gpgcheck=1",
+                "repository-packages",
+                "anolisa-configured",
                 "install",
                 "copilot-shell",
             ],
             ok_out(Some(0), "Installed:\n  copilot-shell\n", ""),
         );
         t.install("copilot-shell").expect("install ok");
+    }
+
+    #[test]
+    fn update_with_repo_uses_repository_packages_upgrade() {
+        // `dnf repository-packages` uses `upgrade`, not `update`.
+        let t = txn_with_repo(
+            "update",
+            "copilot-shell",
+            &[
+                "-y",
+                "--repofrompath=anolisa-configured,http://repo.example/alinux/4/agentic-os/x86_64/os",
+                "--enablerepo=anolisa-configured",
+                "--setopt=anolisa-configured.gpgcheck=1",
+                "repository-packages",
+                "anolisa-configured",
+                "upgrade",
+                "copilot-shell",
+            ],
+            ok_out(Some(0), "Upgraded:\n  copilot-shell\n", ""),
+        );
+        t.update("copilot-shell").expect("update ok");
+    }
+
+    #[test]
+    fn remove_with_repo_uses_plain_verb() {
+        // Remove must NOT use `repository-packages`: the package should be
+        // removed regardless of which repo it was installed from (e.g. an
+        // adopted system RPM that was later recorded as rpm-managed).
+        let t = txn_with_repo(
+            "remove",
+            "copilot-shell",
+            &[
+                "-y",
+                "--repofrompath=anolisa-configured,http://repo.example/alinux/4/agentic-os/x86_64/os",
+                "--enablerepo=anolisa-configured",
+                "--setopt=anolisa-configured.gpgcheck=1",
+                "remove",
+                "copilot-shell",
+            ],
+            ok_out(Some(0), "Removed:\n  copilot-shell\n", ""),
+        );
+        t.remove("copilot-shell").expect("remove ok");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes RPM backend install failures where dnf could not resolve cross-repo
`Requires` dependencies (e.g. `bubblewrap` in EPEL) because the transaction
path used `--disablerepo=*`, disabling all system repositories.

The `DnfRepoSource` now exposes two methods:
- `append_dnf_options` — for read-only queries (`repoquery`), keeps
  `--disablerepo=*` so availability probes only report ANOLISA repo packages.
- `append_dnf_txn_options` — for write transactions (`install`/`update`/
  `remove`), does NOT emit `--disablerepo=*`, allowing dnf to resolve the
  full dependency graph including system-level `Requires` from the host's
  enabled repos while still pulling ANOLISA components from the configured repo.

## Related Issue

Ref #1290 — RPM install issues affecting cosh/sec-core (component name ≠
package name). PR #1231 introduced `--disablerepo=*` to isolate RPM source
provenance, but the blanket repo disable also blocked dnf from resolving
cross-repo `Requires` dependencies, causing `anolisa install sec-core
--backend=rpm` to fail with `nothing provides bubblewrap`.

## Ship Note

`anolisa install <component> --backend rpm` no longer fails with
`nothing provides bubblewrap` when the dependency lives in a system
repo (e.g. EPEL) outside the ANOLISA-configured repository. dnf
transactions now keep system repos enabled so cross-repo `Requires`
can be resolved in a single pass.

No behavior change for availability queries — `repoquery` still
isolates to the ANOLISA-configured repo.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-platform)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
