### PR TITLE
fix(sight): add claude BoringSSL detection and downgrade high-frequency logs to trace

### DIFF
--- a/src/agentsight/src/aggregator/unified.rs
+++ b/src/agentsight/src/aggregator/unified.rs
@@ -96,7 +96,7 @@ impl Aggregator {
 
     /// Process parse result
     pub fn process_result(&mut self, result: ParseResult) -> Vec<AggregatedResult> {
-        log::debug!(
+        log::trace!(
             "Aggregating parsed results({}): {}",
             result.messages.len(),
             result

--- a/src/agentsight/src/parser/unified.rs
+++ b/src/agentsight/src/parser/unified.rs
@@ -184,7 +184,7 @@ impl Parser {
 
     /// Parse unified Event
     pub fn parse_event(&self, event: Event) -> ParseResult {
-        log::debug!("Parsing event({:?})", event.event_type());
+        log::trace!("Parsing event({:?})", event.event_type());
         match event {
             Event::Ssl(ssl_event) => self.parse_ssl_event(Rc::new(ssl_event)),
             Event::Proc(proc_event) => self.parse_proc_event(&proc_event),

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -726,6 +726,7 @@ fn classify_ssl_lib(path: &str) -> Option<SslLibKind> {
             | "chromium"
             | "google-chrome"
             | "google-chrome-stable"
+            | "claude"
             | "claude.exe"
     ) {
         return Some(SslLibKind::Boring);


### PR DESCRIPTION
## Description

Claude CLI on Linux runs as a process named `claude` (without `.exe` suffix), but the BoringSSL classification table only listed `claude.exe`. This caused agentsight to fail to identify the Claude CLI's SSL library on Linux, resulting in missed SSL capture.

Additionally, the per-event logs `Parsing event(...)` and `Aggregating parsed results(...)` were using `log::debug!` which caused excessive log output at debug level. These are high-frequency, per-event logs only useful for deep debugging and should be at trace level, consistent with the existing convention for `Processing event`, `Process created`, and `Process exited` logs.

## Related Issue

no-issue: minor fix and log hygiene

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/probes/sslsniff.rs`: Add `"claude"` (without `.exe`) to the BoringSSL process name match table so Linux Claude CLI is correctly classified
- `src/parser/unified.rs`: Downgrade `Parsing event` log from `debug!` to `trace!`
- `src/aggregator/unified.rs`: Downgrade `Aggregating parsed results` log from `debug!` to `trace!`

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] `cargo fmt --check` pass
- [ ] `cargo clippy --all-targets -- -D warnings` pass (upstream has 7 pre-existing warnings; no new issues introduced)
- [x] `cargo test` pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- Run `agentsight trace`, start Claude CLI and make an LLM request, verify agentsight correctly identifies BoringSSL and captures SSL traffic
- Run agentsight with `RUST_LOG=debug`, confirm `Parsing event` and `Aggregating parsed results` logs are suppressed; set `RUST_LOG=trace` and confirm these logs appear as expected