### PR TITLE
fix(cosh-ng): [shell] stop extdebug leak via exported BASHOPTS

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
@@ -547,13 +547,15 @@ _cosh_prompt_command() {
   _COSH_IN_PROMPT_COMMAND=0
   return "$status"
 }
-shopt -s extdebug 2>/dev/null || true
 # If BASHOPTS arrived exported from the login environment it stays exported
-# (readonly keeps the -x attribute), so the extdebug enabled above would leak
-# into every child bash and force debugger startup (bashdb) there. Drop the
-# export attribute only; imported options stay effective in this shell and
-# the guard makes a refusing bash fall back to current behavior (fail-safe).
+# (readonly keeps the -x attribute). Drop the export attribute *before*
+# enabling extdebug: the user rcfile has already run, so its DEBUG trap is
+# live and fires between these two commands — a child bash spawned there
+# would otherwise inherit the exported extdebug and fail debugger startup
+# (bashdb). Dropping -x only removes the export attribute; imported options
+# stay effective in this shell and the guard keeps a refusing bash fail-safe.
 export -n BASHOPTS 2>/dev/null || true
+shopt -s extdebug 2>/dev/null || true
 _COSH_OLD_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null | sed "s/^trap -- '\\(.*\\)' DEBUG$/\\1/" || true)"
 _COSH_ACTIVE_DEBUG_TRAP="trap -- '_cosh_preexec_marker' DEBUG"
 trap '_cosh_preexec_marker' DEBUG

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
@@ -548,6 +548,12 @@ _cosh_prompt_command() {
   return "$status"
 }
 shopt -s extdebug 2>/dev/null || true
+# If BASHOPTS arrived exported from the login environment it stays exported
+# (readonly keeps the -x attribute), so the extdebug enabled above would leak
+# into every child bash and force debugger startup (bashdb) there. Drop the
+# export attribute only; imported options stay effective in this shell and
+# the guard makes a refusing bash fall back to current behavior (fail-safe).
+export -n BASHOPTS 2>/dev/null || true
 _COSH_OLD_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null | sed "s/^trap -- '\\(.*\\)' DEBUG$/\\1/" || true)"
 _COSH_ACTIVE_DEBUG_TRAP="trap -- '_cosh_preexec_marker' DEBUG"
 trap '_cosh_preexec_marker' DEBUG

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -119,15 +119,18 @@ fn bash_extdebug_does_not_leak_via_exported_bashopts() {
     // extdebug lands in BASHOPTS; when BASHOPTS arrived exported from the
     // environment it stays exported (readonly keeps -x), leaking extdebug to
     // every child bash which then fails to load bashdb on hosts without it.
+    // The user rcfile runs before this hook setup, so its DEBUG trap is live
+    // in between: the export attribute must be dropped *before* extdebug is
+    // enabled, or a trap-spawned child inherits the leak.
     let shopt = script
         .find("shopt -s extdebug")
         .expect("extdebug setup should exist");
     let unexport = script
         .find("export -n BASHOPTS 2>/dev/null || true")
-        .expect("BASHOPTS export attribute must be dropped after enabling extdebug");
+        .expect("BASHOPTS export attribute must be dropped before enabling extdebug");
     assert!(
-        unexport > shopt,
-        "export -n BASHOPTS must follow shopt -s extdebug"
+        unexport < shopt,
+        "export -n BASHOPTS must precede shopt -s extdebug"
     );
 
     // The unexport must land in the same hook-setup block, before the DEBUG

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -113,6 +113,42 @@ fn bash_history_file_marker_is_native_only() {
 }
 
 #[test]
+fn bash_extdebug_does_not_leak_via_exported_bashopts() {
+    let script = bash_marker_script();
+
+    // extdebug lands in BASHOPTS; when BASHOPTS arrived exported from the
+    // environment it stays exported (readonly keeps -x), leaking extdebug to
+    // every child bash which then fails to load bashdb on hosts without it.
+    let shopt = script
+        .find("shopt -s extdebug")
+        .expect("extdebug setup should exist");
+    let unexport = script
+        .find("export -n BASHOPTS 2>/dev/null || true")
+        .expect("BASHOPTS export attribute must be dropped after enabling extdebug");
+    assert!(
+        unexport > shopt,
+        "export -n BASHOPTS must follow shopt -s extdebug"
+    );
+
+    // The unexport must land in the same hook-setup block, before the DEBUG
+    // trap is (re-)installed there, so no child spawned afterwards sees the
+    // leak. Anchor on the trap occurrence after the shopt line: earlier
+    // occurrences live inside recovery helper functions.
+    let debug_trap = script[shopt..]
+        .find("trap '_cosh_preexec_marker' DEBUG")
+        .map(|offset| shopt + offset)
+        .expect("hook-setup DEBUG trap installation should exist");
+    assert!(
+        unexport < debug_trap,
+        "export -n BASHOPTS must precede the DEBUG trap installation"
+    );
+
+    // BASHOPTS/extdebug are bash-only mechanisms; the zsh marker must not
+    // grow references to them.
+    assert!(!zsh_marker_script().contains("BASHOPTS"));
+}
+
+#[test]
 fn bash_preexec_marker_skips_completion_with_comp_type_guard() {
     let script = bash_marker_script();
 

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1292,8 +1292,8 @@ fn shell_host_bash_unexports_bashopts_while_keeping_extdebug_local() {
 
     // BASHOPTS arrives exported from the environment: bash keeps the export
     // attribute, which is exactly the leak precondition from issue #1782.
-    let config = ShellHostConfig::new("bashopts-unexport-test", &work_dir)
-        .with_env("BASHOPTS", "cdspell");
+    let config =
+        ShellHostConfig::new("bashopts-unexport-test", &work_dir).with_env("BASHOPTS", "cdspell");
     let output = run_scripted_bash(
         &config,
         &[

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1320,3 +1320,69 @@ fn shell_host_bash_unexports_bashopts_while_keeping_extdebug_local() {
     assert!(terminal.contains("child-extdebug-rc=1"), "{terminal}");
     assert!(!terminal.contains("bashdb"), "{terminal}");
 }
+
+#[test]
+fn shell_host_bash_debug_trap_children_never_see_exported_extdebug() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+    // Same BASHOPTS-import gate as the leak test above.
+    let bashopts_supported = Command::new("bash")
+        .env("BASHOPTS", "cdspell")
+        .args(["--noprofile", "--norc", "-c", "shopt -q cdspell"])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if !bashopts_supported {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-bashopts-trap-window-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    // A user rcfile runs before the marker's hook setup, so its DEBUG trap
+    // is live while the marker enables extdebug. The trap records every
+    // BASHOPTS frame and pipes child-bash stderr into evidence files; the
+    // trailing ':' keeps the handler's exit status at 0 so it can never
+    // suppress commands under extdebug. The leak detector is the exported
+    // extdebug frame plus the child's bashdb load failure, because a leaking
+    // child disables extdebug before shopt state could be probed.
+    std::fs::write(
+        home_dir.join(".bashrc"),
+        "trap 'declare -p BASHOPTS >> \"$HOME/trap-log\" 2>/dev/null; bash -c \":\" 2>> \"$HOME/trap-err\"; :' DEBUG\n",
+    )
+    .expect("bashrc");
+
+    let config = ShellHostConfig::new("bashopts-trap-window-test", &work_dir)
+        .with_env("HOME", home_dir.display().to_string())
+        .with_env("BASHOPTS", "cdspell");
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line("printf 'shell-alive-%s\\n' ok"),
+            ScriptedInput::user_line(
+                "leak=trap-child-extdebug-leaked; clean=window-clean; \
+                 if grep -q \"^declare -[^ ]*x[^ ]* BASHOPTS=.*extdebug\" \"$HOME/trap-log\" || \
+                    [[ -s \"$HOME/trap-err\" ]]; \
+                 then echo \"__${leak}__\"; else echo \"trap-${clean}-ok\"; fi",
+            ),
+        ],
+    )
+    .expect("scripted bash pty");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    // The marker must drop the BASHOPTS export attribute before enabling
+    // extdebug, so no DEBUG trap firing in between can leak it to children.
+    // Markers only appear after runtime expansion, so the echoed input line
+    // cannot satisfy either assertion by itself.
+    assert!(
+        !terminal.contains("__trap-child-extdebug-leaked__"),
+        "{terminal}"
+    );
+    assert!(terminal.contains("trap-window-clean-ok"), "{terminal}");
+    assert!(terminal.contains("shell-alive-ok"), "{terminal}");
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1255,3 +1255,68 @@ fn shell_host_bash_captured_debug_trap_keeps_path_generation_trusted() {
         .expect("command after captured DEBUG trap");
     assert!(block.shell_environment_generation.is_some());
 }
+
+#[test]
+fn shell_host_bash_unexports_bashopts_while_keeping_extdebug_local() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+    // BASHOPTS environment import exists since bash 4.1; on older hosts
+    // (e.g. macOS /bin/bash 3.2) the leak vector cannot exist, so skip.
+    let bashopts_supported = Command::new("bash")
+        .env("BASHOPTS", "cdspell")
+        .args(["--noprofile", "--norc", "-c", "shopt -q cdspell"])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if !bashopts_supported {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-bashopts-unexport-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+    // Child probe reporting whether extdebug leaked into a fresh bash. The
+    // rc markers are expanded at runtime so the echoed input line can never
+    // satisfy the assertions by itself.
+    let probe_path = work_dir.join("bashopts-probe.sh");
+    std::fs::write(
+        &probe_path,
+        "#!/bin/bash\nshopt -q extdebug; echo \"child-extdebug-rc=$?\"\n",
+    )
+    .expect("probe script");
+    make_executable(&probe_path);
+
+    // BASHOPTS arrives exported from the environment: bash keeps the export
+    // attribute, which is exactly the leak precondition from issue #1782.
+    let config = ShellHostConfig::new("bashopts-unexport-test", &work_dir)
+        .with_env("BASHOPTS", "cdspell");
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line("shopt -q extdebug; echo \"host-extdebug-rc=$?\""),
+            ScriptedInput::user_line("shopt -q cdspell; echo \"host-cdspell-rc=$?\""),
+            ScriptedInput::user_line(
+                "attrs=\"$(declare -p BASHOPTS)\"; attrs=\"${attrs%%BASHOPTS*}\"; \
+                 [[ \"$attrs\" == *x* ]]; echo \"bashopts-export-rc=$?\"",
+            ),
+            ScriptedInput::user_line(format!("bash {}", shell_arg(&probe_path))),
+        ],
+    )
+    .expect("scripted bash pty");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    // The marker keeps extdebug enabled in the interactive shell (DEBUG trap
+    // return-1 suppression depends on it) and keeps imported options alive.
+    assert!(terminal.contains("host-extdebug-rc=0"), "{terminal}");
+    assert!(terminal.contains("host-cdspell-rc=0"), "{terminal}");
+    // The export attribute must be gone so shopt changes stop propagating.
+    assert!(terminal.contains("bashopts-export-rc=1"), "{terminal}");
+    // A child bash spawned from the session must not start in extdebug mode
+    // and must not trip the bashdb debugger-profile load.
+    assert!(terminal.contains("child-extdebug-rc=1"), "{terminal}");
+    assert!(!terminal.contains("bashdb"), "{terminal}");
+}


### PR DESCRIPTION
## 问题

修复 #1782：登录环境导出了 `BASHOPTS` 的机器上（如挂载 `/etc/sysconfig/bash-prompt-history` 审计脚本的 Alinux 运维环境），cosh bash marker 开启的 `extdebug` 会随导出的 `BASHOPTS` 透传给所有子 bash，未安装 `bashdb` 时每个 prompt 刷两行加载失败报错，且所有子 bash 被迫以调试模式启动。

## 修复

`shopt -s extdebug` 后紧跟 `export -n BASHOPTS 2>/dev/null || true`（marker.rs bash 段，唯一 extdebug 设置点）：

- readonly 只限制赋值/unset，不阻止摘除导出属性；
- 当前 shell 的 extdebug 与 DEBUG trap `return 1` slash 拦截语义不受影响；
- 用户从环境导入的合法选项（如 `cdspell`）仍生效（因此不采用 Rust 侧 `env_remove`——那会使导入选项整体失效）；
- 用户可重新 `export BASHOPTS` 恢复透传（逃生舱）；
- 环境未导出 BASHOPTS 时该语句为 no-op；guard 保证最坏情况仅是修复不生效（fail-safe）。

zsh 段不涉及（BASHOPTS/extdebug 为 bash 特有）。长期根治仍走 I-A InputBroker 落地后移除全局 extdebug 的既定路线，本修复是其前的通用防泄漏加固。

## 验证（cosh-lab，container backend，Alinux3 arm64，bash 4.4，未装 bashdb）

**真机 PTY 前后对照**（真实 cosh 二进制 + `script(1)` 真 PTY + `env BASHOPTS=cdspell` + PROMPT_COMMAND 审计脚本仿真）：

| 指标 | 基线（无修复） | 修复版 |
|---|---|---|
| bashdb 加载失败报错 | 5 | **0** |
| cannot start debugger 警告 | 5 | **0** |
| `declare -p BASHOPTS` | `-rx`（导出，含 extdebug） | `-r`（已摘除导出） |
| 审计脚本 audit-tick 输出 | 4 | 4（功能无损） |
| 子 bash probe 执行 | 正常 | 正常 |

**测试（focused，明确口径：非全仓）**：
- unit scope：929 passed（含新增 `bash_extdebug_does_not_leak_via_exported_bashopts`）✅
- protocol scope：56 passed ✅
- logic：1805 passed ✅（其中 1 例 startup notice 首跑 flaky，串行复跑绿，与本 diff 无关）
- raw-cli scope：容器内红为基线既有（同环境 origin/main 基线 14 failed ⊇ 修复分支 8 failed，passthrough 三例两侧同败），非本 PR 引入
- gate evaluate（unit+protocol run）：**Go**；环境 cleanup：`cleaned`

机制级安全性此前已在 bash 4.4（Alinux3 实机）与 bash 5.2（容器）双版本实证（详见 issue #1782）。

Closes #1782
