### PR TITLE
fix(sight): avoid false interruption signals

### DIFF
--- a/src/agentsight/src/interruption/detector.rs
+++ b/src/agentsight/src/interruption/detector.rs
@@ -101,10 +101,15 @@ impl InterruptionDetector {
             .and_then(|s| s.parse().ok())
             .unwrap_or(200);
 
-        // 修复：从 call.response.raw_body 读取响应体，而非 call.metadata（builder 不会写入 metadata）
         let error_text = call.error.as_deref().unwrap_or("");
         let response_body = call.response.raw_body.as_deref().unwrap_or("");
-        let combined_error = format!("{error_text} {response_body}").to_ascii_lowercase();
+        let structured_error = error_text.to_ascii_lowercase();
+        let response_error_body = if status_code >= 400 {
+            response_body
+        } else {
+            ""
+        };
+        let combined_error = format!("{error_text} {response_error_body}").to_ascii_lowercase();
 
         let is_context_overflow = combined_error.contains("context_length_exceeded")
             || combined_error.contains("maximum context length")
@@ -174,9 +179,9 @@ impl InterruptionDetector {
         // ── 3. NetworkTimeout (408/504 / timeout) ─────────────────────────────
         if status_code == 408
             || status_code == 504
-            || combined_error.contains("timeout")
-            || combined_error.contains("timed out")
-            || combined_error.contains("deadline exceeded")
+            || structured_error.contains("timeout")
+            || structured_error.contains("timed out")
+            || structured_error.contains("deadline exceeded")
         {
             let detail = serde_json::json!({
                 "model": call.model,
@@ -752,6 +757,76 @@ mod tests {
             events[0].interruption_type,
             InterruptionType::NetworkTimeout
         );
+    }
+
+    #[test]
+    fn test_ignores_timeout_text_in_successful_response_body() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.response.raw_body = Some(
+            r#"{"content":"Run journalctl -u app | grep -i \"timeout\" to inspect timeout logs."}"#
+                .to_string(),
+        );
+
+        let events = detector.detect(&call);
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_ignores_auth_text_in_successful_response_body() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.response.raw_body = Some(
+            r#"{"content":"Use rejectUnauthorized:false only for local TLS smoke tests."}"#
+                .to_string(),
+        );
+
+        let events = detector.detect(&call);
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_ignores_rate_limit_text_in_successful_response_body() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.response.raw_body = Some(
+            r#"{"content":"Document rate limit and too many requests troubleshooting steps."}"#
+                .to_string(),
+        );
+
+        let events = detector.detect(&call);
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_ignores_service_unavailable_text_in_successful_response_body() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.response.raw_body = Some(
+            r#"{"content":"Explain service_unavailable and overloaded model symptoms."}"#
+                .to_string(),
+        );
+
+        let events = detector.detect(&call);
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_ignores_context_overflow_text_in_successful_response_body() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.response.raw_body = Some(
+            r#"{"content":"Compare context window, input is too long, and prompt is too long errors."}"#
+                .to_string(),
+        );
+
+        let events = detector.detect(&call);
+
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/src/agentsight/src/interruption/detector.rs
+++ b/src/agentsight/src/interruption/detector.rs
@@ -20,6 +20,85 @@ fn is_token_limit_finish(reason: Option<&str>) -> bool {
     matches!(reason, Some("length" | "max_tokens"))
 }
 
+fn structured_stream_error_text(raw_body: &str) -> Option<String> {
+    if let Some(error) = structured_error_json_text(raw_body.trim()) {
+        return Some(error);
+    }
+
+    raw_body.lines().find_map(|line| {
+        let payload = line
+            .trim()
+            .strip_prefix("data:")
+            .map(str::trim)
+            .unwrap_or_else(|| line.trim());
+        if payload.is_empty() || payload == "[DONE]" || payload.starts_with("event:") {
+            return None;
+        }
+        structured_error_json_text(payload)
+    })
+}
+
+fn structured_error_json_text(candidate: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(candidate)
+        .ok()
+        .and_then(|value| structured_error_value_text(&value))
+}
+
+fn structured_error_value_text(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Array(items) => items.iter().find_map(structured_error_value_text),
+        serde_json::Value::Object(map) => {
+            let event_type = map.get("type").and_then(|value| value.as_str());
+            let is_error_event = event_type.is_some_and(|kind| {
+                kind == "error" || kind.ends_with(".failed") || kind.ends_with(".error")
+            });
+
+            if let Some(error) = map.get("error") {
+                return summarize_error_value(error);
+            }
+
+            let response_error = map
+                .get("response")
+                .and_then(|response| response.get("error"))
+                .and_then(summarize_error_value);
+            if let Some(error) = response_error {
+                return Some(error);
+            }
+
+            if is_error_event {
+                return summarize_error_value(value);
+            }
+
+            None
+        }
+        _ => None,
+    }
+}
+
+fn summarize_error_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        serde_json::Value::Object(map) => {
+            let text = ["type", "code", "message"]
+                .iter()
+                .filter_map(|key| map.get(*key).and_then(|value| value.as_str()))
+                .filter(|text| !text.trim().is_empty())
+                .map(str::trim)
+                .collect::<Vec<_>>()
+                .join(" ");
+            if text.is_empty() { None } else { Some(text) }
+        }
+        _ => None,
+    }
+}
+
 /// Configuration for the interruption detector
 pub struct DetectorConfig {
     /// Ratio of output_tokens / max_tokens that triggers token_limit (default: 0.95)
@@ -101,8 +180,19 @@ impl InterruptionDetector {
             .and_then(|s| s.parse().ok())
             .unwrap_or(200);
 
-        let error_text = call.error.as_deref().unwrap_or("");
+        let is_sse = call
+            .metadata
+            .get("is_sse")
+            .map(|s| s == "true")
+            .unwrap_or(false);
         let response_body = call.response.raw_body.as_deref().unwrap_or("");
+        let stream_error = if status_code < 400 && is_sse {
+            structured_stream_error_text(response_body)
+        } else {
+            None
+        };
+        let effective_error = call.error.as_deref().or(stream_error.as_deref());
+        let error_text = effective_error.unwrap_or("");
         let structured_error = error_text.to_ascii_lowercase();
         let response_error_body = if status_code >= 400 {
             response_body
@@ -135,7 +225,7 @@ impl InterruptionDetector {
             let detail = serde_json::json!({
                 "model": call.model,
                 "status_code": status_code,
-                "error": call.error,
+                "error": effective_error,
             });
             events.push(InterruptionEvent::new(
                 InterruptionType::AuthError,
@@ -160,7 +250,7 @@ impl InterruptionDetector {
             let detail = serde_json::json!({
                 "model": call.model,
                 "status_code": status_code,
-                "error": call.error,
+                "error": effective_error,
             });
             events.push(InterruptionEvent::new(
                 InterruptionType::RateLimit,
@@ -186,7 +276,7 @@ impl InterruptionDetector {
             let detail = serde_json::json!({
                 "model": call.model,
                 "status_code": status_code,
-                "error": call.error,
+                "error": effective_error,
             });
             events.push(InterruptionEvent::new(
                 InterruptionType::NetworkTimeout,
@@ -213,7 +303,7 @@ impl InterruptionDetector {
             let detail = serde_json::json!({
                 "model": call.model,
                 "status_code": status_code,
-                "error": call.error,
+                "error": effective_error,
             });
             events.push(InterruptionEvent::new(
                 InterruptionType::ServiceUnavailable,
@@ -235,7 +325,7 @@ impl InterruptionDetector {
             let detail = serde_json::json!({
                 "model": call.model,
                 "status_code": status_code,
-                "error": call.error,
+                "error": effective_error,
                 "input_tokens": call.token_usage.as_ref().map(|u| u.input_tokens),
             });
             events.push(InterruptionEvent::new(
@@ -263,7 +353,7 @@ impl InterruptionDetector {
             let detail = serde_json::json!({
                 "model": call.model,
                 "finish_reason": "content_filter",
-                "error": call.error,
+                "error": effective_error,
             });
             events.push(InterruptionEvent::new(
                 InterruptionType::SafetyFilter,
@@ -281,10 +371,10 @@ impl InterruptionDetector {
 
         // ── 7. LLM error (non-context HTTP/API errors) ────────────────────────
         // 通用兜底：所有 HTTP >= 400 且未被上述规则匹配的错误
-        if status_code >= 400 || call.error.is_some() {
+        if status_code >= 400 || call.error.is_some() || stream_error.is_some() {
             let detail = serde_json::json!({
                 "status_code": status_code,
-                "error": call.error,
+                "error": effective_error,
                 "model": call.model,
             });
             events.push(InterruptionEvent::new(
@@ -305,11 +395,6 @@ impl InterruptionDetector {
         // 严格条件：SSE 流 + 持续时间 >= 阈值 + 无正常终止标志 + 非 token-limit
         // 正常终止标志：finish_reason 为 stop/tool_calls/end_turn/tool_use/stop_sequence
         // token-limit (length/max_tokens) 由 rule 9/10 单独处理
-        let is_sse = call
-            .metadata
-            .get("is_sse")
-            .map(|s| s == "true")
-            .unwrap_or(false);
         if is_sse
             && !is_normal_finish(finish_reason)
             && !is_token_limit_finish(finish_reason)
@@ -827,6 +912,44 @@ mod tests {
         let events = detector.detect(&call);
 
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_detects_anthropic_sse_error_event_in_200_stream() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata
+            .insert("is_sse".to_string(), "true".to_string());
+        call.duration_ns = 500_000_000;
+        call.response.raw_body = Some(
+            "event: error\n\
+             data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n"
+                .to_string(),
+        );
+
+        let events = detector.detect(&call);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].interruption_type,
+            InterruptionType::ServiceUnavailable
+        );
+    }
+
+    #[test]
+    fn test_detects_structured_sse_error_object_in_200_stream() {
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata
+            .insert("is_sse".to_string(), "true".to_string());
+        call.duration_ns = 100_000_000;
+        call.response.raw_body =
+            Some(r#"data: {"error":{"message":"upstream failed before completion"}}"#.to_string());
+
+        let events = detector.detect(&call);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].interruption_type, InterruptionType::LlmError);
     }
 
     #[test]

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -345,7 +345,7 @@ impl Probes {
                         }
                         ChannelPolicy::Sample(n) => {
                             let idx = drop_counter.fetch_add(1, Ordering::Relaxed);
-                            if idx % n == 0 {
+                            if idx.is_multiple_of(n) {
                                 if event_tx.try_send(e).is_err() {
                                     log::warn!(
                                         "Probes event channel full (capacity={}); dropping sampled event",

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -622,7 +622,7 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
         hs_matches[0]
     } else {
         // Multiple matches: choose the one closest before read_off.
-        match hs_matches.iter().filter(|&&o| o < read_off).next_back() {
+        match hs_matches.iter().rfind(|&&o| o < read_off) {
             Some(&o) => o,
             None => {
                 if verbose {

--- a/src/agentsight/src/storage/sqlite/token.rs
+++ b/src/agentsight/src/storage/sqlite/token.rs
@@ -208,7 +208,7 @@ pub fn format_tokens_with_commas(count: u64) -> String {
     let s = count.to_string();
     let mut result = String::new();
     for (i, c) in s.chars().enumerate() {
-        if i > 0 && (s.len() - i) % 3 == 0 {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
             result.push(',');
         }
         result.push(c);

--- a/src/agentsight/src/storage/unified.rs
+++ b/src/agentsight/src/storage/unified.rs
@@ -272,7 +272,7 @@ impl Storage {
         // Auto-purge check: trigger every `purge_interval` inserts
         if self.purge_interval > 0 && self.retention_days > 0 {
             let count = self.insert_count.fetch_add(1, Ordering::Relaxed) + 1;
-            if count % self.purge_interval == 0 {
+            if count.is_multiple_of(self.purge_interval) {
                 if let Err(e) = self.purge_expired() {
                     log::warn!("Auto-purge failed: {e}");
                 }


### PR DESCRIPTION
## Description

Avoid false interruption records when a successful assistant response mentions troubleshooting words such as timeout, auth, or rate limit. The detector now only scans structured provider error text and non-2xx response bodies for runtime error classifications.

This PR is split out of #1349 so the interruption classifier fix can be reviewed independently. It also includes the current-toolchain mechanical AgentSight clippy fixes required for this split PR to pass `-D warnings` independently.

## Related Issue

Refs #1304

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran on the Linux AgentSight test host from an archive of this split branch:

- `cargo fmt --all -- --check`
- `cargo test -p agentsight interruption::detector --locked --quiet`
- `cargo clippy -q -p agentsight --all-targets --locked -- -D warnings`

## Additional Notes

Split from #1349 following review feedback to keep capture fixes and the grader feature reviewable in smaller units.
