### PR TITLE
fix(sight): make raw HTTPS FFI output opt-in

### DIFF
--- a/src/agentsight/cbindgen.toml
+++ b/src/agentsight/cbindgen.toml
@@ -54,6 +54,7 @@ const char *agentsight_last_error(void);
 AgentsightConfigHandle *agentsight_config_new(void);
 void agentsight_config_set_verbose(AgentsightConfigHandle *cfg, int verbose);
 void agentsight_config_set_log_path(AgentsightConfigHandle *cfg, const char *path);
+void agentsight_config_set_enable_raw_https(AgentsightConfigHandle *cfg, int enabled);
 void agentsight_config_add_cmdline_rule(AgentsightConfigHandle *cfg, const char *const *rule, const char *agent_name, int allow);
 void agentsight_config_add_https(AgentsightConfigHandle *cfg, const char *rule);
 int  agentsight_config_add_http(AgentsightConfigHandle *cfg, const char *target);

--- a/src/agentsight/docs/design-docs/c-ffi-api.md
+++ b/src/agentsight/docs/design-docs/c-ffi-api.md
@@ -159,6 +159,7 @@ int agentsight_read(AgentsightHandle* h,
 | `log_path` | NULL | 日志文件保存路径，NULL 时输出到 stderr |
 | `cmdline_rules` | 空 | 用户自定义规则列表；allow=1 为进程白名单，allow=0 为进程黑名单 |
 | `domain_rules` | 空 | 域名白名单规则列表，DNS 阶段独立判定是否 attach |
+| raw HTTPS FFI 输出 | `false` | 仅通过 `agentsight_config_set_enable_raw_https` 显式开启 |
 
 ### 3.2 Cmdline Rule 配置
 
@@ -257,7 +258,7 @@ void agentsight_config_add_domain_rule(
 - **匹配对象**：HTTP 请求的目标域名（从 `Host` header 或 URL 中提取，不含端口号）
 - **Glob 通配符**：支持 `*`（匹配任意字符序列）和 `?`（匹配单个字符）
 - **大小写不敏感**：域名匹配忽略大小写
-- **对 LLMData 和 HttpsData 均生效**：LLMData 从 `request_url` 提取域名，HttpsData 从请求 headers 中的 `Host` 提取
+- **仅作用于 attach 判定**：域名规则只决定是否为进程 attach SSL 探针，不再过滤上报。启用 raw HTTPS FFI 输出后，进程一旦被 attach（无论是命中 cmdline 白名单还是域名规则），其无法解析为 LLM 语义的流量均产生 `AgentsightHttpsData`，不受域名白名单限制
 
 #### 域名提取逻辑
 
@@ -421,6 +422,23 @@ DNS 事件到达
 - **cmdline_deny 两阶段都生效**：黑名单一票否决
 - **都不配置**：无事件输出
 
+### 3.6 Raw HTTPS FFI 输出
+
+raw HTTPS fallback 默认关闭。需要接收 `AgentsightHttpsData` 的 FFI 调用方必须在
+`agentsight_new()` 前显式开启：
+
+```c
+void agentsight_config_set_enable_raw_https(
+    AgentsightConfigHandle* cfg,
+    int enabled
+);
+```
+
+- `enabled == 0`：不可解析为 LLM 语义的 HTTPS 流量不会构造或进入 FFI 事件队列。
+- `enabled != 0`：不可解析流量通过 HTTPS callback 上报，不再受域名规则过滤。
+- 配置句柄为 NULL 时静默忽略。
+- 此开关仅影响 FFI raw HTTPS 输出，不改变 standalone binary 的分析和存储行为。
+
 ## 4. 使用示例
 
 完整示例程序见 `tools/examples/agentsight/agentsight_example.c`。
@@ -512,7 +530,7 @@ agentsight_free(h);
 
 ## 6. HttpsData 与 LLMData 的关系
 
-一条被捕获的 HTTPS 流量只会产生一种数据：若被识别为 LLM API 调用，则产生 `AgentsightLLMData`；否则产生 `AgentsightHttpsData`。两者互斥，不会同时产生，无需关联。
+一条被捕获的 HTTPS 流量最多产生一种 FFI 数据：若被识别为 LLM API 调用，则产生 `AgentsightLLMData`；否则仅在 raw HTTPS FFI 输出开启时产生 `AgentsightHttpsData`。两者互斥，不会同时产生，无需关联。
 
 ## 7. 编译与链接
 

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -842,6 +842,9 @@ pub struct AgentsightConfig {
     pub https_rules: Vec<HttpsRule>,
     /// User-defined HTTP targets (IP/port endpoints + domains for tcpsniff)
     pub http_targets: Vec<HttpTarget>,
+    /// Whether FFI mode emits raw HTTPS fallback events.
+    /// This is configured only through the C API and is not part of agentsight.json.
+    pub ffi_enable_raw_https: bool,
 
     // --- Config File Path ---
     /// Path to JSON configuration file
@@ -929,6 +932,7 @@ impl Default for AgentsightConfig {
             cmdline_rules: Vec::new(),
             https_rules: Vec::new(),
             http_targets: Vec::new(),
+            ffi_enable_raw_https: false,
 
             // Config file path default
             config_path: None,

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -63,50 +63,6 @@ pub fn match_domain_glob(domain: &str, patterns: &[String]) -> bool {
     false
 }
 
-/// Domain-based filter deciding whether a captured HTTP flow should be
-/// reported via the raw-HTTP FFI callback (`AgentsightHttpsData`).
-///
-/// Patterns are glob rules collected from the config `https` and `http`
-/// sections. An **empty** pattern set means "no domain restriction" — every
-/// flow is reported, preserving the pre-existing full-report behaviour.
-#[derive(Debug, Clone, Default)]
-pub struct HttpReportFilter {
-    patterns: Vec<String>,
-}
-
-impl HttpReportFilter {
-    /// Build a filter from a set of glob patterns.
-    pub fn new(patterns: Vec<String>) -> Self {
-        Self { patterns }
-    }
-
-    /// Decide whether a flow to `host` should be reported.
-    ///
-    /// * Empty pattern set → always `true` (unrestricted).
-    /// * `host = None` (could not be determined) under a restricted filter →
-    ///   `false` (strict: do not report what we cannot match).
-    /// * Otherwise match `host`, with and without a trailing `:port`, against
-    ///   the glob patterns (case-insensitive).
-    pub fn should_report(&self, host: Option<&str>) -> bool {
-        if self.patterns.is_empty() {
-            return true;
-        }
-        let Some(host) = host else {
-            return false;
-        };
-        if match_domain_glob(host, &self.patterns) {
-            return true;
-        }
-        // Also try the host without its port (e.g. "api.openai.com:443").
-        if let Some((bare, _port)) = host.rsplit_once(':') {
-            if match_domain_glob(bare, &self.patterns) {
-                return true;
-            }
-        }
-        false
-    }
-}
-
 /// Matcher based on cmdline glob patterns (config-driven).
 pub struct CmdlineGlobMatcher {
     info: AgentInfo,
@@ -247,49 +203,6 @@ mod tests {
         assert!(match_domain_glob("api.openai.com", &patterns));
         assert!(match_domain_glob("api.anthropic.com", &patterns));
         assert!(!match_domain_glob("example.com", &patterns));
-    }
-
-    #[test]
-    fn test_http_report_filter_unrestricted_reports_everything() {
-        let filter = HttpReportFilter::new(vec![]);
-        assert!(filter.should_report(Some("anything.example.com")));
-        // Even a missing host is reported when unrestricted.
-        assert!(filter.should_report(None));
-    }
-
-    #[test]
-    fn test_http_report_filter_matches_glob() {
-        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
-        assert!(filter.should_report(Some("api.openai.com")));
-        assert!(!filter.should_report(Some("example.com")));
-    }
-
-    #[test]
-    fn test_http_report_filter_strips_port() {
-        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
-        assert!(filter.should_report(Some("api.openai.com:443")));
-    }
-
-    #[test]
-    fn test_http_report_filter_matches_ip_endpoint() {
-        // Endpoint IPs are contributed as literal patterns.
-        let filter = HttpReportFilter::new(vec!["10.0.0.1".to_string()]);
-        assert!(filter.should_report(Some("10.0.0.1")));
-        assert!(filter.should_report(Some("10.0.0.1:8080")));
-        assert!(!filter.should_report(Some("10.0.0.2")));
-    }
-
-    #[test]
-    fn test_http_report_filter_strict_when_host_missing() {
-        // Restricted filter + unknown host → do not report.
-        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
-        assert!(!filter.should_report(None));
-    }
-
-    #[test]
-    fn test_http_report_filter_case_insensitive() {
-        let filter = HttpReportFilter::new(vec!["*.OpenAI.com".to_string()]);
-        assert!(filter.should_report(Some("API.OPENAI.COM")));
     }
 
     #[test]

--- a/src/agentsight/src/discovery/mod.rs
+++ b/src/agentsight/src/discovery/mod.rs
@@ -32,7 +32,5 @@ pub mod scanner;
 
 pub use agent::{AgentInfo, DiscoveredAgent};
 pub use connection_scanner::{ConnectionScanResult, ConnectionScanner, IpDomainCache};
-pub use matcher::{
-    CmdlineGlobMatcher, HttpReportFilter, ProcessContext, match_cmdline_glob, match_domain_glob,
-};
+pub use matcher::{CmdlineGlobMatcher, ProcessContext, match_cmdline_glob, match_domain_glob};
 pub use scanner::AgentScanner;

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -44,6 +44,7 @@ enum ProbeCommand {
 pub(crate) struct FfiEventSender {
     tx: mpsc::SyncSender<FfiEvent>,
     eventfd: i32,
+    enable_raw_https: bool,
 }
 
 impl FfiEventSender {
@@ -68,6 +69,13 @@ impl FfiEventSender {
                 // Receiver gone; nothing to do.
             }
         }
+    }
+
+    pub fn send_https(&self, record: &HttpRecord) {
+        if !self.enable_raw_https {
+            return;
+        }
+        self.send(FfiEvent::Https(record.clone()));
     }
 }
 
@@ -226,17 +234,17 @@ type LlmCallbackFn = Option<unsafe extern "C" fn(*const AgentsightLLMData, *mut 
 pub const AGENTSIGHT_READ_BLOCK: c_int = 1;
 
 // ===========================================================================
-// Temporary data holders (keep CStrings alive during callbacks)
+// Temporary data holders (keep C strings and byte buffers alive during callbacks)
 // ===========================================================================
 
 struct HttpsDataHolder {
     c_data: AgentsightHttpsData,
     _method: CString,
     _path: CString,
-    _req_headers: CString,
-    _req_body: Option<CString>,
-    _resp_headers: CString,
-    _resp_body: Option<CString>,
+    _req_headers: Vec<u8>,
+    _req_body: Option<Vec<u8>>,
+    _resp_headers: Vec<u8>,
+    _resp_body: Option<Vec<u8>>,
 }
 
 struct LlmDataHolder {
@@ -259,10 +267,10 @@ struct LlmDataHolder {
 fn build_https_data(record: &HttpRecord) -> HttpsDataHolder {
     let method = safe_cstring(&record.method);
     let path = safe_cstring(&record.path);
-    let req_headers = safe_cstring(&record.request_headers);
-    let req_body = record.request_body.as_ref().map(|b| safe_cstring(b));
-    let resp_headers = safe_cstring(&record.response_headers);
-    let resp_body = record.response_body.as_ref().map(|b| safe_cstring(b));
+    let req_headers = record.request_headers.as_bytes().to_vec();
+    let req_body = record.request_body.as_ref().map(|b| b.as_bytes().to_vec());
+    let resp_headers = record.response_headers.as_bytes().to_vec();
+    let resp_body = record.response_body.as_ref().map(|b| b.as_bytes().to_vec());
 
     let c_data = AgentsightHttpsData {
         pid: record.pid as i32,
@@ -279,14 +287,16 @@ fn build_https_data(record: &HttpRecord) -> HttpsDataHolder {
         path: path.as_ptr(),
         status_code: record.status_code,
         is_sse: record.is_sse as u8,
-        request_headers: req_headers.as_ptr(),
-        request_headers_len: record.request_headers.len() as u32,
-        request_body: req_body.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
-        request_body_len: record.request_body.as_ref().map_or(0, |s| s.len() as u32),
-        response_headers: resp_headers.as_ptr(),
-        response_headers_len: record.response_headers.len() as u32,
-        response_body: resp_body.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
-        response_body_len: record.response_body.as_ref().map_or(0, |s| s.len() as u32),
+        request_headers: req_headers.as_ptr().cast(),
+        request_headers_len: req_headers.len() as u32,
+        request_body: req_body.as_ref().map_or(ptr::null(), |s| s.as_ptr().cast()),
+        request_body_len: req_body.as_ref().map_or(0, |s| s.len() as u32),
+        response_headers: resp_headers.as_ptr().cast(),
+        response_headers_len: resp_headers.len() as u32,
+        response_body: resp_body
+            .as_ref()
+            .map_or(ptr::null(), |s| s.as_ptr().cast()),
+        response_body_len: resp_body.as_ref().map_or(0, |s| s.len() as u32),
     };
 
     HttpsDataHolder {
@@ -526,6 +536,21 @@ pub unsafe extern "C" fn agentsight_config_set_log_path(
         } else {
             Some(CStr::from_ptr(path).to_string_lossy().to_string())
         };
+    }
+}
+
+/// Enable or disable raw HTTPS fallback events in FFI mode (0 = off, non-zero = on).
+///
+/// # Safety
+///
+/// `cfg` must be a valid pointer returned by `agentsight_config_new()`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agentsight_config_set_enable_raw_https(
+    cfg: *mut AgentsightConfigHandle,
+    enabled: c_int,
+) {
+    if !cfg.is_null() {
+        unsafe { (*cfg).ffi_enable_raw_https = enabled != 0 };
     }
 }
 
@@ -777,7 +802,11 @@ fn ffi_background_thread(
     running: Arc<AtomicBool>,
     probe_cmd_rx: mpsc::Receiver<ProbeCommand>,
 ) {
-    let sender = FfiEventSender { tx, eventfd };
+    let sender = FfiEventSender {
+        tx,
+        eventfd,
+        enable_raw_https: config.ffi_enable_raw_https,
+    };
 
     let mut sight = match AgentSight::new(config) {
         Ok(s) => s,
@@ -1114,6 +1143,24 @@ mod tests {
     }
 
     #[test]
+    fn test_config_set_enable_raw_https() {
+        let cfg = agentsight_config_new();
+        assert!(!cfg.is_null());
+        assert!(!unsafe { (*cfg).ffi_enable_raw_https });
+
+        unsafe { agentsight_config_set_enable_raw_https(cfg, 1) };
+        assert!(unsafe { (*cfg).ffi_enable_raw_https });
+
+        unsafe { agentsight_config_set_enable_raw_https(cfg, 0) };
+        assert!(!unsafe { (*cfg).ffi_enable_raw_https });
+
+        unsafe {
+            agentsight_config_set_enable_raw_https(ptr::null_mut(), 1);
+            agentsight_config_free(cfg);
+        }
+    }
+
+    #[test]
     #[allow(clippy::needless_range_loop)]
     fn test_copy_process_name_truncate() {
         let name = "very_long_process_name_that_exceeds_16";
@@ -1151,6 +1198,90 @@ mod tests {
     }
 
     // ─── build_llm_data tests ───────────────────────────────────────────────
+
+    fn make_http_record(request_body: Option<String>, response_body: Option<String>) -> HttpRecord {
+        HttpRecord {
+            timestamp_ns: 1,
+            pid: 1,
+            comm: "test".to_string(),
+            method: "POST".to_string(),
+            path: "/raw".to_string(),
+            status_code: 200,
+            request_headers: "{\"host\":\"example.com\"}".to_string(),
+            request_body,
+            response_headers: "{\"content-type\":\"application/octet-stream\"}".to_string(),
+            response_body,
+            duration_ns: 1,
+            is_sse: false,
+            sse_event_count: 0,
+        }
+    }
+
+    #[test]
+    fn test_build_https_data_preserves_interior_nul_bytes() {
+        let request_body = "a\0b\0c".to_string();
+        let response_body = "\0x\0y\0".to_string();
+        let request_headers = "{\0\"host\":\"example.com\"\0}".to_string();
+        let response_headers = "{\0\"content-type\":\"application/octet-stream\"\0}".to_string();
+        let mut record = make_http_record(Some(request_body.clone()), Some(response_body.clone()));
+        record.request_headers = request_headers.clone();
+        record.response_headers = response_headers.clone();
+        let holder = build_https_data(&record);
+
+        let copied_request_headers = unsafe {
+            std::slice::from_raw_parts(
+                holder.c_data.request_headers.cast::<u8>(),
+                holder.c_data.request_headers_len as usize,
+            )
+        };
+        let copied_request = unsafe {
+            std::slice::from_raw_parts(
+                holder.c_data.request_body.cast::<u8>(),
+                holder.c_data.request_body_len as usize,
+            )
+        };
+        let copied_response_headers = unsafe {
+            std::slice::from_raw_parts(
+                holder.c_data.response_headers.cast::<u8>(),
+                holder.c_data.response_headers_len as usize,
+            )
+        };
+        let copied_response = unsafe {
+            std::slice::from_raw_parts(
+                holder.c_data.response_body.cast::<u8>(),
+                holder.c_data.response_body_len as usize,
+            )
+        };
+        assert_eq!(copied_request_headers, request_headers.as_bytes());
+        assert_eq!(copied_request, request_body.as_bytes());
+        assert_eq!(copied_response_headers, response_headers.as_bytes());
+        assert_eq!(copied_response, response_body.as_bytes());
+    }
+
+    #[test]
+    fn test_disabled_https_sender_does_not_consume_channel_capacity() {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let sender = FfiEventSender {
+            tx,
+            eventfd: -1,
+            enable_raw_https: false,
+        };
+        sender.send_https(&make_http_record(None, None));
+        sender.send(FfiEvent::Llm(make_llm_call(None, 1)));
+        assert!(matches!(rx.try_recv(), Ok(FfiEvent::Llm(_))));
+    }
+
+    #[test]
+    fn test_enabled_https_sender_enqueues_event() {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let sender = FfiEventSender {
+            tx,
+            eventfd: -1,
+            enable_raw_https: true,
+        };
+        sender.send_https(&make_http_record(None, None));
+        assert!(matches!(rx.try_recv(), Ok(FfiEvent::Https(_))));
+    }
 
     fn make_llm_call(agent_name: Option<&str>, pid: i32) -> LLMCall {
         use crate::genai::semantic::{LLMRequest, LLMResponse};

--- a/src/agentsight/src/parser/http/request.rs
+++ b/src/agentsight/src/parser/http/request.rs
@@ -303,6 +303,12 @@ mod tests {
         assert!(ParsedRequest::decode_chunked_json("not chunked").is_none());
     }
 
+    /// Regression: a binary body (e.g. OTLP/Protobuf) passed through
+    /// `String::from_utf8_lossy` contains `U+FFFD` replacement chars that are
+    /// 3 bytes wide. If the chunk-size parser succeeds by accident and the
+    /// computed slice boundary lands inside one of those chars, the old
+    /// implementation panicked with "byte index N is not a char boundary".
+    /// The current implementation must return `None` instead.
     #[test]
     fn test_decode_chunked_json_binary_body_does_not_panic() {
         // A hex digit + \r\n + arbitrary invalid-UTF8 bytes (rendered as
@@ -313,6 +319,7 @@ mod tests {
             raw.push(0xC2); // invalid stray UTF-8 lead byte
         }
         let lossy = String::from_utf8_lossy(&raw);
+        // Must not panic; chunked decode should give up and return None.
         assert!(ParsedRequest::decode_chunked_json(&lossy).is_none());
     }
 

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -100,9 +100,6 @@ pub struct AgentSight {
     pid_agent_name_cache: lru::LruCache<u32, String>,
     /// HTTP domain patterns from config, used for runtime DNS-based tcpsniff target addition
     http_domains: Vec<String>,
-    /// Domain filter gating raw-HTTP (`AgentsightHttpsData`) FFI reporting.
-    /// Built from the config `https` + `http` rules; empty = report everything.
-    http_report_filter: crate::discovery::HttpReportFilter,
     /// Mailbox for watcher thread to deposit a dynamically-created LogtailExporter
     pending_logtail: Arc<Mutex<Option<Box<dyn GenAIExporter>>>>,
     /// DeadLoop auto-kill: enabled flag
@@ -519,23 +516,6 @@ impl AgentSight {
             crate::background::start_stale_scanner(Arc::clone(sqlite_store), Arc::clone(&running));
         }
 
-        // Domain filter for raw-HTTP FFI reporting: reuse the config `https`
-        // globs and `http` domain/endpoint rules. Empty → report everything.
-        let mut report_patterns: Vec<String> = config
-            .https_rules
-            .iter()
-            .map(|r| r.pattern.clone())
-            .collect();
-        report_patterns.extend(http_domains.iter().cloned());
-        for target in &config.http_targets {
-            if let crate::config::HttpTarget::Endpoint(ep) = target {
-                if let Some(ip) = ep.ip {
-                    report_patterns.push(ip.to_string());
-                }
-            }
-        }
-        let http_report_filter = crate::discovery::HttpReportFilter::new(report_patterns);
-
         Ok(AgentSight {
             probes,
             parser: Parser::new(),
@@ -569,7 +549,6 @@ impl AgentSight {
             last_interruption_purge: std::time::Instant::now(),
             pid_agent_name_cache,
             http_domains,
-            http_report_filter,
             pending_logtail,
             deadloop_kill_enabled: config.deadloop_kill_enabled,
             deadloop_kill_after_count: config.deadloop_kill_after_count,
@@ -864,20 +843,11 @@ impl AgentSight {
                 }
             } else if let Some(ref sender) = self.ffi_sender {
                 // Either no LLM event was produced, or all LLM events were
-                // semantically empty (fallback). Send raw HTTP via FFI, but only
-                // for flows whose host matches the configured domain rules.
-                // An empty rule set reports everything (backward compatible).
+                // semantically empty (fallback). The FFI sender suppresses
+                // raw HTTPS before cloning or enqueueing when it is disabled.
                 for ar in &analysis_results {
                     if let crate::analyzer::AnalysisResult::Http(record) = ar {
-                        let host = Self::http_record_host(record);
-                        if self.http_report_filter.should_report(host.as_deref()) {
-                            sender.send(FfiEvent::Https(record.clone()));
-                        } else {
-                            log::debug!(
-                                "Skipping AgentsightHttpsData for host {:?}: no domain-rule match",
-                                host
-                            );
-                        }
+                        sender.send_https(record);
                     }
                 }
             }
@@ -1024,23 +994,6 @@ impl AgentSight {
     /// only caller lives in this crate's FFI layer.
     pub(crate) fn set_ffi_sender(&mut self, sender: FfiEventSender) {
         self.ffi_sender = Some(sender);
-    }
-
-    /// Extract the target host from an `HttpRecord`'s request headers.
-    ///
-    /// Checks the `host`, `Host`, and HTTP/2 `:authority` header keys. Returns
-    /// `None` when headers are unparseable or no host header is present.
-    fn http_record_host(record: &crate::analyzer::HttpRecord) -> Option<String> {
-        let headers: serde_json::Value = serde_json::from_str(&record.request_headers).ok()?;
-        let obj = headers.as_object()?;
-        for key in ["host", "Host", ":authority"] {
-            if let Some(v) = obj.get(key).and_then(|v| v.as_str()) {
-                if !v.is_empty() {
-                    return Some(v.to_string());
-                }
-            }
-        }
-        None
     }
 
     /// Export GenAI events to all registered exporters
@@ -2341,24 +2294,6 @@ mod tests {
 
     // ── Tests for the AgentsightHttpsData fallback path ──
 
-    fn make_http_record(request_headers: &str) -> crate::analyzer::HttpRecord {
-        crate::analyzer::HttpRecord {
-            timestamp_ns: 1,
-            pid: 1,
-            comm: "test".to_string(),
-            method: "POST".to_string(),
-            path: "/v1/chat/completions".to_string(),
-            status_code: 200,
-            request_headers: request_headers.to_string(),
-            request_body: None,
-            response_headers: "{}".to_string(),
-            response_body: None,
-            duration_ns: 0,
-            is_sse: false,
-            sse_event_count: 0,
-        }
-    }
-
     #[test]
     fn test_events_are_empty_llm() {
         use crate::genai::semantic::{InputMessage, MessagePart};
@@ -2395,46 +2330,5 @@ mod tests {
             pid: 1,
         });
         assert!(!events_are_empty_llm(&[empty, tool]));
-    }
-
-    #[test]
-    fn test_http_record_host_extraction() {
-        // Lowercase `host` key.
-        let r = make_http_record(r#"{"host":"api.openai.com","accept":"*/*"}"#);
-        assert_eq!(
-            AgentSight::http_record_host(&r).as_deref(),
-            Some("api.openai.com")
-        );
-
-        // HTTP/2 `:authority` pseudo-header.
-        let r = make_http_record(r#"{":authority":"api.anthropic.com"}"#);
-        assert_eq!(
-            AgentSight::http_record_host(&r).as_deref(),
-            Some("api.anthropic.com")
-        );
-
-        // No host header → None.
-        let r = make_http_record(r#"{"accept":"*/*"}"#);
-        assert_eq!(AgentSight::http_record_host(&r), None);
-
-        // Unparseable headers → None.
-        let r = make_http_record("not json");
-        assert_eq!(AgentSight::http_record_host(&r), None);
-    }
-
-    #[test]
-    fn test_http_report_filter_gates_by_host() {
-        use crate::discovery::HttpReportFilter;
-
-        let filter = HttpReportFilter::new(vec!["*.openai.com".to_string()]);
-        let matched = make_http_record(r#"{"host":"api.openai.com"}"#);
-        let other = make_http_record(r#"{"host":"telemetry.example.com"}"#);
-
-        assert!(filter.should_report(AgentSight::http_record_host(&matched).as_deref()));
-        assert!(!filter.should_report(AgentSight::http_record_host(&other).as_deref()));
-
-        // Empty rule set reports everything (backward compatible).
-        let unrestricted = HttpReportFilter::new(vec![]);
-        assert!(unrestricted.should_report(AgentSight::http_record_host(&other).as_deref()));
     }
 }


### PR DESCRIPTION
## Description

PR #1593 introduced raw HTTPS fallback events for traffic that cannot be converted into meaningful LLM semantic events. However, raw HTTPS reporting was implicitly enabled, and domain rules were also reused as a report-time filter despite originally being intended to control probe attachment.

This follow-up makes raw HTTPS FFI output explicitly opt-in and gates it before records are cloned or enqueued. Once enabled, raw events from an attached process are reported without an additional domain filter. It also preserves headers and bodies as length-delimited byte buffers so payloads containing interior NUL bytes are delivered without modification.

The change only affects FFI raw HTTPS fallback output. Standalone AgentSight analysis, semantic LLM events, probe attachment, and `agentsight.json` behavior remain unchanged.

## Related Issue

no-issue: follow-up hardening for #1593 based on FFI integration requirements.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Behavior Changes

| Area | Previous behavior | New behavior |
|---|---|---|
| Raw HTTPS FFI output | Implicitly enabled | Disabled by default and enabled explicitly through the C API |
| Domain rules | Used for both probe attachment and raw-event filtering | Used only for probe attachment |
| Disabled raw events | Could be cloned and queued | Suppressed before cloning or queue consumption |
| Headers and bodies | Backed by `CString` values | Preserved as length-delimited byte buffers |
| Standalone mode | Unchanged | Unchanged |

FFI callers that need `AgentsightHttpsData` must enable it before calling `agentsight_new()`:

```c
agentsight_config_set_enable_raw_https(cfg, 1);
```

## Key Changes

- Add `agentsight_config_set_enable_raw_https()` to the C API.
- Default raw HTTPS FFI output to disabled.
- Move raw-event gating into `FfiEventSender` to avoid unnecessary cloning and queue usage.
- Remove the report-time `HttpReportFilter`; domain rules continue to determine probe attachment.
- Preserve interior NUL bytes in length-delimited request and response fields.
- Update the C FFI design documentation with the new configuration and reporting semantics.
- Add unit coverage for configuration toggling, queue behavior, and binary payload preservation.

## Compatibility

- No existing C symbols or `#[repr(C)]` structure layouts were changed.
- The new configuration setter is additive.
- Callers relying on raw HTTPS fallback events must explicitly opt in.
- The setting is C-API-only and is not part of `agentsight.json`, so no schema-version bump is required.
- No eBPF programs were changed.

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove the fix is effective
- [x] I have updated the documentation accordingly
- [x] For `sight`: formatting, Clippy, and tests pass
- [x] Lock files are unchanged

## Testing

The following checks were run from `src/agentsight`:

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
cargo doc --workspace --no-deps
```

Results:

- 1,170 AgentSight library tests passed, with no failures.
- CLI, integration, and doctests passed.
- The C API drift guard passed during compilation.
- Documentation generation completed successfully.

## Additional Notes

This change does not alter eBPF capture behavior or standalone storage and analysis. It only controls whether non-semantic fallback records are exposed to an embedding application through `AgentsightHttpsData`.
