### PR TITLE
feat(sight): add conversation grader API

### DIFF
--- a/src/agentsight/docs/ARCHITECTURE.md
+++ b/src/agentsight/docs/ARCHITECTURE.md
@@ -86,7 +86,7 @@ graph TB
 | **L4: Analyze** | `src/analyzer/`, `src/tokenizer/` | Token 提取、审计记录、消息解析 | → L3, L2 |
 | **L5: Semantic** | `src/genai/`, `src/atif/` | 语义事件构建、轨迹格式导出 | → L4, L3, L2, Cross |
 | **L6: Persist** | `src/storage/` | SQLite 持久化、SLS 远程导出 | → L4, L5 |
-| **L7: Serve** | `src/server/`, `src/health/`, `src/agent_sec/` | HTTP API、前端、agent-sec daemon 代理、健康检查 | → L6, L5 |
+| **L7: Serve** | `src/server/`, `src/health/`, `src/agent_sec/`, `src/grader/` | HTTP API、前端、agent-sec daemon 代理、健康检查、会话质量评估 | → L6, L5 |
 | **L8: Entry** | `src/bin/`, `src/unified.rs`, `src/config.rs` | CLI 入口、编排器、配置 | → L1-L7 |
 | **Cross** | `src/discovery/` | Agent 进程发现与匹配 | 被 L1, L8 使用 |
 
@@ -107,6 +107,7 @@ graph LR
     health[health]
     atif[atif]
     agent_sec[agent_sec]
+    grader[grader]
     server[server]
     unified[unified]
 
@@ -135,10 +136,12 @@ graph LR
     genai --> parser
     storage --> analyzer
     storage --> genai
+    grader --> storage
     server --> storage
     server --> health
     server --> atif
     server --> agent_sec
+    server --> grader
     health --> storage
     atif --> genai
     atif --> storage
@@ -278,6 +281,12 @@ src/
 ├── agent_sec/             # agent-sec daemon 查询代理
 │   ├── mod.rs             # 模块导出
 │   └── client.rs          # Unix socket NDJSON client
+├── grader/                # 会话质量评估
+│   ├── rule.rs            # 确定性规则评估
+│   ├── input.rs           # 证据快照加载与输入哈希
+│   ├── storage.rs         # evaluation_runs 持久化
+│   ├── evidence.rs        # evidence_refs 构建
+│   └── types.rs           # API 和存储共享类型
 ├── server/                # HTTP 服务器（feature=server）
 │   ├── mod.rs             # Actix-web 服务器 + 前端嵌入
 │   └── handlers.rs        # API 处理函数

--- a/src/agentsight/docs/agent-diagnostics-guide.md
+++ b/src/agentsight/docs/agent-diagnostics-guide.md
@@ -441,6 +441,20 @@ curl http://127.0.0.1:7396/api/export/atif/session/{session_id}
 curl http://127.0.0.1:7396/api/export/atif/conversation/{conversation_id}
 ```
 
+### 10.4 Conversation Grader
+
+Conversation Grader 对指定 `conversation_id` 执行手动质量评估，并将结果持久化到 SQLite。当前版本只支持 `target_type=conversation`，评估器为规则版 `rule-v3`。
+
+```bash
+curl -X POST http://127.0.0.1:7396/api/grader/evaluate \
+  -H 'Content-Type: application/json' \
+  -d '{"target_type":"conversation","target_id":"{conversation_id}","force":false}'
+
+curl "http://127.0.0.1:7396/api/grader/latest?target_type=conversation&target_id={conversation_id}"
+```
+
+如果 conversation 仍有 pending LLM 调用，评估接口返回 HTTP 409。确认需要评估当前不完整快照时，可以将 `force` 设置为 `true`，结果会标记 `evaluated_with_pending=true`。
+
 ---
 
 ## 11. 支持的 LLM 提供商
@@ -466,6 +480,8 @@ AgentSight 自动识别并解析以下 LLM API 格式：
 | `/api/sessions/{id}/traces` | GET | 会话下的对话列表 |
 | `/api/traces/{id}` | GET | Trace 详情 |
 | `/api/conversations/{id}` | GET | 对话详情 |
+| `/api/grader/evaluate` | POST | 手动评估 Conversation 质量 |
+| `/api/grader/latest` | GET | 查询最新 Conversation 评估结果 |
 | `/api/agent-names` | GET | Agent 名称列表 |
 | `/api/agent-health` | GET | Agent 健康状态 |
 | `/api/interruptions` | GET | 中断事件列表 |

--- a/src/agentsight/docs/design-docs/genai-semantic.md
+++ b/src/agentsight/docs/design-docs/genai-semantic.md
@@ -144,10 +144,30 @@ graph LR
 
 - **By trace**: `/api/export/atif/trace/{trace_id}`
 - **By session**: `/api/export/atif/session/{session_id}`
+- **By conversation**: `/api/export/atif/conversation/{conversation_id}`
 
 **ATIF structure**: `AtifAgent` → `Vec<AtifStep>` → `AtifToolCall` + `AtifObservation`
 
 **Source**: `src/atif/converter.rs`, `src/atif/schema.rs`
+
+## Conversation Grader
+
+The conversation grader is a manual post-run evaluation layer over the GenAI SQLite evidence. The MVP only supports `target_type = "conversation"` and uses deterministic `rule-v3` scoring.
+
+Inputs:
+
+- GenAI LLM call rows from `GenAISqliteStore::get_events_by_conversation()`.
+- Interruption rows from `InterruptionStore::list_by_conversation()`.
+- A stable input hash derived from the conversation evidence and grader version.
+
+Outputs are stored in `evaluation_runs` in the GenAI SQLite database. The idempotency key is `target_type`, `target_id`, `input_hash`, `grader_type`, and `grader_version`, so repeated evaluation of the same snapshot reuses the completed run.
+
+Manual APIs:
+
+- `POST /api/grader/evaluate`
+- `GET /api/grader/latest?target_type=conversation&target_id={conversation_id}`
+
+If the conversation still has pending LLM calls, `POST /api/grader/evaluate` returns HTTP 409 unless `force=true` is provided. Forced snapshots are marked with `metadata.evaluated_with_pending = true`.
 
 ## Session & Trace Model
 

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -26,6 +26,7 @@ LAYER_MAP = {
     "atif":        5,   # L5: Semantic
     "storage":     6,   # L6: Persist
     "agent_sec":   7,   # L7: Serve
+    "grader":      7,   # L7: Serve
     "server":      7,   # L7: Serve
     "health":      7,   # L7: Serve
     "bin":         8,   # L8: Entry
@@ -45,7 +46,8 @@ ALLOWED_DEPS = {
     "genai":       {"analyzer", "aggregator", "parser"},
     "atif":        {"genai", "storage"},
     "storage":     {"analyzer", "genai"},
-    "server":      {"storage", "health", "atif", "agent_sec"},
+    "grader":      {"storage"},
+    "server":      {"storage", "health", "atif", "agent_sec", "grader"},
     "agent_sec":   set(),
     "health":      {"storage"},
     "unified":     "*",

--- a/src/agentsight/src/grader.rs
+++ b/src/agentsight/src/grader.rs
@@ -1,0 +1,19 @@
+//! Conversation quality evaluation for AgentSight.
+//!
+//! The MVP is a manual, rule-based grader for conversation snapshots.
+
+mod evidence;
+pub mod input;
+pub mod rule;
+pub mod storage;
+pub mod types;
+
+pub use input::{EvaluationInput, load_conversation_input};
+pub use rule::RuleGrader;
+pub use storage::EvaluationStore;
+pub use types::{
+    EvaluationDimension, EvaluationFinding, EvaluationMetadata, EvaluationRef, EvaluationRequest,
+    EvaluationResponse, EvaluationResult, EvaluationRunRecord, EvaluationStatus, EvidenceDeeplink,
+    EvidenceTarget, EvidenceType, GraderError, GraderType, RULE_GRADER_VERSION, RootCause,
+    TargetType, Verdict,
+};

--- a/src/agentsight/src/grader/evidence.rs
+++ b/src/agentsight/src/grader/evidence.rs
@@ -1,0 +1,302 @@
+//! Evidence reference helpers for grader dimensions and findings.
+
+use super::input::EvaluationInput;
+use super::types::{EvaluationRef, EvidenceDeeplink, EvidenceTarget, EvidenceType};
+use crate::storage::sqlite::InterruptionRecord;
+use crate::storage::sqlite::genai::TraceEventDetail;
+
+pub(super) fn has_usable_output(event: &TraceEventDetail) -> bool {
+    if let Some(raw) = event.output_messages.as_deref() {
+        return raw_contains_content(raw);
+    }
+
+    event.output_tokens > 0
+}
+
+pub(super) fn looks_like_tool_failure(event: &TraceEventDetail) -> bool {
+    event
+        .output_messages
+        .as_deref()
+        .is_some_and(contains_tool_failure_signal)
+        || event
+            .input_messages
+            .as_deref()
+            .is_some_and(contains_structured_tool_failure_signal)
+}
+
+fn contains_tool_failure_signal(raw: &str) -> bool {
+    if contains_structured_tool_failure_signal(raw) {
+        return true;
+    }
+
+    let text = raw.to_ascii_lowercase();
+    text.contains("tool_call_response")
+        && (text.contains("\"error\"")
+            || text.contains("traceback")
+            || text.contains("exception")
+            || text.contains("failed"))
+}
+
+fn contains_structured_tool_failure_signal(raw: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .map(|value| json_has_tool_failure(&value))
+        .unwrap_or(false)
+}
+
+fn json_has_tool_failure(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Array(items) => items.iter().any(json_has_tool_failure),
+        serde_json::Value::Object(map) => {
+            let is_tool_response = map
+                .get("type")
+                .and_then(|value| value.as_str())
+                .is_some_and(|kind| matches!(kind, "tool_call_response" | "tool_result"))
+                || map.contains_key("tool_call_response");
+
+            if is_tool_response && tool_response_has_error(map) {
+                return true;
+            }
+
+            map.values().any(json_has_tool_failure)
+        }
+        _ => false,
+    }
+}
+
+fn tool_response_has_error(map: &serde_json::Map<String, serde_json::Value>) -> bool {
+    if map.get("is_error").and_then(|value| value.as_bool()) == Some(true) {
+        return true;
+    }
+
+    ["response", "content", "error"]
+        .iter()
+        .any(|key| map.get(*key).is_some_and(value_has_error_signal))
+}
+
+fn value_has_error_signal(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(text) => text_has_error_signal(text),
+        serde_json::Value::Array(items) => items.iter().any(value_has_error_signal),
+        serde_json::Value::Object(map) => {
+            map.get("is_error").and_then(|value| value.as_bool()) == Some(true)
+                || map.values().any(value_has_error_signal)
+        }
+        _ => false,
+    }
+}
+
+fn text_has_error_signal(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("traceback")
+        || lower.contains("exception")
+        || lower.contains("failed")
+        || lower.contains("exit code 1")
+        || lower.contains("no such file or directory")
+        || lower.contains("permission denied")
+        || lower.contains("command not found")
+        || lower.contains("\"error\"")
+        || lower.contains("error:")
+}
+
+pub(super) fn first_event_refs(input: &EvaluationInput, label: &str) -> Vec<EvaluationRef> {
+    input
+        .events
+        .first()
+        .map(|event| vec![genai_ref(&input.target_id, event, label)])
+        .unwrap_or_default()
+}
+
+pub(super) fn genai_ref(
+    conversation_id: &str,
+    event: &TraceEventDetail,
+    label: &str,
+) -> EvaluationRef {
+    let id = event
+        .call_id
+        .clone()
+        .unwrap_or_else(|| format!("genai-event-{}", event.id));
+    EvaluationRef {
+        evidence_type: EvidenceType::GenaiEvent,
+        id,
+        label: label.to_string(),
+        severity: event.interruption_type.clone(),
+        target: EvidenceTarget {
+            conversation_id: conversation_id.to_string(),
+            trace_id: event.trace_id.clone(),
+            call_id: event.call_id.clone(),
+            step_id: None,
+        },
+        deeplink: Some(EvidenceDeeplink {
+            route: "/atif".to_string(),
+            query: serde_json::json!({
+                "type": "conversation",
+                "id": conversation_id,
+                "highlight_call_id": &event.call_id,
+            }),
+        }),
+        metadata: serde_json::json!({
+            "event_id": event.id,
+            "model": &event.model,
+            "status": &event.status,
+        }),
+    }
+}
+
+pub(super) fn interruption_ref(
+    conversation_id: &str,
+    record: &InterruptionRecord,
+) -> EvaluationRef {
+    EvaluationRef {
+        evidence_type: EvidenceType::Interruption,
+        id: record.interruption_id.clone(),
+        label: record.interruption_type.clone(),
+        severity: Some(record.severity.clone()),
+        target: EvidenceTarget {
+            conversation_id: conversation_id.to_string(),
+            trace_id: record.trace_id.clone(),
+            call_id: record.call_id.clone(),
+            step_id: None,
+        },
+        deeplink: Some(EvidenceDeeplink {
+            route: "/atif".to_string(),
+            query: serde_json::json!({
+                "type": "conversation",
+                "id": conversation_id,
+                "highlight_call_id": &record.call_id,
+                "interruption_id": &record.interruption_id,
+            }),
+        }),
+        metadata: serde_json::json!({
+            "occurred_at_ns": record.occurred_at_ns,
+            "detail": &record.detail,
+            "resolved": record.resolved,
+        }),
+    }
+}
+
+fn raw_contains_content(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "[]" || trimmed == "{}" {
+        return false;
+    }
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .map(|value| json_has_text(&value))
+        .unwrap_or_else(|_| !trimmed.is_empty())
+}
+
+fn json_has_text(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(text) => !text.trim().is_empty(),
+        serde_json::Value::Array(values) => values.iter().any(json_has_text),
+        serde_json::Value::Object(map) => map.iter().any(|(key, value)| {
+            matches!(
+                key.as_str(),
+                "content" | "text" | "message" | "output" | "response"
+            ) && json_has_text(value)
+                || key == "parts" && json_has_text(value)
+                || key == "Text" && json_has_text(value)
+                || key == "Reasoning" && json_has_text(value)
+        }),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(
+        input_messages: Option<&str>,
+        output_messages: Option<&str>,
+        event_json: Option<&str>,
+    ) -> TraceEventDetail {
+        TraceEventDetail {
+            id: 1,
+            call_id: Some("call-1".to_string()),
+            start_timestamp_ns: 100,
+            end_timestamp_ns: Some(200),
+            model: Some("test-model".to_string()),
+            input_tokens: 10,
+            output_tokens: 10,
+            total_tokens: 20,
+            input_messages: input_messages.map(str::to_string),
+            output_messages: output_messages.map(str::to_string),
+            system_instructions: None,
+            agent_name: Some("agent".to_string()),
+            process_name: None,
+            pid: Some(1),
+            user_query: Some("do work".to_string()),
+            event_json: event_json.map(str::to_string),
+            trace_id: Some("trace-1".to_string()),
+            conversation_id: Some("conv-1".to_string()),
+            cache_read_tokens: None,
+            status: Some("complete".to_string()),
+            interruption_type: None,
+        }
+    }
+
+    #[test]
+    fn ignores_historical_tool_failure_text_in_raw_event_json() {
+        let event = event(
+            Some(r#"[{"role":"user","content":"write a Linux troubleshooting guide"}]"#),
+            Some(r#"[{"role":"assistant","content":"step 1: check the process"}]"#),
+            Some(
+                r#"{"request":{"messages":[{"role":"user","content":"tool_call_response: {\"error\":\"failed\", \"traceback\":\"FileNotFoundError\"}"}]},"response":{"messages":[{"role":"assistant","content":"step 1: check the process"}]},"error":null}"#,
+            ),
+        );
+
+        assert!(!looks_like_tool_failure(&event));
+    }
+
+    #[test]
+    fn detects_tool_failure_in_current_assistant_output() {
+        let event = event(
+            Some(r#"[{"role":"user","content":"run the tool"}]"#),
+            Some(
+                r#"[{"role":"assistant","content":"tool_call_response: {\"error\":\"failed to read config\", \"traceback\":\"FileNotFoundError\"}"}]"#,
+            ),
+            None,
+        );
+
+        assert!(looks_like_tool_failure(&event));
+    }
+
+    #[test]
+    fn detects_tool_failure_in_structured_input_tool_result() {
+        let event = event(
+            Some(
+                r#"[{"role":"user","parts":[{"type":"tool_call_response","id":"toolu_1","response":{"content":"Exit code 1\ncat: /tmp/missing.txt: No such file or directory","is_error":true}}]}]"#,
+            ),
+            Some(r#"[{"role":"assistant","parts":[{"type":"text","content":"file missing"}]}]"#),
+            None,
+        );
+
+        assert!(looks_like_tool_failure(&event));
+    }
+
+    #[test]
+    fn detects_tool_failure_from_nested_is_error_flag() {
+        let event = event(
+            Some(
+                r#"[{"role":"user","parts":[{"type":"tool_call_response","id":"toolu_1","response":{"is_error":true}}]}]"#,
+            ),
+            Some(r#"[{"role":"assistant","parts":[{"type":"text","content":"tool failed"}]}]"#),
+            None,
+        );
+
+        assert!(looks_like_tool_failure(&event));
+    }
+
+    #[test]
+    fn ignores_tool_failure_text_in_user_prompt() {
+        let event = event(
+            Some(
+                r#"[{"role":"user","content":"please quote this: tool_call_response: {\"error\":\"failed\", \"traceback\":\"FileNotFoundError\"}"}]"#,
+            ),
+            Some(r#"[{"role":"assistant","content":"quoted text omitted"}]"#),
+            None,
+        );
+
+        assert!(!looks_like_tool_failure(&event));
+    }
+}

--- a/src/agentsight/src/grader/evidence.rs
+++ b/src/agentsight/src/grader/evidence.rs
@@ -64,8 +64,8 @@ fn json_has_tool_failure(value: &serde_json::Value) -> bool {
 }
 
 fn tool_response_has_error(map: &serde_json::Map<String, serde_json::Value>) -> bool {
-    if map.get("is_error").and_then(|value| value.as_bool()) == Some(true) {
-        return true;
+    if let Some(is_error) = map.get("is_error").and_then(|value| value.as_bool()) {
+        return is_error;
     }
 
     ["response", "content", "error"]
@@ -78,8 +78,11 @@ fn value_has_error_signal(value: &serde_json::Value) -> bool {
         serde_json::Value::String(text) => text_has_error_signal(text),
         serde_json::Value::Array(items) => items.iter().any(value_has_error_signal),
         serde_json::Value::Object(map) => {
-            map.get("is_error").and_then(|value| value.as_bool()) == Some(true)
-                || map.values().any(value_has_error_signal)
+            if let Some(is_error) = map.get("is_error").and_then(|value| value.as_bool()) {
+                return is_error;
+            }
+
+            map.values().any(value_has_error_signal)
         }
         _ => false,
     }
@@ -272,6 +275,19 @@ mod tests {
         );
 
         assert!(looks_like_tool_failure(&event));
+    }
+
+    #[test]
+    fn ignores_structured_tool_result_with_explicit_non_error_flag() {
+        let event = event(
+            Some(
+                r#"[{"role":"user","parts":[{"type":"tool_call_response","id":"toolu_1","response":{"content":"5 passed, 2 failed","is_error":false}}]}]"#,
+            ),
+            Some(r#"[{"role":"assistant","parts":[{"type":"text","content":"tests completed"}]}]"#),
+            None,
+        );
+
+        assert!(!looks_like_tool_failure(&event));
     }
 
     #[test]

--- a/src/agentsight/src/grader/input.rs
+++ b/src/agentsight/src/grader/input.rs
@@ -1,0 +1,257 @@
+//! Snapshot loading and stable input hashing for grader runs.
+
+use std::path::Path;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::types::{GraderError, RULE_GRADER_VERSION, TargetType};
+use crate::storage::sqlite::genai::TraceEventDetail;
+use crate::storage::sqlite::{GenAISqliteStore, InterruptionRecord, InterruptionStore};
+
+/// Evidence snapshot used by a grader run.
+pub struct EvaluationInput {
+    /// Evaluated target kind.
+    pub target_type: TargetType,
+    /// Evaluated conversation id.
+    pub target_id: String,
+    /// Captured LLM call rows for the conversation.
+    pub events: Vec<TraceEventDetail>,
+    /// Captured interruption rows for the conversation.
+    pub interruptions: Vec<InterruptionRecord>,
+    /// Stable hash over the evaluated snapshot.
+    pub input_hash: String,
+    /// True when the snapshot contains pending calls and was forced.
+    pub evaluated_with_pending: bool,
+    /// Number of pending LLM calls in the snapshot.
+    pub pending_call_count: usize,
+}
+
+/// Load a conversation snapshot and compute its stable input hash.
+pub fn load_conversation_input(
+    storage_path: &Path,
+    interruption_store: Option<&InterruptionStore>,
+    conversation_id: &str,
+    force: bool,
+) -> Result<EvaluationInput, GraderError> {
+    let genai_store = GenAISqliteStore::new_with_path(storage_path)
+        .map_err(|error| GraderError::Storage(error.to_string()))?;
+    let events = genai_store
+        .get_events_by_conversation(conversation_id)
+        .map_err(|error| GraderError::Storage(error.to_string()))?;
+
+    if events.is_empty() {
+        return Err(GraderError::ConversationNotFound(
+            conversation_id.to_string(),
+        ));
+    }
+
+    let pending_call_count = events
+        .iter()
+        .filter(|event| event.status.as_deref() == Some("pending"))
+        .count();
+    if pending_call_count > 0 && !force {
+        return Err(GraderError::ConversationNotReady {
+            pending_count: pending_call_count,
+        });
+    }
+
+    let interruptions = load_conversation_interruptions(interruption_store, conversation_id)?;
+    let input_hash = compute_input_hash(conversation_id, &events, &interruptions)?;
+
+    Ok(EvaluationInput {
+        target_type: TargetType::Conversation,
+        target_id: conversation_id.to_string(),
+        events,
+        interruptions,
+        input_hash,
+        evaluated_with_pending: pending_call_count > 0,
+        pending_call_count,
+    })
+}
+
+fn load_conversation_interruptions(
+    interruption_store: Option<&InterruptionStore>,
+    conversation_id: &str,
+) -> Result<Vec<InterruptionRecord>, GraderError> {
+    match interruption_store {
+        Some(store) => store
+            .list_by_conversation(conversation_id)
+            .map_err(|error| GraderError::Storage(error.to_string())),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn compute_input_hash(
+    conversation_id: &str,
+    events: &[TraceEventDetail],
+    interruptions: &[InterruptionRecord],
+) -> Result<String, GraderError> {
+    #[derive(Serialize)]
+    struct HashPayload<'a> {
+        schema: &'static str,
+        grader_version: &'static str,
+        conversation_id: &'a str,
+        events: Vec<serde_json::Value>,
+        interruptions: Vec<serde_json::Value>,
+    }
+
+    let payload = HashPayload {
+        schema: "agentsight-grader-input-v1",
+        grader_version: RULE_GRADER_VERSION,
+        conversation_id,
+        events: events.iter().map(event_hash_value).collect(),
+        interruptions: interruptions.iter().map(interruption_hash_value).collect(),
+    };
+    let bytes = serde_json::to_vec(&payload)?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn event_hash_value(event: &TraceEventDetail) -> serde_json::Value {
+    serde_json::json!({
+        "id": event.id,
+        "call_id": &event.call_id,
+        "start_timestamp_ns": event.start_timestamp_ns,
+        "end_timestamp_ns": &event.end_timestamp_ns,
+        "model": &event.model,
+        "input_tokens": event.input_tokens,
+        "output_tokens": event.output_tokens,
+        "total_tokens": event.total_tokens,
+        "input_messages": &event.input_messages,
+        "output_messages": &event.output_messages,
+        "system_instructions": &event.system_instructions,
+        "agent_name": &event.agent_name,
+        "process_name": &event.process_name,
+        "pid": &event.pid,
+        "user_query": &event.user_query,
+        "event_json": &event.event_json,
+        "trace_id": &event.trace_id,
+        "conversation_id": &event.conversation_id,
+        "cache_read_tokens": &event.cache_read_tokens,
+        "status": &event.status,
+        "interruption_type": &event.interruption_type,
+    })
+}
+
+fn interruption_hash_value(record: &InterruptionRecord) -> serde_json::Value {
+    serde_json::json!({
+        "interruption_id": &record.interruption_id,
+        "session_id": &record.session_id,
+        "trace_id": &record.trace_id,
+        "conversation_id": &record.conversation_id,
+        "call_id": &record.call_id,
+        "pid": &record.pid,
+        "agent_name": &record.agent_name,
+        "interruption_type": &record.interruption_type,
+        "severity": &record.severity,
+        "occurred_at_ns": record.occurred_at_ns,
+        "detail": &record.detail,
+        "resolved": record.resolved,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::genai::GenAIExporter;
+    use crate::genai::semantic::{GenAISemanticEvent, LLMCall, LLMRequest};
+    use crate::interruption::{InterruptionEvent, InterruptionType};
+
+    use super::*;
+
+    #[test]
+    fn load_conversation_input_uses_injected_interruption_store() {
+        let root = temp_root("grader_input_interruption_store");
+        let genai_path = root.join("genai").join("events.db");
+        let interruption_path = root.join("interruptions").join("events.db");
+        write_conversation_event(&genai_path, "conv-injected");
+
+        let interruption_store = InterruptionStore::new_with_path(&interruption_path).unwrap();
+        let event = InterruptionEvent::new(
+            InterruptionType::NetworkTimeout,
+            Some("session-1".to_string()),
+            Some("trace-1".to_string()),
+            Some("conv-injected".to_string()),
+            Some("call-1".to_string()),
+            Some(1234),
+            Some("Codex".to_string()),
+            1_700_000_000_000_000_100,
+            None,
+        );
+        interruption_store.insert(&event).unwrap();
+
+        let input = load_conversation_input(
+            &genai_path,
+            Some(&interruption_store),
+            "conv-injected",
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(input.events.len(), 1);
+        assert_eq!(input.interruptions.len(), 1);
+        assert_eq!(
+            input.interruptions[0].interruption_type,
+            InterruptionType::NetworkTimeout.as_str()
+        );
+
+        cleanup_db(&genai_path);
+        cleanup_db(&interruption_path);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn write_conversation_event(path: &Path, conversation_id: &str) {
+        let store = GenAISqliteStore::new_with_path(path).unwrap();
+        let mut call = LLMCall::new(
+            "call-1".to_string(),
+            1_700_000_000_000_000_000,
+            "anthropic".to_string(),
+            "claude".to_string(),
+            LLMRequest {
+                messages: Vec::new(),
+                temperature: None,
+                max_tokens: None,
+                frequency_penalty: None,
+                presence_penalty: None,
+                top_p: None,
+                top_k: None,
+                seed: None,
+                stop_sequences: None,
+                stream: false,
+                tools: None,
+                raw_body: None,
+            },
+            1234,
+            "claude".to_string(),
+        );
+        call.metadata
+            .insert("conversation_id".to_string(), conversation_id.to_string());
+        call.metadata
+            .insert("response_id".to_string(), "trace-1".to_string());
+        call.metadata
+            .insert("user_query".to_string(), "hello".to_string());
+
+        store.export(&[GenAISemanticEvent::LLMCall(call)]);
+        store.flush();
+    }
+
+    fn temp_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "agentsight_{label}_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn cleanup_db(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+    }
+}

--- a/src/agentsight/src/grader/input.rs
+++ b/src/agentsight/src/grader/input.rs
@@ -160,6 +160,7 @@ mod tests {
     use crate::genai::GenAIExporter;
     use crate::genai::semantic::{GenAISemanticEvent, LLMCall, LLMRequest};
     use crate::interruption::{InterruptionEvent, InterruptionType};
+    use crate::storage::sqlite::genai::TraceEventDetail;
 
     use super::*;
 
@@ -202,6 +203,74 @@ mod tests {
         cleanup_db(&genai_path);
         cleanup_db(&interruption_path);
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn compute_input_hash_is_stable_and_changes_with_snapshot_inputs() {
+        let base_events = vec![trace_event("call-1", "complete", 10)];
+        let base_hash = compute_input_hash("conv-1", &base_events, &[]).unwrap();
+        let repeated_hash =
+            compute_input_hash("conv-1", &[trace_event("call-1", "complete", 10)], &[]).unwrap();
+
+        let changed_conversation_hash =
+            compute_input_hash("conv-2", &[trace_event("call-1", "complete", 10)], &[]).unwrap();
+        let changed_event_hash =
+            compute_input_hash("conv-1", &[trace_event("call-1", "complete", 11)], &[]).unwrap();
+        let changed_interruption_hash = compute_input_hash(
+            "conv-1",
+            &[trace_event("call-1", "complete", 10)],
+            &[interruption_record("rate_limit", false)],
+        )
+        .unwrap();
+
+        assert_eq!(base_hash, repeated_hash);
+        assert_ne!(base_hash, changed_conversation_hash);
+        assert_ne!(base_hash, changed_event_hash);
+        assert_ne!(base_hash, changed_interruption_hash);
+    }
+
+    fn trace_event(call_id: &str, status: &str, output_tokens: i64) -> TraceEventDetail {
+        TraceEventDetail {
+            id: 1,
+            call_id: Some(call_id.to_string()),
+            start_timestamp_ns: 1_700_000_000_000_000_000,
+            end_timestamp_ns: Some(1_700_000_000_000_000_100),
+            model: Some("claude".to_string()),
+            input_tokens: 100,
+            output_tokens,
+            total_tokens: 100 + output_tokens,
+            input_messages: Some(r#"[{"role":"user","content":"hello"}]"#.to_string()),
+            output_messages: Some(r#"[{"role":"assistant","content":"done"}]"#.to_string()),
+            system_instructions: None,
+            agent_name: Some("claude".to_string()),
+            process_name: Some("claude".to_string()),
+            pid: Some(1234),
+            user_query: Some("hello".to_string()),
+            event_json: None,
+            trace_id: Some("trace-1".to_string()),
+            conversation_id: Some("conv-1".to_string()),
+            cache_read_tokens: None,
+            status: Some(status.to_string()),
+            interruption_type: None,
+        }
+    }
+
+    fn interruption_record(interruption_type: &str, resolved: bool) -> InterruptionRecord {
+        InterruptionRecord {
+            id: 1,
+            interruption_id: format!("intr-{interruption_type}"),
+            session_id: Some("session-1".to_string()),
+            trace_id: Some("trace-1".to_string()),
+            conversation_id: Some("conv-1".to_string()),
+            call_id: Some("call-1".to_string()),
+            pid: Some(1234),
+            agent_name: Some("claude".to_string()),
+            interruption_type: interruption_type.to_string(),
+            severity: "medium".to_string(),
+            occurred_at_ns: 1_700_000_000_000_000_200,
+            detail: None,
+            resolved,
+        }
     }
 
     fn write_conversation_event(path: &Path, conversation_id: &str) {

--- a/src/agentsight/src/grader/rule.rs
+++ b/src/agentsight/src/grader/rule.rs
@@ -214,7 +214,7 @@ fn score_safety(input: &EvaluationInput) -> EvaluationDimension {
     let safety_refs: Vec<EvaluationRef> = input
         .interruptions
         .iter()
-        .filter(|record| record.interruption_type.contains("safety"))
+        .filter(|record| !record.resolved && record.interruption_type.contains("safety"))
         .map(|record| interruption_ref(&input.target_id, record))
         .collect();
     if !safety_refs.is_empty() {
@@ -333,7 +333,14 @@ fn select_root_cause(
     if findings.iter().any(|finding| {
         matches!(
             finding.code.as_str(),
-            "llm_error" | "sse_truncated" | "network_timeout" | "service_unavailable"
+            "llm_error"
+                | "sse_truncated"
+                | "network_timeout"
+                | "service_unavailable"
+                | "rate_limit"
+                | "auth_error"
+                | "context_overflow"
+                | "token_limit"
         )
     }) {
         return RootCause::RuntimeError;
@@ -350,10 +357,12 @@ fn select_root_cause(
     {
         return RootCause::SafetyRisk;
     }
-    if findings
-        .iter()
-        .any(|finding| finding.code == "loop_detected")
-    {
+    if findings.iter().any(|finding| {
+        matches!(
+            finding.code.as_str(),
+            "loop_detected" | "retry_storm" | "dead_loop"
+        )
+    }) {
         return RootCause::LoopDetected;
     }
     if dimensions
@@ -492,6 +501,7 @@ fn round_score(score: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::grader::types::TargetType;
+    use crate::storage::sqlite::InterruptionRecord;
     use crate::storage::sqlite::genai::TraceEventDetail;
 
     fn event(id: i64, status: &str, output_tokens: i64) -> TraceEventDetail {
@@ -536,6 +546,24 @@ mod tests {
         }
     }
 
+    fn interruption(interruption_type: &str, severity: &str, resolved: bool) -> InterruptionRecord {
+        InterruptionRecord {
+            id: 1,
+            interruption_id: format!("intr-{interruption_type}"),
+            session_id: Some("session-1".to_string()),
+            trace_id: Some("trace-1".to_string()),
+            conversation_id: Some("conv-1".to_string()),
+            call_id: Some("call-1".to_string()),
+            pid: Some(1),
+            agent_name: Some("agent".to_string()),
+            interruption_type: interruption_type.to_string(),
+            severity: severity.to_string(),
+            occurred_at_ns: 1_700_000_000_000_000_000,
+            detail: None,
+            resolved,
+        }
+    }
+
     #[test]
     fn passes_completed_conversation_with_output() {
         let result = RuleGrader::evaluate(&input(vec![event(1, "complete", 10)]));
@@ -543,6 +571,25 @@ mod tests {
         assert_eq!(result.verdict, Verdict::Pass);
         assert_eq!(result.root_cause, RootCause::None);
         assert!(result.score >= 0.8);
+    }
+
+    #[test]
+    fn weighted_score_and_score_cutoffs_are_discriminating() {
+        let mut snapshot = input(vec![event(1, "complete", 250_000)]);
+        snapshot.interruptions = vec![interruption("rate_limit", "medium", false)];
+        snapshot.events[0].output_messages = Some(
+            r#"[{"role":"assistant","content":"tool_call_response: {\"error\":\"failed\"}"}]"#
+                .to_string(),
+        );
+
+        let result = RuleGrader::evaluate(&snapshot);
+
+        assert_eq!(result.score, 0.69);
+        assert_eq!(result.verdict, Verdict::Warn);
+        assert_eq!(verdict_for_score(0.80), Verdict::Pass);
+        assert_eq!(verdict_for_score(0.79), Verdict::Warn);
+        assert_eq!(verdict_for_score(0.50), Verdict::Warn);
+        assert_eq!(verdict_for_score(0.49), Verdict::Fail);
     }
 
     #[test]
@@ -589,5 +636,55 @@ mod tests {
         assert_eq!(result.verdict, Verdict::Warn);
         assert_eq!(result.root_cause, RootCause::PartialSnapshot);
         assert!(result.metadata.evaluated_with_pending);
+    }
+
+    #[test]
+    fn resolved_safety_interruption_does_not_penalize_safety() {
+        let mut snapshot = input(vec![event(1, "complete", 10)]);
+        snapshot.interruptions = vec![interruption("safety_filter", "medium", true)];
+
+        let result = RuleGrader::evaluate(&snapshot);
+        let safety = result
+            .dimensions
+            .iter()
+            .find(|dimension| dimension.name == "safety")
+            .expect("safety dimension should exist");
+
+        assert_eq!(safety.score, 1.0);
+        assert_eq!(result.root_cause, RootCause::None);
+        assert!(
+            !result
+                .findings
+                .iter()
+                .any(|finding| finding.code == "safety_filter")
+        );
+    }
+
+    #[test]
+    fn unresolved_interruption_codes_select_specific_root_causes() {
+        for code in [
+            "rate_limit",
+            "auth_error",
+            "context_overflow",
+            "token_limit",
+        ] {
+            let mut snapshot = input(vec![event(1, "complete", 10)]);
+            snapshot.interruptions = vec![interruption(code, "high", false)];
+
+            let result = RuleGrader::evaluate(&snapshot);
+
+            assert_eq!(result.root_cause, RootCause::RuntimeError, "{code}");
+            assert!(!result.summary.ends_with("none."));
+        }
+
+        for code in ["retry_storm", "dead_loop"] {
+            let mut snapshot = input(vec![event(1, "complete", 10)]);
+            snapshot.interruptions = vec![interruption(code, "critical", false)];
+
+            let result = RuleGrader::evaluate(&snapshot);
+
+            assert_eq!(result.root_cause, RootCause::LoopDetected, "{code}");
+            assert!(!result.summary.ends_with("none."));
+        }
     }
 }

--- a/src/agentsight/src/grader/rule.rs
+++ b/src/agentsight/src/grader/rule.rs
@@ -1,0 +1,593 @@
+//! Deterministic rule-based conversation grader.
+
+use super::input::EvaluationInput;
+use super::types::{
+    EvaluationDimension, EvaluationFinding, EvaluationMetadata, EvaluationRef, EvaluationResult,
+    GraderType, RULE_GRADER_VERSION, RootCause, Verdict,
+};
+use crate::grader::evidence::{
+    first_event_refs, genai_ref, has_usable_output, interruption_ref, looks_like_tool_failure,
+};
+use uuid::Uuid;
+
+/// Deterministic MVP grader for conversation snapshots.
+pub struct RuleGrader;
+
+impl RuleGrader {
+    /// Evaluate a conversation snapshot with the current deterministic rule set.
+    pub fn evaluate(input: &EvaluationInput) -> EvaluationResult {
+        let completion = score_completion(input);
+        let runtime = score_runtime_health(input);
+        let tool_use = score_tool_use(input);
+        let efficiency = score_efficiency(input);
+        let safety = score_safety(input);
+
+        let dimensions = vec![
+            completion.clone(),
+            runtime.clone(),
+            tool_use.clone(),
+            efficiency.clone(),
+            safety.clone(),
+        ];
+        let weighted_score = round_score(
+            completion.score * 0.35
+                + runtime.score * 0.25
+                + tool_use.score * 0.20
+                + efficiency.score * 0.10
+                + safety.score * 0.10,
+        );
+        let findings = build_findings(input, &dimensions);
+        let root_cause = select_root_cause(input, &dimensions, &findings);
+        let verdict = select_verdict(input, weighted_score, root_cause, &findings);
+
+        EvaluationResult {
+            target_type: input.target_type,
+            target_id: input.target_id.clone(),
+            run_id: Uuid::new_v4().to_string(),
+            input_hash: input.input_hash.clone(),
+            verdict,
+            score: weighted_score,
+            summary: summary_for(verdict, root_cause),
+            root_cause,
+            recommended_action: recommended_action_for(verdict, root_cause).to_string(),
+            dimensions,
+            findings,
+            metadata: EvaluationMetadata {
+                evaluated_with_pending: input.evaluated_with_pending,
+                pending_call_count: input.pending_call_count,
+                input_event_count: input.events.len(),
+                grader_type: GraderType::Rule,
+                grader_version: RULE_GRADER_VERSION.to_string(),
+                rubric_version: None,
+                judge_model: None,
+                prompt_hash: None,
+                confidence: None,
+            },
+        }
+    }
+}
+
+fn score_completion(input: &EvaluationInput) -> EvaluationDimension {
+    let output_refs: Vec<EvaluationRef> = input
+        .events
+        .iter()
+        .filter(|event| has_usable_output(event))
+        .map(|event| genai_ref(&input.target_id, event, "Assistant output"))
+        .collect();
+
+    if output_refs.is_empty() {
+        return dimension(
+            "completion",
+            0.0,
+            "No usable assistant output was captured.",
+            first_event_refs(input, "No output"),
+        );
+    }
+
+    let pending_penalty = if input.evaluated_with_pending {
+        0.15
+    } else {
+        0.0
+    };
+    dimension(
+        "completion",
+        1.0 - pending_penalty,
+        if input.evaluated_with_pending {
+            "A usable output exists, but the snapshot still has pending calls."
+        } else {
+            "A usable assistant output was captured."
+        },
+        output_refs,
+    )
+}
+
+fn score_runtime_health(input: &EvaluationInput) -> EvaluationDimension {
+    let interrupted_refs: Vec<EvaluationRef> = input
+        .events
+        .iter()
+        .filter(|event| event.status.as_deref() == Some("interrupted"))
+        .map(|event| genai_ref(&input.target_id, event, "Interrupted LLM call"))
+        .collect();
+    if !interrupted_refs.is_empty() {
+        return dimension(
+            "runtime_health",
+            0.0,
+            "One or more LLM calls were interrupted.",
+            interrupted_refs,
+        );
+    }
+
+    let unresolved: Vec<EvaluationRef> = input
+        .interruptions
+        .iter()
+        .filter(|record| !record.resolved)
+        .map(|record| interruption_ref(&input.target_id, record))
+        .collect();
+    if !unresolved.is_empty() {
+        return dimension(
+            "runtime_health",
+            0.45,
+            "Unresolved interruption signals were captured for this conversation.",
+            unresolved,
+        );
+    }
+
+    if input.evaluated_with_pending {
+        return dimension(
+            "runtime_health",
+            0.75,
+            "The snapshot contains pending calls and may still change.",
+            first_event_refs(input, "Pending call"),
+        );
+    }
+
+    dimension(
+        "runtime_health",
+        1.0,
+        "No runtime interruption was detected.",
+        Vec::new(),
+    )
+}
+
+fn score_tool_use(input: &EvaluationInput) -> EvaluationDimension {
+    let failed_tool_refs: Vec<EvaluationRef> = input
+        .events
+        .iter()
+        .filter(|event| looks_like_tool_failure(event))
+        .map(|event| genai_ref(&input.target_id, event, "Tool failure signal"))
+        .collect();
+    if !failed_tool_refs.is_empty() {
+        return dimension(
+            "tool_use",
+            0.45,
+            "Tool output contains deterministic error signals.",
+            failed_tool_refs,
+        );
+    }
+
+    let call_count = input.events.len();
+    if call_count > 12 {
+        return dimension(
+            "tool_use",
+            0.55,
+            "The conversation required an unusually large number of LLM calls.",
+            first_event_refs(input, "Repeated calls"),
+        );
+    }
+
+    dimension(
+        "tool_use",
+        1.0,
+        "No deterministic tool failure was detected.",
+        Vec::new(),
+    )
+}
+
+fn score_efficiency(input: &EvaluationInput) -> EvaluationDimension {
+    let total_tokens: i64 = input.events.iter().map(|event| event.total_tokens).sum();
+    if total_tokens >= 200_000 || input.events.len() > 20 {
+        return dimension(
+            "efficiency",
+            0.35,
+            "Token usage or call count is unusually high for a single conversation.",
+            first_event_refs(input, "High cost"),
+        );
+    }
+    if total_tokens >= 64_000 || input.events.len() > 10 {
+        return dimension(
+            "efficiency",
+            0.65,
+            "Token usage or call count is elevated for a single conversation.",
+            first_event_refs(input, "Elevated cost"),
+        );
+    }
+
+    dimension(
+        "efficiency",
+        1.0,
+        "Token usage and call count are within normal bounds.",
+        Vec::new(),
+    )
+}
+
+fn score_safety(input: &EvaluationInput) -> EvaluationDimension {
+    let safety_refs: Vec<EvaluationRef> = input
+        .interruptions
+        .iter()
+        .filter(|record| record.interruption_type.contains("safety"))
+        .map(|record| interruption_ref(&input.target_id, record))
+        .collect();
+    if !safety_refs.is_empty() {
+        return dimension(
+            "safety",
+            0.0,
+            "Safety-related interruption signal was captured.",
+            safety_refs,
+        );
+    }
+
+    dimension(
+        "safety",
+        1.0,
+        "No safety-specific signal was available or triggered.",
+        Vec::new(),
+    )
+}
+
+fn build_findings(
+    input: &EvaluationInput,
+    dimensions: &[EvaluationDimension],
+) -> Vec<EvaluationFinding> {
+    let mut findings = Vec::new();
+
+    if !dimensions
+        .iter()
+        .any(|dimension| dimension.name == "completion" && dimension.score > 0.0)
+    {
+        findings.push(finding(
+            "no_final_answer",
+            "critical",
+            "The conversation has no usable assistant output.",
+            first_event_refs(input, "No output"),
+        ));
+    }
+
+    for event in input
+        .events
+        .iter()
+        .filter(|event| event.status.as_deref() == Some("interrupted"))
+    {
+        findings.push(finding(
+            "interrupted_main_call",
+            "critical",
+            "An LLM call was interrupted before normal completion.",
+            vec![genai_ref(&input.target_id, event, "Interrupted call")],
+        ));
+    }
+
+    if input.evaluated_with_pending {
+        findings.push(finding(
+            "partial_snapshot",
+            "medium",
+            "Evaluation was forced while LLM calls were still pending.",
+            first_event_refs(input, "Pending snapshot"),
+        ));
+    }
+
+    for record in input.interruptions.iter().filter(|record| !record.resolved) {
+        findings.push(finding(
+            &record.interruption_type,
+            severity_to_finding(&record.severity),
+            "An unresolved interruption was recorded for this conversation.",
+            vec![interruption_ref(&input.target_id, record)],
+        ));
+    }
+
+    if input.events.iter().any(looks_like_tool_failure) {
+        findings.push(finding(
+            "tool_failure",
+            "medium",
+            "Tool output contains an error-like signal.",
+            input
+                .events
+                .iter()
+                .filter(|event| looks_like_tool_failure(event))
+                .map(|event| genai_ref(&input.target_id, event, "Tool failure"))
+                .collect(),
+        ));
+    }
+
+    if input.events.len() > 12 {
+        findings.push(finding(
+            "loop_detected",
+            "medium",
+            "The conversation used many LLM calls and may need loop inspection.",
+            first_event_refs(input, "Repeated calls"),
+        ));
+    }
+
+    findings
+}
+
+fn select_root_cause(
+    input: &EvaluationInput,
+    dimensions: &[EvaluationDimension],
+    findings: &[EvaluationFinding],
+) -> RootCause {
+    let completion_failed = dimensions.iter().any(|dimension| {
+        dimension.name == "completion" && (dimension.score - 0.0).abs() < f64::EPSILON
+    });
+    if completion_failed {
+        return RootCause::NoFinalAnswer;
+    }
+    if input
+        .events
+        .iter()
+        .any(|event| event.status.as_deref() == Some("interrupted"))
+    {
+        return RootCause::InterruptedMainCall;
+    }
+    if findings.iter().any(|finding| finding.code == "agent_crash") {
+        return RootCause::AgentCrash;
+    }
+    if findings.iter().any(|finding| {
+        matches!(
+            finding.code.as_str(),
+            "llm_error" | "sse_truncated" | "network_timeout" | "service_unavailable"
+        )
+    }) {
+        return RootCause::RuntimeError;
+    }
+    if findings
+        .iter()
+        .any(|finding| finding.code == "tool_failure")
+    {
+        return RootCause::ToolFailure;
+    }
+    if findings
+        .iter()
+        .any(|finding| finding.code.contains("safety"))
+    {
+        return RootCause::SafetyRisk;
+    }
+    if findings
+        .iter()
+        .any(|finding| finding.code == "loop_detected")
+    {
+        return RootCause::LoopDetected;
+    }
+    if dimensions
+        .iter()
+        .any(|dimension| dimension.name == "efficiency" && dimension.score < 0.5)
+    {
+        return RootCause::ExcessiveCost;
+    }
+    if input.evaluated_with_pending {
+        return RootCause::PartialSnapshot;
+    }
+    RootCause::None
+}
+
+fn select_verdict(
+    input: &EvaluationInput,
+    score: f64,
+    root_cause: RootCause,
+    findings: &[EvaluationFinding],
+) -> Verdict {
+    if matches!(
+        root_cause,
+        RootCause::NoFinalAnswer | RootCause::InterruptedMainCall
+    ) {
+        return Verdict::Fail;
+    }
+    if score < 0.5 {
+        return Verdict::Fail;
+    }
+    if input.evaluated_with_pending
+        || score < 0.8
+        || findings.iter().any(|finding| finding.severity != "low")
+    {
+        return Verdict::Warn;
+    }
+    Verdict::Pass
+}
+
+fn dimension(
+    name: &str,
+    score: f64,
+    reason: &str,
+    evidence_refs: Vec<EvaluationRef>,
+) -> EvaluationDimension {
+    EvaluationDimension {
+        name: name.to_string(),
+        score: round_score(score),
+        verdict: verdict_for_score(score),
+        reason: reason.to_string(),
+        evidence_refs,
+    }
+}
+
+fn finding(
+    code: &str,
+    severity: &str,
+    message: &str,
+    evidence_refs: Vec<EvaluationRef>,
+) -> EvaluationFinding {
+    EvaluationFinding {
+        code: code.to_string(),
+        severity: severity.to_string(),
+        message: message.to_string(),
+        evidence_refs,
+    }
+}
+
+fn verdict_for_score(score: f64) -> Verdict {
+    if score >= 0.8 {
+        Verdict::Pass
+    } else if score >= 0.5 {
+        Verdict::Warn
+    } else {
+        Verdict::Fail
+    }
+}
+
+fn summary_for(verdict: Verdict, root_cause: RootCause) -> String {
+    match verdict {
+        Verdict::Pass => {
+            "Conversation completed successfully with no deterministic quality issue.".to_string()
+        }
+        Verdict::Warn => format!(
+            "Conversation is usable but needs review for {}.",
+            root_cause.as_str()
+        ),
+        Verdict::Fail => format!(
+            "Conversation failed quality evaluation because of {}.",
+            root_cause.as_str()
+        ),
+    }
+}
+
+fn recommended_action_for(verdict: Verdict, root_cause: RootCause) -> &'static str {
+    match (verdict, root_cause) {
+        (Verdict::Pass, _) => "No immediate action required.",
+        (_, RootCause::NoFinalAnswer) => {
+            "Inspect the final LLM call and provider response parsing."
+        }
+        (_, RootCause::InterruptedMainCall) => {
+            "Inspect interruption evidence and retry the conversation after fixing runtime stability."
+        }
+        (_, RootCause::AgentCrash) => "Inspect agent health and crash diagnostics before retrying.",
+        (_, RootCause::RuntimeError) => {
+            "Inspect provider errors, network stability, and retry behavior."
+        }
+        (_, RootCause::ToolFailure) => "Inspect failing tool calls and tool response parsing.",
+        (_, RootCause::SafetyRisk) => {
+            "Review safety/security findings before re-running the agent."
+        }
+        (_, RootCause::LoopDetected) => "Inspect repeated calls and tighten stopping conditions.",
+        (_, RootCause::ExcessiveCost) => {
+            "Review prompts, tool outputs, and token-saving opportunities."
+        }
+        (_, RootCause::PartialSnapshot) => {
+            "Wait for pending calls to complete or keep the partial result marked as forced."
+        }
+        (_, RootCause::None) => "Review warnings and supporting evidence.",
+    }
+}
+
+fn severity_to_finding(severity: &str) -> &'static str {
+    match severity {
+        "critical" | "high" => "high",
+        "medium" => "medium",
+        _ => "low",
+    }
+}
+
+fn round_score(score: f64) -> f64 {
+    let clamped = score.clamp(0.0, 1.0);
+    (clamped * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grader::types::TargetType;
+    use crate::storage::sqlite::genai::TraceEventDetail;
+
+    fn event(id: i64, status: &str, output_tokens: i64) -> TraceEventDetail {
+        TraceEventDetail {
+            id,
+            call_id: Some(format!("call-{id}")),
+            start_timestamp_ns: id * 100,
+            end_timestamp_ns: Some(id * 100 + 50),
+            model: Some("gpt-test".to_string()),
+            input_tokens: 100,
+            output_tokens,
+            total_tokens: 100 + output_tokens,
+            input_messages: None,
+            output_messages: if output_tokens > 0 {
+                Some(r#"[{"role":"assistant","content":"done"}]"#.to_string())
+            } else {
+                Some("[]".to_string())
+            },
+            system_instructions: None,
+            agent_name: Some("agent".to_string()),
+            process_name: None,
+            pid: Some(1),
+            user_query: Some("do work".to_string()),
+            event_json: None,
+            trace_id: Some(format!("trace-{id}")),
+            conversation_id: Some("conv-1".to_string()),
+            cache_read_tokens: None,
+            status: Some(status.to_string()),
+            interruption_type: None,
+        }
+    }
+
+    fn input(events: Vec<TraceEventDetail>) -> EvaluationInput {
+        EvaluationInput {
+            target_type: TargetType::Conversation,
+            target_id: "conv-1".to_string(),
+            events,
+            interruptions: Vec::new(),
+            input_hash: "hash".to_string(),
+            evaluated_with_pending: false,
+            pending_call_count: 0,
+        }
+    }
+
+    #[test]
+    fn passes_completed_conversation_with_output() {
+        let result = RuleGrader::evaluate(&input(vec![event(1, "complete", 10)]));
+
+        assert_eq!(result.verdict, Verdict::Pass);
+        assert_eq!(result.root_cause, RootCause::None);
+        assert!(result.score >= 0.8);
+    }
+
+    #[test]
+    fn fails_when_no_usable_output_exists() {
+        let result = RuleGrader::evaluate(&input(vec![event(1, "complete", 0)]));
+
+        assert_eq!(result.verdict, Verdict::Fail);
+        assert_eq!(result.root_cause, RootCause::NoFinalAnswer);
+    }
+
+    #[test]
+    fn ignores_event_json_metadata_when_no_output_exists() {
+        let mut no_output = event(1, "complete", 0);
+        no_output.output_messages = None;
+        no_output.event_json = Some(
+            r#"{"model":"gpt-test","user_query":"do work","response":{"messages":[]}}"#.to_string(),
+        );
+
+        let result = RuleGrader::evaluate(&input(vec![no_output]));
+
+        assert_eq!(result.verdict, Verdict::Fail);
+        assert_eq!(result.root_cause, RootCause::NoFinalAnswer);
+    }
+
+    #[test]
+    fn ignores_role_only_output_messages() {
+        let mut no_output = event(1, "complete", 0);
+        no_output.output_messages = Some(r#"[{"role":"assistant"}]"#.to_string());
+
+        let result = RuleGrader::evaluate(&input(vec![no_output]));
+
+        assert_eq!(result.verdict, Verdict::Fail);
+        assert_eq!(result.root_cause, RootCause::NoFinalAnswer);
+    }
+
+    #[test]
+    fn forced_pending_snapshot_warns_without_hard_failure() {
+        let mut snapshot = input(vec![event(1, "pending", 10)]);
+        snapshot.evaluated_with_pending = true;
+        snapshot.pending_call_count = 1;
+
+        let result = RuleGrader::evaluate(&snapshot);
+
+        assert_eq!(result.verdict, Verdict::Warn);
+        assert_eq!(result.root_cause, RootCause::PartialSnapshot);
+        assert!(result.metadata.evaluated_with_pending);
+    }
+}

--- a/src/agentsight/src/grader/rule.rs
+++ b/src/agentsight/src/grader/rule.rs
@@ -38,7 +38,7 @@ impl RuleGrader {
         );
         let findings = build_findings(input, &dimensions);
         let root_cause = select_root_cause(input, &dimensions, &findings);
-        let verdict = select_verdict(input, weighted_score, root_cause, &findings);
+        let verdict = select_verdict(input, weighted_score, root_cause, &dimensions, &findings);
 
         EvaluationResult {
             target_type: input.target_type,
@@ -381,6 +381,7 @@ fn select_verdict(
     input: &EvaluationInput,
     score: f64,
     root_cause: RootCause,
+    dimensions: &[EvaluationDimension],
     findings: &[EvaluationFinding],
 ) -> Verdict {
     if matches!(
@@ -392,8 +393,13 @@ fn select_verdict(
     if score < 0.5 {
         return Verdict::Fail;
     }
+    let has_failed_dimension = dimensions
+        .iter()
+        .any(|dimension| dimension.verdict == Verdict::Fail);
     if input.evaluated_with_pending
         || score < 0.8
+        || root_cause != RootCause::None
+        || has_failed_dimension
         || findings.iter().any(|finding| finding.severity != "low")
     {
         return Verdict::Warn;
@@ -590,6 +596,26 @@ mod tests {
         assert_eq!(verdict_for_score(0.79), Verdict::Warn);
         assert_eq!(verdict_for_score(0.50), Verdict::Warn);
         assert_eq!(verdict_for_score(0.49), Verdict::Fail);
+    }
+
+    #[test]
+    fn warns_when_dimension_fails_despite_high_weighted_score() {
+        let result = RuleGrader::evaluate(&input(vec![event(1, "complete", 250_000)]));
+        let efficiency = result
+            .dimensions
+            .iter()
+            .find(|dimension| dimension.name == "efficiency")
+            .expect("efficiency dimension should exist");
+
+        assert_eq!(result.score, 0.94);
+        assert_eq!(result.root_cause, RootCause::ExcessiveCost);
+        assert_eq!(efficiency.verdict, Verdict::Fail);
+        assert_eq!(result.verdict, Verdict::Warn);
+        assert_ne!(
+            result.summary,
+            "Conversation completed successfully with no deterministic quality issue."
+        );
+        assert_ne!(result.recommended_action, "No immediate action required.");
     }
 
     #[test]

--- a/src/agentsight/src/grader/storage.rs
+++ b/src/agentsight/src/grader/storage.rs
@@ -319,3 +319,87 @@ fn parse_root_cause(value: String) -> Result<RootCause, GraderError> {
         _ => Err(GraderError::Storage(format!("unknown root_cause: {value}"))),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+    use crate::grader::types::{
+        EvaluationMetadata, EvaluationResult, GraderType, RULE_GRADER_VERSION, TargetType, Verdict,
+    };
+
+    #[test]
+    fn insert_completed_is_idempotent_for_same_input_key() {
+        let path = temp_db_path("grader_store_idempotency");
+        let store = EvaluationStore::new_with_path(&path).unwrap();
+        let first = evaluation_result("run-first", "input-hash-1");
+        let duplicate = evaluation_result("run-duplicate", "input-hash-1");
+
+        assert!(store.insert_completed(&first).unwrap());
+        assert!(!store.insert_completed(&duplicate).unwrap());
+
+        let found = store
+            .find_completed(
+                TargetType::Conversation,
+                "conv-1",
+                "input-hash-1",
+                GraderType::Rule,
+                RULE_GRADER_VERSION,
+            )
+            .unwrap()
+            .expect("completed run should be found");
+
+        assert_eq!(found.run_id, "run-first");
+        assert_eq!(
+            found.result.expect("result_json should exist").run_id,
+            "run-first"
+        );
+
+        cleanup_db(&path);
+    }
+
+    fn evaluation_result(run_id: &str, input_hash: &str) -> EvaluationResult {
+        EvaluationResult {
+            target_type: TargetType::Conversation,
+            target_id: "conv-1".to_string(),
+            run_id: run_id.to_string(),
+            input_hash: input_hash.to_string(),
+            verdict: Verdict::Pass,
+            score: 1.0,
+            summary: "ok".to_string(),
+            root_cause: RootCause::None,
+            recommended_action: "none".to_string(),
+            dimensions: Vec::new(),
+            findings: Vec::new(),
+            metadata: EvaluationMetadata {
+                evaluated_with_pending: false,
+                pending_call_count: 0,
+                input_event_count: 1,
+                grader_type: GraderType::Rule,
+                grader_version: RULE_GRADER_VERSION.to_string(),
+                rubric_version: None,
+                judge_model: None,
+                prompt_hash: None,
+                confidence: Some(1.0),
+            },
+        }
+    }
+
+    fn temp_db_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "agentsight_{label}_{}.db",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn cleanup_db(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+    }
+}

--- a/src/agentsight/src/grader/storage.rs
+++ b/src/agentsight/src/grader/storage.rs
@@ -1,0 +1,321 @@
+//! SQLite persistence for grader evaluation runs.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use rusqlite::{Connection, params};
+
+use super::types::{
+    EvaluationResult, EvaluationRunRecord, EvaluationStatus, GraderError, GraderType, RootCause,
+    TargetType, Verdict,
+};
+use crate::storage::sqlite::create_connection;
+
+/// SQLite-backed persistence for evaluation runs.
+pub struct EvaluationStore {
+    conn: Mutex<Connection>,
+}
+
+impl EvaluationStore {
+    /// Open an evaluation store using the given SQLite path.
+    ///
+    /// The MVP stores `evaluation_runs` beside GenAI events so `serve --db`
+    /// controls both conversation evidence and evaluation results.
+    pub fn new_with_path(path: &Path) -> Result<Self, GraderError> {
+        let conn =
+            create_connection(path).map_err(|error| GraderError::Storage(error.to_string()))?;
+        let store = EvaluationStore {
+            conn: Mutex::new(conn),
+        };
+        store.init_tables()?;
+        Ok(store)
+    }
+
+    fn init_tables(&self) -> Result<(), GraderError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|error| GraderError::Storage(error.to_string()))?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS evaluation_runs (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id           TEXT NOT NULL UNIQUE,
+                target_type      TEXT NOT NULL,
+                target_id        TEXT NOT NULL,
+                input_hash       TEXT NOT NULL,
+                grader_type      TEXT NOT NULL,
+                grader_version   TEXT NOT NULL,
+                rubric_version   TEXT,
+                judge_model      TEXT,
+                prompt_hash      TEXT,
+                confidence       REAL,
+                status           TEXT NOT NULL,
+                verdict          TEXT,
+                score            REAL,
+                root_cause       TEXT,
+                created_at       DATETIME DEFAULT CURRENT_TIMESTAMP,
+                completed_at     DATETIME,
+                result_json      TEXT,
+                UNIQUE(target_type, target_id, input_hash, grader_type, grader_version)
+            );
+            CREATE INDEX IF NOT EXISTS idx_evaluation_runs_target_latest
+                ON evaluation_runs(target_type, target_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_evaluation_runs_run_id
+                ON evaluation_runs(run_id);",
+        )
+        .map_err(|error| GraderError::Storage(error.to_string()))?;
+        Ok(())
+    }
+
+    /// Return an existing completed run for the idempotency key, if present.
+    pub fn find_completed(
+        &self,
+        target_type: TargetType,
+        target_id: &str,
+        input_hash: &str,
+        grader_type: GraderType,
+        grader_version: &str,
+    ) -> Result<Option<EvaluationRunRecord>, GraderError> {
+        let raw = {
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|error| GraderError::Storage(error.to_string()))?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, run_id, target_type, target_id, input_hash, grader_type,
+                        grader_version, status, verdict, score, root_cause, created_at,
+                        completed_at, result_json
+                 FROM evaluation_runs
+                 WHERE target_type=?1
+                   AND target_id=?2
+                   AND input_hash=?3
+                   AND grader_type=?4
+                   AND grader_version=?5
+                   AND status='completed'
+                 LIMIT 1",
+                )
+                .map_err(|error| GraderError::Storage(error.to_string()))?;
+            let mut rows = stmt
+                .query(params![
+                    target_type.as_str(),
+                    target_id,
+                    input_hash,
+                    grader_type.as_str(),
+                    grader_version,
+                ])
+                .map_err(|error| GraderError::Storage(error.to_string()))?;
+            match rows
+                .next()
+                .map_err(|error| GraderError::Storage(error.to_string()))?
+            {
+                Some(row) => Some(
+                    read_raw_record(row)
+                        .map_err(|error| GraderError::Storage(error.to_string()))?,
+                ),
+                None => None,
+            }
+        };
+        raw.map(raw_to_record).transpose()
+    }
+
+    /// Insert a completed evaluation result.
+    ///
+    /// Returns `false` when an equivalent completed run already exists.
+    pub fn insert_completed(&self, result: &EvaluationResult) -> Result<bool, GraderError> {
+        let result_json = serde_json::to_string(result)?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|error| GraderError::Storage(error.to_string()))?;
+        let inserted = conn
+            .execute(
+                "INSERT OR IGNORE INTO evaluation_runs (
+                run_id, target_type, target_id, input_hash, grader_type, grader_version,
+                rubric_version, judge_model, prompt_hash, confidence, status, verdict,
+                score, root_cause, completed_at, result_json
+            ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,CURRENT_TIMESTAMP,?15)",
+                params![
+                    &result.run_id,
+                    result.target_type.as_str(),
+                    &result.target_id,
+                    &result.input_hash,
+                    result.metadata.grader_type.as_str(),
+                    &result.metadata.grader_version,
+                    &result.metadata.rubric_version,
+                    &result.metadata.judge_model,
+                    &result.metadata.prompt_hash,
+                    result.metadata.confidence,
+                    EvaluationStatus::Completed.as_str(),
+                    result.verdict.as_str(),
+                    result.score,
+                    result.root_cause.as_str(),
+                    result_json,
+                ],
+            )
+            .map_err(|error| GraderError::Storage(error.to_string()))?;
+        Ok(inserted > 0)
+    }
+
+    /// Return the latest completed run for a target.
+    pub fn latest_completed(
+        &self,
+        target_type: TargetType,
+        target_id: &str,
+    ) -> Result<Option<EvaluationRunRecord>, GraderError> {
+        let raw = {
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|error| GraderError::Storage(error.to_string()))?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, run_id, target_type, target_id, input_hash, grader_type,
+                        grader_version, status, verdict, score, root_cause, created_at,
+                        completed_at, result_json
+                 FROM evaluation_runs
+                 WHERE target_type=?1
+                   AND target_id=?2
+                   AND status='completed'
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT 1",
+                )
+                .map_err(|error| GraderError::Storage(error.to_string()))?;
+            let mut rows = stmt
+                .query(params![target_type.as_str(), target_id])
+                .map_err(|error| GraderError::Storage(error.to_string()))?;
+            match rows
+                .next()
+                .map_err(|error| GraderError::Storage(error.to_string()))?
+            {
+                Some(row) => Some(
+                    read_raw_record(row)
+                        .map_err(|error| GraderError::Storage(error.to_string()))?,
+                ),
+                None => None,
+            }
+        };
+        raw.map(raw_to_record).transpose()
+    }
+}
+
+struct RawEvaluationRunRecord {
+    id: i64,
+    run_id: String,
+    target_type: String,
+    target_id: String,
+    input_hash: String,
+    grader_type: String,
+    grader_version: String,
+    status: String,
+    verdict: Option<String>,
+    score: Option<f64>,
+    root_cause: Option<String>,
+    created_at: String,
+    completed_at: Option<String>,
+    result_json: Option<String>,
+}
+
+fn read_raw_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawEvaluationRunRecord> {
+    Ok(RawEvaluationRunRecord {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        target_type: row.get(2)?,
+        target_id: row.get(3)?,
+        input_hash: row.get(4)?,
+        grader_type: row.get(5)?,
+        grader_version: row.get(6)?,
+        status: row.get(7)?,
+        verdict: row.get(8)?,
+        score: row.get(9)?,
+        root_cause: row.get(10)?,
+        created_at: row.get(11)?,
+        completed_at: row.get(12)?,
+        result_json: row.get(13)?,
+    })
+}
+
+fn raw_to_record(raw: RawEvaluationRunRecord) -> Result<EvaluationRunRecord, GraderError> {
+    let target_type = parse_target_type(raw.target_type)?;
+    let grader_type = parse_grader_type(raw.grader_type)?;
+    let status = parse_status(raw.status)?;
+    let verdict = raw.verdict.map(parse_verdict).transpose()?;
+    let root_cause = raw.root_cause.map(parse_root_cause).transpose()?;
+    let result = raw
+        .result_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()?;
+
+    Ok(EvaluationRunRecord {
+        id: raw.id,
+        run_id: raw.run_id,
+        target_type,
+        target_id: raw.target_id,
+        input_hash: raw.input_hash,
+        grader_type,
+        grader_version: raw.grader_version,
+        status,
+        verdict,
+        score: raw.score,
+        root_cause,
+        created_at: raw.created_at,
+        completed_at: raw.completed_at,
+        result,
+    })
+}
+
+fn parse_target_type(value: String) -> Result<TargetType, GraderError> {
+    match value.as_str() {
+        "conversation" => Ok(TargetType::Conversation),
+        _ => Err(GraderError::Storage(format!(
+            "unknown target_type: {value}"
+        ))),
+    }
+}
+
+fn parse_grader_type(value: String) -> Result<GraderType, GraderError> {
+    match value.as_str() {
+        "rule" => Ok(GraderType::Rule),
+        "llm" => Ok(GraderType::Llm),
+        "agent" => Ok(GraderType::Agent),
+        _ => Err(GraderError::Storage(format!(
+            "unknown grader_type: {value}"
+        ))),
+    }
+}
+
+fn parse_status(value: String) -> Result<EvaluationStatus, GraderError> {
+    match value.as_str() {
+        "completed" => Ok(EvaluationStatus::Completed),
+        "failed" => Ok(EvaluationStatus::Failed),
+        _ => Err(GraderError::Storage(format!(
+            "unknown evaluation status: {value}"
+        ))),
+    }
+}
+
+fn parse_verdict(value: String) -> Result<Verdict, GraderError> {
+    match value.as_str() {
+        "pass" => Ok(Verdict::Pass),
+        "warn" => Ok(Verdict::Warn),
+        "fail" => Ok(Verdict::Fail),
+        _ => Err(GraderError::Storage(format!("unknown verdict: {value}"))),
+    }
+}
+
+fn parse_root_cause(value: String) -> Result<RootCause, GraderError> {
+    match value.as_str() {
+        "none" => Ok(RootCause::None),
+        "no_final_answer" => Ok(RootCause::NoFinalAnswer),
+        "interrupted_main_call" => Ok(RootCause::InterruptedMainCall),
+        "agent_crash" => Ok(RootCause::AgentCrash),
+        "runtime_error" => Ok(RootCause::RuntimeError),
+        "tool_failure" => Ok(RootCause::ToolFailure),
+        "safety_risk" => Ok(RootCause::SafetyRisk),
+        "loop_detected" => Ok(RootCause::LoopDetected),
+        "excessive_cost" => Ok(RootCause::ExcessiveCost),
+        "partial_snapshot" => Ok(RootCause::PartialSnapshot),
+        _ => Err(GraderError::Storage(format!("unknown root_cause: {value}"))),
+    }
+}

--- a/src/agentsight/src/grader/types.rs
+++ b/src/agentsight/src/grader/types.rs
@@ -1,0 +1,372 @@
+//! Public data types shared by grader storage, API handlers, and dashboard clients.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Rule-based grader version used by the MVP.
+pub const RULE_GRADER_VERSION: &str = "rule-v3";
+
+/// Evaluation target kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetType {
+    /// A grouped Agent conversation.
+    Conversation,
+}
+
+impl TargetType {
+    /// Stable string used in SQLite idempotency keys.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TargetType::Conversation => "conversation",
+        }
+    }
+}
+
+/// Evaluator implementation kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraderType {
+    /// Deterministic rules over captured evidence.
+    Rule,
+    /// Reserved for future LLM-as-a-Judge.
+    Llm,
+    /// Reserved for future Agent-as-a-Judge.
+    Agent,
+}
+
+impl GraderType {
+    /// Stable string used in SQLite idempotency keys.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GraderType::Rule => "rule",
+            GraderType::Llm => "llm",
+            GraderType::Agent => "agent",
+        }
+    }
+}
+
+/// Top-level evaluation verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    /// The conversation appears successful.
+    Pass,
+    /// The conversation is usable but has notable risks.
+    Warn,
+    /// The conversation did not produce a usable outcome.
+    Fail,
+}
+
+impl Verdict {
+    /// Stable string used in SQLite summary columns.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::Pass => "pass",
+            Verdict::Warn => "warn",
+            Verdict::Fail => "fail",
+        }
+    }
+}
+
+/// Stored run status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvaluationStatus {
+    /// Evaluation completed and `result_json` is available.
+    Completed,
+    /// Evaluation failed before a result was produced.
+    Failed,
+}
+
+impl EvaluationStatus {
+    /// Stable string used in SQLite summary columns.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EvaluationStatus::Completed => "completed",
+            EvaluationStatus::Failed => "failed",
+        }
+    }
+}
+
+/// Single primary cause selected for the top-level result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootCause {
+    /// No actionable cause was detected.
+    None,
+    /// No usable assistant output was captured.
+    NoFinalAnswer,
+    /// The primary LLM call was interrupted.
+    InterruptedMainCall,
+    /// The agent process crashed.
+    AgentCrash,
+    /// Runtime or provider errors were observed.
+    RuntimeError,
+    /// Tool calls failed or repeated abnormally.
+    ToolFailure,
+    /// Security or safety signal was non-pass.
+    SafetyRisk,
+    /// Repeated calls indicate a likely loop.
+    LoopDetected,
+    /// Token or call count was unusually high.
+    ExcessiveCost,
+    /// The user intentionally evaluated an incomplete snapshot.
+    PartialSnapshot,
+}
+
+impl RootCause {
+    /// Stable string used in SQLite summary columns.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RootCause::None => "none",
+            RootCause::NoFinalAnswer => "no_final_answer",
+            RootCause::InterruptedMainCall => "interrupted_main_call",
+            RootCause::AgentCrash => "agent_crash",
+            RootCause::RuntimeError => "runtime_error",
+            RootCause::ToolFailure => "tool_failure",
+            RootCause::SafetyRisk => "safety_risk",
+            RootCause::LoopDetected => "loop_detected",
+            RootCause::ExcessiveCost => "excessive_cost",
+            RootCause::PartialSnapshot => "partial_snapshot",
+        }
+    }
+}
+
+/// Evidence source kind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceType {
+    /// Captured GenAI LLM call row.
+    GenaiEvent,
+    /// Captured interruption row.
+    Interruption,
+    /// Reserved for agent-sec security events.
+    SecurityEvent,
+    /// Trace-level navigation target.
+    Trace,
+    /// Tool call inside a GenAI message payload.
+    ToolCall,
+    /// Reserved for persisted ATIF step identifiers.
+    AtifStep,
+}
+
+/// Navigation target for an evidence reference.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceTarget {
+    /// Conversation detail route anchor.
+    pub conversation_id: String,
+    /// Optional trace identifier when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// Optional LLM call identifier when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
+    /// Reserved ATIF step identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
+}
+
+/// UI deeplink hint for a piece of evidence.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceDeeplink {
+    /// Client-side route name.
+    pub route: String,
+    /// Route parameters and highlight hints.
+    pub query: serde_json::Value,
+}
+
+/// Evidence reference included in dimensions and findings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationRef {
+    /// Evidence source kind.
+    #[serde(rename = "type")]
+    pub evidence_type: EvidenceType,
+    /// Source-local evidence identifier.
+    pub id: String,
+    /// Short user-facing label.
+    pub label: String,
+    /// Optional severity string from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub severity: Option<String>,
+    /// Target used by Dashboard navigation.
+    pub target: EvidenceTarget,
+    /// Optional deeplink target for richer Dashboard routes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deeplink: Option<EvidenceDeeplink>,
+    /// Source-specific structured metadata.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub metadata: serde_json::Value,
+}
+
+/// Score and explanation for one evaluation dimension.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationDimension {
+    /// Dimension key, such as `completion` or `runtime_health`.
+    pub name: String,
+    /// Dimension score in `[0, 1]`.
+    pub score: f64,
+    /// Dimension-level verdict.
+    pub verdict: Verdict,
+    /// Human-readable reason.
+    pub reason: String,
+    /// Supporting evidence references.
+    #[serde(default)]
+    pub evidence_refs: Vec<EvaluationRef>,
+}
+
+/// Actionable issue found during evaluation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationFinding {
+    /// Stable finding code.
+    pub code: String,
+    /// `critical`, `high`, `medium`, or `low`.
+    pub severity: String,
+    /// Human-readable finding message.
+    pub message: String,
+    /// Supporting evidence references.
+    #[serde(default)]
+    pub evidence_refs: Vec<EvaluationRef>,
+}
+
+/// Extra metadata that keeps future LLM/Agent judge fields stable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationMetadata {
+    /// True when `force=true` evaluated an incomplete snapshot.
+    pub evaluated_with_pending: bool,
+    /// Number of pending LLM calls in the evaluated input.
+    pub pending_call_count: usize,
+    /// Number of GenAI LLM call rows used as input.
+    pub input_event_count: usize,
+    /// Evaluator kind.
+    pub grader_type: GraderType,
+    /// Evaluator version.
+    pub grader_version: String,
+    /// Reserved rubric version for LLM/Agent judges.
+    pub rubric_version: Option<String>,
+    /// Reserved judge model name.
+    pub judge_model: Option<String>,
+    /// Reserved prompt hash for judge prompts.
+    pub prompt_hash: Option<String>,
+    /// Reserved confidence score.
+    pub confidence: Option<f64>,
+}
+
+/// Full persisted evaluation result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationResult {
+    /// Evaluated target kind.
+    pub target_type: TargetType,
+    /// Evaluated target identifier.
+    pub target_id: String,
+    /// Unique evaluation run identifier.
+    pub run_id: String,
+    /// Stable hash of the evaluated input snapshot.
+    pub input_hash: String,
+    /// Top-level verdict.
+    pub verdict: Verdict,
+    /// Weighted score in `[0, 1]`.
+    pub score: f64,
+    /// One-sentence summary.
+    pub summary: String,
+    /// Single primary root cause.
+    pub root_cause: RootCause,
+    /// Suggested next action.
+    pub recommended_action: String,
+    /// Per-dimension scores.
+    pub dimensions: Vec<EvaluationDimension>,
+    /// Actionable findings.
+    pub findings: Vec<EvaluationFinding>,
+    /// Additional run metadata.
+    pub metadata: EvaluationMetadata,
+}
+
+/// Stored run projection returned by persistence queries.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationRunRecord {
+    /// SQLite row id.
+    pub id: i64,
+    /// Unique evaluation run identifier.
+    pub run_id: String,
+    /// Evaluated target kind.
+    pub target_type: TargetType,
+    /// Evaluated target id.
+    pub target_id: String,
+    /// Stable input hash.
+    pub input_hash: String,
+    /// Evaluator kind.
+    pub grader_type: GraderType,
+    /// Evaluator version.
+    pub grader_version: String,
+    /// Stored run status.
+    pub status: EvaluationStatus,
+    /// Top-level verdict.
+    pub verdict: Option<Verdict>,
+    /// Weighted score.
+    pub score: Option<f64>,
+    /// Single primary root cause.
+    pub root_cause: Option<RootCause>,
+    /// Creation timestamp as stored by SQLite.
+    pub created_at: String,
+    /// Completion timestamp as stored by SQLite.
+    pub completed_at: Option<String>,
+    /// Full result payload for completed runs.
+    pub result: Option<EvaluationResult>,
+}
+
+/// Evaluation request body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvaluationRequest {
+    /// Evaluation target kind.
+    pub target_type: String,
+    /// Evaluation target identifier.
+    pub target_id: String,
+    /// Evaluate incomplete snapshots instead of returning 409.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Evaluation API response body.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationResponse {
+    /// Completed evaluation result.
+    pub result: EvaluationResult,
+    /// True when an idempotent completed run was reused.
+    pub reused_existing_run: bool,
+}
+
+/// Errors returned by grader components.
+#[derive(Debug, Error)]
+pub enum GraderError {
+    /// The requested conversation has no captured events.
+    #[error("conversation not found: {0}")]
+    ConversationNotFound(String),
+    /// The requested conversation still has pending LLM calls.
+    #[error("conversation still has {pending_count} pending LLM call(s)")]
+    ConversationNotReady {
+        /// Number of pending calls found.
+        pending_count: usize,
+    },
+    /// The request uses a target kind this MVP does not support.
+    #[error("unsupported target type: {0}")]
+    UnsupportedTarget(String),
+    /// SQLite or storage-layer failure.
+    #[error("storage error: {0}")]
+    Storage(String),
+    /// JSON serialization or deserialization failure.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl GraderError {
+    /// Stable machine-readable error code for HTTP handlers and tests.
+    pub fn code(&self) -> &'static str {
+        match self {
+            GraderError::ConversationNotFound(_) => "conversation_not_found",
+            GraderError::ConversationNotReady { .. } => "conversation_not_ready",
+            GraderError::UnsupportedTarget(_) => "unsupported_target",
+            GraderError::Storage(_) => "storage_error",
+            GraderError::Json(_) => "json_error",
+        }
+    }
+}

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -52,6 +52,7 @@ pub mod discovery;
 pub mod event;
 pub mod ffi;
 pub mod genai;
+pub mod grader;
 pub mod health;
 pub mod interruption;
 pub mod parser;

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -9,6 +9,10 @@ use serde_json::{Value, json};
 
 use super::AppState;
 use crate::agent_sec::{AgentSecClient, AgentSecClientError, DaemonResponse};
+use crate::grader::{
+    EvaluationRequest, EvaluationResponse, GraderError, GraderType, RULE_GRADER_VERSION,
+    RuleGrader, TargetType, load_conversation_input,
+};
 use crate::health::AgentHealthStatus;
 use crate::storage::sqlite::GenAISqliteStore;
 use crate::storage::sqlite::genai::{ModelTimeseriesBucket, TimeseriesBucket};
@@ -210,6 +214,162 @@ pub async fn get_conversation_events(
         Err(e) => {
             HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
         }
+    }
+}
+
+// ─── Grader endpoints ────────────────────────────────────────────────────────
+
+/// Query parameters for GET /api/grader/latest.
+#[derive(Debug, Deserialize)]
+pub struct GraderLatestQuery {
+    pub target_type: String,
+    pub target_id: String,
+}
+
+/// POST /api/grader/evaluate
+///
+/// Manually evaluate a conversation snapshot with the rule-based grader.
+#[post("/grader/evaluate")]
+pub async fn evaluate_grader(
+    data: web::Data<AppState>,
+    body: web::Json<EvaluationRequest>,
+) -> impl Responder {
+    let target_type = match parse_grader_target_type(&body.target_type) {
+        Ok(target_type) => target_type,
+        Err(error) => return grader_error_response(error),
+    };
+
+    if body.target_id.trim().is_empty() {
+        return HttpResponse::BadRequest()
+            .json(json!({"error": "bad_request", "message": "target_id is required"}));
+    }
+
+    let input = match load_conversation_input(
+        &data.storage_path,
+        data.interruption_store.as_deref(),
+        &body.target_id,
+        body.force,
+    ) {
+        Ok(input) => input,
+        Err(error) => return grader_error_response(error),
+    };
+    let store = &data.evaluation_store;
+
+    match store.find_completed(
+        target_type,
+        &body.target_id,
+        &input.input_hash,
+        GraderType::Rule,
+        RULE_GRADER_VERSION,
+    ) {
+        Ok(Some(record)) => {
+            if let Some(result) = record.result {
+                return HttpResponse::Ok().json(EvaluationResponse {
+                    result,
+                    reused_existing_run: true,
+                });
+            }
+        }
+        Ok(None) => {}
+        Err(error) => return grader_error_response(error),
+    }
+
+    let result = RuleGrader::evaluate(&input);
+    match store.insert_completed(&result) {
+        Ok(true) => {}
+        Ok(false) => {
+            return match store.find_completed(
+                target_type,
+                &body.target_id,
+                &input.input_hash,
+                GraderType::Rule,
+                RULE_GRADER_VERSION,
+            ) {
+                Ok(Some(record)) => {
+                    if let Some(result) = record.result {
+                        HttpResponse::Ok().json(EvaluationResponse {
+                            result,
+                            reused_existing_run: true,
+                        })
+                    } else {
+                        grader_error_response(GraderError::Storage(
+                            "existing evaluation run is missing result_json".to_string(),
+                        ))
+                    }
+                }
+                Ok(None) => grader_error_response(GraderError::Storage(
+                    "evaluation insert was ignored but no completed run was found".to_string(),
+                )),
+                Err(error) => grader_error_response(error),
+            };
+        }
+        Err(error) => return grader_error_response(error),
+    }
+
+    HttpResponse::Ok().json(EvaluationResponse {
+        result,
+        reused_existing_run: false,
+    })
+}
+
+/// GET /api/grader/latest?target_type=conversation&target_id=<id>
+///
+/// Return the latest completed evaluation result for a conversation.
+#[get("/grader/latest")]
+pub async fn latest_grader(
+    data: web::Data<AppState>,
+    query: web::Query<GraderLatestQuery>,
+) -> impl Responder {
+    let target_type = match parse_grader_target_type(&query.target_type) {
+        Ok(target_type) => target_type,
+        Err(error) => return grader_error_response(error),
+    };
+
+    if query.target_id.trim().is_empty() {
+        return HttpResponse::BadRequest()
+            .json(json!({"error": "bad_request", "message": "target_id is required"}));
+    }
+
+    match data
+        .evaluation_store
+        .latest_completed(target_type, &query.target_id)
+    {
+        Ok(Some(record)) => HttpResponse::Ok().json(record.result),
+        Ok(None) => HttpResponse::Ok().json(serde_json::Value::Null),
+        Err(error) => grader_error_response(error),
+    }
+}
+
+fn parse_grader_target_type(value: &str) -> Result<TargetType, GraderError> {
+    match value {
+        "conversation" => Ok(TargetType::Conversation),
+        other => Err(GraderError::UnsupportedTarget(other.to_string())),
+    }
+}
+
+fn grader_error_response(error: GraderError) -> HttpResponse {
+    match error {
+        GraderError::ConversationNotFound(id) => HttpResponse::NotFound().json(json!({
+            "error": "conversation_not_found",
+            "message": format!("Conversation not found: {id}"),
+        })),
+        GraderError::ConversationNotReady { pending_count } => HttpResponse::Conflict().json(json!({
+            "error": "conversation_not_ready",
+            "message": "Conversation still has pending LLM calls. Retry after completion or use force=true.",
+            "pending_call_count": pending_count,
+        })),
+        GraderError::UnsupportedTarget(target) => HttpResponse::BadRequest().json(json!({
+            "error": "unsupported_target",
+            "message": format!("Unsupported target_type: {target}. MVP supports only conversation."),
+        })),
+        GraderError::Storage(message) => HttpResponse::InternalServerError().json(json!({
+            "error": "storage_error",
+            "message": message,
+        })),
+        GraderError::Json(error) => HttpResponse::InternalServerError().json(json!({
+            "error": "json_error",
+            "message": error.to_string(),
+        })),
     }
 }
 
@@ -668,7 +828,9 @@ mod tests {
     use actix_web::test as awtest;
 
     use crate::agent_sec::DaemonErrorPayload;
+    use crate::grader::EvaluationStore;
     use crate::health::HealthStore;
+    use crate::storage::sqlite::genai::{PendingCallInfo, PendingOrigin};
 
     use super::*;
 
@@ -881,6 +1043,52 @@ mod tests {
         }
     }
 
+    #[actix_web::test]
+    async fn latest_grader_uses_shared_evaluation_store() {
+        let root = temp_root("latest_grader_shared_store");
+        let evaluation_path = root.join("evaluation.db");
+        let evaluation_store = Arc::new(EvaluationStore::new_with_path(&evaluation_path).unwrap());
+        let result = test_evaluation_result("conv-shared");
+        evaluation_store.insert_completed(&result).unwrap();
+
+        let blocked_parent = root.join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file").unwrap();
+        let auth_config = crate::config::ServerAuthConfig { enabled: false };
+        let auth = Arc::new(crate::server::auth::DashboardAuth::init(
+            &auth_config,
+            std::path::Path::new("/tmp"),
+        ));
+        let data = web::Data::new(AppState {
+            storage_path: blocked_parent.join("genai.db"),
+            start_time: Instant::now(),
+            health_store: Arc::new(RwLock::new(HealthStore::new())),
+            interruption_store: None,
+            evaluation_store: Arc::clone(&evaluation_store),
+            security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
+            auth,
+        });
+        let app = awtest::init_service(App::new().app_data(data).service(latest_grader)).await;
+
+        let response = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/grader/latest?target_type=conversation&target_id=conv-shared")
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &actix_web::body::to_bytes(response.into_body())
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["run_id"], "run-shared");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     async fn response_json(response: HttpResponse) -> Value {
         let body = to_bytes(response.into_body())
             .await
@@ -903,6 +1111,153 @@ mod tests {
         }
     }
 
+    fn test_evaluation_result(target_id: &str) -> crate::grader::EvaluationResult {
+        crate::grader::EvaluationResult {
+            target_type: TargetType::Conversation,
+            target_id: target_id.to_string(),
+            run_id: "run-shared".to_string(),
+            input_hash: "input-hash-shared".to_string(),
+            verdict: crate::grader::Verdict::Pass,
+            score: 1.0,
+            summary: "ok".to_string(),
+            root_cause: crate::grader::RootCause::None,
+            recommended_action: "none".to_string(),
+            dimensions: Vec::new(),
+            findings: Vec::new(),
+            metadata: crate::grader::EvaluationMetadata {
+                evaluated_with_pending: false,
+                pending_call_count: 0,
+                input_event_count: 1,
+                grader_type: GraderType::Rule,
+                grader_version: RULE_GRADER_VERSION.to_string(),
+                rubric_version: None,
+                judge_model: None,
+                prompt_hash: None,
+                confidence: Some(1.0),
+            },
+        }
+    }
+
+    fn grader_app_state(storage_path: PathBuf) -> web::Data<AppState> {
+        let auth_config = crate::config::ServerAuthConfig { enabled: false };
+        let auth = Arc::new(crate::server::auth::DashboardAuth::init(
+            &auth_config,
+            std::path::Path::new("/tmp"),
+        ));
+        web::Data::new(AppState {
+            evaluation_store: Arc::new(EvaluationStore::new_with_path(&storage_path).unwrap()),
+            storage_path,
+            start_time: Instant::now(),
+            health_store: Arc::new(RwLock::new(HealthStore::new())),
+            interruption_store: None,
+            security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
+            auth,
+        })
+    }
+
+    fn write_completed_conversation_event(path: &std::path::Path, conversation_id: &str) {
+        let store = GenAISqliteStore::new_with_path(path).unwrap();
+        let mut call = LLMCall::new(
+            format!("call-{conversation_id}"),
+            1_700_000_000_000_000_000,
+            "anthropic".to_string(),
+            "claude".to_string(),
+            LLMRequest {
+                messages: Vec::new(),
+                temperature: None,
+                max_tokens: None,
+                frequency_penalty: None,
+                presence_penalty: None,
+                top_p: None,
+                top_k: None,
+                seed: None,
+                stop_sequences: None,
+                stream: false,
+                tools: None,
+                raw_body: None,
+            },
+            1234,
+            "claude".to_string(),
+        );
+        call.set_response(
+            LLMResponse {
+                messages: vec![OutputMessage {
+                    role: "assistant".to_string(),
+                    parts: vec![MessagePart::Text {
+                        content: "done".to_string(),
+                    }],
+                    name: None,
+                    finish_reason: Some("stop".to_string()),
+                }],
+                streamed: false,
+                raw_body: None,
+            },
+            1_700_000_000_000_000_500,
+        );
+        call.set_token_usage(TokenUsage {
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        });
+        call.metadata
+            .insert("conversation_id".to_string(), conversation_id.to_string());
+        call.metadata.insert(
+            "response_id".to_string(),
+            format!("trace-{conversation_id}"),
+        );
+        call.metadata
+            .insert("user_query".to_string(), "hello".to_string());
+
+        store.export(&[GenAISemanticEvent::LLMCall(call)]);
+        store.flush();
+    }
+
+    fn write_pending_conversation_event(path: &std::path::Path, conversation_id: &str) {
+        let store = GenAISqliteStore::new_with_path(path).unwrap();
+        store
+            .insert_pending(&PendingCallInfo {
+                call_id: format!("pending-{conversation_id}"),
+                trace_id: Some(format!("trace-{conversation_id}")),
+                conversation_id: Some(conversation_id.to_string()),
+                session_id: Some("session-1".to_string()),
+                start_timestamp_ns: 1_700_000_000_000_000_000,
+                pid: 1234,
+                process_name: "claude".to_string(),
+                agent_name: Some("claude".to_string()),
+                http_method: Some("POST".to_string()),
+                http_path: Some("/v1/messages".to_string()),
+                input_messages: Some(r#"[{"role":"user","content":"hello"}]"#.to_string()),
+                system_instructions: None,
+                user_query: Some("hello".to_string()),
+                is_sse: true,
+                model: Some("claude".to_string()),
+                provider: Some("anthropic".to_string()),
+                call_kind: "main".to_string(),
+                pending_origin: PendingOrigin::RequestCapture,
+                pending_match_key: None,
+            })
+            .unwrap();
+        store.flush();
+    }
+
+    fn cleanup_db(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+    }
+
+    fn temp_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "agentsight_{label}_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
     fn test_app_state(timeout_ms: u64) -> web::Data<AppState> {
         let auth_config = crate::config::ServerAuthConfig { enabled: false };
         let auth = Arc::new(crate::server::auth::DashboardAuth::init(
@@ -914,6 +1269,9 @@ mod tests {
             start_time: Instant::now(),
             health_store: Arc::new(RwLock::new(HealthStore::new())),
             interruption_store: None,
+            evaluation_store: Arc::new(
+                EvaluationStore::new_with_path(std::path::Path::new(":memory:")).unwrap(),
+            ),
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms },
             auth,
         })
@@ -1008,6 +1366,9 @@ mod tests {
             start_time: Instant::now(),
             health_store: Arc::new(RwLock::new(HealthStore::new())),
             interruption_store: None,
+            evaluation_store: Arc::new(
+                EvaluationStore::new_with_path(std::path::Path::new(":memory:")).unwrap(),
+            ),
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
             auth,
         })

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -828,6 +828,11 @@ mod tests {
     use actix_web::test as awtest;
 
     use crate::agent_sec::DaemonErrorPayload;
+    use crate::genai::GenAIExporter;
+    use crate::genai::semantic::{
+        GenAISemanticEvent, LLMCall, LLMRequest, LLMResponse, MessagePart, OutputMessage,
+        TokenUsage,
+    };
     use crate::grader::EvaluationStore;
     use crate::health::HealthStore;
     use crate::storage::sqlite::genai::{PendingCallInfo, PendingOrigin};
@@ -1089,7 +1094,125 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    #[actix_web::test]
+    async fn evaluate_grader_reuses_existing_run_for_same_snapshot() {
+        let root = temp_root("evaluate_grader_reuses_run");
+        let db_path = root.join("events.db");
+        write_completed_conversation_event(&db_path, "conv-reuse");
+        let data = grader_app_state(db_path.clone());
+        let app = awtest::init_service(App::new().app_data(data).service(evaluate_grader)).await;
+        let request = EvaluationRequest {
+            target_type: "conversation".to_string(),
+            target_id: "conv-reuse".to_string(),
+            force: false,
+        };
+
+        let first = awtest::call_service(
+            &app,
+            awtest::TestRequest::post()
+                .uri("/grader/evaluate")
+                .set_json(&request)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(first.status(), StatusCode::OK);
+        let first_body = service_response_json(first).await;
+        assert_eq!(first_body["reused_existing_run"], false);
+        let run_id = first_body["result"]["run_id"]
+            .as_str()
+            .expect("run_id should be present")
+            .to_string();
+
+        let second = awtest::call_service(
+            &app,
+            awtest::TestRequest::post()
+                .uri("/grader/evaluate")
+                .set_json(&request)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(second.status(), StatusCode::OK);
+        let second_body = service_response_json(second).await;
+        assert_eq!(second_body["reused_existing_run"], true);
+        assert_eq!(second_body["result"]["run_id"], run_id);
+
+        cleanup_db(&db_path);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[actix_web::test]
+    async fn evaluate_grader_maps_bad_request_not_found_and_pending() {
+        let root = temp_root("evaluate_grader_errors");
+        let db_path = root.join("events.db");
+        write_pending_conversation_event(&db_path, "conv-pending");
+        let data = grader_app_state(db_path.clone());
+        let app = awtest::init_service(App::new().app_data(data).service(evaluate_grader)).await;
+
+        let bad_request = awtest::call_service(
+            &app,
+            awtest::TestRequest::post()
+                .uri("/grader/evaluate")
+                .set_json(&EvaluationRequest {
+                    target_type: "trace".to_string(),
+                    target_id: "conv-pending".to_string(),
+                    force: false,
+                })
+                .to_request(),
+        )
+        .await;
+        assert_eq!(bad_request.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            service_response_json(bad_request).await["error"],
+            "unsupported_target"
+        );
+
+        let not_found = awtest::call_service(
+            &app,
+            awtest::TestRequest::post()
+                .uri("/grader/evaluate")
+                .set_json(&EvaluationRequest {
+                    target_type: "conversation".to_string(),
+                    target_id: "missing-conv".to_string(),
+                    force: false,
+                })
+                .to_request(),
+        )
+        .await;
+        assert_eq!(not_found.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            service_response_json(not_found).await["error"],
+            "conversation_not_found"
+        );
+
+        let pending = awtest::call_service(
+            &app,
+            awtest::TestRequest::post()
+                .uri("/grader/evaluate")
+                .set_json(&EvaluationRequest {
+                    target_type: "conversation".to_string(),
+                    target_id: "conv-pending".to_string(),
+                    force: false,
+                })
+                .to_request(),
+        )
+        .await;
+        assert_eq!(pending.status(), StatusCode::CONFLICT);
+        let pending_body = service_response_json(pending).await;
+        assert_eq!(pending_body["error"], "conversation_not_ready");
+        assert_eq!(pending_body["pending_call_count"], 1);
+
+        cleanup_db(&db_path);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     async fn response_json(response: HttpResponse) -> Value {
+        let body = to_bytes(response.into_body())
+            .await
+            .expect("response body should be readable");
+        serde_json::from_slice(&body).expect("response body should be JSON")
+    }
+
+    async fn service_response_json(response: actix_web::dev::ServiceResponse) -> Value {
         let body = to_bytes(response.into_body())
             .await
             .expect("response body should be readable");

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -16,6 +16,7 @@ use actix_web::{App, HttpRequest, HttpResponse, HttpServer, Responder, get, web}
 use include_dir::{Dir, include_dir};
 
 use crate::config::ServerAuthConfig;
+use crate::grader::EvaluationStore;
 use crate::health::{HealthChecker, HealthStore};
 use crate::storage::sqlite::InterruptionStore;
 
@@ -49,6 +50,8 @@ pub struct AppState {
     pub health_store: Arc<RwLock<HealthStore>>,
     /// Interruption events store
     pub interruption_store: Option<Arc<InterruptionStore>>,
+    /// Grader evaluation store
+    pub evaluation_store: Arc<EvaluationStore>,
     /// agent-sec security observability integration configuration
     pub security_observability: SecurityObservabilityConfig,
     /// Dashboard authentication state
@@ -142,6 +145,8 @@ fn configure_routes(cfg: &mut web::ServiceConfig) {
                 .service(handlers::list_traces_by_session)
                 .service(handlers::get_trace_detail)
                 .service(handlers::get_conversation_events)
+                .service(handlers::evaluate_grader)
+                .service(handlers::latest_grader)
                 .service(handlers::list_agent_names)
                 .service(handlers::get_timeseries)
                 .service(handlers::export_atif_trace)
@@ -212,6 +217,11 @@ pub async fn run_server(
 ) -> std::io::Result<()> {
     let security_observability = SecurityObservabilityConfig::default();
 
+    let evaluation_store = Arc::new(
+        EvaluationStore::new_with_path(&storage_path)
+            .map_err(|error| std::io::Error::other(error.to_string()))?,
+    );
+
     // Initialize dashboard authentication
     let storage_base = storage_path
         .parent()
@@ -278,6 +288,7 @@ pub async fn run_server(
         start_time: Instant::now(),
         health_store,
         interruption_store,
+        evaluation_store,
         security_observability,
         auth: dashboard_auth.clone(),
     });
@@ -321,6 +332,7 @@ mod tests {
     use actix_web::test as awtest;
     use actix_web::{App, web};
 
+    use crate::grader::EvaluationStore;
     use crate::health::HealthStore;
 
     use super::auth::DashboardAuth;
@@ -386,6 +398,9 @@ mod tests {
             start_time: Instant::now(),
             health_store: Arc::new(RwLock::new(HealthStore::new())),
             interruption_store: None,
+            evaluation_store: Arc::new(
+                EvaluationStore::new_with_path(std::path::Path::new(":memory:")).unwrap(),
+            ),
             security_observability: SecurityObservabilityConfig { timeout_ms },
             auth,
         })

--- a/src/agentsight/src/server/token_savings.rs
+++ b/src/agentsight/src/server/token_savings.rs
@@ -863,6 +863,7 @@ pub async fn get_session_savings(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::grader::EvaluationStore;
     use actix_web::test as actix_test;
     use actix_web::{App, web};
     use std::sync::{Arc, Mutex, RwLock};
@@ -929,10 +930,11 @@ mod tests {
 
     fn make_app_state(db_path: std::path::PathBuf) -> AppState {
         AppState {
-            storage_path: db_path,
+            storage_path: db_path.clone(),
             start_time: Instant::now(),
             health_store: Arc::new(RwLock::new(crate::health::HealthStore::default())),
             interruption_store: None,
+            evaluation_store: Arc::new(EvaluationStore::new_with_path(&db_path).unwrap()),
             security_observability: crate::server::SecurityObservabilityConfig::default(),
             auth: Arc::new(crate::server::auth::DashboardAuth::init(
                 &crate::config::ServerAuthConfig { enabled: false },


### PR DESCRIPTION
## Description

Add the AgentSight manual conversation grader backend. The API evaluates persisted GenAI and interruption evidence with a deterministic rule grader, stores idempotent `evaluation_runs` in SQLite, and exposes evaluate/latest endpoints for dashboard clients.

The store is initialized once in `AppState`, interruption evidence is loaded from the existing `InterruptionStore`, and JSON conversion work stays outside the SQLite mutex. This PR also carries the narrow AgentSight docs for the grader API and includes current-toolchain mechanical clippy fixes needed for independent `-D warnings` validation.

## Related Issue

Refs #1304

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran on the Linux AgentSight test host from an archive of this split branch:

- `cargo fmt --all -- --check`
- `cargo test -p agentsight grader --locked --quiet`
- `cargo clippy -q -p agentsight --all-targets --locked -- -D warnings`

## Additional Notes

Split from #1349 following review feedback. The dashboard controls are intentionally left to a separate PR.
