### PR TITLE
feat(anolisa): pin raw install versions

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -172,6 +172,45 @@ pub(crate) struct DelegatedPin {
     pub(crate) source_repo: Option<String>,
 }
 
+/// Resolved metadata for a version-pinned owned (raw) install, the owned
+/// analog of [`DelegatedPin`]. Built from the distribution entry the exact
+/// version query selected — the raw resolver only returns an entry whose
+/// `version` equals the request, and the contract validator later refuses an
+/// artifact whose embedded manifest disagrees with that entry, so these
+/// fields prove what will actually be placed.
+#[derive(Debug, Clone)]
+pub(crate) struct RawPin {
+    /// The `--version` value the caller requested.
+    requested_version: String,
+    /// Version of the resolved distribution entry (equals
+    /// `requested_version`, restated for an unambiguous JSON contract).
+    resolved_version: String,
+    /// Exact artifact URL the pinned entry downloads from — the raw analog
+    /// of the delegated pin's NEVRA.
+    artifact: String,
+    /// Repository base URL the distribution index was fetched from.
+    source_repo: String,
+}
+
+impl RawPin {
+    /// Capture the pin evidence from a settled raw resolution.
+    ///
+    /// Ordering is enforced by ownership, not convention:
+    /// [`validate_owned_install`] takes the [`RawResolution`] by value, so
+    /// the borrow here cannot compile after validation has consumed it. Any
+    /// future reshuffle that moves the resolution earlier surfaces as a
+    /// borrow error at this call site rather than as silently missing pin
+    /// evidence.
+    fn from_resolution(requested: &str, resolution: &RawResolution) -> Self {
+        Self {
+            requested_version: requested.to_string(),
+            resolved_version: resolution.entry.version.clone(),
+            artifact: resolution.artifact_url.clone(),
+            source_repo: resolution.base_url.clone(),
+        }
+    }
+}
+
 struct ResolvedInstallIdentity {
     component: String,
     pinned: bool,
@@ -520,12 +559,19 @@ fn execute_planned(
 
     let plan_labels: Vec<String> = steps.iter().map(step_label).collect();
 
+    // Pin evidence for an owned `--version` install, captured while the
+    // resolution is still whole (contract validation consumes it below).
+    let raw_pin = match (args.version.as_deref(), resolution.as_ref()) {
+        (Some(requested), Some(resolution)) => Some(RawPin::from_resolution(requested, resolution)),
+        _ => None,
+    };
+
     if ctx.dry_run {
         for warning in resolution.iter().flat_map(|r| r.warnings.iter()) {
             eprintln!("warning: {warning}");
         }
-        // A pinned delegated dry-run reports the version it resolved against
-        // the repository, not the raw `--version` echo — the pin fields carry
+        // A pinned dry-run reports the version it resolved against the
+        // repository, not the raw `--version` echo — the pin fields carry
         // the exact candidate so the preview proves what would be installed.
         let base_version = resolution
             .as_ref()
@@ -547,6 +593,9 @@ fn execute_planned(
         };
         if let Some(pin) = &delegated_pin {
             payload = payload.with_pin(pin);
+        }
+        if let Some(pin) = &raw_pin {
+            payload = payload.with_raw_pin(pin);
         }
         render_result(ctx, &payload)?;
         return Ok(InstallOutcome::Installed);
@@ -570,6 +619,7 @@ fn execute_planned(
             &steps,
             &plan_labels,
             validated,
+            raw_pin.as_ref(),
             native_package.as_deref(),
             &provider,
             &command,
@@ -899,6 +949,7 @@ fn install_owned(
     steps: &[Step],
     plan_labels: &[String],
     validated: ValidatedInstall,
+    raw_pin: Option<&RawPin>,
     native_package: Option<&str>,
     provider: &DelegatedProvider,
     command: &str,
@@ -974,9 +1025,8 @@ fn install_owned(
         eprintln!("warning: {warning}");
     }
 
-    render_result(
-        ctx,
-        &InstallResultPayload {
+    render_result(ctx, &{
+        let mut payload = InstallResultPayload {
             component: target.to_string(),
             package: Some(package),
             version: Some(version),
@@ -989,8 +1039,12 @@ fn install_owned(
             artifact: None,
             dry_run: false,
             plan: plan_labels.to_vec(),
-        },
-    )?;
+        };
+        if let Some(pin) = raw_pin {
+            payload = payload.with_raw_pin(pin);
+        }
+        payload
+    })?;
     Ok(InstallOutcome::Installed)
 }
 
@@ -1415,10 +1469,12 @@ pub(crate) fn step_label(step: &Step) -> String {
 /// JSON payload for a completed (or previewed, or idempotent) install.
 ///
 /// The pin fields (`requested_version`, `resolved_version`, `source_repo`,
-/// `artifact`) are additive and only present for a version-pinned delegated
-/// install; `version` keeps its existing meaning (the effective/installed
-/// version) across every route, so the wire contract stays backward
-/// compatible.
+/// `artifact`) are additive and only present for a version-pinned install.
+/// Their concrete shape is backend-dependent — a delegated pin reports the
+/// resolved EVR and the exact NEVRA handed to dnf, an owned (raw) pin the
+/// resolved distribution version and the exact artifact URL — while
+/// `version` keeps its existing meaning (the effective/installed version)
+/// across every route, so the wire contract stays backward compatible.
 #[derive(Debug, Serialize)]
 struct InstallResultPayload {
     component: String,
@@ -1434,13 +1490,17 @@ struct InstallResultPayload {
     /// `--version` value the caller requested (version-pinned installs only).
     #[serde(skip_serializing_if = "Option::is_none")]
     requested_version: Option<String>,
-    /// Full resolved EVR of the pinned candidate (version-pinned only).
+    /// Resolved candidate of the pin (version-pinned only): the full EVR for
+    /// a delegated install, the distribution entry version for a raw one.
     #[serde(skip_serializing_if = "Option::is_none")]
     resolved_version: Option<String>,
-    /// Source repository the pinned candidate came from (version-pinned only).
+    /// Source repository the pinned candidate came from (version-pinned
+    /// only): the dnf repo id for a delegated install, the raw repository
+    /// base URL for a raw one.
     #[serde(skip_serializing_if = "Option::is_none")]
     source_repo: Option<String>,
-    /// Exact NEVRA handed to dnf (version-pinned only).
+    /// Exact artifact the pin resolved to (version-pinned only): the NEVRA
+    /// handed to dnf for a delegated install, the artifact URL for a raw one.
     #[serde(skip_serializing_if = "Option::is_none")]
     artifact: Option<String>,
     dry_run: bool,
@@ -1462,19 +1522,35 @@ impl InstallResultPayload {
         }
         self
     }
+
+    /// Copy the resolved-candidate fields from an owned (raw) version pin:
+    /// the resolved entry version, the exact artifact URL, and the source
+    /// repository — same additive contract as the delegated pin, so agents
+    /// read one shape for both backends.
+    fn with_raw_pin(mut self, pin: &RawPin) -> Self {
+        self.requested_version = Some(pin.requested_version.clone());
+        self.resolved_version = Some(pin.resolved_version.clone());
+        self.source_repo = Some(pin.source_repo.clone());
+        self.artifact = Some(pin.artifact.clone());
+        if self.version.is_none() {
+            self.version = Some(pin.resolved_version.clone());
+        }
+        self
+    }
 }
 
 /// Detail lines shown above the plan in a dry-run preview.
 ///
-/// For a version-pinned delegated install this makes the resolved candidate
-/// explicit — bare package, requested version, resolved EVR, exact artifact,
+/// For a version-pinned install this makes the resolved candidate explicit
+/// — package, requested version, resolved version (EVR for delegated,
+/// distribution version for raw), exact artifact (NEVRA or artifact URL),
 /// and source repository — so the preview proves what would be installed
-/// rather than echoing the request. Unpinned/owned installs contribute no pin
+/// rather than echoing the request. Unpinned installs contribute no pin
 /// fields and yield an empty list (the plan alone is shown).
 fn dry_run_detail_lines(payload: &InstallResultPayload) -> Vec<String> {
     let mut lines = Vec::new();
-    // Only a version pin populates these; guard on `artifact` so unpinned and
-    // owned dry-runs render exactly as before (plan only).
+    // Only a version pin populates these; guard on `artifact` so unpinned
+    // dry-runs render exactly as before (plan only).
     if payload.artifact.is_some() {
         if let Some(package) = &payload.package {
             lines.push(format!("package: {package}"));
@@ -1659,6 +1735,83 @@ mod tests {
         assert!(json.get("resolved_version").is_none());
         assert!(json.get("source_repo").is_none());
         assert!(json.get("artifact").is_none());
+    }
+
+    fn sample_raw_pin() -> RawPin {
+        RawPin {
+            requested_version: "0.1.0".to_string(),
+            resolved_version: "0.1.0".to_string(),
+            artifact: "https://example.com/anolisa/agentsight-0.1.0.tar.gz".to_string(),
+            source_repo: "https://example.com/anolisa".to_string(),
+        }
+    }
+
+    #[test]
+    fn raw_pinned_payload_json_exposes_requested_resolved_repo_and_artifact() {
+        // The owned pin must fill the same additive envelope fields as the
+        // delegated pin: requested/resolved version, source repo, and the
+        // exact artifact (the URL, the raw analog of a NEVRA). `version`
+        // starts as None so the pin's fallback fills it — the compatible
+        // field must stay answered on the pinned path too.
+        let payload = InstallResultPayload {
+            component: "agentsight".to_string(),
+            package: Some("agentsight".to_string()),
+            version: None,
+            backend: "raw".to_string(),
+            action: "installed",
+            operation_id: Some("op-install-1".to_string()),
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
+            dry_run: false,
+            plan: Vec::new(),
+        }
+        .with_raw_pin(&sample_raw_pin());
+
+        let json = serde_json::to_value(&payload).expect("serialize payload");
+        assert_eq!(json["backend"], "raw");
+        assert_eq!(json["requested_version"], "0.1.0");
+        assert_eq!(json["resolved_version"], "0.1.0");
+        assert_eq!(json["source_repo"], "https://example.com/anolisa");
+        assert_eq!(
+            json["artifact"],
+            "https://example.com/anolisa/agentsight-0.1.0.tar.gz"
+        );
+        // `version` was None going in — the pin must fill the compatible
+        // field with the resolved entry version.
+        assert_eq!(json["version"], "0.1.0");
+    }
+
+    #[test]
+    fn raw_pinned_dry_run_detail_lines_show_resolved_version_and_artifact() {
+        // The raw pinned preview shares the delegated detail contract: the
+        // resolved candidate is spelled out instead of echoing the request.
+        let payload = InstallResultPayload {
+            component: "agentsight".to_string(),
+            package: None,
+            version: None,
+            backend: "raw".to_string(),
+            action: "planned",
+            operation_id: None,
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
+            dry_run: true,
+            plan: Vec::new(),
+        }
+        .with_raw_pin(&sample_raw_pin());
+
+        assert_eq!(
+            dry_run_detail_lines(&payload),
+            vec![
+                "requested version: 0.1.0".to_string(),
+                "resolved version: 0.1.0".to_string(),
+                "artifact: https://example.com/anolisa/agentsight-0.1.0.tar.gz".to_string(),
+                "repository: https://example.com/anolisa".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -11,7 +11,8 @@ use anolisa_core::install_runner::{
 use anolisa_core::path_safety::validate_owned_path;
 use anolisa_core::{
     ArtifactType, CapabilityRequest, ComponentManifest, DistributionIndex, FileKind, HookPhase,
-    HookSpec, ResolveQuery, ServiceRequest, expand_layout_placeholders, resolve_manifest_hooks,
+    HookSpec, ResolveError, ResolveQuery, ServiceRequest, expand_layout_placeholders,
+    resolve_manifest_hooks,
 };
 use anolisa_platform::fs_layout::FsLayout;
 
@@ -49,12 +50,16 @@ pub(crate) fn resolve_raw(
             command: COMMAND.to_string(),
             reason: format!("failed to fetch distribution index {index_url}: {err}"),
         })?;
-    let index = DistributionIndex::load(&downloaded_index.cached_path)
-        .map(installable_raw_index)
-        .map_err(|err| CliError::Runtime {
+    // The unfiltered index is kept for error attribution: a pinned version
+    // that only ships non-installable artifact types must be reported as
+    // "published but not installable", not as unpublished.
+    let full_index = DistributionIndex::load(&downloaded_index.cached_path).map_err(|err| {
+        CliError::Runtime {
             command: COMMAND.to_string(),
             reason: format!("failed to parse distribution index {index_url}: {err}"),
-        })?;
+        }
+    })?;
+    let index = installable_raw_index(full_index.clone());
 
     // The index is keyed by the backend-native package name so that
     // `package_map` / `--package` select between alternate publications.
@@ -69,15 +74,59 @@ pub(crate) fn resolve_raw(
         pkg_base: env.pkg_base.as_deref(),
         preferred_types: &[],
     };
-    let entry = index.resolve(&query).map_err(|err| CliError::InvalidArgument {
-        command: COMMAND.to_string(),
-        reason: format!(
-            "cannot resolve package '{package}' (component '{component}', version {}, {}/{}, {} mode) from {index_url}: {err}",
-            version.unwrap_or("latest"),
-            env.os,
-            env.arch,
-            ctx.install_mode.as_str(),
-        ),
+    let entry = index.resolve(&query).map_err(|err| {
+        // A pinned version the installable index cannot satisfy gets a
+        // dedicated refusal, symmetric with the rpm backend's version-pin
+        // errors. The unfiltered index decides the wording: a version that
+        // exists there but not in the installable view is published — only
+        // its artifact types are outside what the raw backend can place.
+        // Every other resolution failure keeps the generic query rendering.
+        if let (Some(pinned), ResolveError::NotFound) = (version, &err) {
+            let unversioned = ResolveQuery {
+                version: None,
+                ..query.clone()
+            };
+            let installable = index.matching_versions(&unversioned);
+            let installable_note = if installable.is_empty() {
+                String::new()
+            } else {
+                format!(" — installable versions: {}", installable.join(", "))
+            };
+            let published_any_type = full_index
+                .matching_versions(&unversioned)
+                .iter()
+                .any(|v| v == pinned);
+            if published_any_type {
+                return CliError::InvalidArgument {
+                    command: COMMAND.to_string(),
+                    reason: format!(
+                        "version '{pinned}' of component '{component}' (package '{package}') is published in the raw repository {index_url} but only with artifact types the raw backend cannot install (supported: {}); nothing was changed{installable_note}",
+                        SUPPORTED_ARTIFACT_TYPES.join(", "),
+                    ),
+                };
+            }
+            if !installable.is_empty() {
+                return CliError::InvalidArgument {
+                    command: COMMAND.to_string(),
+                    reason: format!(
+                        "version '{pinned}' of component '{component}' (package '{package}') is not published in the raw repository {index_url} for {}/{} ({} mode); nothing was changed{installable_note}",
+                        env.os,
+                        env.arch,
+                        ctx.install_mode.as_str(),
+                    ),
+                };
+            }
+        }
+        CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "cannot resolve package '{package}' (component '{component}', version {}, {}/{}, {} mode) from {index_url}: {err}",
+                version.unwrap_or("latest"),
+                env.os,
+                env.arch,
+                ctx.install_mode.as_str(),
+            ),
+        }
     })?;
 
     let wire_type = artifact_type_wire(&entry.artifact_type);
@@ -125,6 +174,7 @@ pub(crate) fn resolve_raw(
         package,
         artifact_url,
         entry,
+        base_url,
         warnings,
     })
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -182,6 +182,48 @@ pub fn write_local_repo(root: &Path) -> String {
     write_local_repo_component(root, "agentsight", "0.2.0", &["system"])
 }
 
+/// Local file:// repo publishing several versions of one component, so a
+/// version-pinned install can select a non-latest entry.
+pub fn write_local_repo_component_versions(
+    root: &Path,
+    component: &str,
+    versions: &[&str],
+    modes: &[&str],
+) -> String {
+    let v1 = root.join("v1");
+    std::fs::create_dir_all(&v1).expect("create repo dirs");
+
+    let env = anolisa_env::EnvService::detect();
+    let modes_arr = toml_string_array(modes);
+    let mut index =
+        String::from("schema_version = 1\nchannel = \"stable\"\npublisher = \"test\"\n");
+    for version in versions {
+        let artifact = build_component_artifact(component, version, modes);
+        let artifact_name = format!("{component}-{version}.tar.gz");
+        std::fs::write(v1.join(&artifact_name), &artifact).expect("write artifact");
+        let sha = format!("{:x}", Sha256::digest(&artifact));
+        index.push_str(&format!(
+            r#"
+[[entries]]
+component = "{component}"
+version = "{version}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "{artifact_name}"
+os = "{os}"
+arch = "{arch}"
+install_modes = {modes_arr}
+sha256 = "{sha}"
+"#,
+            os = env.os,
+            arch = env.arch,
+        ));
+    }
+    std::fs::write(v1.join("index.toml"), index).expect("write index");
+    format!("file://{}", v1.display())
+}
+
 pub fn write_local_repo_component(
     root: &Path,
     component: &str,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -771,7 +771,14 @@ fn install_resolves_legacy_template_form_repo_url() {
 fn install_unpublished_version_is_invalid_argument() {
     let tmp = tempdir().expect("tmpdir");
     let prefix = tmp.path().join("sys");
-    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    // Two published versions, so the refusal must enumerate the complete
+    // list (highest-first), not just whichever entry resolution saw last.
+    let repo_url = write_local_repo_component_versions(
+        &tmp.path().join("repo"),
+        "agentsight",
+        &["0.1.0", "0.2.0"],
+        &["system"],
+    );
 
     let mut a = args("agentsight");
     a.repo = Some(repo_url);
@@ -780,6 +787,142 @@ fn install_unpublished_version_is_invalid_argument() {
         .expect_err("must fail to resolve");
     assert_eq!(err.code(), "INVALID_ARGUMENT");
     assert!(err.reason().contains("9.9.9"), "got: {}", err.reason());
+    // The pin refusal must name what the repository actually publishes, so
+    // the caller can correct the request without a second query.
+    assert!(
+        err.reason().contains("not published"),
+        "pin refusal must be a dedicated message: {}",
+        err.reason()
+    );
+    assert!(
+        err.reason().contains("installable versions: 0.2.0, 0.1.0"),
+        "pin refusal must list every installable version, highest first: {}",
+        err.reason()
+    );
+}
+
+#[test]
+fn install_pinned_unsupported_artifact_type_is_reported_as_not_installable() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_root = tmp.path().join("repo");
+    let repo_url = write_local_repo(&repo_root);
+    // Publish 9.0.0 as a binary-only entry: present in the repository, but
+    // outside what the raw backend can install.
+    let index_path = repo_root.join("v1/index.toml");
+    let mut index = std::fs::read_to_string(&index_path).expect("read index");
+    let env = anolisa_env::EnvService::detect();
+    index.push_str(&format!(
+        r#"
+[[entries]]
+component = "agentsight"
+version = "9.0.0"
+channel = "stable"
+artifact_type = "binary"
+backend = "raw"
+url = "legacy-agentsight-9.0.0"
+os = "{os}"
+arch = "{arch}"
+install_modes = ["system"]
+sha256 = "{sha}"
+"#,
+        os = env.os,
+        arch = env.arch,
+        sha = "0".repeat(64),
+    ));
+    std::fs::write(index_path, index).expect("write mixed index");
+
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+    a.version = Some("9.0.0".to_string());
+    let err = handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix)))
+        .expect_err("must fail to resolve");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    // A published-but-binary-only pin must not be misreported as
+    // unpublished; the refusal names the artifact-type gap instead.
+    assert!(
+        !err.reason().contains("not published"),
+        "published version must not be reported as unpublished: {}",
+        err.reason()
+    );
+    assert!(
+        err.reason()
+            .contains("artifact types the raw backend cannot install"),
+        "refusal must name the artifact-type gap: {}",
+        err.reason()
+    );
+    assert!(
+        err.reason().contains("installable versions: 0.2.0"),
+        "refusal must still list installable versions: {}",
+        err.reason()
+    );
+}
+
+#[test]
+fn install_pinned_version_places_exact_published_version() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo_component_versions(
+        &tmp.path().join("repo"),
+        "agentsight",
+        &["0.1.0", "0.2.0"],
+        &["system"],
+    );
+
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+    a.version = Some("0.1.0".to_string());
+    handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+        .expect("pinned install must succeed");
+
+    let layout = FsLayout::system(Some(prefix));
+    assert!(layout.bin_dir.join("agentsight").exists());
+    let store = load_v5_store(&layout);
+    let installation = store
+        .find(ObjectKind::Component, "agentsight")
+        .expect("installed object");
+    let artifact = owned_artifact(installation);
+    assert_eq!(
+        artifact.version, "0.1.0",
+        "the pin must beat the higher published 0.2.0"
+    );
+    assert!(
+        artifact
+            .distribution_source
+            .as_deref()
+            .is_some_and(|url| url.ends_with("agentsight-0.1.0.tar.gz")),
+        "distribution_source must record the pinned artifact URL: {:?}",
+        artifact.distribution_source
+    );
+}
+
+#[test]
+fn install_pinned_version_dry_run_previews_without_writing_files() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo_component_versions(
+        &tmp.path().join("repo"),
+        "agentsight",
+        &["0.1.0", "0.2.0"],
+        &["system"],
+    );
+
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+    a.version = Some("0.1.0".to_string());
+    let mut ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    ctx.dry_run = true;
+    handle_with_fake_rpm(a, &ctx).expect("pinned dry-run must succeed");
+
+    let layout = FsLayout::system(Some(prefix));
+    assert!(
+        !layout.bin_dir.join("agentsight").exists(),
+        "dry-run must not install the binary"
+    );
+    assert!(
+        !layout.state_dir.join("installed.toml").exists(),
+        "dry-run must not write state"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/types.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/types.rs
@@ -16,6 +16,10 @@ pub(crate) struct RawResolution {
     pub(crate) package: String,
     pub(crate) entry: DistributionEntry,
     pub(crate) artifact_url: String,
+    /// Repository base URL the index was fetched from, kept so a
+    /// version-pinned install can attribute the resolved candidate to its
+    /// source repository in the result envelope.
+    pub(crate) base_url: String,
     pub(crate) warnings: Vec<String>,
 }
 


### PR DESCRIPTION
## Summary

Make `anolisa install <component> --version <v>` a first-class version pin on the **raw** backend, symmetric with the recently landed rpm pin (#43858f7a's `feat(anolisa): pin rpm install versions`):

- **Exact resolution**: the raw resolver already exact-matches the pinned version against the distribution index; the artifact's embedded manifest version is enforced against the resolved entry before any file lands.
- **Pin disclosure**: a pinned install/dry-run now reports `requested_version`, `resolved_version`, `artifact` (exact artifact URL — the raw analog of a NEVRA), and `source_repo` in the JSON envelope and human dry-run details, using the same additive wire contract as the delegated pin. Unpinned installs are unchanged (fields omitted).
- **Actionable refusal**: pinning an unpublished version now fails with a dedicated INVALID_ARGUMENT that lists the actually published versions for the host tuple, instead of the generic resolver error.

## Testing

- `cargo test -p anolisa-cli`: 762 passed (new e2e: pinned install places the exact non-latest version; pinned dry-run stays side-effect free; unpublished pin lists published versions; unit tests for the JSON/pin detail contract).
- `cargo fmt` / `clippy --all-targets` / `cargo doc --no-deps` clean.
- **Real-host verification** on Alibaba Cloud Linux 4 (x86_64) against the production OSS repo (`anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases`), isolated under `--prefix`:
  - pinned `tokenless --version 0.6.0` installed 0.6.0 while 0.7.1 was latest; state recorded the pinned artifact URL
  - same-version reinstall → idempotent no-op; different version → I5 refusal pointing at `update`
  - `agentsight --version 9.9.9` → refusal listing `0.8.1, 0.8.0, 0.7.0`
  - unpinned install still resolves latest (0.7.1) with no pin fields
  - uninstall left no component state; real system paths untouched