### PR TITLE
fix(memory): format safe_fs_tests.rs import order and indentation

### DIFF
--- a/src/agent-memory/tests/safe_fs_tests.rs
+++ b/src/agent-memory/tests/safe_fs_tests.rs
@@ -272,8 +272,7 @@ fn openat2_rejects_starting_dotdot() {
     assert!(
         matches!(
             err,
-            agent_memory::MemoryError::PathOutsideMount(_)
-                | agent_memory::MemoryError::Other(_)
+            agent_memory::MemoryError::PathOutsideMount(_) | agent_memory::MemoryError::Other(_)
         ),
         "starting .. should be rejected, got {err:?}"
     );
@@ -384,8 +383,7 @@ fn assert_no_symlink_traversal_catches_mid_path_symlink() {
     let root = safe_fs::open_root(tmp.path()).unwrap();
     let fd = root.as_fd();
 
-    let err =
-        safe_fs::assert_no_symlink_traversal(fd, Path::new("a/b/c.txt")).unwrap_err();
+    let err = safe_fs::assert_no_symlink_traversal(fd, Path::new("a/b/c.txt")).unwrap_err();
     assert!(
         matches!(err, agent_memory::MemoryError::PathOutsideMount(_)),
         "mid-path symlink should be caught, got {err:?}"
@@ -638,7 +636,7 @@ mod resolve_path_tests {
 
     use agent_memory::{
         MemoryError,
-        ns::{Namespace, MountPoint, paths},
+        ns::{MountPoint, Namespace, paths},
     };
     use tempfile::tempdir;
 


### PR DESCRIPTION
## Description

Fixes `cargo fmt --all --check` failure on `tests/safe_fs_tests.rs` (3 diffs: import reorder at L638, indentation at L272/L384). Pre-existing formatting drift, not introduced by any feature change. This was causing the "Test agent-memory" CI job to fail at the "Check formatting" step.

## Related Issue

no-issue: pre-existing fmt drift in agent-memory test file.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `memory` (agent-memory)

## Checklist

- [x] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass

## Testing

```bash
cd src/agent-memory
cargo fmt --all -- --check   # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test --locked   # all green (169 unit + integration suites)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)