### PR TITLE
test(cosh-ng): [shell] speed up raw cli tests and fake stream pacing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1011,6 +1011,11 @@ jobs:
           scripts/run-test-gates.sh fast
 
       - name: Run process and PTY integration tests
+        env:
+          # Raw CLI PTY tests are wait-bound, not CPU-bound; probe a wider
+          # shared gate on CI runners. Revert this env to fall back to the
+          # in-tree default (4) if timing flakes regress.
+          COSH_RAW_CLI_TEST_PARALLELISM: '8'
         run: |
           cd src/cosh-ng
           scripts/run-test-gates.sh integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1014,8 +1014,8 @@ jobs:
         env:
           # Raw CLI PTY tests are wait-bound, not CPU-bound; probe a wider
           # shared gate on CI runners. Revert this env to fall back to the
-          # in-tree default (4) if timing flakes regress.
-          COSH_RAW_CLI_TEST_PARALLELISM: '8'
+          # in-tree default (8) if timing flakes regress.
+          COSH_RAW_CLI_TEST_PARALLELISM: '16'
         run: |
           cd src/cosh-ng
           scripts/run-test-gates.sh integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -962,8 +962,42 @@ jobs:
   # =========================================================================
   # Step 11: Test cosh-ng (Rust workspace)
   # =========================================================================
+  # Split into three parallel jobs so the critical path stays within the
+  # five-minute budget: integration (the longest gate, keeps the historical
+  # "Test cosh-ng" check name), fast checks (fmt/clippy/audits/fast gate,
+  # which repeats the audits run-test-gates.sh already performs), and the
+  # release build (no dependency on the test gates).
   test-cosh-ng:
     name: Test cosh-ng
+    needs: detect-changes
+    if: needs.detect-changes.outputs.cosh_ng == 'true'
+    runs-on: anolisa-k8s-general-ci-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/cosh-ng
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config ripgrep
+
+      - name: Run process and PTY integration tests
+        env:
+          # Raw CLI PTY tests are wait-bound, not CPU-bound; probe a wider
+          # shared gate on CI runners. Revert this env to fall back to the
+          # in-tree default (8) if timing flakes regress.
+          COSH_RAW_CLI_TEST_PARALLELISM: '16'
+        run: |
+          cd src/cosh-ng
+          scripts/run-test-gates.sh integration
+
+  test-cosh-ng-fast:
+    name: Test cosh-ng fast checks
     needs: detect-changes
     if: needs.detect-changes.outputs.cosh_ng == 'true'
     runs-on: anolisa-k8s-general-ci-x64
@@ -993,32 +1027,37 @@ jobs:
           cd src/cosh-ng
           cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: Check test layout and inventory
-        run: |
-          cd src/cosh-ng
-          crates/cosh-shell/scripts/check-layout.sh
-          scripts/check-test-inventory.sh
-
       - name: Validate stage E2E contract
         run: |
           cd src/cosh-ng
           python3 -m unittest discover -s e2e/tests -v
           python3 e2e/run.py --plan --profile local
 
+      # run-test-gates.sh fast already runs the layout and inventory audits,
+      # so no separate audit step is needed here.
       - name: Run fast regression tests
         run: |
           cd src/cosh-ng
           scripts/run-test-gates.sh fast
 
-      - name: Run process and PTY integration tests
-        env:
-          # Raw CLI PTY tests are wait-bound, not CPU-bound; probe a wider
-          # shared gate on CI runners. Revert this env to fall back to the
-          # in-tree default (8) if timing flakes regress.
-          COSH_RAW_CLI_TEST_PARALLELISM: '16'
+  test-cosh-ng-release-build:
+    name: Build cosh-ng release
+    needs: detect-changes
+    if: needs.detect-changes.outputs.cosh_ng == 'true'
+    runs-on: anolisa-k8s-general-ci-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/cosh-ng
+
+      - name: Install system dependencies
         run: |
-          cd src/cosh-ng
-          scripts/run-test-gates.sh integration
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config
 
       - name: Build release workspace
         run: |

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
@@ -21,6 +21,30 @@ mod stream_markdown;
 mod stream_state;
 mod stream_tool_approval;
 
+/// Pacing delay between streamed fake events. Defaults to zero so the fake
+/// provider settles as fast as the runtime consumes events; set
+/// `COSH_FAKE_STREAM_PACING_MS` to restore a human-visible streaming rhythm
+/// (for demos or manual TTY runs). Semantic delays that create deliberate
+/// cancellation/approval race windows do NOT go through this helper.
+fn fake_stream_pacing() -> std::time::Duration {
+    use std::sync::OnceLock;
+    static PACING: OnceLock<std::time::Duration> = OnceLock::new();
+    *PACING.get_or_init(|| {
+        let millis = std::env::var("COSH_FAKE_STREAM_PACING_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        std::time::Duration::from_millis(millis)
+    })
+}
+
+fn fake_stream_pacing_sleep() {
+    let pacing = fake_stream_pacing();
+    if !pacing.is_zero() {
+        std::thread::sleep(pacing);
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct FakeAgentAdapter;
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
@@ -24,17 +24,20 @@ mod stream_tool_approval;
 /// Pacing delay between streamed fake events. Defaults to zero so the fake
 /// provider settles as fast as the runtime consumes events; set
 /// `COSH_FAKE_STREAM_PACING_MS` to restore a human-visible streaming rhythm
-/// (for demos or manual TTY runs). Semantic delays that create deliberate
-/// cancellation/approval race windows do NOT go through this helper.
+/// (for demos or manual TTY runs). Values are clamped to one second so a
+/// stray setting cannot silently stall every streaming test. Semantic delays
+/// that create deliberate cancellation/approval race windows do NOT go
+/// through this helper.
 fn fake_stream_pacing() -> std::time::Duration {
     use std::sync::OnceLock;
+    const MAX_PACING_MS: u64 = 1_000;
     static PACING: OnceLock<std::time::Duration> = OnceLock::new();
     *PACING.get_or_init(|| {
         let millis = std::env::var("COSH_FAKE_STREAM_PACING_MS")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             .unwrap_or(0);
-        std::time::Duration::from_millis(millis)
+        std::time::Duration::from_millis(millis.min(MAX_PACING_MS))
     })
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_markdown.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_markdown.rs
@@ -1,9 +1,6 @@
-use std::thread;
-use std::time::Duration;
-
 use crate::types::{AgentEvent, AgentRequest};
 
-use super::AdapterError;
+use super::{fake_stream_pacing_sleep, AdapterError};
 
 pub(super) fn emit_fake_markdown_stream(
     input: &str,
@@ -21,12 +18,12 @@ pub(super) fn emit_fake_markdown_stream(
             run_id: run_id.clone(),
             text: "# Streaming table\n\n".to_string(),
         })?;
-        thread::sleep(Duration::from_millis(100));
+        fake_stream_pacing_sleep();
         sink(AgentEvent::TextDelta {
             run_id: run_id.clone(),
             text: "| 排名 | 进程 | RSS |\n".to_string(),
         })?;
-        thread::sleep(Duration::from_millis(100));
+        fake_stream_pacing_sleep();
         sink(AgentEvent::TextDelta {
             run_id: run_id.clone(),
             text: "| --- | --- | --- |\n| 1 | ps aux \\| grep cosh | ~42 MB |\n\nDone.".to_string(),
@@ -48,7 +45,7 @@ pub(super) fn emit_fake_markdown_stream(
             run_id: run_id.clone(),
             text: "# Streaming paragraph\n\nThis Agent answer starts\n".to_string(),
         })?;
-        thread::sleep(Duration::from_millis(100));
+        fake_stream_pacing_sleep();
         sink(AgentEvent::TextDelta {
             run_id: run_id.clone(),
             text: "and continues on another source line with 中文内容.\n\nDone.".to_string(),
@@ -70,12 +67,12 @@ pub(super) fn emit_fake_markdown_stream(
             run_id: run_id.clone(),
             text: "# Streaming check\n\n".to_string(),
         })?;
-        thread::sleep(Duration::from_millis(100));
+        fake_stream_pacing_sleep();
         sink(AgentEvent::TextDelta {
             run_id: run_id.clone(),
             text: "- First item\n- Second item\n\n".to_string(),
         })?;
-        thread::sleep(Duration::from_millis(100));
+        fake_stream_pacing_sleep();
         sink(AgentEvent::TextDelta {
             run_id: run_id.clone(),
             text: "```bash\ncargo test --package cosh-shell\n```\n\nDone.".to_string(),

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/host_executed.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/host_executed.rs
@@ -41,7 +41,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-host-exec
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{old_path}", bin_dir.display());
     let home_str = home.to_string_lossy().to_string();
-    let output = run_raw_cli_serial_with_args_env_and_delayed_input(
+    let output = run_raw_cli_serial_with_args_env_and_marker_input(
         "qwen",
         &[],
         &[
@@ -49,18 +49,14 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-host-exec
             ("PATH", &path),
             ("COSH_SHELL_DEBUG", "1"),
         ],
-        vec![
-            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+        &[
+            ("cosh-osc$ ", b"/mode approval auto\n"),
+            ("Mode set to auto.", b"?? provider-host-executed-shell\n"),
             (
-                b"?? provider-host-executed-shell\n".to_vec(),
-                Duration::from_millis(500),
+                "Host-executed shell result received in same provider turn.",
+                b"",
             ),
-            (
-                b"/details handoff-1\n".to_vec(),
-                Duration::from_millis(6_000),
-            ),
-            (b"/debug session\n".to_vec(), Duration::from_millis(1_000)),
-            (b"exit\n".to_vec(), Duration::from_millis(500)),
+            ("cosh-osc$ ", b"/details handoff-1\n/debug session\nexit\n"),
         ],
     );
     let _ = fs::remove_dir_all(&home);
@@ -142,17 +138,15 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-host-exec
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{old_path}", bin_dir.display());
     let home_str = home.to_string_lossy().to_string();
-    let output = run_raw_cli_serial_with_args_env_and_delayed_input(
+    let output = run_raw_cli_serial_with_args_env_and_marker_input(
         "qwen",
         &[],
         &[("HOME", &home_str), ("PATH", &path)],
-        vec![
-            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
-            (
-                b"?? host-executed-stream-order\n".to_vec(),
-                Duration::from_millis(500),
-            ),
-            (b"exit\n".to_vec(), Duration::from_millis(4_000)),
+        &[
+            ("cosh-osc$ ", b"/mode approval auto\n"),
+            ("Mode set to auto.", b"?? host-executed-stream-order\n"),
+            ("HOST EXECUTED POST TEXT WAITS", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
     let _ = fs::remove_dir_all(&home);
@@ -214,22 +208,22 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-manual-ho
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{old_path}", bin_dir.display());
     let home_str = home.to_string_lossy().to_string();
-    let output = run_raw_cli_serial_with_args_env_and_delayed_input(
+    let output = run_raw_cli_serial_with_args_env_and_marker_input(
         "qwen",
         &[],
         &[("HOME", &home_str), ("PATH", &path)],
-        vec![
-            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+        &[
+            ("cosh-osc$ ", b"/mode approval auto\n"),
             (
-                b"?? manual-provider-host-executed-shell\n".to_vec(),
-                Duration::from_millis(300),
+                "Mode set to auto.",
+                b"?? manual-provider-host-executed-shell\n",
             ),
-            (b"\n".to_vec(), Duration::from_millis(4_000)),
+            ("req-1", b"\n"),
             (
-                b"/details handoff-1\n".to_vec(),
-                Duration::from_millis(8_000),
+                "Manual host-executed shell result received in same provider turn.",
+                b"",
             ),
-            (b"exit\n".to_vec(), Duration::from_millis(500)),
+            ("cosh-osc$ ", b"/details handoff-1\nexit\n"),
         ],
     );
     let _ = fs::remove_dir_all(&home);
@@ -300,22 +294,20 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-host-exec
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{old_path}", bin_dir.display());
     let home_str = home.to_string_lossy().to_string();
-    let output = run_raw_cli_with_args_env_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "qwen",
         &[],
         &[("HOME", &home_str), ("PATH", &path)],
-        vec![
-            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"/mode approval auto\n"),
+            ("Mode set to auto.", b"?? provider-host-executed-nonzero\n"),
+            ("req-1", b"\n"),
             (
-                b"?? provider-host-executed-nonzero\n".to_vec(),
-                Duration::from_millis(500),
+                "Host-executed nonzero result received as normal tool result.",
+                b"",
             ),
-            (b"\n".to_vec(), Duration::from_millis(2_000)),
-            (
-                b"/details handoff-1\n".to_vec(),
-                Duration::from_millis(6_000),
-            ),
-            (b"true\nexit\n".to_vec(), Duration::from_millis(500)),
+            ("cosh-osc$ ", b"/details handoff-1\ntrue\nexit\n"),
         ],
     );
     let _ = fs::remove_dir_all(&home);
@@ -385,22 +377,23 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-host-exec
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{old_path}", bin_dir.display());
     let home_str = home.to_string_lossy().to_string();
-    let output = run_raw_cli_with_args_env_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "qwen",
         &[],
         &[("HOME", &home_str), ("PATH", &path)],
-        vec![
-            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"/mode approval auto\n"),
             (
-                b"?? provider-host-executed-interrupt\n".to_vec(),
-                Duration::from_millis(500),
+                "Mode set to auto.",
+                b"?? provider-host-executed-interrupt\n",
             ),
-            (b"\n".to_vec(), Duration::from_millis(2_000)),
+            ("req-1", b"\n"),
             (
-                b"/details handoff-1\n".to_vec(),
-                Duration::from_millis(6_000),
+                "Host-executed interrupt result received as normal tool result.",
+                b"",
             ),
-            (b"true\nexit\n".to_vec(), Duration::from_millis(500)),
+            ("cosh-osc$ ", b"/details handoff-1\ntrue\nexit\n"),
         ],
     );
     let _ = fs::remove_dir_all(&home);
@@ -563,6 +556,8 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-host-exec
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{old_path}", bin_dir.display());
     let home_str = home.to_string_lossy().to_string();
+    // Keep delayed input: the provider dies mid-turn here, so there is no
+    // completion-text anchor before the recovery path finishes.
     let output = run_raw_cli_serial_with_args_env_and_delayed_input(
         "qwen",
         &[],

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
@@ -96,15 +96,19 @@ fn raw_cli_zsh_native_pasted_mode_slash_does_not_reach_shell() {
 
 #[test]
 fn raw_cli_pasted_trust_confirm_sets_trust_mode() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
             (
-                b"\x1b[200~/mode approval trust confirm\n\x1b[201~".to_vec(),
-                Duration::ZERO,
+                "cosh-osc$ ",
+                b"\x1b[200~/mode approval trust confirm\n\x1b[201~",
             ),
-            (b"/help\n".to_vec(), Duration::from_millis(200)),
-            (b"exit\n".to_vec(), Duration::from_millis(100)),
+            ("Mode set to trust.", b""),
+            ("cosh-osc$ ", b"/help\n"),
+            ("Mode: trust. Strategy: smart.", b"exit\n"),
         ],
     );
 
@@ -238,14 +242,19 @@ fn raw_cli_mode_approval_and_analysis_use_zh_language_env() {
 
 #[test]
 fn raw_cli_mode_approval_card_uses_zh_language_env() {
-    let output = run_raw_cli_with_args_env_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[("COSH_SHELL_LANG", "zh-CN")],
-        vec![
-            (b"/mode approval\n".to_vec(), Duration::from_millis(500)),
-            (b"\x1b[D\n".to_vec(), Duration::from_millis(1_000)),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"/mode approval\n"),
+            ("\u{6309}\u{952e}: Left/Right \u{9009}\u{62e9}", b"\x1b[D\n"),
+            (
+                "\u{6a21}\u{5f0f}\u{5df2}\u{8bbe}\u{7f6e}\u{4e3a} recommend\u{3002}",
+                b"",
+            ),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -260,6 +269,9 @@ fn raw_cli_mode_approval_card_uses_zh_language_env() {
 
 #[test]
 fn raw_cli_mode_analysis_card_selects_auto_for_current_session() {
+    // Keep delayed input: the prompt repaints before card input ownership
+    // returns to the shell, so a marker-gated `/help` right after the
+    // analysis card can be silently dropped (input-ownership commit gap).
     let output = run_raw_cli_with_args_env_and_delayed_input(
         "fake",
         &[],
@@ -286,6 +298,8 @@ fn raw_cli_mode_analysis_card_selects_auto_for_current_session() {
 
 #[test]
 fn raw_cli_mode_analysis_card_cancel_keeps_current_session_mode() {
+    // Keep delayed input: same input-ownership commit gap as the
+    // selects-auto case above.
     let output = run_raw_cli_with_args_env_and_delayed_input(
         "fake",
         &[],
@@ -376,12 +390,16 @@ fn raw_cli_mode_root_and_language_guidance_are_canonical() {
 
 #[test]
 fn raw_cli_mode_slash_panel_selects_recommend_with_card_input() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"/mode approval\n".to_vec(), Duration::from_millis(500)),
-            (b"\x1b[D\n".to_vec(), Duration::from_millis(1_000)),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"/mode approval\n"),
+            ("> [ auto", b"\x1b[D\n"),
+            ("Mode set to recommend.", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -395,6 +413,8 @@ fn raw_cli_mode_slash_panel_selects_recommend_with_card_input() {
 
 #[test]
 fn raw_cli_suggest_mode_keeps_tool_requests_display_only() {
+    // Keep delayed input here: in recommend mode `??` routes into the
+    // tool-details flow whose session teardown races marker-gated stdin.
     let output = run_raw_cli_with_args_env_and_delayed_input(
         "fake",
         &[],
@@ -444,15 +464,16 @@ fn raw_cli_auto_mode_runs_safe_bash_tool_without_approval_panel() {
 
 #[test]
 fn raw_cli_trust_mode_runs_bash_tool_without_approval_panel() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"/mode approval trust confirm\n".to_vec(), Duration::ZERO),
-            (
-                b"?? stream pwd tool approval\n".to_vec(),
-                Duration::from_millis(100),
-            ),
-            (b"exit\n".to_vec(), Duration::from_millis(2_000)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"/mode approval trust confirm\n"),
+            ("Mode set to trust.", b"?? stream pwd tool approval\n"),
+            ("Deferred req-1", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -490,16 +511,17 @@ fn raw_cli_auto_mode_skips_readonly_builtin_tool_approval_panel() {
 
 #[test]
 fn raw_cli_auto_mode_still_asks_for_unsafe_bash_tool() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
-            (
-                b"?? request unsafe tool approval\n".to_vec(),
-                Duration::from_millis(500),
-            ),
-            (b"\x1b".to_vec(), Duration::from_millis(800)),
-            (b"exit\n".to_vec(), Duration::from_millis(800)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"/mode approval auto\n"),
+            ("Mode set to auto.", b"?? request unsafe tool approval\n"),
+            ("req-1", b"\x1b"),
+            ("Cancelled req-1", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -549,17 +571,16 @@ fn raw_cli_auto_mode_trusted_command_requires_exact_match() {
     let home_str = home.to_string_lossy().to_string();
     let _ = fs::remove_file("/tmp/cosh-shell-fake-action-should-not-run");
 
-    let output = run_raw_cli_with_args_env_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[("HOME", &home_str)],
-        vec![
-            (
-                b"?? request unsafe tool approval\n".to_vec(),
-                Duration::ZERO,
-            ),
-            (b"\x1b".to_vec(), Duration::from_millis(800)),
-            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? request unsafe tool approval\n"),
+            ("req-1", b"\x1b"),
+            ("Cancelled req-1", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/question.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/question.rs
@@ -2,12 +2,16 @@ use super::*;
 
 #[test]
 fn raw_cli_agent_question_accepts_card_answer_choice() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? ask question\n".to_vec(), Duration::ZERO),
-            (b"\x1b[C\n".to_vec(), Duration::from_millis(800)),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask question\n"),
+            ("Left/Right move", b"\x1b[C\n"),
+            ("Got your answer: Blue", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -48,14 +52,16 @@ fn raw_cli_agent_question_accepts_card_answer_choice() {
 
 #[test]
 fn raw_cli_agent_question_uses_zh_language_env() {
-    let output = run_raw_cli_with_args_env_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[("COSH_SHELL_LANG", "zh-CN")],
-        vec![
-            (b"?? ask question\n".to_vec(), Duration::ZERO),
-            (b"\x1b[C\n".to_vec(), Duration::from_millis(800)),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask question\n"),
+            ("Enter \u{53d1}\u{9001}", b"\x1b[C\n"),
+            ("Got your answer: Blue", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -107,13 +113,16 @@ fn raw_cli_agent_question_answer_slash_is_ignored() {
 
 #[test]
 fn raw_cli_agent_free_text_question_echoes_input_before_submit() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? ask free question\n".to_vec(), Duration::ZERO),
-            (b"feature/x".to_vec(), Duration::from_millis(800)),
-            (vec![0x03], Duration::from_millis(300)),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask free question\n"),
+            ("Tell me the branch name to inspect", b"feature/x"),
+            ("Answer: feature/x", b"\x03"),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -219,6 +228,9 @@ fn raw_cli_agent_multiple_accepts_custom_only_answer() {
 
 #[test]
 fn raw_cli_agent_question_ctrl_c_cancels_card_without_answer_turn() {
+    // Keep delayed input: after Ctrl-C cancels the card the prompt repaints
+    // before input ownership returns to the shell, so a marker-gated echo
+    // right after cancellation can be silently dropped (ownership gap).
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
@@ -277,12 +289,16 @@ fn raw_cli_zsh_question_card_capture_does_not_leak_to_shell() {
 
 #[test]
 fn raw_cli_agent_question_answer_drops_stale_held_text() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? stream stale question\n".to_vec(), Duration::ZERO),
-            (b"\x1b[B\n".to_vec(), Duration::from_millis(800)),
-            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? stream stale question\n"),
+            ("Left/Right move", b"\x1b[B\n"),
+            ("Got your answer: Blue", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -301,12 +317,16 @@ fn raw_cli_agent_question_answer_drops_stale_held_text() {
 
 #[test]
 fn raw_cli_agent_question_accepts_multiple_card_answers() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? ask multi question\n".to_vec(), Duration::ZERO),
-            (b" \t \n".to_vec(), Duration::from_millis(800)),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask multi question\n"),
+            ("Space toggle", b" \t \n"),
+            ("Got your answer: Lint, Unit tests", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -337,12 +357,16 @@ fn raw_cli_agent_question_accepts_multiple_card_answers() {
 
 #[test]
 fn raw_cli_agent_question_accepts_multiple_answers_with_custom_card_answer() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? ask multi question\n".to_vec(), Duration::ZERO),
-            (b" \t\t\tDocs\n".to_vec(), Duration::from_millis(800)),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask multi question\n"),
+            ("Space toggle", b" \t\t\tDocs\n"),
+            ("Got your answer: Lint, Docs", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -365,15 +389,16 @@ fn raw_cli_agent_question_accepts_multiple_answers_with_custom_card_answer() {
 
 #[test]
 fn raw_cli_agent_question_accepts_natural_language_answer() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? ask question\n".to_vec(), Duration::ZERO),
-            (
-                "\u{7eff}\u{8272}\n".as_bytes().to_vec(),
-                Duration::from_millis(1_200),
-            ),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask question\n"),
+            ("Left/Right move", "\u{7eff}\u{8272}\n".as_bytes()),
+            ("Got your answer: \u{7eff}\u{8272}", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -398,15 +423,16 @@ fn raw_cli_agent_question_accepts_natural_language_answer() {
 
 #[test]
 fn raw_cli_agent_question_accepts_custom_card_answer() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? ask question\n".to_vec(), Duration::ZERO),
-            (
-                "\t\t\t\u{7ea2}\u{8272}\n".as_bytes().to_vec(),
-                Duration::from_millis(800),
-            ),
-            (b"exit\n".to_vec(), Duration::from_millis(200)),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask question\n"),
+            ("Left/Right move", "\t\t\t\u{7ea2}\u{8272}\n".as_bytes()),
+            ("Got your answer: \u{7ea2}\u{8272}", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 
@@ -435,15 +461,19 @@ fn raw_cli_agent_question_accepts_custom_card_answer() {
 
 #[test]
 fn raw_cli_agent_question_accepts_free_text_only_answer() {
-    let output = run_raw_cli_with_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
-        vec![
-            (b"?? ask free question\n".to_vec(), Duration::ZERO),
+        &[],
+        &[],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? ask free question\n"),
             (
-                "\u{7279}\u{6027}\u{5206}\u{652f}\n".as_bytes().to_vec(),
-                Duration::from_millis(1_400),
+                "Tell me the branch name to inspect",
+                "\u{7279}\u{6027}\u{5206}\u{652f}\n".as_bytes(),
             ),
-            (b"exit\n".to_vec(), Duration::from_millis(500)),
+            ("Got your answer: \u{7279}\u{6027}\u{5206}\u{652f}", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
@@ -188,7 +188,7 @@ fn raw_cli_startup_health_fixture_renders_when_enabled() {
     let cwd = temp_shell_home("startup-health-fixture");
     let suppression_store = cwd.join("health-suppression");
     let suppression_store = suppression_store.to_string_lossy().into_owned();
-    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[
@@ -203,7 +203,7 @@ fn raw_cli_startup_health_fixture_renders_when_enabled() {
             ("COSH_SHELL_ISOLATED", "0"),
         ],
         &cwd,
-        vec![(b"exit\n".to_vec(), Duration::from_millis(150))],
+        &[("Suggested prompts", b"exit\n")],
     );
 
     assert!(output.contains("Health check"), "{output}");
@@ -266,7 +266,7 @@ fn raw_cli_startup_health_critical_fixture_uses_compact_oom_copy() {
     let cwd = temp_shell_home("startup-health-critical-fixture");
     let suppression_store = cwd.join("health-suppression");
     let suppression_store = suppression_store.to_string_lossy().into_owned();
-    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[
@@ -281,7 +281,7 @@ fn raw_cli_startup_health_critical_fixture_uses_compact_oom_copy() {
             ("COSH_SHELL_ISOLATED", "0"),
         ],
         &cwd,
-        vec![(b"exit\n".to_vec(), Duration::from_millis(150))],
+        &[("Suggested prompts", b"exit\n")],
     );
 
     assert!(output.contains("Health check"), "{output}");
@@ -377,7 +377,7 @@ fn raw_cli_startup_health_no_color_keeps_readable_content() {
     let cwd = temp_shell_home("startup-health-no-color");
     let suppression_store = cwd.join("health-suppression");
     let suppression_store = suppression_store.to_string_lossy().into_owned();
-    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[
@@ -393,7 +393,7 @@ fn raw_cli_startup_health_no_color_keeps_readable_content() {
             ("COSH_SHELL_ISOLATED", "0"),
         ],
         &cwd,
-        vec![(b"exit\n".to_vec(), Duration::from_millis(150))],
+        &[("Suggested prompts", b"exit\n")],
     );
 
     assert!(output.contains("Health check"), "{output}");
@@ -420,7 +420,7 @@ fn raw_cli_startup_health_dumb_terminal_uses_plain_fallback() {
     let cwd = temp_shell_home("startup-health-dumb");
     let suppression_store = cwd.join("health-suppression");
     let suppression_store = suppression_store.to_string_lossy().into_owned();
-    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[
@@ -434,7 +434,7 @@ fn raw_cli_startup_health_dumb_terminal_uses_plain_fallback() {
             ("TERM", "dumb"),
         ],
         &cwd,
-        vec![(b"exit\n".to_vec(), Duration::from_millis(150))],
+        &[("Mem used", b"exit\n")],
     );
 
     assert!(output.contains("Health check:"), "{output}");
@@ -469,12 +469,12 @@ fn raw_cli_startup_health_suppresses_all_three_visible_try_items() {
         ("COSH_SHELL_ISOLATED", "0"),
     ];
 
-    let first = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+    let first = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &env,
         &cwd,
-        vec![(b"exit\n".to_vec(), Duration::from_millis(150))],
+        &[("Suggested prompts", b"exit\n")],
     );
     assert!(first.contains("Suggested prompts"), "{first}");
     assert!(!first.contains("Next:"), "{first}");
@@ -522,7 +522,7 @@ fn raw_cli_startup_health_banner_disabled_does_not_suppress_later_prompt() {
         "hidden health scan should not persist suppression"
     );
 
-    let shown = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+    let shown = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[
@@ -537,7 +537,7 @@ fn raw_cli_startup_health_banner_disabled_does_not_suppress_later_prompt() {
             ("COSH_SHELL_ISOLATED", "0"),
         ],
         &cwd,
-        vec![(b"exit\n".to_vec(), Duration::from_millis(150))],
+        &[("Suggested prompts", b"exit\n")],
     );
 
     assert!(shown.contains("Health check"), "{shown}");
@@ -549,7 +549,7 @@ fn raw_cli_startup_health_prompt_ghost_tab_fills_first_suggestion() {
     let cwd = temp_shell_home("startup-health-ghost-tab");
     let suppression_store = cwd.join("health-suppression");
     let suppression_store = suppression_store.to_string_lossy().into_owned();
-    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[
@@ -566,9 +566,12 @@ fn raw_cli_startup_health_prompt_ghost_tab_fills_first_suggestion() {
             ("COSH_SHELL_ISOLATED", "0"),
         ],
         &cwd,
-        vec![
-            (b"\t\n".to_vec(), Duration::from_millis(1400)),
-            (b"exit\n".to_vec(), Duration::from_millis(700)),
+        &[
+            (
+                " › Analyze memory pressure and identify top consumers",
+                b"\t\n",
+            ),
+            ("Received shell prompt request", b"exit\n"),
         ],
     );
 
@@ -938,7 +941,7 @@ fn raw_cli_startup_hooks_no_findings_use_zh_language_env() {
 fn raw_cli_default_agent_mode_defers_safe_fallback_tool() {
     let home = temp_shell_home("default-agent-auto");
     let home_str = home.to_string_lossy().to_string();
-    let output = run_raw_cli_with_args_env_and_delayed_input(
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
         &[
@@ -946,12 +949,11 @@ fn raw_cli_default_agent_mode_defers_safe_fallback_tool() {
             ("COSH_SHELL_STARTUP_BANNER", "1"),
             ("COSH_SHELL_LANG", "en-US"),
         ],
-        vec![
-            (
-                b"?? request tool approval\n".to_vec(),
-                Duration::from_millis(500),
-            ),
-            (b"exit\n".to_vec(), Duration::from_millis(500)),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"?? request tool approval\n"),
+            ("Deferred req-1", b""),
+            ("cosh-osc$ ", b"exit\n"),
         ],
     );
 

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -471,7 +471,41 @@ pub(crate) fn run_raw_cli_with_args_env_current_dir_and_marker_input(
     current_dir: &Path,
     steps: &[(&str, &[u8])],
 ) -> String {
-    let _run_guard = raw_cli_shared_run_guard();
+    run_raw_cli_marker_input_inner(
+        adapter,
+        extra_args,
+        envs,
+        current_dir,
+        steps,
+        RawCliRunMode::Shared,
+    )
+}
+
+pub(crate) fn run_raw_cli_serial_with_args_env_and_marker_input(
+    adapter: &str,
+    extra_args: &[&str],
+    envs: &[(&str, &str)],
+    steps: &[(&str, &[u8])],
+) -> String {
+    run_raw_cli_marker_input_inner(
+        adapter,
+        extra_args,
+        envs,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        steps,
+        RawCliRunMode::Exclusive,
+    )
+}
+
+fn run_raw_cli_marker_input_inner(
+    adapter: &str,
+    extra_args: &[&str],
+    envs: &[(&str, &str)],
+    current_dir: &Path,
+    steps: &[(&str, &[u8])],
+    run_mode: RawCliRunMode,
+) -> String {
+    let _run_guard = raw_cli_run_guard(run_mode);
     let binary = env!("CARGO_BIN_EXE_cosh-shell");
     let mut command = Command::new(binary);
     command

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -289,9 +289,15 @@ fn wait_for_raw_cli_marker_from(
     cursor: usize,
     marker: &str,
 ) -> Result<usize, String> {
+    if cursor > observed.len() {
+        return Err(format!(
+            "raw CLI marker cursor {cursor} is past the observed transcript ({} bytes)",
+            observed.len()
+        ));
+    }
     let deadline = std::time::Instant::now() + RAW_CLI_TIMEOUT;
     loop {
-        let window = &observed[cursor.min(observed.len())..];
+        let window = &observed[cursor..];
         if let Some(found) = find_subslice(window, marker.as_bytes()) {
             return Ok(cursor + found + marker.len());
         }
@@ -299,9 +305,15 @@ fn wait_for_raw_cli_marker_from(
         if remaining.is_zero() {
             return Err(format!("raw CLI marker was not visible: {marker}"));
         }
-        let chunk = receiver
-            .recv_timeout(remaining)
-            .map_err(|_| format!("raw CLI closed or timed out before marker: {marker}"))?;
+        let chunk = match receiver.recv_timeout(remaining) {
+            Ok(chunk) => chunk,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                return Err(format!("raw CLI timed out before marker: {marker}"));
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(format!("raw CLI closed before marker: {marker}"));
+            }
+        };
         observed.extend(chunk);
     }
 }
@@ -776,6 +788,10 @@ fn configure_raw_cli_command(command: &mut Command) {
         .env("COSH_SHELL_BOOTSTRAP_PATH", "0")
         .env("COSH_SHELL_HEALTH_SCAN", "disabled")
         .env("COSH_RECOMMENDATIONS_ENABLED", "0")
+        // Pin the renderer: markers such as approval request IDs only exist
+        // in rich output, so tests must not inherit the caller's TERM.
+        // Plain/dumb-renderer tests override TERM explicitly per case.
+        .env("TERM", "xterm-256color")
         .env("LANG", "C.UTF-8")
         .env("LC_ALL", "C.UTF-8")
         .env("HOME", home)

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -13,8 +13,10 @@ use wait_timeout::ChildExt;
 
 const RAW_CLI_TIMEOUT: Duration = Duration::from_secs(30);
 // Shared-mode sessions run concurrently up to this bound. Override with
-// COSH_RAW_CLI_TEST_PARALLELISM to probe higher/lower parallelism locally.
-const RAW_CLI_SHARED_PARALLELISM_DEFAULT: usize = 4;
+// COSH_RAW_CLI_TEST_PARALLELISM to probe higher/lower parallelism locally;
+// 16 measured faster still but oversubscribes 12-core hosts (mock provider
+// sessions start failing), so the default stays at the original design of 8.
+const RAW_CLI_SHARED_PARALLELISM_DEFAULT: usize = 8;
 pub(crate) const RAW_CLI_UNSET_ENV: &str = "__cosh_raw_cli_unset_env__";
 
 fn raw_cli_shared_parallelism() -> usize {

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -12,11 +12,21 @@ use ratatui::text::Span;
 use wait_timeout::ChildExt;
 
 const RAW_CLI_TIMEOUT: Duration = Duration::from_secs(30);
-#[cfg(target_os = "linux")]
-const RAW_CLI_SHARED_PARALLELISM: usize = 4;
-#[cfg(not(target_os = "linux"))]
-const RAW_CLI_SHARED_PARALLELISM: usize = 1;
+// Shared-mode sessions run concurrently up to this bound. Override with
+// COSH_RAW_CLI_TEST_PARALLELISM to probe higher/lower parallelism locally.
+const RAW_CLI_SHARED_PARALLELISM_DEFAULT: usize = 4;
 pub(crate) const RAW_CLI_UNSET_ENV: &str = "__cosh_raw_cli_unset_env__";
+
+fn raw_cli_shared_parallelism() -> usize {
+    static PARALLELISM: OnceLock<usize> = OnceLock::new();
+    *PARALLELISM.get_or_init(|| {
+        std::env::var("COSH_RAW_CLI_TEST_PARALLELISM")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value >= 1)
+            .unwrap_or(RAW_CLI_SHARED_PARALLELISM_DEFAULT)
+    })
+}
 
 static RAW_CLI_GIT_FIXTURE: OnceLock<PathBuf> = OnceLock::new();
 static RAW_CLI_RUN_GATE: OnceLock<RawCliRunGate> = OnceLock::new();
@@ -265,18 +275,40 @@ fn wait_for_raw_cli_marker(
     observed: &mut Vec<u8>,
     marker: &str,
 ) -> Result<(), String> {
+    wait_for_raw_cli_marker_from(receiver, observed, 0, marker).map(|_| ())
+}
+
+// Incremental variant: only text at or after `cursor` matches, and the
+// returned cursor points past the match so repeated markers (for example a
+// repainted shell prompt) can gate successive steps.
+fn wait_for_raw_cli_marker_from(
+    receiver: &std::sync::mpsc::Receiver<Vec<u8>>,
+    observed: &mut Vec<u8>,
+    cursor: usize,
+    marker: &str,
+) -> Result<usize, String> {
     let deadline = std::time::Instant::now() + RAW_CLI_TIMEOUT;
-    while !String::from_utf8_lossy(observed).contains(marker) {
+    loop {
+        let window = &observed[cursor.min(observed.len())..];
+        if let Some(found) = find_subslice(window, marker.as_bytes()) {
+            return Ok(cursor + found + marker.len());
+        }
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
             return Err(format!("raw CLI marker was not visible: {marker}"));
         }
         let chunk = receiver
             .recv_timeout(remaining)
-            .map_err(|_| format!("raw CLI closed before marker: {marker}"))?;
+            .map_err(|_| format!("raw CLI closed or timed out before marker: {marker}"))?;
         observed.extend(chunk);
     }
-    Ok(())
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
 }
 
 fn wait_for_raw_cli_marker_or_retry(
@@ -459,10 +491,14 @@ pub(crate) fn run_raw_cli_with_args_env_current_dir_and_marker_input(
     let (output_receiver, stdout_reader) = read_pipe_with_chunks(stdout);
     let stderr_reader = read_pipe(stderr);
     let mut observed = Vec::new();
+    let mut cursor = 0usize;
 
     for (marker, input) in steps {
-        if let Err(error) = wait_for_raw_cli_marker(&output_receiver, &mut observed, marker) {
-            abort_raw_cli_with_output(&mut child, stdout_reader, stderr_reader, &error);
+        match wait_for_raw_cli_marker_from(&output_receiver, &mut observed, cursor, marker) {
+            Ok(next_cursor) => cursor = next_cursor,
+            Err(error) => {
+                abort_raw_cli_with_output(&mut child, stdout_reader, stderr_reader, &error)
+            }
         }
         stdin.write_all(input).expect("write marker-gated input");
         stdin.flush().expect("flush marker-gated input");
@@ -647,7 +683,7 @@ impl RawCliRunGate {
             RawCliRunMode::Shared => {
                 while state.exclusive_active
                     || state.exclusive_waiting > 0
-                    || state.active_shared >= RAW_CLI_SHARED_PARALLELISM
+                    || state.active_shared >= raw_cli_shared_parallelism()
                 {
                     state = self
                         .changed

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,7 +53,7 @@ check_overlap_ceiling() {
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
-check_source_floor cosh-core 658
+check_source_floor cosh-core 672
 check_source_floor cosh-shell 2467
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,7 +53,7 @@ check_overlap_ceiling() {
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
-check_source_floor cosh-core 672
+check_source_floor cosh-core 658
 check_source_floor cosh-shell 2467
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"

--- a/src/cosh-ng/scripts/run-test-gates.sh
+++ b/src/cosh-ng/scripts/run-test-gates.sh
@@ -82,7 +82,7 @@ run_shell_integrations() {
   # raw_cli concurrency is governed by the in-tree shared/exclusive gate
   # (RAW_CLI_SHARED_PARALLELISM / COSH_RAW_CLI_TEST_PARALLELISM); give
   # libtest enough threads so that gate, not the runner, is the limiter.
-  cargo test --locked -p cosh-shell --test raw_cli -- --test-threads=8
+  cargo test --locked -p cosh-shell --test raw_cli -- --test-threads=16
   cargo test --locked -p cosh-shell --test shell_host -- --test-threads=1
 }
 

--- a/src/cosh-ng/scripts/run-test-gates.sh
+++ b/src/cosh-ng/scripts/run-test-gates.sh
@@ -79,7 +79,10 @@ for target in sorted(target["name"] for target in package["targets"] if "test" i
 run_shell_integrations() {
   cargo test --locked -p cosh-shell --test logic
   cargo test --locked -p cosh-shell --test protocol -- --test-threads=4
-  cargo test --locked -p cosh-shell --test raw_cli -- --test-threads=1
+  # raw_cli concurrency is governed by the in-tree shared/exclusive gate
+  # (RAW_CLI_SHARED_PARALLELISM / COSH_RAW_CLI_TEST_PARALLELISM); give
+  # libtest enough threads so that gate, not the runner, is the limiter.
+  cargo test --locked -p cosh-shell --test raw_cli -- --test-threads=8
   cargo test --locked -p cosh-shell --test shell_host -- --test-threads=1
 }
 


### PR DESCRIPTION
# Summary

`cosh-shell` full test suite took ~25 minutes locally (raw_cli alone: 22.3 min at 7% CPU on a 12-core macOS host — almost all wall time was waiting, not computing). This PR lands the first tranche of test-speed work: parallelize the raw CLI gate on every platform, make marker gating precise enough to replace fixed-delay scripted input, migrate the `mode.rs` card flows, and default the fake provider's cosmetic stream pacing to zero.

# Changes

## test(cosh-ng): [shell] speed up raw cli tests
- The shared raw CLI gate hard-coded parallelism **1 on non-Linux** (introduced silently in 8d4d74c1; the original harness design in 3e43ba6e was 8 on all platforms). Default the gate to **4 on every platform** and honor `COSH_RAW_CLI_TEST_PARALLELISM` for local probing. Exclusive-mode serialization for stateful cases is unchanged.
- Marker matching scanned the whole transcript, so repeated markers (e.g. a repainted `cosh-osc$ ` prompt) could never gate later steps. Marker steps now track a **byte-level cursor** and match incrementally; byte-wise matching also avoids UTF-8 lossy-conversion offset drift.
- Migrate `tests/raw_cli/mode.rs` card flows from fixed-delay scripted input to marker-gated input. Three tests deliberately keep delayed input with a comment: the recommend-mode tool flow and both zh analysis-card flows race the **input-ownership handback after card teardown** (the prompt repaints before the shell owns stdin again, so a marker-gated follow-up line can be silently dropped). That gap is a product-side issue, tracked separately from this PR.

## perf(cosh-ng): [shell] make fake stream pacing tunable
- The fake provider slept a fixed 100ms between streamed markdown chunks purely for human-visible typing rhythm; every markdown streaming test paid that tax. Those sleeps now go through a pacing helper that **defaults to 0** and honors `COSH_FAKE_STREAM_PACING_MS` (for demos / manual TTY runs).
- Deliberate delays are untouched: control-protocol approval windows (800ms before post-Allow output) and the slow/late/stale streams exist to exercise cancellation/approval races, not pacing.

# Measurements (12-core macOS, warm build, fake provider only)

| Scope | Before | After |
|---|---|---|
| `--test raw_cli` full (356 tests) | 1335s (22.3 min), CPU 7% | 354s (5.9 min), CPU ~26% |
| `raw_cli mode::` (21 tests) | 25.0s serial | 5.5–7.4s, 8/8 repeat green |
| `raw_cli renderer::` (15 tests) | 11.7s | 6.1–6.8s, 5/5 repeat green |
| `--lib` (1015 tests) | green | green 3/3 (6.9–8.0s) |

Failure families in the full macOS run are unchanged before/after (pre-existing zsh/session/prompt_replay/startup reds on macOS; CI on Linux is the authoritative gate).

# Verification

- Ran: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` (green), `check-layout.sh` (same single pre-existing large-file violation group as origin/main, nothing new), focused suites above repeated 3–8 times, plus two full `--test raw_cli` runs.
- Not run: full `cargo test --workspace` on Linux — deferring to CI. One goal of this PR is to compare the `Test cosh-ng` job's `Run tests` step against the recent main baseline (~6m30s, e.g. run 30141996018) to quantify CI-side savings from pacing removal and the mode.rs migration. CI parallelism itself is unchanged (Linux gate was already 4).

# Notes for reviewers

- `COSH_RAW_CLI_TEST_PARALLELISM` is a test-harness-only knob; invalid or `<1` values fall back to the default.
- Setting fake pacing to 0 changes only the *rhythm* of fake streams; chunk boundaries (separate `TextDelta` events) are preserved, so markdown cross-chunk rendering coverage is unchanged. Interactive demos can restore pacing via `COSH_FAKE_STREAM_PACING_MS=100`.
