### PR TITLE
fix(sight): add cosh-ng (cosh-core) to cmdline discovery rules

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -72,6 +72,7 @@
       {"rule": ["*node*", "*cosh*"], "agent_name": "Cosh"},
       {"rule": ["*node*", "*/bin/co*"], "agent_name": "Cosh"},
       {"rule": ["*node*", "*os-copilot*"], "agent_name": "Cosh"},
+      {"rule": ["*cosh-core*"], "agent_name": "Cosh"},
       {"rule": ["*openclaw-gatewa*"], "agent_name": "OpenClaw"},
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
       {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},


### PR DESCRIPTION
## Summary

Add `cosh-core` (cosh-ng's Rust binary) to the cmdline discovery rules so agentsight can detect and attach to it.

Fixes #1594.

## Problem

cosh-ng replaced Node.js copilot-shell with a Rust binary (`cosh-core`). The existing cmdline rules all require `node*` as argv[0], so cosh-core is never discovered → never attached → 0 tokens captured.

## Fix

Add one rule to `agentsight.json`:
```json
{"rule": ["*cosh-core*"], "agent_name": "Cosh"}
```

cosh-core uses `reqwest` + `native-tls` (dynamically links libssl.so), so the existing OpenSSL uprobe path captures its traffic once the process is attached.

## What is NOT changed

- No code changes (JSON config only)
- No schema_version bump needed (additive rule, old configs still work)
- cosh-shell (TUI parent) not added — it doesn't make HTTP calls

## Verification

- E2E: pending ECS test (start cosh-ng, make LLM call, verify agentsight shows agent_name=Cosh with token count > 0)
