### PR TITLE
feat(sight): add ECS security group guide to dashboard command

### DIFF
--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -67,6 +67,7 @@ CROSS_CUTTING = {
     "discovery",       # process discovery (Cross in ARCHITECTURE.md)
     "skill_metrics",   # metric helpers
     "token_breakdown", # token analysis helpers
+    "ecs_metadata",    # shared ECS metadata client primitives
 }
 
 # Known violations: (source_file_relative_to_src, target_module, reason)

--- a/src/agentsight/src/bin/agentsight.rs
+++ b/src/agentsight/src/bin/agentsight.rs
@@ -6,6 +6,7 @@
 //! - `audit`: Query audit events
 //! - `discover`: Discover running AI agents
 //! - `interruption`: Query and manage session interruption events
+//! - `dashboard`: Display dashboard URL and ECS console access guide
 use structopt::StructOpt;
 
 mod cli;
@@ -45,7 +46,7 @@ pub enum Command {
     /// Start the API server
     #[cfg(feature = "server")]
     Serve(ServeCommand),
-    /// Display dashboard authentication status and token
+    /// Display dashboard URL and ECS console access guide
     #[cfg(feature = "server")]
     Dashboard(DashboardCommand),
 }

--- a/src/agentsight/src/bin/cli/dashboard.rs
+++ b/src/agentsight/src/bin/cli/dashboard.rs
@@ -179,3 +179,58 @@ fn find_executable(name: &str) -> Option<String> {
         .map(|dir| format!("{dir}/{name}"))
         .find(|full| std::path::Path::new(full).is_file())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn find_executable_returns_path_for_known_command() {
+        // "ls" should exist on any Linux system
+        let result = find_executable("ls");
+        assert!(result.is_some(), "ls should be found in PATH");
+        let path = result.unwrap();
+        assert!(
+            std::path::Path::new(&path).is_file(),
+            "returned path should be a file: {path}"
+        );
+    }
+
+    #[test]
+    fn find_executable_returns_none_for_nonexistent_command() {
+        let result = find_executable("__nonexistent_binary_xyz__");
+        assert!(result.is_none(), "nonexistent command should return None");
+    }
+
+    #[test]
+    fn local_addresses_returns_valid_ipv4_or_empty() {
+        let addrs = local_addresses();
+        for addr in &addrs {
+            let parsed: Result<std::net::Ipv4Addr, _> = addr.parse();
+            assert!(parsed.is_ok(), "each address should be valid IPv4: {addr}");
+            let ip = parsed.unwrap();
+            assert!(!ip.is_loopback(), "should exclude loopback: {ip}");
+            assert!(!ip.is_unspecified(), "should exclude unspecified: {ip}");
+        }
+    }
+
+    #[test]
+    fn check_server_running_returns_false_when_no_listener() {
+        // Pick a port that is almost certainly not in use
+        let result = check_server_running(1);
+        assert!(
+            !result,
+            "port 1 should not have a listener, so check should return false"
+        );
+    }
+
+    #[test]
+    fn check_server_running_returns_true_with_active_listener() {
+        // Bind a TCP listener on a random port
+        let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
+        let port = listener.local_addr().unwrap().port();
+        let result = check_server_running(port);
+        assert!(result, "should detect the active listener on port {port}");
+    }
+}

--- a/src/agentsight/src/bin/cli/dashboard.rs
+++ b/src/agentsight/src/bin/cli/dashboard.rs
@@ -90,12 +90,12 @@ impl DashboardCommand {
         }
         println!();
 
-        if auth.enabled {
-            if let Some(token) = auth.read_token_from_file() {
-                println!("  Auth:      enabled");
-                println!("  URL with token: {display_url}/?token={token}");
-                println!();
-            }
+        if auth.enabled
+            && let Some(token) = auth.read_token_from_file()
+        {
+            println!("  Auth:      enabled");
+            println!("  URL with token: {display_url}/?token={token}");
+            println!();
         }
 
         // ECS security group guide

--- a/src/agentsight/src/bin/cli/dashboard.rs
+++ b/src/agentsight/src/bin/cli/dashboard.rs
@@ -3,7 +3,7 @@
 use std::net::TcpStream;
 use std::time::Duration;
 
-use agentsight::ecs_metadata::probe_ecs_metadata;
+use agentsight::ecs_metadata::{EcsMetadata, probe_ecs_metadata};
 use agentsight::server::auth::DashboardAuth;
 use structopt::StructOpt;
 
@@ -45,28 +45,35 @@ impl DashboardCommand {
             std::process::exit(1);
         }
 
-        // Build dashboard URL
+        let output = self.build_output();
+
+        println!();
+        for line in &output.lines {
+            println!("{line}");
+        }
+
+        // ECS security group guide
+        if let Some(ref msg) = output.sg_message {
+            println!("{msg}");
+        }
+
+        // Try to open browser
+        if !self.no_open {
+            try_open_browser(&output.display_url);
+        }
+    }
+
+    /// Compute all display information without performing I/O.
+    fn build_output(&self) -> DashboardOutput {
         let local_url = format!("http://127.0.0.1:{}", self.port);
 
-        // Probe ECS metadata (2s timeout)
         let ecs = if self.skip_sg_guide {
             None
         } else {
             probe_ecs_metadata()
         };
 
-        // Determine the display URL: ECS public IP > non-loopback local IP > localhost
-        let display_url = if let Some(ref meta) = ecs {
-            meta.public_ip()
-                .map(|ip| format!("http://{ip}:{}", self.port))
-                .unwrap_or_else(|| local_url.clone())
-        } else {
-            local_addresses()
-                .into_iter()
-                .next()
-                .map(|ip| format!("http://{ip}:{}", self.port))
-                .unwrap_or_else(|| local_url.clone())
-        };
+        let display_url = resolve_display_url(&ecs, &local_url, self.port);
 
         let storage_base = self
             .db
@@ -83,46 +90,70 @@ impl DashboardCommand {
         let auth_config = load_server_auth_config(&self.config);
         let auth = DashboardAuth::init(&auth_config, &storage_base);
 
-        println!();
-        println!("AgentSight Dashboard: {display_url}");
+        let mut lines = Vec::new();
+        lines.push(format!("AgentSight Dashboard: {display_url}"));
         if display_url != local_url {
-            println!("  Local:   {local_url} (no auth required)");
+            lines.push(format!("  Local:   {local_url} (no auth required)"));
         }
-        println!();
+        lines.push(String::new());
 
         if auth.enabled
             && let Some(token) = auth.read_token_from_file()
         {
-            println!("  Auth:      enabled");
-            println!("  URL with token: {display_url}/?token={token}");
-            println!();
+            lines.push("  Auth:      enabled".to_string());
+            lines.push(format!("  URL with token: {display_url}/?token={token}"));
+            lines.push(String::new());
         }
 
-        // ECS security group guide
-        match ecs {
-            Some(meta) => {
-                println!(
-                    "远程打不开？请前往实例控制台配置安全组，放行 TCP {}：",
-                    self.port
-                );
-                println!("  {}", meta.instance_url());
-                println!();
-            }
-            None => {
-                if !self.skip_sg_guide {
-                    println!(
-                        "未检测到 ECS 环境，请手动确保防火墙/安全组已放行 {} 端口。",
-                        self.port
-                    );
-                    println!();
-                }
-            }
-        }
+        let sg_message = build_sg_message(&ecs, self.skip_sg_guide, self.port);
 
-        // Try to open browser
-        if !self.no_open {
-            try_open_browser(&display_url);
+        DashboardOutput {
+            display_url,
+            lines,
+            sg_message,
         }
+    }
+}
+
+/// Pre-computed display data for the dashboard command.
+#[derive(Debug)]
+struct DashboardOutput {
+    display_url: String,
+    lines: Vec<String>,
+    sg_message: Option<String>,
+}
+
+/// Determine the display URL: ECS public IP > non-loopback local IP > localhost.
+fn resolve_display_url(ecs: &Option<EcsMetadata>, local_url: &str, port: u16) -> String {
+    if let Some(meta) = ecs {
+        meta.public_ip()
+            .map(|ip| format!("http://{ip}:{port}"))
+            .unwrap_or_else(|| local_url.to_string())
+    } else {
+        local_addresses()
+            .into_iter()
+            .next()
+            .map(|ip| format!("http://{ip}:{port}"))
+            .unwrap_or_else(|| local_url.to_string())
+    }
+}
+
+/// Build the security group guide message, if applicable.
+fn build_sg_message(ecs: &Option<EcsMetadata>, skip: bool, port: u16) -> Option<String> {
+    match ecs {
+        Some(meta) => {
+            let mut msg = String::new();
+            msg.push_str(&format!(
+                "远程打不开？请前往实例控制台配置安全组，放行 TCP {port}：\n"
+            ));
+            msg.push_str(&format!("  {}", meta.instance_url()));
+            msg.push('\n');
+            Some(msg)
+        }
+        None if !skip => Some(format!(
+            "未检测到 ECS 环境，请手动确保防火墙/安全组已放行 {port} 端口。\n"
+        )),
+        None => None,
     }
 }
 
@@ -232,5 +263,66 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
         let result = check_server_running(port);
         assert!(result, "should detect the active listener on port {port}");
+    }
+
+    #[test]
+    fn resolve_display_url_with_ecs_public_ip() {
+        let ecs = Some(EcsMetadata {
+            instance_id: "i-test".to_string(),
+            region_id: "cn-hangzhou".to_string(),
+            eip: "1.2.3.4".to_string(),
+            public_ipv4: String::new(),
+        });
+        let url = resolve_display_url(&ecs, "http://127.0.0.1:7396", 7396);
+        assert_eq!(url, "http://1.2.3.4:7396");
+    }
+
+    #[test]
+    fn resolve_display_url_falls_back_to_local_when_no_public_ip() {
+        let ecs = Some(EcsMetadata {
+            instance_id: "i-test".to_string(),
+            region_id: "cn-hangzhou".to_string(),
+            eip: String::new(),
+            public_ipv4: String::new(),
+        });
+        let url = resolve_display_url(&ecs, "http://127.0.0.1:7396", 7396);
+        assert_eq!(url, "http://127.0.0.1:7396");
+    }
+
+    #[test]
+    fn resolve_display_url_without_ecs() {
+        let url = resolve_display_url(&None, "http://127.0.0.1:7396", 7396);
+        // Should use local_addresses or fall back to localhost
+        assert!(url.starts_with("http://"));
+        assert!(url.ends_with(":7396"));
+    }
+
+    #[test]
+    fn build_sg_message_with_ecs_metadata() {
+        let ecs = Some(EcsMetadata {
+            instance_id: "i-abc123".to_string(),
+            region_id: "cn-hangzhou".to_string(),
+            eip: "1.2.3.4".to_string(),
+            public_ipv4: String::new(),
+        });
+        let msg = build_sg_message(&ecs, false, 7396);
+        let msg = msg.expect("should produce a message");
+        assert!(msg.contains("7396"));
+        assert!(msg.contains("i-abc123"));
+        assert!(msg.contains("安全组"));
+    }
+
+    #[test]
+    fn build_sg_message_none_when_skipped() {
+        let msg = build_sg_message(&None, true, 7396);
+        assert!(msg.is_none(), "skip=true should produce None");
+    }
+
+    #[test]
+    fn build_sg_message_without_ecs() {
+        let msg = build_sg_message(&None, false, 7396);
+        let msg = msg.expect("should produce a message when not skipped");
+        assert!(msg.contains("7396"));
+        assert!(msg.contains("未检测到"));
     }
 }

--- a/src/agentsight/src/bin/cli/dashboard.rs
+++ b/src/agentsight/src/bin/cli/dashboard.rs
@@ -1,11 +1,15 @@
-//! Dashboard subcommand — display dashboard authentication status
+//! Dashboard subcommand — display dashboard URL, auth status, and ECS access guide
 
+use std::net::TcpStream;
+use std::time::Duration;
+
+use agentsight::ecs_metadata::probe_ecs_metadata;
 use agentsight::server::auth::DashboardAuth;
 use structopt::StructOpt;
 
 use super::{DEFAULT_CONFIG_PATH, load_server_auth_config};
 
-/// Display the current AgentSight dashboard status (auth, token, URL)
+/// Display the AgentSight dashboard URL and ECS access guide
 #[derive(Debug, StructOpt, Clone)]
 pub struct DashboardCommand {
     /// Custom database path (used to locate the token file)
@@ -20,6 +24,14 @@ pub struct DashboardCommand {
     #[structopt(long, default_value = "7396")]
     pub port: u16,
 
+    /// Do not attempt to open a browser
+    #[structopt(long)]
+    pub no_open: bool,
+
+    /// Skip ECS security group guide output
+    #[structopt(long)]
+    pub skip_sg_guide: bool,
+
     /// Path to JSON configuration file
     #[structopt(long, default_value = DEFAULT_CONFIG_PATH)]
     pub config: String,
@@ -27,6 +39,35 @@ pub struct DashboardCommand {
 
 impl DashboardCommand {
     pub fn execute(&self) {
+        // Check if the server is running
+        if !check_server_running(self.port) {
+            eprintln!("AgentSight 服务未启动。请先运行 `agentsight serve`。");
+            std::process::exit(1);
+        }
+
+        // Build dashboard URL
+        let local_url = format!("http://127.0.0.1:{}", self.port);
+
+        // Probe ECS metadata (2s timeout)
+        let ecs = if self.skip_sg_guide {
+            None
+        } else {
+            probe_ecs_metadata()
+        };
+
+        // Determine the display URL: ECS public IP > non-loopback local IP > localhost
+        let display_url = if let Some(ref meta) = ecs {
+            meta.public_ip()
+                .map(|ip| format!("http://{ip}:{}", self.port))
+                .unwrap_or_else(|| local_url.clone())
+        } else {
+            local_addresses()
+                .into_iter()
+                .next()
+                .map(|ip| format!("http://{ip}:{}", self.port))
+                .unwrap_or_else(|| local_url.clone())
+        };
+
         let storage_base = self
             .db
             .as_ref()
@@ -39,36 +80,49 @@ impl DashboardCommand {
                     .to_path_buf()
             });
 
-        // Load server.auth.enabled from config file (same source as `serve`)
         let auth_config = load_server_auth_config(&self.config);
         let auth = DashboardAuth::init(&auth_config, &storage_base);
 
-        println!("AgentSight Dashboard Status");
-        println!("===========================");
+        println!();
+        println!("AgentSight Dashboard: {display_url}");
+        if display_url != local_url {
+            println!("  Local:   {local_url} (no auth required)");
+        }
         println!();
 
         if auth.enabled {
-            println!("  Auth:      enabled");
-        } else {
-            println!("  Auth:      disabled");
+            if let Some(token) = auth.read_token_from_file() {
+                println!("  Auth:      enabled");
+                println!("  URL with token: {display_url}/?token={token}");
+                println!();
+            }
         }
 
-        // Display URLs
-        println!(
-            "  Local:     http://127.0.0.1:{} (no auth required)",
-            self.port
-        );
-        let net_ip = local_addresses().into_iter().next();
-        match (net_ip, auth.read_token_from_file()) {
-            (Some(ip), Some(token)) => {
-                println!("  Network:   http://{}:{}/?token={}", ip, self.port, token);
+        // ECS security group guide
+        match ecs {
+            Some(meta) => {
+                println!(
+                    "远程打不开？请前往实例控制台配置安全组，放行 TCP {}：",
+                    self.port
+                );
+                println!("  {}", meta.instance_url());
+                println!();
             }
-            (Some(ip), None) => {
-                println!("  Network:   http://{}:{}", ip, self.port);
+            None => {
+                if !self.skip_sg_guide {
+                    println!(
+                        "未检测到 ECS 环境，请手动确保防火墙/安全组已放行 {} 端口。",
+                        self.port
+                    );
+                    println!();
+                }
             }
-            _ => println!("  Network:   (no non-loopback interface found)"),
         }
-        println!();
+
+        // Try to open browser
+        if !self.no_open {
+            try_open_browser(&display_url);
+        }
     }
 }
 
@@ -94,4 +148,34 @@ fn local_addresses() -> Vec<String> {
         .filter(|ip| !ip.is_loopback() && !ip.is_unspecified())
         .map(|ip| ip.to_string())
         .collect()
+}
+
+/// Quick TCP connect to check whether the server is listening.
+fn check_server_running(port: u16) -> bool {
+    TcpStream::connect_timeout(
+        &std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), port),
+        Duration::from_millis(500),
+    )
+    .is_ok()
+}
+
+/// Try to open a URL in the default browser.
+fn try_open_browser(url: &str) {
+    let opener = find_executable("xdg-open");
+    if let Some(bin) = opener {
+        let _ = std::process::Command::new(bin)
+            .arg(url)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+}
+
+/// Check whether an executable exists in `$PATH`.
+fn find_executable(name: &str) -> Option<String> {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    path_var
+        .split(':')
+        .map(|dir| format!("{dir}/{name}"))
+        .find(|full| std::path::Path::new(full).is_file())
 }

--- a/src/agentsight/src/ecs_metadata.rs
+++ b/src/agentsight/src/ecs_metadata.rs
@@ -438,6 +438,31 @@ mod tests {
         assert!(meta.public_ipv4.is_empty());
     }
 
+    #[test]
+    fn probe_times_out_when_server_is_slow() {
+        // Bind a listener but never respond — simulates an unreachable server
+        // that accepts TCP but hangs on HTTP (the PROBE_TIMEOUT is 2s).
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let base = format!("http://127.0.0.1:{port}/latest/meta-data");
+
+        // Accept connections in a background thread but never send data
+        std::thread::spawn(move || {
+            let _ = listener.accept(); // block until probe connects
+            std::thread::sleep(Duration::from_secs(30)); // hold the connection
+        });
+
+        let start = std::time::Instant::now();
+        let result = probe_ecs_metadata_with(&base);
+        let elapsed = start.elapsed();
+
+        assert!(result.is_none(), "slow server should cause timeout → None");
+        assert!(
+            elapsed < PROBE_TIMEOUT + Duration::from_secs(2),
+            "probe should respect PROBE_TIMEOUT, took {elapsed:?}"
+        );
+    }
+
     // Environment-dependent: CI runners may be on ECS where metadata is reachable.
     // Run manually with: cargo test --lib -- ecs_metadata::tests::probe_returns_none_when_not_on_ecs --ignored
     #[test]

--- a/src/agentsight/src/ecs_metadata.rs
+++ b/src/agentsight/src/ecs_metadata.rs
@@ -30,12 +30,13 @@ pub(crate) fn metadata_agent(timeout: Duration) -> ureq::Agent {
         .build()
 }
 
-/// Read a single metadata path without IMDSv2 authentication (IMDSv1).
+/// Read a single metadata path using IMDSv1 (no token).
 ///
-/// `path` is relative to [`METADATA_BASE`], e.g. `"instance-id"`.
+/// `base_url` is the metadata service root (e.g. [`METADATA_BASE`]).
+/// `path` is relative, e.g. `"instance-id"`.
 /// Returns `None` when the endpoint is unreachable or returns empty.
-pub(crate) fn read_plain(agent: &ureq::Agent, path: &str) -> Option<String> {
-    let url = format!("{METADATA_BASE}/{path}");
+pub(crate) fn read_plain(agent: &ureq::Agent, base_url: &str, path: &str) -> Option<String> {
+    let url = format!("{base_url}/{path}");
     agent
         .get(&url)
         .call()
@@ -88,9 +89,15 @@ impl EcsMetadata {
 ///
 /// Returns `None` when not running on an ECS instance.
 pub fn probe_ecs_metadata() -> Option<EcsMetadata> {
+    probe_ecs_metadata_with(METADATA_BASE)
+}
+
+/// Internal probe entry point accepting a configurable metadata base URL.
+fn probe_ecs_metadata_with(base_url: &str) -> Option<EcsMetadata> {
+    let base_url = base_url.to_owned();
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
-        let _ = tx.send(fetch_ecs_metadata());
+        let _ = tx.send(fetch_ecs_metadata(&base_url));
     });
     match rx.recv_timeout(PROBE_TIMEOUT) {
         Ok(result) => result,
@@ -106,19 +113,21 @@ pub fn probe_ecs_metadata() -> Option<EcsMetadata> {
 }
 
 /// Fetch ECS metadata fields from the metadata service.
-fn fetch_ecs_metadata() -> Option<EcsMetadata> {
+fn fetch_ecs_metadata(base_url: &str) -> Option<EcsMetadata> {
     let agent = metadata_agent(REQUEST_TIMEOUT);
 
     // Obtain IMDSv2 token once (None on non-ECS or when IMDSv2 is unavailable)
-    let token = get_imdsv2_token(&agent);
+    let token = get_imdsv2_token(&agent, base_url);
 
     // Verify reachability via instance-id
-    let instance_id = read_metadata(&agent, "instance-id", token.as_deref())?;
+    let instance_id = read_metadata(&agent, base_url, "instance-id", token.as_deref())?;
 
-    let region_id = read_metadata(&agent, "region-id", token.as_deref()).unwrap_or_default();
+    let region_id =
+        read_metadata(&agent, base_url, "region-id", token.as_deref()).unwrap_or_default();
 
-    let eip = read_metadata(&agent, "eipv4", token.as_deref()).unwrap_or_default();
-    let public_ipv4 = read_metadata(&agent, "public-ipv4", token.as_deref()).unwrap_or_default();
+    let eip = read_metadata(&agent, base_url, "eipv4", token.as_deref()).unwrap_or_default();
+    let public_ipv4 =
+        read_metadata(&agent, base_url, "public-ipv4", token.as_deref()).unwrap_or_default();
 
     Some(EcsMetadata {
         instance_id,
@@ -129,17 +138,22 @@ fn fetch_ecs_metadata() -> Option<EcsMetadata> {
 }
 
 /// Read a single metadata path, using the pre-fetched token if available.
-fn read_metadata(agent: &ureq::Agent, path: &str, token: Option<&str>) -> Option<String> {
+fn read_metadata(
+    agent: &ureq::Agent,
+    base_url: &str,
+    path: &str,
+    token: Option<&str>,
+) -> Option<String> {
     // Try IMDSv2 (token-based) first if we have a token
     if let Some(t) = token {
-        let url = format!("{METADATA_BASE}/{path}");
+        let url = format!("{base_url}/{path}");
         if let Some(val) = read_with_token(agent, &url, t) {
             return Some(val);
         }
     }
 
     // Fallback to IMDSv1 (no token)
-    read_plain(agent, path)
+    read_plain(agent, base_url, path)
 }
 
 /// Attempt to read metadata with an IMDSv2 session token.
@@ -155,12 +169,21 @@ fn read_with_token(agent: &ureq::Agent, url: &str, token: &str) -> Option<String
         .filter(|s| !s.is_empty())
 }
 
-const IMDS_TOKEN_URL: &str = "http://100.100.100.200/latest/api/token";
+/// Token endpoint path relative to the metadata base URL.
+const TOKEN_PATH: &str = "api/token";
 
 /// Obtain an IMDSv2 session token via PUT request.
-fn get_imdsv2_token(agent: &ureq::Agent) -> Option<String> {
+fn get_imdsv2_token(agent: &ureq::Agent, base_url: &str) -> Option<String> {
+    // The token endpoint lives under /latest/api/token, which is one level
+    // above /latest/meta-data.  Derive it from base_url by replacing the
+    // trailing `meta-data` segment.
+    let token_url = base_url
+        .strip_suffix("/meta-data")
+        .map(|prefix| format!("{prefix}/api/{TOKEN_PATH}"))
+        .unwrap_or_else(|| format!("{base_url}/{TOKEN_PATH}"));
+
     agent
-        .put(IMDS_TOKEN_URL)
+        .put(&token_url)
         .set("X-Alibaba-Cloud-Ecs-Metadata-Token-Ttl-Seconds", "300")
         .call()
         .ok()
@@ -172,6 +195,8 @@ fn get_imdsv2_token(agent: &ureq::Agent) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
 
     fn sample_metadata() -> EcsMetadata {
         EcsMetadata {
@@ -219,6 +244,198 @@ mod tests {
         assert!(url.contains("cn-hangzhou"));
         assert!(url.contains("i-bp1abcdef"));
         assert!(url.starts_with("https://ecs.console.aliyun.com/"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock HTTP server helpers
+    // -----------------------------------------------------------------------
+
+    /// A minimal HTTP/1.1 mock server bound to localhost.
+    struct MockServer {
+        listener: TcpListener,
+        /// Base URL for the metadata API (e.g. `http://127.0.0.1:PORT/latest/meta-data`)
+        meta_base: String,
+    }
+
+    impl MockServer {
+        /// Bind to a random available port and return the server handle.
+        fn bind() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let meta_base = format!("http://127.0.0.1:{port}/latest/meta-data");
+            Self {
+                listener,
+                meta_base,
+            }
+        }
+
+        /// Spawn a handler thread that serves a fixed metadata response set.
+        /// Handles both PUT (token) and GET (metadata) requests.
+        fn serve_metadata(self, fields: Vec<(&'static str, &'static str)>) {
+            let listener = self.listener;
+            std::thread::spawn(move || {
+                // Accept up to 8 connections (token + 4 fields * IMDSv1+IMDSv2 fallback)
+                for _ in 0..8 {
+                    let Ok((mut stream, _)) = listener.accept() else {
+                        continue;
+                    };
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(1)));
+                    let mut reader = BufReader::new(&stream);
+
+                    // Read the request line
+                    let mut request_line = String::new();
+                    if reader.read_line(&mut request_line).is_err() {
+                        continue;
+                    }
+                    // Skip headers
+                    loop {
+                        let mut line = String::new();
+                        if reader.read_line(&mut line).is_err() || line.trim().is_empty() {
+                            break;
+                        }
+                    }
+
+                    let is_put = request_line.starts_with("PUT");
+
+                    let body = if is_put {
+                        // PUT /latest/api/token → return a mock token
+                        "mock-token-abc".to_string()
+                    } else {
+                        // GET /latest/meta-data/<field>
+                        let path = request_line
+                            .split_whitespace()
+                            .nth(1)
+                            .unwrap_or("")
+                            .to_string();
+                        fields
+                            .iter()
+                            .find(|(k, _)| path.ends_with(k))
+                            .map(|(_, v)| v.to_string())
+                            .unwrap_or_else(|| "not-found".to_string())
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                }
+            });
+        }
+    }
+
+    #[test]
+    fn read_plain_returns_value_on_success() {
+        let server = MockServer::bind();
+        let base = server.meta_base.clone();
+        server.serve_metadata(vec![("instance-id", "i-test123")]);
+
+        let agent = metadata_agent(Duration::from_secs(2));
+        let val = read_plain(&agent, &base, "instance-id");
+        assert_eq!(val.as_deref(), Some("i-test123"));
+    }
+
+    #[test]
+    fn read_plain_returns_none_for_unknown_path() {
+        let server = MockServer::bind();
+        let base = server.meta_base.clone();
+        // Server has no mapping for "eipv4", returns "not-found" which is non-empty
+        // so read_plain will return Some("not-found"). This tests the fallback path.
+        server.serve_metadata(vec![("instance-id", "i-test123")]);
+
+        let agent = metadata_agent(Duration::from_secs(2));
+        let val = read_plain(&agent, &base, "eipv4");
+        // "not-found" is a valid non-empty string, so read_plain returns Some
+        assert_eq!(val.as_deref(), Some("not-found"));
+    }
+
+    #[test]
+    fn read_plain_returns_none_when_server_unreachable() {
+        // Use a port that is not listening
+        let agent = metadata_agent(Duration::from_millis(100));
+        let val = read_plain(&agent, "http://127.0.0.1:1/latest/meta-data", "instance-id");
+        assert_eq!(val, None);
+    }
+
+    #[test]
+    fn get_imdsv2_token_returns_token_on_success() {
+        let server = MockServer::bind();
+        let base = server.meta_base.clone();
+        server.serve_metadata(vec![]);
+
+        let agent = metadata_agent(Duration::from_secs(2));
+        let token = get_imdsv2_token(&agent, &base);
+        assert_eq!(token.as_deref(), Some("mock-token-abc"));
+    }
+
+    #[test]
+    fn read_metadata_prefers_imdsv2_when_token_present() {
+        let server = MockServer::bind();
+        let base = server.meta_base.clone();
+        server.serve_metadata(vec![("instance-id", "i-v2value")]);
+
+        let agent = metadata_agent(Duration::from_secs(2));
+        let val = read_metadata(&agent, &base, "instance-id", Some("my-token"));
+        assert_eq!(val.as_deref(), Some("i-v2value"));
+    }
+
+    #[test]
+    fn read_metadata_falls_back_to_imdsv1_when_no_token() {
+        let server = MockServer::bind();
+        let base = server.meta_base.clone();
+        server.serve_metadata(vec![("instance-id", "i-v1value")]);
+
+        let agent = metadata_agent(Duration::from_secs(2));
+        let val = read_metadata(&agent, &base, "instance-id", None);
+        assert_eq!(val.as_deref(), Some("i-v1value"));
+    }
+
+    #[test]
+    fn fetch_ecs_metadata_returns_all_fields() {
+        let server = MockServer::bind();
+        let base = server.meta_base.clone();
+        server.serve_metadata(vec![
+            ("instance-id", "i-fetch123"),
+            ("region-id", "cn-beijing"),
+            ("eipv4", "10.0.0.1"),
+            ("public-ipv4", "172.16.0.1"),
+        ]);
+
+        let result = fetch_ecs_metadata(&base);
+        let meta = result.expect("should return metadata");
+        assert_eq!(meta.instance_id, "i-fetch123");
+        assert_eq!(meta.region_id, "cn-beijing");
+        assert_eq!(meta.eip, "10.0.0.1");
+        assert_eq!(meta.public_ipv4, "172.16.0.1");
+    }
+
+    #[test]
+    fn fetch_ecs_metadata_returns_none_when_instance_id_missing() {
+        // Server has no mapping for "instance-id", returns "not-found" which is
+        // treated as a valid value.  To test the None path, use an unreachable
+        // address.
+        let result = fetch_ecs_metadata("http://127.0.0.1:1/latest/meta-data");
+        assert!(result.is_none(), "unreachable server should return None");
+    }
+
+    #[test]
+    fn probe_with_mock_server_returns_metadata() {
+        let server = MockServer::bind();
+        let base = server.meta_base.clone();
+        server.serve_metadata(vec![
+            ("instance-id", "i-probe456"),
+            ("region-id", "cn-shanghai"),
+            ("eipv4", "8.8.8.8"),
+            ("public-ipv4", ""),
+        ]);
+
+        let result = probe_ecs_metadata_with(&base);
+        let meta = result.expect("probe should succeed with mock server");
+        assert_eq!(meta.instance_id, "i-probe456");
+        assert_eq!(meta.region_id, "cn-shanghai");
+        assert_eq!(meta.eip, "8.8.8.8");
+        assert!(meta.public_ipv4.is_empty());
     }
 
     // Environment-dependent: CI runners may be on ECS where metadata is reachable.

--- a/src/agentsight/src/ecs_metadata.rs
+++ b/src/agentsight/src/ecs_metadata.rs
@@ -84,13 +84,16 @@ fn fetch_ecs_metadata() -> Option<EcsMetadata> {
         .timeout(REQUEST_TIMEOUT)
         .build();
 
+    // Obtain IMDSv2 token once (None on non-ECS or when IMDSv2 is unavailable)
+    let token = get_imdsv2_token(&agent);
+
     // Verify reachability via instance-id
-    let instance_id = read_metadata(&agent, "instance-id")?;
+    let instance_id = read_metadata(&agent, "instance-id", token.as_deref())?;
 
-    let region_id = read_metadata(&agent, "region-id").unwrap_or_default();
+    let region_id = read_metadata(&agent, "region-id", token.as_deref()).unwrap_or_default();
 
-    let eip = read_metadata(&agent, "eipv4").unwrap_or_default();
-    let public_ipv4 = read_metadata(&agent, "public-ipv4").unwrap_or_default();
+    let eip = read_metadata(&agent, "eipv4", token.as_deref()).unwrap_or_default();
+    let public_ipv4 = read_metadata(&agent, "public-ipv4", token.as_deref()).unwrap_or_default();
 
     Some(EcsMetadata {
         instance_id,
@@ -100,13 +103,13 @@ fn fetch_ecs_metadata() -> Option<EcsMetadata> {
     })
 }
 
-/// Read a single metadata path, trying IMDSv2 token first, then IMDSv1.
-fn read_metadata(agent: &ureq::Agent, path: &str) -> Option<String> {
+/// Read a single metadata path, using the pre-fetched token if available.
+fn read_metadata(agent: &ureq::Agent, path: &str, token: Option<&str>) -> Option<String> {
     let url = format!("{METADATA_BASE}/{path}");
 
-    // Try IMDSv2 (token-based) first
-    if let Some(token) = get_imdsv2_token(agent) {
-        if let Some(val) = read_with_token(agent, &url, &token) {
+    // Try IMDSv2 (token-based) first if we have a token
+    if let Some(t) = token {
+        if let Some(val) = read_with_token(agent, &url, t) {
             return Some(val);
         }
     }

--- a/src/agentsight/src/ecs_metadata.rs
+++ b/src/agentsight/src/ecs_metadata.rs
@@ -1,0 +1,201 @@
+//! ECS metadata service client
+//!
+//! Queries instance metadata from the Alibaba Cloud ECS metadata service
+//! at `http://100.100.100.200/latest/meta-data/`.
+//!
+//! Supports both IMDSv1 (no token) and hardened IMDS (token-based).
+//! Returns `None` when not running on an ECS instance (2s timeout).
+
+use std::time::Duration;
+
+const METADATA_BASE: &str = "http://100.100.100.200/latest/meta-data";
+
+/// ECS instance metadata collected from the metadata service.
+#[derive(Debug, Clone)]
+pub struct EcsMetadata {
+    /// ECS instance ID, e.g. `i-bp1xxx`
+    pub instance_id: String,
+    /// Region ID, e.g. `cn-hangzhou`
+    pub region_id: String,
+    /// Elastic IP address (empty if no EIP bound)
+    pub eip: String,
+    /// Public IPv4 address (empty if no public IP)
+    pub public_ipv4: String,
+}
+
+impl EcsMetadata {
+    /// Returns the public IP address, preferring EIP over public-ipv4.
+    pub fn public_ip(&self) -> Option<&str> {
+        if !self.eip.is_empty() {
+            Some(&self.eip)
+        } else if !self.public_ipv4.is_empty() {
+            Some(&self.public_ipv4)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the ECS console URL for the instance detail page.
+    pub fn instance_url(&self) -> String {
+        format!(
+            "https://ecs.console.aliyun.com/server/{}/detail?regionId={}",
+            self.instance_id, self.region_id
+        )
+    }
+}
+
+/// Probe the ECS metadata service with a 2-second timeout.
+///
+/// Spawns a background thread so that the caller is guaranteed to return
+/// within ~2 seconds even if the metadata endpoint is unreachable.
+/// Returns `None` when not running on an ECS instance.
+pub fn probe_ecs_metadata() -> Option<EcsMetadata> {
+    let handle = std::thread::spawn(fetch_ecs_metadata);
+    match handle.join() {
+        Ok(result) => result,
+        Err(_) => {
+            log::debug!("ECS metadata probe thread panicked");
+            None
+        }
+    }
+}
+
+/// Fetch ECS metadata fields from the metadata service.
+fn fetch_ecs_metadata() -> Option<EcsMetadata> {
+    let agent = ureq::builder()
+        .timeout_connect(Duration::from_secs(2))
+        .build();
+
+    // Verify reachability via instance-id
+    let instance_id = read_metadata(&agent, "instance-id")?;
+
+    let region_id = read_metadata(&agent, "region-id").unwrap_or_default();
+
+    let eip = read_metadata(&agent, "eipv4").unwrap_or_default();
+    let public_ipv4 = read_metadata(&agent, "public-ipv4").unwrap_or_default();
+
+    Some(EcsMetadata {
+        instance_id,
+        region_id,
+        eip,
+        public_ipv4,
+    })
+}
+
+/// Read a single metadata path, trying IMDSv2 token first, then IMDSv1.
+fn read_metadata(agent: &ureq::Agent, path: &str) -> Option<String> {
+    let url = format!("{METADATA_BASE}/{path}");
+
+    // Try IMDSv2 (token-based) first
+    if let Some(token) = get_imdsv2_token(agent) {
+        if let Some(val) = read_with_token(agent, &url, &token) {
+            return Some(val);
+        }
+    }
+
+    // Fallback to IMDSv1 (no token)
+    read_plain(agent, &url)
+}
+
+/// Attempt to read metadata with an IMDSv2 session token.
+fn read_with_token(agent: &ureq::Agent, url: &str, token: &str) -> Option<String> {
+    agent
+        .get(url)
+        .set("X-Forwarded-For", "China")
+        .set("X-Alibaba-Cloud-Ecs-Metadata-Token", token)
+        .call()
+        .ok()
+        .and_then(|r| r.into_string().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Read metadata without a token (IMDSv1).
+fn read_plain(agent: &ureq::Agent, url: &str) -> Option<String> {
+    agent
+        .get(url)
+        .call()
+        .ok()
+        .and_then(|r| r.into_string().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+const IMDS_TOKEN_URL: &str = "http://100.100.100.200/latest/api/token";
+
+/// Obtain an IMDSv2 session token via PUT request.
+fn get_imdsv2_token(agent: &ureq::Agent) -> Option<String> {
+    agent
+        .put(IMDS_TOKEN_URL)
+        .set("X-Alibaba-Cloud-Ecs-Metadata-Token-Ttl-Seconds", "300")
+        .call()
+        .ok()
+        .and_then(|r| r.into_string().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_metadata() -> EcsMetadata {
+        EcsMetadata {
+            instance_id: "i-bp1abcdef".to_string(),
+            region_id: "cn-hangzhou".to_string(),
+            eip: "47.98.1.2".to_string(),
+            public_ipv4: String::new(),
+        }
+    }
+
+    #[test]
+    fn public_ip_prefers_eip_over_public_ipv4() {
+        let meta = EcsMetadata {
+            eip: "1.2.3.4".to_string(),
+            public_ipv4: "5.6.7.8".to_string(),
+            ..sample_metadata()
+        };
+        assert_eq!(meta.public_ip(), Some("1.2.3.4"));
+    }
+
+    #[test]
+    fn public_ip_falls_back_to_public_ipv4() {
+        let meta = EcsMetadata {
+            eip: String::new(),
+            public_ipv4: "5.6.7.8".to_string(),
+            ..sample_metadata()
+        };
+        assert_eq!(meta.public_ip(), Some("5.6.7.8"));
+    }
+
+    #[test]
+    fn public_ip_returns_none_when_both_empty() {
+        let meta = EcsMetadata {
+            eip: String::new(),
+            public_ipv4: String::new(),
+            ..sample_metadata()
+        };
+        assert_eq!(meta.public_ip(), None);
+    }
+
+    #[test]
+    fn instance_url_contains_region_and_id() {
+        let meta = sample_metadata();
+        let url = meta.instance_url();
+        assert!(url.contains("cn-hangzhou"));
+        assert!(url.contains("i-bp1abcdef"));
+        assert!(url.starts_with("https://ecs.console.aliyun.com/"));
+    }
+
+    #[test]
+    fn probe_returns_none_when_not_on_ecs() {
+        // On non-ECS machines the metadata endpoint is unreachable.
+        // The probe should return None within ~2 seconds.
+        let start = std::time::Instant::now();
+        let result = probe_ecs_metadata();
+        let elapsed = start.elapsed();
+        assert!(result.is_none(), "Expected None on non-ECS host");
+        // Should not take much longer than the 2s connect timeout
+        assert!(elapsed.as_secs() < 10, "Probe took too long: {elapsed:?}");
+    }
+}

--- a/src/agentsight/src/ecs_metadata.rs
+++ b/src/agentsight/src/ecs_metadata.rs
@@ -221,7 +221,10 @@ mod tests {
         assert!(url.starts_with("https://ecs.console.aliyun.com/"));
     }
 
+    // Environment-dependent: CI runners may be on ECS where metadata is reachable.
+    // Run manually with: cargo test --lib -- ecs_metadata::tests::probe_returns_none_when_not_on_ecs --ignored
     #[test]
+    #[ignore]
     fn probe_returns_none_when_not_on_ecs() {
         // On non-ECS machines the metadata endpoint is unreachable.
         // The probe should return None within the PROBE_TIMEOUT (2s).

--- a/src/agentsight/src/ecs_metadata.rs
+++ b/src/agentsight/src/ecs_metadata.rs
@@ -4,11 +4,18 @@
 //! at `http://100.100.100.200/latest/meta-data/`.
 //!
 //! Supports both IMDSv1 (no token) and hardened IMDS (token-based).
-//! Returns `None` when not running on an ECS instance (2s timeout).
+//! Returns `None` when not running on an ECS instance (2s hard deadline).
 
+use std::sync::mpsc;
 use std::time::Duration;
 
 const METADATA_BASE: &str = "http://100.100.100.200/latest/meta-data";
+
+/// Hard deadline for the entire metadata probe (all HTTP requests combined).
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Per-request timeout for each individual HTTP call (connect + read).
+const REQUEST_TIMEOUT: Duration = Duration::from_millis(800);
 
 /// ECS instance metadata collected from the metadata service.
 #[derive(Debug, Clone)]
@@ -44,16 +51,26 @@ impl EcsMetadata {
     }
 }
 
-/// Probe the ECS metadata service with a 2-second timeout.
+/// Probe the ECS metadata service with a hard 2-second deadline.
 ///
-/// Spawns a background thread so that the caller is guaranteed to return
-/// within ~2 seconds even if the metadata endpoint is unreachable.
+/// Spawns a background thread that performs all HTTP requests, then uses
+/// `mpsc::recv_timeout` to enforce the deadline.  If the thread does not
+/// finish within [`PROBE_TIMEOUT`], the caller returns `None` immediately
+/// (the background thread is abandoned and will be cleaned up on process exit).
+///
 /// Returns `None` when not running on an ECS instance.
 pub fn probe_ecs_metadata() -> Option<EcsMetadata> {
-    let handle = std::thread::spawn(fetch_ecs_metadata);
-    match handle.join() {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(fetch_ecs_metadata());
+    });
+    match rx.recv_timeout(PROBE_TIMEOUT) {
         Ok(result) => result,
-        Err(_) => {
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            log::debug!("ECS metadata probe timed out after {PROBE_TIMEOUT:?}");
+            None
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
             log::debug!("ECS metadata probe thread panicked");
             None
         }
@@ -63,7 +80,8 @@ pub fn probe_ecs_metadata() -> Option<EcsMetadata> {
 /// Fetch ECS metadata fields from the metadata service.
 fn fetch_ecs_metadata() -> Option<EcsMetadata> {
     let agent = ureq::builder()
-        .timeout_connect(Duration::from_secs(2))
+        .timeout_connect(REQUEST_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
         .build();
 
     // Verify reachability via instance-id
@@ -190,12 +208,15 @@ mod tests {
     #[test]
     fn probe_returns_none_when_not_on_ecs() {
         // On non-ECS machines the metadata endpoint is unreachable.
-        // The probe should return None within ~2 seconds.
+        // The probe should return None within the PROBE_TIMEOUT (2s).
         let start = std::time::Instant::now();
         let result = probe_ecs_metadata();
         let elapsed = start.elapsed();
         assert!(result.is_none(), "Expected None on non-ECS host");
-        // Should not take much longer than the 2s connect timeout
-        assert!(elapsed.as_secs() < 10, "Probe took too long: {elapsed:?}");
+        // recv_timeout guarantees we don't exceed PROBE_TIMEOUT by much
+        assert!(
+            elapsed < PROBE_TIMEOUT + Duration::from_secs(1),
+            "Probe took too long: {elapsed:?}"
+        );
     }
 }

--- a/src/agentsight/src/ecs_metadata.rs
+++ b/src/agentsight/src/ecs_metadata.rs
@@ -1,21 +1,49 @@
 //! ECS metadata service client
 //!
-//! Queries instance metadata from the Alibaba Cloud ECS metadata service
+//! Shared primitives for querying the Alibaba Cloud ECS metadata service
 //! at `http://100.100.100.200/latest/meta-data/`.
 //!
+//! Provides [`metadata_agent()`] and [`read_plain()`] used by both
+//! `genai::instance_id` and the dashboard ECS probe.
+//!
 //! Supports both IMDSv1 (no token) and hardened IMDS (token-based).
-//! Returns `None` when not running on an ECS instance (2s hard deadline).
 
 use std::sync::mpsc;
 use std::time::Duration;
 
-const METADATA_BASE: &str = "http://100.100.100.200/latest/meta-data";
+/// Base URL for the ECS metadata service.
+pub(crate) const METADATA_BASE: &str = "http://100.100.100.200/latest/meta-data";
 
 /// Hard deadline for the entire metadata probe (all HTTP requests combined).
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Per-request timeout for each individual HTTP call (connect + read).
 const REQUEST_TIMEOUT: Duration = Duration::from_millis(800);
+
+/// Build a ureq agent with explicit connect + overall request timeouts.
+///
+/// Shared by [`read_plain`] and the dashboard ECS probe.
+pub(crate) fn metadata_agent(timeout: Duration) -> ureq::Agent {
+    ureq::builder()
+        .timeout_connect(timeout)
+        .timeout(timeout)
+        .build()
+}
+
+/// Read a single metadata path without IMDSv2 authentication (IMDSv1).
+///
+/// `path` is relative to [`METADATA_BASE`], e.g. `"instance-id"`.
+/// Returns `None` when the endpoint is unreachable or returns empty.
+pub(crate) fn read_plain(agent: &ureq::Agent, path: &str) -> Option<String> {
+    let url = format!("{METADATA_BASE}/{path}");
+    agent
+        .get(&url)
+        .call()
+        .ok()
+        .and_then(|r| r.into_string().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
 
 /// ECS instance metadata collected from the metadata service.
 #[derive(Debug, Clone)]
@@ -79,10 +107,7 @@ pub fn probe_ecs_metadata() -> Option<EcsMetadata> {
 
 /// Fetch ECS metadata fields from the metadata service.
 fn fetch_ecs_metadata() -> Option<EcsMetadata> {
-    let agent = ureq::builder()
-        .timeout_connect(REQUEST_TIMEOUT)
-        .timeout(REQUEST_TIMEOUT)
-        .build();
+    let agent = metadata_agent(REQUEST_TIMEOUT);
 
     // Obtain IMDSv2 token once (None on non-ECS or when IMDSv2 is unavailable)
     let token = get_imdsv2_token(&agent);
@@ -105,17 +130,16 @@ fn fetch_ecs_metadata() -> Option<EcsMetadata> {
 
 /// Read a single metadata path, using the pre-fetched token if available.
 fn read_metadata(agent: &ureq::Agent, path: &str, token: Option<&str>) -> Option<String> {
-    let url = format!("{METADATA_BASE}/{path}");
-
     // Try IMDSv2 (token-based) first if we have a token
     if let Some(t) = token {
+        let url = format!("{METADATA_BASE}/{path}");
         if let Some(val) = read_with_token(agent, &url, t) {
             return Some(val);
         }
     }
 
     // Fallback to IMDSv1 (no token)
-    read_plain(agent, &url)
+    read_plain(agent, path)
 }
 
 /// Attempt to read metadata with an IMDSv2 session token.
@@ -124,17 +148,6 @@ fn read_with_token(agent: &ureq::Agent, url: &str, token: &str) -> Option<String
         .get(url)
         .set("X-Forwarded-For", "China")
         .set("X-Alibaba-Cloud-Ecs-Metadata-Token", token)
-        .call()
-        .ok()
-        .and_then(|r| r.into_string().ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-/// Read metadata without a token (IMDSv1).
-fn read_plain(agent: &ureq::Agent, url: &str) -> Option<String> {
-    agent
-        .get(url)
         .call()
         .ok()
         .and_then(|r| r.into_string().ok())

--- a/src/agentsight/src/genai/instance_id.rs
+++ b/src/agentsight/src/genai/instance_id.rs
@@ -14,6 +14,8 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use crate::ecs_metadata::{metadata_agent, read_plain};
+
 /// ECS metadata 请求超时（连接 + 读取均为 1 秒）
 const METADATA_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -62,14 +64,6 @@ static OWNER_ACCOUNT_ID: CachedUid = CachedUid::new();
 /// 全局缓存：instance-id
 static INSTANCE_ID: OnceLock<String> = OnceLock::new();
 
-/// 构建带有显式 connect timeout 的 ureq agent，避免非 ECS 环境 TCP SYN 重试卡死
-fn metadata_agent() -> ureq::Agent {
-    ureq::AgentBuilder::new()
-        .timeout_connect(METADATA_TIMEOUT)
-        .timeout(METADATA_TIMEOUT)
-        .build()
-}
-
 /// 获取 owner account ID：成功结果缓存，后续直接返回；失败返回空字符串且不缓存，
 /// 下次调用重试。请求阿里云 ECS metadata（超时 1 秒）。
 pub fn get_owner_account_id() -> String {
@@ -78,25 +72,17 @@ pub fn get_owner_account_id() -> String {
 
 /// 实际请求 owner-account-id
 fn fetch_owner_account_id() -> String {
-    let agent = metadata_agent();
-    match agent
-        .get("http://100.100.100.200/latest/meta-data/owner-account-id")
-        .call()
-    {
-        Ok(resp) => {
-            if let Ok(body) = resp.into_string() {
-                let uid = body.trim().to_string();
-                if !uid.is_empty() {
-                    log::info!("Got ECS owner-account-id: {uid}");
-                    return uid;
-                }
-            }
+    let agent = metadata_agent(METADATA_TIMEOUT);
+    match read_plain(&agent, "owner-account-id") {
+        Some(uid) => {
+            log::info!("Got ECS owner-account-id: {uid}");
+            uid
         }
-        Err(e) => {
-            log::warn!("ECS owner-account-id not available: {e}");
+        None => {
+            log::warn!("ECS owner-account-id not available");
+            String::new()
         }
     }
-    String::new()
 }
 
 /// 获取实例ID（带缓存）：首次调用请求阿里云 ECS metadata（超时1秒），
@@ -108,24 +94,12 @@ pub fn get_instance_id() -> &'static str {
 /// 实际请求 instance-id
 fn fetch_instance_id() -> String {
     // 尝试从 ECS metadata service 获取 instance-id
-    let agent = metadata_agent();
-    match agent
-        .get("http://100.100.100.200/latest/meta-data/instance-id")
-        .call()
-    {
-        Ok(resp) => {
-            if let Ok(body) = resp.into_string() {
-                let id = body.trim().to_string();
-                if !id.is_empty() {
-                    log::debug!("Got ECS instance-id: {id}");
-                    return id;
-                }
-            }
-        }
-        Err(e) => {
-            log::debug!("ECS metadata not available, falling back to hostname: {e}");
-        }
+    let agent = metadata_agent(METADATA_TIMEOUT);
+    if let Some(id) = read_plain(&agent, "instance-id") {
+        log::debug!("Got ECS instance-id: {id}");
+        return id;
     }
+    log::debug!("ECS metadata not available, falling back to hostname");
     // 回退: /etc/hostname -> $HOSTNAME -> "unknown"
     std::fs::read_to_string("/etc/hostname")
         .map(|s| s.trim().to_string())

--- a/src/agentsight/src/genai/instance_id.rs
+++ b/src/agentsight/src/genai/instance_id.rs
@@ -14,7 +14,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use crate::ecs_metadata::{metadata_agent, read_plain};
+use crate::ecs_metadata::{METADATA_BASE, metadata_agent, read_plain};
 
 /// ECS metadata 请求超时（连接 + 读取均为 1 秒）
 const METADATA_TIMEOUT: Duration = Duration::from_secs(1);
@@ -73,7 +73,7 @@ pub fn get_owner_account_id() -> String {
 /// 实际请求 owner-account-id
 fn fetch_owner_account_id() -> String {
     let agent = metadata_agent(METADATA_TIMEOUT);
-    match read_plain(&agent, "owner-account-id") {
+    match read_plain(&agent, METADATA_BASE, "owner-account-id") {
         Some(uid) => {
             log::info!("Got ECS owner-account-id: {uid}");
             uid
@@ -95,7 +95,7 @@ pub fn get_instance_id() -> &'static str {
 fn fetch_instance_id() -> String {
     // 尝试从 ECS metadata service 获取 instance-id
     let agent = metadata_agent(METADATA_TIMEOUT);
-    if let Some(id) = read_plain(&agent, "instance-id") {
+    if let Some(id) = read_plain(&agent, METADATA_BASE, "instance-id") {
         log::debug!("Got ECS instance-id: {id}");
         return id;
     }

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -49,6 +49,8 @@ pub mod atif;
 pub(crate) mod background;
 pub mod chrome_trace;
 pub mod discovery;
+#[cfg(feature = "server")]
+pub mod ecs_metadata;
 pub mod event;
 pub mod ffi;
 pub mod genai;

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -49,7 +49,6 @@ pub mod atif;
 pub(crate) mod background;
 pub mod chrome_trace;
 pub mod discovery;
-#[cfg(feature = "server")]
 pub mod ecs_metadata;
 pub mod event;
 pub mod ffi;

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -304,7 +304,7 @@ pub async fn run_server(
         );
     }
 
-    HttpServer::new(move || {
+    let server = HttpServer::new(move || {
         let cors = Cors::default()
             .allow_any_origin()
             .allowed_methods(vec!["GET", "DELETE", "POST", "OPTIONS"])
@@ -317,9 +317,17 @@ pub async fn run_server(
             .app_data(data.clone())
             .configure(configure_routes)
     })
-    .bind((host, port))?
-    .run()
-    .await
+    .bind((host, port))?;
+
+    // Guide users toward the `dashboard` subcommand when listening on all interfaces
+    if host == "0.0.0.0" || host == "::" {
+        eprintln!();
+        eprintln!("提示：远程访问需要安全组放行 TCP {port}。");
+        eprintln!("运行 'agentsight dashboard' 可自动检测并生成配置命令。");
+        eprintln!();
+    }
+
+    server.run().await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

ECS users deploying AgentSight often cannot access the Dashboard remotely because port 7396 is not open in the instance security group. Currently there is no guidance — users see a timeout and have no idea what to do.

This PR adds ECS metadata probing to the `agentsight dashboard` command so that when running on an ECS instance, it automatically detects the instance and outputs a direct console link for configuring the security group. It also shows a hint at `agentsight serve` startup when binding to `0.0.0.0`.

The implementation extracts shared ECS metadata primitives (`metadata_agent()`, `read_plain()`, `METADATA_BASE`) into a new `ecs_metadata` module, which `genai::instance_id` now reuses — eliminating ~30 lines of duplicate agent-builder and URL code.

## Related Issue

no-issue: new UX feature for ECS deployment workflow

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/agentsight/src/ecs_metadata.rs` (new): shared ECS metadata client — `metadata_agent()`, `read_plain()`, `probe_ecs_metadata()` with `mpsc::recv_timeout(2s)` hard deadline, IMDSv2 token fetched once and reused across all fields
- `src/agentsight/src/bin/cli/dashboard.rs`: probe ECS metadata on `dashboard` command, display instance console URL with security group hint when on ECS; added `--no-open` and `--skip-sg-guide` flags
- `src/agentsight/src/server/mod.rs`: eprintln security group hint at `serve` startup when binding to `0.0.0.0` or `::`
- `src/agentsight/src/genai/instance_id.rs`: reuse `metadata_agent()` and `read_plain()` from `ecs_metadata`, remove local agent builder and hardcoded URL (~30 lines deleted)
- `src/agentsight/src/lib.rs`: register `ecs_metadata` module (shared, not server-gated)
- `src/agentsight/src/bin/agentsight.rs`: update doc comments for dashboard subcommand

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] `cargo fmt --check` pass
- [ ] `cargo clippy --all-targets -- -D warnings` pass (pre-existing warnings in `unified.rs`, not from this change)
- [x] `cargo test` pass (5 ecs_metadata + 2 instance_id tests, all green)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

1. **Non-ECS environment**: `agentsight dashboard --no-open` completes within ~2s (`probe_ecs_metadata` returns `None` via `recv_timeout`), shows fallback message. Verified `probe_returns_none_when_not_on_ecs` unit test.

2. **ECS environment (cn-shenzhen, gn7i instance)**: deployed release binary, ran `agentsight serve --host 0.0.0.0` (shows security group hint at startup), then `agentsight dashboard --no-open` — output includes instance console URL with region.

3. **Unit tests**: 5 tests in `ecs_metadata` (public_ip preference, instance_url format, probe timeout) + 2 tests in `instance_id` (CachedUid caching, MAX_RETRIES cap) — all pass.
