### PR TITLE
fix(tokenless): add integration tests for updatedToolOutput replacement semantics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -770,6 +770,11 @@ jobs:
           cd src/tokenless
           cargo test --workspace -- --test-threads=1
 
+      - name: Run hook integration tests (Python)
+        run: |
+          cd src/tokenless
+          python3 tests/test_compress_response_hook.py
+
   # =========================================================================
   # Step 7: Test ws-ckpt
   # =========================================================================

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -176,7 +176,7 @@ uninstall:
 	rm -rf $(DESTDIR)$(COSH_EXTENSION_DIR)
 
 # Run tests
-test: test-tokenless test-hooks
+test: test-tokenless test-hooks test-integration
 
 test-tokenless:
 	@echo "==> Testing tokenless..."
@@ -185,6 +185,10 @@ test-tokenless:
 test-hooks:
 	@echo "==> Testing copilot-shell hooks..."
 	bash tests/run-all-tests.sh
+
+test-integration:
+	@echo "==> Testing hook integration (Python)..."
+	python3 tests/test_compress_response_hook.py
 
 # Lint (rtk excluded — vendored third-party source)
 lint:

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -57,8 +57,9 @@ def _create_mock_tokenless(tmpdir: str, behavior: str = "compress") -> str:
             #!/usr/bin/env python3
             import json, sys
             if sys.argv[1] == "compress-response":
-                data = sys.stdin.read()
-                print(data + '"extra_padding":"xxxxxxxxxxxxxxxx"')
+                data = json.loads(sys.stdin.read())
+                data["extra_padding"] = "x" * 200
+                print(json.dumps(data))
             elif sys.argv[1] == "compress-toon":
                 sys.exit(1)
         """)
@@ -203,6 +204,13 @@ class TestReplacementProtocol(unittest.TestCase):
         self.assertNotIn(sentinel, additional,
                          "additionalContext must not contain compressed content")
 
+        updated = hso.get("updatedToolOutput", "")
+        self.assertTrue(updated,
+                        "updatedToolOutput should be present for Claude Code")
+        updated_str = json.dumps(updated) if isinstance(updated, (dict, list)) else str(updated)
+        self.assertNotIn(sentinel * 30, updated_str,
+                         "updatedToolOutput must not contain the full original sentinel")
+
 
 @unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
 class TestPassthrough(unittest.TestCase):
@@ -256,10 +264,11 @@ class TestSkipTools(unittest.TestCase):
             mock_tokenless_path=self.mock_bin,
         )
 
+        self.assertEqual(result, {},
+                         "Skip-tools (Read) should produce empty result (pass-through)")
         hso = result.get("hookSpecificOutput", {})
-        if hso:
-            self.assertNotIn("updatedToolOutput", hso,
-                             "Skip-tools should not replace tool output")
+        self.assertNotIn("updatedToolOutput", hso,
+                         "Skip-tools should not replace tool output")
 
 
 @unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -241,10 +241,17 @@ class TestReplacementProtocol(unittest.TestCase):
 
         # The mock compressor truncates strings > 20 chars, so stdout should
         # be truncated. Verify the compressed content is present and parseable.
-        try:
-            compressed_data = json.loads(replacement)
-        except (json.JSONDecodeError, TypeError):
-            self.fail(f"updatedToolOutput should be valid JSON, got: {replacement!r}")
+        # Note: updatedToolOutput may be a JSON string or already-parsed dict
+        # depending on how the hook encodes it.
+        if isinstance(replacement, str):
+            try:
+                compressed_data = json.loads(replacement)
+            except json.JSONDecodeError:
+                self.fail(f"updatedToolOutput should be valid JSON, got: {replacement!r}")
+        elif isinstance(replacement, (dict, list)):
+            compressed_data = replacement
+        else:
+            self.fail(f"updatedToolOutput unexpected type: {type(replacement)}")
 
         # Verify stdout field was compressed (truncated to 20 chars by mock)
         self.assertIn("stdout", compressed_data,

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -17,6 +17,7 @@ import os
 import stat
 import subprocess
 import sys
+import shutil
 import tempfile
 import textwrap
 import unittest
@@ -164,6 +165,10 @@ class TestReplacementProtocol(unittest.TestCase):
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
         self.mock_claude = _create_mock_claude(self.tmpdir)
 
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        shutil.rmtree(self.isolated_home, ignore_errors=True)
+
     def test_claude_code_uses_updated_tool_output(self):
         """Claude Code adapter should use updatedToolOutput, not additionalContext."""
         large_payload = _make_large_json_payload()
@@ -253,19 +258,23 @@ class TestReplacementProtocol(unittest.TestCase):
         else:
             self.fail(f"updatedToolOutput unexpected type: {type(replacement)}")
 
-        # Verify stdout field was compressed (truncated to 20 chars by mock)
+        # Verify stdout field was compressed to exactly 20 chars by mock
+        # (mock truncates strings > 20 to their first 20 chars).
         self.assertIn("stdout", compressed_data,
                        "Compressed output should preserve stdout key")
-        self.assertLessEqual(len(compressed_data["stdout"]), 20,
-                             "stdout should be compressed to <= 20 chars")
+        self.assertEqual(compressed_data["stdout"], "x" * 20,
+                         "stdout should be truncated to exactly 'x' * 20")
 
-        # Verify schema fields are preserved
-        self.assertIn("exit_code", compressed_data)
-        self.assertIn("interrupted", compressed_data)
+        # Verify schema fields are preserved with correct values
+        self.assertEqual(compressed_data["exit_code"], 0)
+        self.assertEqual(compressed_data["interrupted"], False)
 
     def test_no_duplicate_content(self):
         """The original sentinel must not appear alongside compressed output."""
         sentinel = "UNIQUE_SENTINEL_12345"
+        # Mock truncates strings > 20 chars; sentinel is 21 chars,
+        # so truncated form is first 20 chars.
+        truncated_sentinel = sentinel[:20]
         payload = {"stdout": sentinel * 30, "stderr": "", "exit_code": 0, "interrupted": False}
 
         result = _run_hook(
@@ -289,18 +298,26 @@ class TestReplacementProtocol(unittest.TestCase):
         self.assertNotIn(sentinel, additional,
                          "additionalContext must not contain compressed content")
 
-        # updatedToolOutput should exist and contain compressed (truncated) sentinel
+        # updatedToolOutput should exist and contain the truncated sentinel
         self.assertIn("updatedToolOutput", hso,
                        "Claude Code should use updatedToolOutput")
         updated = hso["updatedToolOutput"]
+        if isinstance(updated, str):
+            updated_data = json.loads(updated)
+        else:
+            updated_data = updated
+
+        # The mock truncates the sentinel (21 chars) to its first 20 chars.
+        # Assert the truncated form IS present (proves content wasn't lost).
+        self.assertIn("stdout", updated_data,
+                       "updatedToolOutput should contain stdout field")
+        self.assertEqual(updated_data["stdout"], truncated_sentinel,
+                         "stdout should be the truncated sentinel (first 20 chars)")
+
+        # Full sentinel must NOT appear (proves content wasn't duplicated)
         updated_str = json.dumps(updated) if isinstance(updated, (dict, list)) else str(updated)
         self.assertNotIn(sentinel * 30, updated_str,
                          "updatedToolOutput must not contain the full original sentinel")
-
-        # Verify sentinel appears at most once (truncated) in the replacement
-        sentinel_count = updated_str.count(sentinel)
-        self.assertLessEqual(sentinel_count, 1,
-                             f"Sentinel should appear at most once in replacement, found {sentinel_count}")
 
 
 @unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
@@ -312,6 +329,10 @@ class TestPassthrough(unittest.TestCase):
         self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "no-savings")
         self.mock_claude = _create_mock_claude(self.tmpdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        shutil.rmtree(self.isolated_home, ignore_errors=True)
 
     def test_skip_when_no_compression_savings(self):
         """When compression does not reduce size, output should be empty (skip)."""
@@ -344,6 +365,10 @@ class TestSkipTools(unittest.TestCase):
         self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
         self.mock_claude = _create_mock_claude(self.tmpdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        shutil.rmtree(self.isolated_home, ignore_errors=True)
 
     def test_skip_tools_no_replacement(self):
         """Skip-tools (Read) should not use updatedToolOutput."""
@@ -379,6 +404,10 @@ class TestNonReplacementAdapters(unittest.TestCase):
         self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
         self.mock_claude = _create_mock_claude(self.tmpdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        shutil.rmtree(self.isolated_home, ignore_errors=True)
 
     def test_qwencode_uses_additional_context(self):
         """Qwen Code should use additionalContext (legacy path)."""

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -94,8 +94,21 @@ def _create_mock_claude(tmpdir: str, version: str = "2.1.121") -> str:
     return mock_script
 
 
-def _run_hook(stdin_data: dict, agent_id: str, mock_tokenless_path: str) -> dict:
-    """Run the hook as a subprocess with mocked tokenless binary."""
+def _run_hook(stdin_data: dict, agent_id: str, mock_tokenless_path: str,
+              isolated_home: str = None) -> dict:
+    """Run the hook as a subprocess with mocked tokenless binary.
+
+    Args:
+        stdin_data: JSON payload to feed to the hook via stdin.
+        agent_id: The adapter agent ID (e.g. "claude-code").
+        mock_tokenless_path: Path to the mock tokenless binary.
+        isolated_home: Temporary HOME directory for the subprocess to avoid
+            touching the caller's ~/.tokenless state.
+
+    Returns:
+        Parsed JSON output dict from the hook, or a dict with ``_subprocess_error``
+        key when the hook exits non-zero.
+    """
     hooks_dir = os.path.normpath(os.path.join(
         os.path.dirname(__file__),
         os.pardir, "adapters", "tokenless", "common", "hooks",
@@ -105,6 +118,9 @@ def _run_hook(stdin_data: dict, agent_id: str, mock_tokenless_path: str) -> dict
     env = os.environ.copy()
     env["TOKENLESS_AGENT_ID"] = agent_id
     env["PATH"] = os.path.dirname(mock_tokenless_path) + ":" + env.get("PATH", "")
+    # Isolate HOME so hook doesn't read/write ~/.tokenless/.claude-version
+    if isolated_home:
+        env["HOME"] = isolated_home
 
     proc = subprocess.run(
         [sys.executable, hook_path],
@@ -114,6 +130,18 @@ def _run_hook(stdin_data: dict, agent_id: str, mock_tokenless_path: str) -> dict
         timeout=10,
         env=env,
     )
+
+    # Check returncode first — a non-zero exit indicates a real failure
+    # (import error, runtime crash, etc.) that should not be silently
+    # swallowed as an empty result.
+    if proc.returncode != 0:
+        return {
+            "_subprocess_error": True,
+            "_returncode": proc.returncode,
+            "_stderr": proc.stderr,
+            "_stdout": proc.stdout,
+        }
+
     stdout = proc.stdout.strip()
     if not stdout or stdout == "{}":
         return {}
@@ -132,6 +160,7 @@ class TestReplacementProtocol(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
         self.mock_claude = _create_mock_claude(self.tmpdir)
 
@@ -148,8 +177,11 @@ class TestReplacementProtocol(unittest.TestCase):
             },
             agent_id="claude-code",
             mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
         )
 
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
         hso = result.get("hookSpecificOutput", {})
         self.assertEqual(hso.get("hookEventName"), "PostToolUse")
         self.assertIn("updatedToolOutput", hso,
@@ -170,8 +202,11 @@ class TestReplacementProtocol(unittest.TestCase):
             },
             agent_id="claude-code",
             mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
         )
 
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
         hso = result.get("hookSpecificOutput", {})
         replacement = hso.get("updatedToolOutput", "")
         original_size = len(json.dumps(large_payload, separators=(",", ":")))
@@ -182,6 +217,44 @@ class TestReplacementProtocol(unittest.TestCase):
         )
         self.assertLess(replacement_size, original_size,
                         "Replacement should be smaller than original")
+
+    def test_replacement_content_structure(self):
+        """Replacement should contain compressed stdout and valid schema fields."""
+        large_payload = _make_large_json_payload()
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": large_payload,
+                "session_id": "s",
+                "tool_use_id": "t",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        hso = result.get("hookSpecificOutput", {})
+        replacement = hso.get("updatedToolOutput", "")
+
+        # The mock compressor truncates strings > 20 chars, so stdout should
+        # be truncated. Verify the compressed content is present and parseable.
+        try:
+            compressed_data = json.loads(replacement)
+        except (json.JSONDecodeError, TypeError):
+            self.fail(f"updatedToolOutput should be valid JSON, got: {replacement!r}")
+
+        # Verify stdout field was compressed (truncated to 20 chars by mock)
+        self.assertIn("stdout", compressed_data,
+                       "Compressed output should preserve stdout key")
+        self.assertLessEqual(len(compressed_data["stdout"]), 20,
+                             "stdout should be compressed to <= 20 chars")
+
+        # Verify schema fields are preserved
+        self.assertIn("exit_code", compressed_data)
+        self.assertIn("interrupted", compressed_data)
 
     def test_no_duplicate_content(self):
         """The original sentinel must not appear alongside compressed output."""
@@ -197,19 +270,30 @@ class TestReplacementProtocol(unittest.TestCase):
             },
             agent_id="claude-code",
             mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
         )
 
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
         hso = result.get("hookSpecificOutput", {})
+
+        # additionalContext must not contain compressed content
         additional = hso.get("additionalContext", "")
         self.assertNotIn(sentinel, additional,
                          "additionalContext must not contain compressed content")
 
-        updated = hso.get("updatedToolOutput", "")
-        self.assertTrue(updated,
-                        "updatedToolOutput should be present for Claude Code")
+        # updatedToolOutput should exist and contain compressed (truncated) sentinel
+        self.assertIn("updatedToolOutput", hso,
+                       "Claude Code should use updatedToolOutput")
+        updated = hso["updatedToolOutput"]
         updated_str = json.dumps(updated) if isinstance(updated, (dict, list)) else str(updated)
         self.assertNotIn(sentinel * 30, updated_str,
                          "updatedToolOutput must not contain the full original sentinel")
+
+        # Verify sentinel appears at most once (truncated) in the replacement
+        sentinel_count = updated_str.count(sentinel)
+        self.assertLessEqual(sentinel_count, 1,
+                             f"Sentinel should appear at most once in replacement, found {sentinel_count}")
 
 
 @unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
@@ -218,6 +302,7 @@ class TestPassthrough(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "no-savings")
         self.mock_claude = _create_mock_claude(self.tmpdir)
 
@@ -234,8 +319,11 @@ class TestPassthrough(unittest.TestCase):
             },
             agent_id="claude-code",
             mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
         )
 
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
         self.assertEqual(result, {},
                          "Should skip when compression yields no savings")
 
@@ -246,6 +334,7 @@ class TestSkipTools(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
         self.mock_claude = _create_mock_claude(self.tmpdir)
 
@@ -262,8 +351,11 @@ class TestSkipTools(unittest.TestCase):
             },
             agent_id="claude-code",
             mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
         )
 
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
         self.assertEqual(result, {},
                          "Skip-tools (Read) should produce empty result (pass-through)")
         hso = result.get("hookSpecificOutput", {})
@@ -277,6 +369,7 @@ class TestNonReplacementAdapters(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
         self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
         self.mock_claude = _create_mock_claude(self.tmpdir)
 
@@ -293,8 +386,11 @@ class TestNonReplacementAdapters(unittest.TestCase):
             },
             agent_id="qwencode",
             mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
         )
 
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
         hso = result.get("hookSpecificOutput", {})
         self.assertIn("additionalContext", hso,
                        "Non-replacement adapters should use additionalContext")

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Integration tests for compress_response_hook.py.
+
+Validates the PostToolUse hook output contract:
+- Replacement semantics: updatedToolOutput replaces (not appends to) original.
+- Additivity: additionalContext is reserved for env-attribution diagnostics.
+- No duplicate content in the model-visible output.
+- Pass-through when compression yields no size reduction.
+- Legacy path for non-replacement adapters.
+
+Uses subprocess to invoke the hook with a mock tokenless binary,
+avoiding Python version issues with the hook_utils module.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+def _make_large_json_payload(char_target: int = 500) -> dict:
+    """Build a JSON payload larger than _MIN_RESPONSE_CHARS (200)."""
+    return {
+        "stdout": "x" * char_target,
+        "stderr": "",
+        "exit_code": 0,
+        "interrupted": False,
+    }
+
+
+def _create_mock_tokenless(tmpdir: str, behavior: str = "compress") -> str:
+    """Create a mock tokenless binary that simulates compression behavior."""
+    mock_script = os.path.join(tmpdir, "tokenless")
+
+    if behavior == "compress":
+        script = textwrap.dedent("""\
+            #!/usr/bin/env python3
+            import json, sys
+            if sys.argv[1] == "compress-response":
+                data = json.loads(sys.stdin.read())
+                compressed = {}
+                for k, v in data.items():
+                    if isinstance(v, str) and len(v) > 20:
+                        compressed[k] = v[:20]
+                    else:
+                        compressed[k] = v
+                print(json.dumps(compressed))
+            elif sys.argv[1] == "compress-toon":
+                sys.exit(1)
+        """)
+    elif behavior == "no-savings":
+        script = textwrap.dedent("""\
+            #!/usr/bin/env python3
+            import json, sys
+            if sys.argv[1] == "compress-response":
+                data = sys.stdin.read()
+                print(data + '"extra_padding":"xxxxxxxxxxxxxxxx"')
+            elif sys.argv[1] == "compress-toon":
+                sys.exit(1)
+        """)
+    elif behavior == "passthrough":
+        script = textwrap.dedent("""\
+            #!/usr/bin/env python3
+            import sys
+            data = sys.stdin.read()
+            print(data)
+        """)
+    else:
+        raise ValueError(f"Unknown behavior: {behavior}")
+
+    with open(mock_script, "w") as f:
+        f.write(script)
+    os.chmod(mock_script, os.stat(mock_script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return mock_script
+
+
+def _create_mock_claude(tmpdir: str, version: str = "2.1.121") -> str:
+    """Create a mock claude binary that reports a specific version."""
+    mock_script = os.path.join(tmpdir, "claude")
+    script = textwrap.dedent(f"""\
+        #!/usr/bin/env python3
+        import sys
+        if "--version" in sys.argv:
+            print("{version}")
+    """)
+    with open(mock_script, "w") as f:
+        f.write(script)
+    os.chmod(mock_script, os.stat(mock_script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return mock_script
+
+
+def _run_hook(stdin_data: dict, agent_id: str, mock_tokenless_path: str) -> dict:
+    """Run the hook as a subprocess with mocked tokenless binary."""
+    hooks_dir = os.path.normpath(os.path.join(
+        os.path.dirname(__file__),
+        os.pardir, "adapters", "tokenless", "common", "hooks",
+    ))
+    hook_path = os.path.join(hooks_dir, "compress_response_hook.py")
+
+    env = os.environ.copy()
+    env["TOKENLESS_AGENT_ID"] = agent_id
+    env["PATH"] = os.path.dirname(mock_tokenless_path) + ":" + env.get("PATH", "")
+
+    proc = subprocess.run(
+        [sys.executable, hook_path],
+        input=json.dumps(stdin_data),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+    stdout = proc.stdout.strip()
+    if not stdout or stdout == "{}":
+        return {}
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return {"_raw_stdout": stdout, "_stderr": proc.stderr}
+
+
+_needs_py39 = sys.version_info < (3, 9)
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestReplacementProtocol(unittest.TestCase):
+    """Verify updatedToolOutput replacement semantics for Claude Code."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
+        self.mock_claude = _create_mock_claude(self.tmpdir)
+
+    def test_claude_code_uses_updated_tool_output(self):
+        """Claude Code adapter should use updatedToolOutput, not additionalContext."""
+        large_payload = _make_large_json_payload()
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": large_payload,
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+        )
+
+        hso = result.get("hookSpecificOutput", {})
+        self.assertEqual(hso.get("hookEventName"), "PostToolUse")
+        self.assertIn("updatedToolOutput", hso,
+                       "Claude Code should use updatedToolOutput for replacement")
+        self.assertNotIn("additionalContext", hso,
+                         "Compressed content must not be in additionalContext (duplication)")
+
+    def test_replacement_is_smaller(self):
+        """The replacement output should be smaller than the original."""
+        large_payload = _make_large_json_payload(1000)
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": large_payload,
+                "session_id": "s",
+                "tool_use_id": "t",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+        )
+
+        hso = result.get("hookSpecificOutput", {})
+        replacement = hso.get("updatedToolOutput", "")
+        original_size = len(json.dumps(large_payload, separators=(",", ":")))
+        replacement_size = (
+            len(json.dumps(replacement, separators=(",", ":")))
+            if isinstance(replacement, (dict, list))
+            else len(str(replacement))
+        )
+        self.assertLess(replacement_size, original_size,
+                        "Replacement should be smaller than original")
+
+    def test_no_duplicate_content(self):
+        """The original sentinel must not appear alongside compressed output."""
+        sentinel = "UNIQUE_SENTINEL_12345"
+        payload = {"stdout": sentinel * 30, "stderr": "", "exit_code": 0, "interrupted": False}
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": payload,
+                "session_id": "s",
+                "tool_use_id": "t",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+        )
+
+        hso = result.get("hookSpecificOutput", {})
+        additional = hso.get("additionalContext", "")
+        self.assertNotIn(sentinel, additional,
+                         "additionalContext must not contain compressed content")
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestPassthrough(unittest.TestCase):
+    """Verify pass-through when compression yields no size reduction."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.mock_bin = _create_mock_tokenless(self.tmpdir, "no-savings")
+        self.mock_claude = _create_mock_claude(self.tmpdir)
+
+    def test_skip_when_no_compression_savings(self):
+        """When compression does not reduce size, output should be empty (skip)."""
+        payload = _make_large_json_payload()
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": payload,
+                "session_id": "s",
+                "tool_use_id": "t",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+        )
+
+        self.assertEqual(result, {},
+                         "Should skip when compression yields no savings")
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestSkipTools(unittest.TestCase):
+    """Verify skip-tools behavior (content retrieval tools)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
+        self.mock_claude = _create_mock_claude(self.tmpdir)
+
+    def test_skip_tools_no_replacement(self):
+        """Skip-tools (Read) should not use updatedToolOutput."""
+        payload = {"stdout": "file content", "stderr": "", "exit_code": 0}
+
+        result = _run_hook(
+            {
+                "tool_name": "Read",
+                "tool_response": payload,
+                "session_id": "s",
+                "tool_use_id": "t",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+        )
+
+        hso = result.get("hookSpecificOutput", {})
+        if hso:
+            self.assertNotIn("updatedToolOutput", hso,
+                             "Skip-tools should not replace tool output")
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestNonReplacementAdapters(unittest.TestCase):
+    """Verify non-Claude-Code adapters still get the legacy additionalContext."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.mock_bin = _create_mock_tokenless(self.tmpdir, "compress")
+        self.mock_claude = _create_mock_claude(self.tmpdir)
+
+    def test_qwencode_uses_additional_context(self):
+        """Qwen Code should use additionalContext (legacy path)."""
+        large_payload = _make_large_json_payload()
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": large_payload,
+                "session_id": "s",
+                "tool_use_id": "t",
+            },
+            agent_id="qwencode",
+            mock_tokenless_path=self.mock_bin,
+        )
+
+        hso = result.get("hookSpecificOutput", {})
+        self.assertIn("additionalContext", hso,
+                       "Non-replacement adapters should use additionalContext")
+        self.assertNotIn("updatedToolOutput", hso,
+                         "Non-replacement adapters should not use updatedToolOutput")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds integration tests for the PostToolUse hook's `updatedToolOutput` replacement contract, originally proposed in #1657 (from fork, closed due to merge conflict — main independently implemented the hook fix with a more thorough approach).

## Changes

- `src/tokenless/tests/test_compress_response_hook.py`: New integration tests validating:
  - **Replacement semantics**: `updatedToolOutput` replaces (not appends to) original tool result
  - **No duplicate content**: `additionalContext` must not contain compressed content
  - **Pass-through**: When compression yields no size reduction, hook skips (empty output)
  - **Skip-tools**: Content retrieval tools (Read) do not use `updatedToolOutput`
  - **Legacy path**: Non-replacement adapters (Qwen Code) use `additionalContext`

### Test adaptation

The tests use subprocess to invoke the hook with:
- A mock `tokenless` binary (simulates compression behavior)
- A mock `claude` binary (returns version 2.1.121 for `_claude_supports_replacement()`)

Tests require Python 3.9+ (matching `hook_utils` requirements) and auto-skip on older versions.

## Related

- Replaces #1657 (fork PR closed due to merge conflict)
- Related to ANO-104 / GH-1645
