### PR TITLE
revert(ci): use release token for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           COMPONENT="${{ needs.package.outputs.component }}"
           VERSION="${{ needs.package.outputs.version }}"


### PR DESCRIPTION
## Summary

Restore the dedicated `RELEASE_TOKEN` environment secret for GitHub Release creation.

## Why

The organization policy blocks the built-in `GITHUB_TOKEN` from accessing the Releases API. A classic PAT with the required scopes and organization authorization successfully published `anolisa/v0.2.5`.

## Validation

- `git diff --check`
- YAML parsing with Ruby
- Successful release job: https://github.com/alibaba/anolisa/actions/runs/29382665782/job/87261814201
- Published release: https://github.com/alibaba/anolisa/releases/tag/anolisa/v0.2.5
