### PR TITLE
fix(copilot-shell): add /usr/local/bin symlinks for anolisa {bindir} health check

### DIFF
--- a/src/copilot-shell/copilot-shell.spec.in
+++ b/src/copilot-shell/copilot-shell.spec.in
@@ -35,6 +35,14 @@ make install DESTDIR=%{buildroot} PREFIX=%{_prefix}
 install -d %{buildroot}%{_datadir}/anolisa/components/cosh
 install -m 0644 component.toml %{buildroot}%{_datadir}/anolisa/components/cosh/component.toml
 
+# anolisa resolves {bindir} to /usr/local/bin for system scope (FHS),
+# but this RPM installs binaries under /usr/bin (PREFIX=/usr).
+# Add compatibility symlinks so health checks find cosh at {bindir}/cosh.
+install -d %{buildroot}/usr/local/bin
+ln -sf %{_bindir}/cosh    %{buildroot}/usr/local/bin/cosh
+ln -sf %{_bindir}/co      %{buildroot}/usr/local/bin/co
+ln -sf %{_bindir}/copilot %{buildroot}/usr/local/bin/copilot
+
 # Install cosh-switch script
 cat > %{buildroot}%{_bindir}/cosh-switch << 'EOF'
 #!/bin/bash
@@ -84,6 +92,9 @@ EOF
 %license %{_docdir}/%{name}/LICENSE
 %doc %{_docdir}/%{name}/README.md
 %{_prefix}/lib/%{name}
+/usr/local/bin/cosh
+/usr/local/bin/co
+/usr/local/bin/copilot
 %{_datadir}/%{name}
 %{_datadir}/anolisa/components/cosh/component.toml
 %{_bindir}/co


### PR DESCRIPTION
## 问题

Fixes #1498

After `anolisa install cosh --backend rpm`, the health check `cosh:command:launcher` fails because anolisa resolves `{bindir}` to `/usr/local/bin` (FHS), but the copilot-shell RPM installs binaries to `/usr/bin` (via `PREFIX=%{_prefix}`). The `component.toml` health check command `{bindir}/cosh --version` expands to `/usr/local/bin/cosh --version` — a path that doesn't exist.

Other components (skillfs, agentsight) install to `/usr/local/bin` explicitly. copilot-shell is the outlier.

## 修复

Add compatibility symlinks from `/usr/local/bin` → `/usr/bin` for `cosh`, `co`, and `copilot` in the spec `%install` section, and list them in `%files`. This preserves the existing `/usr/bin` install path (backward compat with scripts that reference `/usr/bin/cosh`) while making the anolisa health check work at `{bindir}/cosh`.

## 验证

```shell
# ECS fresh clone + apply patch + build
cd /root && rm -rf anolisa-verify && git clone https://github.com/alibaba/anolisa.git anolisa-verify
cd anolisa-verify && git apply /tmp/copilot-shell.patch
bash scripts/rpm-build.sh copilot-shell
# → exit 0, copilot-shell-2.7.0-1.alnx4.x86_64.rpm built (4.1M)

# Install patched RPM
rpm -ivh scripts/rpmbuild/RPMS/x86_64/copilot-shell-2.7.0-1.alnx4.x86_64.rpm

# Verify health check
anolisa doctor cosh
# → cosh ok (2.7.0-1.alnx4) scope=system, no issues found

ls -la /usr/local/bin/cosh
# → lrwxrwxrwx 1 root root 13 ... /usr/local/bin/cosh -> /usr/bin/cosh
```

Co-Authored-By: Claude <noreply@anthropic.com>
