### PR TITLE
fix(memory): honor INSTALL_PROFILE so user-mode install does not need root

### DIFF
--- a/src/agent-memory/Makefile
+++ b/src/agent-memory/Makefile
@@ -16,9 +16,22 @@ REMOTE_BRANCH ?= memory
 REMOTE_REPO ?= shiloong
 
 # Install paths
-PREFIX ?= /usr/local
+# INSTALL_PROFILE selects the install layout, matching the contract used by
+# the other Rust components (tokenless, ws-ckpt): in user mode every writable
+# path is rooted at $(HOME)/.local so `make install` runs without root; in
+# system mode paths go under /usr. DATADIR/SHARE_DIR derive from $(PREFIX) so
+# they follow the profile instead of being hardcoded to /usr/share/anolisa
+# (which caused Permission denied under INSTALL_PROFILE=user).
+INSTALL_PROFILE ?= user
+
+ifeq ($(INSTALL_PROFILE),user)
+PREFIX ?= $(HOME)/.local
+else
+PREFIX ?= /usr
+endif
+
 BINDIR ?= $(PREFIX)/bin
-DATADIR ?= /usr/share/anolisa
+DATADIR ?= $(PREFIX)/share/anolisa
 DOCDIR ?= $(PREFIX)/share/doc/$(NAME)
 SHARE_DIR ?= $(DATADIR)/adapters/agent-memory
 


### PR DESCRIPTION
## Problem

`build-all.sh --component memory` in user mode failed at the install step for non-root users:

```
==> Installing agent-memory
    make install (agent-memory)  FAILED
[warn] Failed: make install INSTALL_PROFILE=user PREFIX=/home/taoma/.local

install: cannot create directory '/usr/share/anolisa': Permission denied
make: *** [Makefile:184: install-adapter-resources] Error 1
```

`cargo build --release --locked` succeeded — only the install step was broken.

## Root cause

`src/agent-memory/Makefile` hardcoded `DATADIR ?= /usr/share/anolisa` (an absolute path, not derived from `$(PREFIX)`) and did not handle `INSTALL_PROFILE` at all. So `make install INSTALL_PROFILE=user PREFIX=$HOME/.local` redirected `BINDIR` to `~/.local/bin` but still tried to write adapter resources under `/usr/share/anolisa`, which requires root.

This breaks the component install contract that `build-all.sh` expects (and that the sibling Rust components `tokenless` and `ws-ckpt` already honor): in user mode every writable path must be rooted at `~/.local`.

## Fix

Align the path layout with the `tokenless` / `ws-ckpt` contract:

```makefile
INSTALL_PROFILE ?= user

ifeq ($(INSTALL_PROFILE),user)
PREFIX ?= $(HOME)/.local
else
PREFIX ?= /usr
endif

BINDIR ?= $(PREFIX)/bin
DATADIR ?= $(PREFIX)/share/anolisa      # was: /usr/share/anolisa
DOCDIR ?= $(PREFIX)/share/doc/$(NAME)
SHARE_DIR ?= $(DATADIR)/adapters/agent-memory
```

`DATADIR` / `SHARE_DIR` now derive from `$(PREFIX)`, so they follow the install profile instead of being hardcoded.

## Compatibility

- **system mode unchanged**: `build-all.sh` passes `PREFIX=/usr`, and `$(PREFIX)/share/anolisa` resolves to the same `/usr/share/anolisa`.
- **bare `make install`** default changes from `/usr/local` to `~/.local`, matching the `tokenless` default (`INSTALL_PROFILE ?= user`).
- `install-systemd-user` (hardcoded `/usr/lib/systemd/user/`, not in the `install` dependency chain) is intentionally left untouched to keep the change minimal.

## Verification

Created a non-root account `taoma` and ran a clean install on Ubuntu 26.04 (cmake + libsystemd-dev + pkg-config + jq installed):

```
$ ./scripts/build-all.sh --component memory --ignore-deps
[ok]   agent-memory built successfully
==> Installing agent-memory
       make install (agent-memory)  ok
[ok]   agent-memory installed to /home/taoma/.local/bin/
[ok]   Done
```

Artifacts landed in the correct user paths:
- `~/.local/bin/agent-memory` (16M)
- `~/.local/share/anolisa/adapters/agent-memory/{manifest.json,openclaw/}`
- `~/.local/share/anolisa/agent-memory/default.toml`
- `~/.local/share/anolisa/mcp-servers/agent-memory.json`

Signed-off-by: Shile Zhang <shile.zhang@linux.alibaba.com>