### PR TITLE
chore(tokenless): bump to v0.6.1

### DIFF
--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.6.1
+
+- bundle tool_categories.json into dist for npm installs
+- use node: prefix, eliminate shell subprocess in openclaw plugin
 
 ## 0.6.0
 

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "clap",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "regex",
  "serde_json",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT"
 

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -292,6 +292,7 @@ function loadToolCategories(): ToolCategories {
   try {
     // Try multiple possible locations for tool_categories.json
     const possiblePaths = [
+      join(import.meta.dirname, "tool_categories.json"),
       join(import.meta.dirname, "..", "..", "common", "hooks", "tool_categories.json"),
       join(import.meta.dirname, "common", "hooks", "tool_categories.json"),
       "/usr/share/anolisa/adapters/tokenless/common/hooks/tool_categories.json",

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -20,9 +20,9 @@
  * session; revisit if that changes.
  */
 
-import { execSync, execFileSync, spawnSync } from "child_process";
-import { existsSync, statSync, readFileSync } from "fs";
-import { join } from "path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, statSync, readFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
 
 // ---- Session ID mapping --------------------------------------------------------
 // OpenClaw's tool_result_persist ctx provides sessionKey ("agent:main:main")
@@ -79,14 +79,19 @@ function isExecutable(path: string): boolean {
 }
 
 function resolveBinaryPath(name: string, ...fallbacks: string[]): string | null {
-  try {
-    const result = spawnSync("sh", ["-c", `command -v "$1"`, "--", name], {
-      encoding: "utf-8", timeout: 2000,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const output = result.stdout?.trim();
-    if (output && output !== "") return output;
-  } catch { /* not on PATH */ }
+  // Search PATH directories without spawning a shell (mirrors headroom
+  // and agent-memory plugins).  Avoids `sh -c "command -v"` so the
+  // only child_process calls are direct binary invocations with fixed
+  // paths — no shell interpolation vector exists.
+  const pathEnv = process.env.PATH || "";
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, name);
+    if (existsSync(candidate) && isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+  // Fall back to known locations.
   for (const fb of fallbacks) {
     if (fb && isExecutable(fb)) return fb;
   }

--- a/src/tokenless/adapters/tokenless/openclaw/openclaw.plugin.json.in
+++ b/src/tokenless/adapters/tokenless/openclaw/openclaw.plugin.json.in
@@ -2,7 +2,7 @@
   "id": "tokenless",
   "name": "Tokenless",
   "version": "@VERSION@",
-  "description": "Unified RTK command rewriting + response/TOON compression + Tool Ready environment pre-check",
+  "description": "Unified RTK command rewriting + response/TOON compression + Tool Ready environment pre-check. Wraps tokenless and rtk system binaries via child_process — this is expected and not malicious.",
   "activation": {
     "onCapabilities": ["hook"]
   },

--- a/src/tokenless/adapters/tokenless/openclaw/package.json.in
+++ b/src/tokenless/adapters/tokenless/openclaw/package.json.in
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
-    "build": "npm run clean && tsc --project tsconfig.json"
+    "build": "npm run clean && tsc --project tsconfig.json && cp ../common/hooks/tool_categories.json dist/"
   },
   "peerDependencies": {
     "rtk": ">=0.35.0",

--- a/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
@@ -55,6 +55,16 @@ if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
     exit 0
 fi
 
+# OpenClaw's built-in security scanner flags child_process imports as "dangerous
+# code patterns" and requires --dangerously-force-unsafe-install to proceed.
+# This is expected for the tokenless plugin: it delegates to tokenless and rtk
+# system binaries via execFileSync/spawnSync with fixed paths and timeouts.
+# No shell injection vector exists — all subprocess arguments are hardcoded or
+# come from resolveBinaryPath(), never from user input.
+echo "[${COMPONENT}] Note: --dangerously-force-unsafe-install is required because"
+echo "[${COMPONENT}]       this plugin wraps tokenless/rtk system binaries via child_process."
+echo "[${COMPONENT}]       See https://github.com/alibaba/anolisa for source."
+
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" \
     --force --dangerously-force-unsafe-install || {
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -448,6 +448,10 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Sat Jul 04 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.6.1-1
+- fix(tokenless): use node: prefix, eliminate shell subprocess in openclaw plugin
+- fix(tokenless): bundle tool_categories.json into dist for npm installs
+
 * Mon Jun 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.6.0-1
 - fix(tokenless): add absolute saved values + schema version to JSON output
 - fix(tokenless): use import.meta.dirname instead of __dirname in openclaw plugin


### PR DESCRIPTION
## Description

Patch release **tokenless v0.6.1** on the `0.6.y` maintenance line. Cherry-picks the two `fix` commits that landed on `main` since `tokenless/v0.6.0` (no `feat` content — the stash crate/integration stay on `main` for a later minor bump, so this is a clean PATCH per SemVer).

Branched from `release/tokenless/v0.6.y` (at the v0.6.0 release point) + cherry-picks + version bump, mirroring the 0.5.1 / 0.4.1 patch-release flow (head `release/tokenless/v0.6.y` → base `main`).

**Cherry-picks (fixes since v0.6.0):**
- `fix(tokenless): bundle tool_categories.json into dist for npm installs` (#1250)
- `fix(tokenless): use node: prefix, eliminate shell subprocess in openclaw plugin` (#1257)

**Bump:**
- Workspace `Cargo.toml` 0.6.0 → 0.6.1; `Cargo.lock` synced for `tokenless-schema`/`tokenless-cli`/`tokenless-stats` (`tokenless-ccr` is not on this branch — stash feat excluded).
- `tokenless.spec.in` `%changelog` entry for 0.6.1-1.
- `CHANGELOG.md` 0.6.1 section via `git cliff` (`--prepend`, old history preserved).

On rebase-merge into `main`, the two cherry-picked fixes (same patch-id as the originals already on `main`) are skipped, so only the version bump + changelog land — `main`'s feat content (stash) is untouched.

## Related Issue

no-issue: tokenless patch release v0.6.1.

## Type of Change

- [x] CI/CD or build changes (release bump)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] For `tokenless`: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` pass
- [x] Lock files are up to date (`Cargo.lock`)
- [x] `tokenless.spec.in` changelog + `CHANGELOG.md` updated

## Testing

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace   # 151 tests green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
