### PR TITLE
fix(sec-core): harden audit, PII, and notify

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
@@ -26,6 +26,15 @@ METHOD_SKILLFS_NOTIFY_CHANGE = "skill_ledger.skillfs_notify_change"
 SCHEMA_VERSION = 2
 
 _SKILL_META = ".skill-meta"
+_NOTIFY_V2_PARAM_KEYS = frozenset(
+    {
+        "schemaVersion",
+        "canonicalSkillDir",
+        "skillId",
+        "eventKind",
+        "paths",
+    }
+)
 
 
 def register_skill_ledger_methods(registry: MethodRegistry) -> None:
@@ -77,6 +86,8 @@ def skillfs_notify_change_handler(
 
 def parse_skillfs_change(params: dict[str, Any]) -> SkillFsChange:
     """Validate daemon request params for a SkillFS change notification."""
+    _validate_notify_v2_param_keys(params)
+
     schema_version = params.get("schemaVersion")
     if schema_version != SCHEMA_VERSION:
         raise BadRequestError("params.schemaVersion must be 2")
@@ -96,6 +107,18 @@ def parse_skillfs_change(params: dict[str, Any]) -> SkillFsChange:
         event_kinds={event_kind},
         paths=set(paths),
     )
+
+
+def _validate_notify_v2_param_keys(params: dict[str, Any]) -> None:
+    unknown_fields = sorted(params.keys() - _NOTIFY_V2_PARAM_KEYS)
+    if unknown_fields:
+        names = ", ".join(unknown_fields)
+        raise BadRequestError(f"params contains unknown fields: {names}")
+
+    missing_fields = sorted(_NOTIFY_V2_PARAM_KEYS - params.keys())
+    if missing_fields:
+        names = ", ".join(missing_fields)
+        raise BadRequestError(f"params is missing required fields: {names}")
 
 
 def _validate_canonical_skill_dir(value: Any) -> Path:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/auditor.py
@@ -35,6 +35,13 @@ from agent_sec_cli.skill_ledger.signing.base import SigningBackend
 from pydantic import ValidationError
 
 
+def _public_manifest_error(error: ValueError) -> str:
+    """Avoid returning manifest-controlled values from Pydantic diagnostics."""
+    if isinstance(error, ValidationError):
+        return "schema validation failed"
+    return str(error)
+
+
 @canonical_skill_operation
 def audit(
     skill_dir: SkillRootInput,
@@ -71,7 +78,10 @@ def audit(
             errors.append(
                 {
                     "versionId": vid,
-                    "error": f"Version manifest {vid}.json is corrupted: {exc}",
+                    "error": (
+                        f"Version manifest {vid}.json is corrupted: "
+                        f"{_public_manifest_error(exc)}"
+                    ),
                 }
             )
             prev_signature = None
@@ -184,7 +194,7 @@ def audit(
         errors.append(
             {
                 "versionId": "latest.json",
-                "error": f"latest.json is corrupted: {exc}",
+                "error": f"latest.json is corrupted: {_public_manifest_error(exc)}",
             }
         )
         latest = None
@@ -201,10 +211,11 @@ def audit(
                 }
             )
 
-    return {
+    result = {
         "canonicalSkillDir": str(root.canonical_dir),
         "skillName": root.skill_name,
         "valid": len(errors) == 0,
         "versions_checked": len(version_ids),
         "errors": errors,
     }
+    return root.canonicalize_payload(result)

--- a/src/agent-sec-core/codex-plugin/README.md
+++ b/src/agent-sec-core/codex-plugin/README.md
@@ -80,13 +80,13 @@ codex plugin marketplace remove agent-sec
 | `PROMPT_SCANNER_TIMEOUT` | `10` | 提示词扫描 agent-sec-cli 超时秒数 |
 | `SKILL_LEDGER_MODE` | `observe` | Skill 完整性校验透出模式：`observe`(仅观察记录，不拦截) / `deny`(校验失败时拦截 prompt) |
 | `SKILL_LEDGER_TIMEOUT` | `5` | Skill 完整性校验 agent-sec-cli 超时秒数 |
-| `PII_CHECKER_MODE` | `observe` | PII 敏感信息检测透出模式：`observe`(仅观察记录，不拦截) / `deny`(检测到 PII 时阻断当次 payload，不做脱敏放行) |
+| `PII_CHECKER_MODE` | `observe` | PII 敏感信息检测透出模式：`observe`(仅观察记录) / `deny`(`warn` 告警放行，`deny` 阻断 payload) |
 | `PII_CHECKER_TIMEOUT` | `5` | PII 检测 agent-sec-cli 超时秒数 |
 
 启动示例：
 
 ```bash
-# 全部拦截模式
+# 全部强制策略模式（PII warn 告警放行、deny 阻断）
 CODE_SCANNER_MODE=deny PROMPT_SCANNER_MODE=deny SKILL_LEDGER_MODE=deny PII_CHECKER_MODE=deny codex
 
 # 仅代码扫描拦截
@@ -98,7 +98,7 @@ PROMPT_SCANNER_MODE=deny codex
 # 仅 Skill 完整性校验拦截
 SKILL_LEDGER_MODE=deny codex
 
-# 仅 PII 检测拦截
+# 仅启用 PII 分级处置
 PII_CHECKER_MODE=deny codex
 
 # 默认观察模式（仅记录，即使检测到危险操作也不拦截）
@@ -136,7 +136,7 @@ codex-plugin/
 |-----------|--------|---------|------|
 | `code_scanner_hook.py` | PreToolUse | `Bash` | 扫描 shell 命令，检测反弹shell、危险删除等 |
 | `prompt_scanner_hook.py` | UserPromptSubmit | (all) | 检测用户输入中的 prompt 注入攻击 |
-| `pii_checker_hook.py` | UserPromptSubmit + PreToolUse + PostToolUse | (all) | 检测用户输入、工具输入和工具输出中的 PII，deny 模式下阻断对应 payload（不支持脱敏放行） |
+| `pii_checker_hook.py` | UserPromptSubmit + PreToolUse + PostToolUse | (all) | 检测用户输入、工具输入和工具输出中的 PII，deny 模式下 `warn` 告警放行、`deny` 阻断（不支持脱敏放行） |
 | `skill_ledger_hook.py` | UserPromptSubmit | (all) | 解析 prompt 中的 $skill-name，验证 skill 文件完整性和签名 |
 | `observability_hook.py` | UserPromptSubmit + PreToolUse + PostToolUse + Stop | (all) | 记录 Turn/Tool 生命周期；不改变 Codex 决策 |
 
@@ -211,8 +211,10 @@ echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command"
   python3 hooks-plugin/hooks/observability_hook.py
 ```
 
-阻断模式扫描命中时输出：`{"decision": "block", "reason": "..."}`；可观测 Hook
-始终输出 `{}`，不会改变 Codex 行为。可通过以下命令查看最近一次会话：
+`PII_CHECKER_MODE=deny` 下，scanner `warn` 输出
+`{"systemMessage": "..."}` 并继续执行，scanner `deny` 输出
+`{"decision": "block", "reason": "..."}`；可观测 Hook 始终输出 `{}`，不会改变
+Codex 行为。可通过以下命令查看最近一次会话：
 
 ```bash
 agent-sec-cli observability report --last

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
@@ -7,23 +7,21 @@ Supports THREE hook points via a single script (routed by hook_event_name):
   - PostToolUse: scans tool output before it enters model context.
 
 Protection direction:
-  - UserPromptSubmit / PostToolUse: prevent PII from flowing INTO the LLM
-    provider (user prompt / tool output → model).
-  - PreToolUse: prevent PII from flowing OUT via a tool call (exfiltration),
-    e.g. curl-ing a phone number to an external endpoint or writing PII to
-    a file. This is the only point to catch PII before the tool executes.
+  - UserPromptSubmit / PostToolUse: detect PII flowing INTO the LLM provider
+    (user prompt / tool output → model) before applying the configured policy.
+  - PreToolUse: detect PII flowing OUT via a tool call (exfiltration), e.g.
+    curl-ing a phone number to an external endpoint or writing PII to a file.
+    This is the only point to enforce PII policy before the tool executes.
 
 Modes (controlled by PII_CHECKER_MODE env var, default: observe):
   - observe: silent pass-through, only audit trail via agent-sec-cli events.
              Even if PII is detected, content will NOT be blocked.
-  - deny: block when PII is detected.
-          UserPromptSubmit: reject the prompt (user must rephrase).
-          PreToolUse: block the tool call (the tool will not execute).
-          PostToolUse: replace tool output with reason text (model won't see PII).
+  - deny: surface scanner "warn" verdicts through systemMessage and continue;
+          block scanner "deny" verdicts at all three hook points.
 
-Protocol note: Codex hook protocol is binary (allow/block). There is NO
-"redact and pass" capability — the protocol does not support modifying
-content before forwarding. So we can only block entirely or allow entirely.
+Protocol note: Codex supports non-blocking systemMessage warnings but does not
+support "redact and pass" for these hook points. A warning therefore forwards
+the original payload unchanged, while a deny verdict blocks the payload.
 
 Usage::
 
@@ -75,18 +73,10 @@ def _shorten(value: str, limit: int = _MAX_EVIDENCE_CHARS) -> str:
 # -- output helpers --------------------------------------------------------
 
 
-def _format_block_reason(
-    findings: list[dict], hook_event: str, source_desc: str
-) -> str:
-    """Build a human-readable block reason from structured PII findings.
-
-    The reason is shown to the user (UserPromptSubmit) or replaces tool
-    output visible to the model (PostToolUse). It contains only PII types
-    and redacted evidence — never the raw PII content itself.
-    """
+def _format_finding_details(findings: list[dict]) -> tuple[int, list[str]]:
+    """Build shared, audit-safe detail lines from structured PII findings."""
     typed_findings = [item for item in findings if isinstance(item, dict)]
     count = len(typed_findings)
-
     pii_types = sorted(
         {
             finding_type
@@ -109,14 +99,28 @@ def _format_block_reason(
         if len(redacted_evidence) >= _MAX_EVIDENCE_ITEMS:
             break
 
-    lines = [
-        f"[pii-checker] 🔒 安全拦截：{source_desc}中检测到 {count} 项个人敏感信息",
-        f"  类型      : {', '.join(pii_types) if pii_types else 'unknown'}",
-    ]
+    lines = [f"  类型      : {', '.join(pii_types) if pii_types else 'unknown'}"]
     if severities:
         lines.append(f"  严重级别  : {', '.join(severities)}")
     if redacted_evidence:
         lines.append(f"  脱敏示例  : {', '.join(redacted_evidence)}")
+    return count, lines
+
+
+def _format_block_reason(
+    findings: list[dict], hook_event: str, source_desc: str
+) -> str:
+    """Build a human-readable block reason from structured PII findings.
+
+    The reason is shown to the user (UserPromptSubmit) or replaces tool
+    output visible to the model (PostToolUse). It contains only PII types
+    and redacted evidence — never the raw PII content itself.
+    """
+    count, details = _format_finding_details(findings)
+    lines = [
+        f"[pii-checker] 🔒 安全拦截：{source_desc}中检测到 {count} 项个人敏感信息",
+        *details,
+    ]
     lines.append(f"  拦截环节  : {hook_event}")
 
     if hook_event == "UserPromptSubmit":
@@ -129,10 +133,30 @@ def _format_block_reason(
     return "\n".join(lines)
 
 
+def _format_warning_message(
+    findings: list[dict], hook_event: str, source_desc: str
+) -> str:
+    """Build a non-blocking warning using only redacted finding evidence."""
+    count, details = _format_finding_details(findings)
+    lines = [
+        f"[pii-checker] ⚠️ 隐私告警：{source_desc}中检测到 {count} 项个人敏感信息",
+        *details,
+        f"  告警环节  : {hook_event}",
+        "检测结果为 warn，执行将继续。",
+    ]
+    return "\n".join(lines)
+
+
 def _block(findings: list[dict], hook_event: str, source_desc: str) -> None:
     """Output block decision JSON to stdout."""
     reason = _format_block_reason(findings, hook_event, source_desc)
     print(json.dumps({"decision": "block", "reason": reason}, ensure_ascii=False))
+
+
+def _warn(findings: list[dict], hook_event: str, source_desc: str) -> None:
+    """Output a user-visible warning without changing execution control."""
+    message = _format_warning_message(findings, hook_event, source_desc)
+    print(json.dumps({"systemMessage": message}, ensure_ascii=False))
 
 
 # -- text extraction -------------------------------------------------------
@@ -198,7 +222,7 @@ def _source_for_event(hook_event: str) -> str:
 
 
 def _source_desc_for_event(hook_event: str) -> str:
-    """Return human-readable source description for block reason."""
+    """Return a human-readable source description for a PII notice."""
     if hook_event == "PreToolUse":
         return "工具输入"
     if hook_event == "PostToolUse":
@@ -268,14 +292,16 @@ def main() -> None:
     if verdict == "pass" or not findings:
         return  # no PII detected, allow
 
-    # verdict is "warn" or "deny" — PII detected
     if MODE == "observe":
         return  # observe mode: don't block, audit only via CLI events
     elif MODE == "deny":
-        # Both "warn" and "deny" verdicts trigger block in deny mode,
-        # because Codex protocol has no "warn" transparency — only block or allow.
         source_desc = _source_desc_for_event(hook_event)
-        _block(findings, hook_event, source_desc)
+        if verdict == "warn":
+            # systemMessage is supported by all three hook points and remains non-blocking.
+            _warn(findings, hook_event, source_desc)
+        else:
+            # Preserve the existing fail-safe for deny or unexpected non-pass verdicts.
+            _block(findings, hook_event, source_desc)
     # else: unknown mode, fail-open
 
 

--- a/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
+++ b/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
@@ -167,7 +167,7 @@ class TestPIICheckerE2E:
         )
         assert output == {}
 
-    def test_phone_in_prompt_blocks_deny(self):
+    def test_phone_in_prompt_warns_deny(self):
         output = _run_hook(
             "pii_checker_hook.py",
             {
@@ -176,11 +176,9 @@ class TestPIICheckerE2E:
             },
             env_extra={"PII_CHECKER_MODE": "deny"},
         )
-        assert output.get("decision") == "block"
-        assert (
-            "phone" in output.get("reason", "").lower()
-            or "pii" in output.get("reason", "").lower()
-        )
+        assert set(output) == {"systemMessage"}
+        assert "phone_cn" in output["systemMessage"]
+        assert "执行将继续" in output["systemMessage"]
 
     def test_phone_in_prompt_passes_observe(self):
         output = _run_hook(
@@ -193,7 +191,7 @@ class TestPIICheckerE2E:
         )
         assert output == {}
 
-    def test_email_in_tool_output_blocks_deny(self):
+    def test_email_in_tool_output_warns_deny(self):
         output = _run_hook(
             "pii_checker_hook.py",
             {
@@ -202,8 +200,9 @@ class TestPIICheckerE2E:
             },
             env_extra={"PII_CHECKER_MODE": "deny"},
         )
-        assert output.get("decision") == "block"
-        assert "PostToolUse" in output.get("reason", "")
+        assert set(output) == {"systemMessage"}
+        assert "email" in output["systemMessage"]
+        assert "PostToolUse" in output["systemMessage"]
 
     def test_email_in_tool_output_passes_observe(self):
         output = _run_hook(
@@ -227,7 +226,7 @@ class TestPIICheckerE2E:
         )
         assert output == {}
 
-    def test_phone_in_tool_input_blocks_deny(self):
+    def test_phone_in_tool_input_warns_deny(self):
         output = _run_hook(
             "pii_checker_hook.py",
             {
@@ -238,8 +237,21 @@ class TestPIICheckerE2E:
             },
             env_extra={"PII_CHECKER_MODE": "deny"},
         )
+        assert set(output) == {"systemMessage"}
+        assert "phone_cn" in output["systemMessage"]
+        assert "PreToolUse" in output["systemMessage"]
+
+    def test_api_key_in_prompt_blocks_deny(self):
+        output = _run_hook(
+            "pii_checker_hook.py",
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "API key: sk-00000000000000000000000000000000",
+            },
+            env_extra={"PII_CHECKER_MODE": "deny"},
+        )
         assert output.get("decision") == "block"
-        assert "PreToolUse" in output.get("reason", "")
+        assert "api_key" in output.get("reason", "")
 
     def test_phone_in_tool_input_passes_observe(self):
         output = _run_hook(

--- a/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
+++ b/src/agent-sec-core/tests/e2e/daemon/test_daemon_e2e.py
@@ -379,6 +379,74 @@ def test_daemon_skillfs_notify_refreshes_skill_ledger_activation(
     )
 
 
+def test_daemon_skillfs_notify_rejects_unknown_fields_without_state_change(
+    daemon_command: list[str], tmp_path: Path
+) -> None:
+    socket_path = tmp_path / "runtime" / "daemon.sock"
+    skill_dir = _make_skill(tmp_path / "skills", "weather")
+    original_files = sorted(
+        path.relative_to(skill_dir) for path in skill_dir.rglob("*")
+    )
+    listxattr = getattr(os, "listxattr", None)
+    original_xattrs = listxattr(skill_dir) if listxattr is not None else None
+    process = _start_daemon(daemon_command, socket_path, tmp_path)
+
+    requests = [
+        {
+            "schemaVersion": 2,
+            "canonicalSkillDir": str(skill_dir),
+            "skillId": "weather",
+            "eventKind": "unlink",
+            "paths": ["SKILL.md"],
+            "exists": False,
+        },
+        {
+            "schemaVersion": 2,
+            "canonicalSkillDir": str(skill_dir),
+            "skillId": "weather",
+            "eventKind": "unlink",
+            "paths": ["SKILL.md"],
+            "exists": True,
+        },
+        {
+            "schemaVersion": 2,
+            "canonicalSkillDir": str(skill_dir),
+            "skillId": "weather",
+            "eventKind": "write",
+            "paths": [".skill-meta/latest.json"],
+            "futureField": "unsupported",
+        },
+    ]
+
+    try:
+        responses = [
+            _call_daemon(
+                socket_path,
+                {
+                    "method": "skill_ledger.skillfs_notify_change",
+                    "params": params,
+                },
+            )
+            for params in requests
+        ]
+        time.sleep(1)
+    finally:
+        output = _stop_daemon(process)
+
+    assert all(response["ok"] is False for response in responses)
+    assert all(response["error"]["code"] == "bad_request" for response in responses)
+    assert all(
+        "unknown fields" in response["error"]["message"] for response in responses
+    )
+    assert sorted(path.relative_to(skill_dir) for path in skill_dir.rglob("*")) == (
+        original_files
+    )
+    if original_xattrs is not None:
+        assert listxattr(skill_dir) == original_xattrs
+    assert not (skill_dir / ".skill-meta").exists()
+    assert output.returncode == 0
+
+
 def _write_security_event(db_path: Path) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -37,6 +37,8 @@ from agent_sec_cli.daemon.handlers.security_query import (
 from agent_sec_cli.daemon.protocol import DaemonRequest
 from agent_sec_cli.daemon.runtime import DaemonRuntime
 from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
+from agent_sec_cli.security_middleware.result import ActionResult
+from agent_sec_cli.skill_ledger import cli as skill_ledger_cli
 from agent_sec_cli.skill_ledger import config as config_module
 from agent_sec_cli.skill_ledger.core import decision as decision_core
 from agent_sec_cli.skill_ledger.core import live_root as live_root_core
@@ -1559,6 +1561,131 @@ def test_audit_corrupted_version_file_reports_error_without_traceback(ws):
         error["versionId"] == "v000002" and "prior version manifest" in error["error"]
         for error in out["errors"]
     )
+
+
+def test_audit_projects_backing_paths_across_cli_events_and_daemon(ws, monkeypatch):
+    """Corrupted manifests expose only the canonical root through public channels."""
+    backing = make_skill(ws.skills_dir, "audit-path-projection", {"f.txt": "safe"})
+    backing_marker = f"{ws.skills_dir.name}/{backing.name}"
+    canonical = ws.root / "fuse-view" / backing.name
+    findings = write_findings_file(
+        ws.fixtures,
+        "audit-path-projection.json",
+        [{"rule": "ok", "level": "pass", "message": "pass"}],
+    )
+    env = ws.env()
+    certified = run_skill_ledger(
+        ["certify", str(backing), "--findings", str(findings)],
+        env_extra=env,
+    )
+    assert certified.returncode == 0, certified.stderr
+
+    meta_dir = backing / ".skill-meta"
+    manifest_path = meta_dir / "versions" / "v000001.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["userDecision"] = {"action": str(backing)}
+    manifest_path.write_text(json.dumps(manifest))
+
+    state_before = {
+        str(path.relative_to(meta_dir)): path.read_bytes()
+        for path in sorted(meta_dir.rglob("*"))
+        if path.is_file()
+    }
+    root = ResolvedSkillRoot(canonical, backing, "skillfs")
+    resolver_calls: list[Path] = []
+
+    def fake_resolve(_resolver, canonical_skill_dir):
+        resolver_calls.append(Path(canonical_skill_dir))
+        return root
+
+    monkeypatch.setattr(live_root_core.SkillRootResolver, "resolve", fake_resolve)
+
+    forwarded: list[ActionResult] = []
+    original_forward = skill_ledger_cli._forward
+
+    def capture_forward(result: ActionResult) -> None:
+        forwarded.append(result)
+        original_forward(result)
+
+    monkeypatch.setattr(skill_ledger_cli, "_forward", capture_forward)
+
+    event_data = ws.root / "events_audit_path_projection"
+    event_data.mkdir()
+    audit_env = ws.env({"AGENT_SEC_DATA_DIR": str(event_data)})
+    reset_security_event_writers()
+    try:
+        cli_result = run_skill_ledger(
+            ["audit", str(canonical)],
+            env_extra=audit_env,
+        )
+    finally:
+        reset_security_event_writers()
+
+    assert resolver_calls == [canonical]
+    assert cli_result.returncode == 1
+    assert "Traceback" not in cli_result.stderr
+    assert str(backing) not in cli_result.stdout + cli_result.stderr
+    assert backing_marker not in cli_result.stdout + cli_result.stderr
+    stdout_result = parse_json_output(cli_result.stdout)
+    assert stdout_result["canonicalSkillDir"] == str(canonical)
+    assert stdout_result["valid"] is False
+    assert stdout_result["versions_checked"] == 1
+    assert any(error["versionId"] == "v000001" for error in stdout_result["errors"])
+
+    assert len(forwarded) == 1
+    action_result = forwarded[0]
+    assert action_result.success is False
+    assert action_result.exit_code == 1
+    assert json.loads(action_result.stdout) == stdout_result
+    assert action_result.data["command"] == "audit"
+    assert action_result.data["valid"] is False
+    assert str(backing) not in json.dumps(action_result.data)
+    assert str(backing) not in action_result.stdout
+    assert str(backing) not in action_result.error
+    assert backing_marker not in json.dumps(action_result.data)
+    assert backing_marker not in action_result.stdout
+    assert backing_marker not in action_result.error
+
+    state_after = {
+        str(path.relative_to(meta_dir)): path.read_bytes()
+        for path in sorted(meta_dir.rglob("*"))
+        if path.is_file()
+    }
+    assert state_after == state_before
+
+    jsonl_events = read_security_events(event_data)
+    audit_jsonl = next(
+        event
+        for event in jsonl_events
+        if event["details"]["result"].get("command") == "audit"
+    )
+    assert audit_jsonl["result"] == "failed"
+    assert audit_jsonl["details"]["result"]["valid"] is False
+    assert str(backing) not in json.dumps(audit_jsonl)
+    assert backing_marker not in json.dumps(audit_jsonl)
+
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(event_data))
+    runtime = DaemonRuntime(socket_path=event_data / "daemon.sock")
+    list_result = security_events_list_handler(
+        DaemonRequest(
+            method="sec.events.list",
+            params={
+                "category": "skill_ledger",
+                "result": "failed",
+                "include_details": True,
+            },
+        ),
+        runtime,
+    )
+    daemon_audit = next(
+        item
+        for item in list_result.data["items"]
+        if item["event_id"] == audit_jsonl["event_id"]
+    )
+    assert daemon_audit["details"]["result"]["command"] == "audit"
+    assert daemon_audit["details"]["result"]["valid"] is False
+    assert str(backing) not in json.dumps(daemon_audit)
+    assert backing_marker not in json.dumps(daemon_audit)
 
 
 def test_audit_verify_snapshots(ws):

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
@@ -5,7 +5,7 @@ Coverage targets:
   - Text extraction from different event types
   - Fail-open paths (invalid JSON, empty text, subprocess errors)
   - Mode-based decisions (observe vs deny)
-  - Output formatting (_format_block_reason)
+  - Output formatting for warnings and block reasons
   - Evidence sanitization (no raw PII in output)
   - Trace context injection
 """
@@ -172,6 +172,17 @@ _PII_DENY_RESULT = json.dumps(
 )
 
 
+def _assert_warning_output(output: dict, hook_event: str) -> str:
+    """Assert the common non-blocking warning contract."""
+    assert set(output) == {"systemMessage"}
+    message = output["systemMessage"]
+    assert "phone_cn" in message
+    assert "138****8000" in message
+    assert hook_event in message
+    assert "执行将继续" in message
+    return message
+
+
 # ---------------------------------------------------------------------------
 # Subprocess-based (black-box) tests
 # ---------------------------------------------------------------------------
@@ -235,7 +246,7 @@ class TestTextExtraction:
     """Verify text extraction for different hook events."""
 
     def test_post_tool_use_string_response(self, mock_cli):
-        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        env = mock_cli(output=_PII_DENY_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(
             {
                 "hook_event_name": "PostToolUse",
@@ -246,7 +257,7 @@ class TestTextExtraction:
         assert output["decision"] == "block"
 
     def test_post_tool_use_dict_response(self, mock_cli):
-        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        env = mock_cli(output=_PII_DENY_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(
             {
                 "hook_event_name": "PostToolUse",
@@ -273,7 +284,7 @@ class TestTextExtraction:
         assert output == {}
 
     def test_pre_tool_use_string_input(self, mock_cli):
-        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        env = mock_cli(output=_PII_DENY_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(
             {
                 "hook_event_name": "PreToolUse",
@@ -284,7 +295,7 @@ class TestTextExtraction:
         assert output["decision"] == "block"
 
     def test_pre_tool_use_dict_input(self, mock_cli):
-        env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        env = mock_cli(output=_PII_DENY_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(
             {
                 "hook_event_name": "PreToolUse",
@@ -351,7 +362,7 @@ class TestObserveMode:
 
 
 class TestDenyMode:
-    """In deny mode, PII triggers block."""
+    """Deny mode preserves scanner warn and deny severity."""
 
     def test_pass_verdict_allows(self, mock_cli):
         env = mock_cli(
@@ -369,30 +380,29 @@ class TestDenyMode:
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
         assert output == {}
 
-    def test_warn_verdict_blocks_user_prompt(self, mock_cli):
+    def test_warn_verdict_alerts_user_prompt(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
-        assert output["decision"] == "block"
-        assert "phone_cn" in output["reason"]
-        assert "138****8000" in output["reason"]
-        assert "UserPromptSubmit" in output["reason"]
-        assert "请移除敏感信息" in output["reason"]
+        _assert_warning_output(output, "UserPromptSubmit")
 
-    def test_warn_verdict_blocks_post_tool_use(self, mock_cli):
+    def test_warn_verdict_alerts_post_tool_use(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(_POST_TOOL_USE_EVENT, env_override=env)
-        assert output["decision"] == "block"
-        assert "PostToolUse" in output["reason"]
-        assert "工具输出已被拦截" in output["reason"]
+        _assert_warning_output(output, "PostToolUse")
 
-    def test_deny_verdict_blocks(self, mock_cli):
+    @pytest.mark.parametrize(
+        "event_data",
+        [_USER_PROMPT_EVENT, _PRE_TOOL_USE_EVENT, _POST_TOOL_USE_EVENT],
+    )
+    def test_deny_verdict_blocks(self, mock_cli, event_data):
         env = mock_cli(output=_PII_DENY_RESULT, extra={"PII_CHECKER_MODE": "deny"})
-        output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
+        output = _run_hook(event_data, env_override=env)
         assert output["decision"] == "block"
         assert "credential" in output["reason"]
+        assert event_data["hook_event_name"] in output["reason"]
 
     def test_no_raw_pii_in_output(self, mock_cli):
-        """Block reason must never contain raw PII content."""
+        """Warning output must never contain raw PII content."""
         env = mock_cli(
             output=json.dumps(
                 {
@@ -410,15 +420,33 @@ class TestDenyMode:
             extra={"PII_CHECKER_MODE": "deny"},
         )
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
-        assert "13800138000" not in output["reason"]
-        assert "138****8000" in output["reason"]
+        message = _assert_warning_output(output, "UserPromptSubmit")
+        assert "13800138000" not in message
 
-    def test_warn_verdict_blocks_pre_tool_use(self, mock_cli):
+    def test_warn_verdict_alerts_pre_tool_use(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
+        output = _run_hook(_PRE_TOOL_USE_EVENT, env_override=env)
+        _assert_warning_output(output, "PreToolUse")
+
+    def test_unknown_verdict_with_findings_preserves_block(self, mock_cli):
+        env = mock_cli(
+            output=json.dumps(
+                {
+                    "verdict": "unexpected",
+                    "findings": [
+                        {
+                            "type": "unknown",
+                            "severity": "unexpected",
+                            "evidence_redacted": "[REDACTED]",
+                        }
+                    ],
+                }
+            ),
+            extra={"PII_CHECKER_MODE": "deny"},
+        )
         output = _run_hook(_PRE_TOOL_USE_EVENT, env_override=env)
         assert output["decision"] == "block"
         assert "PreToolUse" in output["reason"]
-        assert "该工具调用已被阻止" in output["reason"]
 
 
 class TestUnknownMode:
@@ -600,8 +628,8 @@ class TestMainMonkeypatch:
         )
         assert captured["input"] == "my phone 13800138000"
 
-    def test_deny_mode_blocks_with_findings(self, monkeypatch, capsys):
-        """deny mode + PII findings → block."""
+    def test_deny_mode_alerts_warn_findings(self, monkeypatch, capsys):
+        """deny mode + warn findings → non-blocking system message."""
 
         def fake_run(args, **kwargs):
             return subprocess.CompletedProcess(
@@ -629,8 +657,9 @@ class TestMainMonkeypatch:
             {"hook_event_name": "UserPromptSubmit", "prompt": "my phone 13800138000"},
             mode="deny",
         )
-        assert output["decision"] == "block"
-        assert "phone_cn" in output["reason"]
+        assert set(output) == {"systemMessage"}
+        assert "phone_cn" in output["systemMessage"]
+        assert "执行将继续" in output["systemMessage"]
 
     def test_deny_mode_blocks_post_tool_use(self, monkeypatch, capsys):
         """deny mode + PostToolUse PII → block with tool output message."""
@@ -879,3 +908,26 @@ class TestFormatBlockReason:
             findings, "UserPromptSubmit", "用户输入"
         )
         assert "请移除敏感信息" in reason
+
+
+class TestFormatWarningMessage:
+    """Test non-blocking warning output formatting."""
+
+    def test_includes_redacted_details_and_continuation(self):
+        findings = [
+            {
+                "type": "phone_cn",
+                "severity": "warn",
+                "evidence_redacted": "138****8000",
+                "raw_evidence": "13800138000",
+            }
+        ]
+        message = pii_checker_hook._format_warning_message(
+            findings, "PreToolUse", "工具输入"
+        )
+        assert "隐私告警" in message
+        assert "phone_cn" in message
+        assert "138****8000" in message
+        assert "13800138000" not in message
+        assert "PreToolUse" in message
+        assert "执行将继续" in message

--- a/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_skill_ledger_handler.py
@@ -5,6 +5,7 @@
 import asyncio
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from agent_sec_cli.daemon.errors import BadRequestError
@@ -95,6 +96,27 @@ def test_parse_skillfs_change_accepts_reconcile_with_empty_paths(tmp_path: Path)
 
 
 @pytest.mark.parametrize(
+    ("unknown_field", "value"),
+    [
+        ("exists", False),
+        ("exists", True),
+        ("futureField", {"semantics": "unsupported"}),
+    ],
+)
+def test_parse_skillfs_change_rejects_unknown_fields(
+    tmp_path: Path,
+    unknown_field: str,
+    value: Any,
+):
+    skill_dir = make_skill(tmp_path, "weather")
+    params = request_for(skill_dir).params
+    params[unknown_field] = value
+
+    with pytest.raises(BadRequestError, match=f"unknown fields: {unknown_field}"):
+        parse_skillfs_change(params)
+
+
+@pytest.mark.parametrize(
     ("overrides", "message"),
     [
         ({"schemaVersion": 1}, "schemaVersion"),
@@ -148,12 +170,25 @@ def test_parse_skillfs_change_accepts_flat_skill_id(tmp_path: Path):
     assert change.reported_skill_id == "weather"
 
 
-def test_parse_skillfs_change_rejects_missing_skill_id(tmp_path: Path):
+@pytest.mark.parametrize(
+    "field",
+    [
+        "schemaVersion",
+        "canonicalSkillDir",
+        "skillId",
+        "eventKind",
+        "paths",
+    ],
+)
+def test_parse_skillfs_change_rejects_missing_required_fields(
+    tmp_path: Path,
+    field: str,
+):
     skill_dir = tmp_path / "hidden" / "weather"
     params = request_for(skill_dir).params
-    params.pop("skillId")
+    params.pop(field)
 
-    with pytest.raises(BadRequestError, match="skillId"):
+    with pytest.raises(BadRequestError, match=f"required fields: {field}"):
         parse_skillfs_change(params)
 
 
@@ -190,6 +225,36 @@ def test_metadata_only_notification_still_requires_skill_id(tmp_path: Path):
 
     with pytest.raises(BadRequestError, match="skillId"):
         skillfs_notify_change_handler(request, runtime)
+
+
+@pytest.mark.parametrize(
+    ("paths", "unknown_fields"),
+    [
+        (["SKILL.md"], {"exists": False}),
+        (["SKILL.md"], {"exists": True}),
+        ([".skill-meta/latest.json"], {"futureField": "unsupported"}),
+    ],
+)
+def test_notify_rejects_unknown_fields_before_ignore_or_enqueue(
+    monkeypatch,
+    tmp_path: Path,
+    paths: list[str],
+    unknown_fields: dict[str, Any],
+):
+    skill_dir = make_skill(tmp_path, "weather")
+    runtime = DaemonRuntime(socket_path=tmp_path / "daemon.sock")
+    job = SkillLedgerActivationJob()
+    enqueue = Mock(return_value=True)
+    monkeypatch.setattr(job, "enqueue", enqueue)
+    runtime.jobs.register(job)
+
+    with pytest.raises(BadRequestError, match="unknown fields"):
+        skillfs_notify_change_handler(
+            request_for(skill_dir, paths=paths, **unknown_fields),
+            runtime,
+        )
+
+    enqueue.assert_not_called()
 
 
 def test_notify_enqueues_registered_activation_job(monkeypatch, tmp_path: Path):

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_canonical_workflows.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_canonical_workflows.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from agent_sec_cli.skill_ledger.core import certifier as certifier_core
 from agent_sec_cli.skill_ledger.core import resolver as resolver_core
+from agent_sec_cli.skill_ledger.core.auditor import audit
 from agent_sec_cli.skill_ledger.core.certifier import (
     certify,
     scan_batch,
@@ -355,3 +356,66 @@ def test_unprojectable_io_path_fails_before_snapshot_creation(
     assert str(live) not in str(exc_info.value)
     assert not (live / ".skill-meta" / "latest.json").exists()
     assert not list((live / ".skill-meta" / "versions").glob("*.snapshot"))
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    [
+        "exact-alias-action",
+        "resolved-physical-version",
+        "file-hash-value-type",
+        "latest-version-id",
+    ],
+)
+def test_audit_projects_io_paths_from_corrupted_manifests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    corruption: str,
+) -> None:
+    canonical = tmp_path / "mount" / "weather"
+    physical = _make_skill(tmp_path / "backing", "weather", "weather")
+    live_alias = tmp_path / "resolved" / "weather"
+    live_alias.parent.mkdir()
+    live_alias.symlink_to(physical, target_is_directory=True)
+    root = ResolvedSkillRoot(canonical, live_alias, "skillfs")
+    _write_config(tmp_path, [canonical])
+    backend = _backend(tmp_path, monkeypatch)
+    certified = certify(
+        root,
+        backend,
+        findings_path=str(_write_findings(tmp_path, "weather")),
+    )
+    version_path = (
+        live_alias / ".skill-meta" / "versions" / f"{certified['versionId']}.json"
+    )
+    manifest_path = (
+        live_alias / ".skill-meta" / "latest.json"
+        if corruption == "latest-version-id"
+        else version_path
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    if corruption == "exact-alias-action":
+        manifest["userDecision"] = {"action": str(live_alias)}
+    elif corruption == "resolved-physical-version":
+        manifest["version"] = str(physical.resolve())
+    elif corruption == "file-hash-value-type":
+        manifest["fileHashes"] = {str(physical.resolve()): 7}
+    else:
+        manifest["versionId"] = str(physical.resolve())
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = audit(root, backend)
+
+    serialized = json.dumps(result)
+    serialized_errors = json.dumps(result["errors"])
+    assert result["valid"] is False
+    assert result["errors"]
+    assert str(canonical) in serialized
+    if corruption == "latest-version-id":
+        assert str(canonical) in serialized_errors
+    assert str(live_alias) not in serialized
+    assert str(physical.resolve()) not in serialized
+    assert "resolved/weather" not in serialized
+    assert "backing/weather" not in serialized
+    assert not root.contains_io_path(result)


### PR DESCRIPTION
## Description

Skill Ledger audit results are projected into canonical identity space before CLI and event publication, with stable schema errors that cannot expose backing paths. The Codex PII hook now preserves scanner severity in `PII_CHECKER_MODE=deny`: `warn` returns a native `systemMessage` and continues, while `deny` remains blocked. Warning and block messages share the existing redacted findings summary and never emit `raw_evidence`; no policy mode, compatibility switch, dependency, or public schema was added. Codex documents `systemMessage` as a warning surfaced in the UI or event stream for all three hook points used here: [Codex Hooks documentation](https://learn.chatgpt.com/docs/hooks). Skill Ledger notify v2 now enforces its exact five-field parameter schema before metadata filtering or activation queueing, so unsupported extension semantics fail closed without downstream state changes.

## Related Issue

closes #1639
closes #1693
closes #1712

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test --locked` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make python-code-pretty`
- `agent-sec-cli/.venv/bin/python -m pytest tests/unit-test/codex_hooks/test_pii_checker_hook.py -q` (62 passed)
- `agent-sec-cli/.venv/bin/python -m pytest tests/e2e/codex-hooks/test_codex_hooks_e2e.py::TestPIICheckerE2E -q` (10 passed)
- `agent-sec-cli/.venv/bin/python -m pytest tests/unit-test/skill_ledger/test_canonical_workflows.py -q` (11 passed)
- `agent-sec-cli/.venv/bin/python -m pytest tests/integration-test/skill-ledger/test_skill_ledger_integration.py -q` (115 passed)
- `agent-sec-cli/.venv/bin/python -m pytest tests/unit-test/daemon/test_skill_ledger_handler.py -q` (37 passed)
- `agent-sec-cli/.venv/bin/python -m pytest tests/e2e/daemon/test_daemon_e2e.py -q` (11 passed)
- `agent-sec-cli/.venv/bin/ruff check --config agent-sec-cli/pyproject.toml ...` (touched Python files passed)
- `make python-lint-ci COMPARE_BRANCH=upstream/main` (local `diff-quality` executable unavailable; the target is non-blocking)
- `git diff upstream/main...HEAD --check`

## Additional Notes

The PR is ready for review. PR Lint, Docs Lint, agent-sec-core tests, Ubuntu/Alinux source builds, system-install, and RPM build all passed on head `f1a6a08b`.