### PR TITLE
fix(cosh-ng): [shell] restore layout gates

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
@@ -1,124 +1,10 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::types::ShellHandoffRequest;
+mod model;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RawObserverAction {
-    Continue,
-    RawPassthrough,
-    HoldShellOutput,
-    DelayShellOutput,
-    CaptureInput(RawInputCapture),
-    EmitToPty(ShellHandoffRequest),
-    EmitToPtyWithPromptRestore(ShellHandoffRequest),
-    InterruptForeground,
-    RestorePrompt {
-        ghost_text: Option<String>,
-        ghost_route: PromptGhostRoute,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PromptGhostRoute {
-    NativeShell,
-    AgentIntercept {
-        suggestion_id: Option<String>,
-    },
-    AgentSelection {
-        candidates: Vec<PromptGhostCandidate>,
-        active: usize,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PromptGhostCandidate {
-    pub text: String,
-    pub suggestion_id: String,
-}
-
-impl Default for PromptGhostRoute {
-    fn default() -> Self {
-        Self::AgentIntercept {
-            suggestion_id: None,
-        }
-    }
-}
-
-impl RawObserverAction {
-    pub(crate) fn hold_shell_output(self) -> bool {
-        matches!(
-            self,
-            Self::HoldShellOutput | Self::DelayShellOutput | Self::CaptureInput(_)
-        )
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum RawInputMode {
-    Passthrough,
-    RawPassthrough,
-    Hold,
-    Delay {
-        generation: u64,
-    },
-    PromptGhost {
-        text: String,
-        route: PromptGhostRoute,
-    },
-    Capture {
-        capture: RawInputCapture,
-        generation: u64,
-        installed_at: std::time::Instant,
-    },
-    Submitted {
-        capture: RawInputCapture,
-        generation: u64,
-    },
-    Draining {
-        previous_capture: RawInputCapture,
-        generation: u64,
-        next_capture: Option<RawInputCapture>,
-        invalidated: bool,
-    },
-    Terminal {
-        previous_capture: RawInputCapture,
-        generation: u64,
-    },
-}
-
-/// Input ownership boundary for a [`RawInputMode`]. Display-only updates
-/// inside the same owner (prompt ghost candidate cycling, card selection
-/// redraws) keep the owner stable, so bytes obtained across such updates are
-/// not treated as an ownership cutover and never get silently dropped.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum InputOwnership {
-    Passthrough,
-    RawPassthrough,
-    Hold,
-    Delay(u64),
-    PromptGhost,
-    Capture(u64),
-    Submitted(u64),
-    Draining(u64),
-    Terminal(u64),
-}
-
-impl RawInputMode {
-    pub(crate) fn input_ownership(&self) -> InputOwnership {
-        match self {
-            Self::Passthrough => InputOwnership::Passthrough,
-            Self::RawPassthrough => InputOwnership::RawPassthrough,
-            Self::Hold => InputOwnership::Hold,
-            Self::Delay { generation } => InputOwnership::Delay(*generation),
-            Self::PromptGhost { .. } => InputOwnership::PromptGhost,
-            Self::Capture { generation, .. } => InputOwnership::Capture(*generation),
-            Self::Submitted { generation, .. } => InputOwnership::Submitted(*generation),
-            Self::Draining { generation, .. } => InputOwnership::Draining(*generation),
-            Self::Terminal { generation, .. } => InputOwnership::Terminal(*generation),
-        }
-    }
-}
+pub(crate) use model::{InputOwnership, RawInputMode};
+pub use model::{PromptGhostCandidate, PromptGhostRoute, RawInputCapture, RawObserverAction};
 
 static CAPTURE_GENERATION: AtomicU64 = AtomicU64::new(1);
 static DELAY_GENERATION: AtomicU64 = AtomicU64::new(1);
@@ -127,48 +13,6 @@ pub(super) fn new_delay_input_mode() -> RawInputMode {
     RawInputMode::Delay {
         generation: DELAY_GENERATION.fetch_add(1, Ordering::Relaxed),
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RawInputCapture {
-    Question {
-        id: String,
-        option_count: usize,
-        allow_free_text: bool,
-        multiple: bool,
-        secret: bool,
-    },
-    Approval {
-        id: String,
-        is_hook: bool,
-    },
-    Mode {
-        id: String,
-        option_count: usize,
-        selected: usize,
-    },
-    Config {
-        id: String,
-        option_count: usize,
-        selected: usize,
-    },
-    ConfigLanguage {
-        id: String,
-        option_count: usize,
-        selected: usize,
-    },
-    Session {
-        id: String,
-        option_count: usize,
-        selected: usize,
-        confirming_clear: bool,
-    },
-    Consultation {
-        id: String,
-    },
-    Evidence {
-        id: String,
-    },
 }
 
 pub(crate) fn update_input_mode(

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -1,0 +1,162 @@
+//! Raw-input mode state and observer action types.
+
+use crate::types::ShellHandoffRequest;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RawObserverAction {
+    Continue,
+    RawPassthrough,
+    HoldShellOutput,
+    DelayShellOutput,
+    CaptureInput(RawInputCapture),
+    EmitToPty(ShellHandoffRequest),
+    EmitToPtyWithPromptRestore(ShellHandoffRequest),
+    InterruptForeground,
+    RestorePrompt {
+        ghost_text: Option<String>,
+        ghost_route: PromptGhostRoute,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptGhostRoute {
+    NativeShell,
+    AgentIntercept {
+        suggestion_id: Option<String>,
+    },
+    AgentSelection {
+        candidates: Vec<PromptGhostCandidate>,
+        active: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptGhostCandidate {
+    pub text: String,
+    pub suggestion_id: String,
+}
+
+impl Default for PromptGhostRoute {
+    fn default() -> Self {
+        Self::AgentIntercept {
+            suggestion_id: None,
+        }
+    }
+}
+
+impl RawObserverAction {
+    pub(crate) fn hold_shell_output(self) -> bool {
+        matches!(
+            self,
+            Self::HoldShellOutput | Self::DelayShellOutput | Self::CaptureInput(_)
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RawInputMode {
+    Passthrough,
+    RawPassthrough,
+    Hold,
+    Delay {
+        generation: u64,
+    },
+    PromptGhost {
+        text: String,
+        route: PromptGhostRoute,
+    },
+    Capture {
+        capture: RawInputCapture,
+        generation: u64,
+        installed_at: std::time::Instant,
+    },
+    Submitted {
+        capture: RawInputCapture,
+        generation: u64,
+    },
+    Draining {
+        previous_capture: RawInputCapture,
+        generation: u64,
+        next_capture: Option<RawInputCapture>,
+        invalidated: bool,
+    },
+    Terminal {
+        previous_capture: RawInputCapture,
+        generation: u64,
+    },
+}
+
+/// Input ownership boundary for a [`RawInputMode`]. Display-only updates
+/// inside the same owner (prompt ghost candidate cycling, card selection
+/// redraws) keep the owner stable, so bytes obtained across such updates are
+/// not treated as an ownership cutover and never get silently dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputOwnership {
+    Passthrough,
+    RawPassthrough,
+    Hold,
+    Delay(u64),
+    PromptGhost,
+    Capture(u64),
+    Submitted(u64),
+    Draining(u64),
+    Terminal(u64),
+}
+
+impl RawInputMode {
+    pub(crate) fn input_ownership(&self) -> InputOwnership {
+        match self {
+            Self::Passthrough => InputOwnership::Passthrough,
+            Self::RawPassthrough => InputOwnership::RawPassthrough,
+            Self::Hold => InputOwnership::Hold,
+            Self::Delay { generation } => InputOwnership::Delay(*generation),
+            Self::PromptGhost { .. } => InputOwnership::PromptGhost,
+            Self::Capture { generation, .. } => InputOwnership::Capture(*generation),
+            Self::Submitted { generation, .. } => InputOwnership::Submitted(*generation),
+            Self::Draining { generation, .. } => InputOwnership::Draining(*generation),
+            Self::Terminal { generation, .. } => InputOwnership::Terminal(*generation),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RawInputCapture {
+    Question {
+        id: String,
+        option_count: usize,
+        allow_free_text: bool,
+        multiple: bool,
+        secret: bool,
+    },
+    Approval {
+        id: String,
+        is_hook: bool,
+    },
+    Mode {
+        id: String,
+        option_count: usize,
+        selected: usize,
+    },
+    Config {
+        id: String,
+        option_count: usize,
+        selected: usize,
+    },
+    ConfigLanguage {
+        id: String,
+        option_count: usize,
+        selected: usize,
+    },
+    Session {
+        id: String,
+        option_count: usize,
+        selected: usize,
+        confirming_clear: bool,
+    },
+    Consultation {
+        id: String,
+    },
+    Evidence {
+        id: String,
+    },
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -25,6 +25,7 @@ use super::{PromptGhostRoute, RawInputEvent, ESC};
 
 mod action;
 mod capture;
+mod prompt_ghost;
 mod reader;
 #[cfg(test)]
 mod tests;
@@ -36,40 +37,15 @@ use capture::{
     relay_input_chunk, CaptureOwnedInput,
 };
 pub(super) use capture::{finish_input_relay, relay_late_capture_input};
+use prompt_ghost::{
+    dismiss_replaced_prompt_ghost, PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix,
+};
 use reader::read_input_chunks;
 
 const PROMPT_GHOST_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
 const DELAY_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
 // Retain a complete split Shift+Tab sequence while the relay handles ESC.
 const INPUT_READ_AHEAD_CAPACITY: usize = 3;
-
-struct PendingPromptGhostEscape {
-    bytes: Vec<u8>,
-    text: String,
-    route: PromptGhostRoute,
-    deadline: Instant,
-}
-
-struct PendingReplacedPromptGhostSuffix {
-    bytes: Vec<u8>,
-    deadline: Instant,
-    expected_capture_generation: Option<u64>,
-}
-
-impl PendingPromptGhostEscape {
-    fn matches_mode(&self, mode: &RawInputMode) -> bool {
-        matches!(
-            mode,
-            RawInputMode::PromptGhost { text, route }
-                if text == &self.text && route == &self.route
-        )
-    }
-}
-
-fn dismiss_replaced_prompt_ghost(input_events: &Sender<RawInputEvent>) {
-    let _ = input_events.send(RawInputEvent::PromptGhostClear);
-    let _ = input_events.send(RawInputEvent::PromptGhostDismissed);
-}
 
 #[derive(Default)]
 pub(super) struct RawInputRelayState {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/prompt_ghost.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/prompt_ghost.rs
@@ -1,0 +1,35 @@
+//! Pending prompt-ghost state shared by raw-input relay paths.
+
+use std::sync::mpsc::Sender;
+use std::time::Instant;
+
+use super::super::mode::RawInputMode;
+use super::super::{PromptGhostRoute, RawInputEvent};
+
+pub(super) struct PendingPromptGhostEscape {
+    pub(super) bytes: Vec<u8>,
+    pub(super) text: String,
+    pub(super) route: PromptGhostRoute,
+    pub(super) deadline: Instant,
+}
+
+pub(super) struct PendingReplacedPromptGhostSuffix {
+    pub(super) bytes: Vec<u8>,
+    pub(super) deadline: Instant,
+    pub(super) expected_capture_generation: Option<u64>,
+}
+
+impl PendingPromptGhostEscape {
+    pub(super) fn matches_mode(&self, mode: &RawInputMode) -> bool {
+        matches!(
+            mode,
+            RawInputMode::PromptGhost { text, route }
+                if text == &self.text && route == &self.route
+        )
+    }
+}
+
+pub(super) fn dismiss_replaced_prompt_ghost(input_events: &Sender<RawInputEvent>) {
+    let _ = input_events.send(RawInputEvent::PromptGhostClear);
+    let _ = input_events.send(RawInputEvent::PromptGhostDismissed);
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -12,13 +12,11 @@ use nix::libc;
 use nix::pty::Winsize;
 
 use crate::raw_input::{
-    set_pty_winsize, signal_foreground_process_group, signal_process_group, update_input_mode,
-    update_locked_input_mode, write_all_pty, RawInputEvent, RawInputMode, RawObserverAction,
-    UserPtyInputGeneration,
+    signal_foreground_process_group, update_input_mode, update_locked_input_mode, write_all_pty,
+    RawInputEvent, RawInputMode, RawObserverAction, UserPtyInputGeneration,
 };
 use crate::types::{ShellEvent, ShellEventKind, ShellHandoffRequest};
 
-use super::model::current_terminal_winsize;
 use super::osc::{DisplayCutKind, OscParser};
 use super::prompt_replay::{
     prompt_prefixed_replay_bytes, prompt_replay_bytes, PromptReplayTracker,
@@ -26,11 +24,13 @@ use super::prompt_replay::{
 
 mod input_events;
 mod terminal_recovery;
+mod terminal_size;
 
 use input_events::drain_raw_input_events;
 use terminal_recovery::{
     restore_terminal_after_interrupted_command, PendingTerminalRecovery, TerminalRecoveryOwner,
 };
+use terminal_size::sync_outer_terminal_winsize;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn read_raw_until_exit<W: Write, F>(
@@ -511,24 +511,6 @@ fn remember_pending_prompt_restore(
     }
 }
 
-fn sync_outer_terminal_winsize(
-    master_fd: i32,
-    child_pid: u32,
-    last_winsize: &mut Winsize,
-) -> io::Result<()> {
-    let Some(current) = current_terminal_winsize() else {
-        return Ok(());
-    };
-    if same_winsize(&current, last_winsize) {
-        return Ok(());
-    }
-
-    set_pty_winsize(master_fd, current)?;
-    signal_process_group(child_pid, libc::SIGWINCH)?;
-    *last_winsize = current;
-    Ok(())
-}
-
 fn write_handoff_request(path: &Path, command: &str) -> io::Result<()> {
     std::fs::write(path, command.as_bytes())
 }
@@ -700,12 +682,6 @@ fn mark_pending_prompt_replayed(parser: &OscParser, prompt: &[u8], display_start
     }
 }
 
-fn same_winsize(left: &Winsize, right: &Winsize) -> bool {
-    left.ws_row == right.ws_row
-        && left.ws_col == right.ws_col
-        && left.ws_xpixel == right.ws_xpixel
-        && left.ws_ypixel == right.ws_ypixel
-}
 #[cfg(test)]
 #[path = "raw_relay_tests.rs"]
 mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/terminal_size.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/terminal_size.rs
@@ -1,0 +1,35 @@
+//! Outer-terminal size synchronization for the shell PTY.
+
+use std::io;
+
+use nix::libc;
+use nix::pty::Winsize;
+
+use crate::raw_input::{set_pty_winsize, signal_process_group};
+
+use super::super::model::current_terminal_winsize;
+
+pub(super) fn sync_outer_terminal_winsize(
+    master_fd: i32,
+    child_pid: u32,
+    last_winsize: &mut Winsize,
+) -> io::Result<()> {
+    let Some(current) = current_terminal_winsize() else {
+        return Ok(());
+    };
+    if same_winsize(&current, last_winsize) {
+        return Ok(());
+    }
+
+    set_pty_winsize(master_fd, current)?;
+    signal_process_group(child_pid, libc::SIGWINCH)?;
+    *last_winsize = current;
+    Ok(())
+}
+
+fn same_winsize(left: &Winsize, right: &Winsize) -> bool {
+    left.ws_row == right.ws_row
+        && left.ws_col == right.ws_col
+        && left.ws_xpixel == right.ws_xpixel
+        && left.ws_ypixel == right.ws_ypixel
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,8 +53,8 @@ check_overlap_ceiling() {
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
-check_source_floor cosh-core 626
-check_source_floor cosh-shell 2371
+check_source_floor cosh-core 658
+check_source_floor cosh-shell 2467
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"
@@ -63,7 +63,7 @@ if [[ "$ignored_count" -ne 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 613
+check_overlap_ceiling cosh-shell cosh-shell 620
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Description

Restore the cosh-ng CI gates after PR #1699 was merged against a newer main baseline than its successful PR check. Concurrent changes from #1742 pushed three raw-input production files over the 700-line layout threshold and also advanced the source-test inventory. This change extracts cohesive model, prompt-ghost, and terminal-size helpers into owner submodules, then refreshes the audited inventory counts without changing runtime behavior.

## Related Issue

no-issue: restores main CI after the concurrent integration of #1699 and #1742

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`
- `scripts/check-test-inventory.sh`
- `scripts/run-test-gates.sh fast`
- `cargo test --locked -p cosh-shell --test shell_host -- --test-threads=1`
- `cargo test --locked -p cosh-shell --test raw_cli approval::details::raw_cli_details_approvals_records_cancelled_not_executed -- --exact --test-threads=1`

The exact raw-cli test above passed on retry after one transient PTY failure during the broader integration run.

## Additional Notes

The three audited production files are now 631, 691, and 687 lines, below the 700-line threshold. No large-file waiver was added.