### PR TITLE
feat(benchmark): add terminal-bench agent adapter

### DIFF
--- a/src/benchmark/terminal-runner/.gitignore
+++ b/src/benchmark/terminal-runner/.gitignore
@@ -1,0 +1,54 @@
+# ---------------------------------------------------------------------------
+# Sensitive / runtime artifacts — never commit
+# ---------------------------------------------------------------------------
+
+# Harbor upstream is cloned by scripts/setup.sh — do not vendor it.
+/harbor/
+
+# Dataset is cloned by scripts/setup.sh — do not vendor it.
+/dataset/
+
+# Job outputs (contain logs, possibly API keys, container output).
+/jobs/
+
+# Local temp / cache.
+*.tmp
+.cache/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+.eggs/
+build/
+dist/
+.venv/
+venv/
+env/
+.python-version
+
+# Node / npm
+node_modules/
+package-lock.json
+bun.lock
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+
+# Logs
+*.log
+logs/

--- a/src/benchmark/terminal-runner/LICENSE
+++ b/src/benchmark/terminal-runner/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Alibaba Cloud
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/benchmark/terminal-runner/README.md
+++ b/src/benchmark/terminal-runner/README.md
@@ -1,5 +1,7 @@
 # terminal-runner
 
+[中文版](README_zh.md)
+
 This guide explains how to test terminal-bench tasks via the [harbor](https://github.com/harbor-framework/harbor) platform, focusing on two implementation approaches — **Installed mode** and **External mode** — their differences, trade-offs, and usage.
 
 ---
@@ -68,7 +70,7 @@ terminal-runner/
 ├── .gitignore
 ├── LICENSE
 ├── README.md
-└── README_CN.md
+└── README_zh.md
 ```
 
 ### What's NOT here (cloned by `setup.sh`)

--- a/src/benchmark/terminal-runner/README.md
+++ b/src/benchmark/terminal-runner/README.md
@@ -90,8 +90,8 @@ terminal-runner/
 ### Install
 
 ```bash
-git clone https://github.com/<your-org>/terminal-runner.git
-cd terminal-runner
+git clone https://github.com/alibaba/anolisa.git
+cd anolisa/src/benchmark/terminal-runner
 ./scripts/setup.sh
 ```
 

--- a/src/benchmark/terminal-runner/README.md
+++ b/src/benchmark/terminal-runner/README.md
@@ -1,0 +1,205 @@
+# terminal-runner
+
+This guide explains how to test terminal-bench tasks via the [harbor](https://github.com/harbor-framework/harbor) platform, focusing on two implementation approaches — **Installed mode** and **External mode** — their differences, trade-offs, and usage.
+
+---
+
+## Two modes, two support paths
+
+[harbor](https://github.com/harbor-framework/harbor) runs agent evaluations inside Docker containers. It supports two ways to supply the agent:
+
+### Installed mode — harbor native
+
+Built into harbor. The agent implements an `install()` method — harbor calls it during `setup()` to automatically install the agent inside the container at runtime (e.g., Node.js + openclaw via nvm). The Docker image stays clean; installation happens on every trial.
+
+```bash
+harbor run --agent openclaw ...
+```
+
+- **Who supports it:** Harbor out of the box via `--agent <name>`.
+- **Cost:** Agent is re-installed every trial (adds setup time).
+
+### External mode — harbor's extensibility API
+
+Harbor provides `BaseAgent` + `--agent`, an interface that lets you plug in any agent running outside the container — a host CLI, a remote agent behind an HTTP service, anything. The external agent communicates with the container through `environment.exec()`.
+
+```bash
+harbor run --agent-import-path external_agent.openclaw_external_agent:OpenClawExternalAgent ...
+```
+
+- **Who supports it:** Harbor's `BaseAgent` API. Anyone can implement an external agent.
+- **Advantage:** Install the agent once on host, skip per-trial install overhead. No runtime inside the container.
+
+### This repo
+
+A **working demo** of external mode, using OpenClaw as the host-side agent:
+
+```
+OpenClaw (host LLM) <-> OpenClawExternalAgent (router) <-> Harbor Docker container
+```
+
+The same pattern works for Claude Code, Codex, or any agent CLI.
+
+---
+
+## Install OpenClaw on host
+
+External mode runs the agent CLI on the host. For this repo's `openclaw_external_agent`, that means the `openclaw` CLI on your host PATH. If you write your own `xxx_external_agent.py`, install the corresponding agent CLI instead.
+
+```bash
+# Requires Node.js >= 22.19 (Node 24 recommended)
+npm install -g openclaw
+openclaw --version
+```
+
+See [OpenClaw docs](https://github.com/openclaw/openclaw) for API key and model setup.
+
+---
+
+## What's inside
+
+```
+terminal-runner/
+├── external_agent/
+│   ├── __init__.py                  # Package marker (no imports — lazy loading)
+│   └── openclaw_external_agent.py   # External agent adapter (extends harbor BaseAgent)
+├── scripts/
+│   └── setup.sh                     # Clone harbor upstream + dataset, install harbor
+├── .gitignore
+├── LICENSE
+├── README.md
+└── README_CN.md
+```
+
+### What's NOT here (cloned by `setup.sh`)
+
+- `harbor/` — upstream harbor framework
+- `dataset/` — terminal-bench task dataset
+
+---
+
+## Quick start
+
+### Prerequisites
+
+- Python ≥ 3.12
+- Docker ≥ 24 with the **compose v2 plugin** (`docker compose version` must work)
+- Node.js ≥ 22.19 + `openclaw` CLI on host PATH (external mode only)
+- `git`, `git-lfs`
+
+### Install
+
+```bash
+git clone https://github.com/<your-org>/terminal-runner.git
+cd terminal-runner
+./scripts/setup.sh
+```
+
+`setup.sh` does:
+1. Checks Python version — if < 3.12, auto-detects conda (Miniconda/Anaconda) and creates a 3.12 environment (env name configurable via `CONDA_ENV_NAME`, default `terminal-runner-py312`)
+2. Creates a Python virtual environment at `.venv/`
+3. `git clone` harbor upstream → `harbor/`, **checks out the pinned release tag** (`v0.15.0`), then `pip install -e` into the venv
+4. `git clone` dataset (via Git LFS) from HuggingFace → `dataset/`
+
+> **Note:** Harbor is pinned to a specific release (`v0.15.0`) for stability. Override with `HARBOR_REF` if needed.
+
+Override sources:
+
+```bash
+HARBOR_URL=git@github.com:your-fork/harbor.git \
+HARBOR_REF=v0.15.0 \
+DATASET_URL=https://huggingface.co/datasets/<org>/<dataset> \
+  ./scripts/setup.sh
+```
+
+---
+
+## Usage
+
+### External mode (this repo)
+
+```bash
+source .venv/bin/activate
+export PYTHONPATH=$(pwd)
+
+harbor run \
+  --agent-import-path external_agent.openclaw_external_agent:OpenClawExternalAgent \
+  -p dataset/nginx-request-logging \
+  -m openai/qwen3.6-plus \
+  --agent-env OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1 \
+  --agent-env OPENAI_API_KEY=sk-xxxxx
+```
+
+### Installed mode (harbor built-in)
+
+In installed mode, harbor's built-in `openclaw` agent runs OpenClaw **inside** the
+container (auto-installed via nvm + npm).  The built-in agent only supports a
+fixed set of providers (`openai`, `anthropic`, `nvidia`); use the `openai`
+provider with `OPENAI_BASE_URL` / `OPENAI_API_KEY` for any OpenAI-compatible
+endpoint (e.g. DashScope).  Qwen models do not support thinking mode, so pass
+`--agent-kwarg thinking=off`.
+
+```bash
+source .venv/bin/activate
+
+harbor run \
+  --agent openclaw \
+  -p dataset/nginx-request-logging \
+  -m openai/qwen3.6-plus \
+  --agent-env OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1 \
+  --agent-env OPENAI_API_KEY=sk-xxxxx \
+  --agent-kwarg thinking=off
+```
+
+### How it works (per iteration)
+
+1. Spawns `openclaw --profile <trial-profile> agent --local --json --message ...` on host
+2. Streams stdout/stderr with heartbeat + three safety guards (total-timeout, no-output timeout, stdout cap)
+3. Extracts bash commands from OpenClaw's response (toolCall or fenced `bash` code blocks)
+4. Executes each command in the harbor container via `environment.exec()`
+5. Feeds the results back to OpenClaw for the next iteration
+6. Stops when OpenClaw outputs `TASK_COMPLETE` or `OPENCLAW_MAX_ITERATIONS` is hit
+
+### Per-trial isolation
+
+Each trial gets its own `~/.openclaw-<profile>` directory (profile name derived from harbor session id), so concurrent trials don't collide.
+
+### Auto-skill
+
+Skill hints are loaded per-task (highest priority first):
+
+1. **`dataset/<task>/skill.md`** — a manual override file. If it exists, its content is injected verbatim (truncated to 3000 chars). Always active.
+2. **`dataset/<task>/solution/solve.sh`** — auto-parsed into a step-by-step hint. **Disabled by default**; enable with `SKILL_FROM_SOLUTION=1`.
+
+The dataset directory is resolved via the `DATASET_DIR` env var (default `dataset`, relative to the `harbor run` working directory).
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OPENCLAW_VERSION` | `2026.4.14` | Version string reported by `version()`. |
+| `OPENCLAW_AGENT_ID` | `main` | OpenClaw agent-id passed via `--agent`. |
+| `OPENCLAW_TIMEOUT` | `600` | Per-call timeout (s) passed as `--timeout` to OpenClaw. Also the floor for the subprocess total-timeout guard. |
+| `OPENCLAW_NO_OUTPUT_TIMEOUT` | `500` | Kill the OpenClaw subprocess after this many seconds with zero stdout (API-hang guard). |
+| `OPENCLAW_THINKING` | `off` | OpenClaw thinking mode (`off` / `low` / `high`). |
+| `OPENCLAW_MAX_ITERATIONS` | `0` | Max agent-loop iterations (0 = unlimited). |
+| `OPENCLAW_MAX_STDOUT_BYTES` | `102400` | Kill OpenClaw subprocess if stdout exceeds this (infinite-generation guard). |
+| `DOCKER_EXEC_TIMEOUT` | `600` | Per-command `environment.exec()` timeout in seconds. |
+| `DATASET_DIR` | `dataset` | Path to the task dataset directory (used to locate `skill.md` / `solution/solve.sh`). |
+| `SKILL_FROM_SOLUTION` | `0` | Set to `1` to enable auto-generated skill hints from `solution/solve.sh`. |
+
+---
+
+## License
+
+Apache License 2.0, matching harbor's license.
+
+---
+
+## Acknowledgements
+
+- [harbor](https://github.com/harbor-framework/harbor) — agent evaluation framework
+- [terminal-bench](https://github.com/laude-institute/terminal-bench) — task dataset format
+- [OpenClaw](https://github.com/openclaw/openclaw) — host-side agent CLI

--- a/src/benchmark/terminal-runner/README_CN.md
+++ b/src/benchmark/terminal-runner/README_CN.md
@@ -1,0 +1,200 @@
+# terminal-runner
+
+本文介绍如何通过 [harbor](https://github.com/harbor-framework/harbor) 平台测试 terminal-bench 任务，重点对比两种实现方式 — **Installed mode** 和 **External mode** — 的差异、各自优缺点及使用方法。
+
+---
+
+## 两种模式，两条支撑路径
+
+[harbor](https://github.com/harbor-framework/harbor) 在 Docker 容器内运行 agent 评测。它支持两种提供 agent 的方式：
+
+### Installed mode — harbor 原生支持
+
+内建于 harbor。agent 实现 `install()` 方法 — harbor 在 `setup()` 阶段自动调用，在容器内动态安装 agent 运行时（如通过 nvm 安装 Node.js + openclaw）。Docker 镜像保持干净，安装过程每次 trial 都会执行。
+
+```bash
+harbor run --agent openclaw ...
+```
+
+- **谁来支撑：** Harbor 通过 `--agent <name>` 原生支持。
+- **代价：** 每次 trial 重新安装 agent（增加启动耗时）。
+
+### External mode — harbor 的可扩展接口
+
+Harbor 提供 `BaseAgent` + `--agent`，这是一个允许你接入任意运行在容器外部的 agent 的接口 — 宿主机 CLI、HTTP 服务背后的远端 agent，任何形式。外部 agent 通过 `environment.exec()` 与容器通信。
+
+```bash
+harbor run --agent-import-path external_agent.openclaw_external_agent:OpenClawExternalAgent ...
+```
+
+- **谁来支撑：** Harbor 的 `BaseAgent` API。任何人都可以实现外部 agent。
+- **优势：** agent 在宿主机安装一次，跳过每次 trial 的安装开销。容器内无需运行 agent。
+
+### 本仓库
+
+External mode 的一个**可运行示例**，以 OpenClaw 作为宿主机端 agent：
+
+```
+OpenClaw (宿主机 LLM) <-> OpenClawExternalAgent (路由器) <-> Harbor Docker 容器
+```
+
+同样的模式适用于 Claude Code、Codex 或任何 agent CLI。
+
+---
+
+## 在宿主机安装 OpenClaw
+
+External mode 在宿主机运行 agent CLI。对于本仓库的 `openclaw_external_agent` 来说，需要 `openclaw` CLI 在宿主机 PATH 中可用。如果你自己实现 `xxx_external_agent.py`，则安装对应的 agent CLI 即可。
+
+```bash
+# 需要 Node.js >= 22.19（推荐 Node 24）
+npm install -g openclaw
+openclaw --version
+```
+
+API key 和模型配置请参考 [OpenClaw 文档](https://github.com/openclaw/openclaw)。
+
+---
+
+## 仓库内容
+
+```
+terminal-runner/
+├── external_agent/
+│   ├── __init__.py                  # 包标记文件（无导入，懒加载）
+│   └── openclaw_external_agent.py   # 外部 agent 适配器（继承 harbor BaseAgent）
+├── scripts/
+│   └── setup.sh                     # 克隆 harbor 上游 + 数据集，安装 harbor
+├── .gitignore
+├── LICENSE
+├── README.md
+└── README_CN.md
+```
+
+### 不在仓库内（由 `setup.sh` 克隆）
+
+- `harbor/` — harbor 上游框架
+- `dataset/` — terminal-bench 任务数据集
+
+---
+
+## 快速开始
+
+### 前置条件
+
+- Python ≥ 3.12
+- Docker ≥ 24，需 **compose v2 插件**（`docker compose version` 必须可用）
+- Node.js ≥ 22.19 + `openclaw` CLI 在宿主机 PATH 中（仅 external mode 需要）
+- `git`、`git-lfs`
+
+### 安装
+
+```bash
+git clone https://github.com/<your-org>/terminal-runner.git
+cd terminal-runner
+./scripts/setup.sh
+```
+
+`setup.sh` 做了什么：
+1. 检查 Python 版本 — 若 < 3.12，自动检测 conda（Miniconda/Anaconda）并创建 3.12 环境（环境名可通过 `CONDA_ENV_NAME` 配置，默认 `terminal-runner-py312`）
+2. 创建 Python 虚拟环境 `.venv/`
+3. `git clone` harbor 上游 → `harbor/`，**checkout 到锁定的 release tag**（`v0.15.0`），然后在 venv 中 `pip install -e`
+4. 通过 Git LFS 从 HuggingFace 克隆数据集 → `dataset/`
+
+> **注意：** Harbor 锁定到特定 release（`v0.15.0`）以保证稳定性。如有需要可通过 `HARBOR_REF` 覆盖。
+
+覆盖源地址：
+
+```bash
+HARBOR_URL=git@github.com:your-fork/harbor.git \
+HARBOR_REF=v0.15.0 \
+DATASET_URL=https://huggingface.co/datasets/<org>/<dataset> \
+  ./scripts/setup.sh
+```
+
+---
+
+## 使用方法
+
+### External mode（本仓库）
+
+```bash
+source .venv/bin/activate
+export PYTHONPATH=$(pwd)
+
+harbor run \
+  --agent-import-path external_agent.openclaw_external_agent:OpenClawExternalAgent \
+  -p dataset/nginx-request-logging \
+  -m openai/qwen3.6-plus \
+  --agent-env OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1 \
+  --agent-env OPENAI_API_KEY=sk-xxxxx
+```
+
+### Installed mode（harbor 内置）
+
+Installed 模式下，harbor 内置的 `openclaw` agent 在**容器内**运行 OpenClaw（通过 nvm + npm 自动安装）。内置 agent 仅支持固定的一组 provider（`openai`、`anthropic`、`nvidia`）；对于任何 OpenAI 兼容端点（如 DashScope），请使用 `openai` provider 配合 `OPENAI_BASE_URL` / `OPENAI_API_KEY`。Qwen 模型不支持 thinking 模式，需传 `--agent-kwarg thinking=off`。
+
+```bash
+source .venv/bin/activate
+
+harbor run \
+  --agent openclaw \
+  -p dataset/nginx-request-logging \
+  -m openai/qwen3.6-plus \
+  --agent-env OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1 \
+  --agent-env OPENAI_API_KEY=sk-xxxxx \
+  --agent-kwarg thinking=off
+```
+
+### 工作原理（单次迭代）
+
+1. 在宿主机启动 `openclaw --profile <trial-profile> agent --local --json --message ...`
+2. 流式读取 stdout/stderr，附带心跳 + 三重安全防护（总超时、无输出超时、stdout 上限）
+3. 从 OpenClaw 响应中提取 bash 命令（toolCall 或 `bash` 代码块）
+4. 通过 `environment.exec()` 在 harbor 容器中执行每条命令
+5. 将结果反馈给 OpenClaw 进入下一轮迭代
+6. 当 OpenClaw 输出 `TASK_COMPLETE` 或达到 `OPENCLAW_MAX_ITERATIONS` 时停止
+
+### 每次试验隔离
+
+每次试验获得独立的 `~/.openclaw-<profile>` 目录（profile 名称源自 harbor session id），并发试验互不冲突。
+
+### 自动 skill 提示
+
+Skill 提示按优先级从高到低加载：
+
+1. **`dataset/<task>/skill.md`** — 手动覆盖文件。若存在，内容原样注入（截断至 3000 字符）。始终生效。
+2. **`dataset/<task>/solution/solve.sh`** — 自动解析为分步提示。**默认禁用**，设置 `SKILL_FROM_SOLUTION=1` 启用。
+
+数据集目录通过 `DATASET_DIR` 环境变量解析（默认 `dataset`，相对于 `harbor run` 的工作目录）。
+
+---
+
+## 环境变量
+
+| 变量 | 默认值 | 说明 |
+|---|---|---|
+| `OPENCLAW_VERSION` | `2026.4.14` | `version()` 返回的版本号。 |
+| `OPENCLAW_AGENT_ID` | `main` | 传给 `--agent` 的 OpenClaw agent-id。 |
+| `OPENCLAW_TIMEOUT` | `600` | 单次调用超时（秒），传给 OpenClaw 的 `--timeout`。同时也是子进程总超时守卫的下限。 |
+| `OPENCLAW_NO_OUTPUT_TIMEOUT` | `500` | OpenClaw 子进程在无 stdout 输出超过该秒数后被杀死（API 挂起守卫）。 |
+| `OPENCLAW_THINKING` | `off` | OpenClaw 思考模式（`off` / `low` / `high`）。 |
+| `OPENCLAW_MAX_ITERATIONS` | `0` | 最大 agent 循环迭代次数（0 = 不限）。 |
+| `OPENCLAW_MAX_STDOUT_BYTES` | `102400` | stdout 超过该字节数时杀死 OpenClaw 子进程（无限生成守卫）。 |
+| `DOCKER_EXEC_TIMEOUT` | `600` | 单条命令 `environment.exec()` 超时（秒）。 |
+| `DATASET_DIR` | `dataset` | 任务数据集目录路径（用于定位 `skill.md` / `solution/solve.sh`）。 |
+| `SKILL_FROM_SOLUTION` | `0` | 设为 `1` 启用从 `solution/solve.sh` 自动生成 skill 提示。 |
+
+---
+
+## 许可证
+
+Apache License 2.0，与 harbor 许可证一致。
+
+---
+
+## 致谢
+
+- [harbor](https://github.com/harbor-framework/harbor) — agent 评测框架
+- [terminal-bench](https://github.com/laude-institute/terminal-bench) — 任务数据集格式
+- [OpenClaw](https://github.com/openclaw/openclaw) — 宿主机端 agent CLI

--- a/src/benchmark/terminal-runner/README_CN.md
+++ b/src/benchmark/terminal-runner/README_CN.md
@@ -90,8 +90,8 @@ terminal-runner/
 ### 安装
 
 ```bash
-git clone https://github.com/<your-org>/terminal-runner.git
-cd terminal-runner
+git clone https://github.com/alibaba/anolisa.git
+cd anolisa/src/benchmark/terminal-runner
 ./scripts/setup.sh
 ```
 

--- a/src/benchmark/terminal-runner/README_zh.md
+++ b/src/benchmark/terminal-runner/README_zh.md
@@ -1,5 +1,7 @@
 # terminal-runner
 
+[English](README.md)
+
 本文介绍如何通过 [harbor](https://github.com/harbor-framework/harbor) 平台测试 terminal-bench 任务，重点对比两种实现方式 — **Installed mode** 和 **External mode** — 的差异、各自优缺点及使用方法。
 
 ---
@@ -68,7 +70,7 @@ terminal-runner/
 ├── .gitignore
 ├── LICENSE
 ├── README.md
-└── README_CN.md
+└── README_zh.md
 ```
 
 ### 不在仓库内（由 `setup.sh` 克隆）

--- a/src/benchmark/terminal-runner/external_agent/__init__.py
+++ b/src/benchmark/terminal-runner/external_agent/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Alibaba Cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""External agent adapters for harbor's ``--agent`` API.
+
+Submodules are imported lazily by harbor (e.g.
+``external_agent.openclaw_external_agent:OpenClawExternalAgent``); keeping
+this file free of imports avoids requiring harbor to be installed just
+to load the package.
+"""

--- a/src/benchmark/terminal-runner/external_agent/openclaw_external_agent.py
+++ b/src/benchmark/terminal-runner/external_agent/openclaw_external_agent.py
@@ -1,0 +1,1365 @@
+# Copyright 2026 Alibaba Cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+OpenClawExternalAgent - Host-side OpenClaw agent adapter for Harbor.
+
+Architecture:
+  OpenClaw (host LLM) <-> OpenClawExternalAgent (router) <-> Harbor Docker container
+
+  1. Harbor calls ``setup()`` to detect the Docker container and validate OpenClaw.
+  2. Harbor calls ``run()`` which enters an agent loop:
+     a. OpenClaw (host subprocess) generates bash commands via LLM inference.
+     b. Router extracts commands from OpenClaw's JSON/text output.
+     c. Router executes commands via ``environment.exec()`` inside the container.
+     d. Results are fed back to OpenClaw for the next iteration.
+  3. On completion, ``AgentContext`` is populated with execution metadata.
+
+This is *not* an installed agent (``BaseInstalledAgent``).  It extends
+``BaseAgent`` directly and is loaded at runtime via Harbor's
+``--agent`` mechanism:
+
+    harbor run --agent external_agent.openclaw_external_agent:OpenClawExternalAgent \
+               -p dataset/my-task -m openai/my-model ...
+
+Environment variables
+--------------------
+.. list-table::
+   :header-rows: 1
+
+   * - Variable
+     - Default
+     - Description
+   * - ``OPENCLAW_VERSION``
+     - ``"2026.4.14"``
+     - Version string reported by ``version()``.
+   * - ``OPENCLAW_AGENT_ID``
+     - ``"main"``
+     - OpenClaw agent-id used in the ``--agent`` flag.
+   * - ``OPENCLAW_TIMEOUT``
+     - ``"600"``
+     - Per-call timeout (seconds) passed as ``--timeout`` to OpenClaw.
+       Also used as the floor for the subprocess total-timeout guard
+       (the guard is ``max(OPENCLAW_TIMEOUT, 600)``).
+   * - ``OPENCLAW_NO_OUTPUT_TIMEOUT``
+     - ``"500"``
+     - Kill the OpenClaw subprocess after this many seconds with zero
+       stdout (API-hang detection).
+   * - ``OPENCLAW_THINKING``
+     - ``"off"``
+     - OpenClaw thinking mode (``"off"`` / ``"low"`` / ``"high"``).
+   * - ``OPENCLAW_MAX_ITERATIONS``
+     - ``"0"``
+     - Max agent-loop iterations (0 = unlimited).
+   * - ``OPENCLAW_MAX_STDOUT_BYTES``
+     - ``"102400"``
+     - Kill OpenClaw subprocess if stdout exceeds this (infinite-generation guard).
+   * - ``DOCKER_EXEC_TIMEOUT``
+     - ``"600"``
+     - Per-command ``environment.exec()`` timeout in seconds.
+   * - ``DATASET_DIR``
+     - ``"dataset"``
+     - Path to the task dataset directory (used to locate ``skill.md`` /
+       ``solution/solve.sh``).  Relative to the working directory from
+       which ``harbor run`` is invoked (the repo root by default).
+   * - ``SKILL_FROM_SOLUTION``
+     - ``"0"``
+     - Set to ``"1"`` to enable auto-generated skill hints from
+       ``solution/solve.sh`` (disabled by default for fair benchmark
+       evaluation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import json
+import logging
+import os
+import re
+import select
+import shutil
+import subprocess
+import time
+import uuid
+from functools import partial
+from typing import Any
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+__all__ = ["OpenClawExternalAgent"]
+
+_log = logging.getLogger(__name__)
+_LOG_PREFIX = "OpenClaw"
+
+
+class OpenClawExternalAgent(BaseAgent):
+    """Route between an OpenClaw process on the **host** and a Harbor Docker container.
+
+    OpenClaw runs on the host for LLM inference.  Commands are extracted from
+    its output and relayed into the Docker container via
+    ``environment.exec()``.  This keeps the agent CLI outside the container.
+
+    The adapter implements three guardrails against hung/stalled subprocesses:
+
+    * **total-timeout** – kill the OpenClaw subprocess after
+      ``_OPENCLAW_TIMEOUT_SEC``.
+    * **no-output timeout** – kill after ``_OPENCLAW_NO_OUTPUT_SEC`` with zero
+      stdout (API hang).
+    * **stdout cap** – kill when stdout exceeds ``_MAX_STDOUT_BYTES``
+      (infinite-generation loop).
+    """
+
+    # ------------------------------------------------------------------
+    # Truncation / sizing constants
+    # ------------------------------------------------------------------
+    _MAX_SKILL_HINT_CHARS: int = 3000
+    _MAX_HEREDOC_BODY_CHARS: int = 800
+    _MAX_STEP_CHARS: int = 200
+    _MAX_EXEC_STDOUT_CHARS: int = 5000
+    _MAX_EXEC_STDERR_CHARS: int = 1000
+    _MAX_CMD_OUTPUT_CHARS: int = 2000
+    _MAX_ERROR_OUTPUT_CHARS: int = 500
+    _DEBUG_OUTPUT_CHARS: int = 500
+    _DEBUG_TEXT_CHARS: int = 300
+
+    # ------------------------------------------------------------------
+    # Timeout constants
+    # ------------------------------------------------------------------
+    _OPENCLAW_TIMEOUT_SEC: int = 600
+    _OPENCLAW_NO_OUTPUT_SEC: int = 500
+    _DEFAULT_DOCKER_EXEC_TIMEOUT: int = 600
+    _HEARTBEAT_INTERVAL_SEC: int = 30
+    _SLOW_EXEC_THRESHOLD_SEC: int = 60
+
+    # ------------------------------------------------------------------
+    # Path / file constants
+    # ------------------------------------------------------------------
+    _DEFAULT_DATASET_DIR: str = "dataset"
+    _DEFAULT_MAX_STDOUT_BYTES: int = 102400
+
+    # ------------------------------------------------------------------
+    # Command-format rules appended to auto-generated skill hints
+    # ------------------------------------------------------------------
+    _SKILL_COMMAND_RULES: str = (
+        "\n## Command Format Rules\n"
+        "- Do NOT use the exec tool — it runs on the HOST, not in the container. "
+        "Put commands in ```bash``` blocks only.\n"
+        "- Do NOT use `cd /app && command` — use absolute paths instead.\n"
+        "- Each command must be a single simple command, not chained with `&&` "
+        "or `;`.\n"
+        "- You MUST execute ALL commands in the Approach section before saying "
+        "TASK_COMPLETE. Do NOT claim completion without executing commands.\n"
+    )
+
+    # ------------------------------------------------------------------
+    # Instance state (declared in __init__, populated during setup / run)
+    # ------------------------------------------------------------------
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Backward compat: _extra_env was added to BaseAgent after v0.15.0.
+        # In v0.15.0 BaseAgent silently drops extra_env via **kwargs, so we
+        # extract it ourselves before calling super().
+        _env = kwargs.pop("extra_env", None)
+        super().__init__(*args, **kwargs)
+        if not hasattr(self, "_extra_env") or not self._extra_env:
+            self._extra_env: dict[str, str] = dict(_env) if _env else {}
+
+        # Set during setup()
+        self._task_name: str = ""
+        self._skill_hint: str = ""
+        self._profile_name: str = ""
+        self._harbor_container_id: str = ""
+        self._harbor_image: str | None = None
+        self._harbor_workdir: str = "/app"
+
+    # ------------------------------------------------------------------
+    # Harbor agent contract
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def name() -> str:
+        return "openclaw-external"
+
+    def version(self) -> str | None:
+        return os.environ.get("OPENCLAW_VERSION", "2026.4.14")
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        # Extract task name (e.g. "crack-7z-hash__abc123" -> "crack-7z-hash")
+        env_name = getattr(environment, "environment_name", "")
+        self._task_name = env_name.split("__")[0] if "__" in env_name else env_name
+
+        self._skill_hint = self._load_skill_hint()
+
+        if hasattr(environment, "session_id"):
+            self._profile_name = re.sub(
+                r"[^a-zA-Z0-9_-]", "_", environment.session_id
+            )
+        else:
+            self._profile_name = f"task_{uuid.uuid4().hex[:8]}"
+
+        container_id = await self._detect_harbor_container(environment)
+        if not container_id:
+            raise RuntimeError(
+                "No Harbor container found. Ensure the Harbor environment is running."
+            )
+
+        self._harbor_container_id = container_id
+
+        returncode, stdout, stderr = await asyncio.get_event_loop().run_in_executor(
+            None, self._sync_run_openclaw, ["openclaw", "--version"]
+        )
+        if returncode != 0:
+            raise RuntimeError(
+                "openclaw not available on host\n"
+                f"stdout={stdout}\nstderr={stderr}"
+            )
+
+        await self._validate_docker_container(container_id)
+        await self._setup_container_info(container_id)
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        execution = await self._run_agent_loop(instruction, environment)
+        self._populate_context(context, execution)
+
+        if execution["returncode"] != 0:
+            raise RuntimeError(
+                "OpenClaw execution failed\n"
+                f"returncode={execution['returncode']}\n"
+                f"stdout:\n{execution['stdout']}\n\n"
+                f"stderr:\n{execution['stderr']}"
+            )
+
+    # ==================================================================
+    # Core routing loop
+    # ==================================================================
+
+    async def _run_agent_loop(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+    ) -> dict[str, Any]:
+        container_id = self._harbor_container_id
+        profile_name = self._profile_name
+
+        profile_config_dir = os.path.expanduser(f"~/.openclaw-{profile_name}")
+        profile_config_path = os.path.join(profile_config_dir, "openclaw.json")
+
+        main_config_path = os.path.expanduser("~/.openclaw/openclaw.json")
+        main_config: dict[str, Any] = {}
+        if os.path.exists(main_config_path):
+            with open(main_config_path) as f:
+                main_config = json.load(f)
+
+        all_executions: list[dict[str, Any]] = []
+        final_result: dict[str, Any] | None = None
+
+        # Clean up old profile for a fresh start (stale models.json can
+        # contain unreachable providers like codex -> chatgpt.com).
+        if os.path.exists(profile_config_dir):
+            shutil.rmtree(profile_config_dir)
+        os.makedirs(profile_config_dir)
+        profile_agents_dir = os.path.join(
+            profile_config_dir, "agents", "main", "agent"
+        )
+        os.makedirs(profile_agents_dir)
+
+        agents_config = main_config.get("agents", {})
+        # Sandbox mode must be "off": we only need OpenClaw for LLM
+        # inference, not command execution (done via _env_exec in the
+        # Harbor container).  "all" would spawn a redundant sandbox.
+        defaults = agents_config.setdefault("defaults", {})
+        defaults["sandbox"] = {"mode": "off"}
+
+        # Update the agent's default model and visibility whitelist to
+        # match the model selected via ``-m``.  openclaw enforces a
+        # visibility policy: if ``agents.defaults.models`` is set, only
+        # keys listed there are accepted as ``--model`` overrides.
+        # Stale entries from a previous run (e.g. ``custom/...``) would
+        # cause ``Model override ... is not allowed for agent "main"``.
+        if self.model_name:
+            defaults.setdefault("model", {})["primary"] = self.model_name
+            allowed = defaults.setdefault("models", {})
+            allowed[self.model_name] = allowed.get(self.model_name, {})
+
+        # Filter out providers with empty apiKey to avoid API hangs.
+        raw_models = main_config.get("models", {})
+        if "providers" in raw_models:
+            filtered_providers = {}
+            for name, provider in raw_models["providers"].items():
+                if provider.get("apiKey"):
+                    filtered_providers[name] = provider
+                else:
+                    self.logger.info(
+                        "%s: skipping provider '%s' (empty apiKey)",
+                        _LOG_PREFIX, name,
+                    )
+            raw_models = {**raw_models, "providers": filtered_providers}
+
+        # Inject provider config from harbor --agent-env.
+        # Env var names follow the ``<PROVIDER>_BASE_URL`` / ``<PROVIDER>_API_KEY``
+        # convention (matching harbor's installed agent behavior), so both
+        # modes use identical env vars for the same model/provider pair.
+        provider_name = ""
+        model_id = "default"
+        if self.model_name and "/" in self.model_name:
+            provider_name, model_id = self.model_name.split("/", 1)
+        elif self.model_name:
+            model_id = self.model_name
+
+        extra = self._extra_env or {}
+        env_prefix = provider_name.upper().replace("-", "_")
+        base_url_env = f"{env_prefix}_BASE_URL"
+        api_key_env = f"{env_prefix}_API_KEY"
+
+        provider_base_url = (
+            extra.get(base_url_env) or os.environ.get(base_url_env)
+        )
+        provider_api_key = (
+            extra.get(api_key_env) or os.environ.get(api_key_env)
+        )
+        if provider_base_url and provider_name:
+            providers = raw_models.setdefault("providers", {})
+            prov = providers.get(provider_name, {})
+            prov["baseUrl"] = provider_base_url
+            if provider_api_key:
+                prov["apiKey"] = provider_api_key
+
+            # Declare the model explicitly.  Non-bundled providers
+            # (e.g. ``custom``) require this; bundled providers (e.g.
+            # ``openai``) tolerate it and benefit from the explicit
+            # ``api`` field for OpenAI-compatible endpoints.
+            existing_models = prov.get("models", [])
+            existing_ids = {
+                m.get("id") for m in existing_models
+                if isinstance(m, dict)
+            }
+            if model_id not in existing_ids:
+                existing_models.append({
+                    "id": model_id,
+                    "name": model_id,
+                    "api": "openai-completions",
+                })
+            prov["models"] = existing_models
+
+            providers[provider_name] = prov
+            self.logger.info(
+                "%s: injected provider '%s' (baseUrl=%s, model=%s)",
+                _LOG_PREFIX, provider_name, provider_base_url, model_id,
+            )
+
+        hybrid_config: dict[str, Any] = {
+            "models": raw_models,
+            "agents": agents_config,
+        }
+        with open(profile_config_path, "w") as f:
+            json.dump(hybrid_config, f, indent=2)
+
+        main_models_path = os.path.expanduser(
+            "~/.openclaw/agents/main/agent/models.json"
+        )
+        profile_models_path = os.path.join(profile_agents_dir, "models.json")
+        if os.path.exists(main_models_path):
+            with open(main_models_path) as f:
+                models_data = json.load(f)
+            # Filter unreachable providers from models.json as well.
+            if "providers" in models_data:
+                models_data["providers"] = {
+                    k: v
+                    for k, v in models_data["providers"].items()
+                    if v.get("apiKey") and v.get("apiKey") != "codex-app-server"
+                }
+            with open(profile_models_path, "w") as f:
+                json.dump(models_data, f, indent=2)
+
+        agent_id = os.environ.get("OPENCLAW_AGENT_ID", "main")
+        timeout = os.environ.get("OPENCLAW_TIMEOUT", "600")
+        thinking = os.environ.get("OPENCLAW_THINKING", "off")
+        max_iterations = int(os.environ.get("OPENCLAW_MAX_ITERATIONS", "0"))
+
+        current_instruction = self._build_initial_instruction(instruction, container_id)
+        iteration = 0
+        oc_session_id: str | None = None
+
+        while not max_iterations or iteration < max_iterations:
+            iteration += 1
+
+            cmd = [
+                "openclaw", "--profile", self._profile_name,
+                "agent", "--local", "--json",
+                "--agent", agent_id,
+                "--timeout", timeout,
+                "--thinking", thinking,
+            ]
+            # Pass the model from harbor's -m flag to OpenClaw.
+            if self.model_name:
+                cmd.extend(["--model", self.model_name])
+
+            # Resume existing session for context continuity.
+            if oc_session_id:
+                cmd.extend(["--session-id", oc_session_id])
+
+            cmd.extend(["--message", current_instruction])
+
+            self.logger.info(
+                "%s: iteration %d | prompt=%d chars | session=%s",
+                _LOG_PREFIX, iteration, len(current_instruction),
+                "new" if not oc_session_id else oc_session_id[:8],
+            )
+
+            # Run OpenClaw via subprocess in thread pool (avoids asyncio pipe
+            # issues).
+            loop = asyncio.get_event_loop()
+            returncode, stdout_text, stderr_text = await loop.run_in_executor(
+                None, partial(self._sync_run_openclaw, cmd, self._extra_env)
+            )
+
+            parsed = self._try_parse_json(stderr_text) or self._try_parse_json(stdout_text)
+            parsed_label = "dict" if isinstance(parsed, dict) else type(parsed).__name__
+            self.logger.info(
+                "%s: iteration %d | returncode=%d | parsed=%s",
+                _LOG_PREFIX, iteration, returncode, parsed_label,
+            )
+
+            # Extract session_id from first call for context continuity.
+            if not oc_session_id and isinstance(parsed, dict):
+                agent_meta = (parsed.get("meta") or {}).get("agentMeta") or {}
+                oc_session_id = agent_meta.get("sessionId")
+                if oc_session_id:
+                    self.logger.info(
+                        "%s: session established (%s...)",
+                        _LOG_PREFIX, oc_session_id[:12],
+                    )
+
+            if not parsed:
+                self.logger.debug(
+                    "%s: stdout(first %d): %s",
+                    _LOG_PREFIX, self._DEBUG_OUTPUT_CHARS,
+                    stdout_text[:self._DEBUG_OUTPUT_CHARS],
+                )
+                self.logger.debug(
+                    "%s: stderr(first %d): %s",
+                    _LOG_PREFIX, self._DEBUG_OUTPUT_CHARS,
+                    stderr_text[:self._DEBUG_OUTPUT_CHARS],
+                )
+
+            if returncode != 0:
+                # API hang guard: retry once with the same session.
+                is_api_hang = (
+                    "no stdout for" in stderr_text
+                    and "likely API hang" in stderr_text
+                )
+                if is_api_hang:
+                    self.logger.warning(
+                        "%s: iteration %d | API hang detected, retrying",
+                        _LOG_PREFIX, iteration,
+                    )
+                    returncode, stdout_text, stderr_text = await loop.run_in_executor(
+                        None, partial(self._sync_run_openclaw, cmd, self._extra_env)
+                    )
+                    parsed = self._try_parse_json(stderr_text) or self._try_parse_json(stdout_text)
+
+                if returncode != 0:
+                    final_result = self._build_result(
+                        returncode, stdout_text, stderr_text,
+                        parsed, container_id, iteration, all_executions,
+                    )
+                    break
+
+            # Extract commands from parsed response.
+            commands = self._extract_commands(parsed)
+            extracted_text = self._extract_final_text(parsed) or ""
+            tool_cmds = self._extract_toolcall_commands(parsed) if parsed else []
+            bash_cmds = (
+                self._extract_commands_from_text(extracted_text)
+                if extracted_text else []
+            )
+            self.logger.info(
+                "%s: iteration %d | commands=%d text=%d [toolCall=%d bash=%d]",
+                _LOG_PREFIX, iteration, len(commands), len(extracted_text),
+                len(tool_cmds), len(bash_cmds),
+            )
+            if extracted_text and not commands:
+                self.logger.debug(
+                    "%s: text(first %d): %s",
+                    _LOG_PREFIX, self._DEBUG_TEXT_CHARS,
+                    extracted_text[:self._DEBUG_TEXT_CHARS],
+                )
+
+            if commands:
+                cmd_outputs: list[str] = []
+                for i, cmd_str in enumerate(commands):
+                    self.logger.info(
+                        "%s: exec[%d] %s", _LOG_PREFIX, i, cmd_str[:200],
+                    )
+                    result = await self._env_exec(environment, cmd_str)
+                    result_code = self._result_exit_code(result)
+                    result_stdout = self._result_stdout(result)
+                    result_stderr = self._result_stderr(result)
+                    self.logger.info(
+                        "%s: exec[%d] exit=%d stdout=%s",
+                        _LOG_PREFIX, i, result_code, result_stdout[:300],
+                    )
+
+                    all_executions.append({
+                        "command": cmd_str,
+                        "returncode": result_code,
+                        "stdout": result_stdout[:self._MAX_EXEC_STDOUT_CHARS],
+                        "stderr": result_stderr[:self._MAX_EXEC_STDERR_CHARS],
+                    })
+                    cmd_outputs.append(
+                        f"Command: {cmd_str}\n"
+                        f"Exit code: {result_code}\n"
+                        f"Output:\n{result_stdout[:self._MAX_CMD_OUTPUT_CHARS]}\n"
+                        f"Errors:\n{result_stderr[:self._MAX_ERROR_OUTPUT_CHARS]}"
+                    )
+
+                current_instruction = self._build_followup_instruction(
+                    cmd_outputs, instruction,
+                )
+                continue
+
+            # No commands extracted – check if task is complete.
+            oc_text = self._extract_final_text(parsed) or ""
+            if "TASK_COMPLETE" in oc_text.upper() and all_executions:
+                self.logger.info(
+                    "%s: iteration %d | TASK_COMPLETE received",
+                    _LOG_PREFIX, iteration,
+                )
+                final_result = self._build_result(
+                    0, stdout_text, stderr_text,
+                    parsed, container_id, iteration, all_executions,
+                )
+                break
+            elif "TASK_COMPLETE" in oc_text.upper() and not all_executions:
+                self.logger.warning(
+                    "%s: iteration %d | TASK_COMPLETE but NO commands yet, "
+                    "re-prompting", _LOG_PREFIX, iteration,
+                )
+                current_instruction = (
+                    "You said TASK_COMPLETE but you have NOT executed any "
+                    "commands yet. You MUST execute bash commands first "
+                    "before claiming completion. Output bash commands in "
+                    "```bash``` code blocks to actually perform the task."
+                )
+                continue
+
+            # No commands and not complete – prompt OpenClaw again.
+            self.logger.warning(
+                "%s: iteration %d | no commands found, re-prompting",
+                _LOG_PREFIX, iteration,
+            )
+            current_instruction = (
+                "Your previous response did not contain bash commands in "
+                "```bash``` code blocks. You MUST output bash commands to "
+                "be executed in the container. Do NOT just analyze – "
+                "directly provide the commands. Output bash commands, or "
+                "say TASK_COMPLETE if the task is truly finished."
+            )
+
+        if not final_result:
+            final_result = {
+                "mode": "hybrid-docker",
+                "returncode": 1,
+                "stdout": "",
+                "stderr": "Max iterations reached",
+                "parsed_json": None,
+                "container_id": container_id,
+                "iterations": iteration,
+                "harbor_executions": all_executions,
+            }
+
+        # Collect per-round token usage from OpenClaw session JSONL.
+        session_token_report = self._collect_session_tokens(profile_config_dir)
+        if session_token_report:
+            final_result["session_tokens"] = session_token_report
+
+        # Record profile directory for traceability.
+        final_result["openclaw_profile_dir"] = profile_config_dir
+
+        return final_result
+
+    # ==================================================================
+    # Session token collection
+    # ==================================================================
+
+    def _collect_session_tokens(self, profile_dir: str) -> dict[str, Any] | None:
+        """Read OpenClaw session JSONL and extract per-round token usage."""
+        sessions_dir = os.path.join(profile_dir, "agents", "main", "sessions")
+        jsonl_files = sorted(glob.glob(os.path.join(sessions_dir, "*.jsonl")))
+        if not jsonl_files:
+            return None
+
+        # Use the most recent session file (by mtime).
+        jsonl_path = max(jsonl_files, key=os.path.getmtime)
+
+        rounds: list[dict[str, Any]] = []
+        total_input = 0
+        total_output = 0
+        prev_input = 0
+
+        try:
+            with open(jsonl_path) as f:
+                for line in f:
+                    try:
+                        d = json.loads(line.strip())
+                        if d.get("type") != "message":
+                            continue
+                        usage = (d.get("message") or {}).get("usage") or {}
+                        if usage.get("totalTokens", 0) <= 0:
+                            continue
+                        inp: int = usage.get("input", 0)
+                        out: int = usage.get("output", 0)
+                        delta = inp - prev_input
+                        total_input += inp
+                        total_output += out
+                        prev_input = inp
+                        rounds.append({
+                            "round": len(rounds) + 1,
+                            "input": inp,
+                            "input_delta": delta,
+                            "output": out,
+                            "total": inp + out,
+                            "cumulative": total_input + total_output,
+                        })
+                    except (json.JSONDecodeError, KeyError, TypeError):
+                        continue
+        except Exception:
+            self.logger.warning(
+                "%s: failed to read session tokens from %s",
+                _LOG_PREFIX, jsonl_path, exc_info=True,
+            )
+            return None
+
+        if not rounds:
+            return None
+
+        return {
+            "session_file": os.path.basename(jsonl_path),
+            "num_rounds": len(rounds),
+            "total_input": total_input,
+            "total_output": total_output,
+            "total_tokens": total_input + total_output,
+            "final_input": rounds[-1]["input"],
+            "avg_input_delta": (
+                (rounds[-1]["input"] - rounds[0]["input"])
+                // max(len(rounds) - 1, 1)
+            ),
+            "rounds": rounds,
+        }
+
+    # ==================================================================
+    # Instruction builders
+    # ==================================================================
+
+    def _build_initial_instruction(self, instruction: str, container_id: str) -> str:
+        parts = [f"Task: {instruction}\n\n"]
+
+        if self._skill_hint:
+            parts.append(
+                f"Suggested approach for this task:\n{self._skill_hint}\n\n"
+            )
+
+        parts.append(
+            f"Container: {container_id} | "
+            f"Image: {self._harbor_image} | "
+            f"Workdir: {self._harbor_workdir or '/app'}\n\n"
+            "CRITICAL: Do NOT use the exec tool or any other tool to run "
+            "commands. The exec tool runs on the HOST machine, NOT in the "
+            "container. You MUST output bash commands ONLY in ```bash``` "
+            "code blocks. Another process will execute them inside the "
+            "Docker container via docker exec.\n\n"
+            "RULES: Keep reasoning under 2 sentences. Use absolute paths, "
+            "NOT `cd && command`. Each bash block = one simple command. "
+            "Say TASK_COMPLETE when done."
+        )
+        return "".join(parts)
+
+    def _build_followup_instruction(
+        self, cmd_outputs: list[str], original_task: str,
+    ) -> str:
+        return (
+            f"Results of your commands:\n\n{chr(10).join(cmd_outputs)}\n\n"
+            "Continue with more bash commands in ```bash``` code blocks, "
+            "or say TASK_COMPLETE if done."
+        )
+
+    # ==================================================================
+    # Skill hint loading (per-task hints for the agent)
+    # ==================================================================
+
+    def _load_skill_hint(self) -> str:
+        """Load per-task skill hint.
+
+        Priority:
+        1. ``dataset/<task_name>/skill.md`` (manual override, if exists).
+        2. Auto-generate from ``dataset/<task_name>/solution/solve.sh``
+           (disabled by default; set ``SKILL_FROM_SOLUTION=1`` to enable).
+        """
+        if not self._task_name:
+            return ""
+
+        dataset_dir = os.environ.get("DATASET_DIR", self._DEFAULT_DATASET_DIR)
+        task_dir = os.path.join(dataset_dir, self._task_name)
+
+        # 1. Try manual skill.md first.
+        skill_path = os.path.join(task_dir, "skill.md")
+        if os.path.isfile(skill_path):
+            try:
+                with open(skill_path) as f:
+                    content = f.read().strip()
+                if content:
+                    if len(content) > self._MAX_SKILL_HINT_CHARS:
+                        content = (
+                            content[:self._MAX_SKILL_HINT_CHARS]
+                            + "\n... (truncated, see full skill.md)"
+                        )
+                    self.logger.info(
+                        "%s: loaded skill hint from %s (%d chars)",
+                        _LOG_PREFIX, skill_path, len(content),
+                    )
+                    return content
+            except OSError:
+                pass
+
+        # 2. Auto-generate from solution/solve.sh (opt-in via SKILL_FROM_SOLUTION=1).
+        if os.environ.get("SKILL_FROM_SOLUTION", "0") != "1":
+            return ""
+
+        solve_path = os.path.join(task_dir, "solution", "solve.sh")
+        if os.path.isfile(solve_path):
+            try:
+                content = self._auto_skill_from_solve(solve_path)
+                if content:
+                    self.logger.info(
+                        "%s: auto-generated skill from %s (%d chars)",
+                        _LOG_PREFIX, solve_path, len(content),
+                    )
+                    return content
+            except Exception:
+                self.logger.warning(
+                    "%s: failed to auto-generate skill from %s",
+                    _LOG_PREFIX, solve_path, exc_info=True,
+                )
+
+        return ""
+
+    @staticmethod
+    def _auto_skill_from_solve(solve_path: str) -> str:
+        """Auto-generate a skill hint from a solve.sh file."""
+        with open(solve_path) as f:
+            raw = f.read()
+
+        lines = raw.split("\n")
+        steps: list[str] = []
+        i = 0
+        while i < len(lines):
+            line = lines[i].strip()
+
+            # Skip empty lines, comments, shebang, canary.
+            # ("#!" is already covered by startswith("#").)
+            if not line or line.startswith("#"):
+                i += 1
+                continue
+            if "BENCHMARK DATA" in line or "canary" in line.lower():
+                i += 1
+                continue
+
+            # Detect heredoc: "<cmd> <<'MARKER' > <file>"
+            # \S+ matches any command (cat, tee, etc.) — single pattern suffices.
+            m = re.match(r"(\S+)\s*<<\s*'(\w+)'\s*>\s*(\S+)", line)
+            marker: str | None = None
+            target_file: str | None = None
+            if m:
+                marker = m.group(2)
+                target_file = m.group(3)
+
+            if marker and target_file:
+                block = [f"Write {target_file} with heredoc:"]
+                i += 1
+                body_lines: list[str] = []
+                while i < len(lines):
+                    if lines[i].strip() == marker:
+                        i += 1
+                        break
+                    body_lines.append(lines[i])
+                    i += 1
+                body = "\n".join(body_lines)
+                if len(body) > OpenClawExternalAgent._MAX_HEREDOC_BODY_CHARS:
+                    body = (
+                        body[:OpenClawExternalAgent._MAX_HEREDOC_BODY_CHARS]
+                        + "\n... (truncated)"
+                    )
+                block.append(body)
+                steps.append("\n".join(block))
+                continue
+
+            # Regular command line – strip trailing comments.
+            if " #" in line and not line.startswith("#"):
+                line = line[:line.index(" #")].strip()
+            if line:
+                steps.append(line)
+            i += 1
+
+        if not steps:
+            return ""
+
+        # Build skill text.
+        task_name = os.path.basename(os.path.dirname(os.path.dirname(solve_path)))
+        parts = [f"# {task_name}\n\n## Approach\n"]
+        for idx, step in enumerate(steps, 1):
+            if "\n" in step:
+                # Multi-line step (heredoc).
+                parts.append(f"{idx}. {step}\n")
+            else:
+                if len(step) > OpenClawExternalAgent._MAX_STEP_CHARS:
+                    step = step[:OpenClawExternalAgent._MAX_STEP_CHARS] + "..."
+                parts.append(f"{idx}. `{step}`\n")
+
+        parts.append(OpenClawExternalAgent._SKILL_COMMAND_RULES)
+
+        content = "".join(parts)
+        if len(content) > OpenClawExternalAgent._MAX_SKILL_HINT_CHARS:
+            content = (
+                content[:OpenClawExternalAgent._MAX_SKILL_HINT_CHARS]
+                + "\n... (truncated)"
+            )
+        return content
+
+    # ==================================================================
+    # OpenClaw subprocess runner
+    # ==================================================================
+
+    @staticmethod
+    def _sync_run_openclaw(
+        cmd: list[str], extra_env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        """Run OpenClaw with real-time output streaming and safety guards.
+
+        Uses ``Popen`` + ``select`` to read output progressively, reporting
+        heartbeat status so long-running calls remain visible.  Three safety
+        guards prevent runaway processes:
+
+        * **Total timeout** – kills after ``_OPENCLAW_TIMEOUT_SEC``.
+        * **No-output timeout** – kills after ``_OPENCLAW_NO_OUTPUT_SEC``
+          with zero stdout (API hang detection).
+        * **Stdout cap** – kills when stdout exceeds
+          ``OPENCLAW_MAX_STDOUT_BYTES`` (infinite-generation loop).
+        """
+        cls = OpenClawExternalAgent
+        max_stdout_bytes = int(
+            os.environ.get("OPENCLAW_MAX_STDOUT_BYTES", str(cls._DEFAULT_MAX_STDOUT_BYTES))
+        )
+        # The total-timeout guard follows the configured OPENCLAW_TIMEOUT so
+        # that raising the per-call timeout also extends the hard kill guard.
+        # _OPENCLAW_TIMEOUT_SEC acts as a floor so the guard is never lower
+        # than the compiled-in default.
+        configured_timeout = int(
+            os.environ.get("OPENCLAW_TIMEOUT", str(cls._OPENCLAW_TIMEOUT_SEC))
+        )
+        total_timeout_sec = max(configured_timeout, cls._OPENCLAW_TIMEOUT_SEC)
+        no_output_timeout_sec = int(
+            os.environ.get("OPENCLAW_NO_OUTPUT_TIMEOUT", str(cls._OPENCLAW_NO_OUTPUT_SEC))
+        )
+
+        try:
+            run_env = {**os.environ, **(extra_env or {})}
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=run_env,
+            )
+        except Exception as e:
+            return 1, "", str(e)
+
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+        last_log_time = time.monotonic()
+        last_output_time = time.monotonic()
+        total_stdout_bytes = 0
+        total_stderr_bytes = 0
+
+        try:
+            start = time.monotonic()
+            while True:
+                elapsed = time.monotonic() - start
+
+                # Guard 1: total timeout.
+                if elapsed >= total_timeout_sec:
+                    proc.kill()
+                    _log.warning(
+                        "%s: subprocess timeout after %ds (limit %ds), killing process",
+                        _LOG_PREFIX, int(elapsed), total_timeout_sec,
+                    )
+                    break
+
+                # Guard 2: stdout cap (infinite generation).
+                if total_stdout_bytes > max_stdout_bytes:
+                    proc.kill()
+                    _log.warning(
+                        "%s: stdout exceeded %dB after %ds, "
+                        "killing process (likely infinite generation)",
+                        _LOG_PREFIX, max_stdout_bytes, int(elapsed),
+                    )
+                    break
+
+                # Guard 3: no-output timeout (API hang).
+                if (
+                    total_stdout_bytes == 0
+                    and (time.monotonic() - last_output_time)
+                    >= no_output_timeout_sec
+                ):
+                    proc.kill()
+                    _log.warning(
+                        "%s: no stdout for %ds after %ds elapsed, "
+                        "killing process (likely API hang)",
+                        _LOG_PREFIX, no_output_timeout_sec, int(elapsed),
+                    )
+                    break
+
+                ready, _, _ = select.select(
+                    [proc.stdout, proc.stderr], [], [], 0.5,
+                )
+                if proc.stdout in ready:
+                    chunk = (
+                        proc.stdout.read1(8192)
+                        if hasattr(proc.stdout, "read1")
+                        else proc.stdout.read(8192)
+                    )
+                    if chunk:
+                        stdout_chunks.append(chunk)
+                        total_stdout_bytes += len(chunk)
+                        last_output_time = time.monotonic()
+                if proc.stderr in ready:
+                    chunk = (
+                        proc.stderr.read1(8192)
+                        if hasattr(proc.stderr, "read1")
+                        else proc.stderr.read(8192)
+                    )
+                    if chunk:
+                        stderr_chunks.append(chunk)
+                        total_stderr_bytes += len(chunk)
+
+                if proc.poll() is not None:
+                    # Drain remaining output.
+                    for _ in range(10):
+                        chunk = proc.stdout.read(65536) if proc.stdout else None
+                        if chunk:
+                            stdout_chunks.append(chunk)
+                            total_stdout_bytes += len(chunk)
+                        else:
+                            break
+                    for _ in range(10):
+                        chunk = proc.stderr.read(65536) if proc.stderr else None
+                        if chunk:
+                            stderr_chunks.append(chunk)
+                            total_stderr_bytes += len(chunk)
+                        else:
+                            break
+                    break
+
+                now = time.monotonic()
+                if now - last_log_time >= cls._HEARTBEAT_INTERVAL_SEC:
+                    _log.debug(
+                        "%s: heartbeat: %ds elapsed, stdout=%dB, stderr=%dB",
+                        _LOG_PREFIX, int(elapsed),
+                        total_stdout_bytes, total_stderr_bytes,
+                    )
+                    last_log_time = now
+
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            _log.warning(
+                "%s: process killed after wait timeout", _LOG_PREFIX,
+            )
+        except Exception:
+            _log.warning(
+                "%s: error during streaming", _LOG_PREFIX, exc_info=True,
+            )
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+        returncode = proc.returncode if proc.returncode is not None else -1
+        stdout_text = b"".join(stdout_chunks).decode("utf-8", errors="replace")
+        stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+        return returncode, stdout_text, stderr_text
+
+    # ==================================================================
+    # Result builder
+    # ==================================================================
+
+    def _build_result(
+        self,
+        returncode: int,
+        stdout: str,
+        stderr: str,
+        parsed: dict[str, Any] | None,
+        container_id: str,
+        iteration: int,
+        executions: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return {
+            "mode": "hybrid-docker",
+            "returncode": returncode,
+            "stdout": stdout,
+            "stderr": stderr,
+            "parsed_json": parsed,
+            "container_id": container_id,
+            "harbor_image": self._harbor_image,
+            "iterations": iteration,
+            "harbor_executions": executions,
+        }
+
+    # ==================================================================
+    # Container detection and setup
+    # ==================================================================
+
+    async def _detect_harbor_container(
+        self, environment: BaseEnvironment,
+    ) -> str | None:
+        """Discover the Harbor Docker container.
+
+        Tries two strategies:
+
+        1. Filter by ``session_id`` (preferred).
+        2. Fallback: scan ``docker ps`` for names containing ``"__"`` and
+           ``"-main-"``.  **Note**: this heuristic depends on Harbor's
+           internal container naming convention and may break if that
+           convention changes.
+        """
+        try:
+            if hasattr(environment, "session_id"):
+                proc = await asyncio.create_subprocess_exec(
+                    "docker", "ps", "-q",
+                    "--filter", f"name={environment.session_id}",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, _ = await proc.communicate()
+                if stdout.decode().strip():
+                    return stdout.decode().strip().split("\n")[0]
+
+            # Fallback: heuristic container name matching, verified via inspect.
+            proc = await asyncio.create_subprocess_exec(
+                "docker", "ps", "--format", "{{.ID}} {{.Names}}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            for line in stdout.decode().strip().split("\n"):
+                if "__" in line and "-main-" in line:
+                    candidate_id = line.split()[0]
+                    # Verify the candidate actually exists.
+                    chk = await asyncio.create_subprocess_exec(
+                        "docker", "inspect", candidate_id,
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await chk.communicate()
+                    if chk.returncode == 0:
+                        return candidate_id
+        except Exception:
+            _log.warning(
+                "%s: failed to detect Harbor container",
+                _LOG_PREFIX, exc_info=True,
+            )
+        return None
+
+    async def _validate_docker_container(self, container_id: str) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "inspect", container_id,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Cannot access Docker container {container_id}\n"
+                f"stderr={stderr.decode(errors='replace')}"
+            )
+
+    async def _setup_container_info(self, container_id: str) -> None:
+        # Image name.
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "inspect", "--format",
+            "{{.Config.Image}}", container_id,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        self._harbor_image = (
+            stdout.decode().strip() if proc.returncode == 0 else None
+        )
+
+        # Working directory.
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "inspect", "--format",
+            "{{.Config.WorkingDir}}", container_id,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        self._harbor_workdir = (
+            stdout.decode().strip() if proc.returncode == 0 else "/app"
+        )
+        if not self._harbor_workdir:
+            self._harbor_workdir = "/app"
+
+        self._harbor_container_id = container_id
+
+    # ==================================================================
+    # Command execution in container
+    # ==================================================================
+
+    async def _env_exec(
+        self, environment: BaseEnvironment, command: str,
+    ) -> Any:
+        """Execute *command* inside the Docker container with a safety timeout.
+
+        Uses ``asyncio.wait_for`` to prevent infinite hangs.  Timeout is
+        configurable via ``DOCKER_EXEC_TIMEOUT`` env var (default 600 s).
+        """
+        timeout = int(
+            os.environ.get("DOCKER_EXEC_TIMEOUT", str(self._DEFAULT_DOCKER_EXEC_TIMEOUT))
+        )
+        start = time.monotonic()
+
+        try:
+            result = await asyncio.wait_for(
+                environment.exec(command),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            self.logger.warning(
+                "%s: docker exec stuck for %ds, returning timeout result: %s",
+                _LOG_PREFIX, timeout, command[:100],
+            )
+            return self._make_timeout_result(command, timeout)
+
+        elapsed = time.monotonic() - start
+        if elapsed > self._SLOW_EXEC_THRESHOLD_SEC:
+            self.logger.info(
+                "%s: slow docker exec (%ds): %s",
+                _LOG_PREFIX, int(elapsed), command[:100],
+            )
+        return result
+
+    @staticmethod
+    def _make_timeout_result(command: str, timeout: int) -> Any:
+        """Return a synthetic result object for timed-out commands."""
+
+        class _TimeoutResult:
+            exit_code: int = -1
+            stdout: str = f"ERROR: command timed out after {timeout}s"
+            stderr: str = ""
+            returncode: int = -1
+
+        return _TimeoutResult()
+
+    @staticmethod
+    def _result_stdout(result: Any) -> str:
+        raw = getattr(result, "stdout", "") or ""
+        # Strip null bytes – they cause ValueError in subprocess.Popen and
+        # are meaningless in text output from container commands.
+        return raw.replace("\x00", "")
+
+    @staticmethod
+    def _result_stderr(result: Any) -> str:
+        raw = getattr(result, "stderr", "") or ""
+        return raw.replace("\x00", "")
+
+    @staticmethod
+    def _result_exit_code(result: Any) -> int:
+        if hasattr(result, "exit_code"):
+            return int(getattr(result, "exit_code"))
+        if hasattr(result, "returncode"):
+            return int(getattr(result, "returncode"))
+        return 0
+
+    # ==================================================================
+    # OpenClaw output parsing
+    # ==================================================================
+
+    def _extract_commands(self, parsed: dict[str, Any] | None) -> list[str]:
+        if not parsed:
+            return []
+        # Prefer toolCall commands; fall back to ```bash``` blocks in text.
+        tool_commands = self._extract_toolcall_commands(parsed)
+        if tool_commands:
+            return tool_commands
+        text = self._extract_final_text(parsed) or ""
+        return self._extract_commands_from_text(text)
+
+    @staticmethod
+    def _extract_toolcall_commands(parsed: dict[str, Any]) -> list[str]:
+        """Extract exec commands from OpenClaw toolCall responses."""
+        commands: list[str] = []
+
+        # Check payloads for toolCall entries.
+        payloads = parsed.get("payloads") or []
+        for item in payloads:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content", [])
+            if isinstance(content, list):
+                for c in content:
+                    if (
+                        isinstance(c, dict)
+                        and c.get("type") == "toolCall"
+                        and c.get("name") == "exec"
+                    ):
+                        args = c.get("arguments", {})
+                        if isinstance(args, dict) and args.get("command"):
+                            commands.append(args["command"])
+
+        # Also check meta-level toolCalls.
+        meta = parsed.get("meta") or {}
+        for key in ("toolCalls", "tool_calls"):
+            calls = meta.get(key, [])
+            if isinstance(calls, list):
+                for call in calls:
+                    if (
+                        isinstance(call, dict)
+                        and call.get("name") == "exec"
+                    ):
+                        args = call.get("arguments", {})
+                        if isinstance(args, dict) and args.get("command"):
+                            commands.append(args["command"])
+        return commands
+
+    @staticmethod
+    def _extract_commands_from_text(text: str) -> list[str]:
+        blocks = re.findall(
+            r"```(?:bash|sh|shell)\s*\n(.*?)\n```", text, re.DOTALL,
+        )
+        return [b.strip() for b in blocks if b.strip()]
+
+    @staticmethod
+    def _try_parse_json(text: str) -> dict[str, Any] | None:
+        """Attempt to parse *text* as JSON, with ANSI-stripping and
+        substring fallback."""
+        cleaned = OpenClawExternalAgent._strip_ansi(text).strip()
+        if not cleaned:
+            return None
+
+        # Direct parse.
+        try:
+            parsed = json.loads(cleaned, strict=False)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+
+        # Substring fallback: find outermost {...}.
+        start, end = cleaned.find("{"), cleaned.rfind("}")
+        if start != -1 and end > start:
+            try:
+                parsed = json.loads(cleaned[start:end + 1], strict=False)
+                if isinstance(parsed, dict):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+        return None
+
+    @staticmethod
+    def _extract_final_text(data: dict[str, Any]) -> str | None:
+        """Extract the final visible/raw text from OpenClaw response dict."""
+        if not data:
+            return None
+
+        meta = data.get("meta") or {}
+        for key in ("finalAssistantVisibleText", "finalAssistantRawText"):
+            value = meta.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        payloads = data.get("payloads")
+        if isinstance(payloads, list):
+            texts = []
+            for item in payloads:
+                if isinstance(item, dict):
+                    text = item.get("text")
+                    if isinstance(text, str) and text.strip():
+                        texts.append(text.strip())
+            if texts:
+                return "\n".join(texts)
+        return None
+
+    @staticmethod
+    def _strip_ansi(text: str) -> str:
+        return re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", text)
+
+    # ==================================================================
+    # Context population
+    # ==================================================================
+
+    def _populate_context(
+        self, context: AgentContext, execution: dict[str, Any],
+    ) -> None:
+        metadata: dict[str, Any] = {
+            "openclaw_execution_mode": execution.get("mode"),
+            "harbor_executions": execution.get("harbor_executions", []),
+            "iterations": execution.get("iterations", 0),
+            "openclaw_profile_dir": execution.get("openclaw_profile_dir"),
+            "stdout": execution.get("stdout", ""),
+            "stderr": execution.get("stderr", ""),
+            "exit_code": execution.get("returncode"),
+        }
+
+        # Include per-round token usage from session JSONL.
+        session_tokens = execution.get("session_tokens")
+        if session_tokens:
+            metadata["session_tokens"] = session_tokens
+
+        parsed = execution.get("parsed_json")
+        if isinstance(parsed, dict):
+            meta = parsed.get("meta") or {}
+            agent_meta = meta.get("agentMeta") or {}
+            prompt_report = meta.get("systemPromptReport") or {}
+
+            metadata["openclaw"] = {
+                "provider": agent_meta.get("provider"),
+                "model": agent_meta.get("model"),
+                "session_id": agent_meta.get("sessionId"),
+                "stop_reason": meta.get("stopReason"),
+                "workspace_dir": prompt_report.get("workspaceDir"),
+            }
+
+            final_message = self._extract_final_text(parsed)
+            if final_message:
+                metadata["final_message"] = final_message
+
+        self._safe_setattr(context, "metadata", metadata)
+
+    @staticmethod
+    def _safe_setattr(obj: Any, name: str, value: Any) -> None:
+        """Set attribute *name* on *obj*, logging a warning on failure."""
+        try:
+            setattr(obj, name, value)
+        except Exception:
+            _log.warning(
+                "%s: failed to set %s on context object",
+                _LOG_PREFIX, name, exc_info=True,
+            )

--- a/src/benchmark/terminal-runner/external_agent/openclaw_external_agent.py
+++ b/src/benchmark/terminal-runner/external_agent/openclaw_external_agent.py
@@ -28,9 +28,9 @@ Architecture:
 
 This is *not* an installed agent (``BaseInstalledAgent``).  It extends
 ``BaseAgent`` directly and is loaded at runtime via Harbor's
-``--agent`` mechanism:
+``--agent-import-path`` mechanism:
 
-    harbor run --agent external_agent.openclaw_external_agent:OpenClawExternalAgent \
+    harbor run --agent-import-path external_agent.openclaw_external_agent:OpenClawExternalAgent \
                -p dataset/my-task -m openai/my-model ...
 
 Environment variables
@@ -259,6 +259,7 @@ class OpenClawExternalAgent(BaseAgent):
     ) -> dict[str, Any]:
         container_id = self._harbor_container_id
         profile_name = self._profile_name
+        agent_id = os.environ.get("OPENCLAW_AGENT_ID", "main")
 
         profile_config_dir = os.path.expanduser(f"~/.openclaw-{profile_name}")
         profile_config_path = os.path.join(profile_config_dir, "openclaw.json")
@@ -278,7 +279,7 @@ class OpenClawExternalAgent(BaseAgent):
             shutil.rmtree(profile_config_dir)
         os.makedirs(profile_config_dir)
         profile_agents_dir = os.path.join(
-            profile_config_dir, "agents", "main", "agent"
+            profile_config_dir, "agents", agent_id, "agent"
         )
         os.makedirs(profile_agents_dir)
 
@@ -390,7 +391,6 @@ class OpenClawExternalAgent(BaseAgent):
             with open(profile_models_path, "w") as f:
                 json.dump(models_data, f, indent=2)
 
-        agent_id = os.environ.get("OPENCLAW_AGENT_ID", "main")
         timeout = os.environ.get("OPENCLAW_TIMEOUT", "600")
         thinking = os.environ.get("OPENCLAW_THINKING", "off")
         max_iterations = int(os.environ.get("OPENCLAW_MAX_ITERATIONS", "0"))
@@ -588,7 +588,7 @@ class OpenClawExternalAgent(BaseAgent):
             }
 
         # Collect per-round token usage from OpenClaw session JSONL.
-        session_token_report = self._collect_session_tokens(profile_config_dir)
+        session_token_report = self._collect_session_tokens(profile_config_dir, agent_id)
         if session_token_report:
             final_result["session_tokens"] = session_token_report
 
@@ -601,9 +601,9 @@ class OpenClawExternalAgent(BaseAgent):
     # Session token collection
     # ==================================================================
 
-    def _collect_session_tokens(self, profile_dir: str) -> dict[str, Any] | None:
+    def _collect_session_tokens(self, profile_dir: str, agent_id: str) -> dict[str, Any] | None:
         """Read OpenClaw session JSONL and extract per-round token usage."""
-        sessions_dir = os.path.join(profile_dir, "agents", "main", "sessions")
+        sessions_dir = os.path.join(profile_dir, "agents", agent_id, "sessions")
         jsonl_files = sorted(glob.glob(os.path.join(sessions_dir, "*.jsonl")))
         if not jsonl_files:
             return None

--- a/src/benchmark/terminal-runner/external_agent/openclaw_external_agent.py
+++ b/src/benchmark/terminal-runner/external_agent/openclaw_external_agent.py
@@ -375,7 +375,7 @@ class OpenClawExternalAgent(BaseAgent):
             json.dump(hybrid_config, f, indent=2)
 
         main_models_path = os.path.expanduser(
-            "~/.openclaw/agents/main/agent/models.json"
+            f"~/.openclaw/agents/{agent_id}/agent/models.json"
         )
         profile_models_path = os.path.join(profile_agents_dir, "models.json")
         if os.path.exists(main_models_path):

--- a/src/benchmark/terminal-runner/scripts/setup.sh
+++ b/src/benchmark/terminal-runner/scripts/setup.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Copyright 2026 Alibaba Cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------------------------------------------------------------------
+# terminal-runner setup — clone harbor + dataset, install harbor in venv.
+#
+# Environment variables (all optional):
+#   HARBOR_URL     Harbor upstream Git URL
+#                  (default: https://github.com/harbor-framework/harbor.git)
+#   HARBOR_REF     Harbor branch/tag (default: main)
+#   DATASET_URL    Dataset Git URL
+#                  (default: https://huggingface.co/datasets/harborframework/terminal-bench-2.0)
+#   DATASET_REF    Dataset branch/tag (default: main)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+VENV_DIR="$ROOT_DIR/.venv"
+
+HARBOR_URL="${HARBOR_URL:-https://github.com/harbor-framework/harbor.git}"
+HARBOR_REF="${HARBOR_REF:-v0.15.0}"
+DATASET_URL="${DATASET_URL:-https://huggingface.co/datasets/harborframework/terminal-bench-2.0}"
+DATASET_REF="${DATASET_REF:-main}"
+
+echo "==> terminal-runner setup"
+echo "    Harbor:   $HARBOR_URL  ($HARBOR_REF)"
+echo "    Dataset:  $DATASET_URL  ($DATASET_REF)"
+
+# --- Virtual environment ---
+# harbor requires Python >= 3.12.  If the system python3 is too old,
+# try to use conda (Miniconda / Anaconda) to provision a 3.12 env.
+_min_python_version() {
+    local ver="$1" req="$2"  # e.g. "3.11.6" "3.12"
+    local major minor
+    major="${ver%%.*}"; ver="${ver#*.}"
+    minor="${ver%%.*}"
+    local r_major r_minor
+    r_major="${req%%.*}"; req="${req#*.}"
+    r_minor="${req%%.*}"
+    [ "$major" -gt "$r_major" ] && return 0
+    [ "$major" -eq "$r_major" ] && [ "$minor" -ge "$r_minor" ] && return 0
+    return 1
+}
+
+CONDA_ENV_NAME="${CONDA_ENV_NAME:-terminal-runner-py312}"
+
+if [ ! -d "$VENV_DIR" ]; then
+    # Detect available python3
+    PY_VERSION="$(python3 -c 'import platform; print(platform.python_version())' 2>/dev/null || echo 0)"
+    echo "==> Detected Python $PY_VERSION"
+
+    if _min_python_version "$PY_VERSION" 3.12; then
+        echo "==> Python >= 3.12, using system python3"
+        python3 -m venv "$VENV_DIR"
+    else
+        echo "==> Python < 3.12 detected, attempting conda fallback ..."
+
+        # Source conda init if available
+        _conda_init() {
+            if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+                source "$HOME/miniconda3/etc/profile.d/conda.sh" 2>/dev/null && return 0
+            fi
+            if [ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]; then
+                source "$HOME/anaconda3/etc/profile.d/conda.sh" 2>/dev/null && return 0
+            fi
+            if [ -f "/opt/miniconda3/etc/profile.d/conda.sh" ]; then
+                source "/opt/miniconda3/etc/profile.d/conda.sh" 2>/dev/null && return 0
+            fi
+            if [ -f "/opt/anaconda3/etc/profile.d/conda.sh" ]; then
+                source "/opt/anaconda3/etc/profile.d/conda.sh" 2>/dev/null && return 0
+            fi
+            if command -v conda &>/dev/null; then
+                return 0
+            fi
+            return 1
+        }
+
+        if ! _conda_init; then
+            echo "ERROR: Python >= 3.12 is required (found $PY_VERSION)" >&2
+            echo "       conda not found.  Install Miniconda:" >&2
+            echo "         curl -sLO https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" >&2
+            echo "         bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3" >&2
+            exit 1
+        fi
+
+        # Accept TOS non-interactively (newer conda versions)
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main 2>/dev/null || true
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r  2>/dev/null || true
+
+        if ! conda env list | grep -q "^${CONDA_ENV_NAME} "; then
+            echo "==> Creating conda env '$CONDA_ENV_NAME' with Python 3.12 ..."
+            conda create -y -n "$CONDA_ENV_NAME" python=3.12
+        fi
+
+        echo "==> Activating conda env '$CONDA_ENV_NAME' ..."
+        conda activate "$CONDA_ENV_NAME"
+        python3 -m venv "$VENV_DIR"
+    fi
+fi
+
+echo "==> Activating virtual environment ..."
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+# --- Harbor ---
+if [ -d "$ROOT_DIR/harbor" ]; then
+    echo "==> harbor/ exists, checking out $HARBOR_REF ..."
+    git -C "$ROOT_DIR/harbor" fetch --tags origin 2>/dev/null || true
+    git -C "$ROOT_DIR/harbor" checkout "$HARBOR_REF" 2>/dev/null || echo "WARNING: could not checkout $HARBOR_REF"
+else
+    echo "==> Cloning harbor from $HARBOR_URL ..."
+    git clone "$HARBOR_URL" "$ROOT_DIR/harbor"
+    git -C "$ROOT_DIR/harbor" checkout "$HARBOR_REF"
+fi
+
+echo "==> Installing harbor (pip install -e) ..."
+pip install -e "$ROOT_DIR/harbor"
+
+# --- Dataset ---
+if [ -d "$ROOT_DIR/dataset" ]; then
+    echo "==> dataset/ exists, skipping clone"
+else
+    if ! command -v git-lfs &>/dev/null; then
+        echo "ERROR: git-lfs is required to clone the dataset." >&2
+        echo "       Install it first:  https://git-lfs.com" >&2
+        exit 1
+    fi
+    echo "==> Cloning dataset from HuggingFace (requires git-lfs) ..."
+    git clone "$DATASET_URL" "$ROOT_DIR/dataset"
+    if [ "$DATASET_REF" != "main" ]; then
+        git -C "$ROOT_DIR/dataset" checkout "$DATASET_REF"
+    fi
+fi
+
+echo ""
+echo "==> Setup complete."
+echo "    Activate venv:  source .venv/bin/activate"
+echo ""
+echo "  External mode (this repo's adapter, OpenClaw on host):"
+echo "    source .venv/bin/activate && export PYTHONPATH=$(pwd)"
+echo "    harbor run --agent-import-path external_agent.openclaw_external_agent:OpenClawExternalAgent \\"
+echo "               -p dataset/<task> -m openai/<model> ..."
+echo ""
+echo "  Installed mode (harbor's built-in openclaw, auto-installed in container):"
+echo "    harbor run --agent openclaw \\"
+echo "               -p dataset/<task> -m openai/<model> --agent-kwarg thinking=off ..."


### PR DESCRIPTION
## Description

This PR introduces the `terminal-runner` package under `src/benchmark/` — a Harbor-based agent adapter for TerminalBench task evaluation.

The package supports two execution modes:

🔧 **Installed mode** — Harbor's built-in `openclaw` agent is auto-installed inside the container via nvm + npm on every trial. The agent runs entirely within the container, communicating through Harbor's native lifecycle.

🚀 **External mode** — OpenClaw runs on the host machine. The `OpenClawExternalAgent` adapter bridges commands to the container via `environment.exec()`, eliminating per-trial install overhead. The same pattern extends to any host-side agent CLI (Claude Code, Codex, etc.).

**Key components:**

- `external_agent/openclaw_external_agent.py` — `BaseAgent` implementation that spawns the OpenClaw subprocess, streams stdout/stderr with heartbeat & safety guards (total-timeout ⏱️, no-output timeout 🔇, stdout cap 📏), extracts bash commands from responses, executes them in-container, and feeds results back for the next iteration
- `scripts/setup.sh` — Automated setup that detects Python version (conda fallback for <3.12), creates venv, clones Harbor v0.15.0 (pinned for stability), installs via `pip install -e`, and clones the terminal-bench dataset via git-lfs
- Bilingual README (EN/CN) covering prerequisites, both modes' usage, environment variables, per-iteration workflow, and the auto-skill system

**Verification ✅**

Both modes were verified end-to-end against the `nginx-request-logging` task:

| Mode | Reward | Runtime |
|---|---|---|---|
| 🚀 External | ✅ 1.0 | 54s |
| 🔧 Installed | ✅ 1.0 | 1m50s |

Test environment: Alibaba Cloud Linux 4, Python 3.12.13, Docker 24.0.9, Node.js v22.22.0, openclaw CLI 2026.6.11.

