### PR TITLE
fix(cosh-ng): [core] restore utility tools

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "dirs",
  "fs2",
  "futures",
+ "glob",
  "hex",
  "hmac",
  "keyring",
@@ -1162,6 +1163,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"

--- a/src/cosh-ng/Cargo.toml
+++ b/src/cosh-ng/Cargo.toml
@@ -19,6 +19,7 @@ repository = "https://github.com/alibaba/anolisa"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false }
+glob = "0.3"
 bincode = "1"
 clap = { version = "4", features = ["derive"] }
 which = "7"

--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3"
 async-trait = "0.1"
 dirs = "5"
 chrono = { workspace = true, features = ["clock"] }
+glob.workspace = true
 which.workspace = true
 toml.workspace = true
 regex.workspace = true

--- a/src/cosh-ng/crates/cosh-core/src/context.rs
+++ b/src/cosh-ng/crates/cosh-core/src/context.rs
@@ -1,4 +1,44 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+const CONTEXT_FILE: &str = ".copilot-shell/CONTEXT.md";
+
+/// Persistence scope for context shared with future sessions.
+#[derive(Clone, Copy)]
+pub(crate) enum ContextScope {
+    /// User-wide context loaded for every project.
+    Global,
+    /// Context associated with the active project.
+    Project,
+}
+
+impl ContextScope {
+    /// Parses the scope names accepted by the memory tool.
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "global" => Some(Self::Global),
+            "project" => Some(Self::Project),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Global => "Global",
+            Self::Project => "Project",
+        }
+    }
+}
+
+/// Resolves the context file for a scope.
+///
+/// Returns `None` when the global scope is requested but no home directory is
+/// available.
+pub(crate) fn context_path(scope: ContextScope, project_root: &Path) -> Option<PathBuf> {
+    match scope {
+        ContextScope::Global => dirs::home_dir().map(|home| home.join(CONTEXT_FILE)),
+        ContextScope::Project => Some(project_root.join(CONTEXT_FILE)),
+    }
+}
 
 pub struct ContextBuilder;
 
@@ -37,8 +77,8 @@ impl ContextBuilder {
             cwd.display(),
         ));
 
-        if let Some(ctx) = Self::load_project_context(cwd) {
-            parts.push(format!("# Project Context\n{ctx}"));
+        if let Some(ctx) = Self::load_context(cwd) {
+            parts.push(format!("# Context\n{ctx}"));
         }
 
         if let Some(context) = extension_context.filter(|context| !context.trim().is_empty()) {
@@ -78,11 +118,28 @@ impl ContextBuilder {
         parts.join("\n\n")
     }
 
-    fn load_project_context(cwd: &Path) -> Option<String> {
-        let path = cwd.join(".copilot-shell/CONTEXT.md");
-        std::fs::read_to_string(&path)
-            .ok()
-            .filter(|s| !s.trim().is_empty())
+    fn load_context(cwd: &Path) -> Option<String> {
+        let paths = [ContextScope::Global, ContextScope::Project]
+            .into_iter()
+            .filter_map(|scope| context_path(scope, cwd).map(|path| (scope, path)));
+        Self::load_context_paths(paths)
+    }
+
+    fn load_context_paths(
+        paths: impl IntoIterator<Item = (ContextScope, PathBuf)>,
+    ) -> Option<String> {
+        let mut contexts = paths.into_iter().filter_map(|(scope, path)| {
+            std::fs::read_to_string(path)
+                .ok()
+                .filter(|content| !content.trim().is_empty())
+                .map(|content| format!("## {} Context\n{}", scope.label(), content.trim()))
+        });
+        let first = contexts.next()?;
+        Some(contexts.fold(first, |mut combined, context| {
+            combined.push_str("\n\n");
+            combined.push_str(&context);
+            combined
+        }))
     }
 }
 
@@ -111,11 +168,36 @@ mod tests {
     }
 
     #[test]
-    fn prompt_without_project_context() {
-        let cwd = PathBuf::from("/nonexistent/path");
-        let prompt = ContextBuilder::build_system_prompt(&cwd, &[], &[], "auto", None);
+    fn labels_context_sources_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let global = dir.path().join("global.md");
+        let project = dir.path().join("project.md");
+        std::fs::write(&global, "shared preference").unwrap();
+        std::fs::write(&project, "project convention").unwrap();
 
-        assert!(!prompt.contains("Project Context"));
+        let context = ContextBuilder::load_context_paths([
+            (ContextScope::Global, global),
+            (ContextScope::Project, project),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            context,
+            "## Global Context\nshared preference\n\n## Project Context\nproject convention"
+        );
+    }
+
+    #[test]
+    fn prompt_labels_project_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let context_dir = dir.path().join(".copilot-shell");
+        std::fs::create_dir(&context_dir).unwrap();
+        std::fs::write(context_dir.join("CONTEXT.md"), "project marker").unwrap();
+
+        let prompt = ContextBuilder::build_system_prompt(dir.path(), &[], &[], "auto", None);
+
+        assert!(prompt.contains("# Context"));
+        assert!(prompt.contains("## Project Context\nproject marker"));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -144,6 +144,10 @@ impl CoshCore {
             return Outcome::Allow;
         }
 
+        if kind == ToolKind::Network {
+            return Outcome::RequireApproval;
+        }
+
         // MCP servers are external programs. Do not infer their side effects
         // from a server-provided description or schema.
         if kind == ToolKind::Mcp {

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -4,7 +4,7 @@ use crate::tool::{Tool, ToolResult};
 use async_trait::async_trait;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc,
+    Arc, Mutex,
 };
 use tokio::io::BufReader;
 
@@ -24,6 +24,28 @@ struct CountingShellTool {
 }
 
 struct ExternalTool;
+
+struct RecordingProvider {
+    messages: Arc<Mutex<Vec<crate::provider::Message>>>,
+}
+
+#[async_trait]
+impl crate::provider::ContentGenerator for RecordingProvider {
+    async fn generate(
+        &self,
+        messages: &[crate::provider::Message],
+        _tools: &[crate::provider::ToolDeclaration],
+        _config: &crate::provider::GenerateConfig,
+    ) -> Result<crate::provider::GenerateStream, String> {
+        *self.messages.lock().unwrap() = messages.to_vec();
+        Ok(Box::pin(futures::stream::iter([
+            crate::provider::GenerateEvent::TextDelta("done".to_string()),
+            crate::provider::GenerateEvent::MessageEnd,
+        ])))
+    }
+
+    fn cancel(&self) {}
+}
 
 #[async_trait]
 impl Tool for ExternalTool {
@@ -148,6 +170,63 @@ fn safe_reload_rebinds_the_complete_snapshot_before_the_next_run() {
     assert_eq!(core.bound_extension_generation, previous + 1);
     assert!(core.tools.get("example.ops/mcp/server/tool").is_some());
     assert_eq!(core.extension_generation.take_retired().len(), 1);
+}
+
+#[test]
+fn web_fetch_requires_approval_outside_trust_mode() {
+    for (mode, expected) in [
+        ("trust", Outcome::Allow),
+        ("auto", Outcome::RequireApproval),
+        ("balanced", Outcome::RequireApproval),
+        ("suggest", Outcome::RequireApproval),
+        ("strict", Outcome::RequireApproval),
+    ] {
+        let mut config = CoreConfig::default();
+        config.agent.approval_mode = mode.to_string();
+        let tools = ToolRegistry::with_defaults_for_test();
+        let core = CoshCore::new(config, Box::new(MockProvider::new(Vec::new())), tools);
+
+        assert_eq!(
+            core.classify_tool("web_fetch", &serde_json::json!({})),
+            expected,
+            "unexpected web_fetch policy in {mode} mode"
+        );
+    }
+}
+
+#[tokio::test]
+async fn project_context_reaches_the_provider_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let context_dir = dir.path().join(".copilot-shell");
+    std::fs::create_dir(&context_dir).unwrap();
+    std::fs::write(context_dir.join("CONTEXT.md"), "provider-visible marker").unwrap();
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        messages: Arc::clone(&captured),
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
+    core.shell_context = Some(ShellContext {
+        cwd: dir.path().to_path_buf(),
+        env: std::collections::HashMap::new(),
+        last_exit_code: 0,
+    });
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("hello", &mut reader, &mut output)
+        .await
+        .unwrap();
+
+    let messages = captured.lock().unwrap();
+    let system = messages.first().expect("provider system message");
+    assert_eq!(system.role, "system");
+    assert!(system.content.as_text().contains("# Context"));
+    assert!(system
+        .content
+        .as_text()
+        .contains("## Project Context\nprovider-visible marker"));
 }
 
 #[async_trait]

--- a/src/cosh-ng/crates/cosh-core/src/tool/file_patterns.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/file_patterns.rs
@@ -1,0 +1,175 @@
+//! Shared path expansion for file-discovery tools.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use glob::{glob_with, MatchOptions, Pattern};
+
+const MAX_MATCHES: usize = 100;
+
+pub(super) struct FileMatches {
+    pub paths: Vec<PathBuf>,
+    pub truncated: bool,
+}
+
+pub(super) fn expand_file_patterns(
+    patterns: &[String],
+    cwd: &Path,
+    max_matches: usize,
+) -> Result<FileMatches, String> {
+    let mut matches = BTreeSet::new();
+    let mut truncated = false;
+    let max_matches = max_matches.min(MAX_MATCHES);
+
+    for pattern in patterns {
+        if expand_pattern(pattern, cwd, &mut matches, max_matches)? {
+            truncated = true;
+            break;
+        }
+    }
+
+    Ok(FileMatches {
+        paths: matches.into_iter().collect(),
+        truncated,
+    })
+}
+
+fn expand_pattern(
+    pattern: &str,
+    cwd: &Path,
+    matches: &mut BTreeSet<PathBuf>,
+    max_matches: usize,
+) -> Result<bool, String> {
+    if pattern.trim().is_empty() {
+        return Err("file pattern must not be empty".to_string());
+    }
+
+    let candidate = resolve_path(pattern, cwd);
+    if candidate.is_file() {
+        return Ok(insert_match(matches, candidate, max_matches));
+    }
+
+    let glob_pattern = if candidate.is_dir() {
+        join_glob(&candidate, "**/*")?
+    } else if Path::new(pattern).is_absolute() {
+        pattern.to_string()
+    } else {
+        join_glob(cwd, pattern)?
+    };
+    expand_glob(&glob_pattern, matches, max_matches)
+}
+
+fn join_glob(base: &Path, pattern: &str) -> Result<String, String> {
+    let base = base
+        .to_str()
+        .ok_or_else(|| format!("file pattern is not valid UTF-8: {}", base.display()))?;
+    let base = Pattern::escape(base);
+    let separator = if base.ends_with(std::path::MAIN_SEPARATOR) {
+        ""
+    } else {
+        std::path::MAIN_SEPARATOR_STR
+    };
+    Ok(format!("{base}{separator}{pattern}"))
+}
+
+fn expand_glob(
+    pattern: &str,
+    matches: &mut BTreeSet<PathBuf>,
+    max_matches: usize,
+) -> Result<bool, String> {
+    Pattern::new(pattern).map_err(|error| format!("invalid glob pattern '{pattern}': {error}"))?;
+
+    let options = MatchOptions {
+        case_sensitive: !cfg!(any(target_os = "macos", target_os = "windows")),
+        require_literal_separator: false,
+        require_literal_leading_dot: false,
+    };
+    let entries = glob_with(pattern, options)
+        .map_err(|error| format!("invalid glob pattern '{pattern}': {error}"))?;
+
+    for entry in entries {
+        match entry {
+            Ok(path) if path.is_file() => {
+                if insert_match(matches, path, max_matches) {
+                    return Ok(true);
+                }
+            }
+            Ok(_) => {}
+            Err(_) => continue,
+        }
+    }
+    Ok(false)
+}
+
+fn insert_match(matches: &mut BTreeSet<PathBuf>, path: PathBuf, max_matches: usize) -> bool {
+    if matches.contains(&path) {
+        return false;
+    }
+    if matches.len() >= max_matches {
+        return true;
+    }
+    matches.insert(path);
+    false
+}
+
+pub(super) fn resolve_path(path: &str, cwd: &Path) -> PathBuf {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_exact_files_and_globs_without_duplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src/nested")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), "lib").unwrap();
+        std::fs::write(dir.path().join("src/nested/mod.rs"), "mod").unwrap();
+        std::fs::write(dir.path().join("src/readme.md"), "readme").unwrap();
+
+        let matches = expand_file_patterns(
+            &[
+                "src/**/*.rs".to_string(),
+                "src/lib.rs".to_string(),
+                "src/readme.md".to_string(),
+            ],
+            dir.path(),
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(matches.paths.len(), 3);
+        assert!(!matches.truncated);
+    }
+
+    #[test]
+    fn caps_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        for index in 0..3 {
+            std::fs::write(dir.path().join(format!("{index}.txt")), "text").unwrap();
+        }
+
+        let matches = expand_file_patterns(&["*.txt".to_string()], dir.path(), 2).unwrap();
+
+        assert_eq!(matches.paths.len(), 2);
+        assert!(matches.truncated);
+    }
+
+    #[test]
+    fn treats_glob_metacharacters_in_base_path_as_literals() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("work[tree]");
+        std::fs::create_dir(&base).unwrap();
+        std::fs::write(base.join("lib.rs"), "lib").unwrap();
+
+        let matches = expand_file_patterns(&["*.rs".to_string()], &base, 10).unwrap();
+
+        assert_eq!(matches.paths, [base.join("lib.rs")]);
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/glob.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/glob.rs
@@ -1,0 +1,118 @@
+//! Glob-based file discovery.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::file_patterns::expand_file_patterns;
+use super::{Tool, ToolContext, ToolKind, ToolResult};
+
+const MAX_RESULTS: usize = 100;
+
+pub(super) struct GlobTool;
+
+#[async_trait]
+impl Tool for GlobTool {
+    fn name(&self) -> &str {
+        "glob"
+    }
+
+    fn description(&self) -> &str {
+        "Find files by glob pattern, such as '**/*.rs'. Returns at most 100 sorted paths."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern to match"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Directory to search from (default: cwd)"
+                }
+            },
+            "required": ["pattern"]
+        })
+    }
+
+    fn kind(&self) -> ToolKind {
+        ToolKind::ReadOnly
+    }
+
+    async fn invoke(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
+        let pattern = params
+            .get("pattern")
+            .and_then(Value::as_str)
+            .ok_or("missing 'pattern' parameter")?
+            .to_string();
+        let base = params
+            .get("path")
+            .and_then(Value::as_str)
+            .map(|path| super::file_patterns::resolve_path(path, &ctx.cwd))
+            .unwrap_or_else(|| ctx.cwd.clone());
+
+        if !base.is_dir() {
+            return Ok(ToolResult::error(format!(
+                "Search path is not a directory: {}",
+                base.display()
+            )));
+        }
+
+        let expand_pattern = pattern.clone();
+        let expand_base = base.clone();
+        let matches = tokio::task::spawn_blocking(move || {
+            expand_file_patterns(&[expand_pattern], &expand_base, MAX_RESULTS)
+        })
+        .await
+        .map_err(|error| format!("File discovery task failed: {error}"))??;
+        if matches.paths.is_empty() {
+            return Ok(ToolResult::success(format!(
+                "No files found matching pattern \"{pattern}\" in {}",
+                base.display()
+            )));
+        }
+
+        let mut output = matches
+            .paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        if matches.truncated {
+            output.push_str("\n\n... results truncated at 100 files");
+        }
+        Ok(ToolResult::success(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn finds_matching_files_only() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("nested")).unwrap();
+        std::fs::write(dir.path().join("one.rs"), "one").unwrap();
+        std::fs::write(dir.path().join("nested/two.rs"), "two").unwrap();
+        std::fs::write(dir.path().join("three.txt"), "three").unwrap();
+        let ctx = ToolContext {
+            cwd: dir.path().to_path_buf(),
+            session_id: "test".to_string(),
+            project_root: PathBuf::from(dir.path()),
+        };
+
+        let result = GlobTool
+            .invoke(serde_json::json!({"pattern": "**/*.rs"}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("one.rs"));
+        assert!(result.output.contains("two.rs"));
+        assert!(!result.output.contains("three.txt"));
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/list_directory.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/list_directory.rs
@@ -1,0 +1,104 @@
+//! Non-recursive directory listing.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::file_patterns::resolve_path;
+use super::{Tool, ToolContext, ToolKind, ToolResult};
+
+const MAX_ENTRIES: usize = 200;
+
+pub(super) struct ListDirectoryTool;
+
+#[async_trait]
+impl Tool for ListDirectoryTool {
+    fn name(&self) -> &str {
+        "list_directory"
+    }
+
+    fn description(&self) -> &str {
+        "List files and subdirectories directly inside a directory."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Directory to list (default: cwd)"
+                }
+            }
+        })
+    }
+
+    fn kind(&self) -> ToolKind {
+        ToolKind::ReadOnly
+    }
+
+    async fn invoke(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
+        let path = resolve_path(
+            params.get("path").and_then(Value::as_str).unwrap_or("."),
+            &ctx.cwd,
+        );
+        if !path.is_dir() {
+            return Ok(ToolResult::error(format!(
+                "Path is not a directory: {}",
+                path.display()
+            )));
+        }
+
+        let mut reader = tokio::fs::read_dir(&path)
+            .await
+            .map_err(|error| format!("Failed to list {}: {error}", path.display()))?;
+        let mut entries = Vec::new();
+        while let Some(entry) = reader
+            .next_entry()
+            .await
+            .map_err(|error| format!("Failed to list {}: {error}", path.display()))?
+        {
+            let file_type = entry.file_type().await.map_err(|error| {
+                format!("Failed to inspect {}: {error}", entry.path().display())
+            })?;
+            let suffix = if file_type.is_dir() { "/" } else { "" };
+            entries.push(format!("{}{}", entry.file_name().to_string_lossy(), suffix));
+        }
+        entries.sort_unstable();
+
+        let total = entries.len();
+        entries.truncate(MAX_ENTRIES);
+        let mut output = if entries.is_empty() {
+            format!("Directory is empty: {}", path.display())
+        } else {
+            entries.join("\n")
+        };
+        if total > MAX_ENTRIES {
+            output.push_str(&format!("\n\n... {} entries omitted", total - MAX_ENTRIES));
+        }
+        Ok(ToolResult::success(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn lists_directories_with_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        let ctx = ToolContext {
+            cwd: dir.path().to_path_buf(),
+            session_id: "test".to_string(),
+            project_root: dir.path().to_path_buf(),
+        };
+
+        let result = ListDirectoryTool
+            .invoke(serde_json::json!({}), &ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(result.output, "Cargo.toml\nsrc/");
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
@@ -1,11 +1,17 @@
 pub mod edit;
+mod file_patterns;
+mod glob;
 pub mod grep;
+mod list_directory;
 pub mod mcp;
 pub mod read_file;
+mod read_many_files;
+mod save_memory;
 pub mod shell;
 pub mod shell_evidence;
 pub mod skill;
 pub mod todo;
+mod web_fetch;
 pub mod write_file;
 
 use std::collections::HashMap;
@@ -21,6 +27,8 @@ use crate::skill::{SkillConfig, SkillManager};
 #[derive(Debug, Clone, PartialEq)]
 pub enum ToolKind {
     ReadOnly,
+    /// A network request that can reach services outside the local process.
+    Network,
     FileEdit,
     ShellExec,
     ShellEvidence,
@@ -146,7 +154,12 @@ impl ToolRegistry {
         registry.register(Box::new(write_file::WriteFileTool));
         registry.register(Box::new(edit::EditTool));
         registry.register(Box::new(grep::GrepTool));
+        registry.register(Box::new(glob::GlobTool));
+        registry.register(Box::new(list_directory::ListDirectoryTool));
+        registry.register(Box::new(read_many_files::ReadManyFilesTool));
+        registry.register(Box::new(save_memory::SaveMemoryTool));
         registry.register(Box::new(todo::TodoTool::new()));
+        registry.register(Box::new(web_fetch::WebFetchTool::new()));
         registry.register(Box::new(skill::SkillTool::new(Arc::clone(&skill_manager))));
         registry.skill_manager = Some(skill_manager);
         registry
@@ -348,6 +361,21 @@ mod tests {
             .expect("default selection");
 
         assert_eq!(registry.names(), before);
+    }
+
+    #[test]
+    fn defaults_include_restored_core_tools() {
+        let registry = ToolRegistry::with_defaults_for_test();
+
+        for name in [
+            "glob",
+            "list_directory",
+            "read_many_files",
+            "save_memory",
+            "web_fetch",
+        ] {
+            assert!(registry.contains(name), "missing default tool: {name}");
+        }
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/tool/read_many_files.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/read_many_files.rs
@@ -1,0 +1,195 @@
+//! Bounded multi-file reads with optional glob expansion.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::io::AsyncReadExt;
+
+use super::file_patterns::expand_file_patterns;
+use super::{Tool, ToolContext, ToolKind, ToolResult};
+
+const MAX_FILES: usize = 50;
+const MAX_FILE_BYTES: usize = 64 * 1024;
+const MAX_TOTAL_BYTES: usize = 256 * 1024;
+
+pub(super) struct ReadManyFilesTool;
+
+#[async_trait]
+impl Tool for ReadManyFilesTool {
+    fn name(&self) -> &str {
+        "read_many_files"
+    }
+
+    fn description(&self) -> &str {
+        "Read and concatenate multiple text files. Paths may be exact files, directories, or glob patterns."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "paths": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "File paths, directories, or glob patterns to read"
+                }
+            },
+            "required": ["paths"]
+        })
+    }
+
+    fn kind(&self) -> ToolKind {
+        ToolKind::ReadOnly
+    }
+
+    async fn invoke(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
+        let patterns = params
+            .get("paths")
+            .and_then(Value::as_array)
+            .ok_or("missing 'paths' parameter")?
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(ToOwned::to_owned)
+                    .ok_or_else(|| "'paths' entries must be strings".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if patterns.is_empty() {
+            return Ok(ToolResult::error("'paths' must not be empty"));
+        }
+
+        let cwd = ctx.cwd.clone();
+        let matches =
+            tokio::task::spawn_blocking(move || expand_file_patterns(&patterns, &cwd, MAX_FILES))
+                .await
+                .map_err(|error| format!("File discovery task failed: {error}"))??;
+        if matches.paths.is_empty() {
+            return Ok(ToolResult::success("No matching files found."));
+        }
+
+        let mut output = String::new();
+        let mut skipped = Vec::new();
+        for path in &matches.paths {
+            let (bytes, file_truncated) = match read_bounded(path).await {
+                Ok(result) => result,
+                Err(error) => {
+                    skipped.push(format!("{}: {error}", path.display()));
+                    continue;
+                }
+            };
+            let available = MAX_TOTAL_BYTES.saturating_sub(output.len());
+            if available == 0 {
+                break;
+            }
+            let limit = bytes.len().min(MAX_FILE_BYTES).min(available);
+            let content = match text_prefix(&bytes[..limit]) {
+                Some(content) => content,
+                None => {
+                    skipped.push(format!("{}: not a UTF-8 text file", path.display()));
+                    continue;
+                }
+            };
+            output.push_str(&format!("--- {} ---\n", path.display()));
+            output.push_str(content);
+            if !content.ends_with('\n') {
+                output.push('\n');
+            }
+            if file_truncated || limit < bytes.len() {
+                output.push_str("[file content truncated]\n");
+            }
+        }
+
+        if matches.truncated || output.len() >= MAX_TOTAL_BYTES {
+            output.push_str("\n[additional files omitted by output limits]\n");
+        }
+        if !skipped.is_empty() {
+            output.push_str("\nSkipped files:\n");
+            output.push_str(&skipped.join("\n"));
+            output.push('\n');
+        }
+        Ok(ToolResult::success(output))
+    }
+}
+
+async fn read_bounded(path: &Path) -> Result<(Vec<u8>, bool), std::io::Error> {
+    let file = tokio::fs::File::open(path).await?;
+    let mut reader = file.take((MAX_FILE_BYTES + 1) as u64);
+    let mut bytes = Vec::with_capacity(MAX_FILE_BYTES + 1);
+    reader.read_to_end(&mut bytes).await?;
+    let truncated = bytes.len() > MAX_FILE_BYTES;
+    bytes.truncate(MAX_FILE_BYTES);
+    Ok((bytes, truncated))
+}
+
+fn text_prefix(bytes: &[u8]) -> Option<&str> {
+    if bytes.contains(&0) {
+        return None;
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(content) => Some(content),
+        Err(error) if error.error_len().is_none() => {
+            std::str::from_utf8(&bytes[..error.valid_up_to()]).ok()
+        }
+        Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn reads_multiple_files_with_boundaries() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "alpha").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "beta").unwrap();
+        let ctx = ToolContext {
+            cwd: dir.path().to_path_buf(),
+            session_id: "test".to_string(),
+            project_root: dir.path().to_path_buf(),
+        };
+
+        let result = ReadManyFilesTool
+            .invoke(serde_json::json!({"paths": ["*.txt"]}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("--- "));
+        assert!(result.output.contains("a.txt ---\nalpha"));
+        assert!(result.output.contains("b.txt ---\nbeta"));
+    }
+
+    #[tokio::test]
+    async fn bounds_large_files_during_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.txt");
+        std::fs::write(&path, vec![b'x'; MAX_FILE_BYTES * 4]).unwrap();
+
+        let (bytes, truncated) = read_bounded(&path).await.unwrap();
+
+        assert_eq!(bytes.len(), MAX_FILE_BYTES);
+        assert!(truncated);
+    }
+
+    #[tokio::test]
+    async fn skips_binary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("binary.dat"), [0, 159, 146, 150]).unwrap();
+        let ctx = ToolContext {
+            cwd: dir.path().to_path_buf(),
+            session_id: "test".to_string(),
+            project_root: dir.path().to_path_buf(),
+        };
+
+        let result = ReadManyFilesTool
+            .invoke(serde_json::json!({"paths": ["binary.dat"]}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(result.output.contains("not a UTF-8 text file"));
+        assert!(!result.output.contains('\u{fffd}'));
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/save_memory.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/save_memory.rs
@@ -1,0 +1,264 @@
+//! Persistent project or user memory stored in context files.
+
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+
+use async_trait::async_trait;
+use fs2::FileExt;
+use serde_json::Value;
+
+use crate::context::{context_path, ContextScope};
+
+use super::{Tool, ToolContext, ToolKind, ToolResult};
+
+const MEMORY_HEADER: &str = "## Saved Memories";
+
+pub(super) struct SaveMemoryTool;
+
+#[async_trait]
+impl Tool for SaveMemoryTool {
+    fn name(&self) -> &str {
+        "save_memory"
+    }
+
+    fn description(&self) -> &str {
+        "Save a concise fact to persistent project or global context for future sessions."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "fact": {
+                    "type": "string",
+                    "description": "A concise, self-contained fact to remember"
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["project", "global"],
+                    "description": "Storage scope (default: project)"
+                }
+            },
+            "required": ["fact"]
+        })
+    }
+
+    fn kind(&self) -> ToolKind {
+        ToolKind::FileEdit
+    }
+
+    async fn invoke(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
+        let fact = params
+            .get("fact")
+            .and_then(Value::as_str)
+            .ok_or("missing 'fact' parameter")?;
+        let fact = normalize_fact(fact);
+        if fact.is_empty() {
+            return Ok(ToolResult::error("'fact' must not be empty"));
+        }
+
+        let scope = params
+            .get("scope")
+            .and_then(Value::as_str)
+            .unwrap_or("project");
+        let scope = ContextScope::parse(scope)
+            .ok_or_else(|| "'scope' must be 'project' or 'global'".to_string())?;
+        let path = context_path(scope, &ctx.project_root)
+            .ok_or_else(|| "cannot resolve home directory for global memory".to_string())?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|error| format!("Failed to create {}: {error}", parent.display()))?;
+        }
+        let update_path = path.clone();
+        let entry = format!("- {fact}");
+        let outcome = tokio::task::spawn_blocking(move || update_memory_file(&update_path, &entry))
+            .await
+            .map_err(|error| format!("Memory update task failed: {error}"))??;
+
+        let message = match outcome {
+            SaveOutcome::Saved => format!("Saved memory to {}", path.display()),
+            SaveOutcome::AlreadyExists => {
+                format!("Memory already exists in {}", path.display())
+            }
+        };
+        Ok(ToolResult::success(message))
+    }
+}
+
+enum SaveOutcome {
+    Saved,
+    AlreadyExists,
+}
+
+fn update_memory_file(path: &std::path::Path, entry: &str) -> Result<SaveOutcome, String> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|error| format!("Failed to open {}: {error}", path.display()))?;
+    file.lock_exclusive()
+        .map_err(|error| format!("Failed to lock {}: {error}", path.display()))?;
+
+    let mut existing = String::new();
+    file.read_to_string(&mut existing)
+        .map_err(|error| format!("Failed to read {}: {error}", path.display()))?;
+    if existing.lines().any(|line| line.trim() == entry) {
+        return Ok(SaveOutcome::AlreadyExists);
+    }
+
+    let updated = add_memory(&existing, entry);
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| format!("Failed to seek {}: {error}", path.display()))?;
+    file.set_len(0)
+        .map_err(|error| format!("Failed to truncate {}: {error}", path.display()))?;
+    file.write_all(updated.as_bytes())
+        .map_err(|error| format!("Failed to write {}: {error}", path.display()))?;
+    file.sync_data()
+        .map_err(|error| format!("Failed to sync {}: {error}", path.display()))?;
+    Ok(SaveOutcome::Saved)
+}
+
+fn add_memory(existing: &str, entry: &str) -> String {
+    let Some(header_index) = memory_header_index(existing) else {
+        let separator = if existing.is_empty() || existing.ends_with("\n\n") {
+            ""
+        } else if existing.ends_with('\n') {
+            "\n"
+        } else {
+            "\n\n"
+        };
+        return format!("{existing}{separator}{MEMORY_HEADER}\n{entry}\n");
+    };
+
+    let section_start = header_index + MEMORY_HEADER.len();
+    let section_end = existing[section_start..]
+        .find("\n## ")
+        .map(|offset| section_start + offset)
+        .unwrap_or(existing.len());
+    let before = existing[..section_end].trim_end();
+    let after = &existing[section_end..];
+    if after.is_empty() {
+        format!("{before}\n{entry}\n")
+    } else {
+        format!("{before}\n{entry}\n{after}")
+    }
+}
+
+fn memory_header_index(existing: &str) -> Option<usize> {
+    let mut offset = 0;
+    for line in existing.split_inclusive('\n') {
+        let content = line.trim_end_matches(['\r', '\n']);
+        if content.trim() == MEMORY_HEADER {
+            return content.find(MEMORY_HEADER).map(|index| offset + index);
+        }
+        offset += line.len();
+    }
+    None
+}
+
+fn normalize_fact(fact: &str) -> String {
+    fact.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim_start_matches(['-', '*'])
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn context(dir: &Path) -> ToolContext {
+        ToolContext {
+            cwd: dir.to_path_buf(),
+            session_id: "test".to_string(),
+            project_root: dir.to_path_buf(),
+        }
+    }
+
+    #[tokio::test]
+    async fn saves_project_memory_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let params = serde_json::json!({
+            "fact": "  - prefer   cargo nextest  ",
+            "scope": "project"
+        });
+
+        let first = SaveMemoryTool
+            .invoke(params.clone(), &context(dir.path()))
+            .await
+            .unwrap();
+        let second = SaveMemoryTool
+            .invoke(params, &context(dir.path()))
+            .await
+            .unwrap();
+
+        assert!(!first.is_error);
+        assert!(second.output.contains("already exists"));
+        let content =
+            std::fs::read_to_string(dir.path().join(".copilot-shell/CONTEXT.md")).unwrap();
+        assert_eq!(content, "## Saved Memories\n- prefer cargo nextest\n");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn preserves_concurrent_memories() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path().to_path_buf();
+        let mut tasks = Vec::new();
+
+        for index in 0..8 {
+            let project_root = project_root.clone();
+            tasks.push(tokio::spawn(async move {
+                SaveMemoryTool
+                    .invoke(
+                        serde_json::json!({
+                            "fact": format!("concurrent fact {index}"),
+                            "scope": "project"
+                        }),
+                        &context(&project_root),
+                    )
+                    .await
+                    .unwrap()
+            }));
+        }
+        for task in tasks {
+            assert!(!task.await.unwrap().is_error);
+        }
+
+        let content =
+            std::fs::read_to_string(dir.path().join(".copilot-shell/CONTEXT.md")).unwrap();
+        for index in 0..8 {
+            assert!(content.contains(&format!("- concurrent fact {index}")));
+        }
+    }
+
+    #[test]
+    fn inserts_memory_before_the_next_section() {
+        let existing = "# Context\n\n## Saved Memories\n- existing\n\n## Rules\nKeep this.";
+
+        let updated = add_memory(existing, "- new fact");
+
+        assert_eq!(
+            updated,
+            "# Context\n\n## Saved Memories\n- existing\n- new fact\n\n## Rules\nKeep this."
+        );
+    }
+
+    #[test]
+    fn ignores_saved_memories_text_outside_an_exact_header() {
+        let existing = "### Saved Memories\nMention ## Saved Memories inline.";
+
+        let updated = add_memory(existing, "- new fact");
+
+        assert_eq!(
+            updated,
+            "### Saved Memories\nMention ## Saved Memories inline.\n\n\
+             ## Saved Memories\n- new fact\n"
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/web_fetch.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/web_fetch.rs
@@ -1,0 +1,277 @@
+//! Bounded HTTP(S) content retrieval.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::redirect::Policy;
+use serde_json::Value;
+
+use super::{Tool, ToolContext, ToolKind, ToolResult};
+
+const MAX_RESPONSE_BYTES: usize = 512 * 1024;
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(super) struct WebFetchTool {
+    client: Option<reqwest::Client>,
+}
+
+impl WebFetchTool {
+    pub(super) fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(FETCH_TIMEOUT)
+            .redirect(Policy::limited(5))
+            .build()
+            .ok();
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Tool for WebFetchTool {
+    fn name(&self) -> &str {
+        "web_fetch"
+    }
+
+    fn description(&self) -> &str {
+        "Fetch bounded text content from an HTTP or HTTPS URL. Network access requires approval outside trust mode."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Fully qualified HTTP or HTTPS URL"
+                },
+                "prompt": {
+                    "type": "string",
+                    "description": "Optional description of the information to extract"
+                }
+            },
+            "required": ["url"]
+        })
+    }
+
+    fn kind(&self) -> ToolKind {
+        ToolKind::Network
+    }
+
+    async fn invoke(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult, String> {
+        let url = params
+            .get("url")
+            .and_then(Value::as_str)
+            .ok_or("missing 'url' parameter")?;
+        let parsed =
+            reqwest::Url::parse(url).map_err(|error| format!("invalid URL '{url}': {error}"))?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return Ok(ToolResult::error(
+                "web_fetch only supports HTTP and HTTPS URLs",
+            ));
+        }
+
+        let client = self
+            .client
+            .as_ref()
+            .ok_or("Failed to initialize the HTTP client")?;
+        let response = client
+            .get(parsed)
+            .send()
+            .await
+            .map_err(|error| format!("Failed to fetch {url}: {error}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            return Ok(ToolResult::error(format!(
+                "Request to {url} failed with HTTP {status}"
+            )));
+        }
+
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+        if let Some(content_type) = content_type.as_deref() {
+            if !is_textual_content_type(content_type) {
+                return Ok(ToolResult::error(format!(
+                    "Unsupported Content-Type '{content_type}' from {url}; \
+                     web_fetch only supports textual responses"
+                )));
+            }
+        }
+        let content_type = content_type.unwrap_or_else(|| "unknown".to_string());
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        let mut truncated = false;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| format!("Failed to read {url}: {error}"))?;
+            let remaining = MAX_RESPONSE_BYTES.saturating_sub(body.len());
+            if chunk.len() > remaining {
+                body.extend_from_slice(&chunk[..remaining]);
+                truncated = true;
+                break;
+            }
+            body.extend_from_slice(&chunk);
+            if body.len() == MAX_RESPONSE_BYTES {
+                truncated = true;
+                break;
+            }
+        }
+
+        let mut output = format!(
+            "Source: {url}\nContent-Type: {content_type}\n\n{}",
+            String::from_utf8_lossy(&body)
+        );
+        if truncated {
+            output.push_str("\n\n[response truncated at 524288 bytes]");
+        }
+        Ok(ToolResult::success(output))
+    }
+}
+
+fn is_textual_content_type(content_type: &str) -> bool {
+    let media_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    let Some((category, subtype)) = media_type.split_once('/') else {
+        return false;
+    };
+
+    category == "text"
+        || (category == "application"
+            && (matches!(
+                subtype,
+                "json"
+                    | "xml"
+                    | "javascript"
+                    | "x-javascript"
+                    | "yaml"
+                    | "x-yaml"
+                    | "toml"
+                    | "x-www-form-urlencoded"
+            ) || subtype.ends_with("+json")
+                || subtype.ends_with("+xml")))
+        || media_type == "image/svg+xml"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn fetches_http_content() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello",
+                )
+                .await
+                .unwrap();
+        });
+        let ctx = ToolContext {
+            cwd: PathBuf::from("/tmp"),
+            session_id: "test".to_string(),
+            project_root: PathBuf::from("/tmp"),
+        };
+
+        let result = WebFetchTool::new()
+            .invoke(
+                serde_json::json!({"url": format!("http://{address}/")}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("Content-Type: text/plain"));
+        assert!(result.output.ends_with("hello"));
+    }
+
+    #[tokio::test]
+    async fn rejects_non_http_urls() {
+        let ctx = ToolContext {
+            cwd: PathBuf::from("/tmp"),
+            session_id: "test".to_string(),
+            project_root: PathBuf::from("/tmp"),
+        };
+
+        let result = WebFetchTool::new()
+            .invoke(serde_json::json!({"url": "file:///etc/passwd"}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn rejects_binary_content_types() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/pdf\r\n\
+                      Content-Length: 4\r\n\r\n\x00\xff\x00\xff",
+                )
+                .await
+                .unwrap();
+        });
+        let ctx = ToolContext {
+            cwd: PathBuf::from("/tmp"),
+            session_id: "test".to_string(),
+            project_root: PathBuf::from("/tmp"),
+        };
+
+        let result = WebFetchTool::new()
+            .invoke(
+                serde_json::json!({"url": format!("http://{address}/document.pdf")}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("application/pdf"));
+        assert!(result.output.contains("only supports textual responses"));
+        assert!(!result.output.contains('\u{fffd}'));
+    }
+
+    #[test]
+    fn recognizes_structured_text_content_types() {
+        for content_type in [
+            "text/plain; charset=utf-8",
+            "application/json",
+            "application/problem+json",
+            "application/xml",
+            "application/atom+xml",
+            "image/svg+xml",
+        ] {
+            assert!(
+                is_textual_content_type(content_type),
+                "expected textual Content-Type: {content_type}"
+            );
+        }
+        for content_type in ["application/pdf", "application/zip", "image/png"] {
+            assert!(
+                !is_textual_content_type(content_type),
+                "expected binary Content-Type: {content_type}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description

Restores five utility tools omitted from the Rust tool framework: `web_fetch`, `glob`, `list_directory`, `read_many_files`, and `save_memory`. Persistent memory intentionally extends context loading from project-only to labeled global-then-project context, and a provider-boundary test verifies that the rendered project context reaches the model request. Network fetches require approval in every mode except explicit `trust` mode. Multi-file reads are bounded while reading and skip non-UTF-8 files, while memory updates use an exclusive file lock to prevent concurrent lost updates.

## Related Issue

Refs #1775

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo check --package cosh-core --all-targets`
- `cargo test --package cosh-core`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo fmt --all -- --check`
- `git diff --check`

The core suite includes regressions for bounded large-file reads, binary-file rejection, concurrent memory updates, WebFetch approval policy, and context delivery to the provider boundary.

## Implementation Notes

- Context files load in global then project order and are labeled `## Global Context` and `## Project Context` in the system prompt.
- `glob` is declared in `[workspace.dependencies]` because repository policy centralizes third-party versions; only `cosh-core` enables it.
- WebFetch deliberately uses the approval boundary instead of an IP denylist, preserving legitimate intranet use while avoiding incomplete DNS/redirect filtering. Explicit `trust` mode continues to allow all tools by design.
- New tool modules remain private to avoid expanding the binary crate surface. Existing public tool modules are pre-existing API debt and are outside this focused fix.
- `Task` still requires a subagent runtime, and `ExitPlanMode` depends on the plan-mode state machine tracked by #1776. They remain follow-up work, so this PR references rather than closes #1775.
