### PR TITLE
fix(cosh): export COSH_SESSION_ID to subprocess env

### DIFF
--- a/src/copilot-shell/packages/cli/src/config/config.ts
+++ b/src/copilot-shell/packages/cli/src/config/config.ts
@@ -1109,6 +1109,15 @@ export async function loadCliConfig(
     }
   }
 
+  // Export the resolved session id so child processes (shell tool, MCP
+  // servers, user `!cmd` escapes) inherit COSH_SESSION_ID, enabling per-run
+  // cross-plane correlation with AgentSight. Idempotent: no-op when the id
+  // was already inherited from the parent env.
+  const resolvedSessionId = config.getSessionId();
+  if (resolvedSessionId) {
+    process.env['COSH_SESSION_ID'] = resolvedSessionId;
+  }
+
   return config;
 }
 


### PR DESCRIPTION
## Summary

`loadCliConfig` in `packages/cli/src/config/config.ts` reads `COSH_SESSION_ID` from the parent env (for `--continue` / `--resume` / inheritance precedence) but never writes the resolved id back to `process.env`. As a result, child processes spawned by cosh — the shell tool, MCP servers, user `!cmd` escapes — do **not** see `COSH_SESSION_ID` in their environment, defeating the per-run cross-plane correlation that the surrounding code comment claims to provide.

This PR writes the resolved id back to `process.env` right after `Config` is constructed. Idempotent — no-op when the id was already inherited from the parent env.

Refs: #1489

## Root cause

`packages/cli/src/config/config.ts` resolves the session id with precedence:

```
--continue / --resume  >  COSH_SESSION_ID env  >  minted uuid (Config constructor)
```

…then passes it to `new Config({ sessionId, ... })`. The only `COSH_SESSION_ID` reference in the codebase is the read at `config.ts:965`; there is no corresponding `process.env['COSH_SESSION_ID'] = sessionId` setter anywhere in `packages/cli` or `packages/core`. So:

- The cosh node process itself does not have `COSH_SESSION_ID` in its environ (environ is frozen at `exec` time, before the id is minted).
- Every child process cosh spawns inherits from `process.env`, which still lacks `COSH_SESSION_ID`.

## Reproduction

1. Install copilot-shell 2.7.0 RPM.
2. Launch the TUI: `cosh`
3. Drop into a shell escape: `!printenv COSH_SESSION_ID`

### Before fix

Result box is **empty**. Only `COSH_DATA_DIR` (set by the `/usr/bin/cosh` wrapper) is visible:

```
!env | grep ^COSH
COSH_DATA_DIR=/usr/share/copilot-shell
```

### After fix

Result box contains a stable UUID that matches the id used for the chat jsonl file under `~/.copilot-shell/`. Repeated invocations return the same value within a single cosh session.

## Verification

Applied the patch, rebuilt `copilot-shell-2.7.0-1.alnx4.x86_64.rpm`, reinstalled, and reran the reproduction. A regression test (TC-3.1: *子进程 `!printenv COSH_SESSION_ID` 存在且稳定*) that previously had to be marked `it.fails()` now passes; the remaining `it.fails()` in the same suite (TC-3.3) is blocked by a separate saved-session fixture problem, not by this export bug.

## Notes

This fix makes child subprocess environ carry `COSH_SESSION_ID`, which is what the code comment and downstream consumers (AgentSight) actually want. Scraping `/proc/<cosh_node_pid>/environ` directly still won't show the id (environ is frozen at exec); a wrapper-level fix would be needed if that is also desired, but that is out of scope here.

## Test plan

- [x] Rebuild copilot-shell RPM with patch
- [x] Install + rerun `!printenv COSH_SESSION_ID` reproduction — returns stable UUID
- [x] Re-run cosh `vitest` TC-3 suite — TC-3.1 now passes (was `it.fails()`)
- [ ] CI on this PR branch passes (typecheck / lint / unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)