### PR TITLE
refactor(sight): skip duplicate SSE message parsing for openai/anthropic

### DIFF
--- a/src/agentsight/src/analyzer/message/mod.rs
+++ b/src/agentsight/src/analyzer/message/mod.rs
@@ -438,4 +438,123 @@ mod tests {
             "https://api.anthropic.com/v1/messages"
         ));
     }
+
+    // -- parse_by_path_sysom_only / parse_by_path_with_sse scoping tests --
+    //
+    // These cover the branch-A/branch-B dedup fix: SSE responses for
+    // OpenAI/Anthropic must no longer be deep-parsed here (that semantic
+    // reconstruction now lives solely in genai::extract_parts_from_sse_body
+    // against the raw HttpRecord), while SysOM must still be deep-parsed
+    // because its llmParamString/tool_use envelope has no HttpRecord fallback.
+
+    #[test]
+    fn test_parse_by_path_sysom_only_rejects_openai_and_anthropic() {
+        let parser = MessageParser::new();
+        let openai_request = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let anthropic_request = serde_json::json!({
+            "model": "claude-3-opus-20240229",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        assert!(
+            parser
+                .parse_by_path_sysom_only("/v1/chat/completions", Some(&openai_request), None)
+                .is_none()
+        );
+        assert!(
+            parser
+                .parse_by_path_sysom_only("/v1/messages", Some(&anthropic_request), None)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_by_path_sysom_only_accepts_sysom() {
+        let parser = MessageParser::new();
+        let params = serde_json::json!({
+            "model": "qwen3-coder-plus",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let request = serde_json::json!({"llmParamString": params.to_string()});
+
+        let result = parser.parse_by_path_sysom_only(
+            "/api/v1/copilot/generate_copilot",
+            Some(&request),
+            None,
+        );
+        match result {
+            Some(ParsedApiMessage::SysomMessage {
+                request: Some(req), ..
+            }) => {
+                assert_eq!(req.params.model, "qwen3-coder-plus");
+            }
+            other => panic!("expected SysomMessage with request, got {other:?}"),
+        }
+    }
+
+    /// Build a `ParsedSseEvent` carrying the given raw SSE `data:` payload (no
+    /// framing needed — `parse_by_path_with_sse` reads the event body as JSON).
+    fn make_sse_event(data: &str) -> ParsedSseEvent {
+        use crate::probes::sslsniff::SslEvent;
+        use std::rc::Rc;
+
+        let ssl_event = Rc::new(SslEvent {
+            source: 0,
+            timestamp_ns: 0,
+            delta_ns: 0,
+            pid: 1,
+            tid: 1,
+            uid: 0,
+            len: data.len() as u32,
+            rw: 0,
+            comm: String::new(),
+            buf: data.as_bytes().to_vec(),
+            is_handshake: false,
+            ssl_ptr: 0,
+        });
+        ParsedSseEvent::new(None, None, None, 0, data.len(), ssl_event)
+    }
+
+    #[test]
+    fn test_parse_by_path_with_sse_skips_openai() {
+        let parser = MessageParser::new();
+        let chunk = serde_json::json!({
+            "id": "chatcmpl-123",
+            "model": "gpt-4o",
+            "choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}]
+        });
+        let events = vec![make_sse_event(&chunk.to_string())];
+
+        // Previously this returned Some(OpenAICompletion { .. }); now branch A
+        // leaves OpenAI/Anthropic SSE responses unparsed since the genai
+        // builder's SSE fallback already reconstructs the same semantics from
+        // the raw HttpRecord.
+        let result = parser.parse_by_path_with_sse("/v1/chat/completions", None, &events);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_by_path_with_sse_still_parses_sysom() {
+        let parser = MessageParser::new();
+        let chunk = serde_json::json!({
+            "choices": [{"message": {"content": "hi", "tool_use": null}}]
+        });
+        let events = vec![make_sse_event(&chunk.to_string())];
+
+        let result =
+            parser.parse_by_path_with_sse("/api/v1/copilot/generate_copilot", None, &events);
+        match result {
+            Some(ParsedApiMessage::SysomMessage {
+                response: Some(resp),
+                ..
+            }) => {
+                assert_eq!(resp.choices[0].message.content, "hi");
+            }
+            other => panic!("expected SysomMessage with response, got {other:?}"),
+        }
+    }
 }

--- a/src/agentsight/src/analyzer/message/mod.rs
+++ b/src/agentsight/src/analyzer/message/mod.rs
@@ -115,16 +115,39 @@ impl MessageParser {
         }
 
         // Try Aliyun SysOM (AK/SK auth mode)
-        if SysomParser::matches_path(path) {
-            let request = request_body.and_then(SysomParser::parse_request);
-            let response = response_body.and_then(SysomParser::parse_response);
-
-            if request.is_some() || response.is_some() {
-                return Some(ParsedApiMessage::SysomMessage { request, response });
-            }
+        if let Some(parsed) = self.parse_by_path_sysom_only(path, request_body, response_body) {
+            return Some(parsed);
         }
 
         log::warn!("Path '{path}' does not match any known LLM API endpoint");
+        None
+    }
+
+    /// Parse request/response bodies against the SysOM parser only.
+    ///
+    /// SysOM's Copilot API is deliberately kept as the *only* deep-parsing
+    /// target for SSE-shaped responses: its body is a non-standard envelope
+    /// (`llmParamString`-encoded request, cumulative SSE chunks, `tool_use`
+    /// array) that the generic HttpRecord/genai-builder SSE fallback cannot
+    /// reconstruct. OpenAI/Anthropic SSE responses are intentionally left
+    /// unparsed here because `genai::builder::extract_parts_from_sse_body`
+    /// already rebuilds their semantic content from the raw HttpRecord —
+    /// parsing them again here would just duplicate that work.
+    pub fn parse_by_path_sysom_only(
+        &self,
+        path: &str,
+        request_body: Option<&serde_json::Value>,
+        response_body: Option<&serde_json::Value>,
+    ) -> Option<ParsedApiMessage> {
+        if !SysomParser::matches_path(path) {
+            return None;
+        }
+        let request = request_body.and_then(SysomParser::parse_request);
+        let response = response_body.and_then(SysomParser::parse_response);
+
+        if request.is_some() || response.is_some() {
+            return Some(ParsedApiMessage::SysomMessage { request, response });
+        }
         None
     }
 
@@ -133,6 +156,11 @@ impl MessageParser {
     /// This method handles streaming responses where the response is delivered
     /// via Server-Sent Events (SSE) instead of a single JSON body.
     /// SSE events are converted to a JSON array and passed to parse_response.
+    ///
+    /// Only the SysOM path is deep-parsed here (see
+    /// [`Self::parse_by_path_sysom_only`] for why) — OpenAI/Anthropic SSE
+    /// responses rely on the HttpRecord-based genai-builder fallback instead,
+    /// avoiding duplicate provider/model/message extraction.
     ///
     /// # Arguments
     /// * `path` - The HTTP request path (e.g., "/v1/chat/completions")
@@ -163,8 +191,7 @@ impl MessageParser {
             Some(serde_json::Value::Array(chunks))
         };
 
-        // Use parse_by_path with the converted response body
-        self.parse_by_path(path, request_body, response_body.as_ref())
+        self.parse_by_path_sysom_only(path, request_body, response_body.as_ref())
     }
 
     /// Detect provider from path without parsing

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -1451,6 +1451,159 @@ mod tests {
         }
     }
 
+    /// Build a minimal `Http2Stream` with an SSE-formatted response body
+    /// (`data: {...}\n\n`) so `response_sse_json_array()` detects it as SSE.
+    fn build_sse_http2_stream(
+        path: &str,
+        request_body: &[u8],
+        sse_chunk: &serde_json::Value,
+    ) -> crate::aggregator::Http2Stream {
+        use crate::aggregator::{ConnectionId, Http2Stream, StreamId};
+        use crate::parser::{Http2FrameType, ParsedHttp2Frame};
+        use crate::probes::sslsniff::SslEvent;
+        use std::rc::Rc;
+
+        let response_body = format!("data: {}\n\ndata: [DONE]\n\n", sse_chunk);
+        let body_bytes = response_body.into_bytes();
+
+        let ssl_event = Rc::new(SslEvent {
+            source: 0,
+            timestamp_ns: 1_000_000_000,
+            delta_ns: 0,
+            pid: 3000,
+            tid: 3000,
+            uid: 0,
+            len: body_bytes.len() as u32,
+            rw: 0,
+            comm: "python3".to_string(),
+            buf: body_bytes.clone(),
+            is_handshake: false,
+            ssl_ptr: 0x6000,
+        });
+
+        let req_event = Rc::new(SslEvent {
+            source: 0,
+            timestamp_ns: 900_000_000,
+            delta_ns: 0,
+            pid: 3000,
+            tid: 3000,
+            uid: 0,
+            len: request_body.len() as u32,
+            rw: 1,
+            comm: "python3".to_string(),
+            buf: request_body.to_vec(),
+            is_handshake: false,
+            ssl_ptr: 0x6000,
+        });
+
+        let mut stream = Http2Stream::new(
+            StreamId {
+                connection_id: ConnectionId {
+                    pid: 3000,
+                    ssl_ptr: 0x6000,
+                },
+                stream_id: 1,
+            },
+            900_000_000,
+        );
+        stream.request_headers = Some(ParsedHttp2Frame {
+            frame_type: Http2FrameType::Headers,
+            flags: 0x4,
+            stream_id: 1,
+            payload_offset: 0,
+            payload_len: 0,
+            source_event: Rc::clone(&req_event),
+        });
+        stream.decoded_request_headers = Some(vec![
+            (":method".to_string(), "POST".to_string()),
+            (":path".to_string(), path.to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]);
+        stream.request_data_frames.push(ParsedHttp2Frame {
+            frame_type: Http2FrameType::Data,
+            flags: 0x1,
+            stream_id: 1,
+            payload_offset: 0,
+            payload_len: request_body.len(),
+            source_event: req_event,
+        });
+        stream.response_headers = Some(ParsedHttp2Frame {
+            frame_type: Http2FrameType::Headers,
+            flags: 0x4,
+            stream_id: 1,
+            payload_offset: 0,
+            payload_len: 0,
+            source_event: Rc::clone(&ssl_event),
+        });
+        stream.decoded_response_headers = Some(vec![
+            (":status".to_string(), "200".to_string()),
+            ("content-type".to_string(), "text/event-stream".to_string()),
+        ]);
+        stream.response_data_frames.push(ParsedHttp2Frame {
+            frame_type: Http2FrameType::Data,
+            flags: 0x1,
+            stream_id: 1,
+            payload_offset: 0,
+            payload_len: body_bytes.len(),
+            source_event: ssl_event,
+        });
+        stream.request_complete = true;
+        stream.response_complete = true;
+        stream.end_timestamp_ns = 1_100_000_000;
+        stream
+    }
+
+    #[test]
+    fn test_extract_message_from_http_skips_openai_sse() {
+        // SSE-shaped OpenAI response: branch A must NOT produce a
+        // ParsedApiMessage here anymore — provider/model/message semantics
+        // for this path are reconstructed solely from the raw HttpRecord by
+        // genai::GenAIBuilder's SSE fallback, so parsing it again in the
+        // analyzer would just duplicate that work.
+        let analyzer = Analyzer::new();
+        let request_body = br#"{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}"#;
+        let chunk = serde_json::json!({
+            "id": "chatcmpl-h2-sse",
+            "model": "gpt-4o",
+            "choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}]
+        });
+        let stream = build_sse_http2_stream("/v1/chat/completions", request_body, &chunk);
+
+        let agg = AggregatedResult::Http2StreamComplete(stream);
+        let result = analyzer.extract_message_from_http(&agg);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_message_from_http_still_parses_sysom_sse() {
+        // SysOM's llmParamString/tool_use envelope has no HttpRecord-based
+        // fallback, so branch A must keep deep-parsing it even over SSE.
+        let analyzer = Analyzer::new();
+        let params = serde_json::json!({
+            "model": "qwen3-coder-plus",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let request_body_val = serde_json::json!({"llmParamString": params.to_string()});
+        let request_body = request_body_val.to_string().into_bytes();
+        let chunk = serde_json::json!({
+            "choices": [{"message": {"content": "hi", "tool_use": null}}]
+        });
+        let stream =
+            build_sse_http2_stream("/api/v1/copilot/generate_copilot", &request_body, &chunk);
+
+        let agg = AggregatedResult::Http2StreamComplete(stream);
+        let result = analyzer.extract_message_from_http(&agg);
+        match result {
+            Some(AnalysisResult::Message(ParsedApiMessage::SysomMessage {
+                response: Some(resp),
+                ..
+            })) => {
+                assert_eq!(resp.choices[0].message.content, "hi");
+            }
+            other => panic!("expected SysomMessage with response, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_extract_token_from_json_body_zero_tokens() {
         let analyzer = Analyzer::new();

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -572,9 +572,17 @@ impl Analyzer {
                     return None;
                 }
                 let req_body = stream.request_json_body();
-                let resp_body = stream
-                    .response_sse_json_array()
-                    .or_else(|| stream.response_json_body());
+                if let Some(sse_json) = stream.response_sse_json_array() {
+                    // SSE-shaped response: OpenAI/Anthropic semantics are already
+                    // reconstructed by the genai builder's SSE fallback from the raw
+                    // HttpRecord, so only SysOM (non-standard llmParamString / tool_use
+                    // envelope) still needs the typed parser here.
+                    return self
+                        .message
+                        .parse_by_path_sysom_only(&path, req_body.as_ref(), Some(&sse_json))
+                        .map(AnalysisResult::Message);
+                }
+                let resp_body = stream.response_json_body();
                 self.analyze_message(&path, req_body.as_ref(), resp_body.as_ref())
             }
             AggregatedResult::ResponseOnly { .. }


### PR DESCRIPTION
## Description

`analyzer::unified::Analyzer::extract_message_from_http` (branch A) previously deep-parsed every SSE-shaped response via the typed OpenAI/Anthropic/SysOM parsers regardless of path. For openai/anthropic, this duplicated work already done independently by `extract_http_record` (branch B) + `genai::GenAIBuilder`, which reconstructs provider/model/messages/finish_reason/tool_calls directly from the raw `HttpRecord` (`extract_provider_from_path`, `extract_model_from_body`, `extract_parts_from_sse_body`). Only SysOM's Copilot API (non-standard `llmParamString` envelope, cumulative SSE chunks, `tool_use` array) cannot be reconstructed by branch B, so it stays the sole SSE deep-parse target now.

Key implementation decision: restrict the *SSE-path* parsing (`parse_by_path_with_sse`, and the `Http2StreamComplete` SSE branch in `extract_message_from_http`) to SysOM only via a new `MessageParser::parse_by_path_sysom_only`. Non-SSE (`stream:false`) responses keep using the full `parse_by_path`, since branch B currently has no fallback for non-streaming JSON response bodies — restricting that path too would silently drop `response.messages`/`finish_reason`/`tool_calls` for non-streaming openai/anthropic calls.

## Related Issue

closes #1677

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib analyzer::` (157 passed, includes `analyzer::message` and `analyzer::unified` suites)

Verified no existing test asserts SSE openai/anthropic paths still return `AnalysisResult::Message` (the only consumers of `parse_by_path_with_sse` / the SSE branch of `Http2StreamComplete`), so no test needed updating; genai builder's SSE fallback (`extract_parts_from_sse_body`) already covers the semantic reconstruction for those paths.

## Additional Notes

Investigated via code review that `build_request` in `genai::call_builder` already falls back to `parse_request_body` from the raw `HttpRecord.request_body` when `parsed_message` is `None`, so request-side semantics are unaffected. Response-side non-SSE fallback is a known gap left for a follow-up if needed.

## Update

Added dedicated unit tests covering the new scoping behavior:
- `analyzer::message::tests::test_parse_by_path_sysom_only_rejects_openai_and_anthropic`
- `analyzer::message::tests::test_parse_by_path_sysom_only_accepts_sysom`
- `analyzer::message::tests::test_parse_by_path_with_sse_skips_openai`
- `analyzer::message::tests::test_parse_by_path_with_sse_still_parses_sysom`
- `analyzer::unified::tests::test_extract_message_from_http_skips_openai_sse`
- `analyzer::unified::tests::test_extract_message_from_http_still_parses_sysom_sse`

All pass together with the full `analyzer::` suite (163 tests), plus `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`.
