### PR TITLE
fix(cosh-ng): add workspace path pre-validation for checkpoint commands

### DIFF
--- a/src/cosh-ng/crates/cosh-cli/src/cmd/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-cli/src/cmd/checkpoint.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Instant;
 
 use clap::Subcommand;
@@ -5,6 +6,7 @@ use clap::Subcommand;
 use cosh_platform::checkpoint::CkptClient;
 use cosh_platform::detect::Distro;
 use cosh_types::checkpoint::DEFAULT_SOCKET_PATH;
+use cosh_types::error::{CoshError, ErrorCode};
 
 use crate::{build_meta, print_failure, print_success};
 
@@ -122,11 +124,34 @@ pub enum CheckpointCommands {
     },
 }
 
+/// Validate that the workspace path exists on the local filesystem.
+/// Returns a CheckpointNotFound error if the path does not exist.
+fn validate_workspace_exists(workspace: &str) -> Result<(), CoshError> {
+    if !Path::new(workspace).exists() {
+        return Err(CoshError::new(
+            ErrorCode::CheckpointNotFound,
+            format!(
+                "workspace '{}' does not exist on local filesystem",
+                workspace
+            ),
+            "checkpoint",
+        )
+        .with_hint(
+            "check workspace path or run 'cosh-cli checkpoint init --workspace <path>' first",
+        )
+        .recoverable(false));
+    }
+    Ok(())
+}
+
 pub fn run(action: CheckpointCommands, distro: &Distro, start: Instant) -> i32 {
     let dry_run = false;
 
     match action {
         CheckpointCommands::Init { workspace, socket } => {
+            if let Err(e) = validate_workspace_exists(&workspace) {
+                return print_failure(e, build_meta("checkpoint", distro, start, dry_run));
+            }
             let client = CkptClient::new(&socket);
             match client.init(&workspace) {
                 Ok(result) => {
@@ -136,6 +161,9 @@ pub fn run(action: CheckpointCommands, distro: &Distro, start: Instant) -> i32 {
             }
         }
         CheckpointCommands::Recover { workspace, socket } => {
+            if let Err(e) = validate_workspace_exists(&workspace) {
+                return print_failure(e, build_meta("checkpoint", distro, start, dry_run));
+            }
             let client = CkptClient::new(&socket);
             match client.recover(&workspace) {
                 Ok(result) => {
@@ -152,6 +180,9 @@ pub fn run(action: CheckpointCommands, distro: &Distro, start: Instant) -> i32 {
             pin,
             socket,
         } => {
+            if let Err(e) = validate_workspace_exists(&workspace) {
+                return print_failure(e, build_meta("checkpoint", distro, start, dry_run));
+            }
             let client = CkptClient::new(&socket);
             match client.create(
                 &workspace,
@@ -180,6 +211,9 @@ pub fn run(action: CheckpointCommands, distro: &Distro, start: Instant) -> i32 {
             workspace,
             socket,
         } => {
+            if let Err(e) = validate_workspace_exists(&workspace) {
+                return print_failure(e, build_meta("checkpoint", distro, start, dry_run));
+            }
             let client = CkptClient::new(&socket);
             match client.restore(&workspace, &id) {
                 Ok(result) => {
@@ -217,6 +251,9 @@ pub fn run(action: CheckpointCommands, distro: &Distro, start: Instant) -> i32 {
             to,
             socket,
         } => {
+            if let Err(e) = validate_workspace_exists(&workspace) {
+                return print_failure(e, build_meta("checkpoint", distro, start, dry_run));
+            }
             let client = CkptClient::new(&socket);
             match client.diff(&workspace, &from, &to) {
                 Ok(result) => {
@@ -230,6 +267,9 @@ pub fn run(action: CheckpointCommands, distro: &Distro, start: Instant) -> i32 {
             keep,
             socket,
         } => {
+            if let Err(e) = validate_workspace_exists(&workspace) {
+                return print_failure(e, build_meta("checkpoint", distro, start, dry_run));
+            }
             let client = CkptClient::new(&socket);
             match client.cleanup(&workspace, keep) {
                 Ok(result) => {

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -912,7 +912,7 @@ fn test_checkpoint_create_skipped_is_success() {
             "checkpoint",
             "create",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--id",
             "snap-001",
             "--socket",
@@ -928,7 +928,7 @@ fn test_checkpoint_create_skipped_is_success() {
     assert_eq!(json["ok"], true);
     assert!(json["error"].is_null());
     assert_eq!(json["data"]["snapshot_id"], serde_json::Value::Null);
-    assert_eq!(json["data"]["workspace"], "/tmp/test-ws");
+    assert_eq!(json["data"]["workspace"], "/tmp");
     assert_eq!(json["data"]["skipped"], true);
     assert_eq!(json["data"]["reason"], reason);
     assert_eq!(json["meta"]["subsystem"], "checkpoint");
@@ -942,7 +942,7 @@ fn test_checkpoint_create_daemon_unavailable() {
             "checkpoint",
             "create",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--id",
             "snap-001",
             "--socket",
@@ -980,7 +980,7 @@ fn test_checkpoint_list_daemon_unavailable() {
             "checkpoint",
             "list",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--socket",
             "/tmp/nonexistent-ws-ckpt.sock",
         ])
@@ -1024,7 +1024,7 @@ fn test_checkpoint_init_daemon_unavailable() {
             "checkpoint",
             "init",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--socket",
             "/tmp/nonexistent-ws-ckpt.sock",
         ])
@@ -1046,7 +1046,7 @@ fn test_checkpoint_diff_daemon_unavailable() {
             "checkpoint",
             "diff",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--from",
             "snap-001",
             "--to",
@@ -1096,7 +1096,7 @@ fn test_checkpoint_restore_daemon_unavailable() {
             "restore",
             "snap-001",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--socket",
             "/tmp/nonexistent-ws-ckpt.sock",
         ])
@@ -1118,7 +1118,7 @@ fn test_checkpoint_recover_daemon_unavailable() {
             "checkpoint",
             "recover",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--socket",
             "/tmp/nonexistent-ws-ckpt.sock",
         ])
@@ -1140,7 +1140,7 @@ fn test_checkpoint_cleanup_daemon_unavailable() {
             "checkpoint",
             "cleanup",
             "--workspace",
-            "/tmp/test-ws",
+            "/tmp",
             "--socket",
             "/tmp/nonexistent-ws-ckpt.sock",
         ])
@@ -1788,4 +1788,112 @@ fn test_audit_policy_explain_newline_compound_returns_deny_with_matched_rule() {
     let data = &json["data"];
     assert_eq!(data["decision"]["outcome"], "Deny");
     assert_eq!(data["decision"]["matched_rule"], "shell-deny-git-mutating");
+}
+
+// --- Issue #1568: workspace path pre-validation ---
+
+#[test]
+fn test_checkpoint_diff_nonexistent_workspace_returns_not_found() {
+    let output = cosh_bin()
+        .args([
+            "checkpoint",
+            "diff",
+            "--workspace",
+            "/tmp/absolutely-nonexistent-workspace-xyz123",
+            "--from",
+            "snap-001",
+            "--to",
+            "snap-002",
+            "--socket",
+            "/tmp/nonexistent-ws-ckpt.sock",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "CheckpointNotFound");
+    assert_eq!(json["error"]["recoverable"], false);
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("does not exist"),
+        "error message should mention workspace does not exist"
+    );
+}
+
+#[test]
+fn test_checkpoint_init_nonexistent_workspace_returns_not_found() {
+    let output = cosh_bin()
+        .args([
+            "checkpoint",
+            "init",
+            "--workspace",
+            "/tmp/absolutely-nonexistent-workspace-xyz123",
+            "--socket",
+            "/tmp/nonexistent-ws-ckpt.sock",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "CheckpointNotFound");
+    assert_eq!(json["error"]["recoverable"], false);
+}
+
+#[test]
+fn test_checkpoint_restore_nonexistent_workspace_returns_not_found() {
+    let output = cosh_bin()
+        .args([
+            "checkpoint",
+            "restore",
+            "snap-001",
+            "--workspace",
+            "/tmp/absolutely-nonexistent-workspace-xyz123",
+            "--socket",
+            "/tmp/nonexistent-ws-ckpt.sock",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "CheckpointNotFound");
+    assert_eq!(json["error"]["recoverable"], false);
+}
+
+#[test]
+fn test_checkpoint_create_nonexistent_workspace_returns_not_found() {
+    let output = cosh_bin()
+        .args([
+            "checkpoint",
+            "create",
+            "--workspace",
+            "/tmp/absolutely-nonexistent-workspace-xyz123",
+            "--id",
+            "snap-001",
+            "--socket",
+            "/tmp/nonexistent-ws-ckpt.sock",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "CheckpointNotFound");
+    assert_eq!(json["error"]["recoverable"], false);
 }


### PR DESCRIPTION
## Description

cosh-cli checkpoint diff --workspace no-such-ws --from aaa --to bbb returned CheckpointDaemonUnavailable when the workspace path did not exist,
even though the real problem was a non-existent workspace. This misled users/agents into troubleshooting the daemon (systemctl status ws-ckpt)
instead of correcting the workspace path (issue #1568).

Fix: Added workspace path pre-validation in the CLI layer for all checkpoint commands that take a required --workspace argument (init, recover,
create, restore, diff, cleanup). Before connecting to the ws-ckpt daemon, the CLI now checks if the workspace path exists on the local
filesystem. If not, it returns CheckpointNotFound with recoverable: false and a hint to check the path or run init first.

Before:

  cosh-cli checkpoint diff --workspace no-such-ws --from aaa --to bbb
{"ok":false,"error":{"code":"CheckpointDaemonUnavailable","message":"I/O error while read response length...","recoverable":true,...}}

After:

  cosh-cli checkpoint diff --workspace no-such-ws --from aaa --to bbb
{"ok":false,"error":{"code":"CheckpointNotFound","message":"workspace 'no-such-ws' does not exist on local
filesystem","recoverable":false,"hint":"check workspace path or run 'cosh-cli checkpoint init --workspace <path>' first",...}}

Commands with optional --workspace (list, status, delete) are not affected — they continue to connect to the daemon directly.

## Related Issue

closes #1568

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] cosh (copilot-shell)
- [x] cosh-ng (cosh-ng)
- [ ] sec-core (agent-sec-core)
- [ ] skill (os-skills)
- [ ] sight (agentsight)
- [ ] tokenless (tokenless)
- [ ] ckpt (ws-ckpt)
- [ ] memory (agent-memory)
- [ ] anolisa (anolisa-cli)
- [ ] skillfs (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the ../CONTRIBUTING.md
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For cosh: Lint passes, type check passes, and tests pass
- [x] For cosh-ng: cargo clippy --all-targets -- -D warnings and cargo fmt --check pass
- [ ] For sec-core (Rust): cargo clippy -- -D warnings and cargo fmt --check pass
- [ ] For sec-core (Python): Ruff format and pytest pass
- [ ] For skill: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For sight: cargo clippy -- -D warnings and cargo fmt --check pass
- [ ] For tokenless: cargo clippy -- -D warnings and cargo fmt --check pass
- [ ] For memory (Linux only): cargo clippy --all-targets -- -D warnings, cargo fmt --check, and cargo test pass
- [ ] For anolisa: cargo clippy --all-targets --locked -- -D warnings, cargo fmt --all --check, and cargo test --locked pass
- [ ] For skillfs: cargo fmt --all --check, cargo clippy --workspace --all-targets -- -D warnings, and cargo test --workspace pass
- [x] Lock files are up to date (package-lock.json / Cargo.lock)

## Testing

    cargo fmt --all -- --check
cargo clippy --workspace --all-targets  # 0 warnings
cargo test --package cosh-cli --test cli_integration checkpoint  # 14/14 passed

Regression tests added:

- test_checkpoint_diff_nonexistent_workspace_returns_not_found
- test_checkpoint_init_nonexistent_workspace_returns_not_found
- test_checkpoint_restore_nonexistent_workspace_returns_not_found
- test_checkpoint_create_nonexistent_workspace_returns_not_found

Existing daemon_unavailable tests updated to use /tmp (exists) so they continue testing the daemon connection path.

## Additional Notes
Changes scoped to crates/cosh-cli/src/cmd/checkpoint.rs (validation logic) and crates/cosh-cli/tests/cli_integration.rs (tests). No i18n changes
needed.