### PR TITLE
feat(ckpt): add explicit telemetry gate to ops log writes

### DIFF
--- a/src/ws-ckpt/src/crates/daemon/src/ops_log.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/ops_log.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use ws_ckpt_common::{Request, Response};
 
 const OPS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/ws-ckpt.jsonl";
+const TELEMETRY_GATE: &str = "/etc/anolisa/.telemetry_disabled";
 const KNOWN_AGENTS: &[&str] = &["user", "hermes", "openclaw"];
 static OPS_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -65,6 +66,11 @@ pub fn detect_agent_name(pid: u32) -> String {
 }
 
 pub fn log_operation(ops_name: &'static str, agent_name: &str, response: &Response) {
+    if std::path::Path::new(TELEMETRY_GATE).exists() || !std::path::Path::new(OPS_LOG_PATH).exists()
+    {
+        return;
+    }
+
     let err_reason = match response {
         Response::Error { message, .. } => message.as_str(),
         _ => "none",


### PR DESCRIPTION
## Description

- ops log 写入前增加显式门控：检查 /etc/anolisa/.telemetry_disabled 是否存在，存在则跳过日志写入
- 同时显式检查日志文件是否存在，不再依赖 open() 失败静默跳过

## Related Issue

no-issue: 简单门控逻辑，无对应 issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `ckpt`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass

## Testing

cargo fmt + clippy + cargo test 均通过

## Additional Notes
