### PR TITLE
fix(anolisa): add RPM build support (rebased + review feedback)

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -5,7 +5,7 @@
 #   ./scripts/rpm-build.sh <package>        Build a single package
 #   ./scripts/rpm-build.sh all              Build all packages
 #
-# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory, skillfs, cosh-ng
+# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory, skillfs, cosh-ng, anolisa
 #
 # Environment variables:
 #   VERSION    Override version for .spec.in templates (default: auto-detect)
@@ -26,6 +26,7 @@ SKILLS_DIR="${ROOT_DIR}/src/os-skills"
 SIGHT_DIR="${ROOT_DIR}/src/agentsight"
 TOKEN_DIR="${ROOT_DIR}/src/tokenless"
 MEM_DIR="${ROOT_DIR}/src/agent-memory"
+ANOLISA_DIR="${ROOT_DIR}/src/anolisa"
 SKILLFS_DIR="${ROOT_DIR}/src/skillfs"
 COSH_DIR="${ROOT_DIR}/src/cosh-ng"
 SANDBOX_PKG_DIR="${ROOT_DIR}/src/anolisa/packaging/sandbox"
@@ -622,6 +623,85 @@ build_agent_memory() {
 }
 
 # =============================================================================
+# anolisa
+# =============================================================================
+build_anolisa() {
+    log "=========================================="
+    log "Building RPM: anolisa"
+    log "=========================================="
+
+    local spec_in="${ANOLISA_DIR}/anolisa.spec.in"
+    if [ ! -f "$spec_in" ]; then
+        err "Spec template not found: $spec_in"
+        return 1
+    fi
+
+    local version="${VERSION:-}"
+    if [ -z "$version" ]; then
+        version=$(grep -m1 '^version = ' "${ANOLISA_DIR}/Cargo.toml" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || true)
+    fi
+    if [ -z "$version" ]; then
+        err "Cannot determine anolisa version. Set VERSION env or ensure Cargo.toml exists."
+        return 1
+    fi
+
+    local pkg_name
+    pkg_name=$(parse_spec_name "$spec_in")
+    local tarball_name="${pkg_name}-${version}.tar.gz"
+    local vendor_tarball_name="${pkg_name}-${version}-vendor.tar.gz"
+    local spec_file
+    spec_file=$(process_spec_template "$spec_in" "$version")
+
+    log "Step 1/3: Creating source tarball ${tarball_name}..."
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local pkg_dir="${tmp_dir}/${pkg_name}"
+    mkdir -p "$pkg_dir"
+
+    # Tarball layout is fixed by the spec:
+    #   Source0 = ${pkg_name}-${version}.tar.gz    → unpacks to top-level `anolisa/`
+    #                                              (no version suffix; spec %prep uses %setup -q)
+    #   Source1 = ${pkg_name}-${version}-vendor.tar.gz → unpacks to `vendor/` next to Source0
+    # Keep runtime assets in Source0; exclude generated deps (target/vendor/.cargo).
+    tar -cf - -C "$ANOLISA_DIR" \
+        --exclude='target' \
+        --exclude='vendor' \
+        --exclude='.cargo' \
+        --exclude='.git' \
+        --exclude='node_modules' \
+        . | tar -xf - -C "$pkg_dir"
+
+    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "$pkg_name"
+    rm -rf "$tmp_dir"
+
+    log "Step 2/3: Creating vendor tarball ${vendor_tarball_name}..."
+    local vendor_tmp
+    vendor_tmp=$(mktemp -d)
+    # `cargo vendor --locked` can fail for three distinct reasons; surface which:
+    #   - lock-file drift (Cargo.lock out of date vs Cargo.toml)        → regenerate lock
+    #   - network unreachable / registry auth                            → check CI network env
+    #   - permission denied on vendor_tmp                                → check mount/owner
+    (
+        cd "$ANOLISA_DIR"
+        cargo vendor --locked "${vendor_tmp}/vendor" >/dev/null
+    ) || {
+        rc=$?
+        err "cargo vendor failed (exit=${rc}). Likely: (1) Cargo.lock out of date — regenerate with 'cargo generate-lockfile' then 'cargo update --workspace'; (2) network/registry auth issue in CI; (3) permission denied on ${vendor_tmp}."
+        rm -rf "$vendor_tmp"
+        return ${rc}
+    }
+    tar -czf "${BUILD_DIR}/SOURCES/${vendor_tarball_name}" -C "$vendor_tmp" vendor
+    rm -rf "$vendor_tmp"
+
+    log "Step 3/3: Running rpmbuild..."
+    "$RPMBUILD" -ba --nodeps \
+        --define "_topdir ${BUILD_DIR}" \
+        "$spec_file"
+
+    ok "anolisa RPM built successfully"
+}
+
+# =============================================================================
 # skillfs
 # =============================================================================
 build_skillfs() {
@@ -1034,6 +1114,7 @@ usage() {
     echo "  tokenless                 Build tokenless RPM"
     echo "  agent-memory              Build agent-memory RPM"
     echo "  skillfs                   Build skillfs RPM"
+    echo "  anolisa                   Build anolisa RPM"
     echo "  gvisor-runsc              Build gvisor-runsc RPM (sandbox)"
     echo "  containerd-shim-runsc-v1  Build containerd-shim-runsc-v1 RPM (sandbox)"
     echo "  atelet                    Build atelet RPM (sandbox, placeholder)"
@@ -1093,6 +1174,9 @@ case "$TARGET" in
     cosh-ng)
         build_cosh_ng
         ;;
+    anolisa)
+        build_anolisa
+        ;;
     gvisor-runsc)
         build_gvisor_runsc
         ;;
@@ -1120,6 +1204,7 @@ case "$TARGET" in
         build_agent_memory
         build_skillfs
         build_cosh_ng
+        build_anolisa
         ;;
     *)
         err "Unknown package: $TARGET"

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -641,7 +641,10 @@ build_anolisa() {
         version=$(grep -m1 '^version = ' "${ANOLISA_DIR}/Cargo.toml" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || true)
     fi
     if [ -z "$version" ]; then
-        err "Cannot determine anolisa version. Set VERSION env or ensure Cargo.toml exists."
+        version=$(grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+' "$spec_in" | head -1)
+    fi
+    if [ -z "$version" ]; then
+        err "Cannot determine anolisa version. Set VERSION env or ensure Cargo.toml/spec exists."
         return 1
     fi
 
@@ -1114,6 +1117,7 @@ usage() {
     echo "  tokenless                 Build tokenless RPM"
     echo "  agent-memory              Build agent-memory RPM"
     echo "  skillfs                   Build skillfs RPM"
+    echo "  cosh-ng                   Build cosh-ng RPM"
     echo "  anolisa                   Build anolisa RPM"
     echo "  gvisor-runsc              Build gvisor-runsc RPM (sandbox)"
     echo "  containerd-shim-runsc-v1  Build containerd-shim-runsc-v1 RPM (sandbox)"


### PR DESCRIPTION
## Summary

Supersedes #1463. Rebases the original commit onto current main (resolves the conflict with the merged #1457 cosh-ng target), applies the two optional qoderai suggestions on #1463, and adds two consistency fixes uncovered while rebasing.

The branch was force-pushed because GitHub denied push access to kongche-jbw's fork even though the PR has `maintainerCanModify=true`. Original author of the first commit is preserved as `空澈 <kongche.jbw@alibaba-inc.com>`; the consistency-fix commit is mine.

## Changes vs #1463

| # | Change | Source |
|---|--------|--------|
| 1 | Source0/Source1 naming convention comment in `build_anolisa` — spec `%prep %setup -q -n anolisa` expects top-level `anolisa/`, Source1 vendor tarball expects `vendor/` next to Source0 | qoderai suggestion on #1463 |
| 2 | `cargo vendor --locked` error wrapping — surface exit code + distinguish lock drift / network / permission failure paths in CI logs | qoderai suggestion on #1463 |
| 3 | Add `cosh-ng` to `usage()` — #1457 added `cosh-ng)` case + `build_cosh_ng` to `all` but missed `usage()`. After #1463 added `anolisa` to usage, cosh-ng was the only component with a TARGET case but no usage line | consistency fix uncovered during rebase |
| 4 | Add 3rd version fallback (`spec_in` regex) to `build_anolisa` to match `build_skillfs` / `build_cosh_ng` (env → Cargo.toml → spec_in version extract) | consistency fix uncovered during rebase |

## Conflict resolution (vs #1463)

`scripts/rpm-build.sh` had three conflict regions after #1457 merged first:
- `# Packages:` header line — keep both `cosh-ng` and `anolisa`
- `case "$TARGET"` — keep both `cosh-ng)` and `anolisa)` (cosh-ng first, matching `all` order)
- `all` block — `build_cosh_ng` before `build_anolisa`

## Related Issue

Closes #1454

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Checklist

- [x] My code follows the project's code style
- [x] I have updated the user-facing package list and command usage accordingly
- [x] Lock files are up to date (\`cargo vendor --locked\` passed during verification)

## Testing

End-to-end verification on a clean Anolis OS ECS (47.83.155.124):

- \`bash -n scripts/rpm-build.sh\` — syntax OK
- \`bash scripts/rpm-build.sh\` (no args) — prints usage with both \`cosh-ng\` and \`anolisa\` listed in the right slots
- \`bash scripts/rpm-build.sh anolisa\` — full build succeeds:
  - Version detection: Cargo.toml fallback → \`0.2.4\` (3rd-level spec_in regex fallback not triggered because Cargo.toml hit, but fallback chain now matches skillfs/cosh-ng)
  - Source0 tarball + Source1 vendor tarball packed correctly
  - \`cargo vendor --locked\` exited 0 (error-wrapping path not triggered; syntax verified)
  - \`rpmbuild -ba --nodeps\` full %prep/%build/%install/%clean passed
  - Output: \`anolisa-0.2.4-1.alnx4.x86_64.rpm\` (2.5M) + \`anolisa-0.2.4-1.alnx4.src.rpm\` (36M)

## Notes for maintainer

If kongche-jbw prefers to keep authorship on #1463, please close this PR and apply commits \`73bb01e5\` + \`c6a60a29\` (from \`zhangtaibo/anolisa:fix/anolisa-rpm-build-rebased\`) directly to the \`fix/anolisa/rpm-build\` branch. The first commit preserves kongche-jbw as author; only the second (consistency-fix) commit is authored by me.