### PR TITLE
perf(sec-core): skip prompt model download on cache hit

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/prompt_scan_protocol.md
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/prompt_scan_protocol.md
@@ -50,11 +50,11 @@ Expected shape:
   "ok": false,
   "data": {},
   "stdout": "",
-  "stderr": "prompt scanner is not ready: status=loading",
+  "stderr": "daemon request timed out after 30000 ms",
   "exit_code": 1,
   "error": {
-    "code": "unavailable",
-    "message": "prompt scanner is not ready: status=loading"
+    "code": "timeout",
+    "message": "daemon request timed out after 30000 ms"
   }
 }
 ```
@@ -63,8 +63,6 @@ Expected shape:
 
 - unknown daemon method
 - malformed daemon request
-- prompt scanner runtime unavailable, including preload states such as
-  `pending`, `downloading`, `loading`, or `degraded`
 - daemon method timeout
 - unexpected handler crash
 
@@ -123,12 +121,16 @@ Expected scanner error result shape:
 `scan-prompt` action results include:
 
 - `PASS`, `WARN`, and `DENY` scan verdicts: `ok=true`, `exit_code=0`
-- backend validation failures, such as missing/empty `text` or invalid `mode`:
+- backend validation failures, such as missing or empty `text`:
   `ok=true`, `exit_code=1`, with `stderr` describing the validation error
 - scanner-produced `ERROR` verdicts: `ok=true`, `exit_code=1`, with structured
   error verdict data
 - scanner domain exceptions that can be converted to an error verdict:
   `ok=true`, `exit_code=1`, with structured error verdict data
+- `standard` or `strict` requests made while the model is not ready run in
+  `fast` mode and return `ok=true` with `degraded=true` and a
+  `degraded_reason`; a degraded `deny` is rewritten to `warn` while the
+  original verdict is retained in `degraded_original_verdict`
 
 Caller behavior:
 
@@ -145,6 +147,36 @@ if response.ok:
 Callers should render structured action output before exiting with a non-zero
 action `exit_code`, so JSON consumers can still parse the error verdict. If an
 action failure has no structured output, callers should display `stderr`.
+
+## Prompt model preload state machine
+
+`daemon.health.data.prompt_scan.status` starts as `pending`. The one-shot
+preload job tries the local model load and probe before starting any download:
+
+```text
+pending -> loading -- success ------------------------> ready
+              |
+              +-- failure --> downloading
+                                |
+                                +-- failure --> degraded
+                                |
+                                +-- success --> loading (retry once)
+                                                 |
+                                                 +-- success --> ready
+                                                 +-- failure --> degraded
+
+active state -- cancellation --> stopped
+```
+
+On a cache hit, the state therefore moves directly from `loading` to `ready`
+and no download child is started. Any ordinary exception from the first local
+load/probe attempt triggers exactly one download/repair child and one
+load/probe retry, preserving the previous recovery opportunity without adding
+an unbounded retry loop. A child failure or retry failure moves the prompt
+runtime to `degraded`; the daemon process remains available and model-dependent
+scans use the `fast` fallback described above. Cancellation is not treated as a
+repairable failure. The one-shot job does not retry again until the daemon is
+restarted.
 
 ## Request parameters
 
@@ -165,5 +197,6 @@ Rules:
 - `mode` must be one of `fast`, `standard`, or `strict`.
 - `source` is optional and defaults to an empty string.
 
-Invalid `text` or `mode` is handled by the prompt scan backend and returned as
-an action failure: `ok=true`, `exit_code=1`.
+Missing or empty `text` is handled by the prompt scan backend and returned as
+an action failure: `ok=true`, `exit_code=1`. An unsupported `mode` is rejected
+at the daemon boundary as `ok=false` with error code `bad_request`.

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/prompt_preload.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/prompt_preload.py
@@ -19,7 +19,7 @@ _PROMPT_PRELOAD_CHILD_MODULE = "agent_sec_cli.daemon.jobs.prompt_preload"
 
 
 class PromptModelPreloadJob(OneShotBackgroundJob):
-    """One-shot startup job that downloads, loads, and probes the prompt model."""
+    """One-shot startup job that loads and probes the prompt model."""
 
     name = PROMPT_PRELOAD_JOB_NAME
 
@@ -35,10 +35,10 @@ class PromptModelPreloadJob(OneShotBackgroundJob):
         self._probe_text = probe_text
 
     def on_run_started(self, started_at: str) -> None:
-        """Mark prompt model preload as downloading."""
+        """Mark prompt model preload as loading from the local cache."""
         _update_prompt_state(
             self._prompt_state,
-            status="downloading",
+            status="loading",
             loaded=False,
             last_error=None,
             last_started_at=started_at,
@@ -46,9 +46,18 @@ class PromptModelPreloadJob(OneShotBackgroundJob):
         )
 
     async def run_once(self) -> None:
-        """Download, load, and probe the prompt model."""
-        await _run_preload_child_process(self._mode)
-        _update_prompt_state(self._prompt_state, status="loading")
+        """Load and probe locally, downloading once only when loading fails."""
+        try:
+            await self._load_and_probe()
+        except Exception:
+            # Preserve the previous recovery contract with one bounded download/repair attempt.
+            _update_prompt_state(self._prompt_state, status="downloading")
+            await _run_preload_child_process(self._mode)
+            _update_prompt_state(self._prompt_state, status="loading")
+            await self._load_and_probe()
+
+    async def _load_and_probe(self) -> None:
+        """Load and probe the prompt model without blocking the event loop."""
         await asyncio.to_thread(
             _preload_prompt_model_sync,
             self._prompt_state,
@@ -183,7 +192,8 @@ def _preload_prompt_model_sync(
 ) -> None:
     """Load and probe the prompt model in a worker thread.
 
-    Downloads are handled by the child process before this function runs.
+    The first call uses only the local cache.  The job may run a download-only
+    child and call this function once more if local model loading fails.
     Avoid redirecting sys.stdout/sys.stderr here: those are process-global
     objects, so changing them in this worker thread could hide unrelated
     daemon output from other threads.
@@ -201,8 +211,10 @@ def _preload_prompt_model_sync(
     _update_prompt_state(prompt_state, model=config.model_name)
 
     scanner = PromptScanner(mode=scan_mode)
-    _update_prompt_state(prompt_state, status="loading")
-    scanner.scan(probe_text, source="daemon-startup")
+    result = scanner.scan(probe_text, source="daemon-startup")
+
+    if not any(layer.layer_name == "ml_classifier" for layer in result.layer_results):
+        raise RuntimeError("prompt model probe did not execute the ML classifier")
 
 
 def _warmup_silently(scanner: Any) -> None:

--- a/src/agent-sec-core/tests/unit-test/daemon/test_jobs.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_jobs.py
@@ -6,6 +6,7 @@ import logging
 import sys
 import threading
 import uuid
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -30,6 +31,7 @@ from agent_sec_cli.daemon.jobs.prompt_preload import (
 )
 from agent_sec_cli.daemon.jobs.registry import register_default_jobs
 from agent_sec_cli.daemon.runtime import PromptScanRuntimeState
+from agent_sec_cli.prompt_scanner.exceptions import ModelLoadError
 
 
 class RecordingPeriodicJob(PeriodicBackgroundJob):
@@ -320,20 +322,19 @@ def test_register_default_jobs_respects_prompt_preload_env(monkeypatch):
     ]
 
 
-def test_prompt_model_preload_job_updates_runtime_state(monkeypatch):
+def test_prompt_model_preload_job_cache_hit_skips_download(monkeypatch):
     prompt_state = PromptScanRuntimeState()
     child_calls: list[str] = []
     calls: list[tuple[str, str]] = []
 
     async def fake_child_preload(mode: str) -> None:
         child_calls.append(mode)
-        assert prompt_state.status == "downloading"
+        raise AssertionError("cache hit should not start the download child")
 
     def fake_preload(state, mode: str, probe_text: str) -> None:
         calls.append((mode, probe_text))
         assert state.status == "loading"
         state.model = "fake-model"
-        state.status = "loading"
 
     monkeypatch.setattr(
         "agent_sec_cli.daemon.jobs.prompt_preload._run_preload_child_process",
@@ -353,7 +354,7 @@ def test_prompt_model_preload_job_updates_runtime_state(monkeypatch):
 
     status = asyncio.run(scenario())
 
-    assert child_calls == ["strict"]
+    assert child_calls == []
     assert calls == [("strict", "probe")]
     assert status["state"] == "completed"
     assert status["last_error"] is None
@@ -370,13 +371,19 @@ def test_prompt_model_preload_job_propagates_trace_context_to_preload_thread(
 ) -> None:
     prompt_state = PromptScanRuntimeState()
     trace_contexts: list[tuple[str, TraceContext | None]] = []
+    preload_calls = 0
 
     async def fake_child_preload(_mode: str) -> None:
+        assert prompt_state.status == "downloading"
         trace_contexts.append(("child", get_current_trace_context()))
 
     def fake_preload(state, _mode: str, _probe_text: str) -> None:
+        nonlocal preload_calls
+        preload_calls += 1
         trace_contexts.append(("preload", get_current_trace_context()))
         state.model = "fake-model"
+        if preload_calls == 1:
+            raise RuntimeError("cache unavailable")
 
     monkeypatch.setattr(
         "agent_sec_cli.daemon.jobs.prompt_preload._run_preload_child_process",
@@ -405,7 +412,7 @@ def test_prompt_model_preload_job_propagates_trace_context_to_preload_thread(
     trace_ids = {ctx.trace_id for ctx in contexts if ctx is not None}
 
     assert status["state"] == "completed"
-    assert labels == ["child", "preload"]
+    assert labels == ["preload", "child", "preload"]
     assert all(ctx is not None for ctx in contexts)
     assert len(trace_ids) == 1
     trace_id = trace_ids.pop()
@@ -417,13 +424,20 @@ def test_prompt_model_preload_job_propagates_trace_context_to_preload_thread(
     assert after_context is None
 
 
-def test_prompt_model_preload_job_marks_prompt_degraded_on_failure(monkeypatch):
+def test_prompt_model_preload_job_retries_unexpected_failure_once_then_degrades(
+    monkeypatch,
+):
     prompt_state = PromptScanRuntimeState()
+    child_calls = 0
+    preload_calls = 0
 
     async def fake_child_preload(_mode: str) -> None:
-        pass
+        nonlocal child_calls
+        child_calls += 1
 
     def fake_preload(_state, _mode: str, _probe_text: str) -> None:
+        nonlocal preload_calls
+        preload_calls += 1
         raise RuntimeError("forced preload failure")
 
     monkeypatch.setattr(
@@ -450,16 +464,23 @@ def test_prompt_model_preload_job_marks_prompt_degraded_on_failure(monkeypatch):
     assert prompt_state.loaded is False
     assert prompt_state.last_error == "forced preload failure"
     assert prompt_state.last_finished_at is not None
+    assert preload_calls == 2
+    assert child_calls == 1
 
 
 def test_prompt_model_preload_job_marks_prompt_degraded_on_child_failure(monkeypatch):
     prompt_state = PromptScanRuntimeState()
+    preload_calls = 0
 
     async def fake_child_preload(_mode: str) -> None:
+        assert prompt_state.status == "downloading"
         raise RuntimeError("forced child failure")
 
-    def fake_preload(_state, _mode: str, _probe_text: str) -> None:
-        raise AssertionError("main preload should not run after child failure")
+    def fake_preload(state, _mode: str, _probe_text: str) -> None:
+        nonlocal preload_calls
+        preload_calls += 1
+        state.model = "fake-model"
+        raise RuntimeError("cache unavailable")
 
     monkeypatch.setattr(
         "agent_sec_cli.daemon.jobs.prompt_preload._run_preload_child_process",
@@ -485,12 +506,56 @@ def test_prompt_model_preload_job_marks_prompt_degraded_on_child_failure(monkeyp
     assert prompt_state.loaded is False
     assert prompt_state.last_error == "forced child failure"
     assert prompt_state.last_finished_at is not None
+    assert preload_calls == 1
+
+
+def test_prompt_model_preload_job_retries_only_once(monkeypatch):
+    prompt_state = PromptScanRuntimeState()
+    preload_calls = 0
+    child_calls = 0
+
+    async def fake_child_preload(_mode: str) -> None:
+        nonlocal child_calls
+        child_calls += 1
+
+    def fake_preload(state, _mode: str, _probe_text: str) -> None:
+        nonlocal preload_calls
+        preload_calls += 1
+        state.model = "fake-model"
+        raise ModelLoadError(f"load failure {preload_calls}")
+
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.jobs.prompt_preload._run_preload_child_process",
+        fake_child_preload,
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.jobs.prompt_preload._preload_prompt_model_sync",
+        fake_preload,
+    )
+
+    async def scenario():
+        job = PromptModelPreloadJob(prompt_state)
+        await job.start()
+        status = await _wait_for_job_state(job, {"completed", "error"})
+        await job.stop()
+        return status
+
+    status = asyncio.run(scenario())
+
+    assert preload_calls == 2
+    assert child_calls == 1
+    assert status["state"] == "error"
+    assert status["last_error"] == "load failure 2"
+    assert prompt_state.status == "degraded"
+    assert prompt_state.loaded is False
+    assert prompt_state.last_error == "load failure 2"
 
 
 def test_prompt_model_preload_job_cancel_during_child_preload(monkeypatch):
     prompt_state = PromptScanRuntimeState()
     child_started = asyncio.Event()
     child_cancelled = False
+    preload_calls = 0
 
     async def fake_child_preload(_mode: str) -> None:
         nonlocal child_cancelled
@@ -501,8 +566,11 @@ def test_prompt_model_preload_job_cancel_during_child_preload(monkeypatch):
             child_cancelled = True
             raise
 
-    def fake_preload(_state, _mode: str, _probe_text: str) -> None:
-        raise AssertionError("main preload should not run after cancellation")
+    def fake_preload(state, _mode: str, _probe_text: str) -> None:
+        nonlocal preload_calls
+        preload_calls += 1
+        state.model = "fake-model"
+        raise RuntimeError("cache unavailable")
 
     monkeypatch.setattr(
         "agent_sec_cli.daemon.jobs.prompt_preload._run_preload_child_process",
@@ -528,6 +596,7 @@ def test_prompt_model_preload_job_cancel_during_child_preload(monkeypatch):
     assert prompt_state.loaded is False
     assert prompt_state.last_error is None
     assert prompt_state.last_finished_at is not None
+    assert preload_calls == 1
 
 
 def test_prompt_model_preload_job_cancel_during_main_preload(monkeypatch):
@@ -537,10 +606,9 @@ def test_prompt_model_preload_job_cancel_during_main_preload(monkeypatch):
     release_preload = threading.Event()
 
     async def fake_child_preload(_mode: str) -> None:
-        pass
+        raise AssertionError("cache hit should not start the download child")
 
-    def fake_preload(state, _mode: str, _probe_text: str) -> None:
-        state.status = "loading"
+    def fake_preload(_state, _mode: str, _probe_text: str) -> None:
         preload_started.set()
         try:
             release_preload.wait(timeout=1.0)
@@ -566,14 +634,13 @@ def test_prompt_model_preload_job_cancel_during_main_preload(monkeypatch):
         assert preload_started.is_set()
 
         await job.stop()
-        prompt_snapshot = prompt_state.to_dict()
         release_preload.set()
         for _attempt in range(50):
             if preload_finished.is_set():
                 break
             await asyncio.sleep(0.01)
         assert preload_finished.is_set()
-        return job.status().to_dict(), prompt_snapshot
+        return job.status().to_dict(), prompt_state.to_dict()
 
     status, prompt_snapshot = asyncio.run(scenario())
 
@@ -742,6 +809,9 @@ def test_prompt_model_preload_sync_does_not_redirect_daemon_stdio(monkeypatch, c
             print("daemon stdout remains visible")
             print("daemon stderr remains visible", file=sys.stderr)
             calls.append(("scan", text, source))
+            return SimpleNamespace(
+                layer_results=[SimpleNamespace(layer_name="ml_classifier")]
+            )
 
     monkeypatch.setattr(
         "agent_sec_cli.prompt_scanner.scanner.PromptScanner",
@@ -758,7 +828,52 @@ def test_prompt_model_preload_sync_does_not_redirect_daemon_stdio(monkeypatch, c
     assert captured.out == "daemon stdout remains visible\n"
     assert captured.err == "daemon stderr remains visible\n"
     assert prompt_state.model == "LLM-Research/Llama-Prompt-Guard-2-86M"
-    assert prompt_state.status == "loading"
+    assert prompt_state.status == "pending"
+
+
+def test_prompt_model_preload_sync_requires_ml_probe_result(monkeypatch):
+    prompt_state = PromptScanRuntimeState()
+
+    class FakePromptScanner:
+        def __init__(self, mode):
+            assert mode.value == "strict"
+
+        def scan(self, _text, source=None):
+            assert source == "daemon-startup"
+            return SimpleNamespace(
+                layer_results=[SimpleNamespace(layer_name="rule_engine")]
+            )
+
+    monkeypatch.setattr(
+        "agent_sec_cli.prompt_scanner.scanner.PromptScanner",
+        FakePromptScanner,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="prompt model probe did not execute the ML classifier",
+    ):
+        _preload_prompt_model_sync(prompt_state, "strict", "probe")
+
+
+def test_prompt_model_preload_sync_propagates_model_load_error(monkeypatch):
+    prompt_state = PromptScanRuntimeState()
+
+    class FakePromptScanner:
+        def __init__(self, mode):
+            assert mode.value == "strict"
+
+        def scan(self, _text, source=None):
+            assert source == "daemon-startup"
+            raise ModelLoadError("cache unavailable")
+
+    monkeypatch.setattr(
+        "agent_sec_cli.prompt_scanner.scanner.PromptScanner",
+        FakePromptScanner,
+    )
+
+    with pytest.raises(ModelLoadError, match="cache unavailable"):
+        _preload_prompt_model_sync(prompt_state, "strict", "probe")
 
 
 async def _wait_for_job_state(


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Try to load model and scan once to check the model availability at daemon startup. Skip model download when model is present.
Fixed-environment warm-cache benchmark, 30 new daemon processes using the 86M Prompt Guard model:

| `prompt_ready` | Baseline | Optimized | Improvement |
  |---|---:|---:|---:|
  | p50 | 7.374s | 4.581s | 37.9% |
  | p95 | 9.432s | 5.101s | 45.9% |
  | max | 11.751s | 5.534s | 52.9% |
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
