### PR TITLE
feat(cosh): export COSH_SESSION_ID for agentsight per-run correlation

### DIFF
--- a/src/agentsight/src/aggregator/proctrace/process.rs
+++ b/src/agentsight/src/aggregator/proctrace/process.rs
@@ -231,6 +231,7 @@ impl ToChromeTraceEvent for AggregatedProcess {
 }
 
 const SESSION_ENV_VARS: &[&str] = &[
+    "COSH_SESSION_ID",
     "CLAUDE_CODE_SESSION_ID",
     "HERMES_SESSION_ID",
     "AGENT_SEC_SESSION_ID",

--- a/src/copilot-shell/packages/cli/src/config/config.test.ts
+++ b/src/copilot-shell/packages/cli/src/config/config.test.ts
@@ -597,6 +597,28 @@ describe('loadCliConfig', () => {
     expect(lspInstance?.start).toHaveBeenCalledTimes(1);
   });
 
+  it('adopts COSH_SESSION_ID from env when not resuming', async () => {
+    vi.stubEnv('COSH_SESSION_ID', 'sight-corr-abc-123');
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv);
+    // Discriminating: without the env-adopt block, sessionId stays undefined and
+    // Config mints a random uuid, so this exact-match assertion fails.
+    expect(config.getSessionId()).toBe('sight-corr-abc-123');
+  });
+
+  it('ignores an empty COSH_SESSION_ID and mints a fresh id', async () => {
+    vi.stubEnv('COSH_SESSION_ID', '');
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv);
+    // Empty value must be treated as absent (guards the `.length > 0` check).
+    expect(config.getSessionId()).not.toBe('');
+    expect(config.getSessionId().length).toBeGreaterThan(0);
+  });
+
   describe('Proxy configuration', () => {
     const originalProxyEnv: { [key: string]: string | undefined } = {};
     const proxyEnvVars = [

--- a/src/copilot-shell/packages/cli/src/config/config.ts
+++ b/src/copilot-shell/packages/cli/src/config/config.ts
@@ -956,6 +956,18 @@ export async function loadCliConfig(
     }
   }
 
+  // Adopt a launcher-provided correlation id (exported as COSH_SESSION_ID
+  // by the cosh wrapper) so this run's own session id matches what AgentSight
+  // scrapes from /proc/<pid>/environ, enabling per-run cross-plane correlation.
+  // Precedence: --continue/--resume > COSH_SESSION_ID env > minted uuid
+  // (Config mints one when sessionId is left undefined). Unauthenticated hint.
+  if (!sessionId) {
+    const envSessionId = process.env['COSH_SESSION_ID'];
+    if (envSessionId && envSessionId.length > 0) {
+      sessionId = envSessionId;
+    }
+  }
+
   const modelProvidersConfig = settings.modelProviders;
 
   const config = new Config({

--- a/src/copilot-shell/scripts/cosh-wrapper.sh
+++ b/src/copilot-shell/scripts/cosh-wrapper.sh
@@ -20,4 +20,12 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
+# ── Correlation session id for observability ──
+# Export a session id into the environment BEFORE exec so it lands in this
+# process's /proc/<pid>/environ snapshot (which AgentSight scrapes for
+# per-run attribution) and is inherited by child tool processes. Idempotent:
+# an inherited value is preserved so nested/parent runs share one id.
+# This is an UNAUTHENTICATED observability hint only — never used for authz.
+export COSH_SESSION_ID="${COSH_SESSION_ID:-$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null)}"
+
 exec node "$LIBDIR/cli.js" "$@"


### PR DESCRIPTION
## 背景与动机

AgentSight 的 proctrace 探针在进程 exec 时从 `/proc/{pid}/environ` 读取 session id 环境变量（`src/agentsight/src/aggregator/proctrace/process.rs:233-237`），用于将 LLM 调用、中断事件归因到一次 agent 运行。

但 Copilot Shell 目前**不把自己的 session id 导出到环境变量**——它内部有完整的 `sessionId`（config.ts:574 `randomUUID()`），流进 hooks、telemetry、输出协议，但进程的 `/proc/environ` 里没有这个值。结果：AgentSight 对 Copilot Shell 运行的归因为空，跨组件 session 关联断裂。

## 本 PR 做什么

4 个文件,闭合归因链:

1. **cosh-wrapper.sh**（生成 `/usr/bin/cosh`，覆盖 `co`/`copilot` symlink）：`exec node` 前导出:
   ```bash
   export COSH_SESSION_ID="${COSH_SESSION_ID:-$(uuidgen ...)}"
   ```
   - 在 `execve` 前落入 environ → 正是 AgentSight proctrace 读到的快照
   - 幂等：已继承的值不覆盖（`:-`），父/嵌套 run 共享同一 id

2. **config.ts**（`loadCliConfig`）：当没有 `--continue`/`--resume` 时，从 `COSH_SESSION_ID` 环境读 session id。优先级：`--resume` > `env` > `randomUUID()`。

3. **agentsight process.rs**：`SESSION_ENV_VARS` 加 `"COSH_SESSION_ID"` 为首位,和 cosh-shell interactive 路径（bootstrap.rs:83 已 export `COSH_SESSION_ID`）一致。

这让 Copilot Shell 报告的 session id == AgentSight 从 environ 观测到的,二者是同一个值。

## 不做什么

- 只统一 audit/proctrace 平面；token/interruption/grader 平面需要 LLM wire 注入（#1014），不在本 scope
- 不碰 cosh-shell interactive 路径已有的 `COSH_SESSION_ID` export（bootstrap.rs:83,本 PR 只是让 agentsight 也认它）
- `COSH_SESSION_ID` 定位为**未认证的观测关联 hint**（env 可 spoof，同 HERMES_SESSION_ID 先例），不 gate 任何 authz

## ECS 端到端验证

在 ecs-test（6.6.102+）实测确认：
- BPF 解锁后 agentsight proctrace 正常加载,attach Cosh 进程,解析 chatcmpl 响应 ✓
- **gap 端到端实锤**：env 设了 session id,但 cosh 输出的 `session_id` 是自己 mint 的 → 证明修复前不 adopt ✓
- 交互模式下 node 存活整个会话,agentsight 有充足时间读 environ（one-shot race 是已知独立问题）

## 测试

- 2 个判别式 vitest 单测（mutation 实证：撤回赋值 → 测试挂）
- tsc --noEmit 0 错 / eslint 干净 / pre-commit hook 通过
- wrapper bash 语法 + 幂等逻辑验证（mint/继承/空串三情形）
- agentsight 侧仅加 1 行字符串到已有数组,无逻辑改动

## 前提说明:效果 gate 在 `features.audit`

补一个准确前提(初版 PR 描述漏了):agentsight 侧这条关联链的**可观测效果 gate 在 `features.audit` 开关上**。

完整链路(已逐点 trace):`COSH_SESSION_ID` env → `read_session_env`(proctrace/process.rs:42)→ proctrace `session_map` ppid 传播 → `AggregatedProcess.session_id` → **唯一消费者** `extract_process_action`(analyzer/audit/analyzer.rs:165)→ `AuditRecord(ProcessAction).session_id` → 持久化闸 `should_persist_analysis_result`(unified.rs:1808:`Audit(_) => audit_enabled`)→ `audit_events.session_id`。

- **代码默认** `audit_enabled=false`(config.rs);**出厂 `src/agentsight/agentsight.json` 显式 `"audit": true`**,所以带出厂配置的真实部署里这条链是通的、有实效。
- 若用空/自定义 config 覆盖且未含 `audit:true`,process_action 审计行在持久化闸被丢,session_id 无可观测效果(纯配置问题,非本 PR 行为)。
- 穷举确认:proctrace 的 session_id **唯一 sink 就是 process_action 审计行**;genai / interruption 平面走各自独立的 session 来源(ResponseSessionMapper / genai-pending),不读 proctrace `session_map`。