### PR TITLE
fix(sec-core): harden deploy compatibility handling

### DIFF
--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -10,11 +10,21 @@ OpenClaw security plugin that hooks into the agent lifecycle via `agent-sec-cli`
 |----------------|-----------|------------------------------|
 | Node.js        | >= 20     | `node --version`             |
 | npm            | >= 10     | `npm --version`              |
-| OpenClaw       | Typed plugin runtime | `openclaw --version`       |
+| OpenClaw       | >= 2026.4.14 | `openclaw --version`       |
 | agent-sec-cli  | (latest)  | `agent-sec-cli --help`       |
 | jq             | >= 1.6    | `jq --version`               |
 
-Development and test builds use the `openclaw` dev dependency pinned in `package.json` so TypeScript can compile against the newest typed hook definitions. The OpenClaw runtime does not need to match that dev dependency. Runtime compatibility is capability-based: older runtimes that do not know a typed hook ignore that hook registration with a diagnostic instead of crashing the gateway.
+Development and test builds use the `openclaw` dev dependency pinned in `package.json` so TypeScript can compile against the newest typed hook definitions. The OpenClaw runtime does not need to match that dev dependency. Runtime compatibility is capability-based: `2026.4.14` and `2026.4.23` are supported legacy baselines for core security hooks, while `model_call_started` and `model_call_ended` telemetry may degrade cleanly on those versions.
+
+## Compatibility Contract
+
+The installable package declares the OpenClaw compatibility boundary in `package.json`:
+
+- `openclaw.install.minHostVersion: ">=2026.4.14"` makes older OpenClaw hosts fail clearly during plugin install or non-bundled manifest loading.
+- `openclaw.compat.pluginApi: ">=2026.4.14"` declares the plugin SDK/runtime API floor used by OpenClaw install compatibility checks.
+- `peerDependencies.openclaw: ">=2026.4.14"` keeps npm peer metadata aligned with the OpenClaw installer contract.
+
+Package entrypoints follow the current OpenClaw plugin contract: `openclaw.extensions` points at the TypeScript source entry for checkout development, and `openclaw.runtimeExtensions` points at the built JavaScript entry used by installed packages. `openclaw.plugin.json` keeps its legacy `extensions` declaration pointed at the same built runtime entry for older manifest readers.
 
 ---
 

--- a/src/agent-sec-core/openclaw-plugin/package-lock.json
+++ b/src/agent-sec-core/openclaw-plugin/package-lock.json
@@ -15,7 +15,7 @@
         "typescript": "^5.8.0"
       },
       "peerDependencies": {
-        "openclaw": "*"
+        "openclaw": ">=2026.4.14"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {

--- a/src/agent-sec-core/openclaw-plugin/package-lock.json
+++ b/src/agent-sec-core/openclaw-plugin/package-lock.json
@@ -16,6 +16,11 @@
       },
       "peerDependencies": {
         "openclaw": ">=2026.4.14"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
       }
     },
     "node_modules/@agentclientprotocol/sdk": {

--- a/src/agent-sec-core/openclaw-plugin/package.json
+++ b/src/agent-sec-core/openclaw-plugin/package.json
@@ -10,7 +10,7 @@
   ],
   "openclaw": {
     "extensions": [
-      "./src/index.ts"
+      "./dist/index.js"
     ],
     "runtimeExtensions": [
       "./dist/index.js"
@@ -32,6 +32,11 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.4.14"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": ">=22",

--- a/src/agent-sec-core/openclaw-plugin/package.json
+++ b/src/agent-sec-core/openclaw-plugin/package.json
@@ -10,8 +10,17 @@
   ],
   "openclaw": {
     "extensions": [
+      "./src/index.ts"
+    ],
+    "runtimeExtensions": [
       "./dist/index.js"
-    ]
+    ],
+    "install": {
+      "minHostVersion": ">=2026.4.14"
+    },
+    "compat": {
+      "pluginApi": ">=2026.4.14"
+    }
   },
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
@@ -22,7 +31,7 @@
     "test:coverage": "npx c8 --reporter=cobertura --reporter=text --reports-dir=coverage tsx --test tests/unit/*test.ts"
   },
   "peerDependencies": {
-    "openclaw": "*"
+    "openclaw": ">=2026.4.14"
   },
   "devDependencies": {
     "@types/node": ">=22",

--- a/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
+++ b/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
@@ -17,6 +17,19 @@
 
 set -euo pipefail
 
+PLUGIN_ID="agent-sec"
+MIN_OPENCLAW_VERSION="2026.4.14"
+MIN_CONVERSATION_ACCESS_VERSION="2026.4.24"
+OPENCLAW_INSTALL_HELP=""
+OPENCLAW_INSTALL_SUPPORTS_UNSAFE=0
+OPENCLAW_INSTALL_REQUIRES_UNSAFE=0
+OPENCLAW_INSPECT_HELP=""
+OPENCLAW_INSPECT_SUPPORTS_RUNTIME=0
+VERIFY_RUNTIME_TMPDIR=""
+VERIFY_RUNTIME_TMPDIR_PREFIX="agent-sec-openclaw-inspect."
+DEPLOY_TMPDIR_MARKER=".agent-sec-openclaw-deploy-owner"
+DEPLOY_TMPDIR_OWNER="agent-sec-openclaw-deploy:${BASHPID:-$$}"
+
 # Default PLUGIN_DIR: resolve relative to this script's location (scripts/ -> parent)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="${1:-$(dirname "$SCRIPT_DIR")}"
@@ -34,25 +47,320 @@ openclaw_cli() {
     fi
 }
 
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+cleanup_verify_runtime_tmpdir() {
+    local tmpdir="${VERIFY_RUNTIME_TMPDIR:-}"
+
+    VERIFY_RUNTIME_TMPDIR=""
+    cleanup_owned_tmpdir "$tmpdir" "$VERIFY_RUNTIME_TMPDIR_PREFIX"
+}
+
+trap cleanup_verify_runtime_tmpdir EXIT
+
+create_owned_tmpdir() {
+    local prefix="$1"
+    local tmp_parent="${TMPDIR:-/tmp}"
+    local tmpdir
+
+    if [[ "$tmp_parent" != /* || ! -d "$tmp_parent" ]]; then
+        tmp_parent="/tmp"
+    fi
+    tmp_parent="${tmp_parent%/}"
+    [[ -n "$tmp_parent" ]] || tmp_parent="/"
+
+    tmpdir="$(mktemp -d "${tmp_parent}/${prefix}XXXXXXXXXX")"
+    printf '%s\n' "$DEPLOY_TMPDIR_OWNER" >"${tmpdir}/${DEPLOY_TMPDIR_MARKER}"
+    printf '%s\n' "$tmpdir"
+}
+
+cleanup_owned_tmpdir() {
+    local tmpdir="$1"
+    local prefix="$2"
+    local tmpbase
+    local marker
+    local marker_owner
+
+    tmpdir="${tmpdir%/}"
+    [[ -n "$tmpdir" ]] || return 0
+
+    tmpbase="${tmpdir##*/}"
+    marker="${tmpdir}/${DEPLOY_TMPDIR_MARKER}"
+    if [[ ! -d "$tmpdir" || "$tmpbase" != "$prefix"* || ! -f "$marker" ]]; then
+        return 0
+    fi
+
+    marker_owner="$(<"$marker")" || return 0
+    [[ "$marker_owner" == "$DEPLOY_TMPDIR_OWNER" ]] || return 0
+
+    rm -rf -- "$tmpdir" || true
+}
+
+create_verify_runtime_tmpdir() {
+    create_owned_tmpdir "$VERIFY_RUNTIME_TMPDIR_PREFIX"
+}
+
+extract_openclaw_version() {
+    local raw="$1"
+
+    printf '%s\n' "$raw" | grep -Eo '[0-9]{4}\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?' | head -n 1 || true
+}
+
+version_core() {
+    local version="$1"
+
+    version="${version%%+*}"
+    version="${version%%-*}"
+    printf '%s\n' "$version"
+}
+
+version_has_prerelease() {
+    local version="$1"
+    local without_build="${version%%+*}"
+
+    [[ "$without_build" == *-* ]]
+}
+
+version_ge() {
+    local current="$1"
+    local minimum="$2"
+    local current_year current_month current_patch
+    local minimum_year minimum_month minimum_patch
+
+    IFS=. read -r current_year current_month current_patch <<<"$(version_core "$current")"
+    IFS=. read -r minimum_year minimum_month minimum_patch <<<"$(version_core "$minimum")"
+
+    current_year="${current_year:-0}"
+    current_month="${current_month:-0}"
+    current_patch="${current_patch:-0}"
+    minimum_year="${minimum_year:-0}"
+    minimum_month="${minimum_month:-0}"
+    minimum_patch="${minimum_patch:-0}"
+
+    if (( current_year != minimum_year )); then
+        (( current_year > minimum_year ))
+        return
+    fi
+    if (( current_month != minimum_month )); then
+        (( current_month > minimum_month ))
+        return
+    fi
+    if (( current_patch != minimum_patch )); then
+        (( current_patch > minimum_patch ))
+        return
+    fi
+
+    if version_has_prerelease "$current" && ! version_has_prerelease "$minimum"; then
+        return 1
+    fi
+    return 0
+}
+
+detect_openclaw_version() {
+    local raw_version
+
+    raw_version="$(openclaw_cli --version 2>/dev/null || true)"
+    extract_openclaw_version "$raw_version"
+}
+
+verify_openclaw_compatibility() {
+    local openclaw_version="$1"
+
+    [[ -n "$openclaw_version" ]] || die "无法识别 OpenClaw 版本。请升级到 >=${MIN_OPENCLAW_VERSION} 后重试。"
+
+    if ! version_ge "$openclaw_version" "$MIN_OPENCLAW_VERSION"; then
+        die "agent-sec OpenClaw 插件要求 OpenClaw >=${MIN_OPENCLAW_VERSION}，当前为 ${openclaw_version}。请升级 OpenClaw，或降级使用支持旧 OpenClaw 的 agent-sec 插件包。"
+    fi
+}
+
+verify_openclaw_install_cli() {
+    local install_help_normalized
+
+    OPENCLAW_INSTALL_HELP="$(openclaw_cli plugins install --help 2>&1)" || die "无法读取 openclaw plugins install --help，请升级 OpenClaw 到 >=${MIN_OPENCLAW_VERSION} 后重试。"
+    install_help_normalized="$OPENCLAW_INSTALL_HELP"
+    install_help_normalized="${install_help_normalized//$'\n'/ }"
+    install_help_normalized="${install_help_normalized//$'\t'/ }"
+    while [[ "$install_help_normalized" == *"  "* ]]; do
+        install_help_normalized="${install_help_normalized//  / }"
+    done
+
+    [[ "$install_help_normalized" == *"--force"* ]] || die "当前 OpenClaw plugins install 不支持 --force。请升级 OpenClaw 到 >=${MIN_OPENCLAW_VERSION} 后重试。"
+    if [[ "$install_help_normalized" == *"--dangerously-force-unsafe-install"* ]]; then
+        OPENCLAW_INSTALL_SUPPORTS_UNSAFE=1
+    fi
+
+    # Treat help output as the CLI contract: if the current OpenClaw installer
+    # advertises the compatibility flag, pass it on the first install attempt
+    # so deploy.sh remains a single-shot install command for all supported hosts.
+    if [[ "$OPENCLAW_INSTALL_SUPPORTS_UNSAFE" == "1" ]]; then
+        OPENCLAW_INSTALL_REQUIRES_UNSAFE=1
+    fi
+}
+
+verify_openclaw_inspect_cli() {
+    OPENCLAW_INSPECT_HELP="$(openclaw_cli plugins inspect --help 2>&1)" || die "无法读取 openclaw plugins inspect --help，请升级 OpenClaw 到 >=${MIN_OPENCLAW_VERSION} 后重试。"
+
+    [[ "$OPENCLAW_INSPECT_HELP" == *"--json"* ]] || die "当前 OpenClaw plugins inspect 不支持 --json。请升级 OpenClaw 到 >=${MIN_OPENCLAW_VERSION} 后重试。"
+    if [[ "$OPENCLAW_INSPECT_HELP" == *"--runtime"* ]]; then
+        OPENCLAW_INSPECT_SUPPORTS_RUNTIME=1
+    fi
+}
+
+install_plugin() {
+    local install_args=("plugins" "install" "$PLUGIN_DIR" "--force")
+
+    if [[ "$OPENCLAW_INSTALL_REQUIRES_UNSAFE" == "1" ]]; then
+        echo "安装策略: OpenClaw ${OPENCLAW_VERSION_DETECTED} 安装器暴露 legacy --dangerously-force-unsafe-install，首次安装将使用该兼容参数。"
+        echo "安装策略: deploy.sh 按当前 CLI help 暴露的参数执行，不基于版本或文案语义推断。"
+        install_args+=("--dangerously-force-unsafe-install")
+    else
+        echo "安装策略: OpenClaw ${OPENCLAW_VERSION_DETECTED} 安装器未暴露 legacy --dangerously-force-unsafe-install。"
+    fi
+
+    openclaw_cli "${install_args[@]}"
+}
+
+configure_conversation_access() {
+    local access_config_key="plugins.entries.agent-sec.hooks.allowConversationAccess"
+
+    if version_ge "$OPENCLAW_VERSION_DETECTED" "$MIN_CONVERSATION_ACCESS_VERSION"; then
+        echo "允许 agent-sec 检查大模型输入输出安全"
+        echo "  openclaw config set ${access_config_key} true"
+        openclaw_cli config set "$access_config_key" true
+        return
+    fi
+
+    echo "OpenClaw ${OPENCLAW_VERSION_DETECTED} 不支持插件会话访问配置"
+    echo "  跳过 plugins.entries.agent-sec.hooks.allowConversationAccess=true (OpenClaw ${MIN_CONVERSATION_ACCESS_VERSION} 引入, #71221)"
+    echo "  llm_input/llm_output/agent_end 会话观测 hook 在当前 OpenClaw 版本中不可用"
+}
+
+verify_runtime_loaded() {
+    local inspect_args=("plugins" "inspect" "$PLUGIN_ID" "--json")
+    local inspect_label="openclaw plugins inspect ${PLUGIN_ID} --json"
+    local inspect_tmpdir
+    local inspect_stdout
+    local inspect_stderr
+    local inspect_json
+    local jq_stderr
+    local runtime_inspect_json
+    local runtime_status
+
+    if [[ "$OPENCLAW_INSPECT_SUPPORTS_RUNTIME" == "1" ]]; then
+        inspect_args=("plugins" "inspect" "$PLUGIN_ID" "--runtime" "--json")
+        inspect_label="openclaw plugins inspect ${PLUGIN_ID} --runtime --json"
+    fi
+
+    cleanup_verify_runtime_tmpdir
+    inspect_tmpdir="$(create_verify_runtime_tmpdir)"
+    VERIFY_RUNTIME_TMPDIR="$inspect_tmpdir"
+    inspect_stdout="$inspect_tmpdir/inspect.stdout"
+    inspect_stderr="$inspect_tmpdir/inspect.stderr"
+    inspect_json="$inspect_tmpdir/inspect.json"
+    jq_stderr="$inspect_tmpdir/jq.stderr"
+
+    if ! openclaw_cli "${inspect_args[@]}" >"$inspect_stdout" 2>"$inspect_stderr"; then
+        print_inspect_debug "$inspect_label" "$inspect_stdout" "$inspect_stderr" "$jq_stderr"
+        die "插件已安装，但 ${inspect_label} 失败。请运行: ${inspect_label}"
+    fi
+
+    if ! extract_json_object_from_output "$inspect_stdout" "$inspect_json"; then
+        print_inspect_debug "$inspect_label" "$inspect_stdout" "$inspect_stderr" "$jq_stderr"
+        die "插件已安装，但 ${inspect_label} 输出中未找到 JSON 对象。请运行: ${inspect_label}"
+    fi
+
+    if ! runtime_status="$(jq -r '.plugin.status // "unknown"' <"$inspect_json" 2>"$jq_stderr")"; then
+        print_inspect_debug "$inspect_label" "$inspect_stdout" "$inspect_stderr" "$jq_stderr"
+        die "插件已安装，但 ${inspect_label} 输出不是可解析 JSON。请运行: ${inspect_label}"
+    fi
+    runtime_inspect_json="$(cat "$inspect_json")"
+
+    if [[ "$runtime_status" != "loaded" ]]; then
+        printf '%s\n' "$runtime_inspect_json" | jq -r '.diagnostics[]?.message' >&2
+        die "插件已安装，但 ${inspect_label} 状态为 ${runtime_status}，未达到 loaded。请运行: ${inspect_label}"
+    fi
+
+    cleanup_verify_runtime_tmpdir
+}
+
+extract_json_object_from_output() {
+    local input_file="$1"
+    local output_file="$2"
+
+    # OpenClaw 2026.4.x may print plugin registration diagnostics to stdout
+    # before the requested --json payload. Keep deploy.sh compatible with that
+    # host behavior while still parsing the official JSON object with jq.
+    sed -n '/^[[:space:]]*{/,$p' "$input_file" >"$output_file"
+    [[ -s "$output_file" ]]
+}
+
+print_debug_file_preview() {
+    local title="$1"
+    local file="$2"
+    local bytes
+
+    bytes="$(wc -c <"$file" 2>/dev/null || printf '0')"
+    echo "----- ${title} (${bytes} bytes, first 160 lines) -----" >&2
+    if [[ -s "$file" ]]; then
+        sed -n '1,160p' "$file" >&2
+    else
+        echo "<empty>" >&2
+    fi
+}
+
+print_inspect_debug() {
+    local inspect_label="$1"
+    local stdout_file="$2"
+    local stderr_file="$3"
+    local jq_stderr_file="$4"
+
+    echo "DEBUG: ${inspect_label} raw output follows for compatibility analysis." >&2
+    print_debug_file_preview "inspect stdout" "$stdout_file"
+    print_debug_file_preview "inspect stderr" "$stderr_file"
+    print_debug_file_preview "jq stderr" "$jq_stderr_file"
+}
+
 # 1. 前置检查
-command -v openclaw >/dev/null 2>&1 || { echo "ERROR: openclaw 不在 PATH 中"; exit 1; }
-command -v agent-sec-cli >/dev/null 2>&1 || { echo "ERROR: agent-sec-cli 不在 PATH 中"; exit 1; }
-[[ -f "$PLUGIN_DIR/openclaw.plugin.json" ]] || { echo "ERROR: 清单文件不存在: $PLUGIN_DIR/openclaw.plugin.json"; exit 1; }
-[[ -d "$PLUGIN_DIR/dist" ]] || { echo "ERROR: dist/ 不存在,请先运行 npm run build"; exit 1; }
+command -v openclaw >/dev/null 2>&1 || die "openclaw 不在 PATH 中"
+command -v agent-sec-cli >/dev/null 2>&1 || die "agent-sec-cli 不在 PATH 中"
+command -v jq >/dev/null 2>&1 || die "jq 不在 PATH 中"
+[[ -f "$PLUGIN_DIR/openclaw.plugin.json" ]] || die "清单文件不存在: $PLUGIN_DIR/openclaw.plugin.json"
+[[ -d "$PLUGIN_DIR/dist" ]] || die "dist/ 不存在,请先运行 npm run build"
+[[ -f "$PLUGIN_DIR/dist/index.js" ]] || die "dist/index.js 不存在,请先运行 npm run build"
+
+OPENCLAW_VERSION_DETECTED="$(detect_openclaw_version)"
+verify_openclaw_compatibility "$OPENCLAW_VERSION_DETECTED"
+verify_openclaw_install_cli
+verify_openclaw_inspect_cli
 
 PLUGIN_VERSION=$(jq -r '.version' "$PLUGIN_DIR/openclaw.plugin.json")
 echo "部署插件: agent-sec v${PLUGIN_VERSION}"
 echo "  路径: $PLUGIN_DIR"
+echo "  OpenClaw: ${OPENCLAW_VERSION_DETECTED}"
 
 # 2. 使用官方命令安装插件
 echo ""
 echo "安装插件..."
-openclaw_cli plugins install "$PLUGIN_DIR" --force --dangerously-force-unsafe-install
+install_plugin
 
 echo "  ✓ 插件已安装/更新"
-echo "允许 agent-sec 检查大模型输入输出安全"
-echo "  openclaw config set plugins.entries.agent-sec.hooks.allowConversationAccess true"
-openclaw_cli config set plugins.entries.agent-sec.hooks.allowConversationAccess true
+configure_conversation_access
+
+echo ""
+echo "校验插件安装记录..."
+openclaw_cli plugins inspect "$PLUGIN_ID" --json >/dev/null
+echo "  ✓ OpenClaw 已记录插件 ${PLUGIN_ID}"
+
+echo "校验插件运行时加载..."
+verify_runtime_loaded
+if [[ "$OPENCLAW_INSPECT_SUPPORTS_RUNTIME" == "1" ]]; then
+    echo "  ✓ openclaw plugins inspect ${PLUGIN_ID} --runtime --json 已证明插件可加载"
+else
+    echo "  ✓ openclaw plugins inspect ${PLUGIN_ID} --json 已证明插件可加载"
+fi
 
 echo ""
 echo "提示: 请重启 OpenClaw gateway 以加载插件"

--- a/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
+++ b/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
@@ -162,7 +162,7 @@ version_ge() {
 detect_openclaw_version() {
     local raw_version
 
-    raw_version="$(openclaw_cli --version 2>/dev/null || true)"
+    raw_version="$(openclaw_cli --version 2>/dev/null)" || die "openclaw 不在 PATH 中或无法执行"
     extract_openclaw_version "$raw_version"
 }
 
@@ -324,7 +324,6 @@ print_inspect_debug() {
 }
 
 # 1. 前置检查
-command -v openclaw >/dev/null 2>&1 || die "openclaw 不在 PATH 中"
 command -v agent-sec-cli >/dev/null 2>&1 || die "agent-sec-cli 不在 PATH 中"
 command -v jq >/dev/null 2>&1 || die "jq 不在 PATH 中"
 [[ -f "$PLUGIN_DIR/openclaw.plugin.json" ]] || die "清单文件不存在: $PLUGIN_DIR/openclaw.plugin.json"
@@ -350,12 +349,9 @@ echo "  ✓ 插件已安装/更新"
 configure_conversation_access
 
 echo ""
-echo "校验插件安装记录..."
-openclaw_cli plugins inspect "$PLUGIN_ID" --json >/dev/null
-echo "  ✓ OpenClaw 已记录插件 ${PLUGIN_ID}"
-
-echo "校验插件运行时加载..."
+echo "校验插件安装和运行时加载..."
 verify_runtime_loaded
+echo "  ✓ OpenClaw 已记录插件 ${PLUGIN_ID}"
 if [[ "$OPENCLAW_INSPECT_SUPPORTS_RUNTIME" == "1" ]]; then
     echo "  ✓ openclaw plugins inspect ${PLUGIN_ID} --runtime --json 已证明插件可加载"
 else

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/deploy-script-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/deploy-script-test.ts
@@ -282,8 +282,8 @@ describe("deploy.sh", () => {
       result.log,
       /config set plugins\.entries\.agent-sec\.hooks\.allowConversationAccess true/,
     );
-    assert.match(result.log, /plugins inspect agent-sec --json/);
     assert.match(result.log, /plugins inspect agent-sec --runtime --json/);
+    assert.doesNotMatch(result.log, /plugins inspect agent-sec --json/);
     assert.match(result.log, /plugins install .* --force --dangerously-force-unsafe-install/);
   });
 

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/deploy-script-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/deploy-script-test.ts
@@ -1,0 +1,415 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+const DEPLOY_SCRIPT = resolve("scripts/deploy.sh");
+
+type DeployOptions = {
+  inspectStdoutPrefixLogs?: boolean;
+  inspectHasRuntime?: boolean;
+  installHelpMode?: "has-unsafe" | "no-force" | "no-unsafe";
+  openclawVersionEnv?: string;
+  precreateUserInspectTmpdir?: boolean;
+  runtimeStatus?: string;
+  version?: string;
+};
+
+type DeployResult = {
+  log: string;
+  rootDir: string;
+  stderr: string;
+  stdout: string;
+  status: number | null;
+  userInspectTmpdir?: string;
+};
+
+function hostSupportsConversationAccess(version: string): boolean {
+  // OpenClaw added plugins.entries.*.hooks.allowConversationAccess validation in
+  // 2026.4.24. The fake CLI rejects the key before that version to prove
+  // deploy.sh gates the config before execution instead of relying on fallback.
+  const match = version.match(/([0-9]{4})\.([0-9]+)\.([0-9]+)/);
+  if (match === null) {
+    return false;
+  }
+
+  const current = match.slice(1).map((part) => Number(part));
+  const minimum = [2026, 4, 24];
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (current[index] !== minimum[index]) {
+      return current[index] > minimum[index];
+    }
+  }
+  return true;
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createExecutable(path: string, content: string): void {
+  writeFileSync(path, content, "utf8");
+  chmodSync(path, 0o755);
+}
+
+function createFakeJq(binDir: string): void {
+  createExecutable(
+    join(binDir, "jq"),
+    `#!/usr/bin/env node
+const { readFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+const raw = args[0] === "-r";
+const query = raw ? args[1] : args[0];
+const file = raw ? args[2] : args[1];
+const input = file ? readFileSync(file, "utf8") : readFileSync(0, "utf8");
+const json = JSON.parse(input);
+
+if (query === ".version") {
+  console.log(json.version ?? "null");
+} else if (query === ".plugin.status // \\"unknown\\"") {
+  console.log(json.plugin?.status ?? "unknown");
+} else if (query === ".diagnostics[]?.message") {
+  for (const diagnostic of json.diagnostics ?? []) {
+    if (diagnostic?.message) {
+      console.log(diagnostic.message);
+    }
+  }
+} else {
+  process.exit(2);
+}
+`,
+  );
+}
+
+function createFakeOpenClaw(binDir: string): void {
+  // This fake models the parts of the OpenClaw CLI contract deploy.sh depends on:
+  // installer help text, inspect shape, runtime status, and config validation.
+  createExecutable(
+    join(binDir, "openclaw"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\\n' "$*" >> "\${OPENCLAW_FAKE_LOG:?}"
+
+if [[ "\${1:-}" == "--version" ]]; then
+    echo "OpenClaw \${OPENCLAW_FAKE_VERSION:-2026.4.14} (test)"
+    exit 0
+fi
+
+if [[ "\${1:-}" == "plugins" && "\${2:-}" == "install" && "\${3:-}" == "--help" ]]; then
+    if [[ "\${OPENCLAW_FAKE_INSTALL_HELP:-has-unsafe}" == "no-force" ]]; then
+        echo "Usage: openclaw plugins install <package>"
+    elif [[ "\${OPENCLAW_FAKE_INSTALL_HELP:-has-unsafe}" == "no-unsafe" ]]; then
+        echo "Usage: openclaw plugins install <package> --force"
+    else
+        echo "Usage: openclaw plugins install <package> --force --dangerously-force-unsafe-install"
+    fi
+    exit 0
+fi
+
+if [[ "\${1:-}" == "plugins" && "\${2:-}" == "install" ]]; then
+    echo "installed"
+    echo "install stderr detail" >&2
+    exit 0
+fi
+
+if [[ "$*" == "config set plugins.entries.agent-sec.hooks.allowConversationAccess true" ]]; then
+    if [[ "\${OPENCLAW_FAKE_ALLOW_CONVERSATION_ACCESS:-1}" != "1" ]]; then
+        echo "unknown config key: plugins.entries.agent-sec.hooks.allowConversationAccess" >&2
+        exit 2
+    fi
+    echo "configured"
+    echo "config stderr detail" >&2
+    exit 0
+fi
+
+if [[ "$*" == "plugins inspect --help" ]]; then
+    if [[ "\${OPENCLAW_FAKE_INSPECT_RUNTIME:-0}" == "1" ]]; then
+        echo "Usage: openclaw plugins inspect <id> --json --runtime"
+    else
+        echo "Usage: openclaw plugins inspect <id> --json"
+    fi
+    exit 0
+fi
+
+if [[ "$*" == "plugins inspect agent-sec --json" ]]; then
+    status="\${OPENCLAW_FAKE_RUNTIME_STATUS:-loaded}"
+    if [[ "\${OPENCLAW_FAKE_INSPECT_STDOUT_PREFIX_LOGS:-0}" == "1" ]]; then
+        echo "[plugins] [agent-sec] registered: scan-code -> [before_tool_call]"
+        echo "[plugins] [agent-sec] 5/5 capabilities active"
+    fi
+    printf '{"plugin":{"id":"agent-sec","status":"%s"},"diagnostics":[{"message":"runtime status %s"}]}\\n' "$status" "$status"
+    exit 0
+fi
+
+if [[ "$*" == "plugins inspect agent-sec --runtime --json" ]]; then
+    status="\${OPENCLAW_FAKE_RUNTIME_STATUS:-loaded}"
+    if [[ "\${OPENCLAW_FAKE_INSPECT_STDOUT_PREFIX_LOGS:-0}" == "1" ]]; then
+        echo "[plugins] [agent-sec] registered: scan-code -> [before_tool_call]"
+        echo "[plugins] [agent-sec] 5/5 capabilities active"
+    fi
+    printf '{"plugin":{"id":"agent-sec","status":"%s"},"diagnostics":[{"message":"runtime status %s"}]}\\n' "$status" "$status"
+    exit 0
+fi
+
+echo "unexpected fake openclaw args: $*" >&2
+exit 2
+`,
+  );
+}
+
+function createPluginFixture(rootDir: string): string {
+  const pluginDir = join(rootDir, "plugin");
+  mkdirSync(join(pluginDir, "dist"), { recursive: true });
+  writeFileSync(join(pluginDir, "openclaw.plugin.json"), '{"version":"0.7.0"}\n', "utf8");
+  writeFileSync(join(pluginDir, "dist", "index.js"), "export {};\n", "utf8");
+  return pluginDir;
+}
+
+function runDeploy(options: DeployOptions = {}): DeployResult {
+  const rootDir = mkdtempSync(join(tmpdir(), "agent-sec-openclaw-deploy-"));
+  tempDirs.push(rootDir);
+  const binDir = join(rootDir, "bin");
+  const logPath = join(rootDir, "openclaw.log");
+  const userInspectTmpdir = options.precreateUserInspectTmpdir
+    ? join(rootDir, "agent-sec-openclaw-inspect.user-owned")
+    : undefined;
+  mkdirSync(binDir, { recursive: true });
+  if (userInspectTmpdir !== undefined) {
+    mkdirSync(userInspectTmpdir);
+    writeFileSync(join(userInspectTmpdir, "keep.txt"), "user-owned\n", "utf8");
+  }
+  createFakeOpenClaw(binDir);
+  createFakeJq(binDir);
+  createExecutable(join(binDir, "agent-sec-cli"), "#!/usr/bin/env bash\nexit 0\n");
+
+  const pluginDir = createPluginFixture(rootDir);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    // Keep the fake host's schema behavior coupled to the requested version so
+    // tests catch accidental unconditional allowConversationAccess writes.
+    OPENCLAW_FAKE_ALLOW_CONVERSATION_ACCESS: hostSupportsConversationAccess(
+      options.version ?? "2026.4.14",
+    )
+      ? "1"
+      : "0",
+    OPENCLAW_FAKE_LOG: logPath,
+    OPENCLAW_FAKE_INSPECT_RUNTIME: options.inspectHasRuntime === true ? "1" : "0",
+    OPENCLAW_FAKE_INSPECT_STDOUT_PREFIX_LOGS:
+      options.inspectStdoutPrefixLogs === true ? "1" : "0",
+    OPENCLAW_FAKE_RUNTIME_STATUS: options.runtimeStatus ?? "loaded",
+    OPENCLAW_FAKE_VERSION: options.version ?? "2026.4.14",
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    TMPDIR: rootDir,
+  };
+  env.OPENCLAW_FAKE_INSTALL_HELP = options.installHelpMode ?? "has-unsafe";
+  delete env.OPENCLAW_HOME;
+  delete env.OPENCLAW_STATE_DIR;
+  delete env.OPENCLAW_VERSION;
+  if (options.openclawVersionEnv !== undefined) {
+    env.OPENCLAW_VERSION = options.openclawVersionEnv;
+  }
+
+  const result = spawnSync("bash", [DEPLOY_SCRIPT, pluginDir], {
+    cwd: resolve("."),
+    encoding: "utf8",
+    env,
+  });
+
+  return {
+    log: existsSync(logPath) ? readFileSync(logPath, "utf8") : "",
+    rootDir,
+    stderr: result.stderr,
+    stdout: result.stdout,
+    status: result.status,
+    userInspectTmpdir,
+  };
+}
+
+describe("deploy.sh", () => {
+  it("uses the unsafe flag when install help exposes it and verifies loading via inspect --json", () => {
+    const result = runDeploy({ version: "2026.4.14" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.4\.14/);
+    assert.match(result.stdout, /安装器暴露 legacy --dangerously-force-unsafe-install/);
+    assert.match(result.stdout, /plugins inspect agent-sec --json/);
+    assert.match(result.log, /plugins install --help/);
+    assert.match(result.log, /plugins inspect --help/);
+    assert.match(result.log, /plugins install .* --force --dangerously-force-unsafe-install/);
+    assert.match(result.log, /plugins inspect agent-sec --json/);
+    assert.doesNotMatch(result.log, /plugins inspect agent-sec --runtime --json/);
+    assert.doesNotMatch(
+      result.log,
+      /config set plugins\.entries\.agent-sec\.hooks\.allowConversationAccess true/,
+    );
+  });
+
+  it("parses inspect JSON when legacy hosts print plugin logs to stdout first", () => {
+    const result = runDeploy({ inspectStdoutPrefixLogs: true, version: "2026.4.14" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.4\.14/);
+    assert.match(result.stdout, /plugins inspect agent-sec --json/);
+    assert.match(result.log, /plugins inspect agent-sec --json/);
+    assert.doesNotMatch(result.stderr, /parse error/);
+    assert.doesNotMatch(result.stderr, /输出不是可解析 JSON/);
+  });
+
+  it("uses the unsafe flag and runtime inspect when both are exposed by help", () => {
+    const result = runDeploy({ inspectHasRuntime: true, version: "2026.5.28" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.5\.28/);
+    assert.match(result.stdout, /plugins inspect agent-sec --runtime --json/);
+    assert.match(result.log, /plugins inspect --help/);
+    assert.match(
+      result.log,
+      /config set plugins\.entries\.agent-sec\.hooks\.allowConversationAccess true/,
+    );
+    assert.match(result.log, /plugins inspect agent-sec --json/);
+    assert.match(result.log, /plugins inspect agent-sec --runtime --json/);
+    assert.match(result.log, /plugins install .* --force --dangerously-force-unsafe-install/);
+  });
+
+  it("uses the unsafe flag whenever OpenClaw install help exposes it", () => {
+    const result = runDeploy({
+      installHelpMode: "has-unsafe",
+      inspectHasRuntime: true,
+      version: "2026.6.10",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.log, /plugins install .* --force --dangerously-force-unsafe-install/);
+  });
+
+  it("passes through successful OpenClaw install and config output", () => {
+    const result = runDeploy({ version: "2026.4.24" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /^installed$/m);
+    assert.match(result.stdout, /^configured$/m);
+    assert.doesNotMatch(result.stdout, /\{"plugin":/);
+    assert.match(result.stderr, /install stderr detail/);
+    assert.match(result.stderr, /config stderr detail/);
+  });
+
+  it("only cleans deploy-owned inspect temp directories", () => {
+    const result = runDeploy({ precreateUserInspectTmpdir: true, version: "2026.4.14" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.userInspectTmpdir);
+    assert.equal(existsSync(join(result.userInspectTmpdir, "keep.txt")), true);
+    assert.deepEqual(
+      readdirSync(result.rootDir).filter((entry) =>
+        entry.startsWith("agent-sec-openclaw-inspect."),
+      ),
+      ["agent-sec-openclaw-inspect.user-owned"],
+    );
+  });
+
+  it("skips conversation access config before OpenClaw 2026.4.24", () => {
+    const result = runDeploy({ version: "2026.4.23" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.4\.23/);
+    assert.match(result.stdout, /跳过 plugins\.entries\.agent-sec\.hooks\.allowConversationAccess=true/);
+    assert.match(result.stdout, /OpenClaw 2026\.4\.24 引入/);
+    assert.doesNotMatch(
+      result.log,
+      /config set plugins\.entries\.agent-sec\.hooks\.allowConversationAccess true/,
+    );
+  });
+
+  it("ignores OPENCLAW_VERSION when detecting host compatibility", () => {
+    const result = runDeploy({
+      openclawVersionEnv: "2026.4.13",
+      version: "2026.4.24",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.4\.24/);
+    assert.match(
+      result.log,
+      /config set plugins\.entries\.agent-sec\.hooks\.allowConversationAccess true/,
+    );
+  });
+
+  it("configures conversation access starting with OpenClaw 2026.4.24", () => {
+    const result = runDeploy({ version: "2026.4.24" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.4\.24/);
+    assert.match(result.stdout, /允许 agent-sec 检查大模型输入输出安全/);
+    assert.match(
+      result.log,
+      /config set plugins\.entries\.agent-sec\.hooks\.allowConversationAccess true/,
+    );
+  });
+
+  it("uses the unsafe flag for newer builds when install help still exposes it", () => {
+    const result = runDeploy({
+      inspectHasRuntime: true,
+      version: "2026.6.10",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.6\.10/);
+    assert.match(result.stdout, /安装器暴露 legacy --dangerously-force-unsafe-install/);
+    assert.match(result.log, /plugins install .* --force --dangerously-force-unsafe-install/);
+  });
+
+  it("does not use the unsafe flag when the install CLI does not expose it", () => {
+    const result = runDeploy({
+      installHelpMode: "no-unsafe",
+      version: "2026.6.11",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw: 2026\.6\.11/);
+    assert.match(result.stdout, /安装器未暴露 legacy --dangerously-force-unsafe-install/);
+    assert.doesNotMatch(result.log, /dangerously-force-unsafe-install/);
+  });
+
+  it("fails before install when OpenClaw is below the supported floor", () => {
+    const result = runDeploy({ version: "2026.4.13" });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /OpenClaw >=2026\.4\.14/);
+    assert.doesNotMatch(result.log, /plugins install .* --force/);
+  });
+
+  it("fails before install when OpenClaw install help does not expose --force", () => {
+    const result = runDeploy({ installHelpMode: "no-force" });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /不支持 --force/);
+    assert.match(result.log, /plugins install --help/);
+    assert.doesNotMatch(result.log, /plugins install .* --force/);
+  });
+
+  it("fails when runtime inspection does not report a loaded plugin", () => {
+    const result = runDeploy({ inspectHasRuntime: true, runtimeStatus: "error" });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /plugins inspect agent-sec --runtime --json 状态为 error/);
+    assert.match(result.stderr, /runtime status error/);
+    assert.match(result.log, /plugins install .* --force/);
+    assert.match(result.log, /plugins inspect agent-sec --runtime --json/);
+  });
+});

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
@@ -76,11 +76,11 @@ describe("capability registration defaults", () => {
     );
   });
 
-  it("declares source and built runtime plugin entry points", () => {
+  it("declares packaged runtime plugin entry points", () => {
     const packageManifest = readJson("package.json");
     const manifest = readJson("openclaw.plugin.json");
 
-    assert.deepEqual(packageManifest.openclaw.extensions, ["./src/index.ts"]);
+    assert.deepEqual(packageManifest.openclaw.extensions, ["./dist/index.js"]);
     assert.deepEqual(packageManifest.openclaw.runtimeExtensions, [
       "./dist/index.js",
     ]);

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/registration-test.ts
@@ -6,6 +6,8 @@ import { isCapabilityEnabled } from "../../src/registration.js";
 import type { SecurityCapability } from "../../src/types.js";
 import { skillLedger } from "../../src/capabilities/skill-ledger.js";
 
+const OPENCLAW_COMPAT_FLOOR = ">=2026.4.14";
+
 function capability(id: string): SecurityCapability {
   return {
     id,
@@ -13,6 +15,10 @@ function capability(id: string): SecurityCapability {
     hooks: [],
     register: () => {},
   };
+}
+
+function readJson(path: string): Record<string, any> {
+  return JSON.parse(readFileSync(resolve(path), "utf8")) as Record<string, any>;
 }
 
 describe("capability registration defaults", () => {
@@ -34,9 +40,7 @@ describe("capability registration defaults", () => {
   });
 
   it("does not give deprecated skill-ledger enableBlock a schema default", () => {
-    const manifest = JSON.parse(
-      readFileSync(resolve("openclaw.plugin.json"), "utf8"),
-    );
+    const manifest = readJson("openclaw.plugin.json");
     const enableBlock =
       manifest.configSchema.properties.capabilities.properties[
         "skill-ledger"
@@ -46,14 +50,40 @@ describe("capability registration defaults", () => {
   });
 
   it("defaults skill-ledger policy to ask", () => {
-    const manifest = JSON.parse(
-      readFileSync(resolve("openclaw.plugin.json"), "utf8"),
-    );
+    const manifest = readJson("openclaw.plugin.json");
     const policy =
       manifest.configSchema.properties.capabilities.properties[
         "skill-ledger"
       ].properties.policy;
 
     assert.equal(policy.default, "ask");
+  });
+
+  it("declares the OpenClaw install and plugin API compatibility floor", () => {
+    const packageManifest = readJson("package.json");
+
+    assert.equal(
+      packageManifest.openclaw.install.minHostVersion,
+      OPENCLAW_COMPAT_FLOOR,
+    );
+    assert.equal(
+      packageManifest.openclaw.compat.pluginApi,
+      OPENCLAW_COMPAT_FLOOR,
+    );
+    assert.equal(
+      packageManifest.peerDependencies.openclaw,
+      OPENCLAW_COMPAT_FLOOR,
+    );
+  });
+
+  it("declares source and built runtime plugin entry points", () => {
+    const packageManifest = readJson("package.json");
+    const manifest = readJson("openclaw.plugin.json");
+
+    assert.deepEqual(packageManifest.openclaw.extensions, ["./src/index.ts"]);
+    assert.deepEqual(packageManifest.openclaw.runtimeExtensions, [
+      "./dist/index.js",
+    ]);
+    assert.deepEqual(manifest.extensions, ["./dist/index.js"]);
   });
 });


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
The openclaw deploy script uses the same flow for all openclaw versions which causes incompatibility between settings and old openclaw versions. Check openclaw CLI helper and set the params only if supported.

Also declare 2026.4.14 as the minimum supported openclaw version.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
