### PR TITLE
chore(sec-core): update source build scripts

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1145,10 +1145,21 @@ _configure_uv_mirror() {
     export UV_PYTHON_INSTALL_MIRROR="$python_install_mirror"
     export PIP_INDEX_URL="$aliyun_pypi"
 
+    # python-install-mirror toml field requires uv >= 0.5.2; skip for older versions
+    local _uv_supports_pim=true
+    if cmd_exists uv; then
+        local _uv_ver
+        _uv_ver=$(extract_ver "$(uv --version 2>/dev/null)")
+        if [[ -n "$_uv_ver" ]] && ! ver_gte "$_uv_ver" "0.5.2"; then
+            _uv_supports_pim=false
+        fi
+    fi
+
     local uv_cfg="$HOME/.config/uv/uv.toml"
     if [[ ! -f "$uv_cfg" ]]; then
         mkdir -p "$(dirname "$uv_cfg")"
-        cat > "$uv_cfg" <<EOF
+        if [[ "$_uv_supports_pim" == "true" ]]; then
+            cat > "$uv_cfg" <<EOF
 # uv configuration — managed by build-all.sh
 python-install-mirror = "$python_install_mirror"
 
@@ -1156,20 +1167,35 @@ python-install-mirror = "$python_install_mirror"
 url = "https://mirrors.aliyun.com/pypi/simple/"
 default = true
 EOF
-        ok "uv PyPI mirror configured: $aliyun_pypi"
-        ok "uv Python install mirror configured: $python_install_mirror"
+            ok "uv PyPI mirror configured: $aliyun_pypi"
+            ok "uv Python install mirror configured: $python_install_mirror"
+        else
+            cat > "$uv_cfg" <<EOF
+# uv configuration — managed by build-all.sh
+
+[[index]]
+url = "https://mirrors.aliyun.com/pypi/simple/"
+default = true
+EOF
+            ok "uv PyPI mirror configured: $aliyun_pypi"
+            info "uv < 0.5.2: python-install-mirror skipped in toml (env var still active)"
+        fi
         return 0
     fi
 
-    if ! grep -Eq '^[[:space:]]*python-install-mirror[[:space:]]*=' "$uv_cfg" 2>/dev/null; then
-        local tmp_cfg
-        tmp_cfg=$(mktemp)
-        {
-            echo "python-install-mirror = \"$python_install_mirror\""
-            echo ""
-            cat "$uv_cfg"
-        } > "$tmp_cfg" && mv "$tmp_cfg" "$uv_cfg"
-        ok "uv Python install mirror configured: $python_install_mirror"
+    if [[ "$_uv_supports_pim" == "true" ]]; then
+        if ! grep -Eq '^[[:space:]]*python-install-mirror[[:space:]]*=' "$uv_cfg" 2>/dev/null; then
+            local tmp_cfg
+            tmp_cfg=$(mktemp)
+            {
+                echo "python-install-mirror = \"$python_install_mirror\""
+                echo ""
+                cat "$uv_cfg"
+            } > "$tmp_cfg" && mv "$tmp_cfg" "$uv_cfg"
+            ok "uv Python install mirror configured: $python_install_mirror"
+        fi
+    else
+        : # uv < 0.5.2 does not support python-install-mirror in toml; env var is sufficient
     fi
 
     if ! grep -q 'mirrors.aliyun.com/pypi/simple/' "$uv_cfg" 2>/dev/null; then

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -180,7 +180,7 @@ setup: ## Install all dependencies (including dev), create .venv
 
 .PHONY: build-openclaw-plugin
 build-openclaw-plugin: ## Build openclaw-plugin TypeScript sources
-	cd openclaw-plugin && npm install && npm run build
+	cd openclaw-plugin && NODE_ENV=development npm install --include=dev && npm run build
 	install -d -m 0755 $(BUILD_DIR)/openclaw-plugin/dist
 	install -d -m 0755 $(BUILD_DIR)/openclaw-plugin/scripts
 	cp openclaw-plugin/openclaw.plugin.json $(BUILD_DIR)/openclaw-plugin/


### PR DESCRIPTION
## Description

修复源码构建过程中遇到的两个兼容性问题：

1. **uv 旧版本不支持 `python-install-mirror` toml 字段**：`build-all.sh` 在 `_configure_uv_mirror` 中无条件写入该字段，导致 uv < 0.5.2 解析失败。
2. **`build-openclaw-plugin` 未显式安装 devDependencies**：`npm install` 可能跳过 devDependencies，导致 `tsc` 命令找不到。

### Changes

| 文件 | 修改内容 |
|------|----------|
| `scripts/build-all.sh` | 在写入 `uv.toml` 前检测 uv 版本，仅 ≥ 0.5.2 时写入 `python-install-mirror` 字段；低版本仅依赖 `UV_PYTHON_INSTALL_MIRROR` 环境变量 |
| `src/agent-sec-core/Makefile` | `build-openclaw-plugin` 中添加 `NODE_ENV=development` + `--include=dev`，确保始终安装 typescript |

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
