### PR TITLE
feat(cosh-ng): let ESC cancel active agent run

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use spawn::{spawn_raw_action_relay, spawn_raw_input_relay};
 
 pub(super) const CTRL_C: u8 = 0x03;
 pub(super) const CTRL_U: u8 = 0x15;
+pub(super) const ESC: u8 = 0x1b;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RawInputEvent {
@@ -26,6 +27,7 @@ pub(crate) enum RawInputEvent {
         empty: bool,
     },
     CtrlC,
+    Esc,
     CandidateRedraw {
         input: Vec<u8>,
         hint: Option<String>,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -133,6 +133,131 @@ impl SelectionRelay {
     }
 }
 
+struct DelayRelay {
+    path: std::path::PathBuf,
+    master: File,
+    input_tx: Option<mpsc::Sender<Vec<u8>>>,
+    event_rx: mpsc::Receiver<RawInputEvent>,
+    input_mode: Arc<Mutex<RawInputMode>>,
+    relay: thread::JoinHandle<io::Result<()>>,
+}
+
+impl DelayRelay {
+    fn start(label: &str) -> Self {
+        let (path, master) = output_file(label);
+        let (input_tx, input_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Delay));
+        let relay = super::super::spawn_raw_input_relay(
+            ChannelReader {
+                receiver: input_rx,
+                pending: Vec::new(),
+            },
+            master.try_clone().expect("clone output file"),
+            event_tx,
+            InputClassifier::default(),
+            input_mode.clone(),
+        );
+        Self {
+            path,
+            master,
+            input_tx: Some(input_tx),
+            event_rx,
+            input_mode,
+            relay,
+        }
+    }
+
+    fn send(&self, bytes: &[u8]) {
+        self.input_tx
+            .as_ref()
+            .expect("input sender")
+            .send(bytes.to_vec())
+            .expect("send input");
+    }
+
+    fn finish(mut self) -> (Vec<RawInputEvent>, Vec<u8>, RawInputMode) {
+        self.input_tx.take();
+        self.relay
+            .join()
+            .expect("relay thread")
+            .expect("relay result");
+        self.master.sync_all().expect("sync test output");
+        let output = fs::read(&self.path).expect("read test output");
+        fs::remove_file(&self.path).ok();
+        let mode = self.input_mode.lock().expect("input mode").clone();
+        (self.event_rx.try_iter().collect(), output, mode)
+    }
+}
+
+fn expect_esc_event(receiver: &mpsc::Receiver<RawInputEvent>) {
+    assert_eq!(
+        receiver.recv_timeout(Duration::from_millis(250)),
+        Ok(RawInputEvent::Esc),
+        "expected Esc cancel event"
+    );
+}
+
+#[test]
+fn delay_bare_escape_requests_cancel_and_does_not_forward() {
+    let relay = DelayRelay::start("delay-bare-escape");
+    relay.send(b"\x1b");
+    expect_esc_event(&relay.event_rx);
+    let (events, output, mode) = relay.finish();
+    assert!(
+        !events.contains(&RawInputEvent::CtrlC),
+        "unexpected CtrlC event"
+    );
+    assert_eq!(output, b"exit\n");
+    assert!(matches!(mode, RawInputMode::Delay));
+}
+
+#[test]
+fn delay_escape_sequence_is_forwarded_without_cancel() {
+    let relay = DelayRelay::start("delay-escape-sequence");
+    relay.send(b"\x1b[A");
+    thread::sleep(Duration::from_millis(100));
+    let (events, output, mode) = relay.finish();
+    assert!(
+        !events.contains(&RawInputEvent::Esc),
+        "unexpected Esc event for arrow sequence"
+    );
+    assert_eq!(output, b"\x1b[Aexit\n");
+    assert!(matches!(mode, RawInputMode::Delay));
+}
+
+#[test]
+fn delay_split_escape_sequence_is_forwarded_without_cancel() {
+    let relay = DelayRelay::start("delay-split-escape-sequence");
+    relay.send(b"\x1b");
+    thread::sleep(Duration::from_millis(10));
+    relay.send(b"[A");
+    thread::sleep(Duration::from_millis(100));
+    let (events, output, mode) = relay.finish();
+    assert!(
+        !events.contains(&RawInputEvent::Esc),
+        "unexpected Esc event for split arrow sequence"
+    );
+    assert_eq!(output, b"\x1b[Aexit\n");
+    assert!(matches!(mode, RawInputMode::Delay));
+}
+
+#[test]
+fn delay_escape_is_forwarded_when_run_finishes_before_deadline() {
+    let relay = DelayRelay::start("delay-escape-run-finishes");
+    relay.send(b"\x1b");
+    thread::sleep(Duration::from_millis(10));
+    *relay.input_mode.lock().expect("input mode") = RawInputMode::Passthrough;
+    relay.send(b"x");
+    let (events, output, mode) = relay.finish();
+    assert!(
+        !events.contains(&RawInputEvent::Esc),
+        "unexpected Esc event after run finished"
+    );
+    assert_eq!(output, b"\x1bxexit\n");
+    assert!(matches!(mode, RawInputMode::Passthrough));
+}
+
 #[test]
 fn selection_bare_escape_times_out_without_waiting_for_another_key() {
     let (path, master) = output_file("selection-bare-escape");

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -20,9 +20,10 @@ use super::relay::{
     relay_prompt_ghost_input, send_held_input_events, send_raw_input_events, ExplicitExitTracker,
     InputRelayContext,
 };
-use super::{PromptGhostRoute, RawInputEvent, RawRelayAction};
+use super::{PromptGhostRoute, RawInputEvent, RawRelayAction, ESC};
 
 const PROMPT_GHOST_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
+const DELAY_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
 // Retain a complete split Shift+Tab sequence while the relay handles ESC.
 const INPUT_READ_AHEAD_CAPACITY: usize = 3;
 
@@ -43,6 +44,11 @@ impl PendingPromptGhostEscape {
     }
 }
 
+struct PendingDelayEscape {
+    bytes: Vec<u8>,
+    deadline: Instant,
+}
+
 #[derive(Default)]
 pub(super) struct RawInputRelayState {
     card_state: CardInputState,
@@ -50,6 +56,7 @@ pub(super) struct RawInputRelayState {
     native_line_state: NativeLineState,
     exit_tracker: ExplicitExitTracker,
     pending_prompt_ghost_escape: Option<PendingPromptGhostEscape>,
+    pending_delay_escape: Option<PendingDelayEscape>,
 }
 
 enum InputRead {
@@ -82,6 +89,15 @@ where
                 Ok(input) => input,
                 Err(RecvTimeoutError::Timeout) => {
                     flush_pending_prompt_ghost_escape(
+                        false,
+                        Instant::now(),
+                        &mut master,
+                        &input_events,
+                        &input_classifier,
+                        &input_mode,
+                        &mut state,
+                    )?;
+                    flush_pending_delay_escape(
                         false,
                         Instant::now(),
                         &mut master,
@@ -146,11 +162,24 @@ fn receive_input(
     receiver: &Receiver<InputRead>,
     state: &RawInputRelayState,
 ) -> Result<InputRead, RecvTimeoutError> {
-    match state.pending_prompt_ghost_escape.as_ref() {
-        Some(pending) => {
-            receiver.recv_timeout(pending.deadline.saturating_duration_since(Instant::now()))
-        }
+    match next_pending_deadline(state) {
+        Some(deadline) => receiver.recv_timeout(deadline.saturating_duration_since(Instant::now())),
         None => receiver.recv().map_err(|_| RecvTimeoutError::Disconnected),
+    }
+}
+
+fn next_pending_deadline(state: &RawInputRelayState) -> Option<Instant> {
+    match (
+        state
+            .pending_prompt_ghost_escape
+            .as_ref()
+            .map(|p| p.deadline),
+        state.pending_delay_escape.as_ref().map(|p| p.deadline),
+    ) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
     }
 }
 
@@ -213,6 +242,49 @@ pub(super) fn relay_input_bytes(
         bytes
     };
 
+    let mut delay_combined = Vec::new();
+    let bytes = if let Some(pending) = state.pending_delay_escape.take() {
+        if !matches!(mode, RawInputMode::Delay) {
+            // The active agent run finished while ESC was pending; forward it.
+            relay_input_for_mode(
+                &pending.bytes,
+                mode,
+                master,
+                input_events,
+                input_classifier,
+                input_mode,
+                state,
+            )?;
+            return relay_input_bytes(
+                bytes,
+                received_at,
+                master,
+                input_events,
+                input_classifier,
+                input_mode,
+                state,
+            );
+        }
+        if received_at > pending.deadline {
+            // Bare ESC while an agent run is active: request cancellation.
+            let _ = input_events.send(RawInputEvent::Esc);
+            return relay_input_bytes(
+                bytes,
+                received_at,
+                master,
+                input_events,
+                input_classifier,
+                input_mode,
+                state,
+            );
+        }
+        delay_combined.extend_from_slice(&pending.bytes);
+        delay_combined.extend_from_slice(bytes);
+        &delay_combined
+    } else {
+        bytes
+    };
+
     if let RawInputMode::PromptGhost {
         text,
         route: route @ PromptGhostRoute::AgentSelection { .. },
@@ -227,6 +299,14 @@ pub(super) fn relay_input_bytes(
             });
             return Ok(());
         }
+    }
+
+    if matches!(mode, RawInputMode::Delay) && bytes.len() == 1 && bytes[0] == ESC {
+        state.pending_delay_escape = Some(PendingDelayEscape {
+            bytes: bytes.to_vec(),
+            deadline: received_at + DELAY_ESCAPE_TIMEOUT,
+        });
+        return Ok(());
     }
 
     relay_input_for_mode(
@@ -351,6 +431,41 @@ fn flush_pending_prompt_ghost_escape(
     )
 }
 
+fn flush_pending_delay_escape(
+    force: bool,
+    now: Instant,
+    master: &mut File,
+    input_events: &Sender<RawInputEvent>,
+    input_classifier: &InputClassifier,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> io::Result<()> {
+    let should_flush = state
+        .pending_delay_escape
+        .as_ref()
+        .is_some_and(|pending| force || now >= pending.deadline);
+    if !should_flush {
+        return Ok(());
+    }
+    let Some(pending) = state.pending_delay_escape.take() else {
+        return Ok(());
+    };
+    let mode = current_raw_input_mode(input_mode);
+    if matches!(mode, RawInputMode::Delay) {
+        let _ = input_events.send(RawInputEvent::Esc);
+        return Ok(());
+    }
+    relay_input_for_mode(
+        &pending.bytes,
+        mode,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )
+}
+
 pub(super) fn finish_input_relay(
     master: &mut File,
     input_events: &Sender<RawInputEvent>,
@@ -359,6 +474,15 @@ pub(super) fn finish_input_relay(
     state: &mut RawInputRelayState,
 ) -> io::Result<()> {
     flush_pending_prompt_ghost_escape(
+        true,
+        Instant::now(),
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )?;
+    flush_pending_delay_escape(
         true,
         Instant::now(),
         master,
@@ -382,17 +506,22 @@ fn wait_for_raw_action(
     state: &mut RawInputRelayState,
 ) -> io::Result<()> {
     let action_end = Instant::now() + duration;
-    while let Some(deadline) = state
-        .pending_prompt_ghost_escape
-        .as_ref()
-        .map(|pending| pending.deadline)
-    {
+    while let Some(deadline) = next_pending_deadline(state) {
         if deadline > action_end {
             break;
         }
         thread::sleep(deadline.saturating_duration_since(Instant::now()));
         // Scripted input must resolve ESC at the same boundary as live input.
         flush_pending_prompt_ghost_escape(
+            false,
+            Instant::now(),
+            master,
+            input_events,
+            input_classifier,
+            input_mode,
+            state,
+        )?;
+        flush_pending_delay_escape(
             false,
             Instant::now(),
             master,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
@@ -26,6 +26,12 @@ pub(crate) fn cancel_ownership_for_event(
     if foreground_command_active && is_control_cancel_event(event) {
         return CancelOwnership::ForegroundCommand;
     }
+    if is_control_esc_event(event) {
+        if state.agent_run.active.is_some() {
+            return CancelOwnership::ActiveAgentTurn;
+        }
+        return CancelOwnership::NotCancel;
+    }
     if is_approval_card_cancel_event(event) {
         return CancelOwnership::ActiveApprovalCard;
     }
@@ -199,6 +205,12 @@ fn is_control_cancel_event(event: &ShellEvent) -> bool {
         && event.input.as_deref() == Some("ctrl_c")
 }
 
+fn is_control_esc_event(event: &ShellEvent) -> bool {
+    event.kind == ShellEventKind::UserInputIntercepted
+        && event.component.as_deref() == Some("control")
+        && event.input.as_deref() == Some("esc")
+}
+
 fn is_approval_card_cancel_event(event: &ShellEvent) -> bool {
     event.component.as_deref() == Some("card")
         && event
@@ -302,6 +314,36 @@ mod tests {
     }
 
     #[test]
+    fn control_esc_cancels_active_agent_run() {
+        let mut state = InlineState::default();
+        state.agent_run.active = Some(test_active_run());
+        let mut output = Vec::new();
+
+        render_agent_cancel_actions(&[control_esc()], &[], &mut state, &mut output, 0)
+            .expect("render ESC agent cancel");
+
+        let rendered = String::from_utf8(output).expect("utf8");
+        assert!(state.agent_run.active.is_none());
+        assert!(
+            rendered.contains("Agent cancellation requested"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("Details: provider-cancel-1"));
+    }
+
+    #[test]
+    fn control_esc_without_active_run_is_ignored() {
+        let mut state = InlineState::default();
+        let mut output = Vec::new();
+
+        render_agent_cancel_actions(&[control_esc()], &[], &mut state, &mut output, 0)
+            .expect("render ESC with no active run");
+
+        assert!(state.agent_run.active.is_none());
+        assert!(output.is_empty());
+    }
+
+    #[test]
     fn cancel_ownership_classifies_foreground_cards_agent_and_prompt() {
         let mut state = InlineState::default();
         assert_eq!(
@@ -346,6 +388,12 @@ mod tests {
 
     fn control_ctrl_c() -> ShellEvent {
         let mut event = ShellEvent::user_input_intercepted("session-1", "ctrl_c");
+        event.component = Some("control".to_string());
+        event
+    }
+
+    fn control_esc() -> ShellEvent {
+        let mut event = ShellEvent::user_input_intercepted("session-1", "esc");
         event.component = Some("control".to_string());
         event
     }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -21,6 +21,7 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 parser.push_shell_input_activity_event(empty)
             }
             RawInputEvent::CtrlC => parser.push_control_event("ctrl_c"),
+            RawInputEvent::Esc => parser.push_control_event("esc"),
             RawInputEvent::CandidateRedraw { input, hint } => {
                 if native_mode {
                     if input.len() >= *native_candidate_echoed_len {


### PR DESCRIPTION
In RawInputMode::Delay, hold a bare ESC for 50ms to distinguish it from escape sequences. When it times out, emit RawInputEvent::Esc and map it to a "control/esc" event. The runtime treats this as a user cancellation of the active agent run, reusing the existing handle.cancel() + Governance card path already used for Ctrl+C and slash /cancel.

Why: issue #1706 reports that ESC cannot stop an LLM task while Ctrl+C works. ESC is the conventional cancel key in TUI interactions, so giving it the same agent-run cancel semantics improves discoverability.

Known limitations:
- Only cancels an active agent run; foreground commands still require Ctrl+C.
- The 50ms delay means an ESC that starts a sequence received within the window is forwarded as a sequence instead of triggering cancel.

Assisted-by: Qoder:1.13.0

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #1706

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
