### PR TITLE
fix(tokenless): exclude generated component.toml from RPM tarball

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -486,14 +486,18 @@ build_tokenless() {
     # Copy full source tree (including vendored rtk), excluding build artifacts and VCS
     # Note: third_party/rtk must be included — it's built separately via --manifest-path
     # Adapter config files (manifest.json, package.json, openclaw.plugin.json, plugin.yaml)
-    # are excluded because they are generated from .in templates by
-    # stamp-adapter-templates during rpmbuild %build (make build-openclaw-plugin).
+    # and the component contract (component.toml) are excluded because they are
+    # generated from .in templates by stamp-adapter-templates during rpmbuild
+    # %build (make build-openclaw-plugin). Excluding them ensures the RPM build
+    # always regenerates from the authoritative .in template, preventing stale
+    # contracts from shipping (see GH-1470).
     tar -cf - -C "$TOKEN_DIR" \
         --exclude='target' \
         --exclude='.git' \
         --exclude='node_modules' \
         --exclude='__pycache__' \
         --exclude='*.pyc' \
+        --exclude='.anolisa/component.toml' \
         --exclude='adapters/tokenless/manifest.json' \
         --exclude='adapters/tokenless/openclaw/package.json' \
         --exclude='adapters/tokenless/openclaw/openclaw.plugin.json' \

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 2
+%define anolis_release 3
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -448,6 +448,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Thu Jul 16 2026 Lin Yan <linyan.lin@alibaba-inc.com> - 0.7.0-3
+- fix(tokenless): declare all shipped adapters (claude-code, codex, cosh, qoder) in RPM component contract template; exclude generated component.toml from source tarball to prevent stale contracts (GH-1470)
+
 * Mon Jul 13 2026 Lin Yan <linyan.lin@alibaba-inc.com> - 0.7.0-1
 - feat(tokenless): add MCP `tokenless_retrieve` stdio server (`tokenless mcp serve`); closes the stash MCP gap vs Headroom CCR's `headroom_retrieve`
 - feat(tokenless): complete reversible-compression (stash) coverage across string, depth, and SchemaCompressor description truncation paths; add `--no-stash`/`--stash-db` to `compress-schema`; SqliteStore lazy TTL purge


### PR DESCRIPTION
## Summary

Fix the tokenless RPM contract declaring only 3 frameworks (openclaw, hermes, qoder) instead of the 6 shipped adapters (missing claude-code, codex, cosh).

**Closes #1470**

## Root Cause

`scripts/rpm-build.sh` created the source tarball including the generated `.anolisa/component.toml` file. When the checked-in copy was stale, `make` would not regenerate it (target already exists on disk), shipping an outdated contract that omitted adapters added after the contract was first committed.

This is the same class of issue as the other stamped adapter files (`manifest.json`, `plugin.yaml`, etc.) — all of which are already excluded from the tarball — but `.anolisa/component.toml` was missed.

## Fix

- **`scripts/rpm-build.sh`**: add `--exclude='.anolisa/component.toml'` to the tarball creation, mirroring the other `.in`-generated files. This forces `make` to always regenerate from the authoritative `.anolisa/component.toml.in` template during `rpmbuild %build`.

- **`src/tokenless/tokenless.spec.in`**: bump `anolis_release` from 2 to 3 and add a changelog entry for the rebuild.

The contract template itself (`.anolisa/component.toml.in`) was already corrected in commit `0f48bd33` ("fix(tokenless): sync adapter contracts"). This change ensures the packaging pipeline reliably delivers that corrected contract.

## Verification

- `make -C src/tokenless check-component-contract` passes — confirms `.toml` is in sync with `.toml.in`
- `grep 'framework =' src/tokenless/.anolisa/component.toml` lists all 6 frameworks: openclaw, hermes, qoder, claude-code, codex, cosh