### PR TITLE
fix(cosh-ng): [shell] group /hooks by event with the /help visual contract

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
@@ -61,14 +61,16 @@ pub(crate) use crate::types::{
     GovernedEvent, OutputRefs, Policy, QuestionSelectionMode, ShellEvent, ShellEventKind,
     ShellHandoffRequest,
 };
+pub(crate) use crate::ui::AgentHooksView;
 pub(crate) use crate::ui::{
     approval_action_at, health_uses_startup_row, hook_approval_action_at, hook_warning_icon,
     render_transcript, ActivityDetailsPanelModel, ActivityPanelModel, ActivityRowModel,
     ActivityToolRowModel, AgentStatusAnimation, ApprovalDetailsPanelModel,
     ApprovalJournalEntryModel, ApprovalJournalPanelModel, ApprovalPanelAction, ApprovalPanelModel,
     ApprovalReceiptPanelModel, CommandAssessmentSummaryModel, HealthBannerModel, HelpPanelEntry,
-    HelpPanelGroup, HelpPanelModel, HookWarningView, MarkdownStreamBlock, NoticePanelModel,
-    QuestionAnswerPanelModel, QuestionInputFeedback, QuestionPanelModel, RatatuiInlineRenderer,
+    HelpPanelGroup, HelpPanelModel, HookEntryView, HookEventGroup, HookStatusPanelModel,
+    HookWarningView, MarkdownStreamBlock, NoticePanelModel, QuestionAnswerPanelModel,
+    QuestionInputFeedback, QuestionPanelModel, RatatuiInlineRenderer,
     RecommendationActionPanelModel, RecommendationPanelModel, ToolInvocationCardModel,
     ToolInvocationDensity, ToolInvocationTone,
 };

--- a/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
@@ -17,48 +17,44 @@ pub(crate) fn render_hooks_command<W: Write>(
         (None, _, _) => {
             let i18n = state.i18n();
             let hooks = state.hooks.engine.registered_hook_infos();
-            let shell_body = hooks_status_body(state, &hooks, &i18n);
+            let shell_lines = hooks_status_body(state, &hooks, &i18n);
 
             // Agent Hooks section (only available with CoshCore backend)
-            let (agent_body, agent_hook_count) =
+            let (agent_view, agent_hook_count) =
                 if let AdapterInstance::CoshCore(cosh_core) = adapter {
                     match cosh_core.registry_query("hooks", "list", Value::Null) {
                         Ok(data) => {
-                            let list = format_agent_hooks_list(&data);
                             let count = data.as_array().map(|a| a.len()).unwrap_or(0);
-                            (list, count)
+                            let groups = group_agent_hooks(&data);
+                            let view = if groups.is_empty() {
+                                AgentHooksView::Message("(none)".to_string())
+                            } else {
+                                AgentHooksView::Groups(groups)
+                            };
+                            (view, count)
                         }
-                        Err(e) => (vec![format!("  Error: {e}")], 0),
+                        Err(e) => (AgentHooksView::Message(format!("Error: {e}")), 0),
                     }
                 } else {
                     (
-                        vec![format!(
-                            "  {}",
-                            i18n.t(MessageId::SlashHooksAgentUnavailable)
-                        )],
+                        AgentHooksView::Message(
+                            i18n.t(MessageId::SlashHooksAgentUnavailable).to_string(),
+                        ),
                         0,
                     )
                 };
 
-            let mut body = Vec::new();
-            body.push(format!(
-                "── {} ──",
-                i18n.t(MessageId::SlashHooksShellSection)
-            ));
-            body.extend(shell_body);
-            body.push(String::new());
-            body.push(format!(
-                "── {} ──",
-                i18n.t(MessageId::SlashHooksAgentSection)
-            ));
-            body.extend(agent_body);
-
             let total_hook_count = hooks.len() + agent_hook_count;
-            render_notice_panel(
+            RatatuiInlineRenderer::for_terminal().write_hook_status_panel(
                 output,
-                i18n.t(MessageId::SlashHooksRegisteredTitle),
-                body,
-                Some(&hooks_footer(state, total_hook_count, &i18n)),
+                HookStatusPanelModel {
+                    title: i18n.t(MessageId::SlashHooksRegisteredTitle),
+                    shell_label: i18n.t(MessageId::SlashHooksShellSection),
+                    shell_lines,
+                    agent_label: i18n.t(MessageId::SlashHooksAgentSection),
+                    agent: agent_view,
+                    footer: hooks_footer(state, total_hook_count, &i18n),
+                },
             )
         }
         (Some("history"), None, None) => render_hooks_history(state, output),
@@ -681,30 +677,71 @@ fn hook_severity_label(severity: FindingSeverity) -> &'static str {
     }
 }
 
-fn format_agent_hooks_list(data: &Value) -> Vec<String> {
+/// Fixed display order for agent hook events; unknown events keep their
+/// first-seen order after the known ones.
+const AGENT_HOOK_EVENT_ORDER: [&str; 12] = [
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "UserPromptSubmit",
+    "BeforeModel",
+    "AfterModel",
+    "Stop",
+    "SessionStart",
+    "SessionEnd",
+    "PreCompact",
+    "Notification",
+    "BeforeToolSelection",
+];
+
+fn agent_hook_event_rank(event: &str) -> usize {
+    AGENT_HOOK_EVENT_ORDER
+        .iter()
+        .position(|known| *known == event)
+        .unwrap_or(AGENT_HOOK_EVENT_ORDER.len())
+}
+
+/// Groups the flat `(name, event)` records returned by cosh-core by event
+/// type so a hook registered for several events no longer scatters across
+/// the panel (#1713). Events follow a fixed lifecycle order; hooks keep the
+/// registry order inside each group.
+pub(super) fn group_agent_hooks(data: &Value) -> Vec<HookEventGroup> {
     let Some(arr) = data.as_array() else {
-        return vec!["  (none)".to_string()];
+        return Vec::new();
     };
-    if arr.is_empty() {
-        return vec!["  (none)".to_string()];
-    }
-    arr.iter()
-        .filter_map(|hook| {
-            let name = hook.get("name")?.as_str()?;
-            let event = hook.get("event").and_then(|v| v.as_str()).unwrap_or("?");
-            let ext = hook
+
+    let mut groups: Vec<HookEventGroup> = Vec::new();
+    for hook in arr {
+        let Some(name) = hook.get("name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let event = hook
+            .get("event")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?")
+            .to_string();
+        let entry = HookEntryView {
+            name: name.to_string(),
+            extension: hook
                 .get("extension")
                 .and_then(|v| v.as_str())
-                .unwrap_or("?");
-            let disabled = hook
+                .unwrap_or("?")
+                .to_string(),
+            disabled: hook
                 .get("disabled")
                 .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            if disabled {
-                Some(format!("  ○ {name} [{event}] (ext: {ext}) [disabled]"))
-            } else {
-                Some(format!("  • {name} [{event}] (ext: {ext})"))
-            }
-        })
-        .collect()
+                .unwrap_or(false),
+        };
+        match groups.iter_mut().find(|group| group.event == event) {
+            Some(group) => group.hooks.push(entry),
+            None => groups.push(HookEventGroup {
+                event,
+                hooks: vec![entry],
+            }),
+        }
+    }
+    // Stable sort: known events by lifecycle rank, unknown events keep their
+    // first-seen order after all known ones.
+    groups.sort_by_key(|group| agent_hook_event_rank(&group.event));
+    groups
 }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
@@ -45,6 +45,11 @@ pub(crate) fn render_hooks_command<W: Write>(
                 };
 
             let total_hook_count = hooks.len() + agent_hook_count;
+            let omitted_template = if i18n.language() == crate::config::Language::ZhCn {
+                "… 另有 {count} 个 hook 未显示（完整列表见 plain 输出）".to_string()
+            } else {
+                "… {count} more hook(s) not shown (full list in plain output)".to_string()
+            };
             RatatuiInlineRenderer::for_terminal().write_hook_status_panel(
                 output,
                 HookStatusPanelModel {
@@ -53,6 +58,7 @@ pub(crate) fn render_hooks_command<W: Write>(
                     shell_lines,
                     agent_label: i18n.t(MessageId::SlashHooksAgentSection),
                     agent: agent_view,
+                    omitted_template,
                     footer: hooks_footer(state, total_hook_count, &i18n),
                 },
             )

--- a/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
@@ -679,6 +679,11 @@ fn hook_severity_label(severity: FindingSeverity) -> &'static str {
 
 /// Fixed display order for agent hook events; unknown events keep their
 /// first-seen order after the known ones.
+///
+/// Currently consumed only by `group_agent_hooks`. If another surface ever
+/// needs the same event ordering (e.g. another panel or CLI output),
+/// extract this constant and `agent_hook_event_rank` into a shared hooks
+/// domain module instead of duplicating the order.
 const AGENT_HOOK_EVENT_ORDER: [&str; 12] = [
     "PreToolUse",
     "PostToolUse",

--- a/src/cosh-ng/crates/cosh-shell/src/slash/hooks_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/hooks_tests.rs
@@ -1,6 +1,63 @@
-use super::hooks::render_hooks_command;
+use super::hooks::{group_agent_hooks, render_hooks_command};
 use crate::hooks::state::{RuntimeHookDisplay, RuntimeHookFinding};
 use crate::runtime::prelude::*;
+
+#[test]
+fn agent_hooks_group_by_event_in_lifecycle_order() {
+    // Mirrors the #1713 reproduction: pii-checker registers five events and
+    // observability-hook seven; the flat rendering scattered them across the
+    // panel. Grouping must list each event once, hooks beneath it.
+    let data = serde_json::json!([
+        {"name": "skill-ledger", "event": "PreToolUse", "extension": "agent-sec-core", "disabled": false},
+        {"name": "pii-checker", "event": "PreToolUse", "extension": "agent-sec-core", "disabled": true},
+        {"name": "pii-checker", "event": "AfterModel", "extension": "agent-sec-core", "disabled": true},
+        {"name": "observability-hook", "event": "Stop", "extension": "agent-sec-core", "disabled": false},
+        {"name": "observability-hook", "event": "PreToolUse", "extension": "agent-sec-core", "disabled": false},
+        {"name": "tokenless-compress-schema", "event": "BeforeModel", "extension": "tokenless", "disabled": false},
+        {"name": "mystery", "event": "CustomEvent", "extension": "x", "disabled": false},
+    ]);
+
+    let groups = group_agent_hooks(&data);
+
+    // Event groups appear exactly once, in lifecycle order, unknown trailing.
+    let events: Vec<&str> = groups.iter().map(|group| group.event.as_str()).collect();
+    assert_eq!(
+        events,
+        vec![
+            "PreToolUse",
+            "BeforeModel",
+            "AfterModel",
+            "Stop",
+            "CustomEvent"
+        ],
+        "{events:?}"
+    );
+
+    // Hooks of one event sit contiguously in registry order with state kept.
+    let pre_tool = &groups[0];
+    let names: Vec<(&str, bool)> = pre_tool
+        .hooks
+        .iter()
+        .map(|hook| (hook.name.as_str(), hook.disabled))
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            ("skill-ledger", false),
+            ("pii-checker", true),
+            ("observability-hook", false)
+        ]
+    );
+    assert_eq!(pre_tool.hooks[0].extension, "agent-sec-core");
+}
+
+#[test]
+fn agent_hooks_grouping_handles_empty_and_malformed_payloads() {
+    assert!(group_agent_hooks(&serde_json::json!([])).is_empty());
+    assert!(group_agent_hooks(&serde_json::json!({"not": "an array"})).is_empty());
+    // Records without a name are skipped entirely.
+    assert!(group_agent_hooks(&serde_json::json!([{"event": "PreToolUse"}])).is_empty());
+}
 
 struct EnvLock {
     path: std::path::PathBuf,

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
@@ -11,10 +11,10 @@ use super::RatatuiInlineRenderer;
 
 /// Command reference panel (`/help`) model.
 ///
-/// Layout follows upstream ratatui conventions (see the official `demo2`
-/// example): group headers are bold + underlined, command names are
-/// highlighted, arguments and scope tags are de-emphasized, and summaries sit
-/// on their own indented line.
+/// Layout follows the shared reference-panel convention (`reference_style`):
+/// group headers are bold + underlined, command names are highlighted,
+/// arguments and scope tags are de-emphasized, and summaries sit on their
+/// own indented line.
 pub(crate) struct HelpPanelModel<'a> {
     pub(crate) title: &'a str,
     pub(crate) groups: Vec<HelpPanelGroup<'a>>,

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
@@ -1,8 +1,11 @@
 use std::io::{self, Write};
 
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
+use super::reference_style::{
+    reference_body_style, reference_emphasis_style, reference_muted_style, reference_section_style,
+};
 use super::wrap::{display_width, wrap_plain_line, wrap_plain_line_with_prefix};
 use super::RatatuiInlineRenderer;
 
@@ -61,12 +64,10 @@ fn split_usage(usage: &str) -> (&str, &str) {
 }
 
 fn styled_help_lines(model: &HelpPanelModel<'_>, inner: usize) -> Vec<Line<'static>> {
-    let header_style = Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED);
-    let name_style = Style::default()
-        .fg(Color::Cyan)
-        .add_modifier(Modifier::BOLD);
-    let args_style = Style::default().fg(Color::DarkGray);
-    let summary_style = Style::default().fg(Color::Gray);
+    let header_style = reference_section_style();
+    let name_style = reference_emphasis_style();
+    let args_style = reference_muted_style();
+    let summary_style = reference_body_style();
 
     let mut lines = Vec::new();
     for (group_index, group) in model.groups.iter().enumerate() {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help_tests.rs
@@ -26,6 +26,36 @@ fn wrap_preserves_deep_space_indentation_with_hanging_indent() {
 }
 
 #[test]
+fn wrap_indent_detection_excludes_control_whitespace() {
+    // Only consecutive ASCII spaces count as indentation: control whitespace
+    // after the spaces must be dropped from both the prefix and the body,
+    // never replayed into terminal output (wrap is shared by every panel).
+    for (input, forbidden) in [
+        ("  \rsecret", '\r'),
+        ("  \tsecret", '\t'),
+        ("  \nsecret", '\n'),
+    ] {
+        let wrapped = wrap_plain_line(input, 30);
+        assert!(
+            wrapped.iter().all(|line| !line.contains(forbidden)),
+            "{input:?} -> {wrapped:?}"
+        );
+        assert!(
+            wrapped.first().is_some_and(|line| line == "  secret"),
+            "{input:?} -> {wrapped:?}"
+        );
+    }
+    // Hanging indent still derives from the space run alone.
+    let wrapped = wrap_plain_line("  \ta rather long body that must wrap around", 20);
+    assert!(
+        wrapped[1..]
+            .iter()
+            .all(|line| line.starts_with("  ") && !line.starts_with("   ") && !line.contains('\t')),
+        "{wrapped:?}"
+    );
+}
+
+#[test]
 fn rich_notice_panel_preserves_leading_indent_and_hanging_wrap() {
     let renderer = RatatuiInlineRenderer::with_width(44);
     let mut output = Vec::new();

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help_tests.rs
@@ -2,9 +2,28 @@
 //! guarantees that its layered layout depends on.
 
 use super::{
-    strip_ansi_escape, HelpPanelEntry, HelpPanelGroup, HelpPanelModel, NoticePanelModel,
-    RatatuiInlineRenderer,
+    strip_ansi_escape, wrap_plain_line, HelpPanelEntry, HelpPanelGroup, HelpPanelModel,
+    NoticePanelModel, RatatuiInlineRenderer,
 };
+
+#[test]
+fn wrap_preserves_deep_space_indentation_with_hanging_indent() {
+    // Nested panel hierarchies (e.g. /hooks event groups) rely on 4-space
+    // entries under 2-space headers; the wrapper must keep the exact indent
+    // width on the first line and reuse it as the hanging indent.
+    let wrapped = wrap_plain_line(
+        "    • some-hook with a rather long descriptive tail that wraps",
+        30,
+    );
+    assert!(wrapped.len() >= 2, "{wrapped:?}");
+    assert!(wrapped[0].starts_with("    • some-hook"), "{wrapped:?}");
+    assert!(
+        wrapped[1..]
+            .iter()
+            .all(|line| line.starts_with("    ") && !line.starts_with("     ")),
+        "{wrapped:?}"
+    );
+}
 
 #[test]
 fn rich_notice_panel_preserves_leading_indent_and_hanging_wrap() {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
@@ -9,6 +9,7 @@ use super::reference_style::{
     reference_body_style, reference_emphasis_style, reference_group_style, reference_muted_style,
     reference_section_style,
 };
+use super::wrap::{strip_ansi_escape, wrap_plain_line, wrap_plain_line_with_prefix};
 use super::RatatuiInlineRenderer;
 
 #[derive(Debug)]
@@ -52,16 +53,33 @@ impl RatatuiInlineRenderer {
         model: HookStatusPanelModel<'_>,
     ) -> io::Result<()> {
         if self.plain {
-            let body = plain_hook_status_lines(&model);
+            let width = self.content_width();
+            let body = plain_hook_status_lines(&model, width);
             return self.write_block(output, model.title, body, Some(&model.footer));
         }
+        let inner = usize::from(self.panel_standard_width().saturating_sub(4)).max(1);
         let title = model.title;
-        let body = styled_hook_status_lines(&model);
+        let body = styled_hook_status_lines(&model, inner);
         self.write_styled_block(output, title, body)
     }
 }
 
-fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>) -> Vec<Line<'static>> {
+/// Removes ANSI escape sequences and any remaining control characters from
+/// registry- or error-provided text before it reaches a terminal. The legacy
+/// notice-panel path stripped escapes in `render_lines`; this panel writes
+/// spans directly, so sanitizing is this module's responsibility for both
+/// backends.
+fn sanitize(text: &str) -> String {
+    strip_ansi_escape(text)
+        .chars()
+        .filter(|ch| !ch.is_control())
+        .collect()
+}
+
+const ENTRY_INDENT: &str = "    ";
+const ENTRY_HANG: &str = "      ";
+
+fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> Vec<Line<'static>> {
     let section = reference_section_style();
     let group = reference_group_style();
     let emphasis = reference_emphasis_style();
@@ -70,49 +88,87 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>) -> Vec<Line<'stati
 
     let mut lines = Vec::new();
     lines.push(Line::from(Span::styled(
-        model.shell_label.to_string(),
+        sanitize(model.shell_label),
         section,
     )));
     for shell_line in &model.shell_lines {
-        lines.push(Line::from(Span::styled(
-            format!("  {}", shell_line.trim_start()),
-            body_style,
-        )));
+        for segment in
+            wrap_plain_line_with_prefix(&sanitize(shell_line.trim_start()), "  ", "  ", inner)
+        {
+            lines.push(Line::from(Span::styled(segment, body_style)));
+        }
     }
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        model.agent_label.to_string(),
+        sanitize(model.agent_label),
         section,
     )));
     match &model.agent {
         AgentHooksView::Message(message) => {
-            lines.push(Line::from(Span::styled(
-                format!("  {}", message.trim_start()),
-                body_style,
-            )));
+            for segment in
+                wrap_plain_line_with_prefix(&sanitize(message.trim_start()), "  ", "  ", inner)
+            {
+                lines.push(Line::from(Span::styled(segment, body_style)));
+            }
         }
         AgentHooksView::Groups(groups) => {
             for (index, event_group) in groups.iter().enumerate() {
                 if index > 0 {
                     lines.push(Line::from(""));
                 }
-                lines.push(Line::from(Span::styled(
-                    format!("  {}", event_group.event),
-                    group,
-                )));
+                for segment in
+                    wrap_plain_line_with_prefix(&sanitize(&event_group.event), "  ", "  ", inner)
+                {
+                    lines.push(Line::from(Span::styled(segment, group)));
+                }
                 for hook in &event_group.hooks {
+                    let name = sanitize(&hook.name);
+                    let extension = sanitize(&hook.extension);
                     if hook.disabled {
-                        lines.push(Line::from(Span::styled(
-                            format!("    ○ {} (ext: {}) [disabled]", hook.name, hook.extension),
-                            muted,
-                        )));
+                        for segment in wrap_plain_line_with_prefix(
+                            &format!("○ {name} (ext: {extension}) [disabled]"),
+                            ENTRY_INDENT,
+                            ENTRY_HANG,
+                            inner,
+                        ) {
+                            lines.push(Line::from(Span::styled(segment, muted)));
+                        }
                     } else {
-                        lines.push(Line::from(vec![
-                            Span::raw("    ".to_string()),
-                            Span::styled("• ".to_string(), emphasis),
-                            Span::raw(hook.name.clone()),
-                            Span::styled(format!(" (ext: {})", hook.extension), muted),
-                        ]));
+                        let wrapped = wrap_plain_line_with_prefix(
+                            &format!("• {name} (ext: {extension})"),
+                            ENTRY_INDENT,
+                            ENTRY_HANG,
+                            inner,
+                        );
+                        for (segment_index, segment) in wrapped.iter().enumerate() {
+                            if segment_index == 0 {
+                                // First segment: "    " + "• " + name [+ metadata tail].
+                                let rest = segment
+                                    .strip_prefix(ENTRY_INDENT)
+                                    .and_then(|rest| rest.strip_prefix("• "));
+                                match rest {
+                                    Some(rest) => {
+                                        let (head, tail) = match rest.find(" (ext:") {
+                                            Some(split) => rest.split_at(split),
+                                            None => (rest, ""),
+                                        };
+                                        let mut spans = vec![
+                                            Span::raw(ENTRY_INDENT.to_string()),
+                                            Span::styled("• ".to_string(), emphasis),
+                                            Span::raw(head.to_string()),
+                                        ];
+                                        if !tail.is_empty() {
+                                            spans.push(Span::styled(tail.to_string(), muted));
+                                        }
+                                        lines.push(Line::from(spans));
+                                    }
+                                    None => lines.push(Line::from(Span::raw(segment.clone()))),
+                                }
+                            } else {
+                                // Continuation segments carry metadata overflow.
+                                lines.push(Line::from(Span::styled(segment.clone(), muted)));
+                            }
+                        }
                     }
                 }
             }
@@ -121,29 +177,48 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>) -> Vec<Line<'stati
     // Spacer before the footer is owned by the styled layout; the plain
     // backend delegates footer spacing to write_block instead.
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(model.footer.clone(), body_style)));
+    for segment in wrap_plain_line(&sanitize(&model.footer), inner) {
+        lines.push(Line::from(Span::styled(segment, body_style)));
+    }
     lines
 }
 
-fn plain_hook_status_lines(model: &HookStatusPanelModel<'_>) -> Vec<String> {
+fn plain_hook_status_lines(model: &HookStatusPanelModel<'_>, width: usize) -> Vec<String> {
     let mut body = Vec::new();
-    body.push(format!("── {} ──", model.shell_label));
-    body.extend(model.shell_lines.iter().cloned());
-    body.push(format!("── {} ──", model.agent_label));
+    body.push(format!("── {} ──", sanitize(model.shell_label)));
+    for shell_line in &model.shell_lines {
+        body.extend(wrap_plain_line(&sanitize(shell_line), width));
+    }
+    body.push(format!("── {} ──", sanitize(model.agent_label)));
     match &model.agent {
-        AgentHooksView::Message(message) => body.push(format!("  {}", message.trim_start())),
+        AgentHooksView::Message(message) => body.extend(wrap_plain_line_with_prefix(
+            &sanitize(message.trim_start()),
+            "  ",
+            "  ",
+            width,
+        )),
         AgentHooksView::Groups(groups) => {
             for event_group in groups {
-                body.push(format!("  {}", event_group.event));
+                body.extend(wrap_plain_line_with_prefix(
+                    &sanitize(&event_group.event),
+                    "  ",
+                    "  ",
+                    width,
+                ));
                 for hook in &event_group.hooks {
-                    if hook.disabled {
-                        body.push(format!(
-                            "    ○ {} (ext: {}) [disabled]",
-                            hook.name, hook.extension
-                        ));
+                    let name = sanitize(&hook.name);
+                    let extension = sanitize(&hook.extension);
+                    let entry = if hook.disabled {
+                        format!("○ {name} (ext: {extension}) [disabled]")
                     } else {
-                        body.push(format!("    • {} (ext: {})", hook.name, hook.extension));
-                    }
+                        format!("• {name} (ext: {extension})")
+                    };
+                    body.extend(wrap_plain_line_with_prefix(
+                        &entry,
+                        ENTRY_INDENT,
+                        ENTRY_HANG,
+                        width,
+                    ));
                 }
             }
         }

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
@@ -22,6 +22,10 @@ pub(crate) struct HookStatusPanelModel<'a> {
     pub(crate) shell_lines: Vec<String>,
     pub(crate) agent_label: &'a str,
     pub(crate) agent: AgentHooksView,
+    /// Localized template for the truncation marker on the styled backend;
+    /// `{count}` is replaced with the number of hooks not shown. The plain
+    /// backend never truncates.
+    pub(crate) omitted_template: String,
     pub(crate) footer: String,
 }
 
@@ -33,13 +37,13 @@ pub(crate) enum AgentHooksView {
     Message(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct HookEventGroup {
     pub(crate) event: String,
     pub(crate) hooks: Vec<HookEntryView>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct HookEntryView {
     pub(crate) name: String,
     pub(crate) extension: String,
@@ -79,6 +83,14 @@ fn sanitize(text: &str) -> String {
 const ENTRY_INDENT: &str = "    ";
 const ENTRY_HANG: &str = "      ";
 
+/// The rich block renderer caps a panel at 200 buffer rows (borders
+/// included). Grouped agent hooks can exceed that on large registries, and
+/// `Paragraph` would silently drop the overflow — including the footer. Keep
+/// the body within this budget and surface an explicit omission marker
+/// instead; the reserve covers the marker, the pre-footer spacer, and the
+/// footer itself.
+const STYLED_BODY_LINE_BUDGET: usize = 195;
+
 fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> Vec<Line<'static>> {
     let section = reference_section_style();
     let group = reference_group_style();
@@ -112,7 +124,14 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> V
             }
         }
         AgentHooksView::Groups(groups) => {
+            let mut omitted = 0usize;
             for (index, event_group) in groups.iter().enumerate() {
+                // Stop emitting once the line budget is spent; keep counting
+                // the hooks that will not be shown.
+                if lines.len() >= STYLED_BODY_LINE_BUDGET {
+                    omitted += event_group.hooks.len();
+                    continue;
+                }
                 if index > 0 {
                     lines.push(Line::from(""));
                 }
@@ -122,6 +141,10 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> V
                     lines.push(Line::from(Span::styled(segment, group)));
                 }
                 for hook in &event_group.hooks {
+                    if lines.len() >= STYLED_BODY_LINE_BUDGET {
+                        omitted += 1;
+                        continue;
+                    }
                     let name = sanitize(&hook.name);
                     let extension = sanitize(&hook.extension);
                     if hook.disabled {
@@ -170,6 +193,14 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> V
                             }
                         }
                     }
+                }
+            }
+            if omitted > 0 {
+                let marker = model
+                    .omitted_template
+                    .replace("{count}", &omitted.to_string());
+                for segment in wrap_plain_line_with_prefix(&sanitize(&marker), "  ", "  ", inner) {
+                    lines.push(Line::from(Span::styled(segment, muted)));
                 }
             }
         }

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
@@ -83,20 +83,72 @@ fn sanitize(text: &str) -> String {
 const ENTRY_INDENT: &str = "    ";
 const ENTRY_HANG: &str = "      ";
 
-/// The rich block renderer caps a panel at 200 buffer rows (borders
-/// included). Grouped agent hooks can exceed that on large registries, and
-/// `Paragraph` would silently drop the overflow — including the footer. Keep
-/// the body within this budget and surface an explicit omission marker
-/// instead; the reserve covers the marker, the pre-footer spacer, and the
-/// footer itself.
-const STYLED_BODY_LINE_BUDGET: usize = 195;
+/// The rich block renderer caps a panel at 200 buffer rows, including borders.
+const STYLED_BODY_LINE_LIMIT: usize = 198;
+
+fn styled_hook_entry_lines(hook: &HookEntryView, inner: usize) -> Vec<Line<'static>> {
+    let emphasis = reference_emphasis_style();
+    let muted = reference_muted_style();
+    let name = sanitize(&hook.name);
+    let extension = sanitize(&hook.extension);
+    if hook.disabled {
+        return wrap_plain_line_with_prefix(
+            &format!("○ {name} (ext: {extension}) [disabled]"),
+            ENTRY_INDENT,
+            ENTRY_HANG,
+            inner,
+        )
+        .into_iter()
+        .map(|segment| Line::from(Span::styled(segment, muted)))
+        .collect();
+    }
+
+    wrap_plain_line_with_prefix(
+        &format!("• {name} (ext: {extension})"),
+        ENTRY_INDENT,
+        ENTRY_HANG,
+        inner,
+    )
+    .into_iter()
+    .enumerate()
+    .map(|(segment_index, segment)| {
+        if segment_index > 0 {
+            return Line::from(Span::styled(segment, muted));
+        }
+
+        // Preserve the enabled-entry emphasis while keeping wrapped metadata muted.
+        let rest = segment
+            .strip_prefix(ENTRY_INDENT)
+            .and_then(|rest| rest.strip_prefix("• "));
+        let Some(rest) = rest else {
+            return Line::from(Span::raw(segment));
+        };
+        let (head, tail) = match rest.find(" (ext:") {
+            Some(split) => rest.split_at(split),
+            None => (rest, ""),
+        };
+        let mut spans = vec![
+            Span::raw(ENTRY_INDENT.to_string()),
+            Span::styled("• ".to_string(), emphasis),
+            Span::raw(head.to_string()),
+        ];
+        if !tail.is_empty() {
+            spans.push(Span::styled(tail.to_string(), muted));
+        }
+        Line::from(spans)
+    })
+    .collect()
+}
 
 fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> Vec<Line<'static>> {
     let section = reference_section_style();
     let group = reference_group_style();
-    let emphasis = reference_emphasis_style();
     let muted = reference_muted_style();
     let body_style = reference_body_style();
+    let footer_lines = wrap_plain_line(&sanitize(&model.footer), inner)
+        .into_iter()
+        .map(|segment| Line::from(Span::styled(segment, body_style)))
+        .collect::<Vec<_>>();
 
     let mut lines = Vec::new();
     lines.push(Line::from(Span::styled(
@@ -124,77 +176,50 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> V
             }
         }
         AgentHooksView::Groups(groups) => {
-            let mut omitted = 0usize;
-            for (index, event_group) in groups.iter().enumerate() {
-                // Stop emitting once the line budget is spent; keep counting
-                // the hooks that will not be shown.
-                if lines.len() >= STYLED_BODY_LINE_BUDGET {
-                    omitted += event_group.hooks.len();
+            let total_hooks: usize = groups
+                .iter()
+                .map(|event_group| event_group.hooks.len())
+                .sum();
+            let marker_reserve = model
+                .omitted_template
+                .replace("{count}", &total_hooks.to_string());
+            let marker_reserve =
+                wrap_plain_line_with_prefix(&sanitize(&marker_reserve), "  ", "  ", inner).len();
+            let tail_reserve = marker_reserve + 1 + footer_lines.len();
+            let mut shown_hooks = 0usize;
+            let mut shown_groups = 0usize;
+
+            'groups: for event_group in groups {
+                if event_group.hooks.is_empty() {
                     continue;
                 }
-                if index > 0 {
-                    lines.push(Line::from(""));
+                let mut group_prefix = Vec::new();
+                if shown_groups > 0 {
+                    group_prefix.push(Line::from(""));
                 }
-                for segment in
+                group_prefix.extend(
                     wrap_plain_line_with_prefix(&sanitize(&event_group.event), "  ", "  ", inner)
-                {
-                    lines.push(Line::from(Span::styled(segment, group)));
-                }
+                        .into_iter()
+                        .map(|segment| Line::from(Span::styled(segment, group))),
+                );
+                let mut group_prefix = Some(group_prefix);
+
                 for hook in &event_group.hooks {
-                    if lines.len() >= STYLED_BODY_LINE_BUDGET {
-                        omitted += 1;
-                        continue;
+                    let hook_lines = styled_hook_entry_lines(hook, inner);
+                    let prefix_len = group_prefix.as_ref().map_or(0, Vec::len);
+                    let required = lines.len() + prefix_len + hook_lines.len() + tail_reserve;
+                    if required > STYLED_BODY_LINE_LIMIT {
+                        break 'groups;
                     }
-                    let name = sanitize(&hook.name);
-                    let extension = sanitize(&hook.extension);
-                    if hook.disabled {
-                        for segment in wrap_plain_line_with_prefix(
-                            &format!("○ {name} (ext: {extension}) [disabled]"),
-                            ENTRY_INDENT,
-                            ENTRY_HANG,
-                            inner,
-                        ) {
-                            lines.push(Line::from(Span::styled(segment, muted)));
-                        }
-                    } else {
-                        let wrapped = wrap_plain_line_with_prefix(
-                            &format!("• {name} (ext: {extension})"),
-                            ENTRY_INDENT,
-                            ENTRY_HANG,
-                            inner,
-                        );
-                        for (segment_index, segment) in wrapped.iter().enumerate() {
-                            if segment_index == 0 {
-                                // First segment: "    " + "• " + name [+ metadata tail].
-                                let rest = segment
-                                    .strip_prefix(ENTRY_INDENT)
-                                    .and_then(|rest| rest.strip_prefix("• "));
-                                match rest {
-                                    Some(rest) => {
-                                        let (head, tail) = match rest.find(" (ext:") {
-                                            Some(split) => rest.split_at(split),
-                                            None => (rest, ""),
-                                        };
-                                        let mut spans = vec![
-                                            Span::raw(ENTRY_INDENT.to_string()),
-                                            Span::styled("• ".to_string(), emphasis),
-                                            Span::raw(head.to_string()),
-                                        ];
-                                        if !tail.is_empty() {
-                                            spans.push(Span::styled(tail.to_string(), muted));
-                                        }
-                                        lines.push(Line::from(spans));
-                                    }
-                                    None => lines.push(Line::from(Span::raw(segment.clone()))),
-                                }
-                            } else {
-                                // Continuation segments carry metadata overflow.
-                                lines.push(Line::from(Span::styled(segment.clone(), muted)));
-                            }
-                        }
+                    if let Some(prefix) = group_prefix.take() {
+                        lines.extend(prefix);
+                        shown_groups += 1;
                     }
+                    lines.extend(hook_lines);
+                    shown_hooks += 1;
                 }
             }
+            let omitted = total_hooks - shown_hooks;
             if omitted > 0 {
                 let marker = model
                     .omitted_template
@@ -203,14 +228,16 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>, inner: usize) -> V
                     lines.push(Line::from(Span::styled(segment, muted)));
                 }
             }
+            lines.push(Line::from(""));
+            lines.extend(footer_lines);
+            debug_assert!(lines.len() <= STYLED_BODY_LINE_LIMIT);
+            return lines;
         }
     }
     // Spacer before the footer is owned by the styled layout; the plain
     // backend delegates footer spacing to write_block instead.
     lines.push(Line::from(""));
-    for segment in wrap_plain_line(&sanitize(&model.footer), inner) {
-        lines.push(Line::from(Span::styled(segment, body_style)));
-    }
+    lines.extend(footer_lines);
     lines
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
@@ -1,0 +1,143 @@
+//! `/hooks` status panel: shell-hook stats plus agent hooks grouped by
+//! event, sharing the reference-panel visual contract with `/help`.
+
+use std::io::{self, Write};
+
+use ratatui::text::{Line, Span};
+
+use super::reference_style::{
+    reference_body_style, reference_emphasis_style, reference_group_style, reference_muted_style,
+    reference_section_style,
+};
+use super::RatatuiInlineRenderer;
+
+pub(crate) struct HookStatusPanelModel<'a> {
+    pub(crate) title: &'a str,
+    pub(crate) shell_label: &'a str,
+    pub(crate) shell_lines: Vec<String>,
+    pub(crate) agent_label: &'a str,
+    pub(crate) agent: AgentHooksView,
+    pub(crate) footer: String,
+}
+
+/// Agent hooks section content: grouped hooks, or a status message
+/// (backend unavailable, registry error, empty registry).
+pub(crate) enum AgentHooksView {
+    Groups(Vec<HookEventGroup>),
+    Message(String),
+}
+
+pub(crate) struct HookEventGroup {
+    pub(crate) event: String,
+    pub(crate) hooks: Vec<HookEntryView>,
+}
+
+pub(crate) struct HookEntryView {
+    pub(crate) name: String,
+    pub(crate) extension: String,
+    pub(crate) disabled: bool,
+}
+
+impl RatatuiInlineRenderer {
+    pub(crate) fn write_hook_status_panel<W: Write>(
+        &self,
+        output: &mut W,
+        model: HookStatusPanelModel<'_>,
+    ) -> io::Result<()> {
+        if self.plain {
+            let body = plain_hook_status_lines(&model);
+            return self.write_block(output, model.title, body, Some(&model.footer));
+        }
+        let title = model.title;
+        let body = styled_hook_status_lines(&model);
+        self.write_styled_block(output, title, body)
+    }
+}
+
+fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>) -> Vec<Line<'static>> {
+    let section = reference_section_style();
+    let group = reference_group_style();
+    let emphasis = reference_emphasis_style();
+    let muted = reference_muted_style();
+    let body_style = reference_body_style();
+
+    let mut lines = Vec::new();
+    lines.push(Line::from(Span::styled(
+        model.shell_label.to_string(),
+        section,
+    )));
+    for shell_line in &model.shell_lines {
+        lines.push(Line::from(Span::styled(
+            format!("  {}", shell_line.trim_start()),
+            body_style,
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        model.agent_label.to_string(),
+        section,
+    )));
+    match &model.agent {
+        AgentHooksView::Message(message) => {
+            lines.push(Line::from(Span::styled(
+                format!("  {}", message.trim_start()),
+                body_style,
+            )));
+        }
+        AgentHooksView::Groups(groups) => {
+            for (index, event_group) in groups.iter().enumerate() {
+                if index > 0 {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", event_group.event),
+                    group,
+                )));
+                for hook in &event_group.hooks {
+                    if hook.disabled {
+                        lines.push(Line::from(Span::styled(
+                            format!("    ○ {} (ext: {}) [disabled]", hook.name, hook.extension),
+                            muted,
+                        )));
+                    } else {
+                        lines.push(Line::from(vec![
+                            Span::raw("    ".to_string()),
+                            Span::styled("• ".to_string(), emphasis),
+                            Span::raw(hook.name.clone()),
+                            Span::styled(format!(" (ext: {})", hook.extension), muted),
+                        ]));
+                    }
+                }
+            }
+        }
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(model.footer.clone(), body_style)));
+    lines
+}
+
+fn plain_hook_status_lines(model: &HookStatusPanelModel<'_>) -> Vec<String> {
+    let mut body = Vec::new();
+    body.push(format!("── {} ──", model.shell_label));
+    body.extend(model.shell_lines.iter().cloned());
+    body.push(format!("── {} ──", model.agent_label));
+    match &model.agent {
+        AgentHooksView::Message(message) => body.push(format!("  {}", message.trim_start())),
+        AgentHooksView::Groups(groups) => {
+            for event_group in groups {
+                body.push(format!("  {}", event_group.event));
+                for hook in &event_group.hooks {
+                    if hook.disabled {
+                        body.push(format!(
+                            "    ○ {} (ext: {}) [disabled]",
+                            hook.name, hook.extension
+                        ));
+                    } else {
+                        body.push(format!("    • {} (ext: {})", hook.name, hook.extension));
+                    }
+                }
+            }
+        }
+    }
+    body
+}

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status.rs
@@ -11,9 +11,13 @@ use super::reference_style::{
 };
 use super::RatatuiInlineRenderer;
 
+#[derive(Debug)]
 pub(crate) struct HookStatusPanelModel<'a> {
     pub(crate) title: &'a str,
     pub(crate) shell_label: &'a str,
+    /// Shell-hook stat lines as logical content without indentation
+    /// prefixes; each backend applies its own indentation (styled indents
+    /// under the section header, plain keeps the legacy flush layout).
     pub(crate) shell_lines: Vec<String>,
     pub(crate) agent_label: &'a str,
     pub(crate) agent: AgentHooksView,
@@ -22,16 +26,19 @@ pub(crate) struct HookStatusPanelModel<'a> {
 
 /// Agent hooks section content: grouped hooks, or a status message
 /// (backend unavailable, registry error, empty registry).
+#[derive(Debug)]
 pub(crate) enum AgentHooksView {
     Groups(Vec<HookEventGroup>),
     Message(String),
 }
 
+#[derive(Debug)]
 pub(crate) struct HookEventGroup {
     pub(crate) event: String,
     pub(crate) hooks: Vec<HookEntryView>,
 }
 
+#[derive(Debug)]
 pub(crate) struct HookEntryView {
     pub(crate) name: String,
     pub(crate) extension: String,
@@ -111,6 +118,8 @@ fn styled_hook_status_lines(model: &HookStatusPanelModel<'_>) -> Vec<Line<'stati
             }
         }
     }
+    // Spacer before the footer is owned by the styled layout; the plain
+    // backend delegates footer spacing to write_block instead.
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(model.footer.clone(), body_style)));
     lines

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
@@ -40,6 +40,7 @@ fn sample_model() -> HookStatusPanelModel<'static> {
                 }],
             },
         ]),
+        omitted_template: "… {count} more hook(s) not shown".to_string(),
         footer: "3 hook(s) registered.".to_string(),
     }
 }
@@ -155,6 +156,7 @@ fn hook_status_panel_wraps_long_entries_with_hanging_indent_when_narrow() {
             event: "PreToolUse".to_string(),
             hooks: vec![long_entry],
         }]),
+        omitted_template: "… {count} more hook(s) not shown".to_string(),
         footer: "1 hook(s) registered.".to_string(),
     };
 
@@ -207,6 +209,7 @@ fn hook_status_panel_wraps_long_entries_with_hanging_indent_when_narrow() {
                 disabled: false,
             }],
         }]),
+        omitted_template: "… {count} more hook(s) not shown".to_string(),
         footer: "1 hook(s) registered.".to_string(),
     };
     let mut output = Vec::new();
@@ -220,6 +223,77 @@ fn hook_status_panel_wraps_long_entries_with_hanging_indent_when_narrow() {
         "plain line overflowed the width contract: {text}"
     );
     assert!(text.contains("very-long-hook-name-that-wraps"), "{text}");
+}
+
+#[test]
+fn hook_status_panel_large_registry_truncates_with_marker_and_keeps_footer() {
+    // The rich block renderer caps panels at 200 buffer rows; a large
+    // registry must degrade to an explicit omission marker instead of
+    // Paragraph silently dropping the tail (including the footer).
+    let groups: Vec<HookEventGroup> = (0..12)
+        .map(|group_index| HookEventGroup {
+            event: format!("Event-{group_index}"),
+            hooks: (0..15)
+                .map(|hook_index| HookEntryView {
+                    name: format!("hook-{group_index}-{hook_index}"),
+                    extension: "agent-sec-core".to_string(),
+                    disabled: false,
+                })
+                .collect(),
+        })
+        .collect();
+    let model = HookStatusPanelModel {
+        title: "Hook status",
+        shell_label: "Shell Hooks",
+        shell_lines: vec!["Registered: 2; enabled: 2; disabled: 0.".to_string()],
+        agent_label: "Agent Hooks",
+        agent: AgentHooksView::Groups(groups.clone()),
+        omitted_template: "… {count} more hook(s) not shown".to_string(),
+        footer: "180 hook(s) registered.".to_string(),
+    };
+
+    let renderer = RatatuiInlineRenderer::with_width(80);
+    let mut output = Vec::new();
+    renderer
+        .write_hook_status_panel(&mut output, model)
+        .unwrap();
+
+    let text = strip_ansi_escape(&String::from_utf8(output).unwrap());
+    // Footer survives, an omission marker is present, and nothing overflows
+    // the renderer's 200-row cap.
+    assert!(text.contains("180 hook(s) registered."), "{text}");
+    assert!(text.contains("more hook(s) not shown"), "{text}");
+    assert!(text.lines().count() <= 200, "{}", text.lines().count());
+    let marker_line = text
+        .lines()
+        .find(|line| line.contains("more hook(s) not shown"))
+        .unwrap();
+    let omitted: usize = marker_line
+        .chars()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .unwrap();
+    assert!(omitted > 0 && omitted < 180, "{marker_line}");
+
+    // The plain backend never truncates: all hooks and the footer remain.
+    let plain = RatatuiInlineRenderer::plain_with_width(120);
+    let model = HookStatusPanelModel {
+        title: "Hook status",
+        shell_label: "Shell Hooks",
+        shell_lines: vec!["Registered: 2; enabled: 2; disabled: 0.".to_string()],
+        agent_label: "Agent Hooks",
+        agent: AgentHooksView::Groups(groups),
+        omitted_template: "… {count} more hook(s) not shown".to_string(),
+        footer: "180 hook(s) registered.".to_string(),
+    };
+    let mut output = Vec::new();
+    plain.write_hook_status_panel(&mut output, model).unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains("hook-11-14"), "{text}");
+    assert!(text.contains("180 hook(s) registered."), "{text}");
+    assert!(!text.contains("more hook(s) not shown"), "{text}");
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
@@ -99,6 +99,127 @@ fn hook_status_panel_layers_sections_events_and_entries() {
 }
 
 #[test]
+fn hook_status_panel_strips_control_sequences_from_registry_text() {
+    // Registry-provided names/extensions and error messages are untrusted:
+    // embedded escape sequences must never reach the terminal (they could
+    // recolor or clear the screen), on either backend.
+    let mut model = sample_model();
+    model.agent = AgentHooksView::Groups(vec![HookEventGroup {
+        event: "Pre\u{1b}[31mToolUse".to_string(),
+        hooks: vec![HookEntryView {
+            name: "evil\u{1b}[31mred".to_string(),
+            extension: "wipe\u{1b}[2Jext".to_string(),
+            disabled: false,
+        }],
+    }]);
+
+    let mut styled = RatatuiInlineRenderer::with_width(100);
+    styled.styled = true;
+    let mut output = Vec::new();
+    styled.write_hook_status_panel(&mut output, model).unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(!text.contains("\u{1b}[31m"), "{text:?}");
+    assert!(!text.contains("\u{1b}[2J"), "{text:?}");
+    assert!(text.contains("evilred"), "{text}");
+    assert!(
+        text.contains("wipeJext") || text.contains("wipeext"),
+        "{text}"
+    );
+
+    let mut model = sample_model();
+    model.agent = AgentHooksView::Message("boom\u{1b}[2J\rcleared".to_string());
+    let plain = RatatuiInlineRenderer::plain_with_width(100);
+    let mut output = Vec::new();
+    plain.write_hook_status_panel(&mut output, model).unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(!text.contains('\u{1b}'), "{text:?}");
+    assert!(!text.contains('\r'), "{text:?}");
+}
+
+#[test]
+fn hook_status_panel_wraps_long_entries_with_hanging_indent_when_narrow() {
+    let long_entry = HookEntryView {
+        name: "very-long-hook-name-that-wraps".to_string(),
+        extension: "very-long-extension-name".to_string(),
+        disabled: false,
+    };
+    let model = HookStatusPanelModel {
+        title: "Hook status",
+        shell_label: "Shell Hooks",
+        shell_lines: vec![
+            "Registered: 2; enabled: 2; disabled: 0. Sources: builtin=2; user=0; project=0."
+                .to_string(),
+        ],
+        agent_label: "Agent Hooks",
+        agent: AgentHooksView::Groups(vec![HookEventGroup {
+            event: "PreToolUse".to_string(),
+            hooks: vec![long_entry],
+        }]),
+        footer: "1 hook(s) registered.".to_string(),
+    };
+
+    let renderer = RatatuiInlineRenderer::with_width(40);
+    let mut output = Vec::new();
+    renderer
+        .write_hook_status_panel(&mut output, model)
+        .unwrap();
+
+    let text = strip_ansi_escape(&String::from_utf8(output).unwrap());
+    let lines = text.lines().collect::<Vec<_>>();
+    // The entry wraps; its continuation keeps the hanging indent instead of
+    // falling back to column zero.
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.starts_with("│     • very-long-hook-name")),
+        "{text}"
+    );
+    let entry_index = lines
+        .iter()
+        .position(|line| line.starts_with("│     • very-long-hook-name"))
+        .unwrap();
+    assert!(
+        lines[entry_index + 1].starts_with("│       "),
+        "continuation lost its hanging indent: {text}"
+    );
+    // Shell stats continuations stay indented under their section too.
+    let stats_index = lines
+        .iter()
+        .position(|line| line.starts_with("│   Registered: 2"))
+        .unwrap();
+    assert!(
+        lines[stats_index + 1].starts_with("│   "),
+        "stats continuation returned to column zero: {text}"
+    );
+
+    // Plain backend wraps to the same width contract instead of overflowing.
+    let plain = RatatuiInlineRenderer::plain_with_width(40);
+    let model = HookStatusPanelModel {
+        title: "Hook status",
+        shell_label: "Shell Hooks",
+        shell_lines: vec!["Registered: 2; enabled: 2; disabled: 0.".to_string()],
+        agent_label: "Agent Hooks",
+        agent: AgentHooksView::Groups(vec![HookEventGroup {
+            event: "PreToolUse".to_string(),
+            hooks: vec![HookEntryView {
+                name: "very-long-hook-name-that-wraps".to_string(),
+                extension: "very-long-extension-name".to_string(),
+                disabled: false,
+            }],
+        }]),
+        footer: "1 hook(s) registered.".to_string(),
+    };
+    let mut output = Vec::new();
+    plain.write_hook_status_panel(&mut output, model).unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(
+        text.lines().all(|line| line.chars().count() <= 60),
+        "plain line overflowed the width contract: {text}"
+    );
+    assert!(text.contains("very-long-hook-name-that-wraps"), "{text}");
+}
+
+#[test]
 fn hook_status_panel_message_view_and_plain_backend_degrade() {
     let mut model = sample_model();
     model.agent = AgentHooksView::Message("(none)".to_string());

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
@@ -1,0 +1,120 @@
+//! Contract tests for the `/hooks` status panel, which shares the
+//! reference-panel visual contract with `/help`.
+
+use super::{
+    strip_ansi_escape, AgentHooksView, HookEntryView, HookEventGroup, HookStatusPanelModel,
+    RatatuiInlineRenderer,
+};
+
+fn sample_model() -> HookStatusPanelModel<'static> {
+    HookStatusPanelModel {
+        title: "Hook status",
+        shell_label: "Shell Hooks",
+        shell_lines: vec![
+            "Registered: 2; enabled: 2; disabled: 0.".to_string(),
+            "Sources: builtin=2; user=0; project=0.".to_string(),
+        ],
+        agent_label: "Agent Hooks",
+        agent: AgentHooksView::Groups(vec![
+            HookEventGroup {
+                event: "PreToolUse".to_string(),
+                hooks: vec![
+                    HookEntryView {
+                        name: "skill-ledger".to_string(),
+                        extension: "agent-sec-core".to_string(),
+                        disabled: false,
+                    },
+                    HookEntryView {
+                        name: "pii-checker".to_string(),
+                        extension: "agent-sec-core".to_string(),
+                        disabled: true,
+                    },
+                ],
+            },
+            HookEventGroup {
+                event: "Stop".to_string(),
+                hooks: vec![HookEntryView {
+                    name: "observability-hook".to_string(),
+                    extension: "agent-sec-core".to_string(),
+                    disabled: false,
+                }],
+            },
+        ]),
+        footer: "3 hook(s) registered.".to_string(),
+    }
+}
+
+#[test]
+fn hook_status_panel_layers_sections_events_and_entries() {
+    let renderer = RatatuiInlineRenderer::with_width(80);
+    let mut output = Vec::new();
+    renderer
+        .write_hook_status_panel(&mut output, sample_model())
+        .unwrap();
+
+    let text = strip_ansi_escape(&String::from_utf8(output).unwrap());
+    let lines = text.lines().collect::<Vec<_>>();
+    // Section headers at column zero, like /help group headers.
+    assert!(
+        lines.iter().any(|line| line.starts_with("│ Shell Hooks")),
+        "{text}"
+    );
+    assert!(
+        lines.iter().any(|line| line.starts_with("│ Agent Hooks")),
+        "{text}"
+    );
+    // Shell stats indented under their section.
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.starts_with("│   Registered: 2")),
+        "{text}"
+    );
+    // Event group headers indented by two, entries by four.
+    assert!(
+        lines.iter().any(|line| line.starts_with("│   PreToolUse")),
+        "{text}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.starts_with("│     • skill-ledger (ext: agent-sec-core)")),
+        "{text}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.starts_with("│     ○ pii-checker (ext: agent-sec-core) [disabled]")),
+        "{text}"
+    );
+    // No legacy per-line event suffix.
+    assert!(!text.contains("[PreToolUse]"), "{text}");
+    // Footer inside the panel body.
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.starts_with("│ 3 hook(s) registered.")),
+        "{text}"
+    );
+}
+
+#[test]
+fn hook_status_panel_message_view_and_plain_backend_degrade() {
+    let mut model = sample_model();
+    model.agent = AgentHooksView::Message("(none)".to_string());
+
+    let renderer = RatatuiInlineRenderer::plain_with_width(80);
+    let mut output = Vec::new();
+    renderer
+        .write_hook_status_panel(&mut output, model)
+        .unwrap();
+
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains("Hook status:"), "{text}");
+    assert!(text.contains("── Shell Hooks ──"), "{text}");
+    assert!(text.contains("── Agent Hooks ──"), "{text}");
+    assert!(text.contains("(none)"), "{text}");
+    assert!(text.contains("3 hook(s) registered."), "{text}");
+    assert!(!text.contains('│'), "{text}");
+    assert!(!text.contains('\u{1b}'), "{text}");
+}

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
@@ -235,7 +235,7 @@ fn hook_status_panel_large_registry_truncates_with_marker_and_keeps_footer() {
             event: format!("Event-{group_index}"),
             hooks: (0..15)
                 .map(|hook_index| HookEntryView {
-                    name: format!("hook-{group_index}-{hook_index}"),
+                    name: format!("observability-hook-{group_index}-{hook_index}"),
                     extension: "agent-sec-core".to_string(),
                     disabled: false,
                 })
@@ -248,11 +248,12 @@ fn hook_status_panel_large_registry_truncates_with_marker_and_keeps_footer() {
         shell_lines: vec!["Registered: 2; enabled: 2; disabled: 0.".to_string()],
         agent_label: "Agent Hooks",
         agent: AgentHooksView::Groups(groups.clone()),
-        omitted_template: "… {count} more hook(s) not shown".to_string(),
+        omitted_template: "… {count} more hook(s) not shown (full list in plain output)"
+            .to_string(),
         footer: "180 hook(s) registered.".to_string(),
     };
 
-    let renderer = RatatuiInlineRenderer::with_width(80);
+    let renderer = RatatuiInlineRenderer::with_width(40);
     let mut output = Vec::new();
     renderer
         .write_hook_status_panel(&mut output, model)
@@ -264,10 +265,7 @@ fn hook_status_panel_large_registry_truncates_with_marker_and_keeps_footer() {
     assert!(text.contains("180 hook(s) registered."), "{text}");
     assert!(text.contains("more hook(s) not shown"), "{text}");
     assert!(text.lines().count() <= 200, "{}", text.lines().count());
-    let marker_line = text
-        .lines()
-        .find(|line| line.contains("more hook(s) not shown"))
-        .unwrap();
+    let marker_line = text.lines().find(|line| line.contains('…')).unwrap();
     let omitted: usize = marker_line
         .chars()
         .skip_while(|ch| !ch.is_ascii_digit())
@@ -294,6 +292,39 @@ fn hook_status_panel_large_registry_truncates_with_marker_and_keeps_footer() {
     assert!(text.contains("hook-11-14"), "{text}");
     assert!(text.contains("180 hook(s) registered."), "{text}");
     assert!(!text.contains("more hook(s) not shown"), "{text}");
+}
+
+#[test]
+fn hook_status_panel_omits_an_entry_that_cannot_fit_atomically() {
+    let model = HookStatusPanelModel {
+        title: "Hook status",
+        shell_label: "Shell Hooks",
+        shell_lines: vec!["Registered: 1; enabled: 1; disabled: 0.".to_string()],
+        agent_label: "Agent Hooks",
+        agent: AgentHooksView::Groups(vec![HookEventGroup {
+            event: "PreToolUse".to_string(),
+            hooks: vec![HookEntryView {
+                name: "x".repeat(8_000),
+                extension: "agent-sec-core".to_string(),
+                disabled: false,
+            }],
+        }]),
+        omitted_template: "… {count} more hook(s) not shown (full list in plain output)"
+            .to_string(),
+        footer: "1 hook(s) registered.".to_string(),
+    };
+
+    let renderer = RatatuiInlineRenderer::with_width(40);
+    let mut output = Vec::new();
+    renderer
+        .write_hook_status_panel(&mut output, model)
+        .unwrap();
+
+    let text = strip_ansi_escape(&String::from_utf8(output).unwrap());
+    assert!(text.contains("1 more hook(s) not shown"), "{text}");
+    assert!(text.contains("1 hook(s) registered."), "{text}");
+    assert!(!text.contains(&"x".repeat(20)), "{text}");
+    assert!(text.lines().count() <= 200, "{}", text.lines().count());
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/hook_status_tests.rs
@@ -2,8 +2,8 @@
 //! reference-panel visual contract with `/help`.
 
 use super::{
-    strip_ansi_escape, AgentHooksView, HookEntryView, HookEventGroup, HookStatusPanelModel,
-    RatatuiInlineRenderer,
+    display_width, strip_ansi_escape, AgentHooksView, HookEntryView, HookEventGroup,
+    HookStatusPanelModel, RatatuiInlineRenderer,
 };
 
 fn sample_model() -> HookStatusPanelModel<'static> {
@@ -212,8 +212,11 @@ fn hook_status_panel_wraps_long_entries_with_hanging_indent_when_narrow() {
     let mut output = Vec::new();
     plain.write_hook_status_panel(&mut output, model).unwrap();
     let text = String::from_utf8(output).unwrap();
+    // The plain renderer is constructed with width 40; every emitted line
+    // must stay within that display-width contract (not merely a loose
+    // char-count bound).
     assert!(
-        text.lines().all(|line| line.chars().count() <= 60),
+        text.lines().all(|line| display_width(line) <= 40),
         "plain line overflowed the width contract: {text}"
     );
     assert!(text.contains("very-long-hook-name-that-wraps"), "{text}");

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
@@ -23,10 +23,14 @@ mod health_labels;
 mod help;
 #[cfg(test)]
 mod help_tests;
+mod hook_status;
+#[cfg(test)]
+mod hook_status_tests;
 mod markdown;
 mod notice;
 mod question;
 mod recommendation;
+mod reference_style;
 mod status;
 mod stream;
 mod wrap;
@@ -49,6 +53,7 @@ pub use consultation::ConsultationCardModel;
 pub use health::HealthBannerModel;
 pub(crate) use health::{health_uses_startup_row, primary_health_prompt_suggestion};
 pub(crate) use help::{HelpPanelEntry, HelpPanelGroup, HelpPanelModel};
+pub(crate) use hook_status::{AgentHooksView, HookEntryView, HookEventGroup, HookStatusPanelModel};
 use markdown::MarkdownRenderModel;
 pub use notice::NoticePanelModel;
 pub use question::{

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/reference_style.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/reference_style.rs
@@ -1,0 +1,35 @@
+//! Shared style tokens for grouped reference panels (`/help`, `/hooks`, ...).
+//!
+//! Panels that present grouped reference data must share one visual
+//! contract, following upstream ratatui conventions (see the official
+//! `demo2` example): bold+underlined section headers, cyan emphasis for the
+//! primary token, dark-gray de-emphasis for metadata, gray body text.
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// Top-level section headers (e.g. `Config`, `Agent Hooks`).
+pub(super) fn reference_section_style() -> Style {
+    Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+}
+
+/// Second-level group headers (e.g. hook event names).
+pub(super) fn reference_group_style() -> Style {
+    Style::default().add_modifier(Modifier::BOLD)
+}
+
+/// The primary token of an entry (e.g. command name, enabled marker).
+pub(super) fn reference_emphasis_style() -> Style {
+    Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// De-emphasized metadata (arguments, scope tags, extension names).
+pub(super) fn reference_muted_style() -> Style {
+    Style::default().fg(Color::DarkGray)
+}
+
+/// Regular body/summary text.
+pub(super) fn reference_body_style() -> Style {
+    Style::default().fg(Color::Gray)
+}

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/reference_style.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/reference_style.rs
@@ -1,9 +1,12 @@
 //! Shared style tokens for grouped reference panels (`/help`, `/hooks`, ...).
 //!
-//! Panels that present grouped reference data must share one visual
-//! contract, following upstream ratatui conventions (see the official
-//! `demo2` example): bold+underlined section headers, cyan emphasis for the
-//! primary token, dark-gray de-emphasis for metadata, gray body text.
+//! These tokens are the team's *default* reference-panel visual convention
+//! (originally inspired by upstream ratatui examples, which are not a
+//! stability contract): bold+underlined section headers, cyan emphasis for
+//! the primary token, dark-gray de-emphasis for metadata, gray body text.
+//! Panels adopt them for consistency by default; a panel with genuinely
+//! different semantics may override or refine individual tokens rather
+//! than being constrained by this module.
 
 use ratatui::style::{Color, Modifier, Style};
 

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/wrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/wrap.rs
@@ -56,8 +56,11 @@ fn split_prefix(line: &str) -> (String, String, &str) {
     } else if line.starts_with("  ") {
         // Preserve arbitrary-width space indentation (2, 4, 6, ... columns)
         // instead of collapsing everything to two spaces, so nested panel
-        // hierarchies survive wrapping with a matching hanging indent.
-        let indent_len = line.len() - line.trim_start().len();
+        // hierarchies survive wrapping with a matching hanging indent. Only
+        // consecutive ASCII spaces count as indentation: control whitespace
+        // (\r, \t, \n) after the spaces must never enter the hanging prefix,
+        // and the body keeps the legacy full leading-whitespace cleanup.
+        let indent_len = line.len() - line.trim_start_matches(' ').len();
         let indent = &line[..indent_len];
         (indent.to_string(), indent.to_string(), line.trim_start())
     } else {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/wrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/wrap.rs
@@ -54,7 +54,12 @@ fn split_prefix(line: &str) -> (String, String, &str) {
     } else if let Some(rest) = line.strip_prefix("> ") {
         ("> ".to_string(), "  ".to_string(), rest)
     } else if line.starts_with("  ") {
-        ("  ".to_string(), "  ".to_string(), line.trim_start())
+        // Preserve arbitrary-width space indentation (2, 4, 6, ... columns)
+        // instead of collapsing everything to two spaces, so nested panel
+        // hierarchies survive wrapping with a matching hanging indent.
+        let indent_len = line.len() - line.trim_start().len();
+        let indent = &line[..indent_len];
+        (indent.to_string(), indent.to_string(), line.trim_start())
     } else {
         ("".to_string(), "".to_string(), line.trim_start())
     }


### PR DESCRIPTION
## Summary

`/hooks` rendered agent hooks as a flat `(name, event)` list: a hook registered for several events scattered across the panel — in the issue reproduction `pii-checker` appeared 5 times and `observability-hook` 7 times, making it hard to see either "which events does this hook register" (vertical scan) or "which hooks run on this event" (horizontal compare).

Two commits:

1. **Generic wrap fix** — `wrap_plain_line` collapsed any leading space indentation to two columns, which would flatten nested panel hierarchies; it now preserves the actual indent width and reuses it as the hanging indent.
2. **`/hooks` grouped by event + shared visual contract (`Fixes #1713`)** — agent hooks grouped by event in a fixed lifecycle order, rendered through the styled channel with the same visual language as `/help`.

## Changes

- `group_agent_hooks` (slash/hooks.rs): groups the flat cosh-core registry records by event; fixed lifecycle order (PreToolUse → PostToolUse → PostToolUseFailure → UserPromptSubmit → BeforeModel → AfterModel → Stop → SessionStart → SessionEnd → PreCompact → Notification → BeforeToolSelection), unknown events keep first-seen order after known ones; hooks keep registry order inside each group; the redundant per-line `[event]` suffix is dropped; hook count and footer semantics unchanged.
- New `reference_style` tokens (ui/agent_render): bold+underlined section headers, bold group headers, cyan emphasis, dark-gray de-emphasis, gray body — `/help` now consumes the same tokens, so `/help` and `/hooks` share one visual contract (and `/skills`, #1703, can reuse it).
- New `HookStatusPanelModel` (ui/agent_render/hook_status.rs): styled layout (section headers, indented shell stats, bold event groups with blank-line separation, `•` cyan for enabled entries, whole-row de-emphasis + `○` + `[disabled]` for disabled ones — state is triple-encoded via marker, label, and color); plain backend degrades to the marker-header + indentation layout without styles or ANSI.

## Tests

- Grouping contract: lifecycle order, in-group registry order, disabled state, unknown-event trailing, empty/malformed payload degradation.
- Hook panel layout contract: styled hierarchy (sections at column zero, events at 2, entries at 4, right-side state label) and plain degradation (no ANSI, marker headers).
- Wrap indent contract: deep space indentation survives wrapping with a matching hanging indent.

## Verification (focused scope, macOS arm64 host, rebased on `1078c9c4`)

- `cargo test -p cosh-shell --lib --bins`: 930 + 1807 passed, 0 failed
- `cargo test -p cosh-shell --test raw_cli -- hooks registry slash::`: 17 passed
- `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` / `check-layout.sh`: clean
- Scripted-PTY acceptance: real branch binary in a PTY with the real `cosh-core --registry` line protocol (`COSH_CORE_PATH` pointing at a mock replaying the exact 21 hook records from the issue's ECS pane); must/must_not checks green, including "no `[event]` suffix" and "no legacy `──` section markers on the rich path".
- Not run: full raw_cli suite (known pre-existing `session::` flakiness on main), other workspace crates, real-ECS backend (no configured profile; the registry protocol layer itself is exercised for real).

## Evidence

`/hooks` after (grouped by event, aligned with the `/help` visual contract; the same 21 hook records as the issue's reproduction):

![hooks-grouped-after](https://raw.githubusercontent.com/SunnyQjm/anolisa/d6ad00fee6d6387b39ad9d80ff09e4c7cf7e9923/hooks-grouped-after.png)

> Screenshot hosted on a standalone assets branch of my fork (`SunnyQjm/anolisa@pr-1713-assets`), pinned by commit SHA; no image files enter this repository.

Fixes #1713
