### PR TITLE
chore(memory): bump to v0.2.1

### DIFF
--- a/src/agent-memory/.anolisa/component.toml
+++ b/src/agent-memory/.anolisa/component.toml
@@ -6,7 +6,7 @@
 # Installed to: %{_datadir}/anolisa/components/agent-memory/component.toml
 [component]
 name = "agent-memory"
-version = "0.2.0"
+version = "0.2.1"
 
 [[adapters]]
 framework = "openclaw"

--- a/src/agent-memory/CHANGELOG.md
+++ b/src/agent-memory/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.2.1
 
+- fix vector/hybrid search panic and empty index when an embedding provider is configured: the index worker ran on a std::thread with no tokio Handle so embeddings were never produced, and memory_search mode=vector|hybrid called Handle::block_on from a worker thread; the runtime handle is now captured at spawn and threaded through to the worker, and the search path uses block_in_place
+- fix memory_get_context leaking .git internals (e.g. .git/logs/HEAD) into agent context by extending the reserved-path filter to cover .git/ via a shared is_under_git predicate in safe_fs
+- fix full_scan (startup and inotify-overflow recovery) only building the BM25 index and never dense embeddings, so preexisting files were invisible to vector search until modified; a paths_without_vec query plus a backfill pass now embeds them, centralised in an embed_sync helper shared with flush
 - fix memory_search returning zero hits for short CJK query terms (< 3 chars, e.g. "花名"/"小云"): the trigram tokenizer emits no tokens for terms shorter than 3 characters, so such queries now fall back to a `body LIKE '%term%'` substring scan that preserves recall, agent-scope filtering, and cold/superseded exclusion
+- resolve embedding dimensions from the first real response instead of hardcoding 1536 (DashScope text-embedding-v3 is 1024): dimensionality is stored in an AtomicUsize seeded with the estimate and overwritten on first embed
+- add anolisa-cli adapter contract via .anolisa/component.toml so the CLI adapter manager can discover the openclaw plugin bundle through the [[adapters]] TOML schema
 
 ## 0.2.0
 

--- a/src/agent-memory/Cargo.lock
+++ b/src/agent-memory/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-memory"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/agent-memory/Cargo.toml
+++ b/src/agent-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-memory"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 # edition 2024 stabilised in rustc 1.85; let-chains land in 1.88 so we
 # avoid them. Anolis ships 1.86, which is fine for build but won't take

--- a/src/agent-memory/adapters/agent-memory/manifest.json
+++ b/src/agent-memory/adapters/agent-memory/manifest.json
@@ -1,15 +1,17 @@
 {
   "component": "agent-memory",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "targets": {
     "openclaw": {
       "compatibleVersions": ">=5.0.0",
       "capabilities": {
-        "plugins": ["memory-anolisa"]
+        "plugins": [
+          "memory-anolisa"
+        ]
       },
       "actions": {
-        "detect":    "openclaw/scripts/detect.sh",
-        "install":   "openclaw/scripts/install.sh",
+        "detect": "openclaw/scripts/detect.sh",
+        "install": "openclaw/scripts/install.sh",
         "uninstall": "openclaw/scripts/uninstall.sh"
       }
     }

--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -1,14 +1,19 @@
 {
   "id": "memory-anolisa",
   "name": "Anolisa Memory",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Persistent memory backed by the agent-memory MCP server with namespace isolation and openat2 sandbox. Provides BM25 search, file read/write, observe, and context assembly tools.",
   "activation": {
     "onStartup": false
   },
   "kind": "memory",
   "contracts": {
-    "tools": ["memory_search", "memory_get", "memory_observe", "memory_get_context"]
+    "tools": [
+      "memory_search",
+      "memory_get",
+      "memory_observe",
+      "memory_get_context"
+    ]
   },
   "configSchema": {
     "type": "object",
@@ -25,7 +30,11 @@
       },
       "profile": {
         "type": "string",
-        "enum": ["basic", "advanced", "expert"],
+        "enum": [
+          "basic",
+          "advanced",
+          "expert"
+        ],
         "description": "Memory profile controlling which tools are visible to the agent."
       },
       "maxReadBytes": {

--- a/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memory-anolisa-openclaw-plugin",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/package.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-memory/agent-memory.spec.in
+++ b/src/agent-memory/agent-memory.spec.in
@@ -205,6 +205,14 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Fri Jul 04 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.1-1
+- fix(memory): unblock vector/hybrid search on tokio runtime (thread runtime handle into index worker, block_in_place in search)
+- fix(memory): stop leaking .git internals via memory_get_context (reserved-path filter covers .git/)
+- fix(memory): backfill vectors for preexisting files in full_scan
+- fix(memory): recall short CJK queries (< 3 chars) via LIKE fallback
+- refactor(memory): resolve embedding dimensions from first response (was hardcoded 1536)
+- feat(memory): add anolisa-cli adapter contract via component.toml
+
 * Mon Jun 29 2026 Shile Zhang <shile.zhang@linux.alibaba.com> - 0.2.0-1
 - Add semantic search (BM25/vector/hybrid via RRF) with OpenAI and Ollama
   embedding providers; graceful fallback to BM25 when unconfigured

--- a/src/agent-memory/config/mcp-server.json
+++ b/src/agent-memory/config/mcp-server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-memory",
   "description": "Agent memory — filesystem memory MCP server. 31 tools across three tiers: Tier A file ops (read/write/append/edit/list/grep/diff/mkdir/remove/promote + mem_session_log), Tier B structured (memory_search, memory_observe, memory_get_context, memory_task_save/resume/list/close, memory_forget, memory_consent, mem_export, mem_import), Tier C governance (mem_snapshot/mem_snapshot_list/mem_snapshot_restore/mem_log/mem_revert/mem_consolidate/mem_compact, memory_about, memory_auto_created). Optional Linux user-namespace isolation, SQLite FTS5 BM25 + vector hybrid background index, time-decay ranking, cold archival, episodic memory extraction, conflict detection, git versioning, tar.gz snapshots, cgroup v2 memory.max, and journald audit fan-out.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "command": "/usr/bin/agent-memory",
   "args": [],
   "env": {},

--- a/src/agent-memory/docs/user_manual.md
+++ b/src/agent-memory/docs/user_manual.md
@@ -582,5 +582,5 @@ For deeper investigation: start with `RUST_LOG=agent_memory=debug` and inspect b
 ---
 
 **License**: Apache-2.0
-**Version**: 0.2.0
+**Version**: 0.2.1
 **Document version**: 2.0 (aligned with ANOLISA-design user-guide structure)

--- a/src/agent-memory/docs/user_manual.zh.md
+++ b/src/agent-memory/docs/user_manual.zh.md
@@ -582,5 +582,5 @@ RUST_LOG=agent_memory=debug agent-memory
 ---
 
 **许可证**：Apache-2.0
-**版本**：0.2.0
+**版本**：0.2.1
 **文档版本**：2.0（对齐 ANOLISA-design user-guide 结构）

--- a/src/agent-memory/tests/common/mod.rs
+++ b/src/agent-memory/tests/common/mod.rs
@@ -37,7 +37,25 @@ impl McpAgent {
             .env("MEMORY_BASE_DIR", data_dir)
             .env("MEMORY_SESSION_DIR", &session_dir)
             .env("MEMORY_MOUNT_STRATEGY", "userland")
-            .env("USER_ID", "tester");
+            .env("USER_ID", "tester")
+            // Hermeticity: the server otherwise reads ~/.anolisa/memory.toml
+            // (default config path), so a developer's global config leaks into
+            // the test. Disable the two subsystems whose leak breaks the BM25
+            // e2e flow:
+            //  - embedding: since 0.2.1 the index worker actually drives
+            //    embeddings (runtime handle is now captured at spawn), so a
+            //    configured provider makes per-file HTTP embed calls that
+            //    delay BM25 upsert past the test's 500 ms wait, making
+            //    memory_search spuriously return empty. Vector/hybrid search
+            //    is covered separately in tier_b_test.rs with a mock provider.
+            //  - git: auto-commit writes .git/logs/HEAD whose commit messages
+            //    echo file paths (e.g. "notes/hello.md"), so mem_grep for a
+            //    pattern that also appears in a path picks up spurious hits.
+            // Tests that need either subsystem set the matching MEMORY_*_ENABLED
+            // / MEMORY_EMBEDDING_BACKEND env via extra_env, which overrides
+            // these defaults (extra_env is applied last).
+            .env("MEMORY_EMBEDDING_BACKEND", "none")
+            .env("MEMORY_GIT_ENABLED", "false");
         for (k, v) in extra_env {
             cmd.env(k, v);
         }

--- a/src/agent-memory/tests/mcp_integration_test.rs
+++ b/src/agent-memory/tests/mcp_integration_test.rs
@@ -70,6 +70,11 @@ async fn spawn_with_dir(
         .env("MEMORY_SESSION_DIR", &session_dir)
         .env("MEMORY_MOUNT_STRATEGY", "userland")
         .env("USER_ID", "tester")
+        // Hermeticity: seal off ~/.anolisa/memory.toml leaks (see
+        // McpAgent::spawn in tests/common/mod.rs for the full rationale).
+        // Tests needing git/embedding use spawn_with_env to override these.
+        .env("MEMORY_EMBEDDING_BACKEND", "none")
+        .env("MEMORY_GIT_ENABLED", "false")
         .spawn()
         .expect("failed to spawn MCP server");
 
@@ -344,6 +349,10 @@ async fn promote_round_trip_from_scratch_to_store() {
         .env("MEMORY_SESSION_ID", "ses_promote_test")
         .env("MEMORY_MOUNT_STRATEGY", "userland")
         .env("USER_ID", "tester")
+        // Hermeticity: seal ~/.anolisa/memory.toml leaks (see
+        // McpAgent::spawn in tests/common/mod.rs).
+        .env("MEMORY_EMBEDDING_BACKEND", "none")
+        .env("MEMORY_GIT_ENABLED", "false")
         .spawn()
         .expect("spawn");
 
@@ -447,7 +456,12 @@ async fn spawn_with_env(
         .env("MEMORY_BASE_DIR", data_dir)
         .env("MEMORY_SESSION_DIR", &session_dir)
         .env("MEMORY_MOUNT_STRATEGY", "userland")
-        .env("USER_ID", "tester");
+        .env("USER_ID", "tester")
+        // Hermeticity defaults (see McpAgent::spawn in tests/common/mod.rs);
+        // extra_env below overrides these, so git/embedding tests flip them
+        // back on by passing the matching MEMORY_* var.
+        .env("MEMORY_EMBEDDING_BACKEND", "none")
+        .env("MEMORY_GIT_ENABLED", "false");
     for (k, v) in extra_env {
         cmd.env(k, v);
     }


### PR DESCRIPTION
## Description

Bugfix release for `agent-memory`, packaging the fixes that landed on `main` after `memory/v0.2.0` (2026-06-29) but were never tagged, plus the anolisa-cli adapter contract and a test-hermeticity fix uncovered during release verification.

**Bugfixes since v0.2.0 (PR #1210, merged 2026-06-30):**
- fix vector/hybrid search panic and empty index when an embedding provider is configured: the index worker ran on a `std::thread` with no tokio `Handle`, so embeddings were never produced; `memory_search mode=vector|hybrid` called `Handle::block_on` from a worker thread and panicked. The runtime handle is now captured at spawn and threaded through `spawn → run_watcher → flush`; the search path uses `block_in_place`.
- fix `memory_get_context` leaking `.git` internals (e.g. `.git/logs/HEAD`) into agent context via a shared `is_under_git` predicate in `safe_fs`.
- fix `full_scan` (startup + inotify-overflow recovery) only building the BM25 index and never dense embeddings, so preexisting files were invisible to vector search until modified; a `paths_without_vec` query plus a backfill pass now embeds them, centralised in an `embed_sync` helper shared with `flush`.
- refactor: resolve embedding dimensions from the first real response instead of hardcoding 1536 (DashScope `text-embedding-v3` is 1024); dimensionality is stored in an `AtomicUsize` seeded with the estimate and overwritten on first embed.

**CJK short-query recall (commit aac15f00, issue #1254):**
- fix `memory_search` returning zero hits for short CJK query terms (< 3 chars, e.g. "花名"/"小云"): the trigram tokenizer emits no tokens for terms shorter than 3 characters, so such queries now fall back to a `body LIKE '%term%'` substring scan that preserves recall, agent-scope filtering, and cold/superseded exclusion.

**Adapter contract (commit add5cb7c):**
- feat: add anolisa-cli adapter contract via `.anolisa/component.toml` so the CLI adapter manager can discover the openclaw plugin bundle through the `[[adapters]]` TOML schema.

**Test hermeticity (this release branch):**
- test: hermeticize e2e and integration spawns. The e2e/mcp_integration harnesses spawned the server without sealing off `~/.anolisa/memory.toml` (default config path), so a developer's global config leaked in. Since PR #1210 activated the index-worker embedding path, a configured provider made per-file HTTP embed calls that delayed BM25 upsert past the tests' 500 ms wait (`memory_search` returned empty); git auto-commit wrote `.git/logs/HEAD` whose commit messages echo file paths, so `mem_grep` over-matched. Force `MEMORY_EMBEDDING_BACKEND=none` + `MEMORY_GIT_ENABLED=false` in all four spawn sites; tests needing either subsystem override via `extra_env`. Mock-provider tier_b tests inject in-process and are unaffected.

Version stamps synced from `Cargo.toml` (single source of truth) into `Cargo.lock`, `component.toml`, adapter manifest, openclaw plugin package/lock/manifest, `mcp-server.json`, and both user manuals. RPM `%changelog` entry added under `0.2.1-1`.

## Related Issue

no-issue: bugfix release packaging merged fixes since v0.2.0 (PR #1210 + aac15f00 + add5cb7c); no tracking issue exists for the release itself. The CJK recall fix closes #1254 (already closed by aac15f00).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [x] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Pre-release CI on the release branch, all green:

- `cargo fmt --check` — pass
- `cargo clippy --all-targets -- -D warnings` — 0 warnings
- `cargo test` — 279 passed / 0 failed (169 unit + 110 integration across 13 test binaries)
- `cargo build --release --locked` — pass (Cargo.lock consistent)
- `make sync-versions` — idempotent (no diff on re-run)

The hermeticity fix was verified by running the full suite on a host with a real DashScope `text-embedding-v3` provider configured in `~/.anolisa/memory.toml`: previously `full_e2e_workflow`, `write_read_grep_workflow`, and `tier_b_observe_search_and_context_via_mcp` failed; all 279 pass after the fix.

## Additional Notes

- No LLM is required for vector search; only an embedding model (`/v1/embeddings` endpoint). agent-memory itself makes zero LLM calls.
- The 0.2.1 range includes one `feat` (`add5cb7c`, component.toml adapter contract — publishing metadata only, no runtime behavior change). Strict SemVer says feat→MINOR, but the feat is metadata-only infra and the release owner requested 0.2.1; it is listed under "feat" in the CHANGELOG for transparency.
- Two commits on this branch: `test(memory): hermeticize e2e and integration spawns` + `chore(memory): bump to v0.2.1`. Both `Signed-off-by: Shile Zhang <shile.zhang@linux.alibaba.com>`.
- After merge: tag `memory/v0.2.1` (annotated) on the merge commit on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)