### PR TITLE
fix(sec-core): expose skill ledger verdicts

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
@@ -1,6 +1,7 @@
 """Read-only daemon handlers for security and observability SQLite data."""
 
 import json
+from pathlib import PurePath
 from typing import Any
 
 from agent_sec_cli.daemon.errors import BadRequestError
@@ -17,7 +18,7 @@ from agent_sec_cli.observability.correlation import (
 )
 from agent_sec_cli.observability.models import ObservabilityEventRecord
 from agent_sec_cli.observability.sqlite_reader import ObservabilityReader
-from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.schema import SecurityEvent, extract_verdict
 from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
 from agent_sec_cli.utils.timestamp import (
     normalize_iso_to_utc_iso,
@@ -350,9 +351,51 @@ def _security_filters(params: dict[str, Any]) -> dict[str, str | None]:
 
 def _event_payload(event: SecurityEvent, *, include_details: bool) -> dict[str, Any]:
     payload = event.to_dict()
+    payload.update(_dashboard_event_fields(event))
     if not include_details:
         payload.pop("details", None)
     return payload
+
+
+def _dashboard_event_fields(event: SecurityEvent) -> dict[str, str]:
+    """Project optional fields needed by dashboard event rows."""
+    fields: dict[str, str] = {}
+    verdict = extract_verdict(event.details)
+    if verdict is not None:
+        fields["verdict"] = verdict
+
+    if event.category != "skill_ledger":
+        return fields
+
+    result = event.details.get("result")
+    result_data = result if isinstance(result, dict) else {}
+    request = event.details.get("request")
+    request_data = request if isinstance(request, dict) else {}
+
+    command = _first_non_empty_string(
+        result_data.get("command"), request_data.get("command")
+    )
+    if command is not None:
+        fields["command"] = command
+
+    if isinstance(result_data.get("results"), list):
+        return fields
+
+    skill_name = _first_non_empty_string(result_data.get("skill_name"))
+    if skill_name is None:
+        skill_dir = _first_non_empty_string(request_data.get("skill_dir"))
+        if skill_dir is not None:
+            skill_name = PurePath(skill_dir).name or None
+    if skill_name is not None:
+        fields["skill_name"] = skill_name
+    return fields
+
+
+def _first_non_empty_string(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 def _observability_item(row: ObservabilityEventRecord) -> dict[str, Any]:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/skill_ledger.py
@@ -47,6 +47,16 @@ _PASSPHRASE_EXISTING_KEY_ERROR = (
 )
 _CAMEL_ACRONYM_BOUNDARY_RE = re.compile(r"(.)([A-Z][a-z]+)")
 _CAMEL_WORD_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
+_VERDICT_SEVERITY = {
+    "pass": 0,
+    "none": 1,
+    "warn": 2,
+    "unmanaged": 3,
+    "drifted": 4,
+    "deny": 5,
+    "tampered": 6,
+    "error": 7,
+}
 
 
 def _to_snake_case(value: str) -> str:
@@ -85,9 +95,60 @@ def _snake_case_event_keys(value: Any) -> Any:
     return normalized
 
 
+def _known_verdict(value: Any) -> str | None:
+    """Return a recognized Skill Ledger verdict value."""
+    if isinstance(value, str) and value in _VERDICT_SEVERITY:
+        return value
+    return None
+
+
+def _batch_verdict(results: Any) -> str | None:
+    """Return the most severe verdict from a batch command result."""
+    if not isinstance(results, list):
+        return None
+
+    verdicts: list[str] = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        for value in (item.get("status"), item.get("verdict")):
+            verdict = _known_verdict(value)
+            if verdict is not None:
+                verdicts.append(verdict)
+
+    if not verdicts:
+        return None
+    return max(verdicts, key=_VERDICT_SEVERITY.__getitem__)
+
+
+def _project_event_verdict(data: dict[str, Any]) -> str | None:
+    """Project command-specific output into the canonical event verdict."""
+    command = data.get("command")
+    if not isinstance(command, str):
+        return None
+
+    if command in {"init", "scan", "check"} and "results" in data:
+        return _batch_verdict(data.get("results"))
+    if command == "show":
+        return _known_verdict(data.get("latest_status"))
+    if command == "check":
+        return _known_verdict(data.get("status"))
+    if command in {"scan", "certify"}:
+        return _known_verdict(data.get("verdict"))
+    if command == "decide":
+        return _known_verdict(data.get("current_status")) or _known_verdict(
+            data.get("verdict")
+        )
+    return None
+
+
 def _normalize_event_result(data: dict[str, Any]) -> dict[str, Any]:
     """Build the Skill Ledger event-only result payload."""
-    return _snake_case_event_keys(data)
+    normalized = _snake_case_event_keys(data)
+    verdict = _project_event_verdict(normalized)
+    if verdict is not None:
+        normalized["verdict"] = verdict
+    return normalized
 
 
 class SkillLedgerBackend(BaseBackend):

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -30,6 +30,13 @@ from pathlib import Path
 import agent_sec_cli.security_events as security_events
 import pytest
 from agent_sec_cli.cli import app as cli_app
+from agent_sec_cli.daemon.handlers.security_query import (
+    security_events_list_handler,
+    security_summary_handler,
+)
+from agent_sec_cli.daemon.protocol import DaemonRequest
+from agent_sec_cli.daemon.runtime import DaemonRuntime
+from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
 from agent_sec_cli.skill_ledger import config as config_module
 from agent_sec_cli.skill_ledger.core import decision as decision_core
 from agent_sec_cli.skill_ledger.core import live_root as live_root_core
@@ -2400,6 +2407,94 @@ def test_show_reports_active_latest_decision_and_root_match(ws):
     assert "allow after review" in out["message"]
     assert out["warnings"]
     assert out["warnings"] == [out["message"]]
+
+
+def test_show_event_flows_through_jsonl_sqlite_and_dashboard(ws, monkeypatch):
+    skill = make_skill(ws.skills_dir, "dashboard-show", {"data.txt": "safe"})
+    findings = write_findings_file(
+        ws.fixtures,
+        "dashboard-show-pass.json",
+        [{"rule": "ok", "level": "pass", "message": "pass"}],
+    )
+    event_data = ws.root / "events_dashboard_show"
+    event_data.mkdir()
+    env = ws.env({"AGENT_SEC_DATA_DIR": str(event_data)})
+
+    reset_security_event_writers()
+    try:
+        certified = run_skill_ledger(
+            ["certify", str(skill), "--findings", str(findings)],
+            env_extra=env,
+        )
+        shown = run_skill_ledger(["show", str(skill)], env_extra=env)
+    finally:
+        reset_security_event_writers()
+
+    assert certified.returncode == 0, certified.stderr
+    assert shown.returncode == 0, shown.stderr
+    stdout_result = parse_json_output(shown.stdout)
+    assert stdout_result["latestStatus"] == "pass"
+    assert "verdict" not in stdout_result
+
+    jsonl_events = read_security_events(event_data)
+    show_jsonl = next(
+        event
+        for event in jsonl_events
+        if event["details"]["result"].get("command") == "show"
+    )
+    assert show_jsonl["details"]["result"]["verdict"] == "pass"
+    assert show_jsonl["details"]["result"]["skill_name"] == skill.name
+
+    sqlite_reader = SqliteEventReader(path=event_data / "security-events.db")
+    try:
+        pass_events = sqlite_reader.query(
+            category="skill_ledger",
+            verdict="pass",
+        )
+        show_sqlite = next(
+            event
+            for event in pass_events
+            if event.details["result"].get("command") == "show"
+        )
+        assert show_sqlite.event_id == show_jsonl["event_id"]
+        assert sqlite_reader.count_by("verdict", category="skill_ledger") == {"pass": 2}
+    finally:
+        sqlite_reader.close()
+
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(event_data))
+    runtime = DaemonRuntime(socket_path=event_data / "daemon.sock")
+    list_result = security_events_list_handler(
+        DaemonRequest(
+            method="sec.events.list",
+            params={"category": "skill_ledger", "verdict": "pass"},
+        ),
+        runtime,
+    )
+    dashboard_show = next(
+        item
+        for item in list_result.data["items"]
+        if item["event_id"] == show_jsonl["event_id"]
+    )
+    assert dashboard_show["verdict"] == "pass"
+    assert dashboard_show["command"] == "show"
+    assert dashboard_show["skill_name"] == skill.name
+    assert "details" not in dashboard_show
+
+    summary_result = security_summary_handler(
+        DaemonRequest(
+            method="sec.summary",
+            params={"category": "skill_ledger", "latest_limit": 10},
+        ),
+        runtime,
+    )
+    summary_show = next(
+        item
+        for item in summary_result.data["latest_events"]
+        if item["event_id"] == show_jsonl["event_id"]
+    )
+    assert summary_show["verdict"] == "pass"
+    assert summary_show["command"] == "show"
+    assert summary_show["skill_name"] == skill.name
 
 
 def test_show_findings_summary_handles_missing_fields_and_empty_findings(ws):

--- a/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
@@ -179,6 +179,93 @@ def test_security_event_queries_read_sqlite_data(tmp_path: Path) -> None:
     assert summary_response.data["affected_runs"] == 2
 
 
+def test_skill_ledger_dashboard_fields_are_available_without_details(
+    tmp_path: Path,
+) -> None:
+    details = {
+        "request": {"command": "show", "skill_dir": "/opt/skills/demo"},
+        "result": {
+            "command": "show",
+            "verdict": "deny",
+            "skill_name": "demo",
+            "latest_status": "deny",
+        },
+    }
+    _write_security_event(
+        tmp_path,
+        event_id="skill-show",
+        event_type="skill_ledger",
+        category="skill_ledger",
+        details=details,
+    )
+
+    list_response = _call_daemon(tmp_path, "sec.events.list")
+    list_item = list_response.data["items"][0]
+    assert list_item["verdict"] == "deny"
+    assert list_item["command"] == "show"
+    assert list_item["skill_name"] == "demo"
+    assert "details" not in list_item
+
+    get_response = _call_daemon(
+        tmp_path,
+        "sec.events.get",
+        {"event_id": "skill-show"},
+    )
+    get_item = get_response.data["event"]
+    assert get_item["verdict"] == "deny"
+    assert get_item["command"] == "show"
+    assert get_item["skill_name"] == "demo"
+    assert get_item["details"] == details
+
+    summary_response = _call_daemon(tmp_path, "sec.summary")
+    latest_item = summary_response.data["latest_events"][0]
+    assert latest_item["verdict"] == "deny"
+    assert latest_item["command"] == "show"
+    assert latest_item["skill_name"] == "demo"
+    assert "details" not in latest_item
+
+
+def test_skill_ledger_dashboard_skill_name_fallback_skips_batch_events() -> None:
+    failed_event = SecurityEvent(
+        event_type="skill_ledger",
+        category="skill_ledger",
+        result="failed",
+        details={
+            "request": {"command": "check", "skill_dir": "/opt/skills/fallback"},
+            "result": {},
+        },
+    )
+    failed_payload = security_query._event_payload(
+        failed_event,
+        include_details=False,
+    )
+
+    assert failed_payload["command"] == "check"
+    assert failed_payload["skill_name"] == "fallback"
+    assert "verdict" not in failed_payload
+
+    batch_event = SecurityEvent(
+        event_type="skill_ledger",
+        category="skill_ledger",
+        details={
+            "request": {"command": "check", "skill_dir": "/opt/skills/not-a-skill"},
+            "result": {
+                "command": "check",
+                "verdict": "tampered",
+                "results": [{"skill_name": "a", "status": "tampered"}],
+            },
+        },
+    )
+    batch_payload = security_query._event_payload(
+        batch_event,
+        include_details=False,
+    )
+
+    assert batch_payload["command"] == "check"
+    assert batch_payload["verdict"] == "tampered"
+    assert "skill_name" not in batch_payload
+
+
 def test_security_summary_handler_uses_repository_summary(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -430,6 +517,7 @@ def test_security_events_list_filters_by_verdict(tmp_path: Path) -> None:
     assert len(response.data["items"]) == 2
     returned_ids = {item["event_id"] for item in response.data["items"]}
     assert returned_ids == {"deny-1", "deny-2"}
+    assert all(item["verdict"] == "deny" for item in response.data["items"])
 
 
 def test_security_events_list_normalizes_explicit_since_until(tmp_path: Path) -> None:

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -12,6 +12,10 @@ import pytest
 from agent_sec_cli.security_events.schema import SecurityEvent, extract_verdict
 from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
 from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
+from agent_sec_cli.security_middleware.backends.skill_ledger import (
+    SkillLedgerBackend,
+)
+from agent_sec_cli.security_middleware.result import ActionResult
 
 CORRELATION_BASE_EPOCH = 1_800_000_000.0
 
@@ -1001,6 +1005,76 @@ class TestVerdictSqlFilter:
         assert len(events) == 3
         total = reader.count()
         assert total == 7
+
+
+def test_new_skill_ledger_events_populate_existing_verdict_index(
+    writer: SqliteEventWriter,
+    reader: SqliteEventReader,
+    db_path: str,
+) -> None:
+    backend = SkillLedgerBackend()
+    show_details = backend.build_event_details(
+        ActionResult(
+            success=True,
+            data={
+                "command": "show",
+                "latestStatus": "deny",
+                "skillName": "risky-skill",
+                "latest": {"scanStatus": "deny"},
+                "active": {"scanStatus": "pass"},
+            },
+        ),
+        {"command": "show", "skill_dir": "/opt/skills/risky-skill"},
+    )
+    check_details = backend.build_event_details(
+        ActionResult(
+            success=False,
+            data={
+                "command": "check",
+                "status": "tampered",
+                "skillName": "tampered-skill",
+            },
+        ),
+        {"command": "check", "skill_dir": "/opt/skills/tampered-skill"},
+    )
+    historical_details = {
+        "request": {"command": "show", "skill_dir": "/opt/skills/old"},
+        "result": {
+            "command": "show",
+            "latest_status": "deny",
+            "latest": {"verdict": "deny"},
+        },
+    }
+
+    for event_id, details in (
+        ("new-show", show_details),
+        ("new-check", check_details),
+        ("historical-shape", historical_details),
+    ):
+        writer.write(
+            SecurityEvent(
+                event_id=event_id,
+                event_type="skill_ledger",
+                category="skill_ledger",
+                details=details,
+            )
+        )
+
+    assert [event.event_id for event in reader.query(verdict="deny")] == ["new-show"]
+    assert [event.event_id for event in reader.query(verdict="tampered")] == [
+        "new-check"
+    ]
+    assert reader.count_by("verdict", category="skill_ledger") == {
+        "deny": 1,
+        "tampered": 1,
+    }
+
+    with sqlite3.connect(db_path) as conn:
+        historical_verdict = conn.execute(
+            "SELECT verdict FROM security_events WHERE event_id = ?",
+            ("historical-shape",),
+        ).fetchone()
+    assert historical_verdict == (None,)
 
 
 def _details_verdict(details: dict[str, Any]) -> str | None:

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_skill_ledger_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_skill_ledger_backend.py
@@ -59,6 +59,7 @@ def test_check_event_result_keeps_skill_ledger_status_contract():
     assert warn_result == {
         "command": "check",
         "status": "warn",
+        "verdict": "warn",
         "skill_name": "demo",
         "version_id": "v000001",
         "created_at": "2026-06-17T00:00:00+00:00",
@@ -78,6 +79,7 @@ def test_check_event_result_keeps_skill_ledger_status_contract():
     assert tampered_result == {
         "command": "check",
         "status": "tampered",
+        "verdict": "tampered",
         "skill_name": "demo",
         "version_id": "v000001",
         "created_at": "2026-06-17T00:00:00+00:00",
@@ -186,6 +188,72 @@ def test_scan_and_certify_event_results_use_scan_verdict_contract():
     }
 
 
+def test_show_event_result_uses_latest_status_instead_of_active_verdict():
+    result = _event_result(
+        {
+            "command": "show",
+            "latestStatus": "deny",
+            "latestVersionId": "v000002",
+            "activeVersionId": "v000001",
+            "skillName": "demo",
+            "latest": {
+                "versionId": "v000002",
+                "status": "deny",
+                "scanStatus": "deny",
+            },
+            "active": {
+                "versionId": "v000001",
+                "status": "pass",
+                "scanStatus": "pass",
+            },
+        }
+    )
+
+    assert result["verdict"] == "deny"
+    assert result["latest"]["verdict"] == "deny"
+    assert result["active"]["verdict"] == "pass"
+
+
+def test_show_event_result_uses_latest_risk_state():
+    for latest_status in ("drifted", "tampered", "unmanaged"):
+        result = _event_result(
+            {
+                "command": "show",
+                "latestStatus": latest_status,
+                "skillName": "demo",
+                "latest": {"status": latest_status, "scanStatus": "pass"},
+                "active": {"status": "pass", "scanStatus": "pass"},
+            }
+        )
+
+        assert result["verdict"] == latest_status
+        assert result["latest"]["verdict"] == "pass"
+        assert result["active"]["verdict"] == "pass"
+
+
+def test_decide_event_result_prefers_current_status_then_scan_verdict():
+    drifted_result = _event_result(
+        {
+            "command": "decide",
+            "status": "decided",
+            "currentStatus": "drifted",
+            "scanStatus": "pass",
+            "skillName": "demo",
+        }
+    )
+    fallback_result = _event_result(
+        {
+            "command": "decide",
+            "status": "decided",
+            "scanStatus": "warn",
+            "skillName": "demo",
+        }
+    )
+
+    assert drifted_result["verdict"] == "drifted"
+    assert fallback_result["verdict"] == "warn"
+
+
 def test_batch_event_results_keep_command_and_child_result_contracts():
     scan_all_result = _event_result(
         {
@@ -226,6 +294,7 @@ def test_batch_event_results_keep_command_and_child_result_contracts():
     assert scan_all_result == {
         "command": "scan",
         "key_created": False,
+        "verdict": "deny",
         "results": [
             {
                 "status": "scanned",
@@ -245,6 +314,7 @@ def test_batch_event_results_keep_command_and_child_result_contracts():
         "command": "init",
         "key_created": True,
         "baseline": True,
+        "verdict": "warn",
         "results": [
             {
                 "status": "scanned",
@@ -254,6 +324,48 @@ def test_batch_event_results_keep_command_and_child_result_contracts():
             }
         ],
     }
+
+
+def test_batch_check_event_result_uses_declared_severity_order():
+    cases = (
+        (["pass", "none"], "none"),
+        (["none", "warn"], "warn"),
+        (["warn", "unmanaged"], "unmanaged"),
+        (["unmanaged", "drifted"], "drifted"),
+        (["drifted", "deny"], "deny"),
+        (["deny", "tampered"], "tampered"),
+        (["tampered", "error"], "error"),
+    )
+
+    for statuses, expected in cases:
+        result = _event_result(
+            {
+                "command": "check",
+                "results": [
+                    {"skillName": f"skill-{index}", "status": status}
+                    for index, status in enumerate(statuses)
+                ],
+            }
+        )
+
+        assert result["verdict"] == expected
+
+
+def test_status_verbose_event_result_does_not_project_verdict():
+    result = _event_result(
+        {
+            "command": "status",
+            "skills": {
+                "discovered": 1,
+                "breakdown": {"tampered": 1},
+                "health": "critical",
+            },
+            "results": [{"skillName": "demo-skill", "status": "tampered"}],
+        }
+    )
+
+    assert "verdict" not in result
+    assert result["results"] == [{"skill_name": "demo-skill", "status": "tampered"}]
 
 
 def test_non_scan_commands_normalize_names_without_changing_business_meaning():
@@ -367,8 +479,13 @@ def test_event_details_are_safe_copies_with_redacted_request():
     }
     original = deepcopy(data)
 
+    action_result = ActionResult(
+        success=True,
+        data=data,
+        stdout=json.dumps(data, ensure_ascii=False) + "\n",
+    )
     details = backend.build_event_details(
-        ActionResult(success=True, data=data),
+        action_result,
         {"command": "scan", "passphrase": "secret"},
     )
 
@@ -381,6 +498,8 @@ def test_event_details_are_safe_copies_with_redacted_request():
         "key_created": True,
     }
     assert data == original
+    assert action_result.data == original
+    assert json.loads(action_result.stdout) == original
 
 
 def test_decide_backend_requires_action_unless_clear(monkeypatch):

--- a/src/agentsight/dashboard/src/pages/security/utils.ts
+++ b/src/agentsight/dashboard/src/pages/security/utils.ts
@@ -190,6 +190,7 @@ export function verdictTone(value: string | null | undefined): VerdictTone {
   }
   if (
     v === 'drifted'
+    || v === 'unmanaged'
     || v.includes('warn')
     || v.includes('review')
     || v.includes('caution')

--- a/src/agentsight/dashboard/src/pages/security/utils.ts
+++ b/src/agentsight/dashboard/src/pages/security/utils.ts
@@ -163,7 +163,8 @@ export function securityDetailRows(details: unknown): Array<{ label: string; val
 }
 
 export function securityEventVerdict(event: SecurityEventRecord): string {
-  const value = findDetailValue(event.details ?? event.details_preview, ['verdict']);
+  const value = event.verdict
+    ?? findDetailValue(event.details ?? event.details_preview, ['verdict']);
   return value === undefined || value === null ? '-' : recordPreview(value);
 }
 
@@ -187,11 +188,18 @@ export function verdictTone(value: string | null | undefined): VerdictTone {
   ) {
     return 'pass';
   }
-  if (v.includes('warn') || v.includes('review') || v.includes('caution') || v.includes('suspicious')) {
+  if (
+    v === 'drifted'
+    || v.includes('warn')
+    || v.includes('review')
+    || v.includes('caution')
+    || v.includes('suspicious')
+  ) {
     return 'warning';
   }
   if (
-    v.includes('deny')
+    v === 'tampered'
+    || v.includes('deny')
     || v.includes('block')
     || v.includes('fail')
     || v.includes('error')

--- a/src/agentsight/dashboard/src/test/SecurityObservabilityPage.test.tsx
+++ b/src/agentsight/dashboard/src/test/SecurityObservabilityPage.test.tsx
@@ -232,10 +232,10 @@ describe('SecurityObservabilityPage', () => {
     mockFetchSecuritySummary.mockResolvedValueOnce({
       state: 'ok',
       data: {
-        total: 2,
-        by_category: { skill_ledger: 2 },
-        by_event_type: { skill_ledger_show: 2 },
-        by_result: { succeeded: 2 },
+        total: 3,
+        by_category: { skill_ledger: 3 },
+        by_event_type: { skill_ledger_show: 3 },
+        by_result: { succeeded: 3 },
         affected_sessions: 0,
         affected_runs: 0,
         latest_events: [summaryEvent],
@@ -246,7 +246,11 @@ describe('SecurityObservabilityPage', () => {
       data: {
         group_by: groupBy,
         items: groupBy === 'verdict'
-          ? [{ value: 'tampered', count: 1 }, { value: 'drifted', count: 1 }]
+          ? [
+            { value: 'tampered', count: 1 },
+            { value: 'drifted', count: 1 },
+            { value: 'unmanaged', count: 1 },
+          ]
           : defaultSecurityCountItems(groupBy),
       },
     }));
@@ -261,10 +265,12 @@ describe('SecurityObservabilityPage', () => {
       expect(within(recentEventsCard!).getByText('tampered')).toHaveClass('bg-red-100');
     });
     expect(await screen.findByText('存在 1 个风险 verdict')).toBeInTheDocument();
-    expect(screen.getByText('风险 1 / Warning 1')).toBeInTheDocument();
-    const driftedBadge = screen.getAllByText('drifted')
-      .find((element) => element.classList.contains('bg-amber-100'));
-    expect(driftedBadge).toBeDefined();
+    expect(screen.getByText('风险 1 / Warning 2')).toBeInTheDocument();
+    for (const verdict of ['drifted', 'unmanaged']) {
+      const warningBadge = screen.getAllByText(verdict)
+        .find((element) => element.classList.contains('bg-amber-100'));
+      expect(warningBadge).toBeDefined();
+    }
   });
 
   it('uses exact verdict counts instead of the overview event sample', async () => {

--- a/src/agentsight/dashboard/src/test/SecurityObservabilityPage.test.tsx
+++ b/src/agentsight/dashboard/src/test/SecurityObservabilityPage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
 vi.mock('../utils/apiClient', () => ({
   SecurityApiClientError: class SecurityApiClientError extends Error {
@@ -216,6 +216,55 @@ describe('SecurityObservabilityPage', () => {
     expect(screen.queryByText('正常')).not.toBeInTheDocument();
     expect(screen.queryByText('近期事件')).not.toBeInTheDocument();
     expect(screen.queryByText('latest events')).not.toBeInTheDocument();
+  });
+
+  it('uses summary verdicts when the detailed event sample is unavailable', async () => {
+    const summaryEvent = {
+      event_id: 'skill-ledger-show',
+      event_type: 'skill_ledger_show',
+      category: 'skill_ledger',
+      result: 'succeeded',
+      verdict: 'tampered',
+      command: 'show',
+      skill_name: 'demo-skill',
+      timestamp: '2026-06-09T00:00:00+00:00',
+    };
+    mockFetchSecuritySummary.mockResolvedValueOnce({
+      state: 'ok',
+      data: {
+        total: 2,
+        by_category: { skill_ledger: 2 },
+        by_event_type: { skill_ledger_show: 2 },
+        by_result: { succeeded: 2 },
+        affected_sessions: 0,
+        affected_runs: 0,
+        latest_events: [summaryEvent],
+      },
+    });
+    mockFetchSecurityCountBy.mockImplementation((groupBy: string) => Promise.resolve({
+      state: 'ok',
+      data: {
+        group_by: groupBy,
+        items: groupBy === 'verdict'
+          ? [{ value: 'tampered', count: 1 }, { value: 'drifted', count: 1 }]
+          : defaultSecurityCountItems(groupBy),
+      },
+    }));
+    mockFetchSecurityEvents.mockRejectedValueOnce(new Error('recent events unavailable'));
+
+    render(<SecurityObservabilityPage />);
+
+    const recentEventsHeading = await screen.findByText('近期安全事件');
+    const recentEventsCard = recentEventsHeading.closest<HTMLElement>('.rounded-lg');
+    expect(recentEventsCard).not.toBeNull();
+    await waitFor(() => {
+      expect(within(recentEventsCard!).getByText('tampered')).toHaveClass('bg-red-100');
+    });
+    expect(await screen.findByText('存在 1 个风险 verdict')).toBeInTheDocument();
+    expect(screen.getByText('风险 1 / Warning 1')).toBeInTheDocument();
+    const driftedBadge = screen.getAllByText('drifted')
+      .find((element) => element.classList.contains('bg-amber-100'));
+    expect(driftedBadge).toBeDefined();
   });
 
   it('uses exact verdict counts instead of the overview event sample', async () => {

--- a/src/agentsight/dashboard/src/test/securityUtils.test.ts
+++ b/src/agentsight/dashboard/src/test/securityUtils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  securityEventVerdict,
+  verdictBadgeClasses,
+  verdictTone,
+} from '../pages/security/utils';
+import type { SecurityEventRecord } from '../utils/apiClient';
+
+describe('security dashboard verdict utilities', () => {
+  it('prefers a top-level verdict while preserving nested fallback support', () => {
+    const projectedEvent: SecurityEventRecord = {
+      event_id: 'skill-ledger-show',
+      category: 'skill_ledger',
+      command: 'show',
+      skill_name: 'demo-skill',
+      verdict: 'tampered',
+      details: { verdict: 'pass' },
+    };
+    const legacyEvent: SecurityEventRecord = {
+      event_id: 'legacy-event',
+      details_preview: { verdict: 'warn' },
+    };
+
+    expect(securityEventVerdict(projectedEvent)).toBe('tampered');
+    expect(securityEventVerdict(legacyEvent)).toBe('warn');
+    expect(securityEventVerdict({ event_id: 'missing-verdict' })).toBe('-');
+  });
+
+  it.each([
+    ['tampered', 'risk', 'bg-red-100'],
+    ['drifted', 'warning', 'bg-amber-100'],
+  ] as const)('classifies %s as %s', (verdict, tone, badgeClass) => {
+    expect(verdictTone(verdict)).toBe(tone);
+    expect(verdictBadgeClasses(verdict)).toContain(badgeClass);
+  });
+});

--- a/src/agentsight/dashboard/src/test/securityUtils.test.ts
+++ b/src/agentsight/dashboard/src/test/securityUtils.test.ts
@@ -30,6 +30,7 @@ describe('security dashboard verdict utilities', () => {
   it.each([
     ['tampered', 'risk', 'bg-red-100'],
     ['drifted', 'warning', 'bg-amber-100'],
+    ['unmanaged', 'warning', 'bg-amber-100'],
   ] as const)('classifies %s as %s', (verdict, tone, badgeClass) => {
     expect(verdictTone(verdict)).toBe(tone);
     expect(verdictBadgeClasses(verdict)).toContain(badgeClass);

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -792,6 +792,9 @@ export interface SecurityEventRecord {
   event_type?: string | null;
   category?: string | null;
   result?: string | null;
+  verdict?: string | null;
+  command?: string | null;
+  skill_name?: string | null;
   timestamp?: string | null;
   timestamp_ns?: number | null;
   timestamp_epoch?: number | null;


### PR DESCRIPTION
## Description

Skill Ledger `show` events currently keep verdicts only under the latest and active
objects, so SQLite cannot index one canonical verdict and Dashboard rows without
details cannot display key fields. This change projects command-specific Skill Ledger
states into `details.result.verdict` without changing CLI results, then exposes optional
`verdict`, `command`, and `skill_name` fields on Dashboard API rows. Dashboard consumers
prefer those top-level fields when details are omitted and classify `tampered` as risk
and `drifted` as warning. Batch `init`, `scan`, and `check` commands use the most severe
child result, while historical records, SQLite schema, and telemetry remain unchanged.

## Related Issue

no-issue: internal security observability compatibility requirement has no public GitHub issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/agent-sec-core
make python-code-pretty
uv run --project agent-sec-cli pytest \
  tests/unit-test/security_middleware/backends/test_skill_ledger_backend.py \
  tests/unit-test/security_events/ \
  tests/unit-test/daemon/test_security_query_handler.py \
  tests/unit-test/telemetry/ \
  tests/integration-test/skill-ledger/test_skill_ledger_integration.py -q

cd ../agentsight/dashboard
npm test -- src/test/securityUtils.test.ts src/test/SecurityObservabilityPage.test.tsx
npm run typecheck
npm run build:embed

cd ../../..
git diff --check upstream/main...HEAD
```

Result: 442 backend tests and 14 targeted Dashboard tests passed. Dashboard typecheck
and the production embed build also passed.

## Additional Notes

- Existing records with a null verdict are intentionally not reprojected.
- `status`, `audit`, `export`, `list-scanners`, and `init-keys` intentionally do not
  project a canonical verdict; `status --verbose` preserves child statuses only.
- No SQLite schema version or SLS telemetry changes are included.
- The full Dashboard suite retains 13 unrelated failures in `AgentHealthSidebar`,
  `App`, and `TokenSavingsPage`; the identical failures reproduce on `upstream/main`.
