### PR TITLE
docs(sight): add system build dependencies and check-deps.sh

### DIFF
--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -213,6 +213,36 @@ When finished, run `make build-frontend && cargo build --release` to embed the u
 
 ### Prerequisites
 
+#### System Packages
+
+Before building, install the required system packages:
+
+**Anolis OS / CentOS / RHEL:**
+```bash
+sudo yum install -y openssl-devel elfutils-libelf-devel perl-IPC-Cmd libbpf-devel clang llvm bpftool
+```
+
+**Ubuntu / Debian:**
+```bash
+sudo apt install -y pkg-config libssl-dev libelf-dev libbpf-dev clang llvm linux-tools-common
+```
+
+| Package | Required for |
+|---------|-------------|
+| `openssl-devel` | OpenSSL vendored build (used via `openssl = { features = ["vendored"] }`) |
+| `elfutils-libelf-devel` | libbpf-sys crate (provides `gelf.h`, `libelf.h`) |
+| `perl-IPC-Cmd` | OpenSSL source build (Perl IPC::Cmd module) |
+| `libbpf-devel` | eBPF program compilation and loading |
+| `clang` / `llvm` | eBPF C program compilation to BPF bytecode |
+| `bpftool` | eBPF skeleton generation |
+
+You can verify all dependencies with the included check script:
+```bash
+./scripts/check-deps.sh
+```
+
+#### Version Requirements
+
 | Component | Version |
 |-----------|---------|
 | Linux kernel | >= 5.8 (BTF support) |
@@ -224,6 +254,11 @@ When finished, run `make build-frontend && cargo build --release` to embed the u
 
 ```bash
 cd src/agentsight
+
+# Verify dependencies (optional but recommended)
+./scripts/check-deps.sh
+
+# Build
 cargo build --release
 ```
 

--- a/src/agentsight/README_CN.md
+++ b/src/agentsight/README_CN.md
@@ -202,6 +202,36 @@ agentsight serve --db /path/to/genai_events.db
 
 ### 环境要求
 
+#### 系统软件包
+
+构建前需安装以下系统软件包：
+
+**Anolis OS / CentOS / RHEL:**
+```bash
+sudo yum install -y openssl-devel elfutils-libelf-devel perl-IPC-Cmd libbpf-devel clang llvm bpftool
+```
+
+**Ubuntu / Debian:**
+```bash
+sudo apt install -y pkg-config libssl-dev libelf-dev libbpf-dev clang llvm linux-tools-common
+```
+
+| 软件包 | 用途 |
+|--------|------|
+| `openssl-devel` | OpenSSL 本地编译（通过 `openssl = { features = ["vendored"] }` 使用） |
+| `elfutils-libelf-devel` | libbpf-sys crate（提供 `gelf.h`、`libelf.h`） |
+| `perl-IPC-Cmd` | OpenSSL 源码构建（Perl IPC::Cmd 模块） |
+| `libbpf-devel` | eBPF 程序编译和加载 |
+| `clang` / `llvm` | eBPF C 程序编译为 BPF 字节码 |
+| `bpftool` | eBPF skeleton 生成 |
+
+可使用包含的依赖检查脚本验证：
+```bash
+./scripts/check-deps.sh
+```
+
+#### 版本要求
+
 | 组件 | 版本 |
 |------|------|
 | Linux 内核 | >= 5.8（需要 BTF 支持） |
@@ -213,6 +243,11 @@ agentsight serve --db /path/to/genai_events.db
 
 ```bash
 cd src/agentsight
+
+# 验证依赖（推荐）
+./scripts/check-deps.sh
+
+# 构建
 cargo build --release
 ```
 

--- a/src/agentsight/scripts/check-deps.sh
+++ b/src/agentsight/scripts/check-deps.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# check-deps.sh — Verify build dependencies for agentsight
+#
+# Usage: ./scripts/check-deps.sh
+#
+# Supports: Anolis OS / CentOS / RHEL / Fedora (rpm-based) and Ubuntu / Debian (dpkg-based)
+# Exit code 0 = all dependencies present, non-zero = missing dependencies.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+MISSING=0
+
+# Detect package manager and distribution
+detect_system() {
+    if command -v rpm &>/dev/null && command -v yum &>/dev/null; then
+        PM="rpm"
+        PKG_MGR="yum"
+    elif command -v dnf &>/dev/null; then
+        PM="rpm"
+        PKG_MGR="dnf"
+    elif command -v dpkg &>/dev/null && command -v apt &>/dev/null; then
+        PM="dpkg"
+        PKG_MGR="apt"
+    else
+        PM="unknown"
+        PKG_MGR="unknown"
+    fi
+    return 0
+}
+
+detect_system
+
+# Package name lookup: rpm-name => dpkg-name
+pkg_dpkg_name() {
+    local rpm_pkg="$1"
+    case "$rpm_pkg" in
+        openssl-devel)       echo "libssl-dev" ;;
+        elfutils-libelf-devel) echo "libelf-dev" ;;
+        perl-IPC-Cmd)        echo "perl" ;;
+        libbpf-devel)        echo "libbpf-dev" ;;
+        *)                   echo "$rpm_pkg" ;;
+    esac
+}
+
+check_cmd() {
+    local name="$1"
+    local hint="$2"
+    if command -v "$name" &>/dev/null; then
+        printf "  ${GREEN}OK${NC}    %s\n" "$name"
+    else
+        printf "  ${RED}MISS${NC} %s — %s\n" "$name" "$hint"
+        MISSING=$((MISSING + 1))
+    fi
+}
+
+check_pkg() {
+    local name="$1"
+    local rpm_pkg="$2"
+
+    if [ "$PM" = "rpm" ]; then
+        if rpm -q "$rpm_pkg" &>/dev/null 2>&1; then
+            local ver
+            ver=$(rpm -q --qf '%{VERSION}-%{RELEASE}' "$rpm_pkg" 2>/dev/null)
+            printf "  ${GREEN}OK${NC}    %s (rpm: %s)\n" "$name" "$ver"
+        else
+            printf "  ${RED}MISS${NC} %s — install with: sudo ${PKG_MGR} install -y %s\n" "$name" "$rpm_pkg"
+            MISSING=$((MISSING + 1))
+        fi
+    elif [ "$PM" = "dpkg" ]; then
+        local dpkg_name
+        dpkg_name=$(pkg_dpkg_name "$rpm_pkg")
+        if dpkg -s "$dpkg_name" &>/dev/null 2>&1; then
+            local ver
+            ver=$(dpkg -s "$dpkg_name" 2>/dev/null | grep '^Version:' | awk '{print $2}')
+            printf "  ${GREEN}OK${NC}    %s (dpkg: %s)\n" "$name" "$ver"
+        else
+            printf "  ${RED}MISS${NC} %s — install with: sudo ${PKG_MGR} install -y %s\n" "$name" "$dpkg_name"
+            MISSING=$((MISSING + 1))
+        fi
+    else
+        printf "  ${YELLOW}???${NC}  %s — unknown package manager, check manually\n" "$name"
+    fi
+}
+
+check_kernel_ver() {
+    local min_major="$1"
+    local min_minor="$2"
+    local ver
+    ver=$(uname -r | cut -d. -f1-2)
+    local major minor
+    major=$(echo "$ver" | cut -d. -f1)
+    minor=$(echo "$ver" | cut -d. -f2)
+    if [ "$major" -gt "$min_major" ] || ([ "$major" -eq "$min_major" ] && [ "$minor" -ge "$min_minor" ]); then
+        printf "  ${GREEN}OK${NC}    Linux kernel %s (%s)\n" "$(uname -r)" ">= ${min_major}.${min_minor}"
+    else
+        printf "  ${RED}FAIL${NC}  Linux kernel %s (need >= ${min_major}.${min_minor})\n" "$(uname -r)"
+        MISSING=$((MISSING + 1))
+    fi
+}
+
+check_btf() {
+    if [ -f /sys/kernel/btf/vmlinux ]; then
+        printf "  ${GREEN}OK${NC}    BTF support (/sys/kernel/btf/vmlinux)\n"
+    else
+        printf "  ${YELLOW}WARN${NC}  BTF not found — eBPF CO-RE may not work\n"
+    fi
+}
+
+pkg_install_hint() {
+    if [ "$PM" = "rpm" ]; then
+        echo "  sudo ${PKG_MGR} install -y openssl-devel elfutils-libelf-devel perl-IPC-Cmd libbpf-devel clang llvm bpftool"
+    elif [ "$PM" = "dpkg" ]; then
+        echo "  sudo apt install -y pkg-config libssl-dev libelf-dev perl libbpf-dev clang llvm linux-tools-common"
+    else
+        echo "  (unknown package manager — consult your distribution's documentation)"
+    fi
+}
+
+echo "agentsight build dependency check"
+echo "=================================="
+if [ "$PM" != "unknown" ]; then
+    printf "Detected: %s-based system (installer: %s)\n" "$PM" "$PKG_MGR"
+else
+    echo "Detected: unknown system"
+fi
+echo ""
+
+echo "System packages:"
+check_pkg "OpenSSL devel" "openssl-devel"
+check_pkg "libelf devel" "elfutils-libelf-devel"
+check_pkg "Perl IPC::Cmd" "perl-IPC-Cmd"
+check_pkg "libbpf devel" "libbpf-devel"
+echo ""
+
+echo "Build tools:"
+check_cmd "cargo" "install via https://rustup.rs"
+check_cmd "rustc" "install via https://rustup.rs"
+check_cmd "clang" "install with: sudo ${PKG_MGR} install -y clang"
+check_cmd "llvm-strip" "install with: sudo ${PKG_MGR} install -y llvm"
+pkg_install_cmd="$(pkg_install_hint | head -1 | sed 's/^  //')"
+check_cmd "bpftool" "install with: ${pkg_install_cmd% openssl*}" # just show the base install hint
+echo ""
+
+echo "Kernel:"
+check_kernel_ver 5 8
+check_btf
+echo ""
+
+echo "Rust toolchain:"
+RUSTC_VER=$(rustc --version 2>/dev/null | awk '{print $2}' || echo "N/A")
+printf "  rustc %s\n" "$RUSTC_VER"
+
+if [ "$MISSING" -gt 0 ]; then
+    echo ""
+    printf "${RED}%d dependency(s) missing.${NC}\n" "$MISSING"
+    echo ""
+    echo "Install missing dependencies:"
+    pkg_install_hint
+    exit 1
+else
+    echo ""
+    printf "${GREEN}All dependencies present. Ready to build.${NC}\n"
+    echo ""
+    echo "Next: cd src/agentsight && cargo build --release"
+    exit 0
+fi


### PR DESCRIPTION
## Summary\n\nAdd system package dependencies to agentsight README and provide a `check-deps.sh` script for automated dependency verification.\nCross-distribution: supports Anolis OS / CentOS / RHEL (rpm/yum) and Ubuntu / Debian (dpkg/apt).\n\n## Motivation\n\nWhen building agentsight from source on a fresh Anolis OS 8.8 system, the build fails due to missing system packages:\n- `openssl-devel` — OpenSSL vendored build needs Perl IPC::Cmd and OpenSSL headers\n- `elfutils-libelf-devel` — libbpf-sys needs `gelf.h` and `libelf.h`\n- `perl-IPC-Cmd` — OpenSSL source build requires Perl IPC::Cmd module\n- `libbpf-devel` — eBPF program compilation\n- `bpftool` — eBPF skeleton generation\n\nThese were discovered during the ANOLISA deployment experience report (2026-07-14).\n\n## Changes\n\n- **README.md**: Expanded Prerequisites section with system package table (Anolis/CentOS/RHEL and Ubuntu/Debian install commands)\n- **README_CN.md**: Synchronized Chinese version\n- **scripts/check-deps.sh**: New cross-distribution dependency verification script\n  - Detects rpm-based (yum/dnf) vs dpkg-based (apt) systems\n  - Maps package names between distributions (e.g. `openssl-devel` → `libssl-dev`)\n  - Checks system packages, build tools, kernel version, BTF support\n  - Colored PASS/MISS output with distribution-appropriate install hints\n\n## Testing\n\n- [x] Aliyun CI pre-check (v1): `cargo fmt --check` PASS, `cargo clippy` PASS, `cargo test --workspace` PASS\n- [x] Bishop review fix: `check-deps.sh` now cross-distribution (rpm + dpkg paths)\n- [x] All three missing dependencies confirmed installable via `yum` on Anolis OS 8.8\n\n## Aliyun CI Pre-check Report\n\n```\n=== Step 2: cargo fetch === PASS (0s)\n=== Step 3: cargo fmt --all -- --check === PASS (1s)\n=== Step 4: cargo clippy --workspace --all-targets --all-features -- -D warnings === PASS (171s)\n=== Step 5: cargo test --workspace --all-features === PASS (202s)\n```