### PR TITLE
fix(cosh-ng): [shell] skip DEBUG trap during bash completion to prevent hang

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
@@ -348,6 +348,15 @@ _cosh_preexec_marker() {
   if [[ "${_COSH_SNAPSHOT_DEBUG_TRAP:-0}" == 1 ]]; then
     return 0
   fi
+  # Skip during completion — with extdebug the DEBUG trap fires for every
+  # internal command bash runs during glob expansion / completion, and the
+  # heavy operations below (date subprocess, file I/O) cause noticeable lag.
+  # Require COMP_TYPE (only set by bash during programmable completion) in
+  # addition to COMP_LINE/COMP_POINT so that residual COMP_LINE values do
+  # not permanently silence preexec markers for real commands.
+  if [[ -n "${COMP_TYPE:-}" && ( -n "${COMP_LINE:-}" || -n "${COMP_POINT:-}" ) ]]; then
+    return 0
+  fi
   local active_debug_trap="${_COSH_ACTIVE_DEBUG_TRAP:-}"
   if [[ "${_COSH_IN_PROMPT_COMMAND:-0}" != 1 && "${_COSH_DEBUG_TRAP_MAY_CHANGE:-0}" == 1 ]]; then
     local trap_snapshot_file="${COSH_RECOVERY_REQUEST_FILE:-/tmp/cosh-recovery}.debug-trap"

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -67,6 +67,30 @@ fn bash_history_file_marker_is_native_only() {
 }
 
 #[test]
+fn bash_preexec_marker_skips_completion_with_comp_type_guard() {
+    let script = bash_marker_script();
+
+    // Locate the start of _cosh_preexec_marker to ensure the guard is at the
+    // function entry, not somewhere later in the script.
+    let fn_start = script
+        .find("_cosh_preexec_marker() {")
+        .expect("_cosh_preexec_marker should exist");
+    let fn_body = &script[fn_start..];
+    let guard = fn_body
+        .find("if [[ -n \"${COMP_TYPE:-}\" && ( -n \"${COMP_LINE:-}\" || -n \"${COMP_POINT:-}\" ) ]]; then")
+        .expect("completion guard with COMP_TYPE should be present");
+
+    // Guard must appear before the first heavy operation (trap snapshot).
+    let trap_snapshot = fn_body
+        .find("trap_snapshot_file")
+        .expect("trap snapshot should exist");
+    assert!(
+        guard < trap_snapshot,
+        "completion guard should precede heavy trap snapshot logic"
+    );
+}
+
+#[test]
 fn parser_clean_strips_zsh_bracketed_paste_and_applies_backspace() {
     let mut parser = parser_for_test("clean-zsh-control");
     let input =


### PR DESCRIPTION
The bash marker script installs a DEBUG trap via extdebug that fires before every command execution. During tab completion (especially glob patterns like `xxx*`), bash runs internal commands for completion generation, each triggering the heavy trap handler (`date` subprocess, file I/O for trap snapshot, history operations), causing noticeable lag.

Add an early return in `_cosh_preexec_marker` when `COMP_LINE` or `COMP_POINT` is set, indicating bash is in a completion context. This avoids all expensive operations during completion while preserving normal marker behavior for actual command execution.

zsh is unaffected because `add-zsh-hook preexec` does not fire during completion.

Fixes: #1697

## Description

bash 的 marker 脚本通过 `shopt -s extdebug` + `trap '_cosh_preexec_marker' DEBUG` 实现命令边界检测。`_cosh_preexec_marker` 内部包含 `date +%s000` 子进程 fork、trap snapshot 文件 I/O、history 操作等重操作。

当用户在 bash 中按 Tab 展开 glob（如 `ls xxx*<TAB>`），bash 内部会执行命令来生成补全候选，每次执行都触发 DEBUG trap，累积的 fork + I/O 导致明显卡顿。zsh 使用 `add-zsh-hook preexec`，preexec 不在补全过程中触发，因此不受影响。

修复方式：在 `_cosh_preexec_marker` 入口检测 `COMP_LINE` / `COMP_POINT` 环境变量，补全上下文下直接 return 0 跳过所有操作。

## Related Issue

closes #1697

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- zsh 下 `ls xxx*<TAB>` 正常（对照组）
- bash 下修复前 `ls xxx*<TAB>` 明显卡顿；修复后恢复流畅
- `cargo test -p cosh-shell --test shell_host` 47 passed, 0 failed

## Additional Notes

无