### PR TITLE
fix(cosh-ng): [shell] raw action relay watchdog

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use nix::libc;
 use nix::pty::Winsize;
@@ -65,6 +66,7 @@ pub struct ShellHostConfig {
     pub native_mode: bool,
     pub login_shell: bool,
     pub env_overrides: Vec<(String, String)>,
+    pub raw_action_watchdog: Duration,
     pub(super) shell_environment_observer: Option<ShellEnvironmentObserver>,
     pub(super) shell_history_file_observer: Option<ShellHistoryFileObserver>,
 }
@@ -83,6 +85,7 @@ impl ShellHostConfig {
             native_mode: true,
             login_shell: false,
             env_overrides: Vec::new(),
+            raw_action_watchdog: Duration::from_secs(120),
             shell_environment_observer: None,
             shell_history_file_observer: None,
         }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -12,10 +12,10 @@ use nix::libc;
 use nix::pty::Winsize;
 
 use crate::raw_input::{
-    signal_foreground_process_group, update_input_mode, update_locked_input_mode, write_all_pty,
-    RawInputEvent, RawInputMode, RawObserverAction, UserPtyInputGeneration,
+    update_input_mode, update_locked_input_mode, RawInputEvent, RawInputMode, RawObserverAction,
+    UserPtyInputGeneration,
 };
-use crate::types::{ShellEvent, ShellEventKind, ShellHandoffRequest};
+use crate::types::{ShellEvent, ShellEventKind};
 
 use super::osc::{DisplayCutKind, OscParser};
 use super::prompt_replay::{
@@ -23,13 +23,15 @@ use super::prompt_replay::{
 };
 
 mod input_events;
+mod pty_emit;
 mod terminal_recovery;
 mod terminal_size;
 
 use input_events::drain_raw_input_events;
-use terminal_recovery::{
-    restore_terminal_after_interrupted_command, PendingTerminalRecovery, TerminalRecoveryOwner,
-};
+use pty_emit::resolve_pty_emit;
+#[cfg(test)]
+use pty_emit::restore_prompt_display_before_handoff;
+use terminal_recovery::{restore_terminal_after_interrupted_command, PendingTerminalRecovery};
 use terminal_size::sync_outer_terminal_winsize;
 
 pub(super) struct RawActionWatchdog {
@@ -539,168 +541,6 @@ fn remember_pending_prompt_restore(
     if matches!(action, RawObserverAction::RestorePrompt { .. }) {
         *pending = Some(action.clone());
     }
-}
-
-fn write_handoff_request(path: &Path, command: &str) -> io::Result<()> {
-    std::fs::write(path, command.as_bytes())
-}
-
-#[allow(clippy::too_many_arguments)]
-fn resolve_pty_emit<W: Write>(
-    master: &mut File,
-    child_pid: u32,
-    terminal_fd: i32,
-    parser: &mut OscParser,
-    output: &mut W,
-    input_mode: &Arc<Mutex<RawInputMode>>,
-    action: RawObserverAction,
-    display_start: &mut usize,
-    prompt_replay: &mut PromptReplayTracker,
-    pending_terminal_restore: &mut PendingTerminalRecovery,
-    recovery_request_file: &Path,
-    handoff_request_file: &Path,
-) -> io::Result<RawObserverAction> {
-    match action {
-        RawObserverAction::EmitToPty(request) => {
-            emit_to_pty(
-                master,
-                terminal_fd,
-                parser,
-                output,
-                request,
-                display_start,
-                prompt_replay,
-                pending_terminal_restore,
-                handoff_request_file,
-                false,
-            )?;
-            Ok(RawObserverAction::RawPassthrough)
-        }
-        RawObserverAction::EmitToPtyWithPromptRestore(request) => {
-            emit_to_pty(
-                master,
-                terminal_fd,
-                parser,
-                output,
-                request,
-                display_start,
-                prompt_replay,
-                pending_terminal_restore,
-                handoff_request_file,
-                true,
-            )?;
-            Ok(RawObserverAction::RawPassthrough)
-        }
-        RawObserverAction::InterruptForeground => {
-            output.flush()?;
-            pending_terminal_restore
-                .mark_owner(TerminalRecoveryOwner::CoshTimeoutInterrupt, terminal_fd);
-            signal_foreground_process_group(
-                master.as_raw_fd(),
-                terminal_fd,
-                child_pid,
-                libc::SIGINT,
-            )?;
-            pending_terminal_restore.restore_modes(terminal_fd)?;
-            pending_terminal_restore.request_shell_recovery(recovery_request_file)?;
-            parser.push_control_event("timeout_interrupt");
-            Ok(RawObserverAction::Continue)
-        }
-        RawObserverAction::RestorePrompt {
-            ghost_text,
-            ghost_route,
-        } => {
-            output.flush()?;
-            let raw_prompt = parser.last_prompt_display();
-            let prompt = prompt_replay_bytes(raw_prompt);
-            if prompt.is_empty() {
-                return Ok(RawObserverAction::RestorePrompt {
-                    ghost_text,
-                    ghost_route,
-                });
-            }
-            if parser.display.len() > *display_start {
-                write_pending_display(parser, output, display_start, prompt_replay)?;
-            } else {
-                output.write_all(prompt)?;
-                mark_pending_prompt_replayed(parser, raw_prompt, display_start);
-                prompt_replay.arm_for_replay(raw_prompt);
-            }
-            if let Some(text) = &ghost_text {
-                let selection = matches!(
-                    ghost_route,
-                    crate::raw_input::PromptGhostRoute::AgentSelection { .. }
-                );
-                if let Ok(mut mode) = input_mode.lock() {
-                    *mode = RawInputMode::PromptGhost {
-                        text: text.clone(),
-                        route: ghost_route,
-                    };
-                }
-                write_prompt_ghost(output, text, selection)?;
-            }
-            output.flush()?;
-            Ok(RawObserverAction::Continue)
-        }
-        other => Ok(other),
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn emit_to_pty<W: Write>(
-    master: &mut File,
-    terminal_fd: i32,
-    parser: &mut OscParser,
-    output: &mut W,
-    request: ShellHandoffRequest,
-    display_start: &mut usize,
-    prompt_replay: &mut PromptReplayTracker,
-    pending_terminal_restore: &mut PendingTerminalRecovery,
-    handoff_request_file: &Path,
-    restore_prompt: bool,
-) -> io::Result<()> {
-    output.flush()?;
-    if restore_prompt {
-        restore_prompt_display_before_handoff(parser, output, display_start, prompt_replay)?;
-    }
-    let bytes = request.pty_bytes().map_err(|message| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("blocked shell handoff: {message}"),
-        )
-    })?;
-    pending_terminal_restore.record_intervention_start(terminal_fd);
-    parser.register_pending_handoff_origin(&request);
-    write_handoff_request(handoff_request_file, &request.command)?;
-    if let Err(err) = write_all_pty(master, &bytes) {
-        let _ = std::fs::remove_file(handoff_request_file);
-        return Err(err);
-    }
-    Ok(())
-}
-
-fn restore_prompt_display_before_handoff<W: Write>(
-    parser: &OscParser,
-    output: &mut W,
-    display_start: &mut usize,
-    prompt_replay: &mut PromptReplayTracker,
-) -> io::Result<()> {
-    if parser.display.len() > *display_start {
-        write_pending_display(parser, output, display_start, prompt_replay)?;
-        output.flush()?;
-        return Ok(());
-    }
-
-    let raw_prompt = parser.last_prompt_display();
-    let prompt = prompt_replay_bytes(raw_prompt);
-    if prompt.is_empty() {
-        return Ok(());
-    }
-    output.write_all(prompt)?;
-    output.flush()?;
-    mark_pending_prompt_replayed(parser, raw_prompt, display_start);
-    prompt_replay.arm_for_replay(raw_prompt);
-    Ok(())
 }
 
 fn mark_pending_prompt_replayed(parser: &OscParser, prompt: &[u8], display_start: &mut usize) {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -32,6 +32,25 @@ use terminal_recovery::{
 };
 use terminal_size::sync_outer_terminal_winsize;
 
+pub(super) struct RawActionWatchdog {
+    driver_done: Arc<Mutex<Option<Instant>>>,
+    grace: Duration,
+}
+
+impl RawActionWatchdog {
+    pub(super) fn new(driver_done: Arc<Mutex<Option<Instant>>>, grace: Duration) -> Self {
+        Self { driver_done, grace }
+    }
+
+    fn expired(&self) -> bool {
+        self.driver_done
+            .lock()
+            .ok()
+            .and_then(|done| *done)
+            .is_some_and(|done| done.elapsed() > self.grace)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn read_raw_until_exit<W: Write, F>(
     master: &mut File,
@@ -47,6 +66,7 @@ pub(super) fn read_raw_until_exit<W: Write, F>(
     prompt: &str,
     recovery_request_file: &Path,
     handoff_request_file: &Path,
+    watchdog: Option<&RawActionWatchdog>,
 ) -> io::Result<()>
 where
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
@@ -252,6 +272,16 @@ where
                 &mut prompt_replay,
             )?;
             return Ok(());
+        }
+        if let Some(watchdog) = watchdog {
+            if watchdog.expired() {
+                child.kill()?;
+                child.wait()?;
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "raw action relay watchdog: shell did not exit after the trailing exit was relayed",
+                ));
+            }
         }
         sync_outer_terminal_winsize(master.as_raw_fd(), child.id(), last_winsize)?;
         if restore_terminal_after_interrupted_command(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
@@ -1,0 +1,179 @@
+use std::fs::File;
+use std::io::{self, Write};
+use std::os::fd::AsRawFd;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use nix::libc;
+
+use crate::raw_input::{
+    signal_foreground_process_group, write_all_pty, RawInputMode, RawObserverAction,
+};
+use crate::types::ShellHandoffRequest;
+
+use super::super::osc::OscParser;
+use super::super::prompt_replay::{prompt_replay_bytes, PromptReplayTracker};
+use super::terminal_recovery::{PendingTerminalRecovery, TerminalRecoveryOwner};
+use super::{mark_pending_prompt_replayed, write_pending_display, write_prompt_ghost};
+
+fn write_handoff_request(path: &Path, command: &str) -> io::Result<()> {
+    std::fs::write(path, command.as_bytes())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn resolve_pty_emit<W: Write>(
+    master: &mut File,
+    child_pid: u32,
+    terminal_fd: i32,
+    parser: &mut OscParser,
+    output: &mut W,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    action: RawObserverAction,
+    display_start: &mut usize,
+    prompt_replay: &mut PromptReplayTracker,
+    pending_terminal_restore: &mut PendingTerminalRecovery,
+    recovery_request_file: &Path,
+    handoff_request_file: &Path,
+) -> io::Result<RawObserverAction> {
+    match action {
+        RawObserverAction::EmitToPty(request) => {
+            emit_to_pty(
+                master,
+                terminal_fd,
+                parser,
+                output,
+                request,
+                display_start,
+                prompt_replay,
+                pending_terminal_restore,
+                handoff_request_file,
+                false,
+            )?;
+            Ok(RawObserverAction::RawPassthrough)
+        }
+        RawObserverAction::EmitToPtyWithPromptRestore(request) => {
+            emit_to_pty(
+                master,
+                terminal_fd,
+                parser,
+                output,
+                request,
+                display_start,
+                prompt_replay,
+                pending_terminal_restore,
+                handoff_request_file,
+                true,
+            )?;
+            Ok(RawObserverAction::RawPassthrough)
+        }
+        RawObserverAction::InterruptForeground => {
+            output.flush()?;
+            pending_terminal_restore
+                .mark_owner(TerminalRecoveryOwner::CoshTimeoutInterrupt, terminal_fd);
+            signal_foreground_process_group(
+                master.as_raw_fd(),
+                terminal_fd,
+                child_pid,
+                libc::SIGINT,
+            )?;
+            pending_terminal_restore.restore_modes(terminal_fd)?;
+            pending_terminal_restore.request_shell_recovery(recovery_request_file)?;
+            parser.push_control_event("timeout_interrupt");
+            Ok(RawObserverAction::Continue)
+        }
+        RawObserverAction::RestorePrompt {
+            ghost_text,
+            ghost_route,
+        } => {
+            output.flush()?;
+            let raw_prompt = parser.last_prompt_display();
+            let prompt = prompt_replay_bytes(raw_prompt);
+            if prompt.is_empty() {
+                return Ok(RawObserverAction::RestorePrompt {
+                    ghost_text,
+                    ghost_route,
+                });
+            }
+            if parser.display.len() > *display_start {
+                write_pending_display(parser, output, display_start, prompt_replay)?;
+            } else {
+                output.write_all(prompt)?;
+                mark_pending_prompt_replayed(parser, raw_prompt, display_start);
+                prompt_replay.arm_for_replay(raw_prompt);
+            }
+            if let Some(text) = &ghost_text {
+                let selection = matches!(
+                    ghost_route,
+                    crate::raw_input::PromptGhostRoute::AgentSelection { .. }
+                );
+                if let Ok(mut mode) = input_mode.lock() {
+                    *mode = RawInputMode::PromptGhost {
+                        text: text.clone(),
+                        route: ghost_route,
+                    };
+                }
+                write_prompt_ghost(output, text, selection)?;
+            }
+            output.flush()?;
+            Ok(RawObserverAction::Continue)
+        }
+        other => Ok(other),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_to_pty<W: Write>(
+    master: &mut File,
+    terminal_fd: i32,
+    parser: &mut OscParser,
+    output: &mut W,
+    request: ShellHandoffRequest,
+    display_start: &mut usize,
+    prompt_replay: &mut PromptReplayTracker,
+    pending_terminal_restore: &mut PendingTerminalRecovery,
+    handoff_request_file: &Path,
+    restore_prompt: bool,
+) -> io::Result<()> {
+    output.flush()?;
+    if restore_prompt {
+        restore_prompt_display_before_handoff(parser, output, display_start, prompt_replay)?;
+    }
+    let bytes = request.pty_bytes().map_err(|message| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("blocked shell handoff: {message}"),
+        )
+    })?;
+    pending_terminal_restore.record_intervention_start(terminal_fd);
+    parser.register_pending_handoff_origin(&request);
+    write_handoff_request(handoff_request_file, &request.command)?;
+    if let Err(err) = write_all_pty(master, &bytes) {
+        let _ = std::fs::remove_file(handoff_request_file);
+        return Err(err);
+    }
+    Ok(())
+}
+
+pub(super) fn restore_prompt_display_before_handoff<W: Write>(
+    parser: &OscParser,
+    output: &mut W,
+    display_start: &mut usize,
+    prompt_replay: &mut PromptReplayTracker,
+) -> io::Result<()> {
+    if parser.display.len() > *display_start {
+        write_pending_display(parser, output, display_start, prompt_replay)?;
+        output.flush()?;
+        return Ok(());
+    }
+
+    let raw_prompt = parser.last_prompt_display();
+    let prompt = prompt_replay_bytes(raw_prompt);
+    if prompt.is_empty() {
+        return Ok(());
+    }
+    output.write_all(prompt)?;
+    output.flush()?;
+    mark_pending_prompt_replayed(parser, raw_prompt, display_start);
+    prompt_replay.arm_for_replay(raw_prompt);
+    Ok(())
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -2,8 +2,8 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
-use std::thread::JoinHandle;
-use std::time::Duration;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use nix::libc;
 
@@ -18,7 +18,7 @@ use super::bootstrap::{start_bash_session, start_zsh_session, PtySession};
 use super::io_loop::{read_until_streaming, wait_child};
 use super::lifecycle::{build_shell_host_output, push_shell_exited_event};
 use super::model::{ShellHostConfig, ShellHostOutput};
-use super::raw_relay::read_raw_until_exit;
+use super::raw_relay::{read_raw_until_exit, RawActionWatchdog};
 
 pub fn run_raw_relay_bash<R, W>(
     config: &ShellHostConfig,
@@ -67,6 +67,7 @@ where
         output,
         event_observer,
         config.input_classifier.clone(),
+        None,
         |master, _, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_input_relay(
                 input,
@@ -97,6 +98,7 @@ where
         output,
         event_observer,
         config.input_classifier.clone(),
+        None,
         |master, _, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_input_relay(
                 input,
@@ -135,6 +137,7 @@ where
         output,
         |_, _| Ok(RawObserverAction::Continue),
         config.input_classifier.clone(),
+        Some(config.raw_action_watchdog),
         |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_action_relay(
                 actions,
@@ -169,6 +172,7 @@ where
             Ok(RawObserverAction::Continue)
         },
         config.input_classifier.clone(),
+        Some(config.raw_action_watchdog),
         |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_action_relay(
                 actions,
@@ -199,6 +203,7 @@ where
         output,
         event_observer,
         config.input_classifier.clone(),
+        Some(config.raw_action_watchdog),
         |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_action_relay(
                 actions,
@@ -219,6 +224,7 @@ fn run_raw_relay_with_driver<W, F, D>(
     mut output: W,
     mut event_observer: F,
     input_classifier: InputClassifier,
+    action_watchdog: Option<Duration>,
     spawn_driver: D,
 ) -> io::Result<ShellHostOutput>
 where
@@ -254,7 +260,7 @@ where
     let (input_event_sender, input_event_receiver) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
     let input_generation = UserPtyInputGeneration::default();
-    let _input_thread = spawn_driver(
+    let driver_thread = spawn_driver(
         input_master,
         session.child.id(),
         input_event_sender,
@@ -262,6 +268,17 @@ where
         Arc::clone(&input_mode),
         input_generation.clone(),
     );
+    let watchdog = action_watchdog.map(|grace| {
+        let driver_done = Arc::new(Mutex::new(None));
+        let done_slot = Arc::clone(&driver_done);
+        thread::spawn(move || {
+            let _ = driver_thread.join();
+            if let Ok(mut done) = done_slot.lock() {
+                *done = Some(Instant::now());
+            }
+        });
+        RawActionWatchdog::new(driver_done, grace)
+    });
     let mut last_winsize = config.winsize;
     let relay_prompt = if config.native_mode {
         ""
@@ -282,6 +299,7 @@ where
         relay_prompt,
         &session.recovery_request_file,
         &session.handoff_request_file,
+        watchdog.as_ref(),
     )?;
     let display_start = session.parser.display.len();
     session.parser.flush_pending();

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
@@ -175,6 +175,34 @@ fn transparent_ctrl_backslash_is_not_synthesized_from_ctrl_c() {
 }
 
 #[test]
+fn raw_relay_action_watchdog_turns_swallowed_exit_into_timeout_error() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-watchdog-timeout-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config = ShellHostConfig::new("watchdog-timeout-test", &work_dir);
+    config.raw_action_watchdog = Duration::from_secs(5);
+    let mut rendered = Vec::new();
+    let err = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::line(
+                "bash -c 'trap \"\" INT QUIT TERM; while IFS= read -r _; do :; done'",
+            ),
+            RawRelayAction::wait(Duration::from_millis(300)),
+        ],
+        &mut rendered,
+    )
+    .expect_err("watchdog must turn a swallowed trailing exit into an error");
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+}
+
+#[test]
 fn raw_relay_host_preserves_user_tty_mutation_after_interrupt() {
     if Command::new("bash").arg("--version").output().is_err() {
         return;

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 672
-check_source_floor cosh-shell 2467
+check_source_floor cosh-shell 2468
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Summary

`shell_host` raw relay action harness could hang **indefinitely** when its trailing `exit` was swallowed by a foreground child of the interactive shell, dragging the whole suite (observed 32+ minutes in the cosh-lab container during PR #1787 validation). This PR adds a finish watchdog scoped to the action-driven harness entry points, turning the unbounded hang into a bounded, attributable test failure.

Fixes #1792

## Root Cause

- `spawn_raw_action_relay` (`src/raw_input/spawn.rs`) finishes by writing a trailing `exit\n` to the PTY. (The `finish_input_relay` mentioned in the issue has since been inlined here.)
- If a foreground child of the interactive bash is still reading stdin (e.g. the `ctrl-backslash` test's `read` loop surviving a rare missed `0x1c → SIGQUIT → trap` chain), that `exit` line is consumed by the child instead of the shell.
- `read_raw_until_exit` (`src/shell_host/raw_relay.rs`) only returns when `child.try_wait()` reports an exit status — it has **no timeout**, so the harness never returns.

## Changes

- `ShellHostConfig` gains `raw_action_watchdog: Duration` (default 120s, as suggested in the issue; tests can lower it).
- `run_raw_relay_with_driver` monitors the action driver thread; once it completes (trailing `exit` relayed), the watchdog window starts. Only the three `*_with_actions*` entry points enable it.
- On expiry, `read_raw_until_exit` kills the session child, reaps it, and returns `io::ErrorKind::TimedOut` with an explicit message — the flake stays visible as a failing test instead of being masked or hanging.
- Interactive entry points (`run_raw_interactive_*` / `spawn_raw_input_relay`) pass no watchdog: product interactive behavior is byte-for-byte unchanged. When the watchdog never fires, action-path behavior is also unchanged (fail-safe).
- Follow-up commit `refactor(cosh-ng): [shell] split raw_relay emit`: the watchdog addition pushed `raw_relay.rs` past the 700-line layout gate (first CI run failed on `check-layout.sh`), so the PTY handoff emission domain (`resolve_pty_emit` / `emit_to_pty` / `restore_prompt_display_before_handoff` / `write_handoff_request`) moved verbatim into the `raw_relay/pty_emit.rs` owner submodule, following the existing `input_events`/`terminal_recovery`/`terminal_size` pattern. No behavior change; the layout audit passes again.

## Tests

- New regression test `termios::raw_relay_action_watchdog_turns_swallowed_exit_into_timeout_error`: leaves a foreground `bash -c 'trap "" INT QUIT TERM; while IFS= read -r _; do :; done'` child that deterministically swallows the trailing `exit`.
  - **Before the fix**: this scenario hangs forever (reproduced deterministically; a 60s-bounded probe hit its limit every run).
  - **After the fix**: returns `Err(TimedOut)` in ~5.4s under a 5s watchdog — test PASS.
- Invariant checks: existing `termios::transparent_ctrl_backslash_is_not_synthesized_from_ctrl_c` (the original hang site) still passes in ~1.4s when the signal chain works.

## Verification

Ran locally on macOS (host toolchain, debug profile), after rebasing onto `origin/main` (`5ade7060`):

- `cargo test -p cosh-shell --test shell_host` — 80 passed / 0 failed / 1 ignored (pre-existing ignore)
- `cargo test -p cosh-shell --lib` — 1022 passed / 0 failed on 4 of 5 rounds; one round hit 2 failures in `adapter::implementation::cosh_core*` tests. These are disjoint from this diff (adapter domain, recently touched upstream by `ca7abe28`), and reproduce intermittently when running only that module — reported honestly as a pre-existing upstream flake, not introduced here.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `crates/cosh-shell/scripts/check-layout.sh` — layout audit passed

Excluded scope (not run locally): Linux behavior and the rest of the workspace test suites are covered by this PR's CI.
