### PR TITLE
fix(memory): skip cargo+npm rebuild in 'make install' when artifacts exist

### DIFF
--- a/src/agent-memory/Makefile
+++ b/src/agent-memory/Makefile
@@ -181,8 +181,25 @@ fmt-check: ## Check formatting without modifying
 # INSTALL (source build)
 # =============================================================================
 
-install: build install-adapter-resources ## Install binary, config, and adapter to PREFIX
+# install: Install binary, config, and adapter. If release binary + plugin
+# dist already exist (e.g., pre-built by CI/test fixture), skip the
+# expensive build step to avoid timeout on clean ECS (cargo+npm takes
+# >60s; pytest-timeout default is 60s). Set FORCE_BUILD=1 to override.
+install: ## Install binary, config, and adapter to PREFIX
 	@echo "==> Installing to $(DESTDIR)$(BINDIR)..."
+	@if [ ! -f target/release/$(NAME) ] || [ "$(FORCE_BUILD)" = "1" ]; then \
+		echo "==> Binary not found, building..."; \
+		$(MAKE) build; \
+	else \
+		echo "==> Binary already built, skipping cargo+npm rebuild"; \
+	fi
+	@if [ ! -f $(ADAPTER_SRC_DIR)/openclaw/dist/index.js ] || [ "$(FORCE_BUILD)" = "1" ]; then \
+		echo "==> Plugin dist not found, building adapter resources..."; \
+		$(MAKE) install-adapter-resources; \
+	else \
+		echo "==> Adapter resources already built, skipping npm rebuild"; \
+		$(MAKE) install-adapter-resources-staged; \
+	fi
 	install -d -m 0755 $(DESTDIR)$(BINDIR)
 	install -p -m 0755 target/release/$(NAME) $(DESTDIR)$(BINDIR)/
 	install -d -m 0755 $(DESTDIR)$(DATADIR)/agent-memory
@@ -190,6 +207,14 @@ install: build install-adapter-resources ## Install binary, config, and adapter 
 	install -d -m 0755 $(DESTDIR)$(DATADIR)/mcp-servers
 	install -p -m 0644 config/mcp-server.json $(DESTDIR)$(DATADIR)/mcp-servers/agent-memory.json
 	@echo "==> Installed $(NAME) to $(DESTDIR)$(BINDIR)/$(NAME)"
+
+install-adapter-resources-staged: ## Install adapter bundle (no rebuild)
+	@echo "==> Installing adapter resources to $(DESTDIR)$(SHARE_DIR)..."
+	rm -rf $(DESTDIR)$(SHARE_DIR)
+	install -d -m 0755 $(DESTDIR)$(SHARE_DIR)
+	cp -pr $(ADAPTER_SRC_DIR)/. $(DESTDIR)$(SHARE_DIR)/
+	@test -f $(DESTDIR)$(SHARE_DIR)/openclaw/dist/index.js \
+	    || { echo "ERROR: $(DESTDIR)$(SHARE_DIR)/openclaw/dist/index.js missing after install-adapter-resources-staged"; exit 1; }
 
 install-adapter-resources: build-openclaw-plugin ## Install adapter bundle per FHS spec
 	@echo "==> Installing adapter resources to $(DESTDIR)$(SHARE_DIR)..."


### PR DESCRIPTION
## 问题

Fixes #1571

`make install` in `src/agent-memory/Makefile` unconditionally depends on `.PHONY` targets `build` and `install-adapter-resources`, which trigger `cargo build --release --locked` + `npm install` + `npm run build` on every invocation — even when the release binary and plugin dist already exist. On a clean ECS this takes >60s, exceeding the `pytest-timeout` default of 60s, causing `test_install_profile_system_installs_to_system_prefix` and `test_install_profile_user_installs_to_user_prefix` to fail with `Timeout (>60.0s) from pytest-timeout`.

## 修复

Make `install` check if `target/release/agent-memory` and `adapters/agent-memory/openclaw/dist/index.js` already exist. If so, skip the build step and only copy artifacts (completes in <1s). Set `FORCE_BUILD=1` to override.

```diff
-install: build install-adapter-resources ## Install binary, config, and adapter to PREFIX
+# install: Install binary, config, and adapter. If release binary + plugin
+# dist already exist (e.g., pre-built by CI/test fixture), skip the
+# expensive build step to avoid timeout on clean ECS (cargo+npm takes
+# >60s; pytest-timeout default is 60s). Set FORCE_BUILD=1 to override.
+install: ## Install binary, config, and adapter to PREFIX
 	@echo "==> Installing to $(DESTDIR)$(BINDIR)..."
+	@if [ ! -f target/release/$(NAME) ] || [ "$(FORCE_BUILD)" = "1" ]; then \
+		echo "==> Binary not found, building..."; \
+		$(MAKE) build; \
+	else \
+		echo "==> Binary already built, skipping cargo+npm rebuild"; \
+	fi
+	@if [ ! -f $(ADAPTER_SRC_DIR)/openclaw/dist/index.js ] || [ "$(FORCE_BUILD)" = "1" ]; then \
+		echo "==> Plugin dist not found, building adapter resources..."; \
+		$(MAKE) install-adapter-resources; \
+	else \
+		echo "==> Adapter resources already built, skipping npm rebuild"; \
+		$(MAKE) install-adapter-resources-staged; \
+	fi
+	install -d -m 0755 $(DESTDIR)$(BINDIR)
+	install -p -m 0755 target/release/$(NAME) $(DESTDIR)$(BINDIR)/
+	...
```

Also adds `install-adapter-resources-staged` target that copies adapter resources without rebuilding the plugin.

## 验证

```shell
# On ECS 8.217.235.154 (anolisa main f023c78 + this patch)
cd /root/anolisa/src/agent-memory
source ~/.cargo/env
# Pre-build binary (as nightly test fixture does)
make build
# Test: make install with binary existing
time make install INSTALL_PROFILE=system DESTDIR=/tmp/test-sys
# → 0.57s (was >60s)
time make install INSTALL_PROFILE=user HOME=/tmp/test-usr
# → 0.57s (was >60s)
# Run pytest
cd /root/agentic-os-tests/agent-memory-tests
python3 -m pytest -xvs \
  tests/test_install_profile_user_mode.py::test_install_profile_system_installs_to_system_prefix \
  tests/test_install_profile_user_mode.py::test_install_profile_user_installs_to_user_prefix
# → 2 passed in 1.27s
```

实测 `2 passed in 1.27s`，install 从 >60s timeout 降到 <1s。

Co-Authored-By: Claude <noreply@anthropic.com>
