### PR TITLE
fix(memory): extract keywords from long prompts for BM25 auto-recall

### DIFF
--- a/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
@@ -14,6 +14,7 @@ import { createHash } from "node:crypto";
 import { McpStdioClient } from "./mcp-client.js";
 import { resolveConfig, type AgentMemoryConfig } from "./config.js";
 import { looksLikePromptInjection, wrapMemoryResultsForPrompt } from "./safety.js";
+import { buildRecallQueries, MAX_RESULTS, RRF_K } from "./keyword-extract.js";
 
 // Module-scoped singleton client. OpenClaw may call register() again
 // during a plugin hot-reload without firing gateway_stop for the old
@@ -91,40 +92,106 @@ export default definePluginEntry({
           const userMessage = event.prompt;
           if (!userMessage || userMessage.trim().length < 3) return;
 
-          const rawText = await client.callTool("memory_search", {
-            query: userMessage,
-            top_k: 5,
-          // Use BM25 mode for auto-recall: memories are synchronously indexed
-          // immediately after observe (PR #1520), so BM25 finds them without delay.
-          // User prompts typically contain keyword matches with stored memories
-          // (e.g., "I decided" matching "decision" memories), making BM25 sufficient.
-          // Hybrid mode adds complexity without benefit when no embedding provider
-          // is configured.
-            mode: "bm25",
-          });
+          // BM25 keyword search performs poorly on long natural-language
+          // prompts: stopwords dilute TF-IDF signal so no document reaches
+          // the relevance threshold (regression of #1462). Build
+          // progressively shorter query candidates, execute every
+          // candidate, and merge the results so that no topic is
+          // silently dropped by an early-break optimisation.  See
+          // keyword-extract.ts for the extraction logic.
+          const queryCandidates = buildRecallQueries(userMessage);
 
-          // Parse to verify we have hits; skip injection on empty results.
-          let hits: Array<Record<string, unknown>> = [];
-          try {
-            hits = JSON.parse(rawText);
-          } catch {
-            api.logger.warn?.(
-              `agent-memory: auto-recall memory_search returned non-JSON response (len=${rawText.length})`,
-            );
-            return;
+          // Reciprocal-rank fusion (RRF) across all candidates.
+          //
+          // Raw BM25 scores from different queries are NOT comparable
+          // (different IDF, term counts, corpus coverage).  Instead we
+          // assign each hit an RRF score: sum of 1/(RRF_K + rank) where
+          // rank is the hit's 1-based position within its own candidate
+          // result set.  This makes scores comparable across candidates.
+          //
+          // Deduplication is by memory path (stable identity).  A single
+          // failing candidate (e.g. query > 1024 bytes) does NOT discard
+          // previously merged results.  Final result count is capped at
+          // MAX_RESULTS (5).
+          interface RrfEntry {
+            hit: Record<string, unknown>;
+            rrfScore: number;
+            bestContribution: number;
           }
-          if (!Array.isArray(hits) || hits.length === 0) {
+          const pathToEntry = new Map<string, RrfEntry>();
+
+          for (const query of queryCandidates) {
+            let rawText: string;
+            try {
+              rawText = await client.callTool("memory_search", {
+                query,
+                top_k: 5,
+                mode: "bm25",
+              });
+            } catch (candidateErr) {
+              // Per-candidate error (e.g. query too long).  Log and
+              // continue — do NOT discard previously merged hits.
+              api.logger.warn?.(
+                `agent-memory: auto-recall candidate failed (query len=${query.length}, err=${candidateErr instanceof Error ? candidateErr.message : String(candidateErr)})`,
+              );
+              continue;
+            }
+            let batch: unknown;
+            try {
+              batch = JSON.parse(rawText);
+            } catch {
+              api.logger.warn?.(
+                `agent-memory: auto-recall memory_search returned non-JSON response (len=${rawText.length})`,
+              );
+              continue;
+            }
+            if (!Array.isArray(batch)) continue;
+            // Within this candidate, hits are already sorted by BM25
+            // score.  Assign RRF score based on rank (0-based index,
+            // so rank 0 → contribution 1/(k+1), rank 1 → 1/(k+2), etc).
+            for (let rank = 0; rank < batch.length; rank++) {
+              const hit = batch[rank] as Record<string, unknown>;
+              const rrfContribution = 1 / (RRF_K + rank + 1);
+              const hitPath = String(hit.path ?? "");
+              const key = hitPath || JSON.stringify(hit);
+              const existing = pathToEntry.get(key);
+              if (existing) {
+                existing.rrfScore += rrfContribution;
+                // Keep the hit from the candidate where it ranked
+                // highest (largest contribution = lowest rank).
+                if (rrfContribution > existing.bestContribution) {
+                  existing.hit = hit;
+                  existing.bestContribution = rrfContribution;
+                }
+              } else {
+                pathToEntry.set(key, {
+                  hit,
+                  rrfScore: rrfContribution,
+                  bestContribution: rrfContribution,
+                });
+              }
+            }
+          }
+
+          // Sort by RRF score descending and limit to MAX_RESULTS.
+          const finalHits = Array.from(pathToEntry.values())
+            .sort((a, b) => b.rrfScore - a.rrfScore)
+            .slice(0, MAX_RESULTS)
+            .map((entry) => entry.hit);
+
+          if (finalHits.length === 0) {
             api.logger.info?.(
               `agent-memory: auto-recall found 0 results for prompt (query len=${userMessage.length})`,
             );
             return;
           }
 
-          const wrapped = wrapMemoryResultsForPrompt(rawText);
+          const finalRawText = JSON.stringify(finalHits);
+          const wrapped = wrapMemoryResultsForPrompt(finalRawText);
           if (!wrapped) return;
 
           api.logger.info?.(
-            `agent-memory: auto-recall injected ${hits.length} memory result(s) for prompt`,
+            `agent-memory: auto-recall injected ${finalHits.length} memory result(s) for prompt`,
           );
           // Dynamic content per turn → use prependContext (NOT prependSystemContext).
           return { prependContext: wrapped };

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/keyword-extract.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/keyword-extract.ts
@@ -1,0 +1,208 @@
+/**
+ * BM25 auto-recall keyword extraction.
+ *
+ * Long natural-language prompts dilute BM25 signal with stopwords,
+ * causing FTS5 to return empty results. This module extracts salient
+ * keywords and builds progressively shorter query candidates so the
+ * BM25 search can find matching memories.
+ */
+
+/** English stopwords filtered before keyword extraction. */
+const STOP_WORDS = new Set([
+  "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+  "have", "has", "had", "do", "does", "did", "will", "would", "should",
+  "could", "may", "might", "must", "shall", "can", "what", "who", "whom",
+  "whose", "which", "that", "this", "these", "those", "i", "you", "he",
+  "she", "it", "we", "they", "me", "him", "her", "us", "them", "my",
+  "your", "his", "its", "our", "their", "to", "of", "in", "on",
+  "at", "by", "for", "with", "about", "against", "between", "into",
+  "through", "during", "before", "after", "above", "below", "from",
+  "up", "down", "out", "off", "over", "under", "again", "further",
+  "then", "once", "here", "there", "when", "where", "why", "how", "all",
+  "any", "both", "each", "few", "more", "most", "other", "some", "such",
+  "no", "nor", "not", "only", "own", "same", "so", "than", "too", "very",
+  "just", "also", "and", "but", "or", "if", "because", "as", "until",
+  "while", "answer", "tell", "give", "say", "know", "think", "want",
+  "need", "like", "get", "got", "make", "made", "go", "going",
+]);
+
+/**
+ * Maximum keywords retained. Stride-sampled from the full list so later
+ * words in the prompt are represented, not just the first N.
+ */
+const MAX_KEYWORDS = 8;
+
+/**
+ * Maximum UTF-8 byte length for any single query candidate.  The
+ * server-side memory_search tool rejects queries over 1024 bytes.
+ */
+export const MAX_QUERY_BYTES = 1024;
+
+/**
+ * Maximum number of results to inject into the prompt.  Aligns with
+ * the per-candidate top_k so we never show more than 5 memories.
+ */
+export const MAX_RESULTS = 5;
+
+/**
+ * Reciprocal-rank fusion constant.  Standard RRF uses k=60.
+ */
+export const RRF_K = 60;
+
+/**
+ * Extract salient keywords from text.
+ *
+ * Strips non-ASCII characters (emoji, CJK, Cyrillic, accented letters,
+ * curly quotes) before tokenising, so English prompts containing a
+ * stray emoji or smart-quote still produce useful keywords.  Purely
+ * non-ASCII text (e.g. a CJK-only prompt) naturally yields zero
+ * keywords, which the caller treats as "no extraction possible" and
+ * falls through to the raw-query path.
+ *
+ * Keywords are lowercased, deduplicated, and filtered to >= 2 chars.
+ * While 2-char tokens (AI, ID, UK) cause the BM25 backend to fall back
+ * to LIKE search with AND semantics, they are important domain terms
+ * that should still be included — other candidates (CJK trigrams,
+ * raw query) will also be tried and merged via reciprocal-rank fusion.
+ *
+ * When the unique keyword count exceeds MAX_KEYWORDS, endpoints-
+ * inclusive linear spacing ensures both the first and last keyword
+ * are always included.
+ */
+export function extractKeywords(text: string): string {
+  const asciiOnly = text.replace(/[^\x00-\x7F]/g, " ");
+
+  const words = asciiOnly
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length >= 2 && !STOP_WORDS.has(w));
+
+  const seen = new Set<string>();
+  const unique = words.filter((w) => {
+    if (seen.has(w)) return false;
+    seen.add(w);
+    return true;
+  });
+
+  if (unique.length <= MAX_KEYWORDS) return unique.join(" ");
+
+  // Endpoints-inclusive linear spacing: index 0 is always the first
+  // keyword and index (length-1) is always the last.
+  return Array.from({ length: MAX_KEYWORDS }, (_, i) =>
+    unique[Math.round((i * (unique.length - 1)) / (MAX_KEYWORDS - 1))]
+  ).join(" ");
+}
+
+/**
+ * Extract CJK trigram segments from text for query candidates.
+ *
+ * CJK text lacks word boundaries (spaces), so a long CJK sentence
+ * cannot be meaningfully split into "keywords".  Instead, we extract
+ * overlapping trigrams (3 consecutive CJK characters) from the text.
+ * Each trigram is >= 3 characters, so the BM25 backend's trigram
+ * tokenizer can match them directly without falling into the
+ * `search_like()` AND path.
+ *
+ * Returns an array of trigram strings.  The caller joins them into
+ * space-separated query candidates.
+ */
+export function extractCjkTrigrams(text: string): string[] {
+  // Keep only CJK Unified Ideographs (U+4E00..U+9FFF), Hiragana
+  // (U+3040..U+309F), Katakana (U+30A0..U+30FF), and CJK
+  // Compatibility (U+F900..U+FAFF).
+  const cjkChars = text.replace(/[^\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uf900-\ufaff]/g, "");
+  if (cjkChars.length < 3) return [];
+
+  // Extract overlapping trigrams from the CJK character sequence.
+  const trigrams: string[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < cjkChars.length - 2; i++) {
+    const trigram = cjkChars[i] + cjkChars[i + 1] + cjkChars[i + 2];
+    if (!seen.has(trigram)) {
+      seen.add(trigram);
+      trigrams.push(trigram);
+    }
+  }
+  return trigrams;
+}
+
+/**
+ * Truncate a string so its UTF-8 encoding does not exceed maxBytes.
+ */
+function truncateToByteLimit(text: string, maxBytes: number): string {
+  if (new TextEncoder().encode(text).byteLength <= maxBytes) return text;
+
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (new TextEncoder().encode(text.slice(0, mid)).byteLength <= maxBytes) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return text.slice(0, lo);
+}
+
+/**
+ * Build deduplicated query candidates for BM25 auto-recall.
+ *
+ * Candidates:
+ * 1. Extracted keywords (stride-sampled with tail coverage, <= 8 words).
+ * 2. First 3 keywords (shorter fallback for sparse corpora).
+ * 3. CJK trigram segments (sampled, <= 8 trigrams) — for CJK prompts
+ *    that have no space-separated keywords.  Each trigram is >= 3
+ *    chars so the BM25 backend uses trigram matching, not LIKE AND.
+ * 4. CJK trigram top-3 — shorter CJK fallback.
+ * 5. Truncated raw prompt (first 200 chars, byte-safe).
+ * 6. Full raw prompt (byte-safe, <= 1024 bytes) — last resort.
+ *
+ * All candidates are truncated to MAX_QUERY_BYTES (1024) UTF-8 bytes.
+ * The list is deduplicated (order-preserving).
+ */
+export function buildRecallQueries(text: string): string[] {
+  const keywords = extractKeywords(text);
+  const cjkTrigrams = extractCjkTrigrams(text);
+
+  const truncated = truncateToByteLimit(text.slice(0, 200), MAX_QUERY_BYTES);
+  const fullText = truncateToByteLimit(text, MAX_QUERY_BYTES);
+
+  const candidates: string[] = [];
+  if (keywords) candidates.push(keywords);
+
+  const top3 = keywords ? keywords.split(" ").slice(0, 3).join(" ") : "";
+  if (top3) candidates.push(top3);
+
+  // CJK trigram candidates: stride-sample up to MAX_KEYWORDS trigrams,
+  // joined with spaces so each trigram (>= 3 chars) is matched by the
+  // BM25 backend's trigram tokenizer.
+  if (cjkTrigrams.length > 0) {
+    let trigramQuery: string;
+    if (cjkTrigrams.length <= MAX_KEYWORDS) {
+      trigramQuery = cjkTrigrams.join(" ");
+    } else {
+      const step = (cjkTrigrams.length - 1) / (MAX_KEYWORDS - 1);
+      trigramQuery = Array.from({ length: MAX_KEYWORDS }, (_, i) =>
+        cjkTrigrams[Math.round(i * step)]
+      ).join(" ");
+    }
+    candidates.push(trigramQuery);
+
+    // Shorter CJK fallback: first 3 trigrams.
+    const trigramTop3 = cjkTrigrams.slice(0, 3).join(" ");
+    if (trigramTop3 !== trigramQuery) candidates.push(trigramTop3);
+  }
+
+  if (truncated.length >= 2) candidates.push(truncated);
+  if (fullText.length >= 2 && fullText !== truncated) candidates.push(fullText);
+
+  const seen = new Set<string>();
+  return candidates.filter((q) => {
+    if (q.length < 2 || seen.has(q)) return false;
+    if (new TextEncoder().encode(q).byteLength > MAX_QUERY_BYTES) return false;
+    seen.add(q);
+    return true;
+  });
+}

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/keyword-extract-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/keyword-extract-test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for BM25 auto-recall keyword extraction.
+ *
+ * Covers the review findings from PR #1574: keyword extraction with
+ * non-ASCII stripping, CJK trigram extraction (>= 3 chars for BM25
+ * trigram tokenizer compatibility), 2-char keyword allowance,
+ * candidate deduplication, stride sampling, byte-length safety.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  extractKeywords,
+  extractCjkTrigrams,
+  buildRecallQueries,
+  MAX_QUERY_BYTES,
+  MAX_RESULTS,
+  RRF_K,
+} = await import("../../src/keyword-extract.js");
+
+describe("extractKeywords", () => {
+  it("extracts salient words from English prompts", () => {
+    const kw = extractKeywords(
+      "What is the secret codeword for this session?",
+    );
+    assert.ok(kw.includes("secret"));
+    assert.ok(kw.includes("codeword"));
+    assert.ok(kw.includes("session"));
+  });
+
+  it("filters stopwords", () => {
+    const kw = extractKeywords("the cat is on the mat");
+    assert.ok(!kw.includes("the"));
+    assert.ok(!kw.includes("is"));
+    assert.ok(!kw.includes("on"));
+    assert.ok(kw.includes("cat"));
+    assert.ok(kw.includes("mat"));
+  });
+
+  it("allows 2-char ASCII keywords (AI, ID, UK)", () => {
+    const kw = extractKeywords(
+      "What is the secret codeword for our AI session in the UK?",
+    );
+    assert.ok(kw.split(" ").includes("ai"), "2-char 'ai' should be kept");
+    assert.ok(kw.split(" ").includes("uk"), "2-char 'uk' should be kept");
+    assert.ok(kw.includes("secret"));
+    assert.ok(kw.includes("codeword"));
+    assert.ok(kw.includes("session"));
+  });
+
+  it("extracts keywords from English prompts containing emoji", () => {
+    const kw = extractKeywords(
+      "What is the secret codeword for this session? \ud83d\udd10",
+    );
+    assert.ok(kw.includes("secret"), "should extract 'secret' despite emoji");
+    assert.ok(kw.includes("codeword"), "should extract 'codeword' despite emoji");
+    assert.ok(kw.includes("session"), "should extract 'session' despite emoji");
+  });
+
+  it("extracts keywords from prompts with smart quotes and accented letters", () => {
+    const kw = extractKeywords(
+      "What is the \u201csecret\u201d codeword for caf\u00e9 session?",
+    );
+    assert.ok(kw.includes("secret"), "should extract 'secret' despite smart quotes");
+    assert.ok(kw.includes("codeword"), "should extract 'codeword'");
+    assert.ok(kw.includes("session"), "should extract 'session'");
+  });
+
+  it("returns empty for pure CJK text (no ASCII keywords available)", () => {
+    assert.equal(extractKeywords("\u8bf7\u95ee\u6211\u4eec\u4e4b\u524d\u7ea6\u5b9a\u7684\u79d8\u5bc6\u4ee3\u53f7\u662f\u4ec0\u4e48"), "");
+    assert.equal(extractKeywords("\u82b1\u540d\u306f\u5c0f\u4e91\u3067\u3059"), "");
+    assert.equal(extractKeywords("\u041a\u0430\u043a \u0434\u0435\u043b\u0430?"), "");
+  });
+
+  it("extracts ASCII keywords from mixed CJK + ASCII text", () => {
+    const kw = extractKeywords("hello\u4e16\u754c");
+    assert.ok(kw.includes("hello"), "should extract 'hello' from mixed text");
+    const kw2 = extractKeywords("test\u30c6\u30b9\u30c8");
+    assert.ok(kw2.includes("test"), "should extract 'test' from mixed text");
+  });
+
+  it("deduplicates repeated words", () => {
+    const kw = extractKeywords("test test test hello hello world");
+    const words = kw.split(" ").filter(Boolean);
+    assert.equal(new Set(words).size, words.length);
+  });
+
+  it("stride-samples endpoints-inclusively so the last keyword is always included", () => {
+    const prompt =
+      "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima codeword";
+    const kw = extractKeywords(prompt);
+    const words = kw.split(" ");
+    assert.ok(words.length <= 8, `expected \u22648 keywords, got ${words.length}`);
+    assert.ok(
+      words.includes("alpha"),
+      "stride sampling must include the first keyword",
+    );
+    assert.ok(
+      words.includes("codeword"),
+      "stride sampling must include the last keyword (tail topic)",
+    );
+  });
+
+  it("returns all keywords when under the cap", () => {
+    const kw = extractKeywords("rust python typescript");
+    assert.equal(kw, "rust python typescript");
+  });
+
+  it("handles empty and very short input", () => {
+    assert.equal(extractKeywords(""), "");
+    assert.equal(extractKeywords("a"), "");
+    assert.equal(extractKeywords("   "), "");
+  });
+
+  it("keeps single 2-char keyword", () => {
+    const kw = extractKeywords("AI");
+    assert.equal(kw, "ai");
+  });
+});
+
+describe("extractCjkTrigrams", () => {
+  it("extracts overlapping trigrams from Chinese text", () => {
+    // 秘密代号是猎鹰 -> 秘密代, 密代号, 代号是, 号是猎, 是猎鹰
+    const trigrams = extractCjkTrigrams("\u79d8\u5bc6\u4ee3\u53f7\u662f\u730e\u9e70");
+    assert.ok(trigrams.includes("\u79d8\u5bc6\u4ee3"), "should include 秘密代");
+    assert.ok(trigrams.includes("\u5bc6\u4ee3\u53f7"), "should include 密代号");
+    assert.ok(trigrams.includes("\u4ee3\u53f7\u662f"), "should include 代号是");
+    assert.ok(trigrams.includes("\u53f7\u662f\u730e"), "should include 号是猎");
+    assert.ok(trigrams.includes("\u662f\u730e\u9e70"), "should include 是猎鹰");
+    assert.equal(trigrams.length, 5);
+  });
+
+  it("extracts trigrams from long CJK sentences", () => {
+    const text = "\u8bf7\u95ee\u6211\u4eec\u4e4b\u524d\u7ea6\u5b9a\u7684\u79d8\u5bc6\u4ee3\u53f7\u662f\u4ec0\u4e48\u8bf7\u53ea\u56de\u7b54\u4ee3\u53f7";
+    const trigrams = extractCjkTrigrams(text);
+    assert.ok(
+      trigrams.some((t) => t.includes("\u79d8\u5bc6")),
+      "should include trigram containing 秘密",
+    );
+    assert.ok(
+      trigrams.some((t) => t.includes("\u4ee3\u53f7")),
+      "should include trigram containing 代号",
+    );
+  });
+
+  it("returns empty for pure ASCII text", () => {
+    assert.deepEqual(extractCjkTrigrams("hello world"), []);
+  });
+
+  it("returns empty for text with fewer than 3 CJK characters", () => {
+    assert.deepEqual(extractCjkTrigrams("\u4f60\u597d"), []);
+    assert.deepEqual(extractCjkTrigrams("\u4f60"), []);
+  });
+
+  it("deduplicates repeated trigrams", () => {
+    // 秘密代秘密代 -> 秘密代, 密代秘, 代秘密, 秘密代 (dup)
+    const trigrams = extractCjkTrigrams("\u79d8\u5bc6\u4ee3\u79d8\u5bc6\u4ee3");
+    const unique = new Set(trigrams);
+    assert.equal(trigrams.length, unique.size, "trigrams should be deduplicated");
+  });
+
+  it("all trigrams are at least 3 characters", () => {
+    const text = "\u8bf7\u95ee\u6211\u4eec\u4e4b\u524d\u7ea6\u5b9a\u7684\u79d8\u5bc6\u4ee3\u53f7";
+    const trigrams = extractCjkTrigrams(text);
+    for (const t of trigrams) {
+      assert.ok(
+        t.length >= 3,
+        `trigram "${t}" has ${t.length} chars, must be >= 3 for BM25 trigram tokenizer`,
+      );
+    }
+  });
+
+  it("handles mixed CJK and ASCII text", () => {
+    const trigrams = extractCjkTrigrams("hello\u79d8\u5bc6\u4ee3\u53f7test");
+    assert.ok(trigrams.length > 0);
+    assert.ok(trigrams.includes("\u79d8\u5bc6\u4ee3"));
+  });
+});
+
+describe("buildRecallQueries", () => {
+  it("returns deduplicated candidates", () => {
+    const queries = buildRecallQueries("codeword");
+    const unique = new Set(queries);
+    assert.equal(queries.length, unique.size, "candidates must be deduplicated");
+    assert.ok(queries.includes("codeword"));
+  });
+
+  it("includes keyword query and top-3 for multi-keyword prompts", () => {
+    const queries = buildRecallQueries(
+      "What is the secret codeword for our session today?",
+    );
+    assert.ok(queries[0].includes("secret"));
+    assert.ok(queries[0].includes("codeword"));
+    const top3 = queries[1].split(" ");
+    assert.ok(top3.length <= 3);
+  });
+
+  it("includes truncated raw prompt as fallback", () => {
+    const longPrompt = "a".repeat(300);
+    const queries = buildRecallQueries(longPrompt);
+    const hasTruncated = queries.some((q) => q.length === 200);
+    assert.ok(hasTruncated, "should include 200-char truncated fallback");
+  });
+
+  it("includes full raw prompt for moderately long text", () => {
+    const prompt = "word ".repeat(50).trim();
+    const queries = buildRecallQueries(prompt);
+    assert.ok(
+      queries.includes(prompt),
+      "full raw prompt should be present as final candidate",
+    );
+  });
+
+  it("handles CJK text with trigram candidates (>= 3 chars each)", () => {
+    const cjkPrompt = "\u8bf7\u95ee\u6211\u4eec\u4e4b\u524d\u7ea6\u5b9a\u7684\u79d8\u5bc6\u4ee3\u53f7\u662f\u4ec0\u4e48";
+    const queries = buildRecallQueries(cjkPrompt);
+    assert.ok(queries.length >= 2, "should have trigram + raw candidates");
+    // All tokens in the trigram candidate should be >= 3 chars
+    const trigramCandidate = queries.find((q) =>
+      q.split(" ").every((t) => t.length >= 3 && /[\u4e00-\u9fff]/.test(t)),
+    );
+    assert.ok(trigramCandidate, "should have a CJK trigram candidate");
+  });
+
+  it("does not duplicate short CJK prompts", () => {
+    const cjkPrompt = "\u79d8\u5bc6\u4ee3\u53f7";
+    const queries = buildRecallQueries(cjkPrompt);
+    assert.ok(queries.length >= 1);
+    // 4 CJK chars -> 2 trigrams: 秘密代, 密代号
+    const hasTrigram = queries.some((q) => q.includes("\u79d8\u5bc6\u4ee3"));
+    assert.ok(hasTrigram, "should have trigram candidate");
+  });
+
+  it("handles mixed CJK and ASCII with keyword extraction and trigrams", () => {
+    const queries = buildRecallQueries("hello\u4e16\u754c\u4f60\u597d test");
+    assert.ok(queries.some((q) => q.includes("hello")));
+  });
+
+  it("does not produce more than 6 candidates", () => {
+    const queries = buildRecallQueries(
+      "What is the secret codeword for this very long session that we are having today?",
+    );
+    assert.ok(queries.length <= 6, `expected \u22646 candidates, got ${queries.length}`);
+  });
+
+  it("extracts keywords from emoji-containing prompts", () => {
+    const queries = buildRecallQueries(
+      "What is the secret codeword for this session? \ud83d\udd10",
+    );
+    assert.ok(queries.length >= 2, "should have keyword + raw candidates");
+    assert.ok(
+      queries[0].includes("secret"),
+      "first candidate should be extracted keywords",
+    );
+  });
+
+  it("truncates candidates exceeding MAX_QUERY_BYTES", () => {
+    const longCjkPrompt = "\u4e00".repeat(350);
+    const queries = buildRecallQueries(longCjkPrompt);
+    const encoder = new TextEncoder();
+    for (const q of queries) {
+      const byteLen = encoder.encode(q).byteLength;
+      assert.ok(
+        byteLen <= MAX_QUERY_BYTES,
+        `candidate exceeds byte limit: ${byteLen} > ${MAX_QUERY_BYTES}`,
+      );
+    }
+  });
+
+  it("truncates very long ASCII raw prompt to byte limit", () => {
+    const longPrompt = "word ".repeat(400);
+    const queries = buildRecallQueries(longPrompt);
+    const encoder = new TextEncoder();
+    for (const q of queries) {
+      assert.ok(
+        encoder.encode(q).byteLength <= MAX_QUERY_BYTES,
+        "all candidates must be within byte limit",
+      );
+    }
+  });
+
+  it("includes CJK trigram candidates for long pure CJK prompts", () => {
+    const cjkLong = "\u8bf7\u95ee\u6211\u4eec\u4e4b\u524d\u7ea6\u5b9a\u7684\u79d8\u5bc6\u4ee3\u53f7\u662f\u4ec0\u4e48\u8bf7\u53ea\u56de\u7b54\u4ee3\u53f7";
+    const queries = buildRecallQueries(cjkLong);
+    assert.ok(queries.length >= 3, `expected >=3 candidates for CJK, got ${queries.length}`);
+    // All tokens in trigram candidates should be >= 3 chars
+    const trigramCandidate = queries.find((q) =>
+      q.split(" ").every((t) => t.length >= 3),
+    );
+    assert.ok(trigramCandidate, "should have trigram candidate with all tokens >= 3 chars");
+  });
+
+  it("includes 2-char keywords like AI and ID in candidates", () => {
+    const queries = buildRecallQueries("What is the AI codeword for our UK session?");
+    const keywordCandidate = queries[0];
+    assert.ok(
+      keywordCandidate.split(" ").includes("ai"),
+      "keyword candidate should include 'ai'",
+    );
+    assert.ok(
+      keywordCandidate.split(" ").includes("uk"),
+      "keyword candidate should include 'uk'",
+    );
+  });
+
+  it("exports MAX_RESULTS and RRF_K constants", () => {
+    assert.equal(MAX_RESULTS, 5);
+    assert.equal(RRF_K, 60);
+    assert.equal(MAX_QUERY_BYTES, 1024);
+  });
+});


### PR DESCRIPTION
## Description

Fix auto-recall returning empty results for long natural-language prompts in agent-memory BM25 mode (regression of #1462).

## Problem

PR #1520 switched auto-recall to `bm25` mode but still passes the **entire user prompt** as the search query. Long sentences contain many stopwords that dilute BM25 TF-IDF signal, causing no document to reach the relevance threshold — returning `[]` even when a matching memory exists.

## Solution

### Keyword Extraction (`keyword-extract.ts`)

- **Strip non-ASCII** (emoji, smart quotes, CJK, accented letters) before tokenising, so English prompts with stray Unicode still produce keywords
- **Allow 2-char keywords** (AI, ID, UK) for important domain terms
- **Endpoints-inclusive stride sampling** preserves tail topics — the last keyword is always included
- **CJK trigram extraction** — `extractCjkTrigrams()` extracts overlapping 3-char CJK segments; each trigram is >= 3 chars so the BM25 backend uses trigram matching directly (not LIKE AND fallback)
- Candidates capped at 8 keywords, deduplicated, and byte-safe (<= 1024 UTF-8 bytes)

### Auto-recall Loop (`index.ts`)

- **Execute ALL candidates** — no early break on first non-empty result
- **Per-candidate error handling** — a failing candidate (e.g. query > 1024 bytes) does not discard previously merged hits
- **Reciprocal-rank fusion (RRF, k=60)** instead of raw BM25 score comparison, since scores from different queries are not comparable
- **Path-based deduplication** — same memory returned by different candidates is kept once
- **Final cap at 5 results** (MAX_RESULTS)

## Query Candidates

1. Extracted keywords (stride-sampled, <= 8 words)
2. First 3 keywords (shorter fallback)
3. CJK trigram segments (sampled, <= 8 trigrams, all >= 3 chars)
4. CJK trigram top-3 (shorter CJK fallback)
5. Truncated raw prompt (first 200 chars, byte-safe)
6. Full raw prompt (byte-safe, <= 1024 bytes)

## Testing

- 33 unit tests passing across 3 suites (extractKeywords, extractCjkTrigrams, buildRecallQueries)
- Coverage: keyword extraction, 2-char keywords, emoji/smart-quote handling, CJK trigrams, stride sampling, byte-limit truncation, deduplication, RRF constants

## Related

Closes #1572
