### PR TITLE
fix(cosh-ng): add sensitive-path audit guard

### DIFF
--- a/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/balanced.toml
+++ b/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/balanced.toml
@@ -504,7 +504,57 @@ operation = "go"
 target = { one_of = ["version", "env", "list"] }
 
 # ==========================================================================
-# Shell: read-only single-token commands. Safe regardless of arguments.
+# Shell: sensitive-path guard.
+#
+# Intercepts any shell command that references sensitive system or
+# credential files. Must appear BEFORE shell-allow-readonly-singletons
+# so the first-match-wins semantics give RequireApproval instead of Allow.
+# Destructive commands (rm, sudo, mv, …) are already Deny'd by earlier
+# rules, so these guards only affect commands that would otherwise be
+# Allow'd by the readonly-singletons fall-through below.
+# ==========================================================================
+
+# Exact sensitive system files.
+[[rules]]
+name = "shell-sensitive-system-files"
+outcome = "RequireApproval"
+reason = "Command references sensitive system file"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { one_of = [
+  "/etc/passwd", "/etc/shadow", "/etc/gshadow", "/etc/sudoers"
+] } }]
+
+# Sudoers drop-in directory.
+[[rules]]
+name = "shell-sensitive-sudoersd"
+outcome = "RequireApproval"
+reason = "Command references sensitive sudoers configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/etc/sudoers.d/*" } }]
+
+# /proc/self/* — environment, cmdline, fd, etc.
+[[rules]]
+name = "shell-sensitive-proc-self"
+outcome = "RequireApproval"
+reason = "Command references process self-info"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/proc/self/*" } }]
+
+# SSH keys and config: ~/.ssh/*, /home/*/.ssh/*, /root/.ssh/*
+[[rules]]
+name = "shell-sensitive-ssh"
+outcome = "RequireApproval"
+reason = "Command references SSH key or configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "*.ssh/*" } }]
+
+# ==========================================================================
+# Shell: read-only single-token commands. Safe unless arguments reference
+# sensitive paths (guarded above).
 # ==========================================================================
 
 [[rules]]

--- a/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/balanced.toml
+++ b/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/balanced.toml
@@ -545,12 +545,53 @@ arg = [{ key = { glob = "/proc/self/*" } }]
 
 # SSH keys and config: ~/.ssh/*, /home/*/.ssh/*, /root/.ssh/*
 [[rules]]
-name = "shell-sensitive-ssh"
+name = "shell-sensitive-ssh-home"
 outcome = "RequireApproval"
 reason = "Command references SSH key or configuration"
 [rules.matches]
 subsystem = "shell"
-arg = [{ key = { glob = "*.ssh/*" } }]
+arg = [{ key = { glob = "/home/*/.ssh/*" } }]
+
+[[rules]]
+name = "shell-sensitive-ssh-root"
+outcome = "RequireApproval"
+reason = "Command references SSH key or configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/root/.ssh/*" } }]
+
+[[rules]]
+name = "shell-sensitive-ssh-tilde"
+outcome = "RequireApproval"
+reason = "Command references SSH key or configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "~/.ssh/*" } }]
+
+# Shell history files: ~/.bash_history, /home/*/.bash_history, /root/.bash_history
+[[rules]]
+name = "shell-sensitive-shell-history-home"
+outcome = "RequireApproval"
+reason = "Command references shell command history"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/home/*/.bash_history" } }]
+
+[[rules]]
+name = "shell-sensitive-shell-history-root"
+outcome = "RequireApproval"
+reason = "Command references shell command history"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/root/.bash_history" } }]
+
+[[rules]]
+name = "shell-sensitive-shell-history-tilde"
+outcome = "RequireApproval"
+reason = "Command references shell command history"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "~/.bash_history" } }]
 
 # ==========================================================================
 # Shell: read-only single-token commands. Safe unless arguments reference

--- a/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/strict.toml
+++ b/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/strict.toml
@@ -6,11 +6,11 @@
 version = "v1-strict"
 default = "Deny"
 
-# Sensitive-path guard — deny access to sensitive system and credential
+# Sensitive-path guard — deny direct access to sensitive system and credential
 # files. Must appear BEFORE shell-allow-readonly-singletons.
 [[rules]]
 name = "shell-sensitive-system-files"
-outcome = "RequireApproval"
+outcome = "Deny"
 reason = "Command references sensitive system file"
 [rules.matches]
 subsystem = "shell"
@@ -20,7 +20,7 @@ arg = [{ key = { one_of = [
 
 [[rules]]
 name = "shell-sensitive-sudoersd"
-outcome = "RequireApproval"
+outcome = "Deny"
 reason = "Command references sensitive sudoers configuration"
 [rules.matches]
 subsystem = "shell"
@@ -28,19 +28,60 @@ arg = [{ key = { glob = "/etc/sudoers.d/*" } }]
 
 [[rules]]
 name = "shell-sensitive-proc-self"
-outcome = "RequireApproval"
+outcome = "Deny"
 reason = "Command references process self-info"
 [rules.matches]
 subsystem = "shell"
 arg = [{ key = { glob = "/proc/self/*" } }]
 
 [[rules]]
-name = "shell-sensitive-ssh"
-outcome = "RequireApproval"
+name = "shell-sensitive-ssh-home"
+outcome = "Deny"
 reason = "Command references SSH key or configuration"
 [rules.matches]
 subsystem = "shell"
-arg = [{ key = { glob = "*.ssh/*" } }]
+arg = [{ key = { glob = "/home/*/.ssh/*" } }]
+
+[[rules]]
+name = "shell-sensitive-ssh-root"
+outcome = "Deny"
+reason = "Command references SSH key or configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/root/.ssh/*" } }]
+
+[[rules]]
+name = "shell-sensitive-ssh-tilde"
+outcome = "Deny"
+reason = "Command references SSH key or configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "~/.ssh/*" } }]
+
+# Shell history files: ~/.bash_history, /home/*/.bash_history, /root/.bash_history
+[[rules]]
+name = "shell-sensitive-shell-history-home"
+outcome = "Deny"
+reason = "Command references shell command history"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/home/*/.bash_history" } }]
+
+[[rules]]
+name = "shell-sensitive-shell-history-root"
+outcome = "Deny"
+reason = "Command references shell command history"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/root/.bash_history" } }]
+
+[[rules]]
+name = "shell-sensitive-shell-history-tilde"
+outcome = "Deny"
+reason = "Command references shell command history"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "~/.bash_history" } }]
 
 # Read-only single-token shell commands.
 [[rules]]

--- a/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/strict.toml
+++ b/src/cosh-ng/crates/cosh-platform/src/audit/builtin_toml/strict.toml
@@ -6,6 +6,42 @@
 version = "v1-strict"
 default = "Deny"
 
+# Sensitive-path guard — deny access to sensitive system and credential
+# files. Must appear BEFORE shell-allow-readonly-singletons.
+[[rules]]
+name = "shell-sensitive-system-files"
+outcome = "RequireApproval"
+reason = "Command references sensitive system file"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { one_of = [
+  "/etc/passwd", "/etc/shadow", "/etc/gshadow", "/etc/sudoers"
+] } }]
+
+[[rules]]
+name = "shell-sensitive-sudoersd"
+outcome = "RequireApproval"
+reason = "Command references sensitive sudoers configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/etc/sudoers.d/*" } }]
+
+[[rules]]
+name = "shell-sensitive-proc-self"
+outcome = "RequireApproval"
+reason = "Command references process self-info"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "/proc/self/*" } }]
+
+[[rules]]
+name = "shell-sensitive-ssh"
+outcome = "RequireApproval"
+reason = "Command references SSH key or configuration"
+[rules.matches]
+subsystem = "shell"
+arg = [{ key = { glob = "*.ssh/*" } }]
+
 # Read-only single-token shell commands.
 [[rules]]
 name = "shell-allow-readonly-singletons"

--- a/src/cosh-ng/crates/cosh-platform/src/audit/evaluate.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/audit/evaluate.rs
@@ -247,6 +247,93 @@ mod tests {
         assert_outcome("find . -type f", Outcome::Allow);
     }
 
+    // ---- Sensitive-path guard -----------------------------------------
+
+    #[test]
+    fn balanced_require_approval_for_sensitive_system_files() {
+        for cmd in [
+            "cat /etc/passwd",
+            "cat /etc/shadow",
+            "cat /etc/gshadow",
+            "cat /etc/sudoers",
+            "head /etc/passwd",
+            "tail /etc/shadow",
+            "grep root /etc/passwd",
+            "wc /etc/passwd",
+        ] {
+            assert_outcome(cmd, Outcome::RequireApproval);
+        }
+    }
+
+    #[test]
+    fn balanced_require_approval_for_ssh_keys() {
+        for cmd in [
+            "cat ~/.ssh/id_rsa",
+            "cat ~/.ssh/id_ed25519",
+            "head ~/.ssh/config",
+            "cat /root/.ssh/authorized_keys",
+        ] {
+            assert_outcome(cmd, Outcome::RequireApproval);
+        }
+    }
+
+    #[test]
+    fn balanced_require_approval_for_proc_and_sudoersd() {
+        for cmd in [
+            "cat /proc/self/environ",
+            "cat /proc/self/cmdline",
+            "cat /etc/sudoers.d/myuser",
+        ] {
+            assert_outcome(cmd, Outcome::RequireApproval);
+        }
+    }
+
+    #[test]
+    fn balanced_require_approval_for_flag_before_sensitive_path() {
+        // Flags before the path: target would be the flag, but arg matching
+        // still catches the sensitive path in args.
+        assert_outcome("cat -n /etc/passwd", Outcome::RequireApproval);
+        assert_outcome("head -5 /etc/shadow", Outcome::RequireApproval);
+    }
+
+    #[test]
+    fn balanced_still_allows_non_sensitive_readonly() {
+        for cmd in [
+            "cat /etc/hosts",
+            "cat /tmp/test.txt",
+            "head README.md",
+            "ls -la",
+            "echo hello",
+        ] {
+            assert_outcome(cmd, Outcome::Allow);
+        }
+    }
+
+    #[test]
+    fn balanced_destructive_on_sensitive_path_still_denied() {
+        // rm /etc/passwd is Deny'd by the destructive rule before the
+        // sensitive-path guard is reached.
+        assert_outcome("rm /etc/passwd", Outcome::Deny);
+        assert_outcome("sudo cat /etc/shadow", Outcome::Deny);
+    }
+
+    #[test]
+    fn strict_require_approval_for_sensitive_paths() {
+        // Strict mode also uses RequireApproval for sensitive paths.
+        let action = parse_action_string("cat /etc/passwd").unwrap();
+        let loaded = builtin::strict();
+        let d = evaluate(&action, &loaded);
+        assert_eq!(d.outcome, Outcome::RequireApproval);
+    }
+
+    #[test]
+    fn strict_still_allows_non_sensitive_readonly() {
+        let action = parse_action_string("cat /etc/hosts").unwrap();
+        let loaded = builtin::strict();
+        let d = evaluate(&action, &loaded);
+        assert_eq!(d.outcome, Outcome::Allow);
+    }
+
     // ---- Pkg / Svc / Checkpoint ---------------------------------------
 
     #[test]

--- a/src/cosh-ng/crates/cosh-platform/src/audit/evaluate.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/audit/evaluate.rs
@@ -272,6 +272,8 @@ mod tests {
             "cat ~/.ssh/id_ed25519",
             "head ~/.ssh/config",
             "cat /root/.ssh/authorized_keys",
+            "cat /home/user/.ssh/id_rsa",
+            "head /home/alice/.ssh/config",
         ] {
             assert_outcome(cmd, Outcome::RequireApproval);
         }
@@ -283,6 +285,18 @@ mod tests {
             "cat /proc/self/environ",
             "cat /proc/self/cmdline",
             "cat /etc/sudoers.d/myuser",
+        ] {
+            assert_outcome(cmd, Outcome::RequireApproval);
+        }
+    }
+
+    #[test]
+    fn balanced_require_approval_for_shell_history() {
+        for cmd in [
+            "cat ~/.bash_history",
+            "cat /root/.bash_history",
+            "cat /home/user/.bash_history",
+            "head /home/alice/.bash_history",
         ] {
             assert_outcome(cmd, Outcome::RequireApproval);
         }
@@ -318,12 +332,35 @@ mod tests {
     }
 
     #[test]
-    fn strict_require_approval_for_sensitive_paths() {
-        // Strict mode also uses RequireApproval for sensitive paths.
-        let action = parse_action_string("cat /etc/passwd").unwrap();
+    fn strict_denies_sensitive_paths() {
+        // Strict mode denies direct access to sensitive system and credential
+        // files; non-sensitive read-only commands still fall through to Allow.
         let loaded = builtin::strict();
-        let d = evaluate(&action, &loaded);
-        assert_eq!(d.outcome, Outcome::RequireApproval);
+        for cmd in [
+            "cat /etc/passwd",
+            "cat /etc/shadow",
+            "head /etc/sudoers",
+            "cat /etc/sudoers.d/myuser",
+            "cat /proc/self/environ",
+            "cat /proc/self/cmdline",
+            "cat ~/.ssh/id_rsa",
+            "cat /root/.ssh/authorized_keys",
+            "cat /home/user/.ssh/id_rsa",
+            "cat ~/.bash_history",
+            "cat /root/.bash_history",
+            "cat /home/user/.bash_history",
+        ] {
+            let action = parse_action_string(cmd).unwrap();
+            let d = evaluate(&action, &loaded);
+            assert_eq!(
+                d.outcome,
+                Outcome::Deny,
+                "for input {:?}: expected Deny, got {:?} (matched={:?})",
+                cmd,
+                d.outcome,
+                d.matched_rule
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Insert interception rules before shell-allow-readonly-singletons in balanced and strict policies so first-match-wins yields RequireApproval instead of Allow for sensitive paths. Uses arg matching rather than target to catch paths in any position (e.g. cat -n /etc/passwd). Destructive commands stay Deny by earlier rules.

Covers system identity files (/etc/passwd, /etc/shadow, /etc/gshadow, /etc/sudoers), sudoers.d, /proc/self/*, and SSH keys (*.ssh/*).

Assisted-by: Qoder

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #1569

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
