### PR TITLE
fix(sight): correct SSL library attribution and expand unit test coverage

### DIFF
--- a/src/agentsight/docs/codex-adaptation.md
+++ b/src/agentsight/docs/codex-adaptation.md
@@ -1,13 +1,13 @@
 # Codex CLI 适配指南
 
-AgentSight 通过 eBPF uprobe 捕获 Codex CLI 的 TLS 明文流量。Codex 静态链接 aws-lc（BoringSSL 兼容 C ABI），并使用 `SSL_write_ex` / `SSL_read_ex` 作为加密入口。当二进制保留符号时按符号挂载即可；剥离了符号时需要通过内置 offset 表查表。
+AgentSight 通过 eBPF uprobe 捕获 Codex CLI 的 TLS 明文流量。Codex 通过 reqwest → native-tls → openssl-sys 静态链接 OpenSSL 3.x，并使用 `SSL_write_ex` / `SSL_read_ex` 作为加密入口（rustls + aws-lc-rs 仅用于 WebSocket TLS，不走 `SSL_write_ex`）。当二进制保留符号时按符号挂载即可；剥离了符号时需要通过内置 offset 表查表。
 
 ## 三级回退
 
 | Tier | 方式 | 适用场景 |
 |------|------|---------|
 | 1 | 按符号名挂 uprobe | 二进制保留 `.dynsym` / `.symtab` 时（自编译默认） |
-| 2 | 字节码 pattern 扫描 | 已收录指纹的常见 BoringSSL 构建 |
+| 2 | 字节码 pattern 扫描 | 已收录指纹的常见 BoringSSL / OpenSSL 构建 |
 | 3 | 内置 offset 表查表 | 已收录版本的 stripped binary |
 
 未命中三级则放弃挂载并打印 warn 日志。
@@ -115,7 +115,7 @@ python3 src/agentsight/scripts/extract-codex-offsets.py /path/to/codex-with-symb
 ## 手动提取（无脚本时）
 
 ```bash
-# 优先用 _ex 变体（aws-lc / BoringSSL 默认导出）
+# 优先用 _ex 变体（OpenSSL 3.x 默认导出）
 nm --defined-only /path/to/codex-with-symbols | grep -E ' (SSL_write_ex|SSL_read_ex|SSL_do_handshake)$'
 
 # 如果没有 _ex，退到普通 SSL_write / SSL_read
@@ -128,13 +128,49 @@ nm --defined-only /path/to/codex-with-symbols | grep -E ' (SSL_write|SSL_read|SS
 
 极端情况下既拿不到 symbols 包也无法重新编译（比如目标版本源码已不可获取），可以用 `objdump` 加 `bpftrace` / tracefs uprobe 的命中数比对来人工锁定地址。已收录的 0.137 偏移就是这样拿到的。大致思路：
 
-1. `objdump -d` 找具备 aws-lc `SSL_write_ex` 序言特征的候选地址，可借助 `strings -t x` 反查 aws-lc 内部字符串引用收窄范围。
+1. `objdump -d` 找具备 OpenSSL `SSL_write_ex` 序言特征的候选地址，可借助 `strings -t x` 反查 OpenSSL 内部字符串引用收窄范围。
 2. 用 `bpftrace -e 'uprobe:/path/to/codex:0x<CANDIDATE> { @ = count(); }'` 挂到候选 offset，同时跑一次真实 codex 请求；命中数应满足 `SSL_do_handshake = 1`、`SSL_write_ex ≈ 1`、`SSL_read_ex` 与 SSE chunk 数同阶。
 3. 用 uretprobe 抓 `$retval` 判断是否 `_ex` 变体（返回值仅 0/1，真实长度由第 4 参数 `*written` 回写），据此设置 `write_is_ex` / `read_is_ex`。
 
 这条路线工作量大且容易出错，建议优先走前面三种带符号副本的方式。
 
+## 误判记录：为什么曾误认为 aws-lc
+
+早期分析将 codex 的 TLS 库误判为 aws-lc（BoringSSL 兼容），原因如下：
+
+1. **依赖树误读**：Cargo.toml 声明了 `rustls` + `aws_lc_rs` feature，分析者假设所有 TLS 流量都走 rustls/aws-lc-rs。实际上 reqwest 用的是 `default-tls`（→ native-tls → openssl-sys），rustls 仅用于 tokio-tungstenite 的 WebSocket TLS。
+2. **API 名称歧义**：`SSL_write_ex` 在 OpenSSL 和 aws-lc 中都存在（aws-lc 是 BoringSSL fork，实现了相同的 SSL C API），stripped binary 无法用 `nm` 区分。
+3. **缺少 symbols 包**：0.139 及以下没有官方 symbols 包，无法做符号级验证。直到下载了 0.141.0 的 symbols 包，`nm` 才看到 `SSL_write_ex` 周围全是 `ossl_*` 前缀的函数（2705 个），而 `aws_lc_*` 前缀的函数（5 个）全是 crypto 原语（AES、HKDF 等），没有 SSL API。
+4. **Runloop 场景误导**：Runloop 场景下 codex 连本地代理走明文，Node.js 代理走 OpenSSL，这让分析者更确信 codex 不走 OpenSSL——但实际原因是 Runloop 把 codex 配置为连本地代理，不是 codex 本身不支持 OpenSSL。
+
+验证结论：0.50.0 / 0.137 / 0.141 三个版本均通过 `strings` 确认内嵌 `OpenSSL 3.5.x`，REST API 全程走 OpenSSL，AgentSight 挂 `SSL_write_ex` 可抓到全部 LLM 流量。
+
 ## 符号与 ABI
+
+### 为什么 codex 用 `_ex` 变体
+
+Codex 静态链接 OpenSSL 3.x（通过 reqwest → native-tls → openssl-sys）。OpenSSL 3.0+ 引入了 `SSL_write_ex` / `SSL_read_ex` 作为推荐 API，返回 0/1 表示成功/失败，字节数通过出参回写。虽然 OpenSSL 仍导出传统 `SSL_write` / `SSL_read`，但 reqwest / native-tls 默认调用 `_ex` 变体。经实测（带符号二进制 `nm` 验证），`SSL_write_ex` 地址与 offset 表完全吻合，且 `SSL_write` / `SSL_read` 也存在于同一段地址空间。
+
+### `_ex` 与普通 `SSL_write` 的 ABI 差异
+
+| | `SSL_write` (OpenSSL ≤2.x) | `SSL_write_ex` (OpenSSL 3.x) |
+|---|---|---|
+| 返回值 | 写入字节数（≥0 成功，<0 失败） | 0/1（1=成功，0=失败） |
+| 字节数来源 | 返回值 `rax` | 第 4 参数出参 `*written`（`rcx` 指向的内存） |
+| BPF 读取方式 | `kretprobe` 读 `rax` | `kretprobe` 读 `*written` 指针指向的内存 |
+
+`SSL_read_ex` 同理：返回 0/1，真实字节数在 `*readbytes` 出参里。
+
+### BPF 程序路由
+
+offset 表的 `write_is_ex` / `read_is_ex` 标志决定 `attach_static_ssl_by_offset` 挂载哪组 BPF 程序：
+
+- `write_is_ex = true` → 挂 `probe_SSL_write_ex_enter`（entry 保存 `rcx` = `*written` 指针）+ `probe_SSL_write_ex_exit`（return 时读 `*written` 得到字节数）
+- `write_is_ex = false` → 挂 `probe_SSL_rw_enter`（entry 保存 `rsi` = buf 指针、`rdx` = len）+ `SSL_exit`（return 时读 `rax` 得到字节数）
+
+如果 `write_is_ex` 标志设错（比如把 `_ex` 函数当成普通 `SSL_write` 挂），BPF 会从返回值 `rax` 读字节数——但 `_ex` 的返回值只有 0/1，导致每次事件只上报 1 字节，HTTP parser 拿到的是垃圾数据。
+
+### 符号总表
 
 | 符号 | 角色 | 说明 |
 |------|------|------|
@@ -142,7 +178,7 @@ nm --defined-only /path/to/codex-with-symbols | grep -E ' (SSL_write|SSL_read|SS
 | `SSL_read` / `SSL_read_ex` | 读端 | 解密明文交给应用 |
 | `SSL_do_handshake` | 握手 | 标记 TLS 握手完成 |
 
-`*_ex` 与普通 `SSL_write/SSL_read` 的关键差异：返回值是 0/1 成功标志，真实长度通过出参 `written` / `readbytes` 写回。这要求 BPF 探针在 `kretprobe` 中读取出参而不是返回值，因此 offset 表里 `write_is_ex` / `read_is_ex` 不能省。
+offset 表里 `write_is_ex` / `read_is_ex` 不能省——它决定了 BPF 从哪个位置读取真实字节数。
 
 ## PR 模板
 

--- a/src/agentsight/scripts/extract-codex-offsets.py
+++ b/src/agentsight/scripts/extract-codex-offsets.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Extract aws-lc/BoringSSL function offsets from a codex binary.
+"""Extract OpenSSL 3.x function offsets from a codex binary.
 
-Codex CLI links aws-lc statically (BoringSSL-compatible C ABI). When the
-release binary keeps its symbol table, the offsets of `SSL_write_ex`,
+Codex CLI links OpenSSL 3.x statically (via reqwest → native-tls → openssl-sys).
+When the release binary keeps its symbol table, the offsets of `SSL_write_ex`,
 `SSL_read_ex`, and `SSL_do_handshake` can be read directly with `nm`.
 Falls back to `SSL_write` / `SSL_read` when the `_ex` variants are absent.
 
@@ -31,7 +31,7 @@ from typing import Dict, Optional
 
 HEAD_SIZE = 65536
 
-# Preferred symbols (aws-lc _ex variants). `SSL_write_ex` and `SSL_read_ex`
+# Preferred symbols (OpenSSL 3.x _ex variants). `SSL_write_ex` and `SSL_read_ex`
 # return 0/1 with the actual byte count in `*written` / `*readbytes`; the
 # Rust user-space gate routes BPF probes accordingly when `write_is_ex` /
 # `read_is_ex` is true.

--- a/src/agentsight/src/probes/codex_offsets.rs
+++ b/src/agentsight/src/probes/codex_offsets.rs
@@ -3,14 +3,14 @@ use std::fs::File;
 use std::io::Read;
 
 use super::elf_buildid;
-use super::sslsniff::BoringSslOffsets;
+use super::sslsniff::StaticSslOffsets;
 
 const HEAD_SIZE: usize = 65536;
 
 #[derive(Debug)]
 struct OffsetEntry {
     fingerprint: Fingerprint,
-    offsets: Option<BoringSslOffsets>,
+    offsets: Option<StaticSslOffsets>,
 }
 
 #[derive(Debug)]
@@ -55,7 +55,7 @@ impl OffsetTable {
                         .get("read_is_ex")
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
-                    Some(BoringSslOffsets {
+                    Some(StaticSslOffsets {
                         ssl_write: w,
                         ssl_read: r,
                         ssl_do_handshake: h,
@@ -75,7 +75,7 @@ impl OffsetTable {
         Some(Self { entries })
     }
 
-    pub fn lookup(&self, path: &str) -> Option<BoringSslOffsets> {
+    pub fn lookup(&self, path: &str) -> Option<StaticSslOffsets> {
         let metadata = std::fs::metadata(path).ok()?;
         let file_size = metadata.len();
 

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -297,7 +297,7 @@ impl SslSniff {
     /// Attach SSL probes to a running process by reading its `/proc/<pid>/maps`.
     ///
     /// Detects which SSL libraries the process has mapped (OpenSSL, GnuTLS, NSS,
-    /// or BoringSSL embedded in a binary), attaches uprobes, and skips any
+    /// or statically-linked SSL — BoringSSL/OpenSSL), attaches uprobes, and skips any
     /// library whose inode has already been traced (dedup via `traced_files`).
     pub fn attach_process(&mut self, pid: i32) -> Result<()> {
         let libs = ssl_libs_from_maps(pid)?;
@@ -321,8 +321,8 @@ impl SslSniff {
             // Uprobes are attached globally (pid=-1), and the kernel's
             // uprobe_mmap mechanism automatically installs breakpoints for
             // new processes that map an already-registered inode, so each
-            // library only needs to be attached once — including BoringSSL
-            // static binaries (codex, node, etc).
+            // library only needs to be attached once — including statically-linked
+            // SSL binaries (codex, node, etc).
             if !self.traced_files.insert(inode) {
                 log::debug!("[attach_process] pid={pid}: skipping already-traced {path}");
                 // Still record the pid→inode association so detach_process
@@ -338,53 +338,59 @@ impl SslSniff {
                 SslLibKind::OpenSsl => attach_openssl(&mut self.skel, &path, -1),
                 SslLibKind::GnuTls => attach_gnutls(&mut self.skel, &path, -1),
                 SslLibKind::Nss => attach_nss(&mut self.skel, &path, -1),
-                SslLibKind::Boring => match attach_boringssl_by_symbol(&mut self.skel, &path, -1) {
-                    Ok(ls) => Ok(ls),
-                    Err(sym_err) => {
-                        log::debug!(
-                            "[attach_process] pid={pid}: BoringSSL symbol attach failed for {path} ({sym_err:#}), falling back to byte-pattern"
-                        );
-                        match find_boringssl_offsets(&path) {
-                            Some(off) => {
-                                attach_boringssl_by_offset(&mut self.skel, &path, &off, false, -1)
-                            }
-                            None => {
-                                // Tier 3: codex offset table lookup (for static-pie binaries
-                                // like Codex CLI that embed aws-lc/BoringSSL without symbols)
-                                if let Some(ref table) = *CODEX_OFFSET_TABLE {
-                                    if let Some(off) = table.lookup(&path) {
-                                        log::info!(
-                                            "[attach_process] pid={pid}: codex offset table matched for {path} \
+                SslLibKind::Static => {
+                    match attach_static_ssl_by_symbol(&mut self.skel, &path, -1) {
+                        Ok(ls) => Ok(ls),
+                        Err(sym_err) => {
+                            log::debug!(
+                                "[attach_process] pid={pid}: Static SSL symbol attach failed for {path} ({sym_err:#}), falling back to byte-pattern"
+                            );
+                            match find_static_ssl_offsets(&path) {
+                                Some(off) => attach_static_ssl_by_offset(
+                                    &mut self.skel,
+                                    &path,
+                                    &off,
+                                    false,
+                                    -1,
+                                ),
+                                None => {
+                                    // Tier 3: codex offset table lookup (for static-pie binaries
+                                    // like Codex CLI that statically link OpenSSL/BoringSSL without symbols)
+                                    if let Some(ref table) = *CODEX_OFFSET_TABLE {
+                                        if let Some(off) = table.lookup(&path) {
+                                            log::info!(
+                                                "[attach_process] pid={pid}: codex offset table matched for {path} \
                                              (write=0x{:x}, read=0x{:x}, handshake=0x{:x})",
-                                            off.ssl_write,
-                                            off.ssl_read,
-                                            off.ssl_do_handshake
-                                        );
-                                        attach_boringssl_by_offset(
-                                            &mut self.skel,
-                                            &path,
-                                            &off,
-                                            true,
-                                            -1,
-                                        )
+                                                off.ssl_write,
+                                                off.ssl_read,
+                                                off.ssl_do_handshake
+                                            );
+                                            attach_static_ssl_by_offset(
+                                                &mut self.skel,
+                                                &path,
+                                                &off,
+                                                true,
+                                                -1,
+                                            )
+                                        } else {
+                                            log::warn!(
+                                                "[attach_process] pid={pid}: SSL detection failed for {path} \
+                                             (no SSL_* in .dynsym, no byte-pattern match, and not in codex offset table), skipping"
+                                            );
+                                            continue;
+                                        }
                                     } else {
                                         log::warn!(
-                                            "[attach_process] pid={pid}: BoringSSL detection failed for {path} \
-                                             (no SSL_* in .dynsym, no byte-pattern match, and not in codex offset table), skipping"
+                                            "[attach_process] pid={pid}: SSL detection failed for {path} \
+                                         (no SSL_* in .dynsym and no byte-pattern match), skipping"
                                         );
                                         continue;
                                     }
-                                } else {
-                                    log::warn!(
-                                        "[attach_process] pid={pid}: BoringSSL detection failed for {path} \
-                                         (no SSL_* in .dynsym and no byte-pattern match), skipping"
-                                    );
-                                    continue;
                                 }
                             }
                         }
                     }
-                },
+                }
             };
 
             match result {
@@ -535,16 +541,16 @@ impl Drop for SslPoller {
     }
 }
 
-// ─── BoringSSL pattern detection ─────────────────────────────────────────────
+// ─── Static SSL pattern detection ────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
-pub(super) struct BoringSslOffsets {
+pub(super) struct StaticSslOffsets {
     pub ssl_write: usize,
     pub ssl_read: usize,
     pub ssl_do_handshake: usize,
     /// True when `ssl_write` points to `SSL_write_ex` (returns 0/1 + *written),
-    /// rather than `SSL_write` (returns byte count). Required for aws-lc where
-    /// only the _ex variant is exported.
+    /// rather than `SSL_write` (returns byte count). Required for OpenSSL 3.x
+    /// where the `_ex` variant is preferred by native-tls / openssl-sys.
     pub write_is_ex: bool,
     /// True when `ssl_read` points to `SSL_read_ex` rather than `SSL_read`.
     pub read_is_ex: bool,
@@ -575,8 +581,8 @@ fn find_all_patterns(haystack: &[u8], pattern: &[u8]) -> Vec<usize> {
     results
 }
 
-fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
-    // BoringSSL function prologue byte patterns (x86_64).
+fn find_static_ssl_offsets(path: &str) -> Option<StaticSslOffsets> {
+    // SSL function prologue byte patterns (x86_64).
     // These are stable across versions because they represent the fixed
     // parameter-saving and state-setup logic of the POSIX SSL API.
     const HANDSHAKE_PAT: &[u8] = &[
@@ -601,7 +607,7 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
     let read_matches = find_all_patterns(&data, READ_PAT);
     if read_matches.is_empty() {
         if verbose {
-            eprintln!("BoringSSL: SSL_read pattern not found in {path}");
+            eprintln!("Static SSL: SSL_read pattern not found in {path}");
         }
         return None;
     }
@@ -610,7 +616,7 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
     } else {
         if verbose {
             eprintln!(
-                "BoringSSL: SSL_read pattern has {} matches, expected 1",
+                "Static SSL: SSL_read pattern has {} matches, expected 1",
                 read_matches.len()
             );
         }
@@ -621,7 +627,7 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
     let hs_matches = find_all_patterns(&data, HANDSHAKE_PAT);
     if hs_matches.is_empty() {
         if verbose {
-            eprintln!("BoringSSL: SSL_do_handshake pattern not found in {path}");
+            eprintln!("Static SSL: SSL_do_handshake pattern not found in {path}");
         }
         return None;
     }
@@ -635,7 +641,7 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
             None => {
                 if verbose {
                     eprintln!(
-                        "BoringSSL: SSL_do_handshake has {} matches, none before SSL_read",
+                        "Static SSL: SSL_do_handshake has {} matches, none before SSL_read",
                         hs_matches.len()
                     );
                 }
@@ -648,7 +654,7 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
     let write_matches = find_all_patterns(&data, WRITE_PAT);
     if write_matches.is_empty() {
         if verbose {
-            eprintln!("BoringSSL: SSL_write pattern not found in {path}");
+            eprintln!("Static SSL: SSL_write pattern not found in {path}");
         }
         return None;
     }
@@ -661,7 +667,7 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
         .or_else(|| {
             if verbose {
                 eprintln!(
-                    "BoringSSL: SSL_write has {} matches but none within {}B after SSL_read ({:#x})",
+                    "Static SSL: SSL_write has {} matches but none within {}B after SSL_read ({:#x})",
                     write_matches.len(),
                     ADJACENCY_THRESHOLD,
                     read_off
@@ -670,12 +676,12 @@ fn find_boringssl_offsets(path: &str) -> Option<BoringSslOffsets> {
             None
         })?;
 
-    log::debug!("BoringSSL detected in {path}:");
+    log::debug!("Static SSL detected in {path}:");
     log::debug!("  SSL_do_handshake: {hs_off:#x}");
     log::debug!("  SSL_read:         {read_off:#x}");
     log::debug!("  SSL_write:        {wr_off:#x}");
 
-    Some(BoringSslOffsets {
+    Some(StaticSslOffsets {
         ssl_write: wr_off,
         ssl_read: read_off,
         ssl_do_handshake: hs_off,
@@ -695,8 +701,8 @@ enum SslLibKind {
     GnuTls,
     /// libnspr4.so (NSS / Firefox)
     Nss,
-    /// BoringSSL / aws-lc embedded in binary (e.g. Node.js, Chrome, Codex CLI)
-    Boring,
+    /// Statically-linked SSL (BoringSSL or OpenSSL, e.g. Node.js, Chrome, Codex CLI)
+    Static,
 }
 
 /// Classify a mapped file path into an `SslLibKind`, if it is an SSL library.
@@ -714,8 +720,8 @@ fn classify_ssl_lib(path: &str) -> Option<SslLibKind> {
     if name.starts_with("libnspr4.so") || name.starts_with("libnspr4-") {
         return Some(SslLibKind::Nss);
     }
-    // BoringSSL is typically linked statically into a binary (node, chrome, etc.).
-    // Detect common binary names that are known to embed BoringSSL.
+    // Statically-linked SSL (BoringSSL in node/chrome, OpenSSL in codex).
+    // Detect common binary names that are known to statically link SSL.
     if matches!(
         name.as_ref(),
         "node"
@@ -729,11 +735,11 @@ fn classify_ssl_lib(path: &str) -> Option<SslLibKind> {
             | "claude"
             | "claude.exe"
     ) {
-        return Some(SslLibKind::Boring);
+        return Some(SslLibKind::Static);
     }
-    // Codex CLI statically links aws-lc (BoringSSL-compatible TLS library).
+    // Codex CLI statically links OpenSSL 3.x (via openssl-sys / native-tls).
     if name.starts_with("codex") && !name.contains('.') {
-        return Some(SslLibKind::Boring);
+        return Some(SslLibKind::Static);
     }
     // uv Python statically links OpenSSL into the binary. The ELF .symtab contains
     // SSL_write/SSL_read/SSL_do_handshake as LOCAL symbols, so attach_openssl()
@@ -785,8 +791,8 @@ fn ssl_libs_from_maps(pid: i32) -> Result<Vec<(String, u64, SslLibKind)>> {
             // both host and container processes.
             let path_str = if path_str.ends_with(" (deleted)") {
                 format!("/proc/{pid}/exe")
-            } else if matches!(kind, SslLibKind::Boring) {
-                // BoringSSL is typically a static binary (codex, node, etc).
+            } else if matches!(kind, SslLibKind::Static) {
+                // Statically-linked SSL binary (codex, node, etc).
                 // /proc/<pid>/exe is a kernel-maintained symlink that stays
                 // valid even when the backing file has been replaced or
                 // unlinked, which is common for npm-installed binaries that
@@ -938,7 +944,7 @@ fn attach_nss(skel: &mut SslsniffSkel<'_>, lib: &str, pid: i32) -> Result<Vec<Li
     ])
 }
 
-fn attach_boringssl_by_symbol(
+fn attach_static_ssl_by_symbol(
     skel: &mut SslsniffSkel<'_>,
     lib: &str,
     pid: i32,
@@ -968,10 +974,10 @@ fn attach_boringssl_by_symbol(
     ])
 }
 
-fn attach_boringssl_by_offset(
+fn attach_static_ssl_by_offset(
     skel: &mut SslsniffSkel<'_>,
     lib: &str,
-    off: &BoringSslOffsets,
+    off: &StaticSslOffsets,
     handshake: bool,
     pid: i32,
 ) -> Result<Vec<Link>> {

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -1302,6 +1302,7 @@ mod tests {
             1234,
             "claude".to_string(),
         );
+        call.agent_name = Some("claude".to_string());
         call.set_response(
             LLMResponse {
                 messages: vec![OutputMessage {
@@ -1329,6 +1330,10 @@ mod tests {
         call.metadata.insert(
             "response_id".to_string(),
             format!("trace-{conversation_id}"),
+        );
+        call.metadata.insert(
+            "session_id".to_string(),
+            format!("session-{conversation_id}"),
         );
         call.metadata
             .insert("user_query".to_string(), "hello".to_string());
@@ -1614,6 +1619,694 @@ mod tests {
             serde_json::from_slice(&actix_web::body::to_bytes(resp.into_body()).await.unwrap())
                 .unwrap();
         assert_eq!(body["authenticated"], true);
+    }
+
+    fn test_app_state_with_storage(storage_path: PathBuf) -> web::Data<AppState> {
+        let auth_config = crate::config::ServerAuthConfig { enabled: false };
+        let auth = Arc::new(crate::server::auth::DashboardAuth::init(
+            &auth_config,
+            std::path::Path::new("/tmp"),
+        ));
+        web::Data::new(AppState {
+            storage_path: storage_path.clone(),
+            start_time: Instant::now(),
+            health_store: Arc::new(RwLock::new(HealthStore::new())),
+            interruption_store: None,
+            evaluation_store: Arc::new(EvaluationStore::new_with_path(&storage_path).unwrap()),
+            security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
+            auth,
+        })
+    }
+
+    fn test_app_state_with_interruption_store(
+        store: Arc<crate::storage::sqlite::InterruptionStore>,
+    ) -> web::Data<AppState> {
+        let auth_config = crate::config::ServerAuthConfig { enabled: false };
+        let auth = Arc::new(crate::server::auth::DashboardAuth::init(
+            &auth_config,
+            std::path::Path::new("/tmp"),
+        ));
+        web::Data::new(AppState {
+            storage_path: PathBuf::from(":memory:"),
+            start_time: Instant::now(),
+            health_store: Arc::new(RwLock::new(HealthStore::new())),
+            interruption_store: Some(store),
+            evaluation_store: Arc::new(
+                EvaluationStore::new_with_path(std::path::Path::new(":memory:")).unwrap(),
+            ),
+            security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
+            auth,
+        })
+    }
+
+    fn unique_handler_db(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "agentsight_handler_{label}_{}_{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn make_interruption_event(
+        id: &str,
+        session_id: &str,
+        conversation_id: &str,
+        itype: crate::interruption::InterruptionType,
+    ) -> crate::interruption::InterruptionEvent {
+        crate::interruption::InterruptionEvent {
+            interruption_id: id.to_string(),
+            session_id: Some(session_id.to_string()),
+            trace_id: Some(format!("trace-{conversation_id}")),
+            conversation_id: Some(conversation_id.to_string()),
+            call_id: Some(format!("call-{id}")),
+            pid: Some(1234),
+            agent_name: Some("Agent-A".to_string()),
+            interruption_type: itype,
+            severity: crate::interruption::types::Severity::High,
+            occurred_at_ns: 1_700_000_000_000_000_000,
+            detail: Some(r#"{"error":"rate limit"}"#.to_string()),
+            resolved: false,
+        }
+    }
+
+    #[actix_web::test]
+    async fn health_reports_status_version_and_uptime() {
+        let app =
+            awtest::init_service(App::new().app_data(test_app_state(0)).service(health)).await;
+        let response =
+            awtest::call_service(&app, awtest::TestRequest::get().uri("/health").to_request())
+                .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = service_response_json(response).await;
+        assert_eq!(body["status"], "ok");
+        assert!(body["version"].as_str().is_some());
+        assert!(body["uptime_seconds"].as_u64().is_some());
+    }
+
+    #[actix_web::test]
+    async fn genai_query_handlers_return_persisted_data() {
+        let db_path = unique_handler_db("genai_queries");
+        write_completed_conversation_event(&db_path, "conv-handler");
+        let app = awtest::init_service(
+            App::new()
+                .app_data(test_app_state_with_storage(db_path.clone()))
+                .service(list_sessions)
+                .service(list_traces_by_session)
+                .service(get_trace_detail)
+                .service(get_conversation_events)
+                .service(list_agent_names)
+                .service(get_timeseries),
+        )
+        .await;
+
+        let sessions = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/sessions?start_ns=0&end_ns=9223372036854775807")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(sessions.status(), StatusCode::OK);
+        let sessions_body = service_response_json(sessions).await;
+        assert_eq!(sessions_body.as_array().unwrap().len(), 1);
+        let session_id = sessions_body[0]["session_id"].as_str().unwrap();
+
+        let traces = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri(&format!(
+                    "/sessions/{session_id}/traces?start_ns=0&end_ns=9223372036854775807"
+                ))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(traces.status(), StatusCode::OK);
+        let traces_body = service_response_json(traces).await;
+        assert_eq!(traces_body.as_array().unwrap().len(), 1);
+
+        let detail = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/traces/trace-conv-handler")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(detail.status(), StatusCode::OK);
+        assert_eq!(
+            service_response_json(detail)
+                .await
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let conversation = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/conversations/conv-handler")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(conversation.status(), StatusCode::OK);
+        assert_eq!(
+            service_response_json(conversation)
+                .await
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let agent_names = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/agent-names?start_ns=0&end_ns=9223372036854775807")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(agent_names.status(), StatusCode::OK);
+        assert_eq!(service_response_json(agent_names).await[0], "claude");
+
+        let timeseries = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/timeseries?start_ns=0&end_ns=9223372036854775807&buckets=2")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(timeseries.status(), StatusCode::OK);
+        let timeseries_body = service_response_json(timeseries).await;
+        assert!(timeseries_body["token_series"].as_array().is_some());
+        assert!(timeseries_body["model_series"].as_array().is_some());
+
+        cleanup_db(&db_path);
+    }
+
+    #[actix_web::test]
+    async fn metrics_returns_prometheus_text_for_agent_tokens_and_interruptions() {
+        let db_path = unique_handler_db("metrics");
+        write_completed_conversation_event(&db_path, "conv-metrics");
+        let interruption_path = unique_handler_db("metrics_interruptions");
+        let istore = Arc::new(
+            crate::storage::sqlite::InterruptionStore::new_with_path(&interruption_path).unwrap(),
+        );
+        istore
+            .insert(&make_interruption_event(
+                "int-metrics",
+                "sess-metrics",
+                "conv-metrics",
+                crate::interruption::InterruptionType::RateLimit,
+            ))
+            .unwrap();
+        let auth_config = crate::config::ServerAuthConfig { enabled: false };
+        let auth = Arc::new(crate::server::auth::DashboardAuth::init(
+            &auth_config,
+            std::path::Path::new("/tmp"),
+        ));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(web::Data::new(AppState {
+                    storage_path: db_path.clone(),
+                    start_time: Instant::now(),
+                    health_store: Arc::new(RwLock::new(HealthStore::new())),
+                    interruption_store: Some(Arc::clone(&istore)),
+                    evaluation_store: Arc::new(EvaluationStore::new_with_path(&db_path).unwrap()),
+                    security_observability: super::super::SecurityObservabilityConfig {
+                        timeout_ms: 0,
+                    },
+                    auth,
+                }))
+                .service(metrics),
+        )
+        .await;
+
+        let response = awtest::call_service(
+            &app,
+            awtest::TestRequest::get().uri("/metrics").to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("agentsight_token_input_total"));
+        assert!(text.contains("agent=\"claude\""));
+        assert!(text.contains("agentsight_interruptions_total"));
+        assert!(text.contains("type=\"rate_limit\""));
+
+        cleanup_db(&db_path);
+        cleanup_db(&interruption_path);
+    }
+
+    #[actix_web::test]
+    async fn agent_health_filters_clients_and_allows_deletion() {
+        let state = test_app_state(0);
+        {
+            let mut store = state.health_store.write().unwrap();
+            store.update(
+                1001,
+                crate::health::AgentHealthStatus {
+                    pid: 1001,
+                    agent_name: "Gateway".to_string(),
+                    category: "agent".to_string(),
+                    exe_path: "/bin/gateway".to_string(),
+                    ports: vec![8080],
+                    status: crate::health::store::AgentHealthState::Healthy,
+                    last_check_time: 1,
+                    latency_ms: Some(10),
+                    error_message: None,
+                    restart_cmd: None,
+                    offline_since: None,
+                    role: crate::health::store::AgentRole::Gateway,
+                    parent_pid: None,
+                    has_crash: false,
+                },
+            );
+            store.update(
+                1002,
+                crate::health::AgentHealthStatus {
+                    pid: 1002,
+                    agent_name: "Client".to_string(),
+                    category: "agent".to_string(),
+                    exe_path: "/bin/client".to_string(),
+                    ports: Vec::new(),
+                    status: crate::health::store::AgentHealthState::Healthy,
+                    last_check_time: 1,
+                    latency_ms: None,
+                    error_message: None,
+                    restart_cmd: None,
+                    offline_since: None,
+                    role: crate::health::store::AgentRole::Client,
+                    parent_pid: None,
+                    has_crash: false,
+                },
+            );
+            store.update(
+                1003,
+                crate::health::AgentHealthStatus {
+                    pid: 1003,
+                    agent_name: "Cosh".to_string(),
+                    category: "agent".to_string(),
+                    exe_path: "/bin/cosh".to_string(),
+                    ports: Vec::new(),
+                    status: crate::health::store::AgentHealthState::Offline,
+                    last_check_time: 1,
+                    latency_ms: None,
+                    error_message: Some("offline".to_string()),
+                    restart_cmd: None,
+                    offline_since: Some(1),
+                    role: crate::health::store::AgentRole::Client,
+                    parent_pid: None,
+                    has_crash: true,
+                },
+            );
+        }
+        let app = awtest::init_service(
+            App::new()
+                .app_data(state)
+                .service(get_agent_health)
+                .route("/agent-health/{pid}", web::delete().to(delete_agent_health)),
+        )
+        .await;
+
+        let filtered = awtest::call_service(
+            &app,
+            awtest::TestRequest::get().uri("/agent-health").to_request(),
+        )
+        .await;
+        let filtered_body = service_response_json(filtered).await;
+        let filtered_agents = filtered_body["agents"].as_array().unwrap();
+        assert_eq!(filtered_agents.len(), 1);
+        assert_eq!(filtered_agents[0]["pid"], 1001);
+
+        let include_clients = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/agent-health?include_clients=true")
+                .to_request(),
+        )
+        .await;
+        let include_body = service_response_json(include_clients).await;
+        let agents = include_body["agents"].as_array().unwrap();
+        assert_eq!(agents.len(), 2, "Cosh should still be excluded");
+
+        let deleted = awtest::call_service(
+            &app,
+            awtest::TestRequest::delete()
+                .uri("/agent-health/1001")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(deleted.status(), StatusCode::OK);
+        assert_eq!(service_response_json(deleted).await["ok"], true);
+
+        let missing = awtest::call_service(
+            &app,
+            awtest::TestRequest::delete()
+                .uri("/agent-health/9999")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn interruption_handlers_cover_list_stats_counts_detail_and_resolve() {
+        let interruption_path = unique_handler_db("interruptions");
+        let istore = Arc::new(
+            crate::storage::sqlite::InterruptionStore::new_with_path(&interruption_path).unwrap(),
+        );
+        istore
+            .insert(&make_interruption_event(
+                "int-handler-1",
+                "sess-handler",
+                "conv-handler-i",
+                crate::interruption::InterruptionType::RateLimit,
+            ))
+            .unwrap();
+        istore
+            .insert(&make_interruption_event(
+                "int-handler-2",
+                "sess-handler",
+                "conv-handler-i",
+                crate::interruption::InterruptionType::AuthError,
+            ))
+            .unwrap();
+        let app = awtest::init_service(
+            App::new()
+                .app_data(test_app_state_with_interruption_store(Arc::clone(&istore)))
+                .service(list_interruptions)
+                .service(interruption_count)
+                .service(interruption_stats)
+                .service(interruption_session_counts)
+                .service(interruption_conversation_counts)
+                .service(list_session_interruptions)
+                .service(list_conversation_interruptions)
+                .service(get_interruption)
+                .route(
+                    "/interruptions/{interruption_id}/resolve",
+                    web::post().to(resolve_interruption),
+                ),
+        )
+        .await;
+
+        let list = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/interruptions?start_ns=0&end_ns=9223372036854775807")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(list.status(), StatusCode::OK);
+        assert_eq!(
+            service_response_json(list).await.as_array().unwrap().len(),
+            2
+        );
+
+        let count = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/interruptions/count?start_ns=0&end_ns=9223372036854775807")
+                .to_request(),
+        )
+        .await;
+        let count_body = service_response_json(count).await;
+        assert_eq!(count_body["total"], 2);
+        assert_eq!(count_body["by_severity"]["high"], 2);
+
+        let stats = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/interruptions/stats?start_ns=0&end_ns=9223372036854775807")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            service_response_json(stats).await.as_array().unwrap().len(),
+            2
+        );
+
+        let session_counts = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/interruptions/session-counts?start_ns=0&end_ns=9223372036854775807")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(service_response_json(session_counts).await[0]["total"], 2);
+
+        let conversation_counts = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/interruptions/conversation-counts?start_ns=0&end_ns=9223372036854775807")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            service_response_json(conversation_counts).await[0]["total"],
+            2
+        );
+
+        let by_session = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/sessions/sess-handler/interruptions")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            service_response_json(by_session)
+                .await
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+
+        let by_conversation = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/conversations/conv-handler-i/interruptions")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            service_response_json(by_conversation)
+                .await
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+
+        let detail = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/interruptions/int-handler-1")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            service_response_json(detail).await["interruption_id"],
+            "int-handler-1"
+        );
+
+        let resolved = awtest::call_service(
+            &app,
+            awtest::TestRequest::post()
+                .uri("/interruptions/int-handler-1/resolve")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resolved.status(), StatusCode::OK);
+        assert_eq!(service_response_json(resolved).await["status"], "resolved");
+
+        let missing = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/interruptions/missing-id")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+        cleanup_db(&interruption_path);
+    }
+
+    #[actix_web::test]
+    async fn interruption_handlers_return_unavailable_without_store() {
+        let app = awtest::init_service(
+            App::new()
+                .app_data(test_app_state(0))
+                .service(list_interruptions)
+                .service(interruption_count)
+                .service(interruption_stats),
+        )
+        .await;
+
+        for uri in [
+            "/interruptions",
+            "/interruptions/count",
+            "/interruptions/stats",
+        ] {
+            let response =
+                awtest::call_service(&app, awtest::TestRequest::get().uri(uri).to_request()).await;
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        }
+    }
+
+    #[actix_web::test]
+    async fn atif_export_handlers_return_documents_and_not_found() {
+        let db_path = unique_handler_db("atif_exports");
+        write_completed_conversation_event(&db_path, "conv-atif");
+        let app = awtest::init_service(
+            App::new()
+                .app_data(test_app_state_with_storage(db_path.clone()))
+                .service(export_atif_trace)
+                .service(export_atif_session)
+                .service(export_atif_conversation),
+        )
+        .await;
+
+        for uri in [
+            "/export/atif/trace/trace-conv-atif",
+            "/export/atif/session/session-conv-atif",
+            "/export/atif/conversation/conv-atif",
+        ] {
+            let response =
+                awtest::call_service(&app, awtest::TestRequest::get().uri(uri).to_request()).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "{uri} should export ATIF"
+            );
+            let body = service_response_json(response).await;
+            assert!(body.is_object(), "{uri} should return a JSON document");
+        }
+
+        for (uri, message) in [
+            ("/export/atif/trace/missing-trace", "trace not found"),
+            ("/export/atif/session/missing-session", "session not found"),
+            (
+                "/export/atif/conversation/missing-conversation",
+                "conversation not found",
+            ),
+        ] {
+            let response =
+                awtest::call_service(&app, awtest::TestRequest::get().uri(uri).to_request()).await;
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            assert_eq!(service_response_json(response).await["error"], message);
+        }
+
+        cleanup_db(&db_path);
+    }
+
+    #[actix_web::test]
+    async fn skill_metrics_handlers_return_reports_for_all_metric_variants() {
+        let db_path = unique_handler_db("skill_metrics");
+        write_completed_conversation_event(&db_path, "conv-skill-metrics");
+        let app = awtest::init_service(
+            App::new()
+                .app_data(test_app_state_with_storage(db_path.clone()))
+                .service(skill_metrics_all)
+                .service(skill_metrics_downloads)
+                .service(skill_metrics_loads)
+                .service(skill_metrics_usage_ratio)
+                .service(skill_metrics_distribution)
+                .service(skill_metrics_hotness),
+        )
+        .await;
+
+        for uri in [
+            "/skill-metrics?start_ns=0&end_ns=9223372036854775807&granularity=day",
+            "/skill-metrics/downloads?start_ns=0&end_ns=9223372036854775807",
+            "/skill-metrics/loads?start_ns=0&end_ns=9223372036854775807",
+            "/skill-metrics/usage-ratio?start_ns=0&end_ns=9223372036854775807",
+            "/skill-metrics/distribution?start_ns=0&end_ns=9223372036854775807",
+            "/skill-metrics/hotness?start_ns=0&end_ns=9223372036854775807&granularity=day",
+        ] {
+            let response =
+                awtest::call_service(&app, awtest::TestRequest::get().uri(uri).to_request()).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "{uri} should return report"
+            );
+            let body = service_response_json(response).await;
+            assert!(body.is_object(), "{uri} should return JSON object");
+        }
+
+        cleanup_db(&db_path);
+    }
+
+    #[actix_web::test]
+    async fn storage_backed_handlers_report_database_open_errors() {
+        let root = temp_root("handler_open_errors");
+        std::fs::write(&root, b"not a directory").unwrap();
+        let blocked_db = root.join("events.db");
+        let auth_config = crate::config::ServerAuthConfig { enabled: false };
+        let auth = Arc::new(crate::server::auth::DashboardAuth::init(
+            &auth_config,
+            std::path::Path::new("/tmp"),
+        ));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(web::Data::new(AppState {
+                    storage_path: blocked_db.clone(),
+                    start_time: Instant::now(),
+                    health_store: Arc::new(RwLock::new(HealthStore::new())),
+                    interruption_store: None,
+                    evaluation_store: Arc::new(
+                        EvaluationStore::new_with_path(std::path::Path::new(":memory:")).unwrap(),
+                    ),
+                    security_observability: super::super::SecurityObservabilityConfig {
+                        timeout_ms: 0,
+                    },
+                    auth,
+                }))
+                .service(list_sessions)
+                .service(list_agent_names)
+                .service(get_timeseries)
+                .service(metrics)
+                .service(export_atif_trace)
+                .service(skill_metrics_all),
+        )
+        .await;
+
+        for (uri, status) in [
+            ("/sessions", StatusCode::INTERNAL_SERVER_ERROR),
+            ("/agent-names", StatusCode::INTERNAL_SERVER_ERROR),
+            ("/timeseries", StatusCode::INTERNAL_SERVER_ERROR),
+            (
+                "/export/atif/trace/trace-1",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            ("/skill-metrics", StatusCode::INTERNAL_SERVER_ERROR),
+        ] {
+            let response =
+                awtest::call_service(&app, awtest::TestRequest::get().uri(uri).to_request()).await;
+            assert_eq!(response.status(), status, "{uri} should fail opening DB");
+        }
+
+        let metrics_response = awtest::call_service(
+            &app,
+            awtest::TestRequest::get().uri("/metrics").to_request(),
+        )
+        .await;
+        assert_eq!(metrics_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = actix_web::body::to_bytes(metrics_response.into_body())
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("# ERROR opening database"));
+
+        let _ = std::fs::remove_file(&root);
     }
 }
 

--- a/src/agentsight/src/storage/sqlite/interruption.rs
+++ b/src/agentsight/src/storage/sqlite/interruption.rs
@@ -786,4 +786,479 @@ mod tests {
         let event = make_event("conv-poison", InterruptionType::DeadLoop);
         store.insert(&event).unwrap();
     }
+
+    // ── insert / get_by_id ──────────────────────────────────────────────────
+
+    #[test]
+    fn insert_and_get_by_id() {
+        let store = temp_store();
+        let mut event = make_event("conv-ins", InterruptionType::LlmError);
+        event.interruption_id = "int-get-1".to_string();
+        event.detail = Some(r#"{"error":"bad request"}"#.to_string());
+        store.insert(&event).unwrap();
+
+        let row = store
+            .get_by_id("int-get-1")
+            .unwrap()
+            .expect("row should exist");
+        assert_eq!(row.interruption_id, "int-get-1");
+        assert_eq!(row.interruption_type, "llm_error");
+        assert_eq!(row.severity, "critical");
+        assert!(!row.resolved);
+        assert_eq!(row.detail.as_deref(), Some(r#"{"error":"bad request"}"#));
+    }
+
+    #[test]
+    fn insert_duplicate_ignored() {
+        let store = temp_store();
+        let event = make_event("conv-dup", InterruptionType::RateLimit);
+        // First insert
+        store.insert(&event).unwrap();
+        // Second insert with same interruption_id is silently ignored
+        store.insert(&event).unwrap();
+
+        let records = store
+            .list(0, i64::MAX, None, None, None, None, 100)
+            .unwrap();
+        assert_eq!(records.len(), 1, "duplicate should be ignored");
+    }
+
+    #[test]
+    fn insert_batch_inserts_multiple() {
+        let store = temp_store();
+        let events: Vec<_> = (0..3)
+            .map(|i| {
+                let mut e = make_event("conv-batch", InterruptionType::SseTruncated);
+                e.interruption_id = format!("int-batch-{i}");
+                e
+            })
+            .collect();
+        store.insert_batch(&events).unwrap();
+
+        let records = store
+            .list(0, i64::MAX, None, None, None, None, 100)
+            .unwrap();
+        assert_eq!(records.len(), 3);
+    }
+
+    // ── resolve ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_existing_event() {
+        let store = temp_store();
+        let mut event = make_event("conv-resolve", InterruptionType::AuthError);
+        event.interruption_id = "int-resolve-1".to_string();
+        store.insert(&event).unwrap();
+
+        assert!(store.resolve("int-resolve-1").unwrap());
+
+        let row = store.get_by_id("int-resolve-1").unwrap().unwrap();
+        assert!(row.resolved);
+    }
+
+    #[test]
+    fn resolve_nonexistent_returns_false() {
+        let store = temp_store();
+        assert!(!store.resolve("no-such-id").unwrap());
+    }
+
+    // ── list with filters ────────────────────────────────────────────────────
+
+    #[test]
+    fn list_filters_by_agent_name_type_severity_resolved() {
+        let store = temp_store();
+        let mut e1 = make_event("conv-f1", InterruptionType::RateLimit);
+        e1.interruption_id = "int-f1".to_string();
+        e1.agent_name = Some("Agent-A".to_string());
+        e1.severity = crate::interruption::types::Severity::Medium;
+        store.insert(&e1).unwrap();
+
+        let mut e2 = make_event("conv-f2", InterruptionType::AuthError);
+        e2.interruption_id = "int-f2".to_string();
+        e2.agent_name = Some("Agent-B".to_string());
+        e2.severity = crate::interruption::types::Severity::High;
+        store.insert(&e2).unwrap();
+
+        // Filter by agent_name
+        let rows = store
+            .list(0, i64::MAX, Some("Agent-A"), None, None, None, 100)
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].interruption_id, "int-f1");
+
+        // Filter by type
+        let rows = store
+            .list(0, i64::MAX, None, Some("auth_error"), None, None, 100)
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].interruption_id, "int-f2");
+
+        // Filter by severity
+        let rows = store
+            .list(0, i64::MAX, None, None, Some("medium"), None, 100)
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].interruption_id, "int-f1");
+
+        // Filter by resolved=false (both unresolved)
+        let rows = store
+            .list(0, i64::MAX, None, None, None, Some(false), 100)
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+
+        // Resolve one, then filter resolved=true
+        store.resolve("int-f1").unwrap();
+        let rows = store
+            .list(0, i64::MAX, None, None, None, Some(true), 100)
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].interruption_id, "int-f1");
+    }
+
+    #[test]
+    fn list_respects_time_range_and_limit() {
+        let store = temp_store();
+        for i in 0..5 {
+            let mut e = make_event("conv-tr", InterruptionType::LlmError);
+            e.interruption_id = format!("int-tr-{i}");
+            e.occurred_at_ns = 1_000_000_000 + i * 1_000_000_000;
+            store.insert(&e).unwrap();
+        }
+
+        // Time range: only events at 2B and 3B ns
+        let rows = store
+            .list(2_000_000_000, 3_000_000_000, None, None, None, None, 100)
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+
+        // Limit 2 (most recent first)
+        let rows = store.list(0, i64::MAX, None, None, None, None, 2).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(
+            rows[0].occurred_at_ns >= rows[1].occurred_at_ns,
+            "should be DESC order"
+        );
+    }
+
+    // ── list_by_session / list_by_conversation ───────────────────────────────
+
+    #[test]
+    fn list_by_session_returns_matching_rows() {
+        let store = temp_store();
+        let mut e1 = make_event("conv-ls", InterruptionType::DeadLoop);
+        e1.interruption_id = "int-ls-1".to_string();
+        e1.session_id = Some("sess-A".to_string());
+        store.insert(&e1).unwrap();
+
+        let mut e2 = make_event("conv-ls2", InterruptionType::RetryStorm);
+        e2.interruption_id = "int-ls-2".to_string();
+        e2.session_id = Some("sess-B".to_string());
+        store.insert(&e2).unwrap();
+
+        let rows = store.list_by_session("sess-A").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].interruption_id, "int-ls-1");
+    }
+
+    #[test]
+    fn list_by_conversation_returns_matching_rows() {
+        let store = temp_store();
+        let mut e1 = make_event("conv-lc", InterruptionType::TokenLimit);
+        e1.interruption_id = "int-lc-1".to_string();
+        store.insert(&e1).unwrap();
+
+        let rows = store.list_by_conversation("conv-lc").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].conversation_id.as_deref(), Some("conv-lc"));
+    }
+
+    // ── stats ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn stats_groups_by_type() {
+        let store = temp_store();
+        for i in 0..2 {
+            let mut e = make_event("conv-st", InterruptionType::RateLimit);
+            e.interruption_id = format!("int-st-rl-{i}");
+            e.occurred_at_ns = 5_000_000_000;
+            store.insert(&e).unwrap();
+        }
+        let mut e = make_event("conv-st2", InterruptionType::AgentCrash);
+        e.interruption_id = "int-st-crash".to_string();
+        e.occurred_at_ns = 5_000_000_000;
+        store.insert(&e).unwrap();
+
+        let stats = store.stats(0, i64::MAX).unwrap();
+        // rate_limit should have count=2, agent_crash count=1
+        let rl = stats
+            .iter()
+            .find(|s| s.interruption_type == "rate_limit")
+            .unwrap();
+        assert_eq!(rl.count, 2);
+        let crash = stats
+            .iter()
+            .find(|s| s.interruption_type == "agent_crash")
+            .unwrap();
+        assert_eq!(crash.count, 1);
+    }
+
+    // ── count_unresolved_by_session/conversation_detailed ─────────────────────
+
+    #[test]
+    fn count_unresolved_by_session_detailed_groups_correctly() {
+        let store = temp_store();
+        let mut e1 = make_event("conv-csd1", InterruptionType::DeadLoop);
+        e1.interruption_id = "int-csd-1".to_string();
+        e1.session_id = Some("sess-X".to_string());
+        store.insert(&e1).unwrap();
+
+        // Resolved event should be excluded
+        let mut e2 = make_event("conv-csd2", InterruptionType::DeadLoop);
+        e2.interruption_id = "int-csd-2".to_string();
+        e2.session_id = Some("sess-X".to_string());
+        store.insert(&e2).unwrap();
+        store.resolve("int-csd-2").unwrap();
+
+        let rows = store
+            .count_unresolved_by_session_detailed(0, i64::MAX)
+            .unwrap();
+        assert_eq!(rows.len(), 1, "only unresolved rows should appear");
+        assert_eq!(rows[0].0, "sess-X");
+        assert_eq!(rows[0].3, 1, "count should be 1 (resolved excluded)");
+    }
+
+    #[test]
+    fn count_unresolved_by_conversation_detailed_groups_correctly() {
+        let store = temp_store();
+        let mut e = make_event("conv-ccd", InterruptionType::LlmError);
+        e.interruption_id = "int-ccd-1".to_string();
+        store.insert(&e).unwrap();
+
+        let rows = store
+            .count_unresolved_by_conversation_detailed(0, i64::MAX)
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "conv-ccd");
+    }
+
+    // ── OOM dedup ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn oom_event_exists_and_latest_oom_event_ns() {
+        let store = temp_store();
+        let mut event = make_event("conv-oom", InterruptionType::AgentCrash);
+        event.interruption_id = "int-oom-1".to_string();
+        event.pid = Some(9999);
+        event.occurred_at_ns = 7_000_000_000;
+        event.detail = Some(r#"{"oom":true,"reason":"out of memory"}"#.to_string());
+        store.insert(&event).unwrap();
+
+        assert!(store.oom_event_exists(9999, 7_000_000_000));
+        assert!(!store.oom_event_exists(9999, 8_000_000_000));
+        assert!(!store.oom_event_exists(1111, 7_000_000_000));
+        assert_eq!(store.latest_oom_event_ns(), 7_000_000_000);
+    }
+
+    #[test]
+    fn latest_oom_event_ns_returns_zero_when_no_oom() {
+        let store = temp_store();
+        assert_eq!(store.latest_oom_event_ns(), 0);
+    }
+
+    // ── exists_for_call ──────────────────────────────────────────────────────
+
+    #[test]
+    fn exists_for_call_dedup() {
+        let store = temp_store();
+        let mut event = make_event("conv-efc", InterruptionType::SseTruncated);
+        event.interruption_id = "int-efc-1".to_string();
+        event.call_id = Some("call-abc".to_string());
+        store.insert(&event).unwrap();
+
+        assert!(store.exists_for_call("call-abc", &InterruptionType::SseTruncated));
+        assert!(!store.exists_for_call("call-abc", &InterruptionType::RateLimit));
+        assert!(!store.exists_for_call("call-xyz", &InterruptionType::SseTruncated));
+    }
+
+    // ── exists_for_conversation ──────────────────────────────────────────────
+
+    #[test]
+    fn exists_for_conversation_no_filter_matches_any() {
+        let store = temp_store();
+        let mut e = make_event("conv-efn", InterruptionType::RetryStorm);
+        e.interruption_id = "int-efn-1".to_string();
+        store.insert(&e).unwrap();
+
+        // No error_msg filter: any unresolved row with same conv+type matches
+        assert!(store.exists_for_conversation("conv-efn", &InterruptionType::RetryStorm, None));
+        assert!(!store.exists_for_conversation("conv-efn", &InterruptionType::DeadLoop, None));
+    }
+
+    #[test]
+    fn exists_for_conversation_resolved_not_matched() {
+        let store = temp_store();
+        let mut e = make_event("conv-efr", InterruptionType::LlmError);
+        e.interruption_id = "int-efr-1".to_string();
+        store.insert(&e).unwrap();
+        store.resolve("int-efr-1").unwrap();
+
+        // Resolved rows should not match (resolved=0 filter in SQL)
+        assert!(!store.exists_for_conversation("conv-efr", &InterruptionType::LlmError, None));
+    }
+
+    #[test]
+    fn exists_for_conversation_json_error_matching() {
+        let store = temp_store();
+        let mut e = make_event("conv-efj", InterruptionType::LlmError);
+        e.interruption_id = "int-efj-1".to_string();
+        e.detail = Some(r#"{"error":"rate limit exceeded"}"#.to_string());
+        store.insert(&e).unwrap();
+
+        // Same error substring should match
+        assert!(store.exists_for_conversation(
+            "conv-efj",
+            &InterruptionType::LlmError,
+            Some("rate limit exceeded")
+        ));
+        // Unrelated error should not match
+        assert!(!store.exists_for_conversation(
+            "conv-efj",
+            &InterruptionType::LlmError,
+            Some("completely different error")
+        ));
+    }
+
+    // ── agent_crash_exists_recent ────────────────────────────────────────────
+
+    #[test]
+    fn agent_crash_exists_recent_finds_recent_crash() {
+        let store = temp_store();
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+        let mut e = make_event("conv-acer", InterruptionType::AgentCrash);
+        e.interruption_id = "int-acer-1".to_string();
+        e.pid = Some(5555);
+        e.occurred_at_ns = now_ns;
+        store.insert(&e).unwrap();
+
+        assert!(store.agent_crash_exists_recent(5555, 60));
+        assert!(!store.agent_crash_exists_recent(6666, 60));
+    }
+
+    // ── purge ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn purge_before_deletes_old_rows() {
+        let store = temp_store();
+        let mut e1 = make_event("conv-pb1", InterruptionType::LlmError);
+        e1.interruption_id = "int-pb-1".to_string();
+        e1.occurred_at_ns = 1_000;
+        store.insert(&e1).unwrap();
+
+        let mut e2 = make_event("conv-pb2", InterruptionType::LlmError);
+        e2.interruption_id = "int-pb-2".to_string();
+        e2.occurred_at_ns = 10_000_000_000;
+        store.insert(&e2).unwrap();
+
+        let deleted = store.purge_before(5_000_000_000).unwrap();
+        assert_eq!(deleted, 1);
+
+        let remaining = store
+            .list(0, i64::MAX, None, None, None, None, 100)
+            .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].interruption_id, "int-pb-2");
+    }
+
+    #[test]
+    fn purge_old_and_oversized_age_based() {
+        let store = temp_store();
+        let mut e = make_event("conv-poo", InterruptionType::LlmError);
+        e.interruption_id = "int-poo-1".to_string();
+        e.occurred_at_ns = 1; // very old
+        store.insert(&e).unwrap();
+
+        let deleted = store.purge_old_and_oversized(1, 0).unwrap();
+        assert_eq!(
+            deleted, 1,
+            "very old row should be purged with 1-day retention"
+        );
+    }
+
+    // ── pure helper functions ────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_error_key_plain_string() {
+        assert_eq!(
+            normalize_error_key("Rate Limit Exceeded"),
+            "rate limit exceeded"
+        );
+    }
+
+    #[test]
+    fn normalize_error_key_json_message() {
+        let json = r#"{"error":{"message":"model overloaded"}}"#;
+        assert_eq!(normalize_error_key(json), "model overloaded");
+    }
+
+    #[test]
+    fn normalize_error_key_top_level_message() {
+        let json = r#"{"message":"bad request"}"#;
+        assert_eq!(normalize_error_key(json), "bad request");
+    }
+
+    #[test]
+    fn normalize_error_key_embedded_json() {
+        let raw = r#"curl error: {"error":{"message":"connection refused"}}"#;
+        assert_eq!(normalize_error_key(raw), "connection refused");
+    }
+
+    #[test]
+    fn extract_message_from_json_nested_error() {
+        let json = r#"{"error":{"message":"nested msg"}}"#;
+        assert_eq!(
+            extract_message_from_json(json),
+            Some("nested msg".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_message_from_json_top_level() {
+        let json = r#"{"message":"top msg"}"#;
+        assert_eq!(extract_message_from_json(json), Some("top msg".to_string()));
+    }
+
+    #[test]
+    fn extract_message_from_json_no_message() {
+        let json = r#"{"error":"just a string"}"#;
+        assert_eq!(extract_message_from_json(json), None);
+    }
+
+    #[test]
+    fn extract_message_from_json_invalid() {
+        assert_eq!(extract_message_from_json("not json"), None);
+    }
+
+    #[test]
+    fn errors_match_identical() {
+        assert!(errors_match("rate limit", "rate limit"));
+    }
+
+    #[test]
+    fn errors_match_case_insensitive() {
+        assert!(errors_match("Rate Limit", "rate limit"));
+    }
+
+    #[test]
+    fn errors_match_substring_containment() {
+        assert!(errors_match("rate limit exceeded", "rate limit"));
+        assert!(errors_match("rate limit", "rate limit exceeded"));
+    }
+
+    #[test]
+    fn errors_match_unrelated() {
+        assert!(!errors_match("rate limit", "auth error"));
+    }
 }

--- a/src/agentsight/src/storage/sqlite/token.rs
+++ b/src/agentsight/src/storage/sqlite/token.rs
@@ -174,7 +174,7 @@ impl TokenComparison {
     pub fn formatted_change(&self) -> String {
         let sign = if self.change >= 0 { "+" } else { "" };
         let change_formatted = format_tokens(self.change.unsigned_abs());
-        let percent = format!("{:.0}%", self.change_percent.abs());
+        let percent = format!("{:.0}", self.change_percent.abs());
 
         if self.change >= 0 {
             format!("{sign}{change_formatted} (+{percent}%)")
@@ -740,5 +740,306 @@ mod tests {
 
         // Cleanup
         std::fs::remove_file("/tmp/test_tokens_query.db").ok();
+    }
+
+    fn unique_db_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "agentsight_token_{label}_{}_{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn cleanup_db(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+    }
+
+    fn make_record(timestamp_ns: u64, agent: Option<&str>, input: u64, output: u64) -> TokenRecord {
+        TokenRecord {
+            id: 0,
+            timestamp_ns,
+            pid: 1234,
+            comm: "python".to_string(),
+            agent: agent.map(str::to_string),
+            model: Some("gpt-4".to_string()),
+            provider: "openai".to_string(),
+            input_tokens: input,
+            output_tokens: output,
+            cache_creation_tokens: Some(7),
+            cache_read_tokens: Some(3),
+            request_id: Some("req-1".to_string()),
+            endpoint: Some("/v1/chat/completions".to_string()),
+            tool_calls: Vec::new(),
+            reasoning_content: None,
+        }
+    }
+
+    #[test]
+    fn test_time_period_display_and_previous_period() {
+        assert_eq!(TimePeriod::Today.to_string(), "今天");
+        assert_eq!(TimePeriod::Yesterday.to_string(), "昨天");
+        assert_eq!(TimePeriod::Week.to_string(), "本周");
+        assert_eq!(TimePeriod::LastWeek.to_string(), "上周");
+        assert_eq!(TimePeriod::Month.to_string(), "本月");
+        assert_eq!(TimePeriod::LastMonth.to_string(), "上月");
+
+        assert_eq!(TimePeriod::Today.previous_period(), TimePeriod::Yesterday);
+        assert_eq!(TimePeriod::Week.previous_period(), TimePeriod::LastWeek);
+        assert_eq!(TimePeriod::Month.previous_period(), TimePeriod::LastMonth);
+    }
+
+    #[test]
+    fn test_token_query_result_formatters() {
+        let result = TokenQueryResult {
+            period: "test".to_string(),
+            input_tokens: 1_500,
+            output_tokens: 2_000_000,
+            total_tokens: 2_001_500,
+            request_count: 1,
+            comparison: None,
+            breakdown: Vec::new(),
+        };
+
+        assert_eq!(result.formatted_input(), "1.5K");
+        assert_eq!(result.formatted_output(), "2.0M");
+        assert_eq!(result.formatted_total(), "2.0M");
+    }
+
+    #[test]
+    fn test_token_comparison_formatted_change() {
+        let up = TokenComparison {
+            previous_total: 100,
+            change: 50,
+            change_percent: 50.0,
+            trend: Trend::Up,
+        };
+        assert_eq!(up.formatted_change(), "+50 (+50%)");
+
+        let down = TokenComparison {
+            previous_total: 200,
+            change: -75,
+            change_percent: -37.5,
+            trend: Trend::Down,
+        };
+        assert_eq!(down.formatted_change(), "-75 (-38%)");
+    }
+
+    #[test]
+    fn test_insert_count_all_and_clear() {
+        let path = unique_db_path("insert_count_clear");
+        let mut store = TokenStore::new(&path);
+        let id = store
+            .insert(&make_record(1_000, Some("Agent-A"), 10, 5))
+            .unwrap();
+        assert!(id > 0);
+        assert_eq!(store.count(), 1);
+
+        let rows = store.all();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].agent.as_deref(), Some("Agent-A"));
+        assert_eq!(rows[0].cache_creation_tokens, Some(7));
+        assert_eq!(rows[0].cache_read_tokens, Some(3));
+
+        store.clear().unwrap();
+        assert_eq!(store.count(), 0);
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_custom_table_isolated_from_default_table() {
+        let path = unique_db_path("custom_table");
+        let custom = TokenStore::with_table(&path, "custom_tokens");
+        custom
+            .insert(&make_record(1_000, Some("Agent-A"), 10, 5))
+            .unwrap();
+        assert_eq!(custom.count(), 1);
+
+        let default_store = TokenStore::new(&path);
+        assert_eq!(default_store.count(), 0);
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_by_time_range_owned_filters_and_orders_desc() {
+        let path = unique_db_path("time_range");
+        let store = TokenStore::new(&path);
+        store
+            .insert(&make_record(1_000, Some("old"), 1, 1))
+            .unwrap();
+        store
+            .insert(&make_record(2_000, Some("mid"), 2, 2))
+            .unwrap();
+        store
+            .insert(&make_record(3_000, Some("new"), 3, 3))
+            .unwrap();
+
+        let rows = store.by_time_range_owned(1_500, 3_000);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].agent.as_deref(), Some("new"));
+        assert_eq!(rows[1].agent.as_deref(), Some("mid"));
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_by_last_hours_returns_recent_rows() {
+        let path = unique_db_path("last_hours");
+        let store = TokenStore::new(&path);
+        let now_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        store
+            .insert(&make_record(
+                now_ns.saturating_sub(1_000),
+                Some("recent"),
+                1,
+                2,
+            ))
+            .unwrap();
+        store
+            .insert(&make_record(
+                now_ns.saturating_sub(3 * 3600 * 1_000_000_000),
+                Some("old"),
+                10,
+                20,
+            ))
+            .unwrap();
+
+        let rows = store.by_last_hours(1);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].agent.as_deref(), Some("recent"));
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_purge_before_deletes_old_records() {
+        let path = unique_db_path("purge_before");
+        let store = TokenStore::new(&path);
+        store
+            .insert(&make_record(1_000, Some("old"), 1, 1))
+            .unwrap();
+        store
+            .insert(&make_record(5_000, Some("new"), 2, 2))
+            .unwrap();
+
+        let deleted = store.purge_before(3_000).unwrap();
+        assert_eq!(deleted, 1);
+        assert_eq!(store.count(), 1);
+        assert_eq!(store.all()[0].agent.as_deref(), Some("new"));
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_checkpoint_succeeds() {
+        let path = unique_db_path("checkpoint");
+        let store = TokenStore::new(&path);
+        store
+            .insert(&make_record(1_000, Some("Agent-A"), 1, 1))
+            .unwrap();
+        store.checkpoint().unwrap();
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_query_by_hours_and_compare() {
+        let path = unique_db_path("hours_compare");
+        let store = TokenStore::new(&path);
+        let now_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let hour_ns = 3600 * 1_000_000_000;
+        store
+            .insert(&make_record(
+                now_ns - 30 * 60 * 1_000_000_000,
+                Some("current"),
+                100,
+                50,
+            ))
+            .unwrap();
+        store
+            .insert(&make_record(
+                now_ns - hour_ns - 30 * 60 * 1_000_000_000,
+                Some("previous"),
+                20,
+                10,
+            ))
+            .unwrap();
+
+        let query = TokenQuery::new(&store);
+        let result = query.by_hours_with_compare(1);
+        assert_eq!(result.total_tokens, 150);
+        let comparison = result.comparison.expect("comparison should be populated");
+        assert_eq!(comparison.previous_total, 30);
+        assert_eq!(comparison.change, 120);
+        assert_eq!(comparison.trend, Trend::Up);
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_query_by_period_with_compare_and_breakdown() {
+        let path = unique_db_path("period_breakdown");
+        let store = TokenStore::new(&path);
+        let (today_start, _) = TimePeriod::Today.time_range();
+        let (yesterday_start, _) = TimePeriod::Yesterday.time_range();
+
+        store
+            .insert(&make_record(today_start + 1_000, Some("Agent-A"), 100, 50))
+            .unwrap();
+        store
+            .insert(&make_record(today_start + 2_000, Some("Agent-A"), 30, 20))
+            .unwrap();
+        store
+            .insert(&make_record(today_start + 3_000, Some("Agent-B"), 10, 10))
+            .unwrap();
+        store
+            .insert(&make_record(
+                yesterday_start + 1_000,
+                Some("Agent-C"),
+                20,
+                10,
+            ))
+            .unwrap();
+
+        let query = TokenQuery::new(&store);
+        let compared = query.by_period_with_compare(TimePeriod::Today);
+        assert_eq!(compared.total_tokens, 220);
+        let comparison = compared.comparison.expect("comparison should exist");
+        assert_eq!(comparison.previous_total, 30);
+        assert_eq!(comparison.change, 190);
+        assert_eq!(comparison.trend, Trend::Up);
+
+        let with_breakdown = query.by_period_with_breakdown(TimePeriod::Today);
+        assert_eq!(with_breakdown.breakdown.len(), 2);
+        assert_eq!(with_breakdown.breakdown[0].name, "Agent-A");
+        assert_eq!(with_breakdown.breakdown[0].total_tokens, 200);
+        assert_eq!(with_breakdown.breakdown[0].request_count, 2);
+        assert!((with_breakdown.breakdown[0].percentage - 90.90).abs() < 0.1);
+
+        let full = query.full_query(TimePeriod::Today);
+        assert!(full.comparison.is_some());
+        assert_eq!(full.breakdown.len(), 2);
+        cleanup_db(&path);
+    }
+
+    #[test]
+    fn test_breakdown_falls_back_to_comm_when_agent_missing() {
+        let path = unique_db_path("breakdown_comm");
+        let store = TokenStore::new(&path);
+        let (today_start, _) = TimePeriod::Today.time_range();
+        store
+            .insert(&make_record(today_start + 1_000, None, 10, 5))
+            .unwrap();
+
+        let query = TokenQuery::new(&store);
+        let result = query.by_period_with_breakdown(TimePeriod::Today);
+        assert_eq!(result.breakdown.len(), 1);
+        assert_eq!(result.breakdown[0].name, "python");
+        cleanup_db(&path);
     }
 }


### PR DESCRIPTION
## Description

This PR fixes two issues:

1. **SSL library attribution correction**: Codex CLI statically links OpenSSL 3.x (via `reqwest → native-tls → openssl-sys`) for REST API traffic, not aws-lc/BoringSSL as previously documented. `rustls + aws-lc-rs` is only used for WebSocket TLS and does not call `SSL_write_ex`. All BoringSSL-specific identifiers have been renamed to generic Static SSL names (`BoringSslOffsets → StaticSslOffsets`, `attach_boringssl_by_* → attach_static_ssl_by_*`, `SslLibKind::Boring → SslLibKind::Static`). Documentation updated with misjudgment record explaining four root causes.

2. **Unit test expansion**: Added comprehensive tests for handler endpoints (ATIF export, skill metrics, DB error scenarios), interruption store (CRUD, filtering, stats), and token store (formatters, period logic). Fixed duplicate `%` in `TokenComparison::formatted_change` output.

Verified on Codex 0.50.0 / 0.137 / 0.141 via `strings` analysis: all three embed OpenSSL 3.5.x, AgentSight hooks `SSL_write_ex` successfully.

## Related Issue

closes #1493

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

```bash
cd src/agentsight
cargo fmt --check          # passed
cargo clippy --all-targets --locked -- -D warnings  # passed
cargo test --locked --lib  # 1140 passed, 0 failed
```

## Additional Notes

The SSL attribution misjudgment did not affect runtime behavior — `SSL_write_ex` has identical ABI in both OpenSSL and aws-lc, so the uprobe implementation was always correct. Only documentation and identifier naming needed correction.