### PR TITLE
fix(sight): don't auto-overwrite invalid JSON configs

### DIFF
--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -516,6 +516,18 @@ pub fn ensure_default_agents_config(path: &Path) -> anyhow::Result<()> {
 
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read existing config at {path:?}"))?;
+
+    // If the file is not valid JSON at all, leave it untouched so the caller's
+    // load_from_file → parse_json_rules surfaces "JSON parse error: ..." and
+    // AgentSight::new emits its `Failed to load config from {path:?}: {e},
+    // using embedded defaults` warn log. Auto-upgrade is only meaningful for
+    // *valid* JSON whose schema_version is outdated; silently overwriting an
+    // invalid file masks the parse error and breaks the documented fallback
+    // contract (see issue #1502).
+    if serde_json::from_str::<serde_json::Value>(&content).is_err() {
+        return Ok(());
+    }
+
     let on_disk_version = extract_schema_version(&content);
 
     if on_disk_version >= Some(CURRENT_SCHEMA_VERSION) {
@@ -2073,5 +2085,60 @@ mod tests {
             extract_schema_version(&content),
             Some(CURRENT_SCHEMA_VERSION)
         );
+    }
+
+    #[test]
+    fn ensure_default_agents_config_leaves_invalid_json_untouched() {
+        // Regression for issue #1502: an unparseable config file must NOT be
+        // silently backed up + overwritten with the default. The caller's
+        // load_from_file → parse_json_rules surfaces "JSON parse error: ..."
+        // and AgentSight::new emits its "using embedded defaults" warn log.
+        // Auto-upgrade is only meaningful for valid JSON with an outdated
+        // schema_version.
+        let dir = unique_temp_dir();
+        let path = dir.join("agentsight.json");
+        let invalid = "NOT_VALID_JSON_AT_ALL{{{";
+        std::fs::write(&path, invalid).unwrap();
+        ensure_default_agents_config(&path).unwrap();
+        // File content must be unchanged — no silent overwrite.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), invalid);
+        // No backup file should be created either.
+        let parent = path.parent().unwrap();
+        let backups: Vec<_> = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("agentsight.json.bak.")
+            })
+            .collect();
+        assert!(
+            backups.is_empty(),
+            "invalid JSON must not trigger backup+overwrite"
+        );
+    }
+
+    #[test]
+    fn ensure_default_agents_config_leaves_truncated_json_untouched() {
+        // Same regression, with a truncated-JSON variant (parses as partial
+        // JSON, fails serde_json::from_str). Should also be left untouched.
+        let dir = unique_temp_dir();
+        let path = dir.join("agentsight.json");
+        let truncated = r#"{"cmdline": {"allow": [{"rule": ["*cosh*""#;
+        std::fs::write(&path, truncated).unwrap();
+        ensure_default_agents_config(&path).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), truncated);
+        let parent = path.parent().unwrap();
+        let backups: Vec<_> = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("agentsight.json.bak.")
+            })
+            .collect();
+        assert!(backups.is_empty());
     }
 }


### PR DESCRIPTION
## What & Why

Fixes #1502.

`ensure_default_agents_config` (added in 98158d24 to fix #1427) silently overwrote invalid JSON config files with the embedded default, suppressing the documented `WARN Failed to load config from {path:?}: {e}, using embedded defaults` log line.

**Root cause:** `extract_schema_version` internally does `serde_json::from_str::<VersionProbe>(json).ok()` — for invalid JSON it returns `None`. Then `None < Some(CURRENT_SCHEMA_VERSION)` is true, so the function backed up the file to `.bak.<ts>` and overwrote it with the default. By the time `load_from_file` ran, the file was valid JSON → `parse_json_rules` succeeded → the `config_load_err` warn branch in `AgentSight::new` (src/unified.rs:186) never fired.

## Reproduction (on 0.8.0 RPM, before this fix)

```bash
echo 'NOT_VALID_JSON_AT_ALL{{{' > /tmp/agentsight_invalid_cfg_test.json
timeout 8 agentsight trace --config /tmp/agentsight_invalid_cfg_test.json > /tmp/invalid_config_test.log 2>&1
cat /tmp/invalid_config_test.log
# empty — no "JSON parse error" warn
ls /tmp/agentsight_invalid_cfg_test.json*
# original silently backed up to .bak.<ts>, file rewritten with default schema_version=2
```

This breaks `agentic-os-tests/agentsight-tests/tests/test_config_validation.py::TestInvalidConfigHandling::test_invalid_json_config_returns_error` and `TestConfigFileParsingErrors::test_config_truncated_json_error` (both failing on the 2026-07-15 regression run).

## Fix

In `ensure_default_agents_config` (src/agentsight/src/config.rs), probe JSON validity with `serde_json::from_str::<serde_json::Value>` before calling `extract_schema_version`. If the parse fails, return `Ok(())` **without touching the file** — this lets the caller's `load_from_file → parse_json_rules` surface `JSON parse error: <serde error>` and the warn-fallback path fire. Auto-upgrade is only meaningful for *valid* JSON whose `schema_version` is outdated.

```rust
let content = std::fs::read_to_string(path)
    .with_context(|| format!("Failed to read existing config at {path:?}"))?;

// If the file is not valid JSON at all, leave it untouched so the caller's
// load_from_file → parse_json_rules surfaces "JSON parse error: ..." and
// AgentSight::new emits its `Failed to load config from {path:?}: {e},
// using embedded defaults` warn log. Auto-upgrade is only meaningful for
// *valid* JSON whose schema_version is outdated; silently overwriting an
// invalid file masks the parse error and breaks the documented fallback
// contract (see issue #1502).
if serde_json::from_str::<serde_json::Value>(&content).is_err() {
    return Ok(());
}

let on_disk_version = extract_schema_version(&content);
// ... existing auto-upgrade logic unchanged ...
```

This preserves the #1427 auto-upgrade behavior for valid-but-stale configs (still backed up + overwritten when `schema_version < CURRENT_SCHEMA_VERSION`) while restoring the parse-error warn log for invalid JSON.

## Tests

Added 2 regression tests in `config::tests`:

- `ensure_default_agents_config_leaves_invalid_json_untouched` — writes `"NOT_VALID_JSON_AT_ALL{{{"`, calls `ensure_default_agents_config`, asserts file content unchanged and no `.bak` file created.
- `ensure_default_agents_config_leaves_truncated_json_untouched` — same with a truncated-JSON variant.

All existing `ensure_default_agents_config_*` tests still pass:

```
running 6 tests
test config::tests::ensure_default_agents_config_leaves_truncated_json_untouched ... ok
test config::tests::ensure_default_agents_config_leaves_invalid_json_untouched ... ok
test config::tests::ensure_default_agents_config_preserves_current_config ... ok
test config::tests::ensure_default_agents_config_creates_file_when_missing ... ok
test config::tests::ensure_default_agents_config_upgrades_old_schema_version ... ok
test config::tests::ensure_default_agents_config_upgrades_stale_config ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1083 filtered out
```

## End-to-end verification on test env (47.239.61.17)

Built `agentsight` release binary with this fix, scp'd to test env, ran manual repro:

```
$ echo 'NOT_VALID_JSON_AT_ALL{{{' > /tmp/agentsight_invalid_cfg_test.json
$ timeout 8 /tmp/agentsight-fixed trace --config /tmp/agentsight_invalid_cfg_test.json > /tmp/invalid_config_test.log 2>&1
$ cat /tmp/invalid_config_test.log
[2026-07-15T13:55:17.835Z WARN  agentsight::unified:186] Failed to load config from "/tmp/agentsight_invalid_cfg_test.json": Failed to parse config from "/tmp/agentsight_invalid_cfg_test.json": JSON parse error: expected value at line 1 column 1, using embedded defaults
$ cat /tmp/agentsight_invalid_cfg_test.json
NOT_VALID_JSON_AT_ALL{{{
$ ls /tmp/agentsight_invalid_cfg_test.json*
/tmp/agentsight_invalid_cfg_test.json
```

The expected `WARN ... JSON parse error: ... using embedded defaults` log line now fires, and the invalid file is left untouched (no `.bak` backup). Same behavior verified for truncated JSON (`{"cmdline": {"allow": [{"rule": ["*cosh*"`).

## Related

- Fixes #1502
- #1427 (closed) — original auto-upgrade feature request that introduced the regression
- #1496 (open) — separate but related: `agentsight serve` schema migration overwrites user customizations for valid v1 configs (different code path, same theme of schema-migration logic silently clobbering user state)
