### PR TITLE
fix(cosh-ng): cosh-shell --help 输出到 stderr 而非 stdout，违反 POSIX 约定

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle.rs
@@ -154,7 +154,7 @@ fn parse_args(args: &[String]) -> Result<ExportOptions, String> {
 }
 
 fn print_help() {
-    eprintln!("Usage: cosh-shell diagnostics export [--output PATH] [--since-hours HOURS]");
+    println!("Usage: cosh-shell diagnostics export [--output PATH] [--since-hours HOURS]");
 }
 
 fn default_output_path() -> PathBuf {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -346,7 +346,7 @@ fn passthrough_shell_args(args: &[String]) -> Vec<String> {
 }
 
 pub(crate) fn print_usage_help() {
-    eprintln!(
+    println!(
         "Usage: cosh-shell [OPTIONS]\n\
          \n\
          AI-augmented interactive shell wrapper.\n\

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
@@ -2,6 +2,94 @@ use super::*;
 use ratatui::text::Span;
 
 #[test]
+fn help_flag_writes_to_stdout_not_stderr() {
+    // POSIX/GNU convention: --help output goes to stdout, not stderr.
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = Command::new(binary)
+        .arg("--help")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn cosh-shell --help");
+
+    assert!(output.status.success(), "--help should exit 0");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stdout.contains("Usage: cosh-shell"),
+        "--help text should be on stdout, got stdout={:?}",
+        stdout
+    );
+    assert!(
+        stderr.is_empty(),
+        "--help should not write to stderr, got stderr={:?}",
+        stderr
+    );
+}
+
+#[test]
+fn version_flag_writes_to_stdout_not_stderr() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = Command::new(binary)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn cosh-shell --version");
+
+    assert!(output.status.success(), "--version should exit 0");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stdout.contains("cosh-shell"),
+        "--version text should be on stdout, got stdout={:?}",
+        stdout
+    );
+    assert!(
+        stderr.is_empty(),
+        "--version should not write to stderr, got stderr={:?}",
+        stderr
+    );
+}
+
+#[test]
+fn diagnostics_export_help_writes_to_stdout_not_stderr() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = Command::new(binary)
+        .args(["diagnostics", "export", "--help"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn cosh-shell diagnostics export --help");
+
+    assert!(
+        output.status.success(),
+        "diagnostics export --help should exit 0"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stdout.contains("Usage:"),
+        "diagnostics export --help should write to stdout, got stdout={:?}",
+        stdout
+    );
+    assert!(
+        stderr.is_empty(),
+        "diagnostics export --help should not write to stderr, got stderr={:?}",
+        stderr
+    );
+}
+
+#[test]
 fn raw_cli_startup_banner_renders_when_enabled() {
     let output = run_raw_cli_with_env(
         "fake",


### PR DESCRIPTION
## Description

  `cosh-shell --help` was writing help text to stderr instead of stdout, violating POSIX/GNU convention. Scripts could not pipe help output (e.g.
  `cosh-shell --help | grep Modes`) and `2>/dev/null` would swallow the help text entirely.

  **Root cause**: Both `print_usage_help()` in `runtime/startup.rs` and `print_help()` in `diagnostics/bundle.rs` used `eprintln!` instead of
  `println!`.

  **Changes**:
  - `runtime/startup.rs`: `print_usage_help()` now uses `println!`
  - `diagnostics/bundle.rs`: `print_help()` now uses `println!`
  - Added regression tests: `help_flag_writes_to_stdout_not_stderr`, `version_flag_writes_to_stdout_not_stderr`

  ## Related Issue

  closes #1566

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional change)
  - [ ] Performance improvement
  - [ ] CI/CD or build changes

  ## Scope

  - [ ] `cosh` (copilot-shell)
  - [x] `cosh-ng` (cosh-ng)
  - [ ] `sec-core` (agent-sec-core)
  - [ ] `skill` (os-skills)
  - [ ] `sight` (agentsight)
  - [ ] `tokenless` (tokenless)
  - [ ] `ckpt` (ws-ckpt)
  - [ ] `memory` (agent-memory)
  - [ ] `anolisa` (anolisa-cli)
  - [ ] `skillfs` (SkillFS)
  - [ ] `blaze` (blaze)
  - [ ] Multiple / Project-wide

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [x] My code follows the project's code style
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have updated the documentation accordingly
  - [ ] For `cosh`: Lint passes, type check passes, and tests pass
  - [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
  - [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
  - [ ] For `sec-core` (Python): Ruff format and pytest pass
  - [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
  - [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
  - [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
  - [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
  - [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
  - [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
  - [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

  ## Testing

  ```bash
  # Format
  cargo fmt --all -- --check    # clean

  # Lint
  cargo clippy --workspace --all-targets    # 0 warnings

  # Unit tests (bundle)
  cargo test -p cosh-shell --lib diagnostics::bundle    # 8/8 passed

  # Integration tests (startup, includes new regression tests)
  cargo test -p cosh-shell --test raw_cli startup -- --test-threads=4    # 33/33 passed

  New regression tests:
  - help_flag_writes_to_stdout_not_stderr — asserts --help text is on stdout and stderr is empty
  - version_flag_writes_to_stdout_not_stderr — asserts --version text is on stdout and stderr is empty
  ```

  ## Additional Notes

  --version was already using println! (correct), the second test was added as a belt-and-suspenders guard to prevent future regression.
