### PR TITLE
feat(sec-core): qwen plugin and observability hooks

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -224,7 +224,7 @@ build_agent_sec_core() {
     local tmp_dir
     tmp_dir=$(mktemp -d)
     local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
-    mkdir -p "$pkg_dir"/{skills,linux-sandbox,agent-sec-cli,cosh-extension,openclaw-plugin,hermes-plugin,qoder-plugin,scripts,tools}
+    mkdir -p "$pkg_dir"/{skills,linux-sandbox,agent-sec-cli,cosh-extension,openclaw-plugin,hermes-plugin,qwen-code-extension,qoder-plugin,scripts,tools}
 
     # skills: use cp -rp dir/. to include hidden files/directories
     cp -rp "${SEC_DIR}/skills/." "$pkg_dir/skills/"
@@ -249,6 +249,11 @@ build_agent_sec_core() {
     tar -cf - -C "${SEC_DIR}" \
         --exclude='__pycache__' \
         hermes-plugin/src hermes-plugin/scripts | tar -xf - -C "$pkg_dir/"
+
+    # qwen-code-extension (exclude Python cache artifacts)
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='__pycache__' \
+        qwen-code-extension/ | tar -xf - -C "$pkg_dir/"
 
     # codex-plugin (hooks + install script + .agents registry, exclude __pycache__)
     tar -cf - -C "${SEC_DIR}" \

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -195,6 +195,11 @@ build-hermes-plugin: ## Stage hermes-plugin Python sources to BUILD_DIR
 	cp -rp hermes-plugin/src/. $(BUILD_DIR)/hermes-plugin/src/
 	cp -rp hermes-plugin/scripts/. $(BUILD_DIR)/hermes-plugin/scripts/
 
+.PHONY: build-qwen-code-extension
+build-qwen-code-extension: ## Stage Qwen Code extension files (no compilation)
+	install -d -m 0755 $(BUILD_DIR)/qwen-code-extension
+	cp -rp qwen-code-extension/. $(BUILD_DIR)/qwen-code-extension/
+
 .PHONY: stage-codex-plugin
 stage-codex-plugin: ## Stage codex-plugin hooks and install script to BUILD_DIR
 	install -d -m 0755 $(BUILD_DIR)/codex-plugin
@@ -229,7 +234,7 @@ stage-component-manifest: ## Stage component.toml into BUILD_DIR
 		$(BUILD_DIR)/share/anolisa/components/sec-core/component.toml
 
 .PHONY: build-all
-build-all: build-sandbox build-cli build-openclaw-plugin build-hermes-plugin stage-codex-plugin stage-qoder-plugin stage-cosh-extension stage-skills stage-component-manifest ## Build all components
+build-all: build-sandbox build-cli build-openclaw-plugin build-hermes-plugin build-qwen-code-extension stage-codex-plugin stage-qoder-plugin stage-cosh-extension stage-skills stage-component-manifest ## Build all components
 	@echo "📦 All artifacts collected to $(BUILD_DIR)/"
 
 .PHONY: export-requirements
@@ -268,6 +273,7 @@ ifeq ($(INSTALL_PROFILE),user)
   SKILLDIR        ?= $(HOME)/.copilot-shell/skills
   OPENCLAW_PLUGIN_DIR ?= $(LIBDIR)/openclaw-plugin
   HERMES_PLUGIN_DIR   ?= $(LIBDIR)/hermes-plugin
+  QWEN_CODE_EXTENSION_DIR ?= $(LIBDIR)/qwen-code-extension
   CODEX_PLUGIN_DIR    ?= $(LIBDIR)/codex-plugin
   QODER_PLUGIN_DIR    ?= $(LIBDIR)/qoder-plugin
 else
@@ -277,6 +283,7 @@ else
   SKILLDIR        ?= $(ANOLISA_DATADIR)/skills
   OPENCLAW_PLUGIN_DIR ?= $(LIBDIR)/openclaw-plugin
   HERMES_PLUGIN_DIR   ?= $(LIBDIR)/hermes-plugin
+  QWEN_CODE_EXTENSION_DIR ?= $(LIBDIR)/qwen-code-extension
   CODEX_PLUGIN_DIR    ?= $(LIBDIR)/codex-plugin
   QODER_PLUGIN_DIR    ?= $(LIBDIR)/qoder-plugin
 endif
@@ -295,6 +302,7 @@ RPM_OPENCLAW_PLUGIN_DIR ?= /opt/agent-sec/openclaw-plugin
 RPM_CODEX_PLUGIN_DIR  ?= /opt/agent-sec/codex-plugin
 RPM_HERMES_PLUGIN_DIR ?= /opt/agent-sec/hermes-plugin
 RPM_QODER_PLUGIN_DIR  ?= /opt/agent-sec/qoder-plugin
+RPM_QWEN_CODE_EXTENSION_DIR ?= /opt/agent-sec/qwen-code-extension
 SYSTEMD_USER_UNIT_DIR ?= /usr/lib/systemd/user
 SYSTEMD_USER_UNIT_SOURCE ?= agent-sec-cli/config/systemd/agent-sec-core.service
 
@@ -374,6 +382,13 @@ install-hermes-plugin: ## Install hermes-plugin to target directory
 	cp -rp $(BUILD_DIR)/hermes-plugin/scripts/. $(DESTDIR)$(HERMES_PLUGIN_DIR)/scripts/
 	chmod 0755 $(DESTDIR)$(HERMES_PLUGIN_DIR)/scripts/*.sh
 
+.PHONY: install-qwen-code-extension
+install-qwen-code-extension: ## Install Qwen Code extension to target directory
+	install -d -m 0755 $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)
+	cp -rp $(BUILD_DIR)/qwen-code-extension/. $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)/
+	chmod 0755 $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)/scripts/*.sh
+	chmod 0755 $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)/hooks/observability_hook.py
+
 .PHONY: install-codex-plugin
 install-codex-plugin: ## Install codex-plugin hooks and install script
 	install -d -m 0755 $(DESTDIR)$(CODEX_PLUGIN_DIR)
@@ -406,14 +421,15 @@ install-systemd-user: ## Install agent-sec-core systemd user service
 	install -p -m 0644 $(SYSTEMD_USER_UNIT_SOURCE) $(DESTDIR)$(SYSTEMD_USER_UNIT_DIR)/agent-sec-core.service
 
 .PHONY: install-all
-install-all: install-cli-venv install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-skills ## Install all (user source build)
+install-all: install-cli-venv install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-qwen-code-extension install-skills ## Install all (user source build)
 
 .PHONY: install-all-for-rpmbuild
 install-all-for-rpmbuild: OPENCLAW_PLUGIN_DIR := $(RPM_OPENCLAW_PLUGIN_DIR)
 install-all-for-rpmbuild: HERMES_PLUGIN_DIR := $(RPM_HERMES_PLUGIN_DIR)
+install-all-for-rpmbuild: QWEN_CODE_EXTENSION_DIR := $(RPM_QWEN_CODE_EXTENSION_DIR)
 install-all-for-rpmbuild: CODEX_PLUGIN_DIR := $(RPM_CODEX_PLUGIN_DIR)
 install-all-for-rpmbuild: QODER_PLUGIN_DIR := $(RPM_QODER_PLUGIN_DIR)
-install-all-for-rpmbuild: install-cli-site install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-skills install-component-manifest install-systemd-user ## Install all (RPM build)
+install-all-for-rpmbuild: install-cli-site install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-qwen-code-extension install-skills install-component-manifest install-systemd-user ## Install all (RPM build)
 
 # =============================================================================
 # UNINSTALL
@@ -449,6 +465,10 @@ uninstall-openclaw-plugin: ## Remove openclaw plugin
 uninstall-hermes-plugin: ## Remove hermes plugin
 	rm -rf $(DESTDIR)$(HERMES_PLUGIN_DIR)
 
+.PHONY: uninstall-qwen-code-extension
+uninstall-qwen-code-extension: ## Remove Qwen Code extension
+	rm -rf $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)
+
 .PHONY: uninstall-codex-plugin
 uninstall-codex-plugin: ## Remove codex plugin
 	rm -rf $(DESTDIR)$(CODEX_PLUGIN_DIR)
@@ -470,7 +490,7 @@ uninstall-component-manifest: ## Remove component manifest
 	rm -rf $(DESTDIR)$(COMPONENT_DIR)
 
 .PHONY: uninstall
-uninstall: uninstall-cli-venv uninstall-cosh-hook uninstall-codex-plugin uninstall-qoder-plugin uninstall-openclaw-plugin uninstall-hermes-plugin uninstall-skills ## Uninstall everything install-all installed
+uninstall: uninstall-cli-venv uninstall-cosh-hook uninstall-codex-plugin uninstall-qoder-plugin uninstall-openclaw-plugin uninstall-hermes-plugin uninstall-qwen-code-extension uninstall-skills ## Uninstall everything install-all installed
 
 .PHONY: help
 help: ## Show this help message

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -57,6 +57,7 @@ Requires:       agent-sec-codex-hook = %{version}-%{release}
 Requires:       agent-sec-qoder-hook = %{version}-%{release}
 Requires:       agent-sec-openclaw-hook = %{version}-%{release}
 Requires:       agent-sec-hermes-hook = %{version}-%{release}
+Requires:       agent-sec-qwen-code-hook = %{version}-%{release}
 Requires:       agent-sec-skills = %{version}-%{release}
 
 %description
@@ -159,7 +160,27 @@ Provides OS-level security guardrails for Hermes Agent via agent-sec-cli.
 %license LICENSE
 
 # =============================================================================
-# Subpackage 5: agent-sec-skills
+# Subpackage 5: agent-sec-qwen-code-hook
+# =============================================================================
+%package -n agent-sec-qwen-code-hook
+Summary:        Qwen Code extension for agent security
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       python3 >= 3.11
+Requires:       python3 < 3.12
+
+%description -n agent-sec-qwen-code-hook
+Qwen Code security extension powered by agent-sec-core.
+Provides lifecycle observability through Qwen Code command hooks.
+
+%files -n agent-sec-qwen-code-hook
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /opt/agent-sec/qwen-code-extension/scripts/deploy.sh
+%attr(0755,root,root) /opt/agent-sec/qwen-code-extension/hooks/observability_hook.py
+/opt/agent-sec/qwen-code-extension/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 6: agent-sec-skills
 # =============================================================================
 %package -n agent-sec-skills
 Summary:        Agent security skill definitions for copilot-shell
@@ -175,7 +196,7 @@ Includes skill-ledger, code-scanner, prompt-scanner and related skill definition
 %license LICENSE
 
 # =============================================================================
-# Subpackage 6: agent-sec-codex-hook
+# Subpackage 7: agent-sec-codex-hook
 # =============================================================================
 %package -n agent-sec-codex-hook
 Summary:        Codex plugin security hooks
@@ -194,7 +215,7 @@ and skill ledger verification for Codex agent.
 %license LICENSE
 
 # =============================================================================
-# Subpackage 7: agent-sec-qoder-hook
+# Subpackage 8: agent-sec-qoder-hook
 # =============================================================================
 %package -n agent-sec-qoder-hook
 Summary:        Qoder plugin security hooks

--- a/src/agent-sec-core/cosh-extension/hooks/observability_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/observability_hook.py
@@ -19,6 +19,8 @@ from pii_text import json_dumps as _json_dumps
 from pii_text import text_sha256, value_to_text
 
 _CLI_TIMEOUT_SECONDS = 3
+# Read one extra byte below to distinguish an exact-limit payload from truncation.
+_MAX_PAYLOAD_SIZE = 1024 * 1024
 _OBSERVABILITY_COMMAND = [
     "agent-sec-cli",
     "observability",
@@ -184,6 +186,16 @@ def _base_record(
 
 def _diagnostic(message: str) -> None:
     print(f"observability-hook: {message}", file=sys.stderr)
+
+
+def _read_stdin_payload() -> str | bytes | None:
+    """Read one bounded hook payload, returning None when it exceeds the limit."""
+    stream = getattr(sys.stdin, "buffer", sys.stdin)
+    payload = stream.read(_MAX_PAYLOAD_SIZE + 1)
+    if len(payload) > _MAX_PAYLOAD_SIZE:
+        _diagnostic(f"hook input exceeds {_MAX_PAYLOAD_SIZE} bytes; skipping event")
+        return None
+    return payload
 
 
 def _process_text(value: Any) -> str:
@@ -453,8 +465,12 @@ def _record_observability(record: dict[str, Any]) -> None:
 
 def main() -> None:
     try:
-        input_data = json.loads(sys.stdin.read())
-    except (json.JSONDecodeError, EOFError, ValueError):
+        payload = _read_stdin_payload()
+        if payload is None:
+            print(_noop())
+            return
+        input_data = json.loads(payload)
+    except (json.JSONDecodeError, EOFError, OSError, ValueError):
         print(_noop())
         return
 

--- a/src/agent-sec-core/qwen-code-extension/README.md
+++ b/src/agent-sec-core/qwen-code-extension/README.md
@@ -16,15 +16,13 @@ extension manifest、变量替换和安装行为同时依据
 - 当前目录已被 Qwen Code 信任；Qwen Code 会拒绝从不受信任的工作区安装扩展。
 
 当前实现与真实安装测试以 Qwen Code `0.19.9` 源码为基线；该版本声明需要
-Node.js `>=22`。部署脚本会在修改 extension 状态前校验可见的 Node 主版本、
-Qwen Code 语义化版本及 extension 管理接口，并校验 `agent-sec-cli` 的版本前缀、
-Observability schema、`observability record` 和 `scan-pii` 接口。
+Node.js `>=22`。与仓库内其他插件部署脚本一致，本脚本仅通过 `command -v` 检查
+`qwen`、`python3` 和 `agent-sec-cli` 是否存在，不绑定或推断其版本和接口实现。
 
-这些行为检查用于尽早发现 PATH 误配或不兼容版本，不能证明二进制来源，也不能防止
-恶意程序伪造相同输出。部署前应通过系统包管理、制品签名或校验和确认 `qwen`、
-`python3`、`node` 和 `agent-sec-cli` 来自受信源，并检查 `command -v` 返回的路径；
-自动化部署建议用绝对路径设置 `QWEN_BIN`。运行中的 hook 仍会从 Qwen Code 进程的
-`PATH` 查找 `python3` 和 `agent-sec-cli`，因此该运行时 PATH 也必须只包含受信目录。
+存在性检查不能证明二进制来源。部署前应通过系统包管理、制品签名或校验和确认
+`qwen`、`python3`、`node` 和 `agent-sec-cli` 来自受信源；运行中的 hook 也会从
+Qwen Code 进程的 `PATH` 查找 `python3` 和 `agent-sec-cli`，因此该运行时 PATH
+必须只包含受信目录。
 
 ## 部署
 

--- a/src/agent-sec-core/qwen-code-extension/README.md
+++ b/src/agent-sec-core/qwen-code-extension/README.md
@@ -16,8 +16,15 @@ extension manifest、变量替换和安装行为同时依据
 - 当前目录已被 Qwen Code 信任；Qwen Code 会拒绝从不受信任的工作区安装扩展。
 
 当前实现与真实安装测试以 Qwen Code `0.19.9` 源码为基线；该版本声明需要
-Node.js `>=22`。部署脚本会先校验可见的 Node 主版本并执行 `qwen --version`，
-在 Node/Qwen 运行时不可用时于修改 extension 状态前失败。
+Node.js `>=22`。部署脚本会在修改 extension 状态前校验可见的 Node 主版本、
+Qwen Code 语义化版本及 extension 管理接口，并校验 `agent-sec-cli` 的版本前缀、
+Observability schema、`observability record` 和 `scan-pii` 接口。
+
+这些行为检查用于尽早发现 PATH 误配或不兼容版本，不能证明二进制来源，也不能防止
+恶意程序伪造相同输出。部署前应通过系统包管理、制品签名或校验和确认 `qwen`、
+`python3`、`node` 和 `agent-sec-cli` 来自受信源，并检查 `command -v` 返回的路径；
+自动化部署建议用绝对路径设置 `QWEN_BIN`。运行中的 hook 仍会从 Qwen Code 进程的
+`PATH` 查找 `python3` 和 `agent-sec-cli`，因此该运行时 PATH 也必须只包含受信目录。
 
 ## 部署
 

--- a/src/agent-sec-core/qwen-code-extension/README.md
+++ b/src/agent-sec-core/qwen-code-extension/README.md
@@ -1,0 +1,79 @@
+# Qwen Code extension
+
+全本地、零 Token 成本地把 Qwen Code 的生命周期事件写入 agent-sec-core
+Observability。扩展通过 Qwen Code 原生 command hook 挂载，不自行实现 HookRegistry
+或事件聚合器。
+
+协议依据是 Qwen Code 官方的
+[Hooks 文档](https://qwenlm.github.io/qwen-code-docs/en/users/features/hooks/)；
+extension manifest、变量替换和安装行为同时依据
+[Extensions 文档](https://qwenlm.github.io/qwen-code-docs/en/developers/extensions/extension/)
+及当前 Qwen Code 源码校验。
+
+## 前置条件
+
+- `qwen`、`python3` 和 `agent-sec-cli` 均在 `PATH` 中。
+- 当前目录已被 Qwen Code 信任；Qwen Code 会拒绝从不受信任的工作区安装扩展。
+
+当前实现与真实安装测试以 Qwen Code `0.19.9` 源码为基线；该版本声明需要
+Node.js `>=22`。部署脚本会先校验可见的 Node 主版本并执行 `qwen --version`，
+在 Node/Qwen 运行时不可用时于修改 extension 状态前失败。
+
+## 部署
+
+```bash
+./qwen-code-extension/scripts/deploy.sh
+```
+
+脚本调用 Qwen Code 的 `extensions install`、`extensions update` 和
+`extensions enable` 命令，安装到 user scope。可通过 `QWEN_BIN` 和 `QWEN_HOME`
+覆盖 Qwen Code 可执行文件及配置目录。也可以把扩展目录作为第一个参数传入：
+
+```bash
+./qwen-code-extension/scripts/deploy.sh /path/to/qwen-code-extension
+```
+
+Qwen Code 对本地扩展按 manifest 版本判断是否更新。因此修改扩展内容后必须同步提升
+`qwen-extension.json` 中的 `version`，部署脚本才会执行更新。
+
+## 可观测事件映射
+
+| Qwen Code event | agent-sec-core hook |
+| --- | --- |
+| `UserPromptSubmit` | `before_agent_run` |
+| `PreToolUse` | `before_tool_call` |
+| `PostToolUse` | `after_tool_call`（success） |
+| `PostToolUseFailure` | `after_tool_call`（error/interrupted） |
+| `Stop` | `after_agent_run`（success） |
+| `StopFailure` | `after_agent_run`（failure） |
+
+Qwen Code 当前没有与 `before_llm_call` / `after_llm_call` 对应的模型调用 hook，
+所以本扩展不会伪造这两类记录。当前直接 HookInput 也没有贯穿 prompt、tool 和 stop
+事件的稳定 run 标识，因此现阶段所有记录的 `runId` 统一使用全零 GUID；
+`tool_call_id` 优先作为 `toolCallId`，缺失时回退到 `tool_use_id`。
+
+Qwen Code 的工具结果回填会再次触发 `UserPromptSubmit`，其中仅包含 function response
+的回填会被序列化为空 `prompt`。扩展直接检查 HookInput：缺失或空白的 `prompt` 不记录，
+非空 `prompt` 记录为 `before_agent_run`。该判断不创建本地 active-run 状态，因此不会因
+并发或缺失 `Stop` / `StopFailure` 而影响后续用户 prompt。
+
+`SessionStart`、`SessionEnd`、compact、notification、subagent 和 todo 等官方事件目前
+没有与 agent-sec-core Observability schema 含义一致的记录类型，因此不会被错误映射到
+agent/tool run；后续应先扩展 schema，再单独挂载。
+
+所有 hook 均异步执行并保持 fail-open：任何脚本、PII 扫描或记录写入异常都不会改变
+Qwen Code 的执行决策。敏感指标在写入前由本地 `scan-pii` 脱敏；脱敏失败时直接丢弃
+对应敏感字段。
+
+## 测试
+
+```bash
+QWEN_CODE_EXTENSION_E2E_DIR="$PWD/qwen-code-extension" \
+  uv run --project agent-sec-cli pytest \
+  tests/unit-test/qwen-code-extension \
+  tests/e2e/qwen-code-extension -v
+```
+
+E2E 测试从 `qwen-extension.json` 读取并直接执行 command hook，使用独立进程和隔离的
+`AGENT_SEC_DATA_DIR` 验证 JSON 输出、Observability JSONL、全零 `runId`、tool call
+关联以及空 prompt 工具结果回填的过滤。它不安装或启动 Qwen Code。

--- a/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
@@ -405,8 +405,14 @@ def main() -> None:
         record = _build_record(input_data)
         if record is not None:
             _record_observability(record)
-    except Exception:
-        pass
+    except Exception as exc:
+        event_name = input_data.get("hook_event_name")
+        if not isinstance(event_name, str) or not event_name:
+            event_name = "unknown"
+        _diagnostic(
+            f"unexpected error while processing {event_name}: "
+            f"{type(exc).__name__}: {exc}"
+        )
     print(_noop())
 
 

--- a/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Map Qwen Code hook input to agent-sec-core observability records.
+
+This command hook is fail-open. It never returns a Qwen Code decision and
+never forwards an unredacted sensitive metric when PII redaction fails.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from pii_text import json_dumps as _json_dumps
+from pii_text import text_sha256, value_to_text
+
+_CLI_TIMEOUT_SECONDS = 3
+# Qwen Code HookInput does not currently expose one stable run identifier across
+# prompt, tool, and stop events. Use the zero GUID deliberately until reliable
+# run correlation can be implemented from the hook protocol itself.
+_ZERO_RUN_ID = "00000000-0000-0000-0000-000000000000"
+_OBSERVABILITY_COMMAND = [
+    "agent-sec-cli",
+    "observability",
+    "record",
+    "--format",
+    "json",
+    "--stdin",
+]
+_PII_REDACT_COMMAND = [
+    "agent-sec-cli",
+    "scan-pii",
+    "--stdin",
+    "--format",
+    "json",
+    "--redact-output",
+    "--source",
+    "observability",
+]
+_SENSITIVE_METRIC_KEYS = {
+    "prompt",
+    "user_input",
+    "system_prompt",
+    "messages",
+    "response",
+    "parameters",
+    "result",
+    "error",
+    "tool_calls",
+}
+_DROP = object()
+
+
+def _noop() -> str:
+    """Return an empty Qwen Code HookOutput JSON string."""
+    return json.dumps({})
+
+
+def _json_size_bytes(value: Any) -> int:
+    return len(_json_dumps(value).encode("utf-8"))
+
+
+def _pii_scan_input_sha256(value: Any) -> str | None:
+    text = value_to_text(value)
+    if not text.strip():
+        return None
+    return text_sha256(text)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _non_empty_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = value if isinstance(value, str) else str(value)
+    return text if text else None
+
+
+def _session_id(input_data: dict[str, Any]) -> str | None:
+    return _non_empty_string(input_data.get("session_id")) or _non_empty_string(
+        os.environ.get("QWEN_CODE_SESSION_ID")
+    )
+
+
+def _metadata(
+    input_data: dict[str, Any], *, needs_tool_call_id: bool = False
+) -> dict[str, Any] | None:
+    session_id = _session_id(input_data)
+    if session_id is None:
+        return None
+
+    metadata = {
+        "sessionId": session_id,
+        "runId": _ZERO_RUN_ID,
+    }
+    if needs_tool_call_id:
+        tool_call_id = _non_empty_string(
+            input_data.get("tool_call_id") or input_data.get("tool_use_id")
+        )
+        if tool_call_id is None:
+            return None
+        metadata["toolCallId"] = tool_call_id
+    return metadata
+
+
+def _observed_at(input_data: dict[str, Any]) -> str:
+    timestamp = input_data.get("timestamp")
+    if isinstance(timestamp, str) and timestamp:
+        return timestamp
+    return _now_iso()
+
+
+def _base_record(
+    input_data: dict[str, Any],
+    *,
+    hook: str,
+    metrics: dict[str, Any],
+    needs_tool_call_id: bool = False,
+) -> dict[str, Any] | None:
+    if not metrics:
+        return None
+    metadata = _metadata(input_data, needs_tool_call_id=needs_tool_call_id)
+    if metadata is None:
+        return None
+    return {
+        "hook": hook,
+        "observedAt": _observed_at(input_data),
+        "metadata": metadata,
+        "metrics": metrics,
+    }
+
+
+def _diagnostic(message: str) -> None:
+    print(f"qwen-observability-hook: {message}", file=sys.stderr)
+
+
+def _process_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace").strip()
+    return str(value).strip()
+
+
+def _process_output_details(*values: Any) -> str:
+    details = "\n".join(part for value in values if (part := _process_text(value)))
+    return details or "no stderr or stdout was captured"
+
+
+def _redact_text(text: str) -> str | None:
+    try:
+        result = subprocess.run(
+            _PII_REDACT_COMMAND,
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    redacted = data.get("redacted_text")
+    return redacted if isinstance(redacted, str) else None
+
+
+def _redact_sensitive_value(value: Any) -> Any:
+    """Redact a sensitive metric value, or return _DROP on scan failure."""
+    if isinstance(value, str):
+        redacted = _redact_text(value)
+        return _DROP if redacted is None else redacted
+
+    redacted = _redact_text(_json_dumps(value))
+    if redacted is None:
+        return _DROP
+    try:
+        return json.loads(redacted)
+    except (json.JSONDecodeError, ValueError):
+        return redacted
+
+
+def _redact_metrics(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            safe_item = (
+                _redact_sensitive_value(item)
+                if key in _SENSITIVE_METRIC_KEYS
+                else _redact_metrics(item)
+            )
+            if safe_item is not _DROP:
+                redacted[key] = safe_item
+        return redacted
+    if isinstance(value, list):
+        return [
+            item
+            for item in (_redact_metrics(item) for item in value)
+            if item is not _DROP
+        ]
+    return value
+
+
+def _redact_observability_record(record: dict[str, Any]) -> dict[str, Any]:
+    safe_record = dict(record)
+    metrics = safe_record.get("metrics")
+    if isinstance(metrics, dict):
+        safe_record["metrics"] = _redact_metrics(metrics)
+    return safe_record
+
+
+def _build_user_prompt_submit(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    prompt = input_data.get("prompt")
+    # Qwen serializes a function-response-only tool re-entry as an empty prompt.
+    if not isinstance(prompt, str) or not prompt.strip():
+        return None
+
+    metrics: dict[str, Any] = {
+        "prompt": prompt,
+        "user_input": prompt,
+    }
+    pii_hash = _pii_scan_input_sha256(prompt)
+    if pii_hash is not None:
+        metrics["pii_scan_input_sha256"] = pii_hash
+    return _base_record(input_data, hook="before_agent_run", metrics=metrics)
+
+
+def _build_pre_tool_use(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    metrics: dict[str, Any] = {}
+    if "tool_name" in input_data:
+        metrics["tool_name"] = input_data["tool_name"]
+    if "tool_input" in input_data:
+        tool_input = input_data["tool_input"]
+        metrics["parameters"] = tool_input
+        pii_hash = _pii_scan_input_sha256(tool_input)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+    return _base_record(
+        input_data,
+        hook="before_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _extract_exit_code(value: Any) -> Any | None:
+    if not isinstance(value, dict):
+        return None
+    if "exit_code" in value:
+        return value["exit_code"]
+    if "exitCode" in value:
+        return value["exitCode"]
+    for key in ("returnDisplay", "llmContent"):
+        nested = _extract_exit_code(value.get(key))
+        if nested is not None:
+            return nested
+    return None
+
+
+def _build_post_tool_use(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    metrics: dict[str, Any] = {"status": "success"}
+    if "tool_response" in input_data:
+        tool_response = input_data["tool_response"]
+        metrics["result"] = tool_response
+        metrics["result_size_bytes"] = _json_size_bytes(tool_response)
+        pii_hash = _pii_scan_input_sha256(tool_response)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+        exit_code = _extract_exit_code(tool_response)
+        if exit_code is not None:
+            metrics["exit_code"] = exit_code
+    return _base_record(
+        input_data,
+        hook="after_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _build_post_tool_use_failure(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    metrics: dict[str, Any] = {
+        "status": "interrupted" if input_data.get("is_interrupt") is True else "error"
+    }
+    if "error" in input_data:
+        error = input_data["error"]
+        metrics["error"] = error
+        pii_hash = _pii_scan_input_sha256(error)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+    return _base_record(
+        input_data,
+        hook="after_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _build_stop(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    response = input_data.get("last_assistant_message", "")
+    has_text = bool(response)
+    metrics: dict[str, Any] = {
+        "response": response,
+        "output_kind": "text" if has_text else "empty",
+        "assistant_texts_count": 1 if has_text else 0,
+        "success": True,
+    }
+    return _base_record(input_data, hook="after_agent_run", metrics=metrics)
+
+
+def _build_stop_failure(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    error = input_data.get("error_details") or input_data.get("error") or "unknown"
+    response = input_data.get("last_assistant_message", "")
+    metrics: dict[str, Any] = {
+        "error": error,
+        "output_kind": "text" if response else "empty",
+        "success": False,
+    }
+    if response:
+        metrics["response"] = response
+        metrics["assistant_texts_count"] = 1
+    if input_data.get("error"):
+        metrics["stop_reason"] = input_data["error"]
+    return _base_record(input_data, hook="after_agent_run", metrics=metrics)
+
+
+_BUILDERS = {
+    "UserPromptSubmit": _build_user_prompt_submit,
+    "PreToolUse": _build_pre_tool_use,
+    "PostToolUse": _build_post_tool_use,
+    "PostToolUseFailure": _build_post_tool_use_failure,
+    "Stop": _build_stop,
+    "StopFailure": _build_stop_failure,
+}
+
+
+def _build_record(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Map a Qwen Code hook input to one observability record payload."""
+    if not isinstance(input_data, dict):
+        return None
+    builder = _BUILDERS.get(input_data.get("hook_event_name"))
+    if builder is None:
+        return None
+    return builder(input_data)
+
+
+def _record_observability(record: dict[str, Any]) -> None:
+    record = _redact_observability_record(record)
+    if not record.get("metrics"):
+        return
+    try:
+        result = subprocess.run(
+            _OBSERVABILITY_COMMAND,
+            input=json.dumps(record, ensure_ascii=False),
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        _diagnostic(
+            "agent-sec-cli executable was not found; install agent-sec-cli or add it to PATH"
+        )
+        return
+    except subprocess.TimeoutExpired as exc:
+        details = _process_output_details(exc.stderr, exc.stdout)
+        _diagnostic(
+            "agent-sec-cli observability record timed out "
+            f"after {exc.timeout} seconds: {details}"
+        )
+        return
+    except OSError as exc:
+        _diagnostic(f"failed to start agent-sec-cli observability record: {exc}")
+        return
+
+    if result.returncode != 0:
+        details = _process_output_details(
+            getattr(result, "stderr", None), getattr(result, "stdout", None)
+        )
+        _diagnostic(
+            "agent-sec-cli observability record failed "
+            f"with exit code {result.returncode}: {details}"
+        )
+
+
+def main() -> None:
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, EOFError, ValueError):
+        print(_noop())
+        return
+
+    try:
+        record = _build_record(input_data)
+        if record is not None:
+            _record_observability(record)
+    except Exception:
+        pass
+    print(_noop())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
@@ -16,6 +16,8 @@ from pii_text import json_dumps as _json_dumps
 from pii_text import text_sha256, value_to_text
 
 _CLI_TIMEOUT_SECONDS = 3
+# Read one extra byte below to distinguish an exact-limit payload from truncation.
+_MAX_PAYLOAD_SIZE = 1024 * 1024
 # Qwen Code HookInput does not currently expose one stable run identifier across
 # prompt, tool, and stop events. Use the zero GUID deliberately until reliable
 # run correlation can be implemented from the hook protocol itself.
@@ -135,6 +137,16 @@ def _base_record(
 
 def _diagnostic(message: str) -> None:
     print(f"qwen-observability-hook: {message}", file=sys.stderr)
+
+
+def _read_stdin_payload() -> str | bytes | None:
+    """Read one bounded hook payload, returning None when it exceeds the limit."""
+    stream = getattr(sys.stdin, "buffer", sys.stdin)
+    payload = stream.read(_MAX_PAYLOAD_SIZE + 1)
+    if len(payload) > _MAX_PAYLOAD_SIZE:
+        _diagnostic(f"hook input exceeds {_MAX_PAYLOAD_SIZE} bytes; skipping event")
+        return None
+    return payload
 
 
 def _process_text(value: Any) -> str:
@@ -355,6 +367,13 @@ def _build_record(input_data: dict[str, Any]) -> dict[str, Any] | None:
     return builder(input_data)
 
 
+def _diagnostic_event_name(input_data: Any) -> str:
+    if not isinstance(input_data, dict):
+        return "unknown"
+    event_name = input_data.get("hook_event_name")
+    return event_name if event_name in _BUILDERS else "unknown"
+
+
 def _record_observability(record: dict[str, Any]) -> None:
     record = _redact_observability_record(record)
     if not record.get("metrics"):
@@ -396,8 +415,12 @@ def _record_observability(record: dict[str, Any]) -> None:
 
 def main() -> None:
     try:
-        input_data = json.loads(sys.stdin.read())
-    except (json.JSONDecodeError, EOFError, ValueError):
+        payload = _read_stdin_payload()
+        if payload is None:
+            print(_noop())
+            return
+        input_data = json.loads(payload)
+    except (json.JSONDecodeError, EOFError, OSError, ValueError):
         print(_noop())
         return
 
@@ -406,12 +429,9 @@ def main() -> None:
         if record is not None:
             _record_observability(record)
     except Exception as exc:
-        event_name = input_data.get("hook_event_name")
-        if not isinstance(event_name, str) or not event_name:
-            event_name = "unknown"
         _diagnostic(
-            f"unexpected error while processing {event_name}: "
-            f"{type(exc).__name__}: {exc}"
+            f"unexpected {type(exc).__name__} while processing "
+            f"{_diagnostic_event_name(input_data)}"
         )
     print(_noop())
 

--- a/src/agent-sec-core/qwen-code-extension/hooks/pii_text.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/pii_text.py
@@ -1,0 +1,29 @@
+"""Shared PII scan text helpers for Qwen Code hooks."""
+
+import hashlib
+import json
+from typing import Any
+
+
+def json_dumps(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
+
+
+def value_to_text(value: Any) -> str:
+    """Convert a hook value to the exact text sent to scan-pii."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json_dumps(value)
+
+
+def text_sha256(text: str) -> str:
+    """Return the scan-pii audit hash for *text*."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/src/agent-sec-core/qwen-code-extension/qwen-extension.json
+++ b/src/agent-sec-core/qwen-code-extension/qwen-extension.json
@@ -1,0 +1,91 @@
+{
+  "name": "agent-sec-core-qwen-code-extension",
+  "version": "0.8.0",
+  "description": "ANOLISA security integration for Qwen Code",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "description": "Record the Qwen Code user prompt event",
+            "timeout": 10000,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "description": "Record the Qwen Code pre-tool event",
+            "timeout": 10000,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "description": "Record the Qwen Code successful tool event",
+            "timeout": 10000,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "description": "Record the Qwen Code failed tool event",
+            "timeout": 10000,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "description": "Record the Qwen Code completed agent run",
+            "timeout": 10000,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "description": "Record the Qwen Code failed agent run",
+            "timeout": 10000,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/agent-sec-core/qwen-code-extension/scripts/deploy.sh
+++ b/src/agent-sec-core/qwen-code-extension/scripts/deploy.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXTENSION_DIR="${1:-${DEFAULT_EXTENSION_DIR}}"
+QWEN_BIN="${QWEN_BIN:-qwen}"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+require_command() {
+    local command_name="$1"
+    command -v "${command_name}" >/dev/null 2>&1 || fail "${command_name} is not available in PATH"
+}
+
+absolute_path() {
+    python3 -c \
+        'import os, sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' \
+        "$1"
+}
+
+json_field() {
+    local json_path="$1"
+    local field_name="$2"
+    python3 -c \
+        'import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    value = json.load(stream).get(sys.argv[2], "")
+print(value if isinstance(value, str) else "")' \
+        "${json_path}" "${field_name}"
+}
+
+require_command python3
+require_command "${QWEN_BIN}"
+require_command agent-sec-cli
+
+if command -v node >/dev/null 2>&1; then
+    NODE_VERSION="$(node --version 2>/dev/null || true)"
+    if [[ "${NODE_VERSION}" =~ ^v?([0-9]+) ]] && ((BASH_REMATCH[1] < 22)); then
+        fail "Qwen Code 0.19.9 requires Node.js >=22; found ${NODE_VERSION}"
+    fi
+fi
+if ! "${QWEN_BIN}" --version >/dev/null 2>&1; then
+    fail "qwen failed to start; verify the Qwen Code installation and its Node.js runtime"
+fi
+
+EXTENSION_DIR="$(absolute_path "${EXTENSION_DIR}")"
+MANIFEST_PATH="${EXTENSION_DIR}/qwen-extension.json"
+HOOK_PATH="${EXTENSION_DIR}/hooks/observability_hook.py"
+
+[[ -f "${MANIFEST_PATH}" ]] || fail "missing extension manifest: ${MANIFEST_PATH}"
+[[ -f "${HOOK_PATH}" ]] || fail "missing observability hook: ${HOOK_PATH}"
+
+EXTENSION_NAME="$(json_field "${MANIFEST_PATH}" name)"
+EXTENSION_VERSION="$(json_field "${MANIFEST_PATH}" version)"
+[[ -n "${EXTENSION_NAME}" ]] || fail "qwen-extension.json must define a string name"
+[[ -n "${EXTENSION_VERSION}" ]] || fail "qwen-extension.json must define a string version"
+
+QWEN_HOME_DIR="$(absolute_path "${QWEN_HOME:-${HOME}/.qwen}")"
+TARGET_DIR="${QWEN_HOME_DIR}/extensions/${EXTENSION_NAME}"
+TARGET_MANIFEST="${TARGET_DIR}/qwen-extension.json"
+INSTALL_METADATA="${TARGET_DIR}/.qwen-extension-install.json"
+
+if [[ -d "${TARGET_DIR}" ]]; then
+    [[ -f "${TARGET_MANIFEST}" ]] || fail \
+        "existing extension is not a copied local install; uninstall it before deploying"
+    [[ -f "${INSTALL_METADATA}" ]] || fail \
+        "existing extension has no install metadata; uninstall it before deploying"
+
+    INSTALL_TYPE="$(json_field "${INSTALL_METADATA}" type)"
+    INSTALL_SOURCE="$(json_field "${INSTALL_METADATA}" source)"
+    [[ "${INSTALL_TYPE}" == "local" ]] || fail \
+        "existing extension uses install type '${INSTALL_TYPE:-unknown}'; uninstall it before deploying"
+    [[ -n "${INSTALL_SOURCE}" ]] || fail "existing extension install metadata has no source"
+
+    INSTALL_SOURCE="$(absolute_path "${INSTALL_SOURCE}")"
+    [[ "${INSTALL_SOURCE}" == "${EXTENSION_DIR}" ]] || fail \
+        "existing extension points to ${INSTALL_SOURCE}; uninstall it before deploying from ${EXTENSION_DIR}"
+
+    INSTALLED_VERSION="$(json_field "${TARGET_MANIFEST}" version)"
+    if [[ "${INSTALLED_VERSION}" == "${EXTENSION_VERSION}" ]]; then
+        echo "Qwen Code extension ${EXTENSION_NAME} ${EXTENSION_VERSION} is already installed."
+    else
+        echo "Updating ${EXTENSION_NAME}: ${INSTALLED_VERSION:-unknown} -> ${EXTENSION_VERSION}"
+        "${QWEN_BIN}" extensions update "${EXTENSION_NAME}"
+    fi
+else
+    echo "Installing ${EXTENSION_NAME} ${EXTENSION_VERSION} from ${EXTENSION_DIR}"
+    "${QWEN_BIN}" extensions install "${EXTENSION_DIR}" --consent --scope user
+fi
+
+[[ -f "${TARGET_MANIFEST}" ]] || fail "Qwen Code did not create ${TARGET_MANIFEST}"
+DEPLOYED_NAME="$(json_field "${TARGET_MANIFEST}" name)"
+DEPLOYED_VERSION="$(json_field "${TARGET_MANIFEST}" version)"
+[[ "${DEPLOYED_NAME}" == "${EXTENSION_NAME}" ]] || fail \
+    "deployed extension name is '${DEPLOYED_NAME}', expected '${EXTENSION_NAME}'"
+[[ "${DEPLOYED_VERSION}" == "${EXTENSION_VERSION}" ]] || fail \
+    "deployed extension version is '${DEPLOYED_VERSION}', expected '${EXTENSION_VERSION}'"
+
+"${QWEN_BIN}" extensions enable --scope user "${EXTENSION_NAME}"
+
+echo "Deployed ${EXTENSION_NAME} ${EXTENSION_VERSION} to ${TARGET_DIR}"
+echo "Restart running Qwen Code sessions to load the extension."

--- a/src/agent-sec-core/qwen-code-extension/scripts/deploy.sh
+++ b/src/agent-sec-core/qwen-code-extension/scripts/deploy.sh
@@ -23,16 +23,6 @@ absolute_path() {
         "$1"
 }
 
-resolve_executable() {
-    local command_name="$1"
-    local command_path
-    command_path="$(command -v "${command_name}" 2>/dev/null)" || \
-        fail "${command_name} is not available in PATH"
-    [[ -f "${command_path}" && -x "${command_path}" ]] || \
-        fail "${command_name} does not resolve to an executable file: ${command_path}"
-    absolute_path "${command_path}"
-}
-
 json_field() {
     local json_path="$1"
     local field_name="$2"
@@ -45,58 +35,8 @@ print(value if isinstance(value, str) else "")' \
 }
 
 require_command python3
-QWEN_BIN="$(resolve_executable "${QWEN_BIN}")"
-AGENT_SEC_CLI_BIN="$(resolve_executable agent-sec-cli)"
-
-if command -v node >/dev/null 2>&1; then
-    NODE_VERSION="$(node --version 2>/dev/null || true)"
-    if [[ "${NODE_VERSION}" =~ ^v?([0-9]+) ]] && ((BASH_REMATCH[1] < 22)); then
-        fail "Qwen Code 0.19.9 requires Node.js >=22; found ${NODE_VERSION}"
-    fi
-fi
-if ! QWEN_VERSION="$("${QWEN_BIN}" --version 2>/dev/null)"; then
-    fail "qwen failed to start; verify the Qwen Code installation and its Node.js runtime"
-fi
-SEMVER_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
-[[ "${QWEN_VERSION}" =~ ${SEMVER_PATTERN} ]] || \
-    fail "unexpected qwen --version output; expected a Qwen Code semantic version"
-
-if ! QWEN_EXTENSIONS_HELP="$("${QWEN_BIN}" extensions --help 2>&1)"; then
-    fail "qwen does not provide the extension management interface"
-fi
-for REQUIRED_FRAGMENT in \
-    "Manage Qwen Code extensions." \
-    "qwen extensions install <source>" \
-    "qwen extensions update" \
-    "qwen extensions enable"; do
-    [[ "${QWEN_EXTENSIONS_HELP}" == *"${REQUIRED_FRAGMENT}"* ]] || \
-        fail "qwen extensions --help does not match the required Qwen Code interface"
-done
-
-if ! AGENT_SEC_CLI_VERSION="$("${AGENT_SEC_CLI_BIN}" --version 2>/dev/null)"; then
-    fail "agent-sec-cli failed to start"
-fi
-AGENT_SEC_CLI_VERSION_PATTERN='^agent-sec-cli[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
-[[ "${AGENT_SEC_CLI_VERSION}" =~ ${AGENT_SEC_CLI_VERSION_PATTERN} ]] || \
-    fail "unexpected agent-sec-cli --version output"
-
-if ! "${AGENT_SEC_CLI_BIN}" observability schema 2>/dev/null | python3 -c \
-    'import json, sys
-schema = json.load(sys.stdin)
-mapping = schema.get("discriminator", {}).get("mapping", {})
-required = {"before_agent_run", "before_tool_call", "after_tool_call", "after_agent_run"}
-raise SystemExit(0 if isinstance(mapping, dict) and required <= mapping.keys() else 1)'; then
-    fail "agent-sec-cli observability schema is incompatible with this extension"
-fi
-if ! "${AGENT_SEC_CLI_BIN}" observability record --help >/dev/null 2>&1; then
-    fail "agent-sec-cli does not provide observability record"
-fi
-if ! "${AGENT_SEC_CLI_BIN}" scan-pii --help >/dev/null 2>&1; then
-    fail "agent-sec-cli does not provide scan-pii"
-fi
-
-echo "Using Qwen Code ${QWEN_VERSION} from ${QWEN_BIN}"
-echo "Using ${AGENT_SEC_CLI_VERSION} from ${AGENT_SEC_CLI_BIN}"
+require_command "${QWEN_BIN}"
+require_command agent-sec-cli
 
 EXTENSION_DIR="$(absolute_path "${EXTENSION_DIR}")"
 MANIFEST_PATH="${EXTENSION_DIR}/qwen-extension.json"

--- a/src/agent-sec-core/qwen-code-extension/scripts/deploy.sh
+++ b/src/agent-sec-core/qwen-code-extension/scripts/deploy.sh
@@ -23,6 +23,16 @@ absolute_path() {
         "$1"
 }
 
+resolve_executable() {
+    local command_name="$1"
+    local command_path
+    command_path="$(command -v "${command_name}" 2>/dev/null)" || \
+        fail "${command_name} is not available in PATH"
+    [[ -f "${command_path}" && -x "${command_path}" ]] || \
+        fail "${command_name} does not resolve to an executable file: ${command_path}"
+    absolute_path "${command_path}"
+}
+
 json_field() {
     local json_path="$1"
     local field_name="$2"
@@ -35,8 +45,8 @@ print(value if isinstance(value, str) else "")' \
 }
 
 require_command python3
-require_command "${QWEN_BIN}"
-require_command agent-sec-cli
+QWEN_BIN="$(resolve_executable "${QWEN_BIN}")"
+AGENT_SEC_CLI_BIN="$(resolve_executable agent-sec-cli)"
 
 if command -v node >/dev/null 2>&1; then
     NODE_VERSION="$(node --version 2>/dev/null || true)"
@@ -44,9 +54,49 @@ if command -v node >/dev/null 2>&1; then
         fail "Qwen Code 0.19.9 requires Node.js >=22; found ${NODE_VERSION}"
     fi
 fi
-if ! "${QWEN_BIN}" --version >/dev/null 2>&1; then
+if ! QWEN_VERSION="$("${QWEN_BIN}" --version 2>/dev/null)"; then
     fail "qwen failed to start; verify the Qwen Code installation and its Node.js runtime"
 fi
+SEMVER_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+[[ "${QWEN_VERSION}" =~ ${SEMVER_PATTERN} ]] || \
+    fail "unexpected qwen --version output; expected a Qwen Code semantic version"
+
+if ! QWEN_EXTENSIONS_HELP="$("${QWEN_BIN}" extensions --help 2>&1)"; then
+    fail "qwen does not provide the extension management interface"
+fi
+for REQUIRED_FRAGMENT in \
+    "Manage Qwen Code extensions." \
+    "qwen extensions install <source>" \
+    "qwen extensions update" \
+    "qwen extensions enable"; do
+    [[ "${QWEN_EXTENSIONS_HELP}" == *"${REQUIRED_FRAGMENT}"* ]] || \
+        fail "qwen extensions --help does not match the required Qwen Code interface"
+done
+
+if ! AGENT_SEC_CLI_VERSION="$("${AGENT_SEC_CLI_BIN}" --version 2>/dev/null)"; then
+    fail "agent-sec-cli failed to start"
+fi
+AGENT_SEC_CLI_VERSION_PATTERN='^agent-sec-cli[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+[[ "${AGENT_SEC_CLI_VERSION}" =~ ${AGENT_SEC_CLI_VERSION_PATTERN} ]] || \
+    fail "unexpected agent-sec-cli --version output"
+
+if ! "${AGENT_SEC_CLI_BIN}" observability schema 2>/dev/null | python3 -c \
+    'import json, sys
+schema = json.load(sys.stdin)
+mapping = schema.get("discriminator", {}).get("mapping", {})
+required = {"before_agent_run", "before_tool_call", "after_tool_call", "after_agent_run"}
+raise SystemExit(0 if isinstance(mapping, dict) and required <= mapping.keys() else 1)'; then
+    fail "agent-sec-cli observability schema is incompatible with this extension"
+fi
+if ! "${AGENT_SEC_CLI_BIN}" observability record --help >/dev/null 2>&1; then
+    fail "agent-sec-cli does not provide observability record"
+fi
+if ! "${AGENT_SEC_CLI_BIN}" scan-pii --help >/dev/null 2>&1; then
+    fail "agent-sec-cli does not provide scan-pii"
+fi
+
+echo "Using Qwen Code ${QWEN_VERSION} from ${QWEN_BIN}"
+echo "Using ${AGENT_SEC_CLI_VERSION} from ${AGENT_SEC_CLI_BIN}"
 
 EXTENSION_DIR="$(absolute_path "${EXTENSION_DIR}")"
 MANIFEST_PATH="${EXTENSION_DIR}/qwen-extension.json"

--- a/src/agent-sec-core/scripts/bump-version.sh
+++ b/src/agent-sec-core/scripts/bump-version.sh
@@ -21,7 +21,8 @@
 #   9. adapters/component.toml              (component.version)
 #  10. codex-plugin/hooks-plugin/.codex-plugin/plugin.json ("version" field)
 #  11. qoder-plugin/.qoder-plugin/plugin.json ("version" field)
-#  12. Lock files: Cargo.lock, uv.lock, package-lock.json (auto-regenerated)
+#  12. qwen-code-extension/qwen-extension.json ("version" field)
+#  13. Lock files: Cargo.lock, uv.lock, package-lock.json (auto-regenerated)
 #
 # Manual update required (not automated):
 #   - agent-sec-core.spec.in  (%changelog entry)
@@ -208,7 +209,15 @@ bump_file "$PROJECT_ROOT/qoder-plugin/.qoder-plugin/plugin.json" \
     "qoder-plugin/.qoder-plugin/plugin.json"
 
 # -----------------------------------------------------------------------------
-# 12. Regenerate lock files
+# 12. qwen-code-extension/qwen-extension.json
+# -----------------------------------------------------------------------------
+bump_file "$PROJECT_ROOT/qwen-code-extension/qwen-extension.json" \
+    "\"version\": \"$OLD_VERSION\"" \
+    "\"version\": \"$NEW_VERSION\"" \
+    "qwen-code-extension/qwen-extension.json"
+
+# -----------------------------------------------------------------------------
+# 13. Regenerate lock files
 # -----------------------------------------------------------------------------
 log "Regenerating lock files..."
 

--- a/src/agent-sec-core/tests/e2e/qwen-code-extension/test_direct_hook_execution.py
+++ b/src/agent-sec-core/tests/e2e/qwen-code-extension/test_direct_hook_execution.py
@@ -1,0 +1,284 @@
+"""E2E checks for Qwen Code extension command-hook execution."""
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_RPM_EXTENSION_DIR = Path("/opt/agent-sec/qwen-code-extension")
+_SYSTEM_EXTENSION_DIR = Path("/usr/local/lib/anolisa/sec-core/qwen-code-extension")
+_USER_EXTENSION_DIR = (
+    Path.home() / ".local" / "lib" / "anolisa" / "sec-core" / "qwen-code-extension"
+)
+_SOURCE_EXTENSION_DIR = Path(__file__).resolve().parents[3] / "qwen-code-extension"
+_ZERO_RUN_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _extension_dir() -> Path:
+    override = os.environ.get("QWEN_CODE_EXTENSION_E2E_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    for extension_dir in (
+        _RPM_EXTENSION_DIR,
+        _SYSTEM_EXTENSION_DIR,
+        _USER_EXTENSION_DIR,
+    ):
+        if (extension_dir / "qwen-extension.json").exists():
+            return extension_dir
+    return _SOURCE_EXTENSION_DIR
+
+
+def _manifest_hook_commands(extension_dir: Path) -> dict[str, list[str]]:
+    manifest = json.loads(
+        (extension_dir / "qwen-extension.json").read_text(encoding="utf-8")
+    )
+    commands: dict[str, list[str]] = {}
+    for event_name, hook_groups in manifest["hooks"].items():
+        event_commands: list[str] = []
+        for group in hook_groups:
+            for hook in group.get("hooks", []):
+                command = hook.get("command")
+                if isinstance(command, str) and command.startswith("python3 "):
+                    event_commands.append(command)
+        commands[event_name] = event_commands
+    return commands
+
+
+def _command_argv(command: str, extension_dir: Path) -> list[str]:
+    expanded = command.replace("${extensionPath}", str(extension_dir)).replace(
+        "${/}", os.sep
+    )
+    return shlex.split(expanded)
+
+
+def _event_argv(extension_dir: Path, event_name: str) -> list[str]:
+    commands = _manifest_hook_commands(extension_dir)[event_name]
+    assert len(commands) == 1
+    return _command_argv(commands[0], extension_dir)
+
+
+def _ensure_agent_sec_cli(env: dict[str, str], tmp_path: Path) -> None:
+    if shutil.which("agent-sec-cli", path=env.get("PATH")):
+        return
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    wrapper = wrapper_dir / "agent-sec-cli"
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import runpy\n"
+        'runpy.run_module("agent_sec_cli.cli", run_name="__main__")\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    env["PATH"] = f"{wrapper_dir}{os.pathsep}{env.get('PATH', '')}"
+
+
+def _run_hook(
+    extension_dir: Path,
+    input_data: dict,
+    *,
+    env: dict[str, str],
+    cwd: Path,
+) -> subprocess.CompletedProcess:
+    event_name = input_data["hook_event_name"]
+    return subprocess.run(
+        _event_argv(extension_dir, event_name),
+        input=json.dumps(input_data),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=env,
+        text=True,
+        timeout=15,
+    )
+
+
+def _payload(event_name: str, timestamp: str, **fields) -> dict:
+    return {
+        "session_id": "qwen-e2e-session",
+        "transcript_path": "/unused/qwen-e2e-transcript.jsonl",
+        "cwd": "/workspace",
+        "hook_event_name": event_name,
+        "timestamp": timestamp,
+        **fields,
+    }
+
+
+def test_qwen_manifest_hooks_are_directly_executable(tmp_path) -> None:
+    extension_dir = _extension_dir()
+    commands_by_event = _manifest_hook_commands(extension_dir)
+    assert set(commands_by_event) == {
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "StopFailure",
+    }
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env["AGENT_SEC_DATA_DIR"] = str(tmp_path / "agent-sec-data")
+
+    failed: list[str] = []
+    commands = sorted(
+        {
+            command
+            for event_commands in commands_by_event.values()
+            for command in event_commands
+        }
+    )
+    for command in commands:
+        proc = subprocess.run(
+            _command_argv(command, extension_dir),
+            input="{}\n",
+            capture_output=True,
+            check=False,
+            cwd=tmp_path,
+            env=env,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            failed.append(
+                f"{command}: exit={proc.returncode}, stderr={proc.stderr.strip()}"
+            )
+            continue
+        try:
+            output = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            failed.append(f"{command}: invalid stdout JSON: {exc}: {proc.stdout!r}")
+            continue
+        if output != {}:
+            failed.append(f"{command}: expected fail-open empty output, got {output!r}")
+
+    assert failed == []
+
+
+def test_qwen_observability_lifecycle_records_through_cli(tmp_path) -> None:
+    extension_dir = _extension_dir()
+    data_dir = tmp_path / "agent-sec-data"
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env["AGENT_SEC_DATA_DIR"] = str(data_dir)
+    _ensure_agent_sec_cli(env, tmp_path)
+
+    payloads = [
+        _payload(
+            "UserPromptSubmit",
+            "2026-07-14T10:00:00Z",
+            prompt="List repository files.",
+        ),
+        _payload(
+            "UserPromptSubmit",
+            "2026-07-14T10:00:01Z",
+            prompt="",
+        ),
+        _payload(
+            "PreToolUse",
+            "2026-07-14T10:00:02Z",
+            permission_mode="default",
+            tool_name="run_shell_command",
+            tool_input={"command": "pwd"},
+            tool_call_id="call-success",
+            tool_use_id="call-success",
+        ),
+        _payload(
+            "PostToolUse",
+            "2026-07-14T10:00:03Z",
+            permission_mode="default",
+            tool_name="run_shell_command",
+            tool_input={"command": "pwd"},
+            tool_call_id="call-success",
+            tool_use_id="call-success",
+            tool_response={"returnDisplay": {"stdout": "/workspace\n", "exitCode": 0}},
+        ),
+        _payload(
+            "Stop",
+            "2026-07-14T10:00:04Z",
+            stop_hook_active=False,
+            last_assistant_message="Done.",
+        ),
+        _payload(
+            "UserPromptSubmit",
+            "2026-07-14T10:01:00Z",
+            prompt="Run a failing command.",
+        ),
+        _payload(
+            "PreToolUse",
+            "2026-07-14T10:01:01Z",
+            permission_mode="default",
+            tool_name="run_shell_command",
+            tool_input={"command": "exit 1"},
+            tool_call_id="call-failure",
+            tool_use_id="call-failure",
+        ),
+        _payload(
+            "PostToolUseFailure",
+            "2026-07-14T10:01:02Z",
+            permission_mode="default",
+            tool_name="run_shell_command",
+            tool_input={"command": "exit 1"},
+            tool_call_id="call-failure",
+            tool_use_id="call-failure",
+            error="command failed",
+            is_interrupt=False,
+        ),
+        _payload(
+            "StopFailure",
+            "2026-07-14T10:01:03Z",
+            error="API_ERROR",
+            error_details="model request failed",
+            last_assistant_message="",
+        ),
+    ]
+
+    for payload in payloads:
+        proc = _run_hook(extension_dir, payload, env=env, cwd=tmp_path)
+        assert proc.returncode == 0, proc.stderr
+        assert json.loads(proc.stdout) == {}
+
+    records = [
+        json.loads(line)
+        for line in (data_dir / "observability.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert [record["hook"] for record in records] == [
+        "before_agent_run",
+        "before_tool_call",
+        "after_tool_call",
+        "after_agent_run",
+        "before_agent_run",
+        "before_tool_call",
+        "after_tool_call",
+        "after_agent_run",
+    ]
+    assert [
+        record["metrics"]["prompt"]
+        for record in records
+        if record["hook"] == "before_agent_run"
+    ] == [
+        "List repository files.",
+        "Run a failing command.",
+    ]
+    assert {record["metadata"]["runId"] for record in records} == {_ZERO_RUN_ID}
+    assert [
+        record["metadata"]["toolCallId"]
+        for record in records
+        if "toolCallId" in record["metadata"]
+    ] == ["call-success", "call-success", "call-failure", "call-failure"]
+    assert [
+        record["metrics"]["status"]
+        for record in records
+        if record["hook"] == "after_tool_call"
+    ] == ["success", "error"]
+    assert [
+        record["metrics"]["success"]
+        for record in records
+        if record["hook"] == "after_agent_run"
+    ] == [True, False]
+    assert not (data_dir / "qwen-code-extension").exists()

--- a/src/agent-sec-core/tests/e2e/qwen-code-extension/test_qwen_direct_hook_execution.py
+++ b/src/agent-sec-core/tests/e2e/qwen-code-extension/test_qwen_direct_hook_execution.py
@@ -1,4 +1,4 @@
-"""E2E checks for Qwen Code extension command-hook execution."""
+"""E2E checks for Qwen Code command-hook execution."""
 
 import json
 import os

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_observability_hook.py
@@ -371,6 +371,49 @@ def test_main_invalid_json_returns_noop_without_cli(monkeypatch, capsys):
     assert json.loads(capsys.readouterr().out) == {}
 
 
+def test_main_oversized_payload_is_diagnosed_and_fail_open(monkeypatch, capsys):
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    payload = b"alice@example.com" + b"x" * observability_hook._MAX_PAYLOAD_SIZE
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload)))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == (
+        "observability-hook: hook input exceeds "
+        f"{observability_hook._MAX_PAYLOAD_SIZE} bytes; skipping event\n"
+    )
+    assert "alice@example.com" not in captured.err
+
+
+def test_main_payload_at_size_limit_is_processed(monkeypatch, capsys):
+    prefix = (
+        b'{"hook_event_name":"UserPromptSubmit",'
+        b'"session_id":"session-123","run_id":"run-123",'
+        b'"prompt":"hello","padding":"'
+    )
+    suffix = b'"}'
+    padding_size = observability_hook._MAX_PAYLOAD_SIZE - len(prefix) - len(suffix)
+    payload = prefix + b"x" * padding_size + suffix
+    records = []
+    assert len(payload) == observability_hook._MAX_PAYLOAD_SIZE
+
+    monkeypatch.setattr(observability_hook, "_record_observability", records.append)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload)))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == ""
+    assert len(records) == 1
+    assert records[0]["metrics"]["prompt"] == "hello"
+
+
 @pytest.mark.parametrize(
     "subprocess_result",
     (

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_deploy_script.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_deploy_script.py
@@ -1,0 +1,173 @@
+"""Tests for the Qwen Code extension deployment script."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+_EXTENSION_DIR = _ROOT / "qwen-code-extension"
+_DEPLOY_SCRIPT = _EXTENSION_DIR / "scripts" / "deploy.sh"
+
+
+def _write_executable(path, content):
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def _fake_qwen(path):
+    _write_executable(
+        path,
+        """#!/usr/bin/env python3
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+if args == ["--version"]:
+    print("0.19.9")
+    raise SystemExit(0)
+
+log_path = Path(os.environ["QWEN_TEST_LOG"])
+with log_path.open("a", encoding="utf-8") as stream:
+    stream.write(json.dumps(args) + "\\n")
+
+home = Path(os.environ["QWEN_HOME"])
+if args[:2] == ["extensions", "install"]:
+    source = Path(args[2]).resolve()
+    manifest = json.loads((source / "qwen-extension.json").read_text())
+    target = home / "extensions" / manifest["name"]
+    shutil.copytree(source, target)
+    (target / ".qwen-extension-install.json").write_text(
+        json.dumps({"type": "local", "source": str(source)})
+    )
+elif args[:2] == ["extensions", "update"]:
+    target = home / "extensions" / args[2]
+    metadata = json.loads((target / ".qwen-extension-install.json").read_text())
+    source = Path(metadata["source"])
+    shutil.rmtree(target)
+    shutil.copytree(source, target)
+    (target / ".qwen-extension-install.json").write_text(json.dumps(metadata))
+elif args[:2] == ["extensions", "enable"]:
+    pass
+else:
+    raise SystemExit(f"unexpected qwen invocation: {args}")
+""",
+    )
+
+
+def _run_deploy(tmp_path, extension_dir, *, node_version="v22.0.0"):
+    fake_qwen = tmp_path / "qwen"
+    fake_cli = tmp_path / "agent-sec-cli"
+    fake_node = tmp_path / "node"
+    qwen_home = tmp_path / "qwen-home"
+    log_path = tmp_path / "qwen.log"
+    if log_path.exists():
+        log_path.unlink()
+    _fake_qwen(fake_qwen)
+    _write_executable(fake_cli, "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(fake_node, f"#!/usr/bin/env bash\necho {node_version}\n")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "QWEN_BIN": str(fake_qwen),
+            "QWEN_HOME": str(qwen_home),
+            "QWEN_TEST_LOG": str(log_path),
+            "PATH": f"{tmp_path}:{env['PATH']}",
+        }
+    )
+    result = subprocess.run(
+        [str(_DEPLOY_SCRIPT), str(extension_dir)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    calls = (
+        [json.loads(line) for line in log_path.read_text().splitlines()]
+        if log_path.exists()
+        else []
+    )
+    return result, calls, qwen_home
+
+
+def test_fresh_deploy_installs_and_enables_user_scope(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+
+    result, calls, qwen_home = _run_deploy(tmp_path, source)
+
+    manifest = json.loads((source / "qwen-extension.json").read_text())
+    target = qwen_home / "extensions" / manifest["name"]
+    assert result.returncode == 0, result.stderr
+    assert calls == [
+        ["extensions", "install", str(source), "--consent", "--scope", "user"],
+        ["extensions", "enable", "--scope", "user", manifest["name"]],
+    ]
+    assert json.loads((target / "qwen-extension.json").read_text())["version"] == (
+        manifest["version"]
+    )
+
+
+def test_deploy_updates_when_manifest_version_changes(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+    manifest = json.loads((source / "qwen-extension.json").read_text())
+    qwen_home = tmp_path / "qwen-home"
+    target = qwen_home / "extensions" / manifest["name"]
+    shutil.copytree(source, target)
+    installed_manifest = dict(manifest)
+    installed_manifest["version"] = "0.7.0"
+    (target / "qwen-extension.json").write_text(json.dumps(installed_manifest))
+    (target / ".qwen-extension-install.json").write_text(
+        json.dumps({"type": "local", "source": str(source)})
+    )
+
+    result, calls, _ = _run_deploy(tmp_path, source)
+
+    assert result.returncode == 0, result.stderr
+    assert calls == [
+        ["extensions", "update", manifest["name"]],
+        ["extensions", "enable", "--scope", "user", manifest["name"]],
+    ]
+    assert json.loads((target / "qwen-extension.json").read_text())["version"] == (
+        manifest["version"]
+    )
+
+
+def test_deploy_is_idempotent_at_same_version(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+
+    first, _, _ = _run_deploy(tmp_path, source)
+    second, calls, _ = _run_deploy(tmp_path, source)
+
+    assert first.returncode == 0
+    assert second.returncode == 0, second.stderr
+    assert calls == [
+        [
+            "extensions",
+            "enable",
+            "--scope",
+            "user",
+            "agent-sec-core-qwen-code-extension",
+        ],
+    ]
+    assert "is already installed" in second.stdout
+
+
+def test_deploy_rejects_unsupported_node_before_install(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+
+    result, calls, qwen_home = _run_deploy(tmp_path, source, node_version="v18.19.1")
+
+    assert result.returncode == 1
+    assert calls == []
+    assert not (qwen_home / "extensions").exists()
+    assert "requires Node.js >=22; found v18.19.1" in result.stderr

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_deploy_script.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_deploy_script.py
@@ -16,20 +16,10 @@ def _write_executable(path, content):
     path.chmod(0o755)
 
 
-def _fake_qwen(path, *, version_output="0.19.9", extensions_help=None):
-    if extensions_help is None:
-        extensions_help = """qwen extensions <command>
-
-Manage Qwen Code extensions.
-
-Commands:
-  qwen extensions install <source>          Installs an extension.
-  qwen extensions update [<name>] [--all]   Updates extensions.
-  qwen extensions enable [--scope] <name>   Enables an extension.
-"""
+def _fake_qwen(path):
     _write_executable(
         path,
-        f"""#!/usr/bin/env python3
+        """#!/usr/bin/env python3
 import json
 import os
 import shutil
@@ -37,13 +27,6 @@ import sys
 from pathlib import Path
 
 args = sys.argv[1:]
-if args == ["--version"]:
-    print({version_output!r})
-    raise SystemExit(0)
-if args == ["extensions", "--help"]:
-    print({extensions_help!r})
-    raise SystemExit(0)
-
 log_path = Path(os.environ["QWEN_TEST_LOG"])
 with log_path.open("a", encoding="utf-8") as stream:
     stream.write(json.dumps(args) + "\\n")
@@ -55,7 +38,7 @@ if args[:2] == ["extensions", "install"]:
     target = home / "extensions" / manifest["name"]
     shutil.copytree(source, target)
     (target / ".qwen-extension-install.json").write_text(
-        json.dumps({{"type": "local", "source": str(source)}})
+        json.dumps({"type": "local", "source": str(source)})
     )
 elif args[:2] == ["extensions", "update"]:
     target = home / "extensions" / args[2]
@@ -67,39 +50,7 @@ elif args[:2] == ["extensions", "update"]:
 elif args[:2] == ["extensions", "enable"]:
     pass
 else:
-    raise SystemExit(f"unexpected qwen invocation: {{args}}")
-""",
-    )
-
-
-def _fake_agent_sec_cli(
-    path, *, version_output="agent-sec-cli 0.8.0", valid_schema=True
-):
-    mapping = (
-        {
-            "before_agent_run": "before-agent",
-            "before_tool_call": "before-tool",
-            "after_tool_call": "after-tool",
-            "after_agent_run": "after-agent",
-        }
-        if valid_schema
-        else {}
-    )
-    _write_executable(
-        path,
-        f"""#!/usr/bin/env python3
-import json
-import sys
-
-args = sys.argv[1:]
-if args == ["--version"]:
-    print({version_output!r})
-elif args == ["observability", "schema"]:
-    print(json.dumps({{"discriminator": {{"mapping": {mapping!r}}}}}))
-elif args in (["observability", "record", "--help"], ["scan-pii", "--help"]):
-    pass
-else:
-    raise SystemExit(f"unexpected agent-sec-cli invocation: {{args}}")
+    raise SystemExit(f"unexpected qwen invocation: {args}")
 """,
     )
 
@@ -108,30 +59,27 @@ def _run_deploy(
     tmp_path,
     extension_dir,
     *,
-    node_version="v22.0.0",
-    qwen_version="0.19.9",
-    qwen_extensions_help=None,
-    agent_sec_cli_version="agent-sec-cli 0.8.0",
-    valid_observability_schema=True,
+    qwen_available=True,
+    agent_sec_cli_available=True,
 ):
     fake_qwen = tmp_path / "qwen"
     fake_cli = tmp_path / "agent-sec-cli"
-    fake_node = tmp_path / "node"
+    support_bin = tmp_path / "support-bin"
     qwen_home = tmp_path / "qwen-home"
     log_path = tmp_path / "qwen.log"
     if log_path.exists():
         log_path.unlink()
-    _fake_qwen(
-        fake_qwen,
-        version_output=qwen_version,
-        extensions_help=qwen_extensions_help,
-    )
-    _fake_agent_sec_cli(
-        fake_cli,
-        version_output=agent_sec_cli_version,
-        valid_schema=valid_observability_schema,
-    )
-    _write_executable(fake_node, f"#!/usr/bin/env bash\necho {node_version}\n")
+    if qwen_available:
+        _fake_qwen(fake_qwen)
+    if agent_sec_cli_available:
+        _write_executable(fake_cli, "#!/usr/bin/env bash\nexit 0\n")
+    support_bin.mkdir(exist_ok=True)
+    for command_name in ("bash", "dirname", "python3"):
+        command_path = shutil.which(command_name)
+        assert command_path is not None
+        command_link = support_bin / command_name
+        if not command_link.exists():
+            command_link.symlink_to(command_path)
 
     env = os.environ.copy()
     env.update(
@@ -139,7 +87,7 @@ def _run_deploy(
             "QWEN_BIN": str(fake_qwen),
             "QWEN_HOME": str(qwen_home),
             "QWEN_TEST_LOG": str(log_path),
-            "PATH": f"{tmp_path}:{env['PATH']}",
+            "PATH": os.pathsep.join((str(tmp_path), str(support_bin))),
         }
     )
     result = subprocess.run(
@@ -223,73 +171,29 @@ def test_deploy_is_idempotent_at_same_version(tmp_path):
     assert "is already installed" in second.stdout
 
 
-def test_deploy_rejects_unsupported_node_before_install(tmp_path):
+def test_deploy_rejects_missing_qwen(tmp_path):
     source = tmp_path / "extension-source"
     shutil.copytree(_EXTENSION_DIR, source)
 
-    result, calls, qwen_home = _run_deploy(tmp_path, source, node_version="v18.19.1")
+    result, calls, qwen_home = _run_deploy(tmp_path, source, qwen_available=False)
 
     assert result.returncode == 1
     assert calls == []
     assert not (qwen_home / "extensions").exists()
-    assert "requires Node.js >=22; found v18.19.1" in result.stderr
+    assert "is not available in PATH" in result.stderr
 
 
-def test_deploy_rejects_unrecognized_qwen_version_output(tmp_path):
-    source = tmp_path / "extension-source"
-    shutil.copytree(_EXTENSION_DIR, source)
-
-    result, calls, qwen_home = _run_deploy(tmp_path, source, qwen_version="not-qwen")
-
-    assert result.returncode == 1
-    assert calls == []
-    assert not (qwen_home / "extensions").exists()
-    assert "unexpected qwen --version output" in result.stderr
-
-
-def test_deploy_rejects_qwen_without_required_extension_interface(tmp_path):
+def test_deploy_rejects_missing_agent_sec_cli(tmp_path):
     source = tmp_path / "extension-source"
     shutil.copytree(_EXTENSION_DIR, source)
 
     result, calls, qwen_home = _run_deploy(
         tmp_path,
         source,
-        qwen_extensions_help="unrelated extension command",
+        agent_sec_cli_available=False,
     )
 
     assert result.returncode == 1
     assert calls == []
     assert not (qwen_home / "extensions").exists()
-    assert "does not match the required Qwen Code interface" in result.stderr
-
-
-def test_deploy_rejects_unrecognized_agent_sec_cli_version_output(tmp_path):
-    source = tmp_path / "extension-source"
-    shutil.copytree(_EXTENSION_DIR, source)
-
-    result, calls, qwen_home = _run_deploy(
-        tmp_path,
-        source,
-        agent_sec_cli_version="0.8.0",
-    )
-
-    assert result.returncode == 1
-    assert calls == []
-    assert not (qwen_home / "extensions").exists()
-    assert "unexpected agent-sec-cli --version output" in result.stderr
-
-
-def test_deploy_rejects_incompatible_agent_sec_cli_observability_schema(tmp_path):
-    source = tmp_path / "extension-source"
-    shutil.copytree(_EXTENSION_DIR, source)
-
-    result, calls, qwen_home = _run_deploy(
-        tmp_path,
-        source,
-        valid_observability_schema=False,
-    )
-
-    assert result.returncode == 1
-    assert calls == []
-    assert not (qwen_home / "extensions").exists()
-    assert "observability schema is incompatible" in result.stderr
+    assert "agent-sec-cli is not available in PATH" in result.stderr

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_deploy_script.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_deploy_script.py
@@ -16,10 +16,20 @@ def _write_executable(path, content):
     path.chmod(0o755)
 
 
-def _fake_qwen(path):
+def _fake_qwen(path, *, version_output="0.19.9", extensions_help=None):
+    if extensions_help is None:
+        extensions_help = """qwen extensions <command>
+
+Manage Qwen Code extensions.
+
+Commands:
+  qwen extensions install <source>          Installs an extension.
+  qwen extensions update [<name>] [--all]   Updates extensions.
+  qwen extensions enable [--scope] <name>   Enables an extension.
+"""
     _write_executable(
         path,
-        """#!/usr/bin/env python3
+        f"""#!/usr/bin/env python3
 import json
 import os
 import shutil
@@ -28,7 +38,10 @@ from pathlib import Path
 
 args = sys.argv[1:]
 if args == ["--version"]:
-    print("0.19.9")
+    print({version_output!r})
+    raise SystemExit(0)
+if args == ["extensions", "--help"]:
+    print({extensions_help!r})
     raise SystemExit(0)
 
 log_path = Path(os.environ["QWEN_TEST_LOG"])
@@ -42,7 +55,7 @@ if args[:2] == ["extensions", "install"]:
     target = home / "extensions" / manifest["name"]
     shutil.copytree(source, target)
     (target / ".qwen-extension-install.json").write_text(
-        json.dumps({"type": "local", "source": str(source)})
+        json.dumps({{"type": "local", "source": str(source)}})
     )
 elif args[:2] == ["extensions", "update"]:
     target = home / "extensions" / args[2]
@@ -54,12 +67,53 @@ elif args[:2] == ["extensions", "update"]:
 elif args[:2] == ["extensions", "enable"]:
     pass
 else:
-    raise SystemExit(f"unexpected qwen invocation: {args}")
+    raise SystemExit(f"unexpected qwen invocation: {{args}}")
 """,
     )
 
 
-def _run_deploy(tmp_path, extension_dir, *, node_version="v22.0.0"):
+def _fake_agent_sec_cli(
+    path, *, version_output="agent-sec-cli 0.8.0", valid_schema=True
+):
+    mapping = (
+        {
+            "before_agent_run": "before-agent",
+            "before_tool_call": "before-tool",
+            "after_tool_call": "after-tool",
+            "after_agent_run": "after-agent",
+        }
+        if valid_schema
+        else {}
+    )
+    _write_executable(
+        path,
+        f"""#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+if args == ["--version"]:
+    print({version_output!r})
+elif args == ["observability", "schema"]:
+    print(json.dumps({{"discriminator": {{"mapping": {mapping!r}}}}}))
+elif args in (["observability", "record", "--help"], ["scan-pii", "--help"]):
+    pass
+else:
+    raise SystemExit(f"unexpected agent-sec-cli invocation: {{args}}")
+""",
+    )
+
+
+def _run_deploy(
+    tmp_path,
+    extension_dir,
+    *,
+    node_version="v22.0.0",
+    qwen_version="0.19.9",
+    qwen_extensions_help=None,
+    agent_sec_cli_version="agent-sec-cli 0.8.0",
+    valid_observability_schema=True,
+):
     fake_qwen = tmp_path / "qwen"
     fake_cli = tmp_path / "agent-sec-cli"
     fake_node = tmp_path / "node"
@@ -67,8 +121,16 @@ def _run_deploy(tmp_path, extension_dir, *, node_version="v22.0.0"):
     log_path = tmp_path / "qwen.log"
     if log_path.exists():
         log_path.unlink()
-    _fake_qwen(fake_qwen)
-    _write_executable(fake_cli, "#!/usr/bin/env bash\nexit 0\n")
+    _fake_qwen(
+        fake_qwen,
+        version_output=qwen_version,
+        extensions_help=qwen_extensions_help,
+    )
+    _fake_agent_sec_cli(
+        fake_cli,
+        version_output=agent_sec_cli_version,
+        valid_schema=valid_observability_schema,
+    )
     _write_executable(fake_node, f"#!/usr/bin/env bash\necho {node_version}\n")
 
     env = os.environ.copy()
@@ -171,3 +233,63 @@ def test_deploy_rejects_unsupported_node_before_install(tmp_path):
     assert calls == []
     assert not (qwen_home / "extensions").exists()
     assert "requires Node.js >=22; found v18.19.1" in result.stderr
+
+
+def test_deploy_rejects_unrecognized_qwen_version_output(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+
+    result, calls, qwen_home = _run_deploy(tmp_path, source, qwen_version="not-qwen")
+
+    assert result.returncode == 1
+    assert calls == []
+    assert not (qwen_home / "extensions").exists()
+    assert "unexpected qwen --version output" in result.stderr
+
+
+def test_deploy_rejects_qwen_without_required_extension_interface(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+
+    result, calls, qwen_home = _run_deploy(
+        tmp_path,
+        source,
+        qwen_extensions_help="unrelated extension command",
+    )
+
+    assert result.returncode == 1
+    assert calls == []
+    assert not (qwen_home / "extensions").exists()
+    assert "does not match the required Qwen Code interface" in result.stderr
+
+
+def test_deploy_rejects_unrecognized_agent_sec_cli_version_output(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+
+    result, calls, qwen_home = _run_deploy(
+        tmp_path,
+        source,
+        agent_sec_cli_version="0.8.0",
+    )
+
+    assert result.returncode == 1
+    assert calls == []
+    assert not (qwen_home / "extensions").exists()
+    assert "unexpected agent-sec-cli --version output" in result.stderr
+
+
+def test_deploy_rejects_incompatible_agent_sec_cli_observability_schema(tmp_path):
+    source = tmp_path / "extension-source"
+    shutil.copytree(_EXTENSION_DIR, source)
+
+    result, calls, qwen_home = _run_deploy(
+        tmp_path,
+        source,
+        valid_observability_schema=False,
+    )
+
+    assert result.returncode == 1
+    assert calls == []
+    assert not (qwen_home / "extensions").exists()
+    assert "observability schema is incompatible" in result.stderr

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
@@ -355,7 +355,7 @@ def test_redaction_failure_drops_sensitive_fields_but_keeps_hash(monkeypatch):
 
 def test_unexpected_processing_error_is_diagnosed_and_fail_open(monkeypatch, capsys):
     def fail_record(_record):
-        raise RuntimeError("writer exploded")
+        raise KeyError("alice@example.com")
 
     monkeypatch.setattr(observability_hook, "_record_observability", fail_record)
     monkeypatch.setattr(
@@ -369,9 +369,75 @@ def test_unexpected_processing_error_is_diagnosed_and_fail_open(monkeypatch, cap
     captured = capsys.readouterr()
     assert json.loads(captured.out) == {}
     assert captured.err == (
-        "qwen-observability-hook: unexpected error while processing "
-        "UserPromptSubmit: RuntimeError: writer exploded\n"
+        "qwen-observability-hook: unexpected KeyError while processing UserPromptSubmit\n"
     )
+    assert "alice@example.com" not in captured.err
+
+
+def test_unexpected_processing_error_does_not_log_untrusted_event_name(
+    monkeypatch, capsys
+):
+    def fail_build(_input_data):
+        raise KeyError("secret-value")
+
+    monkeypatch.setattr(observability_hook, "_build_record", fail_build)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "alice@example.com"})),
+    )
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == (
+        "qwen-observability-hook: unexpected KeyError while processing unknown\n"
+    )
+    assert "alice@example.com" not in captured.err
+    assert "secret-value" not in captured.err
+
+
+def test_oversized_payload_is_diagnosed_and_fail_open(monkeypatch, capsys):
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    payload = b"alice@example.com" + b"x" * observability_hook._MAX_PAYLOAD_SIZE
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload)))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == (
+        "qwen-observability-hook: hook input exceeds "
+        f"{observability_hook._MAX_PAYLOAD_SIZE} bytes; skipping event\n"
+    )
+    assert "alice@example.com" not in captured.err
+
+
+def test_payload_at_size_limit_is_processed(monkeypatch, capsys):
+    prefix = (
+        b'{"hook_event_name":"UserPromptSubmit",'
+        b'"session_id":"session-123","prompt":"'
+    )
+    suffix = b'"}'
+    prompt_size = observability_hook._MAX_PAYLOAD_SIZE - len(prefix) - len(suffix)
+    payload = prefix + b"x" * prompt_size + suffix
+    records = []
+    assert len(payload) == observability_hook._MAX_PAYLOAD_SIZE
+
+    monkeypatch.setattr(observability_hook, "_record_observability", records.append)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload)))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == ""
+    assert len(records) == 1
+    assert len(records[0]["metrics"]["prompt"]) == prompt_size
 
 
 def test_invalid_json_returns_noop_without_cli(monkeypatch, capsys):

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
@@ -1,0 +1,400 @@
+"""Unit tests for the Qwen Code observability command hook."""
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[3]
+_EXTENSION_DIR = _ROOT / "qwen-code-extension"
+_HOOK_PATH = _EXTENSION_DIR / "hooks" / "observability_hook.py"
+sys.path.insert(0, str(_HOOK_PATH.parent))
+
+
+def _load_observability_hook():
+    spec = importlib.util.spec_from_file_location("qwen_observability_hook", _HOOK_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+observability_hook = _load_observability_hook()
+
+_TS = "2026-07-14T10:00:00Z"
+
+
+@pytest.fixture(autouse=True)
+def _qwen_environment(monkeypatch):
+    monkeypatch.setenv("QWEN_CODE_SESSION_ID", "env-session")
+    monkeypatch.setenv("QWEN_CODE_PROMPT_ID", "prompt-run-123")
+
+
+def _base(hook_event_name, **overrides):
+    payload = {
+        "hook_event_name": hook_event_name,
+        "session_id": "session-123",
+        "transcript_path": "/tmp/qwen-transcript.jsonl",
+        "cwd": "/workspace",
+        "timestamp": _TS,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _record(input_data):
+    record = observability_hook._build_record(input_data)
+    assert record is not None
+    assert record["metadata"]["runId"] == observability_hook._ZERO_RUN_ID
+    return record
+
+
+def test_user_prompt_submit_maps_prompt_with_zero_run_id():
+    record = _record(_base("UserPromptSubmit", prompt="Summarize this repository."))
+
+    assert record == {
+        "hook": "before_agent_run",
+        "observedAt": _TS,
+        "metadata": {
+            "sessionId": "session-123",
+            "runId": observability_hook._ZERO_RUN_ID,
+        },
+        "metrics": {
+            "prompt": "Summarize this repository.",
+            "user_input": "Summarize this repository.",
+            "pii_scan_input_sha256": observability_hook.text_sha256(
+                "Summarize this repository."
+            ),
+        },
+    }
+
+
+@pytest.mark.parametrize("prompt", (None, "", "   \n"))
+def test_user_prompt_submit_skips_empty_tool_result_reentry(prompt):
+    payload = _base("UserPromptSubmit")
+    if prompt is not None:
+        payload["prompt"] = prompt
+
+    assert observability_hook._build_record(payload) is None
+
+
+def test_run_id_ignores_prompt_context():
+    record = _record(_base("UserPromptSubmit", prompt="hello"))
+
+    assert record["metadata"] == {
+        "sessionId": "session-123",
+        "runId": observability_hook._ZERO_RUN_ID,
+    }
+
+
+def test_session_id_falls_back_to_qwen_environment():
+    payload = _base("UserPromptSubmit", prompt="hello")
+    payload.pop("session_id")
+
+    record = _record(payload)
+
+    assert record["metadata"]["sessionId"] == "env-session"
+
+
+def test_pre_tool_use_prefers_tool_call_id_and_hashes_parameters():
+    tool_input = {"command": "pwd"}
+    record = _record(
+        _base(
+            "PreToolUse",
+            permission_mode="default",
+            tool_name="run_shell_command",
+            tool_input=tool_input,
+            tool_call_id="tool-call-123",
+            tool_use_id="tool-use-123",
+        )
+    )
+
+    assert record["hook"] == "before_tool_call"
+    assert record["metadata"]["toolCallId"] == "tool-call-123"
+    assert record["metrics"] == {
+        "tool_name": "run_shell_command",
+        "parameters": tool_input,
+        "pii_scan_input_sha256": observability_hook.text_sha256(
+            observability_hook.value_to_text(tool_input)
+        ),
+    }
+
+
+def test_post_tool_use_maps_nested_exit_code_and_result():
+    tool_response = {
+        "llmContent": "ok",
+        "returnDisplay": {"stdout": "ok\n", "exitCode": 0},
+    }
+    record = _record(
+        _base(
+            "PostToolUse",
+            permission_mode="default",
+            tool_name="run_shell_command",
+            tool_input={"command": "echo ok"},
+            tool_use_id="tool-use-123",
+            tool_response=tool_response,
+        )
+    )
+
+    assert record["hook"] == "after_tool_call"
+    assert record["metadata"]["toolCallId"] == "tool-use-123"
+    assert record["metrics"]["status"] == "success"
+    assert record["metrics"]["result"] == tool_response
+    assert record["metrics"]["exit_code"] == 0
+    assert record["metrics"]["result_size_bytes"] > 0
+
+
+@pytest.mark.parametrize(
+    ("is_interrupt", "expected_status"),
+    ((True, "interrupted"), (False, "error"), (None, "error")),
+)
+def test_post_tool_use_failure_maps_status(is_interrupt, expected_status):
+    payload = _base(
+        "PostToolUseFailure",
+        permission_mode="default",
+        tool_name="run_shell_command",
+        tool_input={"command": "exit 1"},
+        tool_use_id="tool-use-123",
+        error="sandbox denied",
+    )
+    if is_interrupt is not None:
+        payload["is_interrupt"] = is_interrupt
+
+    record = _record(payload)
+
+    assert record["hook"] == "after_tool_call"
+    assert record["metrics"]["status"] == expected_status
+    assert record["metrics"]["error"] == "sandbox denied"
+
+
+def test_stop_maps_successful_agent_run():
+    record = _record(
+        _base(
+            "Stop",
+            stop_hook_active=False,
+            last_assistant_message="Done.",
+            context_usage=0.4,
+            context_limit=131072,
+            input_tokens=52428,
+            background_tasks=[],
+            crons=[],
+        )
+    )
+
+    assert record["hook"] == "after_agent_run"
+    assert record["metrics"] == {
+        "response": "Done.",
+        "output_kind": "text",
+        "assistant_texts_count": 1,
+        "success": True,
+    }
+
+
+def test_stop_failure_maps_error_details():
+    record = _record(
+        _base(
+            "StopFailure",
+            error="TURN_LIMIT",
+            error_details="maximum turns reached",
+            last_assistant_message="Partial answer",
+        )
+    )
+
+    assert record["hook"] == "after_agent_run"
+    assert record["metrics"] == {
+        "error": "maximum turns reached",
+        "output_kind": "text",
+        "success": False,
+        "response": "Partial answer",
+        "assistant_texts_count": 1,
+        "stop_reason": "TURN_LIMIT",
+    }
+
+
+def test_missing_required_correlation_returns_none(monkeypatch):
+    monkeypatch.delenv("QWEN_CODE_SESSION_ID")
+    assert (
+        observability_hook._build_record(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "timestamp": _TS,
+                "prompt": "hello",
+            }
+        )
+        is None
+    )
+    assert (
+        observability_hook._build_record(
+            _base("PreToolUse", tool_name="shell", tool_input={})
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "event_name",
+    ("SessionStart", "SessionEnd", "PreCompact", "Notification"),
+)
+def test_official_events_without_observability_schema_mapping_are_skipped(event_name):
+    assert observability_hook._build_record(_base(event_name)) is None
+
+
+def test_main_redacts_payload_and_emits_no_decision(monkeypatch, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if "scan-pii" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "redacted_text": kwargs["input"].replace(
+                            "alice@example.com", "a***@example.com"
+                        )
+                    }
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(_base("UserPromptSubmit", prompt="email alice@example.com"))
+        ),
+    )
+
+    observability_hook.main()
+
+    assert json.loads(capsys.readouterr().out) == {}
+    payload = json.loads(calls[-1][1]["input"])
+    payload_text = json.dumps(payload, ensure_ascii=False)
+    assert "alice@example.com" not in payload_text
+    assert "a***@example.com" in payload_text
+    assert calls[-1][0] == observability_hook._OBSERVABILITY_COMMAND
+
+
+def test_main_skips_empty_tool_result_reentry_without_local_state(monkeypatch, capsys):
+    records = []
+    monkeypatch.setattr(observability_hook, "_record_observability", records.append)
+
+    payloads = [
+        _base("UserPromptSubmit", prompt="first user prompt"),
+        _base("UserPromptSubmit", prompt=""),
+        _base("Stop", last_assistant_message="Done."),
+        _base("UserPromptSubmit", prompt="next user prompt"),
+    ]
+    for payload in payloads:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        observability_hook.main()
+
+    assert [record["hook"] for record in records] == [
+        "before_agent_run",
+        "after_agent_run",
+        "before_agent_run",
+    ]
+    assert [
+        record["metrics"]["prompt"]
+        for record in records
+        if record["hook"] == "before_agent_run"
+    ] == [
+        "first user prompt",
+        "next user prompt",
+    ]
+    assert [json.loads(line) for line in capsys.readouterr().out.splitlines()] == [
+        {},
+        {},
+        {},
+        {},
+    ]
+
+
+def test_main_records_user_prompts_from_each_session(monkeypatch, capsys):
+    records = []
+    monkeypatch.setattr(observability_hook, "_record_observability", records.append)
+
+    for session_id in ("session-a", "session-b"):
+        payload = _base("UserPromptSubmit", session_id=session_id, prompt=session_id)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        observability_hook.main()
+
+    assert [record["metadata"]["sessionId"] for record in records] == [
+        "session-a",
+        "session-b",
+    ]
+    assert [json.loads(line) for line in capsys.readouterr().out.splitlines()] == [
+        {},
+        {},
+    ]
+
+
+def test_redaction_failure_drops_sensitive_fields_but_keeps_hash(monkeypatch):
+    def fake_run(cmd, **_kwargs):
+        if "scan-pii" in cmd:
+            return SimpleNamespace(returncode=1, stdout="", stderr="failed")
+        raise AssertionError("record command is invoked separately")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fake_run)
+    record = _record(_base("UserPromptSubmit", prompt="alice@example.com"))
+
+    redacted = observability_hook._redact_observability_record(record)
+
+    assert "prompt" not in redacted["metrics"]
+    assert "user_input" not in redacted["metrics"]
+    assert redacted["metrics"]["pii_scan_input_sha256"]
+
+
+def test_invalid_json_returns_noop_without_cli(monkeypatch, capsys):
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not-json"))
+
+    observability_hook.main()
+
+    assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_non_object_json_returns_noop_without_cli(monkeypatch, capsys):
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("[]"))
+
+    observability_hook.main()
+
+    assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_manifest_mounts_only_supported_observability_events():
+    manifest = json.loads((_EXTENSION_DIR / "qwen-extension.json").read_text())
+    expected_events = {
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "StopFailure",
+    }
+
+    assert set(manifest["hooks"]) == expected_events
+    for entries in manifest["hooks"].values():
+        assert len(entries) == 1
+        hooks = entries[0]["hooks"]
+        assert len(hooks) == 1
+        assert hooks[0]["name"] == "agent-sec-observability"
+        assert hooks[0]["async"] is True
+        assert hooks[0]["command"] == (
+            'python3 "${extensionPath}${/}hooks${/}observability_hook.py"'
+        )

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
@@ -353,6 +353,27 @@ def test_redaction_failure_drops_sensitive_fields_but_keeps_hash(monkeypatch):
     assert redacted["metrics"]["pii_scan_input_sha256"]
 
 
+def test_unexpected_processing_error_is_diagnosed_and_fail_open(monkeypatch, capsys):
+    def fail_record(_record):
+        raise RuntimeError("writer exploded")
+
+    monkeypatch.setattr(observability_hook, "_record_observability", fail_record)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps(_base("UserPromptSubmit", prompt="hello"))),
+    )
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == (
+        "qwen-observability-hook: unexpected error while processing "
+        "UserPromptSubmit: RuntimeError: writer exploded\n"
+    )
+
+
 def test_invalid_json_returns_noop_without_cli(monkeypatch, capsys):
     def fail_run(*_args, **_kwargs):
         raise AssertionError("subprocess.run should not be called")


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Agent-sec-core plugin for new agent runtime qwen-code with observability hook.

Currently the runId source QWEN_CODE_PROMPT_ID is not accurate at ToolUse related hooks so manually set it as ZERO guid to prevent confusion.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
