### PR TITLE
fix(sec-core): unify model resources into handles

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
@@ -266,7 +266,8 @@ def scan_prompt(
     # single trace_id, losing that granularity without any performance benefit:
     # under STANDARD/STRICT mode scan_batch() is sequential anyway because the
     # HuggingFace tokenizer (Rust-backed, uses RefCell internally) is NOT
-    # thread-safe — all inference is serialised behind _inference_lock.
+    # thread-safe — all inference is serialised behind the shared
+    # ModelManager.inference_context (keyed by model_name).
     for t in texts:
         if use_daemon:
             try:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/model_manager.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/model_manager.py
@@ -13,6 +13,8 @@ import contextlib
 import logging
 import os
 import threading
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -24,6 +26,19 @@ if TYPE_CHECKING:
     import torch
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _ModelHandle:
+    """Model, tokenizer and inference lock for one loaded model.
+
+    Bundling them binds the lock to the tokenizer it protects —
+    structurally, not by convention.
+    """
+
+    model: object
+    tokenizer: object
+    inference_lock: threading.Lock
 
 
 class ClassifierResult(BaseModel):
@@ -47,12 +62,9 @@ class ModelManager:
 
     Responsibilities:
     - Lazy-load models on first use.
-    - Cache loaded (model, tokenizer) pairs in memory.
+    - Cache loaded models in memory as ``_ModelHandle`` instances.
     - Auto-detect best available device (CPU / CUDA / MPS).
     - Provide ``clear_cache()`` for memory reclamation.
-
-    Each cache entry is a ``(model, tokenizer)`` tuple so callers
-    never need to manage the tokenizer separately.
     """
 
     _DEFAULT_CACHE_DIR = "~/.cache/prompt_scanner/models"
@@ -62,9 +74,10 @@ class ModelManager:
         # Defer device detection until first inference to avoid importing torch
         # at module load time (which would slow down non-ML subcommands like code-scan).
         self._device_cached: str | None = device
-        # cache: model_name -> (model, tokenizer)
-        self._loaded_models: dict[str, tuple[object, object]] = {}
-        self._load_lock = threading.Lock()
+        # ``_lock`` guards the registry (insert / lookup / clear); each
+        # handle's ``inference_lock`` serialises use of its tokenizer.
+        self._handles: dict[str, _ModelHandle] = {}
+        self._lock = threading.RLock()
 
     # ------------------------------------------------------------------
     # Public API
@@ -103,7 +116,7 @@ class ModelManager:
         """Return a cached ``(model, tokenizer)`` pair, loading on demand.
 
         Thread-safe: concurrent calls for the same model will block on the
-        lock and reuse the result of the first successful load.
+        registry lock and reuse the result of the first successful load.
 
         The model **must** have been downloaded beforehand (e.g. via
         ``scan-prompt warmup``).  If it is not present locally, a
@@ -119,25 +132,50 @@ class ModelManager:
             agent_sec_cli.prompt_scanner.exceptions.ModelLoadError: if the
                 model cannot be loaded (missing deps, not downloaded, etc.).
         """
-        # Fast path: model already loaded (no lock needed for dict reads under GIL).
-        if model_name in self._loaded_models:
-            return self._loaded_models[model_name]
-
-        with self._load_lock:
-            # Double-check after acquiring the lock.
-            if model_name in self._loaded_models:
-                return self._loaded_models[model_name]
-            pair = self._do_load(model_name)
-            self._loaded_models[model_name] = pair
-            return pair
+        h = self._get_handle(model_name)
+        return h.model, h.tokenizer
 
     def get_model(self, model_name: str) -> tuple[object, object] | None:
-        """Return the cached ``(model, tokenizer)`` pair if already loaded."""
-        return self._loaded_models.get(model_name)
+        """Return ``(model, tokenizer)`` if already loaded, else ``None``.
+
+        Peek-only — does not trigger a load.
+        """
+        h = self._handles.get(model_name)
+        if h is None:
+            return None
+        return h.model, h.tokenizer
 
     def clear_cache(self) -> None:
-        """Release all loaded models from memory."""
-        self._loaded_models.clear()
+        """Drop all handles from the registry.
+
+        In-flight callers keep their handle alive via their own reference;
+        new callers will reload on next access.
+        """
+        with self._lock:
+            self._handles.clear()
+
+    @contextlib.contextmanager
+    def inference_context(self, model_name: str) -> Iterator[tuple[object, object]]:
+        """Acquire the per-tokenizer lock and yield ``(model, tokenizer)``.
+
+        Fetching the handle and taking its lock in one step guarantees the
+        lock is the one bound to the yielded tokenizer — even if
+        ``clear_cache()`` races, the handle stays alive via this caller's
+        reference.  The HuggingFace tokenizer (Rust-backed, RefCell) is not
+        re-entrant, so inference must be serialised by this lock.
+
+        Args:
+            model_name: ModelScope model identifier.
+
+        Yields:
+            ``(model, tokenizer)``.  The lock is held for the ``with`` block.
+
+        Raises:
+            ModelLoadError: if the model cannot be loaded.
+        """
+        handle = self._get_handle(model_name)
+        with handle.inference_lock:
+            yield handle.model, handle.tokenizer
 
     @property
     def device(self) -> str:
@@ -153,6 +191,32 @@ class ModelManager:
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
+
+    def _get_handle(self, model_name: str) -> _ModelHandle:
+        """Return the handle for *model_name*, loading on first use.
+
+        Single registration point for ``load_model`` and ``inference_context``:
+        model, tokenizer and lock are always created and discovered together.
+        Double-checked locking — fast path reads ``_handles`` unlocked
+        (``dict.get`` is atomic under the GIL), slow path re-checks under
+        ``_lock`` before ``_do_load``.
+        """
+        handle = self._handles.get(model_name)
+        if handle is not None:
+            return handle
+
+        with self._lock:
+            # Double-check after acquiring the registry lock.
+            handle = self._handles.get(model_name)
+            if handle is None:
+                model, tokenizer = self._do_load(model_name)
+                handle = _ModelHandle(
+                    model=model,
+                    tokenizer=tokenizer,
+                    inference_lock=threading.Lock(),
+                )
+                self._handles[model_name] = handle
+            return handle
 
     @staticmethod
     def detect_device() -> str:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/prompt_guard.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/models/prompt_guard.py
@@ -14,7 +14,6 @@ separate INJECTION label; the model flags any malicious prompt
 """
 
 import logging
-import threading
 
 from agent_sec_cli.prompt_scanner.models.model_manager import (
     ClassifierResult,
@@ -116,12 +115,6 @@ class PromptGuardClassifier:
         self._model_name = model_name
         self._temperature = temperature
         self._manager = manager or ModelManager(device=device)
-        # The HuggingFace tokenizer (Rust-backed) uses RefCell internally
-        # and is NOT thread-safe.  Concurrent calls from scan_batch's
-        # ThreadPoolExecutor cause "Already borrowed" panics.  We
-        # serialise inference with a lock; L1 (regex) still runs in
-        # parallel so overall throughput is barely affected.
-        self._inference_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Public inference API
@@ -143,9 +136,11 @@ class PromptGuardClassifier:
     def classify(self, text: str) -> ClassifierResult:
         """Classify a single prompt and return a ``ClassifierResult``.
 
-        Lazy-loads the model on the first call.  Thread-safe: concurrent
-        calls are serialised via ``_inference_lock`` because the Rust-backed
-        tokenizer is not re-entrant.
+        Lazy-loads the model on first call.  Thread-safe: inference is
+        serialised via ``ModelManager.inference_context`` so all classifier
+        instances sharing one tokenizer (e.g. the daemon, which rebuilds a
+        ``PromptScanner`` per request) share one lock — the Rust-backed
+        tokenizer is not re-entrant and would panic with "Already borrowed".
 
         Args:
             text: Raw prompt text to classify.
@@ -157,8 +152,10 @@ class PromptGuardClassifier:
         Raises:
             ModelLoadError: if the model cannot be loaded.
         """
-        model, tokenizer = self._manager.load_model(self._model_name)
-        with self._inference_lock:
+        with self._manager.inference_context(self._model_name) as (
+            model,
+            tokenizer,
+        ):
             probs = self._get_probabilities(text, model, tokenizer)
         return self._probs_to_result(probs)
 
@@ -176,12 +173,14 @@ class PromptGuardClassifier:
         """
         if not texts:
             return []
-        model, tokenizer = self._manager.load_model(self._model_name)
 
         import torch  # lazy import: only needed when actually running ML inference
         from torch.nn.functional import softmax  # lazy import
 
-        with self._inference_lock:
+        with self._manager.inference_context(self._model_name) as (
+            model,
+            tokenizer,
+        ):
             preprocessed = [self._preprocess(t, tokenizer) for t in texts]
             inputs = tokenizer(
                 preprocessed,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/scanner.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/scanner.py
@@ -205,10 +205,12 @@ class PromptScanner:
             # Why sequential?  The HuggingFace tokenizer (Rust-backed,
             # uses RefCell internally) is NOT thread-safe.  To prevent
             # "Already borrowed" panics, PromptGuardClassifier serialises
-            # all inference behind _inference_lock.  With that lock in
-            # place a ThreadPoolExecutor only adds thread-creation and
-            # context-switch overhead while every worker queues on the
-            # same lock — net effect is *slower* than a plain loop.
+            # all inference behind the shared ModelManager.inference_context
+            # (keyed by model_name, shared across all classifier instances
+            # using the same tokenizer).  With that lock in place a
+            # ThreadPoolExecutor only adds thread-creation and context-switch
+            # overhead while every worker queues on the same lock — net
+            # effect is *slower* than a plain loop.
             return [self.scan(t) for t in texts]
 
         # FAST mode (L1 only): pure-regex detectors are thread-safe.

--- a/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
+++ b/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
@@ -621,5 +621,5 @@ uv run python -c "from modelscope import snapshot_download; snapshot_download('L
 | 自定义规则加载 | `ScanConfig.custom_rules_path` 字段已定义；内置规则自动加载，自定义规则加载集成待完成（可直接调用 `load_rules_from_yaml()` 后传给 `RuleEngine`）|
 | L2 模型冷启动 | 首次加载约 2–5 s；**建议安装后执行 `scan-prompt warmup` 预热** |
 | L2 为二分类器 | Llama-Prompt-Guard-2 只区分 BENIGN 和 JAILBREAK，injection 类型最终通过 L1 规则的 category 字段推断 |
-| 批量扫描并发策略 | `scan_batch` 在 STANDARD/STRICT 模式下强制串行执行（HuggingFace tokenizer Rust 后端非线程安全，`_inference_lock` 序列化推理，多线程只会增加开销）；仅 FAST 模式（纯 L1）使用 `ThreadPoolExecutor` |
+| 批量扫描并发策略 | `scan_batch` 在 STANDARD/STRICT 模式下强制串行执行（HuggingFace tokenizer Rust 后端非线程安全，`ModelManager.inference_context` 序列化推理，多线程只会增加开销）；仅 FAST 模式（纯 L1）使用 `ThreadPoolExecutor` |
 | 语言检测 | 当前为启发式规则（Unicode 脚本块比例 ≥ 15%），非 ML 模型；支持 `zh`/`ar`/`ru`/`hi`/`en`；日文汉字及韩文归为 `zh` |

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_ml_classifier.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_ml_classifier.py
@@ -25,6 +25,25 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+
+def _make_handle(model: Any, tokenizer: Any) -> Any:
+    """Build a ``_ModelHandle`` with a fresh inference lock for tests.
+
+    Tests that inject pre-loaded models bypass ``_do_load`` by writing
+    directly into ``ModelManager._handles``; this helper keeps the
+    construction site consistent with the production layout.
+    """
+    from agent_sec_cli.prompt_scanner.models.model_manager import (  # noqa: PLC0415
+        _ModelHandle,
+    )
+
+    return _ModelHandle(
+        model=model,
+        tokenizer=tokenizer,
+        inference_lock=threading.Lock(),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers to build minimal torch / transformers fakes
 # ---------------------------------------------------------------------------
@@ -247,9 +266,9 @@ class TestModelManagerCache(unittest.TestCase):
 
     def test_clear_cache_empties_store(self) -> None:
         mgr = self._make_manager()
-        mgr._loaded_models["dummy"] = (object(), object())  # type: ignore[union-attr]
+        mgr._handles["dummy"] = _make_handle(object(), object())  # type: ignore[union-attr]
         mgr.clear_cache()  # type: ignore[union-attr]
-        self.assertEqual(len(mgr._loaded_models), 0)  # type: ignore[union-attr]
+        self.assertEqual(len(mgr._handles), 0)  # type: ignore[union-attr]
 
     def test_device_property(self) -> None:
         from agent_sec_cli.prompt_scanner.models.model_manager import (
@@ -280,10 +299,10 @@ class TestModelManagerCache(unittest.TestCase):
         )
 
         mgr = ModelManager(device="cpu")
-        fake_pair = (object(), object())
-        mgr._loaded_models["cached-model"] = fake_pair
+        fake_model, fake_tokenizer = object(), object()
+        mgr._handles["cached-model"] = _make_handle(fake_model, fake_tokenizer)
         result = mgr.load_model("cached-model")
-        self.assertIs(result, fake_pair)
+        self.assertEqual(result, (fake_model, fake_tokenizer))
 
 
 # ---------------------------------------------------------------------------
@@ -328,15 +347,15 @@ class TestPromptGuardClassifier(unittest.TestCase):
 
         fake_probs = self._make_mock_probs(benign, jailbreak)
 
-        # Inject mocked (model, tokenizer) into cache
-        mgr._loaded_models["test-model"] = (MagicMock(), MagicMock())
+        # Inject mocked (model, tokenizer) into registry
+        mgr._handles["test-model"] = _make_handle(MagicMock(), MagicMock())
         clf._get_probabilities = MagicMock(return_value=fake_probs)  # type: ignore[method-assign]
         return clf
 
     def _classify_with_mock(self, clf, text: str):
         """Call classify() with load_model patched out to avoid actual downloads."""
         mgr = clf._manager
-        mgr._loaded_models[clf._model_name] = (MagicMock(), MagicMock())
+        mgr._handles[clf._model_name] = _make_handle(MagicMock(), MagicMock())
         return clf.classify(text)
 
     def test_classify_injection_as_jailbreak_label(self) -> None:
@@ -650,7 +669,7 @@ class TestPromptGuardConcurrentSharedManager(unittest.TestCase):
     def test_concurrent_classify_serializes_tokenizer(self) -> None:
         mgr = self.ModelManager(device="cpu")
         tokenizer = _RefCellTokenizer()
-        mgr._loaded_models["test-model"] = (
+        mgr._handles["test-model"] = _make_handle(
             _make_fake_model(self.fake_torch),
             tokenizer,
         )
@@ -717,7 +736,7 @@ class TestMLClassifierConcurrentSharedManager(unittest.TestCase):
         # manager so every layer's classifier hits the same instance.
         shared_manager = self.MLClassifier._shared_manager
         tokenizer = _RefCellTokenizer()
-        shared_manager._loaded_models["LLM-Research/Llama-Prompt-Guard-2-86M"] = (
+        shared_manager._handles["LLM-Research/Llama-Prompt-Guard-2-86M"] = _make_handle(
             _make_fake_model(self.fake_torch),
             tokenizer,
         )

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_ml_classifier.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_ml_classifier.py
@@ -17,10 +17,12 @@ Test classes
 """
 
 import sys
-import tempfile
+import threading
+import time
 import types
 import unittest
-from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
@@ -532,3 +534,209 @@ class TestMLClassifierLayer(unittest.TestCase):
     def test_detect_layer_name(self) -> None:
         result = self._detect_with_mocked_availability("BENIGN", 0.99)
         self.assertEqual(result.layer_name, "ml_classifier")
+
+
+# ---------------------------------------------------------------------------
+# Helpers: concurrent-access-detecting tokenizer (mimics Rust RefCell)
+# ---------------------------------------------------------------------------
+
+
+class _RefCellTokenizer:
+    """Mimic HuggingFace Rust-backed tokenizer's RefCell borrow semantics.
+
+    Raises ``RuntimeError("Already borrowed")`` if ``__call__`` is entered
+    while a previous call is still in-flight — reproducing the panic that
+    occurs when a non-reentrant tokenizer is used from multiple threads.
+
+    ``tokenize`` / ``convert_tokens_to_string`` are read-only and left
+    unsynchronised, mirroring the real tokenizer where only ``__call__``
+    triggers a mutable borrow.
+    """
+
+    def __init__(self) -> None:
+        self._active = 0
+        self._guard = threading.Lock()
+        self.overlap_count = 0
+
+    def __call__(self, text: Any, **kwargs: Any) -> dict:
+        with self._guard:
+            if self._active > 0:
+                self.overlap_count += 1
+                raise RuntimeError("Already borrowed")
+            self._active += 1
+        try:
+            # Hold the borrow window open so concurrent callers trip the check.
+            time.sleep(0.002)
+            return {"input_ids": MagicMock(), "attention_mask": MagicMock()}
+        finally:
+            with self._guard:
+                self._active -= 1
+
+    def tokenize(self, text: str) -> list[str]:
+        return text.split()
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        return " ".join(tokens)
+
+
+class _FakeModelOutput:
+    """Wraps a fake logits tensor so ``model(**inputs).logits`` works."""
+
+    def __init__(self, logits: Any) -> None:
+        self.logits = logits
+
+
+def _make_fake_model(fake_torch: types.ModuleType) -> Any:
+    """Return a model stub whose forward call yields a fixed fake logits tensor."""
+
+    class _FakeModel:
+        def __call__(self, **kwargs: Any) -> _FakeModelOutput:
+            return _FakeModelOutput(fake_torch.Tensor([0.05, 0.95]))
+
+        def to(self, device: Any) -> "_FakeModel":
+            return self
+
+        def eval(self) -> "_FakeModel":
+            return self
+
+    return _FakeModel()
+
+
+def _install_fake_torch() -> tuple[Any, types.ModuleType]:
+    """Patch sys.modules with a minimal fake torch and its nn submodules.
+
+    ``PromptGuardClassifier._get_probabilities`` does
+    ``from torch.nn.functional import softmax``, so ``torch.nn.functional``
+    must be importable as a submodule, not merely an attribute of ``torch``.
+    """
+    fake_torch = _make_fake_torch()
+    modules = {
+        "torch": fake_torch,
+        "torch.nn": fake_torch.nn,
+        "torch.nn.functional": fake_torch.nn.functional,
+    }
+    return patch.dict(sys.modules, modules), fake_torch
+
+
+# ---------------------------------------------------------------------------
+# Tests: PromptGuardClassifier concurrency (issue #1305)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptGuardConcurrentSharedManager(unittest.TestCase):
+    """Reproduce issue #1305: concurrent classify() on a shared tokenizer.
+
+    Multiple PromptGuardClassifier instances backed by the same shared
+    ModelManager must serialise inference so the Rust-backed tokenizer is
+    never borrowed re-entrantly — otherwise "Already borrowed" panics.
+    """
+
+    def setUp(self) -> None:
+        from agent_sec_cli.prompt_scanner.models.model_manager import (  # noqa: PLC0415
+            ModelManager,
+        )
+        from agent_sec_cli.prompt_scanner.models.prompt_guard import (  # noqa: PLC0415
+            PromptGuardClassifier,
+        )
+
+        self._torch_patch, self.fake_torch = _install_fake_torch()
+        self._torch_patch.start()
+        self.ModelManager = ModelManager
+        self.PromptGuardClassifier = PromptGuardClassifier
+
+    def tearDown(self) -> None:
+        self._torch_patch.stop()
+
+    def test_concurrent_classify_serializes_tokenizer(self) -> None:
+        mgr = self.ModelManager(device="cpu")
+        tokenizer = _RefCellTokenizer()
+        mgr._loaded_models["test-model"] = (
+            _make_fake_model(self.fake_torch),
+            tokenizer,
+        )
+        # Distinct classifier instances sharing one manager — mirrors the
+        # daemon / PromptScanBackend path where each request builds a fresh
+        # PromptScanner (and thus a fresh PromptGuardClassifier).
+        classifiers = [
+            self.PromptGuardClassifier(model_name="test-model", manager=mgr)
+            for _ in range(8)
+        ]
+
+        errors: list[str] = []
+
+        def _work(i: int) -> None:
+            clf = classifiers[i % len(classifiers)]
+            try:
+                clf.classify(f"prompt {i}")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{type(exc).__name__}: {exc}")
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(_work, range(200)))
+
+        self.assertEqual(errors, [], f"concurrent classify failed: {errors[:3]}")
+        self.assertEqual(
+            tokenizer.overlap_count,
+            0,
+            "tokenizer was borrowed concurrently (Already borrowed)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: MLClassifier concurrency (issue #1305, non-daemon / daemon path)
+# ---------------------------------------------------------------------------
+
+
+class TestMLClassifierConcurrentSharedManager(unittest.TestCase):
+    """Reproduce issue #1305 at the MLClassifier layer.
+
+    Each ``MLClassifier()`` builds its own ``PromptGuardClassifier`` but
+    shares ``MLClassifier._shared_manager`` (a class-level singleton
+    ModelManager).  Concurrent ``detect()`` across many such layers must
+    serialise on the shared tokenizer — covering both the daemon path
+    (per-request PromptScanner) and the non-daemon Python API path.
+    """
+
+    def setUp(self) -> None:
+        from agent_sec_cli.prompt_scanner.detectors.ml_classifier import (  # noqa: PLC0415
+            MLClassifier,
+        )
+
+        MLClassifier._shared_manager = None
+        self._torch_patch, self.fake_torch = _install_fake_torch()
+        self._torch_patch.start()
+        self.MLClassifier = MLClassifier
+
+    def tearDown(self) -> None:
+        self._torch_patch.stop()
+        self.MLClassifier._shared_manager = None
+
+    def test_concurrent_detect_serializes_tokenizer(self) -> None:
+        layers = [self.MLClassifier() for _ in range(8)]
+        # Inject a shared concurrent-detecting tokenizer into the singleton
+        # manager so every layer's classifier hits the same instance.
+        shared_manager = self.MLClassifier._shared_manager
+        tokenizer = _RefCellTokenizer()
+        shared_manager._loaded_models["LLM-Research/Llama-Prompt-Guard-2-86M"] = (
+            _make_fake_model(self.fake_torch),
+            tokenizer,
+        )
+
+        errors: list[str] = []
+
+        def _work(i: int) -> None:
+            layer = layers[i % len(layers)]
+            try:
+                layer.detect(f"prompt {i}")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{type(exc).__name__}: {exc}")
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(_work, range(200)))
+
+        self.assertEqual(errors, [], f"concurrent detect failed: {errors[:3]}")
+        self.assertEqual(
+            tokenizer.overlap_count,
+            0,
+            "tokenizer was borrowed concurrently (Already borrowed)",
+        )


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #1305
    fixes #1305
    resolves #1305

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
