### PR TITLE
feat(anolisa): add adapter notices

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -42,6 +42,7 @@ use anolisa_core::adapter::manager::{
     AdapterManager, AdapterSourceStatus, DisableOutcome, EnableOptions, EnableOutcome, ScanEntry,
     ScanReport, StatusReport,
 };
+use anolisa_core::manifest::{AdapterNotice, NoticeLevel, NoticeWhen};
 
 use crate::commands::common;
 use crate::context::CliContext;
@@ -136,6 +137,29 @@ struct ScanPayload {
     warnings: Vec<String>,
 }
 
+/// One notice in `--json` output. A stable shape: `when` and `level` are
+/// always present (never elided for defaults) so consumers can rely on the
+/// field layout; `command` is optional display-only text.
+#[derive(Serialize)]
+struct NoticeRow {
+    when: NoticeWhen,
+    level: NoticeLevel,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command: Option<String>,
+}
+
+impl From<&AdapterNotice> for NoticeRow {
+    fn from(notice: &AdapterNotice) -> Self {
+        NoticeRow {
+            when: notice.when,
+            level: notice.level,
+            text: notice.text.clone(),
+            command: notice.command.clone(),
+        }
+    }
+}
+
 /// `adapter enable` JSON output.
 #[derive(Serialize)]
 struct EnablePayload {
@@ -146,6 +170,9 @@ struct EnablePayload {
     plan: Option<DriverPlan>,
     #[serde(skip_serializing_if = "Option::is_none")]
     claim: Option<AdapterClaim>,
+    /// Notices displayed (real enable) or that would be displayed
+    /// (dry-run). Always present; empty when the adapter declares none.
+    notices: Vec<NoticeRow>,
 }
 
 /// `adapter disable` JSON output.
@@ -158,6 +185,9 @@ struct DisablePayload {
     claim_removed: bool,
     cleanup_complete: bool,
     messages: Vec<String>,
+    /// Notices displayed (real disable) or that would be displayed
+    /// (dry-run). Always present; empty when none apply.
+    notices: Vec<NoticeRow>,
 }
 
 /// One row of `adapter status` JSON output.
@@ -323,7 +353,7 @@ fn handle_enable(
         .map_err(|e| map_err(COMMAND, e))?;
 
     match outcome {
-        EnableOutcome::Planned(plan) => {
+        EnableOutcome::Planned { plan, notices } => {
             if ctx.json {
                 let payload = EnablePayload {
                     component: plan.component.clone(),
@@ -331,6 +361,7 @@ fn handle_enable(
                     dry_run: true,
                     plan: Some(plan),
                     claim: None,
+                    notices: notices.iter().map(NoticeRow::from).collect(),
                 };
                 return render_json(COMMAND, payload);
             }
@@ -344,9 +375,11 @@ fn handle_enable(
             if let Some(cmd) = &plan.register_command {
                 println!("  command: {cmd}");
             }
+            print_notices(&notices, true, ctx.quiet);
             Ok(())
         }
         EnableOutcome::Enabled(claim) => {
+            let notices = post_enable_notices(&claim);
             if ctx.json {
                 let payload = EnablePayload {
                     component: claim.component.clone(),
@@ -354,6 +387,7 @@ fn handle_enable(
                     dry_run: false,
                     plan: None,
                     claim: Some(*claim),
+                    notices: notices.iter().map(NoticeRow::from).collect(),
                 };
                 return render_json(COMMAND, payload);
             }
@@ -361,6 +395,7 @@ fn handle_enable(
             if let Some(pid) = &claim.plugin_id {
                 println!("  plugin: {pid}");
             }
+            print_notices(&notices, false, ctx.quiet);
             Ok(())
         }
     }
@@ -391,6 +426,7 @@ fn handle_disable(
                 claim_removed: false,
                 cleanup_complete: outcome.report.cleanup_complete,
                 messages: outcome.report.messages.clone(),
+                notices: outcome.notices.iter().map(NoticeRow::from).collect(),
             };
             return render_json(COMMAND, payload);
         }
@@ -399,6 +435,7 @@ fn handle_disable(
         for msg in &outcome.report.messages {
             println!("  - {msg}");
         }
+        print_notices(&outcome.notices, true, ctx.quiet);
         return Ok(());
     }
 
@@ -424,6 +461,7 @@ fn handle_disable(
             claim_removed: outcome.claim_removed,
             cleanup_complete: outcome.report.cleanup_complete,
             messages: outcome.report.messages.clone(),
+            notices: outcome.notices.iter().map(NoticeRow::from).collect(),
         };
         return render_json(COMMAND, payload);
     }
@@ -439,7 +477,56 @@ fn handle_disable(
     for msg in &outcome.report.messages {
         println!("  - {msg}");
     }
+    print_notices(&outcome.notices, false, ctx.quiet);
     degraded.map_or(Ok(()), Err)
+}
+
+/// The `post_enable` notices persisted in a receipt.
+fn post_enable_notices(claim: &AdapterClaim) -> Vec<AdapterNotice> {
+    claim
+        .notices
+        .iter()
+        .filter(|notice| notice.when == NoticeWhen::PostEnable)
+        .cloned()
+        .collect()
+}
+
+/// Print notices for human output. Suppressed entirely under `--quiet`.
+/// Under `dry_run` the notices are only a preview of what a real operation
+/// would display, so the heading says so. Control characters are escaped to
+/// keep untrusted contract or receipt text from altering terminal state.
+fn print_notices(notices: &[AdapterNotice], dry_run: bool, quiet: bool) {
+    if quiet || notices.is_empty() {
+        return;
+    }
+    if dry_run {
+        println!("  would show notices:");
+    } else {
+        println!("  notices:");
+    }
+    for notice in notices {
+        let level = match notice.level {
+            NoticeLevel::Info => "info",
+            NoticeLevel::Warning => "warning",
+        };
+        println!("    [{level}] {}", escape_notice_for_terminal(&notice.text));
+        if let Some(command) = &notice.command {
+            println!("      command: {}", escape_notice_for_terminal(command));
+        }
+    }
+}
+
+/// Escape control characters while preserving printable Unicode text.
+fn escape_notice_for_terminal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_control() {
+            escaped.extend(character.escape_default());
+        } else {
+            escaped.push(character);
+        }
+    }
+    escaped
 }
 
 /// Human-facing `component/framework` label for a disable outcome, falling

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -855,6 +855,7 @@ mod tests {
             bundle_digest: None,
             driver_schema: 1,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: Vec::new(),
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "state".to_string(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -468,6 +468,7 @@ mod tests {
             bundle_digest: None,
             driver_schema: 1,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: Vec::new(),
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "state".to_string(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -2025,6 +2025,7 @@ mod tests {
             bundle_digest: None,
             driver_schema: 1,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: Vec::new(),
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "state".to_string(),

--- a/src/anolisa/crates/anolisa-cli/tests/adapter_notices.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/adapter_notices.rs
@@ -1,0 +1,452 @@
+//! End-to-end coverage for adapter operation notices across human, `--json`,
+//! `--quiet`, and `--dry-run` output.
+//!
+//! Uses the `cosh` extension driver because it needs no external CLI:
+//! detection succeeds when the cosh home directory exists, and enable/disable
+//! are pure filesystem operations. That keeps this test hermetic while still
+//! driving the real binary through the full enable/disable path.
+
+use std::path::PathBuf;
+use std::process::Output;
+
+use anolisa_core::{
+    InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
+    Ownership, SubscriptionScope,
+};
+use anolisa_platform::fs_layout::FsLayout;
+
+mod common;
+
+const COMPONENT: &str = "notice-demo";
+
+/// Component contract declaring one `post_enable` and one `post_disable`
+/// notice on a cosh extension adapter.
+const MANIFEST: &str = r#"[component]
+name = "notice-demo"
+version = "0.1.0"
+
+[[adapters]]
+framework = "cosh"
+adapter_type = "extension"
+source = "adapters/notice-demo/cosh"
+dest = "{datadir}/adapters/{component}/cosh/"
+
+[[adapters.notices]]
+when = "post_enable"
+level = "info"
+text = "Start a new shell to load the extension."
+command = "cosh --version"
+
+[[adapters.notices]]
+when = "post_disable"
+level = "warning"
+text = "Extension files were removed from the shell."
+"#;
+
+struct NoticeFixture {
+    _tmp: tempfile::TempDir,
+    system_prefix: PathBuf,
+    home: PathBuf,
+    data_home: PathBuf,
+    config_home: PathBuf,
+    state_home: PathBuf,
+    cache_home: PathBuf,
+    runtime_dir: PathBuf,
+}
+
+impl NoticeFixture {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let system_prefix = root.join("system");
+        let home = root.join("home");
+        let data_home = root.join("xdg-data");
+        let config_home = root.join("xdg-config");
+        let state_home = root.join("xdg-state");
+        let cache_home = root.join("xdg-cache");
+        let runtime_dir = root.join("xdg-runtime");
+        let user_layout = FsLayout::user_with_overrides(
+            home.clone(),
+            Some(data_home.clone()),
+            Some(config_home.clone()),
+            Some(state_home.clone()),
+            Some(cache_home.clone()),
+            Some(runtime_dir.clone()),
+        );
+        let system_layout = FsLayout::system(Some(system_prefix.clone()));
+
+        // The cosh framework counts as detected when its home exists.
+        std::fs::create_dir_all(home.join(".copilot-shell")).expect("cosh home");
+
+        // Adapter resource bundle with the cosh extension manifest.
+        let resource_root = user_layout
+            .datadir
+            .join("adapters")
+            .join(COMPONENT)
+            .join("cosh");
+        std::fs::create_dir_all(&resource_root).expect("resource root");
+        std::fs::write(
+            resource_root.join("cosh-extension.json"),
+            format!(r#"{{"id":"{COMPONENT}","name":"Notice Demo"}}"#),
+        )
+        .expect("cosh extension manifest");
+
+        // Component contract snapshot carrying the notices.
+        let manifest_path = user_layout.snapshot_path(COMPONENT);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("manifest dir");
+        std::fs::write(&manifest_path, MANIFEST).expect("component manifest");
+
+        // Component installed in the user scope; empty system scope.
+        write_state(
+            &user_layout,
+            StateInstallMode::User,
+            vec![component(COMPONENT)],
+        );
+        write_state(&system_layout, StateInstallMode::System, Vec::new());
+
+        Self {
+            _tmp: tmp,
+            system_prefix,
+            home,
+            data_home,
+            config_home,
+            state_home,
+            cache_home,
+            runtime_dir,
+        }
+    }
+
+    /// Run `anolisa [flags] adapter <sub_args>` in user mode against this
+    /// fixture's temp roots.
+    fn run_adapter(&self, flags: &[&str], sub_args: &[&str]) -> Output {
+        let prefix = self.system_prefix.to_string_lossy();
+        let mut args: Vec<&str> = Vec::new();
+        args.extend_from_slice(flags);
+        args.extend(["--install-mode", "user", "--prefix", &prefix]);
+        args.push("adapter");
+        args.extend_from_slice(sub_args);
+        common::run_with_path_env(
+            &args,
+            &[
+                ("HOME", self.home.as_path()),
+                ("XDG_DATA_HOME", self.data_home.as_path()),
+                ("XDG_CONFIG_HOME", self.config_home.as_path()),
+                ("XDG_STATE_HOME", self.state_home.as_path()),
+                ("XDG_CACHE_HOME", self.cache_home.as_path()),
+                ("XDG_RUNTIME_DIR", self.runtime_dir.as_path()),
+            ],
+        )
+    }
+
+    fn enable(&self, flags: &[&str]) -> Output {
+        self.run_adapter(flags, &["enable", COMPONENT, "cosh"])
+    }
+
+    fn disable(&self, flags: &[&str]) -> Output {
+        self.run_adapter(flags, &["disable", COMPONENT, "cosh"])
+    }
+
+    /// The delivered cosh extension directory.
+    fn extension_dir(&self) -> PathBuf {
+        self.home
+            .join(".copilot-shell")
+            .join("extensions")
+            .join(COMPONENT)
+    }
+}
+
+fn write_state(layout: &FsLayout, mode: StateInstallMode, objects: Vec<InstalledObject>) {
+    std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    InstalledState {
+        install_mode: mode,
+        prefix: layout.prefix.clone(),
+        objects,
+        ..InstalledState::default()
+    }
+    .save(&layout.state_dir.join("installed.toml"))
+    .expect("state");
+}
+
+fn component(name: &str) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: name.to_string(),
+        version: "0.1.0".to_string(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("raw".to_string()),
+        ownership: Some(Ownership::RawManaged),
+        rpm_metadata: None,
+        installed_at: "2026-01-01T00:00:00Z".to_string(),
+        last_operation_id: None,
+        managed: true,
+        adopted: false,
+        subscription_scope: SubscriptionScope::None,
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "exit {:?}; stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn enable_human_shows_post_enable_notices() {
+    let fixture = NoticeFixture::new();
+    let output = fixture.enable(&[]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("Enabled notice-demo/cosh."), "{out}");
+    assert!(out.contains("notices:"), "{out}");
+    assert!(
+        out.contains("[info] Start a new shell to load the extension."),
+        "{out}"
+    );
+    assert!(out.contains("command: cosh --version"), "{out}");
+    // The post_disable notice must not appear on enable.
+    assert!(!out.contains("Extension files were removed"), "{out}");
+}
+
+#[test]
+fn enable_escapes_terminal_controls_only_in_human_output() {
+    let fixture = NoticeFixture::new();
+    let manifest_path = FsLayout::user_with_overrides(
+        fixture.home.clone(),
+        Some(fixture.data_home.clone()),
+        Some(fixture.config_home.clone()),
+        Some(fixture.state_home.clone()),
+        Some(fixture.cache_home.clone()),
+        Some(fixture.runtime_dir.clone()),
+    )
+    .snapshot_path(COMPONENT);
+    let manifest = MANIFEST
+        .replace(
+            "Start a new shell to load the extension.",
+            r"Set title: \u001b]2;spoofed-title\u0007",
+        )
+        .replace("cosh --version", r"cosh \u001b[31m--version");
+    std::fs::write(&manifest_path, manifest).expect("unsafe notice manifest");
+
+    let human = fixture.enable(&["--dry-run"]);
+    assert_success(&human);
+    let out = stdout(&human);
+    assert!(
+        !out.contains('\u{1b}'),
+        "ESC must not reach stdout: {out:?}"
+    );
+    assert!(!out.contains('\u{7}'), "BEL must not reach stdout: {out:?}");
+    assert!(
+        out.contains(r"[info] Set title: \u{1b}]2;spoofed-title\u{7}"),
+        "{out:?}"
+    );
+    assert!(
+        out.contains(r"command: cosh \u{1b}[31m--version"),
+        "{out:?}"
+    );
+
+    let json = fixture.enable(&["--json", "--dry-run"]);
+    assert_success(&json);
+    let envelope: serde_json::Value = serde_json::from_slice(&json.stdout).expect("json");
+    assert_eq!(
+        envelope["data"]["notices"][0]["text"],
+        "Set title: \u{1b}]2;spoofed-title\u{7}"
+    );
+    assert_eq!(
+        envelope["data"]["notices"][0]["command"],
+        "cosh \u{1b}[31m--version"
+    );
+}
+
+#[test]
+fn enable_quiet_suppresses_notices() {
+    let fixture = NoticeFixture::new();
+    let output = fixture.enable(&["--quiet"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(
+        !out.contains("notices:") && !out.contains("Start a new shell"),
+        "--quiet must not print notices: {out}"
+    );
+}
+
+#[test]
+fn enable_json_returns_notices() {
+    let fixture = NoticeFixture::new();
+    let output = fixture.enable(&["--json"]);
+    assert_success(&output);
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
+    assert_eq!(envelope["ok"], true);
+    let notices = envelope["data"]["notices"].as_array().expect("array");
+    assert_eq!(notices.len(), 1);
+    assert_eq!(notices[0]["when"], "post_enable");
+    assert_eq!(notices[0]["level"], "info");
+    assert_eq!(
+        notices[0]["text"],
+        "Start a new shell to load the extension."
+    );
+    assert_eq!(notices[0]["command"], "cosh --version");
+}
+
+#[test]
+fn enable_json_without_notices_is_stable_empty_array() {
+    // An adapter with no notices still returns a stable `notices: []`.
+    let fixture = NoticeFixture::new();
+    let manifest_path = FsLayout::user_with_overrides(
+        fixture.home.clone(),
+        Some(fixture.data_home.clone()),
+        Some(fixture.config_home.clone()),
+        Some(fixture.state_home.clone()),
+        Some(fixture.cache_home.clone()),
+        Some(fixture.runtime_dir.clone()),
+    )
+    .snapshot_path(COMPONENT);
+    std::fs::write(
+        &manifest_path,
+        r#"[component]
+name = "notice-demo"
+version = "0.1.0"
+
+[[adapters]]
+framework = "cosh"
+adapter_type = "extension"
+source = "adapters/notice-demo/cosh"
+dest = "{datadir}/adapters/{component}/cosh/"
+"#,
+    )
+    .expect("rewrite manifest without notices");
+
+    let output = fixture.enable(&["--json"]);
+    assert_success(&output);
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
+    assert_eq!(
+        envelope["data"]["notices"],
+        serde_json::json!([]),
+        "notices must be a stable empty array"
+    );
+}
+
+#[test]
+fn enable_dry_run_previews_notices_without_executing() {
+    let fixture = NoticeFixture::new();
+    let output = fixture.enable(&["--dry-run"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(
+        out.contains("[dry-run] would enable notice-demo/cosh:"),
+        "{out}"
+    );
+    assert!(out.contains("would show notices:"), "{out}");
+    assert!(
+        out.contains("[info] Start a new shell to load the extension."),
+        "{out}"
+    );
+    // Preview only: nothing was delivered and no receipt persisted.
+    assert!(
+        !fixture.extension_dir().exists(),
+        "dry-run must not deliver the extension"
+    );
+}
+
+#[test]
+fn enable_dry_run_json_marks_preview_not_executed() {
+    let fixture = NoticeFixture::new();
+    let output = fixture.enable(&["--json", "--dry-run"]);
+    assert_success(&output);
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
+    assert_eq!(envelope["data"]["dry_run"], true);
+    assert!(
+        envelope["data"]["claim"].is_null(),
+        "dry-run must not carry a claim"
+    );
+    assert_eq!(envelope["data"]["notices"][0]["when"], "post_enable");
+    assert!(
+        !fixture.extension_dir().exists(),
+        "dry-run must not deliver the extension"
+    );
+}
+
+#[test]
+fn disable_human_shows_post_disable_notices() {
+    let fixture = NoticeFixture::new();
+    assert_success(&fixture.enable(&[]));
+    let output = fixture.disable(&[]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("Disabled notice-demo/cosh."), "{out}");
+    assert!(
+        out.contains("[warning] Extension files were removed from the shell."),
+        "{out}"
+    );
+    // The post_enable notice must not appear on disable.
+    assert!(!out.contains("Start a new shell"), "{out}");
+}
+
+#[test]
+fn disable_json_returns_post_disable_notices() {
+    let fixture = NoticeFixture::new();
+    assert_success(&fixture.enable(&["--json"]));
+    let output = fixture.disable(&["--json"]);
+    assert_success(&output);
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
+    let notices = envelope["data"]["notices"].as_array().expect("array");
+    assert_eq!(notices.len(), 1);
+    assert_eq!(notices[0]["when"], "post_disable");
+    assert_eq!(notices[0]["level"], "warning");
+    assert_eq!(
+        notices[0]["text"],
+        "Extension files were removed from the shell."
+    );
+}
+
+#[test]
+fn disable_quiet_suppresses_notices() {
+    let fixture = NoticeFixture::new();
+    assert_success(&fixture.enable(&[]));
+    let output = fixture.disable(&["--quiet"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(
+        !out.contains("Extension files were removed"),
+        "--quiet must not print notices: {out}"
+    );
+}
+
+#[test]
+fn disable_dry_run_previews_notices_and_keeps_receipt() {
+    let fixture = NoticeFixture::new();
+    assert_success(&fixture.enable(&[]));
+    let output = fixture.disable(&["--dry-run"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(
+        out.contains("[dry-run] would disable notice-demo/cosh:"),
+        "{out}"
+    );
+    assert!(out.contains("would show notices:"), "{out}");
+    assert!(
+        out.contains("[warning] Extension files were removed from the shell."),
+        "{out}"
+    );
+    // The receipt survived the preview: a real disable still succeeds.
+    let real = fixture.disable(&[]);
+    assert_success(&real);
+    assert!(stdout(&real).contains("Disabled notice-demo/cosh."));
+}

--- a/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
@@ -289,6 +289,7 @@ fn adapter_claim(component: &str) -> AdapterClaim {
         bundle_digest: None,
         driver_schema: 1,
         status: ClaimStatus::Enabled,
+        notices: Vec::new(),
         resources: Vec::new(),
         driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
             state_dir_resource: "state".to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -5,9 +5,11 @@
 //! over on behalf of one component, so [`status`](super::manager) and
 //! [`disable`](super::manager) can run later without re-reading the
 //! resource directory and without trusting any executable instruction
-//! from disk. Receipts never carry argv, shell strings, script paths, or
-//! reverse commands — the framework CLI invocation is constructed by the
-//! built-in driver, not read back from the receipt.
+//! from disk. Receipts never carry executable argv, script paths, or reverse
+//! commands. [`AdapterNotice::command`](crate::manifest::AdapterNotice::command)
+//! is the sole command-like string: an inert display hint that must never be
+//! parsed into argv or executed. Framework CLI invocations are constructed by
+//! built-in drivers, not read back from receipts.
 //!
 //! Every value that `status`/`disable` would interpret as a path, a
 //! symlink, or a framework-registry entry must live in [`ClaimResource`],
@@ -83,6 +85,14 @@ pub struct AdapterClaim {
     pub driver_schema: u32,
     /// Lifecycle status of the receipt itself.
     pub status: ClaimStatus,
+    /// Static, display-only notices declared in the component manifest at
+    /// enable time. Persisted so `disable` can show `post_disable` notices
+    /// from the receipt alone, without depending on the manifest still
+    /// being present (same rationale as `adapter_type`). Inert text: never
+    /// shell-expanded, template-substituted, or executed. Declared after
+    /// the scalar fields so TOML emits it among the sub-tables.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notices: Vec<crate::manifest::AdapterNotice>,
     /// Manager-validatable resource declarations — the receipt's security
     /// boundary. Re-validated before every `status`/`disable`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -883,6 +893,7 @@ mod tests {
             bundle_digest: Some("sha256:abc".to_string()),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "openclaw_state_dir".to_string(),
@@ -1008,6 +1019,7 @@ mod tests {
             bundle_digest: Some("sha256:def".to_string()),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "hermes_home".to_string(),
@@ -1121,6 +1133,7 @@ mod tests {
             bundle_digest: None,
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "state_dir".to_string(),
@@ -1213,6 +1226,7 @@ mod tests {
             bundle_digest: Some("sha256:c0de".to_string()),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "codex_marketplace_dir".to_string(),
@@ -1301,6 +1315,7 @@ mod tests {
             bundle_digest: Some("sha256:c05h".to_string()),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![ClaimResource {
                 id: "cosh_extension_dir".to_string(),
                 purpose: "cosh_extension_dir".to_string(),
@@ -1336,6 +1351,7 @@ mod tests {
             bundle_digest: None,
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "cc_marketplace".to_string(),
@@ -1376,6 +1392,7 @@ mod tests {
             bundle_digest: Some("sha256:90de".to_string()),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "qoder_plugin".to_string(),
@@ -1452,6 +1469,7 @@ mod tests {
             bundle_digest: Some("sha256:0wen".to_string()),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "qwencode_extension_dir".to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
@@ -237,6 +237,7 @@ impl FrameworkDriver for ClaudeCodeDriver {
                 bundle_digest: bundle.digest.clone(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
+                notices: Vec::new(),
                 resources,
                 driver_payload: DriverPayload::ClaudeCode(ClaudeCodeClaim {
                     marketplace_resource: RES_MARKETPLACE.to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -218,6 +218,7 @@ impl FrameworkDriver for CodexDriver {
                 bundle_digest: bundle.digest.clone(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
+                notices: Vec::new(),
                 resources,
                 driver_payload: DriverPayload::Codex(CodexClaim {
                     marketplace_dir_resource: RES_MARKETPLACE_DIR.to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
@@ -179,6 +179,7 @@ impl FrameworkDriver for CoshDriver {
                 bundle_digest: bundle.digest.clone(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
+                notices: Vec::new(),
                 resources,
                 driver_payload: DriverPayload::Cosh(CoshClaim {
                     extension_dir_resource: RES_EXTENSION_DIR.to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -222,6 +222,7 @@ impl FrameworkDriver for HermesDriver {
                 bundle_digest: bundle.digest.clone(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
+                notices: Vec::new(),
                 resources,
                 driver_payload: DriverPayload::Hermes(HermesClaim {
                     home_resource: RES_HOME.to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -59,8 +59,16 @@ const OUTPUT_CAP: usize = 64 * 1024;
 #[derive(Debug, Clone)]
 pub enum EnableOutcome {
     /// `--dry-run`: what enable *would* do, no state mutated.
-    Planned(DriverPlan),
-    /// Enable ran; the persisted receipt.
+    Planned {
+        /// The driver's plan.
+        plan: DriverPlan,
+        /// Static `post_enable` notices a real enable would display.
+        /// Preview only — nothing was executed.
+        notices: Vec<crate::manifest::AdapterNotice>,
+    },
+    /// Enable ran; the persisted receipt. The declared notices are carried
+    /// in [`AdapterClaim::notices`]; the `post_enable` subset is what a
+    /// caller displays after success.
     Enabled(Box<AdapterClaim>),
 }
 
@@ -95,6 +103,11 @@ pub struct DisableOutcome {
     pub claim_removed: bool,
     /// True when the operation was a dry-run (no state mutated).
     pub dry_run: bool,
+    /// Static `post_disable` notices from the receipt. Populated when a
+    /// disable succeeds, or as a preview under dry-run; empty for the
+    /// no-op and degraded (cleanup-incomplete) outcomes. Display-only;
+    /// the text is inert and never executed.
+    pub notices: Vec<crate::manifest::AdapterNotice>,
 }
 
 /// One row of [`AdapterManager::scan`].
@@ -557,6 +570,7 @@ impl AdapterManager {
         let config = declared_config(&manifest, &framework);
         let framework_version_req = declared_framework_version_req(&manifest, &framework);
         let bundle_entry = declared_bundle_entry(&manifest, &framework);
+        let all_notices = declared_all_notices(&manifest, &framework);
         if adapter_type.as_deref() == Some("skill_bundle") && !config.is_empty() {
             return Err(AdapterError::InvalidAdapterInput {
                 component: component.to_string(),
@@ -690,7 +704,12 @@ impl AdapterManager {
 
         if dry_run {
             let plan = driver.plan_enable(&bundle, &ctx)?;
-            return Ok(EnableOutcome::Planned(plan));
+            let notices = declared_notices(
+                &manifest,
+                &framework,
+                crate::manifest::NoticeWhen::PostEnable,
+            );
+            return Ok(EnableOutcome::Planned { plan, notices });
         }
 
         // enable mutates framework state, so the framework must be usable.
@@ -705,6 +724,10 @@ impl AdapterManager {
         }
 
         let (mut claim, prepared) = driver.prepare_enable(&bundle, &ctx)?;
+        // Persist the manifest's static notices in the receipt so a later
+        // disable can show `post_disable` notices from the receipt alone.
+        // Inert text — never expanded or executed.
+        claim.notices = all_notices;
         let claim_allowed_roots = driver.allowed_external_roots(&ctx);
         if let Some(prior) = state.find_adapter_claim(component, &framework).cloned() {
             // A forged prior receipt must not gain authority merely because a
@@ -813,6 +836,7 @@ impl AdapterManager {
                             },
                             claim_removed: false,
                             dry_run,
+                            notices: Vec::new(),
                         });
                     }
                     1 => claimed[0].clone(),
@@ -841,6 +865,7 @@ impl AdapterManager {
                     },
                     claim_removed: false,
                     dry_run,
+                    notices: Vec::new(),
                 });
             }
         };
@@ -924,17 +949,21 @@ impl AdapterManager {
 
         if dry_run {
             let report = plan_disable_report(&claim);
+            let notices = post_disable_notices(&claim);
             return Ok(DisableOutcome {
                 component: component.to_string(),
                 framework: Some(framework),
                 report,
                 claim_removed: false,
                 dry_run: true,
+                notices,
             });
         }
 
         let report = driver.disable(&claim, &ctx)?;
         let claim_removed = report.cleanup_complete;
+        // Extract before the branch below moves `claim` into the kept receipt.
+        let disable_notices = post_disable_notices(&claim);
         if claim_removed {
             state.remove_adapter_claim(component, &framework);
             self.log_operation(&label, component, LogStatus::Ok, "adapter disabled", None);
@@ -959,6 +988,13 @@ impl AdapterManager {
             report,
             claim_removed,
             dry_run: false,
+            // Notices are shown only on a successful disable; a degraded
+            // (cleanup-incomplete) disable shows the retry path instead.
+            notices: if claim_removed {
+                disable_notices
+            } else {
+                Vec::new()
+            },
         })
     }
 
@@ -2615,6 +2651,52 @@ fn declared_config(
     adapter.config.clone()
 }
 
+/// Extract every declared notice for a framework, checking the
+/// framework-specific section first then falling back to the generic one.
+///
+/// Notices are inert, display-only text: they are returned verbatim and
+/// never shell-expanded, template-substituted, or executed.
+fn declared_all_notices(
+    manifest: &ComponentManifest,
+    framework: &str,
+) -> Vec<crate::manifest::AdapterNotice> {
+    let adapter = manifest
+        .adapters
+        .iter()
+        .find(|a| a.framework.as_deref().map(str::trim) == Some(framework));
+    let adapter = match adapter {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    // Framework-specific section takes precedence.
+    let notices = match framework {
+        "openclaw" => adapter
+            .openclaw
+            .as_ref()
+            .filter(|oc| !oc.notices.is_empty())
+            .map_or(&adapter.notices, |oc| &oc.notices),
+        "hermes" => adapter
+            .hermes
+            .as_ref()
+            .filter(|h| !h.notices.is_empty())
+            .map_or(&adapter.notices, |h| &h.notices),
+        _ => &adapter.notices,
+    };
+    notices.clone()
+}
+
+/// The subset of a framework's declared notices matching `when`.
+fn declared_notices(
+    manifest: &ComponentManifest,
+    framework: &str,
+    when: crate::manifest::NoticeWhen,
+) -> Vec<crate::manifest::AdapterNotice> {
+    declared_all_notices(manifest, framework)
+        .into_iter()
+        .filter(|notice| notice.when == when)
+        .collect()
+}
+
 /// Resolve the adapter-level framework version requirement for a framework.
 ///
 /// `[adapters.compat].framework_version` is the primary source; the legacy
@@ -2667,6 +2749,17 @@ fn declared_bundle_entry(manifest: &ComponentManifest, framework: &str) -> Optio
         _ => {}
     }
     adapter.bundle.entry.clone()
+}
+
+/// The `post_disable` notices persisted in a receipt, verbatim. Notices are
+/// inert display text — never expanded, substituted, or executed.
+fn post_disable_notices(claim: &AdapterClaim) -> Vec<crate::manifest::AdapterNotice> {
+    claim
+        .notices
+        .iter()
+        .filter(|notice| notice.when == crate::manifest::NoticeWhen::PostDisable)
+        .cloned()
+        .collect()
 }
 
 /// Build a non-mutating [`DisableReport`] from a validated receipt,
@@ -3617,6 +3710,7 @@ source = "adapters/openclaw"
             bundle_digest: None,
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: Vec::new(),
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "openclaw_state".to_string(),
@@ -5761,6 +5855,7 @@ dest = "{datadir}/skills"
             bundle_digest: None,
             driver_schema: 1,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources,
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "state_dir".to_string(),
@@ -5945,6 +6040,7 @@ dest = "{datadir}/skills"
             bundle_digest: None,
             driver_schema: 1,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "hermes_home".to_string(),
@@ -6016,6 +6112,7 @@ dest = "{datadir}/skills"
             bundle_digest: None,
             driver_schema: 1,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "hermes_home".to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -289,6 +289,7 @@ impl FrameworkDriver for OpenClawDriver {
             bundle_digest: bundle.digest.clone(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources,
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: RES_STATE_DIR.to_string(),
@@ -3389,6 +3390,7 @@ mod tests {
             bundle_digest: None,
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::CleanupFailed,
+            notices: Vec::new(),
             resources: vec![
                 ClaimResource {
                     id: "openclaw_config_0".to_string(),
@@ -3578,6 +3580,7 @@ mod tests {
             bundle_digest: None,
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources: vec![ClaimResource {
                 id: RES_PLUGIN.to_string(),
                 purpose: "openclaw_plugin".to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
@@ -262,6 +262,7 @@ impl FrameworkDriver for QoderDriver {
                 bundle_digest: bundle.digest.clone(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
+                notices: Vec::new(),
                 resources,
                 driver_payload: DriverPayload::Qoder(QoderClaim {
                     plugin_resource: RES_PLUGIN.to_string(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
@@ -216,6 +216,7 @@ impl FrameworkDriver for QwenCodeDriver {
             bundle_digest: bundle.digest.clone(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
+            notices: Vec::new(),
             resources,
             driver_payload: DriverPayload::QwenCode(QwenCodeClaim {
                 extension_dir_resource: RES_EXTENSION_DIR.to_string(),

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -1087,6 +1087,7 @@ mod tests {
                 bundle_digest: None,
                 driver_schema: 1,
                 status: ClaimStatus::Enabled,
+                notices: Vec::new(),
                 resources: Vec::new(),
                 driver_payload: DriverPayload::Cosh(CoshClaim {
                     extension_dir_resource: "ext".to_string(),

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -91,8 +91,8 @@ pub use lifecycle::{
 };
 pub use lock::{InstallLock, LockError};
 pub use manifest::{
-    AdapterSpec, ComponentManifest, DependencyKind, DistributionSelector, FileKind, PackageNames,
-    RuntimeDependency, ServiceScope, declared_unit_scope,
+    AdapterNotice, AdapterSpec, ComponentManifest, DependencyKind, DistributionSelector, FileKind,
+    NoticeLevel, NoticeWhen, PackageNames, RuntimeDependency, ServiceScope, declared_unit_scope,
 };
 pub use metadata::MetadataClient;
 pub use provisioner::{

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -649,6 +649,11 @@ pub struct AdapterSpec {
     /// Post-install config key/value pairs the driver should apply.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub config: Vec<AdapterConfigSetSpec>,
+    /// Static, display-only operator notices shown after `adapter enable`
+    /// or `adapter disable` succeeds. Inert text: never expanded,
+    /// substituted, or executed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notices: Vec<AdapterNotice>,
     /// Semver constraint on the target framework version, e.g. `">=1.2"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub framework_version_req: Option<String>,
@@ -719,6 +724,56 @@ pub struct AdapterConfigSetSpec {
     /// so those manifests round-trip byte-stable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub framework_version: Option<String>,
+}
+
+/// A static, display-only operator notice attached to an adapter. The
+/// adapter manager surfaces matching notices after `adapter enable`
+/// ([`NoticeWhen::PostEnable`]) or `adapter disable`
+/// ([`NoticeWhen::PostDisable`]) succeeds.
+///
+/// Notices are inert text: `text` and `command` are never shell-expanded,
+/// template-substituted, or executed. Structured output preserves their
+/// values, while human output escapes control characters. Required framework
+/// configuration is NOT a notice — it stays a structured
+/// [`AdapterConfigSetSpec`] entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdapterNotice {
+    /// When the notice is displayed.
+    pub when: NoticeWhen,
+    /// Notice severity. Defaults to [`NoticeLevel::Info`] when absent.
+    #[serde(default, skip_serializing_if = "is_default_level")]
+    pub level: NoticeLevel,
+    /// The notice body. Required; human output escapes control characters.
+    pub text: String,
+    /// Optional display-only command hint (e.g. a follow-up the operator
+    /// may run). Never parsed or executed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+}
+
+/// Lifecycle point at which an [`AdapterNotice`] is displayed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NoticeWhen {
+    /// Show after `adapter enable` succeeds.
+    PostEnable,
+    /// Show after `adapter disable` succeeds.
+    PostDisable,
+}
+
+/// Severity of an [`AdapterNotice`].
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NoticeLevel {
+    /// Informational notice.
+    #[default]
+    Info,
+    /// Warning the operator should pay attention to.
+    Warning,
+}
+
+fn is_default_level(level: &NoticeLevel) -> bool {
+    matches!(level, NoticeLevel::Info)
 }
 
 /// One skill entry in an `[[adapters]]` or framework-specific section.
@@ -799,12 +854,18 @@ pub struct OpenClawAdapterSpec {
     /// Post-install config key/value pairs for OpenClaw.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub config: Vec<AdapterConfigSetSpec>,
+    /// Static, display-only operator notices for the OpenClaw adapter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notices: Vec<AdapterNotice>,
 }
 
 impl OpenClawAdapterSpec {
     /// Whether no framework-specific data is present.
     pub fn is_empty(&self) -> bool {
-        self.bundle.is_empty() && self.skills.is_empty() && self.config.is_empty()
+        self.bundle.is_empty()
+            && self.skills.is_empty()
+            && self.config.is_empty()
+            && self.notices.is_empty()
     }
 }
 
@@ -824,12 +885,15 @@ pub struct HermesAdapterSpec {
         serialize_with = "serialize_skills"
     )]
     pub skills: Vec<AdapterSkillSpec>,
+    /// Static, display-only operator notices for the Hermes adapter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notices: Vec<AdapterNotice>,
 }
 
 impl HermesAdapterSpec {
     /// Whether no framework-specific data is present.
     pub fn is_empty(&self) -> bool {
-        self.bundle.is_empty() && self.skills.is_empty()
+        self.bundle.is_empty() && self.skills.is_empty() && self.notices.is_empty()
     }
 }
 
@@ -1111,6 +1175,8 @@ struct AdapterRaw {
     #[serde(default)]
     config: Vec<AdapterConfigSetSpec>,
     #[serde(default)]
+    notices: Vec<AdapterNotice>,
+    #[serde(default)]
     framework_version_req: Option<String>,
     #[serde(default)]
     openclaw: Option<OpenClawAdapterSpec>,
@@ -1327,6 +1393,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
                 detect: a.detect,
                 skills: a.skills,
                 config: a.config,
+                notices: a.notices,
                 framework_version_req: a.framework_version_req,
                 openclaw: a.openclaw,
                 hermes: a.hermes,
@@ -2905,6 +2972,242 @@ mod tests {
         assert!(
             !serialized.contains("[hermes]"),
             "absent hermes section must be skipped: {serialized}"
+        );
+    }
+
+    #[test]
+    fn adapter_notices_parse_generic() {
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.1.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            plugin_id = "sec-core"
+
+            [[adapters.notices]]
+            when = "post_enable"
+            level = "info"
+            text = "Restart the framework to load the plugin."
+            command = "openclaw restart"
+
+            [[adapters.notices]]
+            when = "post_disable"
+            level = "warning"
+            text = "Cached tokens remain until the framework restarts."
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let a = &m.adapters[0];
+        assert_eq!(a.notices.len(), 2);
+        assert_eq!(a.notices[0].when, NoticeWhen::PostEnable);
+        assert_eq!(a.notices[0].level, NoticeLevel::Info);
+        assert_eq!(
+            a.notices[0].text,
+            "Restart the framework to load the plugin."
+        );
+        assert_eq!(a.notices[0].command.as_deref(), Some("openclaw restart"));
+        assert_eq!(a.notices[1].when, NoticeWhen::PostDisable);
+        assert_eq!(a.notices[1].level, NoticeLevel::Warning);
+        assert!(a.notices[1].command.is_none());
+    }
+
+    #[test]
+    fn adapter_notice_level_defaults_to_info() {
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.1.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.notices]]
+            when = "post_enable"
+            text = "No level declared."
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.adapters[0].notices[0].level, NoticeLevel::Info);
+    }
+
+    #[test]
+    fn adapter_notices_parse_framework_specific_sections() {
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.1.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.openclaw.notices]]
+            when = "post_enable"
+            text = "OpenClaw-specific notice."
+
+            [[adapters]]
+            framework = "hermes"
+
+            [[adapters.hermes.notices]]
+            when = "post_disable"
+            level = "warning"
+            text = "Hermes-specific notice."
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let oc = m.adapters[0].openclaw.as_ref().expect("openclaw section");
+        assert_eq!(oc.notices.len(), 1);
+        assert_eq!(oc.notices[0].when, NoticeWhen::PostEnable);
+        assert_eq!(oc.notices[0].text, "OpenClaw-specific notice.");
+        let h = m.adapters[1].hermes.as_ref().expect("hermes section");
+        assert_eq!(h.notices.len(), 1);
+        assert_eq!(h.notices[0].when, NoticeWhen::PostDisable);
+        assert_eq!(h.notices[0].level, NoticeLevel::Warning);
+    }
+
+    #[test]
+    fn adapter_notices_round_trip() {
+        let toml_text = r#"
+            [component]
+            name = "roundtrip"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.notices]]
+            when = "post_enable"
+            level = "warning"
+            text = "Keep this verbatim: {datadir} $HOME `id`"
+            command = "echo {datadir}/$HOME"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        let m2 = ComponentManifest::from_toml_str(&serialized).expect("re-parse");
+        assert_eq!(
+            m.adapters, m2.adapters,
+            "round-trip must preserve notices verbatim"
+        );
+    }
+
+    #[test]
+    fn adapter_notices_text_is_verbatim_and_inert() {
+        // Placeholders and shell metacharacters must survive parsing
+        // unchanged: notices are display-only and never expanded/executed.
+        let toml_text = r#"
+            [component]
+            name = "inert"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.notices]]
+            when = "post_enable"
+            text = "run {datadir}/bin/tool; rm -rf $(whoami)"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(
+            m.adapters[0].notices[0].text,
+            "run {datadir}/bin/tool; rm -rf $(whoami)"
+        );
+    }
+
+    #[test]
+    fn adapter_notices_skip_serializing_when_empty() {
+        let toml_text = r#"
+            [component]
+            name = "skiptest"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        assert!(
+            !serialized.contains("notices"),
+            "absent notices must be skipped: {serialized}"
+        );
+    }
+
+    #[test]
+    fn adapter_notice_default_level_skips_serializing_field() {
+        let toml_text = r#"
+            [component]
+            name = "skiptest"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.notices]]
+            when = "post_enable"
+            text = "info-level notice"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        assert!(
+            !serialized.contains("level ="),
+            "default info level must be skipped: {serialized}"
+        );
+    }
+
+    #[test]
+    fn adapter_notice_unknown_when_rejected() {
+        let toml_text = r#"
+            [component]
+            name = "bad"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.notices]]
+            when = "post_install"
+            text = "unsupported trigger"
+        "#;
+        assert!(
+            ComponentManifest::from_toml_str(toml_text).is_err(),
+            "unknown `when` must fail closed"
+        );
+    }
+
+    #[test]
+    fn adapter_notice_unknown_level_rejected() {
+        let toml_text = r#"
+            [component]
+            name = "bad"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.notices]]
+            when = "post_enable"
+            level = "critical"
+            text = "unsupported level"
+        "#;
+        assert!(
+            ComponentManifest::from_toml_str(toml_text).is_err(),
+            "unknown `level` must fail closed"
+        );
+    }
+
+    #[test]
+    fn adapter_notice_missing_text_rejected() {
+        let toml_text = r#"
+            [component]
+            name = "bad"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.notices]]
+            when = "post_enable"
+        "#;
+        assert!(
+            ComponentManifest::from_toml_str(toml_text).is_err(),
+            "missing required `text` must fail"
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -253,7 +253,7 @@ fn cosh_enable_status_disable_touches_only_extension_dir() {
         .expect("enable")
     {
         EnableOutcome::Enabled(c) => *c,
-        EnableOutcome::Planned(_) => panic!("expected enabled"),
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
     };
     assert_eq!(claim.adapter_type.as_deref(), Some("extension"));
 
@@ -311,7 +311,7 @@ fn cosh_dry_run_enable_writes_nothing() {
         .enable(COMPONENT, Some("cosh"), true)
         .expect("dry-run");
     match outcome {
-        EnableOutcome::Planned(plan) => {
+        EnableOutcome::Planned { plan, .. } => {
             assert_eq!(plan.framework, "cosh");
             assert!(
                 plan.actions
@@ -469,7 +469,7 @@ fn codex_enable_records_argv_and_builds_marketplace() {
         .expect("enable")
     {
         EnableOutcome::Enabled(c) => *c,
-        EnableOutcome::Planned(_) => panic!("expected enabled"),
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
     };
 
     // Marketplace layout on disk.
@@ -551,7 +551,7 @@ fn codex_dry_run_enable_writes_nothing() {
     let outcome = manager
         .enable(COMPONENT, Some("codex"), true)
         .expect("dry-run");
-    assert!(matches!(outcome, EnableOutcome::Planned(_)));
+    assert!(matches!(outcome, EnableOutcome::Planned { .. }));
     assert!(
         !marketplace_root.exists(),
         "dry-run must not create marketplace dir"
@@ -744,7 +744,7 @@ fn codex_enable_succeeds_with_bundle_under_packaged_datadir() {
         .expect("enable must succeed with bundle under a packaged datadir")
     {
         EnableOutcome::Enabled(c) => *c,
-        EnableOutcome::Planned(_) => panic!("expected enabled"),
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
     };
     // The symlink target points at the packaged-datadir bundle, outside the
     // install-prefix layout roots — the very case that previously failed.
@@ -838,7 +838,7 @@ fn claude_code_enable_records_validate_marketplace_and_install() {
         .expect("enable")
     {
         EnableOutcome::Enabled(c) => *c,
-        EnableOutcome::Planned(_) => panic!("expected enabled"),
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
     };
     assert_eq!(claim.plugin_id.as_deref(), Some("tokenless"));
 
@@ -1121,7 +1121,7 @@ fn qoder_enable_installs_writes_receipt_and_merges_settings() {
         .expect("enable")
     {
         EnableOutcome::Enabled(c) => *c,
-        EnableOutcome::Planned(_) => panic!("expected enabled"),
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
     };
     assert_eq!(claim.plugin_id.as_deref(), Some("tokenless"));
 
@@ -1363,7 +1363,7 @@ fn qoder_dry_run_enable_writes_nothing() {
     let outcome = manager
         .enable(COMPONENT, Some("qoder"), true)
         .expect("dry-run");
-    assert!(matches!(outcome, EnableOutcome::Planned(_)));
+    assert!(matches!(outcome, EnableOutcome::Planned { .. }));
     assert!(!log.exists(), "dry-run must not invoke qodercli (no log)");
     assert!(!settings.exists(), "dry-run must not write settings.json");
     assert!(

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -24,6 +24,7 @@ use anolisa_core::adapter::claim::{
 };
 use anolisa_core::adapter::driver::{AdapterSummary, ConditionStatus};
 use anolisa_core::adapter::manager::{AdapterManager, EnableOptions, EnableOutcome};
+use anolisa_core::manifest::{NoticeLevel, NoticeWhen};
 use anolisa_core::state::InstallMode as StateInstallMode;
 use anolisa_core::state_store::StateStore;
 use anolisa_platform::fs_layout::FsLayout;
@@ -483,7 +484,7 @@ fn enable_status_disable_happy_path() {
         .expect("enable");
     let claim = match outcome {
         EnableOutcome::Enabled(c) => *c,
-        EnableOutcome::Planned(_) => panic!("expected enabled, got plan"),
+        EnableOutcome::Planned { .. } => panic!("expected enabled, got plan"),
     };
     assert_eq!(claim.component, COMPONENT);
     assert_eq!(claim.framework, FRAMEWORK);
@@ -685,7 +686,7 @@ fn dry_run_enable_does_not_register_or_persist() {
         .enable(COMPONENT, Some(FRAMEWORK), true)
         .expect("dry-run enable");
     match outcome {
-        EnableOutcome::Planned(plan) => {
+        EnableOutcome::Planned { plan, .. } => {
             assert_eq!(plan.component, COMPONENT);
             assert!(plan.register_command.is_some());
         }
@@ -1047,6 +1048,237 @@ fn dry_run_disable_no_receipt_is_noop() {
         "must report no receipt: {:?}",
         outcome.report.messages
     );
+}
+
+// ---------------------------------------------------------------------------
+// Adapter operation notices
+// ---------------------------------------------------------------------------
+
+/// An OpenClaw plugin adapter block declaring both a `post_enable` and a
+/// `post_disable` notice.
+fn notices_adapter_block() -> String {
+    format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.notices]]
+when = "post_enable"
+level = "info"
+text = "Restart the framework to load the plugin."
+command = "openclaw restart"
+
+[[adapters.notices]]
+when = "post_disable"
+level = "warning"
+text = "Cached tokens remain until the framework restarts."
+"#
+    )
+}
+
+#[test]
+fn enable_persists_all_declared_notices_in_receipt() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &notices_adapter_block());
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let claim = match outcome {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
+    };
+    // Both triggers are persisted so a later receipt-only disable can show
+    // the post_disable notice.
+    assert_eq!(claim.notices.len(), 2);
+
+    let state = world.load_state();
+    let persisted = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("receipt persisted");
+    assert_eq!(persisted.notices.len(), 2);
+    assert!(
+        persisted
+            .notices
+            .iter()
+            .any(|n| n.when == NoticeWhen::PostEnable)
+    );
+    assert!(
+        persisted
+            .notices
+            .iter()
+            .any(|n| n.when == NoticeWhen::PostDisable)
+    );
+}
+
+#[test]
+fn dry_run_enable_previews_only_post_enable_notices() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &notices_adapter_block());
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run enable");
+    match outcome {
+        EnableOutcome::Planned { notices, .. } => {
+            assert_eq!(notices.len(), 1, "preview only post_enable notices");
+            assert_eq!(notices[0].when, NoticeWhen::PostEnable);
+            assert_eq!(notices[0].level, NoticeLevel::Info);
+            assert_eq!(notices[0].text, "Restart the framework to load the plugin.");
+            assert_eq!(notices[0].command.as_deref(), Some("openclaw restart"));
+        }
+        EnableOutcome::Enabled(_) => panic!("dry-run must not enable"),
+    }
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_none(),
+        "dry-run must not persist a receipt"
+    );
+}
+
+#[test]
+fn disable_returns_post_disable_notices_from_receipt() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &notices_adapter_block());
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    assert_eq!(disabled.notices.len(), 1);
+    assert_eq!(disabled.notices[0].when, NoticeWhen::PostDisable);
+    assert_eq!(disabled.notices[0].level, NoticeLevel::Warning);
+    assert_eq!(
+        disabled.notices[0].text,
+        "Cached tokens remain until the framework restarts."
+    );
+}
+
+#[test]
+fn dry_run_disable_previews_post_disable_notices() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &notices_adapter_block());
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+
+    let outcome = manager
+        .disable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run disable");
+    assert!(outcome.dry_run);
+    assert!(!outcome.claim_removed);
+    assert_eq!(outcome.notices.len(), 1);
+    assert_eq!(outcome.notices[0].when, NoticeWhen::PostDisable);
+    // The receipt is untouched: a real disable still shows the notice once.
+    assert!(world.has_claim());
+}
+
+#[test]
+fn failed_disable_shows_no_notices() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &notices_adapter_block());
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+
+    world.apply_env(&guard, Some("uninstall"));
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("disable runs");
+    assert!(!disabled.claim_removed);
+    assert!(
+        disabled.notices.is_empty(),
+        "a degraded disable must not display post_disable notices"
+    );
+}
+
+#[test]
+fn notice_text_is_preserved_verbatim_in_receipt() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.notices]]
+when = "post_enable"
+text = "run {{datadir}}/bin/tool; echo $HOME `id`"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let claim = match outcome {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
+    };
+    // Inert text: placeholders and shell metacharacters survive unchanged.
+    assert_eq!(
+        claim.notices[0].text,
+        "run {datadir}/bin/tool; echo $HOME `id`"
+    );
+}
+
+#[test]
+fn framework_specific_notices_take_precedence() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.notices]]
+when = "post_enable"
+text = "generic notice"
+
+[[adapters.openclaw.notices]]
+when = "post_enable"
+text = "openclaw-specific notice"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run enable");
+    match outcome {
+        EnableOutcome::Planned { notices, .. } => {
+            assert_eq!(notices.len(), 1);
+            assert_eq!(notices[0].text, "openclaw-specific notice");
+        }
+        EnableOutcome::Enabled(_) => panic!("dry-run must not enable"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1850,7 +2082,7 @@ fn dry_run_probes_but_does_not_mutate() {
         .enable(COMPONENT, Some(FRAMEWORK), true)
         .expect("dry-run enable");
     match outcome {
-        EnableOutcome::Planned(plan) => {
+        EnableOutcome::Planned { plan, .. } => {
             let cmd = plan
                 .register_command
                 .expect("plan shows the install command");
@@ -2499,7 +2731,7 @@ fn authorized_unsafe_dry_run_shows_flag_without_mutation() {
         )
         .expect("dry-run enable");
     match outcome {
-        EnableOutcome::Planned(plan) => {
+        EnableOutcome::Planned { plan, .. } => {
             let cmd = plan
                 .register_command
                 .expect("plan shows the install command");

--- a/src/anolisa/docs/COMPONENT_CONTRACT.md
+++ b/src/anolisa/docs/COMPONENT_CONTRACT.md
@@ -126,6 +126,56 @@ If an RPM-installed component has no package datadir contract, commands should
 treat adapter declarations as unavailable and report that the RPM does not
 publish an ANOLISA component contract.
 
+## Adapter Operation Notices
+
+An adapter contract may declare static, display-only operator notices that
+ANOLISA shows after `adapter enable` or `adapter disable` succeeds. Notices
+are declared with `[[adapters.notices]]` on a generic adapter entry, or with
+`[[adapters.openclaw.notices]]` / `[[adapters.hermes.notices]]` in a
+framework-specific section (which takes precedence over the generic entry):
+
+```toml
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+
+[[adapters.notices]]
+when = "post_enable"
+level = "info"
+text = "Restart the framework to load the plugin."
+command = "openclaw restart"
+
+[[adapters.notices]]
+when = "post_disable"
+level = "warning"
+text = "Cached tokens remain until the framework restarts."
+```
+
+Each notice has:
+
+- `when` (required): `post_enable` or `post_disable`.
+- `level` (optional): `info` (default) or `warning`.
+- `text` (required): the notice body.
+- `command` (optional): a display-only command hint.
+
+Notices are inert text. `text` and `command` are never shell-expanded,
+template-substituted, or executed. Human-readable output escapes control
+characters to protect terminal state, while structured JSON preserves the
+declared values. Required framework configuration is not a notice — it stays
+a structured `[[adapters.config]]` entry.
+
+Display behavior:
+
+- `adapter enable` shows `post_enable` notices after a successful enable;
+  `adapter disable` shows `post_disable` notices after a successful disable.
+  `post_disable` notices are taken from the enable-time receipt, so they are
+  shown even if the component manifest is no longer present.
+- Human-readable output prints the notices; `--quiet` suppresses them.
+- `--json` returns the notices in a stable `data.notices` array.
+- `--dry-run` previews the notices that a real operation would show, labeled
+  as a preview; nothing is executed.
+
 ## Contract Template
 
 Use a shipped component manifest such as


### PR DESCRIPTION
## Description

Adds static, display-only adapter operation notices to component contracts. `adapter enable` and `adapter disable` render phase-specific notices in human and JSON output, including dry-run previews; `--quiet` suppresses human rendering. Notices are persisted in adapter receipts so post-disable guidance remains available when adapter sources are absent.

## Related Issue

closes #1153

## Type / Scope

- [x] New feature
- [x] Documentation update
- [x] anolisa

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `cargo doc --workspace --no-deps`

Focused tests cover human, JSON, quiet, and dry-run adapter output; core tests cover manifest parsing, receipt persistence, and framework-specific selection.

### Ship Note

- Changed: Component contracts can return operator follow-up notices after adapter operations.
- Known limitations: Notices are static text and intentionally never execute commands.
- Not covered: Real framework CLI integration beyond hermetic adapter tests.
- Verification: All commands listed above.