### PR TITLE
fix(cosh-ng): [platform,cli] honor svc dry-run

### DIFF
--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -905,43 +905,32 @@ fn test_svc_status_nonexistent_service() {
 // --- svc: dry-run ---
 
 #[test]
-fn test_svc_enable_dry_run_json_envelope() {
-    let output = cosh_bin()
-        .args([
-            "svc",
-            "enable",
-            "--dry-run",
-            "cosh-nonexistent-test-svc-xyz",
-        ])
-        .output()
-        .unwrap();
+fn test_svc_actions_dry_run_nonexistent_service_succeed() {
+    let name = "cosh-nonexistent-test-svc-1361";
 
-    // dry-run queries status first, so a nonexistent service still fails
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    for action in ["start", "stop", "restart", "enable", "disable"] {
+        let output = cosh_bin()
+            .args(["svc", action, "--dry-run", name])
+            .output()
+            .unwrap();
 
-    // Either succeeds (dry-run envelope) or fails (SvcNotFound) — both are valid JSON
-    assert!(json["meta"]["subsystem"] == "svc");
-    assert!(json["meta"]["dry_run"] == true);
-}
+        assert!(
+            output.status.success(),
+            "dry-run {action} failed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
 
-#[test]
-fn test_svc_disable_dry_run_json_envelope() {
-    let output = cosh_bin()
-        .args([
-            "svc",
-            "disable",
-            "--dry-run",
-            "cosh-nonexistent-test-svc-xyz",
-        ])
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-
-    assert!(json["meta"]["subsystem"] == "svc");
-    assert!(json["meta"]["dry_run"] == true);
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["ok"], true, "action={action}: {json}");
+        assert_eq!(json["data"]["name"], name);
+        assert_eq!(json["data"]["action"], action);
+        assert_eq!(json["data"]["success"], true);
+        assert_eq!(json["data"]["previous_state"]["Unknown"], "(dry-run)");
+        assert_eq!(json["data"]["new_state"]["Unknown"], "(dry-run)");
+        assert_eq!(json["meta"]["subsystem"], "svc");
+        assert_eq!(json["meta"]["dry_run"], true);
+    }
 }
 
 // --- Input validation ---

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -808,7 +808,7 @@ impl CoshCore {
                             ),
                         );
                         let request_id = self.next_request_id();
-                        let bypass_tool_use_id = format!("{}-bypass", &tc.id);
+                        let bypass_tool_use_id = format!("{}-bypass", tc.id);
                         self.emit(
                             writer,
                             &OutputMessage::can_use_tool(

--- a/src/cosh-ng/crates/cosh-platform/src/svc.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/svc.rs
@@ -99,19 +99,19 @@ pub fn svc_action(name: &str, action: &str, dry_run: bool) -> Result<SvcActionRe
         ));
     }
 
-    // Get current state before action
-    let before = svc_status(name)?;
-    let previous_state = before.state.clone();
-
     if dry_run {
+        let dry_run_state = SvcState::Unknown("(dry-run)".to_string());
         return Ok(SvcActionResult {
             name: name.to_string(),
             action: action.to_string(),
             success: true,
-            previous_state,
-            new_state: SvcState::Unknown("(dry-run)".to_string()),
+            previous_state: dry_run_state.clone(),
+            new_state: dry_run_state,
         });
     }
+
+    let before = svc_status(name)?;
+    let previous_state = before.state.clone();
 
     let output = run_command(
         Command::new("systemctl").args([action, name]),
@@ -497,6 +497,25 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidInput);
         assert!(err.message.contains("destroy"));
+    }
+
+    #[test]
+    fn test_svc_action_dry_run_skips_status_query_for_all_actions() {
+        let name = "cosh-nonexistent-test-svc-1361";
+
+        for action in ["start", "stop", "restart", "enable", "disable"] {
+            let result = svc_action(name, action, true)
+                .unwrap_or_else(|err| panic!("dry-run {action} failed: {err:?}"));
+
+            assert_eq!(result.name, name);
+            assert_eq!(result.action, action);
+            assert!(result.success);
+            assert_eq!(
+                result.previous_state,
+                SvcState::Unknown("(dry-run)".to_string())
+            );
+            assert_eq!(result.new_state, SvcState::Unknown("(dry-run)".to_string()));
+        }
     }
 
     // --- PID parsing edge cases ---


### PR DESCRIPTION
## Description

Make service action dry-runs return before querying systemd, matching the package dry-run contract and keeping previews independent of service existence. Preserve action and service-name validation, all real service execution paths, and the existing public response types. Strengthen platform and CLI regression coverage across start, stop, restart, enable, and disable. A second atomic commit removes an unchanged-main redundant formatting borrow exposed by Rust 1.97 so the required cosh-ng CI gate can proceed without changing runtime behavior.

## Related Issue

closes #1361

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Passed after rebasing onto `origin/main`:

- `cargo fmt --all -- --check`
- `cargo test --package cosh-core` (`275 passed; 0 failed` across unit and integration targets)
- `cargo test --package cosh-platform svc::tests::test_svc_action_dry_run_skips_status_query_for_all_actions -- --exact` (`1 passed`)
- `cargo test --package cosh-cli --test cli_integration test_svc_actions_dry_run_nonexistent_service_succeed -- --exact` (`1 passed`)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- CI-equivalent commitlint 19.x for both commits (`0 problems; 0 warnings`)
- [GitHub Actions `Test cosh-ng`](https://github.com/alibaba/anolisa/actions/runs/29072923127/job/86298171049): Rust 1.97 formatting, all-targets Clippy, and `cargo test --workspace` passed

Earlier focused and manual validation also passed:

- `cargo test --package cosh-platform -- --skip test_parse_installed_version_bash` (`175 passed; 0 failed; 1 filtered out`)
- `cargo test --package cosh-cli --test cli_integration -- --skip test_pkg_search_bash_shows_installed` (`53 passed; 0 failed; 1 filtered out`)
- `cargo run --quiet --package cosh-cli -- svc start cosh-nonexistent-test-svc-1361 --dry-run`
- `cargo run --quiet --package cosh-cli -- pkg install cosh-nonexistent-test-pkg-1361 --dry-run`

The local toolchain is Rust/Clippy 1.91. The previous Linux CI RED on Rust 1.97 was `clippy::useless_borrows_in_formatting` in unchanged main code; the second commit applies Clippy's exact one-line suggestion. The refreshed Linux `Test cosh-ng` job passed in 8m51s, providing the final Rust 1.97 and complete workspace gate.

The unskipped package baseline and broader workspace checks are not green on this macOS host. Two pre-existing Nix/Homebrew package-manager baseline tests fail: `pkg::tests::test_parse_installed_version_bash` and `test_pkg_search_bash_shows_installed`. With both package tests skipped, two broad workspace runs exposed seven unrelated `cosh-shell` PTY timing failures; every failure passed an isolated exact rerun. No package-manager or `cosh-shell` code was changed for this fix.

## Additional Notes

The manual dry-run comparison was performed on macOS, where the regression previously surfaced as a failed `systemctl` spawn. The automated test uses a guaranteed nonexistent service and covers all five service actions without executing host mutations. Both dry-run state fields use the existing `Unknown("(dry-run)")` representation, avoiding a public API change. The Rust 1.97 cleanup is isolated in its own `[core]` commit and preserves the generated bypass id and later uses of `tc.id`.
