### PR TITLE
fix(tokenless): avoid optional tool fixes

### DIFF
--- a/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
+++ b/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
@@ -247,7 +247,11 @@ def main() -> None:
     if status == "UNKNOWN":
         _skip()
 
-    # === Phase 2: FIX (auto-install missing dependencies) ===
+    if status == "PARTIAL":
+        print(_build_response(tool_name, status, missing, "allow"))
+        return
+
+    # === Phase 2: FIX (auto-install missing required dependencies) ===
     _warn(f"{tool_name}: {status}, attempting auto-fix"
           + (f" (missing: {', '.join(missing)})" if missing else ""))
 

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tokenless-hook-version: 9
+# tokenless-hook-version: 10
 # Token-Less Tool Ready environment pre-check.
 #
 # Hook event: PreToolUse (matcher: "" — matches all tools)
@@ -194,6 +194,37 @@ REQUIRED=$(normalize_deps "$(jq -c --arg key "$SPEC_KEY" '.[$key].required // []
 RECOMMENDED=$(normalize_deps "$(jq -c --arg key "$SPEC_KEY" '.[$key].recommended // []' "$SPEC_FILE")")
 PERMISSIONS=$(jq -r --arg key "$SPEC_KEY" '.[$key].permissions[] // empty' "$SPEC_FILE" 2>/dev/null || echo '')
 
+SHELL_COMMAND=$(echo "$INPUT" | jq -r '
+  .tool_input.command //
+  .tool_input.cmd //
+  .input.command //
+  .parameters.command //
+  .arguments.command //
+  empty
+' 2>/dev/null || echo '')
+
+command_uses_binary() {
+  local command_text="$1"
+  local binary="$2"
+  [ -n "$command_text" ] || return 1
+  echo "$command_text" | grep -Eq "(^|[[:space:];|&()<>])(/[^[:space:];|&()<>]*/)?${binary}([[:space:];|&()<>]|$)"
+}
+
+if [ "$SPEC_KEY" = "Shell" ] && [ -n "$SHELL_COMMAND" ]; then
+  FILTERED_RECOMMENDED="[]"
+  rec_filter_count=$(echo "$RECOMMENDED" | jq 'length')
+  if [ "$rec_filter_count" -gt 0 ]; then
+    for i in $(seq 0 $((rec_filter_count - 1))); do
+      dep_json=$(echo "$RECOMMENDED" | jq -c ".[$i]")
+      binary=$(echo "$dep_json" | jq -r '.binary')
+      if command_uses_binary "$SHELL_COMMAND" "$binary"; then
+        FILTERED_RECOMMENDED=$(echo "$FILTERED_RECOMMENDED" | jq -c ". + [$dep_json]")
+      fi
+    done
+  fi
+  RECOMMENDED="$FILTERED_RECOMMENDED"
+fi
+
 # --- Version comparison helper ---
 # Handles prefixed versions (v22.1.0), build suffixes (1.2.3-rc1), and
 # arbitrary segment counts (1.2, 1.2.3, 1.2.3.4, etc.).
@@ -291,19 +322,21 @@ PERM_MISSING=$(check_permissions)
 
 # Check required deps
 req_count=$(echo "$REQUIRED" | jq 'length')
-for i in $(seq 0 $((req_count - 1))); do
-  dep_json=$(echo "$REQUIRED" | jq -c ".[$i]")
-  status=$(check_dep "$dep_json")
-  case "$status" in
-    missing)
-      HAS_REQUIRED_MISSING=true
-      MISSING_DEP_JSONS=$(echo "$MISSING_DEP_JSONS" | jq -c ". + [$dep_json]")
-      ;;
-    version_low:*)
-      HAS_VERSION_LOW=true
-      ;;
-  esac
-done
+if [ "$req_count" -gt 0 ]; then
+  for i in $(seq 0 $((req_count - 1))); do
+    dep_json=$(echo "$REQUIRED" | jq -c ".[$i]")
+    status=$(check_dep "$dep_json")
+    case "$status" in
+      missing)
+        HAS_REQUIRED_MISSING=true
+        MISSING_DEP_JSONS=$(echo "$MISSING_DEP_JSONS" | jq -c ". + [$dep_json]")
+        ;;
+      version_low:*)
+        HAS_VERSION_LOW=true
+        ;;
+    esac
+  done
+fi
 
 REQUIRED_MISSING_COUNT=$(echo "$MISSING_DEP_JSONS" | jq 'length' 2>/dev/null || echo 0)
 
@@ -311,18 +344,19 @@ REQUIRED_MISSING_COUNT=$(echo "$MISSING_DEP_JSONS" | jq 'length' 2>/dev/null || 
 rec_count=$(echo "$RECOMMENDED" | jq 'length')
 missing_count_rec=0
 RECOMMENDED_MISSING_LIST=""
-for i in $(seq 0 $((rec_count - 1))); do
-  dep_json=$(echo "$RECOMMENDED" | jq -c ".[$i]")
-  status=$(check_dep "$dep_json")
-  case "$status" in
-    missing)
-      MISSING_DEP_JSONS=$(echo "$MISSING_DEP_JSONS" | jq -c ". + [$dep_json]")
-      binary=$(echo "$dep_json" | jq -r '.binary')
-      RECOMMENDED_MISSING_LIST="${RECOMMENDED_MISSING_LIST} ${binary}"
-      missing_count_rec=$((missing_count_rec + 1))
-      ;;
-  esac
-done
+if [ "$rec_count" -gt 0 ]; then
+  for i in $(seq 0 $((rec_count - 1))); do
+    dep_json=$(echo "$RECOMMENDED" | jq -c ".[$i]")
+    status=$(check_dep "$dep_json")
+    case "$status" in
+      missing)
+        binary=$(echo "$dep_json" | jq -r '.binary')
+        RECOMMENDED_MISSING_LIST="${RECOMMENDED_MISSING_LIST} ${binary}"
+        missing_count_rec=$((missing_count_rec + 1))
+        ;;
+    esac
+  done
+fi
 
 # --- Determine readiness ---
 IS_READY=true
@@ -373,30 +407,34 @@ if [ "$missing_count" -gt 0 ] && [ -n "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; t
 
     # Re-check version_low entries after fix
     HAS_VERSION_LOW=false
-    for i in $(seq 0 $((req_count - 1))); do
-        dep_json=$(echo "$REQUIRED" | jq -c ".[$i]")
-        status=$(check_dep "$dep_json")
-        case "$status" in
-            version_low:*)
-                HAS_VERSION_LOW=true
-                ;;
-        esac
-    done
+    if [ "$req_count" -gt 0 ]; then
+        for i in $(seq 0 $((req_count - 1))); do
+            dep_json=$(echo "$REQUIRED" | jq -c ".[$i]")
+            status=$(check_dep "$dep_json")
+            case "$status" in
+                version_low:*)
+                    HAS_VERSION_LOW=true
+                    ;;
+            esac
+        done
+    fi
 
     # Re-scan recommended deps after fix
     RECOMMENDED_MISSING_LIST=""
     missing_count_rec=0
-    for i in $(seq 0 $((rec_count - 1))); do
-        dep_json=$(echo "$RECOMMENDED" | jq -c ".[$i]")
-        status=$(check_dep "$dep_json")
-        case "$status" in
-            missing)
-                binary=$(echo "$dep_json" | jq -r '.binary')
-                RECOMMENDED_MISSING_LIST="${RECOMMENDED_MISSING_LIST} ${binary}"
-                missing_count_rec=$((missing_count_rec + 1))
-                ;;
-        esac
-    done
+    if [ "$rec_count" -gt 0 ]; then
+        for i in $(seq 0 $((rec_count - 1))); do
+            dep_json=$(echo "$RECOMMENDED" | jq -c ".[$i]")
+            status=$(check_dep "$dep_json")
+            case "$status" in
+                missing)
+                    binary=$(echo "$dep_json" | jq -r '.binary')
+                    RECOMMENDED_MISSING_LIST="${RECOMMENDED_MISSING_LIST} ${binary}"
+                    missing_count_rec=$((missing_count_rec + 1))
+                    ;;
+            esac
+        done
+    fi
 
     if [ -z "$STILL_MISSING" ] && ! $HAS_VERSION_LOW && [ -z "$PERM_MISSING" ]; then
         exit 0
@@ -438,10 +476,12 @@ fi
 
 # NOT_READY: required deps or permissions missing → block with "Skip retry"
 MISSING_LIST=""
-for i in $(seq 0 $((missing_count - 1))); do
-    binary=$(echo "$MISSING_DEP_JSONS" | jq -r ".[$i].binary")
-    MISSING_LIST="${MISSING_LIST} ${binary}"
-done
+if [ "$missing_count" -gt 0 ]; then
+    for i in $(seq 0 $((missing_count - 1))); do
+        binary=$(echo "$MISSING_DEP_JSONS" | jq -r ".[$i].binary")
+        MISSING_LIST="${MISSING_LIST} ${binary}"
+    done
+fi
 
 DIAG_PARTS=""
 [ -n "$MISSING_LIST" ]  && DIAG_PARTS="${DIAG_PARTS} missing:${MISSING_LIST};"

--- a/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
+++ b/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 SUDO_PREFIX=""
-[ "$(id -u)" -ne 0 ] && SUDO_PREFIX="sudo"
+[ "$(id -u)" -ne 0 ] && SUDO_PREFIX="sudo -n"
 
 FIX_LOG_DIR="${HOME}/.tokenless"
 FIX_LOG="${FIX_LOG_DIR}/env-fix.log"
@@ -65,6 +65,24 @@ was_recently_fixed() {
   # dep names may contain '.' (e.g. "python3.11") which is a regex wildcard.
   awk -v c="$cutoff" '$0 >= c {print}' "$FIX_LOG" 2>/dev/null \
     | grep -Fq "fix=${dep} status=success"
+}
+
+classify_recent_failure() {
+  if [ ! -f "$FIX_LOG" ]; then
+    echo "unknown failure"
+    return
+  fi
+  local recent
+  recent=$(tail -n 80 "$FIX_LOG" 2>/dev/null || true)
+  if echo "$recent" | grep -Eiq 'sudo:.*(password|required|try again|authentication|not in the sudoers)|a password is required|no tty present'; then
+    echo "auth failed: non-interactive sudo unavailable"
+  elif echo "$recent" | grep -Eiq '(Could not resolve|Temporary failure resolving|Name or service not known|Network is unreachable|Connection timed out|Connection refused|TLS|SSL|certificate|curl: \([0-9]+\)|wget: unable|Failed to connect)'; then
+    echo "network failed"
+  elif echo "$recent" | grep -Eiq '(Permission denied|Operation not permitted)'; then
+    echo "permission denied"
+  else
+    echo "unknown failure"
+  fi
 }
 
 # --- Normalize a dep spec to object format ---
@@ -576,8 +594,9 @@ fix_dep() {
   fi
 
   # All strategies failed
-  log_fix "$binary" "failed" "all strategies failed (primary: ${manager}, fallbacks: ${fallback_count})"
-  echo "[tokenless-env-fix] ${binary}: install failed (primary: ${manager}, ${fallback_count} fallbacks exhausted)"
+  failure_detail=$(classify_recent_failure)
+  log_fix "$binary" "failed" "${failure_detail} (primary: ${manager}, fallbacks: ${fallback_count})"
+  echo "[tokenless-env-fix] ${binary}: install failed — ${failure_detail} (primary: ${manager}, ${fallback_count} fallbacks exhausted)"
   return 1
 }
 

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -1199,7 +1199,14 @@ pub fn run(
         let spec = specs.get(tool_name).unwrap();
         let result = check_tool(tool_name, spec);
 
-        // Collect missing and version-low deps for auto-fix
+        // Collect missing deps for reporting, but auto-fix only required deps.
+        let fixable_deps: Vec<DepEntry> = result
+            .required_results
+            .iter()
+            .filter(|(_, s)| matches!(s, DepStatus::Missing | DepStatus::VersionLow { .. }))
+            .map(|(d, _)| d.clone())
+            .collect();
+
         let missing_deps: Vec<DepEntry> = result
             .required_results
             .iter()
@@ -1208,19 +1215,20 @@ pub fn run(
             .map(|(d, _)| d.clone())
             .collect();
 
+        let fixable_names: Vec<String> = fixable_deps.iter().map(|d| d.binary.clone()).collect();
         let missing_names: Vec<String> = missing_deps.iter().map(|d| d.binary.clone()).collect();
 
-        if fix && !missing_deps.is_empty() {
+        if fix && !fixable_deps.is_empty() {
             if !json {
                 println!(
                     "{}: {} (fixing: {})",
                     tool_name,
                     format_status(&result.status),
-                    missing_names.join(", ")
+                    fixable_names.join(", ")
                 );
                 println!("  Attempting auto-fix...");
             }
-            let fix_output = auto_fix(&missing_deps).map_err(|e| (e, 1))?;
+            let fix_output = auto_fix(&fixable_deps).map_err(|e| (e, 1))?;
             if !json {
                 for line in fix_output.lines() {
                     println!("  {}", line);
@@ -1237,7 +1245,7 @@ pub fn run(
                 .map(|(d, _)| d.binary.clone())
                 .collect();
 
-            let fixed: Vec<String> = missing_names
+            let fixed: Vec<String> = fixable_names
                 .iter()
                 .filter(|n| !post_missing.contains(n))
                 .cloned()
@@ -1298,14 +1306,22 @@ pub fn run(
                 println!("  network: {} — {}", net, if *ok { "✓" } else { "missing" });
             }
 
-            if !missing_deps.is_empty() {
+            if !fixable_deps.is_empty() {
                 println!(
-                    "  Hint: run with --fix to auto-install missing deps: {}",
-                    missing_deps
+                    "  Hint: run with --fix to auto-install missing required deps: {}",
+                    fixable_deps
                         .iter()
                         .map(|d| d.binary.clone())
                         .collect::<Vec<_>>()
                         .join(", ")
+                );
+            } else if result
+                .recommended_results
+                .iter()
+                .any(|(_, s)| matches!(s, DepStatus::Missing | DepStatus::VersionLow { .. }))
+            {
+                println!(
+                    "  Note: missing recommended deps are optional and are not auto-installed."
                 );
             }
         }

--- a/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
@@ -1153,6 +1153,57 @@ fn run_unknown_tool_json_output() {
     assert!(run(Some("UnknownTool"), false, false, false, true).is_ok());
 }
 
+#[cfg(unix)]
+#[test]
+fn run_fix_skips_recommended_only_missing_deps() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_spec = std::env::var_os("TOKENLESS_TOOL_READY_SPEC");
+    let prev_fix = std::env::var_os("TOKENLESS_ENV_FIX_SCRIPT");
+
+    let dir = tempfile::tempdir().unwrap();
+    let spec_path = dir.path().join("recommended-only-spec.json");
+    let marker_path = dir.path().join("fix-called");
+    let fix_script_path = dir.path().join("env-fix.sh");
+    let spec = json!({
+        "Shell": {
+            "required": ["sh"],
+            "recommended": ["nonexistent_recommended_binary_xyz_99"],
+            "config_files": [],
+            "permissions": [],
+            "network": [],
+            "aliases": ["Bash"]
+        }
+    });
+    std::fs::write(&spec_path, serde_json::to_string(&spec).unwrap()).unwrap();
+    std::fs::write(
+        &fix_script_path,
+        format!("#!/bin/sh\ntouch '{}'\n", marker_path.display()),
+    )
+    .unwrap();
+    chmod_file(&fix_script_path, 0o755);
+
+    unsafe {
+        std::env::set_var("TOKENLESS_TOOL_READY_SPEC", &spec_path);
+        std::env::set_var("TOKENLESS_ENV_FIX_SCRIPT", &fix_script_path);
+    }
+
+    let result = run(Some("Shell"), false, true, false, true);
+
+    unsafe {
+        match prev_spec {
+            Some(v) => std::env::set_var("TOKENLESS_TOOL_READY_SPEC", v),
+            None => std::env::remove_var("TOKENLESS_TOOL_READY_SPEC"),
+        }
+        match prev_fix {
+            Some(v) => std::env::set_var("TOKENLESS_ENV_FIX_SCRIPT", v),
+            None => std::env::remove_var("TOKENLESS_ENV_FIX_SCRIPT"),
+        }
+    }
+
+    assert!(result.is_ok());
+    assert!(!marker_path.exists(), "recommended deps must not trigger auto-fix");
+}
+
 #[test]
 fn run_no_tool_no_all_errors() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Description

Tool-ready now checks Shell recommended dependencies only when the
invoked command uses those binaries. Recommended dependencies remain
non-blocking and are no longer auto-installed, while required dependency
fixes still run through the existing env-fix path with non-interactive
sudo for fast failure.

## Related Issue

closes #1581
Closes ANO-4
Related: #1497, #1582

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `bash -n adapters/tokenless/common/hooks/tool_ready_hook.sh && bash -n adapters/tokenless/common/tokenless-env-fix.sh`
- `cargo fmt --all -- --check`
- Manual: `Shell` + `mkdir -p demo` stays silent and does not check optional Docker, uv, cargo, or rustc dependencies.
- Manual: `Shell` + `docker ps` reports only missing Docker as a non-blocking recommended dependency and does not auto-install it.
- Attempted: `cargo test -p tokenless-cli run_fix_skips_recommended_only_missing_deps -- --nocapture`. This is blocked locally because the current Rust toolchain does not support existing `if let` chains in `tokenless-schema/src/response_compressor.rs` or `toon-format`'s `unsigned_is_multiple_of` usage.

## Additional Notes

The hook version was bumped to 10 for the shared tool-ready script behavior change.