### PR TITLE
fix(cosh-ng): [types,platform] fix wire errors

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -444,8 +444,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -658,6 +660,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "ws-ckpt-common",
 ]
 
 [[package]]
@@ -3936,6 +3939,21 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "ws-ckpt-common"
+version = "0.4.2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml",
+ "tracing",
+]
 
 [[package]]
 name = "xdg-home"

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -920,6 +920,110 @@ fn test_redacted_password_does_not_appear_in_log() {
 
 // --- Checkpoint: daemon unavailable graceful error ---
 
+fn checkpoint_diff_with_fake_response(response: Vec<u8>) -> (serde_json::Value, String, String) {
+    let directory = tempfile::tempdir().unwrap();
+    let workspace = directory.path().join("test-ws");
+    std::fs::create_dir(&workspace).unwrap();
+    let socket_path = directory.path().join("daemon.sock");
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let server = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(connection) => break connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for cosh-cli to connect to fake ws-ckpt daemon"
+                    );
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("fake ws-ckpt daemon failed to accept connection: {error}"),
+            }
+        };
+        stream.set_nonblocking(false).unwrap();
+        let mut length = [0; 4];
+        stream.read_exact(&mut length).unwrap();
+        let mut request = vec![0; u32::from_le_bytes(length) as usize];
+        stream.read_exact(&mut request).unwrap();
+        stream.write_all(&response).unwrap();
+    });
+
+    let socket_path = socket_path.to_string_lossy().into_owned();
+    let output = cosh_bin()
+        .args([
+            "checkpoint",
+            "diff",
+            "--workspace",
+            workspace.to_str().unwrap(),
+            "--from",
+            "snap-001",
+            "--to",
+            "snap-002",
+            "--socket",
+            &socket_path,
+        ])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json = serde_json::from_str(&stdout).unwrap();
+    (json, stdout, socket_path)
+}
+
+fn assert_checkpoint_protocol_error(response: Vec<u8>, expected_kind: &str) {
+    let (json, stdout, socket_path) = checkpoint_diff_with_fake_response(response);
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "CheckpointProtocolError");
+    assert_eq!(json["error"]["subsystem"], "checkpoint");
+    assert_eq!(
+        json["error"]["details"],
+        serde_json::json!({
+            "phase": "response",
+            "kind": expected_kind,
+        })
+    );
+    assert_eq!(json["meta"]["subsystem"], "checkpoint");
+    for secret in [
+        socket_path.as_str(),
+        "failed to fill whole buffer",
+        "ConnectionReset",
+        "invalid value",
+        "bincode",
+    ] {
+        assert!(!stdout.contains(secret), "protocol detail leaked: {secret}");
+    }
+}
+
+#[test]
+fn test_checkpoint_diff_truncated_length_is_protocol_error() {
+    assert_checkpoint_protocol_error(vec![1, 2], "truncated_length");
+}
+
+#[test]
+fn test_checkpoint_diff_truncated_payload_is_protocol_error() {
+    let mut response = 8_u32.to_le_bytes().to_vec();
+    response.extend_from_slice(&[1, 2]);
+    assert_checkpoint_protocol_error(response, "truncated_payload");
+}
+
+#[test]
+fn test_checkpoint_diff_oversized_length_is_protocol_error() {
+    assert_checkpoint_protocol_error(
+        (64_u32 * 1024 * 1024 + 1).to_le_bytes().to_vec(),
+        "oversized_length",
+    );
+}
+
+#[test]
+fn test_checkpoint_diff_invalid_bincode_is_protocol_error() {
+    let mut response = 4_u32.to_le_bytes().to_vec();
+    response.extend_from_slice(&u32::MAX.to_le_bytes());
+    assert_checkpoint_protocol_error(response, "decode_failed");
+}
+
 #[test]
 fn test_checkpoint_create_skipped_is_success() {
     let reason = "workspace has no changes";

--- a/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
@@ -19,6 +19,23 @@ const DEFAULT_TIMEOUT_MS: u64 = 5000;
 /// misbehaving or corrupted daemon.
 const MAX_RESPONSE_LEN: usize = 64 * 1024 * 1024;
 
+#[derive(Clone, Copy)]
+enum IoPhase {
+    Connect,
+    WriteRequest,
+    ReadResponseLength,
+    ReadResponsePayload,
+}
+
+#[derive(Clone, Copy)]
+enum ProtocolFailure {
+    TruncatedLength,
+    TruncatedPayload,
+    OversizedLength,
+    InvalidPayload,
+    UnexpectedResponse,
+}
+
 /// Client for ws-ckpt daemon IPC.
 pub struct CkptClient {
     socket_path: String,
@@ -147,7 +164,8 @@ impl CkptClient {
     pub fn restore(&self, workspace: &str, snapshot_id: &str) -> Result<CkptRestored, CoshError> {
         let req = WsCkptRequest::Rollback {
             workspace: workspace.to_string(),
-            to: snapshot_id.to_string(),
+            to: Some(snapshot_id.to_string()),
+            num_ancestors: None,
         };
         match self.send_request(&req)? {
             WsCkptResponse::RollbackOk { from, to } => Ok(CkptRestored { from, to }),
@@ -197,7 +215,7 @@ impl CkptClient {
         let req = WsCkptRequest::Diff {
             workspace: workspace.to_string(),
             from: from.to_string(),
-            to: to.to_string(),
+            to: Some(to.to_string()),
         };
         match self.send_request(&req)? {
             WsCkptResponse::DiffOk { changes } => Ok(CkptDiffResult { changes }),
@@ -234,7 +252,7 @@ impl CkptClient {
         if !Path::new(&self.socket_path).exists() {
             return Err(CoshError::new(
                 ErrorCode::CheckpointDaemonUnavailable,
-                format!("ws-ckpt daemon socket not found at {}", self.socket_path),
+                "ws-ckpt daemon socket is unavailable",
                 "checkpoint",
             )
             .with_hint("Start daemon with: systemctl start ws-ckpt")
@@ -243,7 +261,7 @@ impl CkptClient {
 
         // 2. Connect to Unix socket.
         let mut stream = UnixStream::connect(&self.socket_path)
-            .map_err(|e| classify_io_error(e, &self.socket_path, "connect to ws-ckpt daemon"))?;
+            .map_err(|error| classify_io_error(error, IoPhase::Connect))?;
 
         // 3. Apply configurable timeout to both read and write.
         let timeout = Duration::from_millis(self.timeout_ms);
@@ -254,31 +272,32 @@ impl CkptClient {
         let frame = encode_frame(req)?;
         stream
             .write_all(&frame)
-            .map_err(|e| classify_io_error(e, &self.socket_path, "write request frame"))?;
+            .map_err(|error| classify_io_error(error, IoPhase::WriteRequest))?;
 
         // 5. Read response length prefix (4 bytes, little-endian).
         let mut len_buf = [0u8; 4];
-        stream
-            .read_exact(&mut len_buf)
-            .map_err(|e| classify_io_error(e, &self.socket_path, "read response length"))?;
+        stream.read_exact(&mut len_buf).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::UnexpectedEof {
+                protocol_error(ProtocolFailure::TruncatedLength)
+            } else {
+                classify_io_error(error, IoPhase::ReadResponseLength)
+            }
+        })?;
         let resp_len = u32::from_le_bytes(len_buf) as usize;
 
         if resp_len > MAX_RESPONSE_LEN {
-            return Err(CoshError::new(
-                ErrorCode::Unknown,
-                format!(
-                    "Daemon response length {} exceeds maximum ({} bytes)",
-                    resp_len, MAX_RESPONSE_LEN
-                ),
-                "checkpoint",
-            ));
+            return Err(protocol_error(ProtocolFailure::OversizedLength));
         }
 
         // 6. Read response payload.
         let mut resp_buf = vec![0u8; resp_len];
-        stream
-            .read_exact(&mut resp_buf)
-            .map_err(|e| classify_io_error(e, &self.socket_path, "read response payload"))?;
+        stream.read_exact(&mut resp_buf).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::UnexpectedEof {
+                protocol_error(ProtocolFailure::TruncatedPayload)
+            } else {
+                classify_io_error(error, IoPhase::ReadResponsePayload)
+            }
+        })?;
 
         // 7. Decode response.
         decode_response(&resp_buf)
@@ -308,13 +327,7 @@ fn encode_frame<T: Serialize>(msg: &T) -> Result<Vec<u8>, CoshError> {
 
 /// Decode a bincode payload into a WsCkptResponse.
 fn decode_response(data: &[u8]) -> Result<WsCkptResponse, CoshError> {
-    bincode::deserialize(data).map_err(|e| {
-        CoshError::new(
-            ErrorCode::Unknown,
-            format!("Failed to parse daemon response: {}", e),
-            "checkpoint",
-        )
-    })
+    bincode::deserialize(data).map_err(|_| protocol_error(ProtocolFailure::InvalidPayload))
 }
 
 // ---------------------------------------------------------------------------
@@ -362,6 +375,11 @@ fn ws_error_to_cosh(code: WsCkptErrorCode, message: String) -> CoshError {
             ErrorCode::CheckpointCreateFailed,
             Some("Not enough disk space. Run 'cosh checkpoint cleanup' to free space"),
         ),
+        WsCkptErrorCode::CwdOccupied => (
+            ErrorCode::CheckpointRestoreFailed,
+            Some("Leave the workspace before retrying the restore"),
+        ),
+        WsCkptErrorCode::CwdScanFailed => (ErrorCode::CheckpointRestoreFailed, None),
     };
 
     let mut err = CoshError::new(error_code, message, "checkpoint");
@@ -372,63 +390,51 @@ fn ws_error_to_cosh(code: WsCkptErrorCode, message: String) -> CoshError {
 }
 
 fn unexpected_response() -> CoshError {
-    CoshError::new(
-        ErrorCode::Unknown,
-        "Unexpected response type from ws-ckpt daemon",
-        "checkpoint",
-    )
+    protocol_error(ProtocolFailure::UnexpectedResponse)
 }
 
-/// Classify an I/O error into a structured CoshError with specific handling
-/// for daemon crash (BrokenPipe / ConnectionReset) and timeout scenarios.
-fn classify_io_error(e: std::io::Error, socket_path: &str, context: &str) -> CoshError {
-    match e.kind() {
-        std::io::ErrorKind::BrokenPipe => CoshError::new(
-            ErrorCode::CheckpointDaemonUnavailable,
-            format!("ws-ckpt daemon crashed while {}: BrokenPipe", context),
-            "checkpoint",
-        )
-        .with_hint(
-            "ws-ckpt daemon process terminated unexpectedly. Restart with: systemctl start ws-ckpt",
-        )
-        .recoverable(true),
+fn protocol_error(failure: ProtocolFailure) -> CoshError {
+    let kind = match failure {
+        ProtocolFailure::TruncatedLength => "truncated_length",
+        ProtocolFailure::TruncatedPayload => "truncated_payload",
+        ProtocolFailure::OversizedLength => "oversized_length",
+        ProtocolFailure::InvalidPayload => "decode_failed",
+        ProtocolFailure::UnexpectedResponse => "unexpected_response",
+    };
+    CoshError::new(
+        ErrorCode::CheckpointProtocolError,
+        "Invalid response from ws-ckpt daemon",
+        "checkpoint",
+    )
+    .with_hint("Retry the operation; restart ws-ckpt if the problem persists")
+    .with_details(serde_json::json!({"phase": "response", "kind": kind}))
+}
 
-        std::io::ErrorKind::ConnectionReset => CoshError::new(
-            ErrorCode::CheckpointDaemonUnavailable,
-            format!("ws-ckpt daemon crashed while {}: ConnectionReset", context),
-            "checkpoint",
-        )
-        .with_hint(
-            "ws-ckpt daemon process terminated unexpectedly. Restart with: systemctl start ws-ckpt",
-        )
-        .recoverable(true),
-
-        std::io::ErrorKind::TimedOut => CoshError::new(
+fn classify_io_error(error: std::io::Error, phase: IoPhase) -> CoshError {
+    if error.kind() == std::io::ErrorKind::TimedOut {
+        return CoshError::new(
             ErrorCode::Timeout,
-            format!("Timeout while {} on {}", context, socket_path),
+            "Timed out while communicating with ws-ckpt daemon",
             "checkpoint",
         )
-        .with_hint("ws-ckpt daemon may be overloaded, retry later")
-        .recoverable(true),
-
-        std::io::ErrorKind::ConnectionRefused => CoshError::new(
-            ErrorCode::CheckpointDaemonUnavailable,
-            format!(
-                "Cannot connect to ws-ckpt daemon at {}: Connection refused",
-                socket_path
-            ),
-            "checkpoint",
-        )
-        .with_hint("Start daemon with: systemctl start ws-ckpt")
-        .recoverable(true),
-
-        _ => CoshError::new(
-            ErrorCode::CheckpointDaemonUnavailable,
-            format!("I/O error while {}: {} ({})", context, e, socket_path),
-            "checkpoint",
-        )
-        .recoverable(true),
+        .with_hint("ws-ckpt daemon may be overloaded; retry later")
+        .recoverable(true);
     }
+
+    let message = match phase {
+        IoPhase::Connect => "Cannot connect to ws-ckpt daemon",
+        IoPhase::WriteRequest => "ws-ckpt daemon became unavailable while sending a request",
+        IoPhase::ReadResponseLength | IoPhase::ReadResponsePayload => {
+            "ws-ckpt daemon became unavailable while receiving a response"
+        }
+    };
+    CoshError::new(
+        ErrorCode::CheckpointDaemonUnavailable,
+        message,
+        "checkpoint",
+    )
+    .with_hint("Start or restart ws-ckpt with: systemctl start ws-ckpt")
+    .recoverable(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -441,6 +447,63 @@ mod tests {
     use std::thread;
 
     use super::*;
+
+    fn send_fake_response(response: Vec<u8>) -> (CoshError, String) {
+        let directory = tempfile::tempdir().unwrap();
+        let socket_path = directory.path().join("daemon.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut length = [0; 4];
+            stream.read_exact(&mut length).unwrap();
+            let mut request = vec![0; u32::from_le_bytes(length) as usize];
+            stream.read_exact(&mut request).unwrap();
+            stream.write_all(&response).unwrap();
+        });
+
+        let socket_path = socket_path.to_string_lossy().into_owned();
+        let error = CkptClient::new(&socket_path)
+            .send_request(&WsCkptRequest::Config)
+            .unwrap_err();
+        server.join().unwrap();
+        (error, socket_path)
+    }
+
+    fn assert_protocol_error(error: &CoshError, socket_path: &str) {
+        assert_eq!(error.code, ErrorCode::CheckpointProtocolError);
+        assert!(!error.message.contains(socket_path));
+        assert!(!error.message.contains("failed to fill whole buffer"));
+        assert!(!error.message.contains("invalid value"));
+    }
+
+    #[test]
+    fn response_truncated_length_is_protocol_error() {
+        let (error, socket_path) = send_fake_response(vec![1, 2]);
+        assert_protocol_error(&error, &socket_path);
+    }
+
+    #[test]
+    fn response_truncated_payload_is_protocol_error() {
+        let mut response = 8_u32.to_le_bytes().to_vec();
+        response.extend_from_slice(&[1, 2]);
+        let (error, socket_path) = send_fake_response(response);
+        assert_protocol_error(&error, &socket_path);
+    }
+
+    #[test]
+    fn response_oversized_length_is_protocol_error() {
+        let response = ((MAX_RESPONSE_LEN + 1) as u32).to_le_bytes().to_vec();
+        let (error, socket_path) = send_fake_response(response);
+        assert_protocol_error(&error, &socket_path);
+    }
+
+    #[test]
+    fn response_invalid_bincode_is_protocol_error() {
+        let mut response = 4_u32.to_le_bytes().to_vec();
+        response.extend_from_slice(&u32::MAX.to_le_bytes());
+        let (error, socket_path) = send_fake_response(response);
+        assert_protocol_error(&error, &socket_path);
+    }
 
     fn spawn_one_shot_daemon(
         response: WsCkptResponse,
@@ -601,12 +664,11 @@ mod tests {
     fn test_classify_broken_pipe() {
         let err = classify_io_error(
             std::io::Error::new(std::io::ErrorKind::BrokenPipe, "broken pipe"),
-            "/tmp/test.sock",
-            "write request",
+            IoPhase::WriteRequest,
         );
         assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
-        assert!(err.message.contains("crashed"));
-        assert!(err.message.contains("BrokenPipe"));
+        assert!(err.message.contains("unavailable"));
+        assert!(!err.message.contains("BrokenPipe"));
         assert!(err
             .hint
             .as_ref()
@@ -619,12 +681,11 @@ mod tests {
     fn test_classify_connection_reset() {
         let err = classify_io_error(
             std::io::Error::new(std::io::ErrorKind::ConnectionReset, "reset"),
-            "/tmp/test.sock",
-            "read response",
+            IoPhase::ReadResponsePayload,
         );
         assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
-        assert!(err.message.contains("crashed"));
-        assert!(err.message.contains("ConnectionReset"));
+        assert!(err.message.contains("unavailable"));
+        assert!(!err.message.contains("ConnectionReset"));
         assert!(err.recoverable);
     }
 
@@ -632,8 +693,7 @@ mod tests {
     fn test_classify_timeout() {
         let err = classify_io_error(
             std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out"),
-            "/tmp/test.sock",
-            "read response",
+            IoPhase::ReadResponseLength,
         );
         assert_eq!(err.code, ErrorCode::Timeout);
         assert!(err.hint.as_ref().unwrap().contains("overloaded"));
@@ -644,8 +704,7 @@ mod tests {
     fn test_classify_connection_refused() {
         let err = classify_io_error(
             std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused"),
-            "/tmp/test.sock",
-            "connect",
+            IoPhase::Connect,
         );
         assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
         assert!(err
@@ -659,8 +718,7 @@ mod tests {
     fn test_classify_other_io_error() {
         let err = classify_io_error(
             std::io::Error::other("something else"),
-            "/tmp/test.sock",
-            "do thing",
+            IoPhase::WriteRequest,
         );
         assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
         assert!(err.recoverable);

--- a/src/cosh-ng/crates/cosh-types/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-types/Cargo.toml
@@ -10,3 +10,6 @@ serde.workspace = true
 serde_json.workspace = true
 chrono = { workspace = true, features = ["serde", "alloc"] }
 bincode.workspace = true
+
+[dev-dependencies]
+ws-ckpt-common = { path = "../../../ws-ckpt/src/crates/common" }

--- a/src/cosh-ng/crates/cosh-types/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-types/src/checkpoint.rs
@@ -28,7 +28,8 @@ pub enum WsCkptRequest {
     },
     Rollback {
         workspace: String,
-        to: String,
+        to: Option<String>,
+        num_ancestors: Option<u32>,
     },
     Delete {
         workspace: Option<String>,
@@ -42,7 +43,7 @@ pub enum WsCkptRequest {
     Diff {
         workspace: String,
         from: String,
-        to: String,
+        to: Option<String>,
     },
     Status {
         workspace: Option<String>,
@@ -53,10 +54,38 @@ pub enum WsCkptRequest {
     },
     Config,
     ReloadConfig,
+    ReloadGlobalConfig,
+    ReloadWorkspacePolicy {
+        workspace: String,
+    },
+    ConfigOverview,
     Recover {
         workspace: String,
     },
     HealthAdvisory,
+    GetWorkspacePolicy {
+        workspace: String,
+    },
+    ResetWorkspacePolicy {
+        workspace: String,
+    },
+    PatchWorkspacePolicy {
+        workspace: String,
+        auto_cleanup: PolicyFieldOp<bool>,
+        auto_cleanup_keep: PolicyFieldOp<CleanupRetention>,
+    },
+    RollbackPreview {
+        workspace: String,
+        to: Option<String>,
+        num_ancestors: Option<u32>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum PolicyFieldOp<T> {
+    #[default]
+    Unchanged,
+    Set(T),
 }
 
 /// Response received from ws-ckpt daemon (bincode wire format).
@@ -95,7 +124,9 @@ pub enum WsCkptResponse {
     ConfigOk {
         config: ConfigReport,
     },
-    ReloadConfigOk,
+    ReloadConfigOk {
+        config: ConfigReport,
+    },
     CheckpointSkipped {
         reason: String,
     },
@@ -106,6 +137,21 @@ pub enum WsCkptResponse {
         over_limit_workspace_count: u32,
         fs_total_bytes: u64,
         fs_used_bytes: u64,
+    },
+    WorkspacePolicyOk {
+        ws_id: String,
+        effective: EffectivePolicy,
+        local: WorkspacePolicy,
+        global: GlobalPolicySnapshot,
+    },
+    ConfigOverviewOk {
+        config: ConfigReport,
+        ws_total: usize,
+        ws_with_override: usize,
+    },
+    RollbackPreviewOk {
+        to: String,
+        changes: Vec<DiffEntry>,
     },
 }
 
@@ -124,6 +170,8 @@ pub enum WsCkptErrorCode {
     SnapshotAlreadyExists,
     WriteLockConflict,
     DiskSpaceInsufficient,
+    CwdOccupied,
+    CwdScanFailed,
 }
 
 // ===========================================================================
@@ -137,12 +185,43 @@ pub struct SnapshotEntry {
     pub meta: SnapshotMeta,
 }
 
+mod metadata_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_json::Value;
+
+    pub fn serialize<S: Serializer>(v: &Option<Value>, s: S) -> Result<S::Ok, S::Error> {
+        let normalized = v.as_ref().filter(|value| !value.is_null());
+        if s.is_human_readable() {
+            normalized.serialize(s)
+        } else {
+            normalized.map(|value| value.to_string()).serialize(s)
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Value>, D::Error> {
+        if d.is_human_readable() {
+            Option::<Value>::deserialize(d)
+        } else {
+            Option::<String>::deserialize(d)?
+                .map(|value| serde_json::from_str(&value).map_err(serde::de::Error::custom))
+                .transpose()
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotMeta {
     pub message: Option<String>,
+    #[serde(default, with = "metadata_serde")]
     pub metadata: Option<serde_json::Value>,
     pub pinned: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default)]
+    pub missing: bool,
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    #[serde(default)]
+    pub child_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -176,10 +255,109 @@ pub struct WorkspaceInfo {
 }
 
 /// Cleanup retention policy — mirrors ws-ckpt-common exactly.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum CleanupRetention {
     Count(u32),
     Age { raw: String, secs: u64 },
+}
+
+impl CleanupRetention {
+    pub fn age(raw: impl Into<String>) -> Result<Self, String> {
+        let raw = raw.into();
+        let secs = parse_duration_secs(&raw)?;
+        Ok(Self::Age { raw, secs })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+enum CleanupRetentionWire {
+    Count(u32),
+    Age(String),
+}
+
+impl Serialize for CleanupRetention {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            match self {
+                Self::Count(count) => serializer.serialize_u32(*count),
+                Self::Age { raw, .. } => serializer.serialize_str(raw),
+            }
+        } else {
+            match self {
+                Self::Count(count) => CleanupRetentionWire::Count(*count),
+                Self::Age { raw, .. } => CleanupRetentionWire::Age(raw.clone()),
+            }
+            .serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CleanupRetention {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            struct CleanupRetentionVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for CleanupRetentionVisitor {
+                type Value = CleanupRetention;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    formatter.write_str("a non-negative count or a duration string")
+                }
+
+                fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<Self::Value, E> {
+                    u32::try_from(value)
+                        .map(CleanupRetention::Count)
+                        .map_err(E::custom)
+                }
+
+                fn visit_i64<E: serde::de::Error>(self, value: i64) -> Result<Self::Value, E> {
+                    u32::try_from(value)
+                        .map(CleanupRetention::Count)
+                        .map_err(E::custom)
+                }
+
+                fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                    CleanupRetention::age(value).map_err(E::custom)
+                }
+
+                fn visit_string<E: serde::de::Error>(
+                    self,
+                    value: String,
+                ) -> Result<Self::Value, E> {
+                    CleanupRetention::age(value).map_err(E::custom)
+                }
+            }
+
+            deserializer.deserialize_any(CleanupRetentionVisitor)
+        } else {
+            match CleanupRetentionWire::deserialize(deserializer)? {
+                CleanupRetentionWire::Count(count) => Ok(Self::Count(count)),
+                CleanupRetentionWire::Age(raw) => Self::age(raw).map_err(serde::de::Error::custom),
+            }
+        }
+    }
+}
+
+fn parse_duration_secs(value: &str) -> Result<u64, String> {
+    let value = value.trim();
+    let mut chars = value.chars();
+    let unit = chars.next_back().ok_or("empty duration")?;
+    let count: u64 = chars
+        .as_str()
+        .parse()
+        .map_err(|_| format!("invalid duration: {value}"))?;
+    let seconds = match unit.to_ascii_lowercase() {
+        's' => count,
+        'm' => count.saturating_mul(60),
+        'h' => count.saturating_mul(3_600),
+        'd' => count.saturating_mul(86_400),
+        'w' => count.saturating_mul(604_800),
+        _ => return Err(format!("invalid duration unit: {unit}")),
+    };
+    if seconds > i64::MAX as u64 {
+        return Err("duration is too large".to_string());
+    }
+    Ok(seconds)
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -191,9 +369,26 @@ pub struct ConfigReport {
     pub auto_cleanup_keep: CleanupRetention,
     pub auto_cleanup_interval_secs: u64,
     pub health_check_interval_secs: u64,
-    pub img_path: String,
     pub img_size: u64,
     pub img_max_percent: f64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct WorkspacePolicy {
+    pub auto_cleanup: Option<bool>,
+    pub auto_cleanup_keep: Option<CleanupRetention>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EffectivePolicy {
+    pub auto_cleanup: bool,
+    pub auto_cleanup_keep: CleanupRetention,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GlobalPolicySnapshot {
+    pub auto_cleanup: bool,
+    pub auto_cleanup_keep: CleanupRetention,
 }
 
 // ===========================================================================
@@ -314,7 +509,8 @@ mod tests {
             },
             WsCkptRequest::Rollback {
                 workspace: "/tmp/ws".into(),
-                to: "snap-001".into(),
+                to: Some("snap-001".into()),
+                num_ancestors: None,
             },
             WsCkptRequest::Delete {
                 workspace: Some("/tmp/ws".into()),
@@ -328,7 +524,7 @@ mod tests {
             WsCkptRequest::Diff {
                 workspace: "/tmp/ws".into(),
                 from: "snap-001".into(),
-                to: "snap-002".into(),
+                to: Some("snap-002".into()),
             },
             WsCkptRequest::Status { workspace: None },
             WsCkptRequest::Cleanup {
@@ -404,12 +600,23 @@ mod tests {
                     auto_cleanup_keep: CleanupRetention::Count(5),
                     auto_cleanup_interval_secs: 3600,
                     health_check_interval_secs: 60,
-                    img_path: "/var/lib/ws-ckpt/img".into(),
                     img_size: 10_737_418_240,
                     img_max_percent: 80.0,
                 },
             },
-            WsCkptResponse::ReloadConfigOk,
+            WsCkptResponse::ReloadConfigOk {
+                config: ConfigReport {
+                    mount_path: "/mnt/snapshots".into(),
+                    socket_path: "/run/ws-ckpt/ws-ckpt.sock".into(),
+                    log_level: "info".into(),
+                    auto_cleanup: true,
+                    auto_cleanup_keep: CleanupRetention::Count(5),
+                    auto_cleanup_interval_secs: 3600,
+                    health_check_interval_secs: 60,
+                    img_size: 10_737_418_240,
+                    img_max_percent: 80.0,
+                },
+            },
             WsCkptResponse::CheckpointSkipped {
                 reason: "no changes".into(),
             },
@@ -456,7 +663,8 @@ mod tests {
                 2,
                 WsCkptRequest::Rollback {
                     workspace: "/ws".into(),
-                    to: "snap".into(),
+                    to: Some("snap".into()),
+                    num_ancestors: None,
                 },
             ),
             (
@@ -479,7 +687,7 @@ mod tests {
                 WsCkptRequest::Diff {
                     workspace: "/ws".into(),
                     from: "a".into(),
-                    to: "b".into(),
+                    to: Some("b".into()),
                 },
             ),
             (6, WsCkptRequest::Status { workspace: None }),
@@ -492,13 +700,49 @@ mod tests {
             ),
             (8, WsCkptRequest::Config),
             (9, WsCkptRequest::ReloadConfig),
+            (10, WsCkptRequest::ReloadGlobalConfig),
             (
-                10,
+                11,
+                WsCkptRequest::ReloadWorkspacePolicy {
+                    workspace: "/ws".into(),
+                },
+            ),
+            (12, WsCkptRequest::ConfigOverview),
+            (
+                13,
                 WsCkptRequest::Recover {
                     workspace: "/ws".into(),
                 },
             ),
-            (11, WsCkptRequest::HealthAdvisory),
+            (14, WsCkptRequest::HealthAdvisory),
+            (
+                15,
+                WsCkptRequest::GetWorkspacePolicy {
+                    workspace: "/ws".into(),
+                },
+            ),
+            (
+                16,
+                WsCkptRequest::ResetWorkspacePolicy {
+                    workspace: "/ws".into(),
+                },
+            ),
+            (
+                17,
+                WsCkptRequest::PatchWorkspacePolicy {
+                    workspace: "/ws".into(),
+                    auto_cleanup: PolicyFieldOp::Set(true),
+                    auto_cleanup_keep: PolicyFieldOp::Set(CleanupRetention::Count(5)),
+                },
+            ),
+            (
+                18,
+                WsCkptRequest::RollbackPreview {
+                    workspace: "/ws".into(),
+                    to: Some("snap".into()),
+                    num_ancestors: None,
+                },
+            ),
         ];
 
         for (expected_idx, req) in &variants {
@@ -527,6 +771,8 @@ mod tests {
             WsCkptErrorCode::SnapshotAlreadyExists,
             WsCkptErrorCode::WriteLockConflict,
             WsCkptErrorCode::DiskSpaceInsufficient,
+            WsCkptErrorCode::CwdOccupied,
+            WsCkptErrorCode::CwdScanFailed,
         ];
 
         for (idx, code) in codes.iter().enumerate() {
@@ -565,6 +811,22 @@ mod tests {
     }
 
     #[test]
+    fn test_cleanup_retention_rejects_invalid_human_readable_values() {
+        for input in [
+            r#""""#,
+            r#""d""#,
+            r#""9223372036854775808s""#,
+            r#""30天""#,
+            r#""天""#,
+        ] {
+            assert!(
+                serde_json::from_str::<CleanupRetention>(input).is_err(),
+                "invalid retention value should fail: {input}"
+            );
+        }
+    }
+
+    #[test]
     fn test_config_report_bincode_roundtrip() {
         let report = ConfigReport {
             mount_path: "/mnt/ws-ckpt".into(),
@@ -574,7 +836,6 @@ mod tests {
             auto_cleanup_keep: CleanupRetention::Count(10),
             auto_cleanup_interval_secs: 3600,
             health_check_interval_secs: 60,
-            img_path: "/var/lib/ws-ckpt.img".into(),
             img_size: 536870912,
             img_max_percent: 80.0,
         };
@@ -587,7 +848,6 @@ mod tests {
         assert_eq!(decoded.auto_cleanup_keep, CleanupRetention::Count(10));
         assert_eq!(decoded.auto_cleanup_interval_secs, 3600);
         assert_eq!(decoded.health_check_interval_secs, 60);
-        assert_eq!(decoded.img_path, "/var/lib/ws-ckpt.img");
         assert_eq!(decoded.img_size, 536870912);
         assert_eq!(decoded.img_max_percent, 80.0);
     }

--- a/src/cosh-ng/crates/cosh-types/src/error.rs
+++ b/src/cosh-ng/crates/cosh-types/src/error.rs
@@ -26,6 +26,7 @@ pub enum ErrorCode {
     CheckpointCreateFailed = 301,
     CheckpointRestoreFailed = 302,
     CheckpointNotFound = 303,
+    CheckpointProtocolError = 304,
     // Audit (4xx)
     AuditDenied = 400,
     AuditPolicyError = 401,
@@ -115,5 +116,14 @@ mod tests {
         assert!(s.contains("svc"));
         assert!(s.contains("202"));
         assert!(s.contains("exit code 1"));
+    }
+
+    #[test]
+    fn test_checkpoint_protocol_error_contract() {
+        assert_eq!(ErrorCode::CheckpointProtocolError as u32, 304);
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::CheckpointProtocolError).unwrap(),
+            "\"CheckpointProtocolError\""
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-types/tests/checkpoint_wire_conformance.rs
+++ b/src/cosh-ng/crates/cosh-types/tests/checkpoint_wire_conformance.rs
@@ -1,0 +1,829 @@
+use chrono::{TimeZone, Utc};
+use cosh_types::checkpoint as local;
+use ws_ckpt_common as wire;
+
+fn assert_same_bincode<L: serde::Serialize, R: serde::Serialize>(left: &L, right: &R) {
+    assert_eq!(
+        bincode::serialize(left).unwrap(),
+        bincode::serialize(right).unwrap()
+    );
+}
+
+fn local_retention(value: &wire::CleanupRetention) -> local::CleanupRetention {
+    match value {
+        wire::CleanupRetention::Count(count) => local::CleanupRetention::Count(*count),
+        wire::CleanupRetention::Age { raw, secs } => local::CleanupRetention::Age {
+            raw: raw.clone(),
+            secs: *secs,
+        },
+    }
+}
+
+fn wire_retention(value: &local::CleanupRetention) -> wire::CleanupRetention {
+    match value {
+        local::CleanupRetention::Count(count) => wire::CleanupRetention::Count(*count),
+        local::CleanupRetention::Age { raw, secs } => wire::CleanupRetention::Age {
+            raw: raw.clone(),
+            secs: *secs,
+        },
+    }
+}
+
+fn local_bool_op(value: &wire::PolicyFieldOp<bool>) -> local::PolicyFieldOp<bool> {
+    match value {
+        wire::PolicyFieldOp::Unchanged => local::PolicyFieldOp::Unchanged,
+        wire::PolicyFieldOp::Set(value) => local::PolicyFieldOp::Set(*value),
+    }
+}
+
+fn wire_bool_op(value: &local::PolicyFieldOp<bool>) -> wire::PolicyFieldOp<bool> {
+    match value {
+        local::PolicyFieldOp::Unchanged => wire::PolicyFieldOp::Unchanged,
+        local::PolicyFieldOp::Set(value) => wire::PolicyFieldOp::Set(*value),
+    }
+}
+
+fn local_retention_op(
+    value: &wire::PolicyFieldOp<wire::CleanupRetention>,
+) -> local::PolicyFieldOp<local::CleanupRetention> {
+    match value {
+        wire::PolicyFieldOp::Unchanged => local::PolicyFieldOp::Unchanged,
+        wire::PolicyFieldOp::Set(value) => local::PolicyFieldOp::Set(local_retention(value)),
+    }
+}
+
+fn wire_retention_op(
+    value: &local::PolicyFieldOp<local::CleanupRetention>,
+) -> wire::PolicyFieldOp<wire::CleanupRetention> {
+    match value {
+        local::PolicyFieldOp::Unchanged => wire::PolicyFieldOp::Unchanged,
+        local::PolicyFieldOp::Set(value) => wire::PolicyFieldOp::Set(wire_retention(value)),
+    }
+}
+
+fn wire_request(value: &local::WsCkptRequest) -> wire::Request {
+    match value {
+        local::WsCkptRequest::Init { workspace } => wire::Request::Init {
+            workspace: workspace.clone(),
+        },
+        local::WsCkptRequest::Checkpoint {
+            workspace,
+            id,
+            message,
+            metadata,
+            pin,
+        } => wire::Request::Checkpoint {
+            workspace: workspace.clone(),
+            id: id.clone(),
+            message: message.clone(),
+            metadata: metadata.clone(),
+            pin: *pin,
+        },
+        local::WsCkptRequest::Rollback {
+            workspace,
+            to,
+            num_ancestors,
+        } => wire::Request::Rollback {
+            workspace: workspace.clone(),
+            to: to.clone(),
+            num_ancestors: *num_ancestors,
+        },
+        local::WsCkptRequest::Delete {
+            workspace,
+            snapshot,
+            force,
+        } => wire::Request::Delete {
+            workspace: workspace.clone(),
+            snapshot: snapshot.clone(),
+            force: *force,
+        },
+        local::WsCkptRequest::List { workspace, format } => wire::Request::List {
+            workspace: workspace.clone(),
+            format: format.clone(),
+        },
+        local::WsCkptRequest::Diff {
+            workspace,
+            from,
+            to,
+        } => wire::Request::Diff {
+            workspace: workspace.clone(),
+            from: from.clone(),
+            to: to.clone(),
+        },
+        local::WsCkptRequest::Status { workspace } => wire::Request::Status {
+            workspace: workspace.clone(),
+        },
+        local::WsCkptRequest::Cleanup { workspace, keep } => wire::Request::Cleanup {
+            workspace: workspace.clone(),
+            keep: *keep,
+        },
+        local::WsCkptRequest::Config => wire::Request::Config,
+        local::WsCkptRequest::ReloadConfig => wire::Request::ReloadConfig,
+        local::WsCkptRequest::ReloadGlobalConfig => wire::Request::ReloadGlobalConfig,
+        local::WsCkptRequest::ReloadWorkspacePolicy { workspace } => {
+            wire::Request::ReloadWorkspacePolicy {
+                workspace: workspace.clone(),
+            }
+        }
+        local::WsCkptRequest::ConfigOverview => wire::Request::ConfigOverview,
+        local::WsCkptRequest::Recover { workspace } => wire::Request::Recover {
+            workspace: workspace.clone(),
+        },
+        local::WsCkptRequest::HealthAdvisory => wire::Request::HealthAdvisory,
+        local::WsCkptRequest::GetWorkspacePolicy { workspace } => {
+            wire::Request::GetWorkspacePolicy {
+                workspace: workspace.clone(),
+            }
+        }
+        local::WsCkptRequest::ResetWorkspacePolicy { workspace } => {
+            wire::Request::ResetWorkspacePolicy {
+                workspace: workspace.clone(),
+            }
+        }
+        local::WsCkptRequest::PatchWorkspacePolicy {
+            workspace,
+            auto_cleanup,
+            auto_cleanup_keep,
+        } => wire::Request::PatchWorkspacePolicy {
+            workspace: workspace.clone(),
+            auto_cleanup: wire_bool_op(auto_cleanup),
+            auto_cleanup_keep: wire_retention_op(auto_cleanup_keep),
+        },
+        local::WsCkptRequest::RollbackPreview {
+            workspace,
+            to,
+            num_ancestors,
+        } => wire::Request::RollbackPreview {
+            workspace: workspace.clone(),
+            to: to.clone(),
+            num_ancestors: *num_ancestors,
+        },
+    }
+}
+
+fn local_request(value: &wire::Request) -> local::WsCkptRequest {
+    match value {
+        wire::Request::Init { workspace } => local::WsCkptRequest::Init {
+            workspace: workspace.clone(),
+        },
+        wire::Request::Checkpoint {
+            workspace,
+            id,
+            message,
+            metadata,
+            pin,
+        } => local::WsCkptRequest::Checkpoint {
+            workspace: workspace.clone(),
+            id: id.clone(),
+            message: message.clone(),
+            metadata: metadata.clone(),
+            pin: *pin,
+        },
+        wire::Request::Rollback {
+            workspace,
+            to,
+            num_ancestors,
+        } => local::WsCkptRequest::Rollback {
+            workspace: workspace.clone(),
+            to: to.clone(),
+            num_ancestors: *num_ancestors,
+        },
+        wire::Request::Delete {
+            workspace,
+            snapshot,
+            force,
+        } => local::WsCkptRequest::Delete {
+            workspace: workspace.clone(),
+            snapshot: snapshot.clone(),
+            force: *force,
+        },
+        wire::Request::List { workspace, format } => local::WsCkptRequest::List {
+            workspace: workspace.clone(),
+            format: format.clone(),
+        },
+        wire::Request::Diff {
+            workspace,
+            from,
+            to,
+        } => local::WsCkptRequest::Diff {
+            workspace: workspace.clone(),
+            from: from.clone(),
+            to: to.clone(),
+        },
+        wire::Request::Status { workspace } => local::WsCkptRequest::Status {
+            workspace: workspace.clone(),
+        },
+        wire::Request::Cleanup { workspace, keep } => local::WsCkptRequest::Cleanup {
+            workspace: workspace.clone(),
+            keep: *keep,
+        },
+        wire::Request::Config => local::WsCkptRequest::Config,
+        wire::Request::ReloadConfig => local::WsCkptRequest::ReloadConfig,
+        wire::Request::ReloadGlobalConfig => local::WsCkptRequest::ReloadGlobalConfig,
+        wire::Request::ReloadWorkspacePolicy { workspace } => {
+            local::WsCkptRequest::ReloadWorkspacePolicy {
+                workspace: workspace.clone(),
+            }
+        }
+        wire::Request::ConfigOverview => local::WsCkptRequest::ConfigOverview,
+        wire::Request::Recover { workspace } => local::WsCkptRequest::Recover {
+            workspace: workspace.clone(),
+        },
+        wire::Request::HealthAdvisory => local::WsCkptRequest::HealthAdvisory,
+        wire::Request::GetWorkspacePolicy { workspace } => {
+            local::WsCkptRequest::GetWorkspacePolicy {
+                workspace: workspace.clone(),
+            }
+        }
+        wire::Request::ResetWorkspacePolicy { workspace } => {
+            local::WsCkptRequest::ResetWorkspacePolicy {
+                workspace: workspace.clone(),
+            }
+        }
+        wire::Request::PatchWorkspacePolicy {
+            workspace,
+            auto_cleanup,
+            auto_cleanup_keep,
+        } => local::WsCkptRequest::PatchWorkspacePolicy {
+            workspace: workspace.clone(),
+            auto_cleanup: local_bool_op(auto_cleanup),
+            auto_cleanup_keep: local_retention_op(auto_cleanup_keep),
+        },
+        wire::Request::RollbackPreview {
+            workspace,
+            to,
+            num_ancestors,
+        } => local::WsCkptRequest::RollbackPreview {
+            workspace: workspace.clone(),
+            to: to.clone(),
+            num_ancestors: *num_ancestors,
+        },
+    }
+}
+
+fn local_request_samples() -> Vec<local::WsCkptRequest> {
+    vec![
+        local::WsCkptRequest::Init {
+            workspace: "/ws".into(),
+        },
+        local::WsCkptRequest::Checkpoint {
+            workspace: "/ws".into(),
+            id: "s1".into(),
+            message: Some("m".into()),
+            metadata: Some("{\"k\":1}".into()),
+            pin: true,
+        },
+        local::WsCkptRequest::Rollback {
+            workspace: "/ws".into(),
+            to: Some("s1".into()),
+            num_ancestors: Some(2),
+        },
+        local::WsCkptRequest::Delete {
+            workspace: Some("/ws".into()),
+            snapshot: "s1".into(),
+            force: true,
+        },
+        local::WsCkptRequest::List {
+            workspace: Some("/ws".into()),
+            format: Some("json".into()),
+        },
+        local::WsCkptRequest::Diff {
+            workspace: "/ws".into(),
+            from: "s1".into(),
+            to: Some("s2".into()),
+        },
+        local::WsCkptRequest::Status {
+            workspace: Some("/ws".into()),
+        },
+        local::WsCkptRequest::Cleanup {
+            workspace: "/ws".into(),
+            keep: Some(3),
+        },
+        local::WsCkptRequest::Config,
+        local::WsCkptRequest::ReloadConfig,
+        local::WsCkptRequest::ReloadGlobalConfig,
+        local::WsCkptRequest::ReloadWorkspacePolicy {
+            workspace: "/ws".into(),
+        },
+        local::WsCkptRequest::ConfigOverview,
+        local::WsCkptRequest::Recover {
+            workspace: "/ws".into(),
+        },
+        local::WsCkptRequest::HealthAdvisory,
+        local::WsCkptRequest::GetWorkspacePolicy {
+            workspace: "/ws".into(),
+        },
+        local::WsCkptRequest::ResetWorkspacePolicy {
+            workspace: "/ws".into(),
+        },
+        local::WsCkptRequest::PatchWorkspacePolicy {
+            workspace: "/ws".into(),
+            auto_cleanup: local::PolicyFieldOp::Set(true),
+            auto_cleanup_keep: local::PolicyFieldOp::Set(local::CleanupRetention::Count(7)),
+        },
+        local::WsCkptRequest::RollbackPreview {
+            workspace: "/ws".into(),
+            to: None,
+            num_ancestors: Some(3),
+        },
+    ]
+}
+
+fn wire_request_samples() -> Vec<wire::Request> {
+    local_request_samples().iter().map(wire_request).collect()
+}
+
+#[test]
+fn every_request_variant_matches_authoritative_bincode() {
+    for value in local_request_samples() {
+        assert_same_bincode(&value, &wire_request(&value));
+    }
+    for value in wire_request_samples() {
+        assert_same_bincode(&local_request(&value), &value);
+    }
+}
+
+fn wire_error(value: &local::WsCkptErrorCode) -> wire::ErrorCode {
+    match value {
+        local::WsCkptErrorCode::WorkspaceNotFound => wire::ErrorCode::WorkspaceNotFound,
+        local::WsCkptErrorCode::SnapshotNotFound => wire::ErrorCode::SnapshotNotFound,
+        local::WsCkptErrorCode::AlreadyInitialized => wire::ErrorCode::AlreadyInitialized,
+        local::WsCkptErrorCode::BtrfsError => wire::ErrorCode::BtrfsError,
+        local::WsCkptErrorCode::IoError => wire::ErrorCode::IoError,
+        local::WsCkptErrorCode::InvalidPath => wire::ErrorCode::InvalidPath,
+        local::WsCkptErrorCode::ConfirmationRequired => wire::ErrorCode::ConfirmationRequired,
+        local::WsCkptErrorCode::InternalError => wire::ErrorCode::InternalError,
+        local::WsCkptErrorCode::SnapshotAlreadyExists => wire::ErrorCode::SnapshotAlreadyExists,
+        local::WsCkptErrorCode::WriteLockConflict => wire::ErrorCode::WriteLockConflict,
+        local::WsCkptErrorCode::DiskSpaceInsufficient => wire::ErrorCode::DiskSpaceInsufficient,
+        local::WsCkptErrorCode::CwdOccupied => wire::ErrorCode::CwdOccupied,
+        local::WsCkptErrorCode::CwdScanFailed => wire::ErrorCode::CwdScanFailed,
+    }
+}
+
+fn local_error(value: &wire::ErrorCode) -> local::WsCkptErrorCode {
+    match value {
+        wire::ErrorCode::WorkspaceNotFound => local::WsCkptErrorCode::WorkspaceNotFound,
+        wire::ErrorCode::SnapshotNotFound => local::WsCkptErrorCode::SnapshotNotFound,
+        wire::ErrorCode::AlreadyInitialized => local::WsCkptErrorCode::AlreadyInitialized,
+        wire::ErrorCode::BtrfsError => local::WsCkptErrorCode::BtrfsError,
+        wire::ErrorCode::IoError => local::WsCkptErrorCode::IoError,
+        wire::ErrorCode::InvalidPath => local::WsCkptErrorCode::InvalidPath,
+        wire::ErrorCode::ConfirmationRequired => local::WsCkptErrorCode::ConfirmationRequired,
+        wire::ErrorCode::InternalError => local::WsCkptErrorCode::InternalError,
+        wire::ErrorCode::SnapshotAlreadyExists => local::WsCkptErrorCode::SnapshotAlreadyExists,
+        wire::ErrorCode::WriteLockConflict => local::WsCkptErrorCode::WriteLockConflict,
+        wire::ErrorCode::DiskSpaceInsufficient => local::WsCkptErrorCode::DiskSpaceInsufficient,
+        wire::ErrorCode::CwdOccupied => local::WsCkptErrorCode::CwdOccupied,
+        wire::ErrorCode::CwdScanFailed => local::WsCkptErrorCode::CwdScanFailed,
+    }
+}
+
+#[test]
+fn every_wire_error_variant_matches_authoritative_bincode() {
+    let local_values = [
+        local::WsCkptErrorCode::WorkspaceNotFound,
+        local::WsCkptErrorCode::SnapshotNotFound,
+        local::WsCkptErrorCode::AlreadyInitialized,
+        local::WsCkptErrorCode::BtrfsError,
+        local::WsCkptErrorCode::IoError,
+        local::WsCkptErrorCode::InvalidPath,
+        local::WsCkptErrorCode::ConfirmationRequired,
+        local::WsCkptErrorCode::InternalError,
+        local::WsCkptErrorCode::SnapshotAlreadyExists,
+        local::WsCkptErrorCode::WriteLockConflict,
+        local::WsCkptErrorCode::DiskSpaceInsufficient,
+        local::WsCkptErrorCode::CwdOccupied,
+        local::WsCkptErrorCode::CwdScanFailed,
+    ];
+    for value in local_values {
+        assert_same_bincode(&value, &wire_error(&value));
+    }
+    let wire_values = [
+        wire::ErrorCode::WorkspaceNotFound,
+        wire::ErrorCode::SnapshotNotFound,
+        wire::ErrorCode::AlreadyInitialized,
+        wire::ErrorCode::BtrfsError,
+        wire::ErrorCode::IoError,
+        wire::ErrorCode::InvalidPath,
+        wire::ErrorCode::ConfirmationRequired,
+        wire::ErrorCode::InternalError,
+        wire::ErrorCode::SnapshotAlreadyExists,
+        wire::ErrorCode::WriteLockConflict,
+        wire::ErrorCode::DiskSpaceInsufficient,
+        wire::ErrorCode::CwdOccupied,
+        wire::ErrorCode::CwdScanFailed,
+    ];
+    for value in wire_values {
+        assert_same_bincode(&local_error(&value), &value);
+    }
+}
+
+fn local_snapshot() -> local::SnapshotEntry {
+    local::SnapshotEntry {
+        id: "s1".into(),
+        workspace: "/ws".into(),
+        meta: local::SnapshotMeta {
+            message: Some("message".into()),
+            metadata: Some(serde_json::json!({"k": 1})),
+            pinned: true,
+            created_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            missing: true,
+            parent_id: Some("s0".into()),
+            child_ids: vec!["s2".into()],
+        },
+    }
+}
+
+fn wire_snapshot() -> wire::SnapshotEntry {
+    wire::SnapshotEntry {
+        id: "s1".into(),
+        workspace: "/ws".into(),
+        meta: wire::SnapshotMeta {
+            message: Some("message".into()),
+            metadata: Some(serde_json::json!({"k": 1})),
+            pinned: true,
+            created_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            missing: true,
+            parent_id: Some("s0".into()),
+            child_ids: vec!["s2".into()],
+        },
+    }
+}
+
+fn local_change() -> local::DiffEntry {
+    local::DiffEntry {
+        path: "src/lib.rs".into(),
+        change_type: local::ChangeType::Renamed,
+        detail: Some("old.rs".into()),
+    }
+}
+
+fn wire_change() -> wire::DiffEntry {
+    wire::DiffEntry {
+        path: "src/lib.rs".into(),
+        change_type: wire::ChangeType::Renamed,
+        detail: Some("old.rs".into()),
+    }
+}
+
+fn local_status() -> local::StatusReport {
+    local::StatusReport {
+        uptime_secs: 9,
+        workspaces: vec![local::WorkspaceInfo {
+            ws_id: "id".into(),
+            path: "/ws".into(),
+            snapshot_count: 2,
+        }],
+        fs_total_bytes: 100,
+        fs_used_bytes: 30,
+    }
+}
+
+fn wire_status() -> wire::StatusReport {
+    wire::StatusReport {
+        uptime_secs: 9,
+        workspaces: vec![wire::WorkspaceInfo {
+            ws_id: "id".into(),
+            path: "/ws".into(),
+            snapshot_count: 2,
+        }],
+        fs_total_bytes: 100,
+        fs_used_bytes: 30,
+    }
+}
+
+fn local_config() -> local::ConfigReport {
+    local::ConfigReport {
+        mount_path: "/mnt".into(),
+        socket_path: "/run/x".into(),
+        log_level: "debug".into(),
+        auto_cleanup: true,
+        auto_cleanup_keep: local::CleanupRetention::Age {
+            raw: "2d".into(),
+            secs: 172_800,
+        },
+        auto_cleanup_interval_secs: 11,
+        health_check_interval_secs: 12,
+        img_size: 13,
+        img_max_percent: 0.4,
+    }
+}
+
+fn wire_config() -> wire::ConfigReport {
+    wire::ConfigReport {
+        mount_path: "/mnt".into(),
+        socket_path: "/run/x".into(),
+        log_level: "debug".into(),
+        auto_cleanup: true,
+        auto_cleanup_keep: wire::CleanupRetention::Age {
+            raw: "2d".into(),
+            secs: 172_800,
+        },
+        auto_cleanup_interval_secs: 11,
+        health_check_interval_secs: 12,
+        img_size: 13,
+        img_max_percent: 0.4,
+    }
+}
+
+fn wire_response(value: &local::WsCkptResponse) -> wire::Response {
+    match value {
+        local::WsCkptResponse::InitOk { ws_id } => wire::Response::InitOk {
+            ws_id: ws_id.clone(),
+        },
+        local::WsCkptResponse::CheckpointOk { snapshot_id } => wire::Response::CheckpointOk {
+            snapshot_id: snapshot_id.clone(),
+        },
+        local::WsCkptResponse::RollbackOk { from, to } => wire::Response::RollbackOk {
+            from: from.clone(),
+            to: to.clone(),
+        },
+        local::WsCkptResponse::DeleteOk { target } => wire::Response::DeleteOk {
+            target: target.clone(),
+        },
+        local::WsCkptResponse::Error { code, message } => wire::Response::Error {
+            code: wire_error(code),
+            message: message.clone(),
+        },
+        local::WsCkptResponse::ListOk { snapshots } => {
+            assert_eq!(snapshots.len(), 1);
+            wire::Response::ListOk {
+                snapshots: vec![wire_snapshot()],
+            }
+        }
+        local::WsCkptResponse::DiffOk { changes } => {
+            assert_eq!(changes.len(), 1);
+            wire::Response::DiffOk {
+                changes: vec![wire_change()],
+            }
+        }
+        local::WsCkptResponse::StatusOk { report } => {
+            assert_eq!(report.uptime_secs, 9);
+            wire::Response::StatusOk {
+                report: wire_status(),
+            }
+        }
+        local::WsCkptResponse::CleanupOk { removed } => wire::Response::CleanupOk {
+            removed: removed.clone(),
+        },
+        local::WsCkptResponse::ConfigOk { config } => {
+            assert_eq!(config.img_size, 13);
+            wire::Response::ConfigOk {
+                config: wire_config(),
+            }
+        }
+        local::WsCkptResponse::ReloadConfigOk { config } => {
+            assert_eq!(config.img_size, 13);
+            wire::Response::ReloadConfigOk {
+                config: wire_config(),
+            }
+        }
+        local::WsCkptResponse::CheckpointSkipped { reason } => wire::Response::CheckpointSkipped {
+            reason: reason.clone(),
+        },
+        local::WsCkptResponse::RecoverOk { workspace } => wire::Response::RecoverOk {
+            workspace: workspace.clone(),
+        },
+        local::WsCkptResponse::HealthAdvisoryOk {
+            over_limit_workspace_count,
+            fs_total_bytes,
+            fs_used_bytes,
+        } => wire::Response::HealthAdvisoryOk {
+            over_limit_workspace_count: *over_limit_workspace_count,
+            fs_total_bytes: *fs_total_bytes,
+            fs_used_bytes: *fs_used_bytes,
+        },
+        local::WsCkptResponse::WorkspacePolicyOk {
+            ws_id,
+            effective,
+            local,
+            global,
+        } => wire::Response::WorkspacePolicyOk {
+            ws_id: ws_id.clone(),
+            effective: wire::EffectivePolicy {
+                auto_cleanup: effective.auto_cleanup,
+                auto_cleanup_keep: wire_retention(&effective.auto_cleanup_keep),
+            },
+            local: wire::WorkspacePolicy {
+                auto_cleanup: local.auto_cleanup,
+                auto_cleanup_keep: local.auto_cleanup_keep.as_ref().map(wire_retention),
+            },
+            global: wire::GlobalPolicySnapshot {
+                auto_cleanup: global.auto_cleanup,
+                auto_cleanup_keep: wire_retention(&global.auto_cleanup_keep),
+            },
+        },
+        local::WsCkptResponse::ConfigOverviewOk {
+            config,
+            ws_total,
+            ws_with_override,
+        } => {
+            assert_eq!(config.img_size, 13);
+            wire::Response::ConfigOverviewOk {
+                config: wire_config(),
+                ws_total: *ws_total,
+                ws_with_override: *ws_with_override,
+            }
+        }
+        local::WsCkptResponse::RollbackPreviewOk { to, changes } => {
+            assert_eq!(changes.len(), 1);
+            wire::Response::RollbackPreviewOk {
+                to: to.clone(),
+                changes: vec![wire_change()],
+            }
+        }
+    }
+}
+
+fn local_response(value: &wire::Response) -> local::WsCkptResponse {
+    match value {
+        wire::Response::InitOk { ws_id } => local::WsCkptResponse::InitOk {
+            ws_id: ws_id.clone(),
+        },
+        wire::Response::CheckpointOk { snapshot_id } => local::WsCkptResponse::CheckpointOk {
+            snapshot_id: snapshot_id.clone(),
+        },
+        wire::Response::RollbackOk { from, to } => local::WsCkptResponse::RollbackOk {
+            from: from.clone(),
+            to: to.clone(),
+        },
+        wire::Response::DeleteOk { target } => local::WsCkptResponse::DeleteOk {
+            target: target.clone(),
+        },
+        wire::Response::Error { code, message } => local::WsCkptResponse::Error {
+            code: local_error(code),
+            message: message.clone(),
+        },
+        wire::Response::ListOk { snapshots } => {
+            assert_eq!(snapshots.len(), 1);
+            local::WsCkptResponse::ListOk {
+                snapshots: vec![local_snapshot()],
+            }
+        }
+        wire::Response::DiffOk { changes } => {
+            assert_eq!(changes.len(), 1);
+            local::WsCkptResponse::DiffOk {
+                changes: vec![local_change()],
+            }
+        }
+        wire::Response::StatusOk { report } => {
+            assert_eq!(report.uptime_secs, 9);
+            local::WsCkptResponse::StatusOk {
+                report: local_status(),
+            }
+        }
+        wire::Response::CleanupOk { removed } => local::WsCkptResponse::CleanupOk {
+            removed: removed.clone(),
+        },
+        wire::Response::ConfigOk { config } => {
+            assert_eq!(config.img_size, 13);
+            local::WsCkptResponse::ConfigOk {
+                config: local_config(),
+            }
+        }
+        wire::Response::ReloadConfigOk { config } => {
+            assert_eq!(config.img_size, 13);
+            local::WsCkptResponse::ReloadConfigOk {
+                config: local_config(),
+            }
+        }
+        wire::Response::CheckpointSkipped { reason } => local::WsCkptResponse::CheckpointSkipped {
+            reason: reason.clone(),
+        },
+        wire::Response::RecoverOk { workspace } => local::WsCkptResponse::RecoverOk {
+            workspace: workspace.clone(),
+        },
+        wire::Response::HealthAdvisoryOk {
+            over_limit_workspace_count,
+            fs_total_bytes,
+            fs_used_bytes,
+        } => local::WsCkptResponse::HealthAdvisoryOk {
+            over_limit_workspace_count: *over_limit_workspace_count,
+            fs_total_bytes: *fs_total_bytes,
+            fs_used_bytes: *fs_used_bytes,
+        },
+        wire::Response::WorkspacePolicyOk {
+            ws_id,
+            effective,
+            local,
+            global,
+        } => local::WsCkptResponse::WorkspacePolicyOk {
+            ws_id: ws_id.clone(),
+            effective: local::EffectivePolicy {
+                auto_cleanup: effective.auto_cleanup,
+                auto_cleanup_keep: local_retention(&effective.auto_cleanup_keep),
+            },
+            local: local::WorkspacePolicy {
+                auto_cleanup: local.auto_cleanup,
+                auto_cleanup_keep: local.auto_cleanup_keep.as_ref().map(local_retention),
+            },
+            global: local::GlobalPolicySnapshot {
+                auto_cleanup: global.auto_cleanup,
+                auto_cleanup_keep: local_retention(&global.auto_cleanup_keep),
+            },
+        },
+        wire::Response::ConfigOverviewOk {
+            config,
+            ws_total,
+            ws_with_override,
+        } => {
+            assert_eq!(config.img_size, 13);
+            local::WsCkptResponse::ConfigOverviewOk {
+                config: local_config(),
+                ws_total: *ws_total,
+                ws_with_override: *ws_with_override,
+            }
+        }
+        wire::Response::RollbackPreviewOk { to, changes } => {
+            assert_eq!(changes.len(), 1);
+            local::WsCkptResponse::RollbackPreviewOk {
+                to: to.clone(),
+                changes: vec![local_change()],
+            }
+        }
+    }
+}
+
+fn local_response_samples() -> Vec<local::WsCkptResponse> {
+    vec![
+        local::WsCkptResponse::InitOk { ws_id: "id".into() },
+        local::WsCkptResponse::CheckpointOk {
+            snapshot_id: "s1".into(),
+        },
+        local::WsCkptResponse::RollbackOk {
+            from: "s2".into(),
+            to: "s1".into(),
+        },
+        local::WsCkptResponse::DeleteOk {
+            target: "s1".into(),
+        },
+        local::WsCkptResponse::Error {
+            code: local::WsCkptErrorCode::CwdScanFailed,
+            message: "failed".into(),
+        },
+        local::WsCkptResponse::ListOk {
+            snapshots: vec![local_snapshot()],
+        },
+        local::WsCkptResponse::DiffOk {
+            changes: vec![local_change()],
+        },
+        local::WsCkptResponse::StatusOk {
+            report: local_status(),
+        },
+        local::WsCkptResponse::CleanupOk {
+            removed: vec!["s0".into()],
+        },
+        local::WsCkptResponse::ConfigOk {
+            config: local_config(),
+        },
+        local::WsCkptResponse::ReloadConfigOk {
+            config: local_config(),
+        },
+        local::WsCkptResponse::CheckpointSkipped {
+            reason: "unchanged".into(),
+        },
+        local::WsCkptResponse::RecoverOk {
+            workspace: "/ws".into(),
+        },
+        local::WsCkptResponse::HealthAdvisoryOk {
+            over_limit_workspace_count: 2,
+            fs_total_bytes: 100,
+            fs_used_bytes: 20,
+        },
+        local::WsCkptResponse::WorkspacePolicyOk {
+            ws_id: "id".into(),
+            effective: local::EffectivePolicy {
+                auto_cleanup: true,
+                auto_cleanup_keep: local::CleanupRetention::Count(3),
+            },
+            local: local::WorkspacePolicy {
+                auto_cleanup: Some(false),
+                auto_cleanup_keep: Some(local::CleanupRetention::Count(2)),
+            },
+            global: local::GlobalPolicySnapshot {
+                auto_cleanup: true,
+                auto_cleanup_keep: local::CleanupRetention::Count(4),
+            },
+        },
+        local::WsCkptResponse::ConfigOverviewOk {
+            config: local_config(),
+            ws_total: 10,
+            ws_with_override: 2,
+        },
+        local::WsCkptResponse::RollbackPreviewOk {
+            to: "s1".into(),
+            changes: vec![local_change()],
+        },
+    ]
+}
+
+#[test]
+fn every_response_variant_matches_authoritative_bincode() {
+    for value in local_response_samples() {
+        assert_same_bincode(&value, &wire_response(&value));
+    }
+    for value in local_response_samples().iter().map(wire_response) {
+        assert_same_bincode(&local_response(&value), &value);
+    }
+}

--- a/src/cosh-ng/scripts/test-necessity-registry.tsv
+++ b/src/cosh-ng/scripts/test-necessity-registry.tsv
@@ -1,5 +1,6 @@
 rule	pattern	owner	layer	contract	failure	observable	minimum_layer	unique_dimension	evidence	cost	reliability	gate	disposition
 types-unit	crates/cosh-types/src/*	cosh-types	unit	wire-and-domain-types	serialization-or-domain-invariant-regression	value-or-wire-shape	unit	pure-type-boundaries	assertions	low	deterministic	fast	keep
+types-wire-conformance	crates/cosh-types/tests/*	cosh-types	integration	ws-ckpt-wire-protocol-conformance	silent-wire-encoding-drift-from-daemon	bincode-byte-layout	integration	authoritative-wire-encoding	byte-level-assertions	low	deterministic	fast	keep
 platform-unit	crates/cosh-platform/src/*	cosh-platform	unit	platform-routing-and-validation	wrong-backend-or-invalid-platform-action	selected-backend-or-validation-result	unit	platform-adapter-branch	assertions	low	deterministic	fast	keep
 cli-integration	crates/cosh-cli/tests/*	cosh-cli	integration	cli-json-envelope-and-exit	wrong-json-output-routing-or-exit	stdout-stderr-and-exit	integration	compiled-cli-boundary	process-assertions	medium	deterministic	integration	keep
 cli-unit	crates/cosh-cli/src/*	cosh-cli	unit	cli-argument-and-command-policy	wrong-parse-default-or-denial-routing	return-value-or-command-decision	unit	cli-command-branch	assertions	low	deterministic	fast	keep


### PR DESCRIPTION
## Description

Fix checkpoint protocol error handling so incomplete daemon frames are reported as
`CheckpointProtocolError` without exposing the internal Unix socket path or raw
`std::io` text.

The change also aligns the local checkpoint wire types with the authoritative
`ws-ckpt-common` protocol and adds bidirectional bincode conformance coverage to
prevent request, response, and error enum drift.

## Related Issue

closes #1363

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Passed after rebasing onto `d0398c79`:

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `cargo test --package cosh-types --test checkpoint_wire_conformance` (3 passed)
- `cargo test --package cosh-platform checkpoint` (22 passed)
- `cargo test --package cosh-cli --test cli_integration checkpoint` (15 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release`

`cargo test --workspace` reaches two macOS baseline failures introduced by current
`main`: the package tests assume `bash` is Homebrew-installed. This PR does not
modify those test bodies; all checkpoint-focused tests pass.

## Additional Notes

- Human override: publish the Draft PR without the autonomous VERIFY gate.
- CI remains the fresh validation gate for the rebased commit.
- The diff does not touch `cosh-shell`; reviewer routing requests `kongche-jbw` only.