### PR TITLE
feat(anolisa): add rpm image upgrade

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -100,6 +100,8 @@ pub enum ComponentCommands {
     Restart(tier1::restart::RestartArgs),
     /// Update a component (`update <component>`), the CLI binary (`self`), or everything (`all`)
     Update(tier1::update::UpdateArgs),
+    /// Upgrade the RPM/system image to the target toolchain profile (system-only)
+    Upgrade(tier1::upgrade::UpgradeArgs),
     /// Reconcile a component's ANOLISA state with rpmdb after manual RPM changes
     Repair(tier1::repair::RepairArgs),
     /// Drop a component's ANOLISA state record without any package operation
@@ -208,6 +210,7 @@ pub fn dispatch(cli: Cli, ctx: &CliContext) -> Result<(), CliError> {
             ComponentCommands::Logs(args) => tier1::logs::handle(args, ctx),
             ComponentCommands::Restart(args) => tier1::restart::handle(args, ctx),
             ComponentCommands::Update(args) => tier1::update::handle(args, ctx),
+            ComponentCommands::Upgrade(args) => tier1::upgrade::handle(args, ctx),
             ComponentCommands::Repair(args) => tier1::repair::handle(args, ctx),
             ComponentCommands::Forget(args) => tier1::forget::handle(args, ctx),
             ComponentCommands::Adopt(args) => tier1::adopt::handle(args, ctx),
@@ -399,6 +402,11 @@ fn command_policy(command: &Commands) -> CommandPolicy {
                 CommandPolicy::new("update", CommandScope::ReadOnly)
             }
             ComponentCommands::Update(_) => mode_scoped("update", true),
+            // `upgrade` is a system-only RPM image mutation: real execution
+            // needs root. `--dry-run` waives only the root requirement, not the
+            // system-mode one, so an explicit system-mode dry-run can preview
+            // the plan without root (matching `repair`).
+            ComponentCommands::Upgrade(_) => system_only("upgrade", true),
             ComponentCommands::Repair(_) => system_only("repair", true),
             ComponentCommands::Forget(_) => mode_scoped("forget", true),
             ComponentCommands::Adopt(_) => system_only("adopt", false),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
@@ -13,6 +13,7 @@ pub mod restart;
 pub mod status;
 pub mod uninstall;
 pub mod update;
+pub mod upgrade;
 
 // Cross-command end-to-end MVP lifecycle coverage (#963); test-only.
 #[cfg(test)]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -71,7 +71,9 @@ use crate::context::CliContext;
 use crate::repo_config::{HostVars, RepoConfig};
 use crate::response::{self, CliError};
 
-mod check;
+// `pub(crate)` so `anolisa upgrade` (issue #1411) can reuse the read-only
+// planner (`check::compute_update_check_report`) instead of re-deriving it.
+pub(crate) mod check;
 
 /// Command label for JSON envelopes and error routing.
 const COMMAND: &str = "update";
@@ -342,7 +344,9 @@ fn resolve_update_target(
     }
 }
 
-fn rpm_repo_source_for_update(
+// `pub(crate)`: shared with `check` (read-only) and `upgrade` (issue #1411) so
+// all three resolve the configured ANOLISA RPM repository the same way.
+pub(crate) fn rpm_repo_source_for_update(
     repo_config: &RepoConfig,
     env: &anolisa_env::EnvFacts,
     command: &str,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -83,22 +83,26 @@ const BUILTIN_DEFAULT_TARGET_PROFILE: &str = include_str!(concat!(
 const PROFILES_SUBDIR: &str = "profiles";
 
 // Stable action vocabulary shared by JSON, cache, and human/MOTD rendering.
-const ACTION_UPDATE: &str = "update";
-const ACTION_NOOP: &str = "noop";
-const ACTION_INSTALL: &str = "install";
-const ACTION_UNSUPPORTED: &str = "unsupported";
-const ACTION_UNSUPPORTED_RPM: &str = "unsupported_in_rpm_upgrade";
-const ACTION_ERROR: &str = "error";
+// `pub(crate)` so the `upgrade` command (issue #1411) can classify a report's
+// items against the same vocabulary the check produces.
+pub(crate) const ACTION_UPDATE: &str = "update";
+pub(crate) const ACTION_NOOP: &str = "noop";
+pub(crate) const ACTION_INSTALL: &str = "install";
+pub(crate) const ACTION_UNSUPPORTED: &str = "unsupported";
+pub(crate) const ACTION_UNSUPPORTED_RPM: &str = "unsupported_in_rpm_upgrade";
+pub(crate) const ACTION_ERROR: &str = "error";
 
 /// Wire shape for `update --check` (`--json`) and the on-disk cache.
 ///
 /// Owned `String`s (rather than `&'static str`) so the same struct round-trips
-/// through the cache via `Deserialize`.
+/// through the cache via `Deserialize`. Exposed `pub(crate)` so `anolisa
+/// upgrade` (issue #1411) can consume the same planning output; only the fields
+/// the upgrade planner reads are widened past module scope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct UpdateCheckReport {
+pub(crate) struct UpdateCheckReport {
     /// Target profile evaluated, when `--target` was given.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    target: Option<String>,
+    pub(crate) target: Option<String>,
     /// Upgrade backend this report covers. Always `rpm` in the first version.
     backend: String,
     /// True when at least one component/CLI `update` was found. Deliberately
@@ -107,49 +111,49 @@ struct UpdateCheckReport {
     upgrade_available: bool,
     /// True when there is anything to do: an upgrade **or** a missing default to
     /// install. This is the signal machine callers should gate on when driving
-    /// the (future) `anolisa upgrade`; `upgrade_available` alone would report
+    /// `anolisa upgrade`; `upgrade_available` alone would report
     /// "nothing to upgrade" on a fresh image that is only missing defaults.
     action_required: bool,
-    cli: CliCheck,
-    components: Vec<ComponentCheck>,
+    pub(crate) cli: CliCheck,
+    pub(crate) components: Vec<ComponentCheck>,
     summary: CheckSummary,
 }
 
 /// Upgrade status of the running `anolisa` CLI binary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct CliCheck {
+pub(crate) struct CliCheck {
     /// RPM package that owns the CLI binary; `None` when it is not RPM-owned.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    package: Option<String>,
+    pub(crate) package: Option<String>,
     /// Installed EVR from rpmdb.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    installed: Option<String>,
+    pub(crate) installed: Option<String>,
     /// Newest repo candidate EVR, when an upgrade is available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    available: Option<String>,
-    action: String,
+    pub(crate) available: Option<String>,
+    pub(crate) action: String,
     /// Item-level failure that did not abort the whole check.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 /// Upgrade status of one installed (or profile-declared) component.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct ComponentCheck {
-    component: String,
+pub(crate) struct ComponentCheck {
+    pub(crate) component: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    package: Option<String>,
+    pub(crate) package: Option<String>,
     /// Provenance label (`rpm-managed` / `rpm-observed` / `raw-managed`);
     /// `None` for a profile default that is not installed yet.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    ownership: Option<String>,
+    pub(crate) ownership: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    installed: Option<String>,
+    pub(crate) installed: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    available: Option<String>,
-    action: String,
+    pub(crate) available: Option<String>,
+    pub(crate) action: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 /// Aggregate counts used by the summary line, MOTD, and exit signalling.
@@ -245,7 +249,7 @@ pub(super) fn handle_update_check(args: &UpdateArgs, ctx: &CliContext) -> Result
         return Ok(());
     }
 
-    let report = match compute_report(args, ctx, &layout) {
+    let report = match compute_update_check_report(args.target.as_deref(), ctx, &layout) {
         Ok(report) => report,
         Err(err) => {
             // MOTD must stay quiet and low-noise on failure; a JSON/human check
@@ -267,8 +271,17 @@ pub(super) fn handle_update_check(args: &UpdateArgs, ctx: &CliContext) -> Result
 
 /// Build the report from live host state (repo config, rpmdb/dnf, target
 /// profile). Split from [`run_update_check`] so the pure logic stays testable.
-fn compute_report(
-    args: &UpdateArgs,
+///
+/// This is the shared, read-only planner behind both `anolisa update --check`
+/// and `anolisa upgrade` (issue #1411): it runs only read-only rpm/dnf queries,
+/// never a [`PackageTransaction`](anolisa_platform::pkg_transaction::PackageTransaction),
+/// never writes `installed.toml`, and never persists repo/adapter config. The
+/// `upgrade` command consumes the returned report and converts it into an RPM
+/// transaction plan; it does not re-derive the plan. Takes the resolved
+/// `--target` value directly (rather than the whole `UpdateArgs`) so callers
+/// without an `UpdateArgs` can reuse it.
+pub(crate) fn compute_update_check_report(
+    target: Option<&str>,
     ctx: &CliContext,
     layout: &FsLayout,
 ) -> Result<UpdateCheckReport, CliError> {
@@ -300,7 +313,7 @@ fn compute_report(
 
     // An omitted `--target` resolves to the release default profile, so the
     // report always carries a target and can surface missing defaults.
-    let (target_name, target) = load_effective_target_profile(layout, args.target.as_deref())?;
+    let (target_name, target_profile) = load_effective_target_profile(layout, target)?;
 
     // Best-effort component identity index so a profile default already present
     // on the host (but not adopted into ANOLISA state) is checked against rpmdb
@@ -316,7 +329,7 @@ fn compute_report(
         cli_exe_path: &exe_path,
         arch: &env.arch,
         target_name: Some(target_name),
-        target: Some(target),
+        target: Some(target_profile),
         component_index: component_index.as_ref(),
     }))
 }
@@ -638,9 +651,20 @@ fn check_default_component(
         // Genuinely absent from both ANOLISA state and rpmdb.
         DefaultProbe::Missing => {
             summary.missing_defaults += 1;
+            // Best-effort: resolve the RPM package name the profile default maps
+            // to so a downstream `anolisa upgrade` can `dnf install` it. The
+            // check stays read-only — this is an in-memory index lookup, not a
+            // query. A missing/ambiguous mapping leaves `package = None`; the
+            // default is still reported installable here (preserving
+            // `update --check` behaviour), and it is `upgrade`'s job to refuse
+            // an install with no resolved package rather than the check's.
+            let package = match index_rpm_packages(index, name).as_slice() {
+                [only] => Some(only.clone()),
+                _ => None,
+            };
             ComponentCheck {
                 component: name.to_string(),
-                package: None,
+                package,
                 ownership: None,
                 installed: None,
                 available: None,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -53,8 +53,11 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 use super::UpdateArgs;
 use crate::commands::common;
 use crate::context::CliContext;
-use crate::repo_config::RepoConfig;
-use crate::resolution::{ComponentIndex, rpm_component_provide};
+use crate::repo_config::{BackendConfig, RepoConfig};
+use crate::resolution::{
+    BackendKind, ComponentIndex, ComponentResolver, ResolutionSet, ResolutionUse, ResolveOptions,
+    rpm_component_provide,
+};
 use crate::response::CliError;
 
 /// Command label for JSON envelopes and error routing on the check path.
@@ -154,6 +157,10 @@ pub(crate) struct ComponentCheck {
     pub(crate) action: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) error: Option<String>,
+    /// Internal planner hint: this row came from a target-profile default that was
+    /// absent from ANOLISA state. It is intentionally not part of JSON/cache.
+    #[serde(skip)]
+    pub(crate) absent_from_state: bool,
 }
 
 /// Aggregate counts used by the summary line, MOTD, and exit signalling.
@@ -213,6 +220,8 @@ struct CheckInputs<'a> {
     /// (best-effort); the check then relies on the `anolisa-component(...)`
     /// provide alone.
     component_index: Option<&'a ComponentIndex>,
+    /// RPM backend config used for missing-default package resolution.
+    rpm_backend: Option<&'a BackendConfig>,
 }
 
 /// Production entry point for `anolisa update --check`.
@@ -331,6 +340,7 @@ pub(crate) fn compute_update_check_report(
         target_name: Some(target_name),
         target: Some(target_profile),
         component_index: component_index.as_ref(),
+        rpm_backend: repo_config.backends.get("rpm"),
     }))
 }
 
@@ -386,6 +396,7 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
             components.push(check_default_component(
                 inputs.query,
                 inputs.component_index,
+                inputs.rpm_backend,
                 name,
                 inputs.arch,
                 &mut summary,
@@ -521,6 +532,7 @@ fn check_component(
             available: None,
             action: ACTION_UNSUPPORTED_RPM.to_string(),
             error: None,
+            absent_from_state: false,
         };
     }
 
@@ -602,6 +614,7 @@ fn check_component(
                 available: Some(available),
                 action: ACTION_UPDATE.to_string(),
                 error: None,
+                absent_from_state: false,
             }
         }
         Ok(None) => ComponentCheck {
@@ -612,6 +625,7 @@ fn check_component(
             available: None,
             action: ACTION_NOOP.to_string(),
             error: None,
+            absent_from_state: false,
         },
         Err(err) => {
             summary.errors += 1;
@@ -639,6 +653,7 @@ fn check_component(
 fn check_default_component(
     query: &dyn PackageQuery,
     index: Option<&ComponentIndex>,
+    rpm_backend: Option<&BackendConfig>,
     name: &str,
     arch: &str,
     summary: &mut CheckSummary,
@@ -650,26 +665,57 @@ fn check_default_component(
         }
         // Genuinely absent from both ANOLISA state and rpmdb.
         DefaultProbe::Missing => {
-            summary.missing_defaults += 1;
-            // Best-effort: resolve the RPM package name the profile default maps
-            // to so a downstream `anolisa upgrade` can `dnf install` it. The
-            // check stays read-only — this is an in-memory index lookup, not a
-            // query. A missing/ambiguous mapping leaves `package = None`; the
-            // default is still reported installable here (preserving
-            // `update --check` behaviour), and it is `upgrade`'s job to refuse
-            // an install with no resolved package rather than the check's.
-            let package = match index_rpm_packages(index, name).as_slice() {
-                [only] => Some(only.clone()),
-                _ => None,
+            // Resolve the RPM package name using the shared install resolver so
+            // package_map and available Provides fallbacks stay available.
+            // Missing/ambiguous resolution is an item error: otherwise the check
+            // would claim an installable action that `upgrade` cannot apply.
+            let package = match resolve_default_install_package(query, index, rpm_backend, name) {
+                Ok(package) => package,
+                Err(reason) => {
+                    summary.errors += 1;
+                    return ComponentCheck {
+                        component: name.to_string(),
+                        package: None,
+                        ownership: None,
+                        installed: None,
+                        available: None,
+                        action: ACTION_ERROR.to_string(),
+                        error: Some(reason),
+                        absent_from_state: true,
+                    };
+                }
             };
+            match query.query_installed(&package) {
+                Ok(Some(_)) => {
+                    return check_present_default(query, name, &package, arch, summary);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    summary.errors += 1;
+                    return ComponentCheck {
+                        component: name.to_string(),
+                        package: Some(package),
+                        ownership: None,
+                        installed: None,
+                        available: None,
+                        action: ACTION_ERROR.to_string(),
+                        error: Some(format!(
+                            "cannot query installed version of resolved package for default component '{name}': {err}"
+                        )),
+                        absent_from_state: true,
+                    };
+                }
+            }
+            summary.missing_defaults += 1;
             ComponentCheck {
                 component: name.to_string(),
-                package,
+                package: Some(package),
                 ownership: None,
                 installed: None,
                 available: None,
                 action: ACTION_INSTALL.to_string(),
                 error: None,
+                absent_from_state: true,
             }
         }
         // Could not determine presence (query failure, ambiguous providers).
@@ -686,8 +732,47 @@ fn check_default_component(
                 available: None,
                 action: ACTION_ERROR.to_string(),
                 error: Some(reason),
+                absent_from_state: true,
             }
         }
+    }
+}
+
+/// Resolve the package to install for a genuinely missing target-profile default.
+///
+/// This delegates to the shared RPM resolver instead of using only the component
+/// index, preserving site-local package_map and repo-side available-provides
+/// fallbacks for `anolisa upgrade`.
+fn resolve_default_install_package(
+    query: &dyn PackageQuery,
+    index: Option<&ComponentIndex>,
+    rpm_backend: Option<&BackendConfig>,
+    name: &str,
+) -> Result<String, String> {
+    let resolver = ComponentResolver::new(index, rpm_backend, Some(query));
+    match resolver.resolve(
+        name,
+        BackendKind::Rpm,
+        ResolutionUse::Install,
+        ResolveOptions::default(),
+    ) {
+        Ok(ResolutionSet::Unique(target)) => Ok(target.package),
+        Ok(ResolutionSet::None) => Err(format!(
+            "cannot resolve RPM package for default component '{name}': no package mapping or provider found"
+        )),
+        Ok(ResolutionSet::Ambiguous(targets)) => {
+            let packages = targets
+                .iter()
+                .map(|target| target.package.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(format!(
+                "cannot resolve RPM package for default component '{name}': multiple candidates ({packages})"
+            ))
+        }
+        Err(err) => Err(format!(
+            "cannot resolve RPM package for default component '{name}': {err}"
+        )),
     }
 }
 
@@ -839,6 +924,7 @@ fn check_present_default(
                 available: Some(available),
                 action: ACTION_UPDATE.to_string(),
                 error: None,
+                absent_from_state: true,
             }
         }
         Ok(None) => ComponentCheck {
@@ -849,6 +935,7 @@ fn check_present_default(
             available: None,
             action: ACTION_NOOP.to_string(),
             error: None,
+            absent_from_state: true,
         },
         Err(err) => {
             summary.errors += 1;
@@ -927,6 +1014,7 @@ fn component_error(
         available: None,
         action: ACTION_ERROR.to_string(),
         error: Some(reason),
+        absent_from_state: false,
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/render.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/render.rs
@@ -60,7 +60,7 @@ pub(super) fn build_motd(report: &UpdateCheckReport) -> Option<String> {
         ));
     }
     Some(format!(
-        "ANOLISA toolchain update is available.\n{}.\nRun: anolisa update --check for details",
+        "ANOLISA toolchain update is available.\n{}.\nRun: sudo anolisa upgrade to apply, or anolisa update --check for details",
         parts.join("; ")
     ))
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anolisa_platform::pkg_query::{PackageInfo, PackageVersion};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
@@ -30,6 +30,8 @@ struct FakeHost {
     installed_multi: HashSet<String>,
     /// capabilities whose `what_provides_installed` returns a query error.
     provides_errors: HashSet<String>,
+    /// capability → available repo provider package names.
+    available_providers: HashMap<String, Vec<String>>,
     txn_calls: Cell<usize>,
 }
 
@@ -80,6 +82,14 @@ impl PackageQuery for FakeHost {
         }
         Ok(self.provides.get(capability).cloned().unwrap_or_default())
     }
+
+    fn what_provides_available(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        Ok(self
+            .available_providers
+            .get(capability)
+            .cloned()
+            .unwrap_or_default())
+    }
 }
 
 impl PackageTransaction for FakeHost {
@@ -107,6 +117,23 @@ fn info(name: &str, version: &str, release: Option<&str>) -> PackageInfo {
         },
         arch: "x86_64".to_string(),
         origin: None,
+    }
+}
+
+fn rpm_backend_with_package_map(
+    component: &str,
+    package: &str,
+) -> crate::repo_config::BackendConfig {
+    let mut package_map = BTreeMap::new();
+    package_map.insert(component.to_string(), package.to_string());
+    crate::repo_config::BackendConfig {
+        base_url: "https://example.com/rpm/".to_string(),
+        insecure: false,
+        gpgcheck: None,
+        scope: None,
+        cache_ttl_secs: None,
+        offline_fallback: None,
+        package_map,
     }
 }
 
@@ -198,6 +225,17 @@ fn run_with_index(
     target_name: Option<String>,
     component_index: Option<&crate::resolution::ComponentIndex>,
 ) -> UpdateCheckReport {
+    run_with_index_and_backend(host, installed, target, target_name, component_index, None)
+}
+
+fn run_with_index_and_backend(
+    host: &FakeHost,
+    installed: &InstalledState,
+    target: Option<TargetProfile>,
+    target_name: Option<String>,
+    component_index: Option<&crate::resolution::ComponentIndex>,
+    rpm_backend: Option<&crate::repo_config::BackendConfig>,
+) -> UpdateCheckReport {
     run_update_check(CheckInputs {
         installed,
         query: host,
@@ -206,6 +244,7 @@ fn run_with_index(
         target_name,
         target,
         component_index,
+        rpm_backend,
     })
 }
 
@@ -402,7 +441,15 @@ fn update_check_raw_component_is_unsupported() {
 
 #[test]
 fn update_check_missing_default_reports_install() {
-    let host = FakeHost::with_cli_noop();
+    let mut host = FakeHost::with_cli_noop();
+    host.available_providers.insert(
+        "anolisa-component(cosh)".to_string(),
+        vec!["copilot-shell".to_string()],
+    );
+    host.available_providers.insert(
+        "anolisa-component(sec-core)".to_string(),
+        vec!["agent-sec-core".to_string()],
+    );
     let state = state_with(vec![]);
     let profile = TargetProfile {
         default_components: vec!["cosh".to_string(), "sec-core".to_string()],
@@ -547,10 +594,39 @@ fn update_check_default_present_via_index_package_without_provide() {
     assert_eq!(report.summary.missing_defaults, 0);
 }
 
+#[test]
+fn update_check_default_present_via_package_map_without_provide() {
+    let mut host = FakeHost::with_cli_noop();
+    host.installed.insert(
+        "copilot-shell".to_string(),
+        info("copilot-shell", "2.6.1", Some("1")),
+    );
+    let backend = rpm_backend_with_package_map("cosh", "copilot-shell");
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["cosh".to_string()],
+    };
+
+    let report = run_with_index_and_backend(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        None,
+        Some(&backend),
+    );
+
+    let item = &report.components[0];
+    assert_eq!(item.action, ACTION_NOOP);
+    assert_eq!(item.package.as_deref(), Some("copilot-shell"));
+    assert_eq!(item.ownership.as_deref(), Some("rpm-observed"));
+    assert_eq!(report.summary.missing_defaults, 0);
+}
+
 /// A default absent from both ANOLISA state and rpmdb is still reported as an
 /// install (the pre-fix behaviour for genuinely missing defaults).
 #[test]
-fn update_check_default_absent_from_rpmdb_reports_install() {
+fn update_check_unresolved_missing_default_is_item_error() {
     let host = FakeHost::with_cli_noop();
     let state = state_with(vec![]);
     let profile = TargetProfile {
@@ -564,8 +640,90 @@ fn update_check_default_absent_from_rpmdb_reports_install() {
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
     );
     let item = &report.components[0];
+    assert_eq!(item.action, ACTION_ERROR);
+    assert!(
+        item.error
+            .as_deref()
+            .unwrap_or("")
+            .contains("cannot resolve")
+    );
+    assert_eq!(report.summary.missing_defaults, 0);
+    assert_eq!(report.summary.errors, 1);
+}
+
+#[test]
+fn update_check_missing_default_resolves_package_from_package_map() {
+    let host = FakeHost::with_cli_noop();
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["cosh".to_string()],
+    };
+    let backend = rpm_backend_with_package_map("cosh", "copilot-shell");
+
+    let report = run_with_index_and_backend(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        None,
+        Some(&backend),
+    );
+
+    let item = &report.components[0];
     assert_eq!(item.action, ACTION_INSTALL);
+    assert_eq!(item.package.as_deref(), Some("copilot-shell"));
     assert_eq!(report.summary.missing_defaults, 1);
+}
+
+#[test]
+fn update_check_missing_default_resolves_package_from_available_provide() {
+    let mut host = FakeHost::with_cli_noop();
+    host.available_providers.insert(
+        "anolisa-component(cosh)".to_string(),
+        vec!["copilot-shell".to_string()],
+    );
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["cosh".to_string()],
+    };
+
+    let report = run(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+    );
+
+    let item = &report.components[0];
+    assert_eq!(item.action, ACTION_INSTALL);
+    assert_eq!(item.package.as_deref(), Some("copilot-shell"));
+    assert_eq!(report.summary.missing_defaults, 1);
+}
+
+#[test]
+fn update_check_ambiguous_missing_default_is_item_error() {
+    let mut host = FakeHost::with_cli_noop();
+    host.available_providers.insert(
+        "anolisa-component(cosh)".to_string(),
+        vec!["copilot-shell".to_string(), "cosh-alt".to_string()],
+    );
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["cosh".to_string()],
+    };
+
+    let report = run(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+    );
+
+    let item = &report.components[0];
+    assert_eq!(item.action, ACTION_ERROR);
+    assert!(item.error.as_deref().unwrap_or("").contains("multiple"));
+    assert_eq!(report.summary.missing_defaults, 0);
+    assert_eq!(report.summary.errors, 1);
 }
 
 /// A failed rpmdb provide query for a default must not be reported as an
@@ -771,11 +929,8 @@ fn update_check_motd_text_lists_upgrades_and_installs() {
     assert!(text.contains("ANOLISA toolchain update is available."));
     assert!(text.contains("1 component can be upgraded"));
     assert!(text.contains("1 new default component can be installed"));
-    assert!(text.contains("Run: anolisa update --check for details"));
-    assert!(
-        !text.contains("anolisa upgrade"),
-        "MOTD must not reference the not-yet-existing `anolisa upgrade`"
-    );
+    assert!(text.contains("Run: sudo anolisa upgrade to apply"));
+    assert!(text.contains("anolisa update --check for details"));
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -33,8 +33,8 @@ use serde::Serialize;
 use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
 use anolisa_core::lock::InstallLock;
 use anolisa_core::state::{
-    InstallMode as StateInstallMode, InstalledObject, ObjectKind, ObjectStatus, OperationRecord,
-    Ownership, RpmMetadata,
+    InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
+    OperationRecord, Ownership, RpmMetadata,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery};
@@ -169,6 +169,8 @@ struct PlannedUpdate {
     from: String,
     /// Newest repo candidate EVR the check reported.
     to: String,
+    /// Whether a missing state row should be recorded as an observed RPM default.
+    adopt_if_missing: bool,
 }
 
 /// A missing default component the upgrade will `dnf install`.
@@ -176,6 +178,15 @@ struct PlannedUpdate {
 struct PlannedInstall {
     name: String,
     package: String,
+}
+
+/// A target default already present in rpmdb but absent from ANOLISA state, with
+/// no dnf transaction needed. Upgrade records it as observed state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedObservedDefault {
+    name: String,
+    package: String,
+    installed: String,
 }
 
 /// An item deliberately left untouched (raw-managed, non-RPM CLI).
@@ -202,6 +213,7 @@ struct UpgradePlan {
     cli: Option<PlannedUpdate>,
     updates: Vec<PlannedUpdate>,
     installs: Vec<PlannedInstall>,
+    observed_defaults: Vec<PlannedObservedDefault>,
     skipped: Vec<SkippedItem>,
     errors: Vec<PlanError>,
 }
@@ -288,7 +300,17 @@ fn build_plan(
                 name: component.component.clone(),
                 reason: RAW_SKIP_REASON.to_string(),
             }),
-            ACTION_NOOP => {}
+            ACTION_NOOP => {
+                if component.absent_from_state {
+                    match observed_default(component) {
+                        Ok(observed) => plan.observed_defaults.push(observed),
+                        Err(reason) => plan.errors.push(PlanError {
+                            name: component.component.clone(),
+                            reason,
+                        }),
+                    }
+                }
+            }
             ACTION_ERROR => plan.errors.push(PlanError {
                 name: component.component.clone(),
                 reason: component
@@ -328,6 +350,7 @@ fn cli_update(cli: &CliCheck) -> Result<PlannedUpdate, String> {
         package,
         from,
         to,
+        adopt_if_missing: false,
     })
 }
 
@@ -351,6 +374,25 @@ fn component_update(component: &ComponentCheck) -> Result<PlannedUpdate, String>
         package,
         from,
         to,
+        adopt_if_missing: component.absent_from_state,
+    })
+}
+
+/// Build a no-transaction observed-default record plan, or an error string when
+/// the check row is missing the fields needed to refresh rpmdb/state.
+fn observed_default(component: &ComponentCheck) -> Result<PlannedObservedDefault, String> {
+    let package = component
+        .package
+        .clone()
+        .ok_or_else(|| "observed default reported without an RPM package".to_string())?;
+    let installed = component
+        .installed
+        .clone()
+        .ok_or_else(|| "observed default reported without an installed version".to_string())?;
+    Ok(PlannedObservedDefault {
+        name: component.component.clone(),
+        package,
+        installed,
     })
 }
 
@@ -366,6 +408,7 @@ struct UpgradeResult {
     dry_run: bool,
     updated: Vec<UpdatedItem>,
     installed: Vec<InstalledItem>,
+    recorded: Vec<RecordedItem>,
     skipped: Vec<SkippedResult>,
     errors: Vec<ErrorResult>,
     warnings: Vec<String>,
@@ -389,6 +432,15 @@ struct InstalledItem {
 }
 
 #[derive(Debug, Serialize)]
+struct RecordedItem {
+    name: String,
+    package: String,
+    /// Installed EVR recorded into ANOLISA state; `None` on a dry-run preview.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
 struct SkippedResult {
     name: String,
     reason: String,
@@ -402,11 +454,10 @@ struct ErrorResult {
 
 // ── apply ──────────────────────────────────────────────────────────────────
 
-/// A component update whose dnf transaction and rpmdb re-read both succeeded,
-/// awaiting the state save. The CLI update is intentionally not modelled here:
-/// the CLI binary is rpm-owned and not tracked as an ANOLISA component object,
-/// so it is reported but never written to `installed.toml` (self-update owns
-/// that concern).
+/// A component state refresh awaiting the state save. Most rows follow a
+/// successful dnf update; already-current observed defaults use the same shape
+/// after a read-only rpmdb refresh. The CLI update is intentionally not modelled
+/// here because the binary is not an ANOLISA component object.
 struct PendingUpdate {
     name: String,
     package: String,
@@ -414,6 +465,13 @@ struct PendingUpdate {
     from: String,
     /// Post-transaction rpmdb truth used to refresh recorded version/EVR/arch.
     refreshed: PackageInfo,
+    /// Installed package source repository, if rpm/dnf can report it separately.
+    source_repo: Option<String>,
+    /// True for a target default that was present in rpmdb but absent from state.
+    adopt_if_missing: bool,
+    /// True when no package update occurred and the item should be reported as a
+    /// state recording rather than an update.
+    record_only: bool,
 }
 
 /// A newly installed default whose dnf transaction and rpmdb re-read both
@@ -422,6 +480,7 @@ struct PendingInstall {
     name: String,
     package: String,
     refreshed: PackageInfo,
+    source_repo: Option<String>,
 }
 
 /// Outcome of the single state save: the items it actually recorded (reported as
@@ -430,7 +489,110 @@ struct PendingInstall {
 struct PersistOutcome {
     updated: Vec<UpdatedItem>,
     installed: Vec<InstalledItem>,
+    recorded: Vec<RecordedItem>,
     errors: Vec<ErrorResult>,
+}
+
+#[derive(Default)]
+struct AuthorizedPlan<'a> {
+    updates: Vec<&'a PlannedUpdate>,
+    installs: Vec<&'a PlannedInstall>,
+    observed_defaults: Vec<&'a PlannedObservedDefault>,
+    errors: Vec<ErrorResult>,
+}
+
+struct UpgradeAudit {
+    started_at: String,
+    operation_id: String,
+}
+
+struct FinalizeUpgrade<'a> {
+    ctx: &'a CliContext,
+    layout: &'a FsLayout,
+    command: &'a str,
+    state: &'a mut InstalledState,
+    audit: &'a UpgradeAudit,
+    cli_updated: Option<&'a UpdatedItem>,
+    updates: &'a [PendingUpdate],
+    installs: &'a [PendingInstall],
+    prior_errors: usize,
+    warnings: &'a [String],
+}
+
+fn new_upgrade_audit() -> UpgradeAudit {
+    let lock_ts = Utc::now();
+    UpgradeAudit {
+        started_at: now_iso8601(),
+        operation_id: format!(
+            "op-upgrade-{}-{}",
+            lock_ts.format("%Y%m%d%H%M%S"),
+            lock_ts.timestamp_subsec_nanos()
+        ),
+    }
+}
+
+/// Revalidate the plan against the locked ANOLISA state before any RPM
+/// transaction runs. Only authorized items are handed to dnf.
+fn authorize_plan<'a>(state: &InstalledState, plan: &'a UpgradePlan) -> AuthorizedPlan<'a> {
+    let mut authorized = AuthorizedPlan::default();
+
+    for update in &plan.updates {
+        match state.find_object(ObjectKind::Component, &update.name) {
+            Some(obj) if is_matching_rpm_object(obj, &update.package) => {
+                authorized.updates.push(update);
+            }
+            Some(obj) => authorized.errors.push(ErrorResult {
+                name: update.name.clone(),
+                reason: format!(
+                    "component '{}' is now {} in ANOLISA state; refusing to run dnf update for '{}'",
+                    update.name,
+                    obj.effective_ownership().label(),
+                    update.package
+                ),
+            }),
+            None if update.adopt_if_missing => authorized.updates.push(update),
+            None => authorized.errors.push(ErrorResult {
+                name: update.name.clone(),
+                reason: format!(
+                    "component '{}' is no longer present in ANOLISA state; refusing to run dnf update for '{}'",
+                    update.name, update.package
+                ),
+            }),
+        }
+    }
+
+    for install in &plan.installs {
+        match classify_install_slot(state, &install.name, &install.package) {
+            InstallSlot::Absent | InstallSlot::MatchingRpm => authorized.installs.push(install),
+            InstallSlot::Conflict(existing_ownership) => authorized.errors.push(ErrorResult {
+                name: install.name.clone(),
+                reason: format!(
+                    "component '{}' already exists as {existing_ownership} in ANOLISA state; refusing to run dnf install for '{}'",
+                    install.name, install.package
+                ),
+            }),
+        }
+    }
+
+    for observed in &plan.observed_defaults {
+        match state.find_object(ObjectKind::Component, &observed.name) {
+            Some(obj) if is_matching_rpm_object(obj, &observed.package) => {
+                authorized.observed_defaults.push(observed);
+            }
+            Some(obj) => authorized.errors.push(ErrorResult {
+                name: observed.name.clone(),
+                reason: format!(
+                    "default component '{}' already exists as {} in ANOLISA state; refusing to record '{}' as rpm-observed",
+                    observed.name,
+                    obj.effective_ownership().label(),
+                    observed.package
+                ),
+            }),
+            None => authorized.observed_defaults.push(observed),
+        }
+    }
+
+    authorized
 }
 
 /// Core of [`handle`] with the package query, transaction, root status, and
@@ -471,142 +633,197 @@ fn run_upgrade_with_deps(
     }
 
     let mut errors: Vec<ErrorResult> = Vec::new();
-    // The CLI update is applied first and reported, but is never an ANOLISA
-    // component object (the binary is rpm-owned). Held separately so the audit
-    // step can count it toward the outcome even on a CLI-only upgrade.
-    let mut cli_updated: Option<UpdatedItem> = None;
-    // Component updates / installs whose dnf transaction and rpmdb re-read both
-    // succeeded, held back until the single state save can confirm they landed.
-    // Only items the state write actually records are reported as
-    // updated/installed — a transaction that mutated rpmdb but could not be
-    // reflected in ANOLISA state must surface as an error, never a silent `ok`.
-    let mut pending_updates: Vec<PendingUpdate> = Vec::new();
-    let mut pending_installs: Vec<PendingInstall> = Vec::new();
-
-    // 1. CLI package (rpm-owned binary). Reported but never recorded as a
-    //    component object, so it is not gated on the state save.
-    if let Some(cli) = &plan.cli {
-        match txn.update(&cli.package) {
-            Ok(()) => match refresh_evr(query, &cli.package) {
-                Ok(to) => {
-                    cli_updated = Some(UpdatedItem {
-                        name: cli.name.clone(),
-                        package: cli.package.clone(),
-                        from: cli.from.clone(),
-                        to,
-                    })
-                }
-                Err(reason) => errors.push(ErrorResult {
-                    name: cli.name.clone(),
-                    reason,
-                }),
-            },
-            Err(err) => errors.push(ErrorResult {
-                name: cli.name.clone(),
-                reason: txn_error_reason(err),
-            }),
-        }
-    }
-
-    // 2. Already-installed RPM-backed components.
-    for update in &plan.updates {
-        match txn.update(&update.package) {
-            Ok(()) => match query.query_installed(&update.package) {
-                Ok(Some(info)) => pending_updates.push(PendingUpdate {
-                    name: update.name.clone(),
-                    package: update.package.clone(),
-                    from: update.from.clone(),
-                    refreshed: info,
-                }),
-                Ok(None) => errors.push(ErrorResult {
-                    name: update.name.clone(),
-                    reason: format!(
-                        "dnf upgraded '{}' but it is no longer in rpmdb under that name; run `anolisa repair {}`",
-                        update.package, update.name
-                    ),
-                }),
-                Err(err) => errors.push(ErrorResult {
-                    name: update.name.clone(),
-                    reason: format!(
-                        "dnf upgraded '{}' but reading the new version failed ({err}); run `anolisa repair {}`",
-                        update.package, update.name
-                    ),
-                }),
-            },
-            Err(err) => errors.push(ErrorResult {
-                name: update.name.clone(),
-                reason: txn_error_reason(err),
-            }),
-        }
-    }
-
-    // 3. Missing default components.
-    for install in &plan.installs {
-        match txn.install(&install.package) {
-            Ok(()) => match query.query_installed(&install.package) {
-                Ok(Some(info)) => pending_installs.push(PendingInstall {
-                    name: install.name.clone(),
-                    package: install.package.clone(),
-                    refreshed: info,
-                }),
-                Ok(None) => errors.push(ErrorResult {
-                    name: install.name.clone(),
-                    reason: format!(
-                        "dnf installed '{}' but it is not present in rpmdb; state was not recorded",
-                        install.package
-                    ),
-                }),
-                Err(err) => errors.push(ErrorResult {
-                    name: install.name.clone(),
-                    reason: format!(
-                        "dnf installed '{}' but reading its version failed ({err}); state was not recorded",
-                        install.package
-                    ),
-                }),
-            },
-            Err(err) => errors.push(ErrorResult {
-                name: install.name.clone(),
-                reason: txn_error_reason(err),
-            }),
-        }
-    }
-
-    // 4. Refresh ANOLISA state and write the durable audit under the install
-    //    lock. This runs whenever any dnf transaction was attempted — including
-    //    a CLI-only upgrade with no component changes — so a real system
-    //    mutation always leaves an operation record and central-log entry, never
-    //    a silent `ok`. Persistence reloads state and validates each component
-    //    against it, so a drifted item (vanished, changed RPM identity, or
-    //    already present under a different backend) is reported as an error
-    //    rather than reported updated/installed or silently overwriting a
-    //    non-RPM record. Only items the save actually recorded come back as
-    //    updated/installed.
+    let mut warnings: Vec<String> = Vec::new();
     let mut updated: Vec<UpdatedItem> = Vec::new();
     let mut installed: Vec<InstalledItem> = Vec::new();
-    let attempted_transaction =
-        plan.cli.is_some() || !plan.updates.is_empty() || !plan.installs.is_empty();
-    if attempted_transaction {
-        // The transaction-phase errors (dnf/refresh failures) and the CLI
-        // success are passed in so the persisted operation/audit record reflects
-        // the true `ok`/`partial`/`failed` outcome of the whole command.
-        let outcome = finalize_upgrade(
+    let mut recorded: Vec<RecordedItem> = Vec::new();
+    let needs_finalize = plan.cli.is_some()
+        || !plan.updates.is_empty()
+        || !plan.installs.is_empty()
+        || !plan.observed_defaults.is_empty();
+    if needs_finalize {
+        let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to acquire install lock: {err}"),
+        })?;
+        let mut state = common::load_installed_state(ctx, command)?;
+        let audit = new_upgrade_audit();
+
+        // Upgrade only runs in system mode; keep the state scope consistent with
+        // install/adopt so a fresh state file records the right mode/prefix.
+        state.install_mode = StateInstallMode::System;
+        state.prefix = layout.prefix.clone();
+
+        let authorized = authorize_plan(&state, plan);
+        errors.extend(authorized.errors);
+
+        // The CLI update is applied first and reported, but is never an ANOLISA
+        // component object (the binary is rpm-owned). Held separately so the
+        // audit step can count it toward the outcome even on a CLI-only upgrade.
+        let mut cli_updated: Option<UpdatedItem> = None;
+        // Component updates / installs whose dnf transaction and rpmdb re-read
+        // both succeeded, held back until the single state save records them.
+        let mut pending_updates: Vec<PendingUpdate> = Vec::new();
+        let mut pending_installs: Vec<PendingInstall> = Vec::new();
+
+        // 1. CLI package (rpm-owned binary). Reported but never recorded as a
+        //    component object, so it is not gated on component state.
+        if let Some(cli) = &plan.cli {
+            match txn.update(&cli.package) {
+                Ok(()) => match refresh_evr(query, &cli.package) {
+                    Ok(to) => {
+                        cli_updated = Some(UpdatedItem {
+                            name: cli.name.clone(),
+                            package: cli.package.clone(),
+                            from: cli.from.clone(),
+                            to,
+                        })
+                    }
+                    Err(reason) => errors.push(ErrorResult {
+                        name: cli.name.clone(),
+                        reason,
+                    }),
+                },
+                Err(err) => errors.push(ErrorResult {
+                    name: cli.name.clone(),
+                    reason: txn_error_reason(err),
+                }),
+            }
+        }
+
+        // 2. Already-installed RPM-backed components authorized by locked state.
+        for update in authorized.updates {
+            match txn.update(&update.package) {
+                Ok(()) => match query.query_installed(&update.package) {
+                    Ok(Some(info)) => {
+                        let source_repo =
+                            installed_origin_or_warn(query, &update.package, &mut warnings);
+                        pending_updates.push(PendingUpdate {
+                            name: update.name.clone(),
+                            package: update.package.clone(),
+                            from: update.from.clone(),
+                            refreshed: info,
+                            source_repo,
+                            adopt_if_missing: update.adopt_if_missing,
+                            record_only: false,
+                        });
+                    }
+                    Ok(None) => errors.push(ErrorResult {
+                        name: update.name.clone(),
+                        reason: format!(
+                            "dnf upgraded '{}' but it is no longer in rpmdb under that name; run `anolisa repair {}`",
+                            update.package, update.name
+                        ),
+                    }),
+                    Err(err) => errors.push(ErrorResult {
+                        name: update.name.clone(),
+                        reason: format!(
+                            "dnf upgraded '{}' but reading the new version failed ({err}); run `anolisa repair {}`",
+                            update.package, update.name
+                        ),
+                    }),
+                },
+                Err(err) => errors.push(ErrorResult {
+                    name: update.name.clone(),
+                    reason: txn_error_reason(err),
+                }),
+            }
+        }
+
+        // 3. Missing default components authorized by locked state.
+        for install in authorized.installs {
+            match txn.install(&install.package) {
+                Ok(()) => match query.query_installed(&install.package) {
+                    Ok(Some(info)) => {
+                        let source_repo =
+                            installed_origin_or_warn(query, &install.package, &mut warnings);
+                        pending_installs.push(PendingInstall {
+                            name: install.name.clone(),
+                            package: install.package.clone(),
+                            refreshed: info,
+                            source_repo,
+                        });
+                    }
+                    Ok(None) => errors.push(ErrorResult {
+                        name: install.name.clone(),
+                        reason: format!(
+                            "dnf installed '{}' but it is not present in rpmdb; state was not recorded",
+                            install.package
+                        ),
+                    }),
+                    Err(err) => errors.push(ErrorResult {
+                        name: install.name.clone(),
+                        reason: format!(
+                            "dnf installed '{}' but reading its version failed ({err}); state was not recorded",
+                            install.package
+                        ),
+                    }),
+                },
+                Err(err) => errors.push(ErrorResult {
+                    name: install.name.clone(),
+                    reason: txn_error_reason(err),
+                }),
+            }
+        }
+
+        // 4. Already-current target defaults authorized by locked state. No dnf
+        //    transaction is needed; refresh rpmdb truth and record as observed.
+        for observed in authorized.observed_defaults {
+            match query.query_installed(&observed.package) {
+                Ok(Some(info)) => {
+                    let source_repo =
+                        installed_origin_or_warn(query, &observed.package, &mut warnings);
+                    pending_updates.push(PendingUpdate {
+                        name: observed.name.clone(),
+                        package: observed.package.clone(),
+                        from: observed.installed.clone(),
+                        refreshed: info,
+                        source_repo,
+                        adopt_if_missing: true,
+                        record_only: true,
+                    });
+                }
+                Ok(None) => errors.push(ErrorResult {
+                    name: observed.name.clone(),
+                    reason: format!(
+                        "default component '{}' resolved to package '{}' but it is absent from rpmdb; state was not recorded",
+                        observed.name, observed.package
+                    ),
+                }),
+                Err(err) => errors.push(ErrorResult {
+                    name: observed.name.clone(),
+                    reason: format!(
+                        "default component '{}' resolved to package '{}' but reading its version failed ({err}); state was not recorded",
+                        observed.name, observed.package
+                    ),
+                }),
+            }
+        }
+
+        // Refresh ANOLISA state and write the durable audit while the same lock
+        // that authorized the RPM work is still held.
+        let outcome = finalize_upgrade(FinalizeUpgrade {
             ctx,
             layout,
             command,
-            cli_updated.as_ref(),
-            &pending_updates,
-            &pending_installs,
-            errors.len(),
-        )?;
+            state: &mut state,
+            audit: &audit,
+            cli_updated: cli_updated.as_ref(),
+            updates: &pending_updates,
+            installs: &pending_installs,
+            prior_errors: errors.len(),
+            warnings: &warnings,
+        })?;
         if let Some(item) = cli_updated {
             updated.push(item);
         }
         updated.extend(outcome.updated);
         installed.extend(outcome.installed);
+        recorded.extend(outcome.recorded);
         errors.extend(outcome.errors);
     }
 
-    let succeeded = updated.len() + installed.len();
+    let succeeded = updated.len() + installed.len() + recorded.len();
     let status = apply_status(succeeded, errors.len());
 
     Ok(UpgradeResult {
@@ -616,9 +833,10 @@ fn run_upgrade_with_deps(
         dry_run: false,
         updated,
         installed,
+        recorded,
         skipped: skipped_results(plan),
         errors,
-        warnings: Vec::new(),
+        warnings,
     })
 }
 
@@ -645,6 +863,22 @@ fn refresh_evr(query: &dyn PackageQuery, package: &str) -> Result<String, String
         Err(err) => Err(format!(
             "dnf upgraded '{package}' but reading the new version failed: {err}"
         )),
+    }
+}
+
+fn installed_origin_or_warn(
+    query: &dyn PackageQuery,
+    package: &str,
+    warnings: &mut Vec<String>,
+) -> Option<String> {
+    match query.installed_origin(package) {
+        Ok(origin) => origin,
+        Err(err) => {
+            warnings.push(format!(
+                "could not determine source repo for '{package}': {err}"
+            ));
+            None
+        }
     }
 }
 
@@ -688,6 +922,15 @@ fn render_plan_preview(plan: &UpgradePlan) -> UpgradeResult {
             version: None,
         })
         .collect();
+    let recorded = plan
+        .observed_defaults
+        .iter()
+        .map(|observed| RecordedItem {
+            name: observed.name.clone(),
+            package: observed.package.clone(),
+            version: None,
+        })
+        .collect();
 
     // A dry-run whose plan carries errors would be blocked if applied for real;
     // report that so automation can gate on it, otherwise `ok`.
@@ -704,6 +947,7 @@ fn render_plan_preview(plan: &UpgradePlan) -> UpgradeResult {
         dry_run: true,
         updated,
         installed,
+        recorded,
         skipped: skipped_results(plan),
         errors: plan_errors(plan),
         warnings: Vec::new(),
@@ -719,6 +963,7 @@ fn blocked_result(plan: &UpgradePlan) -> UpgradeResult {
         dry_run: false,
         updated: Vec::new(),
         installed: Vec::new(),
+        recorded: Vec::new(),
         skipped: skipped_results(plan),
         errors: plan_errors(plan),
         warnings: Vec::new(),
@@ -756,21 +1001,21 @@ fn plan_errors(plan: &UpgradePlan) -> Vec<ErrorResult> {
 
 // ── state persistence + audit ────────────────────────────────────────────────
 
-/// Refresh ANOLISA state for the successful component transactions and write the
-/// durable audit (operation record + central log) under the install lock.
+/// Refresh ANOLISA state for successful component work and write the durable
+/// audit (operation record + central log) while the caller holds the install
+/// lock used to authorize the RPM transactions.
 ///
 /// Audit is decoupled from component-state changes: because a real dnf
 /// transaction may have run even when nothing lands in `installed.toml` (a
-/// CLI-only upgrade, or a run where every component drifted/failed), this always
-/// appends an operation record and central-log entry whenever any transaction
-/// was attempted — so a real system mutation is never left unaudited. The
-/// recorded status is the true `ok` / `partial` / `failed` outcome of the whole
-/// command (`cli_updated` and `prior_errors` from the transaction phase are
-/// folded in), not just the component-persistence result.
+/// CLI-only upgrade, or a run where every component drifted/failed), and some
+/// already-current defaults only need a state record, this appends an operation
+/// record and central-log entry whenever real work was attempted. The recorded
+/// status is the true `ok` / `partial` / `failed` outcome of the whole command
+/// (`cli_updated` and `prior_errors` from the transaction phase are folded in),
+/// not just the component-persistence result.
 ///
-/// State is reloaded under the lock and each pending change is re-validated
-/// against it, because the plan was computed before the lock was held and before
-/// the dnf transactions ran — the on-disk state may have drifted in between:
+/// Each pending change is still re-validated against the locked state before it
+/// is recorded:
 /// - **updates**: the component must still exist and still be the same RPM
 ///   package (mirrors the single-component update guard); otherwise the new EVR
 ///   is not grafted on and the item is reported as an error.
@@ -785,39 +1030,50 @@ fn plan_errors(plan: &UpgradePlan) -> Vec<ErrorResult> {
 /// refused change is returned as an error so the caller downgrades the overall
 /// status rather than claiming a clean `ok` while state is stale. RPM-owned
 /// files are never recorded — dnf owns the file transaction.
-fn finalize_upgrade(
-    ctx: &CliContext,
-    layout: &FsLayout,
-    command: &str,
-    cli_updated: Option<&UpdatedItem>,
-    updates: &[PendingUpdate],
-    installs: &[PendingInstall],
-    prior_errors: usize,
-) -> Result<PersistOutcome, CliError> {
-    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("failed to acquire install lock: {err}"),
-    })?;
-    let mut state = common::load_installed_state(ctx, command)?;
-
-    let started_at = now_iso8601();
-    let lock_ts = Utc::now();
-    let operation_id = format!(
-        "op-upgrade-{}-{}",
-        lock_ts.format("%Y%m%d%H%M%S"),
-        lock_ts.timestamp_subsec_nanos()
-    );
-
-    // Upgrade only runs in system mode; keep the state scope consistent with the
-    // install/adopt paths so a fresh state file records the right mode/prefix.
-    state.install_mode = StateInstallMode::System;
-    state.prefix = layout.prefix.clone();
-
+fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError> {
+    let FinalizeUpgrade {
+        ctx,
+        layout,
+        command,
+        state,
+        audit,
+        cli_updated,
+        updates,
+        installs,
+        prior_errors,
+        warnings,
+    } = req;
     let mut outcome = PersistOutcome::default();
 
     for update in updates {
         let evr = update.refreshed.version.to_string();
         let Some(obj) = state.find_object_mut(ObjectKind::Component, &update.name) else {
+            if update.adopt_if_missing {
+                state.upsert_object(new_observed_rpm_component(
+                    &update.name,
+                    &update.package,
+                    &evr,
+                    &update.refreshed,
+                    update.source_repo.as_deref(),
+                    &audit.started_at,
+                    &audit.operation_id,
+                ));
+                if update.record_only {
+                    outcome.recorded.push(RecordedItem {
+                        name: update.name.clone(),
+                        package: update.package.clone(),
+                        version: Some(evr),
+                    });
+                } else {
+                    outcome.updated.push(UpdatedItem {
+                        name: update.name.clone(),
+                        package: update.package.clone(),
+                        from: update.from.clone(),
+                        to: evr,
+                    });
+                }
+                continue;
+            }
             outcome.errors.push(ErrorResult {
                 name: update.name.clone(),
                 reason: format!(
@@ -830,12 +1086,7 @@ fn finalize_upgrade(
         // Refuse to graft the new EVR onto a row that is no longer this RPM
         // package (a concurrent backend change), mirroring the single-component
         // update guard.
-        let matches = obj
-            .rpm_metadata
-            .as_ref()
-            .is_some_and(|m| m.package_name == update.package)
-            && obj.effective_ownership().is_rpm();
-        if !matches {
+        if !is_matching_rpm_object(obj, &update.package) {
             outcome.errors.push(ErrorResult {
                 name: update.name.clone(),
                 reason: format!(
@@ -846,48 +1097,42 @@ fn finalize_upgrade(
             continue;
         }
         obj.version = evr.clone();
-        obj.last_operation_id = Some(operation_id.clone());
+        obj.last_operation_id = Some(audit.operation_id.clone());
         if let Some(meta) = obj.rpm_metadata.as_mut() {
             meta.evr = Some(evr.clone());
             meta.arch = Some(update.refreshed.arch.clone());
+            if let Some(source_repo) = &update.source_repo {
+                meta.source_repo = Some(source_repo.clone());
+            }
         }
-        outcome.updated.push(UpdatedItem {
-            name: update.name.clone(),
-            package: update.package.clone(),
-            from: update.from.clone(),
-            to: evr,
-        });
+        if update.record_only {
+            outcome.recorded.push(RecordedItem {
+                name: update.name.clone(),
+                package: update.package.clone(),
+                version: Some(evr),
+            });
+        } else {
+            outcome.updated.push(UpdatedItem {
+                name: update.name.clone(),
+                package: update.package.clone(),
+                from: update.from.clone(),
+                to: evr,
+            });
+        }
     }
 
     for install in installs {
         let evr = install.refreshed.version.to_string();
-        // Classify the current state slot with an immutable borrow that is
-        // dropped before any mutation below.
-        let slot = match state.find_object(ObjectKind::Component, &install.name) {
-            None => InstallSlot::Absent,
-            Some(existing) => {
-                let same_rpm = existing
-                    .rpm_metadata
-                    .as_ref()
-                    .is_some_and(|m| m.package_name == install.package)
-                    && existing.effective_ownership().is_rpm();
-                if same_rpm {
-                    InstallSlot::MatchingRpm
-                } else {
-                    InstallSlot::Conflict(existing.effective_ownership().label())
-                }
-            }
-        };
-
-        match slot {
+        match classify_install_slot(state, &install.name, &install.package) {
             InstallSlot::Absent => {
                 state.upsert_object(new_rpm_component(
                     &install.name,
                     &install.package,
                     &evr,
                     &install.refreshed,
-                    &started_at,
-                    &operation_id,
+                    install.source_repo.as_deref(),
+                    &audit.started_at,
+                    &audit.operation_id,
                 ));
                 outcome.installed.push(InstalledItem {
                     name: install.name.clone(),
@@ -900,10 +1145,13 @@ fn finalize_upgrade(
             InstallSlot::MatchingRpm => {
                 if let Some(obj) = state.find_object_mut(ObjectKind::Component, &install.name) {
                     obj.version = evr.clone();
-                    obj.last_operation_id = Some(operation_id.clone());
+                    obj.last_operation_id = Some(audit.operation_id.clone());
                     if let Some(meta) = obj.rpm_metadata.as_mut() {
                         meta.evr = Some(evr.clone());
                         meta.arch = Some(install.refreshed.arch.clone());
+                        if let Some(source_repo) = &install.source_repo {
+                            meta.source_repo = Some(source_repo.clone());
+                        }
                     }
                 }
                 outcome.installed.push(InstalledItem {
@@ -929,8 +1177,10 @@ fn finalize_upgrade(
     // Count the whole command's outcome, not just component state: the CLI
     // update (not an ANOLISA object) and the transaction-phase errors are folded
     // in so the durable record shows the true `ok` / `partial` / `failed`.
-    let total_success =
-        cli_updated.is_some() as usize + outcome.updated.len() + outcome.installed.len();
+    let total_success = cli_updated.is_some() as usize
+        + outcome.updated.len()
+        + outcome.installed.len()
+        + outcome.recorded.len();
     let total_errors = prior_errors + outcome.errors.len();
 
     if total_success == 0 && total_errors == 0 {
@@ -950,10 +1200,10 @@ fn finalize_upgrade(
     // changed (a CLI-only upgrade, or a run where every component drifted): the
     // record is what makes a real system mutation auditable via `anolisa logs`.
     state.operations.push(OperationRecord {
-        id: operation_id.clone(),
+        id: audit.operation_id.clone(),
         command: command.to_string(),
         status: status.to_string(),
-        started_at: started_at.clone(),
+        started_at: audit.started_at.clone(),
         finished_at: Some(now_iso8601()),
     });
 
@@ -965,14 +1215,15 @@ fn finalize_upgrade(
 
     // Audit log is best-effort: state already persisted, so a log failure
     // downgrades to a stderr warning rather than unwinding.
-    let recorded = outcome.updated.len() + outcome.installed.len();
+    let recorded = outcome.updated.len() + outcome.installed.len() + outcome.recorded.len();
     let log = CentralLog::open(layout.central_log.clone());
     let mut objects: Vec<String> = cli_updated.map(|c| c.package.clone()).into_iter().collect();
     objects.extend(outcome.updated.iter().map(|u| u.name.clone()));
     objects.extend(outcome.installed.iter().map(|i| i.name.clone()));
+    objects.extend(outcome.recorded.iter().map(|i| i.name.clone()));
     let record = LogRecord {
         kind: LogKind::Operation,
-        operation_id: Some(operation_id),
+        operation_id: Some(audit.operation_id.clone()),
         command: command.to_string(),
         source: "anolisa-cli".to_string(),
         component: None,
@@ -982,12 +1233,12 @@ fn finalize_upgrade(
         ),
         actor: "cli".to_string(),
         install_mode: Some(ctx.install_mode.as_str().to_string()),
-        started_at,
+        started_at: audit.started_at.clone(),
         finished_at: Some(now_iso8601()),
         status: Some(log_status),
         objects,
         backup_ids: Vec::new(),
-        warnings: Vec::new(),
+        warnings: warnings.to_vec(),
         details: serde_json::Value::Null,
     };
     if let Err(err) = log.append(&record)
@@ -1011,6 +1262,64 @@ enum InstallSlot {
     Conflict(&'static str),
 }
 
+fn classify_install_slot(state: &InstalledState, name: &str, package: &str) -> InstallSlot {
+    match state.find_object(ObjectKind::Component, name) {
+        None => InstallSlot::Absent,
+        Some(existing) if is_matching_rpm_object(existing, package) => InstallSlot::MatchingRpm,
+        Some(existing) => InstallSlot::Conflict(existing.effective_ownership().label()),
+    }
+}
+
+fn is_matching_rpm_object(obj: &InstalledObject, package: &str) -> bool {
+    obj.rpm_metadata
+        .as_ref()
+        .is_some_and(|m| m.package_name == package)
+        && obj.effective_ownership().is_rpm()
+}
+
+/// Build an rpm-observed component object for a target default that was already
+/// installed on the host but absent from ANOLISA state. `upgrade` updated the RPM
+/// package, but ANOLISA still does not own its removal.
+fn new_observed_rpm_component(
+    name: &str,
+    package: &str,
+    evr: &str,
+    refreshed: &PackageInfo,
+    source_repo: Option<&str>,
+    installed_at: &str,
+    operation_id: &str,
+) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: name.to_string(),
+        version: evr.to_string(),
+        status: ObjectStatus::Adopted,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("rpm".to_string()),
+        ownership: Some(Ownership::RpmObserved),
+        rpm_metadata: Some(RpmMetadata {
+            package_name: package.to_string(),
+            evr: Some(evr.to_string()),
+            arch: Some(refreshed.arch.clone()),
+            source_repo: source_repo.map(str::to_string),
+        }),
+        installed_at: installed_at.to_string(),
+        last_operation_id: Some(operation_id.to_string()),
+        managed: false,
+        adopted: true,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
 /// Build a fresh rpm-managed component object for a newly installed default.
 /// Mirrors the delegated-install path: `managed = true`, `adopted = false`,
 /// ownership [`Ownership::RpmManaged`], backend `rpm`, and no owned files (dnf
@@ -1020,6 +1329,7 @@ fn new_rpm_component(
     package: &str,
     evr: &str,
     refreshed: &PackageInfo,
+    source_repo: Option<&str>,
     installed_at: &str,
     operation_id: &str,
 ) -> InstalledObject {
@@ -1037,7 +1347,7 @@ fn new_rpm_component(
             package_name: package.to_string(),
             evr: Some(evr.to_string()),
             arch: Some(refreshed.arch.clone()),
-            source_repo: refreshed.origin.clone(),
+            source_repo: source_repo.map(str::to_string),
         }),
         installed_at: installed_at.to_string(),
         last_operation_id: Some(operation_id.to_string()),
@@ -1114,6 +1424,19 @@ fn render_result(ctx: &CliContext, result: &UpgradeResult) {
             color.muted(format!("({})", item.package)),
         );
     }
+    for item in &result.recorded {
+        let verb = if result.dry_run {
+            "would record".to_string()
+        } else {
+            format!("recorded {}", item.version.as_deref().unwrap_or("-"))
+        };
+        println!(
+            "  {} {} {}",
+            color.ok(format!("✓ {verb}")),
+            item.name,
+            color.muted(format!("({})", item.package)),
+        );
+    }
     for item in &result.skipped {
         println!(
             "  {} {} {}",
@@ -1132,10 +1455,11 @@ fn render_result(ctx: &CliContext, result: &UpgradeResult) {
     }
 
     println!(
-        "{} {} updated, {} installed, {} skipped, {} error(s) [{}]",
+        "{} {} updated, {} installed, {} recorded, {} skipped, {} error(s) [{}]",
         color.label("summary:"),
         result.updated.len(),
         result.installed.len(),
+        result.recorded.len(),
         result.skipped.len(),
         result.errors.len(),
         result.status,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -1,0 +1,1150 @@
+//! `anolisa upgrade` — first-phase RPM/system-image upgrade orchestration
+//! (issue #1411).
+//!
+//! `upgrade` is an orchestration layer over RPM-backed operations, not a generic
+//! backend-migration mechanism. It consumes the exact read-only plan produced by
+//! [`anolisa update --check`](super::update::check::compute_update_check_report)
+//! and, unless `--dry-run` is given, applies it through `dnf`:
+//!
+//! 1. Update the RPM-owned `anolisa` CLI package, if a newer candidate exists.
+//! 2. Update already-installed RPM-backed components.
+//! 3. Install target-profile default components that are missing.
+//! 4. Re-read rpmdb and refresh ANOLISA state so `anolisa status` reflects the
+//!    result.
+//!
+//! Scope is deliberately narrow (first phase):
+//! - RPM / system-image scenario only; user mode is rejected. `--dry-run` waives
+//!   the root requirement but not the system-mode one, so a non-root preview is
+//!   `sudo anolisa upgrade --dry-run` or
+//!   `anolisa --install-mode system upgrade --dry-run` (matching `repair`).
+//! - Raw-managed components are **skipped** with a clear reason — never updated,
+//!   migrated, or overwritten.
+//! - npm/raw upgrade and broad adapter/framework reconciliation are out of
+//!   scope; adapter needs would be surfaced as warnings only if discovered.
+//!
+//! The command never re-derives the plan: the planner lives in `update::check`
+//! and both commands share it, so `upgrade` and `update --check` can never
+//! disagree about what is upgradable.
+
+use chrono::{SecondsFormat, Utc};
+use clap::Parser;
+use serde::Serialize;
+
+use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
+use anolisa_core::lock::InstallLock;
+use anolisa_core::state::{
+    InstallMode as StateInstallMode, InstalledObject, ObjectKind, ObjectStatus, OperationRecord,
+    Ownership, RpmMetadata,
+};
+use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery};
+use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
+use anolisa_platform::privilege;
+use anolisa_platform::rpm_query::RpmPackageQuery;
+use anolisa_platform::rpm_transaction::RpmTransaction;
+
+use super::update::check::{
+    self, ACTION_ERROR, ACTION_INSTALL, ACTION_NOOP, ACTION_UNSUPPORTED, ACTION_UNSUPPORTED_RPM,
+    ACTION_UPDATE, CliCheck, ComponentCheck,
+};
+use crate::color::Palette;
+use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
+use crate::context::{CliContext, InstallMode};
+use crate::response::{self, CliError};
+
+/// Command label for JSON envelopes and error routing.
+const COMMAND: &str = "upgrade";
+
+/// Upgrade backend this command covers. Always `rpm` in the first phase.
+const BACKEND: &str = "rpm";
+
+/// Reason attached to raw-managed components skipped by the RPM upgrade path.
+/// Matches the wording called out in issue #1411 so the boundary reads the same
+/// in the human summary and the JSON envelope.
+const RAW_SKIP_REASON: &str = "raw-managed components are out of scope for RPM image upgrade";
+
+// Stable status vocabulary for the result envelope.
+const STATUS_OK: &str = "ok";
+const STATUS_PARTIAL: &str = "partial";
+const STATUS_FAILED: &str = "failed";
+const STATUS_BLOCKED: &str = "blocked";
+
+/// Arguments for `anolisa upgrade`.
+///
+/// `--dry-run` and `--json` are global flags read from [`CliContext`]; they are
+/// intentionally not redefined here.
+#[derive(Debug, Parser)]
+pub struct UpgradeArgs {
+    /// Target image/toolchain profile (defaults to the repository-declared
+    /// default profile).
+    #[arg(long, value_name = "TARGET")]
+    pub target: Option<String>,
+
+    /// Apply the upgrade non-interactively once the plan is known.
+    ///
+    /// The first phase is already non-interactive (it never prompts), so this
+    /// flag is accepted for forward compatibility and to make the intent
+    /// explicit in scripts; it does not currently change behaviour.
+    #[arg(short = 'y', long = "assume-yes")]
+    pub assume_yes: bool,
+}
+
+/// Dispatch `anolisa upgrade`.
+///
+/// # Errors
+///
+/// Returns [`CliError`] when the install mode is not `system`, real execution
+/// is attempted without root, the configured RPM repository cannot be resolved,
+/// state cannot be persisted, or the applied upgrade finished in a non-`ok`
+/// status (partial / failed / blocked) — in the latter case the result has
+/// already been rendered and only the exit code is propagated.
+pub fn handle(args: UpgradeArgs, ctx: &CliContext) -> Result<(), CliError> {
+    // System-only: `upgrade` reasons about rpm-owned packages and the configured
+    // RPM repository, which do not exist in user mode. The dispatcher already
+    // gates this, but a direct caller (or a test) must be refused here too.
+    if ctx.install_mode != InstallMode::System {
+        return Err(CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: "`anolisa upgrade` supports only system/RPM image scenarios; run `sudo anolisa upgrade` without `--install-mode user`".to_string(),
+        });
+    }
+
+    let layout = common::resolve_layout(ctx);
+
+    // Reuse the read-only planner behind `update --check`. This performs only
+    // rpm/dnf *queries* — no transaction, no state write.
+    let report = check::compute_update_check_report(args.target.as_deref(), ctx, &layout)?;
+
+    // Resolve the configured RPM repository for the apply transactions. The
+    // planner already proved a `[backends.rpm]` table exists, so this load
+    // succeeds; it is repeated here (rather than threaded out of the planner) to
+    // keep the planner's signature read-only and repo-agnostic.
+    let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
+    let env = anolisa_env::EnvService::detect();
+    let repo = super::update::rpm_repo_source_for_update(&repo_config, &env, COMMAND)?
+        .ok_or_else(|| CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: "repo.toml has no [backends.rpm] table; `anolisa upgrade` needs the configured ANOLISA RPM repository".to_string(),
+        })?;
+    let query = RpmPackageQuery::system_with_repo(repo.clone());
+    let txn = RpmTransaction::system_with_repo(repo);
+
+    let plan = build_plan(report.target.clone(), &report.cli, &report.components);
+    let result = run_upgrade_with_deps(
+        ctx,
+        &layout,
+        &plan,
+        &query,
+        &txn,
+        privilege::is_root(),
+        ctx.dry_run,
+        COMMAND,
+    )?;
+
+    render_result(ctx, &result);
+
+    // A non-`ok` status has already been rendered (human or JSON); propagate a
+    // non-zero exit without emitting a second envelope, mirroring the batch
+    // install path.
+    if result.status == STATUS_OK {
+        Ok(())
+    } else {
+        Err(CliError::BatchPartial {
+            command: COMMAND.to_string(),
+        })
+    }
+}
+
+// ── plan conversion ────────────────────────────────────────────────────────
+
+/// A single RPM package the upgrade will `dnf upgrade`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedUpdate {
+    /// ANOLISA component name (or the CLI package name for the CLI update).
+    name: String,
+    /// RPM package to upgrade.
+    package: String,
+    /// EVR recorded before the upgrade (rpmdb truth from the check).
+    from: String,
+    /// Newest repo candidate EVR the check reported.
+    to: String,
+}
+
+/// A missing default component the upgrade will `dnf install`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedInstall {
+    name: String,
+    package: String,
+}
+
+/// An item deliberately left untouched (raw-managed, non-RPM CLI).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SkippedItem {
+    name: String,
+    reason: String,
+}
+
+/// An item that cannot be planned/applied (ambiguous mapping, missing package,
+/// upstream query failure recorded by the check).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlanError {
+    name: String,
+    reason: String,
+}
+
+/// The RPM transaction plan converted from an [`update --check`] report.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct UpgradePlan {
+    target: Option<String>,
+    /// CLI package update, kept separate because it is applied first and is not
+    /// recorded as an ANOLISA component object (the binary is owned by rpm).
+    cli: Option<PlannedUpdate>,
+    updates: Vec<PlannedUpdate>,
+    installs: Vec<PlannedInstall>,
+    skipped: Vec<SkippedItem>,
+    errors: Vec<PlanError>,
+}
+
+impl UpgradePlan {
+    /// Whether the plan carries an item error. Real execution aborts before any
+    /// `dnf` transaction when this is true.
+    fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+}
+
+/// Convert a check report's CLI + component rows into an [`UpgradePlan`].
+///
+/// This is a pure classification with no host access: it maps the check's action
+/// vocabulary onto upgrade intents (see issue #1411 §"Plan conversion"). An
+/// `install` row that carries no resolved RPM package becomes an item **error**
+/// (it cannot be applied) rather than a silent no-op; unsupported/raw-managed
+/// rows become skips and never abort.
+fn build_plan(
+    target: Option<String>,
+    cli: &CliCheck,
+    components: &[ComponentCheck],
+) -> UpgradePlan {
+    let mut plan = UpgradePlan {
+        target,
+        ..UpgradePlan::default()
+    };
+
+    // ── CLI ──
+    match cli.action.as_str() {
+        ACTION_UPDATE => match cli_update(cli) {
+            Ok(update) => plan.cli = Some(update),
+            Err(reason) => plan.errors.push(PlanError {
+                name: cli_name(cli),
+                reason,
+            }),
+        },
+        ACTION_NOOP => {}
+        ACTION_UNSUPPORTED => plan.skipped.push(SkippedItem {
+            name: cli_name(cli),
+            reason: cli.error.clone().unwrap_or_else(|| {
+                "anolisa CLI is not RPM-managed; use `anolisa update self`".to_string()
+            }),
+        }),
+        ACTION_ERROR => plan.errors.push(PlanError {
+            name: cli_name(cli),
+            reason: cli
+                .error
+                .clone()
+                .unwrap_or_else(|| "CLI upgrade check failed".to_string()),
+        }),
+        // Any other/unknown action is treated as nothing to do.
+        _ => {}
+    }
+
+    // ── components ──
+    for component in components {
+        match component.action.as_str() {
+            ACTION_UPDATE => match component_update(component) {
+                Ok(update) => plan.updates.push(update),
+                Err(reason) => plan.errors.push(PlanError {
+                    name: component.component.clone(),
+                    reason,
+                }),
+            },
+            ACTION_INSTALL => match component.package.clone() {
+                Some(package) => plan.installs.push(PlannedInstall {
+                    name: component.component.clone(),
+                    package,
+                }),
+                // A default with no resolved RPM package cannot be installed.
+                // The check leaves `package = None` when the component index has
+                // no unambiguous mapping; refuse rather than guess a name.
+                None => plan.errors.push(PlanError {
+                    name: component.component.clone(),
+                    reason: format!(
+                        "no RPM package could be resolved for default component '{}'; cannot install it (repo component index is missing or ambiguous)",
+                        component.component
+                    ),
+                }),
+            },
+            ACTION_UNSUPPORTED_RPM => plan.skipped.push(SkippedItem {
+                name: component.component.clone(),
+                reason: RAW_SKIP_REASON.to_string(),
+            }),
+            ACTION_NOOP => {}
+            ACTION_ERROR => plan.errors.push(PlanError {
+                name: component.component.clone(),
+                reason: component
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "component upgrade check failed".to_string()),
+            }),
+            _ => {}
+        }
+    }
+
+    plan
+}
+
+/// Human/JSON name for the CLI row (its RPM package, falling back to `anolisa`).
+fn cli_name(cli: &CliCheck) -> String {
+    cli.package.clone().unwrap_or_else(|| "anolisa".to_string())
+}
+
+/// Build the CLI [`PlannedUpdate`], or an error string when the check row is
+/// missing the fields an update needs.
+fn cli_update(cli: &CliCheck) -> Result<PlannedUpdate, String> {
+    let package = cli
+        .package
+        .clone()
+        .ok_or_else(|| "CLI update reported without an RPM package".to_string())?;
+    let from = cli
+        .installed
+        .clone()
+        .ok_or_else(|| "CLI update reported without an installed version".to_string())?;
+    let to = cli
+        .available
+        .clone()
+        .ok_or_else(|| "CLI update reported without a candidate version".to_string())?;
+    Ok(PlannedUpdate {
+        name: package.clone(),
+        package,
+        from,
+        to,
+    })
+}
+
+/// Build a component [`PlannedUpdate`], or an error string when the check row is
+/// missing the fields an update needs.
+fn component_update(component: &ComponentCheck) -> Result<PlannedUpdate, String> {
+    let package = component
+        .package
+        .clone()
+        .ok_or_else(|| "update reported without an RPM package".to_string())?;
+    let from = component
+        .installed
+        .clone()
+        .ok_or_else(|| "update reported without an installed version".to_string())?;
+    let to = component
+        .available
+        .clone()
+        .ok_or_else(|| "update reported without a candidate version".to_string())?;
+    Ok(PlannedUpdate {
+        name: component.component.clone(),
+        package,
+        from,
+        to,
+    })
+}
+
+// ── result envelope ──────────────────────────────────────────────────────────
+
+/// Wire shape for `anolisa upgrade` (`--json`) and the human summary source.
+#[derive(Debug, Serialize)]
+struct UpgradeResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<String>,
+    backend: &'static str,
+    status: &'static str,
+    dry_run: bool,
+    updated: Vec<UpdatedItem>,
+    installed: Vec<InstalledItem>,
+    skipped: Vec<SkippedResult>,
+    errors: Vec<ErrorResult>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdatedItem {
+    name: String,
+    package: String,
+    from: String,
+    to: String,
+}
+
+#[derive(Debug, Serialize)]
+struct InstalledItem {
+    name: String,
+    package: String,
+    /// Installed EVR after `dnf install`; `None` on a dry-run preview.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SkippedResult {
+    name: String,
+    reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResult {
+    name: String,
+    reason: String,
+}
+
+// ── apply ──────────────────────────────────────────────────────────────────
+
+/// A component update whose dnf transaction and rpmdb re-read both succeeded,
+/// awaiting the state save. The CLI update is intentionally not modelled here:
+/// the CLI binary is rpm-owned and not tracked as an ANOLISA component object,
+/// so it is reported but never written to `installed.toml` (self-update owns
+/// that concern).
+struct PendingUpdate {
+    name: String,
+    package: String,
+    /// EVR before the upgrade, carried through so the result can show `from → to`.
+    from: String,
+    /// Post-transaction rpmdb truth used to refresh recorded version/EVR/arch.
+    refreshed: PackageInfo,
+}
+
+/// A newly installed default whose dnf transaction and rpmdb re-read both
+/// succeeded, awaiting the state save.
+struct PendingInstall {
+    name: String,
+    package: String,
+    refreshed: PackageInfo,
+}
+
+/// Outcome of the single state save: the items it actually recorded (reported as
+/// updated/installed) plus per-item drift errors for changes it refused to make.
+#[derive(Default)]
+struct PersistOutcome {
+    updated: Vec<UpdatedItem>,
+    installed: Vec<InstalledItem>,
+    errors: Vec<ErrorResult>,
+}
+
+/// Core of [`handle`] with the package query, transaction, root status, and
+/// dry-run flag injected so tests drive the whole apply path without a live
+/// rpmdb/dnf or real privileges.
+///
+/// Dry-run renders the plan (and any item errors) without touching the host.
+/// Real execution requires root, aborts before any `dnf` transaction if the plan
+/// carries errors, then applies CLI update → component updates → missing-default
+/// installs, refreshing ANOLISA state from rpmdb once at the end.
+#[allow(clippy::too_many_arguments)]
+fn run_upgrade_with_deps(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    plan: &UpgradePlan,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    dry_run: bool,
+    command: &str,
+) -> Result<UpgradeResult, CliError> {
+    if dry_run {
+        return Ok(render_plan_preview(plan));
+    }
+
+    // Real execution needs root for the dnf transactions. Check up front so the
+    // operator gets an actionable message rather than dnf's raw refusal.
+    if !is_root {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: "applying an RPM image upgrade requires root privileges; re-run with sudo: `sudo anolisa upgrade`".to_string(),
+        });
+    }
+
+    // Any planning error blocks the whole run before a single dnf transaction.
+    if plan.has_errors() {
+        return Ok(blocked_result(plan));
+    }
+
+    let mut errors: Vec<ErrorResult> = Vec::new();
+    // The CLI update is applied first and reported, but is never an ANOLISA
+    // component object (the binary is rpm-owned). Held separately so the audit
+    // step can count it toward the outcome even on a CLI-only upgrade.
+    let mut cli_updated: Option<UpdatedItem> = None;
+    // Component updates / installs whose dnf transaction and rpmdb re-read both
+    // succeeded, held back until the single state save can confirm they landed.
+    // Only items the state write actually records are reported as
+    // updated/installed — a transaction that mutated rpmdb but could not be
+    // reflected in ANOLISA state must surface as an error, never a silent `ok`.
+    let mut pending_updates: Vec<PendingUpdate> = Vec::new();
+    let mut pending_installs: Vec<PendingInstall> = Vec::new();
+
+    // 1. CLI package (rpm-owned binary). Reported but never recorded as a
+    //    component object, so it is not gated on the state save.
+    if let Some(cli) = &plan.cli {
+        match txn.update(&cli.package) {
+            Ok(()) => match refresh_evr(query, &cli.package) {
+                Ok(to) => {
+                    cli_updated = Some(UpdatedItem {
+                        name: cli.name.clone(),
+                        package: cli.package.clone(),
+                        from: cli.from.clone(),
+                        to,
+                    })
+                }
+                Err(reason) => errors.push(ErrorResult {
+                    name: cli.name.clone(),
+                    reason,
+                }),
+            },
+            Err(err) => errors.push(ErrorResult {
+                name: cli.name.clone(),
+                reason: txn_error_reason(err),
+            }),
+        }
+    }
+
+    // 2. Already-installed RPM-backed components.
+    for update in &plan.updates {
+        match txn.update(&update.package) {
+            Ok(()) => match query.query_installed(&update.package) {
+                Ok(Some(info)) => pending_updates.push(PendingUpdate {
+                    name: update.name.clone(),
+                    package: update.package.clone(),
+                    from: update.from.clone(),
+                    refreshed: info,
+                }),
+                Ok(None) => errors.push(ErrorResult {
+                    name: update.name.clone(),
+                    reason: format!(
+                        "dnf upgraded '{}' but it is no longer in rpmdb under that name; run `anolisa repair {}`",
+                        update.package, update.name
+                    ),
+                }),
+                Err(err) => errors.push(ErrorResult {
+                    name: update.name.clone(),
+                    reason: format!(
+                        "dnf upgraded '{}' but reading the new version failed ({err}); run `anolisa repair {}`",
+                        update.package, update.name
+                    ),
+                }),
+            },
+            Err(err) => errors.push(ErrorResult {
+                name: update.name.clone(),
+                reason: txn_error_reason(err),
+            }),
+        }
+    }
+
+    // 3. Missing default components.
+    for install in &plan.installs {
+        match txn.install(&install.package) {
+            Ok(()) => match query.query_installed(&install.package) {
+                Ok(Some(info)) => pending_installs.push(PendingInstall {
+                    name: install.name.clone(),
+                    package: install.package.clone(),
+                    refreshed: info,
+                }),
+                Ok(None) => errors.push(ErrorResult {
+                    name: install.name.clone(),
+                    reason: format!(
+                        "dnf installed '{}' but it is not present in rpmdb; state was not recorded",
+                        install.package
+                    ),
+                }),
+                Err(err) => errors.push(ErrorResult {
+                    name: install.name.clone(),
+                    reason: format!(
+                        "dnf installed '{}' but reading its version failed ({err}); state was not recorded",
+                        install.package
+                    ),
+                }),
+            },
+            Err(err) => errors.push(ErrorResult {
+                name: install.name.clone(),
+                reason: txn_error_reason(err),
+            }),
+        }
+    }
+
+    // 4. Refresh ANOLISA state and write the durable audit under the install
+    //    lock. This runs whenever any dnf transaction was attempted — including
+    //    a CLI-only upgrade with no component changes — so a real system
+    //    mutation always leaves an operation record and central-log entry, never
+    //    a silent `ok`. Persistence reloads state and validates each component
+    //    against it, so a drifted item (vanished, changed RPM identity, or
+    //    already present under a different backend) is reported as an error
+    //    rather than reported updated/installed or silently overwriting a
+    //    non-RPM record. Only items the save actually recorded come back as
+    //    updated/installed.
+    let mut updated: Vec<UpdatedItem> = Vec::new();
+    let mut installed: Vec<InstalledItem> = Vec::new();
+    let attempted_transaction =
+        plan.cli.is_some() || !plan.updates.is_empty() || !plan.installs.is_empty();
+    if attempted_transaction {
+        // The transaction-phase errors (dnf/refresh failures) and the CLI
+        // success are passed in so the persisted operation/audit record reflects
+        // the true `ok`/`partial`/`failed` outcome of the whole command.
+        let outcome = finalize_upgrade(
+            ctx,
+            layout,
+            command,
+            cli_updated.as_ref(),
+            &pending_updates,
+            &pending_installs,
+            errors.len(),
+        )?;
+        if let Some(item) = cli_updated {
+            updated.push(item);
+        }
+        updated.extend(outcome.updated);
+        installed.extend(outcome.installed);
+        errors.extend(outcome.errors);
+    }
+
+    let succeeded = updated.len() + installed.len();
+    let status = apply_status(succeeded, errors.len());
+
+    Ok(UpgradeResult {
+        target: plan.target.clone(),
+        backend: BACKEND,
+        status,
+        dry_run: false,
+        updated,
+        installed,
+        skipped: skipped_results(plan),
+        errors,
+        warnings: Vec::new(),
+    })
+}
+
+/// Status for a completed real run: `ok` when nothing errored, `partial` when
+/// some items succeeded and some failed, `failed` when nothing succeeded.
+fn apply_status(succeeded: usize, error_count: usize) -> &'static str {
+    if error_count == 0 {
+        STATUS_OK
+    } else if succeeded > 0 {
+        STATUS_PARTIAL
+    } else {
+        STATUS_FAILED
+    }
+}
+
+/// Re-read the installed EVR of `package` after a transaction, mapping the
+/// "gone/duplicate/query-failed" branches to a human reason string.
+fn refresh_evr(query: &dyn PackageQuery, package: &str) -> Result<String, String> {
+    match query.query_installed(package) {
+        Ok(Some(info)) => Ok(info.version.to_string()),
+        Ok(None) => Err(format!(
+            "dnf upgraded '{package}' but it is no longer in rpmdb under that name"
+        )),
+        Err(err) => Err(format!(
+            "dnf upgraded '{package}' but reading the new version failed: {err}"
+        )),
+    }
+}
+
+/// Human-readable reason for a failed `dnf` transaction.
+fn txn_error_reason(err: PackageTransactionError) -> String {
+    match err {
+        PackageTransactionError::CommandMissing { command } => {
+            format!("{command} not found; cannot run the RPM transaction")
+        }
+        PackageTransactionError::PermissionDenied { command } => {
+            format!("permission denied running {command}; re-run with sudo")
+        }
+        PackageTransactionError::TransactionFailed {
+            operation,
+            code,
+            stderr,
+            ..
+        } => format!(
+            "dnf {operation} failed (exit {}): {}",
+            code.map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string()),
+            stderr.trim(),
+        ),
+    }
+}
+
+/// Build the dry-run preview result from the plan (no host access).
+fn render_plan_preview(plan: &UpgradePlan) -> UpgradeResult {
+    let mut updated: Vec<UpdatedItem> = Vec::new();
+    if let Some(cli) = &plan.cli {
+        updated.push(planned_to_updated(cli));
+    }
+    updated.extend(plan.updates.iter().map(planned_to_updated));
+
+    let installed = plan
+        .installs
+        .iter()
+        .map(|install| InstalledItem {
+            name: install.name.clone(),
+            package: install.package.clone(),
+            version: None,
+        })
+        .collect();
+
+    // A dry-run whose plan carries errors would be blocked if applied for real;
+    // report that so automation can gate on it, otherwise `ok`.
+    let status = if plan.has_errors() {
+        STATUS_BLOCKED
+    } else {
+        STATUS_OK
+    };
+
+    UpgradeResult {
+        target: plan.target.clone(),
+        backend: BACKEND,
+        status,
+        dry_run: true,
+        updated,
+        installed,
+        skipped: skipped_results(plan),
+        errors: plan_errors(plan),
+        warnings: Vec::new(),
+    }
+}
+
+/// Build a `blocked` result: the plan carried errors, so no dnf ran.
+fn blocked_result(plan: &UpgradePlan) -> UpgradeResult {
+    UpgradeResult {
+        target: plan.target.clone(),
+        backend: BACKEND,
+        status: STATUS_BLOCKED,
+        dry_run: false,
+        updated: Vec::new(),
+        installed: Vec::new(),
+        skipped: skipped_results(plan),
+        errors: plan_errors(plan),
+        warnings: Vec::new(),
+    }
+}
+
+fn planned_to_updated(update: &PlannedUpdate) -> UpdatedItem {
+    UpdatedItem {
+        name: update.name.clone(),
+        package: update.package.clone(),
+        from: update.from.clone(),
+        to: update.to.clone(),
+    }
+}
+
+fn skipped_results(plan: &UpgradePlan) -> Vec<SkippedResult> {
+    plan.skipped
+        .iter()
+        .map(|item| SkippedResult {
+            name: item.name.clone(),
+            reason: item.reason.clone(),
+        })
+        .collect()
+}
+
+fn plan_errors(plan: &UpgradePlan) -> Vec<ErrorResult> {
+    plan.errors
+        .iter()
+        .map(|item| ErrorResult {
+            name: item.name.clone(),
+            reason: item.reason.clone(),
+        })
+        .collect()
+}
+
+// ── state persistence + audit ────────────────────────────────────────────────
+
+/// Refresh ANOLISA state for the successful component transactions and write the
+/// durable audit (operation record + central log) under the install lock.
+///
+/// Audit is decoupled from component-state changes: because a real dnf
+/// transaction may have run even when nothing lands in `installed.toml` (a
+/// CLI-only upgrade, or a run where every component drifted/failed), this always
+/// appends an operation record and central-log entry whenever any transaction
+/// was attempted — so a real system mutation is never left unaudited. The
+/// recorded status is the true `ok` / `partial` / `failed` outcome of the whole
+/// command (`cli_updated` and `prior_errors` from the transaction phase are
+/// folded in), not just the component-persistence result.
+///
+/// State is reloaded under the lock and each pending change is re-validated
+/// against it, because the plan was computed before the lock was held and before
+/// the dnf transactions ran — the on-disk state may have drifted in between:
+/// - **updates**: the component must still exist and still be the same RPM
+///   package (mirrors the single-component update guard); otherwise the new EVR
+///   is not grafted on and the item is reported as an error.
+/// - **installs**: a name absent from state is inserted as rpm-managed; a name
+///   already present under the *same* RPM package is refreshed idempotently; a
+///   name present under a **different** backend/package (e.g. a raw-managed
+///   component, or a different RPM) is left untouched and reported as an error,
+///   so a concurrent install can never be silently overwritten with an
+///   rpm-managed record.
+///
+/// Only the changes actually recorded are returned as updated/installed; every
+/// refused change is returned as an error so the caller downgrades the overall
+/// status rather than claiming a clean `ok` while state is stale. RPM-owned
+/// files are never recorded — dnf owns the file transaction.
+fn finalize_upgrade(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    command: &str,
+    cli_updated: Option<&UpdatedItem>,
+    updates: &[PendingUpdate],
+    installs: &[PendingInstall],
+    prior_errors: usize,
+) -> Result<PersistOutcome, CliError> {
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state = common::load_installed_state(ctx, command)?;
+
+    let started_at = now_iso8601();
+    let lock_ts = Utc::now();
+    let operation_id = format!(
+        "op-upgrade-{}-{}",
+        lock_ts.format("%Y%m%d%H%M%S"),
+        lock_ts.timestamp_subsec_nanos()
+    );
+
+    // Upgrade only runs in system mode; keep the state scope consistent with the
+    // install/adopt paths so a fresh state file records the right mode/prefix.
+    state.install_mode = StateInstallMode::System;
+    state.prefix = layout.prefix.clone();
+
+    let mut outcome = PersistOutcome::default();
+
+    for update in updates {
+        let evr = update.refreshed.version.to_string();
+        let Some(obj) = state.find_object_mut(ObjectKind::Component, &update.name) else {
+            outcome.errors.push(ErrorResult {
+                name: update.name.clone(),
+                reason: format!(
+                    "dnf upgraded '{}' but component '{}' vanished from ANOLISA state during the upgrade; run `anolisa repair {}` to refresh it",
+                    update.package, update.name, update.name
+                ),
+            });
+            continue;
+        };
+        // Refuse to graft the new EVR onto a row that is no longer this RPM
+        // package (a concurrent backend change), mirroring the single-component
+        // update guard.
+        let matches = obj
+            .rpm_metadata
+            .as_ref()
+            .is_some_and(|m| m.package_name == update.package)
+            && obj.effective_ownership().is_rpm();
+        if !matches {
+            outcome.errors.push(ErrorResult {
+                name: update.name.clone(),
+                reason: format!(
+                    "dnf upgraded '{}' but component '{}' changed ownership/package in ANOLISA state during the upgrade; state was not refreshed — run `anolisa repair {}`",
+                    update.package, update.name, update.name
+                ),
+            });
+            continue;
+        }
+        obj.version = evr.clone();
+        obj.last_operation_id = Some(operation_id.clone());
+        if let Some(meta) = obj.rpm_metadata.as_mut() {
+            meta.evr = Some(evr.clone());
+            meta.arch = Some(update.refreshed.arch.clone());
+        }
+        outcome.updated.push(UpdatedItem {
+            name: update.name.clone(),
+            package: update.package.clone(),
+            from: update.from.clone(),
+            to: evr,
+        });
+    }
+
+    for install in installs {
+        let evr = install.refreshed.version.to_string();
+        // Classify the current state slot with an immutable borrow that is
+        // dropped before any mutation below.
+        let slot = match state.find_object(ObjectKind::Component, &install.name) {
+            None => InstallSlot::Absent,
+            Some(existing) => {
+                let same_rpm = existing
+                    .rpm_metadata
+                    .as_ref()
+                    .is_some_and(|m| m.package_name == install.package)
+                    && existing.effective_ownership().is_rpm();
+                if same_rpm {
+                    InstallSlot::MatchingRpm
+                } else {
+                    InstallSlot::Conflict(existing.effective_ownership().label())
+                }
+            }
+        };
+
+        match slot {
+            InstallSlot::Absent => {
+                state.upsert_object(new_rpm_component(
+                    &install.name,
+                    &install.package,
+                    &evr,
+                    &install.refreshed,
+                    &started_at,
+                    &operation_id,
+                ));
+                outcome.installed.push(InstalledItem {
+                    name: install.name.clone(),
+                    package: install.package.clone(),
+                    version: Some(evr),
+                });
+            }
+            // A row already present under the same RPM package: treat the
+            // install as an idempotent refresh rather than a duplicate insert.
+            InstallSlot::MatchingRpm => {
+                if let Some(obj) = state.find_object_mut(ObjectKind::Component, &install.name) {
+                    obj.version = evr.clone();
+                    obj.last_operation_id = Some(operation_id.clone());
+                    if let Some(meta) = obj.rpm_metadata.as_mut() {
+                        meta.evr = Some(evr.clone());
+                        meta.arch = Some(install.refreshed.arch.clone());
+                    }
+                }
+                outcome.installed.push(InstalledItem {
+                    name: install.name.clone(),
+                    package: install.package.clone(),
+                    version: Some(evr),
+                });
+            }
+            // A row present under a different backend/package: never overwrite
+            // it (that would erase raw-managed or foreign-RPM provenance).
+            InstallSlot::Conflict(existing_ownership) => {
+                outcome.errors.push(ErrorResult {
+                    name: install.name.clone(),
+                    reason: format!(
+                        "dnf installed '{}' but a {existing_ownership} component named '{}' already exists in ANOLISA state; refusing to overwrite it with an rpm-managed record — run `anolisa status {}`",
+                        install.package, install.name, install.name
+                    ),
+                });
+            }
+        }
+    }
+
+    // Count the whole command's outcome, not just component state: the CLI
+    // update (not an ANOLISA object) and the transaction-phase errors are folded
+    // in so the durable record shows the true `ok` / `partial` / `failed`.
+    let total_success =
+        cli_updated.is_some() as usize + outcome.updated.len() + outcome.installed.len();
+    let total_errors = prior_errors + outcome.errors.len();
+
+    if total_success == 0 && total_errors == 0 {
+        // No transaction actually happened (e.g. only skips/noops reached here);
+        // nothing to audit and nothing to persist.
+        return Ok(outcome);
+    }
+
+    let status = apply_status(total_success, total_errors);
+    let (log_status, severity) = match status {
+        STATUS_OK => (LogStatus::Ok, Severity::Info),
+        STATUS_PARTIAL => (LogStatus::Partial, Severity::Warn),
+        _ => (LogStatus::Failed, Severity::Error),
+    };
+
+    // Always append the operation record and save, even when no component object
+    // changed (a CLI-only upgrade, or a run where every component drifted): the
+    // record is what makes a real system mutation auditable via `anolisa logs`.
+    state.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: status.to_string(),
+        started_at: started_at.clone(),
+        finished_at: Some(now_iso8601()),
+    });
+
+    let state_path = layout.state_dir.join("installed.toml");
+    state.save(&state_path).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to save state: {err}"),
+    })?;
+
+    // Audit log is best-effort: state already persisted, so a log failure
+    // downgrades to a stderr warning rather than unwinding.
+    let recorded = outcome.updated.len() + outcome.installed.len();
+    let log = CentralLog::open(layout.central_log.clone());
+    let mut objects: Vec<String> = cli_updated.map(|c| c.package.clone()).into_iter().collect();
+    objects.extend(outcome.updated.iter().map(|u| u.name.clone()));
+    objects.extend(outcome.installed.iter().map(|i| i.name.clone()));
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: None,
+        severity,
+        message: format!(
+            "applied RPM image upgrade ({total_success} succeeded, {recorded} component state change(s) recorded, {total_errors} error(s))"
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at,
+        finished_at: Some(now_iso8601()),
+        status: Some(log_status),
+        objects,
+        backup_ids: Vec::new(),
+        warnings: Vec::new(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = log.append(&record)
+        && !ctx.quiet
+    {
+        eprintln!("warning: failed to write central log: {err}");
+    }
+
+    Ok(outcome)
+}
+
+/// The current ANOLISA-state slot for a to-be-installed default, classified
+/// under the install lock so the install decision cannot race a concurrent write.
+enum InstallSlot {
+    /// No object with this name exists — a clean insert.
+    Absent,
+    /// An object exists under the same RPM package — an idempotent refresh.
+    MatchingRpm,
+    /// An object exists under a different backend/package (carries its ownership
+    /// label for the error) — must not be overwritten.
+    Conflict(&'static str),
+}
+
+/// Build a fresh rpm-managed component object for a newly installed default.
+/// Mirrors the delegated-install path: `managed = true`, `adopted = false`,
+/// ownership [`Ownership::RpmManaged`], backend `rpm`, and no owned files (dnf
+/// owns the file transaction).
+fn new_rpm_component(
+    name: &str,
+    package: &str,
+    evr: &str,
+    refreshed: &PackageInfo,
+    installed_at: &str,
+    operation_id: &str,
+) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: name.to_string(),
+        version: evr.to_string(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("rpm".to_string()),
+        ownership: Some(Ownership::RpmManaged),
+        rpm_metadata: Some(RpmMetadata {
+            package_name: package.to_string(),
+            evr: Some(evr.to_string()),
+            arch: Some(refreshed.arch.clone()),
+            source_repo: refreshed.origin.clone(),
+        }),
+        installed_at: installed_at.to_string(),
+        last_operation_id: Some(operation_id.to_string()),
+        managed: true,
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
+/// RFC3339 UTC timestamp, seconds precision (matches the install/update paths).
+fn now_iso8601() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+// ── rendering ────────────────────────────────────────────────────────────────
+
+/// Render the upgrade result as JSON (envelope) or a human summary.
+fn render_result(ctx: &CliContext, result: &UpgradeResult) {
+    if ctx.json {
+        // `ok` reflects the status so machine callers can gate on the envelope
+        // flag as well as the inner `status` field; a serialize failure is
+        // ignored so an already-applied upgrade is not reported as failed.
+        let _ = response::render_json_with_status(COMMAND, result.status == STATUS_OK, result);
+        return;
+    }
+    if ctx.quiet {
+        return;
+    }
+    let color = Palette::new(ctx.no_color);
+
+    let mut header = format!("upgrade (backend: {}", result.backend);
+    if let Some(target) = &result.target {
+        header.push_str(&format!(", target: {target}"));
+    }
+    header.push_str(if result.dry_run {
+        ") (dry-run — nothing applied)"
+    } else {
+        ")"
+    });
+    println!("{}", color.command(header));
+
+    for item in &result.updated {
+        let verb = if result.dry_run {
+            "would update"
+        } else {
+            "updated"
+        };
+        println!(
+            "  {} {} {} → {} {}",
+            color.ok(format!("✓ {verb}")),
+            item.name,
+            item.from,
+            item.to,
+            color.muted(format!("({})", item.package)),
+        );
+    }
+    for item in &result.installed {
+        let verb = if result.dry_run {
+            "would install".to_string()
+        } else {
+            format!("installed {}", item.version.as_deref().unwrap_or("-"))
+        };
+        println!(
+            "  {} {} {}",
+            color.ok(format!("✓ {verb}")),
+            item.name,
+            color.muted(format!("({})", item.package)),
+        );
+    }
+    for item in &result.skipped {
+        println!(
+            "  {} {} {}",
+            color.muted("• skipped"),
+            item.name,
+            color.muted(format!("({})", item.reason)),
+        );
+    }
+    for item in &result.errors {
+        println!(
+            "  {} {} {}",
+            color.err("✗ error"),
+            item.name,
+            color.warn(format!("({})", item.reason)),
+        );
+    }
+
+    println!(
+        "{} {} updated, {} installed, {} skipped, {} error(s) [{}]",
+        color.label("summary:"),
+        result.updated.len(),
+        result.installed.len(),
+        result.skipped.len(),
+        result.errors.len(),
+        result.status,
+    );
+
+    for warning in &result.warnings {
+        eprintln!("{} {warning}", color.warn("warning:"));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -1,0 +1,869 @@
+//! Unit tests for `anolisa upgrade`. The apply path is driven entirely through
+//! an injected fake that implements both [`PackageQuery`] and
+//! [`PackageTransaction`], so no live rpmdb/dnf is required. The fake records
+//! transaction call order and refuses to be called on the dry-run path.
+
+use super::*;
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
+
+use anolisa_core::state::{InstalledObject, InstalledState, RpmMetadata, SubscriptionScope};
+
+// ── fake host ────────────────────────────────────────────────────────────────
+
+/// In-memory host: `query_installed` returns the configured post-transaction
+/// version, `update`/`install` record their call order and may be made to fail
+/// for a named package.
+#[derive(Default)]
+struct FakeHost {
+    /// package -> version returned by `query_installed` (post-transaction).
+    installed: HashMap<String, PackageInfo>,
+    /// packages whose `update` transaction fails.
+    fail_update: HashSet<String>,
+    /// packages whose `install` transaction fails.
+    fail_install: HashSet<String>,
+    /// packages whose `query_installed` returns `Ok(None)` (rpmdb miss).
+    missing_after: HashSet<String>,
+    /// ordered transaction log (`"update:<pkg>"` / `"install:<pkg>"`).
+    calls: RefCell<Vec<String>>,
+}
+
+impl FakeHost {
+    fn with_installed(mut self, package: &str, info: PackageInfo) -> Self {
+        self.installed.insert(package.to_string(), info);
+        self
+    }
+
+    fn txn_calls(&self) -> Vec<String> {
+        self.calls.borrow().clone()
+    }
+}
+
+impl PackageQuery for FakeHost {
+    fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+        if self.missing_after.contains(package) {
+            return Ok(None);
+        }
+        Ok(self.installed.get(package).cloned())
+    }
+
+    fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+        Ok(Vec::new())
+    }
+}
+
+impl PackageTransaction for FakeHost {
+    fn install(&self, package: &str) -> Result<(), PackageTransactionError> {
+        self.calls.borrow_mut().push(format!("install:{package}"));
+        if self.fail_install.contains(package) {
+            return Err(PackageTransactionError::TransactionFailed {
+                command: "dnf".to_string(),
+                operation: "install".to_string(),
+                code: Some(1),
+                stderr: "boom".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn update(&self, package: &str) -> Result<(), PackageTransactionError> {
+        self.calls.borrow_mut().push(format!("update:{package}"));
+        if self.fail_update.contains(package) {
+            return Err(PackageTransactionError::TransactionFailed {
+                command: "dnf".to_string(),
+                operation: "update".to_string(),
+                code: Some(1),
+                stderr: "boom".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn remove(&self, package: &str) -> Result<(), PackageTransactionError> {
+        // `upgrade` never removes packages; a call is a routing bug.
+        self.calls.borrow_mut().push(format!("remove:{package}"));
+        Ok(())
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn info(name: &str, version: &str, release: Option<&str>) -> PackageInfo {
+    PackageInfo {
+        name: name.to_string(),
+        version: PackageVersion {
+            epoch: None,
+            version: version.to_string(),
+            release: release.map(str::to_string),
+        },
+        arch: "x86_64".to_string(),
+        origin: None,
+    }
+}
+
+fn cli_check(
+    action: &str,
+    package: Option<&str>,
+    installed: Option<&str>,
+    available: Option<&str>,
+    error: Option<&str>,
+) -> CliCheck {
+    CliCheck {
+        package: package.map(str::to_string),
+        installed: installed.map(str::to_string),
+        available: available.map(str::to_string),
+        action: action.to_string(),
+        error: error.map(str::to_string),
+    }
+}
+
+fn cli_noop() -> CliCheck {
+    cli_check(
+        ACTION_NOOP,
+        Some("anolisa"),
+        Some("1.0.0-1.al4"),
+        None,
+        None,
+    )
+}
+
+fn component_check(
+    component: &str,
+    package: Option<&str>,
+    ownership: Option<&str>,
+    installed: Option<&str>,
+    available: Option<&str>,
+    action: &str,
+    error: Option<&str>,
+) -> ComponentCheck {
+    ComponentCheck {
+        component: component.to_string(),
+        package: package.map(str::to_string),
+        ownership: ownership.map(str::to_string),
+        installed: installed.map(str::to_string),
+        available: available.map(str::to_string),
+        action: action.to_string(),
+        error: error.map(str::to_string),
+    }
+}
+
+/// Build an installed component object as it would exist in state before an
+/// upgrade, so a planned update has a row to refresh.
+fn rpm_component(name: &str, package: &str, evr: &str, ownership: Ownership) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: name.to_string(),
+        version: evr.to_string(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some(
+            if matches!(ownership, Ownership::RawManaged) {
+                "raw"
+            } else {
+                "rpm"
+            }
+            .to_string(),
+        ),
+        ownership: Some(ownership),
+        rpm_metadata: if matches!(ownership, Ownership::RawManaged) {
+            None
+        } else {
+            Some(RpmMetadata {
+                package_name: package.to_string(),
+                evr: Some(evr.to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            })
+        },
+        installed_at: "2026-06-01T10:00:00Z".to_string(),
+        last_operation_id: None,
+        managed: !matches!(ownership, Ownership::RpmObserved),
+        adopted: matches!(ownership, Ownership::RpmObserved),
+        subscription_scope: SubscriptionScope::None,
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
+/// Write a state file under `layout` seeded with `objects` so an apply run can
+/// find (and refresh) already-installed components.
+fn seed_state(layout: &FsLayout, objects: Vec<InstalledObject>) {
+    let mut state = InstalledState::default();
+    for obj in objects {
+        state.upsert_object(obj);
+    }
+    state
+        .save(&layout.state_dir.join("installed.toml"))
+        .expect("seed state");
+}
+
+fn system_ctx(prefix: PathBuf) -> CliContext {
+    CliContext {
+        install_mode: InstallMode::System,
+        prefix: Some(prefix),
+        json: false,
+        dry_run: false,
+        verbose: false,
+        quiet: true,
+        no_color: true,
+    }
+}
+
+fn user_ctx() -> CliContext {
+    CliContext {
+        install_mode: InstallMode::User,
+        prefix: None,
+        json: false,
+        dry_run: false,
+        verbose: false,
+        quiet: true,
+        no_color: true,
+    }
+}
+
+// ── argument parsing ─────────────────────────────────────────────────────────
+
+#[test]
+fn upgrade_parses_bare() {
+    let args = UpgradeArgs::try_parse_from(["upgrade"]).expect("parse");
+    assert!(args.target.is_none());
+    assert!(!args.assume_yes);
+}
+
+#[test]
+fn upgrade_parses_target() {
+    let args =
+        UpgradeArgs::try_parse_from(["upgrade", "--target", "agentic_os-latest"]).expect("parse");
+    assert_eq!(args.target.as_deref(), Some("agentic_os-latest"));
+}
+
+#[test]
+fn upgrade_parses_assume_yes_long_and_short() {
+    assert!(
+        UpgradeArgs::try_parse_from(["upgrade", "--assume-yes"])
+            .expect("parse")
+            .assume_yes
+    );
+    assert!(
+        UpgradeArgs::try_parse_from(["upgrade", "-y"])
+            .expect("parse")
+            .assume_yes
+    );
+}
+
+// ── mode / privilege gating ──────────────────────────────────────────────────
+
+#[test]
+fn upgrade_rejects_user_mode() {
+    let args = UpgradeArgs {
+        target: None,
+        assume_yes: false,
+    };
+    let err = super::handle(args, &user_ctx()).expect_err("user mode must be rejected");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(err.reason().contains("system"));
+}
+
+#[test]
+fn upgrade_real_execution_without_root_is_rejected_with_sudo_hint() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let err = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, false, false, COMMAND)
+        .expect_err("non-root real execution must be rejected");
+    assert_eq!(err.code(), "EXECUTION_FAILED");
+    assert!(err.reason().contains("sudo anolisa upgrade"));
+    assert!(host.txn_calls().is_empty(), "no dnf on a rejected run");
+}
+
+/// The apply layer allows a dry-run without root (no dnf, no state write). Note
+/// this is the *system-mode* apply path: at the dispatcher layer a non-root
+/// `anolisa upgrade --dry-run` still resolves to user mode unless `--install-mode
+/// system` is given (or run under sudo), and is rejected there — the
+/// `system_only("upgrade", true)` policy only waives the root requirement for a
+/// dry-run, not the system-mode requirement (same as `repair`).
+#[test]
+fn upgrade_dry_run_apply_runs_without_root_and_touches_nothing() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(
+        Some("agentic_os-latest".to_string()),
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, false, true, COMMAND)
+        .expect("dry-run is allowed without root");
+    assert!(result.dry_run);
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.updated.len(), 1);
+    assert!(
+        host.txn_calls().is_empty(),
+        "dry-run must not run a transaction"
+    );
+    assert!(
+        !layout.state_dir.join("installed.toml").exists(),
+        "dry-run must not write state"
+    );
+}
+
+// ── plan conversion ──────────────────────────────────────────────────────────
+
+#[test]
+fn plan_classifies_update_install_skip_and_error() {
+    let cli = cli_check(
+        ACTION_UPDATE,
+        Some("anolisa"),
+        Some("0.5.0-1.al4"),
+        Some("1.0.0-1.al4"),
+        None,
+    );
+    let components = vec![
+        // rpm update
+        component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-observed"),
+            Some("0.5.0-1.al4"),
+            Some("1.0.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        ),
+        // installable default (resolved package)
+        component_check(
+            "agent-memory",
+            Some("agent-memory"),
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        ),
+        // raw-managed → skipped
+        component_check(
+            "local-tool",
+            None,
+            Some("raw-managed"),
+            Some("0.5.0"),
+            None,
+            ACTION_UNSUPPORTED_RPM,
+            None,
+        ),
+        // installable default without a resolved package → error
+        component_check("mystery", None, None, None, None, ACTION_INSTALL, None),
+        // item error surfaced by the check
+        component_check(
+            "broken",
+            Some("broken-pkg"),
+            Some("rpm-managed"),
+            Some("1.0.0-1"),
+            None,
+            ACTION_ERROR,
+            Some("rpmdb miss"),
+        ),
+        // noop → nothing
+        component_check(
+            "sec-core",
+            Some("agent-sec-core"),
+            Some("rpm-managed"),
+            Some("1.0.0-1"),
+            None,
+            ACTION_NOOP,
+            None,
+        ),
+    ];
+
+    let plan = build_plan(Some("agentic_os-latest".to_string()), &cli, &components);
+
+    assert_eq!(
+        plan.cli.as_ref().map(|c| c.package.as_str()),
+        Some("anolisa")
+    );
+    assert_eq!(plan.updates.len(), 1);
+    assert_eq!(plan.updates[0].package, "copilot-shell");
+    assert_eq!(plan.installs.len(), 1);
+    assert_eq!(plan.installs[0].package, "agent-memory");
+    assert_eq!(plan.skipped.len(), 1);
+    assert_eq!(plan.skipped[0].name, "local-tool");
+    assert_eq!(plan.skipped[0].reason, RAW_SKIP_REASON);
+    // "mystery" (install without package) + "broken" (check error) → 2 errors.
+    assert_eq!(plan.errors.len(), 2);
+    assert!(plan.has_errors());
+}
+
+#[test]
+fn plan_treats_non_rpm_cli_as_skipped_not_error() {
+    let cli = cli_check(
+        ACTION_UNSUPPORTED,
+        None,
+        None,
+        None,
+        Some("anolisa CLI is not RPM-owned"),
+    );
+    let plan = build_plan(None, &cli, &[]);
+    assert!(plan.cli.is_none());
+    assert_eq!(plan.skipped.len(), 1);
+    assert!(!plan.has_errors());
+}
+
+// ── apply: error blocking ────────────────────────────────────────────────────
+
+#[test]
+fn plan_errors_block_real_execution_before_dnf() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    // An install with no resolvable package is a plan error.
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "mystery",
+            None,
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        )],
+    );
+    assert!(plan.has_errors());
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("blocked plan renders rather than erroring");
+    assert_eq!(result.status, STATUS_BLOCKED);
+    assert!(!result.dry_run);
+    assert!(
+        host.txn_calls().is_empty(),
+        "a blocked plan must not run any dnf transaction"
+    );
+    assert!(
+        !layout.state_dir.join("installed.toml").exists(),
+        "a blocked plan must not write state"
+    );
+}
+
+// ── apply: raw boundary ──────────────────────────────────────────────────────
+
+#[test]
+fn raw_managed_component_is_skipped_and_never_transacted() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "local-tool",
+            None,
+            Some("raw-managed"),
+            Some("0.5.0"),
+            None,
+            ACTION_UNSUPPORTED_RPM,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.skipped.len(), 1);
+    assert_eq!(result.skipped[0].reason, RAW_SKIP_REASON);
+    assert!(
+        host.txn_calls().is_empty(),
+        "a raw-managed component must never be transacted"
+    );
+}
+
+// ── apply: transaction ordering ──────────────────────────────────────────────
+
+#[test]
+fn transaction_order_is_cli_then_updates_then_installs() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default()
+        .with_installed("anolisa", info("anolisa", "1.0.0", Some("1.al4")))
+        .with_installed(
+            "copilot-shell",
+            info("copilot-shell", "1.1.0", Some("1.al4")),
+        )
+        .with_installed("agent-memory", info("agent-memory", "1.0.0", Some("1.al4")));
+    // Seed the component being updated so its state row is refreshed cleanly.
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        )],
+    );
+
+    let cli = cli_check(
+        ACTION_UPDATE,
+        Some("anolisa"),
+        Some("0.5.0-1.al4"),
+        Some("1.0.0-1.al4"),
+        None,
+    );
+    let components = vec![
+        component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        ),
+        component_check(
+            "agent-memory",
+            Some("agent-memory"),
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        ),
+    ];
+    let plan = build_plan(None, &cli, &components);
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(
+        host.txn_calls(),
+        vec![
+            "update:anolisa".to_string(),
+            "update:copilot-shell".to_string(),
+            "install:agent-memory".to_string(),
+        ],
+        "must apply CLI update, then component updates, then installs"
+    );
+}
+
+// ── apply: state refresh for a new default ───────────────────────────────────
+
+#[test]
+fn installed_default_is_recorded_as_rpm_managed_after_refresh() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default()
+        .with_installed("agent-memory", info("agent-memory", "1.0.0", Some("1.al4")));
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "agent-memory",
+            Some("agent-memory"),
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(result.installed[0].version.as_deref(), Some("1.0.0-1.al4"));
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let obj = state
+        .find_object(ObjectKind::Component, "agent-memory")
+        .expect("recorded component");
+    assert_eq!(obj.effective_ownership(), Ownership::RpmManaged);
+    assert_eq!(obj.install_backend.as_deref(), Some("rpm"));
+    assert!(obj.managed);
+    assert!(!obj.adopted);
+    assert_eq!(obj.version, "1.0.0-1.al4");
+    assert_eq!(
+        obj.rpm_metadata.as_ref().map(|m| m.package_name.as_str()),
+        Some("agent-memory")
+    );
+}
+
+// ── apply: partial failure ───────────────────────────────────────────────────
+
+#[test]
+fn partial_transaction_failure_is_reported_and_not_claimed_as_success() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "1.1.0", Some("1.al4")),
+    );
+    // The second component update fails at the dnf layer.
+    host.fail_update.insert("agent-sec-core".to_string());
+    // Seed the component that upgrades cleanly so its update is recorded.
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        )],
+    );
+
+    let components = vec![
+        component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        ),
+        component_check(
+            "sec-core",
+            Some("agent-sec-core"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        ),
+    ];
+    let plan = build_plan(None, &cli_noop(), &components);
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(
+        result.status, STATUS_PARTIAL,
+        "must not claim clean success"
+    );
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].name, "cosh");
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].name, "sec-core");
+
+    // The durable operation record must reflect the partial outcome, not `ok`,
+    // even though the cosh update landed in state.
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(
+        state.operations.last().map(|op| op.status.as_str()),
+        Some("partial"),
+        "a partial upgrade must not record an `ok` operation"
+    );
+}
+
+// ── apply: state drift under the lock ────────────────────────────────────────
+
+/// A default install whose name already belongs to a raw-managed component in
+/// state (a concurrent install between plan and save) must not be overwritten:
+/// the dnf install ran, but the state record is left as raw-managed and the item
+/// is reported as an error, so the run does not claim clean success.
+#[test]
+fn install_does_not_overwrite_existing_raw_managed_component() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default()
+        .with_installed("agent-memory", info("agent-memory", "1.0.0", Some("1.al4")));
+    // A raw-managed component of the same name appeared in state after planning.
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "agent-memory",
+            "agent-memory",
+            "0.9.0",
+            Ownership::RawManaged,
+        )],
+    );
+
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "agent-memory",
+            Some("agent-memory"),
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_FAILED, "nothing landed cleanly");
+    assert!(result.installed.is_empty());
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].name, "agent-memory");
+
+    // State must still describe the original raw-managed component.
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let obj = state
+        .find_object(ObjectKind::Component, "agent-memory")
+        .expect("component");
+    assert_eq!(obj.effective_ownership(), Ownership::RawManaged);
+    assert_eq!(obj.version, "0.9.0");
+}
+
+/// A component update whose state row vanished between planning and the state
+/// save (the dnf transaction succeeded, but the object is gone) must be reported
+/// as an error, not a silent `ok` — the caller must not claim the component was
+/// updated when ANOLISA state no longer reflects it.
+#[test]
+fn update_state_drift_missing_object_is_reported_as_error() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "1.1.0", Some("1.al4")),
+    );
+    // No state is seeded, so the planned update has no row to refresh.
+
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(
+        result.status, STATUS_FAILED,
+        "a dnf success with no state refresh must not be reported as ok"
+    );
+    assert!(
+        result.updated.is_empty(),
+        "drifted update is not reported updated"
+    );
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].name, "cosh");
+    assert!(
+        host.txn_calls()
+            .contains(&"update:copilot-shell".to_string())
+    );
+}
+
+// ── audit for CLI-only / component-less runs ─────────────────────────────────
+
+/// A CLI-only upgrade really mutates the system (dnf updates the CLI RPM) but
+/// records no ANOLISA component object; it must still leave a durable operation
+/// record so the change is auditable via `anolisa logs`, not a silent `ok`.
+#[test]
+fn cli_only_upgrade_records_durable_audit() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host =
+        FakeHost::default().with_installed("anolisa", info("anolisa", "1.0.0", Some("1.al4")));
+    let cli = cli_check(
+        ACTION_UPDATE,
+        Some("anolisa"),
+        Some("0.5.0-1.al4"),
+        Some("1.0.0-1.al4"),
+        None,
+    );
+    let plan = build_plan(None, &cli, &[]);
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].name, "anolisa");
+    assert!(result.installed.is_empty());
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(
+        state.operations.last().map(|op| op.status.as_str()),
+        Some("ok"),
+        "a CLI-only upgrade must still leave an operation record"
+    );
+    assert!(
+        state
+            .find_object(ObjectKind::Component, "anolisa")
+            .is_none(),
+        "the CLI is not recorded as a component object"
+    );
+}
+
+/// A CLI update that succeeds while a component transaction fails records a
+/// `partial` operation, even though no component state object changed.
+#[test]
+fn cli_success_with_component_failure_records_partial_audit() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut host =
+        FakeHost::default().with_installed("anolisa", info("anolisa", "1.0.0", Some("1.al4")));
+    host.fail_update.insert("copilot-shell".to_string());
+
+    let cli = cli_check(
+        ACTION_UPDATE,
+        Some("anolisa"),
+        Some("0.5.0-1.al4"),
+        Some("1.0.0-1.al4"),
+        None,
+    );
+    let components = vec![component_check(
+        "cosh",
+        Some("copilot-shell"),
+        Some("rpm-managed"),
+        Some("1.0.0-1.al4"),
+        Some("1.1.0-1.al4"),
+        ACTION_UPDATE,
+        None,
+    )];
+    let plan = build_plan(None, &cli, &components);
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_PARTIAL);
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].name, "anolisa");
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].name, "cosh");
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(
+        state.operations.last().map(|op| op.status.as_str()),
+        Some("partial"),
+        "CLI success + component failure must record a partial operation"
+    );
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -28,6 +28,10 @@ struct FakeHost {
     fail_install: HashSet<String>,
     /// packages whose `query_installed` returns `Ok(None)` (rpmdb miss).
     missing_after: HashSet<String>,
+    /// package -> source repo returned by `installed_origin`.
+    origins: HashMap<String, String>,
+    /// packages whose `installed_origin` returns an error.
+    fail_origin: HashSet<String>,
     /// ordered transaction log (`"update:<pkg>"` / `"install:<pkg>"`).
     calls: RefCell<Vec<String>>,
 }
@@ -35,6 +39,11 @@ struct FakeHost {
 impl FakeHost {
     fn with_installed(mut self, package: &str, info: PackageInfo) -> Self {
         self.installed.insert(package.to_string(), info);
+        self
+    }
+
+    fn with_origin(mut self, package: &str, origin: &str) -> Self {
+        self.origins.insert(package.to_string(), origin.to_string());
         self
     }
 
@@ -53,6 +62,17 @@ impl PackageQuery for FakeHost {
 
     fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
         Ok(Vec::new())
+    }
+
+    fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+        if self.fail_origin.contains(package) {
+            return Err(PackageQueryError::QueryFailed {
+                command: "dnf".to_string(),
+                code: Some(1),
+                stderr: "repo lookup failed".to_string(),
+            });
+        }
+        Ok(self.origins.get(package).cloned())
     }
 }
 
@@ -148,6 +168,7 @@ fn component_check(
         available: available.map(str::to_string),
         action: action.to_string(),
         error: error.map(str::to_string),
+        absent_from_state: false,
     }
 }
 
@@ -577,7 +598,8 @@ fn installed_default_is_recorded_as_rpm_managed_after_refresh() {
     let ctx = system_ctx(tmp.path().to_path_buf());
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
     let host = FakeHost::default()
-        .with_installed("agent-memory", info("agent-memory", "1.0.0", Some("1.al4")));
+        .with_installed("agent-memory", info("agent-memory", "1.0.0", Some("1.al4")))
+        .with_origin("agent-memory", "alinux4-agentic-os");
     let plan = build_plan(
         None,
         &cli_noop(),
@@ -610,6 +632,103 @@ fn installed_default_is_recorded_as_rpm_managed_after_refresh() {
     assert_eq!(
         obj.rpm_metadata.as_ref().map(|m| m.package_name.as_str()),
         Some("agent-memory")
+    );
+    assert_eq!(
+        obj.rpm_metadata
+            .as_ref()
+            .and_then(|m| m.source_repo.as_deref()),
+        Some("alinux4-agentic-os")
+    );
+}
+
+#[test]
+fn origin_lookup_failure_is_warning_not_apply_failure() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut host = FakeHost::default()
+        .with_installed("agent-memory", info("agent-memory", "1.0.0", Some("1.al4")));
+    host.fail_origin.insert("agent-memory".to_string());
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "agent-memory",
+            Some("agent-memory"),
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.warnings.len(), 1);
+    assert!(result.warnings[0].contains("could not determine source repo"));
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let obj = state
+        .find_object(ObjectKind::Component, "agent-memory")
+        .expect("recorded component");
+    assert_eq!(
+        obj.rpm_metadata
+            .as_ref()
+            .and_then(|m| m.source_repo.as_deref()),
+        None
+    );
+}
+
+#[test]
+fn origin_lookup_failure_preserves_existing_source_repo() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "1.1.0", Some("1.al4")),
+    );
+    host.fail_origin.insert("copilot-shell".to_string());
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.warnings.len(), 1);
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let obj = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("component");
+    assert_eq!(obj.version, "1.1.0-1.al4");
+    assert_eq!(
+        obj.rpm_metadata
+            .as_ref()
+            .and_then(|m| m.source_repo.as_deref()),
+        Some("@System")
     );
 }
 
@@ -683,9 +802,7 @@ fn partial_transaction_failure_is_reported_and_not_claimed_as_success() {
 // ── apply: state drift under the lock ────────────────────────────────────────
 
 /// A default install whose name already belongs to a raw-managed component in
-/// state (a concurrent install between plan and save) must not be overwritten:
-/// the dnf install ran, but the state record is left as raw-managed and the item
-/// is reported as an error, so the run does not claim clean success.
+/// state (a concurrent install after planning) must be refused before dnf runs.
 #[test]
 fn install_does_not_overwrite_existing_raw_managed_component() {
     let tmp = tempfile::tempdir().expect("tmpdir");
@@ -724,6 +841,10 @@ fn install_does_not_overwrite_existing_raw_managed_component() {
     assert!(result.installed.is_empty());
     assert_eq!(result.errors.len(), 1);
     assert_eq!(result.errors[0].name, "agent-memory");
+    assert!(
+        host.txn_calls().is_empty(),
+        "stale state must block dnf before RPM mutation"
+    );
 
     // State must still describe the original raw-managed component.
     let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
@@ -734,19 +855,19 @@ fn install_does_not_overwrite_existing_raw_managed_component() {
     assert_eq!(obj.version, "0.9.0");
 }
 
-/// A component update whose state row vanished between planning and the state
-/// save (the dnf transaction succeeded, but the object is gone) must be reported
-/// as an error, not a silent `ok` — the caller must not claim the component was
-/// updated when ANOLISA state no longer reflects it.
+/// A component update whose state row vanished after planning must be rejected
+/// under the install lock before dnf mutates the host.
 #[test]
 fn update_state_drift_missing_object_is_reported_as_error() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let ctx = system_ctx(tmp.path().to_path_buf());
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-    let host = FakeHost::default().with_installed(
-        "copilot-shell",
-        info("copilot-shell", "1.1.0", Some("1.al4")),
-    );
+    let host = FakeHost::default()
+        .with_installed(
+            "copilot-shell",
+            info("copilot-shell", "1.1.0", Some("1.al4")),
+        )
+        .with_origin("copilot-shell", "alinux4-agentic-os");
     // No state is seeded, so the planned update has no row to refresh.
 
     let plan = build_plan(
@@ -776,8 +897,104 @@ fn update_state_drift_missing_object_is_reported_as_error() {
     assert_eq!(result.errors.len(), 1);
     assert_eq!(result.errors[0].name, "cosh");
     assert!(
-        host.txn_calls()
-            .contains(&"update:copilot-shell".to_string())
+        host.txn_calls().is_empty(),
+        "stale state must block dnf before RPM mutation"
+    );
+}
+
+#[test]
+fn observed_default_update_missing_from_state_is_recorded_as_rpm_observed() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default()
+        .with_installed(
+            "copilot-shell",
+            info("copilot-shell", "1.1.0", Some("1.al4")),
+        )
+        .with_origin("copilot-shell", "alinux4-agentic-os");
+    let mut observed_default = component_check(
+        "cosh",
+        Some("copilot-shell"),
+        Some("rpm-observed"),
+        Some("1.0.0-1.al4"),
+        Some("1.1.0-1.al4"),
+        ACTION_UPDATE,
+        None,
+    );
+    observed_default.absent_from_state = true;
+    let plan = build_plan(None, &cli_noop(), &[observed_default]);
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.updated.len(), 1);
+    assert!(result.errors.is_empty());
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let obj = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("observed default recorded");
+    assert_eq!(obj.effective_ownership(), Ownership::RpmObserved);
+    assert_eq!(obj.status, ObjectStatus::Adopted);
+    assert!(obj.adopted);
+    assert!(!obj.managed);
+    assert_eq!(obj.version, "1.1.0-1.al4");
+    assert_eq!(
+        obj.rpm_metadata.as_ref().map(|m| m.package_name.as_str()),
+        Some("copilot-shell")
+    );
+    assert_eq!(
+        obj.rpm_metadata
+            .as_ref()
+            .and_then(|m| m.source_repo.as_deref()),
+        Some("alinux4-agentic-os")
+    );
+}
+
+#[test]
+fn observed_default_noop_missing_from_state_is_recorded_without_dnf() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "1.1.0", Some("1.al4")),
+    );
+    let mut observed_default = component_check(
+        "cosh",
+        Some("copilot-shell"),
+        Some("rpm-observed"),
+        Some("1.1.0-1.al4"),
+        None,
+        ACTION_NOOP,
+        None,
+    );
+    observed_default.absent_from_state = true;
+    let plan = build_plan(None, &cli_noop(), &[observed_default]);
+
+    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
+        .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert!(result.updated.is_empty(), "no package update happened");
+    assert_eq!(result.recorded.len(), 1);
+    assert_eq!(result.recorded[0].name, "cosh");
+    assert_eq!(result.recorded[0].version.as_deref(), Some("1.1.0-1.al4"));
+    assert!(
+        host.txn_calls().is_empty(),
+        "recording an observed default must not run dnf"
+    );
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let obj = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("observed default recorded");
+    assert_eq!(obj.effective_ownership(), Ownership::RpmObserved);
+    assert_eq!(obj.status, ObjectStatus::Adopted);
+    assert_eq!(obj.version, "1.1.0-1.al4");
+    assert_eq!(
+        obj.rpm_metadata.as_ref().map(|m| m.package_name.as_str()),
+        Some("copilot-shell")
     );
 }
 


### PR DESCRIPTION
## Description

This PR adds the first-phase `anolisa upgrade` command for RPM/system image
upgrade scenarios. The command reuses `update --check` as the read-only planner,
then applies CLI RPM updates, installed RPM component updates, and resolved
target-profile default installs through dnf.

Raw-managed components remain explicitly out of scope and are skipped without
migration or mutation. Upgrade results are refreshed into ANOLISA state where
applicable, and durable operation/audit records reflect `ok`, `partial`, or
`failed` outcomes.

## Related Issue

closes #1411

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope
- [x] `anolisa` (anolisa-cli)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p anolisa-cli --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli --locked`
- `cargo doc -p anolisa-cli --no-deps`

Covered parse behavior, dry-run/root gating, transaction ordering, missing
default installs, raw-managed skip boundaries, state drift handling, partial
failure reporting, and CLI-only upgrade audit records.

## Additional Notes

First-phase scope is limited to RPM/system image upgrades. Raw-managed, npm, and
raw backend upgrade or migration paths are intentionally out of scope.
