### PR TITLE
fix(cosh): clarify cosh-switch post-switch guidance

### DIFF
--- a/src/copilot-shell/copilot-shell.spec.in
+++ b/src/copilot-shell/copilot-shell.spec.in
@@ -42,13 +42,25 @@ set -e
 current=$(rpm -q --qf '%%{NAME}' -f /usr/bin/cosh 2>/dev/null || echo "none")
 case "$current" in
   cosh-ng)
+    target="copilot-shell"
     echo "Current: cosh-ng -> switching to copilot-shell"
     sudo yum swap cosh-ng copilot-shell ;;
   copilot-shell)
+    target="cosh-ng"
     echo "Current: copilot-shell -> switching to cosh-ng"
     sudo yum swap copilot-shell cosh-ng ;;
   *)
     echo "Error: neither cosh-ng nor copilot-shell is installed."; exit 1 ;;
+esac
+case "${LANG:-}" in
+  zh_*|zh)
+    echo ""
+    echo "已切换到 ${target}。当前会话仍运行在旧模式下，无法热切换。"
+    echo "请退出并重新打开 shell（或重新连接会话），再运行 \"cosh\" 进入新模式。" ;;
+  *)
+    echo ""
+    echo "Switched to $target. The current session still runs the old mode and cannot hot-switch."
+    echo "Please exit and reopen your shell (or reconnect the session), then run \"cosh\" to enter the new mode." ;;
 esac
 EOF
 chmod 0755 %{buildroot}%{_bindir}/cosh-switch
@@ -69,13 +81,25 @@ run = """set -e
 current=$(rpm -q --qf '%%{NAME}' -f /usr/bin/cosh 2>/dev/null || echo 'none')
 case "$current" in
   cosh-ng)
-    echo "Current: cosh-ng -> switching to copilot-shell"
+    target='copilot-shell'
+    echo 'Current: cosh-ng -> switching to copilot-shell'
     sudo yum swap cosh-ng copilot-shell ;;
   copilot-shell)
-    echo "Current: copilot-shell -> switching to cosh-ng"
+    target='cosh-ng'
+    echo 'Current: copilot-shell -> switching to cosh-ng'
     sudo yum swap copilot-shell cosh-ng ;;
   *)
-    echo "Error: neither cosh-ng nor copilot-shell is installed."; exit 1 ;;
+    echo 'Error: neither cosh-ng nor copilot-shell is installed.'; exit 1 ;;
+esac
+case "${LANG:-}" in
+  zh_*|zh)
+    echo ''
+    echo "已切换到 ${target}。当前会话仍运行在旧模式下，无法热切换。"
+    echo '请退出并重新打开 shell（或重新连接会话），再运行 cosh 进入新模式。' ;;
+  *)
+    echo ''
+    echo "Switched to $target. The current session still runs the old mode and cannot hot-switch."
+    echo 'Please exit and reopen your shell (or reconnect the session), then run cosh to enter the new mode.' ;;
 esac"""
 EOF
 


### PR DESCRIPTION
## Description

After `/cosh-switch` (or `cosh-switch` in bash) runs a successful `yum swap`, the only feedback was yum's raw `Complete!` output, leaving users unsure whether the switch worked — the current session still runs the old mode because a live shell process cannot hot-switch. This adds clear, bilingual (zh/en) post-switch guidance that names the target package and instructs the user to reopen the shell (or reconnect the session) and run `cosh` to enter the new mode. The message is applied consistently to both the standalone `/usr/bin/cosh-switch` script and the `/cosh-switch` slash command, with language selected from `$LANG`.

## Related Issue

closes #1352

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

The change is confined to the RPM packaging shell script in `copilot-shell.spec.in`; there is no TypeScript code path, so vitest cannot cover it. Verified via:

```bash
bash -n <extracted switch script>          # both variants pass
# TOML run field: triple-quotes balanced, parses cleanly
# functional check of the $LANG branch:
LANG=zh_CN.UTF-8 -> Chinese guidance
LANG=en_US.UTF-8 / unset -> English guidance
```

The `yum swap` step itself requires a live RPM environment and root, so it cannot be exercised in CI/unit tests.

## Additional Notes

Issue #1352 is labeled `component:cosh` but is framed as an enhancement rather than a Bug; implemented per user request. The two switch script definitions in the spec remain duplicated (pre-existing); this PR keeps them in sync rather than refactoring.
