### PR TITLE
fix(agent-memory/install): set allowConversationAccess=true after plugin install

### DIFF
--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -55,4 +55,12 @@ env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" pl
 }
 
 echo "[${COMPONENT}] ${AGENT} plugin installed via openclaw CLI."
+
+# Non-bundled plugins must explicitly set hooks.allowConversationAccess=true
+# to register conversation hooks (agent_end, before_agent_reply, etc.).
+# Without this, OpenClaw silently blocks the agent_end auto-capture hook,
+# and auto-capture never fires (E2E test_openclaw_e2e failures).
+env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" config set \
+    "plugins.entries.memory-anolisa.hooks.allowConversationAccess" true 2>/dev/null || true
+
 echo "[${COMPONENT}] Run '${OPENCLAW_BIN} gateway restart' to activate."


### PR DESCRIPTION
## 问题

agent-memory E2E 测试 `test_auto_capture_persists_trigger_phrase` 失败：assistant 回复含触发词 "I decided" 但 token 未被 auto-capture 落盘到 `notes/observed/`。

## 根因

OpenClaw 2026.6.11 对非 bundled 插件要求显式设置 `plugins.entries.<id>.hooks.allowConversationAccess=true` 才能注册 conversation hooks（`agent_end`、`before_agent_reply` 等）。

日志证据：
```
[plugins] typed hook "agent_end" blocked because non-bundled plugins must set
plugins.entries.memory-anolisa.hooks.allowConversationAccess=true
(plugin=memory-anolisa, source=/root/.openclaw/extensions/memory-anolisa/dist/index.js)
```

`install.sh` 安装插件后未设置此配置项，导致 `agent_end` auto-capture 钩子被静默阻断。

## 修复

在 `install.sh` 的 `openclaw plugins install` 之后、提示 restart 之前，添加：
```bash
openclaw config set \
    "plugins.entries.memory-anolisa.hooks.allowConversationAccess" true
```

## 验证

```shell
# 1. 应用修复后重启 gateway
openclaw config set plugins.entries.memory-anolisa.hooks.allowConversationAccess true
openclaw gateway restart

# 2. 运行 E2E 测试
cd /root/agentic-os-tests/agent-memory-tests
python3 -m pytest tests/test_openclaw_e2e.py::TestAutoCapture::test_auto_capture_persists_trigger_phrase -xvs --timeout=180
```

实测 PASS（14.26s）。

ECS: 8.217.255.16, OpenClaw 2026.6.11, agent-memory 0.2.3
