### PR TITLE
feat(sec-core): observability hook for qodercli

### DIFF
--- a/src/agent-sec-core/qoder-plugin/hooks/hooks.json
+++ b/src/agent-sec-core/qoder-plugin/hooks/hooks.json
@@ -6,6 +6,20 @@
         "hooks": [
           {
             "type": "command",
+            "name": "agent-sec-observability",
+            "description": "Records the agent run start for local security observability",
+            "command": "python3",
+            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "name": "agent-sec-pii-user-prompt",
             "description": "Scans user prompts for PII and credentials",
             "command": "python3",
@@ -26,6 +40,20 @@
       }
     ],
     "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "description": "Records a tool call before execution",
+            "command": "python3",
+            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      },
       {
         "matcher": "Skill",
         "hooks": [
@@ -61,12 +89,74 @@
         "hooks": [
           {
             "type": "command",
+            "name": "agent-sec-observability",
+            "description": "Records a successful tool call result",
+            "command": "python3",
+            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "name": "agent-sec-pii-tool-output",
             "description": "Scans tool output for PII and credentials before model context",
             "command": "python3",
             "args": ["${QODER_PLUGIN_ROOT}/hooks/pii_checker_hook.py"],
             "timeout": 10,
             "statusMessage": "Checking tool output for PII..."
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "description": "Records a failed tool call",
+            "command": "python3",
+            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "description": "Records successful agent run completion",
+            "command": "python3",
+            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "agent-sec-observability",
+            "description": "Records failed agent run completion",
+            "command": "python3",
+            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "timeout": 10,
+            "async": true
           }
         ]
       }

--- a/src/agent-sec-core/qoder-plugin/hooks/observability_hook.py
+++ b/src/agent-sec-core/qoder-plugin/hooks/observability_hook.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Record Qoder agent and tool lifecycle events as AgentSec observability data.
+
+Qoder does not expose model-call lifecycle events, so this hook deliberately
+maps only agent-run and tool-call events. The hook is fail-open and never emits
+a Qoder decision. Sensitive metrics are persisted only after local PII
+redaction succeeds.
+"""
+
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from qoder_hook_common import trace_context
+
+_CLI_TIMEOUT_SECONDS = 3
+_MAX_PAYLOAD_SIZE = 1024 * 1024
+# Qoder does not expose a stable run identifier across its hook events. Match
+# the Hermes/Qwen adapters and use a schema-compatible zero GUID rather than
+# inventing plugin-owned correlation state.
+_ZERO_RUN_ID = "00000000-0000-0000-0000-000000000000"
+_OBSERVABILITY_COMMAND = [
+    "agent-sec-cli",
+    "observability",
+    "record",
+    "--format",
+    "json",
+    "--stdin",
+]
+_PII_REDACT_COMMAND = [
+    "agent-sec-cli",
+    "scan-pii",
+    "--stdin",
+    "--format",
+    "json",
+    "--redact-output",
+    "--include-low-confidence",
+    "--source",
+    "observability",
+]
+_SENSITIVE_METRIC_KEYS = {
+    "prompt",
+    "user_input",
+    "system_prompt",
+    "messages",
+    "response",
+    "parameters",
+    "result",
+    "error",
+    "tool_calls",
+}
+_DROP = object()
+
+
+def _diagnostic(message: str) -> None:
+    """Write a payload-free diagnostic without affecting Qoder execution."""
+    print(f"qoder-observability-hook: {message}", file=sys.stderr)
+
+
+def _read_stdin_payload() -> str | bytes | None:
+    """Read one bounded hook payload, returning ``None`` when oversized."""
+    stream = getattr(sys.stdin, "buffer", sys.stdin)
+    payload = stream.read(_MAX_PAYLOAD_SIZE + 1)
+    if len(payload) > _MAX_PAYLOAD_SIZE:
+        _diagnostic(f"hook input exceeds {_MAX_PAYLOAD_SIZE} bytes; skipping event")
+        return None
+    return payload
+
+
+def _json_dumps(value: Any) -> str:
+    """Serialize values deterministically for subprocess input and hashing."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
+
+
+def _json_size_bytes(value: Any) -> int:
+    """Return the UTF-8 size of one deterministic JSON representation."""
+    return len(_json_dumps(value).encode("utf-8"))
+
+
+def _value_to_text(value: Any) -> str:
+    """Convert a hook value to the exact text sent to PII scanning."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return _json_dumps(value)
+
+
+def _pii_scan_input_sha256(value: Any) -> str | None:
+    """Return the hash used to correlate a redaction PII security event."""
+    text = _value_to_text(value)
+    if not text.strip():
+        return None
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _now_iso() -> str:
+    """Return a timezone-aware UTC timestamp in wire format."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _non_empty_string(value: Any) -> str | None:
+    """Return a stripped non-empty string, otherwise ``None``."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _observability_metadata(
+    context: dict[str, str], *, needs_tool_call_id: bool = False
+) -> dict[str, str] | None:
+    """Build metadata accepted by the current AgentSec schema."""
+    session_id = _non_empty_string(context.get("session_id"))
+    if session_id is None:
+        return None
+
+    metadata = {
+        "sessionId": session_id,
+        "runId": _ZERO_RUN_ID,
+    }
+    if needs_tool_call_id:
+        tool_call_id = _non_empty_string(context.get("tool_call_id"))
+        if tool_call_id is None:
+            return None
+        metadata["toolCallId"] = tool_call_id
+        call_id = _non_empty_string(context.get("call_id"))
+        if call_id is not None:
+            metadata["callId"] = call_id
+    return metadata
+
+
+def _with_resolved_trace_context(args: list[str], context: dict[str, str]) -> list[str]:
+    """Prepend one host-derived trace context to an AgentSec CLI command."""
+    return [
+        args[0],
+        "--trace-context",
+        json.dumps(context, ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+        *args[1:],
+    ]
+
+
+def _base_record(
+    context: dict[str, str],
+    *,
+    hook: str,
+    metrics: dict[str, Any],
+    needs_tool_call_id: bool = False,
+) -> dict[str, Any] | None:
+    """Build one record accepted by the current AgentSec schema."""
+    if not metrics:
+        return None
+    metadata = _observability_metadata(context, needs_tool_call_id=needs_tool_call_id)
+    if metadata is None:
+        return None
+    return {
+        "hook": hook,
+        "observedAt": _now_iso(),
+        "metadata": metadata,
+        "metrics": metrics,
+    }
+
+
+def _build_user_prompt_submit(
+    input_data: dict[str, Any], context: dict[str, str]
+) -> dict[str, Any] | None:
+    """Map ``UserPromptSubmit`` to ``before_agent_run``."""
+    prompt = input_data.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return None
+    metrics: dict[str, Any] = {
+        "prompt": prompt,
+        "user_input": prompt,
+    }
+    pii_hash = _pii_scan_input_sha256(prompt)
+    if pii_hash is not None:
+        metrics["pii_scan_input_sha256"] = pii_hash
+    return _base_record(
+        context,
+        hook="before_agent_run",
+        metrics=metrics,
+    )
+
+
+def _build_pre_tool_use(
+    input_data: dict[str, Any], context: dict[str, str]
+) -> dict[str, Any] | None:
+    """Map ``PreToolUse`` to ``before_tool_call``."""
+    metrics: dict[str, Any] = {}
+    tool_name = _non_empty_string(input_data.get("tool_name"))
+    if tool_name is not None:
+        metrics["tool_name"] = tool_name
+    if "tool_input" in input_data:
+        tool_input = input_data["tool_input"]
+        metrics["parameters"] = tool_input
+        pii_hash = _pii_scan_input_sha256(tool_input)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+    return _base_record(
+        context,
+        hook="before_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _extract_exit_code(tool_response: Any) -> Any:
+    """Return a directly exposed tool exit code without guessing response shapes."""
+    if not isinstance(tool_response, dict):
+        return None
+    if "exit_code" in tool_response:
+        return tool_response["exit_code"]
+    if "exitCode" in tool_response:
+        return tool_response["exitCode"]
+    return None
+
+
+def _exit_status(exit_code: Any) -> str | None:
+    """Derive a status only when Qoder exposes an integer exit code."""
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+        return None
+    return "success" if exit_code == 0 else "error"
+
+
+def _build_post_tool_use(
+    input_data: dict[str, Any], context: dict[str, str]
+) -> dict[str, Any] | None:
+    """Map successful ``PostToolUse`` to ``after_tool_call``."""
+    metrics: dict[str, Any] = {"status": "success"}
+    if "tool_response" in input_data:
+        tool_response = input_data["tool_response"]
+        metrics["result"] = tool_response
+        metrics["result_size_bytes"] = _json_size_bytes(tool_response)
+        pii_hash = _pii_scan_input_sha256(tool_response)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+
+        exit_code = _extract_exit_code(tool_response)
+        if exit_code is not None:
+            metrics["exit_code"] = exit_code
+        status = _exit_status(exit_code)
+        if status is not None:
+            metrics["status"] = status
+    return _base_record(
+        context,
+        hook="after_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _build_post_tool_use_failure(
+    input_data: dict[str, Any], context: dict[str, str]
+) -> dict[str, Any] | None:
+    """Map ``PostToolUseFailure`` to a failed ``after_tool_call`` record."""
+    metrics: dict[str, Any] = {
+        "status": "interrupted" if input_data.get("is_interrupt") is True else "error"
+    }
+    if "error" in input_data:
+        error = input_data["error"]
+        metrics["error"] = error
+        pii_hash = _pii_scan_input_sha256(error)
+        if pii_hash is not None:
+            metrics["pii_scan_input_sha256"] = pii_hash
+    return _base_record(
+        context,
+        hook="after_tool_call",
+        metrics=metrics,
+        needs_tool_call_id=True,
+    )
+
+
+def _build_stop(
+    input_data: dict[str, Any], context: dict[str, str]
+) -> dict[str, Any] | None:
+    """Map ``Stop`` to a successful ``after_agent_run`` record."""
+    response = input_data.get("last_assistant_message", "")
+    has_text = isinstance(response, str) and bool(response)
+    metrics: dict[str, Any] = {
+        "response": response,
+        "output_kind": "text" if has_text else "empty",
+        "assistant_texts_count": 1 if has_text else 0,
+        "success": True,
+    }
+    return _base_record(
+        context,
+        hook="after_agent_run",
+        metrics=metrics,
+    )
+
+
+def _build_stop_failure(
+    input_data: dict[str, Any], context: dict[str, str]
+) -> dict[str, Any] | None:
+    """Map ``StopFailure`` to a failed ``after_agent_run`` record."""
+    response = input_data.get("last_assistant_message", "")
+    has_text = isinstance(response, str) and bool(response)
+    error = input_data.get("error_details") or input_data.get("error") or "unknown"
+    metrics: dict[str, Any] = {
+        "error": error,
+        "output_kind": "text" if has_text else "empty",
+        "assistant_texts_count": 1 if has_text else 0,
+        "success": False,
+    }
+    if has_text:
+        metrics["response"] = response
+    error_type = _non_empty_string(input_data.get("error_type"))
+    if error_type is not None:
+        metrics["stop_reason"] = error_type
+    return _base_record(
+        context,
+        hook="after_agent_run",
+        metrics=metrics,
+    )
+
+
+_RecordBuilder = Callable[[dict[str, Any], dict[str, str]], dict[str, Any] | None]
+_BUILDERS: dict[str, _RecordBuilder] = {
+    "UserPromptSubmit": _build_user_prompt_submit,
+    "PreToolUse": _build_pre_tool_use,
+    "PostToolUse": _build_post_tool_use,
+    "PostToolUseFailure": _build_post_tool_use_failure,
+    "Stop": _build_stop,
+    "StopFailure": _build_stop_failure,
+}
+
+
+def _build_record(
+    input_data: dict[str, Any], context: dict[str, str] | None = None
+) -> dict[str, Any] | None:
+    """Map one supported Qoder payload to an observability record."""
+    if not isinstance(input_data, dict):
+        return None
+    builder = _BUILDERS.get(input_data.get("hook_event_name"))
+    if builder is None:
+        return None
+    resolved = trace_context(input_data) if context is None else context
+    return builder(input_data, resolved)
+
+
+def _diagnostic_event_name(input_data: Any) -> str:
+    """Return only a trusted event name for diagnostic output."""
+    if not isinstance(input_data, dict):
+        return "unknown"
+    event_name = input_data.get("hook_event_name")
+    return event_name if event_name in _BUILDERS else "unknown"
+
+
+def _process_text(value: Any) -> str:
+    """Normalize subprocess output for bounded diagnostics."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="replace").strip()
+    else:
+        text = str(value).strip()
+    return text[:1000]
+
+
+def _process_output_details(*values: Any) -> str:
+    """Return subprocess details without including raw Qoder hook payloads."""
+    details = "\n".join(part for value in values if (part := _process_text(value)))
+    return details or "no stderr or stdout was captured"
+
+
+def _redact_text(text: str, context: dict[str, str]) -> str | None:
+    """Return locally redacted text, or ``None`` when redaction fails."""
+    try:
+        result = subprocess.run(
+            _with_resolved_trace_context(_PII_REDACT_COMMAND, context),
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    redacted = data.get("redacted_text")
+    return redacted if isinstance(redacted, str) else None
+
+
+def _redact_sensitive_value(
+    value: Any,
+    cache: dict[str, Any],
+    context: dict[str, str],
+) -> Any:
+    """Redact one sensitive value, returning ``_DROP`` on scan failure."""
+    cache_key = f"{type(value).__name__}:{_json_dumps(value)}"
+    if cache_key in cache:
+        return cache[cache_key]
+
+    if isinstance(value, str):
+        safe_value: Any = _redact_text(value, context)
+        if safe_value is None:
+            safe_value = _DROP
+    else:
+        redacted = _redact_text(_json_dumps(value), context)
+        if redacted is None:
+            safe_value = _DROP
+        else:
+            try:
+                safe_value = json.loads(redacted)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                safe_value = redacted
+    cache[cache_key] = safe_value
+    return safe_value
+
+
+def _redact_metrics(
+    value: Any,
+    cache: dict[str, Any],
+    context: dict[str, str],
+) -> Any:
+    """Recursively redact allowlisted sensitive metric fields."""
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in _SENSITIVE_METRIC_KEYS:
+                safe_item = _redact_sensitive_value(item, cache, context)
+            else:
+                safe_item = _redact_metrics(item, cache, context)
+            if safe_item is not _DROP:
+                redacted[key] = safe_item
+        return redacted
+    if isinstance(value, list):
+        return [
+            item
+            for item in (_redact_metrics(item, cache, context) for item in value)
+            if item is not _DROP
+        ]
+    return value
+
+
+def _redact_observability_record(
+    record: dict[str, Any], context: dict[str, str]
+) -> dict[str, Any]:
+    """Return a record whose sensitive metrics are redacted or removed."""
+    safe_record = dict(record)
+    metrics = safe_record.get("metrics")
+    if isinstance(metrics, dict):
+        safe_record["metrics"] = _redact_metrics(metrics, {}, context)
+    return safe_record
+
+
+def _record_observability(record: dict[str, Any], context: dict[str, str]) -> None:
+    """Redact and persist one record through the public AgentSec CLI."""
+    safe_record = _redact_observability_record(record, context)
+    metrics = safe_record.get("metrics")
+    if not isinstance(metrics, dict) or not metrics:
+        _diagnostic("skipping record because no safe metrics remain after redaction")
+        return
+
+    command = _with_resolved_trace_context(_OBSERVABILITY_COMMAND, context)
+    try:
+        result = subprocess.run(
+            command,
+            input=_json_dumps(safe_record),
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        _diagnostic(
+            "agent-sec-cli executable was not found; install agent-sec-cli or add it to PATH"
+        )
+        return
+    except subprocess.TimeoutExpired as exc:
+        details = _process_output_details(exc.stderr, exc.stdout)
+        _diagnostic(
+            "agent-sec-cli observability record timed out "
+            f"after {exc.timeout} seconds: {details}"
+        )
+        return
+    except OSError as exc:
+        _diagnostic(f"failed to start agent-sec-cli observability record: {exc}")
+        return
+
+    if result.returncode != 0:
+        details = _process_output_details(result.stderr, result.stdout)
+        _diagnostic(
+            "agent-sec-cli observability record failed "
+            f"with exit code {result.returncode}: {details}"
+        )
+
+
+def main() -> None:
+    """Read one Qoder hook event and record it without affecting execution."""
+    try:
+        payload = _read_stdin_payload()
+        if payload is None:
+            return
+        input_data = json.loads(payload)
+    except (json.JSONDecodeError, EOFError, OSError, TypeError, ValueError):
+        return
+    if not isinstance(input_data, dict):
+        return
+
+    try:
+        context = trace_context(input_data)
+        record = _build_record(input_data, context)
+        if record is not None:
+            _record_observability(record, context)
+    except Exception as exc:  # noqa: BLE001 - hook boundary must remain fail-open
+        _diagnostic(
+            f"unexpected {type(exc).__name__} while processing "
+            f"{_diagnostic_event_name(input_data)}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/qoder-plugin/hooks/observability_hook.py
+++ b/src/agent-sec-core/qoder-plugin/hooks/observability_hook.py
@@ -57,7 +57,10 @@ _DROP = object()
 
 def _diagnostic(message: str) -> None:
     """Write a payload-free diagnostic without affecting Qoder execution."""
-    print(f"qoder-observability-hook: {message}", file=sys.stderr)
+    try:
+        print(f"qoder-observability-hook: {message}", file=sys.stderr)
+    except Exception:  # noqa: BLE001 - diagnostics must preserve fail-open behavior
+        pass
 
 
 def _read_stdin_payload() -> str | bytes | None:
@@ -303,7 +306,11 @@ def _build_stop_failure(
     """Map ``StopFailure`` to a failed ``after_agent_run`` record."""
     response = input_data.get("last_assistant_message", "")
     has_text = isinstance(response, str) and bool(response)
-    error = input_data.get("error_details") or input_data.get("error") or "unknown"
+    error_details = _non_empty_string(input_data.get("error_details"))
+    error_category = _non_empty_string(input_data.get("error"))
+    # The required error category identifies an API failure, not a model stop
+    # reason. Use it only when Qoder omits the optional human-readable details.
+    error = error_details or error_category or "unknown"
     metrics: dict[str, Any] = {
         "error": error,
         "output_kind": "text" if has_text else "empty",
@@ -312,9 +319,6 @@ def _build_stop_failure(
     }
     if has_text:
         metrics["response"] = response
-    error_type = _non_empty_string(input_data.get("error_type"))
-    if error_type is not None:
-        metrics["stop_reason"] = error_type
     return _base_record(
         context,
         hook="after_agent_run",
@@ -339,7 +343,10 @@ def _build_record(
     """Map one supported Qoder payload to an observability record."""
     if not isinstance(input_data, dict):
         return None
-    builder = _BUILDERS.get(input_data.get("hook_event_name"))
+    event_name = _non_empty_string(input_data.get("hook_event_name"))
+    if event_name is None:
+        return None
+    builder = _BUILDERS.get(event_name)
     if builder is None:
         return None
     resolved = trace_context(input_data) if context is None else context
@@ -350,8 +357,19 @@ def _diagnostic_event_name(input_data: Any) -> str:
     """Return only a trusted event name for diagnostic output."""
     if not isinstance(input_data, dict):
         return "unknown"
-    event_name = input_data.get("hook_event_name")
+    event_name = _non_empty_string(input_data.get("hook_event_name"))
     return event_name if event_name in _BUILDERS else "unknown"
+
+
+def _unexpected_failure_diagnostic(exc: Exception, input_data: Any) -> None:
+    """Report an unexpected failure without allowing reporting to raise."""
+    try:
+        _diagnostic(
+            f"unexpected {type(exc).__name__} while processing "
+            f"{_diagnostic_event_name(input_data)}"
+        )
+    except Exception:  # noqa: BLE001 - failure reporting is the final hook boundary
+        pass
 
 
 def _process_text(value: Any) -> str:
@@ -382,19 +400,15 @@ def _redact_text(text: str, context: dict[str, str]) -> str | None:
             timeout=_CLI_TIMEOUT_SECONDS,
             check=False,
         )
-    except (OSError, subprocess.SubprocessError, TimeoutError):
-        return None
-    if result.returncode != 0:
-        return None
-
-    try:
+        if result.returncode != 0:
+            return None
         data = json.loads(result.stdout)
-    except (json.JSONDecodeError, TypeError, ValueError):
+        if not isinstance(data, dict):
+            return None
+        redacted = data.get("redacted_text")
+        return redacted if isinstance(redacted, str) else None
+    except Exception:  # noqa: BLE001 - any redaction failure must remain fail-open
         return None
-    if not isinstance(data, dict):
-        return None
-    redacted = data.get("redacted_text")
-    return redacted if isinstance(redacted, str) else None
 
 
 def _redact_sensitive_value(
@@ -420,6 +434,8 @@ def _redact_sensitive_value(
                 safe_value = json.loads(redacted)
             except (json.JSONDecodeError, TypeError, ValueError):
                 safe_value = redacted
+    if safe_value is _DROP:
+        _diagnostic("PII redaction failed; sensitive metric dropped")
     cache[cache_key] = safe_value
     return safe_value
 
@@ -504,26 +520,24 @@ def _record_observability(record: dict[str, Any], context: dict[str, str]) -> No
 
 def main() -> None:
     """Read one Qoder hook event and record it without affecting execution."""
+    input_data: Any = None
     try:
-        payload = _read_stdin_payload()
-        if payload is None:
+        try:
+            payload = _read_stdin_payload()
+            if payload is None:
+                return
+            input_data = json.loads(payload)
+        except (json.JSONDecodeError, EOFError, OSError, TypeError, ValueError):
             return
-        input_data = json.loads(payload)
-    except (json.JSONDecodeError, EOFError, OSError, TypeError, ValueError):
-        return
-    if not isinstance(input_data, dict):
-        return
+        if not isinstance(input_data, dict):
+            return
 
-    try:
         context = trace_context(input_data)
         record = _build_record(input_data, context)
         if record is not None:
             _record_observability(record, context)
     except Exception as exc:  # noqa: BLE001 - hook boundary must remain fail-open
-        _diagnostic(
-            f"unexpected {type(exc).__name__} while processing "
-            f"{_diagnostic_event_name(input_data)}"
-        )
+        _unexpected_failure_diagnostic(exc, input_data)
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/qoder-plugin/install.sh
+++ b/src/agent-sec-core/qoder-plugin/install.sh
@@ -44,11 +44,15 @@ require_agent_sec_cli() {
     command -v agent-sec-cli >/dev/null 2>&1 || die "agent-sec-cli not found on PATH"
     agent-sec-cli scan-pii --help >/dev/null 2>&1 || die "agent-sec-cli scan-pii is unavailable"
     agent-sec-cli skill-ledger check --help >/dev/null 2>&1 || die "agent-sec-cli skill-ledger check is unavailable"
+    agent-sec-cli observability record --help >/dev/null 2>&1 || die "agent-sec-cli observability record is unavailable"
 }
 
 require_plugin_files() {
     [[ -f "${PLUGIN_DIR}/.qoder-plugin/plugin.json" ]] || die "plugin manifest not found"
     [[ -f "${PLUGIN_DIR}/hooks/hooks.json" ]] || die "hook configuration not found"
+    [[ -f "${PLUGIN_DIR}/hooks/qoder_hook_common.py" ]] || die "shared hook helper not found"
+    [[ -f "${PLUGIN_DIR}/hooks/pii_checker_hook.py" ]] || die "PII hook not found"
+    [[ -f "${PLUGIN_DIR}/hooks/observability_hook.py" ]] || die "observability hook not found"
 }
 
 while [[ $# -gt 0 ]]; do

--- a/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_observability_hook.py
@@ -1,0 +1,472 @@
+"""Unit tests for the Qoder observability command hook."""
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from agent_sec_cli.observability.schema import validate_observability_record
+
+_ROOT = Path(__file__).resolve().parents[3]
+_PLUGIN_DIR = _ROOT / "qoder-plugin"
+_HOOKS_DIR = _PLUGIN_DIR / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "observability_hook.py"
+sys.path.insert(0, str(_HOOKS_DIR))
+
+
+def _load_observability_hook():
+    spec = importlib.util.spec_from_file_location(
+        "qoder_observability_hook", _HOOK_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+observability_hook = _load_observability_hook()
+
+_TS = "2026-07-20T08:00:00Z"
+_ZERO_RUN_ID = "00000000-0000-0000-0000-000000000000"
+_CONTEXT = {
+    "agent_name": "qoder",
+    "session_id": "session-123",
+}
+
+
+@pytest.fixture(autouse=True)
+def _fixed_runtime(monkeypatch) -> None:
+    monkeypatch.setattr(observability_hook, "_now_iso", lambda: _TS)
+
+
+def _base(hook_event_name: str, **overrides):
+    payload = {
+        "hook_event_name": hook_event_name,
+        "session_id": "session-123",
+        "transcript_path": "/private/qoder-transcript.jsonl",
+        "cwd": "/workspace",
+        "permission_mode": "default",
+        "agent_id": "agent-1",
+        "agent_type": "main",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _record(input_data):
+    record = observability_hook._build_record(input_data, dict(_CONTEXT))
+    assert record is not None
+    return record
+
+
+def test_user_prompt_submit_maps_before_agent_run() -> None:
+    prompt = "Summarize this repository."
+
+    record = _record(_base("UserPromptSubmit", prompt=prompt))
+
+    assert record == {
+        "hook": "before_agent_run",
+        "observedAt": _TS,
+        "metadata": {
+            "sessionId": "session-123",
+            "runId": _ZERO_RUN_ID,
+        },
+        "metrics": {
+            "prompt": prompt,
+            "user_input": prompt,
+            "pii_scan_input_sha256": observability_hook._pii_scan_input_sha256(prompt),
+        },
+    }
+
+
+@pytest.mark.parametrize("prompt", (None, "", "  \n"))
+def test_user_prompt_submit_skips_empty_prompt(prompt) -> None:
+    payload = _base("UserPromptSubmit")
+    if prompt is not None:
+        payload["prompt"] = prompt
+
+    assert observability_hook._build_record(payload, dict(_CONTEXT)) is None
+
+
+def test_pre_tool_use_maps_tool_metadata_and_parameters() -> None:
+    tool_input = {"command": "pwd"}
+    context = {**_CONTEXT, "tool_call_id": "tool-123"}
+
+    record = observability_hook._build_record(
+        _base(
+            "PreToolUse",
+            tool_name="Bash",
+            tool_input=tool_input,
+            tool_use_id="tool-123",
+        ),
+        context,
+    )
+
+    assert record is not None
+    assert record["hook"] == "before_tool_call"
+    assert record["metadata"] == {
+        "sessionId": "session-123",
+        "runId": _ZERO_RUN_ID,
+        "toolCallId": "tool-123",
+    }
+    assert record["metrics"] == {
+        "tool_name": "Bash",
+        "parameters": tool_input,
+        "pii_scan_input_sha256": observability_hook._pii_scan_input_sha256(tool_input),
+    }
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected_status"),
+    ((0, "success"), (2, "error")),
+)
+def test_post_tool_use_maps_result_exit_code_and_status(
+    exit_code: int, expected_status: str
+) -> None:
+    response = {"stdout": "done\n", "exit_code": exit_code}
+    context = {**_CONTEXT, "tool_call_id": "tool-123"}
+
+    record = observability_hook._build_record(
+        _base(
+            "PostToolUse",
+            tool_name="Bash",
+            tool_response=response,
+            tool_use_id="tool-123",
+        ),
+        context,
+    )
+
+    assert record is not None
+    assert record["hook"] == "after_tool_call"
+    assert record["metadata"]["toolCallId"] == "tool-123"
+    assert record["metrics"] == {
+        "status": expected_status,
+        "result": response,
+        "result_size_bytes": observability_hook._json_size_bytes(response),
+        "pii_scan_input_sha256": observability_hook._pii_scan_input_sha256(response),
+        "exit_code": exit_code,
+    }
+
+
+@pytest.mark.parametrize(
+    ("is_interrupt", "expected_status"),
+    ((True, "interrupted"), (False, "error"), (None, "error")),
+)
+def test_post_tool_use_failure_maps_error(
+    is_interrupt: bool | None, expected_status: str
+) -> None:
+    payload = _base(
+        "PostToolUseFailure",
+        tool_name="Bash",
+        tool_use_id="tool-123",
+        error="command failed",
+        error_type="execution_failed",
+    )
+    if is_interrupt is not None:
+        payload["is_interrupt"] = is_interrupt
+    context = {**_CONTEXT, "tool_call_id": "tool-123"}
+
+    record = observability_hook._build_record(payload, context)
+
+    assert record is not None
+    assert record["hook"] == "after_tool_call"
+    assert record["metrics"]["status"] == expected_status
+    assert record["metrics"]["error"] == "command failed"
+
+
+def test_stop_maps_successful_agent_run() -> None:
+    record = _record(
+        _base("Stop", stop_hook_active=False, last_assistant_message="Done.")
+    )
+
+    assert record["hook"] == "after_agent_run"
+    assert record["metrics"] == {
+        "response": "Done.",
+        "output_kind": "text",
+        "assistant_texts_count": 1,
+        "success": True,
+    }
+
+
+def test_stop_failure_maps_error_type_and_partial_response() -> None:
+    record = _record(
+        _base(
+            "StopFailure",
+            error_type="rate_limit",
+            error="request failed",
+            error_details="rate limit exceeded",
+            last_assistant_message="Partial answer",
+        )
+    )
+
+    assert record["hook"] == "after_agent_run"
+    assert record["metrics"] == {
+        "error": "rate limit exceeded",
+        "output_kind": "text",
+        "assistant_texts_count": 1,
+        "success": False,
+        "response": "Partial answer",
+        "stop_reason": "rate_limit",
+    }
+
+
+@pytest.mark.parametrize("event_name", ("BeforeModel", "AfterModel", "SessionStart"))
+def test_events_without_schema_mapping_are_skipped(event_name: str) -> None:
+    assert observability_hook._build_record(_base(event_name), dict(_CONTEXT)) is None
+
+
+def test_missing_required_correlation_is_skipped() -> None:
+    assert (
+        observability_hook._build_record(
+            _base("UserPromptSubmit", prompt="hello"),
+            {"agent_name": "qoder"},
+        )
+        is None
+    )
+    assert (
+        observability_hook._build_record(
+            _base("PreToolUse", tool_name="Bash", tool_input={}),
+            dict(_CONTEXT),
+        )
+        is None
+    )
+
+
+def test_qoder_only_fields_are_not_added_to_current_schema_metadata() -> None:
+    record = _record(_base("UserPromptSubmit", prompt="hello"))
+
+    assert record["metadata"] == {
+        "sessionId": "session-123",
+        "runId": _ZERO_RUN_ID,
+    }
+    serialized = json.dumps(record)
+    assert "cwd" not in serialized
+    assert "agent_id" not in serialized
+    assert "transcript_path" not in serialized
+
+
+def test_all_six_qoder_events_build_schema_valid_records() -> None:
+    tool_context = {**_CONTEXT, "tool_call_id": "tool-123"}
+    cases = [
+        (_base("UserPromptSubmit", prompt="hello"), _CONTEXT),
+        (
+            _base(
+                "PreToolUse",
+                tool_name="Bash",
+                tool_input={"command": "pwd"},
+                tool_use_id="tool-123",
+            ),
+            tool_context,
+        ),
+        (
+            _base(
+                "PostToolUse",
+                tool_name="Bash",
+                tool_response={"stdout": "ok"},
+                tool_use_id="tool-123",
+            ),
+            tool_context,
+        ),
+        (
+            _base(
+                "PostToolUseFailure",
+                tool_name="Bash",
+                error="failed",
+                tool_use_id="tool-123",
+            ),
+            tool_context,
+        ),
+        (_base("Stop", last_assistant_message="done"), _CONTEXT),
+        (
+            _base("StopFailure", error_type="unknown", error="failed"),
+            _CONTEXT,
+        ),
+    ]
+
+    records = []
+    for payload, context in cases:
+        record = observability_hook._build_record(payload, dict(context))
+        assert record is not None
+        records.append(validate_observability_record(record).to_record())
+
+    assert {record["hook"] for record in records} == {
+        "before_agent_run",
+        "before_tool_call",
+        "after_tool_call",
+        "after_agent_run",
+    }
+
+
+def test_main_redacts_and_uses_host_trace_context_for_both_cli_calls(
+    monkeypatch, capsys
+) -> None:
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if "scan-pii" in command:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "redacted_text": kwargs["input"].replace(
+                            "alice@example.com", "a***@example.com"
+                        )
+                    }
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                _base(
+                    "UserPromptSubmit",
+                    prompt="contact alice@example.com",
+                )
+            )
+        ),
+    )
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert len(calls) == 2
+
+    contexts = []
+    for command, _kwargs in calls:
+        context_index = command.index("--trace-context") + 1
+        contexts.append(json.loads(command[context_index]))
+    assert "--include-low-confidence" in calls[0][0]
+    assert (
+        contexts[0]
+        == contexts[1]
+        == {
+            "agent_name": "qoder",
+            "session_id": "session-123",
+        }
+    )
+
+    record_payload = json.loads(calls[-1][1]["input"])
+    assert record_payload["metadata"]["runId"] == _ZERO_RUN_ID
+    serialized = json.dumps(record_payload, ensure_ascii=False)
+    assert "alice@example.com" not in serialized
+    assert "a***@example.com" in serialized
+
+
+def test_redaction_failure_drops_raw_value_but_keeps_safe_metrics(monkeypatch) -> None:
+    monkeypatch.setattr(
+        observability_hook,
+        "_redact_text",
+        lambda _text, _context: None,
+    )
+    record = _record(_base("UserPromptSubmit", prompt="alice@example.com"))
+
+    safe_record = observability_hook._redact_observability_record(
+        record, dict(_CONTEXT)
+    )
+
+    assert "prompt" not in safe_record["metrics"]
+    assert "user_input" not in safe_record["metrics"]
+    assert safe_record["metrics"]["pii_scan_input_sha256"]
+
+
+@pytest.mark.parametrize("payload", ("not-json", "[]"))
+def test_invalid_input_is_fail_open_without_cli(
+    payload: str, monkeypatch, capsys
+) -> None:
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", fail_run)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_oversized_input_is_diagnosed_without_leaking_payload(
+    monkeypatch, capsys
+) -> None:
+    payload = b"alice@example.com" + b"x" * observability_hook._MAX_PAYLOAD_SIZE
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload)))
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "qoder-observability-hook: hook input exceeds "
+        f"{observability_hook._MAX_PAYLOAD_SIZE} bytes; skipping event\n"
+    )
+    assert "alice@example.com" not in captured.err
+
+
+def test_record_timeout_is_fail_open(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        observability_hook,
+        "_redact_text",
+        lambda text, _context: text,
+    )
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=["agent-sec-cli", "observability", "record"],
+            timeout=3,
+            stderr="record timeout",
+        )
+
+    monkeypatch.setattr(observability_hook.subprocess, "run", timeout)
+    observability_hook._record_observability(
+        _record(_base("Stop", last_assistant_message="Done.")),
+        dict(_CONTEXT),
+    )
+
+    assert "timed out after 3 seconds" in capsys.readouterr().err
+
+
+def test_hooks_config_registers_observability_for_all_supported_events() -> None:
+    config = json.loads((_HOOKS_DIR / "hooks.json").read_text())
+    expected_events = {
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "StopFailure",
+    }
+    expected_args = ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"]
+
+    assert set(config["hooks"]) == expected_events
+    for event_name in expected_events:
+        first_group_names = {
+            hook.get("name") for hook in config["hooks"][event_name][0]["hooks"]
+        }
+        assert first_group_names == {"agent-sec-observability"}
+        matching = [
+            hook
+            for group in config["hooks"][event_name]
+            for hook in group["hooks"]
+            if hook.get("name") == "agent-sec-observability"
+        ]
+        assert len(matching) == 1
+        hook = matching[0]
+        assert hook["command"] == "python3"
+        assert hook["args"] == expected_args
+        assert hook["timeout"] == 10
+        assert hook["async"] is True

--- a/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_observability_hook.py
@@ -1,5 +1,6 @@
 """Unit tests for the Qoder observability command hook."""
 
+import builtins
 import importlib.util
 import io
 import json
@@ -194,12 +195,11 @@ def test_stop_maps_successful_agent_run() -> None:
     }
 
 
-def test_stop_failure_maps_error_type_and_partial_response() -> None:
+def test_stop_failure_prefers_error_details_and_maps_partial_response() -> None:
     record = _record(
         _base(
             "StopFailure",
-            error_type="rate_limit",
-            error="request failed",
+            error="rate_limit",
             error_details="rate limit exceeded",
             last_assistant_message="Partial answer",
         )
@@ -212,12 +212,47 @@ def test_stop_failure_maps_error_type_and_partial_response() -> None:
         "assistant_texts_count": 1,
         "success": False,
         "response": "Partial answer",
-        "stop_reason": "rate_limit",
+    }
+
+
+def test_stop_failure_falls_back_to_required_error_category() -> None:
+    record = _record(_base("StopFailure", error="rate_limit"))
+
+    assert record["hook"] == "after_agent_run"
+    assert record["metrics"] == {
+        "error": "rate_limit",
+        "output_kind": "empty",
+        "assistant_texts_count": 0,
+        "success": False,
+    }
+
+
+def test_stop_failure_normalizes_malformed_optional_fields() -> None:
+    record = _record(
+        _base(
+            "StopFailure",
+            error={"category": "rate_limit"},
+            error_details=["unexpected shape"],
+            last_assistant_message={"text": "unexpected shape"},
+        )
+    )
+
+    assert record["hook"] == "after_agent_run"
+    assert record["metrics"] == {
+        "error": "unknown",
+        "output_kind": "empty",
+        "assistant_texts_count": 0,
+        "success": False,
     }
 
 
 @pytest.mark.parametrize("event_name", ("BeforeModel", "AfterModel", "SessionStart"))
 def test_events_without_schema_mapping_are_skipped(event_name: str) -> None:
+    assert observability_hook._build_record(_base(event_name), dict(_CONTEXT)) is None
+
+
+@pytest.mark.parametrize("event_name", ([], {}))
+def test_malformed_event_name_is_skipped_without_raising(event_name) -> None:
     assert observability_hook._build_record(_base(event_name), dict(_CONTEXT)) is None
 
 
@@ -284,7 +319,7 @@ def test_all_six_qoder_events_build_schema_valid_records() -> None:
         ),
         (_base("Stop", last_assistant_message="done"), _CONTEXT),
         (
-            _base("StopFailure", error_type="unknown", error="failed"),
+            _base("StopFailure", error="unknown"),
             _CONTEXT,
         ),
     ]
@@ -366,7 +401,9 @@ def test_main_redacts_and_uses_host_trace_context_for_both_cli_calls(
     assert "a***@example.com" in serialized
 
 
-def test_redaction_failure_drops_raw_value_but_keeps_safe_metrics(monkeypatch) -> None:
+def test_redaction_failure_drops_raw_value_and_reports_once(
+    monkeypatch, capsys
+) -> None:
     monkeypatch.setattr(
         observability_hook,
         "_redact_text",
@@ -381,6 +418,12 @@ def test_redaction_failure_drops_raw_value_but_keeps_safe_metrics(monkeypatch) -
     assert "prompt" not in safe_record["metrics"]
     assert "user_input" not in safe_record["metrics"]
     assert safe_record["metrics"]["pii_scan_input_sha256"]
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "qoder-observability-hook: PII redaction failed; sensitive metric dropped\n"
+    )
+    assert "alice@example.com" not in captured.err
 
 
 @pytest.mark.parametrize("payload", ("not-json", "[]"))
@@ -398,6 +441,77 @@ def test_invalid_input_is_fail_open_without_cli(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+
+
+def test_unexpected_input_error_is_fail_open_without_leaking_details(
+    monkeypatch, capsys
+) -> None:
+    def fail_read():
+        raise RecursionError("alice@example.com")
+
+    monkeypatch.setattr(observability_hook, "_read_stdin_payload", fail_read)
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "qoder-observability-hook: unexpected RecursionError while processing unknown\n"
+    )
+    assert "alice@example.com" not in captured.err
+
+
+def test_unexpected_processing_error_is_fail_open_without_leaking_payload(
+    monkeypatch, capsys
+) -> None:
+    def fail_build(_input_data, _context):
+        raise RuntimeError("alice@example.com")
+
+    monkeypatch.setattr(observability_hook, "_build_record", fail_build)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                _base(
+                    "StopFailure",
+                    error="rate_limit",
+                    error_details="alice@example.com",
+                )
+            )
+        ),
+    )
+
+    observability_hook.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "qoder-observability-hook: unexpected RuntimeError while processing StopFailure\n"
+    )
+    assert "alice@example.com" not in captured.err
+
+
+def test_diagnostic_write_failure_is_fail_open(monkeypatch) -> None:
+    def fail_print(*_args, **_kwargs):
+        raise BrokenPipeError("stderr is closed")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(builtins, "print", fail_print)
+        observability_hook._diagnostic("ignored")
+
+
+def test_failure_reporting_failure_is_fail_open(monkeypatch) -> None:
+    def fail_read():
+        raise RecursionError("input failed")
+
+    def fail_event_name(_input_data):
+        raise TypeError("diagnostic failed")
+
+    monkeypatch.setattr(observability_hook, "_read_stdin_payload", fail_read)
+    monkeypatch.setattr(observability_hook, "_diagnostic_event_name", fail_event_name)
+
+    observability_hook.main()
 
 
 def test_oversized_input_is_diagnosed_without_leaking_payload(

--- a/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_pii_checker_hook.py
@@ -144,6 +144,48 @@ def test_user_prompt_observe_scans_and_allows_silently(mock_cli) -> None:
     assert captured["stdin"] == "phone 13800138000"
 
 
+def test_hook_trace_context_contains_only_host_correlation_ids(mock_cli) -> None:
+    env, capture = mock_cli(output=_PII_WARN_RESULT)
+
+    first = _run_hook(
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "hello",
+            "session_id": "sess-1",
+        },
+        env,
+    )
+    assert first.returncode == 0
+    first_call = _captured_call(capture)
+    first_index = first_call["argv"].index("--trace-context") + 1
+    first_context = json.loads(first_call["argv"][first_index])
+
+    second = _run_hook(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "pwd"},
+            "tool_use_id": "tool-1",
+            "session_id": "sess-1",
+        },
+        env,
+    )
+    assert second.returncode == 0
+    second_call = _captured_call(capture)
+    second_index = second_call["argv"].index("--trace-context") + 1
+    second_context = json.loads(second_call["argv"][second_index])
+
+    assert first_context == {
+        "agent_name": "qoder",
+        "session_id": "sess-1",
+    }
+    assert second_context == {
+        "agent_name": "qoder",
+        "session_id": "sess-1",
+        "tool_call_id": "tool-1",
+    }
+
+
 def test_user_prompt_deny_blocks_without_raw_pii(mock_cli) -> None:
     env, _capture = mock_cli(
         output=_PII_DENY_RESULT,

--- a/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_plugin_framework.py
+++ b/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_plugin_framework.py
@@ -110,7 +110,7 @@ _AGENT_SEC_CLI = textwrap.dedent("""\
     #!/usr/bin/env bash
     set -euo pipefail
     case "$*" in
-        "scan-pii --help"|"skill-ledger check --help")
+        "scan-pii --help"|"skill-ledger check --help"|"observability record --help")
             exit 0
             ;;
         *)
@@ -144,7 +144,14 @@ def test_hooks_json_uses_qoder_plugin_wrapper() -> None:
     hooks = json.loads((_HOOKS_DIR / "hooks.json").read_text())
 
     assert set(hooks) == {"hooks"}
-    assert set(hooks["hooks"]) == {"UserPromptSubmit", "PreToolUse", "PostToolUse"}
+    assert set(hooks["hooks"]) == {
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "StopFailure",
+    }
     pre_tool = hooks["hooks"]["PreToolUse"]
     skill_ledger = next(entry for entry in pre_tool if entry["matcher"] == "Skill")
     hook = skill_ledger["hooks"][0]


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Add observability hook for qodercli plugin including before/after agent_run and before/after tool_use. 

Use zero guid for run id since the agent doesn't pass run id to hooks.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
