### PR TITLE
[cosh-ng] fix SSH remote command execution for cosh login shell

### DIFF
--- a/src/cosh-ng/cosh-ng.spec.in
+++ b/src/cosh-ng/cosh-ng.spec.in
@@ -46,6 +46,16 @@ install -m 0755 target/release/cosh-cli %{buildroot}%{_bindir}/cosh-cli
 # Install launcher script
 cat > %{buildroot}%{_bindir}/cosh << 'EOF'
 #!/bin/bash
+case "${1:-}" in
+  -c|--|--help|--version)
+    exec %{_libexecdir_cosh}/cosh-shell "$@"
+    ;;
+esac
+
+if [ "$#" -eq 0 ] && [ ! -t 0 ]; then
+  exec %{_libexecdir_cosh}/cosh-shell "$@"
+fi
+
 exec %{_libexecdir_cosh}/cosh-shell raw cosh-core "$@"
 EOF
 chmod 0755 %{buildroot}%{_bindir}/cosh

--- a/src/cosh-ng/crates/cosh-platform/src/svc.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/svc.rs
@@ -535,8 +535,12 @@ mod tests {
         }
         let sys_uptime = sys_uptime.unwrap();
 
-        // Pretend service started 120 seconds ago
-        let active_enter_mono = (sys_uptime.saturating_sub(120)) * 1_000_000;
+        if sys_uptime <= 1 {
+            return;
+        }
+
+        let expected_age = 120.min(sys_uptime - 1);
+        let active_enter_mono = (sys_uptime - expected_age) * 1_000_000;
         let mut props = std::collections::HashMap::new();
         props.insert(
             "ActiveEnterTimestampMonotonic".to_string(),
@@ -545,9 +549,12 @@ mod tests {
 
         let uptime = parse_uptime_secs(&props);
         assert!(uptime.is_some());
-        // Allow 2 second tolerance for timing drift
         let val = uptime.unwrap();
-        assert!((119..=122).contains(&val), "unexpected uptime: {}", val);
+        assert!(
+            (expected_age..=expected_age + 2).contains(&val),
+            "unexpected uptime: {}",
+            val
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/main.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/main.rs
@@ -41,7 +41,9 @@ mod types;
 mod ui;
 
 use runtime::cli_args::{configured_raw_invocation, should_start_default_raw};
-use runtime::startup::{passthrough_non_interactive, print_usage_help};
+use runtime::startup::{
+    passthrough_non_interactive, passthrough_raw_non_interactive, print_usage_help,
+};
 
 #[allow(unused_imports)]
 mod binary_compat {
@@ -93,6 +95,9 @@ fn main() {
         args.get(1).map(String::as_str),
         Some("demo" | "host-demo" | "raw" | "interactive" | "interactive-demo" | "adapter-demo")
     );
+    if let Some(status) = passthrough_raw_non_interactive(&args) {
+        std::process::exit(status);
+    }
     if !has_subcommand {
         if let Some(status) = passthrough_non_interactive(&args) {
             std::process::exit(status);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -323,6 +323,61 @@ pub(crate) fn passthrough_non_interactive(args: &[String]) -> Option<i32> {
     None
 }
 
+pub(crate) fn passthrough_raw_non_interactive(args: &[String]) -> Option<i32> {
+    let passthrough_args = raw_passthrough_args(args)?;
+    passthrough_non_interactive(&passthrough_args)
+}
+
+fn raw_passthrough_args(args: &[String]) -> Option<Vec<String>> {
+    if args.get(1).map(String::as_str) != Some("raw") {
+        return None;
+    }
+
+    let mut out = vec![args[0].clone()];
+    let mut skipped_adapter = false;
+    let mut idx = 2;
+    while idx < args.len() {
+        let arg = &args[idx];
+        match arg.as_str() {
+            "--" => {
+                out.push(arg.clone());
+                out.extend(args[idx + 1..].iter().cloned());
+                break;
+            }
+            "-c" => {
+                out.extend(args[idx..].iter().cloned());
+                break;
+            }
+            "--shell" => {
+                out.push(arg.clone());
+                if let Some(value) = args.get(idx + 1) {
+                    out.push(value.clone());
+                    idx += 2;
+                } else {
+                    idx += 1;
+                }
+            }
+            "--isolated" | "--login" | "-l" => {
+                out.push(arg.clone());
+                idx += 1;
+            }
+            _ if arg.starts_with("--shell=") => {
+                out.push(arg.clone());
+                idx += 1;
+            }
+            _ if !arg.starts_with('-') && !skipped_adapter => {
+                skipped_adapter = true;
+                idx += 1;
+            }
+            _ => return None,
+        }
+    }
+
+    let has_dash_c = out.iter().any(|arg| arg == "-c");
+    let has_double_dash = out.get(1).map(String::as_str) == Some("--");
+    (has_dash_c || has_double_dash).then_some(out)
+}
+
 fn detect_passthrough_shell(args: &[String]) -> String {
     for (i, arg) in args.iter().enumerate() {
         if arg == "--shell" {
@@ -405,7 +460,7 @@ fn merge_path_lists(paths: &[&str]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_bootstrap_path, merge_path_lists};
+    use super::{extract_bootstrap_path, merge_path_lists, raw_passthrough_args};
 
     #[test]
     fn bootstrap_path_extracts_last_marked_value() {
@@ -423,6 +478,46 @@ mod tests {
                 "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
             ]),
             "/opt/homebrew/bin:/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin"
+        );
+    }
+
+    #[test]
+    fn raw_passthrough_args_strips_raw_adapter_for_dash_c() {
+        assert_eq!(
+            raw_passthrough_args(&[
+                "cosh-shell".to_string(),
+                "raw".to_string(),
+                "cosh-core".to_string(),
+                "-c".to_string(),
+                "echo ok".to_string()
+            ]),
+            Some(vec![
+                "cosh-shell".to_string(),
+                "-c".to_string(),
+                "echo ok".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn raw_passthrough_args_preserves_shell_option() {
+        assert_eq!(
+            raw_passthrough_args(&[
+                "cosh-shell".to_string(),
+                "raw".to_string(),
+                "--shell".to_string(),
+                "bash".to_string(),
+                "cosh-core".to_string(),
+                "-c".to_string(),
+                "echo ok".to_string()
+            ]),
+            Some(vec![
+                "cosh-shell".to_string(),
+                "--shell".to_string(),
+                "bash".to_string(),
+                "-c".to_string(),
+                "echo ok".to_string()
+            ])
         );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
@@ -148,6 +148,62 @@ fn raw_cli_dash_c_passthrough_filters_wrapper_shell_option() {
 }
 
 #[test]
+fn raw_cli_raw_adapter_dash_c_passthrough_executes_without_agent_ui() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .args(["raw", "cosh-core", "-c", "echo raw-adapter-c-ok"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run raw adapter dash-c passthrough");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+    assert!(
+        stdout.contains("raw-adapter-c-ok"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("Agent:"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("Thinking..."),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[test]
+fn raw_cli_raw_adapter_dash_c_passthrough_preserves_exit_status() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .args(["raw", "cosh-core", "-c", "exit 48"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run raw adapter dash-c passthrough with nonzero exit");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(48),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("Agent:"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("Thinking..."),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[test]
 fn raw_cli_stdin_passthrough_preserves_exit_status() {
     let binary = env!("CARGO_BIN_EXE_cosh-shell");
     let mut child = raw_cli_command(binary)


### PR DESCRIPTION
## Summary

Fix SSH remote command execution when `cosh` is configured as the user's login shell.

## Root Cause

OpenSSH executes remote commands through the user's login shell as `shell -c <command>`. The installed `/usr/bin/cosh` launcher always prepended `raw cosh-core`, so `ssh host 'echo ok'` became:

```bash
cosh-shell raw cosh-core -c 'echo ok'
```

The raw subcommand path did not recognize this as a non-interactive shell command and entered interactive raw mode instead.

## Changes

- Teach `cosh-shell raw <adapter> -c <command>` to normalize back into the existing non-interactive passthrough path.
- Preserve shell options such as `--shell` while stripping the raw adapter segment for passthrough execution.
- Update the RPM `cosh` launcher so explicit non-interactive CLI entry points (`-c`, `--`, `--help`, `--version`, non-TTY stdin) go directly to `cosh-shell`.
- Add raw CLI regression coverage for command output and exit status preservation.

Fixes #1357

## Validation

```bash
cargo test -p cosh-shell raw_passthrough_args
cargo test -p cosh-shell --test raw_cli passthrough
cargo check -p cosh-shell
git diff --check
awk '/cat > %\{buildroot\}%\{_bindir\}\/cosh << '\''EOF'\''/{flag=1; next} flag && /^EOF$/{flag=0} flag{print}' src/cosh-ng/cosh-ng.spec.in | bash -n
```

Manual verification on an affected host after applying the launcher hotfix:

```bash
ssh root@47.110.58.189 'echo __SSH_REMOTE_COMMAND_OK__'
ssh root@47.110.58.189 'exit 37'
ssh root@47.110.58.189 'cosh --version'
ssh root@47.110.58.189 'cosh -- echo __COSH_DOUBLE_DASH_OK__'
```
