### PR TITLE
fix(sight): fix syscall tracepoint probe attach on PREEMPT_LAZY kernels

### DIFF
--- a/src/agentsight/src/bpf/procmon.bpf.c
+++ b/src/agentsight/src/bpf/procmon.bpf.c
@@ -12,6 +12,16 @@
 #define NO_CGROUP_FILTER
 #include "common.h"
 
+// Use the kernel's `struct syscall_trace_exit` (what a syscall tracepoint
+// program actually receives), NOT `trace_event_raw_sys_exit`. The latter
+// declares the syscall number as `long id` (8 bytes); on kernels carrying the
+// PREEMPT_LAZY backport (e.g. RHEL/Anolis 9 5.14) `struct trace_entry` grows a
+// `preempt_lazy_count` field, and CO-RE then relocates `ret` past the real
+// tracepoint record, so the kernel rejects the attach with EACCES.
+// `syscall_trace_exit` uses `int nr` (4 bytes), matching the record layout, so
+// `ret` relocates to the correct offset on every kernel. See
+// inspektor-gadget#2444 / BCC#4920.
+
 // Tracepoint for execve exit - captures process execution after it completes
 // NOTE: We use sys_exit_execve instead of sys_enter_execve because:
 // - At sys_enter_execve, the process hasn't completed execve yet
@@ -19,7 +29,7 @@
 // - Reading /proc/[pid]/comm returns old values
 // - At sys_exit_execve, execve has completed and process info is updated
 SEC("tp/syscalls/sys_exit_execve")
-int trace_execve_exit(struct trace_event_raw_sys_exit *ctx)
+int trace_execve_exit(struct syscall_trace_exit *ctx)
 {
     // Check execve return value - skip if failed
     // ret == 0: success, ret < 0: error (e.g., -ENOENT, -EACCES)

--- a/src/agentsight/src/bpf/proctrace.bpf.c
+++ b/src/agentsight/src/bpf/proctrace.bpf.c
@@ -41,25 +41,17 @@ struct
     __type(value, struct proc_event_t);
 } event_scratch SEC(".maps");
 
-// Tracepoint for execve - captures new process execution
-// For syscall tracepoints, we need to use the raw tracepoint format
-struct sys_enter_execve_args
-{
-    unsigned short common_type;
-    unsigned char common_flags;
-    unsigned char common_preempt_count;
-    int common_pid;
-    int __syscall_nr;
-    const char *filename;
-    const char *const *argv;
-    const char *const *envp;
-};
-
+// Tracepoint for execve - captures new process execution.
+// Use the kernel's `struct syscall_trace_enter` (with `int nr`) rather than
+// `trace_event_raw_sys_enter`: on PREEMPT_LAZY kernels the widened
+// `struct trace_entry` shifts the latter's CO-RE offsets past the real
+// tracepoint record and the attach fails with EACCES. Syscall args are read
+// from ctx->args[] (args[0]=filename, args[1]=argv).
 SEC("tp/syscalls/sys_enter_execve")
-int trace_execve_enter(struct sys_enter_execve_args *args)
+int trace_execve_enter(struct syscall_trace_enter *ctx)
 {
-    const char *filename = args->filename;
-    const char *const *argv = args->argv;
+    const char *filename = (const char *)ctx->args[0];
+    const char *const *argv = (const char *const *)ctx->args[1];
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     u32 tid = (u32)pid_tgid;
@@ -172,26 +164,18 @@ store:
     return 0;
 }
 
-// Tracepoint for execve exit - only submit event if execve succeeded
-struct sys_exit_execve_args
-{
-    unsigned short common_type;
-    unsigned char common_flags;
-    unsigned char common_preempt_count;
-    int common_pid;
-    int __syscall_nr;
-    long ret;
-};
+// Tracepoint for execve exit - only submit event if execve succeeded.
+// Uses `struct syscall_trace_exit` (see trace_execve_enter for why).
 
 // Maximum size for exec event (header + exec_data + full args_buf)
 #define MAX_EXEC_EVENT_SIZE (sizeof(struct proc_event_header) + sizeof(struct proc_exec_data) + LAST_ARG)
 
 SEC("tp/syscalls/sys_exit_execve")
-int trace_execve_exit(struct sys_exit_execve_args *args)
+int trace_execve_exit(struct syscall_trace_exit *ctx)
 {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
-    long ret = args->ret;
+    long ret = ctx->ret;
     u64 cg_id = get_cgroup_id_compat();
 
     // Look up pending event


### PR DESCRIPTION
## Description

On kernels carrying the PREEMPT_LAZY backport (e.g. RHEL/Anolis 9, kernel 5.14),
`struct trace_entry` gains an extra `preempt_lazy_count` field, widening the
tracepoint common header. The execve enter/exit probes read their context via
vmlinux's `trace_event_raw_sys_{enter,exit}`, which declare the syscall number as
`long` (8 bytes). CO-RE then relocated `ret`/args past the actual `sys_exit_execve`
tracepoint record (only 24 bytes), so the kernel rejected the BPF attach with
`EACCES` (`max_ctx_offset > record size`) and `agentsight trace` aborted with
"Failed to attach probes". `agentsight serve` was unaffected since it uses no
tracepoints.

The fix switches the execve enter/exit probes to the kernel's own
`struct syscall_trace_{enter,exit}`, which declare the syscall number as `int nr`
(4 bytes) — matching the real record layout — so CO-RE relocates `ret`/args to the
correct offset on every kernel. This is the same fix adopted upstream by
inspektor-gadget (#2444) and BCC (#4920), and it is what a syscall tracepoint
program actually receives. proctrace's stdout probe already used
`syscall_trace_enter`, so this also unifies the context types.

## Related Issue

no-issue: kernel-specific probe-attach failure found during on-host validation

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Key Changes

- `src/agentsight/src/bpf/procmon.bpf.c`: `trace_execve_exit` now takes `struct syscall_trace_exit *` instead of `trace_event_raw_sys_exit *`.
- `src/agentsight/src/bpf/proctrace.bpf.c`: `trace_execve_enter` / `trace_execve_exit` now take `struct syscall_trace_enter *` / `struct syscall_trace_exit *`; execve args are read from `ctx->args[0]` (filename) and `ctx->args[1]` (argv), consistent with the existing stdout probe.

## Checklist

- [x] I have read the Contributing Guide
- [x] `cargo fmt --check` pass
- [x] `cargo clippy --all-targets -- -D warnings` pass
- [x] `cargo test` pass (1239 passed, 0 failed)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Verified on an Anolis 9 host (kernel `5.14.0-710.el9.x86_64`, PREEMPT_DYNAMIC with
`common_preempt_lazy_count`) and locally on `5.10.134` (standard layout):

- **Before**: `agentsight trace -v` on 5.14 reproducibly failed at
  `trace_execve_exit -> syscalls/sys_exit_execve: -EACCES` -> "Failed to attach
  probes". Confirmed independent of `perf_event_paranoid` (retested at 1 and -1).
- **After (5.14)**: all probes attach cleanly (no EACCES); `RUST_LOG=trace` shows
  procmon exec events flowing, and a process matching an agent rule (`*codex*`) is
  discovered -> `Attached to agent: Codex`. A traced parent spawning a child exec
  ran through proctrace's enter/exit with no attach/poll/panic errors.
- **After (5.10)**: no regression — probes attach and `Attached to agent: Claude`.

Note: attach success itself validates the context accesses, since the BPF verifier
checks every `ctx` offset against the tracepoint record at load time. An automated
regression test is not included because the failure only manifests on kernels with
the PREEMPT_LAZY tracepoint layout; validation was done manually on such a host per
the project's real-kernel eBPF testing rule.