### PR TITLE
perf(sec-core): isolate skill ledger worker

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
@@ -1,0 +1,135 @@
+"""Daemon handler for SkillFS change notifications."""
+
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.daemon.errors import BadRequestError, UnavailableError
+from agent_sec_cli.daemon.jobs.skill_ledger.activation import (
+    SKILL_LEDGER_ACTIVATION_JOB,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
+    SKILLFS_EVENT_KINDS,
+    SkillFsChange,
+)
+from agent_sec_cli.daemon.protocol import DaemonRequest
+from agent_sec_cli.daemon.registry import (
+    HandlerResult,
+    MethodRegistry,
+    MethodSpec,
+)
+from agent_sec_cli.daemon.runtime import DaemonRuntime
+
+METHOD_SKILLFS_NOTIFY_CHANGE = "skill_ledger.skillfs_notify_change"
+SCHEMA_VERSION = 1
+
+_SKILL_MANIFEST = "SKILL.md"
+_SKILL_META = ".skill-meta"
+
+
+def register_skill_ledger_methods(registry: MethodRegistry) -> None:
+    """Register the SkillFS notification method."""
+    registry.register(
+        MethodSpec(
+            method=METHOD_SKILLFS_NOTIFY_CHANGE,
+            handler=skillfs_notify_change_handler,
+            lifecycle="skill_ledger",
+            queue="skill_ledger",
+            timeout_ms=1000,
+            access_log=True,
+        )
+    )
+
+
+def skillfs_notify_change_handler(
+    request: DaemonRequest,
+    runtime: DaemonRuntime,
+) -> HandlerResult:
+    """Validate a SkillFS change notification and enqueue daemon processing."""
+    change = parse_skillfs_change(request.params)
+    if _paths_are_metadata_only(change.paths):
+        return HandlerResult(
+            data={
+                "schemaVersion": SCHEMA_VERSION,
+                "accepted": True,
+                "ignored": True,
+                "reason": "metadata-only change",
+                "skill": change.to_dict(),
+            }
+        )
+
+    job = runtime.jobs.get(SKILL_LEDGER_ACTIVATION_JOB)
+    if job is None or not hasattr(job, "enqueue"):
+        raise UnavailableError("skill-ledger activation job is not registered")
+    newly_queued = job.enqueue(change)
+    return HandlerResult(
+        data={
+            "schemaVersion": SCHEMA_VERSION,
+            "accepted": True,
+            "ignored": False,
+            "queued": True,
+            "coalesced": not newly_queued,
+            "skill": change.to_dict(),
+        }
+    )
+
+
+def parse_skillfs_change(params: dict[str, Any]) -> SkillFsChange:
+    """Validate daemon request params for a SkillFS change notification."""
+    schema_version = params.get("schemaVersion")
+    if schema_version != SCHEMA_VERSION:
+        raise BadRequestError("params.schemaVersion must be 1")
+
+    skill_dir = _validate_skill_dir(params.get("skillDir"))
+    skill_name = params.get("skillName")
+    if not isinstance(skill_name, str) or not skill_name:
+        raise BadRequestError("params.skillName must be a non-empty string")
+    if skill_name != skill_dir.name:
+        raise BadRequestError("params.skillName must match skillDir basename")
+
+    event_kind = params.get("eventKind")
+    if event_kind not in SKILLFS_EVENT_KINDS:
+        allowed = ", ".join(sorted(SKILLFS_EVENT_KINDS))
+        raise BadRequestError(f"params.eventKind must be one of: {allowed}")
+
+    paths = _validate_paths(params.get("paths"))
+    return SkillFsChange(
+        skill_dir=skill_dir,
+        skill_name=skill_name,
+        event_kinds={event_kind},
+        paths=set(paths),
+    )
+
+
+def _validate_skill_dir(value: Any) -> Path:
+    if not isinstance(value, str) or not value:
+        raise BadRequestError("params.skillDir must be a non-empty string")
+    path = Path(value)
+    if not path.is_absolute():
+        raise BadRequestError("params.skillDir must be an absolute path")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise BadRequestError(f"params.skillDir is not accessible: {exc}") from exc
+    if not resolved.is_dir():
+        raise BadRequestError("params.skillDir must be a directory")
+    if not (resolved / _SKILL_MANIFEST).is_file():
+        raise BadRequestError("params.skillDir must contain SKILL.md")
+    return resolved
+
+
+def _validate_paths(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise BadRequestError("params.paths must be a list")
+    paths: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise BadRequestError("params.paths must contain non-empty strings")
+        path = Path(item)
+        if not path.parts or path.is_absolute() or ".." in path.parts:
+            raise BadRequestError("params.paths must be relative paths under skillDir")
+        paths.append(item)
+    return paths
+
+
+def _paths_are_metadata_only(paths: set[str]) -> bool:
+    return bool(paths) and all(Path(path).parts[0] == _SKILL_META for path in paths)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
@@ -103,6 +103,8 @@ def parse_skillfs_change(params: dict[str, Any]) -> SkillFsChange:
 def _validate_skill_dir(value: Any) -> Path:
     if not isinstance(value, str) or not value:
         raise BadRequestError("params.skillDir must be a non-empty string")
+    if "\x00" in value:
+        raise BadRequestError("params.skillDir must not contain NUL characters")
     path = Path(value)
     if not path.is_absolute():
         raise BadRequestError("params.skillDir must be an absolute path")
@@ -124,6 +126,8 @@ def _validate_paths(value: Any) -> list[str]:
     for item in value:
         if not isinstance(item, str) or not item:
             raise BadRequestError("params.paths must contain non-empty strings")
+        if "\x00" in item:
+            raise BadRequestError("params.paths must not contain NUL characters")
         path = Path(item)
         if not path.parts or path.is_absolute() or ".." in path.parts:
             raise BadRequestError("params.paths must be relative paths under skillDir")

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/registry.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/registry.py
@@ -7,7 +7,7 @@ from agent_sec_cli.daemon.jobs.prompt_preload import (
     PromptModelPreloadJob,
     prompt_preload_enabled,
 )
-from agent_sec_cli.daemon.skill_ledger_activation import (
+from agent_sec_cli.daemon.jobs.skill_ledger import (
     SkillLedgerActivationJob,
 )
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/__init__.py
@@ -1,0 +1,15 @@
+"""Stable daemon-facing exports for the Skill Ledger job."""
+
+from agent_sec_cli.daemon.jobs.skill_ledger.activation import (
+    METHOD_SKILLFS_NOTIFY_CHANGE,
+    SKILL_LEDGER_ACTIVATION_JOB,
+    SkillLedgerActivationJob,
+    skillfs_notify_method_spec,
+)
+
+__all__ = [
+    "METHOD_SKILLFS_NOTIFY_CHANGE",
+    "SKILL_LEDGER_ACTIVATION_JOB",
+    "SkillLedgerActivationJob",
+    "skillfs_notify_method_spec",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/__init__.py
@@ -1,15 +1,11 @@
-"""Stable daemon-facing exports for the Skill Ledger job."""
+"""Stable exports for the Skill Ledger job."""
 
 from agent_sec_cli.daemon.jobs.skill_ledger.activation import (
-    METHOD_SKILLFS_NOTIFY_CHANGE,
     SKILL_LEDGER_ACTIVATION_JOB,
     SkillLedgerActivationJob,
-    skillfs_notify_method_spec,
 )
 
 __all__ = [
-    "METHOD_SKILLFS_NOTIFY_CHANGE",
     "SKILL_LEDGER_ACTIVATION_JOB",
     "SkillLedgerActivationJob",
-    "skillfs_notify_method_spec",
 ]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/activation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/activation.py
@@ -1,31 +1,19 @@
-"""Skill Ledger activation job and SkillFS notification handler."""
+"""Skill Ledger activation job scheduling."""
 
 import asyncio
 import contextlib
 from pathlib import Path
 from typing import Any
 
-from agent_sec_cli.daemon.errors import BadRequestError, UnavailableError
+from agent_sec_cli.daemon.errors import UnavailableError
 from agent_sec_cli.daemon.jobs.base import BackgroundJob, JobStatus, utc_now
-from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
-    SKILLFS_EVENT_KINDS,
-    SkillFsChange,
-)
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
 from agent_sec_cli.daemon.jobs.skill_ledger.worker_client import (
     SkillLedgerWorkerClient,
 )
-from agent_sec_cli.daemon.protocol import DaemonRequest
-from agent_sec_cli.daemon.registry import HandlerResult, MethodSpec
-from agent_sec_cli.daemon.runtime import DaemonRuntime
 
-METHOD_SKILLFS_NOTIFY_CHANGE = "skill_ledger.skillfs_notify_change"
-SCHEMA_VERSION = 1
 SKILL_LEDGER_ACTIVATION_JOB = "skill-ledger-activation"
 DEFAULT_DEBOUNCE_SECONDS = 0.5
-
-_SKILL_MANIFEST = "SKILL.md"
-_SKILL_META = ".skill-meta"
-_ALLOWED_EVENT_KINDS = SKILLFS_EVENT_KINDS
 
 
 class SkillLedgerActivationJob(BackgroundJob):
@@ -169,113 +157,6 @@ class SkillLedgerActivationJob(BackgroundJob):
         except Exception as exc:
             self._last_error = str(exc)
             self._state = "error"
-
-
-def skillfs_notify_change_handler(
-    request: DaemonRequest,
-    runtime: DaemonRuntime,
-) -> HandlerResult:
-    """Validate a SkillFS change notification and enqueue daemon processing."""
-    change = parse_skillfs_change(request.params)
-    if _paths_are_metadata_only(change.paths):
-        return HandlerResult(
-            data={
-                "schemaVersion": SCHEMA_VERSION,
-                "accepted": True,
-                "ignored": True,
-                "reason": "metadata-only change",
-                "skill": change.to_dict(),
-            }
-        )
-
-    job = runtime.jobs.get(SKILL_LEDGER_ACTIVATION_JOB)
-    if job is None or not hasattr(job, "enqueue"):
-        raise UnavailableError("skill-ledger activation job is not registered")
-    newly_queued = job.enqueue(change)
-    return HandlerResult(
-        data={
-            "schemaVersion": SCHEMA_VERSION,
-            "accepted": True,
-            "ignored": False,
-            "queued": True,
-            "coalesced": not newly_queued,
-            "skill": change.to_dict(),
-        }
-    )
-
-
-def skillfs_notify_method_spec() -> MethodSpec:
-    """Return the daemon method spec for SkillFS change notifications."""
-    return MethodSpec(
-        method=METHOD_SKILLFS_NOTIFY_CHANGE,
-        handler=skillfs_notify_change_handler,
-        lifecycle="skill_ledger",
-        queue="skill_ledger",
-        timeout_ms=1000,
-        access_log=True,
-    )
-
-
-def parse_skillfs_change(params: dict[str, Any]) -> SkillFsChange:
-    """Validate daemon request params for a SkillFS change notification."""
-    schema_version = params.get("schemaVersion")
-    if schema_version != SCHEMA_VERSION:
-        raise BadRequestError("params.schemaVersion must be 1")
-
-    skill_dir = _validate_skill_dir(params.get("skillDir"))
-    skill_name = params.get("skillName")
-    if not isinstance(skill_name, str) or not skill_name:
-        raise BadRequestError("params.skillName must be a non-empty string")
-    if skill_name != skill_dir.name:
-        raise BadRequestError("params.skillName must match skillDir basename")
-
-    event_kind = params.get("eventKind")
-    if event_kind not in _ALLOWED_EVENT_KINDS:
-        allowed = ", ".join(sorted(_ALLOWED_EVENT_KINDS))
-        raise BadRequestError(f"params.eventKind must be one of: {allowed}")
-
-    paths = _validate_paths(params.get("paths"))
-    return SkillFsChange(
-        skill_dir=skill_dir,
-        skill_name=skill_name,
-        event_kinds={event_kind},
-        paths=set(paths),
-    )
-
-
-def _validate_skill_dir(value: Any) -> Path:
-    if not isinstance(value, str) or not value:
-        raise BadRequestError("params.skillDir must be a non-empty string")
-    path = Path(value)
-    if not path.is_absolute():
-        raise BadRequestError("params.skillDir must be an absolute path")
-    try:
-        resolved = path.resolve(strict=True)
-    except OSError as exc:
-        raise BadRequestError(f"params.skillDir is not accessible: {exc}") from exc
-    if not resolved.is_dir():
-        raise BadRequestError("params.skillDir must be a directory")
-    if not (resolved / _SKILL_MANIFEST).is_file():
-        raise BadRequestError("params.skillDir must contain SKILL.md")
-    return resolved
-
-
-def _validate_paths(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        raise BadRequestError("params.paths must be a list")
-    paths: list[str] = []
-    for item in value:
-        if not isinstance(item, str) or not item:
-            raise BadRequestError("params.paths must contain non-empty strings")
-        path = Path(item)
-        if not path.parts or path.is_absolute() or ".." in path.parts:
-            raise BadRequestError("params.paths must be relative paths under skillDir")
-        paths.append(item)
-    return paths
-
-
-def _paths_are_metadata_only(paths: set[str]) -> bool:
-    return bool(paths) and all(Path(path).parts[0] == _SKILL_META for path in paths)
 
 
 def _resolve_managed_skill_dirs() -> list[Path]:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/activation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/activation.py
@@ -1,22 +1,19 @@
-"""Skill Ledger activation daemon job and SkillFS notification handler.
-
-This module intentionally keeps top-level imports light. Skill Ledger modules
-are imported inside worker paths so daemon health/registry construction stays
-cheap and does not initialize scanner or signing machinery.
-"""
+"""Skill Ledger activation job and SkillFS notification handler."""
 
 import asyncio
 import contextlib
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from agent_sec_cli.daemon.errors import BadRequestError, UnavailableError
 from agent_sec_cli.daemon.jobs.base import BackgroundJob, JobStatus, utc_now
+from agent_sec_cli.daemon.jobs.skill_ledger.processor import (
+    process_skill_change,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
 from agent_sec_cli.daemon.protocol import DaemonRequest
 from agent_sec_cli.daemon.registry import HandlerResult, MethodSpec
 from agent_sec_cli.daemon.runtime import DaemonRuntime
-from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 METHOD_SKILLFS_NOTIFY_CHANGE = "skill_ledger.skillfs_notify_change"
 SCHEMA_VERSION = 1
@@ -38,30 +35,6 @@ _ALLOWED_EVENT_KINDS = frozenset(
         "reconcile",
     }
 )
-
-
-@dataclass
-class SkillFsChange:
-    """Validated SkillFS change notification."""
-
-    skill_dir: Path
-    skill_name: str
-    event_kinds: set[str] = field(default_factory=set)
-    paths: set[str] = field(default_factory=set)
-
-    def merge(self, other: "SkillFsChange") -> None:
-        """Merge another notification for the same skill."""
-        self.event_kinds.update(other.event_kinds)
-        self.paths.update(other.paths)
-
-    def to_dict(self) -> dict[str, Any]:
-        """Return a JSON-serializable job/debug payload."""
-        return {
-            "skillDir": str(self.skill_dir),
-            "skillName": self.skill_name,
-            "eventKinds": sorted(self.event_kinds),
-            "paths": sorted(self.paths),
-        }
 
 
 class SkillLedgerActivationJob(BackgroundJob):
@@ -265,59 +238,6 @@ def parse_skillfs_change(params: dict[str, Any]) -> SkillFsChange:
     )
 
 
-def process_skill_change(change: SkillFsChange) -> dict[str, Any]:
-    """Run scan and activation resolution for a debounced SkillFS change."""
-    backend = _ensure_default_backend()
-    policy = _resolve_activation_policy()
-    scan_result: dict[str, Any] | None = None
-    scan_error: str | None = None
-    scan_exception: Exception | None = None
-    try:
-        scan_result = _scan_skill(str(change.skill_dir), backend)
-    except Exception as exc:
-        if _is_unresolved_live_root_error(exc):
-            return _skipped_unmanaged_result(change, str(exc))
-        scan_error = str(exc)
-        scan_exception = exc
-
-    try:
-        activation_result = _resolve_activation(str(change.skill_dir), backend, policy)
-    except Exception as exc:
-        if _is_unresolved_live_root_error(exc):
-            if scan_exception is None:
-                return _skipped_unmanaged_result(change, str(exc))
-            # A prior scanner failure is the health signal; keep it attached
-            # instead of downgrading the later live-root failure to skipped.
-            raise exc from scan_exception
-        if scan_exception is not None:
-            raise exc from scan_exception
-        raise
-    result: dict[str, Any] = {
-        "status": "processed" if scan_error is None else "error",
-        "skill": change.to_dict(),
-        "scan": scan_result,
-        "activation": activation_result,
-    }
-    if scan_error is not None:
-        result["error"] = scan_error
-    return result
-
-
-def _is_unresolved_live_root_error(exc: Exception) -> bool:
-    return isinstance(exc, UnresolvedLiveRootError)
-
-
-def _skipped_unmanaged_result(change: SkillFsChange, message: str) -> dict[str, Any]:
-    return {
-        "status": "skipped",
-        "reasonCode": "unmanaged_skill_root",
-        "message": message,
-        "skill": change.to_dict(),
-        "scan": None,
-        "activation": None,
-    }
-
-
 def _validate_skill_dir(value: Any) -> Path:
     if not isinstance(value, str) or not value:
         raise BadRequestError("params.skillDir must be a non-empty string")
@@ -351,43 +271,6 @@ def _validate_paths(value: Any) -> list[str]:
 
 def _paths_are_metadata_only(paths: set[str]) -> bool:
     return bool(paths) and all(Path(path).parts[0] == _SKILL_META for path in paths)
-
-
-def _ensure_default_backend() -> Any:
-    from agent_sec_cli.skill_ledger.signing.ed25519 import (  # noqa: PLC0415
-        NativeEd25519Backend,
-    )
-    from agent_sec_cli.skill_ledger.signing.key_manager import (  # noqa: PLC0415
-        keys_exist,
-    )
-
-    if not keys_exist():
-        NativeEd25519Backend().generate_keys(passphrase=None)
-    return NativeEd25519Backend()
-
-
-def _scan_skill(skill_dir: str, backend: Any) -> dict[str, Any]:
-    from agent_sec_cli.skill_ledger.core.certifier import (  # noqa: PLC0415
-        scan_skill,
-    )
-
-    return scan_skill(skill_dir, backend, force=False)
-
-
-def _resolve_activation(skill_dir: str, backend: Any, policy: str) -> dict[str, Any]:
-    from agent_sec_cli.skill_ledger.core.resolver import (  # noqa: PLC0415
-        resolve_activation,
-    )
-
-    return resolve_activation(skill_dir, backend, policy=policy)
-
-
-def _resolve_activation_policy() -> str:
-    from agent_sec_cli.skill_ledger.config import (  # noqa: PLC0415
-        resolve_activation_policy,
-    )
-
-    return resolve_activation_policy()
 
 
 def _resolve_managed_skill_dirs() -> list[Path]:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/activation.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/activation.py
@@ -7,10 +7,13 @@ from typing import Any
 
 from agent_sec_cli.daemon.errors import BadRequestError, UnavailableError
 from agent_sec_cli.daemon.jobs.base import BackgroundJob, JobStatus, utc_now
-from agent_sec_cli.daemon.jobs.skill_ledger.processor import (
-    process_skill_change,
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
+    SKILLFS_EVENT_KINDS,
+    SkillFsChange,
 )
-from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
+from agent_sec_cli.daemon.jobs.skill_ledger.worker_client import (
+    SkillLedgerWorkerClient,
+)
 from agent_sec_cli.daemon.protocol import DaemonRequest
 from agent_sec_cli.daemon.registry import HandlerResult, MethodSpec
 from agent_sec_cli.daemon.runtime import DaemonRuntime
@@ -22,19 +25,7 @@ DEFAULT_DEBOUNCE_SECONDS = 0.5
 
 _SKILL_MANIFEST = "SKILL.md"
 _SKILL_META = ".skill-meta"
-_ALLOWED_EVENT_KINDS = frozenset(
-    {
-        "mkdir",
-        "create",
-        "write",
-        "rename",
-        "unlink",
-        "rmdir",
-        "setattr",
-        "truncate",
-        "reconcile",
-    }
-)
+_ALLOWED_EVENT_KINDS = SKILLFS_EVENT_KINDS
 
 
 class SkillLedgerActivationJob(BackgroundJob):
@@ -42,7 +33,11 @@ class SkillLedgerActivationJob(BackgroundJob):
 
     name = SKILL_LEDGER_ACTIVATION_JOB
 
-    def __init__(self, debounce_seconds: float = DEFAULT_DEBOUNCE_SECONDS) -> None:
+    def __init__(
+        self,
+        debounce_seconds: float = DEFAULT_DEBOUNCE_SECONDS,
+        worker_client: SkillLedgerWorkerClient | None = None,
+    ) -> None:
         if debounce_seconds < 0:
             raise ValueError("debounce_seconds must be non-negative")
         self.debounce_seconds = debounce_seconds
@@ -53,6 +48,7 @@ class SkillLedgerActivationJob(BackgroundJob):
         self._last_error: str | None = None
         self._last_tick_at: str | None = None
         self._last_processed: dict[str, Any] | None = None
+        self._worker_client = worker_client or SkillLedgerWorkerClient()
 
     async def start(self) -> None:
         """Start the activation worker and enqueue startup reconciliation."""
@@ -65,20 +61,24 @@ class SkillLedgerActivationJob(BackgroundJob):
 
     async def stop(self) -> None:
         """Stop the activation worker."""
-        if self._task is not None:
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._task
-            self._task = None
-        self._wake_event = None
-        self._state = "stopped"
+        try:
+            if self._task is not None:
+                self._task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._task
+                self._task = None
+        finally:
+            await self._worker_client.stop()
+            self._wake_event = None
+            self._state = "stopped"
 
     def status(self) -> JobStatus:
         """Return current job status."""
+        last_error = self._last_error or self._worker_client.last_error
         return JobStatus(
             name=self.name,
-            state=self._state,
-            last_error=self._last_error,
+            state="error" if last_error and self._state == "running" else self._state,
+            last_error=last_error,
             last_tick_at=self._last_tick_at,
         )
 
@@ -99,6 +99,11 @@ class SkillLedgerActivationJob(BackgroundJob):
     def last_processed(self) -> dict[str, Any] | None:
         """Return the last processed result for tests and diagnostics."""
         return self._last_processed
+
+    @property
+    def worker_pid(self) -> int | None:
+        """Return the worker PID for diagnostics."""
+        return self._worker_client.pid
 
     async def _run_loop(self) -> None:
         while True:
@@ -134,7 +139,7 @@ class SkillLedgerActivationJob(BackgroundJob):
     async def _process_change(self, change: SkillFsChange) -> None:
         self._last_tick_at = utc_now()
         try:
-            result = await asyncio.to_thread(process_skill_change, change)
+            result = await self._worker_client.process_change(change)
             self._last_processed = result
             self._last_error = result.get("error")
             self._state = "error" if self._last_error else "running"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/processor.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/processor.py
@@ -1,0 +1,96 @@
+"""Synchronous Skill Ledger scan and activation processing."""
+
+from typing import Any
+
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
+from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
+
+
+def process_skill_change(change: SkillFsChange) -> dict[str, Any]:
+    """Run scan and activation resolution for a debounced SkillFS change."""
+    backend = _ensure_default_backend()
+    policy = _resolve_activation_policy()
+    scan_result: dict[str, Any] | None = None
+    scan_error: str | None = None
+    scan_exception: Exception | None = None
+    try:
+        scan_result = _scan_skill(str(change.skill_dir), backend)
+    except Exception as exc:
+        if _is_unresolved_live_root_error(exc):
+            return _skipped_unmanaged_result(change, str(exc))
+        scan_error = str(exc)
+        scan_exception = exc
+
+    try:
+        activation_result = _resolve_activation(str(change.skill_dir), backend, policy)
+    except Exception as exc:
+        if _is_unresolved_live_root_error(exc):
+            if scan_exception is None:
+                return _skipped_unmanaged_result(change, str(exc))
+            # A prior scanner failure is the health signal; keep it attached
+            # instead of downgrading the later live-root failure to skipped.
+            raise exc from scan_exception
+        if scan_exception is not None:
+            raise exc from scan_exception
+        raise
+    result: dict[str, Any] = {
+        "status": "processed" if scan_error is None else "error",
+        "skill": change.to_dict(),
+        "scan": scan_result,
+        "activation": activation_result,
+    }
+    if scan_error is not None:
+        result["error"] = scan_error
+    return result
+
+
+def _is_unresolved_live_root_error(exc: Exception) -> bool:
+    return isinstance(exc, UnresolvedLiveRootError)
+
+
+def _skipped_unmanaged_result(change: SkillFsChange, message: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "reasonCode": "unmanaged_skill_root",
+        "message": message,
+        "skill": change.to_dict(),
+        "scan": None,
+        "activation": None,
+    }
+
+
+def _ensure_default_backend() -> Any:
+    from agent_sec_cli.skill_ledger.signing.ed25519 import (  # noqa: PLC0415
+        NativeEd25519Backend,
+    )
+    from agent_sec_cli.skill_ledger.signing.key_manager import (  # noqa: PLC0415
+        keys_exist,
+    )
+
+    if not keys_exist():
+        NativeEd25519Backend().generate_keys(passphrase=None)
+    return NativeEd25519Backend()
+
+
+def _scan_skill(skill_dir: str, backend: Any) -> dict[str, Any]:
+    from agent_sec_cli.skill_ledger.core.certifier import (  # noqa: PLC0415
+        scan_skill,
+    )
+
+    return scan_skill(skill_dir, backend, force=False)
+
+
+def _resolve_activation(skill_dir: str, backend: Any, policy: str) -> dict[str, Any]:
+    from agent_sec_cli.skill_ledger.core.resolver import (  # noqa: PLC0415
+        resolve_activation,
+    )
+
+    return resolve_activation(skill_dir, backend, policy=policy)
+
+
+def _resolve_activation_policy() -> str:
+    from agent_sec_cli.skill_ledger.config import (  # noqa: PLC0415
+        resolve_activation_policy,
+    )
+
+    return resolve_activation_policy()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/protocol.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/protocol.py
@@ -1,8 +1,31 @@
-"""Data models shared by Skill Ledger activation scheduling and processing."""
+"""Validated NDJSON protocol for the Skill Ledger worker."""
 
+import json
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+WORKER_SCHEMA_VERSION = 1
+WORKER_PROCESS_CHANGE_METHOD = "process_change"
+MAX_WORKER_FRAME_BYTES = 4 * 1024 * 1024
+SKILLFS_EVENT_KINDS = frozenset(
+    {
+        "mkdir",
+        "create",
+        "write",
+        "rename",
+        "unlink",
+        "rmdir",
+        "setattr",
+        "truncate",
+        "reconcile",
+    }
+)
+
+
+class WorkerProtocolError(ValueError):
+    """Raised when a Skill Ledger worker frame violates the protocol."""
 
 
 @dataclass
@@ -27,3 +50,225 @@ class SkillFsChange:
             "eventKinds": sorted(self.event_kinds),
             "paths": sorted(self.paths),
         }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SkillFsChange":
+        """Validate and build a change received by the worker."""
+        skill_dir = payload.get("skillDir")
+        skill_name = payload.get("skillName")
+        event_kinds = payload.get("eventKinds")
+        paths = payload.get("paths")
+
+        if not isinstance(skill_dir, str) or not skill_dir:
+            raise WorkerProtocolError("change.skillDir must be a non-empty string")
+        if not Path(skill_dir).is_absolute():
+            raise WorkerProtocolError("change.skillDir must be an absolute path")
+        if not isinstance(skill_name, str) or not skill_name:
+            raise WorkerProtocolError("change.skillName must be a non-empty string")
+        if skill_name != Path(skill_dir).name:
+            raise WorkerProtocolError("change.skillName must match skillDir basename")
+        return cls(
+            skill_dir=Path(skill_dir),
+            skill_name=skill_name,
+            event_kinds=_event_kind_set(event_kinds),
+            paths=_relative_path_set(paths),
+        )
+
+
+@dataclass(frozen=True)
+class WorkerRequest:
+    """Validated request sent to the Skill Ledger worker."""
+
+    request_id: str
+    change: SkillFsChange
+
+
+@dataclass(frozen=True)
+class WorkerError:
+    """Structured worker execution error."""
+
+    error_type: str
+    message: str
+
+
+@dataclass(frozen=True)
+class WorkerResponse:
+    """Validated response returned by the Skill Ledger worker."""
+
+    request_id: str
+    ok: bool
+    result: dict[str, Any] | None = None
+    error: WorkerError | None = None
+
+
+def new_worker_request(change: SkillFsChange) -> WorkerRequest:
+    """Build a request with a daemon-owned correlation id."""
+    return WorkerRequest(request_id=str(uuid.uuid4()), change=change)
+
+
+def serialize_worker_request(request: WorkerRequest) -> bytes:
+    """Serialize one worker request as a bounded NDJSON frame."""
+    return _serialize_frame(
+        {
+            "schemaVersion": WORKER_SCHEMA_VERSION,
+            "requestId": request.request_id,
+            "method": WORKER_PROCESS_CHANGE_METHOD,
+            "change": request.change.to_dict(),
+        }
+    )
+
+
+def parse_worker_request(line: bytes) -> WorkerRequest:
+    """Parse and validate one worker request frame."""
+    payload = _decode_frame(line)
+    _validate_schema(payload)
+    request_id = _request_id(payload)
+    if payload.get("method") != WORKER_PROCESS_CHANGE_METHOD:
+        raise WorkerProtocolError(f"method must be {WORKER_PROCESS_CHANGE_METHOD!r}")
+    change = payload.get("change")
+    if not isinstance(change, dict):
+        raise WorkerProtocolError("change must be a JSON object")
+    return WorkerRequest(
+        request_id=request_id,
+        change=SkillFsChange.from_dict(change),
+    )
+
+
+def success_worker_response(
+    request_id: str,
+    result: dict[str, Any],
+) -> WorkerResponse:
+    """Build a successful worker response."""
+    return WorkerResponse(request_id=request_id, ok=True, result=result)
+
+
+def error_worker_response(
+    request_id: str,
+    exc: Exception,
+) -> WorkerResponse:
+    """Build a worker response for a processing exception."""
+    return WorkerResponse(
+        request_id=request_id,
+        ok=False,
+        error=WorkerError(error_type=type(exc).__name__, message=str(exc)),
+    )
+
+
+def serialize_worker_response(response: WorkerResponse) -> bytes:
+    """Serialize one worker response as a bounded NDJSON frame."""
+    payload: dict[str, Any] = {
+        "schemaVersion": WORKER_SCHEMA_VERSION,
+        "requestId": response.request_id,
+        "ok": response.ok,
+    }
+    if response.ok:
+        payload["result"] = response.result
+    elif response.error is not None:
+        payload["error"] = {
+            "type": response.error.error_type,
+            "message": response.error.message,
+        }
+    return _serialize_frame(payload)
+
+
+def parse_worker_response(line: bytes) -> WorkerResponse:
+    """Parse and validate one worker response frame."""
+    payload = _decode_frame(line)
+    _validate_schema(payload)
+    request_id = _request_id(payload)
+    ok = payload.get("ok")
+    if not isinstance(ok, bool):
+        raise WorkerProtocolError("ok must be a boolean")
+
+    if ok:
+        result = payload.get("result")
+        if not isinstance(result, dict):
+            raise WorkerProtocolError("result must be a JSON object")
+        return WorkerResponse(request_id=request_id, ok=True, result=result)
+
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        raise WorkerProtocolError("error must be a JSON object")
+    error_type = error.get("type")
+    message = error.get("message")
+    if not isinstance(error_type, str) or not error_type:
+        raise WorkerProtocolError("error.type must be a non-empty string")
+    if not isinstance(message, str):
+        raise WorkerProtocolError("error.message must be a string")
+    return WorkerResponse(
+        request_id=request_id,
+        ok=False,
+        error=WorkerError(error_type=error_type, message=message),
+    )
+
+
+def _decode_frame(line: bytes) -> dict[str, Any]:
+    if len(line) > MAX_WORKER_FRAME_BYTES:
+        raise WorkerProtocolError(
+            f"worker frame exceeds {MAX_WORKER_FRAME_BYTES} bytes"
+        )
+    stripped = line.strip()
+    if not stripped:
+        raise WorkerProtocolError("worker frame must not be empty")
+    try:
+        payload = json.loads(stripped.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise WorkerProtocolError("worker frame must be valid UTF-8") from exc
+    except json.JSONDecodeError as exc:
+        raise WorkerProtocolError("worker frame must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise WorkerProtocolError("worker frame must be a JSON object")
+    return payload
+
+
+def _serialize_frame(payload: dict[str, Any]) -> bytes:
+    try:
+        frame = (
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise WorkerProtocolError("worker payload must be JSON serializable") from exc
+    if len(frame) > MAX_WORKER_FRAME_BYTES:
+        raise WorkerProtocolError(
+            f"worker frame exceeds {MAX_WORKER_FRAME_BYTES} bytes"
+        )
+    return frame
+
+
+def _validate_schema(payload: dict[str, Any]) -> None:
+    if payload.get("schemaVersion") != WORKER_SCHEMA_VERSION:
+        raise WorkerProtocolError(f"schemaVersion must be {WORKER_SCHEMA_VERSION}")
+
+
+def _request_id(payload: dict[str, Any]) -> str:
+    request_id = payload.get("requestId")
+    if not isinstance(request_id, str) or not request_id:
+        raise WorkerProtocolError("requestId must be a non-empty string")
+    return request_id
+
+
+def _string_set(value: Any, field_name: str) -> set[str]:
+    if not isinstance(value, list):
+        raise WorkerProtocolError(f"{field_name} must be a list")
+    if any(not isinstance(item, str) or not item for item in value):
+        raise WorkerProtocolError(f"{field_name} must contain non-empty strings")
+    return set(value)
+
+
+def _event_kind_set(value: Any) -> set[str]:
+    event_kinds = _string_set(value, "change.eventKinds")
+    if not event_kinds or not event_kinds.issubset(SKILLFS_EVENT_KINDS):
+        allowed = ", ".join(sorted(SKILLFS_EVENT_KINDS))
+        raise WorkerProtocolError(f"change.eventKinds must contain only: {allowed}")
+    return event_kinds
+
+
+def _relative_path_set(value: Any) -> set[str]:
+    paths = _string_set(value, "change.paths")
+    for item in paths:
+        path = Path(item)
+        if not path.parts or path.is_absolute() or ".." in path.parts:
+            raise WorkerProtocolError(
+                "change.paths must contain relative paths under skillDir"
+            )
+    return paths

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/protocol.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/protocol.py
@@ -61,6 +61,8 @@ class SkillFsChange:
 
         if not isinstance(skill_dir, str) or not skill_dir:
             raise WorkerProtocolError("change.skillDir must be a non-empty string")
+        if "\x00" in skill_dir:
+            raise WorkerProtocolError("change.skillDir must not contain NUL characters")
         if not Path(skill_dir).is_absolute():
             raise WorkerProtocolError("change.skillDir must be an absolute path")
         if not isinstance(skill_name, str) or not skill_name:
@@ -266,6 +268,8 @@ def _event_kind_set(value: Any) -> set[str]:
 def _relative_path_set(value: Any) -> set[str]:
     paths = _string_set(value, "change.paths")
     for item in paths:
+        if "\x00" in item:
+            raise WorkerProtocolError("change.paths must not contain NUL characters")
         path = Path(item)
         if not path.parts or path.is_absolute() or ".." in path.parts:
             raise WorkerProtocolError(

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/protocol.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/protocol.py
@@ -1,0 +1,29 @@
+"""Data models shared by Skill Ledger activation scheduling and processing."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class SkillFsChange:
+    """Validated SkillFS change notification."""
+
+    skill_dir: Path
+    skill_name: str
+    event_kinds: set[str] = field(default_factory=set)
+    paths: set[str] = field(default_factory=set)
+
+    def merge(self, other: "SkillFsChange") -> None:
+        """Merge another notification for the same skill."""
+        self.event_kinds.update(other.event_kinds)
+        self.paths.update(other.paths)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable job/debug payload."""
+        return {
+            "skillDir": str(self.skill_dir),
+            "skillName": self.skill_name,
+            "eventKinds": sorted(self.event_kinds),
+            "paths": sorted(self.paths),
+        }

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/worker.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/worker.py
@@ -1,0 +1,58 @@
+"""Persistent child-process entry point for Skill Ledger processing."""
+
+import os
+import sys
+import traceback
+from typing import BinaryIO
+
+from agent_sec_cli.daemon.jobs.skill_ledger.processor import (
+    process_skill_change,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
+    MAX_WORKER_FRAME_BYTES,
+    WorkerProtocolError,
+    error_worker_response,
+    parse_worker_request,
+    serialize_worker_response,
+    success_worker_response,
+)
+
+
+def _main() -> int:
+    # Keep the protocol pipe private from scanner and native-library output.
+    protocol_fd = os.dup(sys.stdout.fileno())
+    os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+    with os.fdopen(protocol_fd, "wb") as protocol_stdout:
+        return _run(protocol_stdout)
+
+
+def _run(protocol_stdout: BinaryIO) -> int:
+    while True:
+        line = sys.stdin.buffer.readline(MAX_WORKER_FRAME_BYTES + 1)
+        if not line:
+            return 0
+
+        try:
+            request = parse_worker_request(line)
+        except WorkerProtocolError as exc:
+            print(f"invalid Skill Ledger worker request: {exc}", file=sys.stderr)
+            return 2
+
+        try:
+            result = process_skill_change(request.change)
+            response = success_worker_response(request.request_id, result)
+        except Exception as exc:
+            traceback.print_exc(file=sys.stderr)
+            response = error_worker_response(request.request_id, exc)
+
+        try:
+            frame = serialize_worker_response(response)
+        except WorkerProtocolError as exc:
+            print(f"invalid Skill Ledger worker response: {exc}", file=sys.stderr)
+            return 2
+        protocol_stdout.write(frame)
+        protocol_stdout.flush()
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/worker_client.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/worker_client.py
@@ -15,6 +15,7 @@ from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
 )
 
 _WORKER_MODULE = "agent_sec_cli.daemon.jobs.skill_ledger.worker"
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 300.0
 _GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 2.0
 _TERMINATE_TIMEOUT_SECONDS = 5.0
 _MAX_STDERR_BYTES = 64 * 1024
@@ -39,7 +40,13 @@ class SkillLedgerWorkerExecutionError(SkillLedgerWorkerError):
 class SkillLedgerWorkerClient:
     """Own one lazily started, serial Skill Ledger worker process."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        request_timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        if request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be positive")
+        self._request_timeout_seconds = request_timeout_seconds
         self._lock = asyncio.Lock()
         self._process: asyncio.subprocess.Process | None = None
         self._stderr_task: asyncio.Task[None] | None = None
@@ -64,7 +71,16 @@ class SkillLedgerWorkerClient:
         async with self._lock:
             for attempt in range(2):
                 try:
-                    result = await self._process_once(change)
+                    try:
+                        result = await asyncio.wait_for(
+                            self._process_once(change),
+                            timeout=self._request_timeout_seconds,
+                        )
+                    except asyncio.TimeoutError as exc:
+                        raise SkillLedgerWorkerTransportError(
+                            "worker request timed out after "
+                            f"{self._request_timeout_seconds:g}s"
+                        ) from exc
                 except asyncio.CancelledError:
                     await self._cancel_worker()
                     raise
@@ -103,11 +119,14 @@ class SkillLedgerWorkerClient:
             ) from exc
 
         if not line:
-            returncode = await process.wait()
+            returncode = process.returncode
+            exit_status = (
+                f"exit code {returncode}"
+                if returncode is not None
+                else "closing stdout before exit"
+            )
             raise SkillLedgerWorkerTransportError(
-                self._transport_message(
-                    f"worker closed stdout with exit code {returncode}"
-                )
+                self._transport_message(f"worker closed stdout with {exit_status}")
             )
         if len(line) > MAX_WORKER_FRAME_BYTES:
             raise SkillLedgerWorkerTransportError(
@@ -179,8 +198,12 @@ class SkillLedgerWorkerClient:
         return f"{message}: {stderr}" if stderr else message
 
     async def _cancel_worker(self) -> None:
-        with contextlib.suppress(asyncio.CancelledError):
-            await asyncio.shield(self._terminate_worker())
+        cleanup_task = asyncio.create_task(self._terminate_worker())
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            with contextlib.suppress(asyncio.CancelledError):
+                await cleanup_task
 
     async def _shutdown_worker(self) -> None:
         process, stderr_task = self._detach_worker()
@@ -249,9 +272,14 @@ class SkillLedgerWorkerClient:
     ) -> None:
         if stderr_task is None:
             return
+        caller = asyncio.current_task()
+        cancellation_count = caller.cancelling() if caller is not None else 0
+        if not stderr_task.done():
+            stderr_task.cancel()
         try:
-            await stderr_task
+            await asyncio.shield(stderr_task)
         except asyncio.CancelledError:
-            raise
+            if caller is not None and caller.cancelling() > cancellation_count:
+                raise
         except Exception:
             return

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/worker_client.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/jobs/skill_ledger/worker_client.py
@@ -1,0 +1,257 @@
+"""Lifecycle and NDJSON transport for the Skill Ledger worker process."""
+
+import asyncio
+import contextlib
+import sys
+from typing import Any
+
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
+    MAX_WORKER_FRAME_BYTES,
+    SkillFsChange,
+    WorkerProtocolError,
+    new_worker_request,
+    parse_worker_response,
+    serialize_worker_request,
+)
+
+_WORKER_MODULE = "agent_sec_cli.daemon.jobs.skill_ledger.worker"
+_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 2.0
+_TERMINATE_TIMEOUT_SECONDS = 5.0
+_MAX_STDERR_BYTES = 64 * 1024
+
+
+class SkillLedgerWorkerError(RuntimeError):
+    """Base class for Skill Ledger worker failures."""
+
+
+class SkillLedgerWorkerTransportError(SkillLedgerWorkerError):
+    """Raised when the worker process or protocol transport fails."""
+
+
+class SkillLedgerWorkerExecutionError(SkillLedgerWorkerError):
+    """Raised when Skill Ledger processing fails inside a healthy worker."""
+
+    def __init__(self, error_type: str, message: str) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
+class SkillLedgerWorkerClient:
+    """Own one lazily started, serial Skill Ledger worker process."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._process: asyncio.subprocess.Process | None = None
+        self._stderr_task: asyncio.Task[None] | None = None
+        self._stderr = bytearray()
+        self._stopping = False
+        self._last_error: str | None = None
+
+    @property
+    def pid(self) -> int | None:
+        """Return the active worker PID, if one exists."""
+        if self._process is None or self._process.returncode is not None:
+            return None
+        return self._process.pid
+
+    @property
+    def last_error(self) -> str | None:
+        """Return the last worker transport error."""
+        return self._last_error
+
+    async def process_change(self, change: SkillFsChange) -> dict[str, Any]:
+        """Process one change, restarting once after transport failure."""
+        async with self._lock:
+            for attempt in range(2):
+                try:
+                    result = await self._process_once(change)
+                except asyncio.CancelledError:
+                    await self._cancel_worker()
+                    raise
+                except SkillLedgerWorkerTransportError as exc:
+                    self._last_error = str(exc)
+                    await self._terminate_worker()
+                    if attempt == 1:
+                        raise
+                    continue
+                self._last_error = None
+                return result
+        raise AssertionError("worker retry loop must return or raise")
+
+    async def stop(self) -> None:
+        """Close stdin, then terminate and kill the worker if needed."""
+        async with self._lock:
+            self._stopping = True
+            try:
+                await self._shutdown_worker()
+            finally:
+                self._stopping = False
+
+    async def _process_once(self, change: SkillFsChange) -> dict[str, Any]:
+        process = await self._ensure_worker()
+        if process.stdin is None or process.stdout is None:
+            raise SkillLedgerWorkerTransportError("worker stdio is unavailable")
+
+        request = new_worker_request(change)
+        try:
+            process.stdin.write(serialize_worker_request(request))
+            await process.stdin.drain()
+            line = await process.stdout.readline()
+        except (BrokenPipeError, ConnectionError, OSError, ValueError) as exc:
+            raise SkillLedgerWorkerTransportError(
+                self._transport_message(f"worker communication failed: {exc}")
+            ) from exc
+
+        if not line:
+            returncode = await process.wait()
+            raise SkillLedgerWorkerTransportError(
+                self._transport_message(
+                    f"worker closed stdout with exit code {returncode}"
+                )
+            )
+        if len(line) > MAX_WORKER_FRAME_BYTES:
+            raise SkillLedgerWorkerTransportError(
+                f"worker response exceeds {MAX_WORKER_FRAME_BYTES} bytes"
+            )
+
+        try:
+            response = parse_worker_response(line)
+        except WorkerProtocolError as exc:
+            raise SkillLedgerWorkerTransportError(
+                self._transport_message(f"invalid worker response: {exc}")
+            ) from exc
+        if response.request_id != request.request_id:
+            raise SkillLedgerWorkerTransportError(
+                "worker response requestId does not match the request"
+            )
+        if not response.ok:
+            if response.error is None:
+                raise SkillLedgerWorkerTransportError(
+                    "worker error response is missing error details"
+                )
+            raise SkillLedgerWorkerExecutionError(
+                response.error.error_type,
+                response.error.message,
+            )
+        if response.result is None:
+            raise SkillLedgerWorkerTransportError("worker response is missing a result")
+        return response.result
+
+    async def _ensure_worker(self) -> asyncio.subprocess.Process:
+        if self._stopping:
+            raise SkillLedgerWorkerTransportError("worker is stopping")
+        if self._process is not None and self._process.returncode is None:
+            return self._process
+        if self._process is not None:
+            await self._dispose_exited_worker()
+
+        self._stderr.clear()
+        try:
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                _WORKER_MODULE,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                limit=MAX_WORKER_FRAME_BYTES + 1,
+            )
+        except OSError as exc:
+            raise SkillLedgerWorkerTransportError(
+                f"failed to start Skill Ledger worker: {exc}"
+            ) from exc
+        self._process = process
+        if process.stderr is not None:
+            self._stderr_task = asyncio.create_task(self._drain_stderr(process.stderr))
+        return process
+
+    async def _drain_stderr(self, reader: asyncio.StreamReader) -> None:
+        while True:
+            chunk = await reader.read(4096)
+            if not chunk:
+                return
+            self._stderr.extend(chunk)
+            if len(self._stderr) > _MAX_STDERR_BYTES:
+                del self._stderr[: len(self._stderr) - _MAX_STDERR_BYTES]
+
+    def _transport_message(self, message: str) -> str:
+        stderr = self._stderr.decode("utf-8", errors="replace").strip()
+        return f"{message}: {stderr}" if stderr else message
+
+    async def _cancel_worker(self) -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.shield(self._terminate_worker())
+
+    async def _shutdown_worker(self) -> None:
+        process, stderr_task = self._detach_worker()
+        if process is None:
+            return
+        await self._close_stdin(process)
+        if process.returncode is None:
+            try:
+                await asyncio.wait_for(
+                    process.wait(),
+                    timeout=_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                await self._terminate_process(process)
+        await self._finish_stderr_task(stderr_task)
+
+    async def _terminate_worker(self) -> None:
+        process, stderr_task = self._detach_worker()
+        if process is None:
+            return
+        await self._close_stdin(process)
+        if process.returncode is None:
+            await self._terminate_process(process)
+        await self._finish_stderr_task(stderr_task)
+
+    async def _terminate_process(self, process: asyncio.subprocess.Process) -> None:
+        with contextlib.suppress(ProcessLookupError):
+            process.terminate()
+        try:
+            await asyncio.wait_for(
+                process.wait(),
+                timeout=_TERMINATE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+
+    async def _dispose_exited_worker(self) -> None:
+        process, stderr_task = self._detach_worker()
+        if process is None:
+            return
+        await self._close_stdin(process)
+        await process.wait()
+        await self._finish_stderr_task(stderr_task)
+
+    def _detach_worker(
+        self,
+    ) -> tuple[asyncio.subprocess.Process | None, asyncio.Task[None] | None]:
+        process = self._process
+        stderr_task = self._stderr_task
+        self._process = None
+        self._stderr_task = None
+        return process, stderr_task
+
+    async def _close_stdin(self, process: asyncio.subprocess.Process) -> None:
+        if process.stdin is None:
+            return
+        process.stdin.close()
+        with contextlib.suppress(BrokenPipeError, ConnectionError, OSError):
+            await process.stdin.wait_closed()
+
+    async def _finish_stderr_task(
+        self,
+        stderr_task: asyncio.Task[None] | None,
+    ) -> None:
+        if stderr_task is None:
+            return
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
@@ -37,6 +37,7 @@ from agent_sec_cli.daemon.handlers.security_query import (
 )
 from agent_sec_cli.daemon.health import register_health_methods
 from agent_sec_cli.daemon.jobs.registry import register_default_jobs
+from agent_sec_cli.daemon.jobs.skill_ledger import skillfs_notify_method_spec
 from agent_sec_cli.daemon.logging import log_daemon_event, setup_daemon_logging
 from agent_sec_cli.daemon.protocol import (
     DEFAULT_MAX_REQUEST_BYTES,
@@ -54,9 +55,6 @@ from agent_sec_cli.daemon.runtime import (
     ensure_runtime_directory,
     lock_path_for_socket,
     resolve_socket_path,
-)
-from agent_sec_cli.daemon.skill_ledger_activation import (
-    skillfs_notify_method_spec,
 )
 
 LOGGER = logging.getLogger("agent-sec-core.daemon")

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
@@ -35,9 +35,11 @@ from agent_sec_cli.daemon.handlers.prompt_scan import (
 from agent_sec_cli.daemon.handlers.security_query import (
     register_security_query_methods,
 )
+from agent_sec_cli.daemon.handlers.skill_ledger import (
+    register_skill_ledger_methods,
+)
 from agent_sec_cli.daemon.health import register_health_methods
 from agent_sec_cli.daemon.jobs.registry import register_default_jobs
-from agent_sec_cli.daemon.jobs.skill_ledger import skillfs_notify_method_spec
 from agent_sec_cli.daemon.logging import log_daemon_event, setup_daemon_logging
 from agent_sec_cli.daemon.protocol import (
     DEFAULT_MAX_REQUEST_BYTES,
@@ -69,7 +71,7 @@ def create_default_registry() -> MethodRegistry:
     registry = MethodRegistry()
     register_health_methods(registry)
     register_prompt_scan_methods(registry)
-    registry.register(skillfs_notify_method_spec())
+    register_skill_ledger_methods(registry)
     register_security_query_methods(registry)
     return registry
 

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -1,20 +1,49 @@
 """Integration tests for Skill Ledger daemon activation refresh."""
 
+# ruff: noqa: I001
+
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any
 
+import pytest
 from agent_sec_cli.daemon.client import DaemonClient
-from agent_sec_cli.daemon.jobs.skill_ledger import METHOD_SKILLFS_NOTIFY_CHANGE
+from agent_sec_cli.daemon.jobs.skill_ledger import (
+    METHOD_SKILLFS_NOTIFY_CHANGE,
+    SKILL_LEDGER_ACTIVATION_JOB,
+    SkillLedgerActivationJob,
+)
 from agent_sec_cli.daemon.jobs.skill_ledger import (
     processor as skill_ledger_processor,
 )
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
 from agent_sec_cli.daemon.server import DaemonServer
 from agent_sec_cli.skill_ledger import config as config_module
 from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 PENDING_DECISION_TARGET = ".skill-meta/versions/__pending_decision__.snapshot"
+
+
+class InProcessWorkerClient:
+    """Keep parent-process monkeypatches visible in focused integration tests."""
+
+    last_error = None
+    pid = None
+
+    async def process_change(self, change: SkillFsChange) -> dict[str, Any]:
+        return skill_ledger_processor.process_skill_change(change)
+
+    async def stop(self) -> None:
+        pass
+
+
+def install_in_process_worker(server: DaemonServer) -> None:
+    """Replace the real worker only where a test patches processor internals."""
+    job = server.runtime.jobs.get(SKILL_LEDGER_ACTIVATION_JOB)
+    assert isinstance(job, SkillLedgerActivationJob)
+    job._worker_client = InProcessWorkerClient()
 
 
 def make_skill(parent: Path, name: str, files: dict[str, str] | None = None) -> Path:
@@ -134,6 +163,25 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
                     else None
                 )
             )
+            job = server.runtime.jobs.get(SKILL_LEDGER_ACTIVATION_JOB)
+            assert isinstance(job, SkillLedgerActivationJob)
+            first_result = await wait_for(lambda: job.last_processed)
+            first_pid = job.worker_pid
+            assert first_pid is not None
+            await asyncio.to_thread(
+                client.call,
+                METHOD_SKILLFS_NOTIFY_CHANGE,
+                notify_payload(skill_dir),
+                trace_context={},
+            )
+            await wait_for(
+                lambda: (
+                    job.last_processed
+                    if job.last_processed is not first_result
+                    else None
+                )
+            )
+            second_pid = job.worker_pid
             health = await asyncio.to_thread(
                 client.call,
                 "daemon.health",
@@ -142,9 +190,11 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
             config = read_skill_ledger_config(tmp_path)
         finally:
             await server.stop()
-        return response, activation, health, config
+        return response, activation, health, config, first_pid, second_pid
 
-    response, activation, health, config = asyncio.run(scenario())
+    response, activation, health, config, first_pid, second_pid = asyncio.run(
+        scenario()
+    )
 
     assert response.ok is True
     assert response.data["accepted"] is True
@@ -155,6 +205,10 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
     assert (skill_dir / activation["target"]).is_dir()
     jobs = {job["name"]: job for job in health.data["jobs"]}
     assert jobs["skill-ledger-activation"]["state"] == "running"
+    assert first_pid != os.getpid()
+    assert second_pid == first_pid
+    with pytest.raises(ProcessLookupError):
+        os.kill(first_pid, 0)
 
 
 def test_daemon_reconcile_scans_unmanaged_skill_and_remembers_it(
@@ -226,6 +280,7 @@ def test_daemon_reconcile_existing_clean_skill_keeps_existing_version(
 
     async def scenario():
         server = DaemonServer(socket_path=socket_path)
+        install_in_process_worker(server)
         await server.start()
         try:
             client = DaemonClient(socket_path=socket_path, timeout_ms=3000)
@@ -599,6 +654,7 @@ def test_daemon_pass_warn_only_policy_hides_deny_snapshot(
 
     async def scenario():
         server = DaemonServer(socket_path=socket_path)
+        install_in_process_worker(server)
         await server.start()
         try:
             client = DaemonClient(socket_path=socket_path, timeout_ms=3000)
@@ -738,6 +794,7 @@ def test_daemon_startup_reconcile_ignores_default_discovery_dirs(
 
     async def scenario():
         server = DaemonServer(socket_path=socket_path)
+        install_in_process_worker(server)
         await server.start()
         try:
             activation = await wait_for(
@@ -782,6 +839,7 @@ def test_daemon_unresolved_live_root_keeps_job_running(monkeypatch, tmp_path: Pa
 
     async def scenario():
         server = DaemonServer(socket_path=socket_path)
+        install_in_process_worker(server)
         await server.start()
         try:
             client = DaemonClient(socket_path=socket_path, timeout_ms=3000)

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -9,9 +9,12 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from agent_sec_cli.daemon.client import DaemonClient
-from agent_sec_cli.daemon.jobs.skill_ledger import (
+from agent_sec_cli.daemon.handlers.skill_ledger import (
     METHOD_SKILLFS_NOTIFY_CHANGE,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger import (
     SKILL_LEDGER_ACTIVATION_JOB,
     SkillLedgerActivationJob,
 )

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -5,12 +5,12 @@ import json
 from pathlib import Path
 from typing import Any
 
-from agent_sec_cli.daemon import skill_ledger_activation
 from agent_sec_cli.daemon.client import DaemonClient
-from agent_sec_cli.daemon.server import DaemonServer
-from agent_sec_cli.daemon.skill_ledger_activation import (
-    METHOD_SKILLFS_NOTIFY_CHANGE,
+from agent_sec_cli.daemon.jobs.skill_ledger import METHOD_SKILLFS_NOTIFY_CHANGE
+from agent_sec_cli.daemon.jobs.skill_ledger import (
+    processor as skill_ledger_processor,
 )
+from agent_sec_cli.daemon.server import DaemonServer
 from agent_sec_cli.skill_ledger import config as config_module
 from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
@@ -213,14 +213,14 @@ def test_daemon_reconcile_existing_clean_skill_keeps_existing_version(
     socket_path = daemon_socket_path(tmp_path)
     scan_calls = {"count": 0}
 
-    real_scan = skill_ledger_activation._scan_skill
+    real_scan = skill_ledger_processor._scan_skill
 
     def spy_scan(skill_path: str, backend: Any) -> dict[str, Any]:
         scan_calls["count"] += 1
         return real_scan(skill_path, backend)
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         spy_scan,
     )
 
@@ -593,7 +593,7 @@ def test_daemon_pass_warn_only_policy_hides_deny_snapshot(
         return certify(skill_path, backend, findings_path=str(findings_path))
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         fake_scan,
     )
 
@@ -725,14 +725,14 @@ def test_daemon_startup_reconcile_ignores_default_discovery_dirs(
     socket_path = daemon_socket_path(tmp_path)
     scanned: list[str] = []
 
-    real_scan = skill_ledger_activation._scan_skill
+    real_scan = skill_ledger_processor._scan_skill
 
     def spy_scan(skill_path: str, backend: Any) -> dict[str, Any]:
         scanned.append(skill_path)
         return real_scan(skill_path, backend)
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         spy_scan,
     )
 
@@ -772,11 +772,11 @@ def test_daemon_unresolved_live_root_keeps_job_running(monkeypatch, tmp_path: Pa
         raise live_root_error
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         fail_live_root,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._resolve_activation",
         lambda _skill_path, _backend, _policy: {"target": None},
     )
 

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from agent_sec_cli.daemon.client import DaemonClient
 from agent_sec_cli.daemon.handlers.skill_ledger import (
     METHOD_SKILLFS_NOTIFY_CHANGE,

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -7,22 +7,15 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from agent_sec_cli.daemon.errors import BadRequestError
+
 from agent_sec_cli.daemon.jobs.skill_ledger import (
-    METHOD_SKILLFS_NOTIFY_CHANGE,
     SKILL_LEDGER_ACTIVATION_JOB,
     SkillLedgerActivationJob,
-)
-from agent_sec_cli.daemon.jobs.skill_ledger.activation import (
-    parse_skillfs_change,
-    skillfs_notify_change_handler,
 )
 from agent_sec_cli.daemon.jobs.skill_ledger.processor import (
     process_skill_change,
 )
 from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
-from agent_sec_cli.daemon.protocol import DaemonRequest
-from agent_sec_cli.daemon.runtime import DaemonRuntime
 from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 
@@ -50,160 +43,6 @@ def make_skill(tmp_path: Path, name: str = "demo-skill") -> Path:
     skill_dir.mkdir()
     (skill_dir / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
     return skill_dir
-
-
-def request_for(skill_dir: Path, **overrides: Any) -> DaemonRequest:
-    """Build a daemon request for SkillFS notify tests."""
-    params: dict[str, Any] = {
-        "schemaVersion": 1,
-        "skillDir": str(skill_dir),
-        "skillName": skill_dir.name,
-        "eventKind": "write",
-        "paths": ["SKILL.md"],
-    }
-    params.update(overrides)
-    return DaemonRequest(
-        method=METHOD_SKILLFS_NOTIFY_CHANGE,
-        params=params,
-    )
-
-
-def test_parse_skillfs_change_validates_request(tmp_path: Path):
-    skill_dir = make_skill(tmp_path, "weather")
-
-    change = parse_skillfs_change(request_for(skill_dir).params)
-
-    assert change.skill_dir == skill_dir.resolve()
-    assert change.skill_name == "weather"
-    assert change.event_kinds == {"write"}
-    assert change.paths == {"SKILL.md"}
-
-
-def test_parse_skillfs_change_accepts_reconcile_with_empty_paths(tmp_path: Path):
-    skill_dir = make_skill(tmp_path, "weather")
-
-    change = parse_skillfs_change(
-        request_for(skill_dir, eventKind="reconcile", paths=[]).params
-    )
-
-    assert change.skill_dir == skill_dir.resolve()
-    assert change.skill_name == "weather"
-    assert change.event_kinds == {"reconcile"}
-    assert change.paths == set()
-
-
-@pytest.mark.parametrize(
-    ("overrides", "message"),
-    [
-        ({"schemaVersion": 2}, "schemaVersion"),
-        ({"skillDir": "relative-skill"}, "absolute path"),
-        ({"skillDir": "~/relative-to-home"}, "absolute path"),
-        ({"skillName": "other"}, "skillName"),
-        ({"eventKind": "chmod"}, "eventKind"),
-        ({"paths": "/absolute"}, "paths"),
-        ({"paths": ["/absolute"]}, "relative paths"),
-        ({"paths": ["../escape"]}, "relative paths"),
-        ({"paths": ["."]}, "relative paths"),
-    ],
-)
-def test_parse_skillfs_change_rejects_invalid_params(
-    tmp_path: Path,
-    overrides: dict[str, Any],
-    message: str,
-):
-    skill_dir = make_skill(tmp_path, "weather")
-
-    with pytest.raises(BadRequestError, match=message):
-        parse_skillfs_change(request_for(skill_dir, **overrides).params)
-
-
-def test_parse_skillfs_change_requires_skill_manifest(tmp_path: Path):
-    skill_dir = tmp_path / "not-a-skill"
-    skill_dir.mkdir()
-
-    with pytest.raises(BadRequestError, match="SKILL.md"):
-        parse_skillfs_change(request_for(skill_dir).params)
-
-
-def test_metadata_only_notification_is_accepted_and_ignored(tmp_path: Path):
-    skill_dir = make_skill(tmp_path, "weather")
-    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
-
-    response = skillfs_notify_change_handler(
-        request_for(skill_dir, paths=[".skill-meta/latest.json"]),
-        runtime,
-    )
-
-    assert response.data["schemaVersion"] == 1
-    assert response.data["accepted"] is True
-    assert response.data["ignored"] is True
-    assert response.data["reason"] == "metadata-only change"
-
-
-def test_notify_enqueues_registered_activation_job(monkeypatch, tmp_path: Path):
-    skill_dir = make_skill(tmp_path, "weather")
-    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
-    job = SkillLedgerActivationJob(
-        debounce_seconds=0,
-        worker_client=FakeWorkerClient(),
-    )
-    runtime.jobs.register(job)
-    monkeypatch.setattr(
-        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
-        lambda: [],
-    )
-
-    async def scenario():
-        await job.start()
-        try:
-            response = skillfs_notify_change_handler(request_for(skill_dir), runtime)
-        finally:
-            await job.stop()
-        return response
-
-    response = asyncio.run(scenario())
-
-    assert response.data["schemaVersion"] == 1
-    assert response.data["accepted"] is True
-    assert response.data["ignored"] is False
-    assert response.data["queued"] is True
-    assert response.data["coalesced"] is False
-    assert response.data["skill"]["skillName"] == "weather"
-
-
-def test_notify_enqueues_reconcile_with_empty_paths(monkeypatch, tmp_path: Path):
-    skill_dir = make_skill(tmp_path, "weather")
-    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
-    job = SkillLedgerActivationJob(
-        debounce_seconds=0,
-        worker_client=FakeWorkerClient(),
-    )
-    runtime.jobs.register(job)
-    monkeypatch.setattr(
-        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
-        lambda: [],
-    )
-
-    async def scenario():
-        await job.start()
-        try:
-            response = skillfs_notify_change_handler(
-                request_for(skill_dir, eventKind="reconcile", paths=[]),
-                runtime,
-            )
-        finally:
-            await job.stop()
-        return response
-
-    response = asyncio.run(scenario())
-
-    assert response.data["schemaVersion"] == 1
-    assert response.data["accepted"] is True
-    assert response.data["ignored"] is False
-    assert response.data["queued"] is True
-    assert response.data["coalesced"] is False
-    assert response.data["skill"]["eventKinds"] == ["reconcile"]
-    assert response.data["skill"]["paths"] == []
 
 
 def test_activation_job_debounces_same_skill(monkeypatch, tmp_path: Path):

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from agent_sec_cli.daemon.errors import BadRequestError
 from agent_sec_cli.daemon.jobs.skill_ledger import (
     METHOD_SKILLFS_NOTIFY_CHANGE,
@@ -25,6 +24,24 @@ from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
 from agent_sec_cli.daemon.protocol import DaemonRequest
 from agent_sec_cli.daemon.runtime import DaemonRuntime
 from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
+
+
+class FakeWorkerClient:
+    """In-process worker client for activation scheduling tests."""
+
+    def __init__(self, process=None):
+        self._process = process or (
+            lambda change: {"status": "processed", "skill": change.to_dict()}
+        )
+        self.last_error = None
+        self.pid = None
+        self.stopped = False
+
+    async def process_change(self, change: SkillFsChange) -> dict[str, Any]:
+        return self._process(change)
+
+    async def stop(self) -> None:
+        self.stopped = True
 
 
 def make_skill(tmp_path: Path, name: str = "demo-skill") -> Path:
@@ -126,7 +143,10 @@ def test_metadata_only_notification_is_accepted_and_ignored(tmp_path: Path):
 def test_notify_enqueues_registered_activation_job(monkeypatch, tmp_path: Path):
     skill_dir = make_skill(tmp_path, "weather")
     runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
-    job = SkillLedgerActivationJob(debounce_seconds=0)
+    job = SkillLedgerActivationJob(
+        debounce_seconds=0,
+        worker_client=FakeWorkerClient(),
+    )
     runtime.jobs.register(job)
     monkeypatch.setattr(
         "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
@@ -154,7 +174,10 @@ def test_notify_enqueues_registered_activation_job(monkeypatch, tmp_path: Path):
 def test_notify_enqueues_reconcile_with_empty_paths(monkeypatch, tmp_path: Path):
     skill_dir = make_skill(tmp_path, "weather")
     runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
-    job = SkillLedgerActivationJob(debounce_seconds=0)
+    job = SkillLedgerActivationJob(
+        debounce_seconds=0,
+        worker_client=FakeWorkerClient(),
+    )
     runtime.jobs.register(job)
     monkeypatch.setattr(
         "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
@@ -196,13 +219,11 @@ def test_activation_job_debounces_same_skill(monkeypatch, tmp_path: Path):
         calls.append(change)
         return {"status": "processed", "skill": change.to_dict()}
 
-    monkeypatch.setattr(
-        "agent_sec_cli.daemon.jobs.skill_ledger.activation.process_skill_change",
-        fake_process,
-    )
-
     async def scenario():
-        job = SkillLedgerActivationJob(debounce_seconds=0.05)
+        job = SkillLedgerActivationJob(
+            debounce_seconds=0.05,
+            worker_client=FakeWorkerClient(fake_process),
+        )
         await job.start()
         try:
             job.enqueue(

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from agent_sec_cli.daemon.jobs.skill_ledger import (
     SKILL_LEDGER_ACTIVATION_JOB,
     SkillLedgerActivationJob,
@@ -16,6 +15,9 @@ from agent_sec_cli.daemon.jobs.skill_ledger.processor import (
     process_skill_change,
 )
 from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
+from agent_sec_cli.daemon.jobs.skill_ledger.worker_client import (
+    SkillLedgerWorkerTransportError,
+)
 from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 
@@ -189,6 +191,36 @@ def test_drain_pending_requeues_batch_on_cancelled_process(
     pending = asyncio.run(scenario())
 
     assert set(pending) == {first.resolve(), second.resolve()}
+
+
+def test_activation_job_records_worker_transport_failure(tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+
+    def fail_process(_change: SkillFsChange) -> dict[str, Any]:
+        raise SkillLedgerWorkerTransportError("worker request timed out after 300s")
+
+    async def scenario():
+        job = SkillLedgerActivationJob(
+            debounce_seconds=0,
+            worker_client=FakeWorkerClient(fail_process),
+        )
+        job._state = "running"
+        await job._process_change(
+            SkillFsChange(
+                skill_dir=skill_dir.resolve(),
+                skill_name=skill_dir.name,
+                event_kinds={"write"},
+                paths={"SKILL.md"},
+            )
+        )
+        return job.status(), job.last_processed
+
+    status, last_processed = asyncio.run(scenario())
+
+    assert status.state == "error"
+    assert status.last_error == "worker request timed out after 300s"
+    assert last_processed is not None
+    assert last_processed["status"] == "error"
 
 
 def test_process_skill_change_resolves_activation_after_scan_error(

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_activation.py
@@ -7,18 +7,23 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from agent_sec_cli.daemon.errors import BadRequestError
-from agent_sec_cli.daemon.protocol import DaemonRequest
-from agent_sec_cli.daemon.runtime import DaemonRuntime
-from agent_sec_cli.daemon.skill_ledger_activation import (
+from agent_sec_cli.daemon.jobs.skill_ledger import (
     METHOD_SKILLFS_NOTIFY_CHANGE,
     SKILL_LEDGER_ACTIVATION_JOB,
-    SkillFsChange,
     SkillLedgerActivationJob,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger.activation import (
     parse_skillfs_change,
-    process_skill_change,
     skillfs_notify_change_handler,
 )
+from agent_sec_cli.daemon.jobs.skill_ledger.processor import (
+    process_skill_change,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
+from agent_sec_cli.daemon.protocol import DaemonRequest
+from agent_sec_cli.daemon.runtime import DaemonRuntime
 from agent_sec_cli.skill_ledger.errors import UnresolvedLiveRootError
 
 
@@ -124,7 +129,7 @@ def test_notify_enqueues_registered_activation_job(monkeypatch, tmp_path: Path):
     job = SkillLedgerActivationJob(debounce_seconds=0)
     runtime.jobs.register(job)
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_managed_skill_dirs",
+        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
         lambda: [],
     )
 
@@ -152,7 +157,7 @@ def test_notify_enqueues_reconcile_with_empty_paths(monkeypatch, tmp_path: Path)
     job = SkillLedgerActivationJob(debounce_seconds=0)
     runtime.jobs.register(job)
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_managed_skill_dirs",
+        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
         lambda: [],
     )
 
@@ -183,7 +188,7 @@ def test_activation_job_debounces_same_skill(monkeypatch, tmp_path: Path):
     calls = []
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_managed_skill_dirs",
+        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
         lambda: [],
     )
 
@@ -192,7 +197,7 @@ def test_activation_job_debounces_same_skill(monkeypatch, tmp_path: Path):
         return {"status": "processed", "skill": change.to_dict()}
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation.process_skill_change",
+        "agent_sec_cli.daemon.jobs.skill_ledger.activation.process_skill_change",
         fake_process,
     )
 
@@ -245,7 +250,7 @@ def test_activation_job_debounces_events_arriving_during_drain(
     calls: list[tuple[set[str], float]] = []
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_managed_skill_dirs",
+        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
         lambda: [],
     )
 
@@ -353,19 +358,19 @@ def test_process_skill_change_resolves_activation_after_scan_error(
         return {"target": None}
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._ensure_default_backend",
         fake_backend,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         fail_scan,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._resolve_activation",
         fake_resolve,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation_policy",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._resolve_activation_policy",
         fake_policy,
     )
 
@@ -404,11 +409,11 @@ def test_process_skill_change_skips_unresolved_live_root_from_scan(
         raise live_root_error
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._ensure_default_backend",
         fake_backend,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         fail_scan,
     )
 
@@ -455,19 +460,19 @@ def test_process_skill_change_skips_unresolved_live_root_from_activation(
         raise live_root_error
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._ensure_default_backend",
         fake_backend,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         fake_scan,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._resolve_activation",
         fail_resolve,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation_policy",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._resolve_activation_policy",
         lambda: "pass_only",
     )
 
@@ -515,19 +520,19 @@ def test_process_skill_change_does_not_skip_live_root_after_scan_error(
         raise live_root_error
 
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._ensure_default_backend",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._ensure_default_backend",
         fake_backend,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._scan_skill",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._scan_skill",
         fail_scan,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._resolve_activation",
         fail_resolve,
     )
     monkeypatch.setattr(
-        "agent_sec_cli.daemon.skill_ledger_activation._resolve_activation_policy",
+        "agent_sec_cli.daemon.jobs.skill_ledger.processor._resolve_activation_policy",
         lambda: "pass_only",
     )
 

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_handler.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from agent_sec_cli.daemon.errors import BadRequestError
 from agent_sec_cli.daemon.handlers.skill_ledger import (
     METHOD_SKILLFS_NOTIFY_CHANGE,
@@ -106,6 +105,7 @@ def test_parse_skillfs_change_accepts_reconcile_with_empty_paths(tmp_path: Path)
         ({"paths": ["/absolute"]}, "relative paths"),
         ({"paths": ["../escape"]}, "relative paths"),
         ({"paths": ["."]}, "relative paths"),
+        ({"paths": ["scripts/run\x00.sh"]}, "NUL"),
     ],
 )
 def test_parse_skillfs_change_rejects_invalid_params(
@@ -117,6 +117,13 @@ def test_parse_skillfs_change_rejects_invalid_params(
 
     with pytest.raises(BadRequestError, match=message):
         parse_skillfs_change(request_for(skill_dir, **overrides).params)
+
+
+def test_parse_skillfs_change_rejects_nul_skill_dir(tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+
+    with pytest.raises(BadRequestError, match="NUL"):
+        parse_skillfs_change(request_for(skill_dir, skillDir=f"{skill_dir}\x00").params)
 
 
 def test_parse_skillfs_change_requires_skill_manifest(tmp_path: Path):

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_handler.py
@@ -1,0 +1,208 @@
+"""Tests for the SkillFS daemon notification handler."""
+
+# ruff: noqa: I001
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent_sec_cli.daemon.errors import BadRequestError
+from agent_sec_cli.daemon.handlers.skill_ledger import (
+    METHOD_SKILLFS_NOTIFY_CHANGE,
+    parse_skillfs_change,
+    register_skill_ledger_methods,
+    skillfs_notify_change_handler,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger import SkillLedgerActivationJob
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
+from agent_sec_cli.daemon.protocol import DaemonRequest
+from agent_sec_cli.daemon.registry import MethodRegistry
+from agent_sec_cli.daemon.runtime import DaemonRuntime
+
+
+class FakeWorkerClient:
+    """In-process worker client for handler queueing tests."""
+
+    def __init__(self) -> None:
+        self.last_error = None
+        self.pid = None
+
+    async def process_change(self, change: SkillFsChange) -> dict[str, Any]:
+        return {"status": "processed", "skill": change.to_dict()}
+
+    async def stop(self) -> None:
+        pass
+
+
+def make_skill(tmp_path: Path, name: str = "demo-skill") -> Path:
+    """Create a minimal skill directory for daemon tests."""
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
+    return skill_dir
+
+
+def request_for(skill_dir: Path, **overrides: Any) -> DaemonRequest:
+    """Build a daemon request for SkillFS notify tests."""
+    params: dict[str, Any] = {
+        "schemaVersion": 1,
+        "skillDir": str(skill_dir),
+        "skillName": skill_dir.name,
+        "eventKind": "write",
+        "paths": ["SKILL.md"],
+    }
+    params.update(overrides)
+    return DaemonRequest(
+        method=METHOD_SKILLFS_NOTIFY_CHANGE,
+        params=params,
+    )
+
+
+def test_register_skill_ledger_methods():
+    registry = MethodRegistry()
+
+    register_skill_ledger_methods(registry)
+
+    spec = registry.get(METHOD_SKILLFS_NOTIFY_CHANGE)
+    assert spec.handler is skillfs_notify_change_handler
+    assert spec.queue == "skill_ledger"
+
+
+def test_parse_skillfs_change_validates_request(tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+
+    change = parse_skillfs_change(request_for(skill_dir).params)
+
+    assert change.skill_dir == skill_dir.resolve()
+    assert change.skill_name == "weather"
+    assert change.event_kinds == {"write"}
+    assert change.paths == {"SKILL.md"}
+
+
+def test_parse_skillfs_change_accepts_reconcile_with_empty_paths(tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+
+    change = parse_skillfs_change(
+        request_for(skill_dir, eventKind="reconcile", paths=[]).params
+    )
+
+    assert change.skill_dir == skill_dir.resolve()
+    assert change.skill_name == "weather"
+    assert change.event_kinds == {"reconcile"}
+    assert change.paths == set()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"schemaVersion": 2}, "schemaVersion"),
+        ({"skillDir": "relative-skill"}, "absolute path"),
+        ({"skillDir": "~/relative-to-home"}, "absolute path"),
+        ({"skillName": "other"}, "skillName"),
+        ({"eventKind": "chmod"}, "eventKind"),
+        ({"paths": "/absolute"}, "paths"),
+        ({"paths": ["/absolute"]}, "relative paths"),
+        ({"paths": ["../escape"]}, "relative paths"),
+        ({"paths": ["."]}, "relative paths"),
+    ],
+)
+def test_parse_skillfs_change_rejects_invalid_params(
+    tmp_path: Path,
+    overrides: dict[str, Any],
+    message: str,
+):
+    skill_dir = make_skill(tmp_path, "weather")
+
+    with pytest.raises(BadRequestError, match=message):
+        parse_skillfs_change(request_for(skill_dir, **overrides).params)
+
+
+def test_parse_skillfs_change_requires_skill_manifest(tmp_path: Path):
+    skill_dir = tmp_path / "not-a-skill"
+    skill_dir.mkdir()
+
+    with pytest.raises(BadRequestError, match="SKILL.md"):
+        parse_skillfs_change(request_for(skill_dir).params)
+
+
+def test_metadata_only_notification_is_accepted_and_ignored(tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
+
+    response = skillfs_notify_change_handler(
+        request_for(skill_dir, paths=[".skill-meta/latest.json"]),
+        runtime,
+    )
+
+    assert response.data["schemaVersion"] == 1
+    assert response.data["accepted"] is True
+    assert response.data["ignored"] is True
+    assert response.data["reason"] == "metadata-only change"
+
+
+def test_notify_enqueues_registered_activation_job(monkeypatch, tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
+    job = SkillLedgerActivationJob(
+        debounce_seconds=0,
+        worker_client=FakeWorkerClient(),
+    )
+    runtime.jobs.register(job)
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
+        lambda: [],
+    )
+
+    async def scenario():
+        await job.start()
+        try:
+            response = skillfs_notify_change_handler(request_for(skill_dir), runtime)
+        finally:
+            await job.stop()
+        return response
+
+    response = asyncio.run(scenario())
+
+    assert response.data["schemaVersion"] == 1
+    assert response.data["accepted"] is True
+    assert response.data["ignored"] is False
+    assert response.data["queued"] is True
+    assert response.data["coalesced"] is False
+    assert response.data["skill"]["skillName"] == "weather"
+
+
+def test_notify_enqueues_reconcile_with_empty_paths(monkeypatch, tmp_path: Path):
+    skill_dir = make_skill(tmp_path, "weather")
+    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
+    job = SkillLedgerActivationJob(
+        debounce_seconds=0,
+        worker_client=FakeWorkerClient(),
+    )
+    runtime.jobs.register(job)
+    monkeypatch.setattr(
+        "agent_sec_cli.daemon.jobs.skill_ledger.activation._resolve_managed_skill_dirs",
+        lambda: [],
+    )
+
+    async def scenario():
+        await job.start()
+        try:
+            response = skillfs_notify_change_handler(
+                request_for(skill_dir, eventKind="reconcile", paths=[]),
+                runtime,
+            )
+        finally:
+            await job.stop()
+        return response
+
+    response = asyncio.run(scenario())
+
+    assert response.data["schemaVersion"] == 1
+    assert response.data["accepted"] is True
+    assert response.data["ignored"] is False
+    assert response.data["queued"] is True
+    assert response.data["coalesced"] is False
+    assert response.data["skill"]["eventKinds"] == ["reconcile"]
+    assert response.data["skill"]["paths"] == []

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_client.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_client.py
@@ -37,6 +37,21 @@ class FakeReader:
         self._queue.put_nowait(data)
 
 
+class BlockingReader:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = False
+
+    async def read(self, _size: int) -> bytes:
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        raise AssertionError("blocking reader must be cancelled")
+
+
 class FakeStdin:
     def __init__(self, process: "FakeProcess") -> None:
         self._process = process
@@ -73,6 +88,8 @@ class FakeStdin:
         elif self._process.behavior == "eof":
             self._process.finish(1)
             self._process.stdout.feed(b"")
+        elif self._process.behavior == "eof_alive":
+            self._process.stdout.feed(b"")
 
     async def drain(self) -> None:
         pass
@@ -94,6 +111,7 @@ class FakeProcess:
         *,
         exit_on_close: bool = True,
         exit_on_terminate: bool = True,
+        blocking_stderr: bool = False,
     ) -> None:
         self.pid = pid
         self.behavior = behavior
@@ -101,7 +119,7 @@ class FakeProcess:
         self.exit_on_terminate = exit_on_terminate
         self.returncode = None
         self.stdout = FakeReader()
-        self.stderr = FakeReader()
+        self.stderr = BlockingReader() if blocking_stderr else FakeReader()
         self.stdin = FakeStdin(self)
         self.signals: list[str] = []
         self._exited = asyncio.Event()
@@ -239,6 +257,73 @@ def test_worker_transport_retries_only_once(monkeypatch, tmp_path: Path):
     assert pid is None
 
 
+def test_worker_request_timeout_restarts_and_retries(monkeypatch, tmp_path: Path):
+    first = FakeProcess(101, "hang", exit_on_close=False)
+    second = FakeProcess(102, "success")
+    calls = install_process_factory(monkeypatch, [first, second])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient(request_timeout_seconds=0.01)
+        result = await client.process_change(make_change(tmp_path))
+        await client.stop()
+        return result
+
+    result = asyncio.run(scenario())
+
+    assert len(calls) == 2
+    assert first.signals == ["terminate"]
+    assert result["workerPid"] == 102
+
+
+def test_worker_request_timeout_retries_only_once_and_releases_lock(
+    monkeypatch,
+    tmp_path: Path,
+):
+    first = FakeProcess(101, "hang", exit_on_close=False)
+    second = FakeProcess(102, "hang", exit_on_close=False)
+    third = FakeProcess(103, "success")
+    calls = install_process_factory(monkeypatch, [first, second, third])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient(request_timeout_seconds=0.01)
+        with pytest.raises(SkillLedgerWorkerTransportError, match="timed out after"):
+            await client.process_change(make_change(tmp_path))
+        result = await client.process_change(make_change(tmp_path))
+        await client.stop()
+        return result
+
+    result = asyncio.run(scenario())
+
+    assert len(calls) == 3
+    assert first.signals == ["terminate"]
+    assert second.signals == ["terminate"]
+    assert result["workerPid"] == 103
+
+
+def test_worker_eof_before_exit_does_not_wait_for_process(
+    monkeypatch,
+    tmp_path: Path,
+):
+    first = FakeProcess(101, "eof_alive", exit_on_close=False)
+    second = FakeProcess(102, "success")
+    calls = install_process_factory(monkeypatch, [first, second])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient(request_timeout_seconds=1.0)
+        result = await asyncio.wait_for(
+            client.process_change(make_change(tmp_path)),
+            timeout=0.5,
+        )
+        await client.stop()
+        return result
+
+    result = asyncio.run(scenario())
+
+    assert len(calls) == 2
+    assert first.signals == ["terminate"]
+    assert result["workerPid"] == 102
+
+
 def test_worker_scan_error_does_not_restart(monkeypatch, tmp_path: Path):
     process = FakeProcess(101, "scan_error")
     calls = install_process_factory(monkeypatch, [process])
@@ -263,6 +348,7 @@ def test_worker_cancellation_terminates_process(monkeypatch, tmp_path: Path):
         "hang",
         exit_on_close=False,
         exit_on_terminate=True,
+        blocking_stderr=True,
     )
     install_process_factory(monkeypatch, [process])
 
@@ -270,15 +356,40 @@ def test_worker_cancellation_terminates_process(monkeypatch, tmp_path: Path):
         client = SkillLedgerWorkerClient()
         task = asyncio.create_task(client.process_change(make_change(tmp_path)))
         await process.stdin.written.wait()
+        await process.stderr.started.wait()
+        stderr_task = client._stderr_task
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        return client.pid
+        return client.pid, stderr_task
 
-    pid = asyncio.run(scenario())
+    pid, stderr_task = asyncio.run(scenario())
 
     assert process.signals == ["terminate"]
+    assert process.stderr.cancelled is True
+    assert stderr_task is not None and stderr_task.done()
     assert pid is None
+
+
+def test_cancelled_stderr_task_does_not_interrupt_stop(monkeypatch, tmp_path: Path):
+    process = FakeProcess(101, "success", blocking_stderr=True)
+    install_process_factory(monkeypatch, [process])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        await client.process_change(make_change(tmp_path))
+        await process.stderr.started.wait()
+        stderr_task = client._stderr_task
+        assert stderr_task is not None
+        stderr_task.cancel()
+        await asyncio.sleep(0)
+        await client.stop()
+        return stderr_task
+
+    stderr_task = asyncio.run(scenario())
+
+    assert process.stderr.cancelled is True
+    assert stderr_task.done()
 
 
 def test_worker_stop_escalates_to_kill(monkeypatch, tmp_path: Path):

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_client.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_client.py
@@ -1,0 +1,311 @@
+"""Tests for Skill Ledger worker process lifecycle management."""
+
+# ruff: noqa: I001
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from agent_sec_cli.daemon.jobs.skill_ledger import (
+    worker_client as worker_client_module,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
+    SkillFsChange,
+    error_worker_response,
+    parse_worker_request,
+    serialize_worker_response,
+    success_worker_response,
+)
+from agent_sec_cli.daemon.jobs.skill_ledger.worker_client import (
+    SkillLedgerWorkerClient,
+    SkillLedgerWorkerExecutionError,
+    SkillLedgerWorkerTransportError,
+)
+
+
+class FakeReader:
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    async def readline(self) -> bytes:
+        return await self._queue.get()
+
+    async def read(self, _size: int) -> bytes:
+        return b""
+
+    def feed(self, data: bytes) -> None:
+        self._queue.put_nowait(data)
+
+
+class FakeStdin:
+    def __init__(self, process: "FakeProcess") -> None:
+        self._process = process
+        self.closed = False
+        self.written = asyncio.Event()
+
+    def write(self, data: bytes) -> None:
+        request = parse_worker_request(data)
+        self.written.set()
+        if self._process.behavior == "success":
+            response = success_worker_response(
+                request.request_id,
+                {"status": "processed", "workerPid": self._process.pid},
+            )
+            self._process.stdout.feed(serialize_worker_response(response))
+        elif self._process.behavior == "scan_error":
+            response = success_worker_response(
+                request.request_id,
+                {
+                    "status": "error",
+                    "error": "scan failed",
+                    "workerPid": self._process.pid,
+                },
+            )
+            self._process.stdout.feed(serialize_worker_response(response))
+        elif self._process.behavior == "execution_error":
+            response = error_worker_response(
+                request.request_id,
+                RuntimeError("scan failed"),
+            )
+            self._process.stdout.feed(serialize_worker_response(response))
+        elif self._process.behavior == "invalid":
+            self._process.stdout.feed(b"{}\n")
+        elif self._process.behavior == "eof":
+            self._process.finish(1)
+            self._process.stdout.feed(b"")
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+        if self._process.exit_on_close:
+            self._process.finish(0)
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        pid: int,
+        behavior: str,
+        *,
+        exit_on_close: bool = True,
+        exit_on_terminate: bool = True,
+    ) -> None:
+        self.pid = pid
+        self.behavior = behavior
+        self.exit_on_close = exit_on_close
+        self.exit_on_terminate = exit_on_terminate
+        self.returncode = None
+        self.stdout = FakeReader()
+        self.stderr = FakeReader()
+        self.stdin = FakeStdin(self)
+        self.signals: list[str] = []
+        self._exited = asyncio.Event()
+
+    async def wait(self) -> int:
+        await self._exited.wait()
+        assert self.returncode is not None
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.signals.append("terminate")
+        if self.exit_on_terminate:
+            self.finish(-15)
+
+    def kill(self) -> None:
+        self.signals.append("kill")
+        self.finish(-9)
+
+    def finish(self, returncode: int) -> None:
+        if self.returncode is None:
+            self.returncode = returncode
+            self._exited.set()
+
+
+def make_change(tmp_path: Path) -> SkillFsChange:
+    skill_dir = tmp_path / "weather"
+    return SkillFsChange(
+        skill_dir=skill_dir,
+        skill_name=skill_dir.name,
+        event_kinds={"write"},
+        paths={"SKILL.md"},
+    )
+
+
+def install_process_factory(monkeypatch, processes: list[FakeProcess]) -> list[tuple]:
+    calls = []
+
+    async def create_process(*args, **kwargs):
+        calls.append((args, kwargs))
+        return processes.pop(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    return calls
+
+
+def test_worker_client_starts_lazily_and_reuses_process(monkeypatch, tmp_path: Path):
+    process = FakeProcess(101, "success")
+    calls = install_process_factory(monkeypatch, [process])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        assert client.pid is None
+        first = await client.process_change(make_change(tmp_path))
+        second = await client.process_change(make_change(tmp_path))
+        pid = client.pid
+        await client.stop()
+        return first, second, pid
+
+    first, second, pid = asyncio.run(scenario())
+
+    assert len(calls) == 1
+    assert calls[0][0][:3] == (
+        worker_client_module.sys.executable,
+        "-m",
+        "agent_sec_cli.daemon.jobs.skill_ledger.worker",
+    )
+    assert first["workerPid"] == 101
+    assert second["workerPid"] == 101
+    assert pid == 101
+
+
+@pytest.mark.parametrize("first_behavior", ["eof", "invalid"])
+def test_worker_client_restarts_once_and_retries_current_change(
+    monkeypatch,
+    tmp_path: Path,
+    first_behavior: str,
+):
+    first = FakeProcess(
+        101,
+        first_behavior,
+        exit_on_close=first_behavior != "invalid",
+    )
+    second = FakeProcess(102, "success")
+    calls = install_process_factory(monkeypatch, [first, second])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        result = await client.process_change(make_change(tmp_path))
+        pid = client.pid
+        await client.stop()
+        return result, pid
+
+    result, pid = asyncio.run(scenario())
+
+    assert len(calls) == 2
+    assert result["workerPid"] == 102
+    assert pid == 102
+    if first_behavior == "invalid":
+        assert first.signals == ["terminate"]
+
+
+def test_worker_execution_error_does_not_restart(monkeypatch, tmp_path: Path):
+    process = FakeProcess(101, "execution_error")
+    calls = install_process_factory(monkeypatch, [process])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        with pytest.raises(SkillLedgerWorkerExecutionError, match="scan failed"):
+            await client.process_change(make_change(tmp_path))
+        pid = client.pid
+        await client.stop()
+        return pid
+
+    pid = asyncio.run(scenario())
+
+    assert len(calls) == 1
+    assert pid == 101
+
+
+def test_worker_transport_retries_only_once(monkeypatch, tmp_path: Path):
+    calls = install_process_factory(
+        monkeypatch,
+        [FakeProcess(101, "eof"), FakeProcess(102, "eof")],
+    )
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        with pytest.raises(SkillLedgerWorkerTransportError, match="exit code 1"):
+            await client.process_change(make_change(tmp_path))
+        return client.pid
+
+    pid = asyncio.run(scenario())
+
+    assert len(calls) == 2
+    assert pid is None
+
+
+def test_worker_scan_error_does_not_restart(monkeypatch, tmp_path: Path):
+    process = FakeProcess(101, "scan_error")
+    calls = install_process_factory(monkeypatch, [process])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        result = await client.process_change(make_change(tmp_path))
+        pid = client.pid
+        await client.stop()
+        return result, pid
+
+    result, pid = asyncio.run(scenario())
+
+    assert len(calls) == 1
+    assert result["error"] == "scan failed"
+    assert pid == 101
+
+
+def test_worker_cancellation_terminates_process(monkeypatch, tmp_path: Path):
+    process = FakeProcess(
+        101,
+        "hang",
+        exit_on_close=False,
+        exit_on_terminate=True,
+    )
+    install_process_factory(monkeypatch, [process])
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        task = asyncio.create_task(client.process_change(make_change(tmp_path)))
+        await process.stdin.written.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        return client.pid
+
+    pid = asyncio.run(scenario())
+
+    assert process.signals == ["terminate"]
+    assert pid is None
+
+
+def test_worker_stop_escalates_to_kill(monkeypatch, tmp_path: Path):
+    process = FakeProcess(
+        101,
+        "success",
+        exit_on_close=False,
+        exit_on_terminate=False,
+    )
+    install_process_factory(monkeypatch, [process])
+    monkeypatch.setattr(
+        worker_client_module,
+        "_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        worker_client_module,
+        "_TERMINATE_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    async def scenario():
+        client = SkillLedgerWorkerClient()
+        await client.process_change(make_change(tmp_path))
+        await client.stop()
+
+    asyncio.run(scenario())
+
+    assert process.stdin.closed is True
+    assert process.signals == ["terminate", "kill"]

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_protocol.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_protocol.py
@@ -1,0 +1,144 @@
+"""Tests for the Skill Ledger worker NDJSON protocol."""
+
+# ruff: noqa: I001
+
+import json
+from pathlib import Path
+
+import pytest
+from agent_sec_cli.daemon.jobs.skill_ledger.protocol import (
+    MAX_WORKER_FRAME_BYTES,
+    SkillFsChange,
+    WorkerProtocolError,
+    error_worker_response,
+    new_worker_request,
+    parse_worker_request,
+    parse_worker_response,
+    serialize_worker_request,
+    serialize_worker_response,
+    success_worker_response,
+)
+
+
+def make_change(tmp_path: Path) -> SkillFsChange:
+    skill_dir = tmp_path / "weather"
+    return SkillFsChange(
+        skill_dir=skill_dir,
+        skill_name=skill_dir.name,
+        event_kinds={"write", "rename"},
+        paths={"SKILL.md", "run.sh"},
+    )
+
+
+def test_worker_request_round_trip(tmp_path: Path):
+    request = new_worker_request(make_change(tmp_path))
+
+    parsed = parse_worker_request(serialize_worker_request(request))
+
+    assert parsed.request_id == request.request_id
+    assert parsed.change == request.change
+
+
+def test_worker_success_response_round_trip():
+    response = success_worker_response("request-1", {"status": "processed"})
+
+    parsed = parse_worker_response(serialize_worker_response(response))
+
+    assert parsed.request_id == "request-1"
+    assert parsed.ok is True
+    assert parsed.result == {"status": "processed"}
+    assert parsed.error is None
+
+
+def test_worker_error_response_round_trip():
+    response = error_worker_response("request-1", RuntimeError("scan failed"))
+
+    parsed = parse_worker_response(serialize_worker_response(response))
+
+    assert parsed.ok is False
+    assert parsed.result is None
+    assert parsed.error is not None
+    assert parsed.error.error_type == "RuntimeError"
+    assert parsed.error.message == "scan failed"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "schemaVersion"),
+        ({"schemaVersion": 1}, "requestId"),
+        (
+            {"schemaVersion": 1, "requestId": "1", "method": "unknown"},
+            "method",
+        ),
+        (
+            {
+                "schemaVersion": 1,
+                "requestId": "1",
+                "method": "process_change",
+                "change": {},
+            },
+            "skillDir",
+        ),
+        (
+            {
+                "schemaVersion": 1,
+                "requestId": "1",
+                "method": "process_change",
+                "change": {
+                    "skillDir": "relative",
+                    "skillName": "relative",
+                    "eventKinds": [],
+                    "paths": [],
+                },
+            },
+            "absolute",
+        ),
+        (
+            {
+                "schemaVersion": 1,
+                "requestId": "1",
+                "method": "process_change",
+                "change": {
+                    "skillDir": "/skills/weather",
+                    "skillName": "weather",
+                    "eventKinds": ["unknown"],
+                    "paths": [],
+                },
+            },
+            "eventKinds",
+        ),
+        (
+            {
+                "schemaVersion": 1,
+                "requestId": "1",
+                "method": "process_change",
+                "change": {
+                    "skillDir": "/skills/weather",
+                    "skillName": "weather",
+                    "eventKinds": ["write"],
+                    "paths": ["../escape"],
+                },
+            },
+            "relative paths",
+        ),
+    ],
+)
+def test_worker_request_rejects_invalid_payload(payload, message):
+    frame = (json.dumps(payload) + "\n").encode()
+
+    with pytest.raises(WorkerProtocolError, match=message):
+        parse_worker_request(frame)
+
+
+@pytest.mark.parametrize("frame", [b"", b"not-json\n", b"[]\n", b"\xff\n"])
+def test_worker_protocol_rejects_invalid_frames(frame: bytes):
+    with pytest.raises(WorkerProtocolError):
+        parse_worker_response(frame)
+
+
+def test_worker_protocol_rejects_oversized_frame():
+    frame = b"x" * (MAX_WORKER_FRAME_BYTES + 1)
+
+    with pytest.raises(WorkerProtocolError, match="exceeds"):
+        parse_worker_request(frame)

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_protocol.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_worker_protocol.py
@@ -122,6 +122,34 @@ def test_worker_error_response_round_trip():
             },
             "relative paths",
         ),
+        (
+            {
+                "schemaVersion": 1,
+                "requestId": "1",
+                "method": "process_change",
+                "change": {
+                    "skillDir": "/skills/weather\x00",
+                    "skillName": "weather",
+                    "eventKinds": ["write"],
+                    "paths": [],
+                },
+            },
+            "NUL",
+        ),
+        (
+            {
+                "schemaVersion": 1,
+                "requestId": "1",
+                "method": "process_change",
+                "change": {
+                    "skillDir": "/skills/weather",
+                    "skillName": "weather",
+                    "eventKinds": ["write"],
+                    "paths": ["scripts/run\x00.sh"],
+                },
+            },
+            "NUL",
+        ),
     ],
 )
 def test_worker_request_rejects_invalid_payload(payload, message):


### PR DESCRIPTION
## Description

This groups the Skill Ledger daemon job under `daemon/jobs/skill_ledger` and removes the old top-level activation module, fixing the placement reported in #1474. It moves synchronous scan and activation work into one lazily started, persistent child process so daemon model preload no longer shares the same Python process with Skill Ledger cold-start work. The parent retains notification validation, debounce, pending queues, and health state; worker transport failures restart once and retry the current change, while scan errors preserve the existing job error behavior.

## Related Issue

closes #1474

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [x] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make python-code-pretty`
- Ruff check over all changed production and test files
- `make test-python`: 2,824 unit/integration tests passed, 74 CLI e2e passed, 11 daemon e2e passed, and 50 Skill Ledger e2e passed
- Real worker integration coverage verifies a distinct PID, PID reuse across requests, and no remaining PID after daemon shutdown
- Worker lifecycle unit coverage verifies protocol validation, single retry after crash/EOF/protocol failure, no restart for scan errors, cancellation, graceful shutdown, terminate, and kill
- Review-fix regression coverage: 162 daemon unit tests passed, 13 Skill Ledger daemon integration tests passed, and 57 focused handler/protocol/worker tests passed

## Additional Notes

The full repository `make python-lint` currently reports 265 pre-existing issues outside this change; Ruff passes for every file changed by this PR. Linux CI is passing. This PR intentionally does not add duplicate-hash suppression, incremental scanning, or batched reconciliation.