### PR TITLE
feat(tokenless): declare qwencode in RPM component contract

### DIFF
--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -81,3 +81,13 @@ dest = "{datadir}/extensions/{component}/"
 
 [adapters.bundle]
 entry = "cosh-extension.json"
+
+[[adapters]]
+framework = "qwencode"
+adapter_type = "extension"
+plugin_id = "tokenless"
+source = "adapters/qwencode"
+dest = "{datadir}/adapters/{component}/qwencode/"
+
+[adapters.bundle]
+entry = "qwen-extension.json"

--- a/src/tokenless/.anolisa/component.toml.in
+++ b/src/tokenless/.anolisa/component.toml.in
@@ -81,3 +81,13 @@ dest = "{datadir}/extensions/{component}/"
 
 [adapters.bundle]
 entry = "cosh-extension.json"
+
+[[adapters]]
+framework = "qwencode"
+adapter_type = "extension"
+plugin_id = "tokenless"
+source = "adapters/qwencode"
+dest = "{datadir}/adapters/{component}/qwencode/"
+
+[adapters.bundle]
+entry = "qwen-extension.json"


### PR DESCRIPTION
## Summary

Add qwencode adapter declaration to the tokenless RPM component contract, completing the 7-framework support (openclaw, hermes, qoder, claude-code, codex, cosh, qwencode).

## Changes

- **`src/tokenless/.anolisa/component.toml.in`**: Add qwencode adapter section
- **`src/tokenless/.anolisa/component.toml`**: Regenerated from template

## Details

The qwencode adapter is declared as an `extension` type (same model as cosh), with `qwen-extension.json` as the bundle entry point. The resource files (hooks, scripts, manifest template) are already packaged by the existing RPM spec — only the contract declaration was missing.

```toml
[[adapters]]
framework = qwencode
adapter_type = extension
plugin_id = tokenless
source = adapters/qwencode
dest = {datadir}/adapters/{component}/qwencode/

[adapters.bundle]
entry = qwen-extension.json
```

## Verification

`make -C src/tokenless check-component-contract` passes, confirming the generated contract matches the template.

## Related

This PR provides the tokenless contract side. The anolisa CLI qwencode driver is in PR #1518.

Both PRs are required to fully enable `anolisa adapter enable tokenless qwencode` for raw installs (issue #1515).