### PR TITLE
fix(skillfs): control-socket error message flag prefix + hermes incompatibility gate

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -958,6 +958,21 @@ async fn cmd_mount(
             .into());
     }
 
+    // Hermes nested skills use slash-containing skill ids that the
+    // daemon-driven control-socket activation path cannot resolve (the
+    // control socket delegates to the same live-source resolver that
+    // rejects slash ids). This gate runs before the control-socket
+    // prerequisite validation so the 'incompatible' message surfaces
+    // instead of a missing-arg complaint.
+    let control_plane_enabled = control_socket.is_some() || trusted_peer_exe.is_some();
+    if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) && control_plane_enabled {
+        return Err("--skill-layout hermes is incompatible with \
+                 --control-socket (the daemon-driven control-socket \
+                 activation path cannot resolve slash-containing hermes \
+                 nested skill ids)"
+            .into());
+    }
+
     // Activation source validation:
     //   --security + --decision-command           => scan -> resolve path
     //   --security + --activation-mode file        => activation.json consumer
@@ -1022,21 +1037,22 @@ async fn cmd_mount(
     }
     // The control plane is enabled by either an explicit socket path or a
     // trusted peer (which selects the default endpoint).
-    let control_plane_enabled = control_socket.is_some() || trusted_peer_exe.is_some();
+    // NOTE: control_plane_enabled was already computed above (before the
+    // hermes incompatibility gate); reuse it here.
     if control_plane_enabled {
         if !security {
-            return Err("control socket requires --security (the control socket \
+            return Err("--control-socket requires --security (the control socket \
                  writes activation state through the active resolver)"
                 .into());
         }
         if activation_mode != ActivationMode::File {
-            return Err("control socket requires --activation-mode file (the \
+            return Err("--control-socket requires --activation-mode file (the \
                  control socket writes activation files consumed by the \
                  file-based activation path)"
                 .into());
         }
         if parsed_decision_command.is_some() {
-            return Err("control socket and --decision-command are mutually \
+            return Err("--control-socket and --decision-command are mutually \
                  exclusive (control socket is the daemon-driven activation \
                  path; --decision-command is the CLI-driven refresh path)"
                 .into());


### PR DESCRIPTION
## Problem

Fixes #1735

Three control-socket validation error messages in `skillfs mount` use "control socket requires" instead of "--control-socket requires", so tests and automation that grep for the `--control-socket` flag prefix in error output fail to match.

Additionally, `--skill-layout hermes` combined with `--control-socket` should fail with an "incompatible" message (the daemon-driven control-socket activation path cannot resolve slash-containing hermes nested skill ids), but the product instead fails on the PrivateTmp source-root guard, surfacing a different error that does not mention "incompatible".

## Fix

Fix in `src/skillfs/crates/skillfs-cli/src/main.rs`:

**1. Error message flag prefix**: Change `"control socket requires"` → `"--control-socket requires"` in three prerequisite validation error messages, so the flag name matches the CLI argument.

**2. Hermes + control-socket incompatibility gate**: Add a new check before the control-socket prerequisite validation that rejects `--skill-layout hermes` + `--control-socket` (or `--trusted-peer-exe`) with an "incompatible" message. This gate runs before the PrivateTmp source-root guard, so the "incompatible" error surfaces correctly.

The `control_plane_enabled` variable is computed earlier (before the hermes incompatibility gate) and reused in the later prerequisite validation block.

## Verification

```shell
# On ECS (fresh clone + apply patch + rpm-build):
cd /root && rm -rf anolisa && git clone https://github.com/alibaba/anolisa.git
cd anolisa && git checkout main && git apply /tmp/skillfs.patch
bash scripts/rpm-build.sh skillfs
# -> VERIFY_EXIT=0, RPM produced
```

Verified: build exit 0, RPM `skillfs-*.rpm` produced.

Co-Authored-By: Claude <noreply@anthropic.com>
