### PR TITLE
fix(cosh-ng): [shell] approval card natural-language risk reason with V6a slim layout

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/approval/panel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/panel.rs
@@ -30,6 +30,13 @@ pub(crate) fn render_current_approval_request<W: Write>(
         return Ok(());
     }
 
+    // The agent status spinner repaints in place (`\r\x1b[2K<frame> ...`) and
+    // leaves the cursor mid-line; clear it before drawing the panel so the
+    // card border starts at column 0 instead of wrapping past the row end.
+    if let Some(active_run) = state.agent_run.active.as_mut() {
+        active_run.status_animation.clear(output)?;
+    }
+
     let pending_total = state
         .approvals
         .requests

--- a/src/cosh-ng/crates/cosh-shell/src/approval/panel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/panel.rs
@@ -62,6 +62,12 @@ pub(crate) fn render_current_approval_request<W: Write>(
         .copied()
         .unwrap_or(ApprovalPanelAction::Approve);
     let expanded = state.approvals.expanded_cards.contains(&request.id);
+    // Card-facing reason policy (ARP): only High risk with a whitelisted
+    // primary reason yields a natural-language phrase; everything else is
+    // fail-quiet. Raw codes stay in details/journal only.
+    let card_reason = request.assessment.as_ref().and_then(|assessment| {
+        crate::ui::card_reason_phrase(request.risk, assessment.primary_reason, state.i18n())
+    });
     let height = RatatuiInlineRenderer::for_terminal()
         .with_language(state.language)
         .write_approval_panel(
@@ -70,10 +76,7 @@ pub(crate) fn render_current_approval_request<W: Write>(
                 id: &request.id,
                 kind: request.kind.label(),
                 risk: request.risk,
-                reason: request
-                    .assessment
-                    .as_ref()
-                    .map(|assessment| assessment.primary_reason),
+                reason: card_reason.as_deref(),
                 subject: &request.subject,
                 preview_label,
                 preview: &request.preview,

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/approval.rs
@@ -121,6 +121,27 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "Provider-native shell tool allowed"
         }
         MessageId::ApprovalHookHeading => "Hook review",
+        MessageId::ApprovalRiskDetailLabel => "Risk: ",
+        MessageId::ApprovalRiskLevelHigh => "high risk",
+        MessageId::ApprovalRiskLevelMedium => "medium risk",
+        MessageId::ApprovalRiskLevelLow => "low risk",
+        MessageId::ApprovalQueueMetaSuffix => " · queue {position}/{total}",
+        MessageId::ApprovalRiskPhrasePrivilegeEscalation => "privilege escalation",
+        MessageId::ApprovalRiskPhraseCredentialAccess => "credential access",
+        MessageId::ApprovalRiskPhraseFilesystemDelete => "file deletion",
+        MessageId::ApprovalRiskPhraseFilesystemWrite => "filesystem write",
+        MessageId::ApprovalRiskPhrasePermissionChange => "permission change",
+        MessageId::ApprovalRiskPhraseProcessControl => "process control",
+        MessageId::ApprovalRiskPhraseServiceControl => "service control",
+        MessageId::ApprovalRiskPhraseServiceOrContainerControl => "service/container control",
+        MessageId::ApprovalRiskPhrasePackageManagerMutation => "package mutation",
+        MessageId::ApprovalRiskPhraseInteractiveEditor => "editor may modify files",
+        MessageId::ApprovalRiskPhraseRemoteCodeExecution => "remote code execution",
+        MessageId::ApprovalRiskPhraseSensitivePath => "sensitive path",
+        MessageId::ApprovalRiskPhraseSensitiveSearch => "sensitive data search",
+        MessageId::ApprovalRiskPhraseCommandSubstitution => "command substitution",
+        MessageId::ApprovalRiskPhraseRedirectionWrite => "write redirection",
+        MessageId::ApprovalRiskPhraseAwkShellExecution => "awk shell execution",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/approval.rs
@@ -142,6 +142,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalRiskPhraseCommandSubstitution => "command substitution",
         MessageId::ApprovalRiskPhraseRedirectionWrite => "write redirection",
         MessageId::ApprovalRiskPhraseAwkShellExecution => "awk shell execution",
+        MessageId::ApprovalRiskLevelUnknown => "unknown risk",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -83,4 +83,5 @@ collect_message_ids!([
     question_interaction_ids,
     session_picker_ids,
     session_fresh_ids,
+    approval_reason_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/approval.rs
@@ -120,6 +120,7 @@ macro_rules! approval_reason_ids {
             ApprovalRiskPhraseCommandSubstitution,
             ApprovalRiskPhraseRedirectionWrite,
             ApprovalRiskPhraseAwkShellExecution,
+            ApprovalRiskLevelUnknown,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/approval.rs
@@ -93,3 +93,33 @@ macro_rules! approval_ids {
         );
     };
 }
+
+macro_rules! approval_reason_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            ApprovalRiskDetailLabel,
+            ApprovalRiskLevelHigh,
+            ApprovalRiskLevelMedium,
+            ApprovalRiskLevelLow,
+            ApprovalQueueMetaSuffix,
+            ApprovalRiskPhrasePrivilegeEscalation,
+            ApprovalRiskPhraseCredentialAccess,
+            ApprovalRiskPhraseFilesystemDelete,
+            ApprovalRiskPhraseFilesystemWrite,
+            ApprovalRiskPhrasePermissionChange,
+            ApprovalRiskPhraseProcessControl,
+            ApprovalRiskPhraseServiceControl,
+            ApprovalRiskPhraseServiceOrContainerControl,
+            ApprovalRiskPhrasePackageManagerMutation,
+            ApprovalRiskPhraseInteractiveEditor,
+            ApprovalRiskPhraseRemoteCodeExecution,
+            ApprovalRiskPhraseSensitivePath,
+            ApprovalRiskPhraseSensitiveSearch,
+            ApprovalRiskPhraseCommandSubstitution,
+            ApprovalRiskPhraseRedirectionWrite,
+            ApprovalRiskPhraseAwkShellExecution,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/approval.rs
@@ -126,6 +126,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalRiskPhraseCommandSubstitution => "命令替换语法",
         MessageId::ApprovalRiskPhraseRedirectionWrite => "重定向写文件",
         MessageId::ApprovalRiskPhraseAwkShellExecution => "awk 执行外部命令",
+        MessageId::ApprovalRiskLevelUnknown => "未知风险",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/approval.rs
@@ -105,6 +105,27 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "已允许 provider-native shell tool 执行"
         }
         MessageId::ApprovalHookHeading => "Hook 审查",
+        MessageId::ApprovalRiskDetailLabel => "风险: ",
+        MessageId::ApprovalRiskLevelHigh => "高风险",
+        MessageId::ApprovalRiskLevelMedium => "中风险",
+        MessageId::ApprovalRiskLevelLow => "低风险",
+        MessageId::ApprovalQueueMetaSuffix => " · 队列 {position}/{total}",
+        MessageId::ApprovalRiskPhrasePrivilegeEscalation => "提权操作",
+        MessageId::ApprovalRiskPhraseCredentialAccess => "凭证访问",
+        MessageId::ApprovalRiskPhraseFilesystemDelete => "文件删除操作",
+        MessageId::ApprovalRiskPhraseFilesystemWrite => "文件系统写入",
+        MessageId::ApprovalRiskPhrasePermissionChange => "权限变更",
+        MessageId::ApprovalRiskPhraseProcessControl => "进程控制",
+        MessageId::ApprovalRiskPhraseServiceControl => "服务控制",
+        MessageId::ApprovalRiskPhraseServiceOrContainerControl => "服务/容器控制",
+        MessageId::ApprovalRiskPhrasePackageManagerMutation => "软件包变更",
+        MessageId::ApprovalRiskPhraseInteractiveEditor => "交互式编辑器可修改文件",
+        MessageId::ApprovalRiskPhraseRemoteCodeExecution => "远程代码执行风险",
+        MessageId::ApprovalRiskPhraseSensitivePath => "涉及敏感路径",
+        MessageId::ApprovalRiskPhraseSensitiveSearch => "敏感信息搜索",
+        MessageId::ApprovalRiskPhraseCommandSubstitution => "命令替换语法",
+        MessageId::ApprovalRiskPhraseRedirectionWrite => "重定向写文件",
+        MessageId::ApprovalRiskPhraseAwkShellExecution => "awk 执行外部命令",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
@@ -9,10 +9,11 @@ use super::is_sensitive_target;
 use super::readonly_pipeline::validate_readonly_pipeline;
 
 pub use super::command_risk_model::{
-    AssessmentConfidence, AssessmentPolicy, AssessmentSource, AssessmentSummary, AutoAllowEvidence,
-    AutoExecutionPolicy, AutoExecutionRoute, CommandAssessment, CommandShape, ExecutionDecision,
-    InteractionRequirement, OutputExposure, OutputStability, ReadonlyEvidence, RiskImpact,
-    RiskReason, SideEffectClass,
+    is_high_risk_explanation, AssessmentConfidence, AssessmentPolicy, AssessmentSource,
+    AssessmentSummary, AutoAllowEvidence, AutoExecutionPolicy, AutoExecutionRoute,
+    CommandAssessment, CommandShape, ExecutionDecision, InteractionRequirement, OutputExposure,
+    OutputStability, ReadonlyEvidence, RiskImpact, RiskReason, SideEffectClass,
+    HIGH_RISK_EXPLANATION_REASONS,
 };
 
 pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandAssessment {
@@ -83,12 +84,15 @@ pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandA
             simple.shape = parsed.shape;
             simple.execution = ExecutionDecision::AskUser;
             simple.confidence = min_confidence(simple.confidence, AssessmentConfidence::Medium);
-            simple.reasons.push(match parsed.shape {
-                CommandShape::AndOrList => "and-or-list-not-auto-executable",
-                CommandShape::Sequence => "sequence-not-auto-executable",
-                CommandShape::RedirectionRead => "read-redirection-not-auto-executable",
-                _ => "complex-shell-not-auto-executable",
-            });
+            insert_structural_reason(
+                &mut simple.reasons,
+                match parsed.shape {
+                    CommandShape::AndOrList => "and-or-list-not-auto-executable",
+                    CommandShape::Sequence => "sequence-not-auto-executable",
+                    CommandShape::RedirectionRead => "read-redirection-not-auto-executable",
+                    _ => "complex-shell-not-auto-executable",
+                },
+            );
             simple
         }
         CommandShape::Complex => {
@@ -99,7 +103,7 @@ pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandA
             if simple.impact < RiskImpact::Medium {
                 simple.impact = RiskImpact::Medium;
             }
-            simple.reasons.push("complex-shell-not-auto-executable");
+            insert_structural_reason(&mut simple.reasons, "complex-shell-not-auto-executable");
             simple
         }
         CommandShape::Empty
@@ -107,6 +111,17 @@ pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandA
         | CommandShape::CommandSubstitution
         | CommandShape::RedirectionWrite => unreachable!("handled above"),
     }
+}
+
+/// Conditional head-insert for structural reasons (ARP SDD design.md §1):
+/// structural verdicts outrank fallback/neutral observations from the first
+/// stage, but must not displace a high-risk explanation as the primary reason.
+fn insert_structural_reason(reasons: &mut Vec<&'static str>, structural: &'static str) {
+    let index = match reasons.first() {
+        Some(first) if is_high_risk_explanation(first) => 1,
+        _ => 0,
+    };
+    reasons.insert(index.min(reasons.len()), structural);
 }
 
 pub fn blocked_shell_binding_assessment(

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
@@ -146,6 +146,32 @@ pub struct CommandAssessment {
 
 pub type RiskReason = &'static str;
 
+/// Card-facing high-risk explanation whitelist (ARP SDD design.md §4).
+/// Shared by the reason ordering rule in `assess_shell_command` and the
+/// approval-card phrase policy in the UI layer so the two cannot drift.
+pub const HIGH_RISK_EXPLANATION_REASONS: &[&str] = &[
+    "privilege-escalation",
+    "credential-access",
+    "filesystem-delete",
+    "filesystem-write",
+    "permission-change",
+    "process-control",
+    "service-control",
+    "service-or-container-control",
+    "package-manager-mutation",
+    "interactive-editor",
+    "remote-code-execution",
+    "sensitive-path",
+    "sensitive-search",
+    "command-substitution",
+    "redirection-write",
+    "awk-shell-execution",
+];
+
+pub fn is_high_risk_explanation(code: &str) -> bool {
+    HIGH_RISK_EXPLANATION_REASONS.contains(&code)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AssessmentSummary {
     pub impact: RiskImpact,

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -234,7 +234,11 @@ const SEMANTICS_BASELINE: &[(bool, &str, &str)] = &[
 #[test]
 fn command_risk_semantics_unchanged_from_baseline() {
     for (auto_mode, command, expected) in SEMANTICS_BASELINE {
-        let assessment = if *auto_mode { auto(command) } else { ask(command) };
+        let assessment = if *auto_mode {
+            auto(command)
+        } else {
+            ask(command)
+        };
         assert_eq!(
             &semantics_signature(&assessment),
             expected,
@@ -265,7 +269,10 @@ fn command_risk_primary_reason_prefers_structural_verdict() {
     // R4: complex shells (subshell syntax) get the structural verdict first.
     let complex = ask("(cd /tmp)");
     assert_eq!(complex.shape, CommandShape::Complex);
-    assert_eq!(complex.primary_reason(), "complex-shell-not-auto-executable");
+    assert_eq!(
+        complex.primary_reason(),
+        "complex-shell-not-auto-executable"
+    );
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -184,3 +184,100 @@ fn command_risk_assessment_unknown_and_parse_failure() {
     assert_eq!(unparseable.impact, RiskImpact::High);
     assert!(unparseable.reasons.contains(&"parse-failed"));
 }
+
+fn semantics_signature(assessment: &CommandAssessment) -> String {
+    let mut reasons = assessment.reasons.clone();
+    reasons.sort_unstable();
+    format!(
+        "{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{}",
+        assessment.execution,
+        assessment.impact,
+        assessment.confidence,
+        assessment.auto_allow,
+        assessment.interaction,
+        assessment.side_effects,
+        reasons.join(",")
+    )
+}
+
+// ARP-R6 semantics baseline captured on origin/main 9a034a2a (T0.2).
+// Reasons are order-insensitive (sorted); only reordering may differ after the fix.
+const SEMANTICS_BASELINE: &[(bool, &str, &str)] = &[
+    (true, "pwd", "AutoAllow|Low|High|Some(DirectReadonlyBroker)|None|[Unknown]|bounded-readonly,unknown-command"),
+    (true, "df -h", "AutoAllow|Low|High|Some(DirectReadonlyBroker)|None|[None]|bounded-readonly,safe-diagnostic-family"),
+    (true, "git status --short", "AutoAllow|Low|High|Some(DirectReadonlyBroker)|None|[Unknown]|bounded-readonly,unknown-command"),
+    (true, "ps aux --sort=-%mem", "AutoAllow|Low|High|Some(GuardedDiagnostic)|None|[None]|safe-diagnostic-family"),
+    (true, "top", "AutoAllow|Low|High|Some(GuardedDiagnostic)|TtyRequired|[None]|safe-diagnostic-family,streaming-diagnostic"),
+    (false, "top", "ForegroundHandoffRequired|Medium|High|None|TtyRequired|[None]|safe-diagnostic-family,streaming-diagnostic"),
+    (false, "custom-command --flag", "AskUser|Medium|Low|None|None|[Unknown]|unknown-command"),
+    (false, "git push", "AskUser|Medium|Low|None|None|[Unknown]|unknown-command"),
+    (false, "sed -i s/a/b/ notes.txt", "AskUser|Medium|Low|None|None|[Unknown]|unknown-command"),
+    (false, "sudo id", "AskUser|High|High|None|CredentialPromptLikely|[PrivilegeEscalation]|privilege-escalation"),
+    (false, "rm -rf target", "AskUser|High|High|None|None|[FilesystemDelete]|filesystem-delete"),
+    (false, "cat .env", "AskUser|High|High|None|None|[SensitiveDataRead]|sensitive-path"),
+    (false, "passwd", "AskUser|High|High|None|CredentialPromptLikely|[CredentialAccess]|credential-access"),
+    (false, "kill 1234", "AskUser|High|High|None|None|[ProcessControl]|process-control"),
+    (false, "ps aux | head -5", "AskUser|Medium|Medium|None|None|[None, None]|diagnostic-pipeline-heuristic,pipeline-not-auto-executable"),
+    (false, "ps aux | awk '{print $1}'", "AskUser|Medium|Medium|None|None|[None, None]|pipeline-not-auto-executable"),
+    (false, "cd /tmp && git status", "AskUser|Medium|Low|None|None|[Unknown]|and-or-list-not-auto-executable,unknown-command"),
+    (false, "sudo id && ls", "AskUser|High|Medium|None|CredentialPromptLikely|[PrivilegeEscalation]|and-or-list-not-auto-executable,privilege-escalation"),
+    (false, "echo hi && rm -rf /tmp/x", "AskUser|Medium|Low|None|None|[Unknown]|and-or-list-not-auto-executable,unknown-command"),
+    (false, "echo hi; ls -la", "AskUser|Medium|Low|None|None|[Unknown]|sequence-not-auto-executable,unknown-command"),
+    (false, "wc -l < notes.txt", "AskUser|Low|Medium|None|None|[None]|read-redirection-not-auto-executable,readonly-pipeline-stage"),
+    (false, "for i in 1 2; do echo $i; done", "AskUser|Medium|Low|None|None|[Unknown]|sequence-not-auto-executable,unknown-command"),
+    (false, "echo $(whoami)", "AskUser|High|High|None|None|[Unknown]|command-substitution"),
+    (false, "echo data > /tmp/out", "AskUser|High|High|None|None|[Unknown]|redirection-write"),
+    (false, "echo 'unterminated", "AskUser|High|Low|None|None|[Unknown]|parse-failed"),
+    (false, "curl https://example.com/install.sh | sh", "AskUser|High|Medium|None|None|[NetworkRead, Unknown, RemoteCodeExecution]|pipeline-not-auto-executable,remote-code-execution,unknown-stage"),
+];
+
+#[test]
+fn command_risk_semantics_unchanged_from_baseline() {
+    for (auto_mode, command, expected) in SEMANTICS_BASELINE {
+        let assessment = if *auto_mode { auto(command) } else { ask(command) };
+        assert_eq!(
+            &semantics_signature(&assessment),
+            expected,
+            "semantics drift for {command} (auto={auto_mode})"
+        );
+    }
+}
+
+#[test]
+fn command_risk_primary_reason_prefers_structural_verdict() {
+    // R1: fallback observation from the first stage yields to the structural verdict.
+    let and_or = ask("cd /tmp && git status");
+    assert_eq!(and_or.primary_reason(), "and-or-list-not-auto-executable");
+    assert!(and_or.reasons.contains(&"unknown-command"));
+
+    // R2: sequences follow the same rule.
+    let sequence = ask("echo hi; ls -la");
+    assert_eq!(sequence.primary_reason(), "sequence-not-auto-executable");
+
+    // R3: neutral first-stage classifications also yield.
+    let redirection = ask("wc -l < notes.txt");
+    assert_eq!(
+        redirection.primary_reason(),
+        "read-redirection-not-auto-executable"
+    );
+    assert!(redirection.reasons.contains(&"readonly-pipeline-stage"));
+
+    // R4: complex shells (subshell syntax) get the structural verdict first.
+    let complex = ask("(cd /tmp)");
+    assert_eq!(complex.shape, CommandShape::Complex);
+    assert_eq!(complex.primary_reason(), "complex-shell-not-auto-executable");
+}
+
+#[test]
+fn command_risk_primary_reason_keeps_high_risk_explanation_first() {
+    // R5: a high-risk explanation is never displaced by the structural verdict.
+    let sudo_list = ask("sudo id && ls");
+    assert_eq!(sudo_list.primary_reason(), "privilege-escalation");
+    assert!(sudo_list
+        .reasons
+        .contains(&"and-or-list-not-auto-executable"));
+
+    // R6: simple commands without structural reasons keep current behavior.
+    let push = ask("git push");
+    assert_eq!(push.primary_reason(), "unknown-command");
+}

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
@@ -160,14 +160,17 @@ impl RatatuiInlineRenderer {
         // `{subject} · {risk badge}[ · queue N/M]`, optional High-risk
         // continuation line, preview, optional next, actions; key hints and
         // policy only when expanded.
+        let risk_label = risk_level_label(model.risk, i18n);
+        let queue_suffix = queue_meta_suffix(&model, i18n);
+        let subject = metadata_subject(
+            model.subject,
+            self.content_width(),
+            &risk_label,
+            &queue_suffix,
+        );
         let mut lines = vec![
             i18n.t(crate::MessageId::ApprovalRequiredTitle).to_string(),
-            format!(
-                "{} · {}{}",
-                model.subject,
-                risk_level_label(model.risk, i18n),
-                queue_meta_suffix(&model, i18n)
-            ),
+            format!("{subject} · {risk_label}{queue_suffix}"),
         ];
         if let Some(reason) = model.reason {
             lines.push(approval_reason_line(reason, i18n));
@@ -333,19 +336,27 @@ fn render_approval_panel(
 
     // Metadata row: `{subject} · {risk badge}[ · queue N/M]` — the badge is
     // localized (ARP-R7); High keeps the border color, low/medium are dimmed.
+    // The subject is ellipsized so the risk badge and queue info always keep
+    // their reserved width (review follow-up: long MCP tool names must never
+    // push the risk signal out of view).
     let risk_style = if model.risk == "high" {
         Style::default().fg(border)
     } else {
         Style::default().fg(Color::DarkGray)
     };
+    let risk_label = risk_level_label(model.risk, i18n);
+    let queue_suffix = queue_meta_suffix(&model, i18n);
+    let subject = metadata_subject(
+        model.subject,
+        inner.width.saturating_sub(2) as usize,
+        &risk_label,
+        &queue_suffix,
+    );
     Paragraph::new(Line::from(vec![
-        Span::styled(model.subject.to_string(), Style::default().fg(Color::Cyan)),
+        Span::styled(subject, Style::default().fg(Color::Cyan)),
         Span::styled(" · ", Style::default().fg(Color::DarkGray)),
-        Span::styled(risk_level_label(model.risk, i18n), risk_style),
-        Span::styled(
-            queue_meta_suffix(&model, i18n),
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(risk_label, risk_style),
+        Span::styled(queue_suffix, Style::default().fg(Color::DarkGray)),
     ]))
     .render(chunks[0], buffer);
 
@@ -777,6 +788,38 @@ fn queue_meta_suffix(model: &ApprovalPanelModel<'_>, i18n: crate::I18n) -> Strin
             ("total", model.queue_total.to_string().as_str()),
         ],
     )
+}
+
+/// Ellipsize the metadata-row subject so the risk badge and queue suffix
+/// always fit: unbounded custom/MCP tool names must never push the risk
+/// signal past the row end (review follow-up on #1786).
+fn metadata_subject(
+    subject: &str,
+    content_width: usize,
+    risk_label: &str,
+    queue_suffix: &str,
+) -> String {
+    const SEPARATOR_WIDTH: usize = 3; // " · "
+    const MIN_SUBJECT_WIDTH: usize = 8;
+    let reserved = SEPARATOR_WIDTH + display_width(risk_label) + display_width(queue_suffix);
+    let budget = content_width
+        .saturating_sub(reserved)
+        .max(MIN_SUBJECT_WIDTH);
+    if display_width(subject) <= budget {
+        return subject.to_string();
+    }
+    let mut truncated = String::new();
+    let mut width = 0;
+    for ch in subject.chars() {
+        let ch_width = char_width(ch);
+        if width + ch_width > budget.saturating_sub(1) {
+            break;
+        }
+        truncated.push(ch);
+        width += ch_width;
+    }
+    truncated.push('\u{2026}');
+    truncated
 }
 
 fn approval_action_label(action: ApprovalPanelAction, i18n: crate::I18n) -> &'static str {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
@@ -753,16 +753,16 @@ fn approval_reason_styled_lines(
 }
 
 /// Localized risk badge value (ARP-R7): high/medium/low map to i18n labels;
-/// unknown values pass through unchanged.
+/// values outside the closed `legacy_risk()` domain fall back to a neutral
+/// localized label so the badge never mixes languages (review follow-up).
 fn risk_level_label(risk: &str, i18n: crate::I18n) -> String {
-    match risk {
-        "high" => i18n.t(crate::MessageId::ApprovalRiskLevelHigh).to_string(),
-        "medium" => i18n
-            .t(crate::MessageId::ApprovalRiskLevelMedium)
-            .to_string(),
-        "low" => i18n.t(crate::MessageId::ApprovalRiskLevelLow).to_string(),
-        other => other.to_string(),
-    }
+    let id = match risk {
+        "high" => crate::MessageId::ApprovalRiskLevelHigh,
+        "medium" => crate::MessageId::ApprovalRiskLevelMedium,
+        "low" => crate::MessageId::ApprovalRiskLevelLow,
+        _ => crate::MessageId::ApprovalRiskLevelUnknown,
+    };
+    i18n.t(id).to_string()
 }
 
 /// Metadata-row queue suffix, only rendered when more than one card is pending.

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
@@ -156,20 +156,22 @@ impl RatatuiInlineRenderer {
             return lines;
         }
 
-        let position = model.queue_position.to_string();
-        let total = model.queue_total.to_string();
-        let risk = i18n.format(
-            crate::MessageId::ApprovalRiskSuffix,
-            &[("risk", model.risk)],
-        );
+        // V6a slim generic card (ARP-R8): title, single metadata row
+        // `{subject} · {risk badge}[ · queue N/M]`, optional High-risk
+        // continuation line, preview, optional next, actions; key hints and
+        // policy only when expanded.
         let mut lines = vec![
             i18n.t(crate::MessageId::ApprovalRequiredTitle).to_string(),
-            format!("{} · {} · {}", model.id, model.kind, risk),
-            i18n.format(
-                crate::MessageId::ApprovalQueueFullLine,
-                &[("position", position.as_str()), ("total", total.as_str())],
+            format!(
+                "{} · {}{}",
+                model.subject,
+                risk_level_label(model.risk, i18n),
+                queue_meta_suffix(&model, i18n)
             ),
         ];
+        if let Some(reason) = model.reason {
+            lines.push(approval_reason_line(reason, i18n));
+        }
         for warning in &model.hook_warnings {
             let icon = hook_warning_icon(warning.decision);
             lines.push(format!("\u{2502} {icon} {}", warning.hook_name));
@@ -177,15 +179,7 @@ impl RatatuiInlineRenderer {
                 lines.push(format!("\u{2502}   {msg_line}"));
             }
         }
-        lines.push(format!(
-            "{}{}",
-            i18n.t(crate::MessageId::ApprovalSubjectLabel),
-            model.subject
-        ));
-        lines.push(format!("{}: {}", model.preview_label, model.preview));
-        if let Some(reason) = model.reason {
-            lines.push(approval_reason_line(reason, i18n));
-        }
+        lines.push(model.preview.to_string());
         if let Some(next) = model.next_label {
             lines.push(format!(
                 "{}{next}",
@@ -263,8 +257,10 @@ fn approval_panel_height(model: &ApprovalPanelModel<'_>, width: u16) -> u16 {
             .len() as u16
         })
         .unwrap_or(0);
-    let policy_rows = if model.expanded { 2 } else { 0 };
-    7 + preview_rows + next_rows + reason_rows + policy_rows + hook_warning_rows
+    // V6a slim generic card: border(2) + metadata(1) + actions(1) + content;
+    // keys(1) + policy(2) only when expanded (ARP-R8).
+    let expanded_rows = if model.expanded { 3 } else { 0 };
+    4 + preview_rows + next_rows + reason_rows + expanded_rows + hook_warning_rows
 }
 
 fn render_approval_panel(
@@ -318,44 +314,49 @@ fn render_approval_panel(
         .iter()
         .map(|w| 1 + w.message.lines().count())
         .sum::<usize>() as u16;
+    // V6a slim generic card: metadata row, optional continuation line,
+    // hook warnings, preview, optional next, actions; keys + policy only
+    // when expanded (ARP-R8).
     let mut constraints = vec![
         Constraint::Length(1),
+        Constraint::Length(reason_height),
         Constraint::Length(hook_warning_height),
-        Constraint::Length(1),
-        Constraint::Length(1),
         Constraint::Length(preview_height),
         Constraint::Length(next_height),
-        Constraint::Length(reason_height),
-        Constraint::Length(1),
         Constraint::Length(1),
     ];
     if model.expanded {
+        constraints.push(Constraint::Length(1));
         constraints.push(Constraint::Length(2));
     }
     let chunks = Layout::vertical(constraints).split(inner);
 
+    // Metadata row: `{subject} · {risk badge}[ · queue N/M]` — the badge is
+    // localized (ARP-R7); High keeps the border color, low/medium are dimmed.
+    let risk_style = if model.risk == "high" {
+        Style::default().fg(border)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
     Paragraph::new(Line::from(vec![
-        Span::styled(model.kind, Style::default().fg(Color::Cyan)),
-        Span::raw("  "),
+        Span::styled(model.subject.to_string(), Style::default().fg(Color::Cyan)),
+        Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+        Span::styled(risk_level_label(model.risk, i18n), risk_style),
         Span::styled(
-            i18n.format(
-                crate::MessageId::ApprovalRiskSuffix,
-                &[("risk", model.risk)],
-            ),
-            Style::default().fg(border),
+            queue_meta_suffix(&model, i18n),
+            Style::default().fg(Color::DarkGray),
         ),
-        Span::raw(format!(
-            "  {}",
-            i18n.format(
-                crate::MessageId::ApprovalQueueCompactLine,
-                &[
-                    ("position", model.queue_position.to_string().as_str()),
-                    ("total", model.queue_total.to_string().as_str()),
-                ],
-            )
-        )),
     ]))
     .render(chunks[0], buffer);
+
+    if !reason_rows.is_empty() {
+        Paragraph::new(Text::from(approval_reason_styled_lines(
+            reason_rows,
+            border,
+            i18n,
+        )))
+        .render(chunks[1], buffer);
+    }
 
     if !model.hook_warnings.is_empty() {
         let mut warning_lines: Vec<Line<'_>> = Vec::new();
@@ -378,31 +379,14 @@ fn render_approval_panel(
                 ]));
             }
         }
-        Paragraph::new(Text::from(warning_lines)).render(chunks[1], buffer);
+        Paragraph::new(Text::from(warning_lines)).render(chunks[2], buffer);
     }
-
-    Paragraph::new(Line::from(vec![
-        Span::styled(
-            i18n.t(crate::MessageId::ApprovalSubjectLabel),
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(model.subject),
-    ]))
-    .render(chunks[2], buffer);
-
-    Paragraph::new(Line::from(Span::styled(
-        format!("{}:", model.preview_label),
-        Style::default()
-            .fg(Color::DarkGray)
-            .add_modifier(Modifier::BOLD),
-    )))
-    .render(chunks[3], buffer);
 
     let preview_lines = preview_rows
         .into_iter()
         .map(|line| Line::from(Span::styled(line, Style::default().fg(Color::White))))
         .collect::<Vec<_>>();
-    Paragraph::new(Text::from(preview_lines)).render(chunks[4], buffer);
+    Paragraph::new(Text::from(preview_lines)).render(chunks[3], buffer);
 
     if let Some(next) = model.next_label {
         Paragraph::new(Line::from(vec![
@@ -412,37 +396,26 @@ fn render_approval_panel(
             ),
             Span::raw(next.to_string()),
         ]))
-        .render(chunks[5], buffer);
+        .render(chunks[4], buffer);
     }
 
-    if !reason_rows.is_empty() {
-        Paragraph::new(Text::from(
-            reason_rows
-                .into_iter()
-                .map(|line| Line::from(Span::raw(line)))
-                .collect::<Vec<_>>(),
-        ))
-        .render(chunks[6], buffer);
-    }
-
-    Paragraph::new(approval_action_spans(model.selected_action, i18n)).render(chunks[7], buffer);
-
-    Paragraph::new(Line::from(vec![
-        Span::styled(
-            i18n.t(crate::MessageId::ApprovalKeysPrefix),
-            Style::default().fg(Color::DarkGray),
-        ),
-        Span::raw(i18n.t(crate::MessageId::ApprovalKeysText)),
-    ]))
-    .render(chunks[8], buffer);
+    Paragraph::new(approval_action_spans(model.selected_action, i18n)).render(chunks[5], buffer);
 
     if model.expanded {
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                i18n.t(crate::MessageId::ApprovalKeysPrefix),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::raw(i18n.t(crate::MessageId::ApprovalKeysText)),
+        ]))
+        .render(chunks[6], buffer);
         Paragraph::new(Text::from(vec![
             Line::from(i18n.t(crate::MessageId::ApprovalExecutableToolPolicy)),
             Line::from(i18n.t(crate::MessageId::ApprovalExecutableToolPolicyExtra)),
         ]))
         .wrap(Wrap { trim: true })
-        .render(chunks[9], buffer);
+        .render(chunks[7], buffer);
     }
 }
 
@@ -533,12 +506,11 @@ fn render_command_tool_approval_panel(
     }
 
     if !reason_rows.is_empty() {
-        Paragraph::new(Text::from(
-            reason_rows
-                .into_iter()
-                .map(|line| Line::from(Span::raw(line)))
-                .collect::<Vec<_>>(),
-        ))
+        Paragraph::new(Text::from(approval_reason_styled_lines(
+            reason_rows,
+            border,
+            i18n,
+        )))
         .render(chunks[2], buffer);
     }
 
@@ -741,15 +713,70 @@ fn approval_action_line(selected: ApprovalPanelAction, i18n: crate::I18n) -> Str
         .join("  ")
 }
 
+/// V6a continuation line under the metadata row: `└ 风险: <phrase>`.
+/// `reason` is already the localized natural-language phrase (never a raw
+/// code) — the policy lives in `approval_reason::card_reason_phrase`.
 fn approval_reason_line(reason: &str, i18n: crate::I18n) -> String {
-    i18n.format(
-        crate::MessageId::ApprovalAssessmentReasonLine,
-        &[("reason", reason)],
+    format!(
+        "\u{2514} {}{reason}",
+        i18n.t(crate::MessageId::ApprovalRiskDetailLabel)
     )
 }
 
 fn approval_reason_rows(reason: &str, width: usize, i18n: crate::I18n) -> Vec<String> {
     wrapped_preview_rows(&approval_reason_line(reason, i18n), width, 2)
+}
+
+/// Styled continuation lines: label in the border color, phrase dimmed.
+fn approval_reason_styled_lines(
+    reason_rows: Vec<String>,
+    border: Color,
+    i18n: crate::I18n,
+) -> Vec<Line<'static>> {
+    let label = format!(
+        "\u{2514} {}",
+        i18n.t(crate::MessageId::ApprovalRiskDetailLabel)
+    );
+    reason_rows
+        .into_iter()
+        .map(|row| {
+            if let Some(phrase) = row.strip_prefix(&label) {
+                Line::from(vec![
+                    Span::styled(label.clone(), Style::default().fg(border)),
+                    Span::styled(phrase.to_string(), Style::default().fg(Color::DarkGray)),
+                ])
+            } else {
+                Line::from(Span::styled(row, Style::default().fg(Color::DarkGray)))
+            }
+        })
+        .collect()
+}
+
+/// Localized risk badge value (ARP-R7): high/medium/low map to i18n labels;
+/// unknown values pass through unchanged.
+fn risk_level_label(risk: &str, i18n: crate::I18n) -> String {
+    match risk {
+        "high" => i18n.t(crate::MessageId::ApprovalRiskLevelHigh).to_string(),
+        "medium" => i18n
+            .t(crate::MessageId::ApprovalRiskLevelMedium)
+            .to_string(),
+        "low" => i18n.t(crate::MessageId::ApprovalRiskLevelLow).to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Metadata-row queue suffix, only rendered when more than one card is pending.
+fn queue_meta_suffix(model: &ApprovalPanelModel<'_>, i18n: crate::I18n) -> String {
+    if model.queue_total <= 1 {
+        return String::new();
+    }
+    i18n.format(
+        crate::MessageId::ApprovalQueueMetaSuffix,
+        &[
+            ("position", model.queue_position.to_string().as_str()),
+            ("total", model.queue_total.to_string().as_str()),
+        ],
+    )
 }
 
 fn approval_action_label(action: ApprovalPanelAction, i18n: crate::I18n) -> &'static str {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
@@ -1,0 +1,87 @@
+use crate::tools::command_risk::HIGH_RISK_EXPLANATION_REASONS;
+
+/// Card-facing reason policy (ARP SDD design.md §2).
+///
+/// Returns the natural-language risk phrase for the approval card
+/// continuation line if and only if the request risk is `high` and the
+/// primary reason belongs to the display whitelist. Every other case —
+/// low/medium risk, structural or fallback codes, and unknown future
+/// codes — is fail-quiet (`None`, no line rendered).
+pub(crate) fn card_reason_phrase(
+    risk: &str,
+    primary_reason: &str,
+    i18n: crate::I18n,
+) -> Option<String> {
+    if risk != "high" {
+        return None;
+    }
+    phrase_message_id(primary_reason).map(|id| i18n.t(id).to_string())
+}
+
+fn phrase_message_id(code: &str) -> Option<crate::MessageId> {
+    use crate::MessageId::*;
+    Some(match code {
+        "privilege-escalation" => ApprovalRiskPhrasePrivilegeEscalation,
+        "credential-access" => ApprovalRiskPhraseCredentialAccess,
+        "filesystem-delete" => ApprovalRiskPhraseFilesystemDelete,
+        "filesystem-write" => ApprovalRiskPhraseFilesystemWrite,
+        "permission-change" => ApprovalRiskPhrasePermissionChange,
+        "process-control" => ApprovalRiskPhraseProcessControl,
+        "service-control" => ApprovalRiskPhraseServiceControl,
+        "service-or-container-control" => ApprovalRiskPhraseServiceOrContainerControl,
+        "package-manager-mutation" => ApprovalRiskPhrasePackageManagerMutation,
+        "interactive-editor" => ApprovalRiskPhraseInteractiveEditor,
+        "remote-code-execution" => ApprovalRiskPhraseRemoteCodeExecution,
+        "sensitive-path" => ApprovalRiskPhraseSensitivePath,
+        "sensitive-search" => ApprovalRiskPhraseSensitiveSearch,
+        "command-substitution" => ApprovalRiskPhraseCommandSubstitution,
+        "redirection-write" => ApprovalRiskPhraseRedirectionWrite,
+        "awk-shell-execution" => ApprovalRiskPhraseAwkShellExecution,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::display_width;
+    use super::*;
+    use crate::{I18n, Language};
+
+    #[test]
+    fn whitelist_codes_have_localized_phrases_within_width_budget() {
+        for language in [Language::ZhCn, Language::EnUs] {
+            let i18n = I18n::new(language);
+            for code in HIGH_RISK_EXPLANATION_REASONS {
+                let phrase = card_reason_phrase("high", code, i18n)
+                    .unwrap_or_else(|| panic!("missing phrase for {code} ({language:?})"));
+                assert_ne!(&phrase, code, "phrase must not echo the raw code: {code}");
+                assert!(
+                    display_width(&phrase) <= 32,
+                    "phrase too wide for {code} ({language:?}): {phrase}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn non_high_risk_never_shows_a_phrase() {
+        let i18n = I18n::new(Language::ZhCn);
+        assert_eq!(card_reason_phrase("medium", "privilege-escalation", i18n), None);
+        assert_eq!(card_reason_phrase("low", "bounded-readonly", i18n), None);
+    }
+
+    #[test]
+    fn structural_fallback_and_unknown_codes_are_fail_quiet() {
+        let i18n = I18n::new(Language::EnUs);
+        for code in [
+            "unknown-command",
+            "and-or-list-not-auto-executable",
+            "pipeline-not-auto-executable",
+            "unsafe-binding",
+            "parse-failed",
+            "not-a-real-code",
+        ] {
+            assert_eq!(card_reason_phrase("high", code, i18n), None, "{code}");
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
@@ -66,7 +66,10 @@ mod tests {
     #[test]
     fn non_high_risk_never_shows_a_phrase() {
         let i18n = I18n::new(Language::ZhCn);
-        assert_eq!(card_reason_phrase("medium", "privilege-escalation", i18n), None);
+        assert_eq!(
+            card_reason_phrase("medium", "privilege-escalation", i18n),
+            None
+        );
         assert_eq!(card_reason_phrase("low", "bounded-readonly", i18n), None);
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
@@ -1,5 +1,11 @@
 use crate::tools::command_risk::HIGH_RISK_EXPLANATION_REASONS;
 
+/// Display-width budget for card risk phrases (ARP SDD validation.md S2:
+/// <= 32 columns / 16 fullwidth chars). Referenced by the exhaustive i18n
+/// test below and by full-card rendering tests so the budget cannot drift
+/// from the SDD contract.
+pub(crate) const CARD_REASON_PHRASE_MAX_WIDTH: usize = 32;
+
 /// Card-facing reason policy (ARP SDD design.md §2).
 ///
 /// Returns the natural-language risk phrase for the approval card
@@ -56,7 +62,7 @@ mod tests {
                     .unwrap_or_else(|| panic!("missing phrase for {code} ({language:?})"));
                 assert_ne!(&phrase, code, "phrase must not echo the raw code: {code}");
                 assert!(
-                    display_width(&phrase) <= 32,
+                    display_width(&phrase) <= CARD_REASON_PHRASE_MAX_WIDTH,
                     "phrase too wide for {code} ({language:?}): {phrase}"
                 );
             }

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
@@ -43,9 +43,9 @@ pub use activity::{
 };
 pub(crate) use approval::hook_warning_icon;
 pub use approval::{ApprovalPanelModel, HookWarningView};
-pub(crate) use approval_reason::card_reason_phrase;
 pub use approval_details::{ApprovalDetailsPanelModel, CommandAssessmentSummaryModel};
 pub use approval_journal::{ApprovalJournalEntryModel, ApprovalJournalPanelModel};
+pub(crate) use approval_reason::card_reason_phrase;
 pub use approval_receipt::ApprovalReceiptPanelModel;
 pub use consultation::ConsultationCardModel;
 pub use health::HealthBannerModel;

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
@@ -45,7 +45,7 @@ pub(crate) use approval::hook_warning_icon;
 pub use approval::{ApprovalPanelModel, HookWarningView};
 pub use approval_details::{ApprovalDetailsPanelModel, CommandAssessmentSummaryModel};
 pub use approval_journal::{ApprovalJournalEntryModel, ApprovalJournalPanelModel};
-pub(crate) use approval_reason::card_reason_phrase;
+pub(crate) use approval_reason::{card_reason_phrase, CARD_REASON_PHRASE_MAX_WIDTH};
 pub use approval_receipt::ApprovalReceiptPanelModel;
 pub use consultation::ConsultationCardModel;
 pub use health::HealthBannerModel;

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
@@ -15,6 +15,7 @@ mod activity;
 mod approval;
 mod approval_details;
 mod approval_journal;
+mod approval_reason;
 mod approval_receipt;
 mod card;
 mod consultation;
@@ -42,6 +43,7 @@ pub use activity::{
 };
 pub(crate) use approval::hook_warning_icon;
 pub use approval::{ApprovalPanelModel, HookWarningView};
+pub(crate) use approval_reason::card_reason_phrase;
 pub use approval_details::{ApprovalDetailsPanelModel, CommandAssessmentSummaryModel};
 pub use approval_journal::{ApprovalJournalEntryModel, ApprovalJournalPanelModel};
 pub use approval_receipt::ApprovalReceiptPanelModel;

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
@@ -85,40 +85,56 @@ fn approval_panel_high_risk_shows_reason_continuation_line() {
 #[test]
 fn approval_panel_high_risk_continuation_wraps_within_narrow_width() {
     // Review follow-up: full-card width contract for the continuation line,
-    // not just the phrase-level budget (validation.md S2).
-    let renderer = RatatuiInlineRenderer::with_width(60);
-    let phrase = crate::ui::card_reason_phrase(
-        "high",
-        "service-or-container-control",
-        crate::I18n::new(crate::Language::EnUs),
-    )
-    .expect("whitelisted high-risk phrase");
-    let text = renderer
-        .approval_panel_lines(ApprovalPanelModel {
-            id: "req-9",
-            kind: "tool request",
-            risk: "high",
-            reason: Some(&phrase),
-            subject: "tool Bash",
-            preview_label: "Tool input",
-            preview: "kubectl delete pod payments --grace-period=0",
-            queue_position: 1,
-            queue_total: 1,
-            next_label: None,
-            selected_action: ApprovalPanelAction::Approve,
-            expanded: false,
-            hook_warnings: Vec::new(),
-        })
-        .join("\n");
+    // not just the phrase-level budget (validation.md S2), in both catalogs
+    // with the widest phrase of each language.
+    for (language, code, expected_label) in [
+        (
+            crate::Language::EnUs,
+            "service-or-container-control",
+            "\u{2514} Risk:",
+        ),
+        (
+            crate::Language::ZhCn,
+            "interactive-editor",
+            "\u{2514} 风险:",
+        ),
+    ] {
+        let renderer = RatatuiInlineRenderer::with_width(60).with_language(language);
+        let phrase = crate::ui::card_reason_phrase("high", code, crate::I18n::new(language))
+            .expect("whitelisted high-risk phrase");
+        assert!(
+            crate::ui::agent_render::display_width(&phrase)
+                <= crate::ui::CARD_REASON_PHRASE_MAX_WIDTH,
+            "{language:?} phrase exceeds SDD budget: {phrase}"
+        );
+        let text = renderer
+            .approval_panel_lines(ApprovalPanelModel {
+                id: "req-9",
+                kind: "tool request",
+                risk: "high",
+                reason: Some(&phrase),
+                subject: "tool Bash",
+                preview_label: "Tool input",
+                preview: "kubectl delete pod payments --grace-period=0",
+                queue_position: 1,
+                queue_total: 1,
+                next_label: None,
+                selected_action: ApprovalPanelAction::Approve,
+                expanded: false,
+                hook_warnings: Vec::new(),
+            })
+            .join("\n");
 
-    assert!(text.contains("\u{2514} Risk:"), "{text}");
-    assert_rendered_width(&text, 60);
+        assert!(text.contains(expected_label), "{language:?}: {text}");
+        assert_rendered_width(&text, 60);
+    }
 }
 
 #[test]
-fn approval_panel_unknown_risk_value_passes_through_without_panic() {
-    // Review follow-up: legacy_risk() is a closed low/medium/high domain; an
-    // unknown value must render verbatim (defensive pass-through contract).
+fn approval_panel_unknown_risk_value_falls_back_to_localized_label() {
+    // Review follow-up: values outside the closed legacy_risk() domain must
+    // render a neutral localized badge instead of leaking the raw string
+    // into a mixed-language metadata row.
     let renderer = RatatuiInlineRenderer::with_width(120).with_language(crate::Language::ZhCn);
     let text = renderer
         .approval_panel_lines(ApprovalPanelModel {
@@ -138,8 +154,8 @@ fn approval_panel_unknown_risk_value_passes_through_without_panic() {
         })
         .join("\n");
 
-    assert!(text.contains("Bash · critical"), "{text}");
-    assert!(!text.contains("风险 critical"), "{text}");
+    assert!(text.contains("Bash · 未知风险"), "{text}");
+    assert!(!text.contains("critical"), "{text}");
     assert_rendered_width(&text, 120);
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
@@ -83,6 +83,67 @@ fn approval_panel_high_risk_shows_reason_continuation_line() {
 }
 
 #[test]
+fn approval_panel_high_risk_continuation_wraps_within_narrow_width() {
+    // Review follow-up: full-card width contract for the continuation line,
+    // not just the phrase-level budget (validation.md S2).
+    let renderer = RatatuiInlineRenderer::with_width(60);
+    let phrase = crate::ui::card_reason_phrase(
+        "high",
+        "service-or-container-control",
+        crate::I18n::new(crate::Language::EnUs),
+    )
+    .expect("whitelisted high-risk phrase");
+    let text = renderer
+        .approval_panel_lines(ApprovalPanelModel {
+            id: "req-9",
+            kind: "tool request",
+            risk: "high",
+            reason: Some(&phrase),
+            subject: "tool Bash",
+            preview_label: "Tool input",
+            preview: "kubectl delete pod payments --grace-period=0",
+            queue_position: 1,
+            queue_total: 1,
+            next_label: None,
+            selected_action: ApprovalPanelAction::Approve,
+            expanded: false,
+            hook_warnings: Vec::new(),
+        })
+        .join("\n");
+
+    assert!(text.contains("\u{2514} Risk:"), "{text}");
+    assert_rendered_width(&text, 60);
+}
+
+#[test]
+fn approval_panel_unknown_risk_value_passes_through_without_panic() {
+    // Review follow-up: legacy_risk() is a closed low/medium/high domain; an
+    // unknown value must render verbatim (defensive pass-through contract).
+    let renderer = RatatuiInlineRenderer::with_width(120).with_language(crate::Language::ZhCn);
+    let text = renderer
+        .approval_panel_lines(ApprovalPanelModel {
+            id: "req-9",
+            kind: "tool request",
+            risk: "critical",
+            reason: None,
+            subject: "Bash",
+            preview_label: "Tool 输入",
+            preview: "echo hi",
+            queue_position: 1,
+            queue_total: 1,
+            next_label: None,
+            selected_action: ApprovalPanelAction::Approve,
+            expanded: false,
+            hook_warnings: Vec::new(),
+        })
+        .join("\n");
+
+    assert!(text.contains("Bash · critical"), "{text}");
+    assert!(!text.contains("风险 critical"), "{text}");
+    assert_rendered_width(&text, 120);
+}
+
+#[test]
 fn approval_panel_uses_zh_labels_without_translating_command() {
     let renderer = RatatuiInlineRenderer::with_width(140).with_language(crate::Language::ZhCn);
     let text = renderer

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
@@ -9,7 +9,8 @@ fn approval_panel_renders_active_request_with_queue_summary() {
             id: "req-1",
             kind: "tool request",
             risk: "medium",
-            reason: Some("diagnostic-pipeline-heuristic"),
+            // Card policy (ARP): medium risk never carries a reason phrase.
+            reason: None,
             subject: "tool Bash",
             preview_label: "Tool input",
             preview: "top -l 1 -o mem -n 20 | head -30",
@@ -24,10 +25,8 @@ fn approval_panel_renders_active_request_with_queue_summary() {
 
     assert!(text.contains("Approval req-1"), "{text}");
     assert!(text.contains("Run Bash command?"), "{text}");
-    assert!(
-        text.contains("Reason: diagnostic-pipeline-heuristic"),
-        "{text}"
-    );
+    assert!(!text.contains("Reason:"), "{text}");
+    assert!(!text.contains("\u{2514} Risk:"), "{text}");
     assert!(
         text.contains("$ top -l 1 -o mem -n 20 | head -30"),
         "{text}"
@@ -43,6 +42,43 @@ fn approval_panel_renders_active_request_with_queue_summary() {
     assert!(!text.contains("/approve"), "{text}");
     assert!(!text.contains("Subject: tool Bash"), "{text}");
     assert!(!text.contains("Tool input"), "{text}");
+    assert_rendered_width(&text, 140);
+}
+
+#[test]
+fn approval_panel_high_risk_shows_reason_continuation_line() {
+    let renderer = RatatuiInlineRenderer::with_width(140);
+    let phrase = crate::ui::card_reason_phrase(
+        "high",
+        "privilege-escalation",
+        crate::I18n::new(crate::Language::EnUs),
+    )
+    .expect("whitelisted high-risk phrase");
+    let text = renderer
+        .approval_panel_lines(ApprovalPanelModel {
+            id: "req-9",
+            kind: "tool request",
+            risk: "high",
+            reason: Some(&phrase),
+            subject: "tool Bash",
+            preview_label: "Tool input",
+            preview: "sudo rm -rf /data/legacy-cache",
+            queue_position: 1,
+            queue_total: 1,
+            next_label: None,
+            selected_action: ApprovalPanelAction::Approve,
+            expanded: false,
+            hook_warnings: Vec::new(),
+        })
+        .join("\n");
+
+    assert!(
+        text.contains("\u{2514} Risk: privilege escalation"),
+        "{text}"
+    );
+    assert!(text.contains("$ sudo rm -rf /data/legacy-cache"), "{text}");
+    assert!(!text.contains("privilege-escalation"), "{text}");
+    assert!(!text.contains("Queue:"), "{text}");
     assert_rendered_width(&text, 140);
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
@@ -131,6 +131,36 @@ fn approval_panel_high_risk_continuation_wraps_within_narrow_width() {
 }
 
 #[test]
+fn approval_panel_long_subject_never_hides_risk_badge() {
+    // Review follow-up (#1786): unbounded custom/MCP tool names are
+    // ellipsized so the risk badge and queue info keep their reserved width
+    // even on a 40-column terminal.
+    let renderer = RatatuiInlineRenderer::with_width(40);
+    let text = renderer
+        .approval_panel_lines(ApprovalPanelModel {
+            id: "req-9",
+            kind: "tool request",
+            risk: "medium",
+            reason: None,
+            subject: "mcp__server__extremely_long_custom_tool_name",
+            preview_label: "Tool input",
+            preview: "echo hi",
+            queue_position: 2,
+            queue_total: 3,
+            next_label: None,
+            selected_action: ApprovalPanelAction::Approve,
+            expanded: false,
+            hook_warnings: Vec::new(),
+        })
+        .join("\n");
+
+    assert!(text.contains("\u{2026} · medium risk"), "{text}");
+    assert!(text.contains("queue 2/3"), "{text}");
+    assert!(!text.contains("extremely_long_custom_tool_name"), "{text}");
+    assert_rendered_width(&text, 40);
+}
+
+#[test]
 fn approval_panel_unknown_risk_value_falls_back_to_localized_label() {
     // Review follow-up: values outside the closed legacy_risk() domain must
     // render a neutral localized badge instead of leaking the raw string

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/details.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/details.rs
@@ -186,7 +186,8 @@ fn raw_cli_details_for_approval_uses_zh_language_env() {
 
     assert_zh_approval_prompt_visible(&output);
     assert!(output.contains("已取消 req-1"), "{output}");
-    assert!(output.contains("风险 medium"), "{output}");
+    assert!(output.contains("Bash · 中风险"), "{output}");
+    assert!(!output.contains("风险 medium"), "{output}");
     assert!(
         output.contains("策略: 可执行 tool 请求必须先经过用户审批。"),
         "{output}"

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/foreground.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/foreground.rs
@@ -10,9 +10,9 @@ fn raw_cli_streaming_tool_approval_renders_before_agent_finishes() {
 
     assert!(output.contains("Preparing a streamed tool request before finishing."));
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("Subject: Bash"));
+    assert!(output.contains("Bash · medium risk"));
     assert!(output.contains("$ git status --short"));
-    assert!(output.contains("medium risk"));
+    assert!(!output.contains("Subject: Bash"));
     assert!(!output.contains("Subject: tool Bash"));
     assert!(!output.contains("Command: git status --short"));
     assert!(output.contains("Approved req-1"), "{output}");
@@ -51,7 +51,7 @@ fn raw_cli_approved_bash_tool_prints_native_command_and_stdout() {
 
     assert!(output.contains("Preparing a streamed pwd request before finishing."));
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("Subject: Bash"), "{output}");
+    assert!(output.contains("Bash · "), "{output}");
     assert!(output.contains("$ pwd"), "{output}");
     assert!(output.contains(expected_cwd), "{output}");
     assert!(output.contains("Approved req-1"), "{output}");
@@ -308,7 +308,7 @@ fn raw_cli_denied_bash_tool_does_not_render_stale_executed_claim() {
 
     assert!(output.contains("Preparing a streamed pwd request before finishing."));
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("Subject: Bash"), "{output}");
+    assert!(output.contains("Bash · "), "{output}");
     assert!(output.contains("Denied req-1"), "{output}");
     assert!(!output.contains("No command ran."), "{output}");
     assert!(
@@ -341,7 +341,8 @@ fn raw_cli_denied_bash_tool_uses_zh_language_env() {
     let expected_cwd = env!("CARGO_MANIFEST_DIR");
 
     assert_zh_approval_prompt_visible(&output);
-    assert!(output.contains("对象: Bash"), "{output}");
+    assert!(output.contains("Bash · "), "{output}");
+    assert!(!output.contains("对象: Bash"), "{output}");
     assert!(output.contains("已拒绝 req-1"), "{output}");
     assert!(output.contains("$ pwd"), "{output}");
     assert!(
@@ -373,7 +374,7 @@ fn raw_cli_user_approved_bash_tool_supports_pipe() {
 
     assert!(output.contains("Preparing a piped streamed tool request before finishing."));
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("Subject: Bash"));
+    assert!(output.contains("Bash · "));
     assert!(output.contains("$ ps aux | head"));
     assert!(output.contains("Approved req-1"), "{output}");
     assert!(!output.contains("Blocked req-1"), "{output}");

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/status.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/status.rs
@@ -43,10 +43,12 @@ fn raw_cli_approval_cancel_records_receipt_and_advances_queue() {
     ]);
 
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("tool request") && output.contains("medium risk"));
+    // V6a slim card: metadata row replaces kind/risk/queue lines; a single
+    // pending card renders no queue info at all (ARP-R8).
+    assert!(output.contains("Bash · medium risk"), "{output}");
     assert!(output.contains("$ git status"));
     assert!(
-        output.contains("Queue: 1/1 pending") || output.contains("Queue: 1 of 1 pending"),
+        !output.contains("Queue: 1/1 pending") && !output.contains("Queue: 1 of 1 pending"),
         "{output}"
     );
     assert!(!output.contains("req-1 · shell tool · medium risk"));
@@ -99,8 +101,11 @@ fn raw_cli_approval_card_uses_zh_language_env() {
     );
 
     assert_zh_approval_prompt_visible(&output);
-    assert!(output.contains("对象: Bash"), "{output}");
-    assert!(output.contains("Tool 输入:"), "{output}");
+    // V6a slim card: single metadata row, no Subject/Tool-input label lines.
+    assert!(output.contains("Bash · 中风险"), "{output}");
+    assert!(!output.contains("对象: Bash"), "{output}");
+    assert!(!output.contains("Tool 输入:"), "{output}");
+    assert!(!output.contains("风险 medium"), "{output}");
     assert!(output.contains("$ git status --short"), "{output}");
     assert!(output.contains("允许一次"), "{output}");
     assert!(output.contains("始终信任"), "{output}");

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/approval_modes.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/approval_modes.rs
@@ -194,7 +194,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
     let _ = fs::remove_dir_all(&home);
 
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("Subject: Write"), "{output}");
+    assert!(output.contains("Write · "), "{output}");
     assert!(
         output.contains("/tmp/cosh-core-provider-smoke.txt"),
         "{output}"
@@ -273,7 +273,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
     let _ = fs::remove_dir_all(&home);
 
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("Subject: Write"), "{output}");
+    assert!(output.contains("Write · "), "{output}");
     assert!(
         output.contains("/tmp/cosh-core-provider-details.txt"),
         "{output}"
@@ -350,7 +350,7 @@ printf '%s\n' '{{"type":"result","subtype":"success","session_id":"sess-cosh-cor
     let _ = fs::remove_dir_all(&home);
 
     assert_approval_prompt_visible(&output);
-    assert!(output.contains("Subject: Write"), "{output}");
+    assert!(output.contains("Write · "), "{output}");
     assert!(output.contains("Denied req-1"), "{output}");
     assert!(
         output.contains("Cosh-core non-shell write permission denied without host execution."),


### PR DESCRIPTION
## Summary

Fixes #1768 — 审批卡片不再直出风险模型 reason 机器码（`Reason: unknown-command`），并按 SDD `shell-approval-reason-presentation`（V6a 决策）完成卡片信息瘦身与风险徽标本地化。

## Evidence（真实二进制 cast 回放帧）

以下截图由本地真实测试产出：debug 二进制 `cosh-shell raw fake` 在 PTY 中驱动（与 raw_cli 集成测试同构的 fake provider 场景），全程录制 asciinema cast 后经 `agg` + `ffmpeg` 提取审批卡停留帧。截图仅托管于个人 fork 的 `pr-1786-assets` 分支（按 commit SHA 固定引用），**不进入主仓源码**。

| 场景 | 输入 | 截图 |
|---|---|---|
| Medium（zh）：无任何 reason 痕迹，`Bash · 中风险` 弱化徽标 | `?? stream tool approval`（git status，只读禁用配置下为 medium） | ![medium-zh](https://raw.githubusercontent.com/SunnyQjm/anolisa/3fa6c04e4e716ef7059d10221a7ffa30ee844380/pr-1786/medium-zh.png) |
| High（zh）：`Bash · 高风险` + 续行 `└ 风险: 提权操作` | `?? stream sudo tool approval` | ![high-zh](https://raw.githubusercontent.com/SunnyQjm/anolisa/3fa6c04e4e716ef7059d10221a7ffa30ee844380/pr-1786/high-zh.png) |
| High（en）：`Bash · high risk` + `└ Risk: privilege escalation` | `?? stream sudo tool approval` | ![high-en](https://raw.githubusercontent.com/SunnyQjm/anolisa/3fa6c04e4e716ef7059d10221a7ffa30ee844380/pr-1786/high-en.png) |

### 修复前后（真实 PTY 测试输出）

修复前（issue 截图场景，全只读组合命令）：

```text
│ tool 请求  风险 medium  队列: 1/1 待处理
│ 对象: Bash
│ Tool 输入:
│ $ cd ~/anolisa/src/cosh-ng && git remote -v && …
│ 原因: unknown-command          ← 机器码直出、语义误导
│ [ 允许一次 ] [ 始终信任 ] [ 拒绝 ] [ 详情 ]
│ 按键: 左/右选择  Enter 确认  d 详情  Esc 取消
```

修复后（zh raw_cli 测试实录）：

```text
╭ 审批 req-1 ────────────────────────────────╮
│ Bash · 中风险                              │
│ $ git status --short                       │
│ > [ 允许一次 ] [ 始终信任 ] [ 拒绝 ] [ 详情 ] │
╰────────────────────────────────────────────╯
```

High 风险时增加自然语言续行（仅 16 code 白名单，其余 fail-quiet）：

```text
│ Bash · 高风险
│ └ 风险: 提权操作
│ $ sudo rm -rf /data/legacy-cache
```

## Changes

- **语义层**（`tools/command_risk*`）：结构性判据（`*-not-auto-executable`）条件头插——兜底/中性首因让位、高危解释类保持 primary 首位；新增 `HIGH_RISK_EXPLANATION_REASONS` 白名单常量（排序与 UI 策略共用，防漂移）。
- **展示策略**（`ui/agent_render/approval_reason.rs` 新增）：仅 `high` risk 且 primary_reason 在白名单内返回本地化短语；low/medium、结构性、兜底、未知 code 一律 `None`（fail-quiet，前向安全）。
- **卡片骨架（V6a）**（`ui/agent_render/approval.rs`、`approval/panel.rs`）：通用卡收敛为单行元数据 `subject · 风险徽标[ · 队列 N/M]` + 命令（唯一白色高亮）+ 按钮；`└ 风险:` 续行仅 High；徽标本地化 `高风险/中风险/低风险`（修复 zh"风险 high"混排）；队列仅 >1 显示（修复 ratatui/plain 双路径不一致）；`按键:` 提示移入 expanded。
- **审计契约零变化**：Details/Journal/决策快照保留原始 reason code，`approval_details.rs`/`approval_journal.rs`/`requests.rs`/`state.rs`/`cards.rs` 零改动。
- **同域顺手修（343d0023）**：审批卡渲染前清除 agent status spinner 行——spinner 原地重绘后光标停在行中，卡片顶框从行中起笔导致溢出折行、边框错位。该缺陷在 main 基线即存在（cast 回放证据），被本 PR 截图验收暴露；修在 `render_current_approval_request` 入口，覆盖全部调用路径（structured events / approval bridge / runtime redraw）。
- **i18n**：新增 21 条 MessageId（16 短语 + 续行标签 + 3 风险等级 + 队列短格式），追加至枚举链尾（保序号契约）。

## Validation（口径声明）

focused checks（`cargo test -p cosh-shell`，非全仓）：

- lib：933+ passed（含新增：primary_reason 排序 R1-R6、策略 fail-quiet 穷举、High 续行/medium 无痕 UI 断言、**26 命令语义零变化快照测试**——期望值取自基线 `9a034a2a` 实测，锁定 execution/impact/auto_allow 不漂移）
- 评审跟进（commit 0d6d5505）：`cargo fmt` 修复 CI fmt gate；新增窄宽度（60 列）整卡续行 wrap 契约测试、未知 risk 值透传防御测试；`cargo clippy --all-targets` 零告警
- `approval` 过滤器（含 raw_cli 集成）：183 passed / 0 failed
- `ui::agent_render`：316 passed / 0 failed；`command_risk`：24 passed / 0 failed
- 全量 `--no-fail-fast` 中 zsh/session/provider_lifecycle 域约 36 个失败：**串行复跑通过或在未打补丁的基线上同样失败**（如 `session::raw_cli_session_status_shows_active_and_selected_ids` 基线即败），分类为预存环境性/并发 flaky，与本 PR 改动域（tools/command_risk、ui/approval）无交集。
- 真机验收（cosh-lab canonical case + 截图证据链）：**待补**——当前 `specs/shell-e2e-validation/cases` 无审批卡 canonical case（doctor `canonical_cases: ok=false`），按 SDD validation §5 口径先标注 Blocked，随后补 case 后出带索引截图/WebM。

## 关联

- 设计文档：SDD 六件套 `specs/shell-approval-reason-presentation/`（工作区仓库），含三轮布局原型选型记录（V0-V6b）。
- 剥离的正交缺陷：组合命令只评首段导致高危尾段漏评 → #1785。
