### PR TITLE
fix(cosh): add actionable error guidance for shell mode exit code 127

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -188,7 +188,7 @@ describe('useShellCommandProcessor', () => {
     expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
   });
 
-  it('should handle command failure and display error status', async () => {
+  it('should show actionable guidance for command not found', async () => {
     const { result } = renderProcessorHook();
 
     act(() => {
@@ -209,10 +209,40 @@ describe('useShellCommandProcessor', () => {
     const finalHistoryItem = addItemToHistoryMock.mock.calls[1][0];
     expect(finalHistoryItem.tools[0].status).toBe(ToolCallStatus.Error);
     expect(finalHistoryItem.tools[0].resultDisplay).toContain(
-      'Command exited with code 127',
+      'Error: command not found (exit code 127)',
+    );
+    expect(finalHistoryItem.tools[0].resultDisplay).toContain('Please check');
+    expect(finalHistoryItem.tools[0].resultDisplay).toContain(
+      'try installing it',
     );
     expect(finalHistoryItem.tools[0].resultDisplay).toContain('not found');
     expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
+  });
+
+  it('should preserve generic guidance for other command failures', async () => {
+    const { result } = renderProcessorHook();
+
+    act(() => {
+      result.current.handleShellCommand(
+        'bad-cmd',
+        new AbortController().signal,
+      );
+    });
+    const execPromise = onExecMock.mock.calls[0][0];
+
+    act(() => {
+      resolveExecutionPromise(
+        createMockServiceResult({ exitCode: 2, output: 'usage error' }),
+      );
+    });
+    await act(async () => await execPromise);
+
+    const finalHistoryItem = addItemToHistoryMock.mock.calls[1][0];
+    expect(finalHistoryItem.tools[0].status).toBe(ToolCallStatus.Error);
+    expect(finalHistoryItem.tools[0].resultDisplay).toContain(
+      'Command exited with code 2',
+    );
+    expect(finalHistoryItem.tools[0].resultDisplay).toContain('usage error');
   });
 
   describe('UI Streaming and Throttling', () => {

--- a/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -281,7 +281,20 @@ export const useShellCommandProcessor = (
                 finalOutput = `Command terminated by signal: ${result.signal}.\n${finalOutput}`;
               } else if (result.exitCode !== 0) {
                 finalStatus = ToolCallStatus.Error;
-                finalOutput = `Command exited with code ${result.exitCode}.\n${finalOutput}`;
+                // Exit code 127 typically means "command not found". Provide
+                // actionable guidance so the user understands the error and
+                // knows what to do next (check spelling, install the tool, etc.).
+                if (result.exitCode === 127) {
+                  finalOutput =
+                    `Error: command not found (exit code 127).\n` +
+                    `Please check the command name and spelling, or use ` +
+                    `'which <command>' to verify the command is installed.\n` +
+                    `If the command is not installed, try installing it or ` +
+                    `adding it to your PATH.\n\n` +
+                    finalOutput;
+                } else {
+                  finalOutput = `Command exited with code ${result.exitCode}.\n${finalOutput}`;
+                }
               }
 
               if (pwdFilePath && fs.existsSync(pwdFilePath)) {


### PR DESCRIPTION
## 问题

Fixes #1318

When a user runs a non-existent command in shell mode (e.g., `!nonexistentcmd123`), the CLI returns exit code 127 and displays `bash: command not found`, but the error output only shows `Command exited with code 127.` — it lacks actionable keywords (like `error`, `please check`, `try installing`) that help the user understand the failure and know what to do next.

The experience oracle test (`F02-05: 执行不存在的命令`) validates that error output matches `ACTIONABLE_ERROR_PATTERNS`, which requires both an error keyword (`error`/`failed`/`错误`) and a guidance keyword (`建议`/`请`/`try`/`check`/`检查`/`install`). The generic `Command exited with code 127.` matches neither.

## 修复

```diff
--- a/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -281,7 +281,20 @@ export const useShellCommandProcessor = (
                 finalOutput = `Command terminated by signal: ${result.signal}.\n${finalOutput}`;
               } else if (result.exitCode !== 0) {
                 finalStatus = ToolCallStatus.Error;
-                finalOutput = `Command exited with code ${result.exitCode}.\n${finalOutput}`;
+                // Exit code 127 typically means "command not found". Provide
+                // actionable guidance so the user understands the error and
+                // knows what to do next (check spelling, install the tool, etc.).
+                if (result.exitCode === 127) {
+                  finalOutput =
+                    `Error: command not found (exit code 127).\n` +
+                    `Please check the command name and spelling, or use ` +
+                    `'which <command>' to verify the command is installed.\n` +
+                    `If the command is not installed, try installing it or ` +
+                    `adding it to your PATH.\n\n` +
+                    finalOutput;
+                } else {
+                  finalOutput = `Command exited with code ${result.exitCode}.\n${finalOutput}`;
+                }
               }
```

## 验证

```shell
# On ECS (47.239.51.100), ALinux 4:
cd /root/anolisa
bash scripts/rpm-build.sh copilot-shell  # → exit 0, RPM built (4.1M)
rpm -ivh --force scripts/rpmbuild/RPMS/x86_64/copilot-shell-2.6.0-1.alnx4.x86_64.rpm

# Run the previously-failing test:
cd /root/agentic-os-tests/cosh-tests
CLI_PATH=/usr/bin/cosh npx vitest run testcase/f02-shell-mode.test.ts -t 'F02-05'
# → ✓ F02-05: 执行不存在的命令 (7810ms) — PASS

# Run full F02 suite for regression:
CLI_PATH=/usr/bin/cosh npx vitest run testcase/f02-shell-mode.test.ts
# → ✓ Test Files 1 passed (1) → Tests 10 passed (10) — ALL GREEN
```

Co-Authored-By: Claude <noreply@anthropic.com>
