### PR TITLE
feat(sec-core): make prompt scan mode env-configurable

### DIFF
--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/prompt_scanner_hook.py
@@ -11,6 +11,11 @@ Modes (controlled by PROMPT_SCANNER_MODE env var, default: observe):
   - deny: block prompt with reason when risk is detected.
           (agent-sec-cli's "warn" verdict is escalated to block in this mode)
 
+Scan mode (controlled by PROMPT_SCANNER_SCAN_MODE env var, default: standard):
+  - fast: lightweight heuristics, lower latency.
+  - standard: balanced detection (default).
+  - strict: not implemented yet; currently behaves the same as standard.
+
 Usage::
 
     python3 prompt_scanner_hook.py          # reads stdin, writes stdout
@@ -34,7 +39,11 @@ try:
     TIMEOUT = int(os.environ.get("PROMPT_SCANNER_TIMEOUT", "10"))
 except (ValueError, TypeError):
     TIMEOUT = 10
-_DEFAULT_SCAN_MODE = "standard"
+_DEFAULT_SCAN_MODE = (
+    os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+)
+if _DEFAULT_SCAN_MODE not in {"fast", "standard", "strict"}:
+    _DEFAULT_SCAN_MODE = "standard"
 _DEFAULT_SOURCE = "user_input"
 
 
@@ -51,7 +60,7 @@ def _block(scan_result: dict) -> None:
         "[prompt-scanner] ⛔ 安全拦截：检测到提示词注入攻击",
         f"  攻击类型 : {threat_type or 'unknown'}",
         f"  风险等级 : {risk_level}",
-        f"  拦截环节 : 用户输入扫描 (UserPromptSubmit)",
+        "  拦截环节 : 用户输入扫描 (UserPromptSubmit)",
     ]
     if confidence is not None:
         try:

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/prompt_scanner_hook.py
@@ -39,11 +39,15 @@ try:
     TIMEOUT = int(os.environ.get("PROMPT_SCANNER_TIMEOUT", "10"))
 except (ValueError, TypeError):
     TIMEOUT = 10
-_DEFAULT_SCAN_MODE = (
-    os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
-)
+_RAW_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+_DEFAULT_SCAN_MODE = _RAW_SCAN_MODE
 if _DEFAULT_SCAN_MODE not in {"fast", "standard", "strict"}:
     _DEFAULT_SCAN_MODE = "standard"
+print(
+    f"[prompt-scanner] scan mode configured: raw={_RAW_SCAN_MODE!r}, "
+    f"effective={_DEFAULT_SCAN_MODE!r}",
+    file=sys.stderr,
+)
 _DEFAULT_SOURCE = "user_input"
 
 

--- a/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
@@ -39,9 +39,15 @@ from trace_context import with_trace_context
 
 # -- config ----------------------------------------------------------------
 
-_DEFAULT_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+_RAW_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+_DEFAULT_MODE = _RAW_SCAN_MODE
 if _DEFAULT_MODE not in {"fast", "standard", "strict"}:
     _DEFAULT_MODE = "standard"
+print(
+    f"[prompt-scanner] scan mode configured: raw={_RAW_SCAN_MODE!r}, "
+    f"effective={_DEFAULT_MODE!r}",
+    file=sys.stderr,
+)
 _DEFAULT_SOURCE = "user_input"
 
 

--- a/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
@@ -21,9 +21,17 @@ Input schema::
 This script is intentionally self-contained — it does NOT import any
 ``agent_sec_cli`` package.  All it needs is the standard library and the
 ``agent-sec-cli`` on $PATH.
+
+Scan mode (controlled by ``PROMPT_SCANNER_SCAN_MODE`` env var, default:
+``standard``):
+
+- ``fast``: lightweight heuristics, lower latency.
+- ``standard``: balanced detection (default).
+- ``strict``: not implemented yet; currently behaves the same as standard.
 """
 
 import json
+import os
 import subprocess
 import sys
 
@@ -31,7 +39,9 @@ from trace_context import with_trace_context
 
 # -- config ----------------------------------------------------------------
 
-_DEFAULT_MODE = "standard"
+_DEFAULT_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+if _DEFAULT_MODE not in {"fast", "standard", "strict"}:
+    _DEFAULT_MODE = "standard"
 _DEFAULT_SOURCE = "user_input"
 
 
@@ -50,10 +60,10 @@ def _build_detail_reason(scan_result: dict) -> str:
     confidence = scan_result.get("confidence")
 
     lines = [
-        f"[prompt-scanner] 检测到安全风险",
+        "[prompt-scanner] 检测到安全风险",
         f"  攻击类型 : {threat_type or 'unknown'}",
         f"  风险等级 : {risk_level}",
-        f"  拦截环节 : 用户输入扫描 (UserPromptSubmit)",
+        "  拦截环节 : 用户输入扫描 (UserPromptSubmit)",
     ]
     if confidence is not None:
         try:

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/prompt_scan.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/prompt_scan.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -12,7 +13,9 @@ from .base import AgentSecCoreCapability
 logger = logging.getLogger("agent-sec-core")
 
 _DEFAULT_WARNING_TTL_SECONDS = 300.0
-_SCAN_MODE = "standard"
+_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+if _SCAN_MODE not in {"fast", "standard", "strict"}:
+    _SCAN_MODE = "standard"
 _USER_INPUT_SOURCE = "user_input"
 
 
@@ -283,10 +286,10 @@ class PromptScanCapability(AgentSecCoreCapability):
         confidence = scan.get("confidence")
 
         lines = [
-            f"\U0001f6e1\ufe0f [prompt-scan] 检测到安全风险",
+            "\U0001f6e1\ufe0f [prompt-scan] 检测到安全风险",
             f"  攻击类型 : {threat_type or 'unknown'}",
             f"  风险等级 : {risk_level}",
-            f"  拦截环节 : 用户输入扫描 (pre_llm_call)",
+            "  拦截环节 : 用户输入扫描 (pre_llm_call)",
         ]
         if confidence is not None:
             try:

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/prompt_scan.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/prompt_scan.py
@@ -13,9 +13,13 @@ from .base import AgentSecCoreCapability
 logger = logging.getLogger("agent-sec-core")
 
 _DEFAULT_WARNING_TTL_SECONDS = 300.0
-_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+_RAW_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+_SCAN_MODE = _RAW_SCAN_MODE
 if _SCAN_MODE not in {"fast", "standard", "strict"}:
     _SCAN_MODE = "standard"
+logger.info(
+    "Prompt scanner scan mode: raw=%r, effective=%r", _RAW_SCAN_MODE, _SCAN_MODE
+)
 _USER_INPUT_SOURCE = "user_input"
 
 

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
@@ -13,7 +13,11 @@ import { buildTraceContext, callAgentSecCli } from "../utils.js";
  * 再做一次 scan-prompt，可覆盖间接注入（tool output 投毒、RAG 投毒等）。
  * 届时独立为新能力 id="prompt-scan-full"，挂 before_prompt_build。
  *
- * CLI: agent-sec-cli scan-prompt --text <prompt> --mode standard --format json --source user_input
+ * Scan mode (controlled by PROMPT_SCANNER_SCAN_MODE env var, default: standard):
+ *   - fast: lightweight heuristics, lower latency.
+ *   - standard: balanced detection (default).
+ *   - strict: not implemented yet; currently behaves the same as standard.
+ * CLI: agent-sec-cli scan-prompt --text <prompt> --mode <fast|standard|strict> --format json --source user_input
  */
 export const promptScan: SecurityCapability = {
   id: "prompt-scan",
@@ -28,8 +32,10 @@ export const promptScan: SecurityCapability = {
           return undefined;
         }
 
+        const scanMode = (process.env.PROMPT_SCANNER_SCAN_MODE ?? "standard").trim().toLowerCase();
+        const validScanMode = ["fast", "standard", "strict"].includes(scanMode) ? scanMode : "standard";
         const result = await callAgentSecCli(
-          ["scan-prompt", "--text", text, "--mode", "standard", "--format", "json", "--source", "user_input"],
+          ["scan-prompt", "--text", text, "--mode", validScanMode, "--format", "json", "--source", "user_input"],
           { timeout: 10000, traceContext: buildTraceContext(event, ctx) },
         );
 

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/prompt-scan.ts
@@ -32,8 +32,11 @@ export const promptScan: SecurityCapability = {
           return undefined;
         }
 
-        const scanMode = (process.env.PROMPT_SCANNER_SCAN_MODE ?? "standard").trim().toLowerCase();
-        const validScanMode = ["fast", "standard", "strict"].includes(scanMode) ? scanMode : "standard";
+        const rawScanMode = (process.env.PROMPT_SCANNER_SCAN_MODE ?? "standard").trim().toLowerCase();
+        const validScanMode = ["fast", "standard", "strict"].includes(rawScanMode) ? rawScanMode : "standard";
+        api.logger.info(
+          `[prompt-scan] scan mode configured: raw=${JSON.stringify(rawScanMode)}, effective=${JSON.stringify(validScanMode)}`,
+        );
         const result = await callAgentSecCli(
           ["scan-prompt", "--text", text, "--mode", validScanMode, "--format", "json", "--source", "user_input"],
           { timeout: 10000, traceContext: buildTraceContext(event, ctx) },

--- a/src/agent-sec-core/qwen-code-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/prompt_scanner_hook.py
@@ -46,11 +46,15 @@ try:
     _TIMEOUT = int(os.environ.get("PROMPT_SCANNER_TIMEOUT", "10"))
 except (TypeError, ValueError):
     _TIMEOUT = 10
-_DEFAULT_SCAN_MODE = (
-    os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
-)
+_RAW_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+_DEFAULT_SCAN_MODE = _RAW_SCAN_MODE
 if _DEFAULT_SCAN_MODE not in {"fast", "standard", "strict"}:
     _DEFAULT_SCAN_MODE = "standard"
+print(
+    f"[prompt-scanner] scan mode configured: raw={_RAW_SCAN_MODE!r}, "
+    f"effective={_DEFAULT_SCAN_MODE!r}",
+    file=sys.stderr,
+)
 _DEFAULT_SOURCE = "user_input"
 
 

--- a/src/agent-sec-core/qwen-code-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/prompt_scanner_hook.py
@@ -14,6 +14,13 @@ Modes (controlled by ``PROMPT_SCANNER_MODE`` env var, default: ``observe``):
 ``PROMPT_SCANNER_TIMEOUT`` controls the inner ``agent-sec-cli`` timeout in
 seconds.
 
+Scan mode (controlled by ``PROMPT_SCANNER_SCAN_MODE`` env var, default:
+``standard``):
+
+- ``fast``: lightweight heuristics, lower latency.
+- ``standard``: balanced detection (default).
+- ``strict``: not implemented yet; currently behaves the same as standard.
+
 Usage::
 
     python3 prompt_scanner_hook.py          # reads stdin, writes stdout
@@ -39,7 +46,11 @@ try:
     _TIMEOUT = int(os.environ.get("PROMPT_SCANNER_TIMEOUT", "10"))
 except (TypeError, ValueError):
     _TIMEOUT = 10
-_DEFAULT_SCAN_MODE = "standard"
+_DEFAULT_SCAN_MODE = (
+    os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().lower()
+)
+if _DEFAULT_SCAN_MODE not in {"fast", "standard", "strict"}:
+    _DEFAULT_SCAN_MODE = "standard"
 _DEFAULT_SOURCE = "user_input"
 
 

--- a/src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh
+++ b/src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh
@@ -121,6 +121,7 @@ agent_sec_cli_e2e_runtime_deps=(
     "sqlalchemy>=2.0"
     "textual>=0.80"
     "typer>=0.9.0"
+    "regex>=2026.4.4"
 )
 
 sync_pilot_workdir() {


### PR DESCRIPTION
Read PROMPT_SCANNER_SCAN_MODE across all prompt-scanner hooks and capabilities so operators can pick fast or standard detection without code changes. Restrict the valid set to {fast, standard}, dropping the unsupported strict mode, and fall back to standard on invalid input. Also fix redundant f-strings flagged by lint.

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
