### PR TITLE
docs(cosh-ng): align task scope

### DIFF
--- a/src/cosh-ng/AGENTS.md
+++ b/src/cosh-ng/AGENTS.md
@@ -72,7 +72,8 @@ Prerequisites: Linux (or macOS for limited functionality), Rust 1.74+. pkg/svc c
 
 ### cosh-shell Code Organization
 
-本轮改造只允许动 `crates/cosh-shell/`；不要顺手修改 `cosh-types`、`cosh-platform`、`cosh-cli`、`cosh-core`、lockfile、`.env` 或 workspace 外代码。
+每个 Issue 或任务只允许修改其 triage、已批准 design 或执行 spec 明确授权的文件；不得顺手扩大范围。
+涉及 `crates/cosh-shell/` 的修改仍须遵守下列组织、owner 与布局约束。
 
 长期 owner 约定：
 
@@ -132,9 +133,11 @@ Don't trust development reports — verify before merging:
 
 Strict [Conventional Commits](https://www.conventionalcommits.org/):
 
-- `type(scope): subject` — types limited to `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`. **Do not use `harden:` / `cleanup:`** — they aren't standard. Map them: closing a known vulnerability → `fix:`; adding a new defensive mechanism → `feat:`; lint/dead-code cleanup → `chore:`.
-- `scope` is the crate short name (`cli`, `core`, `shell`, `platform`, `types`); use `cli,platform` for multi-crate changes.
-- Subject in imperative mood, ≤ 72 chars, no trailing period. Body explains *why*, not *what*.
+- Format: `type(cosh-ng): [crate_scope] imperative subject`.
+- `type` is limited to `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, and `chore`. **Do not use `harden:` / `cleanup:`** — map them to a standard type.
+- `[crate_scope]` names the affected crate or crates, such as `[core]`, `[shell]`, or `[cli,platform]`.
+- The complete subject line is imperative, has no trailing period, and subject 不超过 50 字符；body 每行不超过 100 字符。
+- Detect the active Codex version at commit time and place `Assisted-by: Codex:<version>` above the `Signed-off-by` trailer generated from Git config.
 
 ## Git History Hygiene
 


### PR DESCRIPTION
## Description

This change replaces the historical global shell-only limit with task-scoped authorization from triage, approved design, or an execution spec. It preserves the long-term `cosh-shell` ownership, organization, and layout governance while allowing explicitly approved cross-crate work. It also aligns the documented commit convention with the current `cosh-ng` repository policy.

## Related Issue

no-issue: bootstrap governance prerequisite for autonomous cosh-ng worker

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- Current-main RED: policy tests report 2 failures and 1 pass.
- Policy head GREEN: all 3 policy tests pass.
- Missing/wrong checkout fail-closed coverage: 2 of 2 tests pass.
- Full automation suite with the checkout provided explicitly: 381 of 381 tests pass.
- `git diff --check` passes.

## Additional Notes

This PR changes no product code. The autonomous Worker remains disabled until this PR is merged and its PR number and merge SHA are recorded by the controller.
