### PR TITLE
fix(cosh-ng): [core] report invalid JSONL input

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -220,7 +220,11 @@ pub async fn wait_for_auth_response<R: AsyncBufReadExt + Unpin>(
             }
             let msg: InputMessage = match serde_json::from_str(&line) {
                 Ok(m) => m,
-                Err(_) => continue,
+                Err(_) => {
+                    // Let the headless input loop emit the protocol error.
+                    buffered_lines.push(line);
+                    continue;
+                }
             };
             match msg {
                 InputMessage::ControlResponse { response } => {
@@ -287,6 +291,33 @@ pub fn is_auth_error(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn buffers_invalid_jsonl_during_auth_wait() {
+        let (mut input, output) = tokio::io::duplex(1024);
+        input
+            .write_all(b"token=must-not-echo\n")
+            .await
+            .expect("write invalid JSONL");
+        input
+            .write_all(
+                br#"{"type":"control_response","response":{"subtype":"auth","request_id":"auth-init","response":{"provider_id":"dashscope","values":{"api_key":"test-key"},"persist":false}}}"#,
+            )
+            .await
+            .expect("write auth response");
+        input
+            .write_all(b"\n")
+            .await
+            .expect("terminate auth response");
+        drop(input);
+
+        let mut lines = tokio::io::BufReader::new(output).lines();
+        let result = wait_for_auth_response("auth-init", &mut lines).await;
+
+        assert_eq!(result.buffered_lines, vec!["token=must-not-echo"]);
+        assert!(result.response.is_some(), "expected auth response");
+    }
 
     #[test]
     fn builtin_providers_have_correct_ids() {

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -16,7 +16,7 @@ use crate::skill::SkillManager;
 use crate::sls;
 use crate::tool::ToolRegistry;
 
-pub async fn run(args: &CliArgs, mut config: CoreConfig) {
+pub async fn run(args: &CliArgs, mut config: CoreConfig) -> i32 {
     apply_cli_overrides(args, &mut config);
 
     let stdout = io::stdout();
@@ -25,7 +25,7 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) {
         Ok(session) => session,
         Err(error) => {
             emit_session_error(&mut writer, args.resume.as_deref(), &error);
-            return;
+            return 0;
         }
     };
 
@@ -109,6 +109,7 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) {
                     is_error: false,
                     result: Some("completed".to_string()),
                     errors: None,
+                    error_code: None,
                     session_error_code: None,
                     session_error_phase: None,
                     session_id: Some(engine.session_id.clone()),
@@ -123,12 +124,12 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) {
                 engine.emit(&mut writer, &err_msg);
             }
         }
-        return;
+        return 0;
     }
 
     // Replay any lines that were buffered during the auth wait
     for buffered_line in buffered_lines {
-        if !process_input_line(
+        match process_input_line(
             &buffered_line,
             &mut engine,
             &mut lines,
@@ -138,7 +139,9 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) {
         )
         .await
         {
-            return;
+            InputLineResult::Continue => {}
+            InputLineResult::Shutdown => return 0,
+            InputLineResult::InvalidJson => return 1,
         }
     }
 
@@ -148,7 +151,7 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) {
             continue;
         }
 
-        if !process_input_line(
+        match process_input_line(
             &line,
             &mut engine,
             &mut lines,
@@ -158,12 +161,21 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) {
         )
         .await
         {
-            break;
+            InputLineResult::Continue => {}
+            InputLineResult::Shutdown => return 0,
+            InputLineResult::InvalidJson => return 1,
         }
     }
+    0
 }
 
-/// Process a single input line. Returns `false` if the session should shut down.
+enum InputLineResult {
+    Continue,
+    Shutdown,
+    InvalidJson,
+}
+
+/// Processes a single JSONL input line.
 async fn process_input_line<W, R>(
     line: &str,
     engine: &mut CoshCore,
@@ -171,7 +183,7 @@ async fn process_input_line<W, R>(
     writer: &mut W,
     enable_shell_evidence_tool: bool,
     session: &mut SessionRuntime,
-) -> bool
+) -> InputLineResult
 where
     W: io::Write,
     R: AsyncBufReadExt + Unpin,
@@ -179,8 +191,17 @@ where
     let msg: InputMessage = match serde_json::from_str(line) {
         Ok(m) => m,
         Err(e) => {
-            tracing::debug!("failed to parse input: {e}");
-            return true;
+            const ERROR: &str = "failed to parse stdin line as JSON";
+            tracing::debug!("{ERROR}: {e}");
+            engine.emit(
+                writer,
+                &OutputMessage::result_error_with_code(
+                    &engine.session_id,
+                    ERROR,
+                    Some("InvalidJsonlInput"),
+                ),
+            );
+            return InputLineResult::InvalidJson;
         }
     };
 
@@ -230,7 +251,7 @@ where
             ShellControlRequest::Interrupt => {
                 engine.provider.cancel();
             }
-            ShellControlRequest::Shutdown => return false,
+            ShellControlRequest::Shutdown => return InputLineResult::Shutdown,
             ShellControlRequest::SwitchModel { model } => {
                 engine.model = model.clone();
                 engine.emit(
@@ -273,7 +294,7 @@ where
                         writer,
                         &OutputMessage::result_error(&engine.session_id, &error),
                     );
-                    return true;
+                    return InputLineResult::Continue;
                 }
             }
             if let Some(ctx) = shell_context {
@@ -297,6 +318,7 @@ where
                         is_error: false,
                         result: Some("completed".to_string()),
                         errors: None,
+                        error_code: None,
                         session_error_code: None,
                         session_error_phase: None,
                         session_id: Some(engine.session_id.clone()),
@@ -318,7 +340,7 @@ where
             // Registry requests are handled in registry mode, ignore here
         }
     }
-    true
+    InputLineResult::Continue
 }
 
 struct SessionRuntime {

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -114,7 +114,10 @@ async fn main() {
     if args.is_registry() {
         registry::run(&args, config).await;
     } else if args.is_headless() {
-        headless::run(&args, config).await;
+        let exit_code = headless::run(&args, config).await;
+        if exit_code != 0 {
+            std::process::exit(exit_code);
+        }
     } else {
         interactive::run(&args, config).await;
     }

--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -207,6 +207,8 @@ pub enum OutputMessage {
         #[serde(skip_serializing_if = "Option::is_none")]
         errors: Option<Vec<String>>,
         #[serde(skip_serializing_if = "Option::is_none")]
+        error_code: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         session_error_code: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         session_error_phase: Option<String>,
@@ -513,6 +515,7 @@ impl OutputMessage {
             is_error: false,
             result: Some(result.to_string()),
             errors: None,
+            error_code: None,
             session_error_code: None,
             session_error_phase: None,
             session_id: Some(session_id.to_string()),
@@ -522,11 +525,17 @@ impl OutputMessage {
     }
 
     pub fn result_error(session_id: &str, error: &str) -> Self {
+        Self::result_error_with_code(session_id, error, None)
+    }
+
+    /// Builds an error result with a stable code for machine consumers.
+    pub fn result_error_with_code(session_id: &str, error: &str, error_code: Option<&str>) -> Self {
         Self::Result {
             subtype: Some("error".to_string()),
             is_error: true,
             result: Some(error.to_string()),
             errors: Some(vec![error.to_string()]),
+            error_code: error_code.map(str::to_string),
             session_error_code: None,
             session_error_phase: None,
             session_id: Some(session_id.to_string()),
@@ -546,6 +555,7 @@ impl OutputMessage {
             is_error: true,
             result: Some(error.to_string()),
             errors: Some(vec![error.to_string()]),
+            error_code: None,
             session_error_code: Some(session_error_code.to_string()),
             session_error_phase: Some(session_error_phase.to_string()),
             session_id: Some(session_id.to_string()),

--- a/src/cosh-ng/crates/cosh-core/tests/jsonl_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/jsonl_protocol.rs
@@ -164,3 +164,39 @@ fn output_format_matches_cosh_shell_expectations() {
     assert_eq!(init.get("type").unwrap().as_str().unwrap(), "system");
     assert_eq!(init.get("subtype").unwrap().as_str().unwrap(), "init");
 }
+
+#[test]
+fn invalid_jsonl_input_returns_error_and_fails() {
+    let bin = binary_path();
+    let home = tempfile::tempdir().expect("temp home");
+    let mut child = Command::new(&bin)
+        .env("HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cosh-core");
+
+    const SECRET_INPUT: &str = "token=must-not-echo";
+    writeln!(child.stdin.as_mut().expect("stdin"), "{SECRET_INPUT}").expect("write invalid input");
+    let output = child.wait_with_output().expect("wait for cosh-core");
+    assert!(!output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains(SECRET_INPUT),
+        "invalid input must not be echoed"
+    );
+    let messages = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("valid JSONL output"))
+        .collect::<Vec<_>>();
+    let error = messages
+        .iter()
+        .find(|message| message["type"] == "result" && message["is_error"] == true)
+        .expect("invalid input error result");
+    assert_eq!(error["subtype"], "error");
+    assert_eq!(error["error_code"], "InvalidJsonlInput");
+    assert_eq!(error["errors"][0], "failed to parse stdin line as JSON");
+}


### PR DESCRIPTION
## Description

Return a JSONL error result and exit nonzero when headless input contains invalid JSON. Invalid lines received while waiting for authentication now reach the same error path instead of being discarded.

## Related Issue

closes #1610

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo test --package cosh-core`
- `cargo clippy --package cosh-core --all-targets -- -D warnings`
- Added JSONL integration coverage for error output, `InvalidJsonlInput`, nonzero exit status, and no raw input echo.
- Added an auth-wait unit test proving malformed JSONL is buffered for headless processing.

## Additional Notes

The default interactive TUI is explicitly unimplemented in the current source and is intentionally not included in this focused protocol fix.