### PR TITLE
feat(sight): add grader dashboard controls

### DIFF
--- a/src/agentsight/dashboard/src/components/EvaluationBadge.tsx
+++ b/src/agentsight/dashboard/src/components/EvaluationBadge.tsx
@@ -20,12 +20,19 @@ const LABEL_BY_VERDICT = {
 export const EvaluationBadge: React.FC<EvaluationBadgeProps> = ({ result }) => {
   if (!result) return null;
 
+  const style =
+    STYLE_BY_VERDICT[result.verdict as keyof typeof STYLE_BY_VERDICT] ??
+    'bg-gray-50 text-gray-700 border-gray-200';
+  const label =
+    LABEL_BY_VERDICT[result.verdict as keyof typeof LABEL_BY_VERDICT] ??
+    result.verdict;
+
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs font-semibold ${STYLE_BY_VERDICT[result.verdict]}`}
+      className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs font-semibold ${style}`}
       title={`质量分 ${Math.round(result.score * 100)}`}
     >
-      <span>{LABEL_BY_VERDICT[result.verdict]}</span>
+      <span>{label}</span>
       <span className="font-mono">{Math.round(result.score * 100)}</span>
     </span>
   );

--- a/src/agentsight/dashboard/src/components/EvaluationBadge.tsx
+++ b/src/agentsight/dashboard/src/components/EvaluationBadge.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { EvaluationResult } from '../utils/apiClient';
+
+interface EvaluationBadgeProps {
+  result: Pick<EvaluationResult, 'verdict' | 'score'> | null;
+}
+
+const STYLE_BY_VERDICT = {
+  pass: 'bg-green-50 text-green-700 border-green-200',
+  warn: 'bg-amber-50 text-amber-700 border-amber-200',
+  fail: 'bg-red-50 text-red-700 border-red-200',
+} as const;
+
+const LABEL_BY_VERDICT = {
+  pass: '通过',
+  warn: '需复核',
+  fail: '未通过',
+} as const;
+
+export const EvaluationBadge: React.FC<EvaluationBadgeProps> = ({ result }) => {
+  if (!result) return null;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs font-semibold ${STYLE_BY_VERDICT[result.verdict]}`}
+      title={`质量分 ${Math.round(result.score * 100)}`}
+    >
+      <span>{LABEL_BY_VERDICT[result.verdict]}</span>
+      <span className="font-mono">{Math.round(result.score * 100)}</span>
+    </span>
+  );
+};

--- a/src/agentsight/dashboard/src/components/EvaluationPanel.tsx
+++ b/src/agentsight/dashboard/src/components/EvaluationPanel.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   EvaluationNotReadyError,
   EvaluationRef,
   EvaluationResult,
+  INTERRUPTION_TYPE_CN,
   evaluateConversation,
 } from '../utils/apiClient';
 import { EvaluationBadge } from './EvaluationBadge';
@@ -25,6 +26,10 @@ export const EvaluationPanel: React.FC<EvaluationPanelProps> = ({
   const [loading, setLoading] = useState(false);
   const [pendingCount, setPendingCount] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setResult(initialResult);
+  }, [initialResult]);
 
   const runEvaluation = async (force: boolean) => {
     setLoading(true);
@@ -50,11 +55,11 @@ export const EvaluationPanel: React.FC<EvaluationPanelProps> = ({
 
     return (
       <div className="mt-1 flex flex-wrap gap-1">
-        {refs.slice(0, 3).map((ref) => {
+        {refs.slice(0, 3).map((ref, index) => {
           const path = evidencePath(ref);
           return (
             <button
-              key={`${ref.type}-${ref.id}-${ref.label}`}
+              key={`${ref.type}-${ref.id}-${ref.label}-${index}`}
               onClick={() => path && navigate(path)}
               disabled={!path}
               className="rounded border border-blue-200 bg-white px-1.5 py-0.5 text-[11px] text-blue-700 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50"
@@ -156,8 +161,8 @@ export const EvaluationPanel: React.FC<EvaluationPanelProps> = ({
                   {result.findings.length === 0 ? (
                     <p className="text-xs text-gray-400">未发现问题。</p>
                   ) : (
-                    result.findings.map((finding) => (
-                      <div key={`${finding.code}-${finding.message}`} className="rounded bg-gray-50 px-2 py-1">
+                    result.findings.map((finding, index) => (
+                      <div key={`${finding.code}-${finding.message}-${index}`} className="rounded bg-gray-50 px-2 py-1">
                         <div className="flex items-center justify-between gap-2">
                           <span className="text-xs text-gray-700" title={finding.code}>
                             {findingLabel(finding.code)}
@@ -289,7 +294,7 @@ function findingLabel(value: string): string {
     agent_crash: 'Agent 崩溃',
   };
 
-  return labels[value] ?? value;
+  return labels[value] ?? INTERRUPTION_TYPE_CN[value] ?? value;
 }
 
 function findingMessageText(value: string): string {

--- a/src/agentsight/dashboard/src/components/EvaluationPanel.tsx
+++ b/src/agentsight/dashboard/src/components/EvaluationPanel.tsx
@@ -1,0 +1,336 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  EvaluationNotReadyError,
+  EvaluationRef,
+  EvaluationResult,
+  evaluateConversation,
+} from '../utils/apiClient';
+import { EvaluationBadge } from './EvaluationBadge';
+
+interface EvaluationPanelProps {
+  conversationId: string;
+  initialResult: EvaluationResult | null;
+  onResult?: (result: EvaluationResult) => void;
+}
+
+export const EvaluationPanel: React.FC<EvaluationPanelProps> = ({
+  conversationId,
+  initialResult,
+  onResult,
+}) => {
+  const navigate = useNavigate();
+  const [result, setResult] = useState<EvaluationResult | null>(initialResult);
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [pendingCount, setPendingCount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const runEvaluation = async (force: boolean) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await evaluateConversation(conversationId, force);
+      setResult(response.result);
+      setPendingCount(null);
+      onResult?.(response.result);
+    } catch (err) {
+      if (err instanceof EvaluationNotReadyError) {
+        setPendingCount(err.pendingCallCount);
+      } else {
+        setError(err instanceof Error ? err.message : '质量评估失败');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderEvidenceLinks = (refs: EvaluationRef[]) => {
+    if (refs.length === 0) return null;
+
+    return (
+      <div className="mt-1 flex flex-wrap gap-1">
+        {refs.slice(0, 3).map((ref) => {
+          const path = evidencePath(ref);
+          return (
+            <button
+              key={`${ref.type}-${ref.id}-${ref.label}`}
+              onClick={() => path && navigate(path)}
+              disabled={!path}
+              className="rounded border border-blue-200 bg-white px-1.5 py-0.5 text-[11px] text-blue-700 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50"
+              title={ref.id}
+            >
+              {evidenceLabel(ref.label)}
+            </button>
+          );
+        })}
+        {refs.length > 3 && <span className="text-[11px] text-gray-400">+{refs.length - 3}</span>}
+      </div>
+    );
+  };
+
+  return (
+    <div className="border border-gray-200 bg-white rounded-lg p-3 text-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold text-gray-500">质量评估</span>
+            <EvaluationBadge result={result} />
+          </div>
+          {result ? (
+            <div className="mt-2 space-y-1">
+              <p className="text-sm text-gray-800">{summaryText(result)}</p>
+              <p className="text-xs text-gray-500">
+                根因：<span>{rootCauseLabel(result.root_cause)}</span>
+              </p>
+              <p className="text-xs text-gray-600">{recommendedActionText(result)}</p>
+            </div>
+          ) : (
+            <p className="mt-2 text-xs text-gray-500">暂无质量评估结果。</p>
+          )}
+        </div>
+        <button
+          onClick={() => runEvaluation(false)}
+          disabled={loading}
+          className="px-3 py-1 rounded border border-blue-300 bg-blue-50 text-blue-700 text-xs font-medium hover:bg-blue-100 disabled:opacity-50"
+        >
+          {loading ? '评估中...' : '开始评估'}
+        </button>
+      </div>
+
+      {pendingCount !== null && (
+        <div className="mt-3 flex items-center justify-between gap-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          <span>{pendingCount} 个 LLM 调用仍未完成。</span>
+          <button
+            onClick={() => runEvaluation(true)}
+            disabled={loading}
+            className="rounded border border-amber-300 bg-white px-2 py-0.5 font-medium hover:bg-amber-100 disabled:opacity-50"
+          >
+            强制评估
+          </button>
+        </div>
+      )}
+
+      {result?.metadata.evaluated_with_pending && (
+        <div className="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          评估时仍有 {result.metadata.pending_call_count} 个 LLM 调用未完成。
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="mt-3">
+          <button
+            onClick={() => setExpanded((value) => !value)}
+            className="text-xs font-medium text-blue-700 hover:text-blue-900"
+          >
+            {expanded ? '收起详情' : '查看详情'}
+          </button>
+          {expanded && (
+            <div className="mt-2 grid gap-3 lg:grid-cols-2">
+              <div>
+                <h4 className="text-xs font-semibold text-gray-500">评估维度</h4>
+                <div className="mt-1 space-y-1">
+                  {result.dimensions.map((dimension) => (
+                    <div key={dimension.name} className="rounded bg-gray-50 px-2 py-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs text-gray-700">{dimensionLabel(dimension.name)}</span>
+                        <span className="text-xs text-gray-500">
+                          {Math.round(dimension.score * 100)}
+                        </span>
+                      </div>
+                      <p className="mt-0.5 text-xs text-gray-500">{reasonText(dimension.reason)}</p>
+                      {renderEvidenceLinks(dimension.evidence_refs)}
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h4 className="text-xs font-semibold text-gray-500">问题发现</h4>
+                <div className="mt-1 space-y-1">
+                  {result.findings.length === 0 ? (
+                    <p className="text-xs text-gray-400">未发现问题。</p>
+                  ) : (
+                    result.findings.map((finding) => (
+                      <div key={`${finding.code}-${finding.message}`} className="rounded bg-gray-50 px-2 py-1">
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-xs text-gray-700" title={finding.code}>
+                            {findingLabel(finding.code)}
+                          </span>
+                          <span className="text-xs text-gray-500">{severityLabel(finding.severity)}</span>
+                        </div>
+                        <p className="mt-0.5 text-xs text-gray-500">{findingMessageText(finding.message)}</p>
+                        {renderEvidenceLinks(finding.evidence_refs)}
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function evidencePath(ref: EvaluationRef): string | null {
+  if (!ref.deeplink) return null;
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(ref.deeplink.query ?? {})) {
+    if (value !== null && value !== undefined) {
+      params.set(key, String(value));
+    }
+  }
+  const query = params.toString();
+  return query ? `${ref.deeplink.route}?${query}` : ref.deeplink.route;
+}
+
+function summaryText(result: EvaluationResult): string {
+  if (result.verdict === 'pass') {
+    return '会话已完成，未发现确定性的质量问题。';
+  }
+  if (result.verdict === 'warn') {
+    return `当前会话可用，但需要复核：${rootCauseLabel(result.root_cause)}。`;
+  }
+  return `质量评估未通过，主要原因：${rootCauseLabel(result.root_cause)}。`;
+}
+
+function recommendedActionText(result: EvaluationResult): string {
+  if (result.verdict === 'pass') {
+    return '暂无需要立即处理的动作。';
+  }
+
+  const actions: Record<EvaluationResult['root_cause'], string> = {
+    none: '复核告警项和支撑证据。',
+    no_final_answer: '检查最后一次 LLM 调用和服务端响应解析。',
+    interrupted_main_call: '检查中断证据，修复运行稳定性后再重试会话。',
+    agent_crash: '重试前先检查 Agent 健康状态和崩溃诊断。',
+    runtime_error: '检查模型服务错误、网络稳定性和重试行为。',
+    tool_failure: '检查失败的工具调用和工具响应解析。',
+    safety_risk: '重新运行 Agent 前先复核安全相关发现。',
+    loop_detected: '检查重复调用并收紧停止条件。',
+    excessive_cost: '复核提示词、工具输出和 Token 节省空间。',
+    partial_snapshot: '等待 pending 调用完成，或保留强制评估标记。',
+  };
+
+  return actions[result.root_cause];
+}
+
+function rootCauseLabel(value: EvaluationResult['root_cause']): string {
+  const labels: Record<EvaluationResult['root_cause'], string> = {
+    none: '未发现明确根因',
+    no_final_answer: '未生成最终回答',
+    interrupted_main_call: '主调用被中断',
+    agent_crash: 'Agent 崩溃',
+    runtime_error: '运行时错误',
+    tool_failure: '工具调用失败',
+    safety_risk: '安全风险',
+    loop_detected: '疑似循环调用',
+    excessive_cost: '成本过高',
+    partial_snapshot: '快照未完成',
+  };
+
+  return labels[value];
+}
+
+function dimensionLabel(value: string): string {
+  const labels: Record<string, string> = {
+    completion: '完成度',
+    runtime_health: '运行健康',
+    tool_use: '工具使用',
+    efficiency: '效率',
+    safety: '安全',
+  };
+
+  return labels[value] ?? value;
+}
+
+function reasonText(value: string): string {
+  const labels: Record<string, string> = {
+    'No usable assistant output was captured.': '未捕获到可用的助手输出。',
+    'A usable output exists.': '已捕获可用输出。',
+    'A usable output exists, but the snapshot still has pending calls.': '已捕获可用输出，但快照仍有未完成调用。',
+    'A usable assistant output was captured.': '已捕获可用的助手输出。',
+    'One or more LLM calls were interrupted.': '一个或多个 LLM 调用被中断。',
+    'Unresolved interruption signals were captured for this conversation.': '当前会话存在未解决的中断信号。',
+    'The snapshot contains pending calls and may still change.': '快照包含未完成调用，结果仍可能变化。',
+    'No runtime interruption was detected.': '未检测到运行时中断。',
+    'Tool output contains deterministic error signals.': '工具输出包含确定性错误信号。',
+    'The conversation required an unusually large number of LLM calls.': '当前会话的 LLM 调用次数异常偏高。',
+    'No deterministic tool failure was detected.': '未检测到确定性工具故障。',
+    'Token usage or call count is unusually high for a single conversation.': '单个会话的 Token 用量或调用次数异常偏高。',
+    'Token usage or call count is elevated for a single conversation.': '单个会话的 Token 用量或调用次数偏高。',
+    'Token usage and call count are within normal bounds.': 'Token 用量和调用次数处于正常范围。',
+    'Safety-related interruption signal was captured.': '捕获到安全相关中断信号。',
+    'No safety-specific signal was available or triggered.': '未发现安全专项信号触发。',
+  };
+
+  return labels[value] ?? value;
+}
+
+function findingLabel(value: string): string {
+  const labels: Record<string, string> = {
+    no_final_answer: '未生成最终回答',
+    interrupted_main_call: '主调用被中断',
+    partial_snapshot: '快照未完成',
+    tool_failure: '工具调用失败',
+    loop_detected: '疑似循环调用',
+    llm_error: 'LLM 错误',
+    sse_truncated: 'SSE 流截断',
+    network_timeout: '网络超时',
+    service_unavailable: '服务不可用',
+    agent_crash: 'Agent 崩溃',
+  };
+
+  return labels[value] ?? value;
+}
+
+function findingMessageText(value: string): string {
+  const labels: Record<string, string> = {
+    'The conversation has no usable assistant output.': '会话没有可用的助手输出。',
+    'An LLM call was interrupted before normal completion.': 'LLM 调用在正常完成前被中断。',
+    'Evaluation was forced while LLM calls were still pending.': '仍有 LLM 调用未完成时执行了强制评估。',
+    'Evaluation was forced while calls were pending.': '仍有调用未完成时执行了强制评估。',
+    'An unresolved interruption was recorded for this conversation.': '当前会话存在未解决的中断记录。',
+    'Tool output contains an error-like signal.': '工具输出包含疑似错误信号。',
+    'The conversation used many LLM calls and may need loop inspection.': '会话使用了较多 LLM 调用，可能需要检查循环行为。',
+  };
+
+  return labels[value] ?? value;
+}
+
+function severityLabel(value: string): string {
+  const labels: Record<string, string> = {
+    critical: '严重',
+    high: '高',
+    medium: '中',
+    low: '低',
+  };
+
+  return labels[value] ?? value;
+}
+
+function evidenceLabel(value: string): string {
+  const labels: Record<string, string> = {
+    'Assistant output': '助手输出',
+    'No output': '无输出',
+    'Interrupted LLM call': '中断的 LLM 调用',
+    'Interrupted call': '中断调用',
+    'Pending call': '未完成调用',
+    'Tool failure signal': '工具故障信号',
+    'Repeated calls': '重复调用',
+    'High cost': '高成本',
+    'Elevated cost': '成本偏高',
+    'Pending snapshot': '未完成快照',
+    'Tool failure': '工具故障',
+  };
+
+  return labels[value] ?? findingLabel(value);
+}

--- a/src/agentsight/dashboard/src/components/EvaluationPanel.tsx
+++ b/src/agentsight/dashboard/src/components/EvaluationPanel.tsx
@@ -207,7 +207,7 @@ function recommendedActionText(result: EvaluationResult): string {
     return '暂无需要立即处理的动作。';
   }
 
-  const actions: Record<EvaluationResult['root_cause'], string> = {
+  const actions: Record<string, string> = {
     none: '复核告警项和支撑证据。',
     no_final_answer: '检查最后一次 LLM 调用和服务端响应解析。',
     interrupted_main_call: '检查中断证据，修复运行稳定性后再重试会话。',
@@ -220,11 +220,11 @@ function recommendedActionText(result: EvaluationResult): string {
     partial_snapshot: '等待 pending 调用完成，或保留强制评估标记。',
   };
 
-  return actions[result.root_cause];
+  return actions[result.root_cause] ?? result.recommended_action ?? result.root_cause;
 }
 
-function rootCauseLabel(value: EvaluationResult['root_cause']): string {
-  const labels: Record<EvaluationResult['root_cause'], string> = {
+function rootCauseLabel(value: string): string {
+  const labels: Record<string, string> = {
     none: '未发现明确根因',
     no_final_answer: '未生成最终回答',
     interrupted_main_call: '主调用被中断',
@@ -237,7 +237,7 @@ function rootCauseLabel(value: EvaluationResult['root_cause']): string {
     partial_snapshot: '快照未完成',
   };
 
-  return labels[value];
+  return labels[value] ?? value;
 }
 
 function dimensionLabel(value: string): string {

--- a/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
+++ b/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
@@ -28,6 +28,21 @@ function shortId(id: string, len = 20): string {
   return id.length > len ? id.slice(0, len) + '\u2026' : id;
 }
 
+function highlightedSections(doc: AtifDocument, callId: string | null): Set<string> {
+  const sections = new Set<string>();
+  if (!callId) return sections;
+
+  for (const step of doc.steps) {
+    if (step.tool_calls?.some((toolCall) => toolCall.tool_call_id === callId)) {
+      sections.add(`${step.step_id}-toolcalls`);
+    }
+    if (step.observation?.results.some((result) => result.source_call_id === callId)) {
+      sections.add(`${step.step_id}-observation`);
+    }
+  }
+  return sections;
+}
+
 // ─── Strategy label config (shared with TokenSavingsPage) ────────────────────
 
 const STRATEGY_LABELS: Record<string, { label: string; color: string; bg: string }> = {
@@ -392,7 +407,14 @@ export const AtifViewerPage: React.FC = () => {
     const i = id ?? queryId;
     if (!i.trim()) return;
 
-    setSearchParams({ type: t, id: i.trim() }, { replace: true });
+    const nextParams: Record<string, string> = { type: t, id: i.trim() };
+    if (searchParams.get('id') === i.trim()) {
+      const highlightCallId = searchParams.get('highlight_call_id');
+      const interruptionId = searchParams.get('interruption_id');
+      if (highlightCallId) nextParams.highlight_call_id = highlightCallId;
+      if (interruptionId) nextParams.interruption_id = interruptionId;
+    }
+    setSearchParams(nextParams, { replace: true });
     setLoading(true);
     setError(null);
     setDoc(null);
@@ -406,6 +428,7 @@ export const AtifViewerPage: React.FC = () => {
         data = await fetchAtifBySession(i.trim());
       }
       setDoc(data);
+      setExpandedSections(highlightedSections(data, nextParams.highlight_call_id ?? null));
       // Fetch savings data for the session
       if (data.session_id) {
         fetchSessionSavings(data.session_id)
@@ -417,7 +440,7 @@ export const AtifViewerPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [queryType, queryId, setSearchParams]);
+  }, [queryType, queryId, searchParams, setSearchParams]);
 
   // Auto-load from URL on mount
   useEffect(() => {

--- a/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
+++ b/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
@@ -32,7 +32,7 @@ function highlightedSections(doc: AtifDocument, callId: string | null): Set<stri
   const sections = new Set<string>();
   if (!callId) return sections;
 
-  for (const step of doc.steps) {
+  for (const step of doc.steps ?? []) {
     if (step.tool_calls?.some((toolCall) => toolCall.tool_call_id === callId)) {
       sections.add(`${step.step_id}-toolcalls`);
     }
@@ -369,6 +369,11 @@ const MetricCard: React.FC<{ label: string; value: string; color: string; sub?: 
 export const AtifViewerPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const searchParamsRef = useRef(searchParams);
+
+  useEffect(() => {
+    searchParamsRef.current = searchParams;
+  }, [searchParams]);
 
   // Input state
   const [queryType, setQueryType] = useState<'session' | 'conversation'>(
@@ -408,9 +413,10 @@ export const AtifViewerPage: React.FC = () => {
     if (!i.trim()) return;
 
     const nextParams: Record<string, string> = { type: t, id: i.trim() };
-    if (searchParams.get('id') === i.trim()) {
-      const highlightCallId = searchParams.get('highlight_call_id');
-      const interruptionId = searchParams.get('interruption_id');
+    const currentSearchParams = searchParamsRef.current;
+    if (currentSearchParams.get('id') === i.trim()) {
+      const highlightCallId = currentSearchParams.get('highlight_call_id');
+      const interruptionId = currentSearchParams.get('interruption_id');
       if (highlightCallId) nextParams.highlight_call_id = highlightCallId;
       if (interruptionId) nextParams.interruption_id = interruptionId;
     }
@@ -440,7 +446,7 @@ export const AtifViewerPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [queryType, queryId, searchParams, setSearchParams]);
+  }, [queryType, queryId, setSearchParams]);
 
   // Auto-load from URL on mount
   useEffect(() => {
@@ -490,10 +496,11 @@ export const AtifViewerPage: React.FC = () => {
   }, [doc]);
 
   // Compute metrics (fallback when final_metrics is partial)
+  const steps = doc?.steps ?? [];
   const computedMetrics = doc ? (() => {
     const fm = doc.final_metrics;
     let promptSum = 0, completionSum = 0, cachedSum = 0;
-    for (const s of doc.steps) {
+    for (const s of steps) {
       if (s.metrics) {
         promptSum += s.metrics.prompt_tokens ?? 0;
         completionSum += s.metrics.completion_tokens ?? 0;
@@ -501,7 +508,7 @@ export const AtifViewerPage: React.FC = () => {
       }
     }
     return {
-      steps: fm?.total_steps ?? doc.steps.length,
+      steps: fm?.total_steps ?? steps.length,
       prompt: fm?.total_prompt_tokens ?? promptSum,
       completion: fm?.total_completion_tokens ?? completionSum,
       cached: fm?.total_cached_tokens ?? cachedSum,
@@ -706,11 +713,11 @@ export const AtifViewerPage: React.FC = () => {
               <h2 className="text-lg font-semibold text-gray-900 mb-4">
                 交互轨迹
                 <span className="ml-2 text-sm font-normal text-gray-400">
-                  共 {doc.steps.length} 步
+                  共 {steps.length} 步
                 </span>
               </h2>
 
-              {doc.steps.length === 0 ? (
+              {steps.length === 0 ? (
                 <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
                   <p className="text-4xl text-gray-300 mb-2">--</p>
                   <p className="text-gray-400">该轨迹暂无步骤数据</p>
@@ -720,7 +727,7 @@ export const AtifViewerPage: React.FC = () => {
                   {/* Vertical line */}
                   <div className="absolute left-[5px] top-4 bottom-4 w-0.5 bg-gray-200" />
 
-                  {doc.steps.map(step => (
+                  {steps.map(step => (
                     <StepCard
                       key={step.step_id}
                       step={step}

--- a/src/agentsight/dashboard/src/pages/ConversationList.tsx
+++ b/src/agentsight/dashboard/src/pages/ConversationList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   LineChart, Line, BarChart, Bar,
@@ -6,6 +6,8 @@ import {
 } from 'recharts';
 import { InterruptionBadge } from '../components/InterruptionBadge';
 import { InterruptionPanel, ResolvedEventInfo } from '../components/InterruptionPanel';
+import { EvaluationBadge } from '../components/EvaluationBadge';
+import { EvaluationPanel } from '../components/EvaluationPanel';
 import { DateTimePicker } from '../components/DateTimePicker';
 import { SessionIdHelp } from '../components/SessionIdHelp';
 import {
@@ -18,6 +20,7 @@ import {
   fetchInterruptionStats,
   fetchInterruptionSessionCounts,
   fetchInterruptionConversationCounts,
+  fetchLatestEvaluation,
   fetchTokenSavings,
   SessionSummary,
   TraceSummary,
@@ -28,6 +31,7 @@ import {
   InterruptionTypeStat,
   SessionInterruptionCount,
   ConversationInterruptionCount,
+  EvaluationResult,
   INTERRUPTION_TYPE_CN,
 } from '../utils/apiClient';
 
@@ -316,15 +320,62 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(0); // 0-based
   const [expandedTracePanel, setExpandedTracePanel] = useState<string | null>(null);
+  const [expandedEvaluationPanel, setExpandedEvaluationPanel] = useState<string | null>(null);
+  const [evaluations, setEvaluations] = useState<Map<string, EvaluationResult>>(new Map());
+  const [evaluationLookupDone, setEvaluationLookupDone] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     setLoading(true);
     setPage(0);
+    setEvaluations(new Map());
+    setEvaluationLookupDone(new Set());
     fetchTraces(sessionId, startNs, endNs)
       .then(setTraces)
       .catch((e: Error) => setError(e.message))
       .finally(() => setLoading(false));
   }, [sessionId, startNs, endNs]);
+
+  const totalPages = Math.max(1, Math.ceil(traces.length / PAGE_SIZE));
+  const pageTraces = useMemo(
+    () => traces.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [page, traces]
+  );
+
+  useEffect(() => {
+    if (loading || pageTraces.length === 0) return;
+
+    const missing = pageTraces.filter(
+      (trace) => !evaluationLookupDone.has(trace.conversation_id)
+    );
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+    Promise.all(
+      missing.map((trace) =>
+        fetchLatestEvaluation(trace.conversation_id)
+          .then((result) => result ? [trace.conversation_id, result] as const : null)
+          .catch(() => null)
+      )
+    ).then((entries) => {
+      if (cancelled) return;
+      setEvaluations((prev) => {
+        const next = new Map(prev);
+        for (const entry of entries) {
+          if (entry) next.set(entry[0], entry[1]);
+        }
+        return next;
+      });
+      setEvaluationLookupDone((prev) => {
+        const next = new Set(prev);
+        for (const trace of missing) next.add(trace.conversation_id);
+        return next;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [evaluationLookupDone, loading, pageTraces]);
 
   if (loading)
     return (
@@ -343,21 +394,19 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
       </tr>
     );
 
-  const totalPages = Math.max(1, Math.ceil(traces.length / PAGE_SIZE));
-  const pageTraces = traces.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
-
   return (
     <>
       {/* Sub-header */}
       <tr className="bg-blue-50 border-t border-blue-100">
         <td colSpan={10} className="px-4 lg:px-8 py-2">
-          <div className="grid grid-cols-[260px_274px_120px_120px_160px_80px_100px] text-xs font-semibold text-blue-700 uppercase tracking-wide min-w-[800px]">
+          <div className="grid grid-cols-[230px_244px_110px_110px_150px_74px_100px_90px] text-xs font-semibold text-blue-700 uppercase tracking-wide min-w-[900px]">
             <div>Conversation ID</div>
             <div>用户请求</div>
             <div>输入 Token</div>
             <div>输出 Token</div>
             <div>开始时间</div>
             <div>操作</div>
+            <div>质量评估</div>
             <div>中断</div>
           </div>
         </td>
@@ -375,7 +424,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
         <React.Fragment key={tr.conversation_id}>
           <tr className="bg-blue-50 hover:bg-blue-100 transition-colors">
             <td colSpan={10} className="px-4 lg:px-8 py-2">
-              <div className="grid grid-cols-[260px_274px_120px_120px_160px_80px_100px] items-center text-sm min-w-[800px]">
+              <div className="grid grid-cols-[230px_244px_110px_110px_150px_74px_100px_90px] items-center text-sm min-w-[900px]">
                 {/* Col 1: Conversation ID */}
                 <div className="min-w-0 pr-2">
                   <div className="flex items-center gap-1">
@@ -417,6 +466,20 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
                   </button>
                 </div>
                 <div>
+                  <button
+                    onClick={() => setExpandedEvaluationPanel(
+                      expandedEvaluationPanel === tr.conversation_id ? null : tr.conversation_id
+                    )}
+                    className="inline-flex min-w-[72px] items-center justify-center rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                  >
+                    {evaluations.get(tr.conversation_id) ? (
+                      <EvaluationBadge result={evaluations.get(tr.conversation_id)!} />
+                    ) : (
+                      '评估'
+                    )}
+                  </button>
+                </div>
+                <div>
                   {(() => {
                     const ic = conversationInterruptionCounts.get(tr.conversation_id);
                     if (!ic || ic.total === 0) return <span className="text-xs text-gray-300">—</span>;
@@ -432,8 +495,24 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
                   })()}
                 </div>
               </div>
-            </td>
-          </tr>
+              </td>
+            </tr>
+          {/* Trace evaluation panel */}
+          {expandedEvaluationPanel === tr.conversation_id && (
+            <tr className="bg-blue-50">
+              <td colSpan={10} className="px-4 lg:px-8 pb-3 pt-0">
+                <EvaluationPanel
+                  conversationId={tr.conversation_id}
+                  initialResult={evaluations.get(tr.conversation_id) ?? null}
+                  onResult={(result) => setEvaluations((prev) => {
+                    const next = new Map(prev);
+                    next.set(tr.conversation_id, result);
+                    return next;
+                  })}
+                />
+              </td>
+            </tr>
+          )}
           {/* Trace interruption panel */}
           {expandedTracePanel === tr.trace_id && (
             <tr className="bg-blue-50">

--- a/src/agentsight/dashboard/src/pages/ConversationList.tsx
+++ b/src/agentsight/dashboard/src/pages/ConversationList.tsx
@@ -323,12 +323,14 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
   const [expandedEvaluationPanel, setExpandedEvaluationPanel] = useState<string | null>(null);
   const [evaluations, setEvaluations] = useState<Map<string, EvaluationResult>>(new Map());
   const [evaluationLookupDone, setEvaluationLookupDone] = useState<Set<string>>(new Set());
+  const [evaluationLookupFailed, setEvaluationLookupFailed] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     setLoading(true);
     setPage(0);
     setEvaluations(new Map());
     setEvaluationLookupDone(new Set());
+    setEvaluationLookupFailed(new Set());
     fetchTraces(sessionId, startNs, endNs)
       .then(setTraces)
       .catch((e: Error) => setError(e.message))
@@ -345,7 +347,9 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
     if (loading || pageTraces.length === 0) return;
 
     const missing = pageTraces.filter(
-      (trace) => !evaluationLookupDone.has(trace.conversation_id)
+      (trace) =>
+        !evaluationLookupDone.has(trace.conversation_id) &&
+        !evaluationLookupFailed.has(trace.conversation_id)
     );
     if (missing.length === 0) return;
 
@@ -353,29 +357,58 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
     Promise.all(
       missing.map((trace) =>
         fetchLatestEvaluation(trace.conversation_id)
-          .then((result) => result ? [trace.conversation_id, result] as const : null)
-          .catch(() => null)
+          .then((result) => ({
+            conversationId: trace.conversation_id,
+            result,
+            ok: true,
+          }))
+          .catch(() => ({
+            conversationId: trace.conversation_id,
+            result: null,
+            ok: false,
+          }))
       )
     ).then((entries) => {
       if (cancelled) return;
       setEvaluations((prev) => {
         const next = new Map(prev);
         for (const entry of entries) {
-          if (entry) next.set(entry[0], entry[1]);
+          if (entry.ok && entry.result) {
+            next.set(entry.conversationId, entry.result);
+          }
         }
         return next;
       });
       setEvaluationLookupDone((prev) => {
         const next = new Set(prev);
-        for (const trace of missing) next.add(trace.conversation_id);
-        return next;
+        let changed = false;
+        for (const entry of entries) {
+          if (entry.ok && !next.has(entry.conversationId)) {
+            next.add(entry.conversationId);
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+      setEvaluationLookupFailed((prev) => {
+        const next = new Set(prev);
+        let changed = false;
+        for (const entry of entries) {
+          if (entry.ok) {
+            if (next.delete(entry.conversationId)) changed = true;
+          } else if (!next.has(entry.conversationId)) {
+            next.add(entry.conversationId);
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
       });
     });
 
     return () => {
       cancelled = true;
     };
-  }, [evaluationLookupDone, loading, pageTraces]);
+  }, [evaluationLookupDone, evaluationLookupFailed, loading, pageTraces]);
 
   if (loading)
     return (
@@ -466,18 +499,42 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
                   </button>
                 </div>
                 <div>
-                  <button
-                    onClick={() => setExpandedEvaluationPanel(
-                      expandedEvaluationPanel === tr.conversation_id ? null : tr.conversation_id
-                    )}
-                    className="inline-flex min-w-[72px] items-center justify-center rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
-                  >
-                    {evaluations.get(tr.conversation_id) ? (
-                      <EvaluationBadge result={evaluations.get(tr.conversation_id)!} />
-                    ) : (
-                      '评估'
-                    )}
-                  </button>
+                  {(() => {
+                    const evaluation = evaluations.get(tr.conversation_id);
+                    const lookupFailed = evaluationLookupFailed.has(tr.conversation_id);
+                    return (
+                      <button
+                        onClick={() => {
+                          if (lookupFailed) {
+                            setEvaluationLookupFailed((prev) => {
+                              if (!prev.has(tr.conversation_id)) return prev;
+                              const next = new Set(prev);
+                              next.delete(tr.conversation_id);
+                              return next;
+                            });
+                            return;
+                          }
+                          setExpandedEvaluationPanel(
+                            expandedEvaluationPanel === tr.conversation_id ? null : tr.conversation_id
+                          );
+                        }}
+                        className="inline-flex min-w-[72px] items-center justify-center rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                      >
+                        {evaluation ? (
+                          <EvaluationBadge result={evaluation} />
+                        ) : lookupFailed ? (
+                          <span
+                            className="text-red-600"
+                            title="质量评估结果加载失败，点击重试"
+                          >
+                            加载失败
+                          </span>
+                        ) : (
+                          '评估'
+                        )}
+                      </button>
+                    );
+                  })()}
                 </div>
                 <div>
                   {(() => {

--- a/src/agentsight/dashboard/src/test/AtifViewerPage.test.tsx
+++ b/src/agentsight/dashboard/src/test/AtifViewerPage.test.tsx
@@ -55,13 +55,12 @@ const mockAtifDoc = {
       tool_calls: [
         {
           tool_call_id: 'tc-1',
-          tool_name: 'search',
+          function_name: 'search',
           arguments: { query: 'greeting' },
-          result: 'found: hello',
         },
       ],
       observation: {
-        results: [{ output: 'search result' }],
+        results: [{ source_call_id: 'tc-1', content: 'search result' }],
       },
       metrics: {
         prompt_tokens: 100,
@@ -272,6 +271,17 @@ describe('AtifViewerPage', () => {
       renderPage('/atif?type=session&id=sess-from-url');
     });
     expect(mockFetchAtifBySession).toHaveBeenCalledWith('sess-from-url');
+  });
+
+  it('should expand highlighted evidence sections from URL params', async () => {
+    mockFetchAtifByConversation.mockResolvedValue(mockAtifDoc);
+    await act(async () => {
+      renderPage('/atif?type=conversation&id=conv-1&highlight_call_id=tc-1');
+    });
+
+    expect(mockFetchAtifByConversation).toHaveBeenCalledWith('conv-1');
+    expect(screen.getByText('search')).toBeInTheDocument();
+    expect(screen.getByText('search result')).toBeInTheDocument();
   });
 
   it('should show Token savings comparison card when savings data exists', async () => {

--- a/src/agentsight/dashboard/src/test/AtifViewerPage.test.tsx
+++ b/src/agentsight/dashboard/src/test/AtifViewerPage.test.tsx
@@ -271,6 +271,7 @@ describe('AtifViewerPage', () => {
       renderPage('/atif?type=session&id=sess-from-url');
     });
     expect(mockFetchAtifBySession).toHaveBeenCalledWith('sess-from-url');
+    expect(mockFetchAtifBySession).toHaveBeenCalledTimes(1);
   });
 
   it('should expand highlighted evidence sections from URL params', async () => {
@@ -282,6 +283,21 @@ describe('AtifViewerPage', () => {
     expect(mockFetchAtifByConversation).toHaveBeenCalledWith('conv-1');
     expect(screen.getByText('search')).toBeInTheDocument();
     expect(screen.getByText('search result')).toBeInTheDocument();
+  });
+
+  it('should render an empty timeline when steps are missing', async () => {
+    mockFetchAtifBySession.mockResolvedValue({
+      ...mockAtifDoc,
+      steps: undefined,
+      final_metrics: undefined,
+    });
+
+    await act(async () => {
+      renderPage('/atif?type=session&id=sess-without-steps');
+    });
+
+    expect(screen.getByText('共 0 步')).toBeInTheDocument();
+    expect(screen.getByText('该轨迹暂无步骤数据')).toBeInTheDocument();
   });
 
   it('should show Token savings comparison card when savings data exists', async () => {

--- a/src/agentsight/dashboard/src/test/ConversationList.test.tsx
+++ b/src/agentsight/dashboard/src/test/ConversationList.test.tsx
@@ -29,6 +29,16 @@ vi.mock('../utils/apiClient', () => ({
   fetchInterruptionSessionCounts: vi.fn(),
   fetchInterruptionConversationCounts: vi.fn(),
   fetchTokenSavings: vi.fn(),
+  fetchLatestEvaluation: vi.fn(),
+  evaluateConversation: vi.fn(),
+  EvaluationNotReadyError: class EvaluationNotReadyError extends Error {
+    pendingCallCount: number;
+    constructor(message: string, pendingCallCount: number) {
+      super(message);
+      this.name = 'EvaluationNotReadyError';
+      this.pendingCallCount = pendingCallCount;
+    }
+  },
   INTERRUPTION_TYPE_CN: {
     llm_error: 'LLM 错误',
     sse_truncated: 'SSE 中断',
@@ -54,6 +64,14 @@ vi.mock('../components/InterruptionPanel', () => ({
   ResolvedEventInfo: undefined,
 }));
 
+vi.mock('../components/EvaluationBadge', () => ({
+  EvaluationBadge: ({ result }: any) => result ? <span data-testid="evaluation-badge">{result.verdict}</span> : null,
+}));
+
+vi.mock('../components/EvaluationPanel', () => ({
+  EvaluationPanel: ({ conversationId }: any) => <div data-testid="evaluation-panel">质量评估 {conversationId}</div>,
+}));
+
 import {
   fetchSessions,
   fetchAgentNames,
@@ -64,6 +82,7 @@ import {
   fetchInterruptionConversationCounts,
   fetchTokenSavings,
   fetchTraces,
+  fetchLatestEvaluation,
 } from '../utils/apiClient';
 import { ConversationList } from '../pages/ConversationList';
 
@@ -76,6 +95,7 @@ const mockFetchInterruptionSessionCounts = fetchInterruptionSessionCounts as Ret
 const mockFetchInterruptionConversationCounts = fetchInterruptionConversationCounts as ReturnType<typeof vi.fn>;
 const mockFetchTokenSavings = fetchTokenSavings as ReturnType<typeof vi.fn>;
 const mockFetchTraces = fetchTraces as ReturnType<typeof vi.fn>;
+const mockFetchLatestEvaluation = fetchLatestEvaluation as ReturnType<typeof vi.fn>;
 
 function setupMocks() {
   mockFetchAgentNames.mockResolvedValue(['agent-a', 'agent-b']);
@@ -87,6 +107,7 @@ function setupMocks() {
   mockFetchInterruptionConversationCounts.mockResolvedValue([]);
   mockFetchTokenSavings.mockResolvedValue({ sessions: [], summary: null, stats_available: false });
   mockFetchTraces.mockResolvedValue([]);
+  mockFetchLatestEvaluation.mockResolvedValue(null);
 }
 
 function renderPage(route = '/') {
@@ -249,6 +270,52 @@ describe('ConversationList', () => {
     });
     // Should show trace sub-table content
     expect(screen.getByText('Conversation ID')).toBeInTheDocument();
+  });
+
+  it('should show latest grader badge and panel for a conversation', async () => {
+    mockFetchSessions.mockResolvedValue([
+      {
+        session_id: 'sess-graded',
+        agent_name: 'GradeAgent',
+        model: 'gpt-4o',
+        conversation_count: 1,
+        total_input_tokens: 500,
+        total_output_tokens: 300,
+        last_seen_ns: Date.now() * 1_000_000,
+      },
+    ]);
+    mockFetchTraces.mockResolvedValue([
+      {
+        trace_id: 'trace-graded',
+        conversation_id: 'conv-graded',
+        user_query: 'grade this',
+        total_input_tokens: 300,
+        total_output_tokens: 200,
+        start_ns: Date.now() * 1_000_000,
+        end_ns: Date.now() * 1_000_000,
+        model: 'gpt-4o',
+      },
+    ]);
+    mockFetchLatestEvaluation.mockResolvedValue({
+      target_id: 'conv-graded',
+      verdict: 'warn',
+      score: 0.7,
+    });
+
+    await act(async () => { renderPage(); });
+    await act(async () => {
+      fireEvent.click(screen.getByText('查询'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('GradeAgent').closest('tr')!);
+    });
+
+    expect(mockFetchLatestEvaluation).toHaveBeenCalledWith('conv-graded');
+    const badge = await screen.findByTestId('evaluation-badge');
+    expect(badge).toHaveTextContent('warn');
+
+    fireEvent.click(badge.closest('button')!);
+    expect(screen.getByTestId('evaluation-panel')).toHaveTextContent('conv-graded');
   });
 
   it('should show agent dropdown with loaded names', async () => {

--- a/src/agentsight/dashboard/src/test/ConversationList.test.tsx
+++ b/src/agentsight/dashboard/src/test/ConversationList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 // Mock recharts
@@ -316,6 +316,62 @@ describe('ConversationList', () => {
 
     fireEvent.click(badge.closest('button')!);
     expect(screen.getByTestId('evaluation-panel')).toHaveTextContent('conv-graded');
+  });
+
+  it('should surface failed grader badge lookups and retry from the error state', async () => {
+    mockFetchSessions.mockResolvedValue([
+      {
+        session_id: 'sess-retry',
+        agent_name: 'RetryAgent',
+        model: 'gpt-4o',
+        conversation_count: 11,
+        total_input_tokens: 1100,
+        total_output_tokens: 550,
+        last_seen_ns: Date.now() * 1_000_000,
+      },
+    ]);
+    mockFetchTraces.mockResolvedValue(
+      Array.from({ length: 11 }, (_, i) => ({
+        trace_id: `trace-${i}`,
+        conversation_id: i === 0 ? 'conv-retry' : `conv-${i}`,
+        user_query: `query ${i}`,
+        total_input_tokens: 100,
+        total_output_tokens: 50,
+        start_ns: Date.now() * 1_000_000 + i,
+        end_ns: Date.now() * 1_000_000 + i + 1,
+        model: 'gpt-4o',
+      }))
+    );
+    mockFetchLatestEvaluation.mockImplementation((conversationId: string) => {
+      if (conversationId === 'conv-retry') {
+        return Promise.reject(new Error('temporary outage'));
+      }
+      return Promise.resolve(null);
+    });
+
+    await act(async () => { renderPage(); });
+    await act(async () => {
+      fireEvent.click(screen.getByText('查询'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('RetryAgent').closest('tr')!);
+    });
+
+    expect(await screen.findByText('加载失败')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        mockFetchLatestEvaluation.mock.calls.filter(([id]) => id === 'conv-retry')
+      ).toHaveLength(1);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('加载失败'));
+    });
+    await waitFor(() => {
+      expect(
+        mockFetchLatestEvaluation.mock.calls.filter(([id]) => id === 'conv-retry')
+      ).toHaveLength(2);
+    });
   });
 
   it('should show agent dropdown with loaded names', async () => {

--- a/src/agentsight/dashboard/src/test/EvaluationBadge.test.tsx
+++ b/src/agentsight/dashboard/src/test/EvaluationBadge.test.tsx
@@ -24,4 +24,11 @@ describe('EvaluationBadge', () => {
     render(<EvaluationBadge result={{ verdict: 'fail', score: 0.2 } as any} />);
     expect(screen.getByText('未通过')).toBeInTheDocument();
   });
+
+  it('falls back to the raw verdict for unknown backend variants', () => {
+    render(<EvaluationBadge result={{ verdict: 'skipped', score: 0.5 } as any} />);
+
+    expect(screen.getByText('skipped')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
 });

--- a/src/agentsight/dashboard/src/test/EvaluationBadge.test.tsx
+++ b/src/agentsight/dashboard/src/test/EvaluationBadge.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EvaluationBadge } from '../components/EvaluationBadge';
+
+describe('EvaluationBadge', () => {
+  it('renders nothing when result is null', () => {
+    const { container } = render(<EvaluationBadge result={null} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders pass verdict with score', () => {
+    render(<EvaluationBadge result={{ verdict: 'pass', score: 0.93 } as any} />);
+    expect(screen.getByText('通过')).toBeInTheDocument();
+    expect(screen.getByText('93')).toBeInTheDocument();
+  });
+
+  it('renders warn verdict', () => {
+    render(<EvaluationBadge result={{ verdict: 'warn', score: 0.62 } as any} />);
+    expect(screen.getByText('需复核')).toBeInTheDocument();
+  });
+
+  it('renders fail verdict', () => {
+    render(<EvaluationBadge result={{ verdict: 'fail', score: 0.2 } as any} />);
+    expect(screen.getByText('未通过')).toBeInTheDocument();
+  });
+});

--- a/src/agentsight/dashboard/src/test/EvaluationPanel.test.tsx
+++ b/src/agentsight/dashboard/src/test/EvaluationPanel.test.tsx
@@ -98,6 +98,22 @@ describe('EvaluationPanel', () => {
     expect(screen.getByText('等待 pending 调用完成，或保留强制评估标记。')).toBeInTheDocument();
   });
 
+  it('falls back for unknown root causes from newer backends', () => {
+    renderPanel(
+      <EvaluationPanel
+        conversationId="conv-1"
+        initialResult={{
+          ...result,
+          root_cause: 'provider_backoff' as any,
+          recommended_action: 'Apply provider-specific backoff.',
+        }}
+      />
+    );
+
+    expect(screen.getByText('当前会话可用，但需要复核：provider_backoff。')).toBeInTheDocument();
+    expect(screen.getByText('Apply provider-specific backoff.')).toBeInTheDocument();
+  });
+
   it('reveals dimensions and findings', () => {
     renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={result} />);
     fireEvent.click(screen.getByText('查看详情'));

--- a/src/agentsight/dashboard/src/test/EvaluationPanel.test.tsx
+++ b/src/agentsight/dashboard/src/test/EvaluationPanel.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../utils/apiClient', async () => {
+  const actual = await vi.importActual<any>('../utils/apiClient');
+  return {
+    ...actual,
+    evaluateConversation: vi.fn(),
+  };
+});
+
+import { EvaluationNotReadyError, evaluateConversation, EvaluationResult } from '../utils/apiClient';
+import { EvaluationPanel } from '../components/EvaluationPanel';
+
+const mockEvaluate = evaluateConversation as ReturnType<typeof vi.fn>;
+
+const result: EvaluationResult = {
+  target_type: 'conversation',
+  target_id: 'conv-1',
+  run_id: 'run-1',
+  input_hash: 'hash-1',
+  verdict: 'warn',
+  score: 0.72,
+  summary: 'Conversation is usable but needs review.',
+  root_cause: 'partial_snapshot',
+  recommended_action: 'Wait for pending calls to complete.',
+  dimensions: [
+    {
+      name: 'completion',
+      score: 0.85,
+      verdict: 'pass',
+      reason: 'A usable output exists.',
+      evidence_refs: [
+        {
+          type: 'genai_event',
+          id: 'call-1',
+          label: 'Assistant output',
+          target: {
+            conversation_id: 'conv-1',
+            call_id: 'call-1',
+          },
+          deeplink: {
+            route: '/atif',
+            query: {
+              type: 'conversation',
+              id: 'conv-1',
+              highlight_call_id: 'call-1',
+            },
+          },
+          metadata: null,
+        },
+      ],
+    },
+  ],
+  findings: [
+    {
+      code: 'partial_snapshot',
+      severity: 'medium',
+      message: 'Evaluation was forced while calls were pending.',
+      evidence_refs: [],
+    },
+  ],
+  metadata: {
+    evaluated_with_pending: true,
+    pending_call_count: 1,
+    input_event_count: 2,
+    grader_type: 'rule',
+    grader_version: 'rule-v1',
+    rubric_version: null,
+    judge_model: null,
+    prompt_hash: null,
+    confidence: null,
+  },
+};
+
+beforeEach(() => {
+  mockEvaluate.mockReset();
+});
+
+function renderPanel(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('EvaluationPanel', () => {
+  it('renders evaluate button when no result exists', () => {
+    renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={null} />);
+    expect(screen.getByText('开始评估')).toBeInTheDocument();
+  });
+
+  it('renders compact summary and pending warning', () => {
+    renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={result} />);
+    expect(screen.getByText('需复核')).toBeInTheDocument();
+    expect(screen.getByText('72')).toBeInTheDocument();
+    expect(screen.getByText('当前会话可用，但需要复核：快照未完成。')).toBeInTheDocument();
+    expect(screen.getByText('评估时仍有 1 个 LLM 调用未完成。')).toBeInTheDocument();
+    expect(screen.getByText('等待 pending 调用完成，或保留强制评估标记。')).toBeInTheDocument();
+  });
+
+  it('reveals dimensions and findings', () => {
+    renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={result} />);
+    fireEvent.click(screen.getByText('查看详情'));
+    expect(screen.getByText('完成度')).toBeInTheDocument();
+    expect(screen.getAllByText('快照未完成').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('助手输出')).toBeInTheDocument();
+  });
+
+  it('runs evaluation and emits the new result', async () => {
+    const onResult = vi.fn();
+    mockEvaluate.mockResolvedValue({ result, reused_existing_run: false });
+    renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={null} onResult={onResult} />);
+
+    fireEvent.click(screen.getByText('开始评估'));
+
+    await waitFor(() => expect(mockEvaluate).toHaveBeenCalledWith('conv-1', false));
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(result));
+    expect(screen.getByText('需复核')).toBeInTheDocument();
+  });
+
+  it('shows force action after pending conflict', async () => {
+    mockEvaluate
+      .mockRejectedValueOnce(new EvaluationNotReadyError('pending', 2))
+      .mockResolvedValueOnce({ result, reused_existing_run: false });
+    renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={null} />);
+
+    fireEvent.click(screen.getByText('开始评估'));
+    await waitFor(() => expect(screen.getByText(/2 个 LLM 调用仍未完成/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('强制评估'));
+    await waitFor(() => expect(mockEvaluate).toHaveBeenLastCalledWith('conv-1', true));
+    expect(await screen.findByText('需复核')).toBeInTheDocument();
+  });
+});

--- a/src/agentsight/dashboard/src/test/EvaluationPanel.test.tsx
+++ b/src/agentsight/dashboard/src/test/EvaluationPanel.test.tsx
@@ -98,6 +98,19 @@ describe('EvaluationPanel', () => {
     expect(screen.getByText('等待 pending 调用完成，或保留强制评估标记。')).toBeInTheDocument();
   });
 
+  it('updates the displayed result when initialResult changes', () => {
+    const view = renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={null} />);
+
+    view.rerender(
+      <MemoryRouter>
+        <EvaluationPanel conversationId="conv-1" initialResult={result} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('需复核')).toBeInTheDocument();
+    expect(screen.getByText('72')).toBeInTheDocument();
+  });
+
   it('falls back for unknown root causes from newer backends', () => {
     renderPanel(
       <EvaluationPanel
@@ -120,6 +133,67 @@ describe('EvaluationPanel', () => {
     expect(screen.getByText('完成度')).toBeInTheDocument();
     expect(screen.getAllByText('快照未完成').length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('助手输出')).toBeInTheDocument();
+  });
+
+  it('translates every interruption type used by grader findings and evidence', () => {
+    const interruptionTypes = [
+      'auth_error',
+      'context_overflow',
+      'dead_loop',
+      'rate_limit',
+      'retry_storm',
+      'safety_filter',
+      'token_limit',
+    ];
+    const translatedResult: EvaluationResult = {
+      ...result,
+      findings: interruptionTypes.map((code, index) => ({
+        code,
+        severity: 'high',
+        message: `Interruption ${index}`,
+        evidence_refs: [{
+          type: 'interruption',
+          id: `interruption-${index}`,
+          label: code,
+          target: { conversation_id: 'conv-1' },
+        }],
+      })),
+    };
+
+    renderPanel(<EvaluationPanel conversationId="conv-1" initialResult={translatedResult} />);
+    fireEvent.click(screen.getByText('查看详情'));
+
+    for (const label of ['鉴权错误', '上下文溢出', '死循环', '速率限制', '重试风暴', '安全过滤', 'Token 超限']) {
+      expect(screen.getAllByText(label)).toHaveLength(2);
+    }
+  });
+
+  it('uses unique keys for repeated findings and evidence refs', () => {
+    const duplicateFinding = result.findings[0];
+    const duplicateRef = result.dimensions[0].evidence_refs[0];
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      renderPanel(
+        <EvaluationPanel
+          conversationId="conv-1"
+          initialResult={{
+            ...result,
+            dimensions: [{
+              ...result.dimensions[0],
+              evidence_refs: [duplicateRef, duplicateRef],
+            }],
+            findings: [duplicateFinding, duplicateFinding],
+          }}
+        />
+      );
+      fireEvent.click(screen.getByText('查看详情'));
+
+      const consoleOutput = consoleError.mock.calls.flat().join(' ');
+      expect(consoleOutput).not.toContain('Encountered two children with the same key');
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('runs evaluation and emits the new result', async () => {

--- a/src/agentsight/dashboard/src/test/apiClient.test.ts
+++ b/src/agentsight/dashboard/src/test/apiClient.test.ts
@@ -61,6 +61,11 @@ function mockErrorResponse(status: number, text: string) {
 
 beforeEach(() => {
   mockFetch.mockReset();
+  window.location.hash = '';
+});
+
+afterEach(() => {
+  window.location.hash = '';
 });
 
 describe('apiClient', () => {
@@ -84,7 +89,10 @@ describe('apiClient', () => {
       mockFetch.mockResolvedValueOnce(mockJsonResponse([]));
       const result = await fetchSessions();
       expect(result).toEqual([]);
-      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/api/sessions'));
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/sessions'),
+        expect.objectContaining({ credentials: 'same-origin' }),
+      );
     });
 
     it('should add start_ns and end_ns params', async () => {
@@ -162,6 +170,7 @@ describe('apiClient', () => {
       expect(mockFetch.mock.calls[0][1]).toMatchObject({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
       });
       expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
         target_type: 'conversation',
@@ -189,6 +198,14 @@ describe('apiClient', () => {
         pendingCallCount: 2,
       });
       expect(caught).toBeInstanceOf(EvaluationNotReadyError);
+    });
+
+    it('evaluateConversation should redirect to login after an unauthorized response', async () => {
+      mockFetch.mockResolvedValueOnce(mockJsonResponse({}, 401));
+
+      await expect(evaluateConversation('conv-1')).rejects.toThrow('Authentication required');
+
+      expect(window.location.hash).toBe('#/login');
     });
   });
 
@@ -319,7 +336,10 @@ describe('apiClient', () => {
       mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('') });
       await resolveInterruption('int-1');
       expect(mockFetch.mock.calls[0][0]).toContain('/api/interruptions/int-1/resolve');
-      expect(mockFetch.mock.calls[0][1]).toEqual({ method: 'POST' });
+      expect(mockFetch.mock.calls[0][1]).toEqual({
+        method: 'POST',
+        credentials: 'same-origin',
+      });
     });
 
     it('should throw on error', async () => {
@@ -340,7 +360,10 @@ describe('apiClient', () => {
       mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('') });
       await deleteAgentHealth(1234);
       expect(mockFetch.mock.calls[0][0]).toContain('/api/agent-health/1234');
-      expect(mockFetch.mock.calls[0][1]).toEqual({ method: 'DELETE' });
+      expect(mockFetch.mock.calls[0][1]).toEqual({
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
     });
 
     it('deleteAgentHealth error', async () => {
@@ -357,7 +380,10 @@ describe('apiClient', () => {
       });
       const result = await restartAgentHealth(1234);
       expect(result).toEqual(body);
-      expect(mockFetch.mock.calls[0][1]).toEqual({ method: 'POST' });
+      expect(mockFetch.mock.calls[0][1]).toEqual({
+        method: 'POST',
+        credentials: 'same-origin',
+      });
     });
 
     it('restartAgentHealth error', async () => {
@@ -502,7 +528,10 @@ describe('apiClient', () => {
       mockFetch.mockResolvedValueOnce(mockJsonResponse(mockReport));
       const result = await fetchSkillMetrics();
       expect(result).toEqual(mockReport);
-      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/api/skill-metrics'));
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/skill-metrics'),
+        expect.objectContaining({ credentials: 'same-origin' }),
+      );
     });
 
     it('should add start_ns and end_ns query params', async () => {

--- a/src/agentsight/dashboard/src/test/apiClient.test.ts
+++ b/src/agentsight/dashboard/src/test/apiClient.test.ts
@@ -20,6 +20,9 @@ import {
   fetchAgentHealth,
   deleteAgentHealth,
   restartAgentHealth,
+  fetchLatestEvaluation,
+  evaluateConversation,
+  EvaluationNotReadyError,
   INTERRUPTION_TYPE_CN,
   fetchSkillMetrics,
   fetchSecurityStatus,
@@ -134,6 +137,58 @@ describe('apiClient', () => {
       mockFetch.mockResolvedValueOnce(mockJsonResponse([]));
       await fetchConversationDetail('conv-1');
       expect(mockFetch.mock.calls[0][0]).toContain('/api/conversations/conv-1');
+    });
+  });
+
+  describe('Grader APIs', () => {
+    it('fetchLatestEvaluation should fetch latest conversation evaluation', async () => {
+      mockFetch.mockResolvedValueOnce(mockJsonResponse(null));
+      const result = await fetchLatestEvaluation('conv-1');
+
+      expect(result).toBeNull();
+      const url = mockFetch.mock.calls[0][0];
+      expect(url).toContain('/api/grader/latest');
+      expect(url).toContain('target_type=conversation');
+      expect(url).toContain('target_id=conv-1');
+    });
+
+    it('evaluateConversation should post a manual evaluation request', async () => {
+      const response = { result: { target_id: 'conv-1', verdict: 'pass' }, reused_existing_run: false };
+      mockFetch.mockResolvedValueOnce(mockJsonResponse(response));
+      const result = await evaluateConversation('conv-1', true);
+
+      expect(result).toEqual(response);
+      expect(mockFetch.mock.calls[0][0]).toContain('/api/grader/evaluate');
+      expect(mockFetch.mock.calls[0][1]).toMatchObject({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
+        target_type: 'conversation',
+        target_id: 'conv-1',
+        force: true,
+      });
+    });
+
+    it('evaluateConversation should expose pending conflicts as EvaluationNotReadyError', async () => {
+      mockFetch.mockResolvedValueOnce(mockJsonResponse({
+        error: 'conversation_not_ready',
+        pending_call_count: 2,
+        message: 'pending',
+      }, 409));
+
+      let caught: unknown;
+      try {
+        await evaluateConversation('conv-1');
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toMatchObject({
+        name: 'EvaluationNotReadyError',
+        pendingCallCount: 2,
+      });
+      expect(caught).toBeInstanceOf(EvaluationNotReadyError);
     });
   });
 

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -142,6 +142,138 @@ export async function fetchConversationDetail(conversationId: string): Promise<T
   );
 }
 
+// ─── Grader APIs ─────────────────────────────────────────────────────────────
+
+export type EvaluationVerdict = 'pass' | 'warn' | 'fail';
+export type EvaluationRootCause =
+  | 'none'
+  | 'no_final_answer'
+  | 'interrupted_main_call'
+  | 'agent_crash'
+  | 'runtime_error'
+  | 'tool_failure'
+  | 'safety_risk'
+  | 'loop_detected'
+  | 'excessive_cost'
+  | 'partial_snapshot';
+
+export interface EvaluationTarget {
+  conversation_id: string;
+  trace_id?: string | null;
+  call_id?: string | null;
+  step_id?: string | null;
+}
+
+export interface EvaluationRef {
+  type: 'genai_event' | 'interruption' | 'security_event' | 'trace' | 'tool_call' | 'atif_step';
+  id: string;
+  label: string;
+  severity?: string | null;
+  target: EvaluationTarget;
+  deeplink?: {
+    route: string;
+    query: Record<string, unknown>;
+  } | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface EvaluationDimension {
+  name: string;
+  score: number;
+  verdict: EvaluationVerdict;
+  reason: string;
+  evidence_refs: EvaluationRef[];
+}
+
+export interface EvaluationFinding {
+  code: string;
+  severity: string;
+  message: string;
+  evidence_refs: EvaluationRef[];
+}
+
+export interface EvaluationMetadata {
+  evaluated_with_pending: boolean;
+  pending_call_count: number;
+  input_event_count: number;
+  grader_type: 'rule' | 'llm' | 'agent';
+  grader_version: string;
+  rubric_version: string | null;
+  judge_model: string | null;
+  prompt_hash: string | null;
+  confidence: number | null;
+}
+
+export interface EvaluationResult {
+  target_type: 'conversation';
+  target_id: string;
+  run_id: string;
+  input_hash: string;
+  verdict: EvaluationVerdict;
+  score: number;
+  summary: string;
+  root_cause: EvaluationRootCause;
+  recommended_action: string;
+  dimensions: EvaluationDimension[];
+  findings: EvaluationFinding[];
+  metadata: EvaluationMetadata;
+}
+
+export interface EvaluationResponse {
+  result: EvaluationResult;
+  reused_existing_run: boolean;
+}
+
+export class EvaluationNotReadyError extends Error {
+  readonly pendingCallCount: number;
+
+  constructor(message: string, pendingCallCount: number) {
+    super(message);
+    this.name = 'EvaluationNotReadyError';
+    this.pendingCallCount = pendingCallCount;
+  }
+}
+
+/**
+ * Fetch the latest persisted evaluation for a conversation.
+ */
+export async function fetchLatestEvaluation(conversationId: string): Promise<EvaluationResult | null> {
+  const params = new URLSearchParams({
+    target_type: 'conversation',
+    target_id: conversationId,
+  });
+  return apiFetch<EvaluationResult | null>(`${API_BASE}/api/grader/latest?${params.toString()}`);
+}
+
+/**
+ * Manually evaluate a conversation with the rule-based grader.
+ */
+export async function evaluateConversation(
+  conversationId: string,
+  force = false,
+): Promise<EvaluationResponse> {
+  const res = await fetch(`${API_BASE}/api/grader/evaluate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      target_type: 'conversation',
+      target_id: conversationId,
+      force,
+    }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    if (res.status === 409 && body?.error === 'conversation_not_ready') {
+      throw new EvaluationNotReadyError(
+        body.message ?? 'Conversation still has pending LLM calls.',
+        Number(body.pending_call_count ?? 0),
+      );
+    }
+    throw new Error(`POST /api/grader/evaluate -> ${res.status}: ${body?.message ?? res.statusText}`);
+  }
+  return body as EvaluationResponse;
+}
+
 // ─── Agent-name & time-series APIs ───────────────────────────────────────────
 
 /**

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -73,8 +73,20 @@ export interface TraceEventDetail {
 
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
-async function apiFetch<T>(url: string): Promise<T> {
-  const res = await fetch(url, { credentials: 'same-origin' });
+class ApiRequestError extends Error {
+  readonly status: number;
+  readonly body: Record<string, unknown> | null;
+
+  constructor(url: string, status: number, text: string, body: Record<string, unknown> | null) {
+    super(`API ${url} -> ${status}: ${text}`);
+    this.name = 'ApiRequestError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function apiFetch<T>(url: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(url, { ...init, credentials: 'same-origin' });
   if (res.status === 401) {
     // Session expired or invalid — redirect to login
     window.location.hash = '#/login';
@@ -82,7 +94,16 @@ async function apiFetch<T>(url: string): Promise<T> {
   }
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);
-    throw new Error(`API ${url} -> ${res.status}: ${text}`);
+    let body: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        body = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Error responses may be plain text.
+    }
+    throw new ApiRequestError(url, res.status, text, body);
   }
   return res.json() as Promise<T>;
 }
@@ -252,26 +273,30 @@ export async function evaluateConversation(
   conversationId: string,
   force = false,
 ): Promise<EvaluationResponse> {
-  const res = await fetch(`${API_BASE}/api/grader/evaluate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      target_type: 'conversation',
-      target_id: conversationId,
-      force,
-    }),
-  });
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    if (res.status === 409 && body?.error === 'conversation_not_ready') {
+  try {
+    return await apiFetch<EvaluationResponse>(`${API_BASE}/api/grader/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        target_type: 'conversation',
+        target_id: conversationId,
+        force,
+      }),
+    });
+  } catch (error) {
+    if (
+      error instanceof ApiRequestError &&
+      error.status === 409 &&
+      error.body?.error === 'conversation_not_ready'
+    ) {
+      const message = error.body.message;
       throw new EvaluationNotReadyError(
-        body.message ?? 'Conversation still has pending LLM calls.',
-        Number(body.pending_call_count ?? 0),
+        typeof message === 'string' ? message : 'Conversation still has pending LLM calls.',
+        Number(error.body.pending_call_count ?? 0),
       );
     }
-    throw new Error(`POST /api/grader/evaluate -> ${res.status}: ${body?.message ?? res.statusText}`);
+    throw error;
   }
-  return body as EvaluationResponse;
 }
 
 // ─── Agent-name & time-series APIs ───────────────────────────────────────────


### PR DESCRIPTION
## Description

Add dashboard controls for the conversation grader. The UI can run manual evaluations, show latest-run badges in the conversation list, and display score dimensions, findings, root cause, and evidence links in a detail panel.

This PR is frontend-only and split from the grader backend so the dashboard interaction surface can be reviewed separately.

## Related Issue

Refs #1304

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: dashboard typecheck and tests pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran on the Linux AgentSight test host from an archive of this split branch:

- `npm ci`
- `npm run typecheck`
- `npm test -- src/test/apiClient.test.ts src/test/EvaluationBadge.test.tsx src/test/EvaluationPanel.test.tsx src/test/ConversationList.test.tsx src/test/AtifViewerPage.test.tsx`

Result: 5 test files passed, 95 tests passed.

## Additional Notes

Split from #1349 following review feedback. The backend API is intentionally left to a separate PR.
