### PR TITLE
fix(skillfs): use anolis_release macro instead of hardcoded Release: 1

### DIFF
--- a/src/skillfs/skillfs.spec.in
+++ b/src/skillfs/skillfs.spec.in
@@ -1,10 +1,11 @@
+%define anolis_release 2
 %global         rustflags -C opt-level=3 -C codegen-units=1
 %global         debug_package %{nil}
 %global         _localbindir /usr/local/bin
 
 Name:           skillfs
 Version:        @VERSION@
-Release:        1%{?dist}
+Release:        %{anolis_release}%{?dist}
 Summary:        AI agent skill management via virtual filesystem
 
 License:        Apache-2.0


### PR DESCRIPTION
## Description

skillfs.spec.in hardcoded `Release: 1%{?dist}` instead of using the `%define anolis_release` + `Release: %{anolis_release}%{?dist}` pattern that all other components follow.

When a code fix is committed without bumping `Version`, `rpm -Uvh` sees the same NVR (name-version-release) and skips the upgrade, so the fix never reaches user environments via normal `rpm -Uvh`.

### Root Cause

- `skillfs.spec.in` line 7: `Release: 1%{?dist}` (hardcoded literal `1`)
- All other components (agent-memory, agent-sec-core, agentsight, anolisa, copilot-shell, cosh-ng, tokenless, ws-ckpt) use `%define anolis_release N` + `Release: %{anolis_release}%{?dist}`
- This caused nightly test `test_json_error_entries_have_path` to fail on fresh ECS installs even though the code fix (commit c79b362c) was already in the source tree

## Changes

- Add `%define anolis_release 2` at top of `skillfs.spec.in`
- Change `Release: 1%{?dist}` → `Release: %{anolis_release}%{?dist}`
- Bump to 2 ensures the current code-level fix ships via normal `rpm -Uvh`

## Verification

On ECS (8.218.176.199):
1. `bash scripts/rpm-build.sh skillfs` → build green (exit 0)
2. RPM generated: `skillfs-0.3.2-2.alnx4.x86_64.rpm` (Release 1 → 2)
3. `rpm -Uvh skillfs-0.3.2-2.alnx4.x86_64.rpm` (no `--force`) → successful upgrade from 0.3.2-1 to 0.3.2-2
4. `test_json_error_entries_have_path` → PASSED

Closes #1390