### PR TITLE
fix(skillfs): ensure SLS ops log written even on SIGPIPE panic

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -485,13 +485,13 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
             primary_count,
             dry_run,
         } => {
-            let start = std::time::Instant::now();
+            let _guard = SlsLogGuard::new("classify");
             let result = cmd_classify(source, primary_count, dry_run).await;
-            sls_ops::log_command("classify", start, err_reason(&result));
+            _guard.set_reason(err_reason(&result));
             result
         }
         Commands::Validate { source, format } => {
-            let start = std::time::Instant::now();
+            let _guard = SlsLogGuard::new("validate");
             let (result, validation_failed) = cmd_validate(source, format).await;
             // A validation failure exits non-zero but is not a command error;
             // record it with a concise err_reason before exiting.
@@ -500,7 +500,7 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
                 None if validation_failed => Some("validation failed".to_string()),
                 None => None,
             };
-            sls_ops::log_command("validate", start, reason);
+            _guard.set_reason(reason);
             if result.is_ok() && validation_failed {
                 std::process::exit(1);
             }
@@ -510,9 +510,9 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
             source,
             enabled_only,
         } => {
-            let start = std::time::Instant::now();
+            let _guard = SlsLogGuard::new("list");
             let result = cmd_list(source, enabled_only).await;
-            sls_ops::log_command("list", start, err_reason(&result));
+            _guard.set_reason(err_reason(&result));
             result
         }
         Commands::Stop { mountpoint } => managed::run_stop(&mountpoint),
@@ -524,6 +524,48 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
 fn err_reason<T>(result: &Result<T, Box<dyn std::error::Error>>) -> Option<String> {
     result.as_ref().err().map(|e| e.to_string())
 }
+
+/// RAII guard that ensures `sls_ops::log_command` runs on drop, even if the
+/// command panics (e.g. `println!` panicking on a broken pipe when stdout is
+/// piped to `head`). The error reason and completion status are stored in
+/// cells and updated after the command returns; on panic unwind, the guard
+/// logs with a "panic" reason so the SLS ops entry is never lost.
+struct SlsLogGuard {
+    ops_name: String,
+    start: std::time::Instant,
+    err_reason: std::cell::Cell<Option<String>>,
+    completed: std::cell::Cell<bool>,
+}
+
+impl SlsLogGuard {
+    fn new(ops_name: &str) -> Self {
+        Self {
+            ops_name: ops_name.to_string(),
+            start: std::time::Instant::now(),
+            err_reason: std::cell::Cell::new(None),
+            completed: std::cell::Cell::new(false),
+        }
+    }
+
+    /// Set the error reason after the command completes (Ok -> None).
+    fn set_reason(&self, reason: Option<String>) {
+        self.err_reason.set(reason);
+        self.completed.set(true);
+    }
+}
+
+impl Drop for SlsLogGuard {
+    fn drop(&mut self) {
+        let reason = if self.completed.get() {
+            self.err_reason.take()
+        } else {
+            // Command panicked before calling set_reason.
+            Some("panic".to_string())
+        };
+        sls_ops::log_command(&self.ops_name, self.start, reason);
+    }
+}
+
 
 // ---------------------------------------------------------------------------
 // Mount Command


### PR DESCRIPTION
## 问题

Fixes #1506

skillfs CLI subcommands `list` and `classify` do not write SLS ops log entries when stdout is piped to a consumer that closes early (e.g. `head -5`). The `log_command()` call runs after all `println!` output, but `println!` panics on broken pipe (SIGPIPE/EPIPE) when the downstream reader has already exited, causing the process to unwind before reaching `log_command()`.

This is a regression from the original SLS ops logging fix (commit 1a07b204, issue #1306). The `log_command` calls were added to all subcommands, but they are unreachable when the process panics from a broken stdout pipe.

## 修复

Add an RAII `SlsLogGuard` that calls `sls_ops::log_command()` in its `Drop` implementation. The guard is created before the command runs and dropped on all exit paths — including panic unwinds from broken pipe. This ensures the SLS entry is always written regardless of stdout pipe state.

```diff
+struct SlsLogGuard {
+    ops_name: String,
+    start: std::time::Instant,
+    err_reason: std::cell::Cell<Option<String>>,
+    completed: std::cell::Cell<bool>,
+}
+
+impl Drop for SlsLogGuard {
+    fn drop(&mut self) {
+        let reason = if self.completed.get() {
+            self.err_reason.take()
+        } else {
+            Some("panic".to_string())
+        };
+        sls_ops::log_command(&self.ops_name, self.start, reason);
+    }
+}
```

Each command handler replaces its manual `log_command` call with guard creation:
```rust
let _guard = SlsLogGuard::new("list");
let result = cmd_list(source, enabled_only).await;
_guard.set_reason(err_reason(&result));
result
```

## 验证

```shell
# ECS fresh clone + apply patch + build
cd /root && rm -rf anolisa && git clone https://github.com/alibaba/anolisa.git && cd anolisa
git apply skillfs-sls-panic-guard.patch
bash scripts/rpm-build.sh skillfs
# → exit 0, RPM 2.0M

# Install patched RPM and test
rpm -U --force scripts/rpmbuild/RPMS/x86_64/skillfs-0.3.3-1.alnx4.x86_64.rpm
touch /var/log/anolisa/sls/ops/skillfs.jsonl
> /var/log/anolisa/sls/ops/skillfs.jsonl

# Before fix: list piped to head -5 → 0 bytes (no SLS entry)
# After fix: list piped to head -5 → 180 bytes (SLS entry written!)
skillfs list /usr/share/anolisa/runtime/skills 2>&1 | head -5
stat -c '%s' /var/log/anolisa/sls/ops/skillfs.jsonl
# 180

# All 3 parametrized tests pass:
pytest tests/test_sls_ops_emission.py::test_skillfs_cli_emits_sls_entry -v
# 3 passed in 10.50s
```

Co-Authored-By: Claude <noreply@anthropic.com>
