### PR TITLE
feat(tokenless): complete stash coverage for string/depth/schema truncation

### DIFF
--- a/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
@@ -130,6 +130,14 @@ impl StashStore for SqliteStore {
         // have uppercased by lowercasing the lookup (case-insensitive retrieve).
         let key = hash.to_ascii_lowercase();
         let conn = self.lock_conn();
+        // Lazy purge sweep: physically drop expired rows on every retrieve so
+        // the DB file does not grow unbounded by stale entries that the
+        // `expires_at >= ?` filter only hides, never deletes. Mirrors headroom's
+        // `SqliteCcrStore::get`. Best-effort — a purge failure must not block
+        // the lookup; it falls through to the SELECT below.
+        if let Err(e) = conn.execute("DELETE FROM stash WHERE expires_at < ?", [now as i64]) {
+            eprintln!("[tokenless-ccr] WARNING: stash lazy-purge failed: {}", e);
+        }
         match conn.query_row(
             "SELECT payload FROM stash WHERE hash = ? AND expires_at >= ?",
             rusqlite::params![key, now as i64],
@@ -258,5 +266,22 @@ mod tests {
             h.join().unwrap();
         }
         assert!(store.len() <= 10_000);
+    }
+
+    #[test]
+    fn expired_rows_physically_deleted_after_retrieve() {
+        // Lazy purge: a retrieve must physically DELETE expired rows, not
+        // merely filter them via the WHERE clause. Mirrors headroom's
+        // `SqliteCcrStore::get` lazy-purge sweep.
+        let (store, _dir) = tmp_store(1, 100);
+        store.stash("a").unwrap();
+        store.stash("b").unwrap();
+        assert_eq!(store.len(), 2);
+        thread::sleep(std::time::Duration::from_secs(2));
+        // Both rows are now expired. A retrieve for any (absent) key triggers
+        // the purge sweep; `len()` must then read 0 because the rows were
+        // physically deleted, not just hidden.
+        assert_eq!(store.retrieve("000000000000000000000000").unwrap(), None);
+        assert_eq!(store.len(), 0);
     }
 }

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -46,6 +46,15 @@ enum Commands {
         /// Tool use ID
         #[arg(long)]
         tool_use_id: Option<String>,
+        /// Disable reversible stash. By default, truncated descriptions are
+        /// stashed so they can be retrieved via `tokenless retrieve`; this
+        /// flag makes truncation lossy (the pre-stash behavior).
+        #[arg(long)]
+        no_stash: bool,
+        /// Override the stash database path (default ~/.tokenless/stash.db).
+        /// Resolved under the trusted home directory; rejected if outside.
+        #[arg(long)]
+        stash_db: Option<String>,
     },
     /// Compress API responses
     CompressResponse {
@@ -398,12 +407,29 @@ fn run() -> Result<(), (String, i32)> {
             agent_id,
             session_id,
             tool_use_id,
+            no_stash,
+            stash_db,
         } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
             let value: serde_json::Value = serde_json::from_str(&input)
                 .map_err(|e| (format!("JSON parse error: {}", e), 2))?;
 
-            let compressor = SchemaCompressor::new();
+            // Load config before deciding on the stash so we can skip it
+            // entirely when compression is disabled (dry-run). Attaching the
+            // stash in dry-run would write entries whose `<<tokenless:KEY>>`
+            // markers never reach the LLM (the original input is emitted),
+            // orphaning them.
+            let config = TokenlessConfig::load();
+            let compression_on = config.is_compression_enabled();
+            let stash = if no_stash || !compression_on {
+                None
+            } else {
+                open_stash_store(stash_db.as_deref())
+            };
+            let mut compressor = SchemaCompressor::new();
+            if let Some(ref store) = stash {
+                compressor = compressor.with_stash_store(store.clone());
+            }
 
             let after_compact = if batch || value.is_array() {
                 let arr = value
@@ -424,13 +450,16 @@ fn run() -> Result<(), (String, i32)> {
                     "tokenless: schema compression did not reduce size ({} -> {} est. tokens), outputting original",
                     before_tokens, after_tokens
                 );
+                // No-savings discard edge: if a stash was attached and a
+                // description was truncated, those writes orphan (markers
+                // live in `after_compact`, which is discarded). Truncation
+                // almost always yields savings, so this is rare; orphaned
+                // entries are TTL-cleaned.
                 input.clone()
             } else {
                 after_compact.clone()
             };
 
-            let config = TokenlessConfig::load();
-            let compression_on = config.is_compression_enabled();
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             let emit_text = if compression_on {
                 output_text.clone()

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -4,6 +4,21 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tokenless_ccr::{StashStore, marker_for};
 
+/// Build the stash-augmented truncation suffix for `key`:
+/// `… (truncated, retrieve with <<tokenless:KEY>>)`.
+pub(crate) fn stash_suffix(key: &str) -> String {
+    format!("… (truncated, retrieve with {})", marker_for(key))
+}
+
+/// Char-length of [`stash_suffix`]. Constant because the key is always 24
+/// hex chars, so the budget for the suffix can be reserved before stashing.
+/// Derived from [`stash_suffix`] so the two cannot drift out of sync.
+/// Shared with `schema_compressor` for description truncation.
+pub(crate) fn stash_suffix_char_len() -> usize {
+    // 24-char stand-in; marker_for is `<<tokenless:` + key + `>>`.
+    stash_suffix("000000000000000000000000").chars().count()
+}
+
 /// ResponseCompressor compresses API responses by truncating strings,
 /// limiting array sizes, removing null values, and dropping debug fields.
 pub struct ResponseCompressor {
@@ -166,7 +181,20 @@ impl ResponseCompressor {
                 Value::Array(_) => "array",
                 Value::Object(_) => "object",
             };
-            return Value::String(format!("<{} truncated at depth {}>", type_name, depth));
+            // Try to stash the original subtree so the LLM can retrieve the
+            // verbatim original via the embedded marker. On any failure (no
+            // store, serialization error, stash backend error) fall back to
+            // the plain lossy depth marker.
+            if let Some(store) = self.stash_store.as_ref()
+                && let Ok(serialized) = serde_json::to_string(value)
+                && let Ok(key) = store.stash(&serialized)
+            {
+                return Value::String(format!(
+                    "<{type_name} truncated at depth {depth}, retrieve with {}>",
+                    marker_for(&key)
+                ));
+            }
+            return Value::String(format!("<{type_name} truncated at depth {depth}>"));
         }
 
         match value {
@@ -189,20 +217,48 @@ impl ResponseCompressor {
     /// final output stays within `truncate_strings_at` characters. If the
     /// configured limit is too small to fit both the marker and a content
     /// character, the marker is dropped so the output never exceeds the limit.
+    ///
+    /// When a stash store is attached, the suffix carries a `<<tokenless:KEY>>`
+    /// marker and the ORIGINAL full string is stashed so truncation is
+    /// reversible. On stash failure the suffix degrades to the plain lossy
+    /// `… (truncated)` marker (or hard truncation if even that won't fit).
     fn compress_string(&self, s: &str) -> Value {
         let char_count = s.chars().count();
         if char_count <= self.truncate_strings_at {
             return Value::String(s.to_string());
         }
 
-        const MARKER: &str = "… (truncated)";
-        let marker_len = MARKER.chars().count();
-        // Only attach the marker when the limit can fit it plus at least one
-        // content character; otherwise dropping the marker is the only way to
-        // honor truncate_strings_at.
-        let attach_marker = self.add_truncation_marker && self.truncate_strings_at > marker_len;
+        const LOSSY_MARKER: &str = "… (truncated)";
+        let lossy_marker_len = LOSSY_MARKER.chars().count();
+
+        // Reversible path: a stash store is attached, truncation markers are
+        // enabled, and the limit can fit the stash suffix plus at least one
+        // content character. Stash the ORIGINAL full string (not the truncated
+        // form) so retrieval yields the verbatim original. Fit is checked
+        // BEFORE stashing so a too-small limit (or disabled markers) does not
+        // orphan a stash entry with no embedded marker — a stash without a
+        // reachable marker is unretrievable.
+        if self.add_truncation_marker
+            && self.truncate_strings_at > stash_suffix_char_len()
+            && let Some(store) = self.stash_store.as_ref()
+            && let Ok(key) = store.stash(s)
+        {
+            let target = self.truncate_strings_at - stash_suffix_char_len();
+            let truncate_pos = s
+                .char_indices()
+                .nth(target)
+                .map(|(i, _)| i)
+                .unwrap_or(s.len());
+            return Value::String(format!("{}{}", &s[..truncate_pos], stash_suffix(&key)));
+        }
+
+        // Lossy path: existing behavior. Only attach the marker when the
+        // limit can fit it plus at least one content character; otherwise
+        // dropping the marker is the only way to honor truncate_strings_at.
+        let attach_marker =
+            self.add_truncation_marker && self.truncate_strings_at > lossy_marker_len;
         let target = if attach_marker {
-            self.truncate_strings_at - marker_len
+            self.truncate_strings_at - lossy_marker_len
         } else {
             self.truncate_strings_at
         };
@@ -216,7 +272,7 @@ impl ResponseCompressor {
         let truncated = &s[..truncate_pos];
 
         if attach_marker {
-            Value::String(format!("{}{}", truncated, MARKER))
+            Value::String(format!("{}{}", truncated, LOSSY_MARKER))
         } else {
             Value::String(truncated.to_string())
         }

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -1,6 +1,9 @@
 use regex::Regex;
 use serde_json::Value;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
+use tokenless_ccr::StashStore;
+
+use crate::response_compressor::{stash_suffix, stash_suffix_char_len};
 
 static CODE_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"```[\s\S]*?```").unwrap());
 static INLINE_CODE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`[^`]+`").unwrap());
@@ -22,6 +25,12 @@ pub struct SchemaCompressor {
     drop_titles: bool,
     drop_markdown: bool,
     max_depth: usize,
+    /// Optional reversible stash. When present, truncated descriptions are
+    /// stashed (verbatim original, including markdown) and a
+    /// `<<tokenless:KEY>>` marker is appended so the LLM can retrieve the
+    /// full original. When `None`, truncation is lossy — the pre-stash
+    /// behavior. Mirrors `ResponseCompressor::stash_store`.
+    stash_store: Option<Arc<dyn StashStore>>,
 }
 
 impl Default for SchemaCompressor {
@@ -41,6 +50,7 @@ impl Default for SchemaCompressor {
             // descriptions. 32 keeps a wide safety margin below the
             // ~1024-frame default stack while leaving real schemas intact.
             max_depth: 32,
+            stash_store: None,
         }
     }
 }
@@ -49,6 +59,15 @@ impl SchemaCompressor {
     /// Create a new SchemaCompressor with default settings
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Attach a reversible stash store. When set, truncated descriptions
+    /// carry a `<<tokenless:KEY>>` marker and the verbatim original is
+    /// stashed for retrieval; when unset (the default), truncation stays
+    /// lossy.
+    pub fn with_stash_store(mut self, store: Arc<dyn StashStore>) -> Self {
+        self.stash_store = Some(store);
+        self
     }
 
     /// Set the maximum length for function-level descriptions
@@ -236,7 +255,13 @@ impl SchemaCompressor {
         }
     }
 
-    /// Intelligently truncate a description string
+    /// Intelligently truncate a description string. When a stash store is
+    /// attached, the verbatim original `desc` (including markdown, before
+    /// stripping) is stashed and a `<<tokenless:KEY>>` marker is appended so
+    /// the LLM can retrieve the full original; the stash suffix length is
+    /// reserved from `max_len` so the result still honors the limit. On stash
+    /// failure the suffix is dropped (lossy truncation, the pre-stash
+    /// behavior).
     pub fn truncate_description(&self, desc: &str, max_len: usize) -> String {
         // Trim whitespace
         let mut text = desc.trim().to_string();
@@ -249,20 +274,43 @@ impl SchemaCompressor {
         text = WHITESPACE_RE.replace_all(&text, " ").to_string();
         text = text.trim().to_string();
 
-        // If already within limit, return as-is (use char count, not byte length)
-        if text.chars().count() <= max_len {
+        // When stash is attached, reserve room for the retrievable suffix so
+        // the final string still fits `max_len`. Fit is checked before any
+        // stash call so a too-small `max_len` cannot orphan a stash entry
+        // whose marker never reaches the LLM.
+        let stash_active = self.stash_store.is_some() && max_len > stash_suffix_char_len();
+        let effective_max = if stash_active {
+            max_len - stash_suffix_char_len()
+        } else {
+            max_len
+        };
+
+        // If already within limit, return as-is (use char count, not byte length).
+        // No truncation → nothing stashed (markdown stripping's loss is
+        // pre-existing behavior, out of scope for the reversible-truncation path).
+        if text.chars().count() <= effective_max {
             return text;
         }
 
-        // Try to find a sentence boundary in the range [max_len*0.5, max_len]
-        // Convert char counts to byte positions via char_index so the search
-        // range and hard-truncation fallback use correct byte offsets even for
-        // multi-byte text (CJK, emoji, etc.). Previously max_len was passed
-        // directly as a byte position, truncating CJK text far more
-        // aggressively than expected (e.g. 300 chars cut to ~85 instead of 256).
-        let min_target = (max_len as f64 * 0.5) as usize;
+        // Truncation will happen. Stash the ORIGINAL desc (verbatim, with
+        // markdown) so retrieval yields the unredacted original — matching
+        // ResponseCompressor's "retrieval yields the original content
+        // verbatim" contract.
+        let stash_key = if stash_active {
+            self.stash_store
+                .as_ref()
+                .and_then(|store| store.stash(desc).ok())
+        } else {
+            None
+        };
+
+        // Try to find a sentence boundary in the range [effective_max*0.5,
+        // effective_max]. Convert char counts to byte positions via
+        // char_index so the search range and hard-truncation fallback use
+        // correct byte offsets even for multi-byte text (CJK, emoji, etc.).
+        let min_target = (effective_max as f64 * 0.5) as usize;
         let min_pos = char_index(&text, min_target);
-        let max_pos = char_index(&text, max_len.min(text.chars().count()));
+        let max_pos = char_index(&text, effective_max.min(text.chars().count()));
         let search_range = &text[min_pos..max_pos];
 
         // Look for sentence endings: . 。 ！ ？
@@ -276,13 +324,18 @@ impl SchemaCompressor {
             }
         }
 
-        if let Some(pos) = best_pos {
-            return text[..pos].trim().to_string();
-        }
+        let truncated = if let Some(pos) = best_pos {
+            text[..pos].trim().to_string()
+        } else {
+            // No sentence boundary found, hard truncate at effective_max.
+            let truncate_pos = char_index(&text, effective_max);
+            text[..truncate_pos].trim().to_string()
+        };
 
-        // No sentence boundary found, hard truncate at max_len characters
-        let truncate_pos = char_index(&text, max_len);
-        text[..truncate_pos].trim().to_string()
+        match stash_key {
+            Some(key) => format!("{}{}", truncated, stash_suffix(&key)),
+            None => truncated,
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Completes the stash (CCR) feature's truncation coverage: all four truncation paths are now reversible. Previously only array truncation had stash; string, depth, and schema-description truncation were still lossy. This PR adds stash to those three paths + a lazy-purge hardening on the SQLite backend.

**ResponseCompressor** (`tokenless-schema`):
- **String truncation** (`compress_string`): stash the original full string + embed `<<tokenless:KEY>>` marker. The stash suffix length is reserved from `truncate_strings_at` so the output still honors the limit. Fit is checked BEFORE stashing so a too-small limit (or disabled markers) does not orphan a stash entry with no embedded marker.
- **Depth truncation** (`compress_value` at `max_depth`): stash the original subtree (serialized JSON) + embed marker. On any failure fall back to the plain lossy depth marker.
- Shared helpers `stash_suffix()` / `stash_suffix_char_len()` extracted for reuse by SchemaCompressor.
- 7 new tests: string round-trip, lossy fallback, failing-stash fallback, CJK round-trip, depth round-trip, depth lossy, `add_truncation_marker=false` respects.

**SchemaCompressor** (`tokenless-schema`):
- **Description truncation** (`truncate_description`): stash the verbatim original description (including markdown, before stripping) + append marker. Suffix length reserved from `max_len`. This addresses the earlier "marker overhead 25-40%" deferral — the suffix is ~65 chars, reserved from 256/160-char limits.
- `with_stash_store()` builder + `stash_store: Option<Arc<dyn StashStore>>`.
- 3 new tests: long description round-trip (markdown preserved on retrieval), lossy fallback, CJK round-trip.

**CLI** (`tokenless-cli`):
- `compress-schema` gains `--no-stash` / `--stash-db` (mirroring `compress-response`). Config loaded before stash decision so dry-run (`!compression_on`) skips stash — preventing orphaned entries.

**SqliteStore** (`tokenless-ccr`):
- **Lazy purge** on `retrieve`: physically `DELETE FROM stash WHERE expires_at < ?` before the SELECT, so the DB file does not grow unbounded by stale entries. Best-effort (failure warns, continues). 1 new test.

## Related Issue

no-issue: completes stash truncation coverage (string/depth/schema) + lazy purge.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `tokenless`: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` pass
- [x] Lock files are up to date

## Testing

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace   # ccr 32, schema 37, cli 19, stats 67 — all green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
