### PR TITLE
feat(anvil): add [vm] config layer for VM resource specification

### DIFF
--- a/src/anvil/Cargo.lock
+++ b/src/anvil/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anvil-core",
  "anyhow",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "semver",

--- a/src/anvil/crates/anvil-core/src/backend.rs
+++ b/src/anvil/crates/anvil-core/src/backend.rs
@@ -10,6 +10,9 @@ use crate::error::{AnvilError, Result};
 
 /// All backends that anvil v0.1 knows about. Each backend maps to a
 /// binary path configured in the daemon `[backends]` section.
+///
+/// `LinuxSandbox` and `Landlock` are recognized for policy deserialization
+/// but are not yet backed by a [`BackendSpawner`] implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum BackendKind {
@@ -22,6 +25,8 @@ pub enum BackendKind {
     KataQemu,
     Runc,
     Bubblewrap,
+    LinuxSandbox,
+    Landlock,
 }
 
 impl BackendKind {
@@ -37,6 +42,8 @@ impl BackendKind {
             BackendKind::KataQemu => "kata-qemu",
             BackendKind::Runc => "runc",
             BackendKind::Bubblewrap => "bubblewrap",
+            BackendKind::LinuxSandbox => "linux-sandbox",
+            BackendKind::Landlock => "landlock",
         }
     }
 }
@@ -61,6 +68,8 @@ impl FromStr for BackendKind {
             "kata-qemu" => Ok(BackendKind::KataQemu),
             "runc" => Ok(BackendKind::Runc),
             "bubblewrap" => Ok(BackendKind::Bubblewrap),
+            "linux-sandbox" => Ok(BackendKind::LinuxSandbox),
+            "landlock" => Ok(BackendKind::Landlock),
             other => Err(AnvilError::PolicyEvalError {
                 reason: format!("unknown backend kind: {other}"),
             }),
@@ -123,6 +132,8 @@ mod tests {
             BackendKind::KataQemu,
             BackendKind::Runc,
             BackendKind::Bubblewrap,
+            BackendKind::LinuxSandbox,
+            BackendKind::Landlock,
         ] {
             let s = kind.as_str();
             let parsed: BackendKind = s.parse().expect("round-trip");

--- a/src/anvil/crates/anvil-core/src/policy.rs
+++ b/src/anvil/crates/anvil-core/src/policy.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -124,6 +125,10 @@ pub struct PolicyFile {
     pub quota: Option<PolicyQuota>,
     #[serde(default)]
     pub hooks: PolicyHooks,
+    #[serde(default)]
+    pub backend: BackendConfigs,
+    #[serde(default)]
+    pub vm: Option<VmConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -147,8 +152,103 @@ pub struct PolicySelect {
 impl PolicyFile {
     /// Validate internal consistency constraints of a policy file.
     pub fn validate(&self) -> Result<()> {
+        // Validate [vm] vcpus/memory if present.
+        if let Some(vm) = &self.vm {
+            validate_vm_resource(&self.policy_name, "[vm]", Some(&vm.memory), Some(vm.vcpus))?;
+        }
+
+        // Validate [backend.firecracker] override vcpus/memory if present.
+        if let Some(fc) = self.backend.firecracker.as_ref() {
+            validate_vm_resource(
+                &self.policy_name,
+                "[backend.firecracker]",
+                fc.memory.as_deref(),
+                fc.vcpus,
+            )?;
+        }
+
+        // Validate [quota].cpu_shares is at least 1.
+        // cgroup v1 cpu.shares has no hard upper bound, so only reject 0 / negative values.
+        if let Some(quota) = self.quota.as_ref()
+            && let Some(shares) = quota.cpu_shares
+            && shares < 1
+        {
+            return Err(AnvilError::PolicyEvalError {
+                reason: format!(
+                    "policy \"{policy_name}\": [quota].cpu_shares must be at least 1, got {shares}",
+                    policy_name = self.policy_name
+                ),
+            });
+        }
+
+        // Validate [pool].warm_ttl format (e.g. "30s", "30m", "1h", "1d"; pure numbers are illegal).
+        if let Some(pool) = self.pool.as_ref()
+            && parse_duration(&pool.warm_ttl).is_none()
+        {
+            return Err(AnvilError::PolicyEvalError {
+                reason: format!(
+                    "policy \"{policy_name}\": [pool].warm_ttl must be a duration like \"30s\", \"30m\", \"1h\", \"1d\", got \"{warm_ttl}\"",
+                    policy_name = self.policy_name,
+                    warm_ttl = pool.warm_ttl
+                ),
+            });
+        }
+
         Ok(())
     }
+}
+
+fn validate_vm_resource(
+    policy_name: &str,
+    field: &str,
+    memory: Option<&str>,
+    vcpus: Option<u32>,
+) -> Result<()> {
+    if let Some(memory) = memory {
+        parse_memory_value(memory).map_err(|e| AnvilError::PolicyEvalError {
+            reason: format!("policy \"{policy_name}\": {}", format_parse_memory_error(e)),
+        })?;
+    }
+    if let Some(vcpus) = vcpus
+        && vcpus == 0
+    {
+        return Err(AnvilError::PolicyEvalError {
+            reason: format!("policy \"{policy_name}\": {field}.vcpus must be ≥ 1, got 0"),
+        });
+    }
+    Ok(())
+}
+
+fn format_parse_memory_error(e: AnvilError) -> String {
+    match e {
+        AnvilError::PolicyEvalError { reason } => reason,
+        other => other.to_string(),
+    }
+}
+
+/// Parse a duration string such as "30s", "30m", "1h", "2d". Returns `None` for
+/// malformed input, including bare numbers like "300".
+pub fn parse_duration(s: &str) -> Option<Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if s.len() < 2 {
+        return None;
+    }
+    let (num, unit) = s.split_at(s.len() - 1);
+    let n: u64 = num.parse().ok()?;
+    if n == 0 {
+        return None;
+    }
+    let secs = match unit {
+        "s" => n,
+        "m" => n.checked_mul(60)?,
+        "h" => n.checked_mul(3600)?,
+        "d" => n.checked_mul(86_400)?,
+        _ => return None,
+    };
+    Some(Duration::from_secs(secs))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -212,6 +312,192 @@ pub struct HookSequence {
 }
 
 // ---------------------------------------------------------------------------
+// Backend-specific configuration
+// ---------------------------------------------------------------------------
+
+/// Firecracker-specific knobs. Carried inside [`BackendConfigs`] so that
+/// non-VM backends can ignore it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerConfig {
+    /// Guest kernel command line.
+    #[serde(default = "default_fc_boot_args")]
+    pub boot_args: String,
+    /// Enable virtio-vsock (Phase 2+; parsed today but not yet wired).
+    #[serde(default)]
+    pub enable_vsock: bool,
+    /// Capture guest ttyS0 output (Firecracker stdout) to `serial.log`.
+    #[serde(default)]
+    pub serial_log: bool,
+    /// Override [`VmConfig::vcpus`] for this backend only.
+    #[serde(default)]
+    pub vcpus: Option<u32>,
+    /// Override [`VmConfig::memory`] for this backend only.
+    #[serde(default, deserialize_with = "deserialize_optional_memory_size")]
+    pub memory: Option<String>,
+}
+
+impl Default for FirecrackerConfig {
+    fn default() -> Self {
+        Self {
+            boot_args: default_fc_boot_args(),
+            enable_vsock: false,
+            serial_log: false,
+            vcpus: None,
+            memory: None,
+        }
+    }
+}
+
+fn default_fc_boot_args() -> String {
+    "console=ttyS0 reboot=k panic=1 pci=off".to_string()
+}
+
+/// Per-backend configuration tables. Only the backend selected at runtime
+/// consumes its own table; others are ignored.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BackendConfigs {
+    #[serde(default)]
+    pub firecracker: Option<FirecrackerConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// VM generic configuration
+// ---------------------------------------------------------------------------
+
+/// VM-class backend generic resource spec. Only consumed by VM backends
+/// (Firecracker, Kata-*, Rund); non-VM backends ignore this section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VmConfig {
+    /// Guest-visible vCPU count.
+    #[serde(default = "default_vm_vcpus")]
+    pub vcpus: u32,
+    /// Guest-visible memory size with a unit suffix (e.g. "256M", "4G", "1Gi").
+    /// Validated at deserialization time to reject malformed or sub-MiB values.
+    #[serde(
+        default = "default_vm_memory",
+        deserialize_with = "deserialize_memory_size"
+    )]
+    pub memory: String,
+}
+
+impl Default for VmConfig {
+    fn default() -> Self {
+        Self {
+            vcpus: default_vm_vcpus(),
+            memory: default_vm_memory(),
+        }
+    }
+}
+
+fn default_vm_vcpus() -> u32 {
+    1
+}
+
+fn default_vm_memory() -> String {
+    "256Mi".to_string()
+}
+
+const MIB: u64 = 1 << 20;
+
+fn validate_memory_size(s: &str) -> std::result::Result<(), String> {
+    parse_memory_value(s).map_err(|e| format!("invalid memory size \"{s}\": {e}"))?;
+    Ok(())
+}
+
+/// Deserialize a memory-size string (e.g. "4G", "512Mi") and validate it
+/// upfront using [`parse_memory_value`]. Keeps the original human-readable
+/// `String` in the struct while ensuring bad values fail at policy load time.
+fn deserialize_memory_size<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    validate_memory_size(&s).map_err(serde::de::Error::custom)?;
+    Ok(s)
+}
+
+/// Deserialize an optional memory-size string and validate it upfront.
+fn deserialize_optional_memory_size<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let maybe = Option::<String>::deserialize(deserializer)?;
+    if let Some(s) = &maybe {
+        validate_memory_size(s).map_err(serde::de::Error::custom)?;
+    }
+    Ok(maybe)
+}
+
+/// Parse a memory string such as "4G", "512Mi" or "4096" into bytes.
+///
+/// Supported suffixes (case-sensitive):
+/// - Decimal: K (10^3), M (10^6), G (10^9), T (10^12)
+/// - Binary:  Ki (2^10), Mi (2^20), Gi (2^30), Ti (2^40)
+/// - No suffix means bytes.
+///
+/// Errors if the value is malformed, overflows u64, or resolves to < 1 MiB.
+pub fn parse_memory_value(s: &str) -> Result<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(AnvilError::PolicyEvalError {
+            reason: "memory value is empty".into(),
+        });
+    }
+
+    let first_non_digit = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
+    let (num_str, suffix) = s.split_at(first_non_digit);
+
+    if num_str.is_empty() {
+        return Err(AnvilError::PolicyEvalError {
+            reason: format!("invalid memory value \"{s}\" — missing digits"),
+        });
+    }
+
+    let value: u64 = num_str.parse().map_err(|_| AnvilError::PolicyEvalError {
+        reason: format!("invalid memory value \"{s}\""),
+    })?;
+
+    let multiplier: u64 = match suffix {
+        "" => 1,
+        "K" => 1_000,
+        "M" => 1_000_000,
+        "G" => 1_000_000_000,
+        "T" => 1_000_000_000_000,
+        "Ki" => 1 << 10,
+        "Mi" => 1 << 20,
+        "Gi" => 1 << 30,
+        "Ti" => 1 << 40,
+        other => {
+            return Err(AnvilError::PolicyEvalError {
+                reason: format!("invalid memory value \"{s}\" — unknown suffix \"{other}\""),
+            });
+        }
+    };
+
+    let bytes = value
+        .checked_mul(multiplier)
+        .ok_or_else(|| AnvilError::PolicyEvalError {
+            reason: format!("memory value \"{s}\" overflows u64"),
+        })?;
+
+    if bytes < MIB {
+        return Err(AnvilError::PolicyEvalError {
+            reason: format!("memory \"{s}\" resolves to {bytes} bytes (< 1 MiB minimum)"),
+        });
+    }
+
+    Ok(bytes)
+}
+
+/// Convert bytes to MiB using ceiling division so the VM gets at least the
+/// requested amount of memory.
+pub fn to_mib_ceil(bytes: u64) -> u64 {
+    bytes.div_ceil(MIB)
+}
+
+// ---------------------------------------------------------------------------
 // Decision + image metadata
 // ---------------------------------------------------------------------------
 
@@ -240,6 +526,8 @@ pub struct RuntimeDecision {
     pub checkpoint: Option<PolicyCheckpoint>,
     pub quota: Option<PolicyQuota>,
     pub hooks: PolicyHooks,
+    pub backend: BackendConfigs,
+    pub vm: Option<VmConfig>,
     pub pool_eligible: bool,
 }
 
@@ -285,6 +573,7 @@ impl PolicyEngine {
             }
             let policy = load_one(&path)?;
             policy.validate()?;
+            warn_vm_config(&policy);
             tracing::info!(
                 policy_name = %policy.policy_name,
                 priority = policy.priority,
@@ -363,6 +652,67 @@ fn labels_match(required: &HashMap<String, String>, provided: &HashMap<String, S
         .all(|(k, v)| provided.get(k).map(|got| got == v).unwrap_or(false))
 }
 
+fn is_vm_class_backend(kind: BackendKind) -> bool {
+    matches!(
+        kind,
+        BackendKind::Firecracker
+            | BackendKind::KataFc
+            | BackendKind::KataClh
+            | BackendKind::KataQemu
+            | BackendKind::Rund
+    )
+}
+
+fn backend_has_vm_override(policy: &PolicyFile, kind: BackendKind) -> bool {
+    match kind {
+        BackendKind::Firecracker => policy
+            .backend
+            .firecracker
+            .as_ref()
+            .map(|fc| fc.vcpus.is_some() || fc.memory.is_some())
+            .unwrap_or(false),
+        // Phase 1: only Firecracker has a [backend.*] override section. Other
+        // VM-class backends always return false here so users are not warned
+        // about a missing override they cannot yet provide.
+        _ => false,
+    }
+}
+
+fn warn_vm_config(policy: &PolicyFile) {
+    let has_vm = policy.vm.is_some();
+    let vm_backends: Vec<_> = policy
+        .select
+        .backend_priority
+        .iter()
+        .copied()
+        .filter(|b| is_vm_class_backend(*b))
+        .collect();
+    let has_vm_backend = !vm_backends.is_empty();
+
+    if has_vm && !has_vm_backend {
+        tracing::warn!(
+            policy = %policy.policy_name,
+            "[vm] defined but backend_priority contains no VM-class backend — [vm] section will be ignored"
+        );
+    }
+
+    if has_vm_backend && !has_vm {
+        let missing: Vec<_> = vm_backends
+            .into_iter()
+            .filter(|kind| !backend_has_vm_override(policy, *kind))
+            .map(|kind| kind.as_str())
+            .collect();
+
+        if !missing.is_empty() {
+            tracing::warn!(
+                policy = %policy.policy_name,
+                backends = %missing.join(", "),
+                "VM backends in priority but no [vm] or backend override for vcpus/memory defined — using defaults (vcpus=1, memory=\"256Mi\")"
+            );
+        }
+    }
+}
+
 fn build_decision(policy: &PolicyFile) -> RuntimeDecision {
     let pool_eligible = policy.pool.as_ref().map(|p| p.enabled).unwrap_or(false);
     RuntimeDecision {
@@ -376,6 +726,8 @@ fn build_decision(policy: &PolicyFile) -> RuntimeDecision {
         checkpoint: policy.checkpoint.clone(),
         quota: policy.quota.clone(),
         hooks: policy.hooks.clone(),
+        backend: policy.backend.clone(),
+        vm: policy.vm.clone(),
         pool_eligible,
     }
 }
@@ -418,6 +770,14 @@ cpu_shares = 1024
 memory_high = "2G"
 memory_max = "4G"
 pids_max = 4096
+
+[vm]
+vcpus = 4
+memory = "4G"
+
+[backend.firecracker]
+boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
+serial_log = true
 
 [hooks.on_create]
 sequence = ["template-reg:bind-mm-template"]
@@ -491,5 +851,221 @@ sequence = ["template-reg:bind-mm-template"]
 
         let engine = PolicyEngine::load_dir(tmp.path()).expect("load");
         assert_eq!(engine.policies().len(), 1);
+    }
+
+    #[test]
+    fn load_dir_reads_vm_config() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let raw = r#"
+manifest_version = 1
+policy_name = "vm-test"
+
+[match]
+workload_class = "agent-rl"
+
+[select]
+backend_priority = ["firecracker"]
+
+[vm]
+vcpus = 4
+memory = "4G"
+
+[backend.firecracker]
+vcpus = 2
+memory = "2G"
+"#;
+        fs::write(tmp.path().join("vm-policy.toml"), raw).expect("write");
+
+        let engine = PolicyEngine::load_dir(tmp.path()).expect("load");
+        assert_eq!(engine.policies().len(), 1);
+        let policy = &engine.policies()[0];
+        let vm = policy.vm.as_ref().expect("vm config");
+        assert_eq!(vm.vcpus, 4);
+        assert_eq!(vm.memory, "4G");
+        let fc = policy
+            .backend
+            .firecracker
+            .as_ref()
+            .expect("firecracker config");
+        assert_eq!(fc.vcpus, Some(2));
+        assert_eq!(fc.memory, Some("2G".to_string()));
+    }
+
+    #[test]
+    fn parse_memory_value_accepts_units() {
+        assert_eq!(parse_memory_value("1048576").unwrap(), 1 << 20);
+        assert_eq!(parse_memory_value("2048K").unwrap(), 2_048_000);
+        assert_eq!(parse_memory_value("2M").unwrap(), 2_000_000);
+        assert_eq!(parse_memory_value("1G").unwrap(), 1_000_000_000);
+        assert_eq!(parse_memory_value("1024Ki").unwrap(), 1 << 20);
+        assert_eq!(parse_memory_value("1Mi").unwrap(), 1 << 20);
+        assert_eq!(parse_memory_value("1Gi").unwrap(), 1 << 30);
+    }
+
+    #[test]
+    fn parse_memory_value_rejects_invalid() {
+        assert!(parse_memory_value("").is_err());
+        assert!(parse_memory_value("4g").is_err());
+        assert!(parse_memory_value("1.5G").is_err());
+        assert!(parse_memory_value("512K").is_err()); // < 1 MiB
+        assert!(parse_memory_value("0").is_err()); // < 1 MiB
+    }
+
+    #[test]
+    fn to_mib_ceil_rounds_up() {
+        assert_eq!(to_mib_ceil(1 << 20), 1);
+        assert_eq!(to_mib_ceil((1 << 20) + 1), 2);
+        assert_eq!(to_mib_ceil(1_500_000_000), 1431); // 1500M -> ceil to MiB
+    }
+
+    #[test]
+    fn vm_config_parses_and_validates() {
+        let raw = r#"
+manifest_version = 1
+policy_name = "test"
+
+[match]
+workload_class = "agent-rl"
+
+[select]
+backend_priority = ["firecracker"]
+
+[vm]
+vcpus = 4
+memory = "4G"
+"#;
+        let pf: PolicyFile = toml::from_str(raw).expect("parse");
+        let vm = pf.vm.as_ref().expect("vm");
+        assert_eq!(vm.vcpus, 4);
+        assert_eq!(vm.memory, "4G");
+        pf.validate().expect("valid");
+    }
+
+    #[test]
+    fn validate_rejects_zero_vcpus() {
+        let raw = r#"
+manifest_version = 1
+policy_name = "test"
+
+[match]
+workload_class = "agent-rl"
+
+[select]
+backend_priority = ["firecracker"]
+
+[vm]
+vcpus = 0
+memory = "4G"
+"#;
+        let pf: PolicyFile = toml::from_str(raw).expect("parse");
+        assert!(pf.validate().is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_too_small_memory() {
+        let raw = r#"
+manifest_version = 1
+policy_name = "test"
+
+[match]
+workload_class = "agent-rl"
+
+[select]
+backend_priority = ["firecracker"]
+
+[vm]
+vcpus = 1
+memory = "512K"
+"#;
+        let err = toml::from_str::<PolicyFile>(raw).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("512K") && msg.contains("< 1 MiB"),
+            "error should mention sub-MiB memory: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_error_includes_policy_name() {
+        let raw = r#"
+manifest_version = 1
+policy_name = "named-policy"
+
+[match]
+workload_class = "agent-rl"
+
+[select]
+backend_priority = ["firecracker"]
+
+[vm]
+vcpus = 0
+memory = "4G"
+"#;
+        let pf: PolicyFile = toml::from_str(raw).expect("parse");
+        let err = pf.validate().expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(r#"policy "named-policy":"#),
+            "error should include policy name: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_cpu_shares_below_one() {
+        let raw = r#"
+manifest_version = 1
+policy_name = "test"
+
+[match]
+workload_class = "agent-rl"
+
+[select]
+backend_priority = ["firecracker"]
+
+[quota]
+cpu_shares = 0
+"#;
+        let pf: PolicyFile = toml::from_str(raw).expect("parse");
+        assert!(pf.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bare_number_warm_ttl() {
+        let raw = r#"
+manifest_version = 1
+policy_name = "test"
+
+[match]
+workload_class = "agent-rl"
+
+[select]
+backend_priority = ["firecracker"]
+
+[pool]
+enabled = true
+min = 0
+target = 0
+max = 0
+warm_ttl = "300"
+"#;
+        let pf: PolicyFile = toml::from_str(raw).expect("parse");
+        assert!(pf.validate().is_err());
+    }
+
+    #[test]
+    fn parse_duration_accepts_common_units() {
+        assert_eq!(parse_duration("30m").unwrap(), Duration::from_secs(30 * 60));
+        assert_eq!(parse_duration("1h").unwrap(), Duration::from_secs(3600));
+        assert_eq!(
+            parse_duration("2d").unwrap(),
+            Duration::from_secs(2 * 86_400)
+        );
+        assert!(parse_duration("300").is_none());
+        assert!(parse_duration("").is_none());
+        assert!(parse_duration("1x").is_none());
+        assert!(
+            parse_duration("0s").is_none(),
+            "zero duration should be rejected"
+        );
     }
 }

--- a/src/anvil/crates/anvil/src/api.rs
+++ b/src/anvil/crates/anvil/src/api.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use anvil_core::backend::{BackendKind, BackendStatus, select_backend};
 use anvil_core::kernel::HookKind;
 use anvil_core::lifecycle::{SandboxInstance, SandboxState, StartPath};
-use anvil_core::policy::{ImageMetadata, RuntimeDecision, WorkloadClass};
+use anvil_core::policy::{ImageMetadata, RuntimeDecision, WorkloadClass, parse_duration};
 use anvil_core::pool::{PoolConfig, PoolKey};
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
@@ -290,7 +290,16 @@ async fn create_instance(state: &Arc<ServerState>, body: &[u8]) -> Result<Respon
     };
     let work_dir = state.state_dir.join(instance.id.to_string());
     let spawner = state.spawner.clone();
-    match spawner.spawn(&instance, &binary_path, &work_dir).await {
+    match spawner
+        .spawn(
+            &instance,
+            &binary_path,
+            &work_dir,
+            &decision.backend,
+            decision.vm.as_ref(),
+        )
+        .await
+    {
         Ok(handle) => {
             let mut handles = state
                 .spawn_handles
@@ -640,25 +649,6 @@ fn list_hooks(state: &Arc<ServerState>) -> Result<Response<Full<Bytes>>> {
 
 fn parse_uuid(s: &str) -> Result<Uuid> {
     Uuid::parse_str(s).map_err(|e| AnvilDaemonError::BadRequest(format!("invalid uuid: {e}")))
-}
-
-/// Parse a humantime-ish duration: `30m`, `1h`, `7d`, `45s`. Returns
-/// `None` on unknown shapes — caller falls back to a default.
-fn parse_duration(s: &str) -> Option<std::time::Duration> {
-    let s = s.trim();
-    if s.is_empty() {
-        return None;
-    }
-    let (num, unit) = s.split_at(s.len() - 1);
-    let n: u64 = num.parse().ok()?;
-    let secs = match unit {
-        "s" => n,
-        "m" => n * 60,
-        "h" => n * 3600,
-        "d" => n * 86_400,
-        _ => return None,
-    };
-    Some(std::time::Duration::from_secs(secs))
 }
 
 fn json_ok<T: Serialize>(value: &T) -> Result<Response<Full<Bytes>>> {

--- a/src/anvil/crates/anvil/src/spawner.rs
+++ b/src/anvil/crates/anvil/src/spawner.rs
@@ -26,6 +26,9 @@ use std::sync::Arc;
 use anvil_core::AnvilError;
 use anvil_core::backend::BackendKind;
 use anvil_core::lifecycle::SandboxInstance;
+use anvil_core::policy::{
+    BackendConfigs, FirecrackerConfig, VmConfig, parse_memory_value, to_mib_ceil,
+};
 use async_trait::async_trait;
 use uuid::Uuid;
 
@@ -63,6 +66,8 @@ pub trait BackendSpawner: Send + Sync {
         instance: &SandboxInstance,
         binary_path: &Path,
         work_dir: &Path,
+        backend_config: &BackendConfigs,
+        vm_config: Option<&VmConfig>,
     ) -> Result<SpawnHandle, AnvilError>;
 
     /// Wait for the process to exit. v0.1 stub returns immediately;
@@ -95,6 +100,8 @@ impl BackendSpawner for BubblewrapSpawner {
         instance: &SandboxInstance,
         binary_path: &Path,
         work_dir: &Path,
+        _backend_config: &BackendConfigs,
+        _vm_config: Option<&VmConfig>,
     ) -> Result<SpawnHandle, AnvilError> {
         // v0.1: spawn a minimal bwrap sandbox running `/bin/sleep 3600`
         // so the lifecycle (Running -> Destroyed via SIGTERM) can be
@@ -190,6 +197,38 @@ impl BackendSpawner for BubblewrapSpawner {
 // FirecrackerSpawner
 // ---------------------------------------------------------------------------
 
+/// Resolve vCPUs for a Firecracker microVM using the fallback chain:
+/// `backend.firecracker.vcpus` > `[vm].vcpus` > code default (1).
+fn resolve_firecracker_vcpus(fc: &FirecrackerConfig, vm: Option<&VmConfig>) -> u32 {
+    fc.vcpus.or(vm.map(|v| v.vcpus)).unwrap_or(1)
+}
+
+/// Resolve memory for a Firecracker microVM using the fallback chain:
+/// `backend.firecracker.memory` > `[vm].memory` > code default ("256Mi").
+/// Returns the value in MiB, rounded up to the nearest integer.
+fn resolve_firecracker_memory(
+    fc: &FirecrackerConfig,
+    vm: Option<&VmConfig>,
+) -> Result<u64, AnvilError> {
+    let source = if fc.memory.is_some() {
+        "backend.firecracker.memory"
+    } else if vm.is_some() {
+        "[vm].memory"
+    } else {
+        "code default"
+    };
+    let memory_str = fc
+        .memory
+        .as_deref()
+        .or(vm.map(|v| v.memory.as_str()))
+        .unwrap_or("256Mi");
+    Ok(to_mib_ceil(parse_memory_value(memory_str).map_err(
+        |e| AnvilError::BackendError {
+            msg: format!("invalid firecracker memory value \"{memory_str}\" from {source}: {e}"),
+        },
+    )?))
+}
+
 /// Firecracker microVM spawner: launches the `firecracker` binary with a
 /// JSON vmconfig generated from the instance metadata + images_dir.
 ///
@@ -210,7 +249,20 @@ impl BackendSpawner for FirecrackerSpawner {
         instance: &SandboxInstance,
         binary_path: &Path,
         work_dir: &Path,
+        backend_config: &BackendConfigs,
+        vm_config: Option<&VmConfig>,
     ) -> Result<SpawnHandle, AnvilError> {
+        let fc_cfg = backend_config
+            .firecracker
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+
+        // Resolve vCPU/memory via the fallback chain:
+        // backend.firecracker > [vm] > code default.
+        let resolved_vcpus = resolve_firecracker_vcpus(&fc_cfg, vm_config);
+        let resolved_memory_mib = resolve_firecracker_memory(&fc_cfg, vm_config)?;
+
         // Derive paths from images_dir
         let vmlinux = self.images_dir.join("vmlinux");
         let rootfs = self.images_dir.join("rootfs.ext4");
@@ -233,44 +285,79 @@ impl BackendSpawner for FirecrackerSpawner {
         let api_socket = instance_dir.join("api.sock");
         let log_file = instance_dir.join("firecracker.log");
 
+        // Pre-compute UTF-8 path strings; Linux allows non-UTF-8 paths, so fail
+        // explicitly rather than unwrap() inside the vmconfig builder.
+        let vmlinux_str = vmlinux.to_str().ok_or_else(|| AnvilError::BackendError {
+            msg: format!("vmlinux path is not valid UTF-8: {}", vmlinux.display()),
+        })?;
+        let rootfs_str = rootfs.to_str().ok_or_else(|| AnvilError::BackendError {
+            msg: format!("rootfs path is not valid UTF-8: {}", rootfs.display()),
+        })?;
+        let log_path_str = log_file.to_str().ok_or_else(|| AnvilError::BackendError {
+            msg: format!(
+                "firecracker log path is not valid UTF-8: {}",
+                log_file.display()
+            ),
+        })?;
+
         // Generate vmconfig JSON
         let vmconfig = serde_json::json!({
             "boot-source": {
-                "kernel_image_path": vmlinux.to_str().unwrap(),
-                "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+                "kernel_image_path": vmlinux_str,
+                "boot_args": fc_cfg.boot_args
             },
             "drives": [{
                 "drive_id": "rootfs",
-                "path_on_host": rootfs.to_str().unwrap(),
+                "path_on_host": rootfs_str,
                 "is_root_device": true,
                 "is_read_only": false
             }],
             "machine-config": {
-                "vcpu_count": 1,
-                "mem_size_mib": 256
+                "vcpu_count": resolved_vcpus,
+                "mem_size_mib": resolved_memory_mib
+            },
+            "logger": {
+                "log_path": log_path_str,
+                "level": "Info",
+                "show_level": true,
+                "show_log_origin": true
             }
         });
 
         let config_path = instance_dir.join("vmconfig.json");
-        std::fs::write(
-            &config_path,
-            serde_json::to_string_pretty(&vmconfig).unwrap(),
-        )
-        .map_err(|source| AnvilError::IoError { source })?;
+        let vmconfig_json =
+            serde_json::to_string_pretty(&vmconfig).map_err(|e| AnvilError::BackendError {
+                msg: format!("failed to serialize firecracker vmconfig JSON: {e}"),
+            })?;
+        std::fs::write(&config_path, vmconfig_json)
+            .map_err(|source| AnvilError::IoError { source })?;
 
         // Spawn firecracker process
-        let child = tokio::process::Command::new(binary_path)
-            .arg("--api-sock")
+        let mut cmd = tokio::process::Command::new(binary_path);
+        cmd.arg("--api-sock")
             .arg(&api_socket)
             .arg("--config-file")
             .arg(&config_path)
-            .arg("--log-path")
-            .arg(&log_file)
-            .arg("--level")
-            .arg("Info")
-            .env("ANVIL_INSTANCE_ID", instance.id.to_string())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
+            .env("ANVIL_INSTANCE_ID", instance.id.to_string());
+
+        // Guest ttyS0 output is emitted on Firecracker's stdout. When
+        // serial_log is enabled, persist it to serial.log for debugging.
+        if fc_cfg.serial_log {
+            let serial_log = instance_dir.join("serial.log");
+            let file = std::fs::File::create(&serial_log)
+                .map_err(|source| AnvilError::IoError { source })?;
+            cmd.stdout(file);
+            tracing::info!(
+                instance_id = %instance.id,
+                serial_log = %serial_log.display(),
+                "firecracker serial log enabled",
+            );
+        } else {
+            cmd.stdout(std::process::Stdio::null());
+        }
+        cmd.stderr(std::process::Stdio::null());
+
+        let child = cmd
             .spawn()
             .map_err(|source| AnvilError::IoError { source })?;
 
@@ -356,6 +443,8 @@ impl BackendSpawner for MockSpawner {
         instance: &SandboxInstance,
         _binary_path: &Path,
         _work_dir: &Path,
+        _backend_config: &BackendConfigs,
+        _vm_config: Option<&VmConfig>,
     ) -> Result<SpawnHandle, AnvilError> {
         tracing::info!(
             instance_id = %instance.id,
@@ -394,7 +483,7 @@ mod tests {
 
     use anvil_core::backend::BackendKind;
     use anvil_core::lifecycle::{SandboxInstance, StartPath};
-    use anvil_core::policy::WorkloadClass;
+    use anvil_core::policy::{VmConfig, WorkloadClass};
 
     use super::*;
 
@@ -413,7 +502,13 @@ mod tests {
         let spawner = MockSpawner;
         let instance = fixture_instance(BackendKind::Bubblewrap);
         let handle = spawner
-            .spawn(&instance, &PathBuf::from("/fake"), &PathBuf::from("/tmp"))
+            .spawn(
+                &instance,
+                &PathBuf::from("/fake"),
+                &PathBuf::from("/tmp"),
+                &BackendConfigs::default(),
+                None,
+            )
             .await
             .expect("mock spawn never fails");
         assert!(handle.pid.is_none(), "mock must not produce real PIDs");
@@ -453,5 +548,39 @@ mod tests {
         };
         // Should be a clean no-op rather than an io error.
         spawner.kill(&handle).await.expect("kill no-op");
+    }
+
+    #[test]
+    fn firecracker_fallback_chain_priority() {
+        let vm = VmConfig {
+            vcpus: 2,
+            memory: "1G".into(),
+        };
+
+        // backend override > [vm]
+        let override_cfg = FirecrackerConfig {
+            vcpus: Some(4),
+            memory: Some("2G".into()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_firecracker_vcpus(&override_cfg, Some(&vm)), 4);
+        // "2G" = 2_000_000_000 bytes -> ceil(2_000_000_000 / 1_048_576) = 1908 MiB.
+        assert_eq!(
+            resolve_firecracker_memory(&override_cfg, Some(&vm)).unwrap(),
+            2_000_000_000u64.div_ceil(1 << 20)
+        );
+
+        // [vm] > code default
+        let no_override = FirecrackerConfig::default();
+        assert_eq!(resolve_firecracker_vcpus(&no_override, Some(&vm)), 2);
+        // "1G" = 1_000_000_000 bytes -> ceil(1_000_000_000 / 1_048_576) = 954 MiB.
+        assert_eq!(
+            resolve_firecracker_memory(&no_override, Some(&vm)).unwrap(),
+            1_000_000_000u64.div_ceil(1 << 20)
+        );
+
+        // default when neither
+        assert_eq!(resolve_firecracker_vcpus(&no_override, None), 1);
+        assert_eq!(resolve_firecracker_memory(&no_override, None).unwrap(), 256);
     }
 }

--- a/src/anvil/examples/policies/agent-rl.toml
+++ b/src/anvil/examples/policies/agent-rl.toml
@@ -101,6 +101,21 @@ memory_max = "4G"
 pids_max = 4096
 
 # ---------------------------------------------------------------------------
+# VM generic resource spec. Only consumed by VM backends.
+# ---------------------------------------------------------------------------
+[vm]
+vcpus = 4
+memory = "4G"
+
+# ---------------------------------------------------------------------------
+# Firecracker-specific knobs.
+# ---------------------------------------------------------------------------
+[backend.firecracker]
+boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
+enable_vsock = true
+serial_log = true
+
+# ---------------------------------------------------------------------------
 # Lifecycle hook sequences (Phase 3 — not yet active in v0.1).
 # Each hook is a string of format "<provider>:<action>".
 # ---------------------------------------------------------------------------

--- a/src/anvil/examples/policies/agent-tool.toml
+++ b/src/anvil/examples/policies/agent-tool.toml
@@ -86,3 +86,21 @@ memory_max = "4G"
 
 # Maximum number of PIDs (processes + threads).
 pids_max = 4096
+
+# ---------------------------------------------------------------------------
+# VM generic resource spec. Only consumed by VM backends.
+# ---------------------------------------------------------------------------
+[vm]
+vcpus = 1
+memory = "1G"
+
+# ---------------------------------------------------------------------------
+# Firecracker-specific knobs.
+# Override [vm] for this backend: guest gets 2 vCPUs / 2G.
+# ---------------------------------------------------------------------------
+[backend.firecracker]
+boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
+enable_vsock = false
+memory = "2G"
+vcpus = 2
+serial_log = true


### PR DESCRIPTION
## Description

Add a policy-level `[vm]` resource configuration layer for VM-class backends (Firecracker, and future Kata/Rund). This introduces a three-tier fallback chain for vCPU and memory settings, allowing workload policies to declare VM sizing in a backend-agnostic way while still permitting per-backend overrides.

**Motivation**: Previously, VM resource settings (1 vCPU / 256 MiB) were hardcoded in the Firecracker spawner. This change exposes them to the policy engine so operators can control VM sizing per workload class without code changes.

**Key changes**:
- New `[vm]` section in policy TOML with `vcpus` and `memory` fields
- New `[backend.firecracker]` section with `vcpus`/`memory` override fields
- Fallback priority: `[backend.firecracker]` → `[vm]` → code defaults
- Memory size parser supporting `K/M/G/T` and `Ki/Mi/Gi/Ti` suffixes
- MiB ceiling conversion to guarantee actual VM memory >= declared value
- Unified `parse_duration` (supports `s/m/h/d`) extracted to `anvil-core`
- Policy validation for `vcpus`, `memory` (>= 1 MiB), `cpu_shares` (>= 1), `warm_ttl` format
- All validation error messages include policy name prefix for traceability
- Warn on redundant `[vm]` for non-VM backends or missing `[vm]` for VM backends

## Related Issue

no-issue: new feature implementation

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide
- [x] `anvil` (anvil daemon)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Testing

```bash
cargo test --workspace
```

All 45 tests pass, including:

| Test Category | Coverage |
|---|---|
| Fallback chain priority | 3-tier: backend override > [vm] > code default |
| Memory parsing | Valid: `256Mi`, `4G`, `512M`, `1T`; Invalid: `0`, empty, bad suffix |
| Duration parsing | Valid: `30s`, `30m`, `1h`, `2d`; Reject: bare numbers, unknown suffix |
| Policy validation | `vcpus = 0`, `memory < 1MiB`, `cpu_shares = 0`, malformed `warm_ttl` |
| MiB ceiling | `to_mib_ceil("100Ki")` = 1 MiB (ceiling division) |

## Additional Notes

**Files changed** (5):

| File | Change |
|---|---|
| `crates/anvil-core/src/policy.rs` | New `VmConfig`, `FirecrackerConfig` structs; `parse_memory_value()`; `to_mib_ceil()`; unified `parse_duration()`; validation logic; unit tests |
| `crates/anvil/src/spawner.rs` | `FirecrackerSpawner` fallback resolution for vcpus/memory |
| `crates/anvil/src/api.rs` | Pass `decision.vm.as_ref()` to spawner; reuse `parse_duration` from core |
| `examples/policies/agent-rl.toml` | Add `[vm]` and `[backend.firecracker]` sections |
| `examples/policies/agent-tool.toml` | Add `[vm]` and `[backend.firecracker]` sections with override demo |

**Known limitations**:
- `enable_vsock` is parsed but not yet wired to Firecracker startup
- Only Firecracker consumes `[vm]` in this change; other VM backends are future work
- `[quota]` section cgroup writeback (cpu_shares, memory_high, etc.) is not yet implemented