### PR TITLE
feat(cosh-ng,tokenless): support PostToolUse response replacement and adapt hooks for Cosh-NG

### DIFF
--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_tokenless_hooks.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_tokenless_hooks.py
@@ -125,7 +125,9 @@ class TestLlmContentExtraction:
     def test_falls_back_to_return_display(self):
         """Falls back to returnDisplay when llmContent missing."""
         tool_response = {"returnDisplay": "display only"}
-        llm_content = tool_response.get("llmContent") or tool_response.get("returnDisplay")
+        llm_content = tool_response.get("llmContent") or tool_response.get(
+            "returnDisplay"
+        )
         assert llm_content == "display only"
 
     def test_plain_text_passes_through(self):

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_tokenless_hooks.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_tokenless_hooks.py
@@ -1,0 +1,136 @@
+"""Unit tests for tokenless hooks Cosh-NG compatibility functions.
+
+Tests cover:
+- detect_cosh_ng_runtime() version detection
+- _resolve_agent_id() agent ID resolution
+- llmContent extraction from wrapped responses
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add tokenless hooks directory to path
+_TOKENLESS_HOOKS = str(
+    Path(__file__).resolve().parents[3]
+    / ".."
+    / "tokenless"
+    / "adapters"
+    / "tokenless"
+    / "common"
+    / "hooks"
+)
+sys.path.insert(0, _TOKENLESS_HOOKS)
+
+import hook_utils  # noqa: E402
+
+
+class TestDetectCoshNgRuntime:
+    """Tests for detect_cosh_ng_runtime() function."""
+
+    def test_returns_none_when_not_cosh_ng(self):
+        """When no Cosh-NG env vars set, returns None."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = hook_utils.detect_cosh_ng_runtime()
+            assert result is None
+
+    def test_returns_version_from_cosh_ng_version_env(self):
+        """COSH_NG_VERSION env var is parsed correctly."""
+        with patch.dict(os.environ, {"COSH_NG_VERSION": "0.12.0"}, clear=True):
+            result = hook_utils.detect_cosh_ng_runtime()
+            assert result == (0, 12, 0)
+
+    def test_returns_sentinel_for_unparseable_version(self):
+        """Invalid version string returns (0,0,0) sentinel."""
+        with patch.dict(os.environ, {"COSH_NG_VERSION": "invalid"}, clear=True):
+            result = hook_utils.detect_cosh_ng_runtime()
+            assert result == (0, 0, 0)
+
+    def test_returns_sentinel_for_cosh_runtime_env(self):
+        """COSH_RUNTIME=cosh-ng without version returns sentinel."""
+        with patch.dict(os.environ, {"COSH_RUNTIME": "cosh-ng"}, clear=True):
+            result = hook_utils.detect_cosh_ng_runtime()
+            assert result == (0, 0, 0)
+
+    def test_ignores_other_runtime_values(self):
+        """COSH_RUNTIME with other values returns None."""
+        with patch.dict(os.environ, {"COSH_RUNTIME": "copilot-shell"}, clear=True):
+            result = hook_utils.detect_cosh_ng_runtime()
+            assert result is None
+
+    def test_version_takes_precedence_over_runtime(self):
+        """COSH_NG_VERSION takes precedence over COSH_RUNTIME."""
+        with patch.dict(
+            os.environ,
+            {"COSH_NG_VERSION": "1.2.3", "COSH_RUNTIME": "cosh-ng"},
+            clear=True,
+        ):
+            result = hook_utils.detect_cosh_ng_runtime()
+            assert result == (1, 2, 3)
+
+
+class TestResolveAgentId:
+    """Tests for agent ID resolution in compress_response_hook."""
+
+    def test_uses_cosh_ng_when_detected(self):
+        """When Cosh-NG detected and no env override, uses 'cosh-ng'."""
+        # Import here to avoid module-level side effects
+        import compress_response_hook
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = compress_response_hook._resolve_agent_id(cosh_ng_detected=True)
+            assert result == "cosh-ng"
+
+    def test_uses_tokenless_when_not_detected(self):
+        """When not Cosh-NG and no env override, uses 'tokenless'."""
+        import compress_response_hook
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = compress_response_hook._resolve_agent_id(cosh_ng_detected=False)
+            assert result == "tokenless"
+
+    def test_env_override_takes_precedence(self):
+        """TOKENLESS_AGENT_ID env var overrides default."""
+        import compress_response_hook
+
+        with patch.dict(os.environ, {"TOKENLESS_AGENT_ID": "custom-agent"}, clear=True):
+            result = compress_response_hook._resolve_agent_id(cosh_ng_detected=True)
+            assert result == "custom-agent"
+
+
+class TestLlmContentExtraction:
+    """Tests for llmContent extraction from wrapped tool responses."""
+
+    def test_extracts_llm_content_from_dict(self):
+        """Extracts llmContent from dict wrapper."""
+        tool_response = {"llmContent": "compressed data", "returnDisplay": "display"}
+        # Simulate the extraction logic
+        llm_content = tool_response.get("llmContent")
+        assert llm_content == "compressed data"
+
+    def test_extracts_llm_content_from_json_string(self):
+        """Extracts llmContent from JSON string wrapper."""
+        import json
+
+        tool_response_str = json.dumps(
+            {"llmContent": "compressed data", "returnDisplay": "display"}
+        )
+        parsed = json.loads(tool_response_str)
+        llm_content = parsed.get("llmContent")
+        assert llm_content == "compressed data"
+
+    def test_falls_back_to_return_display(self):
+        """Falls back to returnDisplay when llmContent missing."""
+        tool_response = {"returnDisplay": "display only"}
+        llm_content = tool_response.get("llmContent") or tool_response.get("returnDisplay")
+        assert llm_content == "display only"
+
+    def test_plain_text_passes_through(self):
+        """Plain text without wrapper passes through unchanged."""
+        tool_response = "plain text response"
+        # When it's a string and not valid JSON wrapper, use as-is
+        llm_content = tool_response
+        assert llm_content == "plain text response"

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -820,11 +820,25 @@ impl CoshCore {
                     .await;
                 self.emit_hook_notifications(writer, &post_hook.notifications, Some(&tc.id));
 
+                // Precedence: block/deny > updated response > original,
+                // then append additional context.
                 let mut result = if let HookDecision::Block(reason) = &post_hook.decision {
                     ToolResult::error(format!("Post-tool hook denied: {reason}"))
-                } else if let Some(ref extra) = post_hook.additional_context {
+                } else if post_hook.updated_tool_response.is_some()
+                    || post_hook.additional_context.is_some()
+                {
+                    let base = post_hook
+                        .updated_tool_response
+                        .as_deref()
+                        .unwrap_or(&result.output);
+                    let output = if let Some(ref extra) = post_hook.additional_context {
+                        format!("{base}\n[Hook context] {extra}")
+                    } else {
+                        base.to_string()
+                    };
                     ToolResult {
-                        output: format!("{}\n[Hook context] {extra}", result.output),
+                        output,
+                        // Preserve the original is_error flag on normal replacement.
                         is_error: result.is_error,
                     }
                 } else {

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -348,11 +348,7 @@ impl HookSystem {
         specific
             .get("updated_tool_response")
             .and_then(|v| v.as_str())
-            .or_else(|| {
-                specific
-                    .get("updatedToolResponse")
-                    .and_then(|v| v.as_str())
-            })
+            .or_else(|| specific.get("updatedToolResponse").and_then(|v| v.as_str()))
             .filter(|s| !s.is_empty())
     }
 
@@ -1756,14 +1752,9 @@ mod tests {
             )
             .await;
         assert_eq!(
-            result.updated_tool_response,
-            None,
+            result.updated_tool_response, None,
             "No replacement when hook doesn't emit updatedToolResponse"
         );
-        assert_eq!(
-            result.additional_context.as_deref(),
-            Some("just context"),
-        );
+        assert_eq!(result.additional_context.as_deref(), Some("just context"),);
     }
-
 }

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -94,6 +94,12 @@ pub struct PreToolUseResult {
 pub struct PostToolUseResult {
     pub decision: HookDecision,
     pub additional_context: Option<String>,
+    /// Replacement for the original tool response, emitted by transformation
+    /// hooks (e.g. tokenless response compression).  When present and the
+    /// decision is not Block, the runtime uses this text as the model-visible
+    /// tool result instead of the original output.  `additional_context` is
+    /// still appended after the replacement.
+    pub updated_tool_response: Option<String>,
     pub notifications: Vec<HookNotification>,
 }
 
@@ -333,6 +339,23 @@ impl HookSystem {
             .or_else(|| specific.get("additionalContext").and_then(|v| v.as_str()))
     }
 
+    /// Read `updated_tool_response` / `updatedToolResponse` from hook output.
+    /// Accepts both snake_case (cosh-ng convention) and camelCase
+    /// (copilot-shell convention).  Returns `None` when the field is absent,
+    /// not a string, or empty — callers treat all three cases as "no
+    /// replacement requested".
+    fn pick_updated_tool_response(specific: &Value) -> Option<&str> {
+        specific
+            .get("updated_tool_response")
+            .and_then(|v| v.as_str())
+            .or_else(|| {
+                specific
+                    .get("updatedToolResponse")
+                    .and_then(|v| v.as_str())
+            })
+            .filter(|s| !s.is_empty())
+    }
+
     /// 把 tool 输出文本包装为 copilot-shell 协议要求的 JSON 对象。
     /// 对齐 copilot-shell 行为：始终将原始文本作为 llmContent/returnDisplay
     /// 传递，即使文本本身是合法 JSON。copilot-shell 的 coreToolScheduler
@@ -433,6 +456,7 @@ impl HookSystem {
             return PostToolUseResult {
                 decision: HookDecision::Passthrough,
                 additional_context: None,
+                updated_tool_response: None,
                 notifications: vec![],
             };
         }
@@ -447,6 +471,7 @@ impl HookSystem {
             return PostToolUseResult {
                 decision: HookDecision::Passthrough,
                 additional_context: None,
+                updated_tool_response: None,
                 notifications: vec![],
             };
         }
@@ -922,6 +947,7 @@ impl HookSystem {
     ) -> PostToolUseResult {
         let mut decision = HookDecision::Passthrough;
         let mut additional_context: Option<String> = None;
+        let mut updated_tool_response: Option<String> = None;
         let mut notifications = Vec::new();
 
         for (i, out) in outputs {
@@ -930,11 +956,19 @@ impl HookSystem {
 
             decision = fold_decision(decision, out.decision.as_deref(), out.reason.clone());
             fold_additional_context(&mut additional_context, &out.hook_specific_output);
+
+            // Last valid replacement wins (configuration order).
+            if let Some(ref specific) = out.hook_specific_output {
+                if let Some(replacement) = Self::pick_updated_tool_response(specific) {
+                    updated_tool_response = Some(replacement.to_string());
+                }
+            }
         }
 
         PostToolUseResult {
             decision,
             additional_context,
+            updated_tool_response,
             notifications,
         }
     }
@@ -1537,4 +1571,199 @@ mod tests {
             "stdin write must be bounded by the hook deadline"
         );
     }
+
+    // ─── #1614: updated_tool_response tests ──────────────────────────
+
+    #[test]
+    fn pick_updated_tool_response_snake_case() {
+        let specific = serde_json::json!({
+            "updated_tool_response": "compressed content"
+        });
+        assert_eq!(
+            HookSystem::pick_updated_tool_response(&specific),
+            Some("compressed content")
+        );
+    }
+
+    #[test]
+    fn pick_updated_tool_response_camel_case() {
+        let specific = serde_json::json!({
+            "updatedToolResponse": "compressed content"
+        });
+        assert_eq!(
+            HookSystem::pick_updated_tool_response(&specific),
+            Some("compressed content")
+        );
+    }
+
+    #[test]
+    fn pick_updated_tool_response_absent() {
+        let specific = serde_json::json!({
+            "additionalContext": "some context"
+        });
+        assert_eq!(HookSystem::pick_updated_tool_response(&specific), None);
+    }
+
+    #[test]
+    fn pick_updated_tool_response_empty_string() {
+        let specific = serde_json::json!({
+            "updatedToolResponse": ""
+        });
+        assert_eq!(HookSystem::pick_updated_tool_response(&specific), None);
+    }
+
+    #[test]
+    fn pick_updated_tool_response_non_string() {
+        let specific = serde_json::json!({
+            "updatedToolResponse": 42
+        });
+        assert_eq!(HookSystem::pick_updated_tool_response(&specific), None);
+    }
+
+    #[test]
+    fn pick_updated_tool_response_snake_case_priority() {
+        // When both are present, snake_case wins (cosh-ng convention).
+        let specific = serde_json::json!({
+            "updated_tool_response": "snake value",
+            "updatedToolResponse": "camel value"
+        });
+        assert_eq!(
+            HookSystem::pick_updated_tool_response(&specific),
+            Some("snake value")
+        );
+    }
+
+    #[tokio::test]
+    async fn post_tool_use_hook_emits_updated_tool_response() {
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![],
+            post_tool_use: vec![HookDefinition {
+                command: r#"python3 -c 'import sys,json; print(json.dumps({"hook_specific_output": {"updatedToolResponse": "compressed!", "additionalContext": "env-hint"}}))'"#.to_string(),
+                name: Some("compressor".to_string()),
+                matcher: None,
+                timeout: Some(5000),
+                sequential: None,
+            }],
+            post_tool_use_failure: vec![],
+            user_prompt_submit: vec![],
+            session_start: vec![],
+            stop: vec![],
+            before_model: vec![],
+            after_model: vec![],
+        };
+        let sys = HookSystem::from_config(&config);
+        let result = sys
+            .fire_post_tool_use(
+                "s1",
+                "/tmp",
+                "call-1",
+                "shell",
+                &serde_json::json!({"command": "ls"}),
+                "original output here",
+                None,
+            )
+            .await;
+        assert_eq!(
+            result.updated_tool_response.as_deref(),
+            Some("compressed!"),
+            "Hook should emit updatedToolResponse"
+        );
+        assert_eq!(
+            result.additional_context.as_deref(),
+            Some("env-hint"),
+            "Hook should still emit additionalContext for attribution"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_tool_use_last_replacement_wins() {
+        // Two hooks both emit updatedToolResponse; last one in config order wins.
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![],
+            post_tool_use: vec![
+                HookDefinition {
+                    command: r#"python3 -c 'import sys,json; print(json.dumps({"hook_specific_output": {"updatedToolResponse": "first"}}))'"#.to_string(),
+                    name: Some("first-hook".to_string()),
+                    matcher: None,
+                    timeout: Some(5000),
+                    sequential: None,
+                },
+                HookDefinition {
+                    command: r#"python3 -c 'import sys,json; print(json.dumps({"hook_specific_output": {"updatedToolResponse": "second"}}))'"#.to_string(),
+                    name: Some("second-hook".to_string()),
+                    matcher: None,
+                    timeout: Some(5000),
+                    sequential: None,
+                },
+            ],
+            post_tool_use_failure: vec![],
+            user_prompt_submit: vec![],
+            session_start: vec![],
+            stop: vec![],
+            before_model: vec![],
+            after_model: vec![],
+        };
+        let sys = HookSystem::from_config(&config);
+        let result = sys
+            .fire_post_tool_use(
+                "s1",
+                "/tmp",
+                "call-1",
+                "shell",
+                &serde_json::json!({"command": "ls"}),
+                "original",
+                None,
+            )
+            .await;
+        assert_eq!(
+            result.updated_tool_response.as_deref(),
+            Some("second"),
+            "Last valid replacement should win in configuration order"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_tool_use_no_replacement_when_absent() {
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![],
+            post_tool_use: vec![HookDefinition {
+                command: r#"python3 -c 'import sys,json; print(json.dumps({"hook_specific_output": {"additionalContext": "just context"}}))'"#.to_string(),
+                name: Some("context-only".to_string()),
+                matcher: None,
+                timeout: Some(5000),
+                sequential: None,
+            }],
+            post_tool_use_failure: vec![],
+            user_prompt_submit: vec![],
+            session_start: vec![],
+            stop: vec![],
+            before_model: vec![],
+            after_model: vec![],
+        };
+        let sys = HookSystem::from_config(&config);
+        let result = sys
+            .fire_post_tool_use(
+                "s1",
+                "/tmp",
+                "call-1",
+                "shell",
+                &serde_json::json!({"command": "ls"}),
+                "original output",
+                None,
+            )
+            .await;
+        assert_eq!(
+            result.updated_tool_response,
+            None,
+            "No replacement when hook doesn't emit updatedToolResponse"
+        );
+        assert_eq!(
+            result.additional_context.as_deref(),
+            Some("just context"),
+        );
+    }
+
 }

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -334,7 +334,7 @@ def main() -> None:
             if proc.returncode == 0 and proc.stdout.strip():
                 candidate = proc.stdout.strip()
                 # Compare against actual model-visible before size
-                if len(candidate) < len(str(model_visible_before)):
+                if len(candidate) < len(tool_response):
                     compressed = candidate
                     used_resp_compression = True
             elif proc.returncode != 0:
@@ -432,7 +432,7 @@ def main() -> None:
     # Cosh-NG: use updatedToolResponse for response replacement.
     # Skip compression if it doesn't reduce model-visible size.
     if cosh_ng_detected:
-        if len(final_output) >= len(str(model_visible_before)):
+        if len(final_output) >= len(tool_response):
             _emit_attribution_or_skip(env_attribution)
 
         hook_specific = {

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Tokenless response compression hook with optional TOON encoding.
+"""Tokenless response compression hook with Cosh-NG and Claude Code compatibility.
 
 Reads a PostToolUse JSON from stdin, compresses the tool response
 via ``tokenless compress-response``, then optionally re-encodes to TOON
 format via ``tokenless compress-toon`` for additional token savings.
 
-Pipeline: Env Attribution → Layered分流 → Compression → TOON Encoding
+Pipeline: Env Attribution -> Layered dispatch -> Compression -> TOON Encoding
   1. If tool_response contains errors, classify as environment vs logic issue
      and inject "Skip retry" guidance for LLM
   2. 3-layer tool dispatch:
-     - Content retrieval (Read/Glob/Grep) → skip all compression
-     - Shell/exec (Bash/Shell) → moderate truncation (64K strings)
-     - Other tools → zero-truncation compress-response + TOON
+     - Content retrieval (Read/Glob/Grep) -> skip all compression
+     - Shell/exec (Bash/Shell) -> moderate truncation (64K strings)
+     - Other tools -> zero-truncation compress-response + TOON
   3. Strip debug fields, nulls, empty values (no truncation risk)
   4. If the compressed result is still valid JSON, encode to TOON format
   5. Stats are recorded automatically by tokenless CLI commands.
@@ -26,12 +26,18 @@ Output contract per agent:
     diagnostics (environment attribution). Older Claude Code versions fail
     open: compression is disabled instead of injecting a duplicate payload
     (issue #1645).
+  - cosh-ng: the compressed payload replaces the response via
+    ``hookSpecificOutput.updatedToolResponse``.  Extract only ``llmContent``
+    from wrapped responses; never include ``returnDisplay``.  Keep
+    environment/error attribution in ``additionalContext`` (additive).
+    Unsupported Cosh-NG versions fail open with compression disabled.
   - other agents: the compressed payload is injected via
     ``additionalContext`` per each runtime's hook contract.
 
 The agent ID is read from the TOKENLESS_AGENT_ID environment variable
-(set by the install action script).  Fallback paths follow the ANOLISA
-FHS spec: /usr/bin/tokenless.
+(set by the install action script).  When running under Cosh-NG, the
+agent ID is overridden to ``cosh-ng`` for correct stats attribution.
+Fallback paths follow the ANOLISA FHS spec: /usr/bin/tokenless.
 """
 
 import json
@@ -47,6 +53,7 @@ from hook_utils import (
     _TOKENLESS_LOCAL_SHARE,
     SKIP_TOOLS,
     classify_env_error,
+    detect_cosh_ng_runtime,
     get_thresholds,
     is_skill_file,
     parse_version,
@@ -61,7 +68,6 @@ from hook_utils import (
 
 # -- constants ---------------------------------------------------------------
 
-_AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
 _MIN_RESPONSE_CHARS = 200
 
 # Claude Code added hookSpecificOutput.updatedToolOutput (normal-path tool
@@ -79,6 +85,14 @@ _CLAUDE_VERSION_CACHE = os.path.join(
 
 
 # -- helpers -------------------------------------------------------------------
+
+
+def _resolve_agent_id(cosh_ng_detected: bool) -> str:
+    """Resolve the agent ID, using cosh-ng when detected under that runtime."""
+    env_id = os.environ.get("TOKENLESS_AGENT_ID", "")
+    if cosh_ng_detected:
+        return env_id or "cosh-ng"
+    return env_id or "tokenless"
 
 
 def _build_additional_context(
@@ -199,7 +213,19 @@ def _warn_subprocess(label: str, proc: subprocess.CompletedProcess) -> None:
 
 
 def main() -> None:
-    # 1. Resolve binaries
+    # 1. Detect runtime (Cosh-NG vs copilot-shell)
+    cosh_ng_version = detect_cosh_ng_runtime()
+    cosh_ng_detected = cosh_ng_version is not None
+
+    # If Cosh-NG is detected but unsupported version, fail open
+    if cosh_ng_detected and cosh_ng_version == (0, 0, 0):
+        warn("Unsupported Cosh-NG version. Response compression disabled (fail open).")
+        skip()
+
+    # 2. Resolve agent ID based on runtime
+    agent_id = _resolve_agent_id(cosh_ng_detected)
+
+    # 3. Resolve binaries
     tokenless_bin = resolve_binary(
         "tokenless", _TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB
     )
@@ -207,46 +233,62 @@ def main() -> None:
         warn("tokenless is not installed. Response compression hook disabled.")
         skip()
 
-    # 2. Read stdin JSON
+    # 4. Read stdin JSON
     try:
         input_data = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError, ValueError):
         warn("failed to read PostToolUse payload. Passing through unchanged.")
         skip()
 
-    # 3. Extract tool_name (skip-tools分流 handled after attribution)
+    # 5. Extract tool_name (skip-tools handled after attribution)
     tool_name = input_data.get("tool_name", "unknown")
 
-    # 4. Extract tool_response
+    # 6. Extract tool_response
     tool_response_raw = input_data.get("tool_response", "")
     if not tool_response_raw or tool_response_raw == "{}":
         skip()
 
-    # 5. Skip skill files (YAML frontmatter)
-    if isinstance(tool_response_raw, str) and is_skill_file(tool_response_raw):
+    # 7. For Cosh-NG, extract only llmContent from the wrapped response.
+    #    Never include returnDisplay in the provider-visible replacement.
+    llm_content = None
+    if isinstance(tool_response_raw, dict):
+        llm_content = tool_response_raw.get("llmContent")
+        if llm_content is None:
+            llm_content = tool_response_raw.get("returnDisplay")
+    elif isinstance(tool_response_raw, str):
+        # Try to parse as the {llmContent, returnDisplay} wrapper
+        parsed_wrapper = try_parse_json(tool_response_raw)
+        if isinstance(parsed_wrapper, dict) and "llmContent" in parsed_wrapper:
+            llm_content = parsed_wrapper["llmContent"]
+
+    # The model-visible content we will compress
+    model_visible_before = llm_content if llm_content is not None else tool_response_raw
+
+    # 8. Skip skill files (YAML frontmatter)
+    if isinstance(model_visible_before, str) and is_skill_file(model_visible_before):
         skip()
 
-    # 6. Normalize response
-    if isinstance(tool_response_raw, str):
-        unwrapped = unwrap_string_json(tool_response_raw)
+    # 9. Normalize response
+    if isinstance(model_visible_before, str):
+        unwrapped = unwrap_string_json(model_visible_before)
         if not unwrapped:
             skip()  # Plain text, not JSON
         tool_response = unwrapped
-    elif isinstance(tool_response_raw, (dict, list)):
-        tool_response = json.dumps(tool_response_raw, separators=(",", ":"))
+    elif isinstance(model_visible_before, (dict, list)):
+        tool_response = json.dumps(model_visible_before, separators=(",", ":"))
     else:
         skip()
 
-    # 7. Validate it's JSON (needed for attribution on skip-tools too)
+    # 10. Validate it's JSON (needed for attribution on skip-tools too)
     parsed = try_parse_json(tool_response)
     if parsed is None:
         skip()
 
-    # 8. Extract caller context
+    # 11. Extract caller context
     session_id = input_data.get("session_id", "")
-    tool_use_id = resolve_tool_call_id(_AGENT_ID, input_data)
+    tool_use_id = resolve_tool_call_id(agent_id, input_data)
 
-    # 9. Environment attribution analysis
+    # 12. Environment attribution analysis
     env_attribution = ""
     attr_category, attr_fix_hint = classify_env_error(parsed)
     if attr_category:
@@ -255,20 +297,17 @@ def main() -> None:
             f"{attr_category} ({attr_fix_hint}). Skip retry."
         )
 
-    # 10. Content retrieval — skip entirely (preserve integrity)
+    # 13. Content retrieval -- skip entirely (preserve integrity)
     if tool_name in SKIP_TOOLS:
         _emit_attribution_or_skip(env_attribution)
 
-    # 11. All other tools — skip small responses, but still inject
+    # 14. All other tools -- skip small responses, but still inject
     # env attribution for error cases (small size doesn't mean the
     # error classification is unimportant to the agent).
     if len(tool_response) < _MIN_RESPONSE_CHARS:
         _emit_attribution_or_skip(env_attribution)
 
-    # 12. Step 1: Response compression with 3-layer thresholds
-    #   Layer 1 (content retrieval): already skipped above
-    #   Layer 2 (shell/exec): moderate truncation (64K/128/8) — plain text output
-    #   Layer 3 (API/structured): zero-truncation (1M/64K/32) — preserve content
+    # 15. Step 1: Response compression with 3-layer thresholds
     compressed = tool_response
     used_resp_compression = False
 
@@ -276,7 +315,7 @@ def main() -> None:
         thresholds = get_thresholds(tool_name)
         cmd = [
             tokenless_bin, "compress-response",
-            "--agent-id", _AGENT_ID,
+            "--agent-id", agent_id,
             "--truncate-strings-at", str(thresholds[0]),
             "--truncate-arrays-at", str(thresholds[1]),
             "--max-depth", str(thresholds[2]),
@@ -294,7 +333,8 @@ def main() -> None:
             )
             if proc.returncode == 0 and proc.stdout.strip():
                 candidate = proc.stdout.strip()
-                if len(candidate) < len(tool_response):
+                # Compare against actual model-visible before size
+                if len(candidate) < len(str(model_visible_before)):
                     compressed = candidate
                     used_resp_compression = True
             elif proc.returncode != 0:
@@ -302,13 +342,13 @@ def main() -> None:
         except Exception as e:
             warn(f"Response compression error: {e}")
 
-    # 13. Step 2: TOON encoding
+    # 16. Step 2: TOON encoding
     toon_output = ""
 
     if tokenless_bin:
         toon_parsed = try_parse_json(compressed)
         if toon_parsed is not None:
-            toon_cmd = [tokenless_bin, "compress-toon", "--agent-id", _AGENT_ID]
+            toon_cmd = [tokenless_bin, "compress-toon", "--agent-id", agent_id]
             if session_id:
                 toon_cmd.extend(["--session-id", session_id])
             if tool_use_id:
@@ -336,14 +376,14 @@ def main() -> None:
     if not used_resp_compression and not toon_output:
         _emit_attribution_or_skip(env_attribution)
 
-    # 14. Build response.
+    # 17. Build response — dispatch by agent runtime.
     #
     # Claude Code: additionalContext is *additive* — the model would see both
     # the original tool result and the compressed copy, inflating the context
     # instead of shrinking it (issue #1645). Replace the tool result via
     # updatedToolOutput (>= 2.1.121) and keep additionalContext for additive
     # diagnostics only. Unsupported versions fail open via pass-through.
-    if _AGENT_ID == _CLAUDE_AGENT_ID:
+    if agent_id == _CLAUDE_AGENT_ID:
         if not _claude_supports_replacement():
             warn(
                 "Claude Code < 2.1.121 (or version unknown): "
@@ -387,6 +427,21 @@ def main() -> None:
         if env_attribution:
             hook_output["additionalContext"] = env_attribution
         _emit({"suppressOutput": True, "hookSpecificOutput": hook_output})
+        return
+
+    # Cosh-NG: use updatedToolResponse for response replacement.
+    # Skip compression if it doesn't reduce model-visible size.
+    if cosh_ng_detected:
+        if len(final_output) >= len(str(model_visible_before)):
+            _emit_attribution_or_skip(env_attribution)
+
+        hook_specific = {
+            "hookEventName": "PostToolUse",
+            "updatedToolResponse": final_output,
+        }
+        if env_attribution:
+            hook_specific["additionalContext"] = env_attribution
+        _emit({"suppressOutput": True, "hookSpecificOutput": hook_specific})
         return
 
     # Other agents: inject via additionalContext per their hook contracts.

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -410,6 +410,10 @@ def detect_cosh_ng_runtime() -> tuple | None:
       1. ``COSH_NG_VERSION`` environment variable — set by Cosh-NG when
          launching hook processes.
       2. ``COSH_RUNTIME`` environment variable set to ``cosh-ng``.
+
+    The ``(0, 0, 0)`` sentinel means "Cosh-NG detected but version unknown" —
+    callers should treat this as "unsupported version" and fail open (disable
+    compression) rather than falling back to duplicate injection.
     """
     version_str = os.environ.get("COSH_NG_VERSION", "")
     if version_str:

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -398,6 +398,35 @@ def run(args: list[str], input_data: str, timeout: int = 3) -> subprocess.Comple
         return None
 
 
+def detect_cosh_ng_runtime() -> tuple | None:
+    """Detect if we are running under Cosh-NG and return its version.
+
+    Returns:
+        A (major, minor, patch) version tuple if Cosh-NG is detected,
+        or (0, 0, 0) if Cosh-NG is detected but version is unknown
+        (unsupported), or None if not running under Cosh-NG.
+
+    Detection checks (in order):
+      1. ``COSH_NG_VERSION`` environment variable — set by Cosh-NG when
+         launching hook processes.
+      2. ``COSH_RUNTIME`` environment variable set to ``cosh-ng``.
+    """
+    version_str = os.environ.get("COSH_NG_VERSION", "")
+    if version_str:
+        ver = parse_version(version_str)
+        if ver:
+            return ver
+        # Detected Cosh-NG but can't parse version — unsupported
+        return (0, 0, 0)
+
+    runtime = os.environ.get("COSH_RUNTIME", "")
+    if runtime == "cosh-ng":
+        # Cosh-NG detected via runtime env var but no version available
+        return (0, 0, 0)
+
+    return None
+
+
 def parse_version(version_str: str) -> tuple | None:
     """Parse a version string like '0.35.0' into a (major, minor, patch) tuple."""
     m = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -40,6 +40,11 @@ from hook_utils import (
 _MIN_RTK_VERSION = (0, 35, 0)
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
 
+# Import Cosh-NG detection for stats attribution
+from hook_utils import detect_cosh_ng_runtime as _detect_cosh_ng
+if _detect_cosh_ng() is not None and _AGENT_ID == "tokenless":
+    _AGENT_ID = "cosh-ng"
+
 
 # -- main --------------------------------------------------------------------
 
@@ -132,12 +137,16 @@ def main() -> None:
         skip()
 
     # 7. Build response
+    # Emit both formats for runtime compatibility:
+    # - ``tool_input``: Cosh-NG partial patch (merges with original params)
+    # - ``updatedInput``: copilot-shell full replacement (legacy)
     updated_input = dict(tool_input)
     updated_input["command"] = rewritten
 
     output = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
+            "tool_input": {"command": rewritten},
             "updatedInput": updated_input,
         },
     }


### PR DESCRIPTION
## Summary

This PR implements two related changes for Cosh-NG and tokenless hook compatibility:

### #1614: PostToolUse response replacement in Cosh-NG core

Add an explicit normal-path response replacement field (`updated_tool_response` / `updatedToolResponse`) to `PostToolUseResult`, allowing transformation hooks (like tokenless response compression) to **replace** the tool output rather than appending to it.

- Extract `updatedToolResponse` / `updated_tool_response` from `hook_specific_output`
- Apply precedence: **block/deny > updated response > original**, then append `additionalContext`
- Preserve original `is_error` flag on normal replacement
- Multiple hooks: last valid replacement wins in configuration order
- Fail open: missing/invalid/empty replacement preserves original response

### #1615: Adapt tokenless hooks for Cosh-NG compatibility

- **compress_response_hook**: Emit `updatedToolResponse` for compressed content instead of `additionalContext` (which was duplicating tokens). Keep environment/error attribution in `additionalContext`. Extract only `llmContent` from wrapped responses.
- **rewrite_hook**: Emit `tool_input` patch (partial) for Cosh-NG alongside `updatedInput` (full replacement) for copilot-shell legacy.
- **hook_utils**: Add `detect_cosh_ng_runtime()` for runtime detection and version checking via `COSH_NG_VERSION` / `COSH_RUNTIME` env vars.
- Use `cosh-ng` agent ID for correct stats attribution when running under Cosh-NG.
- Fail open on unsupported Cosh-NG versions (compression disabled, no duplicate injection).

## Changes

| File | Description |
|------|-------------|
| `src/cosh-ng/crates/cosh-core/src/hook.rs` | Add `updated_tool_response` to `PostToolUseResult`, `pick_updated_tool_response()` helper, update aggregation |
| `src/cosh-ng/crates/cosh-core/src/core.rs` | Apply precedence: block > updated response > original, preserve `is_error` |
| `src/tokenless/.../compress_response_hook.py` | Emit `updatedToolResponse`, extract `llmContent`, Cosh-NG runtime detection |
| `src/tokenless/.../rewrite_hook.py` | Emit `tool_input` patch, Cosh-NG agent ID |
| `src/tokenless/.../hook_utils.py` | Add `detect_cosh_ng_runtime()` |

## Testing

- 9 new Rust unit tests covering:
  - `pick_updated_tool_response` with snake_case, camelCase, absent, empty, non-string, priority
  - End-to-end hook emitting `updatedToolResponse`
  - Last-replacement-wins ordering
  - No replacement when field absent
- All 36 existing hook tests continue to pass

Related to ANO-57