### PR TITLE
fix(ckpt): auto-recover orphan .pre-init-bak from interrupted init

### DIFF
--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
@@ -11,7 +11,7 @@ use ws_ckpt_common::backend::*;
 use ws_ckpt_common::{DaemonConfig, DiffEntry, WorkspaceInfo, SNAPSHOTS_DIR};
 
 use super::btrfs_common;
-use btrfs_common::{backup_path_for, resolve_symlink_path};
+use btrfs_common::{backup_path_for, recover_orphan_backup, resolve_symlink_path};
 
 /// Deployment scenario for BtrfsBase backend.
 #[derive(Debug, Clone, Copy)]
@@ -73,12 +73,13 @@ impl BtrfsBaseBackend {
         let orig_gid = orig_meta.gid();
 
         let backup_path = backup_path_for(original_path);
-        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
-            anyhow::bail!(
-                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
-                backup_path
-            );
-        }
+        // Recover orphan `.pre-init-bak` from an interrupted prior init before
+        // proceeding with Step 3 (rename). If recovery is impossible (ambiguous
+        // state — subvol already exists), recover_orphan_backup returns an
+        // actionable error pointing the user at `ws-ckpt recover`. See
+        // btrfs_common::recover_orphan_backup for the full rationale.
+        recover_orphan_backup(original_path, subvol_path).await?;
+
         tokio::fs::rename(original_path, &backup_path)
             .await
             .context("failed to rename original directory to backup")?;
@@ -363,6 +364,18 @@ impl StorageBackend for BtrfsBaseBackend {
         // 5. Remove snapshots/{ws_id} directory
         if let Err(e) = tokio::fs::remove_dir_all(&snap_base).await {
             warn!("failed to remove snapshots dir {:?}: {}", snap_base, e);
+        }
+
+        // 6. Clean orphan `.pre-init-bak` if it still exists (prior interrupted
+        //    init). Safe to remove at this point — subvol is gone, original_path
+        //    has been restored as a normal directory in steps above.
+        let backup_path = backup_path_for(original_path);
+        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
+            if let Err(e) = tokio::fs::remove_dir_all(&backup_path).await {
+                warn!("failed to clean orphan backup {:?}: {:#}", backup_path, e);
+            } else {
+                info!("cleaned orphan backup {:?} during recover", backup_path);
+            }
         }
 
         // NOTE: BtrfsBase does NOT need umount, losetup -d, or img deletion

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -73,8 +73,12 @@ pub async fn recover_orphan_backup(original_path: &str, subvol_path: &Path) -> R
                          refusing to overwrite user data. Inspect {:?} (likely contains \
                          data from interrupted init) and {:?}, move data out of {:?} or \
                          remove {:?} manually, then re-run init",
-                        backup_path, original_path, backup_path, original_path,
-                        original_path, backup_path
+                        backup_path,
+                        original_path,
+                        backup_path,
+                        original_path,
+                        original_path,
+                        backup_path
                     );
                 }
                 let _ = tokio::fs::remove_dir(original_path).await;
@@ -83,7 +87,9 @@ pub async fn recover_orphan_backup(original_path: &str, subvol_path: &Path) -> R
                 bail!(
                     "found orphan backup {:?} but {:?} is an unexpected file type; \
                      remove {:?} manually before retrying",
-                    backup_path, original_path, original_path
+                    backup_path,
+                    original_path,
+                    original_path
                 );
             }
             Err(_) => { /* original_path missing — fine, rename will create it */ }
@@ -1364,7 +1370,9 @@ mod tests {
         let orig = tmp.path().join("ws");
         let subvol = tmp.path().join("subvol");
         tokio::fs::create_dir(&orig).await.unwrap();
-        tokio::fs::write(orig.join("user.txt"), b"keep").await.unwrap();
+        tokio::fs::write(orig.join("user.txt"), b"keep")
+            .await
+            .unwrap();
 
         recover_orphan_backup(orig.to_str().unwrap(), &subvol)
             .await
@@ -1387,7 +1395,9 @@ mod tests {
         let subvol = tmp.path().join("subvol");
 
         tokio::fs::create_dir(&bak).await.unwrap();
-        tokio::fs::write(bak.join("foo.txt"), b"important").await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"important")
+            .await
+            .unwrap();
 
         recover_orphan_backup(orig.to_str().unwrap(), &subvol)
             .await
@@ -1408,7 +1418,9 @@ mod tests {
         let subvol = tmp.path().join("subvol");
 
         tokio::fs::create_dir(&bak).await.unwrap();
-        tokio::fs::write(bak.join("foo.txt"), b"keep").await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"keep")
+            .await
+            .unwrap();
         // Simulate a test fixture's `rm -rf + mkdir -p` leaving an empty dir.
         tokio::fs::create_dir(&orig).await.unwrap();
 
@@ -1434,7 +1446,9 @@ mod tests {
         let ghost = tmp.path().join("nonexistent-target");
 
         tokio::fs::create_dir(&bak).await.unwrap();
-        tokio::fs::write(bak.join("foo.txt"), b"keep").await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"keep")
+            .await
+            .unwrap();
         tokio::fs::symlink(&ghost, &orig).await.unwrap(); // dangling symlink
 
         recover_orphan_backup(orig.to_str().unwrap(), &subvol)
@@ -1460,7 +1474,9 @@ mod tests {
             .await
             .unwrap();
         tokio::fs::create_dir(&orig).await.unwrap();
-        tokio::fs::write(orig.join("racer.txt"), b"foreign").await.unwrap();
+        tokio::fs::write(orig.join("racer.txt"), b"foreign")
+            .await
+            .unwrap();
 
         let err = recover_orphan_backup(orig.to_str().unwrap(), &subvol)
             .await
@@ -1484,7 +1500,9 @@ mod tests {
         let subvol = tmp.path().join("subvol");
 
         tokio::fs::create_dir(&bak).await.unwrap();
-        tokio::fs::write(bak.join("user.txt"), b"keep").await.unwrap();
+        tokio::fs::write(bak.join("user.txt"), b"keep")
+            .await
+            .unwrap();
         tokio::fs::create_dir(&subvol).await.unwrap();
         tokio::fs::write(subvol.join("migrated.txt"), b"partial")
             .await

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -15,6 +15,105 @@ pub fn backup_path_for(original_path: &str) -> String {
     format!("{}.pre-init-bak", original_path.trim_end_matches('/'))
 }
 
+/// Recover an orphan `.pre-init-bak` left by an interrupted prior init.
+///
+/// Called by `do_init_storage` in `btrfs_base.rs` and `btrfs_loop.rs` BEFORE
+/// the Step 3 `rename(original_path -> backup_path)`. Two cases handled:
+///
+/// 1. Backup exists + subvol_path does NOT exist:
+///    Prior init was interrupted AFTER Step 3 (rename) but BEFORE Step 4
+///    (data migration). User's original data is sitting in the backup. The
+///    right thing is to rename the backup back to `original_path`, restoring
+///    the user's data, and let the caller proceed with a fresh normal init.
+///    A stale empty directory at `original_path` (e.g., from a fixture's
+///    `rm -rf + mkdir -p`) is removed first; a non-empty dir is refused to
+///    avoid destroying user data.
+///
+/// 2. Backup exists + subvol_path DOES exist:
+///    Prior init completed data migration (Step 4) and may have created the
+///    symlink (Step 5). State is ambiguous (subvol might be valid, symlink
+///    might be dangling, original_path might be a stale dir, etc.). Auto-
+///    recovery would risk data loss, so we bail with an actionable error
+///    pointing at `ws-ckpt recover -w <path> --force` (which we also patch
+///    in this PR to clean orphan backups at the end of recovery).
+///
+/// 3. No backup exists: noop.
+pub async fn recover_orphan_backup(original_path: &str, subvol_path: &Path) -> Result<()> {
+    let backup_path = backup_path_for(original_path);
+    if tokio::fs::symlink_metadata(&backup_path).await.is_err() {
+        return Ok(());
+    }
+
+    let subvol_exists = tokio::fs::metadata(subvol_path)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false);
+
+    if !subvol_exists {
+        // Case 1: prior init crashed between Step 3 (rename) and Step 4
+        // (data migration). User data is in backup. Restore it back to
+        // original_path so the caller can re-run a clean init.
+        warn!(
+            "init: orphan backup {:?} detected (prior init interrupted before data migration); \
+             restoring user data from backup",
+            backup_path
+        );
+        // Remove stale state at original_path before restoring backup into it.
+        match tokio::fs::symlink_metadata(original_path).await {
+            Ok(m) if m.file_type().is_symlink() => {
+                // dangling or stale symlink — safe to remove
+                let _ = tokio::fs::remove_file(original_path).await;
+            }
+            Ok(m) if m.is_dir() => {
+                let mut entries = tokio::fs::read_dir(original_path).await?;
+                let is_empty = entries.next_entry().await?.is_none();
+                if !is_empty {
+                    bail!(
+                        "found orphan backup {:?} but {:?} is a non-empty directory; \
+                         refusing to overwrite user data. Inspect {:?} (likely contains \
+                         data from interrupted init) and {:?}, move data out of {:?} or \
+                         remove {:?} manually, then re-run init",
+                        backup_path, original_path, backup_path, original_path,
+                        original_path, backup_path
+                    );
+                }
+                let _ = tokio::fs::remove_dir(original_path).await;
+            }
+            Ok(_) => {
+                bail!(
+                    "found orphan backup {:?} but {:?} is an unexpected file type; \
+                     remove {:?} manually before retrying",
+                    backup_path, original_path, original_path
+                );
+            }
+            Err(_) => { /* original_path missing — fine, rename will create it */ }
+        }
+        tokio::fs::rename(&backup_path, original_path)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to restore orphan backup {:?} -> {:?}",
+                    backup_path, original_path
+                )
+            })?;
+        info!(
+            "init: restored user data from orphan backup {:?} to {:?}; proceeding with fresh init",
+            backup_path, original_path
+        );
+        return Ok(());
+    }
+
+    // Case 2: subvol_path exists. Ambiguous state — bail with actionable error.
+    bail!(
+        "found orphan backup {:?} and existing subvolume {:?} from an interrupted prior init. \
+         Run `ws-ckpt recover -w {} --force` to restore user data from the subvolume and clean \
+         up the orphan backup, then re-run init. If `ws-ckpt recover` does not list this workspace, \
+         manually inspect {:?} (likely contains pre-migration user data) and {:?}, move data out \
+         as needed, and remove the backup before retrying",
+        backup_path, subvol_path, original_path, backup_path, subvol_path
+    );
+}
+
 /// Roll back a failed init_workspace; `backup_owned=true` only when this init created the backup (#673).
 pub async fn cleanup_init_storage(
     original_path: &str,
@@ -1252,5 +1351,154 @@ mod tests {
             Some(12345)
         );
         assert_eq!(extract_first_numeric_after_colon("no colon here"), None);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests for recover_orphan_backup
+    // -------------------------------------------------------------------------
+
+    /// No orphan backup → noop. Does not touch original_path or subvol_path.
+    #[tokio::test]
+    async fn recover_orphan_backup_noop_when_no_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let subvol = tmp.path().join("subvol");
+        tokio::fs::create_dir(&orig).await.unwrap();
+        tokio::fs::write(orig.join("user.txt"), b"keep").await.unwrap();
+
+        recover_orphan_backup(orig.to_str().unwrap(), &subvol)
+            .await
+            .unwrap();
+
+        assert!(orig.join("user.txt").exists(), "original untouched");
+        assert!(!subvol.exists(), "subvol untouched");
+        assert!(
+            !tmp.path().join("ws.pre-init-bak").exists(),
+            "no backup created"
+        );
+    }
+
+    /// Orphan backup + no subvol → restores backup to original_path. (Case 1)
+    #[tokio::test]
+    async fn recover_orphan_backup_restores_user_data_when_no_subvol() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let subvol = tmp.path().join("subvol");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"important").await.unwrap();
+
+        recover_orphan_backup(orig.to_str().unwrap(), &subvol)
+            .await
+            .unwrap();
+
+        assert!(!bak.exists(), "backup consumed by rename");
+        assert!(orig.is_dir(), "original restored as real dir");
+        assert!(orig.join("foo.txt").exists(), "user data restored");
+    }
+
+    /// Orphan backup + no subvol + stale empty dir at original → removes the
+    /// stale dir and restores backup. (Case 1 with fixture-like state.)
+    #[tokio::test]
+    async fn recover_orphan_backup_clears_stale_empty_dir_at_original() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let subvol = tmp.path().join("subvol");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"keep").await.unwrap();
+        // Simulate a test fixture's `rm -rf + mkdir -p` leaving an empty dir.
+        tokio::fs::create_dir(&orig).await.unwrap();
+
+        recover_orphan_backup(orig.to_str().unwrap(), &subvol)
+            .await
+            .unwrap();
+
+        assert!(!bak.exists());
+        assert!(
+            orig.join("foo.txt").exists(),
+            "user data restored over empty dir"
+        );
+    }
+
+    /// Orphan backup + no subvol + stale dangling symlink at original → removes
+    /// the symlink and restores backup. (Case 1 with broken symlink.)
+    #[tokio::test]
+    async fn recover_orphan_backup_clears_dangling_symlink_at_original() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let subvol = tmp.path().join("subvol");
+        let ghost = tmp.path().join("nonexistent-target");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("foo.txt"), b"keep").await.unwrap();
+        tokio::fs::symlink(&ghost, &orig).await.unwrap(); // dangling symlink
+
+        recover_orphan_backup(orig.to_str().unwrap(), &subvol)
+            .await
+            .unwrap();
+
+        assert!(!bak.exists());
+        assert!(orig.is_dir(), "original is real dir, not symlink");
+        assert!(orig.join("foo.txt").exists());
+    }
+
+    /// Orphan backup + non-empty dir at original → refuses and preserves user
+    /// data in both locations. (Case 1 safety bail.)
+    #[tokio::test]
+    async fn recover_orphan_backup_refuses_non_empty_dir_at_original() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let subvol = tmp.path().join("subvol");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("from_backup.txt"), b"keep")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(&orig).await.unwrap();
+        tokio::fs::write(orig.join("racer.txt"), b"foreign").await.unwrap();
+
+        let err = recover_orphan_backup(orig.to_str().unwrap(), &subvol)
+            .await
+            .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("non-empty directory"), "got: {}", msg);
+        assert!(msg.contains("remove"), "actionable error: {}", msg);
+
+        // Both must be preserved — no data loss.
+        assert!(bak.join("from_backup.txt").exists());
+        assert!(orig.join("racer.txt").exists());
+    }
+
+    /// Orphan backup + subvol exists → bails with actionable error pointing
+    /// at `ws-ckpt recover`. Does not touch either path. (Case 2.)
+    #[tokio::test]
+    async fn recover_orphan_backup_bails_when_subvol_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = tmp.path().join("ws");
+        let bak = tmp.path().join("ws.pre-init-bak");
+        let subvol = tmp.path().join("subvol");
+
+        tokio::fs::create_dir(&bak).await.unwrap();
+        tokio::fs::write(bak.join("user.txt"), b"keep").await.unwrap();
+        tokio::fs::create_dir(&subvol).await.unwrap();
+        tokio::fs::write(subvol.join("migrated.txt"), b"partial")
+            .await
+            .unwrap();
+
+        let err = recover_orphan_backup(orig.to_str().unwrap(), &subvol)
+            .await
+            .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("ws-ckpt recover"), "actionable error: {}", msg);
+        assert!(msg.contains("interrupted prior init"), "context: {}", msg);
+
+        // Nothing should be destroyed on ambiguous state.
+        assert!(bak.join("user.txt").exists());
+        assert!(subvol.join("migrated.txt").exists());
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -13,7 +13,7 @@ use ws_ckpt_common::{DaemonConfig, DiffEntry, WorkspaceInfo, SNAPSHOTS_DIR};
 
 use super::btrfs_common;
 use crate::util::{is_mounted, run_command, run_command_checked};
-use btrfs_common::{backup_path_for, resolve_symlink_path};
+use btrfs_common::{backup_path_for, recover_orphan_backup, resolve_symlink_path};
 
 pub struct BtrfsLoopBackend {
     pub mount_path: PathBuf,
@@ -57,12 +57,10 @@ impl BtrfsLoopBackend {
         let orig_gid = orig_meta.gid();
 
         let backup_path = backup_path_for(original_path);
-        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
-            anyhow::bail!(
-                "refusing to overwrite pre-existing backup {:?}; remove it manually first",
-                backup_path
-            );
-        }
+        // Recover orphan `.pre-init-bak` from an interrupted prior init before
+        // proceeding with Step 3 (rename). See btrfs_common::recover_orphan_backup.
+        recover_orphan_backup(original_path, subvol_path).await?;
+
         tokio::fs::rename(original_path, &backup_path)
             .await
             .context("failed to rename original directory to backup")?;
@@ -324,6 +322,18 @@ impl StorageBackend for BtrfsLoopBackend {
         // 5. Remove snapshots/{ws_id} directory
         if let Err(e) = tokio::fs::remove_dir_all(&snap_base).await {
             warn!("failed to remove snapshots dir {:?}: {}", snap_base, e);
+        }
+
+        // 6. Clean orphan `.pre-init-bak` if it still exists (prior interrupted
+        //    init). Safe to remove at this point — subvol is gone, original_path
+        //    has been restored as a normal directory in steps above.
+        let backup_path = backup_path_for(original_path);
+        if tokio::fs::symlink_metadata(&backup_path).await.is_ok() {
+            if let Err(e) = tokio::fs::remove_dir_all(&backup_path).await {
+                warn!("failed to clean orphan backup {:?}: {:#}", backup_path, e);
+            } else {
+                info!("cleaned orphan backup {:?} during recover", backup_path);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Closes #1600.

`ws-ckpt init` (and `ws-ckpt checkpoint` when it implicitly triggers init) leaves an orphan `.pre-init-bak` directory behind when init is interrupted between Step 3 (rename original → backup) and Step 7 (cleanup `remove_dir_all`). The next init on the same workspace unconditionally bails with `"refusing to overwrite pre-existing backup; remove it manually first"`, giving users no in-product recovery path:

- The error message is terse — it doesn't tell the user the backup contains their original data, nor point them at `ws-ckpt recover`.
- `ws-ckpt recover -w <path> --force` doesn't help: (a) it only lists workspaces the daemon already knows about (won't help if init crashed before registering); (b) even when it does work, it doesn't clean `.pre-init-bak`, so the next init still bails.

Real users hit this any time init is interrupted once (SIGKILL, OOM, systemd restart, SSH disconnect, machine reboot, btrfs sync timeout). After that, the workspace is permanently broken until manual `rm -rf <workspace>.pre-init-bak`, which silently destroys the user's original data if they didn't realize it was there.

This PR closes the loop on the safety mechanism from #673 by handling the orphan-backup case at init entry:

## Changes

### `btrfs_common.rs`

- New `pub async fn recover_orphan_backup(original_path, subvol_path) -> Result<()>` helper.
- **Case 1** (backup exists + subvol does NOT exist): prior init crashed between Step 3 and Step 4. User data is in the backup. Restore it by `rename(backup_path → original_path)` (after removing any stale empty directory or dangling symlink at original_path; refuse if original_path is a non-empty dir to avoid data loss). Proceed with normal init.
- **Case 2** (backup exists + subvol exists): ambiguous state — could be partial migration, dangling symlink, etc. Bail with an actionable error pointing at `ws-ckpt recover -w <path> --force`. Don't auto-recover (would risk data loss).
- **No backup**: noop.
- 6 new unit tests: noop-when-no-backup, restores-user-data-when-no-subvol, clears-stale-empty-dir, clears-dangling-symlink, refuses-non-empty-dir-at-original, bails-when-subvol-exists.

### `btrfs_base.rs` and `btrfs_loop.rs`

- Replace `bail!("refusing to overwrite pre-existing backup ...; remove it manually first")` in `do_init_storage` Step 3 with `recover_orphan_backup(original_path, subvol_path).await?`. If recovery is impossible, the helper returns an actionable error.
- Append orphan `.pre-init-bak` cleanup to `recover_workspace` Step 6, so `ws-ckpt recover` becomes a real recovery path for this scenario (rsync subvol back to original, delete subvol + snapshots, AND clean the orphan backup).

## Test Plan

Verified on alinux4 ECS at `origin/main` (commit `f1196f05`):

```bash
cd /root/anolisa/src/ws-ckpt/src
cargo build --release -p ws-ckpt-daemon              # OK, 7.35s
cargo test --release -p ws-ckpt-daemon --lib backends::btrfs_common::tests::recover_orphan_backup
# 6 new tests all PASS:
#   recover_orphan_backup_noop_when_no_backup
#   recover_orphan_backup_restores_user_data_when_no_subvol
#   recover_orphan_backup_clears_stale_empty_dir_at_original
#   recover_orphan_backup_clears_dangling_symlink_at_original
#   recover_orphan_backup_refuses_non_empty_dir_at_original
#   recover_orphan_backup_bails_when_subvol_exists
cargo test --release -p ws-ckpt-daemon --lib backends
# 54 tests all PASS (no regression on #673 safety properties)
cargo test --release -p ws-ckpt-daemon --lib
# 211 tests all PASS (no regression on daemon lib overall)
```

The 6 new tests cover:

1. **noop-when-no-backup**: clean state — must not touch anything.
2. **restores-user-data-when-no-subvol** (Case 1 happy path): backup has user data, no subvol → rename backup back to original_path, preserving all user files.
3. **clears-stale-empty-dir-at-original** (Case 1 with fixture-like state): backup exists, original_path is an empty dir from a `rm -rf + mkdir -p` fixture → removes the empty dir, restores user data from backup.
4. **clears-dangling-symlink-at-original** (Case 1 with broken symlink): backup exists, original_path is a dangling symlink → removes the symlink, restores user data from backup.
5. **refuses-non-empty-dir-at-original** (Case 1 safety bail): backup exists, original_path is a non-empty dir (user has foreign data) → refuse, preserve both. No data loss.
6. **bails-when-subvol-exists** (Case 2 actionable error): backup + subvol both exist → bail with error message containing `ws-ckpt recover`. Nothing destroyed.

Pre-existing #673 tests still PASS:

- `restore_swaps_symlink_back_to_backup`
- `restore_clears_empty_racer_dir`
- `restore_preserves_non_empty_foreign_dir_and_backup`
- `restore_is_noop_when_backup_missing`
- `cleanup_does_not_restore_unowned_backup`
- `cleanup_drops_leftover_symlink_when_unowned`
- `cleanup_restores_owned_backup`

## CLA

Author email: `zhangtaibo.ztb@alibaba-inc.com` (already associated with `zhangtaibo` GitHub account; note `taibo` not `taobo`).

🤫 Generated with Claude Code
