### PR TITLE
test(sec-core): fix openclaw e2e test dependency by excluding ML packages

### DIFF
--- a/.github/workflows/openclaw-plugin-e2e.yml
+++ b/.github/workflows/openclaw-plugin-e2e.yml
@@ -13,6 +13,7 @@ on:
       - "src/agent-sec-core/openclaw-plugin/package.json"
       - "src/agent-sec-core/openclaw-plugin/package-lock.json"
       - "src/agent-sec-core/openclaw-plugin/tsconfig.json"
+      - "src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh"
   push:
     branches:
       - main
@@ -25,6 +26,7 @@ on:
       - "src/agent-sec-core/openclaw-plugin/package.json"
       - "src/agent-sec-core/openclaw-plugin/package-lock.json"
       - "src/agent-sec-core/openclaw-plugin/tsconfig.json"
+      - "src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh"
   workflow_dispatch:
 
 permissions:

--- a/src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh
+++ b/src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh
@@ -42,8 +42,9 @@ Environment:
   AGENT_SEC_DAEMON_BIN          Existing agent-sec-daemon binary.
   AGENT_SEC_CLI_WHEEL           Wheel artifact to install into .venv.
   OPENCLAW_E2E_AGENT_SEC_INSTALL_MODE
-                                minimal (default) installs E2E runtime deps
-                                without ML packages; full installs wheel deps.
+                                minimal (default) installs wheel-declared
+                                runtime deps without ML packages; full installs
+                                all wheel deps.
   EXPECT_UNSAFE_INSTALL_FLAG    Optional true/false assertion for deploy.sh.
   OPENCLAW_E2E_RESULT_ROOT      Result root; defaults to target/openclaw-e2e/results.
   OPENCLAW_E2E_SKIP_NPM_CI      Set to 1 to skip npm ci.
@@ -114,14 +115,10 @@ tools_root="${OPENCLAW_E2E_TOOLS_ROOT:-$repo_root/target/openclaw-e2e/tools}"
 npm_cache="${NPM_CONFIG_CACHE:-$result_dir/npm-cache}"
 export NPM_CONFIG_CACHE="$npm_cache"
 export npm_config_cache="$npm_cache"
-agent_sec_cli_e2e_runtime_deps=(
-    "cryptography>=42.0"
-    "pydantic>=2.0"
-    "pyyaml>=6.0"
-    "sqlalchemy>=2.0"
-    "textual>=0.80"
-    "typer>=0.9.0"
-    "regex>=2026.4.4"
+agent_sec_cli_e2e_excluded_deps=(
+    "modelscope"
+    "torch"
+    "transformers"
 )
 
 sync_pilot_workdir() {
@@ -193,12 +190,86 @@ resolve_wheel_spec() {
     die "agent-sec-cli wheel not found from spec: $spec"
 }
 
+resolve_wheel_runtime_deps() {
+    local python_bin="$1"
+    local wheel="$2"
+    shift 2
+
+    "$python_bin" - "$wheel" "$@" <<'PY'
+import re
+import sys
+import zipfile
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+
+requirement_name = re.compile(
+    r"^\s*([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)"
+)
+extra_marker = re.compile(r"\bextra\b", re.IGNORECASE)
+
+
+def canonicalize_package_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+wheel_path = Path(sys.argv[1])
+excluded = {canonicalize_package_name(name) for name in sys.argv[2:]}
+
+try:
+    if not wheel_path.is_file():
+        raise ValueError(f"wheel does not exist: {wheel_path}")
+    with zipfile.ZipFile(wheel_path) as archive:
+        metadata_paths = [
+            name
+            for name in archive.namelist()
+            if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_paths) != 1:
+            raise ValueError(
+                f"expected one .dist-info/METADATA entry, found {len(metadata_paths)}"
+            )
+        metadata_content = archive.read(metadata_paths[0])
+
+    metadata = BytesParser(policy=policy.default).parsebytes(metadata_content)
+    for requirement_header in metadata.get_all("Requires-Dist", []):
+        requirement = str(requirement_header)
+        match = requirement_name.match(requirement)
+        if match is None:
+            raise ValueError(f"invalid Requires-Dist entry: {requirement!r}")
+
+        _, marker_separator, marker = requirement.partition(";")
+        if marker_separator and extra_marker.search(marker):
+            continue
+        if canonicalize_package_name(match.group(1)) in excluded:
+            continue
+        print(requirement)
+except (OSError, KeyError, ValueError, zipfile.BadZipFile) as exc:
+    print(f"ERROR: cannot resolve wheel runtime dependencies: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+}
+
 install_agent_sec_cli_wheel() {
     local wheel="$1"
+    local dependency_output
+    local runtime_deps=()
 
     case "$OPENCLAW_E2E_AGENT_SEC_INSTALL_MODE" in
         minimal)
-            run uv pip install --python "$venv_dir/bin/python" "${agent_sec_cli_e2e_runtime_deps[@]}"
+            if ! dependency_output="$(
+                resolve_wheel_runtime_deps \
+                    "$venv_dir/bin/python" \
+                    "$wheel" \
+                    "${agent_sec_cli_e2e_excluded_deps[@]}"
+            )"; then
+                die "failed to resolve runtime dependencies from wheel: $wheel"
+            fi
+            if [[ -n "$dependency_output" ]]; then
+                mapfile -t runtime_deps <<<"$dependency_output"
+                log "minimal runtime deps from wheel: ${runtime_deps[*]}"
+                run uv pip install --python "$venv_dir/bin/python" "${runtime_deps[@]}"
+            fi
             run uv pip install --python "$venv_dir/bin/python" --no-deps "$wheel"
             ;;
         full)


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
openclaw e2e test uses limited packages to reduce prepare time. However, maintaining a fixed list of packages causes missing packages during e2e test when new packages are added to the dependency of wheel. Now download full list of wheel dependency excluding torch, transformers and modelscope for test stability.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
