### PR TITLE
[GitHub #1549] [cosh-ng] bug: cosh-core --version 未实现 (exit 2 + unexpected argument)

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/cli.rs
+++ b/src/cosh-ng/crates/cosh-core/src/cli.rs
@@ -54,6 +54,7 @@ pub enum McpCommand {
 #[derive(Parser, Debug)]
 #[command(
     name = "cosh-core",
+    version,
     about = "cosh core — agent core + interactive terminal"
 )]
 pub struct CliArgs {

--- a/src/cosh-ng/crates/cosh-core/tests/core_version.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/core_version.rs
@@ -1,0 +1,35 @@
+use std::process::{Command, Stdio};
+
+fn run_version() -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_cosh-core"))
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run cosh-core --version")
+}
+
+#[test]
+fn version_flag_exits_zero_and_prints_name_version() {
+    let output = run_version();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected = format!("cosh-core {}", env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        stdout.trim(),
+        expected,
+        "stdout={stdout:?} expected={expected:?}"
+    );
+
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("unexpected argument"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
由 Multica Issue `ANO-12` 生成。

Codex Review gate: **APPROVED**

Relates to #1549
