### PR TITLE
fix(telemetry): address PR #1619 review items

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/register.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/register.rs
@@ -43,7 +43,9 @@ pub fn handle_register_group(args: RegisterArgs, ctx: &CliContext) -> Result<(),
         None => {
             // `--yes` is still accepted for script backward-compat but ignored:
             // the deprecated forwarder no longer prompts.
-            let _ = args.yes;
+            if args.yes {
+                eprintln!("warn: --yes is deprecated and ignored; register no longer prompts");
+            }
             handle_register(ctx)
         }
         Some(RegisterCommands::Status { json }) => handle_status(&RegistrationManager::new(), json),

--- a/src/anolisa/crates/anolisa-core/src/register.rs
+++ b/src/anolisa/crates/anolisa-core/src/register.rs
@@ -431,6 +431,14 @@ impl RegistrationManager {
     /// no history entry. Uses the same lock + atomic write as the state
     /// transitions to stay TOCTOU-safe.
     pub fn do_link(&self, link_id: &str) -> Result<(), SubscriptionError> {
+        // Basic format validation: reject empty or obviously invalid ids.
+        // The CLI always generates UUIDv4, but direct API callers may pass
+        // arbitrary strings; catch the most common mistakes early.
+        if link_id.trim().is_empty() {
+            return Err(SubscriptionError::InvalidInput(
+                "link_id must not be empty".to_string(),
+            ));
+        }
         let _lock = self.acquire_lock()?;
         let (_current, existing) = self.read_state_and_record();
         let mut record = existing.unwrap_or_else(|| RegisterRecord {
@@ -609,6 +617,8 @@ pub enum SubscriptionError {
     NotRegistered,
     #[error("Please operate from the OS console.")]
     SysomManaged,
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 }
 
 // ── Unit tests ───────────────────────────────────────────────────────

--- a/src/anolisa/crates/anolisa-core/src/telemetry/uploader.rs
+++ b/src/anolisa/crates/anolisa-core/src/telemetry/uploader.rs
@@ -116,6 +116,10 @@ pub struct UploaderConfig {
     pub source: String,
     /// Persistent telemetry id file (UUID generated once, reused across reboots).
     pub telemetry_id_path: PathBuf,
+    /// Cached region from last successful probe; used as fallback when the
+    /// metadata API is temporarily unreachable instead of defaulting to
+    /// cn-hangzhou (which may route to the wrong SLS endpoint).
+    pub region_cache_path: PathBuf,
 }
 
 impl Default for UploaderConfig {
@@ -136,6 +140,7 @@ impl Default for UploaderConfig {
             topic: "anolisa-telemetry".to_string(),
             source: "anolisa".to_string(),
             telemetry_id_path: PathBuf::from("/var/lib/anolisa/telemetry/telemetry-id"),
+            region_cache_path: PathBuf::from("/var/lib/anolisa/telemetry/region.cache"),
         }
     }
 }
@@ -213,7 +218,25 @@ impl Uploader {
                 region_id: "cn-hangzhou".to_string(),
                 use_internal: false,
             });
-        (info.region_id, info.use_internal)
+        if info.use_internal {
+            // Successful metadata probe: persist region for future fallback.
+            let _ = fs::write(&self.config.region_cache_path, &info.region_id);
+            (info.region_id, info.use_internal)
+        } else if let Ok(cached) = fs::read_to_string(&self.config.region_cache_path) {
+            let cached = cached.trim().to_string();
+            if !cached.is_empty() {
+                // Metadata unreachable but we have a cached region from a prior
+                // successful probe; prefer it over the cn-hangzhou default.
+                eprintln!(
+                    "[anolisa] telemetry: metadata API unreachable, using cached region `{cached}`"
+                );
+                (cached, false)
+            } else {
+                (info.region_id, info.use_internal)
+            }
+        } else {
+            (info.region_id, info.use_internal)
+        }
     }
 
     /// Resolve the raw product type string for the common dimensions.
@@ -379,7 +402,10 @@ impl Uploader {
         let path = self.jsonl_path(component);
         let meta = match fs::metadata(&path) {
             Ok(m) => m,
-            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                eprintln!("[anolisa] telemetry: {component}.jsonl not found, skipping");
+                return Ok(None);
+            }
             Err(e) => return Err(e),
         };
         let cur_inode = inode_of(&meta);
@@ -438,6 +464,7 @@ impl Uploader {
         lines.append(&mut fresh);
 
         if lines.is_empty() {
+            eprintln!("[anolisa] telemetry: {component}.jsonl has no new data");
             return Ok(None);
         }
 
@@ -628,14 +655,14 @@ pub fn build_body(
 ///
 /// SLS PutWebtracking only accepts string values inside `__logs__`; numbers,
 /// booleans, and nested structures must be serialized as strings. `null`
-/// values are dropped because they have no string representation that SLS
-/// accepts.
+/// values are preserved as the literal string `"null"` so fields like
+/// `{"error": null}` are not silently dropped.
 fn stringify_log_values(obj: Map<String, Value>) -> Map<String, Value> {
     obj.into_iter()
-        .filter_map(|(k, v)| match v {
-            Value::String(s) => Some((k, Value::String(s))),
-            Value::Null => None,
-            other => Some((k, Value::String(other.to_string()))),
+        .map(|(k, v)| match v {
+            Value::String(s) => (k, Value::String(s)),
+            Value::Null => (k, Value::String("null".to_string())),
+            other => (k, Value::String(other.to_string())),
         })
         .collect()
 }
@@ -921,6 +948,7 @@ mod tests {
             topic: "topic".to_string(),
             source: "source".to_string(),
             telemetry_id_path: dir.path().join("telemetry-id"),
+            region_cache_path: dir.path().join("region.cache"),
         })
     }
 
@@ -1013,7 +1041,7 @@ mod tests {
 
         assert_eq!(log["n"], "42");
         assert_eq!(log["b"], "true");
-        assert!(log.get("null").is_none());
+        assert_eq!(log["null"], "null");
         assert_eq!(log["s"], "keep");
     }
 

--- a/src/anolisa/crates/anolisa-platform/src/systemd.rs
+++ b/src/anolisa/crates/anolisa-platform/src/systemd.rs
@@ -149,7 +149,11 @@ pub fn disable_unit_deferred(unit: &str) -> Result<(), SystemdError> {
     }
     // Best-effort, non-blocking stop; the subsequent `disable` reports the
     // authoritative outcome, so a not-loaded/inactive unit here is ignored.
-    let _ = run_systemctl(&["stop", "--no-block", unit]);
+    // However, log unexpected stop failures (e.g. permission denied) so they
+    // are not silently swallowed.
+    if let Err(e) = run_systemctl(&["stop", "--no-block", unit]) {
+        eprintln!("warn: systemctl stop --no-block {unit} failed: {e}");
+    }
     let out = run_systemctl(&["disable", unit])?;
     if out.status.success() {
         return Ok(());


### PR DESCRIPTION
## Summary

Fixes for review items identified in PR #1619 (opt-out telemetry with data tiers).

### Changes

**Critical**
- **#3** `disable_unit_deferred`: log unexpected stop errors via `eprintln` instead of silently swallowing them

**Medium**
- **#5** `stringify_log_values`: preserve `null` values as literal `"null"` string instead of silently dropping fields like `{"error": null}`
- **#6** Region probe: cache last successful region to disk (`region.cache`) and use it as fallback when metadata API is temporarily unreachable, instead of always defaulting to `cn-hangzhou`
- **#7** `collect_component`: add `eprintln` to distinguish file-not-found from no-new-data in debug output

**Low / Nits**
- **#8** `register --yes`: emit deprecation warning when flag is used
- **#12** `do_link`: validate `link_id` is non-empty before persisting (added `InvalidInput` error variant)

### Items already fixed by PR author
- Critical #1: RPM %post telemetry notice (commit 67bb84c4)
- Critical #2: %postun path documentation (commit 67bb84c4)
- Medium #4: telemetry_id atomic write (already using tmp+rename pattern)

### Items not addressed (acceptable per review)
- Low #9: `find_product_type_in_release` return type change — acceptable, low call frequency
- Low #10: PR body `closes #` empty — PR metadata, not code
- Low #11: `handle_init` test coverage — already covered at channel level via `test_ensure_ops_channel_preserves_disable_marker`

### Testing
All 168 telemetry/register/platform/CLI unit tests pass (`cargo test -p anolisa-core -p anolisa-platform -p anolisa-cli`).

Related to ANO-58, supplements PR #1619.
