### PR TITLE
feat(sight): show LAN/public IP addresses and Chinese output in dashboard CLI

### DIFF
--- a/src/agentsight/src/bin/cli/dashboard.rs
+++ b/src/agentsight/src/bin/cli/dashboard.rs
@@ -438,4 +438,164 @@ mod tests {
         assert!(line.contains("7396"));
         assert!(!line.contains("token"));
     }
+
+    // ─── build_output tests ─────────────────────────────────────────────────
+
+    /// Write a minimal agentsight config file and return its path.
+    fn write_temp_config(auth_enabled: bool, suffix: &str) -> String {
+        let dir =
+            std::env::temp_dir().join(format!("agentsight_test_{}_{}", std::process::id(), suffix));
+        std::fs::create_dir_all(&dir).ok();
+        let config_path = dir.join("config.json");
+        let content = if auth_enabled {
+            r#"{"schema_version":2,"server":{"auth":{"enabled":true}}}"#
+        } else {
+            r#"{"schema_version":2,"server":{"auth":{"enabled":false}}}"#
+        };
+        std::fs::write(&config_path, content).unwrap();
+        config_path.to_string_lossy().to_string()
+    }
+
+    /// Return a unique temp storage directory for a given suffix.
+    fn temp_storage_dir(suffix: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "agentsight_test_storage_{}_{}",
+            std::process::id(),
+            suffix
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn build_output_with_auth_disabled() {
+        let config = write_temp_config(false, "disabled");
+        let storage = temp_storage_dir("disabled");
+        let db_path = storage.join("test.db");
+        std::fs::write(&db_path, b"").ok();
+
+        let cmd = DashboardCommand {
+            db: Some(db_path.to_string_lossy().to_string()),
+            host: "0.0.0.0".to_string(),
+            port: 7396,
+            no_open: true,
+            skip_sg_guide: true,
+            config,
+        };
+
+        let output = cmd.build_output();
+
+        // Should contain Chinese auth status
+        assert!(output.lines.iter().any(|l| l.contains("已关闭")));
+        // Should contain localhost URL
+        assert!(output.lines.iter().any(|l| l.contains("127.0.0.1:7396")));
+        // No token in URLs (auth disabled)
+        assert!(!output.lines.iter().any(|l| l.contains("token=")));
+        // No tip (auth disabled)
+        assert!(!output.lines.iter().any(|l| l.contains("提示")));
+        // SG message should be None (skip_sg_guide = true)
+        assert!(output.sg_message.is_none());
+    }
+
+    #[test]
+    fn build_output_with_auth_enabled() {
+        let config = write_temp_config(true, "enabled");
+        let storage = temp_storage_dir("enabled");
+        let db_path = storage.join("test_auth.db");
+        std::fs::write(&db_path, b"").ok();
+
+        let cmd = DashboardCommand {
+            db: Some(db_path.to_string_lossy().to_string()),
+            host: "0.0.0.0".to_string(),
+            port: 7396,
+            no_open: true,
+            skip_sg_guide: true,
+            config,
+        };
+
+        let output = cmd.build_output();
+
+        // Should contain Chinese auth status
+        assert!(output.lines.iter().any(|l| l.contains("已启用")));
+        // Should contain localhost URL with "无需认证"
+        assert!(output.lines.iter().any(|l| l.contains("无需认证")));
+        // Should contain tip
+        assert!(output.lines.iter().any(|l| l.contains("提示")));
+    }
+
+    #[test]
+    fn build_output_with_host_override() {
+        let config = write_temp_config(true, "host");
+        let storage = temp_storage_dir("host");
+        let db_path = storage.join("test_host.db");
+        std::fs::write(&db_path, b"").ok();
+
+        let cmd = DashboardCommand {
+            db: Some(db_path.to_string_lossy().to_string()),
+            host: "8.8.8.8".to_string(),
+            port: 9999,
+            no_open: true,
+            skip_sg_guide: true,
+            config,
+        };
+
+        let output = cmd.build_output();
+
+        // Display URL should use the overridden host
+        assert!(output.display_url.contains("8.8.8.8"));
+        assert!(output.display_url.contains("9999"));
+        // LAN line should show the overridden host
+        assert!(output.lines.iter().any(|l| l.contains("8.8.8.8")));
+        // No tip (host_override is set)
+        assert!(!output.lines.iter().any(|l| l.contains("提示")));
+    }
+
+    #[test]
+    fn build_output_without_skip_sg_guide() {
+        let config = write_temp_config(false, "sg");
+        let storage = temp_storage_dir("sg");
+        let db_path = storage.join("test_sg.db");
+        std::fs::write(&db_path, b"").ok();
+
+        let cmd = DashboardCommand {
+            db: Some(db_path.to_string_lossy().to_string()),
+            host: "0.0.0.0".to_string(),
+            port: 7396,
+            no_open: true,
+            skip_sg_guide: false,
+            config,
+        };
+
+        let output = cmd.build_output();
+
+        // SG message should be present (not skipped, likely no ECS in CI)
+        assert!(output.sg_message.is_some());
+        let msg = output.sg_message.unwrap();
+        assert!(msg.contains("7396"));
+    }
+
+    // ─── public_address tests ───────────────────────────────────────────────
+
+    #[test]
+    fn public_address_returns_option_without_panicking() {
+        // This makes a real network call; in CI it may succeed or fail.
+        // The test just verifies the function doesn't panic and returns Option.
+        let result = public_address();
+        match &result {
+            Some(ip) => {
+                assert!(!ip.is_empty());
+                assert!(!ip.contains('<'));
+                assert!(ip.len() <= 64);
+            }
+            None => {}
+        }
+    }
+
+    // ─── try_open_browser tests ─────────────────────────────────────────────
+
+    #[test]
+    fn try_open_browser_does_not_panic() {
+        // Just verify it doesn't panic even if no browser opener exists.
+        try_open_browser("http://127.0.0.1:7396");
+    }
 }

--- a/src/agentsight/src/bin/cli/dashboard.rs
+++ b/src/agentsight/src/bin/cli/dashboard.rs
@@ -581,13 +581,10 @@ mod tests {
         // This makes a real network call; in CI it may succeed or fail.
         // The test just verifies the function doesn't panic and returns Option.
         let result = public_address();
-        match &result {
-            Some(ip) => {
-                assert!(!ip.is_empty());
-                assert!(!ip.contains('<'));
-                assert!(ip.len() <= 64);
-            }
-            None => {}
+        if let Some(ip) = &result {
+            assert!(!ip.is_empty());
+            assert!(!ip.contains('<'));
+            assert!(ip.len() <= 64);
         }
     }
 

--- a/src/agentsight/src/bin/cli/dashboard.rs
+++ b/src/agentsight/src/bin/cli/dashboard.rs
@@ -16,7 +16,7 @@ pub struct DashboardCommand {
     #[structopt(long)]
     pub db: Option<String>,
 
-    /// Host the server is bound to
+    /// Host the server is bound to (use a specific IP/hostname to override the Network URL)
     #[structopt(long, default_value = "0.0.0.0")]
     pub host: String,
 
@@ -73,8 +73,6 @@ impl DashboardCommand {
             probe_ecs_metadata()
         };
 
-        let display_url = resolve_display_url(&ecs, &local_url, self.port);
-
         let storage_base = self
             .db
             .as_ref()
@@ -89,20 +87,70 @@ impl DashboardCommand {
 
         let auth_config = load_server_auth_config(&self.config);
         let auth = DashboardAuth::init(&auth_config, &storage_base);
+        let token = auth.read_token_from_file();
 
+        // When --host is a specific address (not wildcard), use it as override
+        let host_override = if self.host != "0.0.0.0" && self.host != "::" {
+            Some(self.host.clone())
+        } else {
+            None
+        };
+
+        // Resolve the primary display URL (ECS public IP > --host > LAN IP > localhost)
+        let display_url = resolve_display_url(&ecs, &host_override, &local_url, self.port);
+
+        // Build output lines
         let mut lines = Vec::new();
-        lines.push(format!("AgentSight Dashboard: {display_url}"));
-        if display_url != local_url {
-            lines.push(format!("  Local:   {local_url} (no auth required)"));
-        }
+        lines.push("AgentSight 仪表盘状态".to_string());
+        lines.push("=====================".to_string());
         lines.push(String::new());
 
-        if auth.enabled
-            && let Some(token) = auth.read_token_from_file()
-        {
-            lines.push("  Auth:      enabled".to_string());
-            lines.push(format!("  URL with token: {display_url}/?token={token}"));
+        if auth.enabled {
+            lines.push("  认证:    已启用".to_string());
+        } else {
+            lines.push("  认证:    已关闭".to_string());
+        }
+
+        // Localhost (loopback bypasses auth)
+        lines.push(format!(
+            "  本机:    {local_url}{}",
+            if auth.enabled { " (无需认证)" } else { "" }
+        ));
+
+        // LAN (private) IP
+        let lan_ip = host_override
+            .as_deref()
+            .map(str::to_string)
+            .or_else(|| local_addresses().into_iter().next());
+        if let Some(ref ip) = lan_ip {
+            lines.push(format_url("  局域网:", ip, self.port, token.as_deref()));
+        }
+
+        // Public IP (ECS metadata > curl detection > hint)
+        let public_ip = ecs
+            .as_ref()
+            .and_then(|m| m.public_ip().map(|s| s.to_string()))
+            .or_else(|| {
+                if host_override.is_none() {
+                    public_address()
+                } else {
+                    None
+                }
+            });
+        match public_ip {
+            Some(ref ip) => {
+                lines.push(format_url("  公网:", ip, self.port, token.as_deref()));
+            }
+            None => {
+                lines.push("  公网:    (无法检测 — 请使用 --host <公网IP> 指定)".to_string());
+            }
+        }
+
+        // Tip for --host usage
+        if auth.enabled && host_override.is_none() {
             lines.push(String::new());
+            lines.push("  提示: 使用 --host <IP> 可覆盖显示的网络地址,".to_string());
+            lines.push("        例如: agentsight dashboard --host <你的公网IP>".to_string());
         }
 
         let sg_message = build_sg_message(&ecs, self.skip_sg_guide, self.port);
@@ -123,19 +171,26 @@ struct DashboardOutput {
     sg_message: Option<String>,
 }
 
-/// Determine the display URL: ECS public IP > non-loopback local IP > localhost.
-fn resolve_display_url(ecs: &Option<EcsMetadata>, local_url: &str, port: u16) -> String {
-    if let Some(meta) = ecs {
-        meta.public_ip()
-            .map(|ip| format!("http://{ip}:{port}"))
-            .unwrap_or_else(|| local_url.to_string())
-    } else {
-        local_addresses()
-            .into_iter()
-            .next()
-            .map(|ip| format!("http://{ip}:{port}"))
-            .unwrap_or_else(|| local_url.to_string())
+/// Determine the display URL: ECS public IP > --host > LAN IP > localhost.
+fn resolve_display_url(
+    ecs: &Option<EcsMetadata>,
+    host_override: &Option<String>,
+    local_url: &str,
+    port: u16,
+) -> String {
+    if let Some(meta) = ecs
+        && let Some(ip) = meta.public_ip()
+    {
+        return format!("http://{ip}:{port}");
     }
+    if let Some(h) = host_override {
+        return format!("http://{h}:{port}");
+    }
+    local_addresses()
+        .into_iter()
+        .next()
+        .map(|ip| format!("http://{ip}:{port}"))
+        .unwrap_or_else(|| local_url.to_string())
 }
 
 /// Build the security group guide message, if applicable.
@@ -155,6 +210,34 @@ fn build_sg_message(ecs: &Option<EcsMetadata>, skip: bool, port: u16) -> Option<
         )),
         None => None,
     }
+}
+
+/// Format a URL line with optional token.
+fn format_url(label: &str, host: &str, port: u16, token: Option<&str>) -> String {
+    match token {
+        Some(t) => format!("{label:<8} http://{host}:{port}/?token={t}"),
+        None => format!("{label:<8} http://{host}:{port}"),
+    }
+}
+
+/// Detect the public IP address via external service.
+///
+/// Uses `curl` with a 3-second timeout to query a lightweight IP echo service.
+/// Returns `None` if detection fails (no network, curl missing, timeout, etc.).
+fn public_address() -> Option<String> {
+    let output = std::process::Command::new("curl")
+        .args(["-s", "-m", "3", "--retry", "1", "https://ifconfig.me"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // Validate that the response looks like an IP or hostname (not an HTML error page)
+    if ip.is_empty() || ip.len() > 64 || ip.contains('<') {
+        return None;
+    }
+    Some(ip)
 }
 
 /// Get non-loopback local IP addresses for URL display.
@@ -273,8 +356,19 @@ mod tests {
             eip: "1.2.3.4".to_string(),
             public_ipv4: String::new(),
         });
-        let url = resolve_display_url(&ecs, "http://127.0.0.1:7396", 7396);
+        let url = resolve_display_url(&ecs, &None, "http://127.0.0.1:7396", 7396);
         assert_eq!(url, "http://1.2.3.4:7396");
+    }
+
+    #[test]
+    fn resolve_display_url_with_host_override() {
+        let url = resolve_display_url(
+            &None,
+            &Some("8.8.8.8".to_string()),
+            "http://127.0.0.1:7396",
+            7396,
+        );
+        assert_eq!(url, "http://8.8.8.8:7396");
     }
 
     #[test]
@@ -285,13 +379,15 @@ mod tests {
             eip: String::new(),
             public_ipv4: String::new(),
         });
-        let url = resolve_display_url(&ecs, "http://127.0.0.1:7396", 7396);
-        assert_eq!(url, "http://127.0.0.1:7396");
+        let url = resolve_display_url(&ecs, &None, "http://127.0.0.1:7396", 7396);
+        // Without public IP, falls through to local_addresses() or localhost fallback
+        assert!(url.starts_with("http://"));
+        assert!(url.ends_with(":7396"));
     }
 
     #[test]
     fn resolve_display_url_without_ecs() {
-        let url = resolve_display_url(&None, "http://127.0.0.1:7396", 7396);
+        let url = resolve_display_url(&None, &None, "http://127.0.0.1:7396", 7396);
         // Should use local_addresses or fall back to localhost
         assert!(url.starts_with("http://"));
         assert!(url.ends_with(":7396"));
@@ -324,5 +420,22 @@ mod tests {
         let msg = msg.expect("should produce a message when not skipped");
         assert!(msg.contains("7396"));
         assert!(msg.contains("未检测到"));
+    }
+
+    #[test]
+    fn format_url_with_token() {
+        let line = format_url("  公网:", "1.2.3.4", 7396, Some("abc123"));
+        assert!(line.contains("1.2.3.4"));
+        assert!(line.contains("7396"));
+        assert!(line.contains("abc123"));
+        assert!(line.contains("公网"));
+    }
+
+    #[test]
+    fn format_url_without_token() {
+        let line = format_url("  局域网:", "10.0.0.1", 7396, None);
+        assert!(line.contains("10.0.0.1"));
+        assert!(line.contains("7396"));
+        assert!(!line.contains("token"));
     }
 }


### PR DESCRIPTION
## Description

`agentsight dashboard` CLI 命令现在同时展示三个网络地址，方便用户根据实际场景选择访问方式：

- **本机**: loopback 地址（免认证）
- **局域网**: 从网卡自动检测的私网 IP（支持 `--host` 覆盖）
- **公网**: 优先使用 ECS 元数据，其次通过 `curl ifconfig.me`（3 秒超时）自动检测；检测失败则提示用户用 `--host <公网IP>` 手动指定

全部终端输出中文化（认证状态、地址标签、提示信息），与 CLI 整体风格保持一致。

## Related Issue

closes #1433

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo test --bin agentsight`: 25 tests passed (新增 3 个测试用例)
- `cargo clippy --bin agentsight -- -D warnings`: clean
- 远程 ECS 机器实测：公网 IP 自动检测正确，三个地址均可访问