### PR TITLE
feat(anolisa): visible install state with cross-scope visibility and scope guards

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -7,6 +7,7 @@
 
 pub mod common;
 pub mod tier1;
+pub mod visible_view;
 
 // Tier 2 surfaces
 pub mod adapter;

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -37,6 +37,150 @@ pub fn resolve_layout(ctx: &CliContext) -> FsLayout {
     }
 }
 
+/// Normalize state file permissions after a mutation, gated by install mode.
+///
+/// In system mode, calls [`normalize_system_state_permissions`] so that
+/// non-root users can read the system state. In user mode, this is a no-op
+/// to avoid exposing user-scope state to other users.
+pub fn normalize_after_save(ctx: &CliContext, layout: &FsLayout) {
+    use crate::context::InstallMode;
+    if matches!(ctx.install_mode, InstallMode::System) {
+        normalize_system_state_permissions(layout);
+    }
+}
+
+/// Return the system-scope [`FsLayout`] regardless of the current
+/// `ctx.install_mode`.
+///
+/// Used by read commands that need to discover system-scope installed
+/// components even when running in user mode.
+pub fn system_layout(ctx: &CliContext) -> FsLayout {
+    FsLayout::system(ctx.prefix.clone())
+}
+
+/// Load system-scope `installed.toml` best-effort.
+///
+/// Returns `None` when the file is missing or fails to parse. This is the
+/// read-only path used by the visible-view merge — never a mutation path.
+#[allow(dead_code)]
+pub fn load_system_state(ctx: &CliContext) -> Option<InstalledState> {
+    let layout = system_layout(ctx);
+    let path = layout.state_dir.join("installed.toml");
+    if !path.exists() {
+        return None;
+    }
+    InstalledState::load(&path).ok()
+}
+
+/// Normalize system-scope state file and directory permissions so that
+/// non-root users can read them.
+///
+/// This is a best-effort sweep: it chmods the state directory, the
+/// `installed.toml` file, `component-manifests/` snapshots, and the
+/// `datadir/components/` + `datadir/adapters/` trees to `0755` (dirs) /
+/// `0644` (regular files) / preserve-execute-bit (scripts).
+///
+/// Errors on individual paths are silently ignored — the primary install
+/// operation must not fail because a permission normalization side-effect
+/// could not be applied.
+///
+/// Call this after any system-mode mutation that writes state files.
+///
+/// This is a no-op in user mode — user-scope state files must not be
+/// made world-readable.
+pub fn normalize_system_state_permissions(layout: &FsLayout) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let chmod = |path: &std::path::Path, mode: u32| {
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+        };
+
+        // State directory → 0755
+        chmod(&layout.state_dir, 0o755);
+
+        // installed.toml → 0644
+        let installed_toml = layout.state_dir.join("installed.toml");
+        chmod(&installed_toml, 0o644);
+
+        // component-manifests/ → 0755
+        let manifests_dir = layout.state_dir.join("component-manifests");
+        chmod(&manifests_dir, 0o755);
+
+        // Walk component-manifests/<component>/ → dirs 0755, *.toml 0644
+        if let Ok(entries) = std::fs::read_dir(&manifests_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    chmod(&path, 0o755);
+                    for name in ["component.toml", "provenance.toml"] {
+                        let toml = path.join(name);
+                        if toml.is_file() {
+                            chmod(&toml, 0o644);
+                        }
+                    }
+                }
+            }
+        }
+
+        // datadir/components/ → dirs 0755, component.toml → 0644
+        normalize_datadir_tree(&layout.datadir.join("components"), &chmod);
+
+        // datadir/adapters/ → dirs 0755, regular files 0644,
+        // executable scripts keep execute bit (→ 0755)
+        normalize_datadir_tree(&layout.datadir.join("adapters"), &chmod);
+
+        // Also normalize the FHS package datadir if distinct
+        if let Some(pkg_dd) = layout.package_datadir() {
+            normalize_datadir_tree(&pkg_dd.join("components"), &chmod);
+            normalize_datadir_tree(&pkg_dd.join("adapters"), &chmod);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = layout;
+    }
+}
+
+/// Recursively normalize a datadir subtree: directories → `0755`,
+/// regular files → `0644`, executable files (already have execute bit)
+/// → `0755` (preserves script executability).
+#[cfg(unix)]
+fn normalize_datadir_tree(root: &std::path::Path, chmod: &impl Fn(&std::path::Path, u32)) {
+    if !root.is_dir() {
+        return;
+    }
+    chmod(root, 0o755);
+    walk_datadir(root, chmod);
+}
+
+#[cfg(unix)]
+fn walk_datadir(dir: &std::path::Path, chmod: &impl Fn(&std::path::Path, u32)) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        use std::os::unix::fs::PermissionsExt;
+        if meta.is_dir() {
+            chmod(&path, 0o755);
+            walk_datadir(&path, chmod);
+        } else if meta.is_file() {
+            let mode = meta.permissions().mode();
+            if mode & 0o111 != 0 {
+                // File has execute bits — preserve as executable script.
+                chmod(&path, 0o755);
+            } else {
+                chmod(&path, 0o644);
+            }
+        }
+    }
+}
+
 /// Refuse a handler-level system-only path when called with user-mode context.
 ///
 /// The dispatcher handles normal CLI entry. This guard protects direct calls

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -1479,6 +1479,10 @@ mod tests {
             rpm_evr: None,
             rpm_source_repo: None,
             provisioned_packages: Vec::new(),
+            scope: String::new(),
+            mutable_by_current_user: false,
+            shadowed_by: None,
+            state_path: None,
         }
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -20,6 +20,9 @@ use anolisa_core::state::{ObjectKind, OperationRecord};
 
 use crate::color::Palette;
 use crate::commands::common;
+use crate::commands::visible_view::{
+    MutationOperation, VisibleInstalledView, resolve_mutation_target, wrong_scope_reason,
+};
 use crate::context::CliContext;
 use crate::response::{CliError, render_json};
 
@@ -63,6 +66,18 @@ pub fn handle(args: ForgetArgs, ctx: &CliContext) -> Result<(), CliError> {
     let installed = common::load_installed_state(ctx, COMMAND)?;
     let resolved = common::lookup_component_name(input, &installed, ctx, COMMAND);
     let target = resolved.as_str();
+
+    // Scope guard: if the component only exists in another scope,
+    // reject with a scope-switch hint instead of a bare "not installed".
+    let view = VisibleInstalledView::load(ctx);
+    if let crate::commands::visible_view::MutationTarget::WrongScope(record) =
+        resolve_mutation_target(MutationOperation::Forget, target, &view)
+    {
+        return Err(CliError::InvalidArgument {
+            command,
+            reason: wrong_scope_reason(MutationOperation::Forget, record),
+        });
+    }
 
     let obj = installed
         .find_object(ObjectKind::Component, target)
@@ -190,6 +205,10 @@ fn persist_forget(
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
+
+    // Normalize state file permissions so non-root users can read
+    // system-scope state after mutation.
+    common::normalize_after_save(ctx, &layout);
 
     // Audit log is best-effort: the state already persisted, so a log failure
     // downgrades to a warning instead of unwinding.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
@@ -196,6 +196,13 @@ pub(crate) fn snapshot_datadir_contract(
 pub(crate) fn write_atomic_text(path: &Path, content: &str) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
+        // Normalize directory permissions so non-root users can traverse
+        // the component-manifests tree.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755));
+        }
     }
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let name = path

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -1366,6 +1366,10 @@ pub(crate) fn execute_raw(
         });
     }
 
+    // Normalize system-scope permissions so non-root users can read
+    // the state file and component manifest snapshots.
+    common::normalize_after_save(ctx, layout);
+
     // Audit log is best-effort: the install already succeeded and state is
     // saved, so a log failure downgrades to a warning instead of unwinding.
     // `log` was opened above for the capability audit and is reused here.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
@@ -597,6 +597,8 @@ pub(crate) fn execute_adopt(
         reason: format!("failed to save state: {err}"),
     })?;
 
+    common::normalize_after_save(ctx, layout);
+
     // Best-effort: snapshot the datadir component contract so adapter commands
     // can discover declared adapters. Missing or unwritable contracts produce
     // warnings, never failures.
@@ -948,6 +950,8 @@ fn persist_delegated_install(
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
+
+    common::normalize_after_save(ctx, layout);
 
     // Best-effort: snapshot the datadir component contract so adapter commands
     // can discover declared adapters. Missing or unwritable contracts produce

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -10,7 +10,6 @@ mod state_view;
 #[cfg(test)]
 mod tests;
 
-use anolisa_core::state::InstalledState;
 use anolisa_platform::pkg_query::PackageQuery;
 use anolisa_platform::rpm_query::RpmPackageQuery;
 use clap::Parser;
@@ -18,12 +17,13 @@ use serde::Serialize;
 
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
-use crate::context::{CliContext, InstallMode};
+use crate::commands::visible_view::VisibleInstalledView;
+use crate::context::CliContext;
 use crate::resolution::{ComponentIndex, ComponentIndexEntry, load_component_index};
 use crate::response::{CliError, render_json};
 
 use self::render::render_human;
-use self::state_view::{LocalProjection, project_component};
+use self::state_view::{LocalProjection, project_visible};
 
 const COMMAND: &str = "list";
 
@@ -34,8 +34,7 @@ pub struct ListArgs {
     pub installed: bool,
 }
 
-// ── Wire / JSON output types ───────────────────────────────────────
-
+/// Wire / JSON output type for one component row.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Row {
     pub name: String,
@@ -46,6 +45,18 @@ pub struct Row {
     pub local_state: String,
     pub ownership: String,
     pub action: String,
+    /// Physical scope of the active record: `"user"` or `"system"`.
+    pub scope: String,
+    /// Whether this row is the active (highest-priority) record.
+    pub active: bool,
+    /// When `active = false`, which scope shadows this record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadowed_by: Option<String>,
+    /// Whether the current user can directly modify this record.
+    pub mutable_by_current_user: bool,
+    /// Path to the `installed.toml` this record came from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rpm_package: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -75,17 +86,29 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
             reason: format!("failed to load component index: {err}"),
         })?;
 
+    // Load current-scope state via fail-fast path so corrupted state
+    // surfaces as an error instead of being silently treated as empty.
     let state = common::load_installed_state(ctx, COMMAND)?;
-    let rpm_query = match ctx.install_mode {
-        InstallMode::System => Some(RpmPackageQuery::system()),
-        InstallMode::User => None,
-    };
-    let rows = build_rows(
-        &index,
-        &args,
-        &state,
-        rpm_query.as_ref().map(|query| query as &dyn PackageQuery),
-    );
+    let view = VisibleInstalledView::load_with_current_state(ctx, &state);
+
+    if !view.system_state_readable() && !ctx.quiet {
+        let color = crate::color::Palette::new(ctx.no_color);
+        if let Some(path) = view.system_state_path() {
+            eprintln!(
+                "{} could not read system state at {}",
+                color.warn("\u{26a0}"),
+                color.path(path.display().to_string()),
+            );
+        } else {
+            eprintln!(
+                "{} system state is not available; showing user-scope records only",
+                color.warn("\u{26a0}"),
+            );
+        }
+    }
+
+    let rpm_query = RpmPackageQuery::system();
+    let rows = build_rows(&index, &args, &view, &rpm_query as &dyn PackageQuery);
 
     if ctx.json {
         return render_json(COMMAND, ListPayload { components: rows });
@@ -100,23 +123,63 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
 fn build_rows(
     index: &ComponentIndex,
     args: &ListArgs,
-    state: &InstalledState,
-    rpm_query: Option<&dyn PackageQuery>,
+    view: &VisibleInstalledView,
+    rpm_query: &dyn PackageQuery,
 ) -> Vec<Row> {
     index
         .components
         .iter()
         .filter_map(|entry| {
-            let projection = project_component(entry, state, rpm_query);
+            let projection = project_visible(entry, view, Some(rpm_query));
             if args.installed && !projection.local_state.matches_installed_filter() {
                 return None;
             }
-            Some(entry_to_row(entry, projection))
+            // Collect scope metadata from the visible view for this component.
+            let records = view.records_for(&entry.name);
+            let active_record = records.first().filter(|r| r.active);
+            let (scope, active, shadowed_by, mutable, state_path) = scope_fields(active_record);
+            Some(entry_to_row(
+                entry,
+                projection,
+                scope,
+                active,
+                shadowed_by,
+                mutable,
+                state_path,
+            ))
         })
         .collect()
 }
 
-fn entry_to_row(entry: &ComponentIndexEntry, projection: LocalProjection) -> Row {
+/// Derive scope-related `Row` fields from the active visible record (if any).
+///
+/// When the component is not in any scope's state (local_state = `not_installed`
+/// or `observed`), scope/active/mutable are filled with defaults because there
+/// is no physical record to attribute them to.
+fn scope_fields(
+    active_record: Option<&&crate::commands::visible_view::VisibleRecord>,
+) -> (String, bool, Option<String>, bool, Option<String>) {
+    match active_record {
+        Some(rec) => (
+            rec.scope.as_str().to_string(),
+            rec.active,
+            rec.shadowed_by.map(|s| s.as_str().to_string()),
+            rec.mutable_by_current_user,
+            Some(rec.state_path.display().to_string()),
+        ),
+        None => ("none".to_string(), false, None, false, None),
+    }
+}
+
+fn entry_to_row(
+    entry: &ComponentIndexEntry,
+    projection: LocalProjection,
+    scope: String,
+    active: bool,
+    shadowed_by: Option<String>,
+    mutable_by_current_user: bool,
+    state_path: Option<String>,
+) -> Row {
     let backends: Vec<String> = entry.backends.iter().map(|b| b.kind.clone()).collect();
     let local_state = projection.local_state.label().to_string();
     let ownership = projection.ownership_label().to_string();
@@ -133,6 +196,11 @@ fn entry_to_row(entry: &ComponentIndexEntry, projection: LocalProjection) -> Row
         local_state,
         ownership,
         action,
+        scope,
+        active,
+        shadowed_by,
+        mutable_by_current_user,
+        state_path,
         rpm_package: projection.rpm_package,
         rpm_evr: projection.rpm_evr,
         rpm_arch: projection.rpm_arch,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
@@ -4,16 +4,18 @@ use crate::commands::tier1::list::Row;
 pub(super) fn human_header(rows: &[Row]) -> String {
     let widths = HumanWidths::for_rows(rows);
     format!(
-        "{:<name_width$}{:<backends_width$}{:<local_state_width$}{:<ownership_width$}{}",
+        "{:<name_width$}{:<backends_width$}{:<local_state_width$}{:<ownership_width$}{:<scope_width$}{}",
         "NAME",
         "BACKENDS",
         "LOCAL STATE",
         "OWNERSHIP",
+        "SCOPE",
         "ACTION",
         name_width = widths.name,
         backends_width = widths.backends,
         local_state_width = widths.local_state,
         ownership_width = widths.ownership,
+        scope_width = widths.scope,
     )
 }
 
@@ -22,6 +24,7 @@ struct HumanWidths {
     backends: usize,
     local_state: usize,
     ownership: usize,
+    scope: usize,
 }
 
 impl HumanWidths {
@@ -55,6 +58,7 @@ impl HumanWidths {
                 .unwrap_or(9)
                 .max(9)
                 + 4,
+            scope: rows.iter().map(|r| r.scope.len()).max().unwrap_or(5).max(5) + 4,
         }
     }
 }
@@ -76,15 +80,17 @@ pub(super) fn render_human(rows: &[Row], no_color: bool) {
             row.backends.join(",")
         };
         println!(
-            "{:<name_width$}{:<backends_width$}{}{:<ownership_width$}{}",
+            "{:<name_width$}{:<backends_width$}{}{:<ownership_width$}{:<scope_width$}{}",
             row.name,
             backend_str,
             pad_right(color.status(&row.local_state), widths.local_state),
             row.ownership,
+            row.scope,
             row.action,
             name_width = widths.name,
             backends_width = widths.backends,
             ownership_width = widths.ownership,
+            scope_width = widths.scope,
         );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/state_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/state_view.rs
@@ -2,6 +2,7 @@ use anolisa_core::state::{InstalledObject, InstalledState, ObjectKind, ObjectSta
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 
 use crate::commands::common;
+use crate::commands::visible_view::VisibleInstalledView;
 use crate::resolution::ComponentIndexEntry;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,6 +92,7 @@ impl LocalProjection {
     }
 }
 
+#[allow(dead_code)] // used by test helpers (projection_for_index)
 pub(super) fn project_component(
     entry: &ComponentIndexEntry,
     state: &InstalledState,
@@ -279,5 +281,25 @@ fn projection_from_observed_rpm(info: PackageInfo) -> LocalProjection {
         rpm_evr: Some(info.version.to_string()),
         rpm_arch: Some(info.arch),
         rpm_source_repo: info.origin,
+    }
+}
+
+/// Project a component from the merged visible view.
+///
+/// Looks up the component's active record in the visible view. If found,
+/// delegates to [`project_tracked_object`]. If not, delegates to
+/// [`project_untracked_entry`] for RPM observed / not_installed detection.
+///
+/// This is the entry point used by `build_rows`; existing tests that call
+/// [`project_component`] directly with a single-scope `InstalledState`
+/// are unaffected.
+pub(super) fn project_visible(
+    entry: &ComponentIndexEntry,
+    view: &VisibleInstalledView,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> LocalProjection {
+    match view.active(&entry.name) {
+        Some(record) => project_tracked_object(&record.object, rpm_query),
+        None => project_untracked_entry(entry, rpm_query),
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
@@ -3,14 +3,19 @@ use anolisa_core::state::{ObjectKind, ObjectStatus};
 use crate::commands::tier1::list::{ListArgs, ListPayload, build_rows};
 use crate::resolution::{ComponentBackendEntry, ComponentIndex, ComponentIndexEntry};
 
-use super::support::{empty_state, sample_index, state_with_object};
+use super::support::{FakeRpmQuery, empty_state, sample_index, state_with_object, view_from_state};
 
 #[test]
 fn index_builds_rows() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = empty_state();
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     assert_eq!(rows.len(), 2);
 
     let sight = &rows[0];
@@ -30,7 +35,12 @@ fn empty_state_all_not_installed() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = empty_state();
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     for row in &rows {
         assert_eq!(row.status, "not_installed");
         assert_eq!(row.local_state, "not_installed");
@@ -42,7 +52,12 @@ fn installed_component_shows_installed() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
 
     let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.status, "not_installed");
@@ -56,7 +71,12 @@ fn adopted_rpm_component_shows_adopted() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
 
     let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.status, "adopted");
@@ -68,7 +88,12 @@ fn compatibility_status_labels_are_preserved_before_local_projection() {
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
 
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
 
     let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.status, "adopted");
@@ -81,7 +106,12 @@ fn adapter_object_does_not_mark_component_installed() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Adapter, "tokenless", ObjectStatus::Installed);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
     assert_eq!(token.status, "not_installed");
 }
@@ -91,7 +121,12 @@ fn failed_component_shows_failed() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Failed);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
     assert_eq!(token.status, "failed");
 }
@@ -101,7 +136,12 @@ fn disabled_component_shows_disabled() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Disabled);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
     assert_eq!(token.status, "disabled");
 }
@@ -111,7 +151,12 @@ fn installed_filter_returns_only_installed() {
     let index = sample_index();
     let args = ListArgs { installed: true };
     let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].name, "tokenless");
     assert_eq!(rows[0].status, "installed");
@@ -122,7 +167,12 @@ fn installed_filter_includes_adopted_rpm_components() {
     let index = sample_index();
     let args = ListArgs { installed: true };
     let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].name, "agentsight");
     assert_eq!(rows[0].status, "adopted");
@@ -133,7 +183,12 @@ fn installed_filter_with_empty_state_returns_empty() {
     let index = sample_index();
     let args = ListArgs { installed: true };
     let state = empty_state();
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     assert!(rows.is_empty());
 }
 
@@ -142,7 +197,12 @@ fn json_payload_uses_components_key() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = empty_state();
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     let payload = ListPayload { components: rows };
     let json_str = serde_json::to_string(&payload).expect("serialize");
     let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
@@ -154,7 +214,12 @@ fn json_payload_status_reflects_install_state() {
     let index = sample_index();
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Installed);
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     let payload = ListPayload { components: rows };
     let json_str = serde_json::to_string(&payload).expect("serialize");
     let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
@@ -187,7 +252,12 @@ fn missing_optional_fields_use_defaults() {
     };
     let args = ListArgs { installed: false };
     let state = empty_state();
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.name, "minimal");
@@ -218,6 +288,11 @@ fn unknown_backend_kind_preserved() {
     };
     let args = ListArgs { installed: false };
     let state = empty_state();
-    let rows = build_rows(&index, &args, &state, None);
+    let rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     assert_eq!(rows[0].backends, vec!["custom-repo"]);
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
@@ -3,7 +3,7 @@ use anolisa_core::state::InstalledState;
 use crate::commands::tier1::list::render::human_header;
 use crate::commands::tier1::list::{ListArgs, ListPayload, Row, build_rows};
 
-use super::support::{FakeRpmQuery, pkg_info, sample_index};
+use super::support::{FakeRpmQuery, pkg_info, sample_index, view_from_state};
 
 #[test]
 fn row_json_retains_status_and_adds_local_fields() {
@@ -18,7 +18,7 @@ fn row_json_retains_status_and_adds_local_fields() {
         command_missing: false,
         what_provides: Vec::new(),
     };
-    let rows = build_rows(&index, &args, &state, Some(&query));
+    let rows = build_rows(&index, &args, &view_from_state(&state), &query);
     let payload = ListPayload { components: rows };
 
     let json_str = serde_json::to_string(&payload).expect("serialize");
@@ -47,6 +47,11 @@ fn human_header_contains_local_state() {
         local_state: "observed".to_string(),
         ownership: "none".to_string(),
         action: "install".to_string(),
+        scope: "none".to_string(),
+        active: false,
+        shadowed_by: None,
+        mutable_by_current_user: false,
+        state_path: None,
         rpm_package: Some("agentsight".to_string()),
         rpm_evr: Some("1.2.3-1.al8".to_string()),
         rpm_arch: Some("x86_64".to_string()),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/rows.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/rows.rs
@@ -4,7 +4,7 @@ use crate::commands::tier1::list::{ListArgs, build_rows};
 
 use super::support::{
     FakeRpmQuery, component_object, pkg_info, rpm_component_object, sample_index,
-    state_with_component_object,
+    state_with_component_object, view_from_state,
 };
 
 #[test]
@@ -21,7 +21,7 @@ fn rows_use_local_projection_for_untracked_observed_rpm() {
         what_provides: Vec::new(),
     };
 
-    let rows = build_rows(&index, &args, &state, Some(&query));
+    let rows = build_rows(&index, &args, &view_from_state(&state), &query);
 
     let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.status, "not_installed");
@@ -35,13 +35,23 @@ fn rows_without_rpm_query_do_not_surface_observed_system_rpms() {
     let index = sample_index();
     let state = InstalledState::default();
 
-    let all_rows = build_rows(&index, &ListArgs { installed: false }, &state, None);
+    let all_rows = build_rows(
+        &index,
+        &ListArgs { installed: false },
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     let sight = all_rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.local_state, "not_installed");
     assert_eq!(sight.ownership, "none");
     assert_eq!(sight.rpm_package, None);
 
-    let installed_rows = build_rows(&index, &ListArgs { installed: true }, &state, None);
+    let installed_rows = build_rows(
+        &index,
+        &ListArgs { installed: true },
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     assert!(installed_rows.is_empty());
 }
 
@@ -56,7 +66,7 @@ fn rows_ignore_rpm_query_failures() {
         what_provides: Vec::new(),
     };
 
-    let rows = build_rows(&index, &args, &state, Some(&query));
+    let rows = build_rows(&index, &args, &view_from_state(&state), &query);
 
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|row| row.local_state == "not_installed"));
@@ -82,7 +92,7 @@ fn rows_use_status_action_for_tracked_rpm_observed_state() {
         what_provides: Vec::new(),
     };
 
-    let rows = build_rows(&index, &args, &state, Some(&query));
+    let rows = build_rows(&index, &args, &view_from_state(&state), &query);
 
     let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.status, "adopted");
@@ -109,7 +119,7 @@ fn rows_project_raw_and_rpm_managed_state_as_installed() {
         ObjectStatus::Installed,
         Ownership::RawManaged,
     ));
-    let raw_rows = build_rows(&index, &args, &raw_state, Some(&query));
+    let raw_rows = build_rows(&index, &args, &view_from_state(&raw_state), &query);
     let token = raw_rows.iter().find(|r| r.name == "tokenless").unwrap();
     assert_eq!(token.local_state, "installed");
     assert_eq!(token.ownership, "raw-managed");
@@ -121,7 +131,7 @@ fn rows_project_raw_and_rpm_managed_state_as_installed() {
         "agentsight",
         "1.2.3-1.al8",
     ));
-    let rpm_rows = build_rows(&index, &args, &rpm_state, Some(&query));
+    let rpm_rows = build_rows(&index, &args, &view_from_state(&rpm_state), &query);
     let sight = rpm_rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.local_state, "installed");
     assert_eq!(sight.ownership, "rpm-managed");
@@ -142,15 +152,15 @@ fn rows_surface_rpm_drift_and_missing() {
     let drifted_rows = build_rows(
         &index,
         &args,
-        &state,
-        Some(&FakeRpmQuery {
+        &view_from_state(&state),
+        &FakeRpmQuery {
             installed: vec![(
                 "agentsight".to_string(),
                 pkg_info("agentsight", "2.0.0", Some("1.al8"), "x86_64"),
             )],
             command_missing: false,
             what_provides: Vec::new(),
-        }),
+        },
     );
     let drifted = drifted_rows
         .iter()
@@ -158,7 +168,12 @@ fn rows_surface_rpm_drift_and_missing() {
         .unwrap();
     assert_eq!(drifted.local_state, "drifted");
 
-    let missing_rows = build_rows(&index, &args, &state, Some(&FakeRpmQuery::default()));
+    let missing_rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&state),
+        &FakeRpmQuery::default(),
+    );
     let missing = missing_rows
         .iter()
         .find(|r| r.name == "agentsight")
@@ -174,15 +189,15 @@ fn installed_filter_keeps_only_currently_installed_local_states() {
     let observed_rows = build_rows(
         &index,
         &args,
-        &InstalledState::default(),
-        Some(&FakeRpmQuery {
+        &view_from_state(&InstalledState::default()),
+        &FakeRpmQuery {
             installed: vec![(
                 "agentsight".to_string(),
                 pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
             )],
             command_missing: false,
             what_provides: Vec::new(),
-        }),
+        },
     );
     assert_eq!(
         observed_rows
@@ -199,7 +214,12 @@ fn installed_filter_keeps_only_currently_installed_local_states() {
     ];
     for (status, ownership, expected_state) in included_cases {
         let state = state_with_component_object(component_object("tokenless", status, ownership));
-        let rows = build_rows(&index, &args, &state, Some(&FakeRpmQuery::default()));
+        let rows = build_rows(
+            &index,
+            &args,
+            &view_from_state(&state),
+            &FakeRpmQuery::default(),
+        );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].local_state, expected_state);
     }
@@ -210,7 +230,12 @@ fn installed_filter_keeps_only_currently_installed_local_states() {
             status,
             Ownership::RawManaged,
         ));
-        let rows = build_rows(&index, &args, &state, Some(&FakeRpmQuery::default()));
+        let rows = build_rows(
+            &index,
+            &args,
+            &view_from_state(&state),
+            &FakeRpmQuery::default(),
+        );
         assert!(rows.is_empty());
     }
 
@@ -224,26 +249,31 @@ fn installed_filter_keeps_only_currently_installed_local_states() {
     let drifted_rows = build_rows(
         &index,
         &args,
-        &rpm_state,
-        Some(&FakeRpmQuery {
+        &view_from_state(&rpm_state),
+        &FakeRpmQuery {
             installed: vec![(
                 "agentsight".to_string(),
                 pkg_info("agentsight", "2.0.0", Some("1.al8"), "x86_64"),
             )],
             command_missing: false,
             what_provides: Vec::new(),
-        }),
+        },
     );
     assert!(drifted_rows.is_empty());
 
-    let missing_rows = build_rows(&index, &args, &rpm_state, Some(&FakeRpmQuery::default()));
+    let missing_rows = build_rows(
+        &index,
+        &args,
+        &view_from_state(&rpm_state),
+        &FakeRpmQuery::default(),
+    );
     assert!(missing_rows.is_empty());
 
     let empty_rows = build_rows(
         &index,
         &args,
-        &InstalledState::default(),
-        Some(&FakeRpmQuery::default()),
+        &view_from_state(&InstalledState::default()),
+        &FakeRpmQuery::default(),
     );
     assert!(empty_rows.is_empty());
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
@@ -1,9 +1,13 @@
+use std::path::PathBuf;
+
 use anolisa_core::state::{
     InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership, RpmMetadata,
 };
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError, PackageVersion};
 
 use crate::commands::tier1::list::state_view::{self, LocalProjection};
+use crate::commands::visible_view::VisibleInstalledView;
+use crate::context::{CliContext, InstallMode};
 use crate::resolution::{
     ComponentAliasEntry, ComponentBackendEntry, ComponentIndex, ComponentIndexEntry,
 };
@@ -221,6 +225,30 @@ pub(super) fn projection_for_index(
         .find(|entry| entry.name == component)
         .unwrap();
     state_view::project_component(entry, state, Some(query))
+}
+
+/// Wrap a single-scope `InstalledState` into a `VisibleInstalledView` for
+/// tests that exercise `build_rows`. The state is placed in user scope with
+/// system scope empty (and unreadable), matching the most common test
+/// scenario where the state represents the current user's install.
+pub(super) fn view_from_state(state: &InstalledState) -> VisibleInstalledView {
+    let ctx = CliContext {
+        install_mode: InstallMode::User,
+        prefix: None,
+        json: false,
+        dry_run: false,
+        verbose: false,
+        quiet: true,
+        no_color: true,
+    };
+    VisibleInstalledView::from_states(
+        state,
+        &InstalledState::default(),
+        PathBuf::from("/test/user/installed.toml"),
+        PathBuf::from("/test/system/installed.toml"),
+        false,
+        &ctx,
+    )
 }
 
 /// A component whose RPM backend package name differs from the component name,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -54,12 +54,23 @@ use crate::color::{Palette, pad_right};
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::rpm_package_candidates_with_index;
-use crate::context::{CliContext, InstallMode};
+use crate::commands::visible_view::{Scope, VisibleInstalledView};
+use crate::context::CliContext;
 use crate::repo_config::BackendConfig;
 use crate::resolution::{ComponentIndex, ResolutionUse, load_optional_component_index};
 use crate::response::{CliError, render_json};
 
 const COMMAND: &str = "status";
+
+/// Serde helper: skip `scope` when it's the default empty string.
+fn scope_is_default(s: &str) -> bool {
+    s.is_empty()
+}
+
+/// Serde helper: skip `mutable_by_current_user` when `false`.
+fn skip_default_bool(b: &bool) -> bool {
+    !b
+}
 
 #[derive(Parser)]
 pub struct StatusArgs {
@@ -125,6 +136,25 @@ pub(crate) struct ComponentRecord {
     /// install. Empty when no packages were provisioned.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) provisioned_packages: Vec<String>,
+    /// Physical scope of the active record: `"user"`, `"system"`, or
+    /// `"none"` for synthetic not_installed / observed records.
+    #[serde(
+        default,
+        skip_serializing_if = "crate::commands::tier1::status::scope_is_default"
+    )]
+    pub(crate) scope: String,
+    /// Whether the current user can directly modify this record.
+    #[serde(
+        default,
+        skip_serializing_if = "crate::commands::tier1::status::skip_default_bool"
+    )]
+    pub(crate) mutable_by_current_user: bool,
+    /// When the record is shadowed by a higher-priority scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) shadowed_by: Option<String>,
+    /// Path to the `installed.toml` this record came from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) state_path: Option<String>,
 }
 
 pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
@@ -140,6 +170,26 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     let adapter_scan = common::build_adapter_manager(ctx).scan().ok();
 
+    // Visible installed view: merges user + system state so read commands
+    // see components from both scopes. Pass the already-migrated
+    // current-scope state so v3 symlink migration is reflected in the view.
+    let view = VisibleInstalledView::load_with_current_state(ctx, &state);
+    if !view.system_state_readable() && !ctx.quiet {
+        let color = Palette::new(ctx.no_color);
+        if let Some(path) = view.system_state_path() {
+            eprintln!(
+                "{} could not read system state at {}",
+                color.warn("\u{26a0}"),
+                color.path(path.display().to_string()),
+            );
+        } else {
+            eprintln!(
+                "{} system state is not available; showing user-scope records only",
+                color.warn("\u{26a0}"),
+            );
+        }
+    }
+
     let query = RpmPackageQuery::system();
     let selected_component = args
         .component
@@ -149,7 +199,7 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     // repo_config / component_index are still needed for the observed-record
     // probe below (system mode only). Name resolution above is handled by
     // common::lookup_component_name which loads its own config.
-    let repo_config = (ctx.install_mode == InstallMode::System && args.component.is_some())
+    let repo_config = (args.component.is_some())
         .then(|| {
             common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort).ok()
         })
@@ -160,9 +210,10 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
         .as_ref()
         .and_then(|cfg| load_optional_component_index(&layout, &env, cfg));
 
-    let mut records = select_components(
-        &state,
+    let mut records = select_components_from_view(
+        &view,
         &layout,
+        ctx,
         catalog.as_ref(),
         install_mode,
         selected_component.as_deref(),
@@ -170,11 +221,10 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     );
 
     // Read-only Observed report (§8): when a named component is absent from
-    // ANOLISA state but present in rpmdb (system mode), upgrade the synthetic
+    // ANOLISA state but present in rpmdb, upgrade the synthetic
     // `not_installed` row to `observed` with the package/EVR/repo. This never
     // writes state — adopting is `install`'s job.
     if let Some(target) = selected_component.as_deref()
-        && ctx.install_mode == InstallMode::System
         && records.len() == 1
         && records[0].status == "not_installed"
     {
@@ -189,7 +239,7 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     // and override the wire status with `drifted` / `missing` on divergence.
     // Like the observed report above this stays strictly read-only — it adjusts
     // only the wire records, never `installed.toml`.
-    apply_rpm_drift(&mut records, &state, &query);
+    apply_rpm_drift_from_view(&mut records, &view, &query);
 
     if ctx.json {
         let data = serde_json::json!({ "components": records });
@@ -248,8 +298,146 @@ pub(crate) fn select_components(
                 rpm_evr: None,
                 rpm_source_repo: None,
                 provisioned_packages: Vec::new(),
+                scope: String::new(),
+                mutable_by_current_user: false,
+                shadowed_by: None,
+                state_path: None,
             }],
         },
+    }
+}
+
+/// Like [`select_components`] but projects from the merged
+/// [`VisibleInstalledView`] instead of a single-scope [`InstalledState`].
+///
+/// Active records from both user and system scope are visible. Each
+/// record carries its physical scope, mutability flag, and shadow status
+/// from the visible view.
+///
+/// When a specific `name` is requested but not found in any scope, a
+/// synthetic `not_installed` record is returned (same as the single-scope
+/// variant).
+fn select_components_from_view(
+    view: &VisibleInstalledView,
+    layout: &FsLayout,
+    ctx: &CliContext,
+    catalog: Option<&Catalog>,
+    install_mode: &str,
+    name: Option<&str>,
+    adapter_scan: Option<&[ScanEntry]>,
+) -> Vec<ComponentRecord> {
+    let active: Vec<_> = view.active_records().collect();
+
+    // Compute the system layout once for cross-scope records. When a
+    // user-mode status views a system-scope component, the integrity
+    // probe must use the system layout so path validation succeeds —
+    // file paths like /usr/local/bin/tokenless are out of bounds
+    // relative to the user layout's ~/.local roots.
+    let system_layout = common::system_layout(ctx);
+    let layout_for = |scope: Scope| -> &FsLayout {
+        match scope {
+            Scope::System => &system_layout,
+            Scope::User => layout,
+        }
+    };
+
+    match name {
+        None => active
+            .iter()
+            .map(|rec| {
+                let mut cr =
+                    record_from_object(layout_for(rec.scope), catalog, install_mode, &rec.object);
+                cr.adapters = adapter_summaries_for(&rec.object.name, adapter_scan);
+                cr.scope = rec.scope.as_str().to_string();
+                cr.mutable_by_current_user = rec.mutable_by_current_user;
+                cr.shadowed_by = rec.shadowed_by.map(|s| s.as_str().to_string());
+                cr.state_path = Some(rec.state_path.display().to_string());
+                cr
+            })
+            .collect(),
+        Some(target) => {
+            // Look up the component in the visible view's active records.
+            if let Some(rec) = view.active(target) {
+                let mut cr =
+                    record_from_object(layout_for(rec.scope), catalog, install_mode, &rec.object);
+                cr.adapters = adapter_summaries_for(&rec.object.name, adapter_scan);
+                cr.scope = rec.scope.as_str().to_string();
+                cr.mutable_by_current_user = rec.mutable_by_current_user;
+                cr.shadowed_by = rec.shadowed_by.map(|s| s.as_str().to_string());
+                cr.state_path = Some(rec.state_path.display().to_string());
+                vec![cr]
+            } else {
+                vec![ComponentRecord {
+                    name: target.to_string(),
+                    status: "not_installed".to_string(),
+                    version: None,
+                    installed_at: None,
+                    last_operation_id: None,
+                    enabled_features: Vec::new(),
+                    health: Vec::new(),
+                    adapters: Vec::new(),
+                    rpm_package: None,
+                    rpm_evr: None,
+                    rpm_source_repo: None,
+                    provisioned_packages: Vec::new(),
+                    scope: String::new(),
+                    mutable_by_current_user: false,
+                    shadowed_by: None,
+                    state_path: None,
+                }]
+            }
+        }
+    }
+}
+
+/// Like [`apply_rpm_drift`] but reads RPM metadata from the merged
+/// [`VisibleInstalledView`] instead of a single-scope [`InstalledState`].
+fn apply_rpm_drift_from_view(
+    records: &mut [ComponentRecord],
+    view: &VisibleInstalledView,
+    query: &dyn PackageQuery,
+) {
+    // Index RPM metadata by component name from active visible records.
+    // Only active records are rendered, so drift detection must use their
+    // metadata — not shadowed records from a lower-priority scope.
+    let rpm_meta: std::collections::HashMap<&str, &RpmMetadata> = view
+        .active_records()
+        .filter_map(|r| {
+            r.object
+                .rpm_metadata
+                .as_ref()
+                .map(|m| (r.component.as_str(), m))
+        })
+        .collect();
+    if rpm_meta.is_empty() {
+        return;
+    }
+    let checked_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    for record in records.iter_mut() {
+        if !matches!(record.status.as_str(), "installed" | "adopted") {
+            continue;
+        }
+        let Some(&meta) = rpm_meta.get(record.name.as_str()) else {
+            continue;
+        };
+        let (status, reason) = match probe_rpm_drift(meta, query) {
+            Some(RpmDrift::Drifted { reason }) => ("drifted", reason),
+            Some(RpmDrift::Missing) => (
+                "missing",
+                format!(
+                    "package {} recorded in ANOLISA state is no longer present in rpmdb",
+                    meta.package_name
+                ),
+            ),
+            None => continue,
+        };
+        record.status = status.to_string();
+        record.health.push(HealthEntry {
+            name: "rpm:drift".to_string(),
+            status: status.to_string(),
+            checked_at: checked_at.clone(),
+            reason: Some(reason),
+        });
     }
 }
 
@@ -298,6 +486,10 @@ fn observed_record(
             rpm_evr: Some(evr),
             rpm_source_repo: source_repo,
             provisioned_packages: Vec::new(),
+            scope: String::new(),
+            mutable_by_current_user: false,
+            shadowed_by: None,
+            state_path: None,
         });
     }
     None
@@ -375,6 +567,7 @@ pub(crate) fn probe_rpm_drift(meta: &RpmMetadata, query: &dyn PackageQuery) -> O
 /// must not mask, so they are left untouched (the divergence still shows up in
 /// `repair`). Objects without RPM metadata (raw installs, legacy rows with no
 /// recorded package name) never reach the rpmdb probe.
+#[allow(dead_code)] // doctor will use this when it adopts the visible view
 fn apply_rpm_drift(
     records: &mut [ComponentRecord],
     state: &InstalledState,
@@ -505,6 +698,10 @@ fn record_from_object(
         rpm_evr,
         rpm_source_repo,
         provisioned_packages: obj.provisioned_packages.clone(),
+        scope: String::new(),
+        mutable_by_current_user: false,
+        shadowed_by: None,
+        state_path: None,
     }
 }
 
@@ -2345,6 +2542,10 @@ mod tests {
             rpm_evr: None,
             rpm_source_repo: None,
             provisioned_packages: Vec::new(),
+            scope: String::new(),
+            mutable_by_current_user: false,
+            shadowed_by: None,
+            state_path: None,
         };
         let json = serde_json::to_value(&record).expect("serialize");
         assert!(
@@ -2861,6 +3062,10 @@ name = "copilot-shell"
             rpm_evr: None,
             rpm_source_repo: None,
             provisioned_packages: Vec::new(),
+            scope: String::new(),
+            mutable_by_current_user: false,
+            shadowed_by: None,
+            state_path: None,
         }];
         // rpmdb has drifted, but the failed status must survive untouched.
         let q = FakeQuery {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -70,6 +70,9 @@ use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use crate::color::Palette;
 use crate::commands::common;
+use crate::commands::visible_view::{
+    MutationOperation, VisibleInstalledView, resolve_mutation_target, wrong_scope_reason,
+};
 use crate::context::CliContext;
 use crate::response::{CliError, render_json};
 
@@ -136,6 +139,18 @@ pub(crate) fn handle_with_deps(
     // resolution is ambiguous or the component index is unavailable.
     let resolved = common::lookup_component_name(input, &installed, ctx, COMMAND);
     let target = resolved.as_str();
+
+    // Scope guard: if the component only exists in another scope,
+    // reject with a scope-switch hint instead of a bare "not installed".
+    let view = VisibleInstalledView::load(ctx);
+    if let crate::commands::visible_view::MutationTarget::WrongScope(record) =
+        resolve_mutation_target(MutationOperation::Uninstall, target, &view)
+    {
+        return Err(CliError::InvalidArgument {
+            command,
+            reason: wrong_scope_reason(MutationOperation::Uninstall, record),
+        });
+    }
 
     // A name that only matches a legacy `kind = "capability"` row written
     // by an older release is not uninstallable — say so instead of a bare
@@ -649,6 +664,10 @@ fn uninstall_rpm_component(
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
+
+    // Normalize state file permissions so non-root users can read
+    // system-scope state after mutation.
+    common::normalize_after_save(ctx, &layout);
 
     // Audit log is best-effort: the state already persisted, so a log failure
     // downgrades to a warning instead of unwinding.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -67,6 +67,9 @@ use super::install::{
 use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
+use crate::commands::visible_view::{
+    MutationOperation, VisibleInstalledView, resolve_mutation_target, wrong_scope_reason,
+};
 use crate::context::CliContext;
 use crate::repo_config::{HostVars, RepoConfig};
 use crate::response::{self, CliError};
@@ -170,6 +173,19 @@ fn handle_component_update(component: &str, ctx: &CliContext) -> Result<(), CliE
     let command = format!("update {component}");
     let installed = common::load_installed_state(ctx, COMMAND)?;
     let resolved = common::lookup_component_name(component, &installed, ctx, COMMAND);
+
+    // Scope guard: if the component only exists in another scope,
+    // reject with a scope-switch hint instead of a bare "not installed".
+    let view = VisibleInstalledView::load(ctx);
+    if let crate::commands::visible_view::MutationTarget::WrongScope(record) =
+        resolve_mutation_target(MutationOperation::Update, &resolved, &view)
+    {
+        return Err(CliError::InvalidArgument {
+            command,
+            reason: wrong_scope_reason(MutationOperation::Update, record),
+        });
+    }
+
     let target = resolve_update_target(&resolved, ctx, &command)?;
     let layout = common::resolve_layout(ctx);
     let repo_config = common::load_repo_config(ctx, &layout, &command, RepoPersistPolicy::Require)?;
@@ -932,6 +948,7 @@ fn execute_raw_update(
     }
     let _ = tx.mark_done(persist_idx);
     let _ = tx.finish(TransactionOutcomeStatus::Ok);
+    common::normalize_after_save(ctx, layout);
 
     // Phase 5 — apply external post-commit side effects after state is durable.
     // Capability xattrs and running systemd processes are not covered by the
@@ -984,6 +1001,8 @@ fn execute_raw_update(
                 activation_state_warnings.push(format!(
                     "failed to persist service activation result after update: {err}"
                 ));
+            } else {
+                common::normalize_after_save(ctx, layout);
             }
         }
     }
@@ -1393,6 +1412,10 @@ fn persist_rpm_update(
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
+
+    // Normalize state file permissions so non-root users can read
+    // system-scope state after mutation.
+    common::normalize_after_save(ctx, &layout);
 
     // Audit log is best-effort: the update already persisted, so a log failure
     // downgrades to a warning instead of unwinding.

--- a/src/anolisa/crates/anolisa-cli/src/commands/visible_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/visible_view.rs
@@ -1,0 +1,506 @@
+//! Visible installed-state merge model.
+//!
+//! Read-only view that merges user-scope and system-scope `installed.toml`
+//! so that read commands (`list`, `status`) show every component visible
+//! to the current user — regardless of which physical scope owns the record.
+//!
+//! ## Merge rules
+//!
+//! - User state has higher priority than system state.
+//! - When the same component name exists in both scopes, the user record is
+//!   **active** and the system record is **shadowed**.
+//! - System state is always read best-effort: a missing or unreadable file
+//!   is not an error — it simply yields no system records.
+//! - `mutable_by_current_user` is `true` when the record's scope matches the
+//!   current [`CliContext`] install mode, meaning the user can directly
+//!   modify that record through a mutation command.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anolisa_core::state::{InstalledObject, InstalledState, ObjectKind};
+use anolisa_platform::fs_layout::FsLayout;
+use serde::Serialize;
+
+use crate::context::{CliContext, InstallMode};
+use crate::packaged;
+
+/// Physical scope of an installed record.
+///
+/// Maps 1:1 to the on-disk `installed.toml` file the record came from:
+/// `user` → `~/.local/state/anolisa/installed.toml`,
+/// `system` → `/var/lib/anolisa/installed.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Scope {
+    /// Per-user (`file-hierarchy(7)`) install scope.
+    User,
+    /// System-wide FHS install scope.
+    System,
+}
+
+impl Scope {
+    /// Wire label (`"user"` or `"system"`).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Scope::User => "user",
+            Scope::System => "system",
+        }
+    }
+}
+
+/// Convert a CLI [`InstallMode`] to a [`Scope`].
+fn install_mode_to_scope(mode: InstallMode) -> Scope {
+    match mode {
+        InstallMode::User => Scope::User,
+        InstallMode::System => Scope::System,
+    }
+}
+
+/// One visible record in the merged view, corresponding to a single
+/// `(component, scope)` pair.
+///
+/// If the same component exists in both scopes, the user-scope record has
+/// `active = true` and the system-scope record has
+/// `active = false, shadowed_by = Some(Scope::User)`.
+#[derive(Debug, Clone)]
+pub struct VisibleRecord {
+    /// Canonical component name.
+    pub component: String,
+    /// Physical scope this record comes from.
+    pub scope: Scope,
+    /// Path to the `installed.toml` file this record was loaded from.
+    pub state_path: PathBuf,
+    /// The underlying installed object from state.
+    pub object: InstalledObject,
+    /// Whether this is the active (highest-priority) record for the
+    /// component. `true` for the user record when both scopes have the
+    /// component; `true` for the sole record when only one scope has it.
+    pub active: bool,
+    /// When `active = false`, which scope's record shadows this one.
+    pub shadowed_by: Option<Scope>,
+    /// Whether the current user can directly modify this record through a
+    /// mutation command. `true` when the record's scope matches
+    /// `ctx.install_mode`.
+    pub mutable_by_current_user: bool,
+    /// Read-only datadir roots where component contracts / adapter payloads
+    /// for this scope can be found. Does not imply the current user owns
+    /// these files.
+    #[allow(dead_code)] // Phase 2/3 will consume this for payload discovery
+    pub payload_roots: Vec<PathBuf>,
+}
+
+/// Merged read-only view of user-scope and system-scope install state.
+///
+/// Built once per read command invocation via [`VisibleInstalledView::load`].
+/// Commands query the view through [`records`](Self::records),
+/// [`active`](Self::active), and
+/// [`records_for`](Self::records_for) rather than loading
+/// `installed.toml` themselves.
+///
+/// System-state read failures are non-fatal: the view is constructed with
+/// whatever state was readable, and [`system_state_readable`] reports
+/// whether the system `installed.toml` was successfully loaded.
+///
+/// [`system_state_readable`]: Self::system_state_readable
+#[derive(Debug)]
+pub struct VisibleInstalledView {
+    records: Vec<VisibleRecord>,
+    system_state_readable: bool,
+    system_state_path: Option<PathBuf>,
+}
+
+impl VisibleInstalledView {
+    /// Load both user-scope and system-scope state and merge them.
+    ///
+    /// User state is loaded from the user layout's `state_dir`; system state
+    /// from the system layout's `state_dir`. A missing or unreadable system
+    /// state file is not an error — it simply produces no system records.
+    pub fn load(ctx: &CliContext) -> Self {
+        let env = anolisa_env::EnvService::detect();
+        let user_layout = FsLayout::user(env.home);
+        let system_layout = FsLayout::system(ctx.prefix.clone());
+
+        let user_state = load_state_from(&user_layout.state_dir);
+        let (system_state, system_readable) = load_system_state(&system_layout.state_dir);
+
+        let user_payload_roots = collect_payload_roots(&user_layout);
+        let system_payload_roots = collect_payload_roots(&system_layout);
+
+        let user_state_path = user_layout.state_dir.join("installed.toml");
+        let system_state_path = system_layout.state_dir.join("installed.toml");
+
+        let mut records = Vec::new();
+
+        // Collect component names from both scopes (user first for stable
+        // ordering).
+        let mut seen_names: HashSet<String> = HashSet::new();
+
+        // User records first — they have higher priority.
+        for obj in user_state
+            .objects
+            .iter()
+            .filter(|o| o.kind == ObjectKind::Component)
+        {
+            seen_names.insert(obj.name.clone());
+            let active = true; // user record is always active unless a later
+            // pass finds a conflict (it can't — user wins).
+            records.push(VisibleRecord {
+                component: obj.name.clone(),
+                scope: Scope::User,
+                state_path: user_state_path.clone(),
+                object: obj.clone(),
+                active,
+                shadowed_by: None,
+                mutable_by_current_user: install_mode_to_scope(ctx.install_mode) == Scope::User,
+                payload_roots: user_payload_roots.clone(),
+            });
+        }
+
+        // System records — shadowed when the same name exists in user state.
+        for obj in system_state
+            .objects
+            .iter()
+            .filter(|o| o.kind == ObjectKind::Component)
+        {
+            let shadowed = seen_names.contains(&obj.name);
+            records.push(VisibleRecord {
+                component: obj.name.clone(),
+                scope: Scope::System,
+                state_path: system_state_path.clone(),
+                object: obj.clone(),
+                active: !shadowed,
+                shadowed_by: shadowed.then_some(Scope::User),
+                mutable_by_current_user: install_mode_to_scope(ctx.install_mode) == Scope::System,
+                payload_roots: system_payload_roots.clone(),
+            });
+        }
+
+        Self {
+            records,
+            system_state_readable: system_readable,
+            system_state_path: system_readable.then_some(system_state_path),
+        }
+    }
+
+    /// Build a view from explicit state objects — used in tests and by
+    /// [`load_with_current_state`].
+    ///
+    /// `user_state_path` / `system_state_path` are recorded on each record
+    /// for diagnostics. `system_readable` indicates whether the system
+    /// state file was loadable.
+    pub(crate) fn from_states(
+        user_state: &InstalledState,
+        system_state: &InstalledState,
+        user_state_path: PathBuf,
+        system_state_path: PathBuf,
+        system_readable: bool,
+        ctx: &CliContext,
+    ) -> Self {
+        let mut records = Vec::new();
+        let mut seen_names: HashSet<String> = HashSet::new();
+
+        for obj in user_state
+            .objects
+            .iter()
+            .filter(|o| o.kind == ObjectKind::Component)
+        {
+            seen_names.insert(obj.name.clone());
+            records.push(VisibleRecord {
+                component: obj.name.clone(),
+                scope: Scope::User,
+                state_path: user_state_path.clone(),
+                object: obj.clone(),
+                active: true,
+                shadowed_by: None,
+                mutable_by_current_user: install_mode_to_scope(ctx.install_mode) == Scope::User,
+                payload_roots: Vec::new(),
+            });
+        }
+
+        for obj in system_state
+            .objects
+            .iter()
+            .filter(|o| o.kind == ObjectKind::Component)
+        {
+            let shadowed = seen_names.contains(&obj.name);
+            records.push(VisibleRecord {
+                component: obj.name.clone(),
+                scope: Scope::System,
+                state_path: system_state_path.clone(),
+                object: obj.clone(),
+                active: !shadowed,
+                shadowed_by: shadowed.then_some(Scope::User),
+                mutable_by_current_user: install_mode_to_scope(ctx.install_mode) == Scope::System,
+                payload_roots: Vec::new(),
+            });
+        }
+
+        Self {
+            records,
+            system_state_readable: system_readable,
+            system_state_path: system_readable.then_some(system_state_path),
+        }
+    }
+
+    /// Load the view, using a pre-loaded current-scope state instead of
+    /// reading it from disk.
+    ///
+    /// Used by `list` and `status` which perform v3 symlink migration on
+    /// the in-memory state before rendering. The other scope's state is
+    /// loaded from disk and also migrated so that cross-scope pre-v4
+    /// symlink entries are upgraded before the integrity probe.
+    pub fn load_with_current_state(ctx: &CliContext, current_state: &InstalledState) -> Self {
+        let env = anolisa_env::EnvService::detect();
+        let user_layout = FsLayout::user(env.home);
+        let system_layout = FsLayout::system(ctx.prefix.clone());
+
+        let user_state_path = user_layout.state_dir.join("installed.toml");
+        let system_state_path = system_layout.state_dir.join("installed.toml");
+
+        match install_mode_to_scope(ctx.install_mode) {
+            Scope::User => {
+                let (mut system_state, system_readable) =
+                    load_system_state(&system_layout.state_dir);
+                if system_readable {
+                    crate::commands::common::migrate_v3_symlinks(&mut system_state, &system_layout);
+                }
+                Self::from_states(
+                    current_state,
+                    &system_state,
+                    user_state_path,
+                    system_state_path,
+                    system_readable,
+                    ctx,
+                )
+            }
+            Scope::System => {
+                let mut user_state = load_state_from(&user_layout.state_dir);
+                crate::commands::common::migrate_v3_symlinks(&mut user_state, &user_layout);
+                Self::from_states(
+                    &user_state,
+                    current_state,
+                    user_state_path,
+                    system_state_path,
+                    true,
+                    ctx,
+                )
+            }
+        }
+    }
+
+    /// All visible records (both scopes, active and shadowed).
+    #[allow(dead_code)] // Phase 2 will consume this for scope guards
+    pub fn records(&self) -> &[VisibleRecord] {
+        &self.records
+    }
+
+    /// Only active records (one per component — the highest-priority scope).
+    pub fn active_records(&self) -> impl Iterator<Item = &VisibleRecord> {
+        self.records.iter().filter(|r| r.active)
+    }
+
+    /// The active record for `component`, if any.
+    ///
+    /// User scope takes priority over system scope.
+    pub fn active(&self, component: &str) -> Option<&VisibleRecord> {
+        self.records
+            .iter()
+            .find(|r| r.active && r.component == component)
+    }
+
+    /// All records for `component` across all scopes (active first).
+    pub fn records_for(&self, component: &str) -> Vec<&VisibleRecord> {
+        let mut matches: Vec<&VisibleRecord> = self
+            .records
+            .iter()
+            .filter(|r| r.component == component)
+            .collect();
+        // Sort: active first, then by scope priority (User before System).
+        matches.sort_by(|a, b| b.active.cmp(&a.active).then_with(|| a.scope.cmp(&b.scope)));
+        matches
+    }
+
+    /// Whether the system `installed.toml` was successfully read.
+    ///
+    /// `false` when the file is missing, unreadable, or failed to parse.
+    /// Read commands should emit a warning when this is `false`.
+    pub fn system_state_readable(&self) -> bool {
+        self.system_state_readable
+    }
+
+    /// Path to the system state file, if it was readable.
+    pub fn system_state_path(&self) -> Option<&Path> {
+        self.system_state_path.as_deref()
+    }
+}
+
+// ── Loading helpers ──────────────────────────────────────────────────
+
+/// Load `installed.toml` from a state directory.
+///
+/// A missing file yields `Default` (fresh-install case). A parse or IO
+/// error also yields `Default` — callers rely on the merge producing
+/// an empty record set rather than propagating errors.
+fn load_state_from(state_dir: &Path) -> InstalledState {
+    let path = state_dir.join("installed.toml");
+    InstalledState::load(&path).unwrap_or_default()
+}
+
+/// Load system-scope `installed.toml`.
+///
+/// Returns `(state, was_readable)`. When the file is missing or fails to
+/// load, returns `(Default, false)`.
+fn load_system_state(system_state_dir: &Path) -> (InstalledState, bool) {
+    let path = system_state_dir.join("installed.toml");
+    if !path.exists() {
+        return (InstalledState::default(), false);
+    }
+    match InstalledState::load(&path) {
+        Ok(state) => (state, true),
+        Err(_) => (InstalledState::default(), false),
+    }
+}
+
+/// Collect datadir roots for payload discovery from a layout.
+///
+/// Includes the layout's primary `datadir` and, for system layouts, the
+/// FHS package-managed datadir (`/usr/share/anolisa`).
+fn collect_payload_roots(layout: &FsLayout) -> Vec<PathBuf> {
+    let mut roots = vec![layout.datadir.clone()];
+    if let Some(pkg) = packaged::packaged_datadir_root(layout) {
+        if !roots.contains(&pkg) {
+            roots.push(pkg);
+        }
+    }
+    if let Some(pkg_dd) = layout.package_datadir() {
+        if !roots.contains(&pkg_dd) {
+            roots.push(pkg_dd);
+        }
+    }
+    roots
+}
+
+// ── Mutation scope guard ───────────────────────────────────────────
+
+/// The kind of mutation being attempted, used by
+/// [`resolve_mutation_target`] to decide whether a missing component is
+/// an error or a legitimate creation path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Install/Repair/Adopt used by future phases; Update/Uninstall/Forget are live
+pub enum MutationOperation {
+    /// `install` — may create a new record in the current scope.
+    Install,
+    /// `update` — requires an existing record in the current scope.
+    Update,
+    /// `uninstall` — requires an existing record in the current scope.
+    Uninstall,
+    /// `forget` — requires an existing record in the current scope.
+    Forget,
+    /// `repair` — requires an existing record in the current scope.
+    Repair,
+    /// `adopt` — system scope only; creates a new record.
+    Adopt,
+}
+
+impl MutationOperation {
+    /// Human-readable verb for error messages.
+    const fn verb(self) -> &'static str {
+        match self {
+            MutationOperation::Install => "install",
+            MutationOperation::Update => "update",
+            MutationOperation::Uninstall => "uninstall",
+            MutationOperation::Forget => "forget",
+            MutationOperation::Repair => "repair",
+            MutationOperation::Adopt => "adopt",
+        }
+    }
+}
+
+/// Result of [`resolve_mutation_target`] — tells mutation commands whether
+/// they may proceed, must reject with a scope hint, or should treat the
+/// target as absent.
+#[derive(Debug)]
+#[allow(dead_code, clippy::enum_variant_names)] // CurrentScope's record is consumed by future callers
+pub enum MutationTarget<'a> {
+    /// The component has a record in the current scope that the current
+    /// user can modify. Proceed with the mutation.
+    CurrentScope(&'a VisibleRecord),
+    /// The component is absent from the current scope, but the operation
+    /// allows creating a new record (e.g. `install` in user mode creating
+    /// a user override). Callers that do not allow creation should treat
+    /// this as "not installed".
+    CreateInCurrentScope,
+    /// The component exists only in a different scope. The command must
+    /// reject and tell the user to switch scope.
+    WrongScope(&'a VisibleRecord),
+}
+
+/// Unified scope guard for mutation commands.
+///
+/// Checks whether `component` is mutable in the current `ctx.install_mode`
+/// by consulting the merged visible view. Returns one of three results:
+///
+/// - [`MutationTarget::CurrentScope`] — a record exists in the current
+///   scope; proceed with the mutation.
+/// - [`MutationTarget::WrongScope`] — the component only exists in other
+///   scopes; the command must reject with a scope-switch hint.
+/// - [`MutationTarget::CreateInCurrentScope`] — the component is not in
+///   any scope; `install`/`adopt` may proceed, other operations should
+///   report "not installed".
+///
+/// When the same component exists in both user and system scope, the
+/// active record might be in a different scope (user scope shadows
+/// system). This function still finds the current scope's record via
+/// [`VisibleInstalledView::records_for`] so that legitimate mutations
+/// are not blocked by the shadowing rule.
+pub fn resolve_mutation_target<'a>(
+    _operation: MutationOperation,
+    component: &str,
+    view: &'a VisibleInstalledView,
+) -> MutationTarget<'a> {
+    let records = view.records_for(component);
+
+    if records.is_empty() {
+        return MutationTarget::CreateInCurrentScope;
+    }
+
+    // Find a record in the current scope (mutable_by_current_user == true).
+    if let Some(record) = records.iter().copied().find(|r| r.mutable_by_current_user) {
+        return MutationTarget::CurrentScope(record);
+    }
+
+    // No record in the current scope; the component only exists in other scopes.
+    MutationTarget::WrongScope(records[0])
+}
+
+/// Build the error message for a [`MutationTarget::WrongScope`] result.
+///
+/// Produces a user-facing message that explains the scope mismatch and
+/// suggests the correct invocation:
+///
+/// ```text
+/// component 'ws-ckpt' is installed in system scope; rerun with sudo and --install-mode system
+/// ```
+pub fn wrong_scope_reason(operation: MutationOperation, record: &VisibleRecord) -> String {
+    let verb = operation.verb();
+    match record.scope {
+        Scope::System => {
+            format!(
+                "component '{}' is installed in system scope; \
+                 rerun with `sudo anolisa --install-mode system {verb} '{}'`",
+                record.component, record.component
+            )
+        }
+        Scope::User => {
+            format!(
+                "component '{}' is installed in user scope; \
+                 rerun with `anolisa --install-mode user {verb} '{}'`",
+                record.component, record.component
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/anolisa/crates/anolisa-cli/src/commands/visible_view/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/visible_view/tests.rs
@@ -1,0 +1,311 @@
+//! Tests for the `VisibleInstalledView` merge model.
+
+use std::path::PathBuf;
+
+use anolisa_core::state::{InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership};
+
+use crate::commands::visible_view::{
+    MutationOperation, MutationTarget, Scope, VisibleInstalledView, resolve_mutation_target,
+};
+use crate::context::{CliContext, InstallMode};
+
+fn user_ctx() -> CliContext {
+    CliContext {
+        install_mode: InstallMode::User,
+        prefix: None,
+        json: false,
+        dry_run: false,
+        verbose: false,
+        quiet: true,
+        no_color: true,
+    }
+}
+
+fn system_ctx() -> CliContext {
+    CliContext {
+        install_mode: InstallMode::System,
+        prefix: None,
+        json: false,
+        dry_run: false,
+        verbose: false,
+        quiet: true,
+        no_color: true,
+    }
+}
+
+fn component_object(name: &str) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: name.to_string(),
+        version: "0.1.0".to_string(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("raw".to_string()),
+        ownership: Some(Ownership::RawManaged),
+        rpm_metadata: None,
+        installed_at: "2026-07-01T00:00:00Z".to_string(),
+        last_operation_id: None,
+        managed: true,
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
+fn state_with(name: &str) -> InstalledState {
+    let mut state = InstalledState::default();
+    state.upsert_object(component_object(name));
+    state
+}
+
+const USER_PATH: &str = "/test/user/installed.toml";
+const SYSTEM_PATH: &str = "/test/system/installed.toml";
+
+fn view(
+    user: &InstalledState,
+    system: &InstalledState,
+    system_readable: bool,
+    ctx: &CliContext,
+) -> VisibleInstalledView {
+    VisibleInstalledView::from_states(
+        user,
+        system,
+        PathBuf::from(USER_PATH),
+        PathBuf::from(SYSTEM_PATH),
+        system_readable,
+        ctx,
+    )
+}
+
+/// Test 1: Only user state exists — records contain only user scope, all active.
+#[test]
+fn only_user_state_exists() {
+    let user = state_with("tokenless");
+    let system = InstalledState::default();
+    let v = view(&user, &system, false, &user_ctx());
+
+    assert_eq!(v.records().len(), 1);
+    let rec = &v.records()[0];
+    assert_eq!(rec.component, "tokenless");
+    assert_eq!(rec.scope, Scope::User);
+    assert!(rec.active);
+    assert_eq!(rec.shadowed_by, None);
+    assert!(rec.mutable_by_current_user);
+    assert_eq!(rec.state_path, PathBuf::from(USER_PATH));
+    assert!(!v.system_state_readable());
+}
+
+/// Test 2: Only system state exists (user mode ctx) — system scope, active,
+/// mutable_by_current_user = false.
+#[test]
+fn only_system_state_user_mode_ctx() {
+    let user = InstalledState::default();
+    let system = state_with("ws-ckpt");
+    let v = view(&user, &system, true, &user_ctx());
+
+    assert_eq!(v.records().len(), 1);
+    let rec = &v.records()[0];
+    assert_eq!(rec.component, "ws-ckpt");
+    assert_eq!(rec.scope, Scope::System);
+    assert!(rec.active);
+    assert_eq!(rec.shadowed_by, None);
+    assert!(!rec.mutable_by_current_user);
+    assert!(v.system_state_readable());
+}
+
+/// Test 3: User + system same component — user is active, system is shadowed.
+#[test]
+fn user_and_system_same_component() {
+    let user = state_with("tokenless");
+    let system = state_with("tokenless");
+    let v = view(&user, &system, true, &user_ctx());
+
+    assert_eq!(v.records().len(), 2);
+
+    let user_rec = v.active("tokenless").expect("active record");
+    assert_eq!(user_rec.scope, Scope::User);
+    assert!(user_rec.active);
+    assert_eq!(user_rec.shadowed_by, None);
+
+    let records = v.records_for("tokenless");
+    assert_eq!(records.len(), 2);
+    let shadowed = records.iter().find(|r| !r.active).expect("shadowed record");
+    assert_eq!(shadowed.scope, Scope::System);
+    assert_eq!(shadowed.shadowed_by, Some(Scope::User));
+}
+
+/// Test 4: System state not readable — view has only user records, no panic.
+#[test]
+fn system_state_not_readable() {
+    let user = state_with("tokenless");
+    let system = InstalledState::default();
+    let v = view(&user, &system, false, &user_ctx());
+
+    assert!(!v.system_state_readable());
+    assert!(v.system_state_path().is_none());
+    assert_eq!(v.records().len(), 1);
+    assert_eq!(v.records()[0].scope, Scope::User);
+}
+
+/// Test 5: System state file does not exist — equivalent to empty system state.
+#[test]
+fn system_state_file_missing() {
+    let user = state_with("tokenless");
+    let system = InstalledState::default();
+    let v = view(&user, &system, false, &user_ctx());
+
+    assert!(!v.system_state_readable());
+    assert_eq!(v.records().len(), 1);
+}
+
+/// Test 6: mutable_by_current_user in system mode — system record is mutable,
+/// user record is not.
+#[test]
+fn mutable_by_current_user_system_mode() {
+    let user = state_with("tokenless");
+    let system = state_with("agentsight");
+    let v = view(&user, &system, true, &system_ctx());
+
+    let user_rec = v.records().iter().find(|r| r.scope == Scope::User).unwrap();
+    assert!(!user_rec.mutable_by_current_user);
+
+    let sys_rec = v
+        .records()
+        .iter()
+        .find(|r| r.scope == Scope::System)
+        .unwrap();
+    assert!(sys_rec.mutable_by_current_user);
+}
+
+/// Test 7: active() returns None for unknown component.
+#[test]
+fn active_returns_none_for_unknown() {
+    let user = InstalledState::default();
+    let system = InstalledState::default();
+    let v = view(&user, &system, false, &user_ctx());
+
+    assert!(v.active("nonexistent").is_none());
+}
+
+/// Test 8: records_for returns active first, then shadowed.
+#[test]
+fn records_for_orders_active_first() {
+    let user = state_with("tokenless");
+    let system = state_with("tokenless");
+    let v = view(&user, &system, true, &user_ctx());
+
+    let records = v.records_for("tokenless");
+    assert_eq!(records.len(), 2);
+    assert!(records[0].active);
+    assert!(!records[1].active);
+}
+
+/// Test 9: Multiple components across scopes.
+#[test]
+fn multiple_components_across_scopes() {
+    let mut user = InstalledState::default();
+    user.upsert_object(component_object("tokenless"));
+    let mut system = InstalledState::default();
+    system.upsert_object(component_object("agentsight"));
+    system.upsert_object(component_object("os-skills"));
+
+    let v = view(&user, &system, true, &user_ctx());
+
+    assert_eq!(v.records().len(), 3);
+    let active: Vec<_> = v.active_records().collect();
+    assert_eq!(active.len(), 3);
+    assert!(
+        active
+            .iter()
+            .any(|r| r.component == "tokenless" && r.scope == Scope::User)
+    );
+    assert!(
+        active
+            .iter()
+            .any(|r| r.component == "agentsight" && r.scope == Scope::System)
+    );
+    assert!(
+        active
+            .iter()
+            .any(|r| r.component == "os-skills" && r.scope == Scope::System)
+    );
+}
+
+// ── resolve_mutation_target tests ────────────────────────────────────
+
+#[test]
+fn mutation_target_current_scope_when_component_only_in_user_scope() {
+    let user = state_with("tokenless");
+    let v = view(&user, &InstalledState::default(), true, &user_ctx());
+
+    let target = resolve_mutation_target(MutationOperation::Uninstall, "tokenless", &v);
+    assert!(matches!(target, MutationTarget::CurrentScope(_)));
+}
+
+#[test]
+fn mutation_target_wrong_scope_when_user_mode_views_system_only() {
+    let system = state_with("tokenless");
+    let v = view(&InstalledState::default(), &system, true, &user_ctx());
+
+    let target = resolve_mutation_target(MutationOperation::Uninstall, "tokenless", &v);
+    assert!(matches!(target, MutationTarget::WrongScope(_)));
+}
+
+#[test]
+fn mutation_target_create_when_component_absent() {
+    let v = view(
+        &InstalledState::default(),
+        &InstalledState::default(),
+        true,
+        &user_ctx(),
+    );
+
+    let target = resolve_mutation_target(MutationOperation::Install, "tokenless", &v);
+    assert!(matches!(target, MutationTarget::CreateInCurrentScope));
+}
+
+/// When the same component exists in both user and system scope,
+/// the active record is the user one. A system-mode user should still
+/// resolve to `CurrentScope` — the system record is mutable by them,
+/// even though it is shadowed.
+#[test]
+fn mutation_target_current_scope_for_system_mode_with_shadowed_record() {
+    let user = state_with("tokenless");
+    let system = state_with("tokenless");
+    let v = view(&user, &system, true, &system_ctx());
+
+    let target = resolve_mutation_target(MutationOperation::Uninstall, "tokenless", &v);
+    match target {
+        MutationTarget::CurrentScope(rec) => {
+            assert_eq!(rec.scope, Scope::System);
+            assert!(!rec.active);
+        }
+        other => panic!("expected CurrentScope for system-mode, got {other:?}"),
+    }
+}
+
+/// Conversely, a user-mode user with the same dual-scope setup should
+/// resolve to the active user record.
+#[test]
+fn mutation_target_current_scope_for_user_mode_with_dual_scope() {
+    let user = state_with("tokenless");
+    let system = state_with("tokenless");
+    let v = view(&user, &system, true, &user_ctx());
+
+    let target = resolve_mutation_target(MutationOperation::Forget, "tokenless", &v);
+    match target {
+        MutationTarget::CurrentScope(rec) => {
+            assert_eq!(rec.scope, Scope::User);
+            assert!(rec.active);
+        }
+        other => panic!("expected CurrentScope for user-mode, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Description

Add a `VisibleInstalledView` read model that merges user-scope and system-scope `installed.toml` so read commands (`list`, `status`) show every component visible to the current user — regardless of which physical scope owns the record.

Key changes:

- **list/status**: use merged view; add `scope`, `active`, `shadowed_by`, `mutable_by_current_user`, `state_path` fields to output rows
- **forget/update/uninstall**: unified scope guard via `resolve_mutation_target`; reject with a scope-switch hint (e.g. "rerun with sudo and `--install-mode system`") when the component only exists in another scope
- **state.rs**: explicit file mode `0o644` and directory `0o755` to bypass restrictive umask; `normalize_system_state_permissions` sweeps datadir trees post-install so non-root users can read system-scope state
- **status integrity fix**: use the record's own scope layout for integrity checks so non-root users see correct `installed` status for system-installed components (was `failed` due to `out_of_bounds`)

## Ship Note

Non-root users can now `list` and `status` system-installed components without `sudo`. Mutation commands (`forget`, `update`, `uninstall`) reject cross-scope modifications with actionable hints instead of bare "not installed" errors. System-scope state files are created with `0644`/`0755` permissions regardless of umask.

## Type of Change

- [x] New feature
- [x] Bug fix

## Scope

- [x] anolisa (anolisa-cli)
- [x] anolisa-core

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p anolisa-cli` (424 tests, all pass)
- End-to-end on remote environment:
  - `sudo anolisa install tokenless` + `anolisa adapter enable tokenless openclaw`
  - Non-root `status tokenless` shows `installed` (was `failed`)
  - Non-root `forget/update/uninstall tokenless` rejected with scope hint
  - `umask 077` install still produces `0644` files and `0755` dirs