### PR TITLE
build(cosh-ng): add cosh-ng RPM target to rpm-build.sh

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -5,7 +5,7 @@
 #   ./scripts/rpm-build.sh <package>        Build a single package
 #   ./scripts/rpm-build.sh all              Build all packages
 #
-# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory, skillfs
+# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory, skillfs, cosh-ng
 #
 # Environment variables:
 #   VERSION    Override version for .spec.in templates (default: auto-detect)
@@ -27,6 +27,7 @@ SIGHT_DIR="${ROOT_DIR}/src/agentsight"
 TOKEN_DIR="${ROOT_DIR}/src/tokenless"
 MEM_DIR="${ROOT_DIR}/src/agent-memory"
 SKILLFS_DIR="${ROOT_DIR}/src/skillfs"
+COSH_DIR="${ROOT_DIR}/src/cosh-ng"
 SANDBOX_PKG_DIR="${ROOT_DIR}/src/anolisa/packaging/sandbox"
 
 # gVisor upstream release (overridable via env). Format: YYYYMMDD
@@ -700,6 +701,67 @@ EOF
 }
 
 # =============================================================================
+# cosh-ng
+# =============================================================================
+build_cosh_ng() {
+    log "=========================================="
+    log "Building RPM: cosh-ng"
+    log "=========================================="
+
+    local spec_in="${COSH_DIR}/cosh-ng.spec.in"
+    if [ ! -f "$spec_in" ]; then
+        err "Spec template not found: $spec_in"
+        return 1
+    fi
+
+    # Version from env, Cargo.toml workspace, then spec fallback
+    local version="${VERSION:-}"
+    if [ -z "$version" ]; then
+        version=$(grep -m1 '^version' "${COSH_DIR}/Cargo.toml" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || true)
+    fi
+    if [ -z "$version" ]; then
+        version=$(grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+' "$spec_in" | head -1)
+    fi
+    if [ -z "$version" ]; then
+        err "Could not derive cosh-ng version from VERSION env, Cargo.toml, or ${spec_in}"
+        exit 1
+    fi
+
+    local pkg_name
+    pkg_name=$(parse_spec_name "$spec_in")
+    local tarball_name="${pkg_name}-${version}.tar.gz"
+
+    local spec_file
+    spec_file=$(process_spec_template "$spec_in" "$version")
+
+    # Single Source0 tarball: spec %build is plain `cargo build --workspace --release`
+    # (online), %prep is `%setup -q` which expects top-level dir `%{name}-%{version}`.
+    log "Step 1/2: Creating source tarball ${tarball_name}..."
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
+    mkdir -p "$pkg_dir"
+
+    # cosh-ng ships component.toml at repo root — must be in the tarball because
+    # spec %install does `install -m 0644 component.toml ...`.
+    tar -cf - -C "$COSH_DIR" \
+        --exclude='target' \
+        --exclude='.git' \
+        --exclude='node_modules' \
+        . | tar -xf - -C "$pkg_dir"
+
+    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
+    rm -rf "$tmp_dir"
+
+    log "Step 2/2: Running rpmbuild..."
+    "$RPMBUILD" -ba --nodeps \
+        --define "_topdir ${BUILD_DIR}" \
+        "$spec_file"
+
+    ok "cosh-ng RPM built successfully"
+}
+
+# =============================================================================
 # sandbox: shared helpers
 # =============================================================================
 
@@ -1028,6 +1090,9 @@ case "$TARGET" in
     skillfs)
         build_skillfs
         ;;
+    cosh-ng)
+        build_cosh_ng
+        ;;
     gvisor-runsc)
         build_gvisor_runsc
         ;;
@@ -1054,6 +1119,7 @@ case "$TARGET" in
         build_tokenless
         build_agent_memory
         build_skillfs
+        build_cosh_ng
         ;;
     *)
         err "Unknown package: $TARGET"


### PR DESCRIPTION
## Summary

\`scripts/rpm-build.sh\` 缺 \`cosh-ng\` target —— \`bash scripts/rpm-build.sh cosh-ng\` 会落到 unknown-package 退出分支,虽然 \`src/cosh-ng/cosh-ng.spec.in\` + Cargo workspace 早就齐备。本 PR 补 \`build_cosh_ng()\` 函数。

## 改动

- 新增 \`build_cosh_ng()\` 函数,采用单 Source0 tarball 模式(类比 \`build_tokenless()\` 减去 rtk vendoring):
  - Source0 顶层目录是 \`cosh-ng-<version>/\`(匹配 spec \`%setup -q\` 默认 \`%{name}-%{version}\` 期望)
  - 不打 vendor tarball —— spec \`%build\` 段是直白的 \`cargo build --workspace --release\`(在线),不带 \`--offline --locked\`
  - \`component.toml\` 在仓根,必须在 tarball 里(spec \`%install\` 段 \`install -m 0644 component.toml ...\`)
  - 版本从 \`VERSION\` env → Cargo.toml \`workspace.package.version\` → spec.in fallback 推导
- \`case "\$TARGET"\` 加 \`cosh-ng) build_cosh_ng ;;\`
- \`all\` target 末尾加 \`build_cosh_ng\`
- 顶部注释 Packages 列表同步加 \`cosh-ng\`

## 验证

AnolisOS x86_64 ECS(47.83.130.134,cargo 1.91.0)实测:

\`\`\`
$ bash scripts/rpm-build.sh cosh-ng
...
[OK] cosh-ng RPM built successfully
  cosh-ng-0.12.0-1.alnx4.x86_64.rpm  (4.3M)
  cosh-ng-0.12.0-1.alnx4.src.rpm      (840K)
\`\`\`

\`rpm -ivh\` 安装(主机未装 copilot-shell,不触发 spec \`Conflicts: copilot-shell\` 子句);安装后:

- \`/usr/bin/cosh\` / \`/usr/bin/cosh-cli\` / \`/usr/bin/cosh-switch\` 都按 spec %files 落位
- \`cosh --version\` 输出 \`cosh-shell 0.12.0\`(版本与 Cargo.toml workspace.package.version 一致)
- \`/usr/libexec/anolisa/cosh-ng/\` 有 cosh-core (7.1M) + cosh-shell (5.6M) 两个 internal binary,匹配 spec %install
- \`/usr/share/anolisa/components/cosh/component.toml\` 落位,内容与 src 一致

## 与 #1456 的关系

#1456 给 anolisa 组件加 RPM target,本 PR 只针对 cosh-ng。两个 PR 互不依赖,可独立合并。用户要求按组件拆 issue + PR 以便清晰追溯。

## Test plan

- [x] \`bash scripts/rpm-build.sh cosh-ng\` 在干净 ECS 上产出 x86_64 RPM + src.rpm
- [x] \`rpm -ivh cosh-ng-*.x86_64.rpm\` 安装无错(无 copilot-shell 冲突)
- [x] \`cosh --version\` 输出与 Cargo.toml workspace.package.version 一致
- [x] \`/usr/libexec/anolisa/cosh-ng/\` + \`/usr/share/anolisa/components/cosh/component.toml\` 按 spec %files / %install 落位
- [ ] 装有 copilot-shell 的主机 \`rpm -ivh cosh-ng\` 触发 \`Conflicts\` 子句拒绝安装(预期行为,用户需 \`yum swap\` 切换)

Closes #1455