### PR TITLE
feat(cosh): export diagnostic bundle

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-shell/Cargo.toml
@@ -14,7 +14,7 @@ name = "cosh-shell"
 path = "src/main.rs"
 
 [dependencies]
-nix = { workspace = true, features = ["fs", "term"] }
+nix = { workspace = true, features = ["dir", "fs", "term"] }
 ratatui = "0.28"
 serde.workspace = true
 serde_json.workspace = true

--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle.rs
@@ -1,0 +1,694 @@
+//! Sanitized, versioned diagnostic bundle export for production troubleshooting.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+
+#[cfg(unix)]
+use nix::dir::{Dir, Type as DirectoryEntryType};
+#[cfg(unix)]
+use nix::fcntl::{openat, OFlag};
+#[cfg(unix)]
+use nix::sys::stat::Mode;
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::config::{load_config, CoshConfig};
+use crate::diagnostics::health::run_health_scan;
+use crate::evidence::redact_sensitive_output;
+
+mod health;
+
+use health::health_json;
+
+const BUNDLE_FORMAT: &str = "cosh-diagnostic-bundle";
+const BUNDLE_VERSION: u32 = 1;
+const DEFAULT_SINCE_HOURS: u64 = 24;
+const MAX_SOURCE_BYTES: u64 = 1024 * 1024;
+const MAX_FILES_PER_SOURCE: usize = 20;
+
+#[derive(Debug, Serialize)]
+struct DiagnosticBundle {
+    format: &'static str,
+    version: u32,
+    created_at_ms: u128,
+    manifest: Vec<ManifestEntry>,
+    sources: BundleSources,
+}
+
+#[derive(Debug, Serialize)]
+struct BundleSources {
+    environment: Value,
+    configuration: Value,
+    health: Option<Value>,
+    recent_events: Vec<CollectedFile>,
+    logs: Vec<CollectedFile>,
+    crashes: Vec<CollectedFile>,
+}
+
+#[derive(Debug, Serialize)]
+struct CollectedFile {
+    path: String,
+    modified_at_ms: Option<u128>,
+    content: String,
+    truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ManifestEntry {
+    source: &'static str,
+    status: SourceStatus,
+    items: usize,
+    detail: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SourceStatus {
+    Included,
+    Unavailable,
+    Partial,
+}
+
+#[derive(Debug)]
+struct ExportOptions {
+    output: PathBuf,
+    since: Duration,
+}
+
+pub(crate) fn run_cli(args: &[String]) -> i32 {
+    let top_level_help = args
+        .first()
+        .is_some_and(|flag| flag == "--help" || flag == "-h");
+    let export_help = matches!(
+        args,
+        [command, flag] if command == "export" && (flag == "--help" || flag == "-h")
+    );
+    if top_level_help || export_help {
+        print_help();
+        return 0;
+    }
+    let options = match parse_args(args) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{message}");
+            print_help();
+            return 2;
+        }
+    };
+
+    match export(&options) {
+        Ok(()) => {
+            println!("{}", options.output.display());
+            0
+        }
+        Err(error) => {
+            eprintln!("diagnostic bundle export failed: {error}");
+            1
+        }
+    }
+}
+
+fn parse_args(args: &[String]) -> Result<ExportOptions, String> {
+    if args.first().map(String::as_str) != Some("export") {
+        return Err("expected `diagnostics export`".to_string());
+    }
+    let mut output = None;
+    let mut since_hours = DEFAULT_SINCE_HOURS;
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--output" | "-o" => {
+                let value = args
+                    .get(index + 1)
+                    .filter(|value| !value.starts_with('-'))
+                    .ok_or_else(|| "--output requires a path".to_string())?;
+                output = Some(PathBuf::from(value));
+                index += 2;
+            }
+            "--since-hours" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| "--since-hours requires a positive integer".to_string())?;
+                since_hours = value
+                    .parse::<u64>()
+                    .ok()
+                    .filter(|hours| *hours > 0)
+                    .ok_or_else(|| "--since-hours requires a positive integer".to_string())?;
+                since_hours
+                    .checked_mul(3600)
+                    .ok_or_else(|| "--since-hours is too large".to_string())?;
+                index += 2;
+            }
+            other => return Err(format!("unknown diagnostics export option: {other}")),
+        }
+    }
+    Ok(ExportOptions {
+        output: output.unwrap_or_else(default_output_path),
+        since: Duration::from_secs(since_hours * 3600),
+    })
+}
+
+fn print_help() {
+    eprintln!("Usage: cosh-shell diagnostics export [--output PATH] [--since-hours HOURS]");
+}
+
+fn default_output_path() -> PathBuf {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    PathBuf::from(format!("cosh-diagnostic-{seconds}.json"))
+}
+
+fn export(options: &ExportOptions) -> io::Result<()> {
+    if options.output.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("refusing to overwrite {}", options.output.display()),
+        ));
+    }
+
+    let config = load_config();
+    let health = run_health_scan(&config.health).map(health_json);
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let (logs, log_errors) = collect_named_files(
+        home.as_deref().map(|path| path.join(".copilot-shell/logs")),
+        options.since,
+        |_| true,
+    );
+    let (recent_events, event_errors) = collect_named_files(
+        home.as_deref().map(|path| path.join(".copilot-shell")),
+        options.since,
+        |name| contains_any(name, &["event", "activity", "audit", "journal"]),
+    );
+    let (crashes, crash_errors) = collect_named_files(
+        home.as_deref().map(|path| path.join(".copilot-shell")),
+        options.since,
+        |name| contains_any(name, &["crash", "panic", "error"]),
+    );
+
+    let manifest = vec![
+        included("environment", 1),
+        included("configuration", 1),
+        optional("health", usize::from(health.is_some()), Vec::new()),
+        optional("recent_events", recent_events.len(), event_errors),
+        optional("logs", logs.len(), log_errors),
+        optional("crashes", crashes.len(), crash_errors),
+    ];
+    let bundle = DiagnosticBundle {
+        format: BUNDLE_FORMAT,
+        version: BUNDLE_VERSION,
+        created_at_ms: now_ms(),
+        manifest,
+        sources: BundleSources {
+            environment: environment_json(),
+            configuration: config_json(&config),
+            health,
+            recent_events,
+            logs,
+            crashes,
+        },
+    };
+    let serialized = serde_json::to_string_pretty(&bundle).map_err(io::Error::other)?;
+    atomic_private_write(&options.output, serialized.as_bytes())
+}
+
+fn included(source: &'static str, items: usize) -> ManifestEntry {
+    ManifestEntry {
+        source,
+        status: SourceStatus::Included,
+        items,
+        detail: None,
+    }
+}
+
+fn optional(source: &'static str, items: usize, errors: Vec<String>) -> ManifestEntry {
+    let status = match (items, errors.is_empty()) {
+        (0, _) => SourceStatus::Unavailable,
+        (_, true) => SourceStatus::Included,
+        _ => SourceStatus::Partial,
+    };
+    ManifestEntry {
+        source,
+        status,
+        items,
+        detail: (!errors.is_empty()).then(|| redact(&errors.join("; "))),
+    }
+}
+
+fn environment_json() -> Value {
+    json!({
+        "cosh_shell_version": env!("CARGO_PKG_VERSION"),
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "family": std::env::consts::FAMILY,
+        "current_executable": std::env::current_exe().ok().and_then(|path| path.file_name().map(|name| name.to_string_lossy().into_owned())),
+    })
+}
+
+fn config_json(config: &CoshConfig) -> Value {
+    json!({
+        "shell_default": redact(&config.shell_default),
+        "analysis_mode": redact(&config.analysis_mode),
+        "approval_mode": redact(&config.approval_mode),
+        "adapter_default": redact(&config.adapter_default),
+        "language": redact(&config.language),
+        "startup_banner": config.startup_banner,
+        "startup_hooks": config.startup_hooks,
+        "debug": config.debug,
+        "log_level": redact(&config.log_level),
+        "ai_enabled": config.ai_enabled,
+        "health": {
+            "enabled": config.health.enabled,
+            "role": config.health.role.as_deref().map(redact),
+            "memory_sensitive": config.health.memory_sensitive,
+            "critical_mounts": config.health.critical_mounts.iter().map(|value| redact(value)).collect::<Vec<_>>(),
+            "verbose": config.health.verbose,
+            "configured_services": config.health.services.len(),
+        },
+        "trusted_commands_count": config.trusted_commands.len(),
+        "trusted_project_roots_count": config.trusted_project_roots.len(),
+    })
+}
+
+fn collect_named_files<F>(
+    root: Option<PathBuf>,
+    since: Duration,
+    include: F,
+) -> (Vec<CollectedFile>, Vec<String>)
+where
+    F: Fn(&str) -> bool,
+{
+    #[cfg(unix)]
+    {
+        collect_named_files_unix(root, since, include)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (root, since, include);
+        (
+            Vec::new(),
+            vec!["secure diagnostic collection is unavailable on this platform".to_string()],
+        )
+    }
+}
+
+#[cfg(unix)]
+fn collect_named_files_unix<F>(
+    root: Option<PathBuf>,
+    since: Duration,
+    include: F,
+) -> (Vec<CollectedFile>, Vec<String>)
+where
+    F: Fn(&str) -> bool,
+{
+    let Some(root) = root else {
+        return (Vec::new(), vec!["HOME is unavailable".to_string()]);
+    };
+    let cutoff = SystemTime::now().checked_sub(since).unwrap_or(UNIX_EPOCH);
+    let mut errors = Vec::new();
+    let mut sources = open_source_files(&root, &include, cutoff, &mut errors);
+    sources.sort_by_key(|source| source.metadata.modified().ok());
+    sources.reverse();
+    if sources.len() > MAX_FILES_PER_SOURCE {
+        errors.push(format!(
+            "source file limit reached; included newest {MAX_FILES_PER_SOURCE} files"
+        ));
+    }
+    sources.truncate(MAX_FILES_PER_SOURCE);
+
+    let files = sources
+        .into_iter()
+        .filter_map(|source| match read_opened_source(source) {
+            Ok(file) => Some(file),
+            Err(error) => {
+                errors.push(format!("source: {error}"));
+                None
+            }
+        })
+        .collect();
+    (files, errors)
+}
+
+#[cfg(unix)]
+fn open_source_files<F>(
+    root: &Path,
+    include: &F,
+    cutoff: SystemTime,
+    errors: &mut Vec<String>,
+) -> Vec<OpenedSource>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut directory = match Dir::open(
+        root,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW,
+        Mode::empty(),
+    ) {
+        Ok(directory) => directory,
+        Err(error) => {
+            errors.push(format!("{}: {error}", display_private_path(root)));
+            return Vec::new();
+        }
+    };
+    let mut sources = Vec::new();
+    let directory_fd = directory.as_raw_fd();
+    for entry in directory.iter() {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                errors.push(format!("{}: {error}", display_private_path(root)));
+                continue;
+            }
+        };
+        let name = entry.file_name();
+        let Ok(name) = name.to_str() else {
+            continue;
+        };
+        if matches!(name, "." | "..") {
+            continue;
+        }
+        if !include(name) {
+            continue;
+        }
+        if matches!(entry.file_type(), Some(DirectoryEntryType::Symlink)) {
+            continue;
+        }
+        let file = match openat(
+            Some(directory_fd),
+            name,
+            OFlag::O_RDONLY | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        ) {
+            Ok(fd) => {
+                // `openat` transfers ownership of a newly opened descriptor to this `File`.
+                unsafe { File::from_raw_fd(fd) }
+            }
+            Err(error) => {
+                errors.push(format!("{}: {error}", redact(name)));
+                continue;
+            }
+        };
+        let metadata = match file.metadata() {
+            Ok(metadata) if metadata.file_type().is_file() => metadata,
+            Ok(_) => continue,
+            Err(error) => {
+                errors.push(format!("{}: {error}", redact(name)));
+                continue;
+            }
+        };
+        if metadata.modified().is_ok_and(|modified| modified >= cutoff) {
+            sources.push(OpenedSource {
+                name: redact(name),
+                file,
+                metadata,
+            });
+        }
+    }
+    sources
+}
+
+#[cfg(unix)]
+struct OpenedSource {
+    name: String,
+    file: File,
+    metadata: fs::Metadata,
+}
+
+#[cfg(unix)]
+fn read_opened_source(mut source: OpenedSource) -> io::Result<CollectedFile> {
+    let truncated = source.metadata.len() > MAX_SOURCE_BYTES;
+    if truncated {
+        source
+            .file
+            .seek(SeekFrom::End(-(MAX_SOURCE_BYTES as i64)))?;
+    }
+    let mut bytes = Vec::with_capacity(source.metadata.len().min(MAX_SOURCE_BYTES) as usize);
+    source.file.take(MAX_SOURCE_BYTES).read_to_end(&mut bytes)?;
+    let content = String::from_utf8_lossy(&bytes).into_owned();
+    Ok(CollectedFile {
+        path: source.name,
+        modified_at_ms: source.metadata.modified().ok().map(system_time_ms),
+        content: redact(&content),
+        truncated,
+    })
+}
+
+fn contains_any(value: &str, needles: &[&str]) -> bool {
+    let value = value.to_ascii_lowercase();
+    needles.iter().any(|needle| value.contains(needle))
+}
+
+fn display_private_path(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "<source>".to_string())
+}
+
+fn redact(input: &str) -> String {
+    let (input, _) = redact_sensitive_output(input);
+    let mut output = String::with_capacity(input.len());
+    for (index, line) in input.lines().enumerate() {
+        if index > 0 {
+            output.push('\n');
+        }
+        output.push_str(&redact_line(line));
+    }
+    if input.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+fn redact_line(line: &str) -> String {
+    let mut line = line.to_string();
+    for key in [
+        "password",
+        "passwd",
+        "token",
+        "secret",
+        "api_key",
+        "api-key",
+        "apikey",
+        "access_key",
+        "access-key",
+        "authorization",
+        "credential",
+    ] {
+        line = redact_key_value(&line, key);
+    }
+    redact_url_userinfo(&redact_token_prefixes(&line))
+}
+
+fn redact_key_value(input: &str, key: &str) -> String {
+    let lower = input.to_ascii_lowercase();
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    while let Some(relative) = lower[cursor..].find(key) {
+        let start = cursor + relative;
+        let key_end = start + key.len();
+        let boundary_before = start == 0 || !lower.as_bytes()[start - 1].is_ascii_alphanumeric();
+        let boundary_after =
+            key_end == lower.len() || !lower.as_bytes()[key_end].is_ascii_alphanumeric();
+        if !boundary_before || !boundary_after {
+            output.push_str(&input[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        }
+        let rest = &input[key_end..];
+        let separator = rest
+            .chars()
+            .next()
+            .filter(|ch| ch.is_whitespace())
+            .map(|_| (0, 0))
+            .or_else(|| rest.find(['=', ':']).map(|offset| (offset, 1)));
+        let Some((separator, separator_width)) = separator else {
+            output.push_str(&input[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        };
+        if separator > 3 {
+            output.push_str(&input[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        }
+        let value_start = key_end + separator + separator_width;
+        let prefix = &input[value_start..];
+        let whitespace = prefix.len() - prefix.trim_start().len();
+        let value_start = value_start + whitespace;
+        let quote = input
+            .as_bytes()
+            .get(value_start)
+            .copied()
+            .filter(|byte| *byte == b'"' || *byte == b'\'');
+        let content_start = value_start + usize::from(quote.is_some());
+        let value_end = input[content_start..]
+            .find(|ch: char| {
+                quote.map_or(ch.is_whitespace() || ch == ',' || ch == '}', |q| {
+                    ch as u8 == q
+                })
+            })
+            .map(|end| content_start + end)
+            .unwrap_or(input.len());
+        output.push_str(&input[cursor..content_start]);
+        output.push_str("<redacted>");
+        cursor = value_end;
+    }
+    output.push_str(&input[cursor..]);
+    output
+}
+
+fn redact_token_prefixes(input: &str) -> String {
+    const PREFIXES: &[(&str, usize)] = &[
+        ("github_pat_", 16),
+        ("ghp_", 12),
+        ("glpat-", 16),
+        ("xoxb-", 16),
+        ("npm_", 16),
+        ("pypi-", 16),
+        ("AIza", 20),
+        ("sk-", 16),
+    ];
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    while cursor < input.len() {
+        let Some((start, prefix, minimum_len)) = PREFIXES
+            .iter()
+            .filter_map(|(prefix, minimum_len)| {
+                input[cursor..]
+                    .find(prefix)
+                    .map(|offset| (cursor + offset, *prefix, *minimum_len))
+            })
+            .min_by_key(|(start, _, _)| *start)
+        else {
+            break;
+        };
+        let end = input[start..]
+            .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')))
+            .map(|offset| start + offset)
+            .unwrap_or(input.len());
+        if end - start < minimum_len {
+            output.push_str(&input[cursor..start + prefix.len()]);
+            cursor = start + prefix.len();
+            continue;
+        }
+        output.push_str(&input[cursor..start]);
+        output.push_str("<redacted>");
+        cursor = end;
+    }
+    output.push_str(&input[cursor..]);
+    output
+}
+
+fn redact_url_userinfo(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    while let Some(relative_scheme) = input[cursor..].find("://") {
+        let authority_start = cursor + relative_scheme + 3;
+        let authority_end = input[authority_start..]
+            .find(|ch: char| ch.is_whitespace() || matches!(ch, '/' | '?' | '#'))
+            .map(|offset| authority_start + offset)
+            .unwrap_or(input.len());
+        let Some(relative_at) = input[authority_start..authority_end].rfind('@') else {
+            output.push_str(&input[cursor..authority_start]);
+            cursor = authority_start;
+            continue;
+        };
+        let at = authority_start + relative_at;
+        output.push_str(&input[cursor..authority_start]);
+        output.push_str("<redacted>@");
+        cursor = at + 1;
+    }
+    output.push_str(&input[cursor..]);
+    output
+}
+
+fn atomic_private_write(path: &Path, content: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    fs::create_dir_all(parent)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("bundle");
+    let (temporary, mut file) = create_private_temp(parent, file_name)?;
+    let result = (|| {
+        file.write_all(content)?;
+        file.sync_all()?;
+        fs::hard_link(&temporary, path)
+    })();
+    drop(file);
+    let _ = fs::remove_file(&temporary);
+    result
+}
+
+fn create_private_temp(parent: &Path, file_name: &str) -> io::Result<(PathBuf, File)> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    create_private_temp_with_nonce(parent, file_name, nonce)
+}
+
+fn create_private_temp_with_nonce(
+    parent: &Path,
+    file_name: &str,
+    nonce: u128,
+) -> io::Result<(PathBuf, File)> {
+    for attempt in 0..16_u128 {
+        let path = parent.join(format!(
+            ".{file_name}.{}.{}.tmp",
+            std::process::id(),
+            nonce.saturating_add(attempt)
+        ));
+        match private_new_file(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique diagnostic bundle temporary file",
+    ))
+}
+
+#[cfg(unix)]
+fn private_new_file(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn private_new_file(path: &Path) -> io::Result<File> {
+    let _ = path;
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "secure diagnostic bundle permissions are unavailable on this platform",
+    ))
+}
+
+fn now_ms() -> u128 {
+    system_time_ms(SystemTime::now())
+}
+
+fn system_time_ms(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+#[path = "bundle/tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle/health.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle/health.rs
@@ -1,0 +1,122 @@
+//! Projection of health reports into the stable diagnostic bundle schema.
+
+use serde_json::{json, Value};
+
+use super::redact;
+use crate::diagnostics::health::{
+    HealthCollector, HealthFactValue, HealthFindingCategory, HealthScanReport, HealthTryKind,
+    HealthUnavailableReason,
+};
+
+pub(super) fn health_json(report: HealthScanReport) -> Value {
+    let facts = report
+        .facts
+        .into_iter()
+        .map(|fact| {
+            let value = match fact.value {
+                HealthFactValue::String(value) => Value::String(redact(&value)),
+                HealthFactValue::Integer(value) => json!(value),
+                HealthFactValue::Unsigned(value) => json!(value),
+                HealthFactValue::Float(value) => json!(value),
+                HealthFactValue::Bool(value) => json!(value),
+            };
+            json!({
+                "id": redact(&fact.id),
+                "key": redact(&fact.key),
+                "value": value,
+                "unit": fact.unit.as_deref().map(redact),
+            })
+        })
+        .collect::<Vec<_>>();
+    let findings = report
+        .findings
+        .into_iter()
+        .map(|finding| {
+            json!({
+                "id": redact(&finding.id),
+                "severity": finding.severity.label(),
+                "category": finding_category(finding.category),
+                "detail_args": finding.detail_args.into_iter().map(|(key, value)| (redact(&key), redact(&value))).collect::<std::collections::BTreeMap<_, _>>(),
+                "evidence_fact_ids": finding.evidence_fact_ids.into_iter().map(|value| redact(&value)).collect::<Vec<_>>(),
+                "suggested_try_ids": finding.suggested_try_ids.into_iter().map(|value| redact(&value)).collect::<Vec<_>>(),
+            })
+        })
+        .collect::<Vec<_>>();
+    let unavailable = report
+        .unavailable
+        .into_iter()
+        .map(|item| {
+            json!({
+                "collector": collector_label(item.collector),
+                "reason": unavailable_reason(item.reason),
+                "severity": item.severity.label(),
+                "elapsed_ms": item.elapsed_ms,
+            })
+        })
+        .collect::<Vec<_>>();
+    let try_items = report
+        .try_items
+        .into_iter()
+        .map(|item| {
+            json!({
+                "id": redact(&item.id),
+                "kind": try_kind(item.kind),
+                "command": item.command.as_deref().map(redact),
+                "score": item.score,
+                "finding_id": redact(&item.finding_id),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "scan_id": redact(&report.scan_id),
+        "host": report.host.as_deref().map(redact),
+        "role": report.role.as_deref().map(redact),
+        "started_at_ms": report.started_at_ms,
+        "elapsed_ms": report.elapsed_ms,
+        "overall_severity": report.overall_severity.label(),
+        "health_score": report.health_score,
+        "checks_done": report.checks_done.iter().map(|value| redact(value)).collect::<Vec<_>>(),
+        "facts": facts,
+        "findings": findings,
+        "unavailable": unavailable,
+        "try_items": try_items,
+    })
+}
+
+fn finding_category(category: HealthFindingCategory) -> &'static str {
+    match category {
+        HealthFindingCategory::RootCause => "root_cause",
+        HealthFindingCategory::Anomaly => "anomaly",
+        HealthFindingCategory::Observation => "observation",
+        HealthFindingCategory::CollectionGap => "collection_gap",
+    }
+}
+
+fn collector_label(collector: HealthCollector) -> &'static str {
+    match collector {
+        HealthCollector::Host => "host",
+        HealthCollector::Cpu => "cpu",
+        HealthCollector::Memory => "memory",
+        HealthCollector::Disk => "disk",
+        HealthCollector::KernelSignal => "kernel_signal",
+        HealthCollector::ConfiguredService => "configured_service",
+    }
+}
+
+fn unavailable_reason(reason: HealthUnavailableReason) -> &'static str {
+    match reason {
+        HealthUnavailableReason::Unsupported => "unsupported",
+        HealthUnavailableReason::PermissionDenied => "permission_denied",
+        HealthUnavailableReason::CommandMissing => "command_missing",
+        HealthUnavailableReason::Timeout => "timeout",
+        HealthUnavailableReason::ParseError => "parse_error",
+    }
+}
+
+fn try_kind(kind: HealthTryKind) -> &'static str {
+    match kind {
+        HealthTryKind::AskAgent => "ask_agent",
+        HealthTryKind::DisplayCommand => "display_command",
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle/tests.rs
@@ -1,0 +1,173 @@
+use super::*;
+
+#[test]
+fn redacts_representative_secrets_and_private_keys() {
+    let input = "token=abc123 password: hunter2 ghp_abcdefghijklmnopqrstuvwxyz\n\
+                 authorization: \"Bearer abc\"\nAuthorization: Bearer unquoted-secret\n\
+                 {\"key\":\"sk-abcdefghijklmnopqrstuvwxyz\"}\n\
+                 cosh --token \"cli secret with spaces\"\n\
+                 url=https://example.test/?access_token=query-secret\n\
+                 mirrors=https://user:basic-password@example.test Bearer first-secret Bearer second-secret\n\
+                 -----BEGIN PRIVATE KEY-----\nsecret-body\n-----END PRIVATE KEY-----\nkeep=true";
+    let output = redact(input);
+    for secret in [
+        "abc123",
+        "hunter2",
+        "ghp_abcdefghijklmnopqrstuvwxyz",
+        "Bearer abc",
+        "unquoted-secret",
+        "sk-abcdefghijklmnopqrstuvwxyz",
+        "cli secret with spaces",
+        "query-secret",
+        "user:basic-password",
+        "first-secret",
+        "second-secret",
+        "secret-body",
+    ] {
+        assert!(!output.contains(secret), "secret leaked: {secret}");
+    }
+    assert!(output.contains("keep=true"));
+}
+
+#[test]
+fn collection_reports_when_the_file_limit_is_reached() {
+    let directory = test_directory("file-limit");
+    fs::create_dir_all(&directory).unwrap_or_else(|error| panic!("mkdir failed: {error}"));
+    for index in 0..=MAX_FILES_PER_SOURCE {
+        fs::write(
+            directory.join(format!("event-{index}.log")),
+            index.to_string(),
+        )
+        .unwrap_or_else(|error| panic!("write fixture failed: {error}"));
+    }
+
+    let (files, errors) =
+        collect_named_files(Some(directory.clone()), Duration::from_secs(3600), |_| true);
+    assert_eq!(files.len(), MAX_FILES_PER_SOURCE);
+    assert!(errors.iter().any(|error| error.contains("limit reached")));
+    cleanup(&directory);
+}
+
+#[cfg(unix)]
+#[test]
+fn collection_does_not_follow_file_or_directory_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let directory = test_directory("symlink");
+    let root = directory.join("root");
+    let outside = directory.join("outside");
+    fs::create_dir_all(&root).unwrap_or_else(|error| panic!("mkdir root failed: {error}"));
+    fs::create_dir_all(&outside).unwrap_or_else(|error| panic!("mkdir outside failed: {error}"));
+    fs::write(outside.join("secret.log"), "must-not-be-collected")
+        .unwrap_or_else(|error| panic!("write outside file failed: {error}"));
+    symlink(outside.join("secret.log"), root.join("linked-file.log"))
+        .unwrap_or_else(|error| panic!("symlink file failed: {error}"));
+    symlink(&outside, root.join("linked-directory"))
+        .unwrap_or_else(|error| panic!("symlink directory failed: {error}"));
+
+    let (files, errors) = collect_named_files(Some(root), Duration::from_secs(3600), |_| true);
+    assert!(files.is_empty());
+    assert!(errors.is_empty());
+    cleanup(&directory);
+}
+
+#[test]
+fn parser_accepts_output_and_time_window() {
+    let options = parse_args(&[
+        "export".to_string(),
+        "--output".to_string(),
+        "bundle.json".to_string(),
+        "--since-hours".to_string(),
+        "6".to_string(),
+    ])
+    .unwrap_or_else(|error| panic!("parse failed: {error}"));
+    assert_eq!(options.output, PathBuf::from("bundle.json"));
+    assert_eq!(options.since, Duration::from_secs(6 * 3600));
+}
+
+#[test]
+fn help_succeeds_and_excessive_time_window_is_rejected() {
+    assert_eq!(run_cli(&["--help".to_string()]), 0);
+    assert_eq!(run_cli(&["export".to_string(), "--help".to_string()]), 0);
+    let error = parse_args(&[
+        "export".to_string(),
+        "--since-hours".to_string(),
+        u64::MAX.to_string(),
+    ])
+    .expect_err("overflowing time window must fail");
+    assert_eq!(error, "--since-hours is too large");
+}
+
+#[test]
+fn truncated_sources_keep_the_recent_tail() {
+    let directory = test_directory("tail");
+    fs::create_dir_all(&directory).unwrap_or_else(|error| panic!("mkdir failed: {error}"));
+    let path = directory.join("large.log");
+    let mut content = b"old-head-must-not-survive\n".to_vec();
+    content.resize(MAX_SOURCE_BYTES as usize + 64, b'x');
+    content.extend_from_slice(b"\nrecent-tail-must-survive\n");
+    fs::write(&path, content).unwrap_or_else(|error| panic!("write failed: {error}"));
+
+    let (files, errors) =
+        collect_named_files(Some(directory.clone()), Duration::from_secs(3600), |_| true);
+    assert!(errors.is_empty(), "{errors:?}");
+    let collected = files.into_iter().next().expect("collect large source");
+    assert!(collected.truncated);
+    assert!(!collected.content.contains("old-head-must-not-survive"));
+    assert!(collected.content.contains("recent-tail-must-survive"));
+    cleanup(&directory);
+}
+
+#[cfg(unix)]
+#[test]
+fn writes_bundle_with_private_permissions_and_refuses_overwrite() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = test_directory("permissions");
+    fs::create_dir_all(&directory).unwrap_or_else(|error| panic!("mkdir failed: {error}"));
+    let path = directory.join("bundle.json");
+    atomic_private_write(&path, b"safe").unwrap_or_else(|error| panic!("write failed: {error}"));
+    let mode = fs::metadata(&path)
+        .unwrap_or_else(|error| panic!("metadata failed: {error}"))
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600);
+    assert!(atomic_private_write(&path, b"overwrite").is_err());
+    cleanup(&directory);
+}
+
+#[test]
+fn temporary_file_collision_preserves_existing_file() {
+    let directory = test_directory("temporary-collision");
+    fs::create_dir_all(&directory).unwrap_or_else(|error| panic!("mkdir failed: {error}"));
+    let nonce = 42;
+    let existing = directory.join(format!(".bundle.{}.{}.tmp", std::process::id(), nonce));
+    fs::write(&existing, "must-survive")
+        .unwrap_or_else(|error| panic!("write collision fixture failed: {error}"));
+
+    let (temporary, file) = create_private_temp_with_nonce(&directory, "bundle", nonce)
+        .unwrap_or_else(|error| panic!("create temporary file failed: {error}"));
+    drop(file);
+
+    assert_ne!(temporary, existing);
+    assert_eq!(
+        fs::read_to_string(&existing)
+            .unwrap_or_else(|error| panic!("read collision failed: {error}")),
+        "must-survive"
+    );
+    fs::remove_file(&temporary).unwrap_or_else(|error| panic!("remove temporary failed: {error}"));
+    cleanup(&directory);
+}
+
+fn test_directory(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "cosh-diagnostic-{label}-test-{}-{}",
+        std::process::id(),
+        now_ms()
+    ))
+}
+
+fn cleanup(path: &Path) {
+    fs::remove_dir_all(path).unwrap_or_else(|error| panic!("cleanup failed: {error}"));
+}

--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod bundle;
 pub(crate) mod health;

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/mod.rs
@@ -16,4 +16,5 @@ pub(crate) use context_window::{
 };
 pub(crate) use model::{evidence_capture_status_for_block, EvidenceCaptureStatus};
 pub(crate) use output_policy::output_excerpt_status_for_block;
+pub(crate) use output_text::redact_sensitive_output;
 pub(crate) use redaction::redact_sensitive_text;

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/output_text.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/output_text.rs
@@ -56,7 +56,8 @@ pub(super) fn provider_output_preview(
     }
 }
 
-pub(super) fn redact_sensitive_output(text: &str) -> (String, bool) {
+/// Applies the shared output policy before content crosses a durable or provider boundary.
+pub(crate) fn redact_sensitive_output(text: &str) -> (String, bool) {
     let (redacted, changed, _) = redact_sensitive_output_with_policy(text);
     (redacted, changed)
 }

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/public.rs
@@ -4,6 +4,7 @@ mod output_text;
 mod redaction;
 
 pub(crate) use model::{evidence_capture_status_for_block, EvidenceCaptureStatus};
+pub(crate) use output_text::redact_sensitive_output;
 
 pub use context_window::{
     build_context_window, build_related_history_index, context_blocks_from_entries,

--- a/src/cosh-ng/crates/cosh-shell/src/main.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/main.rs
@@ -85,6 +85,9 @@ fn main() {
         print_usage_help();
         std::process::exit(0);
     }
+    if args.get(1).map(String::as_str) == Some("diagnostics") {
+        std::process::exit(diagnostics::bundle::run_cli(&args[2..]));
+    }
 
     runtime::terminal::install_terminal_recovery();
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -420,6 +420,7 @@ pub(crate) fn print_usage_help() {
          \n\
          Modes:\n\
           raw [adapter] [--run]   Interactive mode with AI (adapters: fake, claude, co, qwen, cosh-core)\n\
+          diagnostics export      Export a redacted diagnostic bundle\n\
            demo                    Demo with synthetic events\n\
          \n\
          Options:\n\

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli.rs
@@ -22,6 +22,8 @@ mod cancellation;
 mod config;
 #[path = "raw_cli/cosh_core/mod.rs"]
 mod cosh_core;
+#[path = "raw_cli/diagnostics.rs"]
+mod diagnostics;
 #[path = "raw_cli/evidence_request.rs"]
 mod evidence_request;
 #[path = "raw_cli/failed_command.rs"]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/diagnostics.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/diagnostics.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+#[test]
+fn diagnostics_export_collects_sources_without_leaking_secrets() {
+    let home = temp_shell_home("diagnostics-export");
+    let state = home.join(".copilot-shell");
+    let logs = state.join("logs");
+    fs::create_dir_all(&logs).expect("create log directory");
+    fs::write(
+        logs.join("cosh-shell.log.current"),
+        "request token=diagnostic-secret-token\n",
+    )
+    .expect("write diagnostic log");
+    fs::write(
+        state.join("audit-events.jsonl"),
+        "{\"authorization\":\"Bearer diagnostic-secret-auth\"}\n",
+    )
+    .expect("write diagnostic events");
+    fs::write(
+        state.join("last-crash.log"),
+        "password: diagnostic-secret-password\n",
+    )
+    .expect("write crash summary");
+    let output = home.join("diagnostic.json");
+
+    let command_output = Command::new(env!("CARGO_BIN_EXE_cosh-shell"))
+        .args(["diagnostics", "export", "--output"])
+        .arg(&output)
+        .env("HOME", &home)
+        .env("COSH_SHELL_HEALTH_SCAN", "fixture:linux-healthy")
+        .output()
+        .expect("run diagnostics export");
+    assert!(
+        command_output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&command_output.stderr)
+    );
+
+    let content = fs::read_to_string(&output).expect("read diagnostic bundle");
+    let bundle: serde_json::Value =
+        serde_json::from_str(&content).expect("parse diagnostic bundle");
+    assert_eq!(bundle["format"], "cosh-diagnostic-bundle");
+    assert_eq!(bundle["version"], 1);
+    assert_eq!(bundle["sources"]["health"]["overall_severity"], "ok");
+    assert!(bundle["sources"]["health"]["findings"].is_array());
+    assert!(bundle["sources"]["health"]["unavailable"].is_array());
+    assert!(bundle["sources"]["health"]["try_items"].is_array());
+    assert!(!content.contains("diagnostic-secret-token"));
+    assert!(!content.contains("diagnostic-secret-auth"));
+    assert!(!content.contains("diagnostic-secret-password"));
+    assert!(content.contains("<redacted>"));
+    assert_eq!(
+        fs::metadata(&output)
+            .expect("diagnostic metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    let _ = fs::remove_dir_all(home);
+}


### PR DESCRIPTION
## Description

Adds `cosh-shell diagnostics export` to produce a versioned, redacted JSON bundle containing environment and configuration summaries, health output, bounded recent logs, events, and crash records. Source collection is descriptor-bound to reject symlinks and output publication is private and collision-safe.

## Related Issue

closes #1544

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p cosh-shell --all-targets -- -D warnings`
- `cargo test -p cosh-shell --lib -- --test-threads=4` (776 passed)
- `cargo test -p cosh-shell --test raw_cli diagnostics::diagnostics_export_collects_sources_without_leaking_secrets -- --exact --test-threads=1`

## Additional Notes

The export refuses overwrites, writes files with mode `0600`, redacts sensitive material, and bounds source size and count.