### PR TITLE
fix(tokenless): sync stale version stamps to 0.6.1

### DIFF
--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -6,7 +6,7 @@
 # Installed to: %{_datadir}/anolisa/components/tokenless/component.toml
 [component]
 name = "tokenless"
-version = "0.6.0"
+version = "0.6.1"
 
 [[adapters]]
 framework = "openclaw"

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "rusqlite",

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/docs/tokenless-user-manual-en.md
+++ b/src/tokenless/docs/tokenless-user-manual-en.md
@@ -554,5 +554,5 @@ All hooks receive `TOKENLESS_AGENT_ID=copilot-shell`. Auxiliary files: `hook_uti
 ---
 
 **License**: MIT (tokenless core) + Apache-2.0 (vendored rtk)
-**Version**: 0.6.0
+**Version**: 0.6.1
 **Document version**: 2.1 (aligned with ANOLISA-design user-guide structure)

--- a/src/tokenless/docs/tokenless-user-manual-zh.md
+++ b/src/tokenless/docs/tokenless-user-manual-zh.md
@@ -554,5 +554,5 @@ make adapter-scan         # 查看已注册适配器能力
 ---
 
 **许可证**：MIT（tokenless core）+ Apache-2.0（vendored rtk）
-**版本**：0.6.0
+**版本**：0.6.1
 **文档版本**：2.1（对齐 ANOLISA-design user-guide 结构）

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 1
+%define anolis_release 2
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -448,6 +448,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Sat Jul 04 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.6.1-2
+- fix(tokenless): sync stale version stamps to 0.6.1 (component.toml, cosh-extension.json, user-manual footers); bump anolis_release to 2
+
 * Sat Jul 04 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.6.1-1
 - fix(tokenless): use node: prefix, eliminate shell subprocess in openclaw plugin
 - fix(tokenless): bundle tool_categories.json into dist for npm installs


### PR DESCRIPTION
## Description

Sync the stale version-stamped files on `main` to 0.6.1. The 0.6.1 release bump (#1324) updated `Cargo.toml`/`CHANGELOG.md`/`spec.in`-changelog but left the generated/hand-maintained version stamps at 0.6.0 — this PR fixes them so the in-tree version is consistent at 0.6.1, and bumps `anolis_release` to 2 (corrected build).

**Zero merge conflict** — `main` already has `Cargo.toml`/`Cargo.lock` workspace version at 0.6.1; this PR only touches files where `main` still has 0.6.0, flipping them to 0.6.1. No `Cargo.toml` change, no stash-feat involvement.

## Files (6)
- `.anolisa/component.toml` — regenerate from `component.toml.in` (`@VERSION@` → 0.6.1); was 0.6.0
- `adapters/tokenless/common/cosh-extension.json` — 0.6.0 → 0.6.1
- `docs/tokenless-user-manual-en.md` — Version footer 0.6.0 → 0.6.1
- `docs/tokenless-user-manual-zh.md` — 版本 footer 0.6.0 → 0.6.1
- `src/tokenless/Cargo.lock` — `tokenless-ccr` entry 0.6.0 → 0.6.1 (workspace member version stamp; `main`'s Cargo.lock was stale vs its Cargo.toml 0.6.1)
- `tokenless.spec.in` — `anolis_release` 1 → 2; add 0.6.1-2 changelog entry

The other adapter manifests (`manifest.json`/`package.json`/`plugin.yaml`/...) are gitignored and regenerated at build time, so no stale version in-tree.

## Related Issue

no-issue: tokenless v0.6.1 version-stamp sync on main.

## Type of Change

- [x] CI/CD or build changes (version-stamp sync)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] For `tokenless`: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` pass
- [x] Lock files are up to date (`Cargo.lock` tokenless-ccr stamp synced)
- [x] Residual-0.6.0 scan empty (excl Cargo.lock/CHANGELOG/spec.in history)

## Testing

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace   # green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
