### PR TITLE
fix(cosh-ng): [core] preserve revision clock

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
@@ -40,8 +40,12 @@ const CLI_TOOL_DECLARATION_RESERVE: u64 = 2_048;
 pub struct ExpectedRevision {
     /// Session store generation captured when the recommendation was emitted.
     pub generation: u64,
-    /// Projection revision captured when the recommendation was emitted
-    /// (`0` when no projection existed yet).
+    /// Compaction revision clock captured with the recommendation.
+    ///
+    /// Zero means the session has never committed a compaction. This tracks
+    /// the durable clock rather than the live projection, so a projection
+    /// rejected by sanitization does not make an in-flight recommendation
+    /// look stale.
     pub projection_revision: u64,
 }
 
@@ -93,6 +97,8 @@ pub enum CompactionError {
     Conflict,
     /// The summarized prefix changed between snapshot and commit.
     DigestMismatch,
+    /// The persisted compaction revision cannot be incremented.
+    RevisionExhausted,
     /// The session store rejected the operation.
     Session(SessionError),
 }
@@ -112,6 +118,7 @@ impl CompactionError {
             Self::OversizedInput => "oversized_input",
             Self::Conflict => "conflict",
             Self::DigestMismatch => "digest_mismatch",
+            Self::RevisionExhausted => "revision_exhausted",
             Self::Session(error) => error.code(),
         }
     }
@@ -149,6 +156,9 @@ impl std::fmt::Display for CompactionError {
                 formatter,
                 "summarized transcript prefix changed; candidate was discarded"
             ),
+            Self::RevisionExhausted => {
+                write!(formatter, "compaction revision is exhausted")
+            }
             Self::Session(error) => write!(formatter, "{error}"),
         }
     }
@@ -232,15 +242,22 @@ pub async fn compact_session(
         if base_generation != expected.generation {
             return Err(CompactionError::Conflict);
         }
-        let current_revision = session
-            .compaction
-            .as_ref()
-            .map(|state| state.revision)
-            .unwrap_or(0);
-        if current_revision != expected.projection_revision {
+        // Compare the durable revision clock, not whether a projection
+        // survived sanitization: a recommendation emitted at revision `N`
+        // stays valid when loading rejects the revision-`N` projection, and
+        // the next successful commit is still `N + 1`.
+        if session.compaction_revision != expected.projection_revision {
             return Err(CompactionError::Conflict);
         }
     }
+
+    // 1b. Reserve the next revision from the durable clock before any provider
+    //     work. The stored clock is untrusted disk input, so an exhausted
+    //     counter fails closed here instead of wrapping at commit time.
+    let next_revision = session
+        .compaction_revision
+        .checked_add(1)
+        .ok_or(CompactionError::RevisionExhausted)?;
 
     let model = if session.model.is_empty() {
         config.resolve_provider().model
@@ -289,12 +306,7 @@ pub async fn compact_session(
 
     // 5. Validate the candidate before touching persistence.
     let candidate = CompactionState {
-        revision: session
-            .compaction
-            .as_ref()
-            .map(|state| state.revision)
-            .unwrap_or(0)
-            + 1,
+        revision: next_revision,
         compacted_through: cut,
         summary,
         model: model.clone(),
@@ -321,6 +333,10 @@ pub async fn compact_session(
     if current.messages.len() < cut || source_digest(&current.messages[..cut]) != digest {
         return Err(CompactionError::DigestMismatch);
     }
+    // The generation check above proves `current` is the same persisted
+    // version the snapshot read, so `next_revision` is still exactly one past
+    // this session's durable clock. Advance the clock with the projection.
+    current.compaction_revision = candidate.revision;
     current.compaction = Some(candidate.clone());
     match store.persist(&mut current) {
         Ok(()) => {}
@@ -348,11 +364,16 @@ pub async fn compact_session(
 /// running process is the session's only writer; the resulting projection is
 /// committed together with the run's transcript at the next persist.
 ///
-/// Returns `None` when no safe cut exists or the candidate fails validation;
-/// the caller keeps its previous projection in either case.
+/// `previous_revision` is the runtime's durable revision clock, which outlives
+/// any projection dropped by sanitization; the candidate takes the next value.
+///
+/// Returns `None` when no safe cut exists, the revision clock is exhausted, or
+/// the candidate fails validation; the caller keeps its previous projection in
+/// every case.
 pub(crate) async fn compact_in_memory(
     messages: &[crate::provider::Message],
     previous: Option<&CompactionState>,
+    previous_revision: u64,
     provider: &dyn ContentGenerator,
     model: &str,
     config: &CoreConfig,
@@ -362,6 +383,9 @@ pub(crate) async fn compact_in_memory(
     if !policy.enabled {
         return None;
     }
+    // Fail closed before any provider work; the caller's existing emergency
+    // path already treats `None` as "keep the current projection".
+    let revision = previous_revision.checked_add(1)?;
     let previous_cut = previous.map(|state| state.compacted_through).unwrap_or(0);
     let cut = select_compacted_through(messages, policy.preserve_recent_runs, target_tokens)
         .ok()
@@ -383,7 +407,7 @@ pub(crate) async fn compact_in_memory(
 
     let estimated_before = estimate_messages_tokens(&effective_messages(messages, previous));
     let candidate = CompactionState {
-        revision: previous.map(|state| state.revision).unwrap_or(0) + 1,
+        revision,
         compacted_through: cut,
         summary,
         model: model.to_string(),

--- a/src/cosh-ng/crates/cosh-core/src/compaction/engine/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/engine/tests.rs
@@ -375,7 +375,7 @@ async fn compact_in_memory_reduces_and_respects_disabled_policy() {
     let messages = bulky_messages(5);
     let provider = summary_provider();
     let config = CoreConfig::default();
-    let candidate = compact_in_memory(&messages, None, &provider, "mock-model", &config, 0)
+    let candidate = compact_in_memory(&messages, None, 0, &provider, "mock-model", &config, 0)
         .await
         .expect("in-memory candidate");
     assert!(candidate.compacted_through > 0);
@@ -385,7 +385,7 @@ async fn compact_in_memory_reduces_and_respects_disabled_policy() {
     disabled.session.compaction.enabled = false;
     let provider = summary_provider();
     assert!(
-        compact_in_memory(&messages, None, &provider, "mock-model", &disabled, 0)
+        compact_in_memory(&messages, None, 0, &provider, "mock-model", &disabled, 0)
             .await
             .is_none()
     );
@@ -516,6 +516,357 @@ async fn summary_request_never_exceeds_a_small_model_window() {
         "summary request of ~{} tokens exceeds the 12K window",
         requests[0]
     );
+}
+
+/// Locates the persisted envelope for `session_id` under the temp store.
+fn session_file(temp: &tempfile::TempDir, session_id: &ProviderSessionId) -> std::path::PathBuf {
+    let filename = format!("{session_id}.json");
+    let mut pending = vec![temp.path().to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(&directory).expect("read session directory") {
+            let path = entry.expect("session directory entry").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.file_name().and_then(|name| name.to_str()) == Some(filename.as_str()) {
+                return path;
+            }
+        }
+    }
+    panic!("no persisted envelope for session {session_id}");
+}
+
+/// Rewrites the persisted envelope through `edit`.
+///
+/// Tests own this so they can construct damaged or legacy on-disk shapes that
+/// the engine itself must never produce; production code only ever sees the
+/// typed [`PersistedSession`].
+fn edit_envelope<F>(temp: &tempfile::TempDir, session_id: &ProviderSessionId, edit: F)
+where
+    F: FnOnce(&mut serde_json::Map<String, serde_json::Value>),
+{
+    let path = session_file(temp, session_id);
+    let bytes = std::fs::read(&path).expect("read envelope");
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes).expect("parse envelope");
+    edit(value.as_object_mut().expect("envelope object"));
+    std::fs::write(&path, serde_json::to_vec(&value).expect("encode envelope"))
+        .expect("write envelope");
+}
+
+/// Replaces one field of the stored projection, leaving the rest intact.
+fn corrupt_projection_field(
+    temp: &tempfile::TempDir,
+    session_id: &ProviderSessionId,
+    field: &str,
+    value: serde_json::Value,
+) {
+    let field = field.to_string();
+    edit_envelope(temp, session_id, move |envelope| {
+        let projection = envelope
+            .get_mut("compaction")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("stored projection");
+        projection.insert(field, value);
+    });
+}
+
+#[tokio::test]
+async fn rejected_projection_preserves_revision_monotonicity() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 8);
+    let config = CoreConfig::default();
+
+    let provider = summary_provider();
+    let (first, _) = compact(&store, &session, &provider, &config)
+        .await
+        .expect("first compaction");
+    assert_eq!(first.revision, 1);
+
+    // An externally rewritten prefix invalidates the digest; the projection is
+    // no longer usable but its revision was published once.
+    corrupt_projection_field(
+        &temp,
+        &session.session_id,
+        "source_digest",
+        serde_json::Value::String("0".repeat(64)),
+    );
+
+    let loaded = store
+        .load(&session.session_id)
+        .expect("load after corruption");
+    assert!(
+        loaded.compaction.is_none(),
+        "an invalid projection must degrade to the complete transcript"
+    );
+    assert_eq!(
+        loaded.compaction_revision, 1,
+        "the revision floor must survive a rejected projection"
+    );
+
+    // The next successful commit continues the clock instead of reusing 1.
+    let provider = summary_provider();
+    let (second, _) = compact(&store, &loaded, &provider, &config)
+        .await
+        .expect("second compaction");
+    assert_eq!(second.revision, 2);
+
+    let reloaded = store.load(&session.session_id).expect("reload");
+    assert_eq!(
+        reloaded.compaction.expect("projection persisted").revision,
+        2
+    );
+    assert_eq!(reloaded.compaction_revision, 2);
+}
+
+#[tokio::test]
+async fn empty_summary_on_disk_preserves_the_revision_floor() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 4);
+    let provider = summary_provider();
+    compact(&store, &session, &provider, &CoreConfig::default())
+        .await
+        .expect("first compaction");
+
+    corrupt_projection_field(
+        &temp,
+        &session.session_id,
+        "summary",
+        serde_json::Value::String("   \n ".to_string()),
+    );
+    let loaded = store.load(&session.session_id).expect("load");
+    assert!(loaded.compaction.is_none());
+    assert_eq!(loaded.compaction_revision, 1);
+}
+
+#[tokio::test]
+async fn future_prompt_version_preserves_the_revision_floor() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 4);
+    let provider = summary_provider();
+    compact(&store, &session, &provider, &CoreConfig::default())
+        .await
+        .expect("first compaction");
+
+    corrupt_projection_field(
+        &temp,
+        &session.session_id,
+        "prompt_version",
+        serde_json::json!(COMPACTION_PROMPT_VERSION + 1),
+    );
+    let loaded = store.load(&session.session_id).expect("load");
+    assert!(loaded.compaction.is_none());
+    assert_eq!(loaded.compaction_revision, 1);
+}
+
+#[tokio::test]
+async fn revision_floor_is_the_maximum_of_clock_and_projection() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 4);
+    let provider = summary_provider();
+    compact(&store, &session, &provider, &CoreConfig::default())
+        .await
+        .expect("first compaction");
+
+    // Projection ahead of the clock: the projection wins.
+    corrupt_projection_field(&temp, &session.session_id, "revision", serde_json::json!(7));
+    let loaded = store.load(&session.session_id).expect("load");
+    assert_eq!(loaded.compaction.expect("valid projection").revision, 7);
+    assert_eq!(loaded.compaction_revision, 7);
+
+    // Clock ahead of the projection: the clock wins.
+    edit_envelope(&temp, &session.session_id, |envelope| {
+        envelope.insert("compaction_revision".to_string(), serde_json::json!(9));
+    });
+    let loaded = store.load(&session.session_id).expect("load");
+    assert_eq!(loaded.compaction.expect("valid projection").revision, 7);
+    assert_eq!(loaded.compaction_revision, 9);
+}
+
+#[tokio::test]
+async fn exhausted_revision_clock_fails_closed_without_calling_provider() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 4);
+    edit_envelope(&temp, &session.session_id, |envelope| {
+        envelope.insert(
+            "compaction_revision".to_string(),
+            serde_json::json!(u64::MAX),
+        );
+    });
+
+    let error = compact(&store, &session, &PanicProvider, &CoreConfig::default())
+        .await
+        .expect_err("exhausted revision clock");
+    assert_eq!(error.code(), "revision_exhausted");
+    let after = store.load(&session.session_id).expect("load");
+    assert!(after.compaction.is_none());
+    assert_eq!(after.messages.len(), session.messages.len());
+}
+
+#[tokio::test]
+async fn provider_failure_does_not_consume_a_revision() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 4);
+    let config = CoreConfig::default();
+    let provider = summary_provider();
+    compact(&store, &session, &provider, &config)
+        .await
+        .expect("first compaction");
+
+    let mut grown = store.load(&session.session_id).expect("load committed");
+    grown.messages.extend(bulky_messages(3));
+    store.persist(&mut grown).expect("grow transcript");
+
+    let failing = MockProvider::partial_error();
+    let error = compact(&store, &grown, &failing, &config)
+        .await
+        .expect_err("provider failure");
+    assert_eq!(error.code(), "provider_error");
+    assert_eq!(
+        store
+            .load(&session.session_id)
+            .expect("load")
+            .compaction_revision,
+        1
+    );
+
+    // The burned attempt did not advance the clock: the next commit is 2.
+    let provider = summary_provider();
+    let (report, _) = compact(&store, &grown, &provider, &config)
+        .await
+        .expect("retry compaction");
+    assert_eq!(report.revision, 2);
+}
+
+#[tokio::test]
+async fn generation_conflict_does_not_consume_a_revision() {
+    let temp = tempfile::tempdir().unwrap();
+    let persist_dir = temp.path().join("sessions").to_str().unwrap().to_string();
+    let store = store(&temp);
+    let session = persisted(&store, 4);
+    let conflicting = ConflictingProvider {
+        persist_dir,
+        workspace: temp.path().to_path_buf(),
+        session_id: session.session_id.clone(),
+        inner: summary_provider(),
+    };
+    let error = compact(&store, &session, &conflicting, &CoreConfig::default())
+        .await
+        .expect_err("generation conflict");
+    assert_eq!(error.code(), "conflict");
+    assert_eq!(
+        store
+            .load(&session.session_id)
+            .expect("load")
+            .compaction_revision,
+        0
+    );
+
+    let provider = summary_provider();
+    let (report, _) = compact(&store, &session, &provider, &CoreConfig::default())
+        .await
+        .expect("retry compaction");
+    assert_eq!(report.revision, 1);
+}
+
+#[tokio::test]
+async fn emergency_compaction_continues_from_the_saved_revision_floor() {
+    let messages = bulky_messages(5);
+    let config = CoreConfig::default();
+
+    // Sanitization dropped the projection, so `previous` is `None` while the
+    // runtime clock still remembers revision 4.
+    let provider = summary_provider();
+    let candidate = compact_in_memory(&messages, None, 4, &provider, "mock-model", &config, 0)
+        .await
+        .expect("in-memory candidate");
+    assert_eq!(candidate.revision, 5);
+
+    // An exhausted clock takes the existing fail-closed emergency path.
+    let provider = summary_provider();
+    assert!(compact_in_memory(
+        &messages,
+        None,
+        u64::MAX,
+        &provider,
+        "mock-model",
+        &config,
+        0
+    )
+    .await
+    .is_none());
+}
+
+#[test]
+fn runtime_revision_clock_outlives_a_rejected_projection() {
+    let mut runtime = crate::compaction::CompactionRuntime::default();
+    assert_eq!(runtime.revision(), 0);
+    // Loading a session whose projection was rejected keeps the clock.
+    runtime.load_state(None, 4);
+    assert!(runtime.state().is_none());
+    assert_eq!(runtime.revision(), 4);
+}
+
+#[tokio::test]
+async fn legacy_envelope_recovers_the_floor_from_its_projection() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 8);
+    let config = CoreConfig::default();
+    let provider = summary_provider();
+    compact(&store, &session, &provider, &config)
+        .await
+        .expect("first compaction");
+
+    // Pre-`compaction_revision` shape: the clock exists only inside the
+    // projection, and that projection is no longer valid.
+    edit_envelope(&temp, &session.session_id, |envelope| {
+        envelope.remove("compaction_revision");
+        let projection = envelope
+            .get_mut("compaction")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("stored projection");
+        projection.insert(
+            "source_digest".to_string(),
+            serde_json::Value::String("0".repeat(64)),
+        );
+    });
+
+    let loaded = store
+        .load(&session.session_id)
+        .expect("load legacy envelope");
+    assert!(loaded.compaction.is_none());
+    assert_eq!(loaded.compaction_revision, 1);
+    let provider = summary_provider();
+    let (report, _) = compact(&store, &loaded, &provider, &config)
+        .await
+        .expect("compaction after legacy load");
+    assert_eq!(report.revision, 2);
+}
+
+#[tokio::test]
+async fn legacy_envelope_without_projection_starts_at_zero() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 4);
+    edit_envelope(&temp, &session.session_id, |envelope| {
+        envelope.remove("compaction_revision");
+    });
+
+    let loaded = store
+        .load(&session.session_id)
+        .expect("load legacy envelope");
+    assert!(loaded.compaction.is_none());
+    assert_eq!(loaded.compaction_revision, 0);
+    let provider = summary_provider();
+    let (report, _) = compact(&store, &loaded, &provider, &CoreConfig::default())
+        .await
+        .expect("first compaction");
+    assert_eq!(report.revision, 1);
 }
 
 #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/compaction/preflight.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/preflight.rs
@@ -50,6 +50,7 @@ pub(crate) async fn run_context_preflight<W: Write>(
     let candidate = compact_in_memory(
         messages,
         runtime.state(),
+        runtime.revision(),
         provider,
         model,
         config,

--- a/src/cosh-ng/crates/cosh-core/src/compaction/runtime.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/runtime.rs
@@ -34,6 +34,12 @@ pub struct CompactionRuntime {
     /// The engine's transcript always stays complete; the provider only sees
     /// the projected effective context.
     state: Option<CompactionState>,
+    /// Highest revision this session has committed, independent of whether
+    /// the projection that carried it is still active.
+    ///
+    /// Kept separate from `state` so a projection rejected on load cannot let
+    /// the next emergency compaction reuse a published revision.
+    revision: u64,
     /// Provider-reported prompt tokens from the most recent request.
     last_prompt_tokens: Option<u64>,
 }
@@ -44,20 +50,31 @@ impl CompactionRuntime {
         self.state.as_ref()
     }
 
-    /// Replaces the projection with one loaded from a persisted session.
+    /// The monotonic compaction revision clock; `0` before the first commit.
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Replaces the projection and revision clock with values loaded from a
+    /// persisted session.
+    ///
+    /// The clock is passed separately because `state` may have been dropped by
+    /// sanitization while its revision remains published.
     ///
     /// Any provider-reported usage measured the previous projection and is
     /// discarded with it.
-    pub fn load_state(&mut self, state: Option<CompactionState>) {
+    pub fn load_state(&mut self, state: Option<CompactionState>, revision: u64) {
         self.state = state;
+        self.revision = revision;
         self.last_prompt_tokens = None;
     }
 
-    /// Commits a freshly produced projection.
+    /// Commits a freshly produced projection and advances the revision clock.
     ///
     /// The last provider-reported usage measured the pre-compaction context
     /// and must not suppress the shrunken estimate, so it is cleared here.
     pub(super) fn commit_state(&mut self, state: CompactionState) {
+        self.revision = state.revision;
         self.state = Some(state);
         self.last_prompt_tokens = None;
     }

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -116,9 +116,10 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
     );
     engine.extra_params = extra_params;
     engine.messages = session.record.messages.clone();
-    engine
-        .compaction
-        .load_state(session.record.compaction.clone());
+    engine.compaction.load_state(
+        session.record.compaction.clone(),
+        session.record.compaction_revision,
+    );
     if !session.record.model.is_empty() {
         engine.model = session.record.model.clone();
     }
@@ -535,6 +536,9 @@ impl SessionRuntime {
         // Emergency in-run compaction updates the projection in memory; it
         // commits together with the transcript it belongs to.
         self.record.compaction = engine.compaction.state().cloned();
+        // The revision clock is persisted even when no projection survives, so
+        // the next commit cannot reuse an already published revision.
+        self.record.compaction_revision = engine.compaction.revision();
         store.persist(&mut self.record)
     }
 
@@ -568,12 +572,10 @@ impl SessionRuntime {
         if !budget.over_trigger(history_tokens) {
             return;
         }
-        let projection_revision = self
-            .record
-            .compaction
-            .as_ref()
-            .map(|state| state.revision)
-            .unwrap_or(0);
+        // Bind to the durable revision clock, not the live projection: this
+        // recommendation is emitted right after a persist, and a projection
+        // that sanitization later rejects must not make it look stale.
+        let projection_revision = engine.compaction.revision();
         // Versioned protocol: the shell must be able to bind the recommendation
         // to the exact session and context revision it was emitted for, and
         // reject anything malformed. Field order is fixed:

--- a/src/cosh-ng/crates/cosh-core/src/session.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session.rs
@@ -105,6 +105,14 @@ pub struct PersistedSession {
     /// complete transcript, so older readers remain correct.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compaction: Option<CompactionState>,
+    /// Highest committed compaction revision, retained even when the active
+    /// projection is rejected during loading.
+    ///
+    /// This is a monotonic clock, not a property of the live projection: a
+    /// projection dropped by sanitization must not let the next commit reuse
+    /// a revision an earlier commit already published.
+    #[serde(default)]
+    pub compaction_revision: u64,
 }
 
 impl PersistedSession {
@@ -126,6 +134,7 @@ impl PersistedSession {
             generation: 0,
             messages,
             compaction: None,
+            compaction_revision: 0,
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/session/store.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/store.rs
@@ -122,11 +122,14 @@ impl SessionStore {
         self.parse_content(session_id, content, modified_at_ms)
     }
 
-    /// Atomically commits a session if its generation is current.
+    /// Atomically commits a session if its generation is current and its
+    /// compaction revision clock does not move backwards.
     ///
     /// # Errors
     ///
     /// Returns a typed validation, conflict, serialization, or I/O error.
+    /// [`SessionError::Conflict`] also covers a stored compaction revision
+    /// higher than the one being written.
     pub fn persist(&self, session: &mut PersistedSession) -> Result<(), SessionError> {
         if session.schema_version != CURRENT_SCHEMA_VERSION {
             return Err(SessionError::IncompatibleVersion {
@@ -157,7 +160,7 @@ impl SessionStore {
         } else {
             self.lock_legacy_session(&session.session_id)?
         };
-        let current_generation = match scoped_file {
+        let (current_generation, revision_floor) = match scoped_file {
             Some(file) => {
                 let modified_at_ms = open_file_time_ms(&file);
                 let bytes = read_bounded_open_session_file(
@@ -167,11 +170,23 @@ impl SessionStore {
                 )?;
                 let content = decode_session_content(&session.session_id, &bytes)?;
                 let current = self.parse_content(&session.session_id, content, modified_at_ms)?;
-                current.generation
+                (current.generation, current.compaction_revision)
             }
-            None => 0,
+            None => (0, 0),
         };
         if current_generation != session.generation {
+            return Err(SessionError::Conflict {
+                session_id: session.session_id.to_string(),
+            });
+        }
+        // The durable compaction clock may never move backwards. The
+        // generation check above cannot catch an envelope rewritten in place
+        // without bumping it, and the clock exists precisely to survive such
+        // untrusted on-disk edits: writing a lower value would let a later
+        // commit republish a revision this session already used. Failing with
+        // Conflict keeps the caller on its existing recovery path — reload,
+        // observe the higher floor, and retry above it.
+        if session.compaction_revision < revision_floor {
             return Err(SessionError::Conflict {
                 session_id: session.session_id.to_string(),
             });
@@ -193,6 +208,12 @@ impl SessionStore {
         let mut next = session.clone();
         next.generation = next_generation;
         next.updated_at_ms = now_ms();
+        // Hold the same invariant `load` restores: the stored clock is never
+        // below the revision of the projection stored beside it, so no writer
+        // can persist a projection whose revision the clock would forget.
+        if let Some(state) = next.compaction.as_ref() {
+            next.compaction_revision = next.compaction_revision.max(state.revision);
+        }
         // Redact only the on-disk copy; the caller's in-memory turn context
         // keeps the original text for the current provider conversation.
         let mut envelope = next.clone();
@@ -431,6 +452,7 @@ impl SessionStore {
                 generation: 0,
                 messages,
                 compaction: None,
+                compaction_revision: 0,
             });
         }
 
@@ -473,9 +495,17 @@ impl SessionStore {
         // cannot replay an oversized string into init payloads or provider
         // state that the 256-byte summary bound already refuses to carry.
         session.model = bounded_summary_text(&session.model, MAX_SUMMARY_MODEL_BYTES);
+        // Raise the durable revision floor from the stored projection *before*
+        // sanitization can drop it. Pre-`compaction_revision` envelopes carry
+        // the clock only inside the projection, and a projection about to be
+        // rejected still proves that its revision was published once.
+        if let Some(state) = session.compaction.as_ref() {
+            session.compaction_revision = session.compaction_revision.max(state.revision);
+        }
         // A damaged or out-of-contract projection degrades to the complete
         // transcript instead of failing the load; the transcript is always a
-        // safe effective context.
+        // safe effective context. The revision clock survives regardless, so
+        // the next commit cannot reuse a revision that was already published.
         if let Some(state) = session.compaction.take() {
             session.compaction = crate::compaction::sanitize_loaded_state(state, &session.messages);
         }

--- a/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
@@ -48,6 +48,106 @@ fn versioned_persist_and_load_round_trip() {
     assert_eq!(loaded.workspace_scope, store.workspace_scope());
 }
 
+/// Builds a projection carrying `revision`.
+///
+/// The summary and digest are placeholders: these tests exercise the revision
+/// clock at the persistence boundary, not projection validity.
+fn projection(revision: u64) -> crate::compaction::CompactionState {
+    crate::compaction::CompactionState {
+        revision,
+        compacted_through: 1,
+        summary: "summary".to_string(),
+        model: "mock-model".to_string(),
+        prompt_version: 1,
+        source_digest: "digest".to_string(),
+        tokens_before: None,
+        tokens_after: None,
+        created_at_ms: 0,
+    }
+}
+
+/// Reads the stored envelope as untyped JSON.
+fn envelope_json(store: &SessionStore, session_id: &ProviderSessionId) -> serde_json::Value {
+    let bytes = fs::read(store.session_file(session_id)).expect("read persisted session envelope");
+    serde_json::from_slice(&bytes).expect("parse persisted session envelope JSON")
+}
+
+#[test]
+fn persist_rejects_a_lower_compaction_revision_clock() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let mut session = new_session(&store, "hello");
+    session.compaction_revision = 5;
+    store.persist(&mut session).unwrap();
+
+    // Same generation, lower clock: accepting this would let a later commit
+    // republish a revision that reached disk once already.
+    let mut regressing = session.clone();
+    regressing.compaction_revision = 2;
+    let error = store.persist(&mut regressing).unwrap_err();
+    assert_eq!(error.code(), "conflict");
+    assert_eq!(
+        store.load(&session.session_id).unwrap().compaction_revision,
+        5
+    );
+}
+
+#[test]
+fn persist_fails_closed_when_the_stored_clock_advanced_without_a_generation_bump() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let mut session = new_session(&store, "hello");
+    store.persist(&mut session).unwrap();
+
+    // An externally rewritten envelope raises the clock while leaving the
+    // generation untouched, so the generation check alone cannot catch it.
+    let mut value = envelope_json(&store, &session.session_id);
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert("compaction_revision".to_string(), serde_json::json!(9));
+    fs::write(
+        store.session_file(&session.session_id),
+        serde_json::to_vec(&value).unwrap(),
+    )
+    .unwrap();
+
+    let mut stale = session.clone();
+    let error = store.persist(&mut stale).unwrap_err();
+    assert_eq!(error.code(), "conflict");
+    // The tampered floor survives the rejected write.
+    let reloaded = store.load(&session.session_id).unwrap();
+    assert_eq!(reloaded.compaction_revision, 9);
+
+    // Conflict keeps the normal recovery path open: reload, then commit above
+    // the observed floor.
+    let mut recovered = reloaded;
+    recovered.compaction_revision = 10;
+    store.persist(&mut recovered).unwrap();
+    assert_eq!(
+        store.load(&session.session_id).unwrap().compaction_revision,
+        10
+    );
+}
+
+#[test]
+fn persist_raises_the_clock_to_the_stored_projection_revision() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let mut session = new_session(&store, "hello");
+    // A caller that forgets to advance the clock must not leave a projection
+    // whose revision the clock would forget on the next load.
+    session.compaction = Some(projection(4));
+    session.compaction_revision = 0;
+    store.persist(&mut session).unwrap();
+
+    assert_eq!(session.compaction_revision, 4);
+    assert_eq!(
+        envelope_json(&store, &session.session_id)["compaction_revision"],
+        serde_json::json!(4)
+    );
+}
+
 #[test]
 fn persisted_and_loaded_sessions_are_redacted() {
     let temp = tempfile::tempdir().unwrap();

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,7 +53,7 @@ check_overlap_ceiling() {
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
-check_source_floor cosh-core 658
+check_source_floor cosh-core 672
 check_source_floor cosh-shell 2467
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Description

Keep compaction revisions monotonic even when loading rejects a persisted projection. The root cause was that `sanitize_loaded_state()` dropped an invalid projection before `compact_session()` calculated its next revision, causing the clock to restart at `1`.

This change separates the durable revision clock from the active projection, restores the clock before sanitization, and enforces its floor again under the session-store write lock. Manual, automatic, and emergency compaction now share the same checked clock; invalid projections still fall back to the complete transcript.

## Related Issue

closes #1688

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/cosh-ng` after rebasing onto current `main`:

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --package cosh-core
cargo doc --workspace --no-deps
```

All commands pass. The `cosh-core` run covers 36 library tests, 563 binary tests, and all component integration targets.

## Additional Notes

- Pre-existing envelopes remain compatible through `#[serde(default)]`; the revision floor is recovered from their stored projection.
- Revision exhaustion fails closed instead of wrapping.
- Failed provider calls and generation conflicts do not consume revisions.
- The branch was rebased onto `ca7abe28` before final verification.