### PR TITLE
fix(cosh-ng): [shell] add empty arg check for /skills detail

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/slash/skills.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/skills.rs
@@ -41,6 +41,14 @@ pub(super) fn render_skills_command<W: Write>(
         }
         "detail" => {
             let name = arg.unwrap_or("");
+            if name.is_empty() {
+                return render_notice_panel(
+                    output,
+                    i18n.t(MessageId::SlashSkillsTitle),
+                    vec!["Usage: /skills detail <name>".to_string()],
+                    None,
+                );
+            }
             let params = serde_json::json!({ "name": name });
             match cosh_core.registry_query("skills", "detail", params) {
                 Ok(data) => {


### PR DESCRIPTION
## Description

`/skills detail` without `<name>` fell through to `registry_query("skills", "detail", {"name": ""})`, producing a misleading "skill not found: " error. Added an `is_empty()` short-circuit that returns a `Usage: /skills detail <name>` notice panel, consistent with how `enable` and `disable` already handle missing arguments.

## Related Issue

closes #1695

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --check` — pass
- `cargo clippy -p cosh-shell --all-targets -- -D warnings` — pass
- `cargo test -p cosh-shell --bin cosh-shell -- skills` — 2 passed (existing skills tests)

## Additional Notes

The existing test suite uses a `Fake` adapter that returns before reaching the `detail` branch (early `AdapterInstance::CoshCore` guard), so the new guard is covered by the same structural symmetry with `enable`/`disable` which already have identical checks.