### PR TITLE
fix(cosh-ng): reopen stdout blocking after raw mode activation

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -1,5 +1,6 @@
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Write};
+use std::os::fd::AsRawFd;
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -297,6 +298,7 @@ where
 
 pub fn run_raw_interactive_bash(config: &ShellHostConfig) -> io::Result<ShellHostOutput> {
     let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
     run_raw_relay_bash(config, std::io::stdin(), std::io::stdout())
 }
 
@@ -308,6 +310,7 @@ where
     F: FnMut(&[ShellEvent], &mut std::io::Stdout) -> io::Result<()>,
 {
     let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
     run_raw_relay_bash_with_observer(config, std::io::stdin(), std::io::stdout(), event_observer)
 }
 
@@ -319,6 +322,7 @@ where
     F: FnMut(&[ShellEvent], &mut std::io::Stdout) -> io::Result<RawObserverAction>,
 {
     let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
     run_raw_relay_bash_with_output_control(
         config,
         std::io::stdin(),
@@ -335,12 +339,58 @@ where
     F: FnMut(&[ShellEvent], &mut std::io::Stdout) -> io::Result<RawObserverAction>,
 {
     let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
     run_raw_relay_zsh_with_output_control(
         config,
         std::io::stdin(),
         std::io::stdout(),
         event_observer,
     )
+}
+
+/// Re-open stdout on a fresh, blocking file description when needed.
+///
+/// On Linux terminals (and SSH sessions), stdin and stdout often share the
+/// same underlying open file description. `RawModeGuard` sets `O_NONBLOCK` on
+/// stdin (fd 0), which therefore also makes stdout (fd 1) non-blocking.
+/// Subsequent writes to stdout can then return `EAGAIN` / `EWOULDBLOCK`.
+///
+/// This function opens `/dev/tty` to obtain a new, independent file
+/// description that is not marked `O_NONBLOCK`, and uses `dup2` to replace
+/// fd 1 with it. The termios configuration is per-device, so the new fd
+/// inherits the raw-mode settings already applied by `RawModeGuard`.
+///
+/// If stdout is not a terminal, or if `/dev/tty` cannot be opened, the
+/// function logs a warning and returns success so that the shell can still
+/// start. In that case the caller retains the original (possibly
+/// non-blocking) stdout behavior.
+fn reopen_stdout_blocking() -> io::Result<()> {
+    if unsafe { libc::isatty(libc::STDOUT_FILENO) } == 0 {
+        // stdout is not a terminal, so the stdin/stdout shared file
+        // description problem does not apply here.
+        return Ok(());
+    }
+    let tty = match OpenOptions::new().write(true).open("/dev/tty") {
+        Ok(tty) => tty,
+        Err(err) => {
+            eprintln!(
+                "cosh-shell: warning: cannot reopen stdout as blocking: {err}; \
+                 EAGAIN risk remains"
+            );
+            return Ok(());
+        }
+    };
+    let tty_fd = tty.as_raw_fd();
+    if unsafe { libc::dup2(tty_fd, libc::STDOUT_FILENO) } < 0 {
+        let err = io::Error::last_os_error();
+        eprintln!(
+            "cosh-shell: warning: cannot reopen stdout as blocking: {err}; \
+             EAGAIN risk remains"
+        );
+    }
+    // `tty` is dropped here, but the duplicated fd remains alive because fd 1
+    // now refers to the same open file description.
+    Ok(())
 }
 
 struct RawModeGuard {


### PR DESCRIPTION
RawModeGuard::activate_stdin() sets O_NONBLOCK on stdin (fd 0). On Linux terminals/SSH sessions stdin and stdout often share the same open file description, so stdout (fd 1) becomes non-blocking as well and subsequent writes may return EAGAIN.

Add reopen_stdout_blocking() which opens /dev/tty to obtain a fresh, independent blocking file description and replaces fd 1 with it via dup2(). termios settings are per-device, so the new fd keeps the raw-mode configuration. Call it in all four run_raw_interactive_* entry points right after activating raw mode.

If stdout is not a terminal or /dev/tty cannot be opened, the function logs a warning and returns success so the shell can still start.

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #1801

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
