### PR TITLE
fix(cosh-ng): [core] handle inherited SIGINT

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "signal-hook",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/src/cosh-ng/Cargo.toml
+++ b/src/cosh-ng/Cargo.toml
@@ -30,6 +30,7 @@ rustix = { version = "0.38", default-features = false, features = ["fs", "std"] 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
+signal-hook = "0.3"
 
 [profile.release]
 opt-level = 3

--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -39,6 +39,7 @@ rustix.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
+signal-hook.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -29,6 +29,12 @@ mod truncator;
 
 use clap::Parser;
 use std::path::PathBuf;
+#[cfg(unix)]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(unix)]
+use std::sync::Arc;
+#[cfg(unix)]
+use std::time::Duration;
 
 use config::CoreConfig;
 use provider::openai_compat::OpenAICompatProvider;
@@ -94,8 +100,40 @@ fn needs_auth(config: &CoreConfig) -> bool {
     resolved.api_key.is_empty()
 }
 
+#[cfg(unix)]
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|error| {
+            eprintln!("failed to start async runtime: {error}");
+            std::process::exit(1);
+        });
+
+    runtime.block_on(run_until_sigint());
+    // Tokio reads stdin on a blocking thread, which cannot be cancelled while a pipe stays open.
+    runtime.shutdown_timeout(Duration::from_millis(100));
+}
+
+#[cfg(not(unix))]
 #[tokio::main]
 async fn main() {
+    run().await;
+}
+
+#[cfg(unix)]
+async fn run_until_sigint() {
+    let sigint_received = install_sigint_handler();
+
+    tokio::select! {
+        _ = wait_for_sigint(sigint_received) => {
+            tracing::info!("received SIGINT, shutting down cosh-core");
+        }
+        _ = run() => {}
+    }
+}
+
+async fn run() {
     let args = cli::CliArgs::parse();
     if args.is_session_control() {
         std::process::exit(session_control::run());
@@ -117,6 +155,25 @@ async fn main() {
         headless::run(&args, config).await;
     } else {
         interactive::run(&args, config).await;
+    }
+}
+
+#[cfg(unix)]
+fn install_sigint_handler() -> Arc<AtomicBool> {
+    let received = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&received)).unwrap_or_else(
+        |error| {
+            eprintln!("failed to install SIGINT handler: {error}");
+            std::process::exit(1);
+        },
+    );
+    received
+}
+
+#[cfg(unix)]
+async fn wait_for_sigint(received: Arc<AtomicBool>) {
+    while !received.load(Ordering::Relaxed) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
 

--- a/src/cosh-ng/crates/cosh-core/tests/sigint.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/sigint.rs
@@ -1,0 +1,114 @@
+#![cfg(target_os = "linux")]
+
+use std::fs;
+use std::ops::{Deref, DerefMut};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn binary_path() -> std::path::PathBuf {
+    let mut path = std::env::current_exe()
+        .expect("current test executable")
+        .parent()
+        .expect("test binary directory")
+        .parent()
+        .expect("target directory")
+        .to_path_buf();
+    path.push("cosh-core");
+    path
+}
+
+struct ChildGuard(Child);
+
+impl Deref for ChildGuard {
+    type Target = Child;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ChildGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if self.0.try_wait().ok().flatten().is_none() {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+}
+
+fn signal_mask(pid: u32, field: &str) -> u64 {
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).expect("read process status");
+    let value = status
+        .lines()
+        .find_map(|line| line.strip_prefix(field))
+        .expect("signal status")
+        .trim();
+    u64::from_str_radix(value, 16).expect("parse signal mask")
+}
+
+fn send_signal(pid: u32, signal: &str) {
+    let status = Command::new("kill")
+        .args([format!("-{signal}"), pid.to_string()])
+        .status()
+        .expect("run kill");
+    assert!(status.success(), "send SIG{signal}");
+}
+
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("poll child") {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn sigint_exits_when_inherited_as_ignored() {
+    let home = tempfile::tempdir().expect("temp home");
+    let binary = binary_path();
+    let mut child = ChildGuard(
+        Command::new("sh")
+            .args(["-c", "trap '' INT; exec \"$1\" --headless", "sh"])
+            .arg(binary)
+            .env("HOME", home.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn cosh-core"),
+    );
+    let pid = child.id();
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while signal_mask(pid, "SigCgt:\t") & 0b10 == 0 {
+        assert!(
+            Instant::now() < deadline,
+            "SIGINT handler was not installed"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        child.try_wait().expect("poll child").is_none(),
+        "cosh-core exited before receiving SIGINT"
+    );
+
+    send_signal(pid, "INT");
+    let status = wait_for_exit(&mut child, Duration::from_secs(2))
+        .expect("cosh-core did not exit after SIGINT");
+    assert!(
+        status.success(),
+        "cosh-core exited unsuccessfully: {status}"
+    );
+}


### PR DESCRIPTION
## Description

Handle SIGINT explicitly in cosh-core so headless processes do not retain an ignored SIGINT disposition inherited from their launcher. Bound Tokio runtime shutdown so a blocked stdin read cannot keep the process alive after interruption.

## Related Issue

closes #1550

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test --package cosh-core`
- `cargo clippy --package cosh-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc --package cosh-core --no-deps`
- Added a Linux integration test that starts the real headless binary with inherited SIGINT ignored, sends SIGINT, and requires a successful exit within two seconds.

## Additional Notes

No documentation change is needed because the JSONL protocol is unchanged.