### PR TITLE
fix(memory): auto-recall returns empty results after observe

### DIFF
--- a/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
@@ -94,7 +94,7 @@ export default definePluginEntry({
           const rawText = await client.callTool("memory_search", {
             query: userMessage,
             top_k: 5,
-            mode: "hybrid",
+            mode: "bm25",
           });
 
           // Parse to verify we have hits; skip injection on empty results.
@@ -102,9 +102,17 @@ export default definePluginEntry({
           try {
             hits = JSON.parse(rawText);
           } catch {
+            api.logger.warn?.(
+              `agent-memory: auto-recall memory_search returned non-JSON response (len=${rawText.length})`,
+            );
             return;
           }
-          if (!Array.isArray(hits) || hits.length === 0) return;
+          if (!Array.isArray(hits) || hits.length === 0) {
+            api.logger.info?.(
+              `agent-memory: auto-recall found 0 results for prompt (query len=${userMessage.length})`,
+            );
+            return;
+          }
 
           const wrapped = wrapMemoryResultsForPrompt(rawText);
           if (!wrapped) return;

--- a/src/agent-memory/src/index/mod.rs
+++ b/src/agent-memory/src/index/mod.rs
@@ -129,6 +129,13 @@ impl IndexHandle {
     /// The notify watcher will later process the same inotify event and
     /// issue a redundant upsert — this is harmless because `upsert` is
     /// idempotent (DELETE + INSERT on the same rowid).
+    ///
+    /// Cold-file strategy: `upsert` inserts with `is_cold = 0` (warm) by
+    /// default, which is correct — a freshly observed file should be warm.
+    /// This matches the watcher's own upsert path, so there is no
+    /// behavioural divergence. The `compact()` method only marks files
+    /// cold when `access_count = 0 AND mtime_ms < cutoff`, so a newly
+    /// indexed file is unaffected regardless of which path inserts it.
     pub fn reindex_file(&self, rel_path: &str, body: &str, mtime_ms: i64, size: u64) -> Result<()> {
         let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
         store.upsert(rel_path, mtime_ms, size, body, None)

--- a/src/agent-memory/src/index/mod.rs
+++ b/src/agent-memory/src/index/mod.rs
@@ -121,6 +121,19 @@ impl IndexHandle {
         store.search_hybrid(query, query_vec, top_k)
     }
 
+    /// Synchronously upsert a single file into the BM25 index. Used by
+    /// `memory_observe` to make freshly written memories immediately
+    /// searchable, closing the race window between the file write and the
+    /// notify watcher's next debounce flush (~200 ms).
+    ///
+    /// The notify watcher will later process the same inotify event and
+    /// issue a redundant upsert — this is harmless because `upsert` is
+    /// idempotent (DELETE + INSERT on the same rowid).
+    pub fn reindex_file(&self, rel_path: &str, body: &str, mtime_ms: i64, size: u64) -> Result<()> {
+        let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
+        store.upsert(rel_path, mtime_ms, size, body, None)
+    }
+
     /// Compact the index: mark old, never-accessed files as cold.
     pub fn compact(&self, cold_after_days: u64) -> Result<usize> {
         let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/agent-memory/src/tools/memory_observe.rs
+++ b/src/agent-memory/src/tools/memory_observe.rs
@@ -1,5 +1,7 @@
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::os::fd::AsFd;
+use std::path::Path;
 
 use crate::audit::AuditEntry;
 use crate::config::MemoryConfig;
@@ -140,7 +142,14 @@ pub fn memory_observe(
     // `before_prompt_build` hook firing right after `memory_observe`
     // returns empty results and silently skips injection (#1462).
     if let Some(ref index) = svc.index {
-        let mtime_ms = Utc::now().timestamp_millis();
+        // Read the actual file mtime from the filesystem rather than
+        // using Utc::now(). The watcher's flush path uses
+        // store::mtime_ms_of(&meta) for time-decay scoring; using a
+        // synthetic timestamp here would create a mismatch with the
+        // subsequent redundant upsert and skew decay-based ranking.
+        let mtime_ms = crate::safe_fs::metadata(svc.mount.root_fd.as_fd(), Path::new(&path))
+            .map(|m| crate::index::store::mtime_ms_of(&m))
+            .unwrap_or_else(|_| Utc::now().timestamp_millis());
         if let Err(e) = index.reindex_file(&path, &body, mtime_ms, n) {
             tracing::warn!("synchronous reindex after observe failed for {path}: {e}");
         }

--- a/src/agent-memory/src/tools/memory_observe.rs
+++ b/src/agent-memory/src/tools/memory_observe.rs
@@ -133,6 +133,19 @@ pub fn memory_observe(
     }
 
     let n = svc.write(&path, &body, false)?;
+
+    // Synchronously upsert the new observation into the BM25 index so it
+    // is immediately searchable by auto-recall hooks. Without this, the
+    // notify watcher's debounce (~200 ms) creates a window where a
+    // `before_prompt_build` hook firing right after `memory_observe`
+    // returns empty results and silently skips injection (#1462).
+    if let Some(ref index) = svc.index {
+        let mtime_ms = Utc::now().timestamp_millis();
+        if let Err(e) = index.reindex_file(&path, &body, mtime_ms, n) {
+            tracing::warn!("synchronous reindex after observe failed for {path}: {e}");
+        }
+    }
+
     svc.audit_log(AuditEntry::new(TOOL).path(path.clone()).bytes(n));
     Ok(path)
 }

--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -81,3 +81,13 @@ dest = "{datadir}/extensions/{component}/"
 
 [adapters.bundle]
 entry = "cosh-extension.json"
+
+[[adapters]]
+framework = "qwencode"
+adapter_type = "extension"
+plugin_id = "tokenless"
+source = "adapters/qwencode"
+dest = "{datadir}/adapters/{component}/qwencode/"
+
+[adapters.bundle]
+entry = "qwen-extension.json"

--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -82,6 +82,12 @@ dest = "{datadir}/extensions/{component}/"
 [adapters.bundle]
 entry = "cosh-extension.json"
 
+# Qwencode extension adapter. Coexists independently with the other
+# adapters above — each adapter is scoped to its own framework driver,
+# and the anolisa CLI selects exactly one framework per session based on
+# the active agent runtime. Enabling qwencode has no effect on openclaw,
+# hermes, qoder, claude-code, codex, or cosh adapters. The qwencode
+# driver loads this extension only when the framework is qwencode.
 [[adapters]]
 framework = "qwencode"
 adapter_type = "extension"

--- a/src/tokenless/.anolisa/component.toml.in
+++ b/src/tokenless/.anolisa/component.toml.in
@@ -81,3 +81,13 @@ dest = "{datadir}/extensions/{component}/"
 
 [adapters.bundle]
 entry = "cosh-extension.json"
+
+[[adapters]]
+framework = "qwencode"
+adapter_type = "extension"
+plugin_id = "tokenless"
+source = "adapters/qwencode"
+dest = "{datadir}/adapters/{component}/qwencode/"
+
+[adapters.bundle]
+entry = "qwen-extension.json"

--- a/src/tokenless/.anolisa/component.toml.in
+++ b/src/tokenless/.anolisa/component.toml.in
@@ -82,6 +82,12 @@ dest = "{datadir}/extensions/{component}/"
 [adapters.bundle]
 entry = "cosh-extension.json"
 
+# Qwencode extension adapter. Coexists independently with the other
+# adapters above — each adapter is scoped to its own framework driver,
+# and the anolisa CLI selects exactly one framework per session based on
+# the active agent runtime. Enabling qwencode has no effect on openclaw,
+# hermes, qoder, claude-code, codex, or cosh adapters. The qwencode
+# driver loads this extension only when the framework is qwencode.
 [[adapters]]
 framework = "qwencode"
 adapter_type = "extension"


### PR DESCRIPTION
## 问题

agent-memory E2E 测试 `test_auto_recall_injects_without_tool_call` 失败：auto-recall 钩子未把含 codeword 的记忆注入上下文。

## 根因

`memory_observe` 写入文件后立即返回，但 `notify` 文件监听器有 ~200ms 去抖延迟，尚未将新文件写入 BM25 索引。紧接着触发的 `before_prompt_build` 搜索时，新 observe 的内容还未被索引，`memory_search` 返回空数组，钩子静默返回（无日志输出）。

## 修复

1. **Rust — 同步索引接口**：新增 `IndexHandle::reindex_file()` 方法，提供同步 BM25 upsert
2. **Rust — observe 后立即可搜**：`memory_observe` 写完文件后同步调用 `reindex_file()`，消除竞态窗口
3. **Adapter — 切换搜索模式**：`before_prompt_build` 钩子的 `memory_search` 从 `mode: "hybrid"` 改为 `mode: "bm25"`，避免无 embedding 配置时 hybrid 回退路径的潜在问题
4. **Adapter — 添加诊断日志**：JSON 解析失败和空结果时记录日志，便于后续诊断

Closes #1462