### PR TITLE
feat(sight): add Qoder trajectory collector and query API

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -98,6 +98,8 @@ eBPF Probes → Event → Parser → ParsedMessage → Aggregator → Aggregated
 | **Unified** | `src/unified.rs` | 主编排器 | `AgentSight` |
 | **Opt** | `crates/agentsight-opt/` | 三维优化分析（准确性/性能/成本），workspace 成员 crate | `AnalyzePipeline`, `LlmClient`, `Trajectory` |
 | **OptStore** | `crates/agentsight-opt-store/` | 优化结果 SQLite 持久化（optimization.db） | `OptimizationStore`, `Dimension` |
+| **Atif (v1.7)** | `crates/agentsight-atif/` | ATIF v1.7 公共 schema 叶子 crate（采集链路使用；主 crate `src/atif` 仍为 v1.6 导出链路） | `AtifTrajectory`, `Step`, `ATIF_SCHEMA_VERSION` |
+| **TrajectoryCollector** | `crates/agentsight-trajectory-collector/` | 定时扫描 Qoder/QoderWork 会话目录，JSONL → ATIF v1.7 入库（trajectories.db，仅 trace 模式，默认关闭） | `CollectorConfig`, `run_collector_loop`, `TrajectoryStore` |
 
 ## 5. Critical Code Paths
 
@@ -272,6 +274,7 @@ Agent 规则配置文件路径：`/etc/agentsight/config.json`（可通过 `--co
 | 审计 | `features.audit` | `true` | LLM 调用审计持久化 |
 | Token 消费 | `features.token_consumption` | `false` | 聚合消费记录 |
 | SLS Logtail | `features.sls_logtail` | `false` | SLS 日志文件导出 |
+| 轨迹采集 | `features.trajectory_collection.enabled` | `false` | 定时扫描 Qoder/QoderWork 会话目录，JSONL 转 ATIF v1.7 存入 trajectories.db（仅 trace 模式；`scan_interval_secs` 默认 30，`scan_dirs` 可覆盖扫描目录） |
 
 ### 运行时资源上限（`runtime_limits`）
 

--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -99,7 +99,7 @@ eBPF Probes → Event → Parser → ParsedMessage → Aggregator → Aggregated
 | **Opt** | `crates/agentsight-opt/` | 三维优化分析（准确性/性能/成本），workspace 成员 crate | `AnalyzePipeline`, `LlmClient`, `Trajectory` |
 | **OptStore** | `crates/agentsight-opt-store/` | 优化结果 SQLite 持久化（optimization.db） | `OptimizationStore`, `Dimension` |
 | **Atif (v1.7)** | `crates/agentsight-atif/` | ATIF v1.7 公共 schema 叶子 crate（采集链路使用；主 crate `src/atif` 仍为 v1.6 导出链路） | `AtifTrajectory`, `Step`, `ATIF_SCHEMA_VERSION` |
-| **TrajectoryCollector** | `crates/agentsight-trajectory-collector/` | 定时扫描 Qoder/QoderWork 会话目录，JSONL → ATIF v1.7 入库（trajectories.db，仅 trace 模式，默认关闭） | `CollectorConfig`, `run_collector_loop`, `TrajectoryStore` |
+| **TrajectoryCollector** | `crates/agentsight-trajectory-collector/` | 定时扫描 Qoder/QoderWork 会话目录，JSONL → ATIF v1.7 入库（trajectories.db，仅 trace 模式，默认关闭）；serve 侧经 `/api/trajectories` 只读查询 | `CollectorConfig`, `run_collector_loop`, `TrajectoryStore` |
 
 ## 5. Critical Code Paths
 
@@ -232,6 +232,9 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/optimize/sessions/{id}/{dim}` | POST | 运行单维度优化分析，`dim` ∈ `perf` / `perf-issues` / `cost` / `cost-waste` / `accuracy`（后三者需 LLM 配置，10–60s） |
 | `/api/optimize/sessions/{id}/results` | GET | 读取已持久化的优化分析结果 |
 | `/api/optimize/config` | GET/POST | 优化 LLM 配置（api_key 脱敏；持久化到 `optimization_config.json`） |
+| `/api/trajectories` | GET | 采集轨迹列表（`project`, `source`, `agent_name`, `limit`；不含 `atif_json`，按采集时间倒序） |
+| `/api/trajectories/filters` | GET | 轨迹过滤下拉选项（distinct project/source/agent_name） |
+| `/api/trajectories/{session_id}` | GET | 单条轨迹的原始 ATIF v1.7 JSON |
 
 ## 9. Frontend
 

--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -234,7 +234,7 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/optimize/config` | GET/POST | 优化 LLM 配置（api_key 脱敏；持久化到 `optimization_config.json`） |
 | `/api/trajectories` | GET | 采集轨迹列表（`project`, `source`, `agent_name`, `limit`；不含 `atif_json`，按采集时间倒序） |
 | `/api/trajectories/filters` | GET | 轨迹过滤下拉选项（distinct project/source/agent_name） |
-| `/api/trajectories/{session_id}` | GET | 单条轨迹的原始 ATIF v1.7 JSON |
+| `/api/trajectories/{session_id}` | GET | 单条轨迹的原始 ATIF v1.7 JSON（store 不可用或 session 不存在均返回 404，消息不同；列表/过滤端点则降级为空 + 200） |
 
 ## 9. Frontend
 

--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "actix-web",
  "agentsight-opt",
  "agentsight-opt-store",
+ "agentsight-trajectory-collector",
  "anyhow",
  "async-stream",
  "async-trait",
@@ -277,6 +278,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentsight-atif"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "agentsight-opt"
 version = "0.1.0"
 dependencies = [
@@ -298,6 +307,17 @@ dependencies = [
  "rusqlite",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "agentsight-trajectory-collector"
+version = "0.1.0"
+dependencies = [
+ "agentsight-atif",
+ "anyhow",
+ "log 0.4.29",
+ "rusqlite",
+ "serde_json",
 ]
 
 [[package]]

--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "anyhow",
  "log 0.4.29",
  "rusqlite",
+ "serde",
  "serde_json",
 ]
 

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -4,7 +4,12 @@ version = "0.8.1"
 edition = "2024"
 
 [workspace]
-members = ["crates/agentsight-opt", "crates/agentsight-opt-store"]
+members = [
+    "crates/agentsight-atif",
+    "crates/agentsight-opt",
+    "crates/agentsight-opt-store",
+    "crates/agentsight-trajectory-collector",
+]
 
 # Shared third-party dependency versions (AGENTS.md §3.3). Member crates
 # reference these via `{ workspace = true }`; the root crate is being
@@ -40,6 +45,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 agentsight-opt = { path = "crates/agentsight-opt", optional = true }
 agentsight-opt-store = { path = "crates/agentsight-opt-store", optional = true }
+agentsight-trajectory-collector = { path = "crates/agentsight-trajectory-collector" }
 anyhow = { workspace = true }
 async-stream = "0.3.6"
 async-trait = { workspace = true }

--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -310,6 +310,7 @@ All optional features are **enabled by default**. Disable them individually via 
 | Audit | `features.audit` | `true` | LLM call audit event persistence |
 | Token Consumption | `features.token_consumption` | `false` | Aggregated token consumption records |
 | SLS Logtail | `features.sls_logtail` | `false` | Write to SLS log file |
+| Trajectory Collection | `features.trajectory_collection.enabled` | `false` | Periodically scan Qoder/QoderWork session JSONL, convert to ATIF v1.7 and store in `trajectories.db` (trace mode only; `scan_interval_secs` default 30, `scan_dirs` overrides scan roots) |
 
 ### Runtime Resource Limits (`runtime_limits`)
 

--- a/src/agentsight/README_zh.md
+++ b/src/agentsight/README_zh.md
@@ -299,6 +299,7 @@ AgentSight 通过 `agentsight.json` 配置文件进行统一管理（默认路�
 | 审计 | `features.audit` | `true` | LLM 调用审计事件持久化 |
 | Token 消费 | `features.token_consumption` | `false` | 聚合 Token 消费记录 |
 | SLS Logtail | `features.sls_logtail` | `false` | 写入 SLS 日志文件 |
+| 轨迹采集 | `features.trajectory_collection.enabled` | `false` | 定时扫描 Qoder/QoderWork 会话 JSONL，转 ATIF v1.7 存入 `trajectories.db`（仅 trace 模式；`scan_interval_secs` 默认 30，`scan_dirs` 可覆盖扫描目录） |
 
 ### 运行时资源上限（`runtime_limits`）
 

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -36,7 +36,11 @@
     },
     "audit": true,
     "token_consumption": false,
-    "sls_logtail": false
+    "sls_logtail": false,
+    "trajectory_collection": {
+      "enabled": false,
+      "scan_interval_secs": 30
+    }
   },
   "runtime_limits": {
     "event_channel_capacity": 10000,

--- a/src/agentsight/crates/agentsight-atif/Cargo.toml
+++ b/src/agentsight/crates/agentsight-atif/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "agentsight-atif"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/src/agentsight/crates/agentsight-atif/src/lib.rs
+++ b/src/agentsight/crates/agentsight-atif/src/lib.rs
@@ -1,0 +1,328 @@
+//! ATIF v1.7 data models — shared trajectory schema crate.
+//!
+//! Ported from AgentOpt's `atif/models.rs` (the authoritative ATIF v1.7
+//! implementation). Schema follows:
+//! <https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md>
+//!
+//! This is a leaf crate (serde/serde_json only) shared by trajectory
+//! producers (e.g. `agentsight-trajectory-collector`) and future consumers.
+//! The main crate's `src/atif` (v1.6 export path) is unrelated and will be
+//! migrated in a follow-up.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub const ATIF_SCHEMA_VERSION: &str = "ATIF-v1.7";
+
+// ---------------------------------------------------------------------------
+// ToolCall
+// ---------------------------------------------------------------------------
+
+/// A tool/function invocation made by the agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub tool_call_id: String,
+    pub function_name: String,
+    #[serde(default)]
+    pub arguments: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
+}
+
+// ---------------------------------------------------------------------------
+// ObservationResult & Observation
+// ---------------------------------------------------------------------------
+
+/// A single observation result from a tool call or action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObservationResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Environment feedback/results after actions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Observation {
+    #[serde(default)]
+    pub results: Vec<ObservationResult>,
+}
+
+// ---------------------------------------------------------------------------
+// Metrics & FinalMetrics
+// ---------------------------------------------------------------------------
+
+/// LLM operational metrics for a single step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Metrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_token_ids: Option<Vec<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_token_ids: Option<Vec<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Aggregate metrics for the entire trajectory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_prompt_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_completion_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cached_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_steps: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
+}
+
+// ---------------------------------------------------------------------------
+// Agent
+// ---------------------------------------------------------------------------
+
+/// Agent configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Agent {
+    pub name: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_definitions: Option<Vec<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
+}
+
+fn default_version() -> String {
+    "unknown".into()
+}
+
+// ---------------------------------------------------------------------------
+// Step
+// ---------------------------------------------------------------------------
+
+/// Allowed `source` values for a Step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StepSource {
+    System,
+    User,
+    Agent,
+}
+
+/// A single step in an ATIF trajectory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Step {
+    pub step_id: usize,
+    pub source: StepSource,
+    #[serde(default)]
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation: Option<Observation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<Metrics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_call_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_copied_context: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Trajectory (root)
+// ---------------------------------------------------------------------------
+
+/// Root-level ATIF trajectory object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AtifTrajectory {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: String,
+    pub agent: Agent,
+    #[serde(default)]
+    pub steps: Vec<Step>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trajectory_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub final_metrics: Option<FinalMetrics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continued_trajectory_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
+}
+
+fn default_schema_version() -> String {
+    ATIF_SCHEMA_VERSION.into()
+}
+
+impl AtifTrajectory {
+    /// Serialize to a JSON Value with `None` fields stripped out.
+    ///
+    /// # Errors
+    /// Returns a `serde_json` error if serialization fails.
+    pub fn to_json_value(&self) -> serde_json::Result<serde_json::Value> {
+        let v = serde_json::to_value(self)?;
+        Ok(strip_nulls(v))
+    }
+
+    /// Validate step_id sequence (1-based, contiguous).
+    ///
+    /// # Errors
+    /// Returns a message describing the first out-of-sequence step.
+    pub fn validate_step_ids(&self) -> Result<(), String> {
+        for (i, step) in self.steps.iter().enumerate() {
+            if step.step_id != i + 1 {
+                return Err(format!(
+                    "Step at index {} has step_id={}, expected {}",
+                    i,
+                    step.step_id,
+                    i + 1
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Recursively strip null values from a JSON object.
+fn strip_nulls(v: serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => {
+            let filtered: serde_json::Map<String, serde_json::Value> = map
+                .into_iter()
+                .filter(|(_, val)| !val.is_null())
+                .map(|(k, val)| (k, strip_nulls(val)))
+                .collect();
+            serde_json::Value::Object(filtered)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(strip_nulls).collect())
+        }
+        other => other,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+/// Validate an ATIF trajectory from a JSON string.
+///
+/// # Errors
+/// Returns a message on parse failure, schema mismatch, or bad step ids.
+pub fn validate_trajectory_str(json: &str) -> Result<AtifTrajectory, String> {
+    let data: serde_json::Value = serde_json::from_str(json).map_err(|e| e.to_string())?;
+    let trajectory: AtifTrajectory =
+        serde_json::from_value(data).map_err(|e| format!("Schema validation failed: {e}"))?;
+    trajectory.validate_step_ids()?;
+    Ok(trajectory)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_trajectory() -> AtifTrajectory {
+        AtifTrajectory {
+            schema_version: ATIF_SCHEMA_VERSION.into(),
+            agent: Agent {
+                name: "qoder".into(),
+                version: "unknown".into(),
+                model_name: Some("qwen-max".into()),
+                tool_definitions: None,
+                extra: None,
+            },
+            steps: vec![Step {
+                step_id: 1,
+                source: StepSource::User,
+                message: "hello".into(),
+                timestamp: Some("2026-07-25T00:00:00Z".into()),
+                model_name: None,
+                reasoning_effort: None,
+                reasoning_content: None,
+                tool_calls: None,
+                observation: None,
+                metrics: None,
+                extra: None,
+                llm_call_count: None,
+                is_copied_context: None,
+            }],
+            session_id: Some("s-1".into()),
+            trajectory_id: None,
+            notes: None,
+            final_metrics: None,
+            continued_trajectory_ref: None,
+            extra: None,
+        }
+    }
+
+    #[test]
+    fn schema_version_constant() {
+        assert_eq!(ATIF_SCHEMA_VERSION, "ATIF-v1.7");
+    }
+
+    #[test]
+    fn serialize_skips_none_fields() {
+        let traj = minimal_trajectory();
+        let json = serde_json::to_string(&traj).unwrap();
+        assert!(!json.contains("trajectory_id"));
+        assert!(!json.contains("reasoning_content"));
+        assert!(json.contains("\"source\":\"user\""));
+    }
+
+    #[test]
+    fn roundtrip_and_validate() {
+        let traj = minimal_trajectory();
+        let json = serde_json::to_string(&traj).unwrap();
+        let parsed = validate_trajectory_str(&json).unwrap();
+        assert_eq!(parsed.schema_version, ATIF_SCHEMA_VERSION);
+        assert_eq!(parsed.session_id.as_deref(), Some("s-1"));
+        assert_eq!(parsed.steps.len(), 1);
+    }
+
+    #[test]
+    fn validate_rejects_bad_step_ids() {
+        let mut traj = minimal_trajectory();
+        traj.steps[0].step_id = 5;
+        assert!(traj.validate_step_ids().is_err());
+    }
+
+    #[test]
+    fn strip_nulls_removes_nested_nulls() {
+        let v = serde_json::json!({"a": null, "b": {"c": null, "d": 1}, "e": [null, 2]});
+        let stripped = strip_nulls(v);
+        assert_eq!(stripped, serde_json::json!({"b": {"d": 1}, "e": [null, 2]}));
+    }
+}

--- a/src/agentsight/crates/agentsight-trajectory-collector/Cargo.toml
+++ b/src/agentsight/crates/agentsight-trajectory-collector/Cargo.toml
@@ -8,4 +8,5 @@ agentsight-atif = { path = "../agentsight-atif" }
 anyhow = { workspace = true }
 log = { workspace = true }
 rusqlite = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/agentsight/crates/agentsight-trajectory-collector/Cargo.toml
+++ b/src/agentsight/crates/agentsight-trajectory-collector/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "agentsight-trajectory-collector"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+agentsight-atif = { path = "../agentsight-atif" }
+anyhow = { workspace = true }
+log = { workspace = true }
+rusqlite = { workspace = true }
+serde_json = { workspace = true }

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/atif.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/atif.rs
@@ -167,7 +167,9 @@ pub fn convert_qoder_events(
                     step_model = msg.get("model").and_then(|v| v.as_str()).map(String::from);
                 }
 
-                // Extract usage/metrics
+                // Extract usage/metrics — accumulate across multiple usage
+                // events within the same LLM turn (some providers emit partial
+                // usage per chunk); only keeping the last would under-count.
                 if let Some(usage) = msg.get("usage") {
                     let pt = usage.get("input_tokens").and_then(|v| v.as_u64());
                     let ct = usage.get("output_tokens").and_then(|v| v.as_u64());
@@ -180,16 +182,25 @@ pub fn convert_qoder_events(
                                 .and_then(|v| v.as_u64())
                         });
                     if pt.is_some() || ct.is_some() {
-                        step_metrics = Some(Metrics {
-                            prompt_tokens: pt,
-                            completion_tokens: ct,
-                            cached_tokens: cache,
+                        let m = step_metrics.get_or_insert_with(|| Metrics {
+                            prompt_tokens: Some(0),
+                            completion_tokens: Some(0),
+                            cached_tokens: Some(0),
                             cost_usd: None,
                             logprobs: None,
                             completion_token_ids: None,
                             prompt_token_ids: None,
                             extra: None,
                         });
+                        if let Some(v) = pt {
+                            *m.prompt_tokens.get_or_insert(0) += v;
+                        }
+                        if let Some(v) = ct {
+                            *m.completion_tokens.get_or_insert(0) += v;
+                        }
+                        if let Some(v) = cache {
+                            *m.cached_tokens.get_or_insert(0) += v;
+                        }
                     }
                 }
 

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/atif.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/atif.rs
@@ -1,0 +1,635 @@
+//! Qoder/QoderWork JSONL → ATIF v1.7 converter.
+//!
+//! Ported from AgentOpt's `converters/claude_code.rs` (Claude Code, QoderWork
+//! and Qoder share the same JSONL structure):
+//!   - Events have a `type` field: `user`, `assistant`, `runtime-config`,
+//!     `session_meta`, `progress`, `last-prompt`
+//!   - Assistant messages have content blocks: `thinking`, `text`, `tool_use`
+//!   - User messages may have content blocks: `text`, `tool_result`
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use agentsight_atif::{
+    Agent, AtifTrajectory, FinalMetrics, Metrics, Observation, ObservationResult, Step, StepSource,
+    ToolCall, ATIF_SCHEMA_VERSION,
+};
+
+/// Event types to skip entirely.
+const SKIP_TYPES: &[&str] = &["runtime-config", "session_meta", "progress", "last-prompt"];
+
+/// Convert raw Qoder JSONL events into an ATIF v1.7 trajectory.
+pub fn convert_qoder_events(
+    events: &[serde_json::Value],
+    agent_name: &str,
+) -> Result<AtifTrajectory> {
+    let (session_id, model_name, version) = extract_agent_info(events);
+
+    let agent = Agent {
+        name: agent_name.to_string(),
+        version: version.unwrap_or_else(|| "unknown".into()),
+        model_name,
+        tool_definitions: None,
+        extra: None,
+    };
+
+    let mut steps: Vec<Step> = Vec::new();
+    let mut step_id: usize = 0;
+    let mut total_prompt_tokens: u64 = 0;
+    let mut total_completion_tokens: u64 = 0;
+    let mut total_cached_tokens: u64 = 0;
+
+    let mut i: usize = 0;
+    while i < events.len() {
+        let e = &events[i];
+        let t = e.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        // Skip metadata events
+        if SKIP_TYPES.contains(&t) {
+            i += 1;
+            continue;
+        }
+
+        // --- User message ---
+        if t == "user" {
+            let content = e
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+
+            let tool_results = extract_tool_results(&content);
+
+            // If this user event only has tool_results, attach to previous step
+            if !tool_results.is_empty() && !has_text_block(&content) {
+                if let Some(prev) = steps.last_mut() {
+                    let result_ts = e.get("timestamp").and_then(|v| v.as_str());
+                    let mut obs_results = Vec::new();
+                    for tr in &tool_results {
+                        let extra = if tr.is_error {
+                            let mut m = HashMap::new();
+                            m.insert("is_error".into(), serde_json::Value::Bool(true));
+                            Some(m)
+                        } else {
+                            None
+                        };
+                        obs_results.push(ObservationResult {
+                            source_call_id: Some(tr.tool_use_id.clone()),
+                            content: Some(serde_json::Value::String(tr.content.clone())),
+                            extra,
+                        });
+                        // Write result_timestamp into matching ToolCall.extra
+                        if let (Some(ts), Some(tcs)) = (result_ts, prev.tool_calls.as_mut()) {
+                            for tc in tcs.iter_mut() {
+                                if tc.tool_call_id == tr.tool_use_id {
+                                    let mut extra = tc.extra.take().unwrap_or_default();
+                                    extra.insert(
+                                        "result_timestamp".into(),
+                                        serde_json::Value::String(ts.to_string()),
+                                    );
+                                    tc.extra = Some(extra);
+                                }
+                            }
+                        }
+                    }
+                    if !obs_results.is_empty() {
+                        prev.observation = Some(Observation {
+                            results: obs_results,
+                        });
+                    }
+                }
+                i += 1;
+                continue;
+            }
+
+            // Regular user message
+            step_id += 1;
+            let text = extract_text_from_content(&content);
+            steps.push(Step {
+                step_id,
+                timestamp: e
+                    .get("timestamp")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                source: StepSource::User,
+                message: text,
+                model_name: None,
+                reasoning_effort: None,
+                reasoning_content: None,
+                tool_calls: None,
+                observation: None,
+                metrics: None,
+                extra: None,
+                llm_call_count: None,
+                is_copied_context: None,
+            });
+            i += 1;
+            continue;
+        }
+
+        // --- Assistant message ---
+        if t == "assistant" {
+            // Collect all consecutive assistant events (same LLM turn)
+            let mut turn_events: Vec<&serde_json::Value> = vec![e];
+            let mut j = i + 1;
+            while j < events.len() {
+                let ne = &events[j];
+                let nt = ne.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                if nt == "assistant" {
+                    turn_events.push(ne);
+                    j += 1;
+                } else if SKIP_TYPES.contains(&nt) {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Merge turn events into a single step
+            step_id += 1;
+            let mut reasoning_parts: Vec<String> = Vec::new();
+            let mut message_parts: Vec<String> = Vec::new();
+            let mut tool_calls: Vec<ToolCall> = Vec::new();
+            let step_timestamp = turn_events[0]
+                .get("timestamp")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let mut step_model: Option<String> = None;
+            let mut step_metrics: Option<Metrics> = None;
+
+            for te in &turn_events {
+                let msg = match te.get("message") {
+                    Some(m) => m,
+                    None => continue,
+                };
+                if step_model.is_none() {
+                    step_model = msg.get("model").and_then(|v| v.as_str()).map(String::from);
+                }
+
+                // Extract usage/metrics
+                if let Some(usage) = msg.get("usage") {
+                    let pt = usage.get("input_tokens").and_then(|v| v.as_u64());
+                    let ct = usage.get("output_tokens").and_then(|v| v.as_u64());
+                    let cache = usage
+                        .get("cache_read_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .or_else(|| {
+                            usage
+                                .get("cache_creation_input_tokens")
+                                .and_then(|v| v.as_u64())
+                        });
+                    if pt.is_some() || ct.is_some() {
+                        step_metrics = Some(Metrics {
+                            prompt_tokens: pt,
+                            completion_tokens: ct,
+                            cached_tokens: cache,
+                            cost_usd: None,
+                            logprobs: None,
+                            completion_token_ids: None,
+                            prompt_token_ids: None,
+                            extra: None,
+                        });
+                    }
+                }
+
+                // Process content blocks
+                let content_blocks = match msg.get("content").and_then(|v| v.as_array()) {
+                    Some(arr) => arr,
+                    None => continue,
+                };
+                for block in content_blocks {
+                    let bt = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    match bt {
+                        "thinking" => {
+                            let thinking_text = block
+                                .get("thinking")
+                                .or_else(|| block.get("text"))
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("");
+                            if !thinking_text.is_empty() {
+                                reasoning_parts.push(thinking_text.to_string());
+                            }
+                        }
+                        "text" => {
+                            if let Some(text_val) = block.get("text").and_then(|v| v.as_str()) {
+                                if !text_val.is_empty() {
+                                    message_parts.push(text_val.to_string());
+                                }
+                            }
+                        }
+                        "tool_use" => {
+                            let mut tool_input: serde_json::Value = block
+                                .get("input")
+                                .cloned()
+                                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                            if let Some(s) = tool_input.as_str() {
+                                tool_input = serde_json::from_str(s)
+                                    .unwrap_or_else(|_| serde_json::json!({"raw": s}));
+                            }
+                            if !tool_input.is_object() {
+                                tool_input = serde_json::json!({"value": tool_input});
+                            }
+                            tool_calls.push(ToolCall {
+                                tool_call_id: block
+                                    .get("id")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                function_name: block
+                                    .get("name")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                arguments: tool_input,
+                                extra: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            let reasoning = if reasoning_parts.is_empty() {
+                None
+            } else {
+                Some(reasoning_parts.join("\n"))
+            };
+            let message = message_parts.join("\n");
+
+            if let Some(ref m) = step_metrics {
+                total_prompt_tokens += m.prompt_tokens.unwrap_or(0);
+                total_completion_tokens += m.completion_tokens.unwrap_or(0);
+                total_cached_tokens += m.cached_tokens.unwrap_or(0);
+            }
+
+            steps.push(Step {
+                step_id,
+                timestamp: step_timestamp,
+                source: StepSource::Agent,
+                model_name: step_model,
+                message,
+                reasoning_effort: None,
+                reasoning_content: reasoning,
+                tool_calls: if tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(tool_calls.clone())
+                },
+                observation: None,
+                metrics: step_metrics,
+                extra: None,
+                llm_call_count: None,
+                is_copied_context: None,
+            });
+
+            // Collect tool_results that follow
+            let mut k = j;
+            let mut obs_results: Vec<ObservationResult> = Vec::new();
+            let mut result_timestamps: HashMap<String, String> = HashMap::new();
+            while k < events.len() {
+                let ne = &events[k];
+                let nt = ne.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                if SKIP_TYPES.contains(&nt) {
+                    k += 1;
+                    continue;
+                }
+                if nt == "user" {
+                    let nc = ne
+                        .get("message")
+                        .and_then(|m| m.get("content"))
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    let trs = extract_tool_results(&nc);
+                    if !trs.is_empty() {
+                        let result_ts = ne.get("timestamp").and_then(|v| v.as_str());
+                        for tr in &trs {
+                            let extra = if tr.is_error {
+                                let mut m = HashMap::new();
+                                m.insert("is_error".into(), serde_json::Value::Bool(true));
+                                Some(m)
+                            } else {
+                                None
+                            };
+                            obs_results.push(ObservationResult {
+                                source_call_id: Some(tr.tool_use_id.clone()),
+                                content: Some(serde_json::Value::String(tr.content.clone())),
+                                extra,
+                            });
+                            if let Some(ts) = result_ts {
+                                result_timestamps.insert(tr.tool_use_id.clone(), ts.to_string());
+                            }
+                        }
+                        k += 1;
+                        continue;
+                    }
+                }
+                break;
+            }
+
+            // Write result_timestamp into ToolCall.extra
+            if !result_timestamps.is_empty() {
+                if let Some(last_step) = steps.last_mut() {
+                    if let Some(tcs) = last_step.tool_calls.as_mut() {
+                        for tc in tcs.iter_mut() {
+                            if let Some(ts) = result_timestamps.get(&tc.tool_call_id) {
+                                let mut extra = tc.extra.take().unwrap_or_default();
+                                extra.insert(
+                                    "result_timestamp".into(),
+                                    serde_json::Value::String(ts.clone()),
+                                );
+                                tc.extra = Some(extra);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !obs_results.is_empty() {
+                if let Some(last_step) = steps.last_mut() {
+                    last_step.observation = Some(Observation {
+                        results: obs_results,
+                    });
+                }
+            }
+
+            i = k;
+            continue;
+        }
+
+        // Unknown type, skip
+        i += 1;
+    }
+
+    // Build final metrics
+    let final_metrics = if total_prompt_tokens > 0 || total_completion_tokens > 0 {
+        Some(FinalMetrics {
+            total_prompt_tokens: Some(total_prompt_tokens),
+            total_completion_tokens: Some(total_completion_tokens),
+            total_cached_tokens: Some(total_cached_tokens),
+            total_cost_usd: None,
+            total_steps: Some(steps.len()),
+            extra: None,
+        })
+    } else {
+        None
+    };
+
+    Ok(AtifTrajectory {
+        schema_version: ATIF_SCHEMA_VERSION.into(),
+        session_id,
+        agent,
+        steps,
+        trajectory_id: None,
+        notes: None,
+        final_metrics,
+        continued_trajectory_ref: None,
+        extra: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract `(session_id, model_name, version)` from the raw events.
+fn extract_agent_info(
+    events: &[serde_json::Value],
+) -> (Option<String>, Option<String>, Option<String>) {
+    let mut session_id: Option<String> = None;
+    let mut model_name: Option<String> = None;
+    let mut version: Option<String> = None;
+
+    for e in events {
+        let t = e.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        if t == "runtime-config" {
+            if session_id.is_none() {
+                session_id = e
+                    .get("sessionId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+            }
+            if model_name.is_none() {
+                model_name = e.get("model").and_then(|v| v.as_str()).map(String::from);
+            }
+        }
+        if session_id.is_none() {
+            session_id = e
+                .get("sessionId")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+        }
+        if version.is_none() {
+            version = e.get("version").and_then(|v| v.as_str()).map(String::from);
+        }
+        if t == "assistant" && model_name.is_none() {
+            if let Some(msg) = e.get("message") {
+                model_name = msg.get("model").and_then(|v| v.as_str()).map(String::from);
+            }
+        }
+    }
+
+    (session_id, model_name, version)
+}
+
+/// Extract plain text from the various `content` shapes seen in JSONL events.
+///
+/// Handles:
+///   - `String` → returned as-is
+///   - `Array` of content blocks → concatenates `text`-type blocks
+///   - Anything else → `""` or stringified form
+fn extract_text_from_content(content: &serde_json::Value) -> String {
+    match content {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(blocks) => {
+            let mut parts: Vec<&str> = Vec::new();
+            for block in blocks {
+                if let Some(obj) = block.as_object() {
+                    match obj.get("type").and_then(|t| t.as_str()) {
+                        Some("text") => {
+                            if let Some(t) = obj.get("text").and_then(|v| v.as_str()) {
+                                parts.push(t);
+                            }
+                        }
+                        Some("tool_result") => {
+                            let rc = obj.get("content").unwrap_or(&serde_json::Value::Null);
+                            match rc {
+                                serde_json::Value::String(s) => parts.push(s.as_str()),
+                                serde_json::Value::Array(subs) => {
+                                    for sub in subs {
+                                        if let Some(sub_obj) = sub.as_object() {
+                                            if sub_obj.get("type").and_then(|t| t.as_str())
+                                                == Some("text")
+                                            {
+                                                if let Some(t) =
+                                                    sub_obj.get("text").and_then(|v| v.as_str())
+                                                {
+                                                    parts.push(t);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            parts.join("\n")
+        }
+        serde_json::Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+/// A tool_result block extracted from a user-message `content` array.
+#[derive(Debug, Clone)]
+struct ExtractedToolResult {
+    tool_use_id: String,
+    content: String,
+    is_error: bool,
+}
+
+/// Extract `tool_result` blocks from a user-message `content` array.
+fn extract_tool_results(content: &serde_json::Value) -> Vec<ExtractedToolResult> {
+    let blocks = match content.as_array() {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    let mut results = Vec::new();
+    for block in blocks {
+        let obj = match block.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        if obj.get("type").and_then(|t| t.as_str()) != Some("tool_result") {
+            continue;
+        }
+        let tool_use_id = obj
+            .get("tool_use_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let rc = obj.get("content").unwrap_or(&serde_json::Value::Null);
+        let content_str = match rc {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(subs) => {
+                let text_parts: Vec<&str> = subs
+                    .iter()
+                    .filter_map(|sub| {
+                        let so = sub.as_object()?;
+                        if so.get("type").and_then(|t| t.as_str()) == Some("text") {
+                            so.get("text").and_then(|v| v.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                text_parts.join("\n")
+            }
+            other => other.to_string(),
+        };
+
+        let is_error = obj
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        results.push(ExtractedToolResult {
+            tool_use_id,
+            content: content_str,
+            is_error,
+        });
+    }
+    results
+}
+
+/// Return `true` if a content array contains any `text`-type block.
+fn has_text_block(content: &serde_json::Value) -> bool {
+    if let Some(arr) = content.as_array() {
+        arr.iter().any(|b| {
+            b.as_object()
+                .and_then(|o| o.get("type"))
+                .and_then(|t| t.as_str())
+                == Some("text")
+        })
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qoder::load_jsonl_events;
+
+    fn fixture_events() -> Vec<serde_json::Value> {
+        let content = concat!(
+            "{\"type\":\"runtime-config\",\"sessionId\":\"abc-123\",\"model\":\"qwen-max\"}\n",
+            "{\"type\":\"user\",\"timestamp\":\"2026-07-25T10:00:00Z\",\"message\":{\"role\":\"user\",\"content\":\"list files\"}}\n",
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-07-25T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"model\":\"qwen-max\",\"usage\":{\"input_tokens\":100,\"output_tokens\":20},\"content\":[{\"type\":\"thinking\",\"thinking\":\"need ls\"},{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"bash\",\"input\":{\"cmd\":\"ls\"}}]}}\n",
+            "{\"type\":\"user\",\"timestamp\":\"2026-07-25T10:00:03Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\",\"content\":\"a.txt\"}]}}\n",
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-07-25T10:00:05Z\",\"message\":{\"role\":\"assistant\",\"model\":\"qwen-max\",\"usage\":{\"input_tokens\":150,\"output_tokens\":10},\"content\":[{\"type\":\"text\",\"text\":\"Only a.txt exists.\"}]}}\n",
+        );
+        load_jsonl_events(content)
+    }
+
+    #[test]
+    fn test_convert_basic_flow() {
+        let events = fixture_events();
+        let traj = convert_qoder_events(&events, "qoder").unwrap();
+
+        assert_eq!(traj.schema_version, ATIF_SCHEMA_VERSION);
+        assert_eq!(traj.session_id.as_deref(), Some("abc-123"));
+        assert_eq!(traj.agent.name, "qoder");
+        assert_eq!(traj.agent.model_name.as_deref(), Some("qwen-max"));
+        traj.validate_step_ids().unwrap();
+
+        // user + agent(tool) + agent(final answer)
+        assert_eq!(traj.steps.len(), 3);
+        assert_eq!(traj.steps[0].source, StepSource::User);
+        assert_eq!(traj.steps[0].message, "list files");
+
+        let tool_step = &traj.steps[1];
+        assert_eq!(tool_step.source, StepSource::Agent);
+        assert_eq!(tool_step.reasoning_content.as_deref(), Some("need ls"));
+        let tcs = tool_step.tool_calls.as_ref().unwrap();
+        assert_eq!(tcs.len(), 1);
+        assert_eq!(tcs[0].function_name, "bash");
+        // tool_result attached as observation on the tool step
+        let obs = tool_step.observation.as_ref().unwrap();
+        assert_eq!(obs.results[0].source_call_id.as_deref(), Some("t1"));
+
+        assert_eq!(traj.steps[2].message, "Only a.txt exists.");
+
+        // Token totals aggregated into final_metrics
+        let fm = traj.final_metrics.as_ref().unwrap();
+        assert_eq!(fm.total_prompt_tokens, Some(250));
+        assert_eq!(fm.total_completion_tokens, Some(30));
+    }
+
+    #[test]
+    fn test_convert_error_tool_result_marks_extra() {
+        let content = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"t9\",\"name\":\"bash\",\"input\":{}}]}}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t9\",\"content\":\"boom\",\"is_error\":true}]}}\n",
+        );
+        let events = load_jsonl_events(content);
+        let traj = convert_qoder_events(&events, "qoder").unwrap();
+        let obs = traj.steps[0].observation.as_ref().unwrap();
+        let extra = obs.results[0].extra.as_ref().unwrap();
+        assert_eq!(extra["is_error"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn test_convert_empty_events_yields_empty_steps() {
+        let traj = convert_qoder_events(&[], "qoder").unwrap();
+        assert!(traj.steps.is_empty());
+        assert!(traj.final_metrics.is_none());
+    }
+}

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/discovery.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/discovery.rs
@@ -1,0 +1,329 @@
+//! QoderWork / Qoder session file discovery.
+//!
+//! Scans `<home>/.qoderwork/projects` and `<home>/.qoder/projects` for JSONL
+//! session files. Ported from AgentOpt's collector crate; home directories are
+//! enumerated explicitly (`/root` + `/home/*`) because the collector runs
+//! inside the root-owned `agentsight trace` process, not the agent's shell.
+
+use std::path::{Path, PathBuf};
+
+/// A discovered session file.
+#[derive(Debug, Clone)]
+pub struct DiscoveredSession {
+    /// Path to the JSONL file.
+    pub path: PathBuf,
+    /// Decoded project name (e.g., "data-skillopt").
+    pub project: String,
+    /// Session identifier (filename UUID; subagents use
+    /// `<parent>:subagent:<uuid>` to stay unique per file).
+    pub session_id: String,
+    /// Whether this is a sub-agent session.
+    pub is_subagent: bool,
+    /// Which product wrote the file: "qoder" or "qoderwork".
+    pub source: String,
+}
+
+/// Projects directory names relative to each home directory.
+const PROJECT_DIR_NAMES: &[&str] = &[".qoderwork/projects", ".qoder/projects"];
+
+/// Discover all QoderWork/Qoder sessions.
+///
+/// `scan_dirs` overrides the default scan roots; each entry is treated as a
+/// projects directory. When `None`, `/root` and every `/home/*` entry are
+/// probed for `.qoderwork/projects` / `.qoder/projects`.
+pub fn discover_sessions(scan_dirs: Option<&[PathBuf]>) -> Vec<DiscoveredSession> {
+    let dirs = match scan_dirs {
+        Some(list) => list.to_vec(),
+        None => default_projects_dirs(),
+    };
+
+    let mut sessions = Vec::new();
+    for dir in dirs {
+        if !dir.exists() {
+            log::debug!(
+                "Trajectory scan: skipping non-existent dir {}",
+                dir.display()
+            );
+            continue;
+        }
+        let source = source_from_path(&dir);
+        sessions.extend(discover_in_projects_dir(&dir, &source));
+    }
+
+    // Sort by path for stable output
+    sessions.sort_by(|a, b| a.path.cmp(&b.path));
+    sessions
+}
+
+/// Default projects directories: `/root` + `/home/*`, each probed for the
+/// known Qoder/QoderWork layout.
+fn default_projects_dirs() -> Vec<PathBuf> {
+    let mut homes = vec![PathBuf::from("/root")];
+    if let Ok(entries) = std::fs::read_dir("/home") {
+        for entry in entries.flatten() {
+            homes.push(entry.path());
+        }
+    }
+
+    let mut dirs = Vec::new();
+    for home in homes {
+        for name in PROJECT_DIR_NAMES {
+            let p = home.join(name);
+            if p.exists() {
+                dirs.push(p);
+            }
+        }
+    }
+    dirs
+}
+
+/// Derive the source label from a projects directory path.
+fn source_from_path(dir: &Path) -> String {
+    if dir.to_string_lossy().contains(".qoderwork") {
+        "qoderwork".to_string()
+    } else {
+        "qoder".to_string()
+    }
+}
+
+/// Discover sessions within a single projects directory.
+fn discover_in_projects_dir(projects_dir: &Path, source: &str) -> Vec<DiscoveredSession> {
+    let mut sessions = Vec::new();
+
+    let entries = match std::fs::read_dir(projects_dir) {
+        Ok(e) => e,
+        Err(err) => {
+            log::warn!(
+                "Trajectory scan: failed to read {}: {err}",
+                projects_dir.display()
+            );
+            return sessions;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let project = decode_project_dir(&entry.file_name().to_string_lossy());
+        sessions.extend(discover_in_project_dir(&path, &project, source));
+    }
+
+    sessions
+}
+
+/// Discover sessions within a single project directory.
+fn discover_in_project_dir(
+    project_dir: &Path,
+    project: &str,
+    source: &str,
+) -> Vec<DiscoveredSession> {
+    let mut sessions = Vec::new();
+
+    let entries = match std::fs::read_dir(project_dir) {
+        Ok(e) => e,
+        Err(err) => {
+            log::debug!(
+                "Trajectory scan: failed to read {}: {err}",
+                project_dir.display()
+            );
+            return sessions;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+
+        // Main session files: <uuid>.jsonl
+        if !is_dir && name.ends_with(".jsonl") {
+            let stem = name.trim_end_matches(".jsonl");
+            // Skip agent-* files (sub-agents are stored under subagents/)
+            if stem.starts_with("agent-") || !is_valid_session_id(stem) {
+                continue;
+            }
+            sessions.push(DiscoveredSession {
+                path: path.clone(),
+                project: project.to_string(),
+                session_id: stem.to_string(),
+                is_subagent: false,
+                source: source.to_string(),
+            });
+            continue;
+        }
+
+        // Sub-agent sessions: <uuid>/subagents/agent-<uuid>.jsonl
+        if is_dir && is_valid_session_id(&name) {
+            let subagents_dir = path.join("subagents");
+            let Ok(sub_entries) = std::fs::read_dir(&subagents_dir) else {
+                continue;
+            };
+            for sub_entry in sub_entries.flatten() {
+                let sub_name = sub_entry.file_name().to_string_lossy().to_string();
+                if !sub_name.ends_with(".jsonl") || !sub_name.starts_with("agent-") {
+                    continue;
+                }
+                let sub_stem = sub_name
+                    .trim_end_matches(".jsonl")
+                    .trim_start_matches("agent-");
+                if is_valid_session_id(sub_stem) {
+                    sessions.push(DiscoveredSession {
+                        path: sub_entry.path(),
+                        project: project.to_string(),
+                        session_id: format!("{name}:subagent:{sub_stem}"),
+                        is_subagent: true,
+                        source: source.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    sessions
+}
+
+/// Decode a QoderWork/Qoder project directory name.
+///
+/// Examples:
+/// - `-data-skillopt` → `data-skillopt`
+/// - `-Users-john-projects-myapp` → `myapp`
+/// - `myproject` → `myproject`
+pub fn decode_project_dir(encoded: &str) -> String {
+    if !encoded.starts_with('-') {
+        return normalize_name(encoded);
+    }
+
+    let parts: Vec<&str> = encoded.split('-').filter(|s| !s.is_empty()).collect();
+
+    // Look for known parent directory markers (use the LAST match)
+    let parent_markers = [
+        "code",
+        "coding",
+        "dev",
+        "development",
+        "projects",
+        "repos",
+        "src",
+        "work",
+        "workspace",
+    ];
+
+    let mut best_match: Option<usize> = None;
+    for (i, part) in parts.iter().enumerate() {
+        if parent_markers.contains(&part.to_lowercase().as_str()) {
+            best_match = Some(i);
+        }
+    }
+
+    if let Some(i) = best_match {
+        if i + 1 < parts.len() {
+            let project = parts[i + 1..].join("-");
+            if !project.is_empty() {
+                return normalize_name(&project);
+            }
+        }
+    }
+
+    // No marker found — return all parts joined (just strip leading dash)
+    normalize_name(&parts.join("-"))
+}
+
+/// Simple name normalization.
+fn normalize_name(s: &str) -> String {
+    s.trim_start_matches(['-', '.']).to_string()
+}
+
+/// Check if a string looks like a valid session ID (UUID format).
+fn is_valid_session_id(s: &str) -> bool {
+    // UUID format: 8-4-4-4-12 hex digits
+    if s.len() != 36 {
+        return false;
+    }
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 5 {
+        return false;
+    }
+    let expected_lens = [8, 4, 4, 4, 12];
+    for (part, &expected_len) in parts.iter().zip(expected_lens.iter()) {
+        if part.len() != expected_len || !part.chars().all(|c| c.is_ascii_hexdigit()) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UUID_A: &str = "be0aa488-4e56-4604-bdf0-e12cc387392d";
+    const UUID_B: &str = "11111111-2222-3333-4444-555555555555";
+
+    fn tmp_projects_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("traj-disc-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_decode_project_dir() {
+        assert_eq!(decode_project_dir("-data-skillopt"), "data-skillopt");
+        assert_eq!(decode_project_dir("-Users-john-projects-myapp"), "myapp");
+        assert_eq!(decode_project_dir("myproject"), "myproject");
+        assert_eq!(decode_project_dir("-data-work-repos-foo"), "foo");
+    }
+
+    #[test]
+    fn test_is_valid_session_id() {
+        assert!(is_valid_session_id(UUID_A));
+        assert!(!is_valid_session_id("agent-123"));
+        assert!(!is_valid_session_id("not-a-uuid"));
+        assert!(!is_valid_session_id(""));
+    }
+
+    #[test]
+    fn test_discover_filters_and_subagents() {
+        let projects = tmp_projects_dir("main");
+        let proj = projects.join("-data-myapp");
+        std::fs::create_dir_all(&proj).unwrap();
+
+        // Valid main session
+        std::fs::write(proj.join(format!("{UUID_A}.jsonl")), "{}\n").unwrap();
+        // Invalid names must be skipped
+        std::fs::write(proj.join("notes.jsonl"), "{}\n").unwrap();
+        std::fs::write(proj.join(format!("agent-{UUID_B}.jsonl")), "{}\n").unwrap();
+        // Sub-agent session under <uuid>/subagents/
+        let sub = proj.join(UUID_A).join("subagents");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join(format!("agent-{UUID_B}.jsonl")), "{}\n").unwrap();
+
+        let sessions = discover_sessions(Some(std::slice::from_ref(&projects)));
+        assert_eq!(sessions.len(), 2, "one main + one subagent: {sessions:?}");
+
+        let main = sessions.iter().find(|s| !s.is_subagent).unwrap();
+        assert_eq!(main.session_id, UUID_A);
+        assert_eq!(main.project, "data-myapp");
+        assert_eq!(main.source, "qoder");
+
+        let sub = sessions.iter().find(|s| s.is_subagent).unwrap();
+        assert_eq!(sub.session_id, format!("{UUID_A}:subagent:{UUID_B}"));
+
+        let _ = std::fs::remove_dir_all(&projects);
+    }
+
+    #[test]
+    fn test_source_from_path() {
+        assert_eq!(
+            source_from_path(Path::new("/root/.qoderwork/projects")),
+            "qoderwork"
+        );
+        assert_eq!(
+            source_from_path(Path::new("/home/u/.qoder/projects")),
+            "qoder"
+        );
+    }
+}

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
@@ -12,6 +12,8 @@ pub mod discovery;
 pub mod qoder;
 pub mod store;
 
+pub use store::{TrajectoryFilters, TrajectoryRecord, TrajectoryStore, TrajectorySummary};
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, UNIX_EPOCH};
@@ -19,7 +21,6 @@ use std::time::{Duration, UNIX_EPOCH};
 use anyhow::{Context, Result};
 
 use discovery::DiscoveredSession;
-use store::{TrajectoryRecord, TrajectoryStore};
 
 /// Collector runtime configuration (resolved by the main crate from
 /// `agentsight.json`).

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
@@ -1,0 +1,274 @@
+//! Trajectory collector — periodically scans Qoder/QoderWork session
+//! directories, converts JSONL trajectories to ATIF v1.7 and persists them
+//! into a dedicated SQLite database.
+//!
+//! Pure user-space (no eBPF, no inotify): the main crate spawns
+//! [`run_collector_loop`] on a named thread when
+//! `features.trajectory_collection.enabled` is set; the shared stop flag
+//! (`running`) terminates the loop on shutdown.
+
+pub mod atif;
+pub mod discovery;
+pub mod qoder;
+pub mod store;
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+
+use discovery::DiscoveredSession;
+use store::{TrajectoryRecord, TrajectoryStore};
+
+/// Collector runtime configuration (resolved by the main crate from
+/// `agentsight.json`).
+#[derive(Debug, Clone)]
+pub struct CollectorConfig {
+    /// Seconds between two scan rounds.
+    pub scan_interval_secs: u64,
+    /// Optional override of the projects directories to scan; `None` probes
+    /// `/root` + `/home/*` for the default Qoder/QoderWork layout.
+    pub scan_dirs: Option<Vec<PathBuf>>,
+    /// Path of the `trajectories.db` SQLite file.
+    pub db_path: PathBuf,
+}
+
+/// Scan-convert-persist loop; returns when `stop` is cleared.
+///
+/// Runs one scan immediately, then sleeps `scan_interval_secs` between
+/// rounds (checking `stop` every second). Store open failure is logged and
+/// aborts the loop — the feature is best-effort and must never take the
+/// tracer down.
+pub fn run_collector_loop(config: &CollectorConfig, stop: &AtomicBool) {
+    let store = match TrajectoryStore::new_with_path(&config.db_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!(
+                "Trajectory collector disabled: failed to open {}: {e}",
+                config.db_path.display()
+            );
+            return;
+        }
+    };
+    log::info!(
+        "Trajectory collector started (interval={}s, db={})",
+        config.scan_interval_secs,
+        config.db_path.display()
+    );
+
+    while stop.load(Ordering::SeqCst) {
+        scan_once(&store, config);
+        if !sleep_or_stop(stop, config.scan_interval_secs) {
+            break;
+        }
+    }
+    log::info!("Trajectory collector stopped");
+}
+
+/// One scan round: discover sessions and ingest new/changed files.
+/// Per-file failures are logged and skipped so one bad session never blocks
+/// the rest of the round.
+pub fn scan_once(store: &TrajectoryStore, config: &CollectorConfig) {
+    let sessions = discovery::discover_sessions(config.scan_dirs.as_deref());
+    let mut collected = 0usize;
+    for session in &sessions {
+        match process_session(store, session) {
+            Ok(true) => collected += 1,
+            Ok(false) => {}
+            Err(e) => {
+                log::warn!(
+                    "Trajectory collect failed for {}: {e}",
+                    session.path.display()
+                );
+            }
+        }
+    }
+    if collected > 0 {
+        log::info!(
+            "Trajectory scan: {collected}/{} session(s) ingested",
+            sessions.len()
+        );
+    } else {
+        log::debug!(
+            "Trajectory scan: {} session(s), none changed",
+            sessions.len()
+        );
+    }
+}
+
+/// Ingest a single session file. Returns `Ok(true)` when the row was
+/// (re)written, `Ok(false)` when the file is unchanged.
+fn process_session(store: &TrajectoryStore, session: &DiscoveredSession) -> Result<bool> {
+    let meta = std::fs::metadata(&session.path)
+        .with_context(|| format!("stat {}", session.path.display()))?;
+    let file_size = i64::try_from(meta.len()).unwrap_or(i64::MAX);
+    let file_mtime_ns = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+
+    let file_path = session.path.to_string_lossy().to_string();
+    if let Some((size, mtime)) = store.get_file_state(&file_path)? {
+        if size == file_size && mtime == file_mtime_ns {
+            return Ok(false);
+        }
+    }
+
+    let content = std::fs::read_to_string(&session.path)
+        .with_context(|| format!("read {}", session.path.display()))?;
+    let events = qoder::load_jsonl_events(&content);
+    if events.is_empty() {
+        anyhow::bail!("no valid JSONL events");
+    }
+
+    let mut trajectory = atif::convert_qoder_events(&events, &session.source)?;
+    // The discovered id (filename UUID, subagent-composite when nested) is the
+    // canonical per-file identity; keep the ATIF document aligned with the
+    // primary-key column so both always agree.
+    trajectory.session_id = Some(session.session_id.clone());
+    // Qoder-private info (cwd, message counts, project) rides in `extra`.
+    let private = qoder::extract_private_metadata(&events, &session.project);
+    let extra = trajectory.extra.get_or_insert_with(Default::default);
+    extra.extend(private);
+
+    let atif_json = serde_json::to_string(&trajectory.to_json_value()?)?;
+    let record = TrajectoryRecord {
+        session_id: session.session_id.clone(),
+        schema_version: trajectory.schema_version.clone(),
+        agent_name: trajectory.agent.name.clone(),
+        model_name: trajectory.agent.model_name.clone(),
+        num_steps: i64::try_from(trajectory.steps.len()).unwrap_or(i64::MAX),
+        total_prompt_tokens: trajectory
+            .final_metrics
+            .as_ref()
+            .and_then(|m| m.total_prompt_tokens)
+            .map(|v| i64::try_from(v).unwrap_or(i64::MAX)),
+        total_completion_tokens: trajectory
+            .final_metrics
+            .as_ref()
+            .and_then(|m| m.total_completion_tokens)
+            .map(|v| i64::try_from(v).unwrap_or(i64::MAX)),
+        start_time: trajectory.steps.iter().find_map(|s| s.timestamp.clone()),
+        end_time: trajectory
+            .steps
+            .iter()
+            .rev()
+            .find_map(|s| s.timestamp.clone()),
+        atif_json,
+        project: session.project.clone(),
+        source: session.source.clone(),
+        is_subagent: session.is_subagent,
+        file_path,
+        file_size,
+        file_mtime_ns,
+    };
+    store.upsert_trajectory(&record)?;
+    Ok(true)
+}
+
+/// Sleep `interval_secs` in 1s slices; returns `false` as soon as `stop` is
+/// cleared (mirrors the main crate's `utils::thread::sleep_or_stop`).
+fn sleep_or_stop(stop: &AtomicBool, interval_secs: u64) -> bool {
+    for _ in 0..interval_secs {
+        std::thread::sleep(Duration::from_secs(1));
+        if !stop.load(Ordering::SeqCst) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    const UUID_A: &str = "be0aa488-4e56-4604-bdf0-e12cc387392d";
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("traj-loop-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_session(projects: &std::path::Path) -> PathBuf {
+        let proj = projects.join("-data-myapp");
+        std::fs::create_dir_all(&proj).unwrap();
+        let path = proj.join(format!("{UUID_A}.jsonl"));
+        let content = concat!(
+            "{\"type\":\"runtime-config\",\"sessionId\":\"abc-123\",\"model\":\"qwen-max\"}\n",
+            "{\"type\":\"user\",\"cwd\":\"/data/myapp\",\"timestamp\":\"2026-07-25T10:00:00Z\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-07-25T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"model\":\"qwen-max\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n",
+        );
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_scan_once_ingests_and_skips_unchanged() {
+        let base = tmp_dir("scan");
+        let projects = base.join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+        write_session(&projects);
+
+        let store = TrajectoryStore::new_with_path(&base.join("t.db")).unwrap();
+        let config = CollectorConfig {
+            scan_interval_secs: 1,
+            scan_dirs: Some(vec![projects.clone()]),
+            db_path: base.join("t.db"),
+        };
+
+        scan_once(&store, &config);
+        assert_eq!(store.count().unwrap(), 1);
+
+        let rec = store.get(UUID_A).unwrap().unwrap();
+        // Derived columns must agree with the persisted ATIF document.
+        let doc: serde_json::Value = serde_json::from_str(&rec.atif_json).unwrap();
+        assert_eq!(doc["schema_version"], rec.schema_version);
+        assert_eq!(doc["session_id"], rec.session_id);
+        assert_eq!(doc["agent"]["model_name"], "qwen-max");
+        assert_eq!(doc["steps"].as_array().unwrap().len() as i64, rec.num_steps);
+        assert_eq!(rec.total_prompt_tokens, Some(10));
+        assert_eq!(rec.start_time.as_deref(), Some("2026-07-25T10:00:00Z"));
+        assert_eq!(rec.end_time.as_deref(), Some("2026-07-25T10:00:02Z"));
+        // Qoder-private info lives in extra
+        assert_eq!(doc["extra"]["cwd"], "/data/myapp");
+        assert_eq!(doc["extra"]["project"], "data-myapp");
+
+        // Second scan with unchanged file must not fail and keeps one row.
+        scan_once(&store, &config);
+        assert_eq!(store.count().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_run_collector_loop_stops_on_flag() {
+        let base = tmp_dir("loop");
+        let projects = base.join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+        write_session(&projects);
+
+        let config = CollectorConfig {
+            scan_interval_secs: 1,
+            scan_dirs: Some(vec![projects]),
+            db_path: base.join("t.db"),
+        };
+        let stop = Arc::new(AtomicBool::new(true));
+        let stop_clone = Arc::clone(&stop);
+        let config_clone = config.clone();
+        let handle = std::thread::spawn(move || {
+            run_collector_loop(&config_clone, &stop_clone);
+        });
+
+        std::thread::sleep(Duration::from_millis(1500));
+        stop.store(false, Ordering::SeqCst);
+        handle.join().unwrap();
+
+        // The first immediate scan must have ingested the session.
+        let store = TrajectoryStore::new_with_path(&config.db_path).unwrap();
+        assert_eq!(store.count().unwrap(), 1);
+    }
+}

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
@@ -58,7 +58,9 @@ pub fn run_collector_loop(config: &CollectorConfig, stop: &AtomicBool) {
         config.db_path.display()
     );
 
-    while stop.load(Ordering::SeqCst) {
+    // Single exit point: the loop always exits via the `sleep_or_stop` check,
+    // avoiding split semantics between the while-condition and the helper.
+    loop {
         scan_once(&store, config);
         if !sleep_or_stop(stop, config.scan_interval_secs) {
             break;
@@ -122,6 +124,9 @@ fn process_session(store: &TrajectoryStore, session: &DiscoveredSession) -> Resu
         .with_context(|| format!("read {}", session.path.display()))?;
     let events = qoder::load_jsonl_events(&content);
     if events.is_empty() {
+        // Record file state so persistently corrupted files are not re-read
+        // every scan round (they will be retried only when size/mtime change).
+        let _ = store.set_file_state(&file_path, file_size, file_mtime_ns);
         anyhow::bail!("no valid JSONL events");
     }
 

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/qoder.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/qoder.rs
@@ -1,0 +1,96 @@
+//! Qoder/QoderWork JSONL parsing helpers.
+//!
+//! Splits raw session file content into JSON events and extracts the
+//! Qoder-private metadata that rides along in the ATIF document's `extra`
+//! field (it has no dedicated ATIF columns).
+
+use std::collections::HashMap;
+
+/// Parse JSONL content into JSON events; blank/malformed lines are skipped
+/// with a warning so one bad line never poisons a whole session.
+pub fn load_jsonl_events(content: &str) -> Vec<serde_json::Value> {
+    let mut events = Vec::new();
+    for (line_num, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(v) => events.push(v),
+            Err(e) => {
+                log::warn!("Skipping malformed JSON on line {}: {e}", line_num + 1);
+            }
+        }
+    }
+    events
+}
+
+/// Qoder-private session info destined for the ATIF `extra` field.
+///
+/// Returns a map with `cwd` (first seen), `user_message_count`,
+/// `assistant_message_count` and `project`.
+pub fn extract_private_metadata(
+    events: &[serde_json::Value],
+    project: &str,
+) -> HashMap<String, serde_json::Value> {
+    let mut cwd: Option<String> = None;
+    let mut user_count: u64 = 0;
+    let mut assistant_count: u64 = 0;
+
+    for e in events {
+        if cwd.is_none() {
+            cwd = e.get("cwd").and_then(|v| v.as_str()).map(String::from);
+        }
+        match e.get("type").and_then(|v| v.as_str()) {
+            Some("user") => user_count += 1,
+            Some("assistant") => assistant_count += 1,
+            _ => {}
+        }
+    }
+
+    let mut extra = HashMap::new();
+    if let Some(cwd) = cwd {
+        extra.insert("cwd".to_string(), serde_json::Value::String(cwd));
+    }
+    extra.insert(
+        "user_message_count".to_string(),
+        serde_json::Value::from(user_count),
+    );
+    extra.insert(
+        "assistant_message_count".to_string(),
+        serde_json::Value::from(assistant_count),
+    );
+    extra.insert(
+        "project".to_string(),
+        serde_json::Value::String(project.to_string()),
+    );
+    extra
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_jsonl_skips_malformed() {
+        let content = "{\"type\":\"user\"}\n\nnot-json\n{\"type\":\"assistant\"}\n";
+        let events = load_jsonl_events(content);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0]["type"], "user");
+    }
+
+    #[test]
+    fn test_extract_private_metadata() {
+        let content = concat!(
+            "{\"type\":\"runtime-config\",\"sessionId\":\"abc\",\"model\":\"qwen-max\"}\n",
+            "{\"type\":\"user\",\"cwd\":\"/data/myapp\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[]}}\n",
+        );
+        let events = load_jsonl_events(content);
+        let extra = extract_private_metadata(&events, "myapp");
+        assert_eq!(extra["cwd"], "/data/myapp");
+        assert_eq!(extra["user_message_count"], 1);
+        assert_eq!(extra["assistant_message_count"], 1);
+        assert_eq!(extra["project"], "myapp");
+    }
+}

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
 
 /// A row of `collected_trajectories` ready for upsert.
 #[derive(Debug, Clone)]
@@ -32,6 +33,35 @@ pub struct TrajectoryRecord {
     pub file_path: String,
     pub file_size: i64,
     pub file_mtime_ns: i64,
+}
+
+/// Lightweight list row of `collected_trajectories` — deliberately excludes
+/// the (potentially large) `atif_json` column; fetch it via
+/// [`TrajectoryStore::get_atif_json`] for the detail view.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrajectorySummary {
+    pub session_id: String,
+    pub schema_version: String,
+    pub agent_name: String,
+    pub model_name: Option<String>,
+    pub num_steps: i64,
+    pub total_prompt_tokens: Option<i64>,
+    pub total_completion_tokens: Option<i64>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub project: String,
+    /// Which product wrote the file: "qoder" or "qoderwork".
+    pub source: String,
+    pub is_subagent: bool,
+    pub collected_at_ns: i64,
+}
+
+/// Distinct filter values for the trajectory list UI dropdowns.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TrajectoryFilters {
+    pub projects: Vec<String>,
+    pub sources: Vec<String>,
+    pub agent_names: Vec<String>,
 }
 
 /// Thread-safe store over a dedicated `trajectories.db`.
@@ -189,6 +219,106 @@ impl TrajectoryStore {
         Ok(n)
     }
 
+    /// Lists trajectory summaries (without `atif_json`), newest first.
+    ///
+    /// All filters are optional equality matches; `limit` caps the row count.
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn list_summaries(
+        &self,
+        project: Option<&str>,
+        source: Option<&str>,
+        agent_name: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<TrajectorySummary>> {
+        let conn = self.lock_conn()?;
+        let mut sql = String::from(
+            "SELECT session_id, schema_version, agent_name, model_name, num_steps,
+                    total_prompt_tokens, total_completion_tokens, start_time, end_time,
+                    project, source, is_subagent, collected_at_ns
+             FROM collected_trajectories",
+        );
+        let mut clauses: Vec<String> = Vec::new();
+        let mut args: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(p) = project {
+            clauses.push("project = ?".to_string());
+            args.push(Box::new(p.to_string()));
+        }
+        if let Some(s) = source {
+            clauses.push("source = ?".to_string());
+            args.push(Box::new(s.to_string()));
+        }
+        if let Some(a) = agent_name {
+            clauses.push("agent_name = ?".to_string());
+            args.push(Box::new(a.to_string()));
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+        // `limit` is bound as a parameter (never interpolated) to stay injection-free.
+        sql.push_str(&format!(
+            " ORDER BY collected_at_ns DESC LIMIT ?{}",
+            args.len() + 1
+        ));
+        args.push(Box::new(limit));
+
+        let params_ref: Vec<&dyn rusqlite::ToSql> = args.iter().map(|b| b.as_ref()).collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_ref.as_slice(), |row| {
+            Ok(TrajectorySummary {
+                session_id: row.get(0)?,
+                schema_version: row.get(1)?,
+                agent_name: row.get(2)?,
+                model_name: row.get(3)?,
+                num_steps: row.get(4)?,
+                total_prompt_tokens: row.get(5)?,
+                total_completion_tokens: row.get(6)?,
+                start_time: row.get(7)?,
+                end_time: row.get(8)?,
+                project: row.get(9)?,
+                source: row.get(10)?,
+                is_subagent: row.get::<_, i64>(11)? != 0,
+                collected_at_ns: row.get(12)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Returns the stored ATIF v1.7 JSON for one session, if present.
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn get_atif_json(&self, session_id: &str) -> Result<Option<String>> {
+        let conn = self.lock_conn()?;
+        let json = conn
+            .query_row(
+                "SELECT atif_json FROM collected_trajectories WHERE session_id = ?1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(json)
+    }
+
+    /// Returns distinct project / source / agent_name values for UI filters.
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn list_filters(&self) -> Result<TrajectoryFilters> {
+        let conn = self.lock_conn()?;
+        Ok(TrajectoryFilters {
+            projects: distinct_column(&conn, "project")?,
+            sources: distinct_column(&conn, "source")?,
+            agent_names: distinct_column(&conn, "agent_name")?,
+        })
+    }
+
     fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
         self.conn
             .lock()
@@ -201,6 +331,19 @@ fn now_ns() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
         .unwrap_or(0)
+}
+
+/// SELECT DISTINCT on a fixed column name (hard-coded, never user input).
+fn distinct_column(conn: &Connection, column: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT DISTINCT {column} FROM collected_trajectories ORDER BY {column}"
+    ))?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -264,5 +407,88 @@ mod tests {
             store.get_file_state(&rec.file_path).unwrap(),
             Some((1024, 42))
         );
+    }
+
+    #[test]
+    fn test_list_summaries_filters_and_limit() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("list")).unwrap();
+        let mut a = sample_record();
+        a.session_id = "a".into();
+        a.project = "p1".into();
+        a.source = "qoder".into();
+        a.agent_name = "qoder".into();
+        store.upsert_trajectory(&a).unwrap();
+
+        let mut b = sample_record();
+        b.session_id = "b".into();
+        b.project = "p2".into();
+        b.source = "qoderwork".into();
+        b.agent_name = "qoder".into();
+        b.file_path = "/root/.qoderwork/projects/x/b.jsonl".into();
+        store.upsert_trajectory(&b).unwrap();
+
+        // No filter → both rows.
+        assert_eq!(
+            store.list_summaries(None, None, None, 100).unwrap().len(),
+            2
+        );
+        // project filter
+        let p1 = store.list_summaries(Some("p1"), None, None, 100).unwrap();
+        assert_eq!(p1.len(), 1);
+        assert_eq!(p1[0].session_id, "a");
+        // source filter
+        let qw = store
+            .list_summaries(None, Some("qoderwork"), None, 100)
+            .unwrap();
+        assert_eq!(qw.len(), 1);
+        assert_eq!(qw[0].session_id, "b");
+        // combined filters (AND)
+        assert_eq!(
+            store
+                .list_summaries(Some("p1"), Some("qoderwork"), None, 100)
+                .unwrap()
+                .len(),
+            0
+        );
+        // limit caps the result
+        assert_eq!(store.list_summaries(None, None, None, 1).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_get_atif_json_hit_and_miss() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("atif")).unwrap();
+        store.upsert_trajectory(&sample_record()).unwrap();
+        assert_eq!(
+            store.get_atif_json("s-1").unwrap().as_deref(),
+            Some("{\"schema_version\":\"ATIF-v1.7\"}")
+        );
+        assert!(store.get_atif_json("nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_list_filters_distinct() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("filters")).unwrap();
+        let mut a = sample_record();
+        a.session_id = "a".into();
+        a.project = "p1".into();
+        a.source = "qoder".into();
+        a.agent_name = "qoder".into();
+        store.upsert_trajectory(&a).unwrap();
+
+        let mut b = sample_record();
+        b.session_id = "b".into();
+        b.project = "p1".into();
+        b.source = "qoderwork".into();
+        b.agent_name = "qoder".into();
+        b.file_path = "/root/.qoderwork/projects/x/b.jsonl".into();
+        store.upsert_trajectory(&b).unwrap();
+
+        let f = store.list_filters().unwrap();
+        assert_eq!(f.projects, vec!["p1".to_string()]);
+        assert_eq!(
+            f.sources,
+            vec!["qoder".to_string(), "qoderwork".to_string()]
+        );
+        assert_eq!(f.agent_names, vec!["qoder".to_string()]);
     }
 }

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
@@ -1,0 +1,268 @@
+//! SQLite persistence for collected trajectories (`trajectories.db`).
+//!
+//! One row per session file. Queryable columns are derived from the converted
+//! ATIF v1.7 document (never from the raw JSONL) so they always agree with
+//! `atif_json`; bookkeeping columns (`file_*`) drive incremental scanning.
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+/// A row of `collected_trajectories` ready for upsert.
+#[derive(Debug, Clone)]
+pub struct TrajectoryRecord {
+    // ATIF-derived columns
+    pub session_id: String,
+    pub schema_version: String,
+    pub agent_name: String,
+    pub model_name: Option<String>,
+    pub num_steps: i64,
+    pub total_prompt_tokens: Option<i64>,
+    pub total_completion_tokens: Option<i64>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub atif_json: String,
+    // Collection bookkeeping columns
+    pub project: String,
+    pub source: String,
+    pub is_subagent: bool,
+    pub file_path: String,
+    pub file_size: i64,
+    pub file_mtime_ns: i64,
+}
+
+/// Thread-safe store over a dedicated `trajectories.db`.
+pub struct TrajectoryStore {
+    conn: Mutex<Connection>,
+}
+
+impl TrajectoryStore {
+    /// Opens (creating if needed) the database at `path` and ensures the schema.
+    ///
+    /// # Errors
+    /// Returns an error if the database cannot be opened or the schema
+    /// cannot be created.
+    pub fn new_with_path(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("open trajectories db {}", path.display()))?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.busy_timeout(std::time::Duration::from_millis(500))?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS collected_trajectories (
+                session_id TEXT PRIMARY KEY,
+                schema_version TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                model_name TEXT,
+                num_steps INTEGER NOT NULL,
+                total_prompt_tokens INTEGER,
+                total_completion_tokens INTEGER,
+                start_time TEXT,
+                end_time TEXT,
+                atif_json TEXT NOT NULL,
+                project TEXT NOT NULL,
+                source TEXT NOT NULL,
+                is_subagent INTEGER NOT NULL,
+                file_path TEXT NOT NULL,
+                file_size INTEGER NOT NULL,
+                file_mtime_ns INTEGER NOT NULL,
+                collected_at_ns INTEGER NOT NULL
+            )",
+            [],
+        )?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Returns `(file_size, file_mtime_ns)` recorded for `file_path`, if any.
+    /// Drives the incremental scan: unchanged files are skipped.
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn get_file_state(&self, file_path: &str) -> Result<Option<(i64, i64)>> {
+        let conn = self.lock_conn()?;
+        let state = conn
+            .query_row(
+                "SELECT file_size, file_mtime_ns FROM collected_trajectories
+                 WHERE file_path = ?1",
+                params![file_path],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        Ok(state)
+    }
+
+    /// Inserts or updates one trajectory row (keyed by `session_id`).
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn upsert_trajectory(&self, record: &TrajectoryRecord) -> Result<()> {
+        let now_ns = now_ns();
+        let conn = self.lock_conn()?;
+        conn.execute(
+            "INSERT INTO collected_trajectories (
+                session_id, schema_version, agent_name, model_name, num_steps,
+                total_prompt_tokens, total_completion_tokens, start_time, end_time,
+                atif_json, project, source, is_subagent, file_path, file_size,
+                file_mtime_ns, collected_at_ns
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+             ON CONFLICT(session_id) DO UPDATE SET
+                schema_version = ?2, agent_name = ?3, model_name = ?4, num_steps = ?5,
+                total_prompt_tokens = ?6, total_completion_tokens = ?7,
+                start_time = ?8, end_time = ?9, atif_json = ?10, project = ?11,
+                source = ?12, is_subagent = ?13, file_path = ?14, file_size = ?15,
+                file_mtime_ns = ?16, collected_at_ns = ?17",
+            params![
+                record.session_id,
+                record.schema_version,
+                record.agent_name,
+                record.model_name,
+                record.num_steps,
+                record.total_prompt_tokens,
+                record.total_completion_tokens,
+                record.start_time,
+                record.end_time,
+                record.atif_json,
+                record.project,
+                record.source,
+                record.is_subagent as i64,
+                record.file_path,
+                record.file_size,
+                record.file_mtime_ns,
+                now_ns,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Fetches a stored trajectory row by session id (test/inspection helper).
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn get(&self, session_id: &str) -> Result<Option<TrajectoryRecord>> {
+        let conn = self.lock_conn()?;
+        let record = conn
+            .query_row(
+                "SELECT session_id, schema_version, agent_name, model_name, num_steps,
+                        total_prompt_tokens, total_completion_tokens, start_time, end_time,
+                        atif_json, project, source, is_subagent, file_path, file_size,
+                        file_mtime_ns
+                 FROM collected_trajectories WHERE session_id = ?1",
+                params![session_id],
+                |row| {
+                    Ok(TrajectoryRecord {
+                        session_id: row.get(0)?,
+                        schema_version: row.get(1)?,
+                        agent_name: row.get(2)?,
+                        model_name: row.get(3)?,
+                        num_steps: row.get(4)?,
+                        total_prompt_tokens: row.get(5)?,
+                        total_completion_tokens: row.get(6)?,
+                        start_time: row.get(7)?,
+                        end_time: row.get(8)?,
+                        atif_json: row.get(9)?,
+                        project: row.get(10)?,
+                        source: row.get(11)?,
+                        is_subagent: row.get::<_, i64>(12)? != 0,
+                        file_path: row.get(13)?,
+                        file_size: row.get(14)?,
+                        file_mtime_ns: row.get(15)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(record)
+    }
+
+    /// Number of stored trajectories (test/inspection helper).
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn count(&self) -> Result<i64> {
+        let conn = self.lock_conn()?;
+        let n = conn.query_row("SELECT COUNT(*) FROM collected_trajectories", [], |row| {
+            row.get(0)
+        })?;
+        Ok(n)
+    }
+
+    fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
+        self.conn
+            .lock()
+            .map_err(|_| anyhow!("trajectory store mutex poisoned"))
+    }
+}
+
+fn now_ns() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tmp_db(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("traj-store-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("trajectories.db")
+    }
+
+    fn sample_record() -> TrajectoryRecord {
+        TrajectoryRecord {
+            session_id: "s-1".into(),
+            schema_version: "ATIF-v1.7".into(),
+            agent_name: "qoder".into(),
+            model_name: Some("qwen-max".into()),
+            num_steps: 3,
+            total_prompt_tokens: Some(250),
+            total_completion_tokens: Some(30),
+            start_time: Some("2026-07-25T10:00:00Z".into()),
+            end_time: Some("2026-07-25T10:00:05Z".into()),
+            atif_json: "{\"schema_version\":\"ATIF-v1.7\"}".into(),
+            project: "myapp".into(),
+            source: "qoder".into(),
+            is_subagent: false,
+            file_path: "/root/.qoder/projects/-data-myapp/s-1.jsonl".into(),
+            file_size: 1024,
+            file_mtime_ns: 42,
+        }
+    }
+
+    #[test]
+    fn test_upsert_twice_updates_row() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("upsert")).unwrap();
+        let mut rec = sample_record();
+        store.upsert_trajectory(&rec).unwrap();
+
+        rec.num_steps = 5;
+        rec.file_size = 2048;
+        rec.file_mtime_ns = 99;
+        store.upsert_trajectory(&rec).unwrap();
+
+        assert_eq!(store.count().unwrap(), 1);
+        let got = store.get("s-1").unwrap().unwrap();
+        assert_eq!(got.num_steps, 5);
+        assert_eq!(got.file_size, 2048);
+    }
+
+    #[test]
+    fn test_file_state_roundtrip() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("state")).unwrap();
+        let rec = sample_record();
+        assert!(store.get_file_state(&rec.file_path).unwrap().is_none());
+
+        store.upsert_trajectory(&rec).unwrap();
+        assert_eq!(
+            store.get_file_state(&rec.file_path).unwrap(),
+            Some((1024, 42))
+        );
+    }
+}

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
@@ -102,6 +102,16 @@ impl TrajectoryStore {
             )",
             [],
         )?;
+        // Lightweight bookkeeping for files that failed conversion (corrupted
+        // JSONL, empty events, etc.) so they are not re-read every scan round.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS skipped_files (
+                file_path TEXT PRIMARY KEY,
+                file_size INTEGER NOT NULL,
+                file_mtime_ns INTEGER NOT NULL
+            )",
+            [],
+        )?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -109,11 +119,14 @@ impl TrajectoryStore {
 
     /// Returns `(file_size, file_mtime_ns)` recorded for `file_path`, if any.
     /// Drives the incremental scan: unchanged files are skipped.
+    /// Checks both successfully ingested trajectories and skipped (corrupted)
+    /// files.
     ///
     /// # Errors
     /// Returns an error on SQL failure or poisoned mutex.
     pub fn get_file_state(&self, file_path: &str) -> Result<Option<(i64, i64)>> {
         let conn = self.lock_conn()?;
+        // First check successfully ingested files.
         let state = conn
             .query_row(
                 "SELECT file_size, file_mtime_ns FROM collected_trajectories
@@ -122,7 +135,40 @@ impl TrajectoryStore {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()?;
-        Ok(state)
+        if state.is_some() {
+            return Ok(state);
+        }
+        // Then check skipped (corrupted) files.
+        let skipped = conn
+            .query_row(
+                "SELECT file_size, file_mtime_ns FROM skipped_files
+                 WHERE file_path = ?1",
+                params![file_path],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        Ok(skipped)
+    }
+
+    /// Records the file state for a file that failed conversion, preventing
+    /// re-reads until the file changes (size/mtime differ).
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn set_file_state(
+        &self,
+        file_path: &str,
+        file_size: i64,
+        file_mtime_ns: i64,
+    ) -> Result<()> {
+        let conn = self.lock_conn()?;
+        conn.execute(
+            "INSERT INTO skipped_files (file_path, file_size, file_mtime_ns)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(file_path) DO UPDATE SET file_size = ?2, file_mtime_ns = ?3",
+            params![file_path, file_size, file_mtime_ns],
+        )?;
+        Ok(())
     }
 
     /// Inserts or updates one trajectory row (keyed by `session_id`).

--- a/src/agentsight/docs/design-docs/trajectory-query-api.md
+++ b/src/agentsight/docs/design-docs/trajectory-query-api.md
@@ -1,0 +1,276 @@
+# 采集轨迹查询 API 与 Dashboard 接入设计
+
+> 状态：**草案（待评审）**
+> 关联：PR #1789（`feat(sight): add Qoder trajectory collector crates`）的下游消费侧
+> 范围：让 Dashboard 能浏览/检索 `trajectories.db` 中已采集的 Qoder/QoderWork ATIF v1.7 轨迹
+
+## 1. 背景与目标
+
+PR #1789 完成了轨迹的**采集 + 持久化**：后台线程把 Qoder/QoderWork 的 JSONL 会话转换为
+ATIF v1.7 文档，upsert 进 `trajectories.db` 的 `collected_trajectories` 表。但**消费侧缺失**：
+
+- `src/server/` 没有任何 handler 打开 `trajectories.db`；
+- Dashboard 没有浏览入口（现有 "ATIF 查看器" 走的是 eBPF 采集的 v1.6 导出链路，数据源不同）。
+
+**目标**：新增只读查询 API + Dashboard 页面，使用户能按 project / source / agent 检索采集到的轨迹，
+并查看单条轨迹的完整 ATIF 步骤时间线。
+
+**非目标**（本期不做）：
+
+- 不改动采集器写入逻辑与表结构；
+- 不统一 v1.6（eBPF 导出）与 v1.7（文件采集）两条 ATIF 链路（后续独立 ADR）；
+- 不做轨迹的编辑/删除/标注（仅只读浏览）。
+
+## 2. 现状数据流
+
+```mermaid
+graph LR
+    JSONL[Qoder/QoderWork JSONL] --> COL[trajectory-collector 线程<br/>agentsight trace 进程]
+    COL -->|upsert| DB[(trajectories.db<br/>collected_trajectories)]
+    DB -. 无读取方 .-x API[API Server<br/>agentsight serve 进程]
+    API -. 无入口 .-x FE[Dashboard]
+```
+
+**关键约束**：collector 与 API server 是**两个独立进程**（`trace` vs `serve`），
+通过 SQLite **WAL 模式**共享同一 DB 文件（collector 已设 `journal_mode=WAL`，支持单写多读）。
+
+## 3. 目标架构
+
+```mermaid
+graph LR
+    COL[collector 线程<br/>trace 进程] -->|写| DB[(trajectories.db)]
+    DB -->|只读连接| STORE[TrajectoryStore<br/>AppState.trajectory_store]
+    STORE --> H1[GET /api/trajectories]
+    STORE --> H2[GET /api/trajectories/session_id]
+    STORE --> H3[GET /api/trajectories/filters]
+    H1 --> FE[TrajectoryListPage]
+    H2 --> FE2[TrajectoryDetailPage<br/>复用 ATIF 步骤渲染]
+    H3 --> FE
+```
+
+## 4. 后端设计
+
+### 4.1 Store 层（`crates/agentsight-trajectory-collector/src/store.rs`）
+
+在现有 `TrajectoryStore` 上**新增只读查询方法**（Footprint Ladder 级别 1：扩展现有类型）：
+
+| 方法 | 说明 |
+|------|------|
+| `list_summaries(project, source, agent_name, limit) -> Result<Vec<TrajectorySummary>>` | 列表，**不返回 `atif_json`**（该字段可能很大），按 `collected_at_ns DESC` 排序 |
+| `get_atif_json(session_id) -> Result<Option<String>>` | 仅取 `atif_json` 一列，供详情渲染 |
+| `list_filters() -> Result<TrajectoryFilters>` | `SELECT DISTINCT project/source/agent_name`，供前端下拉框 |
+
+新增轻量 DTO（`Serialize`）：
+
+```rust
+pub struct TrajectorySummary {
+    pub session_id: String,
+    pub schema_version: String,
+    pub agent_name: String,
+    pub model_name: Option<String>,
+    pub num_steps: i64,
+    pub total_prompt_tokens: Option<i64>,
+    pub total_completion_tokens: Option<i64>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub project: String,
+    pub source: String,        // "qoder" | "qoderwork"
+    pub is_subagent: bool,
+    pub collected_at_ns: i64,
+}
+
+pub struct TrajectoryFilters {
+    pub projects: Vec<String>,
+    pub sources: Vec<String>,
+    pub agent_names: Vec<String>,
+}
+```
+
+> 所有 SQL 继续使用 `params![]` 参数化（沿用现有防注入规范）；过滤条件用动态 `WHERE` 拼接 + 绑定参数。
+
+### 4.2 AppState 与初始化（`src/server/mod.rs`）
+
+仿照 `interruption_store` 的长连接模式，新增可选字段：
+
+```rust
+pub struct AppState {
+    // ... 既有字段
+    pub trajectory_store: Option<Arc<TrajectoryStore>>,
+}
+```
+
+`run_server` 中初始化（路径经 §4.2.1 的共享 helper 派生，**与 collector 同源**）：
+
+```rust
+let trajectory_store = {
+    let db_path = crate::storage::sqlite::sibling_db_path("trajectories.db");
+    match TrajectoryStore::new_with_path(&db_path) {
+        Ok(s) => Some(Arc::new(s)),
+        Err(e) => { log::warn!("Trajectory store unavailable: {e}"); None }
+    }
+};
+```
+
+**决策**：即使 `features.trajectory_collection.enabled=false`，serve 也**总是尝试只读打开** DB。
+理由：采集由 `trace` 进程负责，`serve` 只消费；用户可能先采集、后开 Dashboard 查看历史数据。
+DB 不存在时 `new_with_path` 会创建空表 → 列表返回 `[]`，前端展示空态（见 §5.3 / §6 D4）。
+
+> **注意**：collector crate 的 `TrajectoryStore::new_with_path` 使用裸 `Connection::open`，
+> **不会创建父目录**（不同于主 crate `connection::create_connection` 的 `create_dir_all`）。
+> 故依赖 base 目录 `/var/log/sysak/.agentsight` 已存在（server 启动时 genai/interruption 等 store 会先创建它）；
+> 若 base 目录缺失，`new_with_path` 报错 → `trajectory_store=None` → 按 D4 返回空 + 200。
+
+#### 4.2.1 共享路径 helper（消除 D3 漂移）
+
+**问题**：`trajectories.db` 的位置是间接推导的——取 `GenAISqliteStore::default_path()`
+（`<base>/genai_events.db`）的父目录再拼文件名。collector（`trace` 进程）与 server（`serve` 进程）
+分属两个进程，若各自手抄这段表达式，一旦 base 路径逻辑变更（如未来支持可配置 base），
+两端推导不一致就会**读到空库**；且 `new_with_path` 在文件缺失时会静默创建空表，
+Dashboard 永远显示"暂无数据"而**无任何错误日志指向路径错误**，极难排查。
+现状 `unified.rs`（collector）与 `mod.rs`（interruption store）已各有一份该表达式副本。
+
+**方案**：在 `src/storage/sqlite/connection.rs` 提取单一来源 helper，读写两端统一调用。
+**关键**：helper 直接基于 `default_base_path()` 派生，而**不**经 `GenAISqliteStore::default_path().parent()`——
+因为 `genai` 模块依赖 `connection`（用其建连接），若底层 `connection.rs` 反向引用上层 `genai` 会形成模块内循环依赖；
+且 `genai_events.db` 本就定义为 `default_base_path().join("genai_events.db")`，两者等价，直接用 base 更干净：
+
+```rust
+/// 与 genai_events.db 同目录（即 default_base_path()）的附属数据库路径
+/// （trajectories.db / interruption_events.db 等），保证跨进程读写同源。
+pub fn sibling_db_path(filename: &str) -> PathBuf {
+    default_base_path().join(filename)
+}
+```
+
+并在 `storage/sqlite/mod.rs` re-export（`pub use connection::{..., sibling_db_path};`）。
+
+落地范围（PR-A 内顺带完成，Footprint Ladder 级别 2）：
+
+- collector（`unified.rs`）：`db_path: sibling_db_path("trajectories.db")`（替换现有 `GenAISqliteStore::default_path().parent()...` 表达式，行为等价）；
+- server（`mod.rs`）：`sibling_db_path("trajectories.db")`；
+- interruption store（`mod.rs`）：`sibling_db_path("interruption_events.db")`（消除既有重复副本）。
+
+### 4.3 Handler 与路由（`src/server/handlers.rs`）
+
+| 路由 | 方法 | 查询参数 | 返回 |
+|------|------|----------|------|
+| `/api/trajectories` | GET | `project`, `source`, `agent_name`, `limit`(默认 200) | `Vec<TrajectorySummary>` |
+| `/api/trajectories/{session_id}` | GET | — | 原始 ATIF v1.7 JSON（直接回传存储的 `atif_json` 字符串，`Content-Type: application/json`，不二次解析） |
+| `/api/trajectories/filters` | GET | — | `TrajectoryFilters` |
+
+错误语义：
+
+- store 为 `None`（DB 不存在或打不开）→ **统一返回空结果 + 200**（`[]` / 空 filters），而非 503；
+  采集是默认关闭的可选功能，DB 缺失是正常状态，Dashboard 其他列表页也都能容忍空数据，故不单独报错（见 §6 D4）；
+- `session_id` 不存在 → `404 {"error":"not_found"}`；
+- SQL 失败 → `500 {"error": ...}`。
+
+> 注意路由注册顺序：`/api/trajectories/filters` 必须在 `/api/trajectories/{session_id}` **之前**
+> 注册，否则 `filters` 会被当成 `session_id` 捕获（actix 动态段匹配）。
+
+### 4.4 文档同步
+
+- `AGENTS.md` §8 API Endpoints 表新增 3 行；
+- `AGENTS.md` §4 Module Map 的 TrajectoryCollector 行补充"可经 `/api/trajectories` 查询"。
+
+## 5. 前端设计
+
+### 5.1 apiClient（`dashboard/src/utils/apiClient.ts`）
+
+```ts
+export interface TrajectorySummary { /* 镜像后端 DTO */ }
+export interface TrajectoryFilters { projects: string[]; sources: string[]; agent_names: string[]; }
+
+export async function fetchTrajectories(params?: {project?: string; source?: string; agent_name?: string; limit?: number}): Promise<TrajectorySummary[]>;
+export async function fetchTrajectoryDetail(sessionId: string): Promise<AtifDocument>; // atif_json 直接解析为 AtifDocument
+export async function fetchTrajectoryFilters(): Promise<TrajectoryFilters>;
+```
+
+> `atif_json` 是 ATIF v1.7，与现有 `AtifDocument` 类型结构兼容（v1.7 多出的
+> `reasoning_effort`/`llm_call_count`/`is_copied_context` 字段前端类型可忽略）。
+
+### 5.2 页面与路由
+
+| 文件 | 职责 |
+|------|------|
+| `pages/TrajectoryListPage.tsx`（新增） | 过滤栏（project/source/agent 下拉）+ 表格（agent、project、source、steps、tokens、采集时间、subagent 标记）；行点击进详情 |
+| `pages/TrajectoryDetailPage.tsx`（新增） | `useParams` 取 `sessionId` → `fetchTrajectoryDetail` → 渲染 ATIF 步骤时间线 |
+| `App.tsx` | 新增 `/trajectories` 与 `/trajectories/:sessionId` 路由 |
+| `components/NavBar.tsx` | `navItems` 新增 `{ path: '/trajectories', label: '轨迹采集', icon: '🧭' }` |
+
+**步骤渲染复用策略**：`AtifViewerPage.tsx`（747 行）当前与 v1.6 导出 API + savings/optimization 耦合。
+本期**不做大重构**：将其中纯展示的步骤时间线子树**抽取**为 `components/AtifStepTimeline.tsx`，
+由 `AtifViewerPage` 与 `TrajectoryDetailPage` 共同复用（Footprint Ladder 级别 2）。
+若抽取导致单 PR 超 800 行，则降级为 `TrajectoryDetailPage` 内独立实现一份精简渲染，重构留待后续。
+
+### 5.3 空态与错误态
+
+- 列表为空：展示引导文案"尚未采集到轨迹。请在 `agentsight.json` 开启
+  `features.trajectory_collection.enabled` 并运行 `agentsight trace`"；
+- 详情 404：提示"轨迹不存在或已被重新采集覆盖"。
+
+## 6. 关键设计决策
+
+| # | 决策点 | 选择 | 理由 / 替代方案 |
+|---|--------|------|-----------------|
+| D1 | store 生命周期 | AppState 长连接（`Option<Arc<TrajectoryStore>>`） | 对齐 `interruption_store`；替代：每请求开连接（对齐 `list_sessions`）——被否，避免频繁 open |
+| D2 | 跨进程共享 | 独立只读连接 + 既有 WAL | collector(trace) 与 server(serve) 不同进程，WAL 支持单写多读，无需 IPC |
+| D3 | DB 路径派生 | 抽 `sibling_db_path()` 共享 helper，读写两端同源（见 §4.2.1） | 避免跨进程手抄表达式漂移导致静默读空库 |
+| D4 | store 缺失语义 | 统一返回空 + 200（非 503） | 采集默认关闭，DB 缺失是正常状态；Dashboard 其他列表页均能容忍空数据，不单独报错，前端无需错误分支 |
+| D5 | 列表是否含 atif_json | 不含，详情接口单独取 | 列表轻量化，避免大 JSON 拖慢首屏 |
+| D6 | v1.6/v1.7 链路 | 本期并存，不统一 | 统一涉及导出链路迁移，范围大，独立 ADR 处理 |
+| D7 | 步骤渲染 | 抽取共享组件（级别 2） | 复用而非复制；超 800 行则降级为独立精简实现 |
+
+## 7. Footprint Ladder 说明
+
+| 变更 | 级别 | 说明 |
+|------|------|------|
+| `TrajectoryStore` 新增查询方法 + DTO | **1** | 扩展现有类型 |
+| 提取 `sibling_db_path` 路径 helper | **2** | 模块内复用，消除既有重复副本 |
+| 抽取 `AtifStepTimeline` 共享组件 | **2** | 模块内复用 |
+| 新增 2 个前端页面 | **3** | 职责独立，现有页面无法容纳 |
+| 新增 3 个 handler | **1** | 扩展现有 `handlers.rs` |
+
+无 eBPF（级别 4）/ FFI（级别 5）变更。
+
+## 8. 测试计划
+
+**后端**（必须，属存储/服务层逻辑变更）：
+
+- `store.rs` 单测：`list_summaries` 过滤组合、排序、`limit`；`get_atif_json` 命中/未命中；`list_filters` 去重；
+- `handlers.rs` 集成测试（`actix_web::test`）：
+  - 列表 200 + 过滤生效；
+  - 详情 200（返回合法 ATIF JSON）/ 404（不存在）；
+  - `filters` 路由不被 `{session_id}` 误捕获（注册顺序回归）；
+  - store 为 `None` 时返回空 + 200。
+
+**前端**：
+
+- `apiClient` 三个方法的类型与 URL 拼装；
+- 列表页过滤交互、详情页 404 兜底（vitest）。
+
+**手工验证**：
+
+1. 开启 `features.trajectory_collection.enabled`，`agentsight trace` 采集真实 Qoder 会话；
+2. `agentsight serve` 打开 Dashboard "轨迹采集" 页，确认列表/过滤/详情步骤时间线正确；
+3. 关闭采集功能重启 serve，确认页面展示空态而非报错。
+
+## 9. 拆分与落地计划
+
+为遵守 PR diff ≤ 800 行约束，建议拆为两个 PR：
+
+| 阶段 | 内容 | 预估规模 |
+|------|------|----------|
+| **PR-A（后端）** | `sibling_db_path` helper + store 查询方法 + DTO + 3 handler + 路由 + AppState 接线 + AGENTS.md + 后端测试 | ~430 行 |
+| **PR-B（前端）** | apiClient + 2 页面 + 路由/导航 + `AtifStepTimeline` 抽取 + 前端测试 | ~500 行 |
+
+PR-B 依赖 PR-A 合入。
+
+> **合入顺序**：PR-A 会修改 `unified.rs` 中 collector 的 `db_path` 派生表达式（§4.2.1），
+> 该段代码由 PR #1789 引入，故 **PR-A 须在 #1789 合入后**再基于最新 main 提交。
+
+## 10. 风险与注意
+
+- **schema 演进**：`collected_trajectories` 表无 `schema_version` 迁移机制；本期只读，新增列需配套 `CREATE TABLE` 兼容（`IF NOT EXISTS` 不升级旧表结构）——若后续加列须处理旧库；
+- **大轨迹**：单条 `atif_json` 可能很大（长会话），详情接口直接返回整串，前端按需渲染/折叠；
+- **路径一致性（D3）**：最大踩坑点——跨进程手抄路径表达式一旦漂移会静默读空库（`new_with_path` 缺失时静默建空表、无错误日志）。**已在 §4.2.1 纳入设计**：PR-A 提取 `sibling_db_path()` 单一来源 helper，collector/server/interruption store 统一调用，物理杜绝漂移。

--- a/src/agentsight/docs/design-docs/trajectory-query-api.md
+++ b/src/agentsight/docs/design-docs/trajectory-query-api.md
@@ -111,9 +111,10 @@ let trajectory_store = {
 };
 ```
 
-**决策**：即使 `features.trajectory_collection.enabled=false`，serve 也**总是尝试只读打开** DB。
+**决策**：serve 仅在 `trajectories.db` 文件**已存在**时尝试只读打开，不会创建空 DB。
 理由：采集由 `trace` 进程负责，`serve` 只消费；用户可能先采集、后开 Dashboard 查看历史数据。
-DB 不存在时 `new_with_path` 会创建空表 → 列表返回 `[]`，前端展示空态（见 §5.3 / §6 D4）。
+DB 不存在时 `trajectory_store=None` → 列表/过滤端点返回空 + 200，detail 端点返回 404（见 §5.3 / §6 D4）。
+这避免了 serve 模式在采集从未启用时产生空 DB 文件的持久化副作用。
 
 > **注意**：collector crate 的 `TrajectoryStore::new_with_path` 使用裸 `Connection::open`，
 > **不会创建父目录**（不同于主 crate `connection::create_connection` 的 `create_dir_all`）。

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -54,6 +54,9 @@ pub const DEFAULT_PID_CACHE_SIZE: usize = 1024;
 /// Default tokenizer cache size (number of loaded tokenizer models).
 pub const DEFAULT_TOKENIZER_CACHE_SIZE: usize = 4;
 
+/// Default seconds between two trajectory-collector scan rounds.
+pub const DEFAULT_TRAJECTORY_SCAN_INTERVAL_SECS: u64 = 30;
+
 /// Default maximum per-connection HTTP body buffer size (8 MB).
 pub const DEFAULT_MAX_CONNECTION_BODY_BYTES: usize = 8 * 1024 * 1024;
 
@@ -321,6 +324,8 @@ pub struct JsonFeatures {
     pub token_consumption: Option<bool>,
     /// SLS Logtail export.
     pub sls_logtail: Option<bool>,
+    /// Qoder/QoderWork trajectory collection into trajectories.db.
+    pub trajectory_collection: Option<JsonTrajectoryCollectionFeature>,
 }
 
 #[derive(serde::Deserialize, Clone, Debug, Default)]
@@ -362,6 +367,17 @@ pub struct JsonInterruptionFeature {
     pub retention_days: Option<u64>,
     #[serde(default)]
     pub max_db_size_mb: Option<u64>,
+}
+
+#[derive(serde::Deserialize, Clone, Debug, Default)]
+#[serde(default)]
+pub struct JsonTrajectoryCollectionFeature {
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub scan_interval_secs: Option<u64>,
+    /// Optional override of the projects directories to scan.
+    #[serde(default)]
+    pub scan_dirs: Option<Vec<String>>,
 }
 
 /// Resource limits and channel policy for memory-leak prevention.
@@ -672,6 +688,12 @@ pub struct FeatureFlags {
     pub token_consumption_enabled: bool,
     /// SLS Logtail export.
     pub sls_logtail_enabled: bool,
+    /// Qoder/QoderWork trajectory collection (scan + ATIF convert + persist).
+    pub trajectory_collection_enabled: bool,
+    /// Seconds between two trajectory scan rounds.
+    pub trajectory_scan_interval_secs: u64,
+    /// Optional override of the trajectory projects directories to scan.
+    pub trajectory_scan_dirs: Option<Vec<String>>,
 }
 
 impl Default for FeatureFlags {
@@ -690,6 +712,9 @@ impl Default for FeatureFlags {
             audit_enabled: false,
             token_consumption_enabled: false,
             sls_logtail_enabled: false,
+            trajectory_collection_enabled: false,
+            trajectory_scan_interval_secs: DEFAULT_TRAJECTORY_SCAN_INTERVAL_SECS,
+            trajectory_scan_dirs: None,
         }
     }
 }
@@ -1168,6 +1193,20 @@ impl AgentsightConfig {
                 audit_enabled: features.audit.unwrap_or(false),
                 token_consumption_enabled: features.token_consumption.unwrap_or(false),
                 sls_logtail_enabled: features.sls_logtail.unwrap_or(false),
+                trajectory_collection_enabled: features
+                    .trajectory_collection
+                    .as_ref()
+                    .and_then(|f| f.enabled)
+                    .unwrap_or(false),
+                trajectory_scan_interval_secs: features
+                    .trajectory_collection
+                    .as_ref()
+                    .and_then(|f| f.scan_interval_secs)
+                    .unwrap_or(DEFAULT_TRAJECTORY_SCAN_INTERVAL_SECS),
+                trajectory_scan_dirs: features
+                    .trajectory_collection
+                    .as_ref()
+                    .and_then(|f| f.scan_dirs.clone()),
             };
         }
 
@@ -1950,6 +1989,50 @@ mod tests {
         assert!(!config.features.audit_enabled);
         assert!(config.features.token_consumption_enabled);
         assert!(config.features.sls_logtail_enabled);
+        // trajectory_collection absent -> defaults (disabled, 30s)
+        assert!(!config.features.trajectory_collection_enabled);
+        assert_eq!(
+            config.features.trajectory_scan_interval_secs,
+            DEFAULT_TRAJECTORY_SCAN_INTERVAL_SECS
+        );
+        assert!(config.features.trajectory_scan_dirs.is_none());
+    }
+
+    #[test]
+    fn test_load_from_json_trajectory_collection() {
+        let json = r#"{
+            "features": {
+                "trajectory_collection": {
+                    "enabled": true,
+                    "scan_interval_secs": 15,
+                    "scan_dirs": ["/tmp/projects"]
+                }
+            }
+        }"#;
+        let mut config = AgentsightConfig::new();
+        config.load_from_json(json).unwrap();
+        assert!(config.features.trajectory_collection_enabled);
+        assert_eq!(config.features.trajectory_scan_interval_secs, 15);
+        assert_eq!(
+            config.features.trajectory_scan_dirs,
+            Some(vec!["/tmp/projects".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_load_from_json_trajectory_collection_disabled() {
+        let json = r#"{
+            "features": {
+                "trajectory_collection": { "enabled": false }
+            }
+        }"#;
+        let mut config = AgentsightConfig::new();
+        config.load_from_json(json).unwrap();
+        assert!(!config.features.trajectory_collection_enabled);
+        assert_eq!(
+            config.features.trajectory_scan_interval_secs,
+            DEFAULT_TRAJECTORY_SCAN_INTERVAL_SECS
+        );
     }
 
     #[test]

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -3215,6 +3215,10 @@ pub struct TrajectoryQuery {
     pub limit: Option<i64>,
 }
 
+/// Default and hard-cap for the trajectory list `limit` parameter.
+const TRAJECTORY_DEFAULT_LIMIT: i64 = 200;
+const TRAJECTORY_MAX_LIMIT: i64 = 1000;
+
 /// GET /api/trajectories?project=&source=&agent_name=&limit=
 ///
 /// Lists collected trajectories (newest first) without the bulky `atif_json`
@@ -3228,7 +3232,13 @@ pub async fn list_trajectories(
     let Some(ref tstore) = data.trajectory_store else {
         return HttpResponse::Ok().json(Vec::<serde_json::Value>::new());
     };
-    let limit = query.limit.unwrap_or(200);
+    // Normalize: <= 0 falls back to default; cap at hard upper bound to
+    // prevent unbounded full-table scans (SQLite treats negative LIMIT as
+    // "no limit").
+    let limit = match query.limit {
+        Some(v) if v > 0 => v.min(TRAJECTORY_MAX_LIMIT),
+        _ => TRAJECTORY_DEFAULT_LIMIT,
+    };
     match tstore.list_summaries(
         query.project.as_deref(),
         query.source.as_deref(),

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -845,6 +845,7 @@ mod tests {
     use crate::grader::EvaluationStore;
     use crate::health::HealthStore;
     use crate::storage::sqlite::genai::{PendingCallInfo, PendingOrigin};
+    use agentsight_trajectory_collector::{TrajectoryRecord, TrajectoryStore};
 
     use super::*;
 
@@ -1081,6 +1082,7 @@ mod tests {
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
             auth,
             optimize: None,
+            trajectory_store: None,
         });
         let app = awtest::init_service(App::new().app_data(data).service(latest_grader)).await;
 
@@ -1286,6 +1288,7 @@ mod tests {
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
             auth,
             optimize: None,
+            trajectory_store: None,
         })
     }
 
@@ -1414,6 +1417,7 @@ mod tests {
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms },
             auth,
             optimize: None,
+            trajectory_store: None,
         })
     }
 
@@ -1512,6 +1516,7 @@ mod tests {
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
             auth,
             optimize: None,
+            trajectory_store: None,
         })
     }
 
@@ -1649,6 +1654,7 @@ mod tests {
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
             auth,
             optimize: None,
+            trajectory_store: None,
         })
     }
 
@@ -1671,6 +1677,7 @@ mod tests {
             security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
             auth,
             optimize: None,
+            trajectory_store: None,
         })
     }
 
@@ -1683,6 +1690,186 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ))
+    }
+
+    // ─── Trajectory handler tests ────────────────────────────────────────
+
+    fn trajectory_record(session_id: &str, project: &str, source: &str) -> TrajectoryRecord {
+        TrajectoryRecord {
+            session_id: session_id.to_string(),
+            schema_version: "ATIF-v1.7".to_string(),
+            agent_name: "qoder".to_string(),
+            model_name: Some("qwen-max".to_string()),
+            num_steps: 2,
+            total_prompt_tokens: Some(100),
+            total_completion_tokens: Some(20),
+            start_time: Some("2026-07-25T10:00:00Z".to_string()),
+            end_time: Some("2026-07-25T10:00:05Z".to_string()),
+            atif_json: format!(
+                "{{\"schema_version\":\"ATIF-v1.7\",\"session_id\":\"{session_id}\"}}"
+            ),
+            project: project.to_string(),
+            source: source.to_string(),
+            is_subagent: false,
+            file_path: format!("/root/.qoder/projects/{project}/{session_id}.jsonl"),
+            file_size: 512,
+            file_mtime_ns: 7,
+        }
+    }
+
+    fn test_app_state_with_trajectory_store(
+        store: Option<Arc<TrajectoryStore>>,
+    ) -> web::Data<AppState> {
+        let auth_config = crate::config::ServerAuthConfig { enabled: false };
+        let auth = Arc::new(crate::server::auth::DashboardAuth::init(
+            &auth_config,
+            std::path::Path::new("/tmp"),
+        ));
+        web::Data::new(AppState {
+            storage_path: PathBuf::from(":memory:"),
+            start_time: Instant::now(),
+            health_store: Arc::new(RwLock::new(HealthStore::new())),
+            interruption_store: None,
+            evaluation_store: Arc::new(
+                EvaluationStore::new_with_path(std::path::Path::new(":memory:")).unwrap(),
+            ),
+            security_observability: super::super::SecurityObservabilityConfig { timeout_ms: 0 },
+            auth,
+            optimize: None,
+            trajectory_store: store,
+        })
+    }
+
+    fn seeded_trajectory_store(tag: &str) -> Arc<TrajectoryStore> {
+        let db = unique_handler_db(tag);
+        let store = TrajectoryStore::new_with_path(&db).unwrap();
+        store
+            .upsert_trajectory(&trajectory_record("s-1", "proj-a", "qoder"))
+            .unwrap();
+        store
+            .upsert_trajectory(&trajectory_record("s-2", "proj-b", "qoderwork"))
+            .unwrap();
+        Arc::new(store)
+    }
+
+    #[actix_web::test]
+    async fn trajectory_list_returns_rows_and_filters() {
+        let data = test_app_state_with_trajectory_store(Some(seeded_trajectory_store("list")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let all_resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories")
+                .to_request(),
+        )
+        .await;
+        let all: serde_json::Value = awtest::read_body_json(all_resp).await;
+        assert_eq!(all.as_array().unwrap().len(), 2);
+
+        let filtered_resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories?project=proj-a")
+                .to_request(),
+        )
+        .await;
+        let filtered: serde_json::Value = awtest::read_body_json(filtered_resp).await;
+        let arr = filtered.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["session_id"], "s-1");
+    }
+
+    #[actix_web::test]
+    async fn trajectory_detail_returns_raw_atif_and_404() {
+        let data = test_app_state_with_trajectory_store(Some(seeded_trajectory_store("detail")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/s-1")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body()).await.unwrap();
+        let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(doc["session_id"], "s-1");
+
+        let miss = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/nope")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(miss.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn trajectory_filters_route_not_captured_by_session_id() {
+        let data = test_app_state_with_trajectory_store(Some(seeded_trajectory_store("filters")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/filters")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = awtest::read_body_json(resp).await;
+        // `filters` must hit the filters handler (object), not the detail handler (404).
+        assert_eq!(body["projects"], serde_json::json!(["proj-a", "proj-b"]));
+        assert_eq!(body["sources"], serde_json::json!(["qoder", "qoderwork"]));
+    }
+
+    #[actix_web::test]
+    async fn trajectory_endpoints_graceful_when_store_absent() {
+        let data = test_app_state_with_trajectory_store(None);
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let list = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(list.status(), StatusCode::OK);
+        let rows: serde_json::Value = awtest::read_body_json(list).await;
+        assert_eq!(rows, serde_json::json!([]));
+
+        let filters = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/filters")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(filters.status(), StatusCode::OK);
     }
 
     fn make_interruption_event(
@@ -1856,6 +2043,7 @@ mod tests {
                     },
                     auth,
                     optimize: None,
+                    trajectory_store: None,
                 }))
                 .service(metrics),
         )
@@ -2286,6 +2474,7 @@ mod tests {
                     },
                     auth,
                     optimize: None,
+                    trajectory_store: None,
                 }))
                 .service(list_sessions)
                 .service(list_agent_names)
@@ -3008,6 +3197,91 @@ pub async fn get_interruption(
         Ok(None) => {
             HttpResponse::NotFound().json(serde_json::json!({"error": "Interruption not found"}))
         }
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}
+
+// ─── Trajectory collection endpoints ────────────────────────────────────
+
+/// Query parameters for `/api/trajectories`.
+#[derive(Debug, Deserialize)]
+pub struct TrajectoryQuery {
+    pub project: Option<String>,
+    pub source: Option<String>,
+    pub agent_name: Option<String>,
+    /// Max rows returned (default 200).
+    pub limit: Option<i64>,
+}
+
+/// GET /api/trajectories?project=&source=&agent_name=&limit=
+///
+/// Lists collected trajectories (newest first) without the bulky `atif_json`
+/// column. When the trajectory store is unavailable (collection never ran),
+/// returns an empty list with 200 for graceful UI degradation.
+#[get("/trajectories")]
+pub async fn list_trajectories(
+    data: web::Data<AppState>,
+    query: web::Query<TrajectoryQuery>,
+) -> impl Responder {
+    let Some(ref tstore) = data.trajectory_store else {
+        return HttpResponse::Ok().json(Vec::<serde_json::Value>::new());
+    };
+    let limit = query.limit.unwrap_or(200);
+    match tstore.list_summaries(
+        query.project.as_deref(),
+        query.source.as_deref(),
+        query.agent_name.as_deref(),
+        limit,
+    ) {
+        Ok(rows) => HttpResponse::Ok().json(rows),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}
+
+/// GET /api/trajectories/filters
+///
+/// Returns distinct project / source / agent_name values for the list UI
+/// dropdowns. Must be registered before `/trajectories/{session_id}`.
+#[get("/trajectories/filters")]
+pub async fn trajectory_filters(data: web::Data<AppState>) -> impl Responder {
+    let Some(ref tstore) = data.trajectory_store else {
+        return HttpResponse::Ok().json(serde_json::json!({
+            "projects": [], "sources": [], "agent_names": []
+        }));
+    };
+    match tstore.list_filters() {
+        Ok(filters) => HttpResponse::Ok().json(filters),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}
+
+/// GET /api/trajectories/{session_id}
+///
+/// Returns the stored ATIF v1.7 JSON document for one trajectory (raw string
+/// passthrough, no re-parsing).
+#[get("/trajectories/{session_id}")]
+pub async fn get_trajectory_detail(
+    data: web::Data<AppState>,
+    path: web::Path<String>,
+) -> impl Responder {
+    let Some(ref tstore) = data.trajectory_store else {
+        return HttpResponse::NotFound().json(
+            serde_json::json!({"error": "not_found", "message": "Trajectory store not available"}),
+        );
+    };
+    let session_id = path.into_inner();
+    match tstore.get_atif_json(&session_id) {
+        Ok(Some(atif_json)) => HttpResponse::Ok()
+            .content_type("application/json")
+            .body(atif_json),
+        Ok(None) => HttpResponse::NotFound()
+            .json(serde_json::json!({"error": "not_found", "message": "Trajectory not found"})),
         Err(e) => {
             HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
         }

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -298,16 +298,23 @@ pub async fn run_server(
     // serve only consumes). Path is derived via the shared sibling_db_path helper
     // so reader and writer always resolve the same file. A missing DB simply
     // yields an empty table → empty API results (graceful degradation).
+    // Only open when the file already exists to avoid creating an empty DB as a
+    // persistent side-effect in serve mode when collection was never enabled.
     let trajectory_store: Option<Arc<TrajectoryStore>> = {
         let db_path = crate::storage::sqlite::sibling_db_path("trajectories.db");
-        match TrajectoryStore::new_with_path(&db_path) {
-            Ok(store) => {
-                log::info!("Trajectory store initialized at {db_path:?}");
-                Some(Arc::new(store))
-            }
-            Err(e) => {
-                log::warn!("Failed to open trajectory store: {e}");
-                None
+        if !db_path.exists() {
+            log::debug!("Trajectory store not found at {db_path:?}; endpoints degrade to empty");
+            None
+        } else {
+            match TrajectoryStore::new_with_path(&db_path) {
+                Ok(store) => {
+                    log::info!("Trajectory store initialized at {db_path:?}");
+                    Some(Arc::new(store))
+                }
+                Err(e) => {
+                    log::warn!("Failed to open trajectory store: {e}");
+                    None
+                }
             }
         }
     };

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -20,6 +20,7 @@ use crate::config::ServerAuthConfig;
 use crate::grader::EvaluationStore;
 use crate::health::{HealthChecker, HealthStore};
 use crate::storage::sqlite::InterruptionStore;
+use agentsight_trajectory_collector::TrajectoryStore;
 
 use self::auth::{AuthMiddleware, DashboardAuth};
 
@@ -59,6 +60,8 @@ pub struct AppState {
     pub auth: Arc<DashboardAuth>,
     /// Optimization analysis state (LLM config + result store)
     pub optimize: Option<Arc<optimize::OptimizeState>>,
+    /// Read-only store over collected trajectories (`trajectories.db`)
+    pub trajectory_store: Option<Arc<TrajectoryStore>>,
 }
 
 // ─── Static file handler ─────────────────────────────────────────────────────
@@ -197,6 +200,10 @@ fn configure_routes(cfg: &mut web::ServiceConfig) {
                 .service(optimize::get_optimization_results)
                 .service(optimize::get_optimize_config)
                 .service(optimize::update_optimize_config)
+                // Trajectory collection API routes (filters before the dynamic segment)
+                .service(handlers::list_trajectories)
+                .service(handlers::trajectory_filters)
+                .service(handlers::get_trajectory_detail)
                 .default_service(web::route().to(api_not_found)),
         )
         // Health scope with not-found fallback
@@ -263,11 +270,7 @@ pub async fn run_server(
 
     // Initialize interruption store
     let interruption_store: Option<Arc<InterruptionStore>> = {
-        use crate::storage::sqlite::GenAISqliteStore;
-        let db_path = GenAISqliteStore::default_path()
-            .parent()
-            .unwrap_or(std::path::Path::new("/var/log/sysak/.agentsight"))
-            .join("interruption_events.db");
+        let db_path = crate::storage::sqlite::sibling_db_path("interruption_events.db");
         match InterruptionStore::new_with_path(&db_path) {
             Ok(store) => {
                 log::info!("Interruption store initialized at {db_path:?}");
@@ -291,6 +294,24 @@ pub async fn run_server(
     }
     checker.start();
 
+    // Initialize read-only trajectory store (collector writes it in `trace` mode;
+    // serve only consumes). Path is derived via the shared sibling_db_path helper
+    // so reader and writer always resolve the same file. A missing DB simply
+    // yields an empty table → empty API results (graceful degradation).
+    let trajectory_store: Option<Arc<TrajectoryStore>> = {
+        let db_path = crate::storage::sqlite::sibling_db_path("trajectories.db");
+        match TrajectoryStore::new_with_path(&db_path) {
+            Ok(store) => {
+                log::info!("Trajectory store initialized at {db_path:?}");
+                Some(Arc::new(store))
+            }
+            Err(e) => {
+                log::warn!("Failed to open trajectory store: {e}");
+                None
+            }
+        }
+    };
+
     let optimize_state = optimize::OptimizeState::init(storage_base);
 
     let data = web::Data::new(AppState {
@@ -302,6 +323,7 @@ pub async fn run_server(
         security_observability,
         auth: dashboard_auth.clone(),
         optimize: Some(optimize_state),
+        trajectory_store,
     });
 
     let has_frontend = FRONTEND.get_file("index.html").is_some();
@@ -423,6 +445,7 @@ mod tests {
             security_observability: SecurityObservabilityConfig { timeout_ms },
             auth,
             optimize: None,
+            trajectory_store: None,
         })
     }
 }

--- a/src/agentsight/src/server/token_savings.rs
+++ b/src/agentsight/src/server/token_savings.rs
@@ -941,6 +941,7 @@ mod tests {
                 std::path::Path::new("/tmp"),
             )),
             optimize: None,
+            trajectory_store: None,
         }
     }
 

--- a/src/agentsight/src/storage/sqlite/connection.rs
+++ b/src/agentsight/src/storage/sqlite/connection.rs
@@ -11,6 +11,20 @@ pub fn default_base_path() -> PathBuf {
     crate::config::default_base_path()
 }
 
+/// Path of a sibling database that lives next to `genai_events.db`
+/// (i.e. under [`default_base_path`]): `trajectories.db`,
+/// `interruption_events.db`, etc.
+///
+/// Single source of truth for cross-process DB path derivation: the
+/// collector (`agentsight trace`) writes and the API server
+/// (`agentsight serve`) reads must resolve the exact same file, otherwise
+/// the reader silently opens an empty database. Deriving from
+/// `default_base_path()` (instead of `GenAISqliteStore::default_path().parent()`)
+/// also avoids a `connection` → `genai` intra-module dependency cycle.
+pub fn sibling_db_path(filename: &str) -> PathBuf {
+    default_base_path().join(filename)
+}
+
 /// Create a new SQLite connection with common settings
 ///
 /// This function:

--- a/src/agentsight/src/storage/sqlite/mod.rs
+++ b/src/agentsight/src/storage/sqlite/mod.rs
@@ -41,7 +41,7 @@ pub use genai::{GenAISqliteStore, PendingCallInfo, PendingOrigin, SseEnrichment}
 pub use interruption::{InterruptionRecord, InterruptionStore, InterruptionTypeStat};
 
 // Re-export connection utilities
-pub use connection::{create_connection, default_base_path};
+pub use connection::{create_connection, default_base_path, sibling_db_path};
 
 // Re-export tokenless stats storage
 pub use tokenless::{TokenlessStatsStore, TokenlessWindowSummary};

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -516,6 +516,30 @@ impl AgentSight {
             crate::background::start_stale_scanner(Arc::clone(sqlite_store), Arc::clone(&running));
         }
 
+        // Trajectory collector (Qoder/QoderWork JSONL → ATIF → trajectories.db).
+        // Feature-gated (default off); the thread shares `running` as stop flag.
+        if config.features.trajectory_collection_enabled {
+            let collector_config = agentsight_trajectory_collector::CollectorConfig {
+                scan_interval_secs: config.features.trajectory_scan_interval_secs,
+                scan_dirs: config
+                    .features
+                    .trajectory_scan_dirs
+                    .as_ref()
+                    .map(|dirs| dirs.iter().map(std::path::PathBuf::from).collect()),
+                db_path: GenAISqliteStore::default_path()
+                    .parent()
+                    .unwrap_or(std::path::Path::new("/var/log/sysak/.agentsight"))
+                    .join("trajectories.db"),
+            };
+            let stop = Arc::clone(&running);
+            std::thread::Builder::new()
+                .name("trajectory-collector".to_string())
+                .spawn(move || {
+                    agentsight_trajectory_collector::run_collector_loop(&collector_config, &stop);
+                })
+                .ok();
+        }
+
         Ok(AgentSight {
             probes,
             parser: Parser::new(),

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -37,7 +37,7 @@ use crate::interruption::{DetectorConfig, InterruptionDetector, recover_oom_even
 use crate::parser::Parser;
 use crate::probes::{FileWatchEvent, FileWriteEvent, Probes, ProbesPoller};
 use crate::response_map::ResponseSessionMapper;
-use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore};
+use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore, sibling_db_path};
 use crate::storage::{SqliteConfig, Storage, TimePeriod, TokenQuery, TokenQueryResult};
 use crate::tokenizer::LlmTokenizer;
 
@@ -463,10 +463,7 @@ impl AgentSight {
         // Initialize interruption store only when interruption detection is enabled.
         let interruption_store: Option<Arc<InterruptionStore>> =
             if config.features.interruption_detection_enabled {
-                let db_path = GenAISqliteStore::default_path()
-                    .parent()
-                    .unwrap_or(std::path::Path::new("/var/log/sysak/.agentsight"))
-                    .join("interruption_events.db");
+                let db_path = sibling_db_path("interruption_events.db");
                 match InterruptionStore::new_with_path(&db_path) {
                     Ok(store) => {
                         log::info!("Interruption events store initialized at {db_path:?}");
@@ -526,10 +523,7 @@ impl AgentSight {
                     .trajectory_scan_dirs
                     .as_ref()
                     .map(|dirs| dirs.iter().map(std::path::PathBuf::from).collect()),
-                db_path: GenAISqliteStore::default_path()
-                    .parent()
-                    .unwrap_or(std::path::Path::new("/var/log/sysak/.agentsight"))
-                    .join("trajectories.db"),
+                db_path: sibling_db_path("trajectories.db"),
             };
             let stop = Arc::clone(&running);
             std::thread::Builder::new()


### PR DESCRIPTION
## Description

AgentSight can already observe LLM API traffic via eBPF, but the full
agent trajectory (user prompts, assistant reasoning, tool calls and
observations) lives in Qoder/QoderWork session JSONL files on disk and
was not collected anywhere. Downstream optimization analysis needs these
trajectories in the standard ATIF format to reason about accuracy,
performance and cost.

This PR adds a pure user-space trajectory pipeline behind a feature
toggle (default **off**), covering both **collection** and **query**:

1. **Collection** — a periodic scanner discovers Qoder/QoderWork session
   JSONL files under `~/.qoderwork/projects` and `~/.qoder/projects`
   (probing `/root` + `/home/*`), converts them to ATIF v1.7 documents
   and upserts them into a dedicated `trajectories.db` SQLite database.
   `(file_size, mtime)` bookkeeping drives incremental scanning so
   unchanged files are skipped. Runs in `agentsight trace` mode.
2. **Query** — the API server (`agentsight serve`) opens `trajectories.db`
   read-only and exposes it via three endpoints so the Dashboard can
   browse collected trajectories (list / filters / single ATIF document).
   When the DB is absent (collection never ran) the endpoints degrade to
   empty results with HTTP 200.

The ATIF v1.7 schema lives in a new serde-only leaf crate
(`agentsight-atif`), ported from the authoritative AgentOpt models. The
main crate's existing v1.6 export path (`src/atif`) is intentionally
untouched and will migrate in a follow-up — this is why the schema
cannot be an extension of the existing module (Footprint Ladder level 3:
the collection pipeline must depend on v1.7 without dragging the v1.6
export chain or the main crate's heavy dependency set into a background
thread crate).

A new `sibling_db_path()` helper is the single source of truth for
cross-process DB path derivation: the collector (writer, `trace`) and the
API server (reader, `serve`) are separate processes sharing
`trajectories.db` via WAL, and both now resolve the exact same path
through this helper — eliminating the duplicated
`GenAISqliteStore::default_path().parent()` expression that risked
silently reading an empty database if the two sides ever drifted.

## Related Issue

no-issue: incremental feature work planned directly on the trajectory
collection roadmap; no tracking issue exists yet.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Key Changes

**Collection (commit 1):**

- `crates/agentsight-atif/`: new serde-only leaf crate with the ATIF
  v1.7 public schema (`AtifTrajectory`, `Step`, `ATIF_SCHEMA_VERSION`)
  plus `validate_trajectory_str` / `validate_step_ids` helpers
- `crates/agentsight-trajectory-collector/`: new crate —
  `discovery.rs` (session file discovery incl. subagent `agent-<uuid>`
  files), `qoder.rs` (JSONL event loading + private metadata),
  `atif.rs` (Qoder events → ATIF v1.7 conversion), `store.rs`
  (WAL-mode SQLite upsert keyed by `session_id`, parameterized SQL),
  `lib.rs` (`run_collector_loop` with 1s-sliced stop-aware sleep)
- `src/config.rs`: new `features.trajectory_collection`
  (`enabled=false`, `scan_interval_secs=30`, optional `scan_dirs`) —
  additive optional fields, old configs stay valid, so no
  `schema_version` bump per AGENTS.md checklist
- `src/unified.rs`: `AgentSight::new` spawns the named
  `trajectory-collector` thread when enabled, reusing the existing
  `running` stop flag; store-open failure only disables the feature,
  never the tracer

**Query API (commit 2):**

- `src/storage/sqlite/connection.rs`: new `sibling_db_path()` helper
  (single source of truth for sibling DB paths; collector, interruption
  store and trajectory store all use it)
- `crates/agentsight-trajectory-collector/src/store.rs`: new read methods
  `list_summaries` / `get_atif_json` / `list_filters` + `TrajectorySummary`
  / `TrajectoryFilters` DTOs (parameterized SQL, injection-free)
- `src/server/`: `AppState.trajectory_store` (long-lived read-only
  connection) + 3 handlers/routes — `GET /api/trajectories`,
  `GET /api/trajectories/filters` (registered before the dynamic segment),
  `GET /api/trajectories/{session_id}` (raw ATIF v1.7 passthrough)
- `docs/design-docs/trajectory-query-api.md`: design doc for the query +
  Dashboard integration (frontend pages land in a follow-up PR)

Note on size: the diff exceeds the 800-line guideline, but the bulk is
two new self-contained leaf crates plus their tests; net changes to
existing main-crate code are small and additive.

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] `cargo fmt --check` pass
- [x] `cargo clippy --all-targets -- -D warnings` pass
- [x] `cargo test` pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo test --workspace --lib`: all green — main crate 1216, plus
  `agentsight-atif` 5, `agentsight-opt` 62, `agentsight-opt-store` 5,
  `agentsight-trajectory-collector` 16
- Collection unit tests: schema round-trip + step-id validation
  (`agentsight-atif`), session discovery incl. subagent files and
  non-UUID filename rejection, Qoder JSONL → ATIF conversion incl. tool
  calls/observations/final metrics and empty input, SQLite upsert
  idempotency + `(size, mtime)` file state, and an end-to-end
  `scan_once` + `run_collector_loop` stop-flag test
- Query API tests:
  - `store.rs`: `list_summaries` filter combinations / ordering / `limit`,
    `get_atif_json` hit + miss, `list_filters` distinct values
  - `handlers.rs` (actix integration through `configure_routes`): list
    200 + project filter, detail 200 (valid ATIF JSON) / 404 (missing),
    `filters` route not captured by `{session_id}`, and store-absent
    degrades to empty + 200
- Config gating verified by `config.rs` tests: absent block → disabled
  with 30s default; explicit block → enabled/interval/dirs honored
