### PR TITLE
[nightly] fix(skillfs): add path field to validate --json error/warning entries

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -2527,6 +2527,7 @@ async fn cmd_validate(
                     if entry.parse_status.is_error() {
                         error_entries.push(serde_json::json!({
                             "name": name,
+                            "path": entry.source_path.to_string_lossy().to_string(),
                             "status": "error",
                             "message": entry.parse_status.message()
                         }));
@@ -2540,6 +2541,7 @@ async fn cmd_validate(
                     if entry.parse_status.is_degraded() {
                         warning_entries.push(serde_json::json!({
                             "name": name,
+                            "path": entry.source_path.to_string_lossy().to_string(),
                             "status": "degraded",
                             "message": entry.parse_status.message()
                         }));


### PR DESCRIPTION
## Summary

Fixes #1343

`skillfs validate --json` error and warning entries were missing the `path` field, making it impossible for consumers to locate the offending skill file from JSON output alone.

## Root Cause

In `cmd_validate()` (`src/skillfs/crates/skillfs-cli/src/main.rs`), the `serde_json::json!({...})` macros that build error and warning entries referenced `entry.source_path` (a `PathBuf` on the `Entry`/`SkillEntry` struct) but never included it in the JSON object.

## Fix

Add `"path": entry.source_path.to_string_lossy().to_string()` to both the error entry and warning entry JSON objects in `cmd_validate()`.

## Verification

ECS (47.238.123.239), anolisa main `8ac16a96`:

```shell
# Build
cd src/skillfs && cargo build --release -p skillfs
# → exit 0, Finished `release` profile [optimized] target(s) in 1m 01s

# Install + test
cp target/release/skillfs /usr/local/bin/skillfs
cd /root/agentic-os-tests/skillfs-tests
python3 -m pytest -xvs 'tests/test_validate.py::TestValidateJsonOutput::test_json_error_entries_have_path'
# → 1 passed in 0.01s
```

---

[nightly] Discovered and fixed by AgenticOS Nightly automated product-fix-agent (regression-20260706-113053).
