### PR TITLE
fix(cosh-ng): [shell] restore healthy startup health row

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
@@ -54,6 +54,12 @@ pub(crate) fn render_startup_banner<W: Write>(
     let recommendation_notice = append_recommendation_notice(state, &mut body);
     state.startup_health.wait_ready(STARTUP_HEALTH_ROW_WAIT);
     let suggestions = prepare_startup_suggestions(state, cwd);
+    if let Some(report) = state.startup_health.report.as_ref() {
+        if health_uses_startup_row(report) {
+            body.push(renderer.startup_section_separator_line());
+            body.extend(renderer.health_startup_row_lines(HealthBannerModel::new(report)));
+        }
+    }
     if let Some(markdown) = startup_hook.markdown {
         body.push(String::new());
         body.push(startup_hook.summary);
@@ -199,17 +205,14 @@ pub(crate) fn render_startup_health_banner<W: Write>(
         .and_then(|path| path.to_str().map(str::to_string))
         .unwrap_or_else(|| ".".to_string());
     let suggestions = prepare_startup_suggestions(state, &cwd);
-    let show_health = !health_uses_startup_row(&report);
-    if !show_health && suggestions.candidates.is_empty() {
-        return Ok(());
-    }
     write!(output, "\r\x1b[2K")?;
-    if show_health {
-        let mut facts = report.clone();
-        facts.try_items.clear();
-        renderer.write_health_banner(output, HealthBannerModel::new(&facts))?;
-        writeln!(output)?;
-    }
+    // Late all-green reports still surface the compact startup row here;
+    // `write_health_banner` renders the row shape for `ok` reports and the
+    // attention panel otherwise, so both stay visible after the banner.
+    let mut facts = report.clone();
+    facts.try_items.clear();
+    renderer.write_health_banner(output, HealthBannerModel::new(&facts))?;
+    writeln!(output)?;
     write_startup_suggestion_card(
         state,
         &renderer,

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
@@ -222,6 +222,24 @@ fn raw_cli_startup_health_fixture_renders_when_enabled() {
 }
 
 #[test]
+fn raw_cli_startup_health_disabled_renders_no_row() {
+    let output = run_raw_cli_with_env(
+        "fake",
+        "exit\n",
+        &[
+            ("COSH_SHELL_STARTUP_BANNER", "1"),
+            ("COSH_SHELL_HEALTH_SCAN", "disabled"),
+            ("COSH_SHELL_LANG", "en-US"),
+            ("TERM", "xterm-256color"),
+        ],
+    );
+
+    assert!(output.contains("/help"), "{output}");
+    assert!(!output.contains("Health: ok"), "{output}");
+    assert!(!output.contains("Health check"), "{output}");
+}
+
+#[test]
 fn raw_cli_startup_health_cards_share_configured_width() {
     let cwd = temp_shell_home("startup-health-card-width");
     let suppression_store = cwd.join("health-suppression");
@@ -344,7 +362,7 @@ fn raw_cli_startup_health_degraded_fixture_is_read_only() {
 }
 
 #[test]
-fn raw_cli_startup_health_healthy_fixture_keeps_only_default_startup_card() {
+fn raw_cli_startup_health_healthy_fixture_renders_startup_row_in_banner() {
     let cwd = temp_shell_home("startup-health-healthy-fixture");
     let suppression_store = cwd.join("health-suppression");
     let suppression_store = suppression_store.to_string_lossy().into_owned();
@@ -366,7 +384,9 @@ fn raw_cli_startup_health_healthy_fixture_keeps_only_default_startup_card() {
     );
 
     assert!(output.contains("cosh-shell"), "{output}");
-    assert!(!output.contains("Health:"), "{output}");
+    assert!(output.contains("Health: ok"), "{output}");
+    assert!(output.contains("Mem used"), "{output}");
+    assert!(output.contains("Disk"), "{output}");
     assert!(!output.contains("Health check"), "{output}");
     assert!(!output.contains("Suggested prompts"), "{output}");
     assert_inline_before_followup(&output, "╭ cosh-shell", "exit");


### PR DESCRIPTION
## Summary

Restores the healthy (`ok` severity) health status row inside the startup banner. Since the prompt-recommendation refactor moved banner assembly into `runtime/startup/recommendations.rs`, an all-green health report was silently dropped: the scan still ran, but nothing was rendered, making a healthy host indistinguishable from a host where the scan never ran (disabled config, unsupported platform, or late report).

Fixes #1817

## Root cause

- `render_startup_banner`: the all-green branch (`health_uses_startup_row == true`) only set `startup_health.rendered = true` without emitting the row that the original startup health scan implementation appended to the banner body.
- `render_startup_health_banner` (deferred path, report arriving after the 150ms banner budget): returned early for all-green reports.

## Changes

- Merge the `ok` health row back into the startup card body (separator + `health_startup_row_lines`): status, scan elapsed, fixed overview (Load / Mem used / Disk used). No gauge, no prompt suggestions, no standalone panel — matching the startup health scan spec's severity rendering matrix.
- Deferred path now always renders via `write_health_banner`, which emits the compact row shape for `ok` reports and the attention panel otherwise.
- Scan-not-run stays silent (a skipped scan must not be presented as healthy).

## Tests

- Re-anchored `raw_cli_startup_health_healthy_fixture_keeps_only_default_startup_card` → `raw_cli_startup_health_healthy_fixture_renders_startup_row_in_banner`: asserts `Health: ok`, `Mem used`, `Disk` present; no `Health check` attention panel; no `Suggested prompts`.
- Added `raw_cli_startup_health_disabled_renders_no_row`: `COSH_SHELL_HEALTH_SCAN=disabled` renders neither row nor panel.

## Verification (focused scope)

- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings`: green (cosh-lab pr preflight ok).
- `cargo test -p cosh-shell --test raw_cli startup`: 35 passed, 1 failed — `raw_cli_startup_health_context_is_not_attached_to_plain_agent_request` also fails identically on unmodified `main` (`ca7abe28`) in this local environment (agent routing input swallowed by bash, exit 127); unrelated to this change, deferring to CI.
- `cargo test -p cosh-shell --lib health` (98 passed) and `--lib startup` (1 passed): green.
- FAIL→PASS reproduction with `COSH_SHELL_HEALTH_SCAN=fixture:linux-healthy` against a real `cosh-shell raw cosh-core` startup:
  - Before: `grep -c "Health"` = 0 (banner rendered, row absent).
  - After (en-US): `│ Health: ok · 1ms · Load 1m 0.8 / 4 cores (0.2x) · Mem used 51% · Disk / used 42% │` inside the startup card.
  - After (zh-CN): `健康: 正常 · 1ms · 1分钟负载 0.8 / 4核（0.2倍） · 内存已用 51% · 磁盘 / 已用 42%`.

Full workspace suite not run locally; relying on CI for the complete gate.
