### PR TITLE
fix(cosh-ng): expand ~ in resolve_path for write_file/read_file/edit/glob/list_directory

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -108,14 +106,9 @@ impl Tool for EditTool {
     }
 }
 
-fn resolve_path(path_str: &str, cwd: &Path) -> std::path::PathBuf {
-    let p = std::path::Path::new(path_str);
-    if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        cwd.join(p)
-    }
-}
+// resolve_path is provided by the parent module (super::resolve_path)
+// and supports ~ expansion.
+use super::resolve_path;
 
 #[cfg(test)]
 mod tests {

--- a/src/cosh-ng/crates/cosh-core/src/tool/file_patterns.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/file_patterns.rs
@@ -51,12 +51,66 @@ fn expand_pattern(
 
     let glob_pattern = if candidate.is_dir() {
         join_glob(&candidate, "**/*")?
-    } else if Path::new(pattern).is_absolute() {
-        pattern.to_string()
+    } else if candidate.is_absolute() {
+        let (base_str, glob_suffix) = split_path_pattern(pattern);
+        let base = resolve_path(base_str, cwd);
+        let escaped = Pattern::escape(
+            base.to_str()
+                .ok_or_else(|| format!("file pattern is not valid UTF-8: {}", base.display()))?,
+        );
+        if glob_suffix.is_empty() {
+            escaped
+        } else {
+            let sep = if escaped.ends_with(std::path::MAIN_SEPARATOR) {
+                ""
+            } else {
+                std::path::MAIN_SEPARATOR_STR
+            };
+            format!("{escaped}{sep}{glob_suffix}")
+        }
     } else {
         join_glob(cwd, pattern)?
     };
     expand_glob(&glob_pattern, matches, max_matches)
+}
+
+/// Split a user-supplied pattern into `(literal_base, glob_suffix)`.
+///
+/// Splits the pattern at the first path segment that contains glob
+/// metacharacters (`*`, `?`, `[`, `]`).  Everything above that segment
+/// becomes the literal base (to be resolved and escaped); everything
+/// from that segment onward is the glob suffix (preserved verbatim).
+///
+/// If no segment contains glob metacharacters, the entire pattern is
+/// the literal base and the glob suffix is empty.
+fn split_path_pattern(pattern: &str) -> (&str, String) {
+    let sep = std::path::MAIN_SEPARATOR;
+    let sep_len = sep.len_utf8();
+    let is_glob_char = |c: char| matches!(c, '*' | '?' | '[' | ']');
+
+    let Some(glob_index) = pattern
+        .split(sep)
+        .position(|segment| segment.chars().any(is_glob_char))
+    else {
+        return (pattern, String::new());
+    };
+    if glob_index == 0 {
+        return ("", pattern.to_string());
+    }
+
+    let suffix_start = pattern
+        .split(sep)
+        .take(glob_index)
+        .map(|segment| segment.len() + sep_len)
+        .sum::<usize>();
+    let base_end = suffix_start.saturating_sub(sep_len);
+    // A leading separator forms the literal base when the first path component is a glob.
+    let base = if base_end == 0 && pattern.starts_with(sep) {
+        std::path::MAIN_SEPARATOR_STR
+    } else {
+        &pattern[..base_end]
+    };
+    (base, pattern[suffix_start..].to_string())
 }
 
 fn join_glob(base: &Path, pattern: &str) -> Result<String, String> {
@@ -112,14 +166,9 @@ fn insert_match(matches: &mut BTreeSet<PathBuf>, path: PathBuf, max_matches: usi
     false
 }
 
-pub(super) fn resolve_path(path: &str, cwd: &Path) -> PathBuf {
-    let path = Path::new(path);
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        cwd.join(path)
-    }
-}
+// resolve_path is provided by the parent module (super::resolve_path)
+// and supports ~ expansion.
+pub(super) use super::resolve_path;
 
 #[cfg(test)]
 mod tests {
@@ -171,5 +220,40 @@ mod tests {
         let matches = expand_file_patterns(&["*.rs".to_string()], &base, 10).unwrap();
 
         assert_eq!(matches.paths, [base.join("lib.rs")]);
+    }
+
+    #[test]
+    fn root_absolute_glob_preserves_literal_base() {
+        assert_eq!(split_path_pattern("/*.rs"), ("/", "*.rs".to_string()));
+        assert_eq!(
+            split_path_pattern("/tmp*/file"),
+            ("/", "tmp*/file".to_string())
+        );
+    }
+
+    #[test]
+    fn absolute_glob_uses_resolved_literal_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("src");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("lib.rs"), "lib").unwrap();
+        std::fs::write(sub.join("main.rs"), "main").unwrap();
+        std::fs::write(dir.path().join("readme.md"), "readme").unwrap();
+
+        let abs_glob = dir.path().join("src").join("*.rs");
+        let pattern = abs_glob.to_str().unwrap().to_string();
+
+        let matches = expand_file_patterns(&[pattern], &PathBuf::from("/nonexistent"), 10).unwrap();
+
+        assert_eq!(matches.paths.len(), 2);
+        for p in &matches.paths {
+            assert!(
+                p.starts_with(&sub),
+                "path {:?} should be under {:?}",
+                p,
+                sub
+            );
+            assert!(p.extension().is_some_and(|e| e == "rs"));
+        }
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
@@ -24,6 +24,48 @@ use serde_json::Value;
 use crate::provider::ToolDeclaration;
 use crate::skill::{SkillConfig, SkillManager};
 
+/// Expand `~`, `~/...`, or `~user/...` to the appropriate home directory.
+///
+/// - `~` or `~/foo` → current user's home directory
+/// - `~user/foo` → specified user's home directory (via passwd lookup)
+/// - If the user is not found, falls back to treating the path as-is.
+pub(super) fn expand_tilde(path_str: &str) -> PathBuf {
+    if path_str == "~" {
+        dirs::home_dir().unwrap_or_else(|| PathBuf::from(path_str))
+    } else if let Some(rest) = path_str.strip_prefix("~/") {
+        dirs::home_dir()
+            .map(|home| home.join(rest.trim_start_matches(std::path::MAIN_SEPARATOR)))
+            .unwrap_or_else(|| PathBuf::from(path_str))
+    } else if let Some(user_path) = path_str.strip_prefix('~') {
+        // ~user or ~user/rest
+        let (username, rest) = match user_path.find('/') {
+            Some(idx) => (&user_path[..idx], Some(&user_path[idx + 1..])),
+            None => (user_path, None),
+        };
+        let home = nix::unistd::User::from_name(username)
+            .ok()
+            .flatten()
+            .map(|u| u.dir);
+        match (home, rest) {
+            (Some(h), Some(r)) => h.join(r.trim_start_matches(std::path::MAIN_SEPARATOR)),
+            (Some(h), None) => h,
+            (None, _) => PathBuf::from(path_str),
+        }
+    } else {
+        PathBuf::from(path_str)
+    }
+}
+
+/// Resolve a path string, expanding `~` and relative paths against `cwd`.
+pub(super) fn resolve_path(path_str: &str, cwd: &std::path::Path) -> PathBuf {
+    let expanded = expand_tilde(path_str);
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        cwd.join(expanded)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ToolKind {
     ReadOnly,
@@ -262,6 +304,12 @@ impl ToolRegistry {
 mod tests {
     use super::*;
 
+    fn current_user() -> Option<nix::unistd::User> {
+        nix::unistd::User::from_uid(nix::unistd::Uid::current())
+            .ok()
+            .flatten()
+    }
+
     struct DummyTool;
 
     #[async_trait]
@@ -441,5 +489,85 @@ mod tests {
         let err = ToolResult::error("failed");
         assert!(err.is_error);
         assert_eq!(err.output, "failed");
+    }
+
+    #[test]
+    fn expand_tilde_bare_tilde() {
+        let result = expand_tilde("~");
+        let home = dirs::home_dir().expect("home dir should exist");
+        assert_eq!(result, home);
+    }
+
+    #[test]
+    fn expand_tilde_with_subpath() {
+        let result = expand_tilde("~/foo/bar");
+        let home = dirs::home_dir().expect("home dir should exist");
+        assert_eq!(result, home.join("foo/bar"));
+        assert_eq!(expand_tilde("~/src/*.rs"), home.join("src/*.rs"));
+    }
+
+    #[test]
+    fn expand_tilde_with_repeated_separator() {
+        let result = expand_tilde("~//tmp/file");
+        let home = dirs::home_dir().expect("home dir should exist");
+        assert_eq!(result, home.join("tmp/file"));
+    }
+
+    #[test]
+    fn expand_tilde_user_root() {
+        if let Some(user) = current_user() {
+            let tilde_user = format!("~{}", user.name);
+            let result = expand_tilde(&tilde_user);
+            assert_eq!(result, user.dir);
+        }
+    }
+
+    #[test]
+    fn expand_tilde_user_with_subpath() {
+        if let Some(user) = current_user() {
+            let tilde_user = format!("~{}/documents/file.txt", user.name);
+            let result = expand_tilde(&tilde_user);
+            assert_eq!(result, user.dir.join("documents/file.txt"));
+        }
+    }
+
+    #[test]
+    fn expand_tilde_user_with_repeated_separator() {
+        if let Some(user) = current_user() {
+            let tilde_user = format!("~{}//tmp/file", user.name);
+            let result = expand_tilde(&tilde_user);
+            assert_eq!(result, user.dir.join("tmp/file"));
+        }
+    }
+
+    #[test]
+    fn expand_tilde_unknown_user_falls_back() {
+        let result = expand_tilde("~nonexistent_user_xyz_12345/file.txt");
+        assert_eq!(
+            result,
+            PathBuf::from("~nonexistent_user_xyz_12345/file.txt")
+        );
+    }
+
+    #[test]
+    fn expand_tilde_no_tilde_passthrough() {
+        let result = expand_tilde("relative/path");
+        assert_eq!(result, PathBuf::from("relative/path"));
+    }
+
+    #[test]
+    fn resolve_path_tilde_is_absolute() {
+        let cwd = std::path::Path::new("/tmp");
+        let result = resolve_path("~/test.rs", cwd);
+        assert!(result.is_absolute());
+        assert!(!result.starts_with(cwd));
+        assert!(result.ends_with("test.rs"));
+    }
+
+    #[test]
+    fn resolve_path_relative_joins_cwd() {
+        let cwd = std::path::Path::new("/workspace");
+        let result = resolve_path("src/main.rs", cwd);
+        assert_eq!(result, PathBuf::from("/workspace/src/main.rs"));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/read_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/read_file.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -118,14 +116,9 @@ impl Tool for ReadFileTool {
     }
 }
 
-fn resolve_path(path_str: &str, cwd: &Path) -> std::path::PathBuf {
-    let p = std::path::Path::new(path_str);
-    if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        cwd.join(p)
-    }
-}
+// resolve_path is provided by the parent module (super::resolve_path)
+// and supports ~ expansion.
+use super::resolve_path;
 
 #[cfg(test)]
 mod tests {

--- a/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
@@ -69,14 +69,9 @@ impl Tool for WriteFileTool {
     }
 }
 
-fn resolve_path(path_str: &str, cwd: &Path) -> std::path::PathBuf {
-    let p = std::path::Path::new(path_str);
-    if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        cwd.join(p)
-    }
-}
+// resolve_path is provided by the parent module (super::resolve_path)
+// and supports ~ expansion.
+use super::resolve_path;
 
 fn write_result_output(content: &str, bytes: usize, lines: usize, path: &Path) -> String {
     let base_message = format!("Wrote {bytes} bytes ({lines} lines) to {}", path.display());

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,7 +53,7 @@ check_overlap_ceiling() {
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
-check_source_floor cosh-core 672
+check_source_floor cosh-core 684
 check_source_floor cosh-shell 2528
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Summary

Fixes #1781

### Problem
`resolve_path()` in `write_file.rs`, `read_file.rs`, `edit.rs`, and `file_patterns.rs` did not expand `~` to the user's home directory. For example, `~/foo` would be treated as a relative path and joined with `cwd`, resulting in `<cwd>/~/foo` instead of the expected `/home/<user>/foo`.

Additionally, `cosh-shell` was already sending `shell_context` (including `cwd`) to `cosh-core` via the `user_message` JSON payload, so the second part of the reported issue (shell_context not being sent) was already addressed.

### Changes
- Added shared `expand_tilde()` and `resolve_path()` functions in `crates/cosh-core/src/tool/mod.rs`
- Replaced local `resolve_path` implementations in `write_file.rs`, `read_file.rs`, `edit.rs`, and `file_patterns.rs` with `use super::resolve_path`
- The new `resolve_path` correctly handles:
  - `~` → home directory
  - `~/path` → home directory + path
  - Absolute paths → unchanged
  - Relative paths → joined with cwd

### Testing
- Existing tests continue to pass (no behavioral change for absolute or relative paths)
- The `dirs` crate (v5) was already a dependency of `cosh-core`

Fixes #1781