### PR TITLE
docs(docs): add unified documentation standard and slim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,15 +299,11 @@ Use [`.github/pull_request_template.md`](.github/pull_request_template.md) as th
 - **Testing**: command used, scope (unit/integration/manual), edge cases verified
 - PR title follows commit message format: `type(scope): description`
 
-## 9. Changelog Entries
+## 9. Documentation Rules
 
-Each user-perceivable change requires a `CHANGELOG.md` entry in the affected component. Follow [Keep a Changelog](https://keepachangelog.com/) format (Added / Changed / Fixed).
+> **MANDATORY**: All documentation rules — file naming, bilingual conventions, CHANGELOG format, file placement, user-guide standards — are defined in [`specs/documentation-standard.md`](specs/documentation-standard.md). You MUST read that file before creating, renaming, or modifying any documentation file. Non-compliance will be rejected in review.
 
-1. **One sentence per bullet** — max 25 English words / 40 Chinese characters
-2. **User perspective** — describe the behavior change, not the code change
-3. **No internal jargon** — command names and config keys are fine; kernel APIs and syscalls are not
-4. **One bullet, one change** — do not combine unrelated changes
-5. **Skip invisible changes** — pure refactors, test infra, and CI tweaks do not belong in the changelog
+This section intentionally does not duplicate the spec. Do NOT invent documentation rules from memory or prior context — the spec is the single source of truth.
 
 ## 10. Code Standards (General)
 
@@ -327,94 +323,10 @@ Components with complex architectures maintain their own AGENTS.md for module-sp
 | **cosh-ng** | [`src/cosh-ng/AGENTS.md`](src/cosh-ng/AGENTS.md) | 5-crate workspace, security heuristics, PTY testing strategy |
 | **skillfs** | [`src/skillfs/AGENTS.md`](src/skillfs/AGENTS.md) | Three-crate layout, dependency exceptions, FUSE e2e testing |
 
-## 11.1 File Placement Rules
+## 11.1 File Placement & Documentation Structure
 
-### Per-component files at `src/<component>/`
-
-Every component MUST have:
-
-| File | Purpose |
-|------|---------|
-| `README.md` | Human entry point: what it is, quick start, architecture overview |
-| `CONTRIBUTING.md` | How to contribute (build, test, lint, PR checklist) |
-| `CHANGELOG.md` | User-perceivable changes per release |
-
-Optional (only when the component has non-trivial AI-agent constraints):
-
-| File | Purpose |
-|------|---------|
-| `AGENTS.md` | Value proposition, doc boundaries, gotchas, terminology |
-
-#### README.md opening paragraph convention
-
-Every component `README.md` MUST open with a structured introduction:
-
-1. **First sentence**: one-line positioning (reusable verbatim in indexes)
-2. **Remainder of paragraph**: 2–4 sentences expanding scope and differentiators
-
-When composing `user-guide` indexes, quote the first sentence verbatim.
-
-### Repo root `/`
-
-| File | Purpose |
-|------|---------|
-| `AGENTS.md` | Global conventions (this file) |
-| `README.md` | Project-level overview |
-| `CONTRIBUTING.md` | General contribution guide (references component-specific ones) |
-| `LICENSE`, `Makefile` | Legal, unified build entry |
-
-### `docs/` structure
-
-| Path | Audience | Content |
-|------|----------|---------|
-| `docs/QUICKSTART.md` | Users | Cross-component quick start |
-| `docs/BUILDING.md` | Developers | Build instructions |
-| `docs/user-guide/{en,zh}/` | Users | Unified user documentation, organized by capability |
-| `docs/developer-guide/{en,zh}/` | Contributors | Architecture, hook development, IPC protocol, testing |
-
-Component user docs migrate into `docs/user-guide/` under the appropriate capability directory.
-Component developer docs migrate into `docs/developer-guide/` under the component name.
-
-Example:
-```
-docs/user-guide/en/user-entrypoint/copilot-shell/    ← users/ content
-docs/developer-guide/en/copilot-shell/               ← developers/ content
-```
-
-Each component directory in `user-guide/` uses `QUICKSTART.md` as its entry point.
+> **MANDATORY**: See [`specs/documentation-standard.md`](specs/documentation-standard.md) §2–§4 for the complete file placement rules, bilingual naming convention, and component-level file requirements. Do NOT rely on cached or memorized rules — read the spec file directly.
 
 ## 12. User Guide Documentation Standards
 
-### Writing Process
-
-- **Source of truth**: code is the ground truth. Read clap definitions, config loaders, and runtime logic before writing. Existing docs (design repo, cloud vendor pages) are reference only — never copy without code verification.
-- **Scope**: only document components whose source code exists in this repository (`src/`). If the code is not here, the component does not exist in the docs.
-- **Verification**: every CLI example, config path, and behavioral claim must be traceable to a specific code location. If you cannot point to the code, do not write it.
-
-### Installation Priority
-
-1. `anolisa install <component>` — always first
-2. RPM package (`yum install`) — alternative for Alinux users
-3. Source build — last, developers only
-- agentsight and agent-sec-core require system mode: `sudo anolisa install`
-- All others use user mode
-
-### Content Boundaries
-
-- Cloud-specific service configuration (SLS endpoints, AK/SK auth, security group rules) belongs to cloud vendor docs, not here
-- Alinux ecosystem tools (loongshield, yum repos) may be mentioned with context
-- Never document planned-but-unimplemented features as available
-- Never describe behavior ("replaces not extends", "auto-assigns") without having verified the code path
-
-### Framing Principles
-
-- Each component doc opens with a value proposition answering "why install this?" — not a technical architecture description
-- Cross-component integration stories belong in docs (e.g. "install AgentSight + Tokenless, savings appear in Dashboard automatically")
-- Gotchas that cause real user confusion deserve prominent warnings, even if technically derivable from code
-
-### Language
-
-- Bilingual: `docs/user-guide/{en/, zh/}` mirror structure
-- en/ and zh/ must be semantically equivalent
-- Technical terms keep English form in Chinese docs (eBPF, Token, CLI)
-- Command examples identical across languages; only prose differs
+> **MANDATORY**: See [`specs/documentation-standard.md`](specs/documentation-standard.md) §4.6 for user-guide writing standards including installation priority, content boundaries, framing principles, and bilingual language rules. You MUST comply — skipping this spec and writing docs from assumptions is a blocking review issue.

--- a/specs/documentation-standard.md
+++ b/specs/documentation-standard.md
@@ -3,12 +3,12 @@
 > Canonical reference for documentation structure, naming, bilingual conventions, and maintenance rules.
 > Both human contributors and AI agents MUST follow this specification.
 
-## Agent Reading Order
+## Agent Navigation (for documentation tasks)
 
-When an agent starts working on this repository:
+Agents enter this repository via `AGENTS.md` (auto-loaded by tooling). For **documentation-related work**, `AGENTS.md` §9/§11.1/§12 redirects here with MANDATORY directives. The reading priority for documentation tasks is:
 
-1. `specs/` — normative rules (this directory)
-2. `AGENTS.md` — development conventions and coding standards
+1. `AGENTS.md` — natural entry; contains redirect to this spec
+2. `specs/documentation-standard.md` — normative documentation rules (this file)
 3. `src/<component>/AGENTS.md` — scoped module rules (if working on that component)
 4. `src/<component>/README.md` — component context
 
@@ -60,15 +60,14 @@ When an agent starts working on this repository:
 | CONTRIBUTING | Structured sections: prerequisites, build, test, PR checklist | Root covers general flow; component covers local build/test only |
 | CHANGELOG | [Keep a Changelog](https://keepachangelog.com/) format (Added / Changed / Fixed) | Root MUST prepend a "Component Versions" table before highlights |
 
-**CHANGELOG writing rules:**
+**CHANGELOG writing rules** (content standard — what to write, not when):
 
-1. Each user-perceivable change requires an entry in the affected component's CHANGELOG
+1. Only record user-perceivable changes; skip pure refactors, test infra, CI tweaks
 2. One sentence per bullet — max 25 English words / 40 Chinese characters
 3. User perspective — describe the behavior change, not the code change
 4. No internal jargon — command names and config keys are fine; kernel APIs and syscalls are not
 5. One bullet, one change — do not combine unrelated changes
-6. Skip invisible changes — pure refactors, test infra, CI tweaks do not belong
-7. Key entries should reference the implementing PR
+6. Key entries should reference the implementing PR
 
 **Root CHANGELOG structural requirement** — each version entry starts with:
 
@@ -115,11 +114,13 @@ docs/
 
 | Content type | Location | NOT here |
 |-------------|----------|----------|
-| User-facing how-to | `docs/user-guide/{en,zh}/` | Component root |
+| Full user-facing how-to / reference | `docs/user-guide/{en,zh}/` | — |
 | Developer architecture / IPC / hooks | `docs/developer-guide/{en,zh}/` | Component root |
 | Component design docs | `src/<component>/docs/` | `docs/` top level |
 | Cross-component quick start | `docs/QUICKSTART.md` | README |
 | Build instructions | `docs/BUILDING.md` | README |
+
+> **Note on component README**: README.md serves as a **summary entry point** (positioning + quick-start + basic install/use). It is NOT a full how-to or reference manual. Complete usage documentation belongs in `docs/user-guide/`. When CLI/config changes occur, update both the README summary and the user-guide reference.
 
 ### 3.2 Design Documents
 
@@ -219,12 +220,13 @@ When a PR introduces any of the following changes, documentation MUST be updated
 
 | Change type | Required doc update |
 |-------------|-------------------|
-| New/modified CLI command or flag | Component README + user-guide |
-| New/modified config option | Component README + user-guide |
-| User-perceivable feature or fix | Component CHANGELOG |
+| New/modified CLI command or flag | Component README (summary) + user-guide (full reference) |
+| New/modified config option | Component README (summary) + user-guide (full reference) |
 | Installation method change | docs/QUICKSTART + component README |
 | Architecture or protocol change | Component `docs/design/` |
 | New component added | Root README + NOTICE (if applicable) |
+
+**CHANGELOG update timing**: Daily feature/fix PRs update README and user-guide only; CHANGELOG is written exclusively in **release version bump PRs** that aggregate all user-perceivable changes since the last release.
 
 ---
 

--- a/specs/documentation-standard.md
+++ b/specs/documentation-standard.md
@@ -1,0 +1,231 @@
+# ANOLISA Documentation Standard
+
+> Canonical reference for documentation structure, naming, bilingual conventions, and maintenance rules.
+> Both human contributors and AI agents MUST follow this specification.
+
+## Agent Reading Order
+
+When an agent starts working on this repository:
+
+1. `specs/` — normative rules (this directory)
+2. `AGENTS.md` — development conventions and coding standards
+3. `src/<component>/AGENTS.md` — scoped module rules (if working on that component)
+4. `src/<component>/README.md` — component context
+
+**Source of truth hierarchy:**
+
+- Code > README/user-guide > design docs
+- Before generating or modifying documentation: read source code, verify CLI examples against `clap`/`argparse` definitions, never document unimplemented features as available
+
+---
+
+## 1. Bilingual Naming Convention
+
+| Scope | English (default) | Chinese | Notes |
+|-------|-------------------|---------|-------|
+| Repo root / component root | `FILE.md` | `FILE_zh.md` | No suffix = English |
+| `docs/` standalone pages | `docs/FILE.md` | `docs/FILE_zh.md` | e.g. QUICKSTART, BUILDING |
+| `docs/` long-form guides | `docs/{type}/en/` | `docs/{type}/zh/` | Directory-based separation |
+
+**Cross-reference convention:**
+
+- English file header: `[中文版](FILE_zh.md)`
+- Chinese file header: `[English](FILE.md)`
+
+**Prohibited patterns:**
+
+- `*_CN.md` — legacy naming, must migrate to `*_zh.md`
+- `*_en.md` — English is the default, no suffix needed
+
+## 2. Repository Root Files
+
+### 2.1 Required Files
+
+| File | Bilingual | Purpose |
+|------|-----------|---------|
+| `README.md` | Yes (`README_zh.md`) | Project overview, component table, quick start, documentation index |
+| `AGENTS.md` | English only | AI agent global constraints and development conventions |
+| `LICENSE` | English only | Apache License 2.0 |
+| `CONTRIBUTING.md` | Yes (`CONTRIBUTING_zh.md`) | General contribution guide: environment, commit rules, PR flow |
+| `CHANGELOG.md` | Yes (`CHANGELOG_zh.md`) | Version changelog with component version composition |
+| `CODE_OF_CONDUCT.md` | English only | Contributor Covenant (standard text) |
+| `SECURITY.md` | English only | Vulnerability reporting process |
+| `NOTICE` | English only | Derived works and dependency attribution |
+
+### 2.2 File Format References
+
+| File | Format standard | Root-specific rule |
+|------|----------------|-------------------|
+| README | First sentence = one-line positioning; then 2–4 sentences expanding scope | Root adds component table + documentation index |
+| CONTRIBUTING | Structured sections: prerequisites, build, test, PR checklist | Root covers general flow; component covers local build/test only |
+| CHANGELOG | [Keep a Changelog](https://keepachangelog.com/) format (Added / Changed / Fixed) | Root MUST prepend a "Component Versions" table before highlights |
+
+**CHANGELOG writing rules:**
+
+1. Each user-perceivable change requires an entry in the affected component's CHANGELOG
+2. One sentence per bullet — max 25 English words / 40 Chinese characters
+3. User perspective — describe the behavior change, not the code change
+4. No internal jargon — command names and config keys are fine; kernel APIs and syscalls are not
+5. One bullet, one change — do not combine unrelated changes
+6. Skip invisible changes — pure refactors, test infra, CI tweaks do not belong
+7. Key entries should reference the implementing PR
+
+**Root CHANGELOG structural requirement** — each version entry starts with:
+
+```markdown
+## [0.3.0] - 2026-08-01
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.2.0 |
+| agent-sec-core | 0.5.0 |
+| ...
+
+### Highlights
+- ...
+```
+
+Chinese version (`CHANGELOG_zh.md`) mirrors the same structure.
+
+## 3. docs/ Directory Structure
+
+```
+docs/
+├── QUICKSTART.md              # Cross-component quick start (English)
+├── QUICKSTART_zh.md           # Cross-component quick start (Chinese)
+├── BUILDING.md                # Build from source (English)
+├── BUILDING_zh.md             # Build from source (Chinese)
+├── user-guide/
+│   ├── en/                    # User manual (English)
+│   │   ├── README.md          # Index page
+│   │   ├── installation.md
+│   │   └── {capability}/      # Organized by capability domain
+│   └── zh/                    # User manual (Chinese, mirrors en/)
+│       └── ...
+└── developer-guide/
+    ├── en/                    # Developer documentation (English)
+    │   └── {component}/       # Organized by component name
+    └── zh/                    # Developer documentation (Chinese)
+        └── ...
+```
+
+### 3.1 What Goes Where
+
+| Content type | Location | NOT here |
+|-------------|----------|----------|
+| User-facing how-to | `docs/user-guide/{en,zh}/` | Component root |
+| Developer architecture / IPC / hooks | `docs/developer-guide/{en,zh}/` | Component root |
+| Component design docs | `src/<component>/docs/` | `docs/` top level |
+| Cross-component quick start | `docs/QUICKSTART.md` | README |
+| Build instructions | `docs/BUILDING.md` | README |
+
+### 3.2 Design Documents
+
+Design documents live **only** in the component's own directory:
+
+```
+src/<component>/docs/design/    ← component-specific design docs
+```
+
+Design docs are **never** placed at:
+- Repository root
+- `docs/` top level
+- `docs/user-guide/` or `docs/developer-guide/`
+
+## 4. Component-Level Files
+
+### 4.1 Required Files (every component)
+
+| File | Bilingual | Purpose |
+|------|-----------|---------|
+| `README.md` | Yes (`README_zh.md`) | Entry point: positioning, use cases, install, usage, relationships |
+| `CHANGELOG.md` | Yes (`CHANGELOG_zh.md`) | User-perceivable changes per release |
+
+### 4.2 Optional Files
+
+| File | Bilingual | When needed | Rule |
+|------|-----------|-------------|------|
+| `CONTRIBUTING.md` | **If exists, `CONTRIBUTING_zh.md` is also required** | When component has specific build/test/lint process | Must NOT repeat root-level general rules |
+| `AGENTS.md` | English only | When component has non-trivial AI-agent constraints | Specific to module scope |
+| `LICENSE` | English only | When component uses a different license than root | e.g. MIT sub-component |
+| `docs/` | — | For design documents, internal protocol specs | NOT for user-guide content |
+
+### 4.3 Files NOT Needed at Component Level
+
+These are inherited from the repository root:
+
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- `NOTICE` (maintained centrally at root)
+
+### 4.4 README Opening Paragraph Convention
+
+Every component `README.md` MUST open with:
+
+1. **First sentence**: one-line positioning statement (reusable verbatim in indexes and tables)
+2. **Remainder of paragraph**: 2–4 sentences expanding scope, differentiators, and target users
+
+Example:
+```markdown
+# AgentSight
+
+[中文版](README_zh.md)
+
+eBPF-based observability tool for AI Agents on Linux, providing zero-intrusion
+monitoring of LLM API calls, token consumption, and process behavior.
+AgentSight captures kernel-level events without modifying agent code...
+```
+
+### 4.5 Differentiation from Root Level
+
+| Dimension | Root | Component |
+|-----------|------|-----------|
+| README | Panoramic — what project, what problem, what's included, how to start | Focused — what this component does, who uses it, how to install & use |
+| CONTRIBUTING | General — environment, commit format, PR flow, branch naming | Specific — this component's build/test/lint commands, special deps |
+| CHANGELOG | Aggregated — version composition + highlights, links to component CHANGELOGs | Detailed — every user-perceivable entry for this component |
+
+### 4.6 User Guide Writing Standards
+
+**Installation priority** (all component docs MUST follow this order):
+
+1. `anolisa install <component>` — always first (agentsight / agent-sec-core require `sudo` system mode)
+2. RPM package (`yum install`) — alternative for Alinux users
+3. Source build — developers only, always last
+
+**Content boundaries:**
+
+- Only document components whose source code exists in `src/`. No code = no docs.
+- Cloud-specific configuration (SLS endpoints, AK/SK auth, security groups) belongs to cloud vendor docs
+- Never document planned-but-unimplemented features as available
+
+**Framing:**
+
+- Open with a value proposition ("why install this?"), not architecture description
+- Cross-component integration stories belong in user-guide (e.g. "install AgentSight + Tokenless, savings appear in Dashboard")
+
+**Language rules for bilingual docs:**
+
+- `en/` and `zh/` MUST be semantically equivalent
+- Technical terms keep English form in Chinese docs (eBPF, Token, CLI)
+- Command examples identical across languages; only prose differs
+
+**Entry point convention:** each component directory in `docs/user-guide/` uses `QUICKSTART.md` as its entry point.
+
+## 5. PR Documentation Update Rules
+
+When a PR introduces any of the following changes, documentation MUST be updated in the same PR:
+
+| Change type | Required doc update |
+|-------------|-------------------|
+| New/modified CLI command or flag | Component README + user-guide |
+| New/modified config option | Component README + user-guide |
+| User-perceivable feature or fix | Component CHANGELOG |
+| Installation method change | docs/QUICKSTART + component README |
+| Architecture or protocol change | Component `docs/design/` |
+| New component added | Root README + NOTICE (if applicable) |
+
+---
+
+*Last updated: 2026-07-04*


### PR DESCRIPTION
## Description

Introduce `specs/documentation-standard.md` as the single source of truth for all documentation rules, and update AGENTS.md to reference it.

### What changed

1. **New file: `specs/documentation-standard.md`** — canonical reference covering:
   - Bilingual naming convention (`_zh.md`, not `_CN.md`)
   - Repository root and component-level file requirements
   - CHANGELOG format (component version table + Keep a Changelog)
   - `docs/` directory structure rules
   - User Guide writing standards (installation priority, content boundaries)
   - PR documentation update triggers
   - Agent reading order and source-of-truth hierarchy

2. **Slimmed `AGENTS.md` §9/§11.1/§12** — replaced ~98 lines of inline rules with mandatory redirects to the spec. Agents are required to read the spec file directly.

### Motivation

Documentation rules were scattered across multiple AGENTS.md sections, making them hard to maintain and easy for agents to skip. This PR establishes a single normative document that both humans and agents must follow.

### Follow-up (separate PRs)

- Batch rename `*_CN.md` → `*_zh.md` (15 files)
- Fix cross-reference links
- Create missing component READMEs
- Add root `CONTRIBUTING_zh.md` and `CHANGELOG_zh.md`