### PR TITLE
fix(anolisa): handle closed stdout safely

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/register.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/register.rs
@@ -360,9 +360,9 @@ fn format_source(source: &Option<anolisa_core::RegisterSource>) -> String {
 }
 
 fn prompt_yn(prompt: &str, default: bool) -> bool {
-    use std::io::{self, BufRead, Write};
+    use std::io::{self, BufRead};
     print!("{prompt}");
-    io::stdout().flush().ok();
+    crate::output::flush_stdout();
     let line = io::stdin()
         .lock()
         .lines()

--- a/src/anolisa/crates/anolisa-cli/src/main.rs
+++ b/src/anolisa/crates/anolisa-cli/src/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod output;
+
 mod color;
 mod commands;
 mod context;
@@ -6,19 +9,91 @@ mod repo_config;
 mod resolution;
 mod response;
 
+use std::io;
 use std::process::ExitCode;
 
 use clap::FromArgMatches as _;
+use clap::error::ErrorKind;
 
 use crate::commands::Cli;
 use crate::context::CliContext;
 
 fn main() -> ExitCode {
-    let matches = commands::build_cli().get_matches();
-    let cli = Cli::from_arg_matches(&matches).expect("clap mismatch");
+    let matches = match commands::build_cli().try_get_matches() {
+        Ok(matches) => matches,
+        Err(error) => return handle_clap_error(error),
+    };
+    let cli = match Cli::from_arg_matches(&matches) {
+        Ok(cli) => cli,
+        Err(error) => return handle_clap_error(error),
+    };
     let ctx = CliContext::from_cli(&cli);
-    match commands::dispatch(cli, &ctx) {
+    let result = commands::dispatch(cli, &ctx);
+    let exit_code = match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => response::render_error(&ctx, &err),
+    };
+    finish(exit_code)
+}
+
+fn handle_clap_error(error: clap::Error) -> ExitCode {
+    let exit_code = match u8::try_from(error.exit_code()) {
+        Ok(code) => ExitCode::from(code),
+        Err(_) => ExitCode::FAILURE,
+    };
+    match error.kind() {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+            output::write_stdout(format_args!("{error}"), false);
+            finish(ExitCode::SUCCESS)
+        }
+        _ => {
+            let _ = error.print();
+            exit_code
+        }
+    }
+}
+
+fn finish(exit_code: ExitCode) -> ExitCode {
+    finish_with_error(exit_code, output::finish_stdout())
+}
+
+fn finish_with_error(exit_code: ExitCode, error: Option<io::Error>) -> ExitCode {
+    match error {
+        Some(error) => {
+            eprintln!("error[EXECUTION_FAILED]: failed writing to stdout: {error}");
+            ExitCode::from(1)
+        }
+        None => exit_code,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::process::ExitCode;
+
+    #[test]
+    fn stdout_success_preserves_business_exit_code() {
+        // Given a business command with a non-zero result and healthy stdout.
+        let business_exit = ExitCode::from(2);
+
+        // When the process resolves stdout precedence.
+        let resolved = super::finish_with_error(business_exit, None);
+
+        // Then the business result remains authoritative.
+        assert_eq!(ExitCode::from(2), resolved);
+    }
+
+    #[test]
+    fn stdout_failure_overrides_business_exit_code() {
+        // Given a business command result and an actionable stdout failure.
+        let business_exit = ExitCode::from(2);
+        let error = io::Error::new(io::ErrorKind::PermissionDenied, "injected stdout failure");
+
+        // When the process resolves stdout precedence.
+        let resolved = super::finish_with_error(business_exit, Some(error));
+
+        // Then the output failure maps to the execution-failed exit code.
+        assert_eq!(ExitCode::from(1), resolved);
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/output.rs
+++ b/src/anolisa/crates/anolisa-cli/src/output.rs
@@ -1,0 +1,324 @@
+//! Fallible standard-output handling for pipeline-safe CLI rendering.
+
+use std::fmt;
+use std::io::{self, Write};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+macro_rules! print {
+    ($($arg:tt)*) => {{
+        crate::output::write_stdout(format_args!($($arg)*), false);
+    }};
+}
+
+macro_rules! println {
+    () => {{
+        crate::output::write_stdout(format_args!(""), true);
+    }};
+    ($($arg:tt)*) => {{
+        crate::output::write_stdout(format_args!($($arg)*), true);
+    }};
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum WriteStatus {
+    Written,
+    Closed,
+}
+
+enum OutputState {
+    Connected,
+    Closed,
+    Failed(io::Error),
+}
+
+struct Output<W> {
+    writer: W,
+    state: OutputState,
+}
+
+impl<W: Write> Output<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            writer,
+            state: OutputState::Connected,
+        }
+    }
+
+    fn write(&mut self, rendered: &str, newline: bool) {
+        if !matches!(self.state, OutputState::Connected) {
+            return;
+        }
+        self.state = match write_to(&mut self.writer, rendered, newline) {
+            Ok(WriteStatus::Written) => OutputState::Connected,
+            Ok(WriteStatus::Closed) => OutputState::Closed,
+            Err(error) => OutputState::Failed(error),
+        };
+    }
+
+    fn take_error(&mut self) -> Option<io::Error> {
+        if !matches!(self.state, OutputState::Failed(_)) {
+            return None;
+        }
+        match std::mem::replace(&mut self.state, OutputState::Closed) {
+            OutputState::Failed(error) => Some(error),
+            OutputState::Connected | OutputState::Closed => None,
+        }
+    }
+
+    fn flush(&mut self) {
+        if !matches!(self.state, OutputState::Connected) {
+            return;
+        }
+        self.state = match self.writer.flush() {
+            Ok(()) => OutputState::Connected,
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => OutputState::Closed,
+            Err(error) => OutputState::Failed(error),
+        };
+    }
+
+    fn finish(&mut self) -> Option<io::Error> {
+        self.flush();
+        self.take_error()
+    }
+}
+
+static STDOUT: OnceLock<Mutex<Output<io::Stdout>>> = OnceLock::new();
+
+fn lock_stdout() -> MutexGuard<'static, Output<io::Stdout>> {
+    let output = STDOUT.get_or_init(|| Mutex::new(Output::new(io::stdout())));
+    match output.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn write_to(writer: &mut impl Write, rendered: &str, newline: bool) -> io::Result<WriteStatus> {
+    let result = writer.write_all(rendered.as_bytes()).and_then(|()| {
+        if newline {
+            writer.write_all(b"\n")
+        } else {
+            Ok(())
+        }
+    });
+    match result {
+        Ok(()) => Ok(WriteStatus::Written),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(WriteStatus::Closed),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn write_stdout(args: fmt::Arguments<'_>, newline: bool) {
+    let rendered = args.to_string();
+    lock_stdout().write(&rendered, newline);
+}
+
+pub(crate) fn flush_stdout() {
+    lock_stdout().flush();
+}
+
+pub(crate) fn finish_stdout() -> Option<io::Error> {
+    lock_stdout().finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+    use std::io::{self, Write};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::{Output, WriteStatus, write_to};
+
+    struct BrokenPipeWriter;
+
+    impl Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "consumer closed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailOnceWriter {
+        writes: usize,
+        kind: io::ErrorKind,
+    }
+
+    impl Write for FailOnceWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            self.writes += 1;
+            Err(io::Error::new(self.kind, "injected write failure"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct RecursiveDisplay;
+
+    impl fmt::Display for RecursiveDisplay {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            super::flush_stdout();
+            formatter.write_str("")
+        }
+    }
+
+    struct FlushErrorWriter;
+
+    impl Write for FlushErrorWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "injected flush failure",
+            ))
+        }
+    }
+
+    struct BrokenPipeOnFlushWriter;
+
+    impl Write for BrokenPipeOnFlushWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "consumer closed during flush",
+            ))
+        }
+    }
+
+    #[test]
+    fn write_reports_closed_when_consumer_closes_pipe() {
+        // Given a downstream consumer that has closed its pipe.
+        let mut writer = BrokenPipeWriter;
+
+        // When CLI output writes another line.
+        let status = write_to(&mut writer, "row", true)
+            .expect("BrokenPipe must be a graceful output condition");
+
+        // Then rendering reports the closed channel without panicking.
+        assert_eq!(WriteStatus::Closed, status);
+    }
+
+    #[test]
+    fn output_stops_writing_after_broken_pipe() {
+        // Given stdout fails with BrokenPipe on its first write.
+        let writer = FailOnceWriter {
+            writes: 0,
+            kind: io::ErrorKind::BrokenPipe,
+        };
+        let mut output = Output::new(writer);
+
+        // When two lines are rendered.
+        output.write("first", true);
+        output.write("second", true);
+        assert!(output.take_error().is_none());
+        output.write("third", true);
+
+        // Then only the first write reaches the disconnected consumer.
+        assert_eq!(1, output.writer.writes);
+    }
+
+    #[test]
+    fn output_defers_non_pipe_error_until_command_finishes() {
+        // Given stdout fails for a reason other than a closed consumer.
+        let writer = FailOnceWriter {
+            writes: 0,
+            kind: io::ErrorKind::PermissionDenied,
+        };
+        let mut output = Output::new(writer);
+
+        // When a command renders output and later inspects the channel.
+        output.write("result", true);
+        let error = output
+            .take_error()
+            .expect("non-pipe output failures must remain actionable");
+
+        // Then the original error classification is preserved.
+        assert_eq!(io::ErrorKind::PermissionDenied, error.kind());
+    }
+
+    #[test]
+    fn formatting_can_write_output_without_deadlocking() {
+        // Given a Display implementation that emits nested CLI output.
+        let (sender, receiver) = mpsc::channel();
+
+        // When the value is rendered through the global output path.
+        std::thread::spawn(move || {
+            super::write_stdout(format_args!("{RecursiveDisplay}"), false);
+            let _ = sender.send(());
+        });
+
+        // Then formatting completes without recursively locking stdout.
+        assert!(receiver.recv_timeout(Duration::from_secs(1)).is_ok());
+    }
+
+    #[test]
+    fn finalization_surfaces_non_pipe_flush_error() {
+        // Given a prompt writer that fails only when flushed.
+        let mut output = Output::new(FlushErrorWriter);
+        output.write("prompt", false);
+
+        // When the process boundary finalizes stdout.
+        let error = output
+            .finish()
+            .expect("non-pipe flush failures must remain actionable");
+
+        // Then the flush error remains available to the process boundary.
+        assert_eq!(io::ErrorKind::PermissionDenied, error.kind());
+    }
+
+    #[test]
+    fn finalization_is_safe_to_repeat() {
+        // Given stdout whose terminal flush fails once finalization begins.
+        let mut output = Output::new(FlushErrorWriter);
+        output.write("result", false);
+
+        // When stdout is finalized twice.
+        let first = output.finish();
+        let second = output.finish();
+
+        // Then the error is reported once and the terminal state remains stable.
+        assert_eq!(
+            Some(io::ErrorKind::PermissionDenied),
+            first.as_ref().map(io::Error::kind)
+        );
+        assert!(second.is_none());
+    }
+
+    #[test]
+    fn finalization_ignores_broken_pipe_from_flush() {
+        // Given writes succeed before the downstream consumer closes.
+        let mut output = Output::new(BrokenPipeOnFlushWriter);
+        output.write("result", false);
+
+        // When the process boundary performs the terminal flush.
+        let error = output.finish();
+
+        // Then the closed consumer is not reported as an output failure.
+        assert!(error.is_none());
+    }
+
+    #[test]
+    fn finalization_succeeds_for_healthy_writer() {
+        // Given a connected writer containing rendered output.
+        let mut output = Output::new(Vec::new());
+        output.write("result", true);
+
+        // When the process boundary finalizes stdout.
+        let error = output.finish();
+
+        // Then finalization succeeds and preserves the rendered bytes.
+        assert!(error.is_none());
+        assert_eq!(b"result\n", output.writer.as_slice());
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/tests/broken_pipe.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/broken_pipe.rs
@@ -1,0 +1,115 @@
+//! Subprocess regression coverage for stdout consumers and failures.
+
+#![cfg(unix)]
+
+use std::io::{self, Write as _};
+use std::net::Shutdown;
+use std::os::fd::OwnedFd;
+use std::os::unix::net::UnixStream;
+use std::process::Stdio;
+
+#[cfg(target_os = "linux")]
+use std::fs::OpenOptions;
+
+mod common;
+
+fn disconnected_stdout() -> Stdio {
+    let (reader, mut writer) = UnixStream::pair().expect("stdout socket pair must be created");
+    reader
+        .shutdown(Shutdown::Both)
+        .expect("stdout peer must shut down before spawning the CLI");
+    drop(reader);
+    let error = writer
+        .write_all(b"disconnection probe")
+        .expect_err("stdout peer must be disconnected before spawning the CLI");
+    assert_eq!(io::ErrorKind::BrokenPipe, error.kind());
+    Stdio::from(OwnedFd::from(writer))
+}
+
+fn assert_graceful_closed_stdout(arguments: &[&str], expected_code: i32) {
+    let output = common::run_with_stdout(arguments, disconnected_stdout());
+    let diagnostic = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        Some(expected_code),
+        output.status.code(),
+        "stderr: {diagnostic}"
+    );
+    assert!(output.stdout.is_empty());
+    assert!(!diagnostic.contains("panicked at"), "stderr: {diagnostic}");
+}
+
+#[test]
+fn normal_human_and_json_env_output_remains_valid() {
+    let human = common::run(&["env", "--no-color"]);
+    assert_eq!(Some(0), human.status.code());
+    assert!(String::from_utf8_lossy(&human.stdout).contains("os:"));
+    assert!(human.stderr.is_empty());
+
+    let json = common::run(&["env", "--json", "--no-color"]);
+    assert_eq!(Some(0), json.status.code());
+    assert!(json.stderr.is_empty());
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("env output must be valid JSON");
+    assert_eq!(Some(true), envelope["ok"].as_bool());
+    assert_eq!(Some("env"), envelope["command"].as_str());
+}
+
+#[test]
+fn successful_stdout_paths_survive_an_immediately_closed_reader() {
+    for arguments in [
+        &["env", "--no-color"][..],
+        &["env", "--json", "--no-color"][..],
+        &["--help"][..],
+        &["--version"][..],
+    ] {
+        assert_graceful_closed_stdout(arguments, 0);
+    }
+}
+
+#[test]
+fn json_business_failure_keeps_exit_code_when_stdout_reader_closes() {
+    let prefix = tempfile::tempdir().expect("temporary prefix must be created");
+    let prefix = prefix.path().to_string_lossy();
+
+    assert_graceful_closed_stdout(
+        &[
+            "--json",
+            "--install-mode",
+            "user",
+            "--prefix",
+            &prefix,
+            "forget",
+            "definitely-missing",
+        ],
+        2,
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn stdout_device_failure_overrides_every_success_output_path() {
+    if !std::path::Path::new("/dev/full").exists() {
+        return;
+    }
+
+    for arguments in [
+        &["env", "--no-color"][..],
+        &["env", "--json", "--no-color"][..],
+        &["--help"][..],
+        &["--version"][..],
+    ] {
+        let full = OpenOptions::new()
+            .write(true)
+            .open("/dev/full")
+            .expect("/dev/full must be writable");
+        let output = common::run_with_stdout(arguments, Stdio::from(full));
+        let diagnostic = String::from_utf8_lossy(&output.stderr);
+
+        assert_eq!(Some(1), output.status.code(), "stderr: {diagnostic}");
+        assert!(
+            diagnostic.contains("error[EXECUTION_FAILED]: failed writing to stdout:"),
+            "stderr: {diagnostic}"
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
@@ -1,0 +1,89 @@
+//! Subprocess coverage for Clap-owned output and diagnostics.
+
+#[cfg(target_os = "linux")]
+use std::fs::OpenOptions;
+use std::process::Output;
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
+
+mod common;
+
+fn run(arguments: &[&str]) -> Output {
+    common::run(arguments)
+}
+
+#[test]
+fn help_renders_to_stdout() {
+    // Given a request for top-level help.
+    let arguments = ["--help"];
+
+    // When the CLI handles the request.
+    let output = run(&arguments);
+
+    // Then the rendered text remains on stdout with a successful status.
+    assert_eq!(Some(0), output.status.code());
+    assert!(!output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn version_renders_to_stdout() {
+    // Given a request for the CLI version.
+    let arguments = ["--version"];
+
+    // When the CLI handles the request.
+    let output = run(&arguments);
+
+    // Then the rendered text remains on stdout with a successful status.
+    assert_eq!(Some(0), output.status.code());
+    assert!(!output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn missing_subcommand_renders_clap_diagnostic_to_stderr() {
+    // Given an invocation without a required subcommand.
+    let arguments = [];
+
+    // When the CLI parses the invocation.
+    let output = run(&arguments);
+
+    // Then Clap preserves its stderr destination and usage-error status.
+    assert_eq!(Some(2), output.status.code());
+    assert!(output.stdout.is_empty());
+    assert!(!output.stderr.is_empty());
+}
+
+#[test]
+fn unknown_option_renders_clap_diagnostic_to_stderr() {
+    // Given an invocation with an unknown option.
+    let arguments = ["--definitely-invalid"];
+
+    // When the CLI parses the invocation.
+    let output = run(&arguments);
+
+    // Then Clap preserves its stderr destination and usage-error status.
+    assert_eq!(Some(2), output.status.code());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unexpected argument"));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn help_reports_stdout_failure_when_output_device_is_full() {
+    // Given stdout is connected to a device that rejects every write.
+    let full = OpenOptions::new()
+        .write(true)
+        .open("/dev/full")
+        .expect("Linux must provide /dev/full");
+
+    // When Clap renders top-level help.
+    let output = common::run_with_stdout(&["--help"], Stdio::from(full));
+
+    // Then the CLI reports the failed stdout write instead of exiting successfully.
+    assert_eq!(Some(1), output.status.code());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("error[EXECUTION_FAILED]: failed writing to stdout:")
+    );
+}

--- a/src/anolisa/crates/anolisa-cli/tests/common/mod.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/common/mod.rs
@@ -1,0 +1,78 @@
+//! Bounded subprocess support shared by CLI integration tests.
+
+use std::io;
+use std::process::{Child, ChildStderr, ChildStdout, Command, ExitStatus, Output, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct ChildGuard(Child);
+
+impl ChildGuard {
+    fn wait_bounded(&mut self, deadline: Instant) -> ExitStatus {
+        loop {
+            match self.0.try_wait() {
+                Ok(Some(status)) => return status,
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(None) => panic!("CLI subprocess exceeded {PROCESS_TIMEOUT:?}"),
+                Err(error) => panic!("failed to wait for CLI subprocess: {error}"),
+            }
+        }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn drain<R: io::Read + Send + 'static>(mut pipe: Option<R>) -> Receiver<io::Result<Vec<u8>>> {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = match pipe.as_mut() {
+            Some(pipe) => pipe.read_to_end(&mut bytes).map(|_| bytes),
+            None => Ok(bytes),
+        };
+        let _ = sender.send(result);
+    });
+    receiver
+}
+
+fn receive_bounded(receiver: Receiver<io::Result<Vec<u8>>>, deadline: Instant) -> Vec<u8> {
+    receiver
+        .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        .expect("CLI output drain exceeded process timeout")
+        .expect("CLI output must be readable")
+}
+
+pub(crate) fn run(arguments: &[&str]) -> Output {
+    run_with_stdout(arguments, Stdio::piped())
+}
+
+pub(crate) fn run_with_stdout(arguments: &[&str], stdout: Stdio) -> Output {
+    let deadline = Instant::now() + PROCESS_TIMEOUT;
+    let mut child = ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_anolisa"))
+            .args(arguments)
+            .stdout(stdout)
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("CLI subprocess must start"),
+    );
+    let stdout = drain::<ChildStdout>(child.0.stdout.take());
+    let stderr = drain::<ChildStderr>(child.0.stderr.take());
+    let status = child.wait_bounded(deadline);
+
+    Output {
+        status,
+        stdout: receive_bounded(stdout, deadline),
+        stderr: receive_bounded(stderr, deadline),
+    }
+}

--- a/src/anolisa/crates/anolisa-platform/src/package_manager.rs
+++ b/src/anolisa/crates/anolisa-platform/src/package_manager.rs
@@ -1,6 +1,8 @@
 //! Package manager abstraction (dnf/apt/zypper).
 
-use std::process::Command;
+use std::io;
+use std::os::fd::{AsFd, OwnedFd};
+use std::process::{Command, ExitStatus, Stdio};
 
 use thiserror::Error;
 
@@ -30,11 +32,12 @@ impl PackageManager for DnfBackend {
         if packages.is_empty() {
             return Ok(());
         }
-        let status = Command::new("dnf")
-            .args(["install", "-y", "--setopt=install_weak_deps=False"])
-            .args(packages)
-            .status()
-            .map_err(|e| PkgError::CommandFailed(format!("failed to spawn dnf: {e}")))?;
+        let status = run_with_progress(
+            Command::new("dnf")
+                .args(["install", "-y", "--setopt=install_weak_deps=False"])
+                .args(packages),
+        )
+        .map_err(|e| PkgError::CommandFailed(format!("failed to spawn dnf: {e}")))?;
         if !status.success() {
             return Err(PkgError::CommandFailed(format!(
                 "dnf install exited with {status}"
@@ -47,10 +50,7 @@ impl PackageManager for DnfBackend {
         if packages.is_empty() {
             return Ok(());
         }
-        let status = Command::new("dnf")
-            .args(["remove", "-y"])
-            .args(packages)
-            .status()
+        let status = run_with_progress(Command::new("dnf").args(["remove", "-y"]).args(packages))
             .map_err(|e| PkgError::CommandFailed(format!("failed to spawn dnf: {e}")))?;
         if !status.success() {
             return Err(PkgError::CommandFailed(format!(
@@ -76,12 +76,13 @@ impl PackageManager for AptBackend {
         if packages.is_empty() {
             return Ok(());
         }
-        let status = Command::new("apt-get")
-            .args(["install", "-y", "--no-install-recommends"])
-            .args(packages)
-            .env("DEBIAN_FRONTEND", "noninteractive")
-            .status()
-            .map_err(|e| PkgError::CommandFailed(format!("failed to spawn apt-get: {e}")))?;
+        let status = run_with_progress(
+            Command::new("apt-get")
+                .args(["install", "-y", "--no-install-recommends"])
+                .args(packages)
+                .env("DEBIAN_FRONTEND", "noninteractive"),
+        )
+        .map_err(|e| PkgError::CommandFailed(format!("failed to spawn apt-get: {e}")))?;
         if !status.success() {
             return Err(PkgError::CommandFailed(format!(
                 "apt-get install exited with {status}"
@@ -94,12 +95,13 @@ impl PackageManager for AptBackend {
         if packages.is_empty() {
             return Ok(());
         }
-        let status = Command::new("apt-get")
-            .args(["remove", "-y"])
-            .args(packages)
-            .env("DEBIAN_FRONTEND", "noninteractive")
-            .status()
-            .map_err(|e| PkgError::CommandFailed(format!("failed to spawn apt-get: {e}")))?;
+        let status = run_with_progress(
+            Command::new("apt-get")
+                .args(["remove", "-y"])
+                .args(packages)
+                .env("DEBIAN_FRONTEND", "noninteractive"),
+        )
+        .map_err(|e| PkgError::CommandFailed(format!("failed to spawn apt-get: {e}")))?;
         if !status.success() {
             return Err(PkgError::CommandFailed(format!(
                 "apt-get remove exited with {status}"
@@ -117,6 +119,19 @@ impl PackageManager for AptBackend {
             .map(|s| s.success())
             .unwrap_or(false)
     }
+}
+
+fn run_with_progress(command: &mut Command) -> io::Result<ExitStatus> {
+    let stderr = io::stderr();
+    let progress = stderr.as_fd().try_clone_to_owned()?;
+    run_with_progress_to(command, progress)
+}
+
+fn run_with_progress_to(command: &mut Command, progress: OwnedFd) -> io::Result<ExitStatus> {
+    command
+        .stdout(Stdio::from(progress))
+        .stderr(Stdio::inherit())
+        .status()
 }
 
 /// Detect the appropriate package manager for the current system.
@@ -169,4 +184,92 @@ fn command_exists(cmd: &str) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::io::Read;
+    use std::path::PathBuf;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    struct Fixture(PathBuf);
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+
+    fn unique_fixture(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("anolisa-pkg-{name}-{}", std::process::id()))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn package_command_writes_progress_to_supplied_fd() {
+        let progress_fixture = Fixture(unique_fixture("progress"));
+        let progress_file =
+            File::create(&progress_fixture.0).expect("progress fixture must be created");
+        let progress: OwnedFd = progress_file.into();
+        let mut command = Command::new("sh");
+        command.args(["-c", "printf progress-marker"]);
+
+        assert!(
+            run_with_progress_to(&mut command, progress)
+                .expect("package command must complete")
+                .success()
+        );
+        let mut marker = String::new();
+        File::open(&progress_fixture.0)
+            .expect("progress fixture must be readable")
+            .read_to_string(&mut marker)
+            .expect("progress fixture must contain UTF-8 text");
+
+        assert_eq!(marker, "progress-marker");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn package_command_does_not_wait_for_background_descendant_holding_progress_fd() {
+        let progress = Fixture(unique_fixture("retained-fd"));
+        let progress_file = File::create(&progress.0).expect("progress fixture must be created");
+        let completion = Fixture(unique_fixture("descendant-complete"));
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "(sleep 1; printf complete > \"$1\") &",
+            "sh",
+            completion
+                .0
+                .to_str()
+                .expect("completion fixture path must be UTF-8"),
+        ]);
+        let progress: OwnedFd = progress_file.into();
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = run_with_progress_to(&mut command, progress);
+            let _ = sender.send(result);
+        });
+        let result = receiver.recv_timeout(Duration::from_millis(500));
+
+        let status = result
+            .expect("direct child completion must not depend on its descendant")
+            .expect("package command must complete");
+        assert!(status.success());
+        assert!(!completion.0.exists());
+
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while !completion.0.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert_eq!(
+            fs::read_to_string(&completion.0)
+                .expect("descendant must complete within three seconds"),
+            "complete"
+        );
+    }
 }


### PR DESCRIPTION
## Description

This PR routes CLI-owned human, JSON, help, and version output through a shared fallible stdout boundary. Early-closing consumers now stop further output without panicking or interrupting an active command, while non-BrokenPipe write failures remain visible as `EXECUTION_FAILED`.

Raw dependency provisioning sends dnf/apt stdout to stderr through direct FD duplication, keeping progress out of structured stdout without introducing a pipe-drain lifecycle. The captured `RpmTransaction` / `CommandRunner` contract remains unchanged.

## Related Issue

closes #1430

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (1349 passed, 0 failed)
- `cargo doc --workspace --no-deps`

Regression coverage includes deterministic BrokenPipe writers, pre-closed subprocess stdout, human and JSON output, Clap help/version, business-error exit-code preservation, `/dev/full`, package progress FD routing, and a self-terminating descendant retaining the progress FD.

## Additional Notes

The package-manager execution seam is tested with isolated child processes; no mutating dnf or apt transaction was run. `.codegraph` and local `.omo` planning/evidence files were not included in the commit.
