### PR TITLE
feat(sight): fall back to raw HTTPS for unparsable LLM traffic

### DIFF
--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -63,6 +63,50 @@ pub fn match_domain_glob(domain: &str, patterns: &[String]) -> bool {
     false
 }
 
+/// Domain-based filter deciding whether a captured HTTP flow should be
+/// reported via the raw-HTTP FFI callback (`AgentsightHttpsData`).
+///
+/// Patterns are glob rules collected from the config `https` and `http`
+/// sections. An **empty** pattern set means "no domain restriction" — every
+/// flow is reported, preserving the pre-existing full-report behaviour.
+#[derive(Debug, Clone, Default)]
+pub struct HttpReportFilter {
+    patterns: Vec<String>,
+}
+
+impl HttpReportFilter {
+    /// Build a filter from a set of glob patterns.
+    pub fn new(patterns: Vec<String>) -> Self {
+        Self { patterns }
+    }
+
+    /// Decide whether a flow to `host` should be reported.
+    ///
+    /// * Empty pattern set → always `true` (unrestricted).
+    /// * `host = None` (could not be determined) under a restricted filter →
+    ///   `false` (strict: do not report what we cannot match).
+    /// * Otherwise match `host`, with and without a trailing `:port`, against
+    ///   the glob patterns (case-insensitive).
+    pub fn should_report(&self, host: Option<&str>) -> bool {
+        if self.patterns.is_empty() {
+            return true;
+        }
+        let Some(host) = host else {
+            return false;
+        };
+        if match_domain_glob(host, &self.patterns) {
+            return true;
+        }
+        // Also try the host without its port (e.g. "api.openai.com:443").
+        if let Some((bare, _port)) = host.rsplit_once(':') {
+            if match_domain_glob(bare, &self.patterns) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
 /// Matcher based on cmdline glob patterns (config-driven).
 pub struct CmdlineGlobMatcher {
     info: AgentInfo,
@@ -203,6 +247,49 @@ mod tests {
         assert!(match_domain_glob("api.openai.com", &patterns));
         assert!(match_domain_glob("api.anthropic.com", &patterns));
         assert!(!match_domain_glob("example.com", &patterns));
+    }
+
+    #[test]
+    fn test_http_report_filter_unrestricted_reports_everything() {
+        let filter = HttpReportFilter::new(vec![]);
+        assert!(filter.should_report(Some("anything.example.com")));
+        // Even a missing host is reported when unrestricted.
+        assert!(filter.should_report(None));
+    }
+
+    #[test]
+    fn test_http_report_filter_matches_glob() {
+        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
+        assert!(filter.should_report(Some("api.openai.com")));
+        assert!(!filter.should_report(Some("example.com")));
+    }
+
+    #[test]
+    fn test_http_report_filter_strips_port() {
+        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
+        assert!(filter.should_report(Some("api.openai.com:443")));
+    }
+
+    #[test]
+    fn test_http_report_filter_matches_ip_endpoint() {
+        // Endpoint IPs are contributed as literal patterns.
+        let filter = HttpReportFilter::new(vec!["10.0.0.1".to_string()]);
+        assert!(filter.should_report(Some("10.0.0.1")));
+        assert!(filter.should_report(Some("10.0.0.1:8080")));
+        assert!(!filter.should_report(Some("10.0.0.2")));
+    }
+
+    #[test]
+    fn test_http_report_filter_strict_when_host_missing() {
+        // Restricted filter + unknown host → do not report.
+        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
+        assert!(!filter.should_report(None));
+    }
+
+    #[test]
+    fn test_http_report_filter_case_insensitive() {
+        let filter = HttpReportFilter::new(vec!["*.OpenAI.com".to_string()]);
+        assert!(filter.should_report(Some("API.OPENAI.COM")));
     }
 
     #[test]

--- a/src/agentsight/src/discovery/mod.rs
+++ b/src/agentsight/src/discovery/mod.rs
@@ -32,5 +32,7 @@ pub mod scanner;
 
 pub use agent::{AgentInfo, DiscoveredAgent};
 pub use connection_scanner::{ConnectionScanResult, ConnectionScanner, IpDomainCache};
-pub use matcher::{CmdlineGlobMatcher, ProcessContext, match_cmdline_glob, match_domain_glob};
+pub use matcher::{
+    CmdlineGlobMatcher, HttpReportFilter, ProcessContext, match_cmdline_glob, match_domain_glob,
+};
 pub use scanner::AgentScanner;

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -760,6 +760,64 @@ mod tests {
         assert!(build_call(&builder, &[AnalysisResult::Http(http)]).is_none());
     }
 
+    // ── Verification: HTTPS-fallback trigger for unparsable LLM traffic ──
+    //
+    // An LLM API path whose body cannot be parsed into semantic messages must
+    // still build an LLMCall (path matched), but that call carries no messages,
+    // so `is_semantically_empty()` is true — this is exactly what drives the FFI
+    // divert to AgentsightHttpsData. A parsable exchange must NOT be empty.
+    #[test]
+    fn test_unparsable_llm_traffic_is_semantically_empty() {
+        let builder = GenAIBuilder::new();
+        let http = make_http(
+            "/v1/chat/completions",
+            Some("this is not a valid chat-completions body".to_string()),
+            Some("neither is this a parseable response".to_string()),
+        );
+        let call = build_call(&builder, &[AnalysisResult::Http(http)])
+            .expect("LLM path still builds an LLMCall");
+        assert!(
+            call.is_semantically_empty(),
+            "unparsable LLM body must yield a semantically-empty call (→ HTTPS fallback)"
+        );
+    }
+
+    #[test]
+    fn test_parsable_llm_traffic_is_not_semantically_empty() {
+        let builder = GenAIBuilder::new();
+        let anth_req = AnthropicRequest {
+            model: "claude-3".to_string(),
+            messages: vec![AnthMsg {
+                role: MessageRole::User,
+                content: AnthropicMessageContent::Text("Hi".to_string()),
+            }],
+            max_tokens: 200,
+            system: None,
+            stream: Some(false),
+            temperature: Some(0.5),
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+        };
+        let parsed = ParsedApiMessage::AnthropicMessage {
+            request: Some(anth_req),
+            response: None,
+        };
+        let http = make_http("/v1/messages", None, None);
+        let call = build_call(
+            &builder,
+            &[AnalysisResult::Http(http), AnalysisResult::Message(parsed)],
+        )
+        .expect("valid LLM call builds");
+        assert!(
+            !call.is_semantically_empty(),
+            "a parsable LLM exchange must carry messages (no HTTPS fallback)"
+        );
+    }
+
     #[test]
     fn test_build_llm_call_returns_none_when_no_http() {
         let builder = GenAIBuilder::new();

--- a/src/agentsight/src/genai/semantic.rs
+++ b/src/agentsight/src/genai/semantic.rs
@@ -308,6 +308,16 @@ impl LLMCall {
         }
     }
 
+    /// Whether this call carries no parsed semantic content.
+    ///
+    /// True when neither the request nor the response produced any structured
+    /// messages — i.e. the underlying body format could not be parsed into
+    /// `AgentsightLLMData`. Used by the FFI dispatch path to decide whether to
+    /// fall back to raw-HTTP (`AgentsightHttpsData`) reporting.
+    pub fn is_semantically_empty(&self) -> bool {
+        self.request.messages.is_empty() && self.response.messages.is_empty()
+    }
+
     /// Set response and calculate duration
     pub fn set_response(&mut self, response: LLMResponse, end_timestamp_ns: u64) {
         self.end_timestamp_ns = end_timestamp_ns;
@@ -403,6 +413,46 @@ mod tests {
         assert_eq!(call.end_timestamp_ns, 5000);
         assert_eq!(call.duration_ns, 4000);
         assert_eq!(call.response.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_is_semantically_empty() {
+        // Request has a user message → not empty.
+        let call = LLMCall::new(
+            "call-3".to_string(),
+            1000,
+            "openai".to_string(),
+            "gpt-4".to_string(),
+            make_request(),
+            100,
+            "test".to_string(),
+        );
+        assert!(!call.is_semantically_empty());
+
+        // Empty request and empty response → semantically empty.
+        let empty = LLMCall::new(
+            "call-4".to_string(),
+            1000,
+            "unknown".to_string(),
+            "unknown".to_string(),
+            LLMRequest {
+                messages: vec![],
+                temperature: None,
+                max_tokens: None,
+                frequency_penalty: None,
+                presence_penalty: None,
+                top_p: None,
+                top_k: None,
+                seed: None,
+                stop_sequences: None,
+                stream: false,
+                tools: None,
+                raw_body: None,
+            },
+            100,
+            "test".to_string(),
+        );
+        assert!(empty.is_semantically_empty());
     }
 
     #[test]

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -100,6 +100,9 @@ pub struct AgentSight {
     pid_agent_name_cache: lru::LruCache<u32, String>,
     /// HTTP domain patterns from config, used for runtime DNS-based tcpsniff target addition
     http_domains: Vec<String>,
+    /// Domain filter gating raw-HTTP (`AgentsightHttpsData`) FFI reporting.
+    /// Built from the config `https` + `http` rules; empty = report everything.
+    http_report_filter: crate::discovery::HttpReportFilter,
     /// Mailbox for watcher thread to deposit a dynamically-created LogtailExporter
     pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>>,
     /// DeadLoop auto-kill: enabled flag
@@ -516,6 +519,23 @@ impl AgentSight {
             crate::background::start_stale_scanner(Arc::clone(sqlite_store), Arc::clone(&running));
         }
 
+        // Domain filter for raw-HTTP FFI reporting: reuse the config `https`
+        // globs and `http` domain/endpoint rules. Empty → report everything.
+        let mut report_patterns: Vec<String> = config
+            .https_rules
+            .iter()
+            .map(|r| r.pattern.clone())
+            .collect();
+        report_patterns.extend(http_domains.iter().cloned());
+        for target in &config.http_targets {
+            if let crate::config::HttpTarget::Endpoint(ep) = target {
+                if let Some(ip) = ep.ip {
+                    report_patterns.push(ip.to_string());
+                }
+            }
+        }
+        let http_report_filter = crate::discovery::HttpReportFilter::new(report_patterns);
+
         Ok(AgentSight {
             probes,
             parser: Parser::new(),
@@ -549,6 +569,7 @@ impl AgentSight {
             last_interruption_purge: std::time::Instant::now(),
             pid_agent_name_cache,
             http_domains,
+            http_report_filter,
             pending_logtail,
             deadloop_kill_enabled: config.deadloop_kill_enabled,
             deadloop_kill_after_count: config.deadloop_kill_after_count,
@@ -758,7 +779,16 @@ impl AgentSight {
                 }
             }
 
-            if !output.events.is_empty() {
+            // FFI fallback: when every built LLM event is semantically empty
+            // (the underlying body format could not be parsed into
+            // `AgentsightLLMData`), skip the useless LLM event and fall through
+            // to raw-HTTP (`AgentsightHttpsData`) reporting instead. Only in FFI
+            // mode; requires *all* events to be empty LLM calls so we never drop
+            // a meaningful event.
+            let ffi_https_fallback =
+                self.ffi_sender.is_some() && events_are_empty_llm(&output.events);
+
+            if !output.events.is_empty() && !ffi_https_fallback {
                 if output.pending_response_id.is_some() {
                     // Session_id not yet resolved — queue for deferred resolution.
                     // Write a pending row NOW so crash detection can see this call
@@ -833,10 +863,21 @@ impl AgentSight {
                     self.detect_and_store_interruptions(&output.events);
                 }
             } else if let Some(ref sender) = self.ffi_sender {
-                // No LLM event produced — send plain HTTP data via FFI channel
+                // Either no LLM event was produced, or all LLM events were
+                // semantically empty (fallback). Send raw HTTP via FFI, but only
+                // for flows whose host matches the configured domain rules.
+                // An empty rule set reports everything (backward compatible).
                 for ar in &analysis_results {
                     if let crate::analyzer::AnalysisResult::Http(record) = ar {
-                        sender.send(FfiEvent::Https(record.clone()));
+                        let host = Self::http_record_host(record);
+                        if self.http_report_filter.should_report(host.as_deref()) {
+                            sender.send(FfiEvent::Https(record.clone()));
+                        } else {
+                            log::debug!(
+                                "Skipping AgentsightHttpsData for host {:?}: no domain-rule match",
+                                host
+                            );
+                        }
                     }
                 }
             }
@@ -983,6 +1024,23 @@ impl AgentSight {
     /// only caller lives in this crate's FFI layer.
     pub(crate) fn set_ffi_sender(&mut self, sender: FfiEventSender) {
         self.ffi_sender = Some(sender);
+    }
+
+    /// Extract the target host from an `HttpRecord`'s request headers.
+    ///
+    /// Checks the `host`, `Host`, and HTTP/2 `:authority` header keys. Returns
+    /// `None` when headers are unparseable or no host header is present.
+    fn http_record_host(record: &crate::analyzer::HttpRecord) -> Option<String> {
+        let headers: serde_json::Value = serde_json::from_str(&record.request_headers).ok()?;
+        let obj = headers.as_object()?;
+        for key in ["host", "Host", ":authority"] {
+            if let Some(v) = obj.get(key).and_then(|v| v.as_str()) {
+                if !v.is_empty() {
+                    return Some(v.to_string());
+                }
+            }
+        }
+        None
     }
 
     /// Export GenAI events to all registered exporters
@@ -1925,6 +1983,20 @@ impl Drop for AgentSight {
 ///
 /// Extracted as a free function so the persistence policy is unit-testable
 /// without constructing a full `AgentSight` instance.
+/// Whether FFI reporting should fall back from LLM to raw-HTTP.
+///
+/// True when there is at least one event and *every* event is a semantically
+/// empty `LLMCall` (no parsed request/response messages). Any non-`LLMCall`
+/// event or any non-empty call disables the fallback so a meaningful event is
+/// never dropped.
+fn events_are_empty_llm(events: &[GenAISemanticEvent]) -> bool {
+    !events.is_empty()
+        && events.iter().all(|e| match e {
+            GenAISemanticEvent::LLMCall(call) => call.is_semantically_empty(),
+            _ => false,
+        })
+}
+
 fn complete_deferred_genai(
     events: &[GenAISemanticEvent],
     sqlite_store: Option<&Arc<GenAISqliteStore>>,
@@ -2265,5 +2337,104 @@ mod tests {
         let bytes = pending.estimated_bytes();
         // 1 event × 512 bytes estimate
         assert!(bytes >= std::mem::size_of::<PendingGenAI>() + 1 + 512);
+    }
+
+    // ── Tests for the AgentsightHttpsData fallback path ──
+
+    fn make_http_record(request_headers: &str) -> crate::analyzer::HttpRecord {
+        crate::analyzer::HttpRecord {
+            timestamp_ns: 1,
+            pid: 1,
+            comm: "test".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            status_code: 200,
+            request_headers: request_headers.to_string(),
+            request_body: None,
+            response_headers: "{}".to_string(),
+            response_body: None,
+            duration_ns: 0,
+            is_sse: false,
+            sse_event_count: 0,
+        }
+    }
+
+    #[test]
+    fn test_events_are_empty_llm() {
+        use crate::genai::semantic::{InputMessage, MessagePart};
+
+        // No events → no fallback.
+        assert!(!events_are_empty_llm(&[]));
+
+        // A single semantically empty LLM call → fallback.
+        let empty = GenAISemanticEvent::LLMCall(make_test_llm_call("c1"));
+        assert!(events_are_empty_llm(std::slice::from_ref(&empty)));
+
+        // A call with parsed request messages → no fallback.
+        let mut call = make_test_llm_call("c2");
+        call.request.messages.push(InputMessage {
+            role: "user".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "hi".to_string(),
+            }],
+            name: None,
+        });
+        assert!(!events_are_empty_llm(&[GenAISemanticEvent::LLMCall(call)]));
+
+        // A non-LLM event alongside an empty call disables the fallback.
+        let tool = GenAISemanticEvent::ToolUse(crate::genai::semantic::ToolUse {
+            tool_use_id: "t1".to_string(),
+            timestamp_ns: 0,
+            tool_name: "grep".to_string(),
+            arguments: serde_json::Value::Null,
+            result: None,
+            duration_ns: None,
+            success: true,
+            error: None,
+            parent_llm_call_id: None,
+            pid: 1,
+        });
+        assert!(!events_are_empty_llm(&[empty, tool]));
+    }
+
+    #[test]
+    fn test_http_record_host_extraction() {
+        // Lowercase `host` key.
+        let r = make_http_record(r#"{"host":"api.openai.com","accept":"*/*"}"#);
+        assert_eq!(
+            AgentSight::http_record_host(&r).as_deref(),
+            Some("api.openai.com")
+        );
+
+        // HTTP/2 `:authority` pseudo-header.
+        let r = make_http_record(r#"{":authority":"api.anthropic.com"}"#);
+        assert_eq!(
+            AgentSight::http_record_host(&r).as_deref(),
+            Some("api.anthropic.com")
+        );
+
+        // No host header → None.
+        let r = make_http_record(r#"{"accept":"*/*"}"#);
+        assert_eq!(AgentSight::http_record_host(&r), None);
+
+        // Unparseable headers → None.
+        let r = make_http_record("not json");
+        assert_eq!(AgentSight::http_record_host(&r), None);
+    }
+
+    #[test]
+    fn test_http_report_filter_gates_by_host() {
+        use crate::discovery::HttpReportFilter;
+
+        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
+        let matched = make_http_record(r#"{"host":"api.openai.com"}"#);
+        let other = make_http_record(r#"{"host":"telemetry.example.com"}"#);
+
+        assert!(filter.should_report(AgentSight::http_record_host(&matched).as_deref()));
+        assert!(!filter.should_report(AgentSight::http_record_host(&other).as_deref()));
+
+        // Empty rule set reports everything (backward compatible).
+        let unrestricted = HttpReportFilter::new(vec![]);
+        assert!(unrestricted.should_report(AgentSight::http_record_host(&other).as_deref()));
     }
 }


### PR DESCRIPTION
## Description

In FFI/embedding mode, when captured traffic is on a recognized LLM API path but
its body cannot be parsed into semantic content (unsupported/garbage body, or an
error response carrying no messages), the pipeline built an empty
`AgentsightLLMData` and never fell back to raw-HTTP reporting — a C consumer saw
an empty LLM record and lost the raw exchange entirely.

Now, in FFI mode, when every built LLM event is semantically empty (no request
and no response messages), the empty LLM event is dropped and the raw HTTP is
reported via `AgentsightHttpsData` instead. Raw-HTTP FFI reporting — both this new
fallback and the existing non-LLM HTTP path — is gated by a domain filter built
from the existing `https` glob rules plus `http` domain/endpoint rules. An empty
rule set reports everything (backward compatible); once rules are configured,
only hosts that match are reported.

## Related Issue

no-issue: migrated from an internal branch; feedback-driven (unparsable LLM
traffic was silently emitted as empty AgentsightLLMData).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/genai/semantic.rs`: `LLMCall::is_semantically_empty()` — true when neither
  the request nor the response produced structured messages.
- `src/discovery/matcher.rs`: `HttpReportFilter` (reuses `match_domain_glob`) —
  gates raw-HTTP FFI reporting by host; strips port, case-insensitive, matches IP
  endpoints; empty rule set reports everything.
- `src/discovery/mod.rs`: export `HttpReportFilter`.
- `src/unified.rs`: `http_report_filter` field (built from `https_rules` +
  `http_domains` + `http_targets` endpoint IPs), `http_record_host` extraction,
  `events_are_empty_llm`, and the divert-to-HTTPS logic in `try_process`
  (FFI-only; requires *all* events to be empty LLM calls so no meaningful event
  is dropped).
- `src/genai/call_builder.rs`: builder-level verification tests.

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] `cargo fmt --check` pass
- [x] `cargo clippy --all-targets -- -D warnings` pass (toolchain 1.89.0)
- [x] `cargo llvm-cov` + incremental `diff-cover --fail-under=80` pass (89%)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (`docs/design-docs/c-ffi-api.md` §6 states LLM/HTTPS are mutually exclusive — needs a note that unparsable LLM now falls back to HTTPS; follow-up)
- [x] Lock files are up to date (`Cargo.lock`) (no dependency change)

## Testing

- Live FFI smoke test: built the C consumer via `make example`, ran it as root
  with eBPF monitoring `dashscope.aliyuncs.com`, and drove `curl` POSTs to
  `/compatible-mode/v1/chat/completions` with an unparsable body (HTTP 400). The
  consumer received `[HTTPS]` (AgentsightHttpsData) events for those LLM-path
  requests with 0 `[LLM]` events — confirming the semantically-empty LLM calls
  were diverted to raw-HTTP. `process=curl` confirmed correct process_name; a
  `GET /` also reported as `[HTTPS]`. All three dashscope flows passed the domain
  filter.
- Builder unit tests: unparsable LLM body -> `is_semantically_empty()` true;
  parsable Anthropic exchange -> false. Plus existing `events_are_empty_llm` and
  6 `HttpReportFilter` tests. `cargo test --lib`: 1174 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)