### PR TITLE
fix(ws-ckpt): populate openclaw.plugin.json configSchema properties

### DIFF
--- a/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json
+++ b/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "ws-ckpt",
   "kind": "tool",
-  "activation": { 
-    "onStartup": true 
+  "activation": {
+    "onStartup": true
   },
   "install": {
     "npmSpec": "@openclaw/ws-ckpt"
@@ -10,6 +10,26 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "autoCheckpoint": {
+        "type": "boolean",
+        "description": "Automatically create a checkpoint before each tool call (default: false)"
+      },
+      "workspace": {
+        "type": "string",
+        "description": "Default workspace absolute path used by every ws-ckpt command without -w."
+      },
+      "cronSchedules": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Cron expressions for scheduled checkpoint snapshots"
+      },
+      "retentionDays": {
+        "type": "integer",
+        "description": "Number of days to retain scheduled checkpoint snapshots (0 = no auto-cleanup)"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 问题

Fixes #1366

`ws-ckpt/src/plugins/openclaw/openclaw.plugin.json` 的 `configSchema.properties` 为空对象 `{}`，导致 OpenClaw 插件配置校验时无法识别合法的配置项（`autoCheckpoint`、`workspace`、`cronSchedules`、`retentionDays`）。同时 JSON 文件中存在尾部空白字符。

## 修复

```diff
diff --git a/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json b/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json
index 1c0dafa5..fcf306cb 100644
--- a/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json
+++ b/src/ws-ckpt/src/plugins/openclaw/openclaw.plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "ws-ckpt",
   "kind": "tool",
-  "activation": { 
-    "onStartup": true 
+  "activation": {
+    "onStartup": true
   },
   "install": {
     "npmSpec": "@openclaw/ws-ckpt"
@@ -10,6 +10,26 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "autoCheckpoint": {
+        "type": "boolean",
+        "description": "Automatically create a checkpoint before each tool call (default: false)"
+      },
+      "workspace": {
+        "type": "string",
+        "description": "Default workspace absolute path used by every ws-ckpt command without -w."
+      },
+      "cronSchedules": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Cron expressions for scheduled checkpoint snapshots"
+      },
+      "retentionDays": {
+        "type": "integer",
+        "description": "Number of days to retain scheduled checkpoint snapshots (0 = no auto-cleanup)"
+      }
+    }
   }
 }
```

## 验证

```shell
# ECS 8.217.109.138 — 源码覆盖修复后运行功能测试
cd /root/anolisa/src/ws-ckpt
ANOLISA_SRC=/root/anolisa/src python3 -m pytest -xvs \
  tests/test_openclaw_plugin.py::test_config_schema_has_properties \
  tests/test_openclaw_plugin.py::test_config_schema_validates_autocheckpoint
# → 2 passed in 0.05s (exit 0)

# RPM 构建
sh build-rpm.sh
# → BUILD_EXIT=0, 产出 ws-ckpt-0.4.1-1.alnx4.x86_64.rpm
```

实测 `ws-ckpt-0.4.1-1.alnx4.x86_64.rpm` 构建成功，2 个功能测试全通过。

Co-Authored-By: Claude <noreply@anthropic.com>
