### PR TITLE
feat(sec-core): add observability capability in codex plugin

### DIFF
--- a/src/agent-sec-core/codex-plugin/README.md
+++ b/src/agent-sec-core/codex-plugin/README.md
@@ -1,6 +1,7 @@
 # agent-sec-core Codex 插件
 
-为 Codex CLI 提供实时安全防护，包括代码扫描、Prompt 注入检测、PII 敏感信息检查和 Skill 完整性验证。
+为 Codex CLI 提供实时安全防护，包括代码扫描、Prompt 注入检测、PII 敏感信息检查和 Skill 完整性验证，
+并提供 Turn/Tool 生命周期可观测记录。
 
 ## 快速安装
 
@@ -125,7 +126,8 @@ codex-plugin/
         ├── prompt_scanner_hook.py          ← UserPromptSubmit: Prompt 注入检测
         ├── pii_checker_hook.py             ← UserPromptSubmit + PostToolUse: PII 检测
         ├── skill_ledger_hook.py            ← UserPromptSubmit: Skill 完整性验证
-        └── trace_context.py               ← 链路追踪工具库
+        ├── observability_hook.py           ← Turn/Tool 生命周期可观测记录
+        └── trace_context.py                ← 链路追踪工具库
 ```
 
 ## Hook 说明
@@ -136,6 +138,25 @@ codex-plugin/
 | `prompt_scanner_hook.py` | UserPromptSubmit | (all) | 检测用户输入中的 prompt 注入攻击 |
 | `pii_checker_hook.py` | UserPromptSubmit + PostToolUse | (all) | 检测用户输入和工具输出中的 PII，deny 模式下阻断对应 payload（不支持脱敏放行） |
 | `skill_ledger_hook.py` | UserPromptSubmit | (all) | 解析 prompt 中的 $skill-name，验证 skill 文件完整性和签名 |
+| `observability_hook.py` | UserPromptSubmit + PreToolUse + PostToolUse + Stop | (all) | 记录 Turn/Tool 生命周期；不改变 Codex 决策 |
+
+## 可观测能力
+
+Codex Hook 与 `agent-sec-cli observability` 的映射如下：
+
+| Codex Hook | Observability Hook | 关联字段 |
+|------------|--------------------|----------|
+| `UserPromptSubmit` | `before_agent_run` | `session_id`、`turn_id` |
+| `PreToolUse` | `before_tool_call` | `session_id`、`turn_id`、`tool_use_id` |
+| `PostToolUse` | `after_tool_call` | `session_id`、`turn_id`、`tool_use_id` |
+| `Stop` | `after_agent_run` | `session_id`、`turn_id` |
+
+其中 `session_id → sessionId`、`turn_id → runId`、`tool_use_id → toolCallId`。
+缺少必需关联字段时会跳过该条记录，不生成伪 ID。Prompt、工具参数、工具结果和最终回复
+会先通过本地 PII Checker 脱敏；脱敏失败时丢弃对应字段。所有错误均 fail-open。
+
+Codex 当前没有 `BeforeModel` / `AfterModel` Hook，因此本插件不会生成
+`before_llm_call` / `after_llm_call` 或伪造 Token、TTFB、模型请求耗时等指标。
 
 ## 调试
 
@@ -172,12 +193,21 @@ echo '{"hook_event_name":"UserPromptSubmit","prompt":"我的手机号是13800138
 # 测试 PII 检测（PostToolUse）
 echo '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"cat contacts.txt"},"tool_response":"张三 13912345678","session_id":"test","turn_id":"t1","cwd":"/tmp","model":"o3","permission_mode":"default","tool_use_id":"call_1"}' | \
   PII_CHECKER_MODE=deny python3 hooks-plugin/hooks/pii_checker_hook.py
+
+# 测试可观测 PreToolUse（输出 {}，记录写入 observability JSONL/SQLite）
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pwd"},"session_id":"test","turn_id":"t1","tool_use_id":"call_1","model":"o3"}' | \
+  python3 hooks-plugin/hooks/observability_hook.py
 ```
 
-预期输出：`{"decision": "block", "reason": "..."}`
+阻断模式扫描命中时输出：`{"decision": "block", "reason": "..."}`；可观测 Hook
+始终输出 `{}`，不会改变 Codex 行为。可通过以下命令查看最近一次会话：
+
+```bash
+agent-sec-cli observability report --last
+```
 
 ## 注意事项
 
 1. **hook 脚本内容变更后**，下次 Codex 启动会重新弹出 Trust Review
-2. **`agent-sec-cli` 不在 PATH 时**，hook 会 fail-open（静默放行），不会阻断正常使用
+2. **`agent-sec-cli` 不在 PATH 时**，hook 会 fail-open，不会阻断正常使用；可观测 Hook 仅向 stderr 写入不含 payload 的诊断
 3. **Codex 必须在真实 TTY 中运行**，不能在子进程或管道中启动

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
   "version": "0.8.0",
-  "description": "Agent security core plugin for Codex - code scanning, prompt scanning, PII checking, and skill ledger integrity verification."
+  "description": "Agent security core plugin for Codex - code scanning, prompt scanning, PII checking, skill ledger integrity verification, and turn/tool observability."
 }

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/hooks.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/hooks.json
@@ -11,6 +11,15 @@
             "statusMessage": "Scanning command for security issues..."
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -33,6 +42,11 @@
             "command": "python3 ${PLUGIN_ROOT}/hooks/skill_ledger_hook.py",
             "timeout": 10,
             "statusMessage": "Checking skill integrity..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "timeout": 10
           }
         ]
       }
@@ -45,6 +59,22 @@
             "command": "python3 ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
             "timeout": 10,
             "statusMessage": "Checking for PII in tool output..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "timeout": 10
           }
         ]
       }

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/observability_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/observability_hook.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""Record Codex turn and tool lifecycle events as AgentSec observability data.
+
+The hook is intentionally self-contained. It reads one Codex hook payload from
+stdin, maps only host-provided fields, redacts sensitive metrics, and invokes
+``agent-sec-cli observability record``. Every failure path is fail-open and the
+hook always emits an empty JSON object so it cannot change Codex behavior.
+"""
+
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+_CLI_TIMEOUT_SECONDS = 3
+# Read one extra byte below to distinguish an exact-limit payload from truncation.
+_MAX_PAYLOAD_SIZE = 1024 * 1024
+_OBSERVABILITY_COMMAND = [
+    "agent-sec-cli",
+    "observability",
+    "record",
+    "--format",
+    "json",
+    "--stdin",
+]
+_PII_REDACT_COMMAND = [
+    "agent-sec-cli",
+    "scan-pii",
+    "--stdin",
+    "--format",
+    "json",
+    "--redact-output",
+    "--source",
+    "observability",
+]
+_SENSITIVE_METRIC_KEYS = {
+    "prompt",
+    "user_input",
+    "system_prompt",
+    "messages",
+    "response",
+    "parameters",
+    "result",
+    "error",
+    "tool_calls",
+}
+_DROP = object()
+
+
+def _noop() -> str:
+    """Return a Codex-compatible empty hook output."""
+    return json.dumps({})
+
+
+def _diagnostic(message: str) -> None:
+    """Write a payload-free diagnostic without affecting hook output."""
+    print(f"observability-hook: {message}", file=sys.stderr)
+
+
+def _read_stdin_payload() -> str | bytes | None:
+    """Read one bounded hook payload, returning ``None`` when it exceeds the limit."""
+    stream = getattr(sys.stdin, "buffer", sys.stdin)
+    payload = stream.read(_MAX_PAYLOAD_SIZE + 1)
+    if len(payload) > _MAX_PAYLOAD_SIZE:
+        _diagnostic(f"hook input exceeds {_MAX_PAYLOAD_SIZE} bytes; skipping event")
+        return None
+    return payload
+
+
+def _json_dumps(value: Any) -> str:
+    """Serialize hook values deterministically for hashing and subprocess input."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
+
+
+def _json_size_bytes(value: Any) -> int:
+    """Return the UTF-8 size of a deterministic JSON representation."""
+    return len(_json_dumps(value).encode("utf-8"))
+
+
+def _value_to_text(value: Any) -> str:
+    """Convert a hook value to the exact text hashed for PII correlation."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return _json_dumps(value)
+
+
+def _pii_scan_input_sha256(value: Any) -> str | None:
+    """Return the scan input hash used to correlate PII security events."""
+    text = _value_to_text(value)
+    if not text.strip():
+        return None
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _now_iso() -> str:
+    """Return a timezone-aware UTC timestamp in wire format."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _non_empty_string(value: Any) -> str | None:
+    """Return a stripped non-empty string, otherwise ``None``."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _metadata(
+    input_data: dict[str, Any], *, needs_tool_call_id: bool = False
+) -> dict[str, str] | None:
+    """Build metadata from Codex IDs without manufacturing correlation values."""
+    session_id = _non_empty_string(input_data.get("session_id"))
+    turn_id = _non_empty_string(input_data.get("turn_id"))
+    missing = []
+    if session_id is None:
+        missing.append("session_id")
+    if turn_id is None:
+        missing.append("turn_id")
+
+    tool_use_id = None
+    if needs_tool_call_id:
+        tool_use_id = _non_empty_string(input_data.get("tool_use_id"))
+        if tool_use_id is None:
+            missing.append("tool_use_id")
+
+    if missing:
+        _diagnostic(
+            f"skipping record with missing correlation field(s): {', '.join(missing)}"
+        )
+        return None
+
+    metadata = {
+        "sessionId": session_id,
+        "runId": turn_id,
+    }
+    if tool_use_id is not None:
+        metadata["toolCallId"] = tool_use_id
+    return metadata
+
+
+def _base_record(
+    input_data: dict[str, Any],
+    *,
+    hook: str,
+    metrics: dict[str, Any],
+    needs_tool_call_id: bool = False,
+) -> dict[str, Any] | None:
+    """Build one schema-compatible record when metadata and metrics exist."""
+    if not metrics:
+        return None
+    metadata = _metadata(input_data, needs_tool_call_id=needs_tool_call_id)
+    if metadata is None:
+        return None
+    return {
+        "hook": hook,
+        "observedAt": _now_iso(),
+        "metadata": metadata,
+        "metrics": metrics,
+    }
+
+
+def _build_user_prompt_submit(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Map ``UserPromptSubmit`` to ``before_agent_run``."""
+    metrics: dict[str, Any] = {}
+    if "prompt" in input_data:
+        prompt = input_data["prompt"]
+        metrics["prompt"] = prompt
+        metrics["user_input"] = prompt
+        pii_hash = _pii_scan_input_sha256(prompt)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+
+    model = _non_empty_string(input_data.get("model"))
+    if model is not None:
+        metrics["model_id"] = model
+
+    return _base_record(input_data, hook="before_agent_run", metrics=metrics)
+
+
+def _build_pre_tool_use(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Map ``PreToolUse`` to ``before_tool_call``."""
+    metrics: dict[str, Any] = {}
+    tool_name = _non_empty_string(input_data.get("tool_name"))
+    if tool_name is not None:
+        metrics["tool_name"] = tool_name
+    if "tool_input" in input_data:
+        tool_input = input_data["tool_input"]
+        metrics["parameters"] = tool_input
+        pii_hash = _pii_scan_input_sha256(tool_input)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+
+    return _base_record(
+        input_data,
+        hook="before_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _extract_exit_code(tool_response: Any) -> Any:
+    """Return a directly exposed tool exit code without guessing nested schemas."""
+    if not isinstance(tool_response, dict):
+        return None
+    if "exit_code" in tool_response:
+        return tool_response["exit_code"]
+    if "exitCode" in tool_response:
+        return tool_response["exitCode"]
+    return None
+
+
+def _exit_status(exit_code: Any) -> str | None:
+    """Derive status only when the host exposes an integer exit code."""
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+        return None
+    return "success" if exit_code == 0 else "error"
+
+
+def _build_post_tool_use(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Map ``PostToolUse`` to ``after_tool_call``."""
+    metrics: dict[str, Any] = {}
+    if "tool_response" in input_data:
+        tool_response = input_data["tool_response"]
+        metrics["result"] = tool_response
+        metrics["result_size_bytes"] = _json_size_bytes(tool_response)
+        pii_hash = _pii_scan_input_sha256(tool_response)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+
+        exit_code = _extract_exit_code(tool_response)
+        if exit_code is not None:
+            metrics["exit_code"] = exit_code
+        status = _exit_status(exit_code)
+        if status is not None:
+            metrics["status"] = status
+
+    return _base_record(
+        input_data,
+        hook="after_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _build_stop(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Map ``Stop`` to ``after_agent_run`` without inventing unavailable metrics."""
+    metrics: dict[str, Any] = {}
+    if "last_assistant_message" in input_data:
+        response = input_data["last_assistant_message"]
+        metrics["response"] = response
+        has_text = isinstance(response, str) and bool(response)
+        metrics["output_kind"] = "text" if has_text else "empty"
+        metrics["assistant_texts_count"] = 1 if has_text else 0
+
+    model = _non_empty_string(input_data.get("model"))
+    if model is not None:
+        metrics["final_model_id"] = model
+
+    return _base_record(input_data, hook="after_agent_run", metrics=metrics)
+
+
+_RecordBuilder = Callable[[dict[str, Any]], dict[str, Any] | None]
+_BUILDERS: dict[str, _RecordBuilder] = {
+    "UserPromptSubmit": _build_user_prompt_submit,
+    "PreToolUse": _build_pre_tool_use,
+    "PostToolUse": _build_post_tool_use,
+    "Stop": _build_stop,
+}
+
+
+def _build_record(input_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Map one supported Codex hook payload to an observability record."""
+    if not isinstance(input_data, dict):
+        return None
+    builder = _BUILDERS.get(input_data.get("hook_event_name"))
+    if builder is None:
+        return None
+    return builder(input_data)
+
+
+def _process_text(value: Any) -> str:
+    """Normalize subprocess output for bounded diagnostics."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace").strip()
+    return str(value).strip()
+
+
+def _process_output_details(*values: Any) -> str:
+    """Return subprocess details without including hook payloads."""
+    details = "\n".join(part for value in values if (part := _process_text(value)))
+    if details:
+        return details
+    return "no stderr or stdout was captured"
+
+
+def _record_trace_context(record: dict[str, Any]) -> dict[str, str]:
+    """Build AgentSec trace context from validated observability metadata."""
+    context = {"agent_name": "codex"}
+    metadata = record.get("metadata")
+    if not isinstance(metadata, dict):
+        return context
+
+    field_map = {
+        "session_id": "sessionId",
+        "run_id": "runId",
+        "tool_call_id": "toolCallId",
+    }
+    for output_key, input_key in field_map.items():
+        value = _non_empty_string(metadata.get(input_key))
+        if value is not None:
+            context[output_key] = value
+    return context
+
+
+def _redact_text(text: str, security_trace_context: dict[str, str]) -> str | None:
+    """Return locally redacted text, or ``None`` when redaction fails."""
+    command = [
+        _PII_REDACT_COMMAND[0],
+        "--trace-context",
+        _json_dumps(security_trace_context),
+        *_PII_REDACT_COMMAND[1:],
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    redacted = data.get("redacted_text")
+    return redacted if isinstance(redacted, str) else None
+
+
+def _redact_sensitive_value(
+    value: Any,
+    cache: dict[str, Any],
+    security_trace_context: dict[str, str],
+) -> Any:
+    """Redact one sensitive value, returning ``_DROP`` on any scan failure."""
+    cache_key = f"{type(value).__name__}:{_json_dumps(value)}"
+    if cache_key in cache:
+        return cache[cache_key]
+
+    if isinstance(value, str):
+        safe_value: Any = _redact_text(value, security_trace_context)
+        if safe_value is None:
+            safe_value = _DROP
+    else:
+        redacted = _redact_text(_json_dumps(value), security_trace_context)
+        if redacted is None:
+            safe_value = _DROP
+        else:
+            try:
+                safe_value = json.loads(redacted)
+            except (json.JSONDecodeError, ValueError):
+                safe_value = redacted
+
+    cache[cache_key] = safe_value
+    return safe_value
+
+
+def _redact_metrics(
+    value: Any,
+    cache: dict[str, Any],
+    security_trace_context: dict[str, str],
+) -> Any:
+    """Recursively redact allowlisted sensitive metric fields."""
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in _SENSITIVE_METRIC_KEYS:
+                safe_item = _redact_sensitive_value(
+                    item,
+                    cache,
+                    security_trace_context,
+                )
+            else:
+                safe_item = _redact_metrics(item, cache, security_trace_context)
+            if safe_item is not _DROP:
+                redacted[key] = safe_item
+        return redacted
+    if isinstance(value, list):
+        return [
+            item
+            for item in (
+                _redact_metrics(item, cache, security_trace_context) for item in value
+            )
+            if item is not _DROP
+        ]
+    return value
+
+
+def _redact_observability_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Return a record whose sensitive metrics are redacted or removed."""
+    safe_record = dict(record)
+    metrics = safe_record.get("metrics")
+    if isinstance(metrics, dict):
+        safe_record["metrics"] = _redact_metrics(
+            metrics,
+            {},
+            _record_trace_context(record),
+        )
+    return safe_record
+
+
+def _record_observability(record: dict[str, Any]) -> None:
+    """Redact and persist one record through the public AgentSec CLI."""
+    safe_record = _redact_observability_record(record)
+    metrics = safe_record.get("metrics")
+    if not isinstance(metrics, dict) or not metrics:
+        _diagnostic("skipping record because no safe metrics remain after redaction")
+        return
+
+    try:
+        result = subprocess.run(
+            _OBSERVABILITY_COMMAND,
+            input=_json_dumps(safe_record),
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        _diagnostic(
+            "agent-sec-cli executable was not found; install agent-sec-cli or add it to PATH"
+        )
+        return
+    except subprocess.TimeoutExpired as exc:
+        details = _process_output_details(exc.stderr, exc.stdout)
+        _diagnostic(
+            "agent-sec-cli observability record timed out "
+            f"after {exc.timeout} seconds: {details}"
+        )
+        return
+    except OSError as exc:
+        _diagnostic(f"failed to start agent-sec-cli observability record: {exc}")
+        return
+
+    if result.returncode != 0:
+        details = _process_output_details(
+            getattr(result, "stderr", None), getattr(result, "stdout", None)
+        )
+        _diagnostic(
+            "agent-sec-cli observability record failed "
+            f"with exit code {result.returncode}: {details}"
+        )
+
+
+def main() -> None:
+    """Read one Codex hook event, record it best-effort, and always continue."""
+    try:
+        payload = _read_stdin_payload()
+        if payload is None:
+            print(_noop())
+            return
+        input_data = json.loads(payload)
+    except (json.JSONDecodeError, EOFError, OSError, ValueError):
+        print(_noop())
+        return
+
+    try:
+        record = _build_record(input_data)
+        if record is not None:
+            _record_observability(record)
+    except Exception as exc:
+        _diagnostic(f"unexpected {type(exc).__name__}; record skipped")
+    print(_noop())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/trace_context.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/trace_context.py
@@ -3,22 +3,24 @@
 import json
 from typing import Any
 
-_FIELD_MAP = {
-    "trace_id": "trace_id",
-    "session_id": "session_id",
-    "run_id": "run_id",
-    "call_id": "call_id",
-    "tool_call_id": "tool_use_id",
+_FIELD_ALIASES = {
+    "trace_id": ("trace_id",),
+    "session_id": ("session_id",),
+    "run_id": ("turn_id", "run_id"),
+    "call_id": ("call_id",),
+    "tool_call_id": ("tool_use_id", "tool_call_id"),
 }
 
 
 def trace_context(input_data: dict[str, Any]) -> dict[str, str] | None:
     """Build canonical trace context from fields directly present on hook input."""
     context: dict[str, str] = {"agent_name": "codex"}
-    for output_key, input_key in _FIELD_MAP.items():
-        value = input_data.get(input_key)
-        if isinstance(value, str) and value.strip():
-            context[output_key] = value.strip()
+    for output_key, input_keys in _FIELD_ALIASES.items():
+        for input_key in input_keys:
+            value = input_data.get(input_key)
+            if isinstance(value, str) and value.strip():
+                context[output_key] = value.strip()
+                break
     return context or None
 
 

--- a/src/agent-sec-core/codex-plugin/install.sh
+++ b/src/agent-sec-core/codex-plugin/install.sh
@@ -98,6 +98,7 @@ do_install() {
     info "   - prompt_scanner_hook.py (UserPromptSubmit)"
     info "   - pii_checker_hook.py    (UserPromptSubmit + PostToolUse)"
     info "   - skill_ledger_hook.py   (UserPromptSubmit)"
+    info "   - observability_hook.py  (UserPromptSubmit + PreToolUse + PostToolUse + Stop)"
     echo ""
     info "启动命令（可选环境变量）："
     info "  CODE_SCANNER_MODE=deny PROMPT_SCANNER_MODE=deny SKILL_LEDGER_MODE=deny PII_CHECKER_MODE=deny codex"

--- a/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
+++ b/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
@@ -13,6 +13,7 @@ Test groups:
    G2: pii_checker_hook — UserPromptSubmit + PostToolUse PII detection
    G3: prompt_scanner_hook — UserPromptSubmit injection detection
    G4: skill_ledger_hook — UserPromptSubmit skill integrity check
+   G5: observability_hook — Turn/Tool lifecycle persistence
 
 CLI resolution: requires ``agent-sec-cli`` on PATH.
 """
@@ -374,3 +375,94 @@ class TestSkillLedgerE2E:
             env_extra={"SKILL_LEDGER_MODE": "deny"},
         )
         assert output == {}
+
+
+# ---------------------------------------------------------------------------
+# G5: observability_hook E2E
+# ---------------------------------------------------------------------------
+
+
+class TestObservabilityHookE2E:
+    """E2E tests for Codex observability records through the real CLI."""
+
+    def test_four_stage_turn_and_tool_lifecycle_is_persisted(self, tmp_path):
+        env = {"AGENT_SEC_DATA_DIR": str(tmp_path)}
+        events = [
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "session_id": "codex-session",
+                "turn_id": "codex-turn",
+                "model": "gpt-5",
+                "prompt": "Call 13800138000, then list the current directory.",
+            },
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": "codex-session",
+                "turn_id": "codex-turn",
+                "tool_use_id": "codex-tool",
+                "tool_name": "Bash",
+                "tool_input": {"command": "pwd"},
+            },
+            {
+                "hook_event_name": "PostToolUse",
+                "session_id": "codex-session",
+                "turn_id": "codex-turn",
+                "tool_use_id": "codex-tool",
+                "tool_name": "Bash",
+                "tool_response": {"stdout": "/workspace\n", "exit_code": 0},
+            },
+            {
+                "hook_event_name": "Stop",
+                "session_id": "codex-session",
+                "turn_id": "codex-turn",
+                "model": "gpt-5",
+                "last_assistant_message": "The current directory is /workspace.",
+            },
+        ]
+
+        for event in events:
+            assert (
+                _run_hook(
+                    "observability_hook.py",
+                    event,
+                    env_extra=env,
+                )
+                == {}
+            )
+
+        records = [
+            json.loads(line)
+            for line in (tmp_path / "observability.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        assert [record["hook"] for record in records] == [
+            "before_agent_run",
+            "before_tool_call",
+            "after_tool_call",
+            "after_agent_run",
+        ]
+        assert all(
+            record["metadata"]["sessionId"] == "codex-session"
+            and record["metadata"]["runId"] == "codex-turn"
+            for record in records
+        )
+        assert records[1]["metadata"]["toolCallId"] == "codex-tool"
+        assert records[2]["metadata"]["toolCallId"] == "codex-tool"
+        assert "13800138000" not in json.dumps(records, ensure_ascii=False)
+
+        pii_events = [
+            json.loads(line)
+            for line in (tmp_path / "security-events.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if json.loads(line).get("event_type") == "pii_scan"
+        ]
+        assert len(pii_events) == 4
+        assert all(
+            event["session_id"] == "codex-session" and event["run_id"] == "codex-turn"
+            for event in pii_events
+        )
+        assert pii_events[1]["tool_call_id"] == "codex-tool"
+        assert pii_events[2]["tool_call_id"] == "codex-tool"
+        assert (tmp_path / "observability.db").exists()

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_observability_hook.py
@@ -1,0 +1,420 @@
+"""Unit tests for codex-plugin/hooks/observability_hook.py."""
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_CODEX_PLUGIN_DIR = Path(__file__).resolve().parents[2] / ".." / "codex-plugin"
+_HOOK = _CODEX_PLUGIN_DIR / "hooks-plugin" / "hooks" / "observability_hook.py"
+
+
+def _load_observability_hook():
+    spec = importlib.util.spec_from_file_location("codex_observability_hook", _HOOK)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+observability_hook = _load_observability_hook()
+
+_TS = "2026-07-15T08:00:00Z"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_timestamp(monkeypatch):
+    monkeypatch.setattr(observability_hook, "_now_iso", lambda: _TS)
+
+
+def _base(hook_event_name, **overrides):
+    payload = {
+        "hook_event_name": hook_event_name,
+        "session_id": "session-123",
+        "turn_id": "turn-123",
+        "model": "gpt-5",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _record(input_data):
+    record = observability_hook._build_record(input_data)
+    assert record is not None
+    return record
+
+
+def test_user_prompt_submit_maps_turn_metadata_and_metrics():
+    prompt = "Summarize this change."
+    record = _record(_base("UserPromptSubmit", prompt=prompt))
+
+    assert record == {
+        "hook": "before_agent_run",
+        "observedAt": _TS,
+        "metadata": {
+            "sessionId": "session-123",
+            "runId": "turn-123",
+        },
+        "metrics": {
+            "prompt": prompt,
+            "user_input": prompt,
+            "pii_scan_input_sha256": observability_hook._pii_scan_input_sha256(prompt),
+            "model_id": "gpt-5",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ("session_id", "turn_id"),
+)
+def test_agent_record_skips_missing_required_correlation_field(missing_field, capsys):
+    payload = _base("UserPromptSubmit", prompt="hello")
+    payload.pop(missing_field)
+
+    assert observability_hook._build_record(payload) is None
+    assert missing_field in capsys.readouterr().err
+
+
+def test_pre_tool_use_maps_all_three_correlation_levels():
+    tool_input = {"command": "pwd"}
+    record = _record(
+        _base(
+            "PreToolUse",
+            tool_name="Bash",
+            tool_input=tool_input,
+            tool_use_id="tool-123",
+        )
+    )
+
+    assert record["hook"] == "before_tool_call"
+    assert record["metadata"] == {
+        "sessionId": "session-123",
+        "runId": "turn-123",
+        "toolCallId": "tool-123",
+    }
+    assert record["metrics"] == {
+        "tool_name": "Bash",
+        "parameters": tool_input,
+        "pii_scan_input_sha256": observability_hook._pii_scan_input_sha256(tool_input),
+    }
+
+
+def test_tool_record_skips_missing_tool_use_id(capsys):
+    payload = _base("PreToolUse", tool_name="Bash", tool_input={"command": "pwd"})
+
+    assert observability_hook._build_record(payload) is None
+    assert "tool_use_id" in capsys.readouterr().err
+
+
+def test_record_trace_context_maps_tool_metadata():
+    record = _record(
+        _base(
+            "PreToolUse",
+            tool_name="Bash",
+            tool_input={"command": "pwd"},
+            tool_use_id="tool-123",
+        )
+    )
+
+    assert observability_hook._record_trace_context(record) == {
+        "agent_name": "codex",
+        "session_id": "session-123",
+        "run_id": "turn-123",
+        "tool_call_id": "tool-123",
+    }
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected_status"),
+    ((0, "success"), (2, "error")),
+)
+def test_post_tool_use_maps_result_size_exit_code_and_status(
+    exit_code, expected_status
+):
+    tool_response = {"stdout": "done\n", "exit_code": exit_code}
+    record = _record(
+        _base(
+            "PostToolUse",
+            tool_name="Bash",
+            tool_use_id="tool-123",
+            tool_response=tool_response,
+        )
+    )
+
+    assert record["hook"] == "after_tool_call"
+    assert record["metadata"]["toolCallId"] == "tool-123"
+    assert record["metrics"] == {
+        "result": tool_response,
+        "result_size_bytes": observability_hook._json_size_bytes(tool_response),
+        "pii_scan_input_sha256": observability_hook._pii_scan_input_sha256(
+            tool_response
+        ),
+        "exit_code": exit_code,
+        "status": expected_status,
+    }
+
+
+def test_post_tool_use_does_not_invent_status_without_exit_code():
+    record = _record(
+        _base(
+            "PostToolUse",
+            tool_use_id="tool-123",
+            tool_response="completed",
+        )
+    )
+
+    assert "status" not in record["metrics"]
+    assert "duration_ms" not in record["metrics"]
+
+
+@pytest.mark.parametrize(
+    ("message", "output_kind", "text_count"),
+    (("Done.", "text", 1), ("", "empty", 0)),
+)
+def test_stop_maps_final_response_without_llm_metrics(message, output_kind, text_count):
+    record = _record(_base("Stop", last_assistant_message=message))
+
+    assert record["hook"] == "after_agent_run"
+    assert record["metrics"] == {
+        "response": message,
+        "output_kind": output_kind,
+        "assistant_texts_count": text_count,
+        "final_model_id": "gpt-5",
+    }
+    assert "total_api_calls" not in record["metrics"]
+    assert "duration_ms" not in record["metrics"]
+
+
+def test_build_record_rejects_unsupported_and_model_events():
+    assert observability_hook._build_record(_base("PermissionRequest")) is None
+    assert observability_hook._build_record(_base("BeforeModel")) is None
+    assert observability_hook._build_record(_base("AfterModel")) is None
+
+
+def test_redaction_caches_duplicate_sensitive_values(monkeypatch):
+    calls = []
+
+    def fake_redact(text, _security_trace_context):
+        calls.append(text)
+        return text.replace("alice@example.com", "a***@example.com")
+
+    monkeypatch.setattr(observability_hook, "_redact_text", fake_redact)
+    record = _record(_base("UserPromptSubmit", prompt="contact alice@example.com"))
+
+    safe_record = observability_hook._redact_observability_record(record)
+
+    assert calls == ["contact alice@example.com"]
+    serialized = json.dumps(safe_record, ensure_ascii=False)
+    assert "alice@example.com" not in serialized
+    assert "a***@example.com" in serialized
+
+
+def test_redaction_failure_drops_raw_value_but_keeps_hash_and_model(monkeypatch):
+    monkeypatch.setattr(
+        observability_hook,
+        "_redact_text",
+        lambda _text, _security_trace_context: None,
+    )
+    record = _record(_base("UserPromptSubmit", prompt="contact alice@example.com"))
+
+    safe_record = observability_hook._redact_observability_record(record)
+
+    assert "prompt" not in safe_record["metrics"]
+    assert "user_input" not in safe_record["metrics"]
+    assert "pii_scan_input_sha256" in safe_record["metrics"]
+    assert safe_record["metrics"]["model_id"] == "gpt-5"
+
+
+def test_main_redacts_then_records_and_returns_noop(monkeypatch, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if "scan-pii" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "redacted_text": kwargs["input"].replace(
+                            "alice@example.com", "a***@example.com"
+                        )
+                    }
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(_base("UserPromptSubmit", prompt="contact alice@example.com"))
+        ),
+    )
+
+    observability_hook.main()
+
+    assert json.loads(capsys.readouterr().out) == {}
+    assert len(calls) == 2
+    pii_command = calls[0][0]
+    trace_context_index = pii_command.index("--trace-context") + 1
+    assert json.loads(pii_command[trace_context_index]) == {
+        "agent_name": "codex",
+        "session_id": "session-123",
+        "run_id": "turn-123",
+    }
+    command, kwargs = calls[-1]
+    assert command == [
+        "agent-sec-cli",
+        "observability",
+        "record",
+        "--format",
+        "json",
+        "--stdin",
+    ]
+    payload = json.loads(kwargs["input"])
+    assert payload["metadata"]["runId"] == "turn-123"
+    assert "alice@example.com" not in json.dumps(payload, ensure_ascii=False)
+
+
+def test_main_invalid_json_returns_noop_without_cli(monkeypatch, capsys):
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not-json"))
+
+    observability_hook.main()
+
+    assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_main_oversized_payload_is_diagnosed_and_fail_open(monkeypatch, capsys):
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    payload = b"alice@example.com" + b"x" * observability_hook._MAX_PAYLOAD_SIZE
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload)))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == (
+        "observability-hook: hook input exceeds "
+        f"{observability_hook._MAX_PAYLOAD_SIZE} bytes; skipping event\n"
+    )
+    assert "alice@example.com" not in captured.err
+
+
+def test_main_payload_at_size_limit_is_processed(monkeypatch, capsys):
+    prefix = (
+        b'{"hook_event_name":"UserPromptSubmit",'
+        b'"session_id":"session-123","turn_id":"turn-123",'
+        b'"prompt":"hello","padding":"'
+    )
+    suffix = b'"}'
+    padding_size = observability_hook._MAX_PAYLOAD_SIZE - len(prefix) - len(suffix)
+    payload = prefix + b"x" * padding_size + suffix
+    records = []
+    assert len(payload) == observability_hook._MAX_PAYLOAD_SIZE
+
+    monkeypatch.setattr(observability_hook, "_record_observability", records.append)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload)))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert captured.err == ""
+    assert len(records) == 1
+    assert records[0]["metrics"]["prompt"] == "hello"
+
+
+def test_main_observability_cli_failure_is_fail_open(monkeypatch, capsys):
+    monkeypatch.setattr(
+        observability_hook,
+        "_redact_text",
+        lambda text, _security_trace_context: text,
+    )
+
+    def fail_run(*_args, **_kwargs):
+        raise FileNotFoundError("agent-sec-cli")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps(_base("Stop", last_assistant_message="Done."))),
+    )
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+    assert "agent-sec-cli executable was not found" in captured.err
+
+
+def test_record_timeout_is_fail_open(monkeypatch, capsys):
+    monkeypatch.setattr(
+        observability_hook,
+        "_redact_text",
+        lambda text, _security_trace_context: text,
+    )
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=["agent-sec-cli", "observability", "record"],
+            timeout=3,
+            stderr="record timeout",
+        )
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", timeout)
+
+    observability_hook._record_observability(
+        _record(_base("Stop", last_assistant_message="Done."))
+    )
+
+    captured = capsys.readouterr()
+    assert "timed out after 3 seconds" in captured.err
+    assert "record timeout" in captured.err
+
+
+def test_hooks_config_registers_observability_for_four_codex_events():
+    config = json.loads(
+        (_CODEX_PLUGIN_DIR / "hooks-plugin" / "hooks" / "hooks.json").read_text()
+    )
+    expected_events = {
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+    }
+    command = "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py"
+
+    registered_events = set()
+    for event_name, entries in config["hooks"].items():
+        matching = [
+            (entry, hook)
+            for entry in entries
+            for hook in entry.get("hooks", [])
+            if hook.get("command") == command
+        ]
+        if matching:
+            registered_events.add(event_name)
+            assert len(matching) == 1
+            entry, hook = matching[0]
+            assert entry.get("matcher") in (None, "", "*")
+            assert hook["timeout"] == 10
+
+    assert registered_events == expected_events

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_trace_context.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_trace_context.py
@@ -44,7 +44,7 @@ class TestTraceContext:
         data = {
             "trace_id": "t1",
             "session_id": "s1",
-            "run_id": "r1",
+            "turn_id": "r1",
             "tool_use_id": "c1",
             "call_id": "c2",
         }
@@ -85,6 +85,15 @@ class TestTraceContext:
         data = {"trace_id": "t1", "session_id": "s1"}
         ctx = trace_context.trace_context(data)
         assert ctx == {"agent_name": "codex", "trace_id": "t1", "session_id": "s1"}
+
+    def test_turn_id_is_preferred_over_legacy_run_id(self):
+        data = {"turn_id": "turn-1", "run_id": "legacy-run"}
+        ctx = trace_context.trace_context(data)
+        assert ctx == {"agent_name": "codex", "run_id": "turn-1"}
+
+    def test_legacy_run_id_remains_supported(self):
+        ctx = trace_context.trace_context({"run_id": "legacy-run"})
+        assert ctx == {"agent_name": "codex", "run_id": "legacy-run"}
 
 
 class TestWithTraceContext:


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Add observability capability in codex plugin. Also fix an existing issue by changing run_id to turn_id in hook input extraction.

Update the document.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
