### PR TITLE
fix(sight): record process pid not thread tid in ns pid helper

### DIFF
--- a/src/agentsight/src/bpf/common.h
+++ b/src/agentsight/src/bpf/common.h
@@ -65,15 +65,28 @@ static inline u32 get_task_ns_pid(struct task_struct *task)
 {
   unsigned int level = 0;
   struct pid *pid = NULL;
+  /* Read from the thread-group leader so we return the PROCESS-level (tgid)
+   * namespace pid, not the calling thread's ns tid. A syscall may run on a
+   * worker thread (e.g. aiohttp/uvloop performs getaddrinfo in a thread pool),
+   * in which case the raw current-task PIDTYPE_PID is a per-thread tid. Reading
+   * the leader keeps event->pid == process pid so it correlates with sslsniff
+   * and cmdline/DNS discovery. For a typical single-threaded process the
+   * leader is the task itself. */
+  struct task_struct *leader = BPF_CORE_READ(task, group_leader);
+  /* Defensive: group_leader is never NULL in practice, but if a CO-RE read
+   * ever yields 0 fall back to task so we degrade to the prior (per-thread)
+   * behaviour instead of dereferencing a NULL leader. */
+  if (!leader)
+    leader = task;
 
   if (bpf_core_type_exists(struct pid_link))
   {
-    struct task_struct___older_v50 *t = (void *)task;
+    struct task_struct___older_v50 *t = (void *)leader;
     pid = BPF_CORE_READ(t, pids[PIDTYPE_PID].pid);
   }
   else
   {
-    pid = BPF_CORE_READ(task, thread_pid);
+    pid = BPF_CORE_READ(leader, thread_pid);
   }
 
   level = BPF_CORE_READ(pid, level);


### PR DESCRIPTION
## Description

`get_task_ns_pid()` (used by `current_ns_pid()`) read `PIDTYPE_PID`/`thread_pid` of the *current task* — i.e. the calling thread's namespace pid, which has tid semantics — even though `current_ns_pid()` is documented as equal to `bpf_get_current_pid_tgid() >> 32`. That equivalence only holds on a process's main thread.

For a multithreaded process a syscall can run on a worker thread. Python agents using aiohttp/uvloop perform DNS resolution (`getaddrinfo`) on a thread-pool thread, so `udpdns` recorded `event->pid` as the worker's tid rather than the process pid. `tcpsniff` (plaintext HTTP) and `filewatch` share the same helper and had the same defect. The result: pid-based correlation and DNS-driven agent discovery attributed events to a thread id rather than the process, so they silently failed to match the real agent process.

Reading the thread-group leader makes the helper return the process-level (tgid) namespace pid. Single-threaded tasks are unaffected (`leader == task`). One change fixes `udpdns`, `tcpsniff`, `filewatch`, and the container ns fallback in `sslsniff`/`procmon`. `sslsniff`'s main path already used `pid_tgid >> 32` and was not affected.

## Related Issue

no-issue: found during on-host debugging of a multithreaded Python agent

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/bpf/common.h`: `get_task_ns_pid()` reads `task->group_leader` before resolving `PIDTYPE_PID`/`thread_pid`, returning the process-level ns pid instead of the calling thread's ns tid.

## Checklist

- [x] `cargo fmt --check` pass
- [x] `cargo clippy` pass (no Rust changed; identical to base)
- [x] Architecture boundaries pass (0 violations)
- [ ] Coverage: N/A — BPF C change only, no Rust lines to cover
- [x] Lock files up to date (no dependency change)

## Testing

A/B test on kernel 5.10 (x86_64) with a purpose-built multithreaded probe: a Python program calling `socket.getaddrinfo` from worker threads while `agentsight trace` ran.

- **Before fix**: process MAINPID `3691249`, worker tids `3691251/52/53`; `udpdns` logged `pid=3691251` (a worker tid).
- **After fix**: process MAINPID `3693376`, worker tids `3693380/81/82`; `udpdns` logged `pid=3693376` (the process pid).

`cargo test --lib`: 1086 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)