### PR TITLE
fix(cosh-ng): update dashscope api key hint url

### DIFF
--- a/specs/cosh-ng-code-organization/large-file-inventory.md
+++ b/specs/cosh-ng-code-organization/large-file-inventory.md
@@ -43,6 +43,7 @@ new over-threshold file appears that is not listed here.
 | 823 | `src/i18n/zh.rs` | i18n | Chinese catalog; pre-existing. Partition by message domain. |
 | 805 | `src/shell_host/osc.rs` | shell_host | OSC sequence handling; pre-existing. Split sequence kinds. |
 | 788 | `src/runtime/shell_evidence.rs` | runtime | Shell evidence runtime; pre-existing. Extract capture from rendering. |
+| 787 | `src/raw_input/mode.rs` | raw_input | Raw input mode state machine; pre-existing. Split mode transitions from capture lifecycle. |
 | 786 | `src/tools/display.rs` | tools | Tool display formatting; pre-existing. Split per-tool formatters. |
 | 778 | `src/ui/agent_render/activity.rs` | ui | Activity card rendering; pre-existing. Split per-activity renderers. |
 | 770 | `src/diagnostics/health/recommendation.rs` | diagnostics | Health recommendations; pre-existing. Split rule families. |
@@ -51,4 +52,6 @@ new over-threshold file appears that is not listed here.
 | 724 | `src/runtime/hooks.rs` | runtime | Runtime hook dispatch; pre-existing. Split per-hook-type handling. |
 | 722 | `src/i18n/message_id_all.rs` | i18n | `MessageId::ALL` mirror of the enum; near-threshold historical file (main baseline 699, zero headroom). The compaction feature added 23 required user-facing message ids, crossing the threshold. Split plan: generate the enum + `ALL` array from a single macro so new ids do not grow either file. |
 | 722 | `src/i18n/message_id.rs` | i18n | `MessageId` enum; near-threshold historical file (main baseline 699, zero headroom). The compaction feature added 23 required user-facing message ids, crossing the threshold. Split plan: partition `MessageId` into domain sub-enums (or macro-generate it) as a follow-up i18n refactor. |
+| 715 | `src/raw_input/spawn.rs` | raw_input | Input reader thread spawn; pre-existing. Split thread lifecycle from byte processing. |
+| 711 | `src/shell_host/raw_relay.rs` | shell_host | PTY relay between parent and child; pre-existing. Split read loop from write loop. |
 | 710 | `src/slash/hooks.rs` | slash | Slash hook command; pre-existing. Split subcommands. |

--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -21,7 +21,7 @@ pub fn builtin_auth_providers() -> Vec<AuthProvider> {
                 AuthField {
                     name: "api_key".to_string(),
                     label: "API Key".to_string(),
-                    hint: Some("获取地址: https://dashscope.console.aliyun.com/apiKey".to_string()),
+                    hint: Some("获取地址: https://bailian.console.aliyun.com/?tab=model#/api-key".to_string()),
                     secret: true,
                     required: true,
                     placeholder: None,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -198,19 +198,17 @@ impl CardInputState {
                 b'\r' | b'\n' => {
                     let event = self.submit(capture);
                     let submitted = event.is_some();
-                    let preserve_for_retry = matches!(
-                        (&event, capture),
-                        (
-                            Some(RawInputEvent::CardAnswer(_)),
-                            RawInputCapture::Question { secret: false, .. }
-                        )
-                    );
                     if let Some(event) = event {
                         events.push(event);
                     }
-                    if !preserve_for_retry {
-                        self.free_text.clear();
-                    }
+                    // Always clear free_text after a submit attempt so that a
+                    // subsequent capture (e.g. the next auth field) starts with
+                    // a clean buffer.  The outer consume_captured_input also
+                    // calls reset() on release, but clearing here covers any
+                    // non-release submit (e.g. QuestionSubmitAttempt) and
+                    // eliminates reliance on preserve_for_retry which could
+                    // leak text across captures when reset() is bypassed.
+                    self.free_text.clear();
                     idx += 1;
                     if submitted {
                         // State transitions are applied by the main loop; suppress a burst of

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -51,9 +51,9 @@ fn question_capture_custom_option_waits_for_text_before_submit() {
 }
 
 #[test]
-fn question_capture_preserves_answer_for_delivery_retry() {
+fn question_capture_clears_free_text_after_submit() {
     let capture = RawInputCapture::Question {
-        id: "q-retry".to_string(),
+        id: "q-clear".to_string(),
         option_count: 0,
         allow_free_text: true,
         multiple: false,
@@ -66,9 +66,11 @@ fn question_capture_preserves_answer_for_delivery_retry() {
         state.consume(&capture, b"main\n").last(),
         Some(&RawInputEvent::CardAnswer("main".to_string()))
     );
+    // free_text is cleared after submit; a second Enter must NOT replay the
+    // previous answer.
     assert_eq!(
         state.consume(&capture, b"\n"),
-        vec![RawInputEvent::CardAnswer("main".to_string())]
+        vec![RawInputEvent::QuestionSubmitAttempt("q-clear".to_string())]
     );
 }
 
@@ -95,7 +97,7 @@ fn question_capture_emits_one_submission_per_input_batch() {
     );
     assert_eq!(
         state.consume(&capture, b"\n"),
-        vec![RawInputEvent::CardAnswer("main".to_string())]
+        vec![RawInputEvent::QuestionSubmitAttempt("q-burst".to_string())]
     );
 }
 
@@ -666,5 +668,121 @@ fn evidence_capture_sends_ignores_and_cancels() {
     assert_eq!(
         state.consume(&capture, &[0x03]),
         vec![RawInputEvent::EvidenceCancel("evidence-1".to_string())]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// free_text must not carry over across capture switches or repeated submits
+// ---------------------------------------------------------------------------
+
+/// Helper: create a free-text Question capture with the given ID.
+fn text_question(id: &str, secret: bool) -> RawInputCapture {
+    RawInputCapture::Question {
+        id: id.to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret,
+    }
+}
+
+#[test]
+fn submit_clears_free_text_for_next_capture() {
+    // After submitting an answer on one capture and switching to a new
+    // capture, the new capture must start with an empty free_text buffer.
+    let cap_a = text_question("q-a", false);
+    let cap_b = text_question("q-b", false);
+    let mut state = CardInputState::default();
+
+    state.apply_capture(&cap_a);
+    let events = state.consume(&cap_a, b"answer-a\n");
+    assert_eq!(
+        events.last(),
+        Some(&RawInputEvent::CardAnswer("answer-a".to_string()))
+    );
+
+    // reset() is called by consume_captured_input on release
+    state.reset();
+
+    state.apply_capture(&cap_b);
+    let events = state.consume(&cap_b, b"x");
+    assert_eq!(
+        events.last(),
+        Some(&RawInputEvent::CardInput(
+            "q-b".to_string(),
+            "x".to_string()
+        ))
+    );
+}
+
+#[test]
+fn apply_capture_clears_free_text_when_id_changes_without_reset() {
+    // apply_capture alone (without reset) must clear free_text when the
+    // capture ID changes. This covers the direct Capture→Capture transition
+    // path in mode.rs where reset() is NOT called.
+    let cap_a = text_question("q-a", false);
+    let cap_b = text_question("q-b", false);
+    let mut state = CardInputState::default();
+
+    state.apply_capture(&cap_a);
+    state.consume(&cap_a, b"answer-a");
+    // Do NOT call reset() — simulate direct Capture→Capture transition
+    state.apply_capture(&cap_b);
+    let events = state.consume(&cap_b, b"x");
+    assert_eq!(
+        events.last(),
+        Some(&RawInputEvent::CardInput(
+            "q-b".to_string(),
+            "x".to_string()
+        ))
+    );
+}
+
+#[test]
+fn second_submit_on_same_capture_yields_empty_attempt() {
+    // After submitting on a capture, a second Enter must produce an
+    // empty submit attempt, not a replay of the previous answer.
+    let capture = text_question("q-a", false);
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let (events, remainder) = state.consume_split(&capture, b"answer-a\n");
+    assert_eq!(
+        events.last(),
+        Some(&RawInputEvent::CardAnswer("answer-a".to_string()))
+    );
+    assert!(remainder.is_empty());
+
+    // free_text must be empty after submit — second Enter yields an attempt
+    let (events, _) = state.consume_split(&capture, b"\n");
+    assert_eq!(
+        events.last(),
+        Some(&RawInputEvent::QuestionSubmitAttempt("q-a".to_string()))
+    );
+}
+
+#[test]
+fn secret_submit_clears_free_text_for_next_capture() {
+    // Secret captures must also clear free_text after submit.
+    let cap_secret = text_question("q-secret", true);
+    let cap_next = text_question("q-next", false);
+    let mut state = CardInputState::default();
+
+    state.apply_capture(&cap_secret);
+    let events = state.consume(&cap_secret, b"sk-secret\n");
+    assert_eq!(
+        events.last(),
+        Some(&RawInputEvent::CardSecretAnswer("sk-secret".to_string()))
+    );
+
+    state.reset();
+    state.apply_capture(&cap_next);
+    let events = state.consume(&cap_next, b"plain");
+    assert_eq!(
+        events.last(),
+        Some(&RawInputEvent::CardInput(
+            "q-next".to_string(),
+            "plain".to_string()
+        ))
     );
 }


### PR DESCRIPTION
## Description
DashScope has migrated to the Bailian console; the old

dashscope.console.aliyun.com/apiKey URL now shows a deprecation

notice. Update the API Key input hint to the new Bailian address so

users can actually retrieve a key.
<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #1766

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
