### PR TITLE
docs(docs): rewrite root CHANGELOG with version history and update spec format rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,226 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## News
+## [1.0] - Unreleased
 
-- **2026-03-30**: ANOLISA open sourced. [Announcement](#)
+### Component Versions
 
-## [0.0.1] - 2026-03-30
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.6.1 |
+| agent-sec-core | 0.7.0 |
+| agentsight | 0.7.1 |
+| tokenless | 0.6.1 |
+| agent-memory | 0.2.1 |
+| os-skills | 0.6.1 |
+| anolisa | 0.1.20 |
+| skillfs | 0.3.2 |
+| ws-ckpt | 0.4.1 |
+| cosh-ng | 0.11.0 |
 
-### Added
+### Highlights
 
-- **Initial Release (init 0.0.1)**: Integrating 4 core components into a unified AI Agent operating system package
-- **copilot-shell**: AI-powered terminal assistant CLI for code understanding, task automation, and system management
-- **agent-sec-core**: OS-level security baseline and hardening framework with sandbox isolation, and asset integrity verification
-- **os-skills**: Operation and maintenance skill collection for AI Agents, covering system administration, monitoring, security, and DevOps
-- **agentsight**: eBPF-based zero-intrusion AI Agent observability probe for monitoring LLM traffic, Token consumption, and running behaviors
+- **anolisa**: Updated to v0.1.20, delivered unified CLI gateway with full component lifecycle and adapter orchestration, users can install/update/diagnose all components with a single command
+- **cosh-ng**: Updated to v0.11.0, completed Core/Shell separation and AI-augmented terminal, Agent can execute structured OS operations deterministically across distros
+- **agent-memory**: Updated to v0.2.1, added user data sovereignty and 4-type memory classification, users can query/forget/control auto-captured memories
+- **tokenless**: Updated to v0.6.1, added compression toggle with A/B testing and QwenCode adapter, users can quantify Token savings per strategy without affecting task execution
+
+### New Components
+
+- **anolisa**: First release v0.1.16, built unified CLI gateway managing component install/update/uninstall with dual-backend (RPM + Raw), users can deploy the entire ANOLISA stack with `anolisa install --all`
+- **cosh-ng**: First release v0.11.0, implemented deterministic Agent-OS interface with 5-crate workspace, Agent can execute cross-distro structured system operations via stable API
+- **skillfs**: First release v0.3.2, built FUSE virtual filesystem for agent skills with view-based SKILL.md exposure, Agent can discover and load skills from a mounted directory
+
+### Updated
+
+- **agent-memory**: Updated to v0.2.1, added sovereignty tools (about/forget/consent), AMA export/import, 4-type classification, and incremental consolidation resilient to SIGKILL, users can control memory retention and migrate memories across agents
+- **tokenless**: Updated to v0.6.1, added compression on/off toggle with dry-run mode, SLS JSONL telemetry default-on, and QwenCode adapter, developers can A/B test compression strategies and monitor Token savings in SLS dashboard
+- **agentsight**: Updated to v0.7.1, added Token saving visualization (strategy pie chart + line-level diff), security dashboard, and container/K8s full support, users can visually assess which optimization saves the most Tokens
+- **copilot-shell**: Updated to v2.6.1, added `/model` dialog for multi-provider switching and SLS session telemetry (32-field JSONL), users can freely switch LLM providers without losing configuration
+- **agent-sec-core**: Updated to v0.7.0, added Skill Ledger integrity chain with GPG signing workflow and Prompt Scanner, users can audit skill security status and get confirmation prompts before risky operations
+- **os-skills**: Updated to v0.6.1, added ANOLISA Guide knowledge skill (13 official docs) and OpenClaw pre-check with bootstrap, Agent can reference accurate product documentation in responses
+- **ws-ckpt**: Updated to v0.4.1, added auto-cleanup scheduling and TOML config hot-reload, users can set retention policies that take effect without restarting the daemon
+
+### Changed
+
+- Documentation governance established via `specs/documentation-standard.md`
+- Bilingual naming convention unified to `_zh.md` (migrated from legacy `_CN.md`)
+
+## [0.6] - 2026-06-12
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.4.1 |
+| agent-sec-core | 0.5.0 |
+| agentsight | 0.5.0 |
+| tokenless | 0.4.1 |
+| agent-memory | 0.1.0 |
+| os-skills | 0.5.0 |
+
+### Highlights
+
+- **agent-memory**: First release v0.1.0, delivered sandboxed filesystem MCP memory server, Agent can persistently store and retrieve context across sessions via BM25 search
+- **tokenless**: Updated to v0.4.1, added Hermes Agent plugin and Tool Ready 4-stage pre-check, Agent environments are automatically validated before tool execution to avoid wasted retries
+- **agentsight**: Updated to v0.5.0, added Skill-level Token metrics and Hermes support, users can pinpoint which Skills consume the most Tokens
+
+### New Components
+
+- **agent-memory**: First release v0.1.0, built 19-tool MCP server with namespace isolation and BM25 background index, Agent can read/write/search persistent memory in a sandboxed filesystem
+- **cosh-ng**: First release (MVP), completed production-ready functionality for deterministic OS operations, Agent can execute structured commands with predictable output format
+
+### Updated
+
+- **tokenless**: Updated to v0.4.1, added Hermes adapter runner and Tool Ready mechanism (4-stage env pre-check as cosh extension), Agent tool calls are pre-validated reducing Token waste from environment failures
+- **agentsight**: Updated to v0.5.0, added Skill-dimension Token/call metrics and Hermes matcher with SSL support, users can see per-Skill Token breakdown in the dashboard
+- **agent-sec-core**: Updated to v0.5.0, added PIIChecker (output PII detection + desensitization) and Skill Scanner (text/code scan + lifecycle trigger), Agent output containing sensitive information is automatically intercepted
+- **copilot-shell**: Updated to v2.4.1, added cross-session auto memory extraction and hook reason visibility in UI, users can see exactly why a security hook blocked an operation
+
+## [0.5] - 2026-05-28
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.4.0 |
+| agent-sec-core | 0.4.0 |
+| agentsight | 0.4.0 |
+| tokenless | 0.4.0 |
+| os-skills | 0.4.0 |
+
+### Highlights
+
+- **tokenless**: Updated to v0.4.0, added Hermes plugin and Tool Ready environment mechanism, Agent tool execution failures due to missing dependencies are prevented before Token consumption
+- **agent-sec-core**: Updated to v0.4.0, delivered PIIChecker and Skill Scanner first version, Agent output is scanned for sensitive information leakage
+
+### Updated
+
+- **tokenless**: Updated to v0.4.0, developed Hermes Agent plugin with Tool Ready 4-stage env pre-check and history compression, Agent runtime dependencies are auto-verified before execution
+- **agent-sec-core**: Updated to v0.4.0, added PIIChecker for output PII detection and Skill Scanner baseline capabilities, users are protected from unintentional sensitive data exposure
+- **agentsight**: Updated to v0.4.0, added Skill-level metrics display, users can view Token consumption grouped by Skill
+- **os-skills**: Updated to v0.4.0, added Nightly automated test coverage, skill quality is continuously validated
+
+## [0.4] - 2026-05-13
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.3.0 |
+| agent-sec-core | 0.4.1 |
+| agentsight | 0.4.0 |
+| tokenless | 0.3.0 |
+| os-skills | 0.3.0 |
+| ws-ckpt | 0.2.0 |
+
+### Highlights
+
+- **agent-sec-core**: Updated to v0.4.1, established Skill security full lifecycle with Prompt Scanner ask policy, users receive confirmation prompts before Agent executes risky instructions
+- **tokenless**: Updated to v0.3.0, built 4-suite Benchmark comparison baselines, developers can quantify Token savings across different Skill/OS environments
+- **ws-ckpt**: Updated to v0.2.0, expanded snapshot management commands, users can auto-clean historical snapshots by count or age policy
+
+### Updated
+
+- **agent-sec-core**: Updated to v0.4.1, integrated Prompt Scanner into cosh hook and OpenClaw plugin with ask strategy, users get interactive confirmation before dangerous operations
+- **tokenless**: Updated to v0.3.0, built batch-concurrent Benchmark platform with comparison reports, developers can one-click benchmark and compare Token savings across configurations
+- **agentsight**: Updated to v0.4.0, optimized resident process memory footprint, 2C2G small-spec instances can run observability stably
+- **copilot-shell**: Updated to v2.3.0, adapted SWEBench evaluation framework, developers can execute code-fix tasks and verify pass rates via cosh
+- **ws-ckpt**: Updated to v0.2.0, enriched snapshot CRUD capabilities, users can manage workspace checkpoints with flexible retention policies
+
+## [0.3] - 2026-04-30
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.2.1 |
+| agent-sec-core | 0.3.0 |
+| agentsight | 0.3.1 |
+| tokenless | 0.2.0 |
+| os-skills | 0.3.0 |
+| ws-ckpt | 0.1.0 |
+
+### Highlights
+
+- **tokenless**: Updated to v0.2.0, delivered command rewriting and TOON context compression, CLI output Token consumption reduced by 60–90%
+- **agentsight**: Updated to v0.3.1, added Token saving Dashboard and Agent anomaly diagnostics, users can visualize savings and detect Agent interruptions
+- **agent-sec-core**: Updated to v0.3.0, added Skill Ledger integrity tracking and Prompt Scanner, every Skill's signature chain is auditable end-to-end
+
+### New Components
+
+- **ws-ckpt**: First release v0.1.0, built btrfs-based workspace checkpoint daemon, Agent can create sub-millisecond snapshots and instantly rollback filesystem state
+
+### Updated
+
+- **tokenless**: Updated to v0.2.0, added command rewriting via RTK and TOON context compression, Agent CLI interactions consume 60–90% fewer Tokens
+- **agentsight**: Updated to v0.3.1, added Token saving Dashboard (session/time-range stats) and Agent interrupt detection with drain mechanism, users can monitor savings trends and get alerted on Agent failures
+- **agent-sec-core**: Updated to v0.3.0, added Skill Ledger full lifecycle (check/certify/bypass/status/audit) and Prompt Scanner with jailbreak detection, users can track and enforce Skill integrity policies
+- **copilot-shell**: Updated to v2.2.1, added extension architecture (command extension + system Hook + instant activation), Skill marketplace integration, and session export (Markdown/HTML/JSON), users can extend cosh capabilities via plugins and export conversation history
+- **os-skills**: Updated to v0.3.0, added Skill marketplace listing, Hermes install skill, and utility skills (xlsx/pdf-reader/image-gen/humanizer), users can discover and install skills from a marketplace
+
+## [0.2] - 2026-04-15
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.0.4 |
+| agent-sec-core | 0.2.0 |
+| agentsight | 0.2.2 |
+| os-skills | 0.2.2 |
+
+### Updated
+
+- **agentsight**: Updated to v0.2.2, added Token consumption observability with precise Tokenizer counting, users can view per-message Token breakdown in real time
+- **copilot-shell**: Updated to v2.0.4, added independent auth (STS/ECS RAM Role) and Skill marketplace browsing, users can authenticate without AK/SK and discover available skills
+- **os-skills**: Updated to v0.2.2, added SysAdmin skills (Linux IO/network/load diagnostics), Agent can independently diagnose common OS performance issues
+- **tokenless**: First release v0.1.0, built Skills-level benchmark test cases, developers can compare Token consumption across different Skills quantitatively
+
+## [0.1] - 2026-03-30
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.0.1 |
+| agent-sec-core | 0.1 |
+| agentsight | 0.1 |
+| os-skills | 0.1 |
+
+### New Components
+
+- **copilot-shell**: First release v2.0.1, built AI-powered terminal assistant with Tab completion, /bash mode, sudo support, and hook security, users get an AI-native CLI experience on first login
+- **agent-sec-core**: First release v0.1, delivered Skill signature verification, security sandbox, and system hardening, Agent operations run in a controlled least-privilege environment
+- **agentsight**: First release v0.1, built eBPF-based zero-intrusion observability probe, users can monitor LLM API calls and Token consumption without modifying Agent code
+- **os-skills**: First release v0.1, curated system administration, SysOM, DevOps, and cloud skills, Agent can autonomously perform common OS operations
 
 ### Security
 
-- Skill full-link security encryption with digital signatures
+- Skill full-link encryption with digital signatures
 - Hardware-level security sandbox for risk isolation
 - Identity authentication and integrity verification for Skill calls
 
 ---
 
 For detailed changelogs of individual components, see:
-- [copilot-shell CHANGELOG](src/copilot-shell/CHANGELOG.md)
+
+**User Entrypoint**
+- [copilot-shell](src/copilot-shell/CHANGELOG.md)
+- [cosh-ng](src/cosh-ng/CHANGELOG.md)
+- [anolisa](src/anolisa/CHANGELOG.md)
+- [os-skills](src/os-skills/CHANGELOG.md)
+
+**Token Saving**
+- [tokenless](src/tokenless/CHANGELOG.md)
+
+**Runtime**
+- [agent-memory](src/agent-memory/CHANGELOG.md)
+- [skillfs](src/skillfs/CHANGELOG.md)
+- [ws-ckpt](src/ws-ckpt/CHANGELOG.md)
+
+**Agent Observability**
+- [agentsight](src/agentsight/CHANGELOG.md)
+
+**Agent Security**
+- [agent-sec-core](src/agent-sec-core/CHANGELOG.md)

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -1,0 +1,231 @@
+# 变更日志
+
+[English](CHANGELOG.md)
+
+本文件记录项目所有值得注意的变更。
+
+格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，项目遵循[语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
+
+## [1.0] - 未发布
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.6.1 |
+| agent-sec-core | 0.7.0 |
+| agentsight | 0.7.1 |
+| tokenless | 0.6.1 |
+| agent-memory | 0.2.1 |
+| os-skills | 0.6.1 |
+| anolisa | 0.1.20 |
+| skillfs | 0.3.2 |
+| ws-ckpt | 0.4.1 |
+| cosh-ng | 0.11.0 |
+
+### 重点特性
+
+- **anolisa**：更新到 v0.1.20，交付统一 CLI 网关提供组件全生命周期管理与适配器编排，用户可通过一条命令安装/更新/诊断所有组件
+- **cosh-ng**：更新到 v0.11.0，完成 Core/Shell 分离与 AI 增强终端，Agent 可跨发行版确定性执行结构化系统操作
+- **agent-memory**：更新到 v0.2.1，新增用户数据主权与 4 类记忆分类，用户可查询/遗忘/控制自动捕获的记忆
+- **tokenless**：更新到 v0.6.1，新增压缩开关与 A/B 对比及 QwenCode 适配器，用户可量化各策略的 Token 节省效果而不影响任务执行
+
+### 新增组件
+
+- **anolisa**：首次发布 v0.1.16，构建统一 CLI 网关管理组件安装/更新/卸载（RPM + Raw 双后端），用户可通过 `anolisa install --all` 一键部署全部组件
+- **cosh-ng**：首次发布 v0.11.0，实现确定性 Agent-OS 接口（5 crate workspace），Agent 可通过稳定 API 跨发行版执行结构化系统操作
+- **skillfs**：首次发布 v0.3.2，构建 FUSE 虚拟文件系统实现基于视图的 SKILL.md 暴露，Agent 可从挂载目录发现并加载技能
+
+### 组件更新
+
+- **agent-memory**：更新到 v0.2.1，新增主权工具集（about/forget/consent）、AMA 导入导出、4 类分类和抗 SIGKILL 增量聚合，用户可自主控制记忆留存并跨 Agent 迁移
+- **tokenless**：更新到 v0.6.1，新增压缩开关（dry-run + 按模式统计）、SLS JSONL 遥测默认开启和 QwenCode 适配器，开发者可 A/B 测试压缩策略并在 SLS 大盘监控 Token 节省
+- **agentsight**：更新到 v0.7.1，新增 Token 节省可视化（策略饼图 + 行级 diff）、安全大盘和容器/K8s 全面支持，用户可直观评估各优化策略的节省贡献
+- **copilot-shell**：更新到 v2.6.1，新增 `/model` 多 Provider 切换对话框和 SLS 会话遥测（32 字段 JSONL），用户可自由切换 LLM Provider 而不丢失配置
+- **agent-sec-core**：更新到 v0.7.0，新增 Skill Ledger 完整性链（GPG 签名工作流）和 Prompt Scanner，用户可审计 Skill 安全状态并在危险操作前收到确认提示
+- **os-skills**：更新到 v0.6.1，新增 ANOLISA Guide 知识库 skill（13 份官方文档）和 OpenClaw 安装预检引导，Agent 可在回答中引用准确的产品文档
+- **ws-ckpt**：更新到 v0.4.1，新增自动清理调度和 TOML 配置热重载，用户可设置保留策略并即时生效无需重启 daemon
+
+### 变更
+
+- 文档治理规范通过 `specs/documentation-standard.md` 建立
+- 双语命名约定统一为 `_zh.md`（从遗留 `_CN.md` 迁移）
+
+## [0.6] - 2026-06-12
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.4.1 |
+| agent-sec-core | 0.5.0 |
+| agentsight | 0.5.0 |
+| tokenless | 0.4.1 |
+| agent-memory | 0.1.0 |
+| os-skills | 0.5.0 |
+
+### 重点特性
+
+- **agent-memory**：首次发布 v0.1.0，交付沙箱化文件系统 MCP 记忆服务器，Agent 可跨会话持久化存储并通过 BM25 检索上下文
+- **tokenless**：更新到 v0.4.1，新增 Hermes Agent 插件和 Tool Ready 4 阶段预检，Agent 工具执行前自动验证环境就绪避免无效重试
+- **agentsight**：更新到 v0.5.0，新增 Skill 维度 Token 指标和 Hermes 支持，用户可精确定位哪些 Skill 消耗最多 Token
+
+### 新增组件
+
+- **agent-memory**：首次发布 v0.1.0，构建 19 工具 MCP 服务器（命名空间隔离 + BM25 后台索引），Agent 可在沙箱化文件系统中读写/检索持久记忆
+- **cosh-ng**：首次发布（MVP），完成确定性 OS 操作的生产可用功能，Agent 可获得格式可预测的结构化命令输出
+
+### 组件更新
+
+- **tokenless**：更新到 v0.4.1，新增 Hermes adapter runner 和 Tool Ready 机制（4 阶段环境预检集成为 cosh extension），Agent 工具调用前自动校验环境减少因环境故障浪费的 Token
+- **agentsight**：更新到 v0.5.0，新增 Skill 维度 Token/调用指标和 Hermes matcher（含 SSL 支持），用户可在 Dashboard 中按 Skill 查看 Token 消耗明细
+- **agent-sec-core**：更新到 v0.5.0，新增 PIIChecker（输出 PII 检测 + 脱敏引擎）和 Skill Scanner（文本/代码扫描 + 生命周期触发），Agent 输出中的敏感信息被自动拦截
+- **copilot-shell**：更新到 v2.4.1，新增跨 Session 自动记忆提取和 hook reason UI 可见性，用户可看到安全 hook 拦截操作的具体原因
+
+## [0.5] - 2026-05-28
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.4.0 |
+| agent-sec-core | 0.4.0 |
+| agentsight | 0.4.0 |
+| tokenless | 0.4.0 |
+| os-skills | 0.4.0 |
+
+### 重点特性
+
+- **tokenless**：更新到 v0.4.0，新增 Hermes 插件和 Tool Ready 环境机制，Agent 工具执行前依赖缺失被提前拦截避免 Token 浪费
+- **agent-sec-core**：更新到 v0.4.0，交付 PIIChecker 和 Skill Scanner 首版，Agent 输出被扫描防止敏感信息泄露
+
+### 组件更新
+
+- **tokenless**：更新到 v0.4.0，开发 Hermes Agent 插件（Tool Ready 4 阶段环境预检 + History 压缩），Agent 运行时依赖在执行前被自动校验
+- **agent-sec-core**：更新到 v0.4.0，新增 PIIChecker 输出 PII 检测和 Skill Scanner 基线能力，用户免受 Agent 无意泄露敏感数据的风险
+- **agentsight**：更新到 v0.4.0，新增 Skill 维度指标展示，用户可按 Skill 查看 Token 消耗分组
+- **os-skills**：更新到 v0.4.0，纳入 Nightly 自动化测试覆盖，Skill 质量持续验证
+
+## [0.4] - 2026-05-13
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.3.0 |
+| agent-sec-core | 0.4.1 |
+| agentsight | 0.4.0 |
+| tokenless | 0.3.0 |
+| os-skills | 0.3.0 |
+| ws-ckpt | 0.2.0 |
+
+### 重点特性
+
+- **agent-sec-core**：更新到 v0.4.1，建立 Skill 安全全生命周期管理（含 Prompt Scanner ask 策略），用户在 Agent 执行危险指令前收到确认提示
+- **tokenless**：更新到 v0.3.0，搭建 4 套 Benchmark 对比基线，开发者可量化评估不同 Skill/OS 环境的 Token 消耗差异
+- **ws-ckpt**：更新到 v0.2.0，扩展快照管理命令集，用户可按数量或时间维度自动清理历史快照
+
+### 组件更新
+
+- **agent-sec-core**：更新到 v0.4.1，集成 Prompt Scanner 至 cosh hook 和 OpenClaw 插件（ask 策略），用户在危险操作前获得交互式确认
+- **tokenless**：更新到 v0.3.0，构建批量并发 Benchmark 平台并生成对比报告，开发者可一键跑分横向对比 Token 节省效果
+- **agentsight**：更新到 v0.4.0，优化常驻进程内存占用，2C2G 小规格实例可稳定运行可观测服务
+- **copilot-shell**：更新到 v2.3.0，适配 SWEBench 评测框架，开发者可通过 cosh 执行代码修复任务并验证通过率
+- **ws-ckpt**：更新到 v0.2.0，丰富快照增删查能力，用户可按策略自动保留最近 N 份快照
+
+## [0.3] - 2026-04-30
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.2.1 |
+| agent-sec-core | 0.3.0 |
+| agentsight | 0.3.1 |
+| tokenless | 0.2.0 |
+| os-skills | 0.3.0 |
+| ws-ckpt | 0.1.0 |
+
+### 重点特性
+
+- **tokenless**：更新到 v0.2.0，交付命令重写和 TOON 上下文压缩，CLI 输出 Token 消耗降低 60–90%
+- **agentsight**：更新到 v0.3.1，新增 Token 节省 Dashboard 和 Agent 异常诊断，用户可可视化节省趋势并检测 Agent 中断
+- **agent-sec-core**：更新到 v0.3.0，新增 Skill Ledger 完整性追踪和 Prompt Scanner，每个 Skill 的签名链可端到端审计
+
+### 新增组件
+
+- **ws-ckpt**：首次发布 v0.1.0，构建基于 btrfs 的工作区快照守护进程，Agent 可毫秒级创建检查点并即时回滚文件系统状态
+
+### 组件更新
+
+- **tokenless**：更新到 v0.2.0，新增通过 RTK 的命令重写和 TOON 上下文压缩，Agent CLI 交互 Token 消耗减少 60–90%
+- **agentsight**：更新到 v0.3.1，新增 Token 节省 Dashboard（Session/时间段统计）和 Agent 中断检测（drain 机制），用户可监控节省趋势并在 Agent 故障时收到告警
+- **agent-sec-core**：更新到 v0.3.0，新增 Skill Ledger 全生命周期（check/certify/bypass/status/audit）和 Prompt Scanner 越狱检测，用户可追踪并强制执行 Skill 完整性策略
+- **copilot-shell**：更新到 v2.2.1，新增 Extension 架构（command extension + system Hook + 即时激活）、Skill 市场对接和会话导出（Markdown/HTML/JSON），用户可通过插件扩展 cosh 能力并导出对话历史
+- **os-skills**：更新到 v0.3.0，新增 Skill 市场上架和实用技能（xlsx/pdf-reader/image-gen/humanizer），用户可从市场发现并安装技能
+
+## [0.2] - 2026-04-15
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.0.4 |
+| agent-sec-core | 0.2.0 |
+| agentsight | 0.2.2 |
+| os-skills | 0.2.2 |
+
+### 组件更新
+
+- **agentsight**：更新到 v0.2.2，新增 Token 消耗可观测（精确 Tokenizer 计量），用户可实时查看每条消息的 Token 明细
+- **copilot-shell**：更新到 v2.0.4，新增独立鉴权（STS/ECS RAM Role）和 Skill 市场浏览，用户无需 AK/SK 即可认证并发现可用技能
+- **os-skills**：更新到 v0.2.2，新增 SysAdmin 技能（Linux IO/网络/负载诊断），Agent 可独立诊断常见 OS 性能问题
+- **tokenless**：首次发布 v0.1.0，构建 Skills 级 Benchmark 测试用例，开发者可跨 Skill 量化对比 Token 消耗
+
+## [0.1] - 2026-03-30
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.0.1 |
+| agent-sec-core | 0.1 |
+| agentsight | 0.1 |
+| os-skills | 0.1 |
+
+### 新增组件
+
+- **copilot-shell**：首次发布 v2.0.1，构建 AI 驱动终端助手（Tab 补全、/bash 模式、sudo、Hook 安全），用户开机即获得 AI 原生 CLI 交互体验
+- **agent-sec-core**：首次发布 v0.1，交付 Skill 签名校验、安全沙箱和系统加固，Agent 操作在受控最小权限环境中运行
+- **agentsight**：首次发布 v0.1，构建基于 eBPF 的零侵入可观测探针，用户无需修改 Agent 代码即可监控 LLM API 调用和 Token 消耗
+- **os-skills**：首次发布 v0.1，整理系统管理、SysOM 运维、DevOps 和云技能库，Agent 可自主执行常见 OS 操作
+
+### 安全
+
+- Skill 全链路安全加密与数字签名
+- 硬件级安全沙箱风险隔离
+- Skill 调用身份认证与完整性校验
+
+---
+
+各组件详细变更日志请参阅：
+
+**用户入口**
+- [copilot-shell](src/copilot-shell/CHANGELOG.md)
+- [cosh-ng](src/cosh-ng/CHANGELOG.md)
+- [anolisa](src/anolisa/CHANGELOG.md)
+- [os-skills](src/os-skills/CHANGELOG.md)
+
+**Token 节省**
+- [tokenless](src/tokenless/CHANGELOG.md)
+
+**运行时**
+- [agent-memory](src/agent-memory/CHANGELOG.md)
+- [skillfs](src/skillfs/CHANGELOG.md)
+- [ws-ckpt](src/ws-ckpt/CHANGELOG.md)
+
+**Agent 可观测**
+- [agentsight](src/agentsight/CHANGELOG.md)
+
+**Agent 安全**
+- [agent-sec-core](src/agent-sec-core/CHANGELOG.md)

--- a/specs/documentation-standard.md
+++ b/specs/documentation-standard.md
@@ -63,30 +63,39 @@ Agents enter this repository via `AGENTS.md` (auto-loaded by tooling). For **doc
 **CHANGELOG writing rules** (content standard — what to write, not when):
 
 1. Only record user-perceivable changes; skip pure refactors, test infra, CI tweaks
-2. One sentence per bullet — max 25 English words / 40 Chinese characters
-3. User perspective — describe the behavior change, not the code change
+2. Three-part bullet format: `**component**: [Updated to vX.Y.Z | First release vX.Y.Z], [verb-object action], [user-perceivable effect]`
+3. User perspective — the third part must describe what the user/Agent can now do, not internal implementation
 4. No internal jargon — command names and config keys are fine; kernel APIs and syscalls are not
-5. One bullet, one change — do not combine unrelated changes
+5. One bullet, one component — do not combine multiple components in one bullet
 6. Key entries should reference the implementing PR
 
-**Root CHANGELOG structural requirement** — each version entry starts with:
+**Root CHANGELOG section structure** — each version entry contains (in order):
 
 ```markdown
-## [0.3.0] - 2026-08-01
+## [X.Y] - YYYY-MM-DD
 
 ### Component Versions
-
 | Component | Version |
 |-----------|--------|
-| copilot-shell | 2.2.0 |
-| agent-sec-core | 0.5.0 |
-| ...
+| ... | ... |
 
 ### Highlights
-- ...
+- **component**: Updated to vX.Y.Z, [action], [user effect]
+
+### New Components
+- **component**: First release vX.Y.Z, [action], [user effect]
+
+### Updated
+- **component**: Updated to vX.Y.Z, [action], [user effect]
 ```
 
-Chinese version (`CHANGELOG_zh.md`) mirrors the same structure.
+- `Highlights`: one bullet per component, version-level summary
+- `New Components`: components first introduced in this release; use "First release vX.Y.Z"
+- `Updated`: existing components with version bumps; use "Updated to vX.Y.Z"
+- Sections with no content may be omitted
+- Unreleased versions use `## [X.Y] - Unreleased`; replace with actual date at release time
+
+Chinese version (`CHANGELOG_zh.md`) mirrors the same structure with translated section headers (`重点特性` / `新增组件` / `组件更新`).
 
 ## 3. docs/ Directory Structure
 


### PR DESCRIPTION
## Description

Rewrite the root CHANGELOG to cover all project releases (v0.1 through v1.0) with proper structure, and update the documentation spec with CHANGELOG format rules.

### What changed

**Commit 1: Spec update** (`specs/documentation-standard.md`)
- Three-part bullet format: `**component**: [Updated to vX.Y.Z | First release vX.Y.Z], [action], [user effect]`
- Section structure per version: `Highlights` → `New Components` → `Updated`
- Unreleased marking convention
- Chinese section header mapping

**Commit 2: CHANGELOG rewrite** (`CHANGELOG.md` + `CHANGELOG_zh.md`)
- Full version history from v0.1 (2026-03-30) through v1.0 (Unreleased)
- Component Versions table per release
- All bullets follow the three-part format
- Component index grouped by capability category (User Entrypoint / Token Saving / Runtime / Agent Observability / Agent Security)
- Bilingual Chinese mirror added

### Context

- Release tags `os-release/v0.4`, `os-release/v0.5`, `os-release/v0.6` were added to origin in this cycle to align with existing v0.1–v0.3 tags
- v1.0 tag will be created at formal release (targeting next week)
- Version dates derived from component tag timestamps and sprint boundaries

no-issue: CHANGELOG governance per specs/documentation-standard.md