### PR TITLE
feat(blaze): v0.3.0 — generic storage provider abstraction

### DIFF
--- a/src/blaze/.anolisa/component.toml
+++ b/src/blaze/.anolisa/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "blaze"
-version = "0.2.1"
+version = "0.3.0"
 type = "daemon"
 language = "rust"
 description = "Per-host sandbox orchestrator daemon"

--- a/src/blaze/CHANGELOG.md
+++ b/src/blaze/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-22
+
+### Added
+
+- Generic `StorageProvider` trait with pluggable backend architecture.
+- `FileStorageProvider`: default file-based storage backend for development and standard deployments.
+- `[storage]` config section: `provider`, `pool_size`, `prefork`, `flush_interval` fields with backward-compatible defaults.
+- `GET /v1/health` now includes `storage_pool` status (ready/capacity/pending).
+- `BackendSpawner` trait extended with `restore`, `pause`, `resume`, `create_snapshot` methods (default unsupported, enabling future snapshot workflows).
+
 ## [0.2.1] - 2026-07-21
 
 ### Changed

--- a/src/blaze/CHANGELOG_zh.md
+++ b/src/blaze/CHANGELOG_zh.md
@@ -9,6 +9,16 @@
 
 ## [未发布]
 
+## [0.3.0] - 2026-07-22
+
+### 新增
+
+- 通用 `StorageProvider` trait，支持可插拔存储后端架构。
+- `FileStorageProvider`：默认文件存储后端，适用于开发和标准部署。
+- `[storage]` 配置段：`provider`、`pool_size`、`prefork`、`flush_interval` 字段，均有向后兼容的默认值。
+- `GET /v1/health` 现返回 `storage_pool` 状态（ready/capacity/pending）。
+- `BackendSpawner` trait 扩展 `restore`、`pause`、`resume`、`create_snapshot` 方法（默认返回不支持，为后续快照工作流预留接口）。
+
 ## [0.2.1] - 2026-07-21
 
 ### 变更

--- a/src/blaze/Cargo.lock
+++ b/src/blaze/Cargo.lock
@@ -113,8 +113,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blaze-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "semver",
  "serde",
@@ -128,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "blazed"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -140,6 +141,7 @@ dependencies = [
  "hyper-util",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/src/blaze/Cargo.toml
+++ b/src/blaze/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/blaze/README.md
+++ b/src/blaze/README.md
@@ -78,6 +78,23 @@ vcpus = 4        # overrides [vm].vcpus for Firecracker only
 memory = "1Gi"   # overrides [vm].memory for Firecracker only
 ```
 
+### Storage Configuration
+
+The `[storage]` section controls the sandbox storage backend:
+
+```toml
+[storage]
+provider = "file"       # Storage provider selection. Currently supported: "file", "auto".
+                        # "auto" probes available providers in priority order (currently equivalent to "file").
+                        # Other values will log a warning and fall back to file.
+images_dir = "/var/lib/blaze/images"
+# pool_size = 0           # [Reserved] Warm pool slots (not yet active)
+# prefork = false         # [Reserved] Pre-start VMs in pool (not yet active)
+# flush_interval = "30s"  # [Reserved] Dirty data flush period (not yet active)
+```
+
+The `file` provider uses standard filesystem operations for sandbox storage. The `auto` provider probes available backends in priority order (currently equivalent to `file`). Unrecognized values will log a warning and fall back to `file`.
+
 ## API Endpoints
 
 | Method | Path | Description |
@@ -100,6 +117,18 @@ memory = "1Gi"   # overrides [vm].memory for Firecracker only
 | GET | `/v1/hooks` | List kernel hooks |
 | GET | `/v1/metrics` | Prometheus metrics |
 | POST | `/v1/admin/reload` | Hot-reload policies |
+
+#### Health Check
+
+`GET /v1/health` returns daemon status including storage pool readiness:
+
+```json
+{
+  "status": "ok",
+  "version": "0.3.0",
+  "storage_pool": { "ready": 0, "capacity": 0, "pending": 0 }
+}
+```
 
 ## Project Layout
 

--- a/src/blaze/README_zh.md
+++ b/src/blaze/README_zh.md
@@ -77,6 +77,23 @@ vcpus = 4        # 仅对 Firecracker 覆盖 [vm].vcpus
 memory = "1Gi"   # 仅对 Firecracker 覆盖 [vm].memory
 ```
 
+### 存储配置
+
+`[storage]` 部分控制 sandbox 存储后端：
+
+```toml
+[storage]
+provider = "file"       # 存储 provider 选择。当前支持："file"、"auto"。
+                        # "auto" 按优先级探测可用 provider（当前等同于 "file"）。
+                        # 其他值将记录告警并回退到 file。
+images_dir = "/var/lib/blaze/images"
+# pool_size = 0           # [Reserved] 预热存储槽位数（尚未启用）
+# prefork = false         # [Reserved] 是否在槽位中预启动 VM（尚未启用）
+# flush_interval = "30s"  # [Reserved] 脏数据刷盘周期（尚未启用）
+```
+
+`file` provider 使用标准文件系统操作管理 sandbox 存储。`auto` 按优先级探测可用 provider（当前等同于 `file`）。无法识别的值将记录告警并回退到 `file`。
+
 ## API 端点
 
 | 方法 | 路径 | 说明 |
@@ -99,6 +116,18 @@ memory = "1Gi"   # 仅对 Firecracker 覆盖 [vm].memory
 | GET | `/v1/hooks` | 列出内核 hook |
 | GET | `/v1/metrics` | Prometheus 指标 |
 | POST | `/v1/admin/reload` | 热加载策略 |
+
+#### 健康检查
+
+`GET /v1/health` 返回 daemon 状态，包含存储池就绪信息：
+
+```json
+{
+  "status": "ok",
+  "version": "0.3.0",
+  "storage_pool": { "ready": 0, "capacity": 0, "pending": 0 }
+}
+```
 
 ## 项目结构
 

--- a/src/blaze/crates/blaze-core/Cargo.toml
+++ b/src/blaze/crates/blaze-core/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 semver = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/blaze/crates/blaze-core/src/config.rs
+++ b/src/blaze/crates/blaze-core/src/config.rs
@@ -141,12 +141,35 @@ pub struct StorageSection {
     /// All runtime image files are looked up here by default.
     #[serde(default = "default_images_dir")]
     pub images_dir: PathBuf,
+
+    /// Storage provider backend name (e.g. "file", "btrfs", "zfs").
+    #[serde(default = "default_storage_provider")]
+    pub provider: String,
+
+    /// Warm pool target size (0 = no pool).
+    /// NOTE: Reserved for future use. Not yet wired into runtime.
+    #[serde(default)]
+    pub pool_size: usize,
+
+    /// Whether to pre-start VMs in pool slots.
+    /// NOTE: Reserved for future use. Not yet wired into runtime.
+    #[serde(default)]
+    pub prefork: bool,
+
+    /// Interval for flushing dirty data.
+    /// NOTE: Reserved for future use. Not yet wired into runtime.
+    #[serde(default = "default_flush_interval")]
+    pub flush_interval: String,
 }
 
 impl Default for StorageSection {
     fn default() -> Self {
         Self {
             images_dir: default_images_dir(),
+            provider: default_storage_provider(),
+            pool_size: 0,
+            prefork: false,
+            flush_interval: default_flush_interval(),
         }
     }
 }
@@ -198,6 +221,12 @@ fn default_prometheus_socket() -> PathBuf {
 }
 fn default_images_dir() -> PathBuf {
     PathBuf::from("/var/lib/blaze/images")
+}
+fn default_storage_provider() -> String {
+    "file".to_string()
+}
+fn default_flush_interval() -> String {
+    "30s".to_string()
 }
 
 #[cfg(test)]

--- a/src/blaze/crates/blaze-core/src/error.rs
+++ b/src/blaze/crates/blaze-core/src/error.rs
@@ -49,6 +49,9 @@ pub enum BlazeError {
 
     #[error("backend error: {msg}")]
     BackendError { msg: String },
+
+    #[error("storage error: {msg}")]
+    StorageError { msg: String },
 }
 
 /// Internal wrapper that lets [`BlazeError::ConfigError`] carry either a

--- a/src/blaze/crates/blaze-core/src/lib.rs
+++ b/src/blaze/crates/blaze-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod kernel;
 pub mod lifecycle;
 pub mod policy;
 pub mod pool;
+pub mod storage;
 pub mod template;
 
 pub use error::{BlazeError, Result};

--- a/src/blaze/crates/blaze-core/src/storage.rs
+++ b/src/blaze/crates/blaze-core/src/storage.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Generic storage provider abstraction.
+//!
+//! Different providers may offer different performance characteristics
+//! (warm pools, copy-on-write, content-addressable dedup) but present
+//! a uniform interface to the daemon layer.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use crate::error::Result;
+
+/// A storage slot allocated for one sandbox instance.
+#[derive(Debug, Clone)]
+pub struct StorageSlot {
+    pub id: String,
+    pub rootfs_path: PathBuf,
+    pub mem_path: PathBuf,
+    pub instance_dir: PathBuf,
+}
+
+/// Pool readiness status.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct PoolStatus {
+    pub ready: usize,
+    pub capacity: usize,
+    pub pending: usize,
+}
+
+/// Options for acquiring a storage slot.
+#[derive(Debug, Clone)]
+pub struct AcquireOpts {
+    pub instance_id: String,
+    pub rootfs_size: u64,
+    pub mem_size: u64,
+}
+
+/// Generic storage backend trait.
+#[async_trait]
+pub trait StorageProvider: Send + Sync {
+    /// Probe whether this provider is available in the current environment.
+    async fn probe(&self) -> Result<bool>;
+
+    /// Acquire a ready storage slot (may come from a warm pool).
+    async fn acquire(&self, opts: &AcquireOpts) -> Result<StorageSlot>;
+
+    /// Release a storage slot (cleanup all associated resources).
+    async fn release(&self, slot: StorageSlot) -> Result<()>;
+
+    /// Flush dirty data to persistent storage (implementation may be no-op).
+    async fn flush_dirty(&self, slot: &StorageSlot) -> Result<()>;
+
+    /// Query warm pool status.
+    fn pool_status(&self) -> PoolStatus;
+
+    /// Drain all ready slots from the warm pool.
+    async fn drain_pool(&self) -> Result<usize>;
+}

--- a/src/blaze/crates/blazed/Cargo.toml
+++ b/src/blaze/crates/blazed/Cargo.toml
@@ -29,3 +29,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -70,7 +70,7 @@ async fn dispatch(
     let m = method.as_str();
 
     match (m, parts.as_slice()) {
-        ("GET", ["v1", "health"]) => health(),
+        ("GET", ["v1", "health"]) => health(state),
         ("GET", ["v1", "instances"]) => list_instances(state),
         ("POST", ["v1", "instances"]) => create_instance(state, &body).await,
         ("GET", ["v1", "instances", id]) => get_instance(state, id),
@@ -98,10 +98,12 @@ async fn dispatch(
 // Health / metrics / admin
 // ---------------------------------------------------------------------------
 
-fn health() -> Result<Response<Full<Bytes>>> {
+fn health(state: &Arc<ServerState>) -> Result<Response<Full<Bytes>>> {
+    let pool_status = state.storage.pool_status();
     json_ok(&json!({
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
+        "storage_pool": pool_status,
     }))
 }
 
@@ -739,6 +741,7 @@ mod tests {
     use blaze_core::pool::PoolManager;
     use blaze_core::template::TemplateRegistry;
 
+    use crate::file_provider::FileStorageProvider;
     use crate::spawner::MockSpawner;
     use crate::state::ServerState;
 
@@ -793,6 +796,10 @@ mod tests {
         // Build state with active_backend = Firecracker (simulating probe
         // selected FC at boot) but using MockSpawner for test portability.
         let spawner: crate::spawner::DynSpawner = Arc::new(MockSpawner);
+        let storage_dir = tmp.join("storage");
+        let _ = std::fs::create_dir_all(&storage_dir);
+        let storage: Arc<dyn blaze_core::storage::StorageProvider> =
+            Arc::new(FileStorageProvider::new(storage_dir));
         let state = Arc::new(ServerState::build(
             config,
             engine,
@@ -801,6 +808,7 @@ mod tests {
             HookRegistry::new(),
             spawner,
             BackendKind::Firecracker,
+            storage,
         ));
 
         // Create instance request for AgentRl workload.

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -9,6 +9,7 @@ use blaze_core::config::{DaemonConfig, PolicyLoadErrorMode};
 use blaze_core::kernel::HookRegistry;
 use blaze_core::policy::PolicyEngine;
 use blaze_core::pool::PoolManager;
+use blaze_core::storage::StorageProvider;
 use blaze_core::template::TemplateRegistry;
 use http_body_util::Full;
 use hyper::body::Bytes;
@@ -38,6 +39,29 @@ pub async fn run(config_path: &Path) -> Result<()> {
     let hook = HookRegistry::new();
     let (spawner, active_backend) = build_spawner(&config).await;
 
+    // Build storage provider
+    if config.storage.provider != "file" && config.storage.provider != "auto" {
+        tracing::warn!(
+            provider = %config.storage.provider,
+            "unsupported storage provider, falling back to file"
+        );
+    }
+    let storage: Arc<dyn StorageProvider> = {
+        use crate::file_provider::FileStorageProvider;
+        // Ensure base_dir exists (acquire uses create_dir, not create_dir_all)
+        tokio::fs::create_dir_all(&config.storage.images_dir).await?;
+        let fp = FileStorageProvider::new(config.storage.images_dir.clone());
+        match fp.probe().await {
+            Ok(true) => {
+                tracing::info!(dir = %config.storage.images_dir.display(), "storage provider ready");
+            }
+            _ => {
+                tracing::warn!("storage probe returned false, continuing anyway");
+            }
+        }
+        Arc::new(fp)
+    };
+
     let socket_path = config.daemon.socket.clone();
     let http_addr = config.listen.http_addr.clone();
     let state = Arc::new(ServerState::build(
@@ -48,6 +72,7 @@ pub async fn run(config_path: &Path) -> Result<()> {
         hook,
         spawner,
         active_backend,
+        storage,
     ));
 
     if socket_path.exists() {

--- a/src/blaze/crates/blazed/src/file_provider.rs
+++ b/src/blaze/crates/blazed/src/file_provider.rs
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+//! File-based storage provider: creates per-instance directories with
+//! rootfs and memory files on a local filesystem. This is the simplest
+//! provider — no CoW, no dedup, no warm pool — suitable for development
+//! and single-node deployments.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use blaze_core::error::{BlazeError, Result};
+use blaze_core::storage::{AcquireOpts, PoolStatus, StorageProvider, StorageSlot};
+
+/// A trivial filesystem-based storage provider. Each [`acquire`] call
+/// creates a fresh directory with empty rootfs and memfile placeholders.
+pub struct FileStorageProvider {
+    base_dir: PathBuf,
+}
+
+impl FileStorageProvider {
+    /// Create a new provider rooted at `base_dir`. The directory need not
+    /// exist yet — [`probe`] checks and [`acquire`] creates subdirs.
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+}
+
+#[async_trait]
+impl StorageProvider for FileStorageProvider {
+    async fn probe(&self) -> Result<bool> {
+        Ok(self.base_dir.exists())
+    }
+
+    async fn acquire(&self, opts: &AcquireOpts) -> Result<StorageSlot> {
+        // Validate instance_id: must be a single path component (no /, .., absolute paths)
+        if opts.instance_id.is_empty()
+            || opts.instance_id.contains('/')
+            || opts.instance_id.contains('\\')
+            || opts.instance_id == ".."
+            || opts.instance_id == "."
+            || std::path::Path::new(&opts.instance_id).is_absolute()
+        {
+            return Err(BlazeError::StorageError {
+                msg: format!(
+                    "invalid instance_id '{}': must be a single path component",
+                    opts.instance_id
+                ),
+            });
+        }
+
+        let instance_dir = self.base_dir.join(&opts.instance_id);
+
+        // Atomic: create_dir fails with AlreadyExists if concurrent acquire races
+        match tokio::fs::create_dir(&instance_dir).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(BlazeError::StorageError {
+                    msg: format!(
+                        "acquire '{}': instance directory already exists",
+                        opts.instance_id
+                    ),
+                });
+            }
+            Err(e) => {
+                return Err(BlazeError::StorageError {
+                    msg: format!("acquire '{}': create dir: {}", opts.instance_id, e),
+                });
+            }
+        }
+
+        // Create rootfs + mem; rollback dir on failure
+        let rootfs_path = instance_dir.join("rootfs.ext4");
+        let mem_path = instance_dir.join("mem.bin");
+
+        let result = async {
+            let f = tokio::fs::File::create(&rootfs_path).await?;
+            if opts.rootfs_size > 0 {
+                f.set_len(opts.rootfs_size).await?;
+            }
+            let f = tokio::fs::File::create(&mem_path).await?;
+            if opts.mem_size > 0 {
+                f.set_len(opts.mem_size).await?;
+            }
+            Ok::<(), std::io::Error>(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            // Rollback: remove the directory we just created
+            let rollback_msg = match tokio::fs::remove_dir_all(&instance_dir).await {
+                Ok(()) => "rolled back".to_string(),
+                Err(cleanup_err) => format!(
+                    "rollback failed (residual dir {}): {}",
+                    instance_dir.display(),
+                    cleanup_err
+                ),
+            };
+            return Err(BlazeError::StorageError {
+                msg: format!(
+                    "acquire '{}': file setup failed, {}: {}",
+                    opts.instance_id, rollback_msg, e
+                ),
+            });
+        }
+
+        Ok(StorageSlot {
+            id: opts.instance_id.clone(),
+            rootfs_path,
+            mem_path,
+            instance_dir,
+        })
+    }
+
+    async fn release(&self, slot: StorageSlot) -> Result<()> {
+        // Re-derive the canonical path from base_dir + slot.id
+        // Do NOT trust slot.instance_dir (it could be externally constructed)
+        if slot.id.is_empty()
+            || slot.id.contains('/')
+            || slot.id.contains('\\')
+            || slot.id == ".."
+            || slot.id == "."
+        {
+            return Err(BlazeError::StorageError {
+                msg: format!("release '{}': path escapes base_dir", slot.id),
+            });
+        }
+        let canonical_dir = self.base_dir.join(&slot.id);
+        if !canonical_dir.starts_with(&self.base_dir) || canonical_dir == self.base_dir {
+            return Err(BlazeError::StorageError {
+                msg: format!("release '{}': path escapes base_dir", slot.id),
+            });
+        }
+        if canonical_dir.exists() {
+            tokio::fs::remove_dir_all(&canonical_dir)
+                .await
+                .map_err(|e| BlazeError::StorageError {
+                    msg: format!("release '{}': {}", slot.id, e),
+                })?;
+        }
+        Ok(())
+    }
+
+    async fn flush_dirty(&self, _slot: &StorageSlot) -> Result<()> {
+        // No-op for the basic file provider.
+        Ok(())
+    }
+
+    fn pool_status(&self) -> PoolStatus {
+        PoolStatus::default()
+    }
+
+    async fn drain_pool(&self) -> Result<usize> {
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn probe_existing_dir_returns_true() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        assert!(provider.probe().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn probe_missing_dir_returns_false() {
+        let provider =
+            FileStorageProvider::new(PathBuf::from("/nonexistent/blaze-test-storage-probe"));
+        assert!(!provider.probe().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn acquire_creates_slot_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let opts = AcquireOpts {
+            instance_id: "test-inst-001".to_string(),
+            rootfs_size: 1024,
+            mem_size: 512,
+        };
+        let slot = provider.acquire(&opts).await.unwrap();
+        assert_eq!(slot.id, "test-inst-001");
+        assert!(slot.rootfs_path.exists());
+        assert!(slot.mem_path.exists());
+        assert!(slot.instance_dir.exists());
+        // Verify sparse file lengths match requested sizes
+        assert_eq!(
+            tokio::fs::metadata(&slot.rootfs_path).await.unwrap().len(),
+            1024
+        );
+        assert_eq!(
+            tokio::fs::metadata(&slot.mem_path).await.unwrap().len(),
+            512
+        );
+    }
+
+    #[tokio::test]
+    async fn release_removes_instance_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let opts = AcquireOpts {
+            instance_id: "test-inst-release".to_string(),
+            rootfs_size: 1024,
+            mem_size: 512,
+        };
+        let slot = provider.acquire(&opts).await.unwrap();
+        let dir = slot.instance_dir.clone();
+        assert!(dir.exists());
+        provider.release(slot).await.unwrap();
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn pool_status_returns_defaults() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let status = provider.pool_status();
+        assert_eq!(status.ready, 0);
+        assert_eq!(status.capacity, 0);
+        assert_eq!(status.pending, 0);
+        assert_eq!(provider.drain_pool().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn release_rejects_forged_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let fp = FileStorageProvider::new(dir.path().to_path_buf());
+        let forged_slot = StorageSlot {
+            id: "../../etc".into(),
+            rootfs_path: PathBuf::from("/etc/passwd"),
+            mem_path: PathBuf::from("/etc/shadow"),
+            instance_dir: PathBuf::from("/etc"),
+        };
+        assert!(fp.release(forged_slot).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_duplicate_id() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let fp = FileStorageProvider::new(dir.path().to_path_buf());
+        let opts = AcquireOpts {
+            instance_id: "dup-1".into(),
+            rootfs_size: 64,
+            mem_size: 32,
+        };
+
+        // First acquire succeeds
+        let _ = fp.acquire(&opts).await.unwrap();
+
+        // Second acquire with same ID fails
+        let r = fp.acquire(&opts).await;
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_path_traversal() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+
+        // Absolute path
+        let r = provider
+            .acquire(&AcquireOpts {
+                instance_id: "/etc/passwd".into(),
+                rootfs_size: 0,
+                mem_size: 0,
+            })
+            .await;
+        assert!(r.is_err());
+
+        // Parent traversal
+        let r = provider
+            .acquire(&AcquireOpts {
+                instance_id: "../escape".into(),
+                rootfs_size: 0,
+                mem_size: 0,
+            })
+            .await;
+        assert!(r.is_err());
+
+        // Slash in middle
+        let r = provider
+            .acquire(&AcquireOpts {
+                instance_id: "foo/bar".into(),
+                rootfs_size: 0,
+                mem_size: 0,
+            })
+            .await;
+        assert!(r.is_err());
+
+        // Empty string
+        let r = provider
+            .acquire(&AcquireOpts {
+                instance_id: "".into(),
+                rootfs_size: 0,
+                mem_size: 0,
+            })
+            .await;
+        assert!(r.is_err());
+
+        // Dot-dot
+        let r = provider
+            .acquire(&AcquireOpts {
+                instance_id: "..".into(),
+                rootfs_size: 0,
+                mem_size: 0,
+            })
+            .await;
+        assert!(r.is_err());
+    }
+}

--- a/src/blaze/crates/blazed/src/main.rs
+++ b/src/blaze/crates/blazed/src/main.rs
@@ -8,6 +8,7 @@ mod api;
 mod cli;
 mod daemon;
 mod error;
+mod file_provider;
 mod metrics;
 mod spawner;
 mod state;

--- a/src/blaze/crates/blazed/src/spawner.rs
+++ b/src/blaze/crates/blazed/src/spawner.rs
@@ -79,6 +79,44 @@ pub trait BackendSpawner: Send + Sync {
 
     /// Probe whether the backend binary at `binary_path` is usable.
     async fn probe(&self, binary_path: &Path) -> Result<bool, BlazeError>;
+
+    /// Restore a sandbox from a snapshot + memory file.
+    async fn restore(
+        &self,
+        _snapshot_path: &Path,
+        _mem_path: &Path,
+        _work_dir: &Path,
+    ) -> Result<SpawnHandle, BlazeError> {
+        Err(BlazeError::BackendError {
+            msg: "restore not supported by this backend".to_string(),
+        })
+    }
+
+    /// Pause a running sandbox (freeze all processes).
+    async fn pause(&self, _handle: &SpawnHandle) -> Result<(), BlazeError> {
+        Err(BlazeError::BackendError {
+            msg: "pause not supported by this backend".to_string(),
+        })
+    }
+
+    /// Resume a paused sandbox.
+    async fn resume(&self, _handle: &SpawnHandle) -> Result<(), BlazeError> {
+        Err(BlazeError::BackendError {
+            msg: "resume not supported by this backend".to_string(),
+        })
+    }
+
+    /// Create a snapshot of a running or paused sandbox.
+    async fn create_snapshot(
+        &self,
+        _handle: &SpawnHandle,
+        _output_path: &Path,
+        _mem_output_path: &Path,
+    ) -> Result<(), BlazeError> {
+        Err(BlazeError::BackendError {
+            msg: "create_snapshot not supported by this backend".to_string(),
+        })
+    }
 }
 
 /// Convenience alias used by `ServerState`.

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use blaze_core::backend::BackendKind;
 use blaze_core::config::DaemonConfig;
@@ -15,6 +15,7 @@ use blaze_core::kernel::HookRegistry;
 use blaze_core::lifecycle::SandboxInstance;
 use blaze_core::policy::PolicyEngine;
 use blaze_core::pool::PoolManager;
+use blaze_core::storage::StorageProvider;
 use blaze_core::template::TemplateRegistry;
 use uuid::Uuid;
 
@@ -37,6 +38,7 @@ pub struct ServerState {
     /// API handlers use this to constrain availability to the single active
     /// backend rather than reporting all configured binaries.
     pub active_backend: BackendKind,
+    pub storage: Arc<dyn StorageProvider>,
     pub state_dir: PathBuf,
     pub metrics: Metrics,
 }
@@ -45,6 +47,7 @@ impl ServerState {
     /// Build a server state, scanning `state_dir` to repopulate the
     /// `instances` map from previous runs (best-effort; corrupt entries
     /// are skipped with a warning).
+    #[allow(clippy::too_many_arguments)]
     pub fn build(
         config: DaemonConfig,
         policy: PolicyEngine,
@@ -53,6 +56,7 @@ impl ServerState {
         hook: HookRegistry,
         spawner: DynSpawner,
         active_backend: BackendKind,
+        storage: Arc<dyn StorageProvider>,
     ) -> Self {
         let state_dir = config.daemon.state_dir.clone();
         let instances = scan_state_dir(&state_dir).unwrap_or_else(|err| {
@@ -70,6 +74,7 @@ impl ServerState {
             spawn_handles: Mutex::new(HashMap::new()),
             spawner,
             active_backend,
+            storage,
             state_dir,
             metrics: Metrics::new(),
         }

--- a/src/blaze/dist/blaze.spec
+++ b/src/blaze/dist/blaze.spec
@@ -2,7 +2,7 @@
 %global debug_package %{nil}
 
 Name:           blaze
-Version:        0.2.1
+Version:        0.3.0
 Release:        %{anolis_release}%{?dist}
 Summary:        Per-host sandbox orchestrator daemon for AI Agent workloads
 

--- a/src/blaze/examples/config.toml
+++ b/src/blaze/examples/config.toml
@@ -76,6 +76,19 @@ on_load_error = "fail"
 # Default: "/var/lib/blaze/images".
 images_dir = "/var/lib/blaze/images"
 
+# Storage provider backend. Currently supported: "file".
+# Additional providers may be registered at runtime.
+provider = "file"
+
+# Number of pre-warmed storage slots to keep ready in the pool.
+# pool_size = 0           # [Reserved] Warm pool slots (not yet active)
+
+# Whether to prefork (pre-allocate) storage slots at daemon startup.
+# prefork = false         # [Reserved] Pre-start VMs in pool (not yet active)
+
+# Interval between flush-dirty sweeps.
+# flush_interval = "30s"   # [Reserved] Dirty data flush period (not yet active)
+
 # ---------------------------------------------------------------------------
 # Instance pool settings (global defaults for warm-pool recycling).
 # Per-workload pool settings are configured in each policy file.

--- a/src/blaze/manifests/blaze.toml
+++ b/src/blaze/manifests/blaze.toml
@@ -3,7 +3,7 @@
 
 [component]
 name = "blaze"
-version = "0.2.1"
+version = "0.3.0"
 layer = "runtime"
 domain = "blaze"
 description = "Per-host sandbox orchestrator — multi-backend lifecycle management, kernel coordination"


### PR DESCRIPTION
## Description

Introduce a pluggable storage provider architecture for the Blaze sandbox orchestrator. This lays the foundation for future high-performance storage backends without coupling the daemon to any specific implementation.

### Ship Notes

**What**: Blaze v0.3.0 adds a `[storage]` configuration section (`provider`, `pool_size`, `prefork`, `flush_interval`) and reports storage pool readiness in the `/v1/health` endpoint. The daemon now boots with a file-based storage provider by default — no configuration changes required for existing users. The `BackendSpawner` trait gains snapshot lifecycle methods (`restore`, `pause`, `resume`, `create_snapshot`) preparing for future checkpoint/hibernate workflows.

## Related Issue

no-issue: planned Phase 2 of the blaze rebrand roadmap

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Scope

- [x] `blaze` (blaze)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

```bash
cd src/blaze
cargo test --workspace        # 61 passed
cargo clippy --workspace -- -D warnings  # 0 warnings
cargo fmt --all -- --check   # pass
```

## Additional Notes

- `StorageProvider` trait is generic and does not reference any kernel-specific implementation
- `FileStorageProvider` serves as the default fallback for development and standard deployments
- All new config fields have `#[serde(default)]` for backward compatibility
- `BackendSpawner` new methods have default implementations returning `Unsupported`, so existing spawner impls are unaffected
- Version bumped from 0.2.1 → 0.3.0 across Cargo.toml, component.toml, manifests, and RPM spec