### PR TITLE
fix(cosh-ng): bound host-executed shell preview

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -775,6 +775,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_control_response_host_executed_shell_with_null_return_display() {
+        let json = r#"{"type":"control_response","response":{"subtype":"success","request_id":"req-3","response":{"behavior":"host_executed_shell","result":{"llmContent":"ShellCommandCompleted evidence\ncommand: df -h","returnDisplay":null,"metadata":{"command":"df -h","status":"completed","exit_code":0}}}}}"#;
+        let msg: InputMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            InputMessage::ControlResponse { response } => {
+                let result = response.response.result.expect("host result");
+                assert!(result.llm_content.contains("ShellCommandCompleted"));
+                assert_eq!(result.return_display, None);
+                assert_eq!(
+                    result
+                        .metadata
+                        .as_ref()
+                        .and_then(|m| m.get("exit_code"))
+                        .and_then(Value::as_i64),
+                    Some(0)
+                );
+            }
+            _ => panic!("expected ControlResponse"),
+        }
+    }
+
+    #[test]
     fn serialize_system_init() {
         let msg = OutputMessage::system_init(
             "sess-1",

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
@@ -363,9 +363,9 @@ fn serialize_deny_format() {
 #[test]
 fn serialize_host_executed_shell_result_format() {
     let result = HostExecutedShellResult {
-        llm_content: "command: df -h\nstatus: completed\nbounded_output:\nFilesystem ..."
+        llm_content: "ShellCommandCompleted evidence\ncommand: df -h\nstatus: completed\nbounded_output_summary:\nFilesystem ..."
             .to_string(),
-        return_display: Some("df -h completed".to_string()),
+        return_display: None,
         metadata: HostExecutedShellMetadata {
             command: "df -h".to_string(),
             status: "completed".to_string(),
@@ -392,7 +392,7 @@ fn serialize_host_executed_shell_result_format() {
     );
     assert_eq!(
         v["response"]["response"]["result"]["returnDisplay"],
-        "df -h completed"
+        Value::Null
     );
     assert_eq!(
         v["response"]["response"]["result"]["metadata"]["command"],
@@ -406,6 +406,18 @@ fn serialize_host_executed_shell_result_format() {
     assert_eq!(
         v["response"]["response"]["result"]["metadata"]["tool_use_id"],
         "toolu-1"
+    );
+    assert_eq!(
+        v["response"]["response"]["result"]["metadata"].get("provider_visible_complete"),
+        None
+    );
+    assert_eq!(
+        v["response"]["response"]["result"]["metadata"].get("provider_visible_truncated"),
+        None
+    );
+    assert_eq!(
+        v["response"]["response"]["result"]["metadata"].get("provider_visible_chars"),
+        None
     );
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/output_policy.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/output_policy.rs
@@ -17,8 +17,10 @@ use crate::evidence::prelude::{CommandStatus, OutputRefs};
 pub(crate) struct EvidenceView {
     pub(crate) provider_summary: String,
     pub(crate) provider_preview: Option<String>,
-    pub(crate) return_display: Option<String>,
     pub(crate) redaction_status: &'static str,
+    pub(crate) provider_preview_truncated: bool,
+    pub(crate) provider_preview_complete: bool,
+    pub(crate) provider_preview_chars: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -178,13 +180,19 @@ fn unavailable_excerpt() -> EvidenceExcerpt {
 }
 
 pub(crate) fn shell_evidence_view(facts: EvidenceFacts<'_>) -> EvidenceView {
-    let preview = provider_output_preview(facts.output_ref);
     let output_id = facts
         .output_ref
         .map(|_| terminal_output_id(facts.shell_session_id, facts.command_id))
         .unwrap_or_else(|| "<none>".to_string());
+    let preview = provider_output_preview(facts.output_ref, &output_id);
     let provider_preview = preview.text;
     let redaction_status = preview.redaction_status;
+    let provider_preview_truncated = preview.truncated;
+    let provider_preview_complete = preview.complete;
+    let provider_preview_chars = provider_preview
+        .as_deref()
+        .map(|text| text.chars().count())
+        .unwrap_or(0);
     let bounded_output = provider_preview.as_deref().unwrap_or(preview.reason);
     let provider_summary = format!(
         "command: {command}\n\
@@ -206,9 +214,11 @@ pub(crate) fn shell_evidence_view(facts: EvidenceFacts<'_>) -> EvidenceView {
 
     EvidenceView {
         provider_summary,
-        return_display: provider_preview.clone(),
         provider_preview,
         redaction_status,
+        provider_preview_truncated,
+        provider_preview_complete,
+        provider_preview_chars,
     }
 }
 
@@ -241,6 +251,8 @@ mod tests {
         });
 
         assert_eq!(view.redaction_status, "preview_redacted");
+        assert!(!view.provider_preview_truncated);
+        assert!(view.provider_preview_complete);
         assert!(view.provider_summary.contains("command: cat secret.txt"));
         assert!(view
             .provider_summary
@@ -299,10 +311,111 @@ mod tests {
 
         let provider_preview = view.provider_preview.expect("provider preview");
         assert_eq!(view.redaction_status, "preview_redacted");
-        assert!(provider_preview.ends_with("... <truncated>"));
+        assert!(view.provider_preview_truncated);
+        assert!(!view.provider_preview_complete);
+        assert!(view.provider_preview_chars <= PROVIDER_PREVIEW_MAX_CHARS);
+        assert!(provider_preview.contains("... <truncated"));
+        assert!(provider_preview.contains("cosh_shell_evidence action=read_output"));
+        assert!(provider_preview.contains("terminal-output://raw-test/cmd-2"));
+        assert!(provider_preview.ends_with(&"x".repeat(100)));
         assert!(view
             .provider_summary
             .contains("redaction_status: preview_redacted"));
+    }
+
+    #[test]
+    fn evidence_view_truncated_json_preview_keeps_tail() {
+        let dir = std::env::temp_dir().join(format!(
+            "cosh-shell-evidence-policy-json-tail-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("dir");
+        let output = dir.join("output.txt");
+        let body = format!(
+            "{{\"findings\":\"{}\",\"next_steps\":[\"sysom-osops memory filecache\"],\"summary\":\"tail kept\"}}",
+            "x".repeat(PROVIDER_PREVIEW_MAX_CHARS)
+        );
+        std::fs::write(&output, body).expect("write output");
+
+        let view = shell_evidence_view(EvidenceFacts {
+            shell_session_id: "raw-test",
+            command_id: "cmd-json",
+            command: "sysom-osops memory classify",
+            cwd: "/tmp",
+            end_cwd: "/tmp",
+            status: "completed",
+            exit_code: 0,
+            duration_ms: 12,
+            output_ref: Some(output.to_str().expect("utf8 output path")),
+        });
+
+        let provider_preview = view.provider_preview.expect("provider preview");
+        assert!(view.provider_preview_truncated);
+        assert!(!view.provider_preview_complete);
+        assert!(view.provider_preview_chars <= PROVIDER_PREVIEW_MAX_CHARS);
+        assert!(provider_preview.starts_with("{\"findings\""));
+        assert!(provider_preview.contains("\"next_steps\""));
+        assert!(provider_preview.contains("\"summary\":\"tail kept\"}"));
+    }
+
+    #[test]
+    fn evidence_view_truncated_preview_stays_bounded_with_long_output_id() {
+        let dir = std::env::temp_dir().join(format!(
+            "cosh-shell-evidence-policy-long-output-id-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("dir");
+        let output = dir.join("output.txt");
+        std::fs::write(&output, "x".repeat(PROVIDER_PREVIEW_MAX_CHARS + 10)).expect("write output");
+
+        let view = shell_evidence_view(EvidenceFacts {
+            shell_session_id: &"s".repeat(PROVIDER_PREVIEW_MAX_CHARS),
+            command_id: "cmd-long",
+            command: "yes",
+            cwd: "/tmp",
+            end_cwd: "/tmp",
+            status: "completed",
+            exit_code: 0,
+            duration_ms: 12,
+            output_ref: Some(output.to_str().expect("utf8 output path")),
+        });
+
+        assert!(view.provider_preview_truncated);
+        assert!(view.provider_preview_chars <= PROVIDER_PREVIEW_MAX_CHARS);
+        assert!(view
+            .provider_preview
+            .as_deref()
+            .expect("provider preview")
+            .contains("output_id from metadata"));
+    }
+
+    #[test]
+    fn evidence_view_unavailable_preview_is_not_complete() {
+        let dir = std::env::temp_dir().join(format!(
+            "cosh-shell-evidence-policy-invalid-utf8-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("dir");
+        let output = dir.join("output.txt");
+        std::fs::write(&output, [0xff, 0xfe, 0xfd]).expect("write output");
+
+        let view = shell_evidence_view(EvidenceFacts {
+            shell_session_id: "raw-test",
+            command_id: "cmd-invalid",
+            command: "cat output.txt",
+            cwd: "/tmp",
+            end_cwd: "/tmp",
+            status: "completed",
+            exit_code: 0,
+            duration_ms: 12,
+            output_ref: Some(output.to_str().expect("utf8 output path")),
+        });
+
+        assert_eq!(view.provider_preview, None);
+        assert_eq!(view.redaction_status, "preview_unavailable");
+        assert!(!view.provider_preview_truncated);
+        assert!(!view.provider_preview_complete);
+        assert_eq!(view.provider_preview_chars, 0);
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/output_text.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/output_text.rs
@@ -2,20 +2,29 @@ use std::path::Path;
 
 use crate::evidence::model::OutputExcerptDirection;
 
-pub(super) const PROVIDER_PREVIEW_MAX_CHARS: usize = 2_000;
+pub(super) const PROVIDER_PREVIEW_MAX_CHARS: usize = 6_000;
+const PROVIDER_PREVIEW_HEAD_CHARS: usize = 4_000;
+const PROVIDER_PREVIEW_TAIL_CHARS: usize = 1_500;
 
 pub(super) struct ProviderOutputPreview {
     pub(super) text: Option<String>,
     pub(super) redaction_status: &'static str,
     pub(super) reason: &'static str,
+    pub(super) truncated: bool,
+    pub(super) complete: bool,
 }
 
-pub(super) fn provider_output_preview(output_ref: Option<&str>) -> ProviderOutputPreview {
+pub(super) fn provider_output_preview(
+    output_ref: Option<&str>,
+    output_id: &str,
+) -> ProviderOutputPreview {
     let Some(output_ref) = output_ref else {
         return ProviderOutputPreview {
             text: None,
             redaction_status: "preview_unavailable",
             reason: "<none>",
+            truncated: false,
+            complete: false,
         };
     };
     let Ok(text) = std::fs::read_to_string(Path::new(output_ref)) else {
@@ -23,12 +32,14 @@ pub(super) fn provider_output_preview(output_ref: Option<&str>) -> ProviderOutpu
             text: None,
             redaction_status: "preview_unavailable",
             reason: "<unavailable>",
+            truncated: false,
+            complete: false,
         };
     };
 
     let text = clean_terminal_control_sequences(&text);
     let (redacted, found_sensitive) = redact_sensitive_output(&text);
-    let (bounded, truncated) = truncate_preview(&redacted, PROVIDER_PREVIEW_MAX_CHARS);
+    let (bounded, truncated) = truncate_preview(&redacted, PROVIDER_PREVIEW_MAX_CHARS, output_id);
     let redaction_status = if found_sensitive || truncated {
         "preview_redacted"
     } else {
@@ -39,6 +50,8 @@ pub(super) fn provider_output_preview(output_ref: Option<&str>) -> ProviderOutpu
         text: Some(bounded),
         redaction_status,
         reason: "<preview omitted>",
+        truncated,
+        complete: !truncated,
     }
 }
 
@@ -153,14 +166,35 @@ fn push_redacted_token(output: &mut String, token: &str, changed: &mut bool) {
     }
 }
 
-fn truncate_preview(value: &str, max_chars: usize) -> (String, bool) {
-    let mut chars = value.chars();
-    let truncated = chars.by_ref().take(max_chars).collect::<String>();
-    if chars.next().is_some() {
-        (format!("{truncated}... <truncated>"), true)
-    } else {
-        (truncated, false)
+fn truncate_preview(value: &str, max_chars: usize, output_id: &str) -> (String, bool) {
+    let total_chars = value.chars().count();
+    if total_chars <= max_chars {
+        return (value.to_string(), false);
     }
+
+    let full_marker = format!(
+        "\n\n... <truncated; for more output use cosh_shell_evidence action=read_output output_id={output_id} direction=tail lines=300>\n\n"
+    );
+    let marker = if full_marker.chars().count() < max_chars {
+        full_marker
+    } else {
+        "\n\n... <truncated; for more output use cosh_shell_evidence read_output with output_id from metadata>\n\n".to_string()
+    };
+    let marker_chars = marker.chars().count();
+    let available_chars = max_chars.saturating_sub(marker_chars);
+    let head_chars = PROVIDER_PREVIEW_HEAD_CHARS.min(available_chars);
+    let tail_chars = PROVIDER_PREVIEW_TAIL_CHARS.min(available_chars.saturating_sub(head_chars));
+    let head = value.chars().take(head_chars).collect::<String>();
+    let tail = value
+        .chars()
+        .rev()
+        .take(tail_chars)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+
+    (format!("{head}{marker}{tail}"), true)
 }
 
 pub(super) fn select_output_lines(

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
@@ -28,9 +28,12 @@ pub(crate) fn record_shell_handoff_completion(
                 .active
                 .as_ref()
                 .map(|run| run.request.id.clone());
-            state
-                .shell_evidence
-                .record_host_executed_shell_output(output_id, run_id);
+            let summary_complete = delivery.provider_preview_complete;
+            state.shell_evidence.record_host_executed_shell_output(
+                output_id,
+                run_id,
+                summary_complete,
+            );
         }
     }
     evidence.apply_provider_result_delivery(delivery);
@@ -83,6 +86,7 @@ fn deliver_host_executed_shell_result_if_supported(
             delivered: false,
             status: "not_provider_tool_request",
             recovery_reason: Some("no provider request id; shell evidence continuation required"),
+            provider_preview_complete: false,
         };
     };
     let Some(capabilities) = state
@@ -97,6 +101,7 @@ fn deliver_host_executed_shell_result_if_supported(
             recovery_reason: Some(
                 "provider run was not active when shell completed; shell evidence continuation required",
             ),
+            provider_preview_complete: false,
         };
     };
     if !capabilities.can_handle_host_executed_shell_tool_result {
@@ -106,6 +111,7 @@ fn deliver_host_executed_shell_result_if_supported(
             recovery_reason: Some(
                 "provider did not advertise host-executed shell result support; shell evidence continuation required",
             ),
+            provider_preview_complete: false,
         };
     }
 
@@ -118,10 +124,13 @@ fn deliver_host_executed_shell_result_if_supported(
             delivered: true,
             status: "duplicate_already_delivered",
             recovery_reason: None,
+            provider_preview_complete: false,
         };
     };
 
-    let result = host_executed_shell_result(handoff, evidence);
+    let view = EvidenceState::provider_visible_view(evidence);
+    let provider_preview_complete = view.provider_preview_complete;
+    let result = host_executed_shell_result_from_view(handoff, evidence, view);
     let delivered = match state.agent_run.active.as_mut() {
         Some(run) => {
             let delivered = run
@@ -153,6 +162,7 @@ fn deliver_host_executed_shell_result_if_supported(
             delivered: true,
             status: "delivered",
             recovery_reason: None,
+            provider_preview_complete,
         }
     } else {
         ShellEvidenceDelivery {
@@ -161,15 +171,25 @@ fn deliver_host_executed_shell_result_if_supported(
             recovery_reason: Some(
                 "provider approval channel closed before host-executed shell result was delivered; shell evidence continuation required",
             ),
+            provider_preview_complete,
         }
     }
 }
 
+#[cfg(test)]
 fn host_executed_shell_result(
     handoff: &ShellHandoffRequest,
     evidence: &RuntimeShellCommandCompleted,
 ) -> HostExecutedShellResult {
     let view = EvidenceState::provider_visible_view(evidence);
+    host_executed_shell_result_from_view(handoff, evidence, view)
+}
+
+fn host_executed_shell_result_from_view(
+    handoff: &ShellHandoffRequest,
+    evidence: &RuntimeShellCommandCompleted,
+    view: crate::evidence::output_policy::EvidenceView,
+) -> HostExecutedShellResult {
     let llm_content = format!(
         "ShellCommandCompleted evidence\n\
          {}",
@@ -177,7 +197,7 @@ fn host_executed_shell_result(
     );
     HostExecutedShellResult {
         llm_content,
-        return_display: view.return_display,
+        return_display: None,
         metadata: HostExecutedShellMetadata {
             command: redact_provider_command_text(&evidence.command),
             status: evidence.status.to_string(),
@@ -292,6 +312,7 @@ mod tests {
         OutputRefs, RatatuiInlineRenderer,
     };
 
+    use crate::adapter::serialize_host_executed_shell_result;
     use crate::agent::run::ActiveAgentRun;
 
     #[test]
@@ -384,14 +405,146 @@ mod tests {
             result.llm_content
         );
         assert_eq!(result.metadata.tool_use_id.as_deref(), Some("toolu-1"));
+        assert_eq!(result.return_display, None);
+        let serialized = serialize_host_executed_shell_result("ctrl-1", &result);
+        assert!(!serialized.contains("provider_visible_complete"));
+        assert!(!serialized.contains("provider_visible_truncated"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn host_executed_shell_result_budget_does_not_duplicate_preview() {
+        let dir = std::env::temp_dir().join(format!(
+            "cosh-shell-host-executed-budget-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let output_ref = dir.join("cmd-budget.txt");
+        const PROVIDER_PREVIEW_MAX_CHARS: usize = 6_000;
+        let preview = "a".repeat(PROVIDER_PREVIEW_MAX_CHARS);
+        std::fs::write(&output_ref, &preview).expect("write output ref");
+        let output_ref_str = output_ref.to_str().expect("utf8 output ref");
+
+        let mut handoff = ShellHandoffRequest::new(
+            "printf budget",
+            "$ printf budget",
+            "provider-tool-call",
+            "agent",
+            "req-budget",
+            "run-budget",
+            10,
+        )
+        .expect("handoff");
+        handoff.request_id = Some("ctrl-budget".to_string());
+        handoff.tool_use_id = Some("toolu-budget".to_string());
+        let block = CommandBlock {
+            id: "cmd-budget".to_string(),
+            session_id: "raw-session".to_string(),
+            command: "printf budget".to_string(),
+            origin: Default::default(),
+            cwd: "/repo".to_string(),
+            end_cwd: "/repo".to_string(),
+            started_at_ms: 10,
+            ended_at_ms: 20,
+            duration_ms: 10,
+            exit_code: 0,
+            status: CommandStatus::Completed,
+            output: OutputRefs {
+                terminal_output_ref: Some(output_ref_str.to_string()),
+                terminal_output_bytes: preview.len() as u64,
+            },
+        };
+        let evidence =
+            RuntimeShellCommandCompleted::from_shell_handoff(&handoff, &block, "completed");
+        let result = host_executed_shell_result(&handoff, &evidence);
+
+        assert_eq!(result.return_display, None);
+        let serialized = serialize_host_executed_shell_result("ctrl-budget", &result);
+        assert!(!serialized.contains("provider_visible_complete"));
+        assert!(!serialized.contains("provider_visible_truncated"));
+        assert!(!serialized.contains("provider_visible_chars"));
+        let preview_count = serialized.matches(&preview).count();
+        assert_eq!(preview_count, 1, "{serialized}");
         assert!(
-            !result
-                .return_display
-                .as_deref()
-                .unwrap_or("")
-                .contains(output_ref_str),
-            "{:?}",
-            result.return_display
+            serialized.len() <= 8_500,
+            "serialized_len={} must stay bounded",
+            serialized.len()
+        );
+
+        let baseline = serialized.replace(&preview, "");
+        assert!(
+            serialized.len() <= baseline.len() + 6_500,
+            "serialized_len={} baseline_len={}",
+            serialized.len(),
+            baseline.len()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn host_executed_shell_result_escaped_preview_stays_within_delta_budget() {
+        let dir = std::env::temp_dir().join(format!(
+            "cosh-shell-host-executed-escaped-budget-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let output_ref = dir.join("cmd-escaped.txt");
+        let mut preview = "a".repeat(5_990);
+        preview.push_str("\"\\\nend");
+        std::fs::write(&output_ref, &preview).expect("write output ref");
+        let output_ref_str = output_ref.to_str().expect("utf8 output ref");
+
+        let mut handoff = ShellHandoffRequest::new(
+            "printf escaped",
+            "$ printf escaped",
+            "provider-tool-call",
+            "agent",
+            "req-escaped",
+            "run-escaped",
+            10,
+        )
+        .expect("handoff");
+        handoff.request_id = Some("ctrl-escaped".to_string());
+        handoff.tool_use_id = Some("toolu-escaped".to_string());
+        let block = CommandBlock {
+            id: "cmd-escaped".to_string(),
+            session_id: "raw-session".to_string(),
+            command: "printf escaped".to_string(),
+            origin: Default::default(),
+            cwd: "/repo".to_string(),
+            end_cwd: "/repo".to_string(),
+            started_at_ms: 10,
+            ended_at_ms: 20,
+            duration_ms: 10,
+            exit_code: 0,
+            status: CommandStatus::Completed,
+            output: OutputRefs {
+                terminal_output_ref: Some(output_ref_str.to_string()),
+                terminal_output_bytes: preview.len() as u64,
+            },
+        };
+        let evidence =
+            RuntimeShellCommandCompleted::from_shell_handoff(&handoff, &block, "completed");
+        let result = host_executed_shell_result(&handoff, &evidence);
+
+        let serialized = serialize_host_executed_shell_result("ctrl-escaped", &result);
+        assert_eq!(result.return_display, None);
+        assert!(!serialized.contains("provider_visible_complete"));
+        assert!(!serialized.contains("provider_visible_truncated"));
+        assert!(!serialized.contains("provider_visible_chars"));
+        let mut baseline_result = result.clone();
+        baseline_result.llm_content = baseline_result.llm_content.replace(&preview, "");
+        let baseline = serialize_host_executed_shell_result("ctrl-escaped", &baseline_result);
+
+        assert!(
+            serialized.len() <= baseline.len() + 6_500,
+            "serialized_len={} baseline_len={}",
+            serialized.len(),
+            baseline.len()
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_state.rs
@@ -127,6 +127,7 @@ pub(crate) struct ShellEvidenceDelivery {
     pub(crate) delivered: bool,
     pub(crate) status: &'static str,
     pub(crate) recovery_reason: Option<&'static str>,
+    pub(crate) provider_preview_complete: bool,
 }
 
 impl ShellEvidenceDelivery {
@@ -135,6 +136,7 @@ impl ShellEvidenceDelivery {
             delivered: false,
             status: "not_attempted",
             recovery_reason: None,
+            provider_preview_complete: false,
         }
     }
 }
@@ -294,6 +296,7 @@ mod tests {
             delivered: true,
             status: "delivered",
             recovery_reason: None,
+            provider_preview_complete: true,
         });
 
         assert!(evidence.provider_result_delivered);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -190,7 +190,7 @@ struct ShellEvidenceActionSignature {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum EvidenceCoverage {
-    Summary,
+    Summary { complete: bool },
     Excerpt { direction: String, lines: u16 },
 }
 
@@ -203,8 +203,15 @@ impl ShellEvidenceState {
         &mut self,
         output_id: String,
         run_id: Option<String>,
+        summary_complete: bool,
     ) {
-        self.push_recent_shell_tool_output(output_id, run_id, EvidenceCoverage::Summary);
+        self.push_recent_shell_tool_output(
+            output_id,
+            run_id,
+            EvidenceCoverage::Summary {
+                complete: summary_complete,
+            },
+        );
     }
 
     pub(crate) fn record_shell_evidence_read_output(
@@ -294,7 +301,7 @@ impl ShellEvidenceState {
 impl EvidenceCoverage {
     fn covers(&self, direction: &str, lines: u16) -> bool {
         match self {
-            Self::Summary => true,
+            Self::Summary { complete } => *complete,
             Self::Excerpt {
                 direction: delivered_direction,
                 lines: delivered_lines,
@@ -313,6 +320,7 @@ mod shell_evidence_recent_tests {
         state.record_host_executed_shell_output(
             "terminal-output://session-1/cmd-1".to_string(),
             Some("run-1".to_string()),
+            true,
         );
 
         assert!(state.read_output_recently_delivered(
@@ -348,14 +356,15 @@ mod shell_evidence_recent_tests {
     }
 
     #[test]
-    fn recent_shell_evidence_summary_suppresses_default_read_even_when_incomplete() {
+    fn recent_shell_evidence_incomplete_summary_does_not_suppress_default_read() {
         let mut state = ShellEvidenceState::default();
         state.record_host_executed_shell_output(
             "terminal-output://session-1/cmd-1".to_string(),
             Some("run-1".to_string()),
+            false,
         );
 
-        assert!(state.read_output_recently_delivered(
+        assert!(!state.read_output_recently_delivered(
             "terminal-output://session-1/cmd-1",
             Some("run-1"),
             "tail",
@@ -393,6 +402,7 @@ mod shell_evidence_recent_tests {
         state.record_host_executed_shell_output(
             "terminal-output://session-1/cmd-1".to_string(),
             Some("run-1".to_string()),
+            true,
         );
 
         assert!(state.read_output_recently_delivered(
@@ -429,6 +439,7 @@ mod shell_evidence_recent_tests {
             state.record_host_executed_shell_output(
                 format!("terminal-output://session-1/cmd-{index}"),
                 Some("run-1".to_string()),
+                true,
             );
         }
 

--- a/src/cosh-ng/crates/cosh-shell/tests/protocol/control/host_executed.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/protocol/control/host_executed.rs
@@ -31,7 +31,7 @@ fn cosh_core_host_executed_shell_result_uses_control_response() {
                         llm_content:
                             "ShellCommandCompleted evidence\ncommand: df -h\nstatus: completed"
                                 .to_string(),
-                        return_display: Some("df -h completed".to_string()),
+                        return_display: None,
                         metadata: HostExecutedShellMetadata {
                             command: "df -h".to_string(),
                             status: "completed".to_string(),
@@ -199,7 +199,7 @@ fn respond_host_executed(
                         llm_content: format!(
                             "ShellCommandCompleted evidence\ncommand: {command}\nstatus: {status}"
                         ),
-                        return_display: Some(format!("{command} {status}")),
+                        return_display: None,
                         metadata: HostExecutedShellMetadata {
                             command: command.to_string(),
                             status: status.to_string(),

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/evidence.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/evidence.rs
@@ -153,7 +153,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
             ),
             (
                 b"?? cosh-core-evidence-agent-split\n".to_vec(),
-                Duration::from_millis(300),
+                Duration::from_millis(800),
             ),
             (b"exit 0\n".to_vec(), Duration::from_millis(2_000)),
         ],
@@ -183,7 +183,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
 }
 
 #[test]
-fn raw_cli_cosh_core_duplicate_read_after_host_executed_is_already_delivered() {
+fn raw_cli_cosh_core_read_after_truncated_host_executed_returns_output() {
     let home = temp_shell_home("cosh-core-shell-evidence-duplicate-read");
     let bin_dir = home.join("bin");
     fs::create_dir_all(&bin_dir).unwrap();
@@ -206,14 +206,10 @@ output_id=${output_tail%%\\n*}
 printf '%s\n' "{\"type\":\"control_request\",\"request_id\":\"evidence-duplicate-read\",\"request\":{\"subtype\":\"shell_evidence\",\"tool_use_id\":\"toolu-evidence-duplicate-read\",\"action\":\"read_output\",\"output_id\":\"$output_id\",\"direction\":\"tail\",\"lines\":120}}"
 IFS= read -r response2 || exit 2
 case "$response2" in
-  *'"behavior":"shell_evidence"'*'excerpt_status: already_delivered'*'already_delivered_recent_shell_tool_output'*)
-    case "$response2" in
-      *'bounded_output_excerpt:'*|*'duplicate-read-line-120'*) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-duplicate-read","is_error":true,"result":"duplicate read returned output body"}'; exit 1 ;;
-    esac
-    ;;
-  *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-duplicate-read","is_error":true,"result":"duplicate read was not suppressed"}'; exit 1 ;;
+  *'"behavior":"shell_evidence"'*'ShellEvidenceExcerpt'*'action: read_output'*'bounded_output_excerpt:'*'duplicate-read-line-120'*) ;;
+  *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-duplicate-read","is_error":true,"result":"truncated host-executed read did not return output body"}'; exit 1 ;;
 esac
-printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-duplicate-read","message":{"content":[{"type":"text","text":"DUPLICATE READ ALREADY DELIVERED FINAL"}]}}'
+printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-duplicate-read","message":{"content":[{"type":"text","text":"TRUNCATED HOST EXECUTED READ FINAL"}]}}'
 printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-duplicate-read","is_error":false,"result":"done"}'
 exit 0
 "#,
@@ -240,22 +236,19 @@ exit 0
     let _ = fs::remove_dir_all(&home);
 
     assert!(
-        output.contains("DUPLICATE READ ALREADY DELIVERED FINAL"),
+        output.contains("TRUNCATED HOST EXECUTED READ FINAL"),
         "{output}"
     );
     assert!(output.contains("Activity details evidence-1"), "{output}");
     assert!(output.contains("Shell evidence completed"), "{output}");
     assert!(
-        output.contains("recent output already delivered; body not repeated"),
+        output.contains("shell output excerpt delivered to Agent"),
         "{output}"
     );
+    assert!(output.contains("duplicate-read-line-120"), "{output}");
     assert!(output.contains("Status: success"), "{output}");
     assert!(
-        !output.contains("duplicate read was not suppressed"),
-        "{output}"
-    );
-    assert!(
-        !output.contains("duplicate read returned output body"),
+        !output.contains("truncated host-executed read did not return output body"),
         "{output}"
     );
     assert!(
@@ -650,11 +643,11 @@ exit 0
             (b"printf 'same-command-line\\n'\n".to_vec(), Duration::ZERO),
             (
                 b"printf 'same-command-line\\n'\n".to_vec(),
-                Duration::from_millis(300),
+                Duration::from_millis(800),
             ),
             (
                 b"?? cosh-core-same-command-text\n".to_vec(),
-                Duration::from_millis(500),
+                Duration::from_millis(1_200),
             ),
             (b"exit 0\n".to_vec(), Duration::from_millis(5_000)),
         ],
@@ -1034,7 +1027,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
                 b"?? \xe6\x9c\x80\xe8\xbf\x91\xe5\x9c\xa8\xe5\xb9\xb2\xe5\x98\x9b evidence-activity-recap\n".to_vec(),
                 Duration::from_millis(300),
             ),
-            (b"/details evidence-1\n".to_vec(), Duration::from_millis(3_000)),
+            (b"/details evidence-1\n".to_vec(), Duration::from_millis(5_000)),
             (b"exit 0\n".to_vec(), Duration::from_millis(500)),
         ],
     );

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
@@ -544,12 +544,27 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-core-ho
 read -r user_message
 case "$user_message" in
   *cosh-core-provider-host-executed-large*)
-    printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-large","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"printf %08000d 0"},"tool_use_id":"toolu-cosh-core-large"}}'
+    printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-large","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"printf \"%b\" \"\\110\\105\\101\\104\\137\\123\\105\\116\\124\\111\\116\\105\\114\"; printf %08000d 0; printf \"%b\" \"\\124\\101\\111\\114\\137\\123\\105\\116\\124\\111\\116\\105\\114\""},"tool_use_id":"toolu-cosh-core-large"}}'
     if IFS= read -r response; then
       response_len=${#response}
       case "$response" in
         *'"behavior":"host_executed_shell"'*'bounded_output_summary'*)
-          if [ "$response_len" -gt 7000 ]; then
+          case "$response" in
+            *'"returnDisplay":null'*) ;;
+            *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-large","is_error":true,"result":"host result carried returnDisplay preview"}'; exit 1 ;;
+          esac
+          case "$response" in
+            *HEAD_SENTINEL*) ;;
+            *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-large","is_error":true,"result":"host result missing head sentinel"}'; exit 1 ;;
+          esac
+          case "$response" in
+            *TAIL_SENTINEL*) ;;
+            *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-large","is_error":true,"result":"host result missing tail sentinel"}'; exit 1 ;;
+          esac
+          case "$response" in
+            *HEAD_SENTINEL*HEAD_SENTINEL*) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-large","is_error":true,"result":"host result duplicated preview"}'; exit 1 ;;
+          esac
+          if [ "$response_len" -gt 10000 ]; then
             printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-large","is_error":true,"result":"host result was not bounded"}'
             exit 1
           fi
@@ -590,7 +605,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
 
     assert!(output.contains("Approved req-1"), "{output}");
     assert!(output.contains("Bash tool sent to shell"), "{output}");
-    assert!(output.contains("$ printf %08000d 0"), "{output}");
+    assert!(output.contains("printf %08000d 0"), "{output}");
     assert!(
         output.contains("Cosh-core large host-executed output was bounded for provider."),
         "{output}"
@@ -605,6 +620,10 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
         "{output}"
     );
     assert!(!output.contains("host result was not bounded"), "{output}");
+    assert!(
+        !output.contains("host result duplicated preview"),
+        "{output}"
+    );
     assert!(!output.contains("Agent timed out:"), "{output}");
 }
 
@@ -659,9 +678,9 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
             ),
             (
                 b"echo AFTER_COSH_CORE_PROVIDER_INPUT\n".to_vec(),
-                Duration::from_millis(1_500),
+                Duration::from_millis(4_000),
             ),
-            (b"exit\n".to_vec(), Duration::from_millis(3_500)),
+            (b"exit\n".to_vec(), Duration::from_millis(1_000)),
         ],
     );
     let _ = fs::remove_dir_all(&home);


### PR DESCRIPTION
## Description

Fix host-executed shell output delivery in cosh-ng so bounded output preview is delivered once through `llmContent` instead of being duplicated through `returnDisplay`.

This also tracks recent host-executed output coverage with internal `Summary { complete }` state. A complete host-executed preview can suppress later `cosh_shell_evidence read_output`, while truncated or unavailable previews still allow `read_output` to return a bounded excerpt.

The provider preview cap is raised to 6000 chars after removing duplicate host-executed preview delivery. Truncated previews now keep bounded head/tail content and include read-output guidance.

## Related Issue

closes #1385

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```shell
cargo fmt --check
git diff --check
cargo test -p cosh-shell host_executed_shell_result_budget -- --nocapture
cargo test -p cosh-core parse_control_response_host_executed_shell -- --nocapture
cargo test -p cosh-shell raw_cli_cosh_core_host_executed_large_output_is_bounded -- --nocapture
cargo test -p cosh-shell raw_cli_cosh_core_read_after_truncated_host_executed_returns_output -- --nocapture
```

Full `cargo clippy --all-targets -- -D warnings` was not run in this local pass.

## Additional Notes

`returnDisplay` remains part of the control protocol. This change only stops using it as the duplicate output-preview carrier for host-executed shell results.
