### PR TITLE
fix(sec-core): fix sec-core source build with system mode, add ci check

### DIFF
--- a/.github/workflows/sec-core-source-code-build.yaml
+++ b/.github/workflows/sec-core-source-code-build.yaml
@@ -90,3 +90,64 @@ jobs:
           ls ~/.local/lib/anolisa/sec-core/venv/bin/agent-sec-cli
       - name: Run E2E tests
         run: make -C src/agent-sec-core test-e2e-source-build
+
+  system-build:
+    name: Source Build System Install (Ubuntu 22.04)
+    runs-on: anolisa-k8s-general-ci-x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93.0
+        with:
+          components: clippy, rustfmt, rust-src
+      - name: Install verification tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y passwd util-linux
+      - name: Build and install in system mode
+        run: |
+          ./scripts/build-all.sh --component sec-core --system
+      - name: Verify system commands
+        run: |
+          agent-sec-cli --version
+          agent-sec-cli --help
+          agent-sec-cli scan-pii --help >/dev/null
+          agent-sec-daemon --help
+          linux-sandbox --help
+      - name: Verify system deployment
+        run: |
+          echo "=== System binaries ==="
+          test -x /usr/local/bin/agent-sec-cli
+          test -x /usr/local/bin/agent-sec-daemon
+          test -x /usr/local/bin/linux-sandbox
+          echo "=== Cosh Extension ==="
+          test -d /usr/share/anolisa/extensions/agent-sec-core/hooks
+          echo "=== OpenClaw Plugin ==="
+          test -d /usr/local/lib/anolisa/sec-core/openclaw-plugin/dist
+          test -x /usr/local/lib/anolisa/sec-core/openclaw-plugin/scripts/deploy.sh
+          echo "=== Hermes Plugin ==="
+          test -f /usr/local/lib/anolisa/sec-core/hermes-plugin/src/plugin.yaml
+          test -x /usr/local/lib/anolisa/sec-core/hermes-plugin/scripts/deploy.sh
+          echo "=== Codex Plugin ==="
+          test -f /usr/local/lib/anolisa/sec-core/codex-plugin/hooks-plugin/hooks/code_scanner_hook.py
+          test -f /usr/local/lib/anolisa/sec-core/codex-plugin/hooks-plugin/hooks/skill_ledger_hook.py
+          test -f /usr/local/lib/anolisa/sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
+          test -x /usr/local/lib/anolisa/sec-core/codex-plugin/install.sh
+          test -f /usr/local/lib/anolisa/sec-core/codex-plugin/.agents/plugins/marketplace.json
+          echo "=== Skills ==="
+          test -d /usr/share/anolisa/skills
+          echo "=== CLI venv ==="
+          test -x /usr/local/lib/anolisa/sec-core/venv/bin/agent-sec-cli
+      - name: Verify system install as regular user
+        run: |
+          python_path="$(readlink -f /usr/local/lib/anolisa/sec-core/venv/bin/python)"
+          echo "venv python: ${python_path}"
+          case "${python_path}" in
+            /root/*)
+              echo "ERROR: venv Python points to root-private path: ${python_path}" >&2
+              exit 1
+              ;;
+          esac
+          namei -l /usr/local/lib/anolisa/sec-core/venv/bin/python
+          sudo useradd -m -s /bin/bash secprobe || true
+          sudo -u secprobe /usr/local/bin/agent-sec-cli --version
+          sudo -u secprobe /usr/local/bin/agent-sec-cli scan-pii --help >/dev/null

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -280,6 +280,7 @@ BINDIR              ?= $(PREFIX)/bin
 LIBDIR              ?= $(PREFIX)/lib/anolisa/sec-core
 LIBEXECDIR          ?= $(PREFIX)/libexec/anolisa/sec-core
 VENV_DIR            ?= $(LIBDIR)/venv
+SYSTEM_SEC_CORE_UV_PYTHON_INSTALL_DIR ?= $(LIBDIR)/uv-python
 WHEEL_DIR           ?= $(LIBDIR)/wheels
 CLI_STAGED_SITE     ?= $(BUILD_DIR)/site-packages
 CLI_PRIVATE_SITE    ?= /opt/agent-sec/lib/python3.11/site-packages
@@ -320,10 +321,15 @@ install-cli-site: ## RPM: Copy staged site-packages to private dir + wrappers
 	install -p -m 0755 scripts/agent-sec-daemon-wrapper.sh $(DESTDIR)/usr/bin/agent-sec-daemon
 
 .PHONY: install-cli-venv
-install-cli-venv: ## User: Create venv, install deps from uv.lock, install wheel, symlink
+install-cli-venv: ## Create venv, install deps from uv.lock, install wheel, symlink
 	@echo "Creating Python venv at $(VENV_DIR) ..."
 	install -d -m 0755 $(VENV_DIR)
+ifeq ($(INSTALL_PROFILE),system)
+	install -d -m 0755 $(SYSTEM_SEC_CORE_UV_PYTHON_INSTALL_DIR)
+	UV_PYTHON_INSTALL_DIR=$(SYSTEM_SEC_CORE_UV_PYTHON_INSTALL_DIR) uv venv --python 3.11.6 --allow-existing $(VENV_DIR)
+else
 	uv venv --python 3.11.6 --allow-existing $(VENV_DIR)
+endif
 	@echo "Installing dependencies from uv.lock ..."
 	cd agent-sec-cli && UV_PROJECT_ENVIRONMENT=$(VENV_DIR) uv sync --frozen --no-dev --no-install-project
 	@echo "Installing agent-sec-cli wheel ..."

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -410,6 +410,9 @@ uninstall-cli-venv: ## Remove venv and agent-sec-cli symlink
 	rm -f $(DESTDIR)$(BINDIR)/agent-sec-cli
 	rm -f $(DESTDIR)$(BINDIR)/agent-sec-daemon
 	rm -rf $(DESTDIR)$(VENV_DIR)
+ifeq ($(INSTALL_PROFILE),system)
+	rm -rf $(DESTDIR)$(SYSTEM_SEC_CORE_UV_PYTHON_INSTALL_DIR)
+endif
 
 .PHONY: uninstall-cli-site
 uninstall-cli-site: ## Remove RPM-style private site-packages and wrappers


### PR DESCRIPTION
## Description

本 PR 修复 sec-core 源码构建在 `system` 安装模式下的多用户可执行性问题，确保安装后的 CLI 不仅 root 可以使用，普通用户也可以正常执行。

此前在 root 用户执行 system 安装时，`uv venv --python 3.11.6` 可能会把 uv 托管的 Python 解释器安装到构建用户的私有家目录下。这样生成的 venv 解释器可能解析到 root 私有路径，导致普通用户执行 `/usr/local/bin/agent-sec-cli` 时因为解释器路径权限问题失败。现在 Makefile 会在 system 安装模式下将 uv 托管 Python 放到 sec-core 的公共库目录 `$(LIBDIR)/uv-python` 下，同时保持 user 安装模式的原有行为不变。

源码构建 CI 也新增了一个 system 安装冒烟验证 job，运行在现有 CI runner 池上，用于验证命令可用性、system 安装文件布局，以及普通用户执行 `agent-sec-cli` 的能力。

## 变更内容

- 在 `src/agent-sec-core/Makefile` 中新增 `SYSTEM_SEC_CORE_UV_PYTHON_INSTALL_DIR`。
- 仅在 `INSTALL_PROFILE=system` 时设置 `UV_PYTHON_INSTALL_DIR=$(LIBDIR)/uv-python`。
- 保持 `INSTALL_PROFILE=user` 下的 venv 创建逻辑不变。
- 在 `sec-core-source-code-build.yaml` 中新增 `system-build` job，执行 `./scripts/build-all.sh --component sec-core --system`。
- 验证 system 安装后的命令可用性，以及 `/usr/local`、`/usr/share/anolisa` 下的文件布局。
- 验证非 root 用户可以执行 `/usr/local/bin/agent-sec-cli --version` 和 `scan-pii --help`。

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
