### PR TITLE
fix(sight): copy agentsight.json into source tarball in rpm-build.sh

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -416,6 +416,9 @@ build_agentsight() {
     # component.toml — spec %install installs it to %{_datadir}/anolisa/components/agentsight/
     [ -f "${SIGHT_DIR}/component.toml" ] && cp "${SIGHT_DIR}/component.toml" "$pkg_dir/"
 
+    # agentsight.json — spec %install installs it to %{_sysconfdir}/agentsight/config.json
+    [ -f "${SIGHT_DIR}/agentsight.json" ] && cp "${SIGHT_DIR}/agentsight.json" "$pkg_dir/"
+
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
     rm -rf "$tmp_dir"
 


### PR DESCRIPTION
## 问题

Fixes #1431

`agentsight.spec.in` 的 `%install` 阶段执行 `install -p -m 0644 agentsight.json %{buildroot}%{_sysconfdir}/agentsight/config.json`（line 45），但 `scripts/rpm-build.sh` 的 `build_agentsight()` 在组装 source tarball 时只拷贝了 `component.toml`，漏拷 `agentsight.json`，导致 rpmbuild `%install` 失败：`install: cannot stat 'agentsight.json': No such file or directory`。

根因：commit 98158d24 在 spec `%install` 新增了 `agentsight.json` 安装，但未同步更新 `rpm-build.sh` 的文件拷贝列表。

## 修复

```diff
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -417,6 +417,9 @@
     # component.toml — spec %install installs it to %{_datadir}/anolisa/components/agentsight/
     [ -f "${SIGHT_DIR}/component.toml" ] && cp "${SIGHT_DIR}/component.toml" "$pkg_dir/"
 
+    # agentsight.json — spec %install installs it to %{_sysconfdir}/agentsight/config.json
+    [ -f "${SIGHT_DIR}/agentsight.json" ] && cp "${SIGHT_DIR}/agentsight.json" "$pkg_dir/"
+
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
     rm -rf "$tmp_dir"
```

## 验证

```shell
# ECS (ALinux 4, cn-hongkong) — fresh clone + apply patch + rpm-build
cd /root && rm -rf anolisa-verify-build && git clone https://github.com/alibaba/anolisa.git anolisa-verify-build
cd anolisa-verify-build && git checkout main && git apply /tmp/agentsight-fix.patch
source /root/.cargo/env && bash scripts/rpm-build.sh agentsight
```

结果：exit 0，产出 `agentsight-0.7.1-1.alnx4.x86_64.rpm (8.6M)`，tarball 含 `agentsight-0.7.1/agentsight.json`。

```
[OK] agentsight RPM built successfully
agentsight-0.7.1-1.alnx4.x86_64.rpm  (8.6M)
agentsight-0.7.1-1.alnx4.src.rpm  (12M)
```

Co-Authored-By: Claude <noreply@anthropic.com>
