### PR TITLE
fix(cosh): keep tips banner visible after initial login

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -504,6 +504,7 @@ export const AppContainer = (props: AppContainerProps) => {
     config,
     historyManager.addItem,
     initializationResult.shouldOpenAuthDialog,
+    refreshStatic,
   );
 
   useInitializationAuthError(initializationResult.authError, onAuthError);

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
@@ -217,4 +217,110 @@ describe('useAuthCommand', () => {
     });
     expect(errorItem).toBeDefined();
   });
+
+  it('refreshes the static area exactly once after the initial login', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    const addItem = vi.fn();
+    const refreshStatic = vi.fn();
+    vi.mocked(config.refreshAuth).mockResolvedValue(undefined);
+    vi.mocked(config.getContentGeneratorConfig).mockReturnValue({
+      model: 'my-model',
+    } as ReturnType<Config['getContentGeneratorConfig']>);
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, false, refreshStatic),
+    );
+
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI, {
+        apiKey: 'sk-test',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'my-model',
+      });
+    });
+
+    expect(refreshStatic).toHaveBeenCalledTimes(1);
+
+    // A subsequent re-authentication (e.g. user switches provider) must not
+    // clear the screen again, otherwise the session scrollback would be lost.
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI, {
+        apiKey: 'sk-test-2',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'my-model',
+      });
+    });
+
+    expect(refreshStatic).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh the static area when the session was already authenticated', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    vi.mocked(config.getAuthType).mockReturnValue(AuthType.USE_OPENAI);
+    vi.mocked(config.refreshAuth).mockResolvedValue(undefined);
+    vi.mocked(config.getContentGeneratorConfig).mockReturnValue({
+      model: 'my-model',
+    } as ReturnType<Config['getContentGeneratorConfig']>);
+    const addItem = vi.fn();
+    const refreshStatic = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, false, refreshStatic),
+    );
+
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI, {
+        apiKey: 'sk-test',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'my-model',
+      });
+    });
+
+    expect(refreshStatic).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh the static area when user chose Continue to Bash then later authenticates', async () => {
+    const settings = createMockSettings();
+    const config = createMockConfig();
+    vi.mocked(config.refreshAuth).mockResolvedValue(undefined);
+    vi.mocked(config.getContentGeneratorConfig).mockReturnValue({
+      model: 'my-model',
+    } as ReturnType<Config['getContentGeneratorConfig']>);
+    const addItem = vi.fn();
+    const refreshStatic = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAuthCommand(settings, config, addItem, true, refreshStatic),
+    );
+
+    // User skips auth and continues to bash
+    act(() => {
+      result.current.handleContinueToBash();
+    });
+
+    // Later the user authenticates via /auth
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI);
+    });
+    await act(async () => {
+      await result.current.handleAuthSelect(AuthType.USE_OPENAI, {
+        apiKey: 'sk-test',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'my-model',
+      });
+    });
+
+    expect(refreshStatic).not.toHaveBeenCalled();
+  });
 });

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -18,7 +18,7 @@ import {
   logAuth,
   saveAliyunCredentials,
 } from '@copilot-shell/core';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { LoadedSettings } from '../../config/settings.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 import type { OpenAICredentials } from '../components/OpenAIKeyPrompt.js';
@@ -48,6 +48,7 @@ export const useAuthCommand = (
   config: Config,
   addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
   showBashOptionOnStartup: boolean,
+  refreshStatic?: () => void,
 ) => {
   const unAuthenticated = config.getAuthType() === undefined;
 
@@ -65,6 +66,12 @@ export const useAuthCommand = (
   const [pendingAuthType, setPendingAuthType] = useState<AuthType | undefined>(
     undefined,
   );
+
+  // Track first-launch auth so we can redraw the static area exactly once
+  // after the very first successful login. Without this, the tips banner is
+  // pushed into scrollback when the auth dialog unmounts and new history
+  // items are appended below Ink's <Static>.
+  const isInitialAuthPending = useRef(unAuthenticated);
 
   const onAuthError = useCallback(
     (error: string | null) => {
@@ -252,8 +259,13 @@ export const useAuthCommand = (
         },
         Date.now(),
       );
+
+      if (isInitialAuthPending.current) {
+        isInitialAuthPending.current = false;
+        refreshStatic?.();
+      }
     },
-    [settings, handleAuthFailure, config, addItem],
+    [settings, handleAuthFailure, config, addItem, refreshStatic],
   );
 
   const performAuth = useCallback(
@@ -466,6 +478,7 @@ export const useAuthCommand = (
   }, [showBashOptionOnStartup]);
 
   const handleContinueToBash = useCallback(() => {
+    isInitialAuthPending.current = false;
     setAuthError(null);
     setIsAuthenticating(false);
     setShowBashOptionInAuthDialog(false);


### PR DESCRIPTION
## Description

On first launch, when the auth dialog appeared and the user completed login, the tips banner rendered at the top of the screen was pushed into the terminal scrollback, forcing users to scroll up to see it. The banner lives inside Ink's `<Static>` region, which freezes items on first paint; appending a new history item after auth then makes the viewport reflow past the frozen header. This change threads `refreshStatic` into `useAuthCommand` and calls it once, right after the initial successful login, so Ink redraws the static area and the tips banner is visible at the top again. Later re-authentications (e.g. provider switches via `/auth`) intentionally skip the refresh so mid-session scrollback is preserved.

## Related Issue

closes #1299

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/copilot-shell
npm run build && npm run test && npm run lint && npm run typecheck
```

- All 179 test files (3780 tests, 2 skipped) pass, including two new `useAuth.test.ts` cases: initial login triggers `refreshStatic` exactly once, and re-auth on an already-authenticated session does not.
- Lint and typecheck both pass with zero warnings/errors.

## Additional Notes

<!-- N/A -->
