### PR TITLE
feat(sec-core): add sensitive_file_paths in code scanner rules

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/_shared.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/bash/_shared.yaml
@@ -25,3 +25,16 @@ sensitive_file_paths:
   - ~/\.zsh_history
   - /etc/kubernetes/
   - kubeconfig
+  # Agent runtime credential and auth state files.
+  - ~/\.codex/auth\.json\b
+  - ~/\.hermes/auth\.json\b
+  - ~/\.hermes/\.env\b
+  - ~/\.hermes/config\.yaml\b
+  - ~/\.hermes/profiles/[^/]+/auth\.json\b
+  - ~/\.hermes/profiles/[^/]+/\.env\b
+  - ~/\.hermes/profiles/[^/]+/config\.yaml\b
+  - ~/\.openclaw/openclaw\.json\b
+  - ~/\.openclaw/agents/[^/]+/agent/models\.json\b
+  - ~/\.copilot-shell/settings\.json\b
+  - ~/\.copilot-shell/aliyun_creds\.json\b
+  - ~/\.copilot-shell/mcp-oauth-tokens(-v2)?\.json\b

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/python/_shared.yaml
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/code_scanner/rules/python/_shared.yaml
@@ -15,3 +15,16 @@ sensitive_file_paths:
   - /boot/
   - /usr/lib/systemd/
   - /etc/systemd/system/
+  # Agent runtime credential and auth state files.
+  - ~/\.codex/auth\.json\b
+  - ~/\.hermes/auth\.json\b
+  - ~/\.hermes/\.env\b
+  - ~/\.hermes/config\.yaml\b
+  - ~/\.hermes/profiles/[^/]+/auth\.json\b
+  - ~/\.hermes/profiles/[^/]+/\.env\b
+  - ~/\.hermes/profiles/[^/]+/config\.yaml\b
+  - ~/\.openclaw/openclaw\.json\b
+  - ~/\.openclaw/agents/[^/]+/agent/models\.json\b
+  - ~/\.copilot-shell/settings\.json\b
+  - ~/\.copilot-shell/aliyun_creds\.json\b
+  - ~/\.copilot-shell/mcp-oauth-tokens(-v2)?\.json\b

--- a/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
+++ b/src/agent-sec-core/tests/unit-test/code_scanner/testdata/scan_test_data.py
@@ -87,12 +87,63 @@ SHELL_READ_SENSITIVE_FILE_CASES = [
     ("cat /etc/crontab", "bash", "shell-read-sensitive-file", 1),
     ("cat /var/spool/cron/root", "bash", "shell-read-sensitive-file", 1),
     ("cat /etc/hostname", "bash", "shell-read-sensitive-file", 1),
+    # --- TP: Agent runtime credentials and auth state ---
+    ("cat ~/.codex/auth.json", "bash", "shell-read-sensitive-file", 1),
+    ("cat ~/.hermes/auth.json", "bash", "shell-read-sensitive-file", 1),
+    ("cat ~/.hermes/.env", "bash", "shell-read-sensitive-file", 1),
+    ("cat ~/.hermes/config.yaml", "bash", "shell-read-sensitive-file", 1),
+    ("cat ~/.hermes/profiles/coder/auth.json", "bash", "shell-read-sensitive-file", 1),
+    ("cat ~/.hermes/profiles/coder/.env", "bash", "shell-read-sensitive-file", 1),
+    (
+        "cat ~/.hermes/profiles/coder/config.yaml",
+        "bash",
+        "shell-read-sensitive-file",
+        1,
+    ),
+    ("cat ~/.openclaw/openclaw.json", "bash", "shell-read-sensitive-file", 1),
+    (
+        "cat ~/.openclaw/agents/main/agent/models.json",
+        "bash",
+        "shell-read-sensitive-file",
+        1,
+    ),
+    ("cat ~/.copilot-shell/settings.json", "bash", "shell-read-sensitive-file", 1),
+    ("cat ~/.copilot-shell/aliyun_creds.json", "bash", "shell-read-sensitive-file", 1),
+    (
+        "cat ~/.copilot-shell/mcp-oauth-tokens.json",
+        "bash",
+        "shell-read-sensitive-file",
+        1,
+    ),
+    (
+        "cat ~/.copilot-shell/mcp-oauth-tokens-v2.json",
+        "bash",
+        "shell-read-sensitive-file",
+        1,
+    ),
     # === True Negatives ===
     ("cat /var/log/syslog", "bash", "shell-read-sensitive-file", 0),
     ("less /tmp/output.txt", "bash", "shell-read-sensitive-file", 0),
     ("head -n 5 README.md", "bash", "shell-read-sensitive-file", 0),
     ("echo /etc/shadow", "bash", "shell-read-sensitive-file", 0),
     ("ls -la /etc/shadow", "bash", "shell-read-sensitive-file", 0),
+    # --- TN: Agent diagnostics and non-credential files ---
+    ("hermes doctor", "bash", "shell-read-sensitive-file", 0),
+    ("openclaw doctor --fix", "bash", "shell-read-sensitive-file", 0),
+    ("cat ~/.codex/skills/example/SKILL.md", "bash", "shell-read-sensitive-file", 0),
+    ("cat ~/.codex/tmp/session-note.txt", "bash", "shell-read-sensitive-file", 0),
+    ("cat ~/.hermes/logs/agent.log", "bash", "shell-read-sensitive-file", 0),
+    ("cat ~/.hermes/skills/demo/SKILL.md", "bash", "shell-read-sensitive-file", 0),
+    ("cat ~/.openclaw/skills/demo/SKILL.md", "bash", "shell-read-sensitive-file", 0),
+    ("cat ~/.openclaw/workspace/SOUL.md", "bash", "shell-read-sensitive-file", 0),
+    ("cat ~/.copilot-shell/commands/demo.md", "bash", "shell-read-sensitive-file", 0),
+    (
+        "cat ~/.copilot-shell/history/session.jsonl",
+        "bash",
+        "shell-read-sensitive-file",
+        0,
+    ),
+    ("cat ~/.copilot-shell/memory.md", "bash", "shell-read-sensitive-file", 0),
     # --- cross-command isolation ---
     ("cat file.txt; echo /etc/shadow", "bash", "shell-read-sensitive-file", 0),
     ("cat file.txt | grep /etc/shadow", "bash", "shell-read-sensitive-file", 0),
@@ -791,6 +842,45 @@ PY_SENSITIVE_FILE_ACCESS_CASES = [
     ("f = open('~/.ssh/id_rsa', 'r')", "python", "py-sensitive-file-access", 1),
     ("open('/etc/sudoers', 'w')", "python", "py-sensitive-file-access", 1),
     ("open('.env', 'r')", "python", "py-sensitive-file-access", 1),
+    # === TP: Agent runtime credentials and auth state ===
+    ("open('~/.codex/auth.json').read()", "python", "py-sensitive-file-access", 1),
+    ("Path('~/.hermes/.env').read_text()", "python", "py-sensitive-file-access", 1),
+    (
+        "Path('~/.hermes/config.yaml').read_text()",
+        "python",
+        "py-sensitive-file-access",
+        1,
+    ),
+    (
+        "open('~/.hermes/profiles/coder/auth.json')",
+        "python",
+        "py-sensitive-file-access",
+        1,
+    ),
+    (
+        "Path('~/.hermes/profiles/coder/config.yaml').read_text()",
+        "python",
+        "py-sensitive-file-access",
+        1,
+    ),
+    (
+        "Path('~/.openclaw/openclaw.json').read_text()",
+        "python",
+        "py-sensitive-file-access",
+        1,
+    ),
+    (
+        "Path('~/.openclaw/agents/main/agent/models.json').read_text()",
+        "python",
+        "py-sensitive-file-access",
+        1,
+    ),
+    (
+        "open('~/.copilot-shell/mcp-oauth-tokens-v2.json').read()",
+        "python",
+        "py-sensitive-file-access",
+        1,
+    ),
     # === TP: pathlib + sensitive path ===
     ("Path('/etc/shadow').read_text()", "python", "py-sensitive-file-access", 1),
     (
@@ -850,6 +940,20 @@ PY_SENSITIVE_FILE_ACCESS_CASES = [
         0,
     ),
     ("Path('output.txt').read_text()", "python", "py-sensitive-file-access", 0),
+    # === TN: Agent runtime non-credential files ===
+    ("open('~/.codex/tmp/session-note.txt')", "python", "py-sensitive-file-access", 0),
+    (
+        "Path('~/.hermes/logs/agent.log').read_text()",
+        "python",
+        "py-sensitive-file-access",
+        0,
+    ),
+    (
+        "Path('~/.copilot-shell/history/session.jsonl').read_text()",
+        "python",
+        "py-sensitive-file-access",
+        0,
+    ),
     # --- cross-line isolation ---
     (
         "open('regular.txt')\nprint('/etc/shadow')",


### PR DESCRIPTION
## Description

在code-scanner中增加常见agent的敏感路径名单，阻断agent通过读取敏感文件，获取api-key等敏感信息

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
